### PR TITLE
feat: implement refresh token rotation strategy

### DIFF
--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -800,7 +800,9 @@ describe('Authentication Flow Integration Tests', () => {
         });
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        mockedJwt.verify = vi
+          .fn()
+          .mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
         MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
@@ -812,10 +814,16 @@ describe('Authentication Flow Integration Tests', () => {
       });
 
       it('should verify refresh token with correct secret', async () => {
-        const mockUser = createMockUser({ userId: 'user-123', emailVerified: true, status: UserStatus.ACTIVE });
+        const mockUser = createMockUser({
+          userId: 'user-123',
+          emailVerified: true,
+          status: UserStatus.ACTIVE,
+        });
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        mockedJwt.verify = vi
+          .fn()
+          .mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
         MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
@@ -833,11 +841,15 @@ describe('Authentication Flow Integration Tests', () => {
           email: 'test@example.com',
           emailVerified: true,
           status: UserStatus.ACTIVE,
-          Roles: [{ roleId: 'role-1', name: 'adopter', description: 'Adopter role', Permissions: [] }],
+          Roles: [
+            { roleId: 'role-1', name: 'adopter', description: 'Adopter role', Permissions: [] },
+          ],
         });
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        mockedJwt.verify = vi
+          .fn()
+          .mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
         MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
@@ -870,8 +882,12 @@ describe('Authentication Flow Integration Tests', () => {
       });
 
       it('should reject refresh for non-existent user', async () => {
-        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'non-existent-user', jti: 'token-123' } as never);
-        MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken({ user_id: 'non-existent-user' }) as never);
+        mockedJwt.verify = vi
+          .fn()
+          .mockReturnValue({ userId: 'non-existent-user', jti: 'token-123' } as never);
+        MockedRefreshToken.findByPk = vi
+          .fn()
+          .mockResolvedValue(buildStoredToken({ user_id: 'non-existent-user' }) as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(null);
 
         await expect(AuthService.refreshToken(validRefreshToken)).rejects.toThrow(
@@ -883,7 +899,9 @@ describe('Authentication Flow Integration Tests', () => {
         const mockUser = createMockUser({ userId: 'user-123', status: UserStatus.SUSPENDED });
         mockUser.canLogin = vi.fn().mockReturnValue(false);
 
-        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        mockedJwt.verify = vi
+          .fn()
+          .mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
         MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
@@ -901,7 +919,9 @@ describe('Authentication Flow Integration Tests', () => {
         });
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        mockedJwt.verify = vi
+          .fn()
+          .mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
         MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
@@ -1317,7 +1337,9 @@ describe('Authentication Flow Integration Tests', () => {
 
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue({ userId: mockUser.userId, jti: 'token-123' } as never);
+        mockedJwt.verify = vi
+          .fn()
+          .mockReturnValue({ userId: mockUser.userId, jti: 'token-123' } as never);
         MockedRefreshToken.findByPk = vi.fn().mockResolvedValue({
           token_id: 'token-123',
           user_id: mockUser.userId,

--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -15,6 +15,7 @@ import crypto from 'crypto';
 import speakeasy from 'speakeasy';
 import { Op } from 'sequelize';
 import User, { UserStatus, UserType } from '../../models/User';
+import RefreshToken from '../../models/RefreshToken';
 import { AuthService } from '../../services/auth.service';
 import { AuditLogService } from '../../services/auditLog.service';
 import {
@@ -28,6 +29,7 @@ import {
 // Mock dependencies
 vi.mock('../../models/User');
 vi.mock('../../models/AuditLog');
+vi.mock('../../models/RefreshToken');
 vi.mock('../../services/auditLog.service');
 vi.mock('../../utils/logger');
 vi.mock('jsonwebtoken');
@@ -49,6 +51,7 @@ vi.mock('../../services/email.service', () => ({
 }));
 
 const MockedUser = User as vi.MockedObject<User>;
+const MockedRefreshToken = RefreshToken as vi.MockedObject<typeof RefreshToken>;
 const MockedAuditLogService = AuditLogService as vi.MockedObject<AuditLogService>;
 const mockedJwt = jwt as vi.MockedObject<jwt>;
 const mockedBcrypt = bcrypt as vi.MockedObject<bcrypt>;
@@ -82,6 +85,11 @@ describe('Authentication Flow Integration Tests', () => {
 
     // Setup default AuditLog mocks
     MockedAuditLogService.log = vi.fn().mockResolvedValue(undefined as never);
+
+    // Setup RefreshToken mocks
+    MockedRefreshToken.create = vi.fn().mockResolvedValue({});
+    MockedRefreshToken.update = vi.fn().mockResolvedValue([0]);
+    MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(null);
   });
 
   describe('User Registration and Email Verification', () => {
@@ -771,25 +779,29 @@ describe('Authentication Flow Integration Tests', () => {
   describe('Token Refresh Workflow', () => {
     const validRefreshToken = 'valid.refresh.token';
 
+    const buildStoredToken = (overrides = {}) => ({
+      token_id: 'token-123',
+      user_id: 'user-123',
+      family_id: 'family-abc',
+      is_revoked: false,
+      expires_at: new Date(Date.now() + 3_600_000),
+      isExpired: vi.fn().mockReturnValue(false),
+      update: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    });
+
     describe('when refreshing access token', () => {
       it('should successfully refresh token with valid refresh token', async () => {
-        const mockPayload = {
-          userId: 'user-123',
-          tokenId: 'token-123',
-          email: 'test@example.com',
-          userType: UserType.ADOPTER,
-        };
-
         const mockUser = createMockUser({
           userId: 'user-123',
           email: 'test@example.com',
           emailVerified: true,
           status: UserStatus.ACTIVE,
         });
-
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue(mockPayload as never);
+        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
         const result = await AuthService.refreshToken(validRefreshToken);
@@ -800,20 +812,11 @@ describe('Authentication Flow Integration Tests', () => {
       });
 
       it('should verify refresh token with correct secret', async () => {
-        const mockPayload = {
-          userId: 'user-123',
-          tokenId: 'token-123',
-        };
-
-        const mockUser = createMockUser({
-          userId: 'user-123',
-          emailVerified: true,
-          status: UserStatus.ACTIVE,
-        });
-
+        const mockUser = createMockUser({ userId: 'user-123', emailVerified: true, status: UserStatus.ACTIVE });
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue(mockPayload as never);
+        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
         await AuthService.refreshToken(validRefreshToken);
@@ -825,29 +828,17 @@ describe('Authentication Flow Integration Tests', () => {
       });
 
       it('should include user roles in refreshed token', async () => {
-        const mockPayload = {
-          userId: 'user-123',
-          tokenId: 'token-123',
-        };
-
         const mockUser = createMockUser({
           userId: 'user-123',
           email: 'test@example.com',
           emailVerified: true,
           status: UserStatus.ACTIVE,
-          Roles: [
-            {
-              roleId: 'role-1',
-              name: 'adopter',
-              description: 'Adopter role',
-              Permissions: [],
-            },
-          ],
+          Roles: [{ roleId: 'role-1', name: 'adopter', description: 'Adopter role', Permissions: [] }],
         });
-
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue(mockPayload as never);
+        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
         const result = await AuthService.refreshToken(validRefreshToken);
@@ -879,12 +870,8 @@ describe('Authentication Flow Integration Tests', () => {
       });
 
       it('should reject refresh for non-existent user', async () => {
-        const mockPayload = {
-          userId: 'non-existent-user',
-          tokenId: 'token-123',
-        };
-
-        mockedJwt.verify = vi.fn().mockReturnValue(mockPayload as never);
+        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'non-existent-user', jti: 'token-123' } as never);
+        MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken({ user_id: 'non-existent-user' }) as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(null);
 
         await expect(AuthService.refreshToken(validRefreshToken)).rejects.toThrow(
@@ -893,19 +880,11 @@ describe('Authentication Flow Integration Tests', () => {
       });
 
       it('should reject refresh for user who cannot login', async () => {
-        const mockPayload = {
-          userId: 'user-123',
-          tokenId: 'token-123',
-        };
-
-        const mockUser = createMockUser({
-          userId: 'user-123',
-          status: UserStatus.SUSPENDED,
-        });
-
+        const mockUser = createMockUser({ userId: 'user-123', status: UserStatus.SUSPENDED });
         mockUser.canLogin = vi.fn().mockReturnValue(false);
 
-        mockedJwt.verify = vi.fn().mockReturnValue(mockPayload as never);
+        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
         await expect(AuthService.refreshToken(validRefreshToken)).rejects.toThrow(
@@ -914,21 +893,16 @@ describe('Authentication Flow Integration Tests', () => {
       });
 
       it('should generate new token pair with same user data', async () => {
-        const mockPayload = {
-          userId: 'user-123',
-          tokenId: 'token-123',
-        };
-
         const mockUser = createMockUser({
           userId: 'user-123',
           email: 'test@example.com',
           userType: UserType.ADOPTER,
           status: UserStatus.ACTIVE,
         });
-
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue(mockPayload as never);
+        mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'token-123' } as never);
+        MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken() as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
         const result = await AuthService.refreshToken(validRefreshToken);
@@ -1167,18 +1141,19 @@ describe('Authentication Flow Integration Tests', () => {
         await expect(AuthService.logout(refreshToken)).resolves.not.toThrow();
       });
 
-      it('should log logout event when refresh token provided', async () => {
+      it('should log when a refresh token is revoked on logout', async () => {
         const refreshToken = 'valid.refresh.token.with.sufficient.length';
         const { logger } = await import('../../utils/logger');
         const loggerSpy = vi.spyOn(logger, 'info');
 
+        // Simulate a valid JWT that yields a jti
+        mockedJwt.verify = vi.fn().mockReturnValue({ jti: 'some-jti' } as never);
+
         await AuthService.logout(refreshToken);
 
         expect(loggerSpy).toHaveBeenCalledWith(
-          'User logout requested',
-          expect.objectContaining({
-            refreshToken: expect.stringContaining('...'),
-          })
+          expect.stringContaining('logout'),
+          expect.any(Object)
         );
 
         loggerSpy.mockRestore();
@@ -1339,14 +1314,19 @@ describe('Authentication Flow Integration Tests', () => {
 
         // Step 2: Refresh token
         const refreshToken = loginResult.refreshToken;
-        const mockPayload = {
-          userId: mockUser.userId,
-          tokenId: 'token-123',
-        };
 
         mockUser.canLogin = vi.fn().mockReturnValue(true);
 
-        mockedJwt.verify = vi.fn().mockReturnValue(mockPayload as never);
+        mockedJwt.verify = vi.fn().mockReturnValue({ userId: mockUser.userId, jti: 'token-123' } as never);
+        MockedRefreshToken.findByPk = vi.fn().mockResolvedValue({
+          token_id: 'token-123',
+          user_id: mockUser.userId,
+          family_id: 'family-abc',
+          is_revoked: false,
+          expires_at: new Date(Date.now() + 3_600_000),
+          isExpired: vi.fn().mockReturnValue(false),
+          update: vi.fn().mockResolvedValue(undefined),
+        } as never);
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
 
         const refreshResult = await AuthService.refreshToken(refreshToken);

--- a/service.backend/src/__tests__/services/auth-security.test.ts
+++ b/service.backend/src/__tests__/services/auth-security.test.ts
@@ -17,6 +17,7 @@ import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import speakeasy from 'speakeasy';
 import User, { UserStatus, UserType } from '../../models/User';
+import RefreshToken from '../../models/RefreshToken';
 import { AuthService } from '../../services/auth.service';
 import { LoginCredentials, RegisterData } from '../../types/auth';
 
@@ -37,6 +38,10 @@ vi.mock('crypto');
 // Mock speakeasy
 vi.mock('speakeasy');
 const MockedSpeakeasy = speakeasy as vi.MockedObject<typeof speakeasy>;
+
+// Mock RefreshToken model so token storage doesn't hit the DB
+vi.mock('../../models/RefreshToken');
+const MockedRefreshToken = RefreshToken as vi.MockedObject<typeof RefreshToken>;
 
 // Mock qrcode
 vi.mock('qrcode', () => ({
@@ -117,6 +122,11 @@ describe('AuthService - Security Business Logic', () => {
     // Setup JWT mocks
     MockedJwt.sign = vi.fn().mockReturnValue('mock-token');
     MockedJwt.verify = vi.fn();
+
+    // Setup RefreshToken mock defaults
+    MockedRefreshToken.create = vi.fn().mockResolvedValue({});
+    MockedRefreshToken.update = vi.fn().mockResolvedValue([0]);
+    MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(null);
 
     // Setup speakeasy mocks
     if (!MockedSpeakeasy.totp) {
@@ -785,9 +795,19 @@ describe('AuthService - Security Business Logic', () => {
     });
 
     it('should verify refresh token before generating new tokens', async () => {
-      // Given: Valid refresh token
+      // Given: Valid refresh token with a matching DB record
       const mockUser = createMockUser();
-      MockedJwt.verify = vi.fn().mockReturnValue({ userId: mockUserId, tokenId: 'token-id' });
+      const mockStoredToken = {
+        token_id: 'token-id',
+        user_id: mockUserId,
+        family_id: 'family-abc',
+        is_revoked: false,
+        expires_at: new Date(Date.now() + 3_600_000),
+        isExpired: vi.fn().mockReturnValue(false),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      MockedJwt.verify = vi.fn().mockReturnValue({ userId: mockUserId, jti: 'token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(mockStoredToken);
       MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser);
 
       // When: Refreshing token
@@ -812,8 +832,18 @@ describe('AuthService - Security Business Logic', () => {
     });
 
     it('should reject refresh token for non-existent user', async () => {
-      // Given: Token for deleted/non-existent user
-      MockedJwt.verify = vi.fn().mockReturnValue({ userId: 'deleted-user', tokenId: 'token-id' });
+      // Given: Token exists in DB but user has been deleted
+      const mockStoredToken = {
+        token_id: 'token-id',
+        user_id: 'deleted-user',
+        family_id: 'family-abc',
+        is_revoked: false,
+        expires_at: new Date(Date.now() + 3_600_000),
+        isExpired: vi.fn().mockReturnValue(false),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      MockedJwt.verify = vi.fn().mockReturnValue({ userId: 'deleted-user', jti: 'token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(mockStoredToken);
       MockedUser.findByPk = vi.fn().mockResolvedValue(null);
 
       // When & Then: Refresh fails
@@ -823,11 +853,20 @@ describe('AuthService - Security Business Logic', () => {
     });
 
     it('should reject refresh token if user cannot login', async () => {
-      // Given: Token for suspended user
+      // Given: Token exists in DB but user is suspended
       const suspendedUser = createMockUser();
       suspendedUser.canLogin.mockReturnValue(false);
-
-      MockedJwt.verify = vi.fn().mockReturnValue({ userId: mockUserId, tokenId: 'token-id' });
+      const mockStoredToken = {
+        token_id: 'token-id',
+        user_id: mockUserId,
+        family_id: 'family-abc',
+        is_revoked: false,
+        expires_at: new Date(Date.now() + 3_600_000),
+        isExpired: vi.fn().mockReturnValue(false),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+      MockedJwt.verify = vi.fn().mockReturnValue({ userId: mockUserId, jti: 'token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(mockStoredToken);
       MockedUser.findByPk = vi.fn().mockResolvedValue(suspendedUser);
 
       // When & Then: Refresh fails

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -16,12 +16,14 @@ import crypto from 'crypto';
 import { AuditLog } from '../../models/AuditLog';
 import { AuditLogService } from '../../services/auditLog.service';
 import User, { UserStatus, UserType } from '../../models/User';
+import RefreshToken from '../../models/RefreshToken';
 import { AuthService } from '../../services/auth.service';
 import { LoginCredentials, RegisterData } from '../../types';
 
 // Mock dependencies
 vi.mock('../../models/User');
 vi.mock('../../models/AuditLog');
+vi.mock('../../models/RefreshToken');
 vi.mock('../../services/auditLog.service');
 vi.mock('../../utils/logger');
 vi.mock('jsonwebtoken');
@@ -31,6 +33,7 @@ vi.mock('crypto');
 // Mock User model
 const MockedUser = User as Mock<typeof User>;
 const MockedAuditLog = AuditLog as Mock<typeof AuditLog>;
+const MockedRefreshToken = RefreshToken as Mock<typeof RefreshToken>;
 const MockedAuditLogService = AuditLogService as unknown as {
   log: Mock;
 };
@@ -65,12 +68,17 @@ describe('AuthService', () => {
     // Mock AuditLogService.log
     MockedAuditLogService.log = vi.fn().mockResolvedValue(undefined);
 
-    // Mock the generateTokens method to avoid JWT secret issues
+    // Mock the generateTokens and storeRefreshToken methods to avoid JWT/DB issues
     vi.spyOn(AuthService as unknown, 'generateTokens').mockResolvedValue({
       token: 'mocked-access-token',
       refreshToken: 'mocked-refresh-token',
       expiresIn: 900000, // 15 minutes in ms
     });
+    vi.spyOn(AuthService as unknown, 'storeRefreshToken').mockResolvedValue(undefined);
+
+    // Default RefreshToken mock – individual tests override as needed
+    MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(null);
+    MockedRefreshToken.update = vi.fn().mockResolvedValue([0]);
   });
 
   afterAll(() => {
@@ -348,9 +356,16 @@ describe('AuthService', () => {
   describe('refreshToken', () => {
     it('should refresh token successfully', async () => {
       const refreshToken = 'valid-refresh-token';
-      const mockPayload = {
-        userId: 'user-123',
-        tokenId: 'token-123',
+      const mockPayload = { userId: 'user-123', jti: 'token-123' };
+
+      const mockStoredToken = {
+        token_id: 'token-123',
+        user_id: 'user-123',
+        family_id: 'family-abc',
+        is_revoked: false,
+        expires_at: new Date(Date.now() + 3_600_000),
+        isExpired: vi.fn().mockReturnValue(false),
+        update: vi.fn().mockResolvedValue(undefined),
       };
 
       const mockUser = {
@@ -366,6 +381,7 @@ describe('AuthService', () => {
       };
 
       mockedJwt.verify = vi.fn().mockReturnValue(mockPayload);
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(mockStoredToken);
       MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser);
 
       const result = await AuthService.refreshToken(refreshToken);
@@ -374,6 +390,7 @@ describe('AuthService', () => {
         refreshToken,
         'test-refresh-secret-min-32-characters-long-12345'
       );
+      expect(MockedRefreshToken.findByPk).toHaveBeenCalledWith(mockPayload.jti);
       expect(MockedUser.findByPk).toHaveBeenCalledWith(mockPayload.userId, expect.any(Object));
       expect(result.user).toBeDefined();
       expect(result.token).toBe('mocked-access-token');
@@ -771,23 +788,16 @@ describe('AuthService', () => {
       await expect(AuthService.logout()).resolves.not.toThrow();
     });
 
-    it('should handle logout with refresh token', async () => {
-      const refreshToken = 'some.refresh.token';
-      await expect(AuthService.logout(refreshToken)).resolves.not.toThrow();
+    it('should handle logout with a valid refresh token', async () => {
+      mockedJwt.verify = vi.fn().mockReturnValue({ jti: 'some-token-id' });
+      await expect(AuthService.logout('some.valid.refresh.jwt')).resolves.not.toThrow();
     });
 
-    it('should log the logout event when refresh token provided', async () => {
-      const refreshToken = 'some.refresh.token.that.is.long.enough';
-      const { logger } = await import('../../utils/logger');
-      const loggerSpy = vi.spyOn(logger, 'info');
-
-      await AuthService.logout(refreshToken);
-
-      expect(loggerSpy).toHaveBeenCalledWith('User logout requested', {
-        refreshToken: 'some.refre...',
+    it('should not throw when logout is called with an expired or malformed token', async () => {
+      mockedJwt.verify = vi.fn().mockImplementation(() => {
+        throw new Error('jwt expired');
       });
-
-      loggerSpy.mockRestore();
+      await expect(AuthService.logout('expired.token')).resolves.not.toThrow();
     });
   });
 });

--- a/service.backend/src/__tests__/services/refresh-token-rotation.test.ts
+++ b/service.backend/src/__tests__/services/refresh-token-rotation.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../services/auditLog.service');
 vi.mock('../../utils/logger');
 vi.mock('jsonwebtoken');
 vi.mock('bcryptjs');
-vi.mock('crypto', async (importOriginal) => {
+vi.mock('crypto', async importOriginal => {
   const actual = await importOriginal<typeof import('crypto')>();
   return {
     ...actual,
@@ -86,12 +86,14 @@ describe('Refresh token rotation', () => {
   });
 
   describe('Token rotation on refresh', () => {
-    const buildStoredToken = (overrides: Partial<{
-      is_revoked: boolean;
-      family_id: string;
-      user_id: string;
-      expires_at: Date;
-    }> = {}) => ({
+    const buildStoredToken = (
+      overrides: Partial<{
+        is_revoked: boolean;
+        family_id: string;
+        user_id: string;
+        expires_at: Date;
+      }> = {}
+    ) => ({
       token_id: 'old-token-id',
       user_id: 'user-123',
       family_id: 'family-abc',

--- a/service.backend/src/__tests__/services/refresh-token-rotation.test.ts
+++ b/service.backend/src/__tests__/services/refresh-token-rotation.test.ts
@@ -1,0 +1,258 @@
+import { vi, describe, it, expect, beforeEach, Mock } from 'vitest';
+
+vi.mock('../../config/env', () => ({
+  env: {
+    JWT_SECRET: 'test-jwt-secret-min-32-characters-long-12345',
+    JWT_REFRESH_SECRET: 'test-refresh-secret-min-32-characters-long-12345',
+    SESSION_SECRET: 'test-session-secret-min-32-characters-long',
+    CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
+  },
+}));
+
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { AuthService } from '../../services/auth.service';
+import User, { UserStatus, UserType } from '../../models/User';
+import RefreshToken from '../../models/RefreshToken';
+import { AuditLogService } from '../../services/auditLog.service';
+
+vi.mock('../../models/User');
+vi.mock('../../models/RefreshToken');
+vi.mock('../../services/auditLog.service');
+vi.mock('../../utils/logger');
+vi.mock('jsonwebtoken');
+vi.mock('bcryptjs');
+vi.mock('crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('crypto')>();
+  return {
+    ...actual,
+    randomUUID: vi.fn().mockReturnValue('generated-uuid'),
+    randomBytes: vi.fn().mockReturnValue({ toString: vi.fn().mockReturnValue('mock-token') }),
+  };
+});
+
+const MockedUser = User as Mock<typeof User>;
+const MockedRefreshToken = RefreshToken as Mock<typeof RefreshToken>;
+const MockedAuditLogService = AuditLogService as unknown as { log: Mock };
+const mockedJwt = jwt as Mock<typeof jwt>;
+const mockedBcrypt = bcrypt as Mock<typeof bcrypt>;
+
+describe('Refresh token rotation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MockedAuditLogService.log = vi.fn().mockResolvedValue(undefined);
+    mockedBcrypt.compare = vi.fn().mockResolvedValue(true as never);
+
+    vi.spyOn(AuthService as unknown, 'generateTokens').mockResolvedValue({
+      token: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      expiresIn: 900000,
+    });
+
+    vi.spyOn(AuthService as unknown, 'storeRefreshToken').mockResolvedValue(undefined);
+  });
+
+  describe('Token issuance on login', () => {
+    it('stores a refresh token record in the database when a user logs in', async () => {
+      const mockUser = {
+        userId: 'user-123',
+        email: 'user@example.com',
+        userType: UserType.ADOPTER,
+        password: 'hashed',
+        status: UserStatus.ACTIVE,
+        emailVerified: true,
+        loginAttempts: 0,
+        lockedUntil: null,
+        twoFactorEnabled: false,
+        isAccountLocked: vi.fn().mockReturnValue(false),
+        save: vi.fn(),
+        toJSON: vi.fn().mockReturnValue({ userId: 'user-123', email: 'user@example.com' }),
+      };
+
+      MockedUser.scope = vi.fn().mockReturnValue({
+        findOne: vi.fn().mockResolvedValue(mockUser),
+      } as unknown);
+
+      const storeRefreshTokenSpy = vi.spyOn(AuthService as unknown, 'storeRefreshToken');
+
+      await AuthService.login({ email: 'user@example.com', password: 'Password1!' });
+
+      expect(storeRefreshTokenSpy).toHaveBeenCalledWith(
+        'user-123',
+        expect.any(String),
+        expect.any(String)
+      );
+    });
+  });
+
+  describe('Token rotation on refresh', () => {
+    const buildStoredToken = (overrides: Partial<{
+      is_revoked: boolean;
+      family_id: string;
+      user_id: string;
+      expires_at: Date;
+    }> = {}) => ({
+      token_id: 'old-token-id',
+      user_id: 'user-123',
+      family_id: 'family-abc',
+      is_revoked: false,
+      expires_at: new Date(Date.now() + 3_600_000),
+      replaced_by_token_id: null,
+      isExpired: vi.fn().mockReturnValue(false),
+      update: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    });
+
+    const buildUser = () => ({
+      userId: 'user-123',
+      email: 'user@example.com',
+      userType: UserType.ADOPTER,
+      status: UserStatus.ACTIVE,
+      emailVerified: true,
+      twoFactorEnabled: false,
+      canLogin: vi.fn().mockReturnValue(true),
+      toJSON: vi.fn().mockReturnValue({ userId: 'user-123', email: 'user@example.com' }),
+    });
+
+    it('issues a new token pair when a valid refresh token is presented', async () => {
+      mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'old-token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(buildStoredToken());
+      MockedUser.findByPk = vi.fn().mockResolvedValue(buildUser());
+
+      const result = await AuthService.refreshToken('valid.refresh.jwt');
+
+      expect(result.token).toBe('new-access-token');
+      expect(result.refreshToken).toBe('new-refresh-token');
+    });
+
+    it('revokes the old refresh token record after a successful rotation', async () => {
+      const storedToken = buildStoredToken();
+      mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'old-token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(storedToken);
+      MockedUser.findByPk = vi.fn().mockResolvedValue(buildUser());
+
+      await AuthService.refreshToken('valid.refresh.jwt');
+
+      expect(storedToken.update).toHaveBeenCalledWith(
+        expect.objectContaining({ is_revoked: true })
+      );
+    });
+
+    it('stores the new token with the same family id to maintain the rotation chain', async () => {
+      const storedToken = buildStoredToken({ family_id: 'family-abc' });
+      mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'old-token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(storedToken);
+      MockedUser.findByPk = vi.fn().mockResolvedValue(buildUser());
+
+      const storeRefreshTokenSpy = vi.spyOn(AuthService as unknown, 'storeRefreshToken');
+
+      await AuthService.refreshToken('valid.refresh.jwt');
+
+      expect(storeRefreshTokenSpy).toHaveBeenCalledWith(
+        'user-123',
+        expect.any(String),
+        'family-abc'
+      );
+    });
+
+    it('rejects a refresh token that does not exist in the database', async () => {
+      mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'unknown-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(null);
+
+      await expect(AuthService.refreshToken('valid.refresh.jwt')).rejects.toThrow(
+        'Invalid refresh token'
+      );
+    });
+
+    it('rejects an expired refresh token and marks it revoked', async () => {
+      const storedToken = buildStoredToken({
+        expires_at: new Date(Date.now() - 1000),
+      });
+      storedToken.isExpired = vi.fn().mockReturnValue(true);
+
+      mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'old-token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(storedToken);
+
+      await expect(AuthService.refreshToken('valid.refresh.jwt')).rejects.toThrow(
+        'Invalid refresh token'
+      );
+
+      expect(storedToken.update).toHaveBeenCalledWith({ is_revoked: true });
+    });
+  });
+
+  describe('Refresh token reuse detection', () => {
+    it('revokes the entire token family when a revoked token is presented (reuse attack)', async () => {
+      const storedToken = {
+        token_id: 'old-token-id',
+        user_id: 'user-123',
+        family_id: 'family-abc',
+        is_revoked: true,
+        expires_at: new Date(Date.now() + 3_600_000),
+        isExpired: vi.fn().mockReturnValue(false),
+        update: vi.fn(),
+      };
+
+      mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'old-token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(storedToken);
+      MockedRefreshToken.update = vi.fn().mockResolvedValue([1]);
+
+      await expect(AuthService.refreshToken('reused.refresh.jwt')).rejects.toThrow(
+        'Invalid refresh token'
+      );
+
+      expect(MockedRefreshToken.update).toHaveBeenCalledWith(
+        { is_revoked: true },
+        { where: { family_id: 'family-abc', user_id: 'user-123' } }
+      );
+    });
+
+    it('does not issue new tokens when a reuse attack is detected', async () => {
+      const storedToken = {
+        token_id: 'old-token-id',
+        user_id: 'user-123',
+        family_id: 'family-abc',
+        is_revoked: true,
+        expires_at: new Date(Date.now() + 3_600_000),
+        isExpired: vi.fn().mockReturnValue(false),
+        update: vi.fn(),
+      };
+
+      mockedJwt.verify = vi.fn().mockReturnValue({ userId: 'user-123', jti: 'old-token-id' });
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(storedToken);
+      MockedRefreshToken.update = vi.fn().mockResolvedValue([1]);
+
+      const generateTokensSpy = vi.spyOn(AuthService as unknown, 'generateTokens');
+
+      await expect(AuthService.refreshToken('reused.refresh.jwt')).rejects.toThrow();
+
+      expect(generateTokensSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Token revocation on logout', () => {
+    it('revokes the refresh token record when a user logs out', async () => {
+      mockedJwt.verify = vi.fn().mockReturnValue({ jti: 'token-id-123' });
+      MockedRefreshToken.update = vi.fn().mockResolvedValue([1]);
+
+      await AuthService.logout('some.valid.refresh.jwt');
+
+      expect(MockedRefreshToken.update).toHaveBeenCalledWith(
+        { is_revoked: true },
+        { where: { token_id: 'token-id-123' } }
+      );
+    });
+
+    it('completes logout successfully without error when no refresh token is provided', async () => {
+      await expect(AuthService.logout()).resolves.not.toThrow();
+    });
+
+    it('completes logout successfully when the refresh token is expired or malformed', async () => {
+      mockedJwt.verify = vi.fn().mockImplementation(() => {
+        throw new Error('jwt expired');
+      });
+
+      await expect(AuthService.logout('expired.or.bad.token')).resolves.not.toThrow();
+    });
+  });
+});

--- a/service.backend/src/models/RefreshToken.ts
+++ b/service.backend/src/models/RefreshToken.ts
@@ -1,0 +1,105 @@
+import { DataTypes, Model, Optional, Op } from 'sequelize';
+import sequelize from '../sequelize';
+
+interface RefreshTokenAttributes {
+  token_id: string;
+  user_id: string;
+  family_id: string;
+  is_revoked: boolean;
+  expires_at: Date;
+  replaced_by_token_id: string | null;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface RefreshTokenCreationAttributes
+  extends Optional<RefreshTokenAttributes, 'is_revoked' | 'replaced_by_token_id' | 'created_at' | 'updated_at'> {}
+
+class RefreshToken
+  extends Model<RefreshTokenAttributes, RefreshTokenCreationAttributes>
+  implements RefreshTokenAttributes
+{
+  public token_id!: string;
+  public user_id!: string;
+  public family_id!: string;
+  public is_revoked!: boolean;
+  public expires_at!: Date;
+  public replaced_by_token_id!: string | null;
+  public created_at!: Date;
+  public updated_at!: Date;
+
+  public isExpired(): boolean {
+    return new Date() > this.expires_at;
+  }
+}
+
+RefreshToken.init(
+  {
+    token_id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+    },
+    user_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'user_id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    },
+    family_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    is_revoked: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    expires_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    replaced_by_token_id: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'refresh_tokens',
+    modelName: 'RefreshToken',
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+    indexes: [
+      { fields: ['user_id'], name: 'refresh_tokens_user_id_idx' },
+      { fields: ['family_id'], name: 'refresh_tokens_family_id_idx' },
+      { fields: ['is_revoked'], name: 'refresh_tokens_is_revoked_idx' },
+      { fields: ['expires_at'], name: 'refresh_tokens_expires_at_idx' },
+      { fields: ['user_id', 'family_id'], name: 'refresh_tokens_user_family_idx' },
+    ],
+    scopes: {
+      active: {
+        where: {
+          is_revoked: false,
+          expires_at: { [Op.gt]: new Date() },
+        },
+      },
+    },
+  }
+);
+
+export default RefreshToken;

--- a/service.backend/src/models/RefreshToken.ts
+++ b/service.backend/src/models/RefreshToken.ts
@@ -13,7 +13,10 @@ interface RefreshTokenAttributes {
 }
 
 interface RefreshTokenCreationAttributes
-  extends Optional<RefreshTokenAttributes, 'is_revoked' | 'replaced_by_token_id' | 'created_at' | 'updated_at'> {}
+  extends Optional<
+    RefreshTokenAttributes,
+    'is_revoked' | 'replaced_by_token_id' | 'created_at' | 'updated_at'
+  > {}
 
 class RefreshToken
   extends Model<RefreshTokenAttributes, RefreshTokenCreationAttributes>

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -18,6 +18,7 @@ import Notification from './Notification';
 
 // Auth & Permissions Models
 import Permission from './Permission';
+import RefreshToken from './RefreshToken';
 import Role from './Role';
 import RolePermission from './RolePermission';
 import UserRole from './UserRole';
@@ -66,6 +67,7 @@ const models = {
   Message,
   Notification,
   DeviceToken,
+  RefreshToken,
   Role,
   Permission,
   RolePermission,
@@ -155,6 +157,9 @@ try {
 
   User.hasMany(DeviceToken, { foreignKey: 'user_id', as: 'DeviceTokens' });
   DeviceToken.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
+
+  User.hasMany(RefreshToken, { foreignKey: 'user_id', as: 'RefreshTokens' });
+  RefreshToken.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
 
   // RBAC associations
   User.belongsToMany(Role, {
@@ -336,6 +341,7 @@ export {
   Chat,
   ChatParticipant,
   DeviceToken,
+  RefreshToken,
   EmailPreference,
   EmailQueue,
   EmailTemplate,

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -5,6 +5,7 @@ import { Op } from 'sequelize';
 import speakeasy from 'speakeasy';
 import qrcode from 'qrcode';
 import User, { UserStatus, UserType } from '../models/User';
+import RefreshToken from '../models/RefreshToken';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
 import { env } from '../config/env';
@@ -108,12 +109,14 @@ export class AuthService {
         // Don't throw error - user is still created, they can request resend
       }
 
-      // Generate tokens
-      const tokens = await this.generateTokens({
-        userId: user.userId,
-        email: user.email,
-        userType: userData.userType,
-      });
+      // Generate tokens with rotation support
+      const tokenId = crypto.randomUUID();
+      const familyId = crypto.randomUUID();
+      const tokens = await this.generateTokens(
+        { userId: user.userId, email: user.email, userType: userData.userType },
+        tokenId
+      );
+      await this.storeRefreshToken(user.userId, tokenId, familyId);
 
       return {
         user: this.sanitizeUser(user),
@@ -225,12 +228,14 @@ export class AuthService {
         ipAddress,
       });
 
-      // Generate tokens
-      const tokens = await this.generateTokens({
-        userId: user.userId,
-        email: user.email,
-        userType: user.userType,
-      });
+      // Generate tokens with rotation support
+      const tokenId = crypto.randomUUID();
+      const familyId = crypto.randomUUID();
+      const tokens = await this.generateTokens(
+        { userId: user.userId, email: user.email, userType: user.userType },
+        tokenId
+      );
+      await this.storeRefreshToken(user.userId, tokenId, familyId);
 
       return {
         user: this.sanitizeUser(user),
@@ -247,22 +252,43 @@ export class AuthService {
   }
 
   static async refreshToken(refreshToken: string): Promise<AuthResponse> {
-    let decoded: { userId: string; tokenId: string } | null = null;
+    let decoded: { userId: string; jti: string } | null = null;
 
     try {
       decoded = jwt.verify(refreshToken, this.JWT_REFRESH_SECRET) as {
         userId: string;
-        tokenId: string;
+        jti: string;
       };
+
+      const storedToken = await RefreshToken.findByPk(decoded.jti);
+
+      if (!storedToken) {
+        throw new Error('Invalid refresh token');
+      }
+
+      if (storedToken.is_revoked) {
+        // Reuse detected: revoke entire token family to protect the account
+        await RefreshToken.update(
+          { is_revoked: true },
+          { where: { family_id: storedToken.family_id, user_id: storedToken.user_id } }
+        );
+        loggerHelpers.logSecurity('Refresh token reuse detected – family revoked', {
+          userId: storedToken.user_id,
+          familyId: storedToken.family_id,
+        });
+        throw new Error('Invalid refresh token');
+      }
+
+      if (storedToken.isExpired()) {
+        await storedToken.update({ is_revoked: true });
+        throw new Error('Invalid refresh token');
+      }
+
       const user = await User.findByPk(decoded.userId, {
         include: [
           {
             association: 'Roles',
-            include: [
-              {
-                association: 'Permissions',
-              },
-            ],
+            include: [{ association: 'Permissions' }],
           },
         ],
       });
@@ -271,14 +297,17 @@ export class AuthService {
         throw new Error('Invalid refresh token');
       }
 
-      const tokens = await this.generateTokens({
-        userId: user.userId,
-        email: user.email,
-        userType: user.userType,
-      });
+      const newTokenId = crypto.randomUUID();
+      const newTokens = await this.generateTokens(
+        { userId: user.userId, email: user.email, userType: user.userType },
+        newTokenId
+      );
+      await this.storeRefreshToken(user.userId, newTokenId, storedToken.family_id);
+      await storedToken.update({ is_revoked: true, replaced_by_token_id: newTokenId });
+
       return {
         user: this.sanitizeUser(user),
-        ...tokens,
+        ...newTokens,
       };
     } catch (error) {
       logger.error('Token refresh failed:', {
@@ -540,26 +569,19 @@ Need help? Contact us at support@adoptdontshop.com
   }
 
   static async logout(refreshToken?: string): Promise<void> {
+    if (!refreshToken) {
+      return;
+    }
+
     try {
-      // TODO: Implement token blacklisting for more secure logout
-      // This would involve:
-      // 1. Adding the refresh token to a blacklist/revoked tokens table
-      // 2. Optionally invalidating all tokens for the user
-      // 3. Cleaning up expired blacklisted tokens periodically
-
-      if (refreshToken) {
-        // For now, we'll just log the logout event
-        // In a production system, you'd want to blacklist the token
-        logger.info('User logout requested', {
-          refreshToken: refreshToken.substring(0, 10) + '...',
-        });
+      const decoded = jwt.verify(refreshToken, this.JWT_REFRESH_SECRET) as { jti?: string };
+      if (decoded.jti) {
+        await RefreshToken.update({ is_revoked: true }, { where: { token_id: decoded.jti } });
+        logger.info('Refresh token revoked on logout', { jti: decoded.jti });
       }
-
-      // Future implementation would include:
-      // await TokenBlacklist.create({ token: refreshToken, expires_at: tokenExpiry });
-    } catch (error) {
-      logger.error('Logout service error:', error);
-      throw error;
+    } catch {
+      // Expired or malformed token — nothing to revoke
+      logger.info('Logout with invalid or expired token, skipping revocation');
     }
   }
 
@@ -627,11 +649,10 @@ Need help? Contact us at support@adoptdontshop.com
     }
   }
 
-  private static async generateTokens(payload: {
-    userId: string;
-    email: string;
-    userType?: UserType;
-  }): Promise<Omit<AuthResponse, 'user'>> {
+  private static async generateTokens(
+    payload: { userId: string; email: string; userType?: UserType },
+    tokenId: string
+  ): Promise<Omit<AuthResponse, 'user'>> {
     const jwtSecret = this.JWT_SECRET;
     const jwtRefreshSecret = this.JWT_REFRESH_SECRET;
 
@@ -643,15 +664,35 @@ Need help? Contact us at support@adoptdontshop.com
       expiresIn: this.JWT_EXPIRES_IN,
     } as SignOptions);
 
-    const refreshToken = jwt.sign(payload, jwtRefreshSecret, {
-      expiresIn: this.JWT_REFRESH_EXPIRES_IN,
-    } as SignOptions);
+    const refreshToken = jwt.sign(
+      { ...payload, jti: tokenId },
+      jwtRefreshSecret,
+      { expiresIn: this.JWT_REFRESH_EXPIRES_IN } as SignOptions
+    );
 
     return {
       token,
       refreshToken,
       expiresIn: this.parseExpirationTime(this.JWT_EXPIRES_IN),
     };
+  }
+
+  private static async storeRefreshToken(
+    userId: string,
+    tokenId: string,
+    familyId: string
+  ): Promise<void> {
+    const expiresAt = new Date(
+      Date.now() + this.parseExpirationTime(this.JWT_REFRESH_EXPIRES_IN)
+    );
+    await RefreshToken.create({
+      token_id: tokenId,
+      user_id: userId,
+      family_id: familyId,
+      is_revoked: false,
+      expires_at: expiresAt,
+      replaced_by_token_id: null,
+    });
   }
 
   private static parseExpirationTime(expiresIn: string): number {

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -664,11 +664,9 @@ Need help? Contact us at support@adoptdontshop.com
       expiresIn: this.JWT_EXPIRES_IN,
     } as SignOptions);
 
-    const refreshToken = jwt.sign(
-      { ...payload, jti: tokenId },
-      jwtRefreshSecret,
-      { expiresIn: this.JWT_REFRESH_EXPIRES_IN } as SignOptions
-    );
+    const refreshToken = jwt.sign({ ...payload, jti: tokenId }, jwtRefreshSecret, {
+      expiresIn: this.JWT_REFRESH_EXPIRES_IN,
+    } as SignOptions);
 
     return {
       token,
@@ -682,9 +680,7 @@ Need help? Contact us at support@adoptdontshop.com
     tokenId: string,
     familyId: string
   ): Promise<void> {
-    const expiresAt = new Date(
-      Date.now() + this.parseExpirationTime(this.JWT_REFRESH_EXPIRES_IN)
-    );
+    const expiresAt = new Date(Date.now() + this.parseExpirationTime(this.JWT_REFRESH_EXPIRES_IN));
     await RefreshToken.create({
       token_id: tokenId,
       user_id: userId,


### PR DESCRIPTION
## Summary

- **New `RefreshToken` model** with `token_id` (PK, doubles as JWT `jti`), `user_id`, `family_id`, `is_revoked`, `expires_at`, and `replaced_by_token_id` for a full audit chain
- **Rotation on every refresh**: old token is revoked in DB, new token issued under the same `family_id`; the `jti` claim links DB records to JWTs
- **Reuse attack detection**: if a revoked token from a family is presented, the entire family is immediately invalidated and a security event is logged
- **Server-side logout**: `logout()` now verifies the JWT and marks the token `is_revoked = true` in the DB instead of being a no-op

## Test plan

- [ ] New test file `refresh-token-rotation.test.ts` covers: token issuance on login, successful rotation, old-token revocation, same-family continuity, unknown/expired token rejection, reuse detection (family wipe), and logout revocation
- [ ] Existing `auth.service.test.ts`, `auth-security.test.ts`, and `auth-flow.test.ts` updated to mock the `RefreshToken` model and use `jti` instead of `tokenId` in decoded payloads
- [ ] All 40 test files pass (`1135 passed | 4 skipped`)

https://claude.ai/code/session_017XRsS3inBx5vVPkQ1FUekF