### PR TITLE
feat: implement notification preferences in rescue app settings

### DIFF
--- a/app.rescue/src/__tests__/notification-preferences.behavior.test.tsx
+++ b/app.rescue/src/__tests__/notification-preferences.behavior.test.tsx
@@ -1,0 +1,470 @@
+/**
+ * Behavioral tests for Notification Preferences feature (Rescue App)
+ *
+ * Tests rescue staff-facing behavior through the public interface:
+ * - Staff can view their notification preferences
+ * - Staff can toggle channel preferences (email, push)
+ * - Staff sees SMS as unavailable
+ * - Staff can toggle category preferences (applications, messages, system, marketing, reminders)
+ * - Staff can change delivery frequency (immediate, daily digest, weekly)
+ * - Staff can configure quiet hours (start time, end time, timezone)
+ * - Staff receives confirmation when preferences are saved
+ * - Staff sees an error message when saving fails
+ * - Staff sees loading state while preferences are being fetched
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, screen, waitFor, userEvent } from '../test-utils';
+import NotificationPreferencesForm from '../components/rescue/NotificationPreferencesForm';
+
+vi.mock('../services/libraryServices', () => ({
+  apiService: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import { apiService } from '../services/libraryServices';
+
+const mockPreferences = {
+  email: true,
+  push: true,
+  sms: false,
+  applications: true,
+  messages: true,
+  system: true,
+  marketing: false,
+  reminders: true,
+  quietHoursStart: '22:00',
+  quietHoursEnd: '08:00',
+  timezone: 'UTC',
+  frequency: 'immediate',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(apiService.get).mockResolvedValue({
+    success: true,
+    data: mockPreferences,
+  });
+  vi.mocked(apiService.put).mockResolvedValue({
+    success: true,
+    message: 'Notification preferences updated successfully',
+    data: mockPreferences,
+  });
+});
+
+describe('Notification Preferences - Behavioral Tests', () => {
+  describe('Loading preferences', () => {
+    it('shows a loading indicator while fetching preferences', () => {
+      vi.mocked(apiService.get).mockImplementation(() => new Promise(() => undefined));
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      expect(screen.getByText(/loading notification preferences/i)).toBeInTheDocument();
+    });
+
+    it('displays preferences once loaded', async () => {
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Notification Channels')).toBeInTheDocument();
+        expect(screen.getByText('Notification Categories')).toBeInTheDocument();
+        expect(screen.getByText('Delivery Frequency')).toBeInTheDocument();
+        expect(screen.getByText('Quiet Hours')).toBeInTheDocument();
+      });
+    });
+
+    it('shows default preferences when loading fails', async () => {
+      vi.mocked(apiService.get).mockRejectedValue(new Error('Network error'));
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/failed to load notification preferences/i)
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Notification Channels')).toBeInTheDocument();
+    });
+  });
+
+  describe('Notification channel toggles', () => {
+    it('shows email toggle as enabled when preference is on', async () => {
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        const emailToggle = screen.getByRole('button', { name: /toggle email notifications/i });
+        expect(emailToggle).toHaveAttribute('aria-pressed', 'true');
+      });
+    });
+
+    it('allows staff to disable email notifications', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /toggle email notifications/i })).toBeInTheDocument();
+      });
+
+      const emailToggle = screen.getByRole('button', { name: /toggle email notifications/i });
+      expect(emailToggle).toHaveAttribute('aria-pressed', 'true');
+
+      await user.click(emailToggle);
+
+      expect(emailToggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('allows staff to enable push notifications', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiService.get).mockResolvedValue({
+        success: true,
+        data: { ...mockPreferences, push: false },
+      });
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        const pushToggle = screen.getByRole('button', { name: /toggle push notifications/i });
+        expect(pushToggle).toHaveAttribute('aria-pressed', 'false');
+      });
+
+      const pushToggle = screen.getByRole('button', { name: /toggle push notifications/i });
+      await user.click(pushToggle);
+
+      expect(pushToggle).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('shows SMS notifications as unavailable', async () => {
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByText('SMS Notifications')).toBeInTheDocument();
+      });
+
+      const smsToggle = screen.getByRole('button', { name: /toggle sms notifications/i });
+      expect(smsToggle).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByText(/sms notifications are not currently available/i)).toBeInTheDocument();
+    });
+
+    it('does not change SMS preference when staff clicks the disabled toggle', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /toggle sms notifications/i })).toBeInTheDocument();
+      });
+
+      const smsToggle = screen.getByRole('button', { name: /toggle sms notifications/i });
+      const initialPressed = smsToggle.getAttribute('aria-pressed');
+      await user.click(smsToggle);
+
+      expect(smsToggle).toHaveAttribute('aria-pressed', initialPressed);
+    });
+  });
+
+  describe('Notification category toggles', () => {
+    it('shows application notifications as enabled', async () => {
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        const toggle = screen.getByRole('button', { name: /toggle application notifications/i });
+        expect(toggle).toHaveAttribute('aria-pressed', 'true');
+      });
+    });
+
+    it('allows staff to disable marketing notifications', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiService.get).mockResolvedValue({
+        success: true,
+        data: { ...mockPreferences, marketing: true },
+      });
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        const toggle = screen.getByRole('button', { name: /toggle marketing notifications/i });
+        expect(toggle).toHaveAttribute('aria-pressed', 'true');
+      });
+
+      const toggle = screen.getByRole('button', { name: /toggle marketing notifications/i });
+      await user.click(toggle);
+
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('allows staff to toggle system update notifications', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /toggle system update notifications/i })
+        ).toBeInTheDocument();
+      });
+
+      const toggle = screen.getByRole('button', { name: /toggle system update notifications/i });
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('allows staff to toggle message notifications', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /toggle message notifications/i })
+        ).toBeInTheDocument();
+      });
+
+      const toggle = screen.getByRole('button', { name: /toggle message notifications/i });
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('allows staff to toggle reminder notifications', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /toggle reminder notifications/i })
+        ).toBeInTheDocument();
+      });
+
+      const toggle = screen.getByRole('button', { name: /toggle reminder notifications/i });
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
+  describe('Delivery frequency', () => {
+    it('shows immediate as the selected frequency by default', async () => {
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        const immediateButton = screen.getByRole('button', { name: /immediate/i });
+        expect(immediateButton).toHaveAttribute('aria-pressed', 'true');
+      });
+    });
+
+    it('allows staff to switch to daily digest', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /daily digest/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /daily digest/i }));
+
+      expect(screen.getByRole('button', { name: /daily digest/i })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+      expect(screen.getByRole('button', { name: /immediate/i })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+    });
+
+    it('allows staff to switch to weekly digest', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /weekly digest/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /weekly digest/i }));
+
+      expect(screen.getByRole('button', { name: /weekly digest/i })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+    });
+
+    it('shows only one frequency option as selected at a time', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /weekly digest/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /weekly digest/i }));
+
+      const frequencies = ['Immediate', 'Daily Digest', 'Weekly Digest'];
+      const selectedCount = frequencies.filter(label => {
+        const btn = screen.getByRole('button', { name: new RegExp(label, 'i') });
+        return btn.getAttribute('aria-pressed') === 'true';
+      }).length;
+
+      expect(selectedCount).toBe(1);
+    });
+  });
+
+  describe('Quiet hours configuration', () => {
+    it('displays quiet hours start and end time inputs', async () => {
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/quiet hours start time/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/quiet hours end time/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows current quiet hours values loaded from preferences', async () => {
+      vi.mocked(apiService.get).mockResolvedValue({
+        success: true,
+        data: { ...mockPreferences, quietHoursStart: '21:00', quietHoursEnd: '07:00' },
+      });
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        const startInput = screen.getByLabelText(/quiet hours start time/i);
+        const endInput = screen.getByLabelText(/quiet hours end time/i);
+        expect(startInput).toHaveValue('21:00');
+        expect(endInput).toHaveValue('07:00');
+      });
+    });
+
+    it('displays a timezone selector', async () => {
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/timezone/i)).toBeInTheDocument();
+      });
+
+      const timezoneSelect = screen.getByLabelText(/timezone/i);
+      expect(timezoneSelect).toHaveValue('UTC');
+    });
+
+    it('allows staff to change the timezone', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/timezone/i)).toBeInTheDocument();
+      });
+
+      await user.selectOptions(
+        screen.getByLabelText(/timezone/i),
+        'America/New_York'
+      );
+
+      expect(screen.getByLabelText(/timezone/i)).toHaveValue('America/New_York');
+    });
+  });
+
+  describe('Saving preferences', () => {
+    it('shows a save button', async () => {
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save preferences/i })).toBeInTheDocument();
+      });
+    });
+
+    it('displays a success message after preferences are saved', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save preferences/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toHaveTextContent(
+          'Preferences saved successfully.'
+        );
+      });
+    });
+
+    it('sends updated preferences to the backend when saving', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /toggle email notifications/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /toggle email notifications/i }));
+      await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+      await waitFor(() => {
+        expect(vi.mocked(apiService.put)).toHaveBeenCalledWith(
+          '/api/v1/notifications/preferences',
+          expect.objectContaining({ email: false })
+        );
+      });
+    });
+
+    it('shows an error message when saving fails', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiService.put).mockRejectedValue(new Error('Server error'));
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save preferences/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(
+          /failed to save notification preferences/i
+        );
+      });
+    });
+
+    it('shows Saving... text on the button while the save request is in progress', async () => {
+      const user = userEvent.setup();
+      let resolveRequest: (value: unknown) => void;
+      vi.mocked(apiService.put).mockImplementation(
+        () => new Promise(resolve => { resolveRequest = resolve; })
+      );
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save preferences/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+      expect(screen.getByRole('button', { name: /saving/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+
+      resolveRequest!({ success: true, data: mockPreferences });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save preferences/i })).toBeInTheDocument();
+      });
+    });
+
+    it('clears the success message when a preference is changed after saving', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotificationPreferencesForm />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /save preferences/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /toggle email notifications/i }));
+
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app.rescue/src/__tests__/notification-preferences.behavior.test.tsx
+++ b/app.rescue/src/__tests__/notification-preferences.behavior.test.tsx
@@ -79,9 +79,7 @@ describe('Notification Preferences - Behavioral Tests', () => {
       renderWithProviders(<NotificationPreferencesForm />);
 
       await waitFor(() => {
-        expect(
-          screen.getByText(/failed to load notification preferences/i)
-        ).toBeInTheDocument();
+        expect(screen.getByText(/failed to load notification preferences/i)).toBeInTheDocument();
       });
 
       expect(screen.getByText('Notification Channels')).toBeInTheDocument();
@@ -103,7 +101,9 @@ describe('Notification Preferences - Behavioral Tests', () => {
       renderWithProviders(<NotificationPreferencesForm />);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /toggle email notifications/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /toggle email notifications/i })
+        ).toBeInTheDocument();
       });
 
       const emailToggle = screen.getByRole('button', { name: /toggle email notifications/i });
@@ -142,7 +142,9 @@ describe('Notification Preferences - Behavioral Tests', () => {
 
       const smsToggle = screen.getByRole('button', { name: /toggle sms notifications/i });
       expect(smsToggle).toHaveAttribute('aria-disabled', 'true');
-      expect(screen.getByText(/sms notifications are not currently available/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/sms notifications are not currently available/i)
+      ).toBeInTheDocument();
     });
 
     it('does not change SMS preference when staff clicks the disabled toggle', async () => {
@@ -150,7 +152,9 @@ describe('Notification Preferences - Behavioral Tests', () => {
       renderWithProviders(<NotificationPreferencesForm />);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /toggle sms notifications/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /toggle sms notifications/i })
+        ).toBeInTheDocument();
       });
 
       const smsToggle = screen.getByRole('button', { name: /toggle sms notifications/i });
@@ -352,10 +356,7 @@ describe('Notification Preferences - Behavioral Tests', () => {
         expect(screen.getByLabelText(/timezone/i)).toBeInTheDocument();
       });
 
-      await user.selectOptions(
-        screen.getByLabelText(/timezone/i),
-        'America/New_York'
-      );
+      await user.selectOptions(screen.getByLabelText(/timezone/i), 'America/New_York');
 
       expect(screen.getByLabelText(/timezone/i)).toHaveValue('America/New_York');
     });
@@ -381,9 +382,7 @@ describe('Notification Preferences - Behavioral Tests', () => {
       await user.click(screen.getByRole('button', { name: /save preferences/i }));
 
       await waitFor(() => {
-        expect(screen.getByRole('status')).toHaveTextContent(
-          'Preferences saved successfully.'
-        );
+        expect(screen.getByRole('status')).toHaveTextContent('Preferences saved successfully.');
       });
     });
 
@@ -392,7 +391,9 @@ describe('Notification Preferences - Behavioral Tests', () => {
       renderWithProviders(<NotificationPreferencesForm />);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /toggle email notifications/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /toggle email notifications/i })
+        ).toBeInTheDocument();
       });
 
       await user.click(screen.getByRole('button', { name: /toggle email notifications/i }));
@@ -428,7 +429,10 @@ describe('Notification Preferences - Behavioral Tests', () => {
       const user = userEvent.setup();
       let resolveRequest: (value: unknown) => void;
       vi.mocked(apiService.put).mockImplementation(
-        () => new Promise(resolve => { resolveRequest = resolve; })
+        () =>
+          new Promise(resolve => {
+            resolveRequest = resolve;
+          })
       );
       renderWithProviders(<NotificationPreferencesForm />);
 

--- a/app.rescue/src/components/rescue/NotificationPreferencesForm.tsx
+++ b/app.rescue/src/components/rescue/NotificationPreferencesForm.tsx
@@ -273,8 +273,7 @@ type BooleanPreferenceKey = {
 }[keyof NotificationPreferencesData];
 
 const NotificationPreferencesForm: React.FC = () => {
-  const [preferences, setPreferences] =
-    useState<NotificationPreferencesData>(DEFAULT_PREFERENCES);
+  const [preferences, setPreferences] = useState<NotificationPreferencesData>(DEFAULT_PREFERENCES);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -464,9 +463,7 @@ const NotificationPreferencesForm: React.FC = () => {
 
       <Section>
         <SectionTitle>Delivery Frequency</SectionTitle>
-        <SectionDescription>
-          Control how often you receive notification digests.
-        </SectionDescription>
+        <SectionDescription>Control how often you receive notification digests.</SectionDescription>
 
         <FrequencyOptions>
           <FrequencyOption
@@ -543,12 +540,8 @@ const NotificationPreferencesForm: React.FC = () => {
         <SaveButton onClick={handleSave} disabled={saving}>
           {saving ? 'Saving...' : 'Save Preferences'}
         </SaveButton>
-        {success && (
-          <SuccessMessage role="status">Preferences saved successfully.</SuccessMessage>
-        )}
-        {error !== null && !success && (
-          <ErrorMessage role="alert">{error}</ErrorMessage>
-        )}
+        {success && <SuccessMessage role="status">Preferences saved successfully.</SuccessMessage>}
+        {error !== null && !success && <ErrorMessage role="alert">{error}</ErrorMessage>}
       </ActionRow>
     </Container>
   );

--- a/app.rescue/src/components/rescue/NotificationPreferencesForm.tsx
+++ b/app.rescue/src/components/rescue/NotificationPreferencesForm.tsx
@@ -1,0 +1,557 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { apiService } from '../../services/libraryServices';
+
+type NotificationFrequency = 'immediate' | 'daily' | 'weekly';
+
+type NotificationPreferencesData = {
+  email: boolean;
+  push: boolean;
+  sms: boolean;
+  applications: boolean;
+  messages: boolean;
+  system: boolean;
+  marketing: boolean;
+  reminders: boolean;
+  quietHoursStart: string;
+  quietHoursEnd: string;
+  timezone: string;
+  frequency: NotificationFrequency;
+};
+
+type PreferencesApiResponse = {
+  success: boolean;
+  data: Omit<NotificationPreferencesData, 'frequency'> & {
+    frequency?: NotificationFrequency;
+  };
+};
+
+const DEFAULT_PREFERENCES: NotificationPreferencesData = {
+  email: true,
+  push: true,
+  sms: false,
+  applications: true,
+  messages: true,
+  system: true,
+  marketing: false,
+  reminders: true,
+  quietHoursStart: '22:00',
+  quietHoursEnd: '08:00',
+  timezone: 'UTC',
+  frequency: 'immediate',
+};
+
+const TIMEZONES = [
+  'UTC',
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'Europe/London',
+  'Europe/Paris',
+  'Asia/Tokyo',
+  'Australia/Sydney',
+];
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const Section = styled.div`
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+`;
+
+const SectionTitle = styled.h3`
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 0.25rem 0;
+`;
+
+const SectionDescription = styled.p`
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin: 0 0 1.25rem 0;
+`;
+
+const ToggleRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #f3f4f6;
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  &:first-child {
+    padding-top: 0;
+  }
+`;
+
+const ToggleLabel = styled.div``;
+
+const ToggleName = styled.span`
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+`;
+
+const ToggleHint = styled.span`
+  display: block;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  margin-top: 0.125rem;
+`;
+
+const Toggle = styled.button<{ $enabled: boolean; $disabled?: boolean }>`
+  position: relative;
+  width: 2.75rem;
+  height: 1.5rem;
+  border-radius: 9999px;
+  border: none;
+  cursor: ${props => (props.$disabled ? 'not-allowed' : 'pointer')};
+  background-color: ${props => (props.$enabled ? '#3b82f6' : '#d1d5db')};
+  opacity: ${props => (props.$disabled ? '0.5' : '1')};
+  transition: background-color 0.2s;
+  flex-shrink: 0;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0.125rem;
+    left: ${props => (props.$enabled ? '1.375rem' : '0.125rem')};
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    background: white;
+    transition: left 0.2s;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  }
+`;
+
+const FrequencyOptions = styled.div`
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+`;
+
+const FrequencyOption = styled.button<{ $selected: boolean }>`
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: 2px solid ${props => (props.$selected ? '#3b82f6' : '#e5e7eb')};
+  background: ${props => (props.$selected ? '#eff6ff' : '#ffffff')};
+  color: ${props => (props.$selected ? '#1d4ed8' : '#374151')};
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: #3b82f6;
+  }
+`;
+
+const QuietHoursGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1rem;
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const FieldLabel = styled.label`
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.375rem;
+`;
+
+const TimeInput = styled.input`
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  color: #111827;
+  background: #ffffff;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+  }
+`;
+
+const Select = styled.select`
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  color: #111827;
+  background: #ffffff;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+  }
+`;
+
+const ActionRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+`;
+
+const SaveButton = styled.button`
+  padding: 0.625rem 1.5rem;
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover:not(:disabled) {
+    background-color: #2563eb;
+  }
+
+  &:disabled {
+    background-color: #9ca3af;
+    cursor: not-allowed;
+  }
+`;
+
+const SuccessMessage = styled.p`
+  font-size: 0.875rem;
+  color: #065f46;
+  background: #d1fae5;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  margin: 0;
+`;
+
+const ErrorMessage = styled.p`
+  font-size: 0.875rem;
+  color: #991b1b;
+  background: #fee2e2;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  margin: 0;
+`;
+
+const LoadingContainer = styled.div`
+  padding: 3rem;
+  text-align: center;
+  color: #6b7280;
+  font-size: 0.875rem;
+`;
+
+type BooleanPreferenceKey = {
+  [K in keyof NotificationPreferencesData]: NotificationPreferencesData[K] extends boolean
+    ? K
+    : never;
+}[keyof NotificationPreferencesData];
+
+const NotificationPreferencesForm: React.FC = () => {
+  const [preferences, setPreferences] =
+    useState<NotificationPreferencesData>(DEFAULT_PREFERENCES);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    const loadPreferences = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await apiService.get<PreferencesApiResponse>(
+          '/api/v1/notifications/preferences'
+        );
+        setPreferences({
+          ...DEFAULT_PREFERENCES,
+          ...response.data,
+          frequency: response.data.frequency ?? 'immediate',
+        });
+      } catch {
+        setError('Failed to load notification preferences. Using defaults.');
+        setPreferences(DEFAULT_PREFERENCES);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPreferences();
+  }, []);
+
+  const togglePreference = (key: BooleanPreferenceKey) => {
+    setPreferences(prev => ({ ...prev, [key]: !prev[key] }));
+    setSuccess(false);
+  };
+
+  const setFrequency = (frequency: NotificationFrequency) => {
+    setPreferences(prev => ({ ...prev, frequency }));
+    setSuccess(false);
+  };
+
+  const setQuietHoursField = (
+    field: 'quietHoursStart' | 'quietHoursEnd' | 'timezone',
+    value: string
+  ) => {
+    setPreferences(prev => ({ ...prev, [field]: value }));
+    setSuccess(false);
+  };
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      setError(null);
+      setSuccess(false);
+      await apiService.put('/api/v1/notifications/preferences', preferences);
+      setSuccess(true);
+    } catch {
+      setError('Failed to save notification preferences. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <LoadingContainer>Loading notification preferences...</LoadingContainer>;
+  }
+
+  return (
+    <Container>
+      <Section>
+        <SectionTitle>Notification Channels</SectionTitle>
+        <SectionDescription>
+          Choose which channels you want to receive notifications through.
+        </SectionDescription>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleName>Email Notifications</ToggleName>
+            <ToggleHint>Receive notifications in your email inbox</ToggleHint>
+          </ToggleLabel>
+          <Toggle
+            $enabled={preferences.email}
+            onClick={() => togglePreference('email')}
+            aria-label="Toggle email notifications"
+            aria-pressed={preferences.email}
+          />
+        </ToggleRow>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleName>Push Notifications</ToggleName>
+            <ToggleHint>Receive in-browser push notifications</ToggleHint>
+          </ToggleLabel>
+          <Toggle
+            $enabled={preferences.push}
+            onClick={() => togglePreference('push')}
+            aria-label="Toggle push notifications"
+            aria-pressed={preferences.push}
+          />
+        </ToggleRow>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleName>SMS Notifications</ToggleName>
+            <ToggleHint>SMS notifications are not currently available</ToggleHint>
+          </ToggleLabel>
+          <Toggle
+            $enabled={preferences.sms}
+            $disabled
+            onClick={() => undefined}
+            aria-label="Toggle SMS notifications"
+            aria-pressed={preferences.sms}
+            aria-disabled="true"
+          />
+        </ToggleRow>
+      </Section>
+
+      <Section>
+        <SectionTitle>Notification Categories</SectionTitle>
+        <SectionDescription>
+          Select which types of events you want to be notified about.
+        </SectionDescription>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleName>Applications</ToggleName>
+            <ToggleHint>New adoption applications and status changes</ToggleHint>
+          </ToggleLabel>
+          <Toggle
+            $enabled={preferences.applications}
+            onClick={() => togglePreference('applications')}
+            aria-label="Toggle application notifications"
+            aria-pressed={preferences.applications}
+          />
+        </ToggleRow>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleName>Messages</ToggleName>
+            <ToggleHint>Direct messages from adopters and staff</ToggleHint>
+          </ToggleLabel>
+          <Toggle
+            $enabled={preferences.messages}
+            onClick={() => togglePreference('messages')}
+            aria-label="Toggle message notifications"
+            aria-pressed={preferences.messages}
+          />
+        </ToggleRow>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleName>System Updates</ToggleName>
+            <ToggleHint>Platform updates and maintenance notices</ToggleHint>
+          </ToggleLabel>
+          <Toggle
+            $enabled={preferences.system}
+            onClick={() => togglePreference('system')}
+            aria-label="Toggle system update notifications"
+            aria-pressed={preferences.system}
+          />
+        </ToggleRow>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleName>Marketing</ToggleName>
+            <ToggleHint>Tips, feature announcements, and promotions</ToggleHint>
+          </ToggleLabel>
+          <Toggle
+            $enabled={preferences.marketing}
+            onClick={() => togglePreference('marketing')}
+            aria-label="Toggle marketing notifications"
+            aria-pressed={preferences.marketing}
+          />
+        </ToggleRow>
+
+        <ToggleRow>
+          <ToggleLabel>
+            <ToggleName>Reminders</ToggleName>
+            <ToggleHint>Follow-up reminders for pending actions</ToggleHint>
+          </ToggleLabel>
+          <Toggle
+            $enabled={preferences.reminders}
+            onClick={() => togglePreference('reminders')}
+            aria-label="Toggle reminder notifications"
+            aria-pressed={preferences.reminders}
+          />
+        </ToggleRow>
+      </Section>
+
+      <Section>
+        <SectionTitle>Delivery Frequency</SectionTitle>
+        <SectionDescription>
+          Control how often you receive notification digests.
+        </SectionDescription>
+
+        <FrequencyOptions>
+          <FrequencyOption
+            $selected={preferences.frequency === 'immediate'}
+            onClick={() => setFrequency('immediate')}
+            aria-pressed={preferences.frequency === 'immediate'}
+          >
+            Immediate
+          </FrequencyOption>
+          <FrequencyOption
+            $selected={preferences.frequency === 'daily'}
+            onClick={() => setFrequency('daily')}
+            aria-pressed={preferences.frequency === 'daily'}
+          >
+            Daily Digest
+          </FrequencyOption>
+          <FrequencyOption
+            $selected={preferences.frequency === 'weekly'}
+            onClick={() => setFrequency('weekly')}
+            aria-pressed={preferences.frequency === 'weekly'}
+          >
+            Weekly Digest
+          </FrequencyOption>
+        </FrequencyOptions>
+      </Section>
+
+      <Section>
+        <SectionTitle>Quiet Hours</SectionTitle>
+        <SectionDescription>
+          Pause notifications during a scheduled quiet period each day.
+        </SectionDescription>
+
+        <QuietHoursGrid>
+          <div>
+            <FieldLabel htmlFor="quiet-hours-start">Start time</FieldLabel>
+            <TimeInput
+              id="quiet-hours-start"
+              type="time"
+              value={preferences.quietHoursStart}
+              onChange={e => setQuietHoursField('quietHoursStart', e.target.value)}
+              aria-label="Quiet hours start time"
+            />
+          </div>
+          <div>
+            <FieldLabel htmlFor="quiet-hours-end">End time</FieldLabel>
+            <TimeInput
+              id="quiet-hours-end"
+              type="time"
+              value={preferences.quietHoursEnd}
+              onChange={e => setQuietHoursField('quietHoursEnd', e.target.value)}
+              aria-label="Quiet hours end time"
+            />
+          </div>
+        </QuietHoursGrid>
+
+        <div>
+          <FieldLabel htmlFor="timezone">Timezone</FieldLabel>
+          <Select
+            id="timezone"
+            value={preferences.timezone}
+            onChange={e => setQuietHoursField('timezone', e.target.value)}
+            aria-label="Timezone"
+          >
+            {TIMEZONES.map(tz => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </Section>
+
+      <ActionRow>
+        <SaveButton onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save Preferences'}
+        </SaveButton>
+        {success && (
+          <SuccessMessage role="status">Preferences saved successfully.</SuccessMessage>
+        )}
+        {error !== null && !success && (
+          <ErrorMessage role="alert">{error}</ErrorMessage>
+        )}
+      </ActionRow>
+    </Container>
+  );
+};
+
+export default NotificationPreferencesForm;

--- a/app.rescue/src/pages/RescueSettings.tsx
+++ b/app.rescue/src/pages/RescueSettings.tsx
@@ -6,6 +6,7 @@ import { apiService, rescueService } from '../services/libraryServices';
 import { RESCUE_SETTINGS_UPDATE } from '@adopt-dont-shop/lib.permissions';
 import RescueProfileForm from '../components/rescue/RescueProfileForm';
 import AdoptionPolicyForm from '../components/rescue/AdoptionPolicyForm';
+import NotificationPreferencesForm from '../components/rescue/NotificationPreferencesForm';
 import type { RescueProfile, AdoptionPolicy } from '../types/rescue';
 
 const PageContainer = styled.div`
@@ -295,13 +296,7 @@ const RescueSettings: React.FC = () => {
       </TabPanel>
 
       <TabPanel $active={activeTab === 'preferences'}>
-        <PlaceholderSection>
-          <h2>⚙️ System Preferences</h2>
-          <p>
-            This feature is coming soon. You'll be able to configure notification settings,
-            auto-responses, and workflow preferences.
-          </p>
-        </PlaceholderSection>
+        <NotificationPreferencesForm />
       </TabPanel>
 
       <TabPanel $active={activeTab === 'security'}>

--- a/app.rescue/src/setup-tests.ts
+++ b/app.rescue/src/setup-tests.ts
@@ -98,6 +98,8 @@ vi.mock('@adopt-dont-shop/lib.rescue', () => ({
 }));
 
 vi.mock('@adopt-dont-shop/lib.components', () => ({
+  lightTheme: {},
+  darkTheme: {},
   ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
   Container: ({ children, ...props }: any) => React.createElement('div', props, children),
   Card: ({ children, ...props }: any) => React.createElement('div', props, children),

--- a/app.rescue/src/test-utils/msw-handlers.ts
+++ b/app.rescue/src/test-utils/msw-handlers.ts
@@ -68,7 +68,47 @@ const mockStaff = [
   },
 ];
 
+const BASE_URL = 'http://localhost:5000';
+
+const mockNotificationPreferences = {
+  email: true,
+  push: true,
+  sms: false,
+  applications: true,
+  messages: true,
+  system: true,
+  marketing: false,
+  reminders: true,
+  quietHoursStart: '22:00',
+  quietHoursEnd: '08:00',
+  timezone: 'UTC',
+  frequency: 'immediate',
+};
+
 export const mswHandlers = [
+  // CSRF token endpoint
+  http.get(`${BASE_URL}/api/v1/csrf-token`, () => {
+    return HttpResponse.json({ csrfToken: 'test-csrf-token' });
+  }),
+
+  // Notification preferences endpoints
+  http.get(`${BASE_URL}/api/v1/notifications/preferences`, () => {
+    return HttpResponse.json({
+      success: true,
+      data: mockNotificationPreferences,
+    });
+  }),
+
+  http.put(`${BASE_URL}/api/v1/notifications/preferences`, async ({ request }) => {
+    const body = (await request.json()) as typeof mockNotificationPreferences;
+    return HttpResponse.json({
+      success: true,
+      message: 'Notification preferences updated successfully',
+      data: { ...mockNotificationPreferences, ...body },
+    });
+  }),
+
+
   // Pet management endpoints
   http.get('/api/v1/pets', ({ request }) => {
     const url = new URL(request.url);

--- a/app.rescue/src/test-utils/msw-handlers.ts
+++ b/app.rescue/src/test-utils/msw-handlers.ts
@@ -108,7 +108,6 @@ export const mswHandlers = [
     });
   }),
 
-
   // Pet management endpoints
   http.get('/api/v1/pets', ({ request }) => {
     const url = new URL(request.url);

--- a/app.rescue/vitest.config.ts
+++ b/app.rescue/vitest.config.ts
@@ -61,6 +61,11 @@ export default defineConfig({
       '@adopt-dont-shop/lib.discovery': path.resolve(__dirname, '../lib.discovery/src/index.ts'),
       '@adopt-dont-shop/lib.validation': path.resolve(__dirname, '../lib.validation/src/index.ts'),
       '@adopt-dont-shop/lib.utils': path.resolve(__dirname, '../lib.utils/src/index.ts'),
+      '@adopt-dont-shop/lib.invitations': path.resolve(
+        __dirname,
+        '../lib.invitations/src/index.ts'
+      ),
+      '@adopt-dont-shop/lib.dev-tools': path.resolve(__dirname, '../lib.dev-tools/src/index.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Replaces the placeholder "Preferences" tab in `RescueSettings` with a fully functional `NotificationPreferencesForm` component
- Staff can configure how and when they receive notifications directly from the Settings page
- Preferences are loaded from and persisted to `GET/PUT /api/v1/notifications/preferences` (existing backend endpoints)

## What was built

**Notification Channels** — toggle email and push independently; SMS shown as unavailable with a clear hint

**Notification Categories** — toggle each category independently: Applications, Messages, System Updates, Marketing, Reminders

**Delivery Frequency** — choose between Immediate, Daily Digest, or Weekly Digest

**Quiet Hours** — configure a daily start/end window with timezone support (9 common timezones)

**Persistence** — loads saved preferences on mount; Save button sends a `PUT` request and shows success/error feedback

## Test plan

- [x] 27 behaviour-driven tests cover all interactive scenarios (`notification-preferences.behavior.test.tsx`)
- [x] Loading state while fetching preferences
- [x] Each channel toggle (email, push, SMS disabled)
- [x] Each category toggle (applications, messages, system, marketing, reminders)
- [x] Frequency selection (immediate / daily / weekly — only one selected at a time)
- [x] Quiet hours inputs and timezone select reflect loaded values
- [x] Save success confirmation message
- [x] Save error message on failure
- [x] Button disabled with "Saving…" text during in-flight request
- [x] Success message clears when preferences are changed after saving
- [x] All 64 existing tests continue to pass

## Additional fixes

- Added missing `lib.invitations` and `lib.dev-tools` aliases to `vitest.config.ts` (prevented any real component from being tested)
- Added `lightTheme` export to the `lib.components` mock in `setup-tests.ts`
- Added CSRF token and notification preference MSW handlers to `msw-handlers.ts` for completeness

https://claude.ai/code/session_012sFMGQHagjWCSR3BMR37Nb