### PR TITLE
Implement refresh token rotation strategy (ENG-91)

### DIFF
--- a/service.backend/src/__tests__/integration/admin-moderation-flow.test.ts
+++ b/service.backend/src/__tests__/integration/admin-moderation-flow.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 vi.mock('../../sequelize', async importOriginal => {

--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 import { generateCryptoUuid as uuidv4 } from '../../utils/uuid-helpers';

--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 import bcrypt from 'bcryptjs';

--- a/service.backend/src/__tests__/integration/chat-messaging-flow.test.ts
+++ b/service.backend/src/__tests__/integration/chat-messaging-flow.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 // Mock sequelize before model imports

--- a/service.backend/src/__tests__/integration/pet-discovery-flow.test.ts
+++ b/service.backend/src/__tests__/integration/pet-discovery-flow.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 import { generateCryptoUuid as uuidv4 } from '../../utils/uuid-helpers';

--- a/service.backend/src/__tests__/integration/pet-discovery-matching.test.ts
+++ b/service.backend/src/__tests__/integration/pet-discovery-matching.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 import { generateCryptoUuid as uuidv4 } from '../../utils/uuid-helpers';

--- a/service.backend/src/__tests__/middleware/auth.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/auth.middleware.test.ts
@@ -56,6 +56,7 @@ vi.mock('../../config/env', () => ({
     POSTGRES_PASSWORD: 'test',
     POSTGRES_DB: 'test',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 // Mock User model before it is imported

--- a/service.backend/src/__tests__/services/auth-security.test.ts
+++ b/service.backend/src/__tests__/services/auth-security.test.ts
@@ -56,6 +56,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 // Test constants

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 import bcrypt from 'bcryptjs';

--- a/service.backend/src/__tests__/services/refresh-token-rotation.test.ts
+++ b/service.backend/src/__tests__/services/refresh-token-rotation.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 import bcrypt from 'bcryptjs';

--- a/service.backend/src/__tests__/setup.test.ts
+++ b/service.backend/src/__tests__/setup.test.ts
@@ -8,6 +8,7 @@ vi.mock('../config/env', () => ({
     SESSION_SECRET: 'test-session-secret-min-32-characters-long',
     CSRF_SECRET: 'test-csrf-secret-min-32-characters-long-123',
   },
+  getDatabaseName: () => 'test_db',
 }));
 
 describe('Setup Test', () => {


### PR DESCRIPTION
## Summary

- Adds stateful `RefreshToken` model (`token_id`, `user_id`, `family_id`, `is_revoked`, `expires_at`, `replaced_by_token_id`) to back every refresh token with a DB record
- `refreshToken()` now rotates on every use: old token is revoked, a new one is issued under the same `family_id`, and `replaced_by_token_id` links the chain
- Reuse detection: presenting a revoked token immediately revokes the entire token family and logs a security event, blocking any attacker who stole a superseded token
- `logout()` explicitly revokes the token record server-side rather than relying on client-side deletion alone
- 11 behaviour tests covering issuance, rotation, reuse detection, and revocation (`refresh-token-rotation.test.ts`)
- Fixed missing `getDatabaseName` export in 11 backend test mocks, unblocking all 1135 tests

## Security model

Each refresh token is single-use. On every `/auth/refresh-token` call:
1. JWT signature and DB record are both verified
2. Old record is marked `is_revoked = true` and `replaced_by_token_id` is set
3. New record is written with the same `family_id`

If an attacker presents a stolen (already-rotated) token, the server detects `is_revoked = true`, revokes every token in that family, and forces a full re-login — protecting the account even if one token was compromised.

## Test plan

- [ ] `cd service.backend && vitest run` — all 1135 tests pass
- [ ] `POST /auth/login` returns both `token` and `refreshToken`
- [ ] `POST /auth/refresh-token` with valid refresh token returns new token pair and the old refresh token can no longer be used
- [ ] Replaying the old refresh token after rotation returns 401 and revokes the whole family
- [ ] `POST /auth/logout` prevents the refresh token being reused

https://claude.ai/code/session_01Qxkkxmm7hSSa2vHQk1Rckf