### PR TITLE
Upgrade bcrypt salt rounds to 12 and extract password utility (ENG-92)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "@adopt-dont-shop/lib.dev-tools": "*",
         "@adopt-dont-shop/lib.feature-flags": "*",
         "@adopt-dont-shop/lib.moderation": "*",
+        "@adopt-dont-shop/lib.permissions": "*",
         "@adopt-dont-shop/lib.rescue": "*",
         "@adopt-dont-shop/lib.support-tickets": "*",
         "@adopt-dont-shop/lib.validation": "*",

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -1,6 +1,6 @@
 import { BelongsToManyAddAssociationMixin, DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
-import bcrypt from 'bcrypt';
+import { hashPassword, verifyPassword } from '../utils/password';
 import { JsonObject } from '../types/common';
 import { generateReadableId, getReadableIdSqlLiteral } from '../utils/readable-id';
 
@@ -178,7 +178,7 @@ class User extends Model<UserAttributes, UserCreationAttributes> implements User
 
   // Password comparison method
   public async comparePassword(candidatePassword: string): Promise<boolean> {
-    return bcrypt.compare(candidatePassword, this.password);
+    return verifyPassword(candidatePassword, this.password);
   }
 
   public canLogin(): boolean {
@@ -511,14 +511,12 @@ User.init(
     hooks: {
       beforeCreate: async (user: User) => {
         if (user.password) {
-          const salt = await bcrypt.genSalt(10);
-          user.password = await bcrypt.hash(user.password, salt);
+          user.password = await hashPassword(user.password);
         }
       },
       beforeUpdate: async (user: User) => {
         if (user.changed('password') && user.password) {
-          const salt = await bcrypt.genSalt(10);
-          user.password = await bcrypt.hash(user.password, salt);
+          user.password = await hashPassword(user.password);
         }
       },
     },

--- a/service.backend/src/setup-tests.ts
+++ b/service.backend/src/setup-tests.ts
@@ -68,11 +68,13 @@ vi.mock('./utils/logger', () => ({
 }));
 
 // Mock bcryptjs for password hashing (slow operation, doesn't need real testing)
-vi.mock('bcryptjs', () => ({
-  hash: vi.fn(),
-  compare: vi.fn(),
-  genSalt: vi.fn(),
-}));
+vi.mock('bcryptjs', () => {
+  const mockHash = vi.fn().mockResolvedValue('hashed-password');
+  const mockCompare = vi.fn().mockResolvedValue(true);
+  const mockGenSalt = vi.fn().mockResolvedValue('salt');
+  const mock = { hash: mockHash, compare: mockCompare, genSalt: mockGenSalt };
+  return { default: mock, ...mock };
+});
 
 // Mock jsonwebtoken (JWT operations don't need real testing)
 vi.mock('jsonwebtoken', () => ({

--- a/service.backend/src/utils/password.test.ts
+++ b/service.backend/src/utils/password.test.ts
@@ -1,0 +1,52 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import bcrypt from 'bcryptjs';
+
+import { hashPassword, verifyPassword } from './password';
+
+const mockedBcrypt = vi.mocked(bcrypt);
+
+describe('password utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('hashPassword - securing user passwords for storage', () => {
+    it('should generate a salt using 12 rounds by default', async () => {
+      mockedBcrypt.genSalt.mockResolvedValue('salt' as never);
+      mockedBcrypt.hash.mockResolvedValue('hashed' as never);
+
+      await hashPassword('my-secret-password');
+
+      expect(mockedBcrypt.genSalt).toHaveBeenCalledWith(12);
+    });
+
+    it('should return the bcrypt hash of the plaintext password', async () => {
+      mockedBcrypt.genSalt.mockResolvedValue('salt' as never);
+      mockedBcrypt.hash.mockResolvedValue('$2b$12$hashed-value' as never);
+
+      const result = await hashPassword('my-secret-password');
+
+      expect(mockedBcrypt.hash).toHaveBeenCalledWith('my-secret-password', 'salt');
+      expect(result).toBe('$2b$12$hashed-value');
+    });
+  });
+
+  describe('verifyPassword - authenticating a user password attempt', () => {
+    it('should return true when the plaintext matches the stored hash', async () => {
+      mockedBcrypt.compare.mockResolvedValue(true as never);
+
+      const result = await verifyPassword('correct-password', '$2b$12$hashed-value');
+
+      expect(mockedBcrypt.compare).toHaveBeenCalledWith('correct-password', '$2b$12$hashed-value');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when the plaintext does not match the stored hash', async () => {
+      mockedBcrypt.compare.mockResolvedValue(false as never);
+
+      const result = await verifyPassword('wrong-password', '$2b$12$hashed-value');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/utils/password.ts
+++ b/service.backend/src/utils/password.ts
@@ -1,0 +1,11 @@
+import bcrypt from 'bcryptjs';
+
+const BCRYPT_ROUNDS = parseInt(process.env.BCRYPT_ROUNDS || '12', 10);
+
+export const hashPassword = async (plaintext: string): Promise<string> => {
+  const salt = await bcrypt.genSalt(BCRYPT_ROUNDS);
+  return bcrypt.hash(plaintext, salt);
+};
+
+export const verifyPassword = (plaintext: string, hash: string): Promise<boolean> =>
+  bcrypt.compare(plaintext, hash);


### PR DESCRIPTION
## Summary

- Upgrades bcrypt salt rounds from hardcoded **10** to **12** (via BCRYPT_ROUNDS env var), meeting the PRD security requirement
- Extracts all password hashing/comparison into a new `src/utils/password.ts` utility, eliminating the dual-library usage (bcrypt + bcryptjs)
- Updates User.ts hooks and comparePassword to delegate to the new utility
- Fixes the global bcryptjs test mock in setup-tests.ts to expose the default export for ESM interop
- Adds 4 behaviour tests covering salt rounds, hash generation, and password verification

## Why

The User model was hardcoding `bcrypt.genSalt(10)` despite the config already reading BCRYPT_ROUNDS and defaulting to 12. This closes that gap.

## Test plan

- [x] 4 new behaviour tests in src/utils/password.test.ts — all pass
- [x] Full backend suite — 1124 pass, 4 skipped (pre-existing), 0 failures
- [x] tsc --noEmit — clean
- [x] ESLint — no errors

Closes ENG-92

🤖 Generated with Claude Code