### PR TITLE
fix(auth,moderation): token revocation, httpOnly cookies, and chat content moderation (ENG-143, ENG-96)

### DIFF
--- a/lib.auth/src/__tests__/auth-service.test.ts
+++ b/lib.auth/src/__tests__/auth-service.test.ts
@@ -21,8 +21,20 @@ const mockLocalStorage = {
   clear: jest.fn(),
 };
 
+// Mock sessionStorage (access tokens are stored here)
+const mockSessionStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+};
+
 Object.defineProperty(window, 'localStorage', {
   value: mockLocalStorage,
+});
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: mockSessionStorage,
 });
 
 describe('AuthService', () => {
@@ -39,10 +51,10 @@ describe('AuthService', () => {
     updatedAt: '2023-01-01T00:00:00Z',
   };
 
+  // Backend no longer returns refreshToken in body — it's set as httpOnly cookie
   const mockAuthResponse: AuthResponse = {
     user: mockUser,
     token: 'mock-token',
-    refreshToken: 'mock-refresh-token',
     expiresIn: 3600,
     accessToken: 'mock-token',
   };
@@ -54,11 +66,14 @@ describe('AuthService', () => {
     mockLocalStorage.getItem.mockClear();
     mockLocalStorage.setItem.mockClear();
     mockLocalStorage.removeItem.mockClear();
+    mockSessionStorage.clear.mockClear();
+    mockSessionStorage.getItem.mockClear();
+    mockSessionStorage.setItem.mockClear();
+    mockSessionStorage.removeItem.mockClear();
   });
 
   describe('initialization', () => {
     it('should configure API service with getAuthToken callback on construction', () => {
-      // Clear previous mock calls and create new instance
       jest.clearAllMocks();
 
       new AuthService();
@@ -70,7 +85,7 @@ describe('AuthService', () => {
   });
 
   describe('login', () => {
-    it('should login successfully and store tokens', async () => {
+    it('should login successfully and store access token in sessionStorage', async () => {
       const credentials: LoginRequest = {
         email: 'test@example.com',
         password: 'password123',
@@ -81,20 +96,23 @@ describe('AuthService', () => {
       const result = await authService.login(credentials);
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/login', credentials);
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'mock-token');
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      // Access token stored in sessionStorage (not localStorage)
+      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'mock-token');
+      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.ACCESS_TOKEN,
         'mock-token'
       );
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.REFRESH_TOKEN,
-        'mock-refresh-token'
-      );
+      // User stored in localStorage (persists across sessions)
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.USER,
         JSON.stringify(mockUser)
       );
-      expect(result).toEqual(mockAuthResponse);
+      // Refresh token NOT stored in localStorage (it's an httpOnly cookie)
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith(
+        'refreshToken',
+        expect.any(String)
+      );
+      expect(result).toEqual({ ...mockAuthResponse, accessToken: 'mock-token' });
     });
 
     it('should handle login failure', async () => {
@@ -107,12 +125,12 @@ describe('AuthService', () => {
       (apiService.post as jest.Mock).mockRejectedValue(error);
 
       await expect(authService.login(credentials)).rejects.toThrow('Invalid credentials');
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
+      expect(mockSessionStorage.setItem).not.toHaveBeenCalled();
     });
   });
 
   describe('register', () => {
-    it('should register successfully and store tokens', async () => {
+    it('should register successfully and store access token in sessionStorage', async () => {
       const userData: RegisterRequest = {
         email: 'test@example.com',
         password: 'password123',
@@ -125,21 +143,24 @@ describe('AuthService', () => {
       const result = await authService.register(userData);
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/register', userData);
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'mock-token');
-      expect(result).toEqual(mockAuthResponse);
+      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'mock-token');
+      // Refresh token NOT stored locally
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith('refreshToken', expect.any(String));
+      expect(result).toEqual({ ...mockAuthResponse, accessToken: 'mock-token' });
     });
   });
 
   describe('logout', () => {
-    it('should logout successfully and clear storage', async () => {
+    it('should logout successfully and clear sessionStorage tokens', async () => {
       (apiService.post as jest.Mock).mockResolvedValue({});
 
       await authService.logout();
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/logout');
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.REFRESH_TOKEN);
+      // Access tokens removed from sessionStorage
+      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
+      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      // User removed from localStorage
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
     });
 
@@ -150,9 +171,8 @@ describe('AuthService', () => {
       await authService.logout();
 
       expect(consoleSpy).toHaveBeenCalledWith('Logout API call failed:', expect.any(Error));
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.REFRESH_TOKEN);
+      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
+      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
 
       consoleSpy.mockRestore();
@@ -179,18 +199,17 @@ describe('AuthService', () => {
   });
 
   describe('isAuthenticated', () => {
-    it('should return true if token and user exist', () => {
-      mockLocalStorage.getItem
-        .mockReturnValueOnce('mock-token') // getToken call
-        .mockReturnValueOnce(JSON.stringify(mockUser)); // getCurrentUser call
+    it('should return true if access token and user exist', () => {
+      mockSessionStorage.getItem.mockReturnValueOnce('mock-token'); // getToken call
+      mockLocalStorage.getItem.mockReturnValueOnce(JSON.stringify(mockUser)); // getCurrentUser call
 
       const isAuth = authService.isAuthenticated();
 
       expect(isAuth).toBe(true);
     });
 
-    it('should return false if no token exists', () => {
-      mockLocalStorage.getItem.mockReturnValue(null);
+    it('should return false if no access token exists', () => {
+      mockSessionStorage.getItem.mockReturnValue(null);
 
       const isAuth = authService.isAuthenticated();
 
@@ -199,42 +218,67 @@ describe('AuthService', () => {
   });
 
   describe('getToken', () => {
-    it('should return auth token from localStorage', () => {
-      mockLocalStorage.getItem.mockReturnValueOnce('auth-token');
+    it('should return auth token from sessionStorage', () => {
+      mockSessionStorage.getItem.mockReturnValueOnce('auth-token');
 
       const token = authService.getToken();
 
-      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
+      expect(mockSessionStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
       expect(token).toBe('auth-token');
     });
 
-    it('should fallback to access token if auth token not found', () => {
-      mockLocalStorage.getItem.mockReturnValueOnce(null).mockReturnValueOnce('access-token');
+    it('should fallback to access token key if auth token not found', () => {
+      mockSessionStorage.getItem.mockReturnValueOnce(null).mockReturnValueOnce('access-token');
 
       const token = authService.getToken();
 
-      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      expect(mockSessionStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
+      expect(mockSessionStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
       expect(token).toBe('access-token');
     });
   });
 
   describe('setToken', () => {
-    it('should set token in localStorage', () => {
+    it('should set token in sessionStorage', () => {
       authService.setToken('new-token');
 
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'new-token');
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN, 'new-token');
+      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'new-token');
+      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN, 'new-token');
     });
   });
 
   describe('clearTokens', () => {
-    it('should clear all tokens from localStorage', () => {
+    it('should clear access tokens from sessionStorage', () => {
       authService.clearTokens();
 
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.REFRESH_TOKEN);
+      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
+      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      // Refresh token is NOT in localStorage/sessionStorage — it's an httpOnly cookie
+      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith('refreshToken');
+    });
+  });
+
+  describe('refreshToken', () => {
+    it('should refresh token via cookie (no body token needed)', async () => {
+      const refreshResponse = {
+        token: 'new-token',
+        // refreshToken not returned — it's set as httpOnly cookie by backend
+      };
+
+      (apiService.post as jest.Mock).mockResolvedValue(refreshResponse);
+
+      const newToken = await authService.refreshToken();
+
+      // Should NOT send refresh token in body — cookie is auto-sent by browser
+      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/refresh-token', {});
+      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'new-token');
+      expect(newToken).toBe('new-token');
+    });
+
+    it('should propagate error if refresh API call fails', async () => {
+      (apiService.post as jest.Mock).mockRejectedValue(new Error('Unauthorized'));
+
+      await expect(authService.refreshToken()).rejects.toThrow('Unauthorized');
     });
   });
 
@@ -269,7 +313,6 @@ describe('AuthService', () => {
         token: '123456',
       });
       expect(result).toEqual(mockResponse);
-      // Should update localStorage with twoFactorEnabled: true
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.USER,
         expect.stringContaining('"twoFactorEnabled":true')
@@ -313,32 +356,6 @@ describe('AuthService', () => {
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/2fa/backup-codes');
       expect(result).toEqual(mockResponse);
-    });
-  });
-
-  describe('refreshToken', () => {
-    it('should refresh token successfully', async () => {
-      const refreshResponse = {
-        token: 'new-token',
-        refreshToken: 'new-refresh-token',
-      };
-
-      mockLocalStorage.getItem.mockReturnValue('mock-refresh-token');
-      (apiService.post as jest.Mock).mockResolvedValue(refreshResponse);
-
-      const newToken = await authService.refreshToken();
-
-      expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/refresh-token', {
-        refreshToken: 'mock-refresh-token',
-      });
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'new-token');
-      expect(newToken).toBe('new-token');
-    });
-
-    it('should throw error if no refresh token available', async () => {
-      mockLocalStorage.getItem.mockReturnValue(null);
-
-      await expect(authService.refreshToken()).rejects.toThrow('No refresh token available');
     });
   });
 });

--- a/lib.auth/src/services/auth-service.ts
+++ b/lib.auth/src/services/auth-service.ts
@@ -34,8 +34,9 @@ const AUTH_ENDPOINTS = {
 /**
  * AuthService - Authentication and user management service
  *
- * This service handles user authentication, registration, profile management,
- * and token management using lib.api as the HTTP transport layer.
+ * Access tokens are stored in sessionStorage (cleared on tab close).
+ * Refresh tokens are stored in httpOnly cookies (managed by the backend,
+ * not accessible to JavaScript — XSS-safe).
  */
 export class AuthService {
   constructor() {
@@ -51,8 +52,8 @@ export class AuthService {
   async login(credentials: LoginRequest): Promise<AuthResponse> {
     const response = await apiService.post<AuthResponse>(AUTH_ENDPOINTS.LOGIN, credentials);
 
-    // Store tokens and user data (backend returns 'token', frontend expects 'accessToken')
-    this.setTokens(response.token, response.refreshToken);
+    // Store access token in sessionStorage; refresh token is in httpOnly cookie
+    this.setToken(response.token);
     this.setUser(response.user);
 
     return {
@@ -67,8 +68,8 @@ export class AuthService {
   async register(userData: RegisterRequest): Promise<AuthResponse> {
     const response = await apiService.post<AuthResponse>(AUTH_ENDPOINTS.REGISTER, userData);
 
-    // Store tokens and user data (backend returns 'token', frontend expects 'accessToken')
-    this.setTokens(response.token, response.refreshToken);
+    // Store access token in sessionStorage; refresh token is in httpOnly cookie
+    this.setToken(response.token);
     this.setUser(response.user);
 
     return {
@@ -84,8 +85,7 @@ export class AuthService {
     try {
       await apiService.post(AUTH_ENDPOINTS.LOGOUT);
     } catch (error) {
-      // Continue with logout even if server request fails
-      console.warn('Logout request failed, clearing local data anyway:', error);
+      console.error('Logout API call failed:', error);
     } finally {
       this.clearTokens();
       localStorage.removeItem(STORAGE_KEYS.USER);
@@ -117,20 +117,13 @@ export class AuthService {
   }
 
   /**
-   * Refresh access token using refresh token
+   * Refresh access token — refresh token is sent automatically via httpOnly cookie
    */
   async refreshToken(): Promise<string> {
-    const refreshToken = this.getRefreshToken();
-    if (!refreshToken) {
-      throw new Error('No refresh token available');
-    }
+    const response = await apiService.post<RefreshTokenResponse>(AUTH_ENDPOINTS.REFRESH, {});
 
-    const response = await apiService.post<RefreshTokenResponse>(AUTH_ENDPOINTS.REFRESH, {
-      refreshToken,
-    });
-
-    // Update stored tokens
-    this.setTokens(response.token, response.refreshToken);
+    // Update stored access token only; new refresh token cookie is set by backend
+    this.setToken(response.token);
 
     return response.token;
   }
@@ -257,54 +250,39 @@ export class AuthService {
   }
 
   /**
-   * Get stored auth token
+   * Get stored access token (from sessionStorage)
    */
   getToken(): string | null {
     return (
-      localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN) ||
-      localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)
+      sessionStorage.getItem(STORAGE_KEYS.AUTH_TOKEN) ||
+      sessionStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)
     );
   }
 
   /**
-   * Get stored refresh token
-   */
-  getRefreshToken(): string | null {
-    return localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
-  }
-
-  /**
-   * Set auth token in storage
+   * Set access token in storage
    */
   setToken(token: string): void {
-    localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, token);
-    localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token); // For backward compatibility
+    sessionStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, token);
+    sessionStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token); // For backward compatibility
   }
 
   /**
    * Clear all stored authentication data
    */
   clearTokens(): void {
-    localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
-    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
-    localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
+    sessionStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
+    sessionStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
   }
 
   // Private helper methods
-  private setTokens(token: string, refreshToken: string): void {
-    localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, token);
-    localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token); // For backward compatibility
-    localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
-  }
-
   private setUser(user: User): void {
     localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(user));
   }
 
   private clearStorage(): void {
-    localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
-    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
-    localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
+    sessionStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
+    sessionStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
     localStorage.removeItem(STORAGE_KEYS.USER);
   }
 }

--- a/lib.auth/src/types/auth.ts
+++ b/lib.auth/src/types/auth.ts
@@ -182,7 +182,7 @@ export interface RegisterRequest {
 export interface AuthResponse {
   user: User;
   token: string; // Backend returns 'token', not 'accessToken'
-  refreshToken: string;
+  refreshToken?: string; // No longer returned in body — sent as httpOnly cookie
   expiresIn: number;
   // Legacy field for frontend compatibility
   accessToken?: string;
@@ -194,12 +194,12 @@ export interface ChangePasswordRequest {
 }
 
 export interface RefreshTokenRequest {
-  refreshToken: string;
+  refreshToken?: string;
 }
 
 export interface RefreshTokenResponse {
   token: string;
-  refreshToken: string;
+  refreshToken?: string; // No longer returned in body — rotated via httpOnly cookie
 }
 
 export interface PasswordResetRequest {
@@ -238,6 +238,5 @@ export interface TokenData {
 export const STORAGE_KEYS = {
   AUTH_TOKEN: 'authToken',
   ACCESS_TOKEN: 'accessToken', // For backward compatibility
-  REFRESH_TOKEN: 'refreshToken',
   USER: 'user',
 } as const;

--- a/service.backend/src/__tests__/middleware/auth.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/auth.middleware.test.ts
@@ -77,6 +77,15 @@ vi.mock('../../models/User', () => ({
   },
 }));
 
+// Mock RevokedToken model
+vi.mock('../../models/RevokedToken', () => ({
+  __esModule: true,
+  default: {
+    findByPk: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
 // Mock Role and Permission models before they are imported
 vi.mock('../../models/Role', () => ({
   __esModule: true,
@@ -125,6 +134,7 @@ import {
   JWTPayload,
 } from '../../middleware/auth';
 import User from '../../models/User';
+import RevokedToken from '../../models/RevokedToken';
 import { AuthenticatedRequest } from '../../types/auth';
 import { logger, loggerHelpers } from '../../utils/logger';
 import { env } from '../../config/env';
@@ -157,6 +167,9 @@ describe('Authentication Middleware', () => {
 
     // Clear all mocks
     vi.clearAllMocks();
+
+    // Default: token is not revoked
+    (RevokedToken.findByPk as vi.Mock).mockResolvedValue(null);
   });
 
   describe('authenticateToken - Required authentication', () => {
@@ -262,6 +275,62 @@ describe('Authentication Middleware', () => {
         expect(mockResponse.json).toHaveBeenCalledWith({
           error: 'Invalid token',
         });
+      });
+    });
+
+    describe('when token has been revoked', () => {
+      it('should reject a blacklisted access token and return 401', async () => {
+        const payload: JWTPayload = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          jti: 'revoked-jti-abc',
+        };
+
+        mockRequest.headers = { authorization: 'Bearer revoked-token' };
+        (jwt.verify as vi.Mock).mockReturnValue(payload);
+        (RevokedToken.findByPk as vi.Mock).mockResolvedValue({ jti: 'revoked-jti-abc' });
+
+        await authenticateToken(
+          mockRequest as AuthenticatedRequest,
+          mockResponse as Response,
+          mockNext
+        );
+
+        expect(mockResponse.status).toHaveBeenCalledWith(401);
+        expect(mockResponse.json).toHaveBeenCalledWith({ error: 'Token has been revoked' });
+        expect(mockNext).not.toHaveBeenCalled();
+        expect(loggerHelpers.logSecurity).toHaveBeenCalledWith(
+          'Authentication failed - token has been revoked',
+          expect.objectContaining({ userId: 'user-123', jti: 'revoked-jti-abc' }),
+          mockRequest
+        );
+      });
+
+      it('should allow tokens without jti to bypass revocation check', async () => {
+        const payload: JWTPayload = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          // no jti
+        };
+        const mockUser = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          status: 'active',
+          Roles: [],
+        };
+
+        mockRequest.headers = { authorization: 'Bearer legacy-token' };
+        (jwt.verify as vi.Mock).mockReturnValue(payload);
+        (User.findByPk as vi.Mock).mockResolvedValue(mockUser);
+
+        await authenticateToken(
+          mockRequest as AuthenticatedRequest,
+          mockResponse as Response,
+          mockNext
+        );
+
+        expect(RevokedToken.findByPk).not.toHaveBeenCalled();
+        expect(mockNext).toHaveBeenCalled();
       });
     });
 

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -18,6 +18,7 @@ import { AuditLog } from '../../models/AuditLog';
 import { AuditLogService } from '../../services/auditLog.service';
 import User, { UserStatus, UserType } from '../../models/User';
 import RefreshToken from '../../models/RefreshToken';
+import RevokedToken from '../../models/RevokedToken';
 import { AuthService } from '../../services/auth.service';
 import { LoginCredentials, RegisterData } from '../../types';
 
@@ -25,6 +26,7 @@ import { LoginCredentials, RegisterData } from '../../types';
 vi.mock('../../models/User');
 vi.mock('../../models/AuditLog');
 vi.mock('../../models/RefreshToken');
+vi.mock('../../models/RevokedToken');
 vi.mock('../../services/auditLog.service');
 vi.mock('../../utils/logger');
 vi.mock('jsonwebtoken');
@@ -35,6 +37,7 @@ vi.mock('crypto');
 const MockedUser = User as Mock<typeof User>;
 const MockedAuditLog = AuditLog as Mock<typeof AuditLog>;
 const MockedRefreshToken = RefreshToken as Mock<typeof RefreshToken>;
+const MockedRevokedToken = RevokedToken as Mock<typeof RevokedToken>;
 const MockedAuditLogService = AuditLogService as unknown as {
   log: Mock;
 };
@@ -80,6 +83,9 @@ describe('AuthService', () => {
     // Default RefreshToken mock – individual tests override as needed
     MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(null);
     MockedRefreshToken.update = vi.fn().mockResolvedValue([0]);
+
+    // Default RevokedToken mock
+    MockedRevokedToken.create = vi.fn().mockResolvedValue(undefined);
   });
 
   afterAll(() => {
@@ -785,20 +791,66 @@ describe('AuthService', () => {
   });
 
   describe('logout', () => {
-    it('should handle logout without refresh token', async () => {
+    it('should handle logout without any tokens', async () => {
       await expect(AuthService.logout()).resolves.not.toThrow();
     });
 
-    it('should handle logout with a valid refresh token', async () => {
+    it('should revoke refresh token on logout', async () => {
       mockedJwt.verify = vi.fn().mockReturnValue({ jti: 'some-token-id' });
-      await expect(AuthService.logout('some.valid.refresh.jwt')).resolves.not.toThrow();
+      await AuthService.logout('some.valid.refresh.jwt');
+      expect(MockedRefreshToken.update).toHaveBeenCalledWith(
+        { is_revoked: true },
+        { where: { token_id: 'some-token-id' } }
+      );
     });
 
-    it('should not throw when logout is called with an expired or malformed token', async () => {
+    it('should blacklist access token on logout', async () => {
+      const accessTokenPayload = {
+        jti: 'access-jti-123',
+        userId: 'user-123',
+        exp: Math.floor(Date.now() / 1000) + 900,
+      };
+      mockedJwt.verify = vi.fn().mockReturnValue({ jti: 'some-token-id' });
+      (jwt.decode as unknown as Mock) = vi.fn().mockReturnValue(accessTokenPayload);
+
+      await AuthService.logout('valid.refresh.jwt', 'valid.access.jwt');
+
+      expect(MockedRevokedToken.create).toHaveBeenCalledWith({
+        jti: 'access-jti-123',
+        user_id: 'user-123',
+        expires_at: expect.any(Date),
+      });
+    });
+
+    it('should blacklist access token even when no refresh token is provided', async () => {
+      const accessTokenPayload = {
+        jti: 'access-jti-456',
+        userId: 'user-456',
+        exp: Math.floor(Date.now() / 1000) + 900,
+      };
+      (jwt.decode as unknown as Mock) = vi.fn().mockReturnValue(accessTokenPayload);
+
+      await AuthService.logout(undefined, 'valid.access.jwt');
+
+      expect(MockedRevokedToken.create).toHaveBeenCalledWith({
+        jti: 'access-jti-456',
+        user_id: 'user-456',
+        expires_at: expect.any(Date),
+      });
+      expect(MockedRefreshToken.update).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when logout is called with an expired or malformed refresh token', async () => {
       mockedJwt.verify = vi.fn().mockImplementation(() => {
         throw new Error('jwt expired');
       });
       await expect(AuthService.logout('expired.token')).resolves.not.toThrow();
+    });
+
+    it('should not throw when access token decoding fails', async () => {
+      (jwt.decode as unknown as Mock) = vi.fn().mockReturnValue(null);
+      await expect(AuthService.logout(undefined, 'malformed.token')).resolves.not.toThrow();
+      expect(MockedRevokedToken.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/service.backend/src/__tests__/services/chat.service.test.ts
+++ b/service.backend/src/__tests__/services/chat.service.test.ts
@@ -1,4 +1,37 @@
 import { vi } from 'vitest';
+
+// Mock content moderation service
+vi.mock('../../services/content-moderation.service', () => ({
+  ContentModerationService: {
+    scanContent: vi.fn(),
+    isMessageBlocked: vi.fn(),
+    shouldAutoReport: vi.fn(),
+  },
+  ScanSeverity: {
+    LOW: 'low',
+    MEDIUM: 'medium',
+    HIGH: 'high',
+    CRITICAL: 'critical',
+  },
+}));
+
+// Mock moderation service (singleton)
+vi.mock('../../services/moderation.service', () => ({
+  default: {
+    submitReport: vi.fn(),
+    getFlaggedMessages: vi.fn(),
+  },
+  ReportCategory: {
+    INAPPROPRIATE_CONTENT: 'inappropriate_content',
+  },
+  ReportSeverity: {
+    LOW: 'low',
+    MEDIUM: 'medium',
+    HIGH: 'high',
+    CRITICAL: 'critical',
+  },
+}));
+
 // Mock models at the models/index level
 vi.mock('../../models', () => ({
   Chat: {
@@ -88,6 +121,8 @@ import { ChatService } from '../../services/chat.service';
 import { ChatStatus, ParticipantRole, MessageContentFormat } from '../../types/chat';
 import { AuditLogService } from '../../services/auditLog.service';
 import { NotificationService } from '../../services/notification.service';
+import { ContentModerationService } from '../../services/content-moderation.service';
+import moderationService from '../../services/moderation.service';
 
 const MockedChat = Chat as vi.MockedObject<Chat>;
 const MockedChatParticipant = ChatParticipant as vi.MockedObject<ChatParticipant>;
@@ -101,6 +136,16 @@ const mockCreateNotification = NotificationService.createNotification as vi.Mock
 describe('ChatService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: content passes moderation
+    (ContentModerationService.scanContent as vi.Mock).mockReturnValue({
+      isFlagged: false,
+      severity: null,
+      reason: null,
+      matchedCategories: [],
+    });
+    (ContentModerationService.isMessageBlocked as vi.Mock).mockReturnValue(false);
+    (ContentModerationService.shouldAutoReport as vi.Mock).mockReturnValue(false);
+    (moderationService.submitReport as vi.Mock).mockResolvedValue({});
   });
 
   describe('Creating chats', () => {
@@ -1093,6 +1138,146 @@ describe('ChatService', () => {
             }),
           })
         );
+      });
+    });
+  });
+
+  describe('Content moderation on send', () => {
+    const chatId = 'chat-123';
+    const senderId = 'user-456';
+
+    const setupSendMessageMocks = () => {
+      (MockedChat.findByPk as vi.Mock).mockResolvedValue({
+        chat_id: chatId,
+        Participants: [{ participant_id: senderId }],
+      });
+      (MockedMessage.count as vi.Mock).mockResolvedValue(0);
+      const mockMessage = {
+        message_id: 'msg-001',
+        chat_id: chatId,
+        sender_id: senderId,
+        content: 'some content',
+        created_at: new Date(),
+        updated_at: new Date(),
+        Sender: { userId: senderId, firstName: 'John', lastName: 'Doe' },
+      };
+      (MockedMessage.create as vi.Mock).mockResolvedValue(mockMessage);
+      (MockedMessage.findByPk as vi.Mock).mockResolvedValue(mockMessage);
+      (MockedChat.update as vi.Mock).mockResolvedValue([1]);
+      (MockedChatParticipant.findAll as vi.Mock).mockResolvedValue([]);
+    };
+
+    describe('when a message passes content moderation', () => {
+      it('should save the message without moderation flags', async () => {
+        setupSendMessageMocks();
+        (ContentModerationService.scanContent as vi.Mock).mockReturnValue({
+          isFlagged: false,
+          severity: null,
+          reason: null,
+          matchedCategories: [],
+        });
+        (ContentModerationService.isMessageBlocked as vi.Mock).mockReturnValue(false);
+        (ContentModerationService.shouldAutoReport as vi.Mock).mockReturnValue(false);
+
+        await ChatService.sendMessage({ chatId, senderId, content: 'Hello there!' });
+
+        expect(MockedMessage.create).toHaveBeenCalledWith(
+          expect.not.objectContaining({ is_flagged: true }),
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('when a message contains CRITICAL content (e.g. animal trafficking)', () => {
+      it('should block the message and not save it', async () => {
+        setupSendMessageMocks();
+        (ContentModerationService.scanContent as vi.Mock).mockReturnValue({
+          isFlagged: true,
+          severity: 'critical',
+          reason: 'animal_trafficking_or_abuse',
+          matchedCategories: ['animal_trafficking_or_abuse'],
+        });
+        (ContentModerationService.isMessageBlocked as vi.Mock).mockReturnValue(true);
+
+        await expect(
+          ChatService.sendMessage({
+            chatId,
+            senderId,
+            content: 'Selling puppies for $500 via wire transfer',
+          })
+        ).rejects.toThrow('Message blocked: content violates platform policy');
+
+        expect(MockedMessage.create).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when a message contains HIGH severity content (e.g. payment request)', () => {
+      it('should save the message with moderation flags and auto-create a report', async () => {
+        setupSendMessageMocks();
+        (ContentModerationService.scanContent as vi.Mock).mockReturnValue({
+          isFlagged: true,
+          severity: 'high',
+          reason: 'financial_fraud_or_threats',
+          matchedCategories: ['financial_fraud_or_threats'],
+        });
+        (ContentModerationService.isMessageBlocked as vi.Mock).mockReturnValue(false);
+        (ContentModerationService.shouldAutoReport as vi.Mock).mockReturnValue(true);
+
+        await ChatService.sendMessage({
+          chatId,
+          senderId,
+          content: 'Please send me $200 via bitcoin',
+        });
+
+        expect(MockedMessage.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            is_flagged: true,
+            flag_severity: 'high',
+            flag_reason: 'financial_fraud_or_threats',
+            moderation_status: 'pending_review',
+          }),
+          expect.any(Object)
+        );
+
+        expect(moderationService.submitReport).toHaveBeenCalledWith(
+          'system',
+          expect.objectContaining({
+            reportedEntityType: 'message',
+            reportedUserId: senderId,
+            severity: 'high',
+          })
+        );
+      });
+    });
+
+    describe('when a message contains LOW severity content (e.g. phone number)', () => {
+      it('should save the message with moderation flags but not auto-report', async () => {
+        setupSendMessageMocks();
+        (ContentModerationService.scanContent as vi.Mock).mockReturnValue({
+          isFlagged: true,
+          severity: 'low',
+          reason: 'off_platform_contact',
+          matchedCategories: ['off_platform_contact'],
+        });
+        (ContentModerationService.isMessageBlocked as vi.Mock).mockReturnValue(false);
+        (ContentModerationService.shouldAutoReport as vi.Mock).mockReturnValue(false);
+
+        await ChatService.sendMessage({
+          chatId,
+          senderId,
+          content: 'Call me at 555-123-4567',
+        });
+
+        expect(MockedMessage.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            is_flagged: true,
+            flag_severity: 'low',
+            moderation_status: 'pending_review',
+          }),
+          expect.any(Object)
+        );
+
+        expect(moderationService.submitReport).not.toHaveBeenCalled();
       });
     });
   });

--- a/service.backend/src/__tests__/services/chat.service.test.ts
+++ b/service.backend/src/__tests__/services/chat.service.test.ts
@@ -13,6 +13,11 @@ vi.mock('../../services/content-moderation.service', () => ({
     HIGH: 'high',
     CRITICAL: 'critical',
   },
+  MessageModerationStatus: {
+    PENDING_REVIEW: 'pending_review',
+    APPROVED: 'approved',
+    REJECTED: 'rejected',
+  },
 }));
 
 // Mock moderation service (singleton)

--- a/service.backend/src/__tests__/services/content-moderation.service.test.ts
+++ b/service.backend/src/__tests__/services/content-moderation.service.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ContentModerationService,
+  ScanSeverity,
+} from '../../services/content-moderation.service';
+
+describe('ContentModerationService', () => {
+  describe('scanContent', () => {
+    describe('when content is clean', () => {
+      it('should return not flagged for normal adoption enquiry messages', () => {
+        const result = ContentModerationService.scanContent(
+          'Hello, I am interested in adopting Max. Can we arrange a meet?'
+        );
+
+        expect(result.isFlagged).toBe(false);
+        expect(result.severity).toBeNull();
+        expect(result.reason).toBeNull();
+      });
+
+      it('should not flag adoption-related pet discussions', () => {
+        const result = ContentModerationService.scanContent(
+          'We are happy to arrange a home visit before the adoption is finalised.'
+        );
+
+        expect(result.isFlagged).toBe(false);
+      });
+    });
+
+    describe('CRITICAL severity — animal trafficking and abuse', () => {
+      it('should flag selling a pet for money', () => {
+        const result = ContentModerationService.scanContent(
+          'I am selling a puppy for $500'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.CRITICAL);
+        expect(result.reason).toBe('animal_trafficking_or_abuse');
+      });
+
+      it('should flag wire transfer requests involving animals', () => {
+        const result = ContentModerationService.scanContent(
+          'Please wire transfer the money for the dog'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.CRITICAL);
+      });
+
+      it('should flag Western Union mentions', () => {
+        const result = ContentModerationService.scanContent(
+          'Send payment via Western Union'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.CRITICAL);
+      });
+
+      it('should flag animal abuse mentions', () => {
+        const result = ContentModerationService.scanContent(
+          'animal cruelty is being reported here'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.CRITICAL);
+      });
+    });
+
+    describe('HIGH severity — financial fraud and threats', () => {
+      it('should flag requests to send money', () => {
+        const result = ContentModerationService.scanContent(
+          'Please send me $200 to cover the shipping costs'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.HIGH);
+        expect(result.reason).toBe('financial_fraud_or_threats');
+      });
+
+      it('should flag bitcoin payment requests', () => {
+        const result = ContentModerationService.scanContent(
+          'Pay using bitcoin and I will send the pet'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.HIGH);
+      });
+
+      it('should flag advance fee mentions', () => {
+        const result = ContentModerationService.scanContent(
+          'I need an advance fee payment before delivery'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.HIGH);
+      });
+
+      it('should flag threats of physical harm', () => {
+        const result = ContentModerationService.scanContent(
+          "I'll hurt you if you don't comply"
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.HIGH);
+      });
+
+      it('should flag requests for bank account details', () => {
+        const result = ContentModerationService.scanContent(
+          'Please share your bank account number for the refund'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.HIGH);
+      });
+    });
+
+    describe('MEDIUM severity — spam and harassment', () => {
+      it('should flag harassment language', () => {
+        const result = ContentModerationService.scanContent(
+          'You are a complete idiot for not accepting my application'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.MEDIUM);
+        expect(result.reason).toBe('spam_or_harassment');
+      });
+
+      it('should flag scammer accusations', () => {
+        const result = ContentModerationService.scanContent(
+          'You are a scammer, I know it'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.MEDIUM);
+      });
+
+      it('should flag external links', () => {
+        const result = ContentModerationService.scanContent(
+          'Check out http://externalsite.com for more info'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.MEDIUM);
+      });
+    });
+
+    describe('LOW severity — off-platform contact attempts', () => {
+      it('should flag phone number sharing', () => {
+        const result = ContentModerationService.scanContent(
+          'Call me at 555-123-4567 anytime'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.LOW);
+        expect(result.reason).toBe('off_platform_contact');
+      });
+
+      it('should flag email sharing', () => {
+        const result = ContentModerationService.scanContent(
+          'My email is john@example.com, please contact me at'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.LOW);
+      });
+
+      it('should flag WhatsApp contact attempts', () => {
+        const result = ContentModerationService.scanContent(
+          'Message me on WhatsApp me for details'
+        );
+
+        expect(result.isFlagged).toBe(true);
+        expect(result.severity).toBe(ScanSeverity.LOW);
+      });
+    });
+
+    describe('severity ordering — highest severity wins', () => {
+      it('should return CRITICAL even when lower-severity patterns also match', () => {
+        const result = ContentModerationService.scanContent(
+          'Send $200 via Western Union for the puppy'
+        );
+
+        expect(result.severity).toBe(ScanSeverity.CRITICAL);
+      });
+    });
+  });
+
+  describe('isMessageBlocked', () => {
+    it('should return true only for CRITICAL severity', () => {
+      expect(
+        ContentModerationService.isMessageBlocked({
+          isFlagged: true,
+          severity: ScanSeverity.CRITICAL,
+          reason: 'animal_trafficking_or_abuse',
+          matchedCategories: ['animal_trafficking_or_abuse'],
+        })
+      ).toBe(true);
+    });
+
+    it('should return false for HIGH severity', () => {
+      expect(
+        ContentModerationService.isMessageBlocked({
+          isFlagged: true,
+          severity: ScanSeverity.HIGH,
+          reason: 'financial_fraud_or_threats',
+          matchedCategories: ['financial_fraud_or_threats'],
+        })
+      ).toBe(false);
+    });
+
+    it('should return false for clean messages', () => {
+      expect(
+        ContentModerationService.isMessageBlocked({
+          isFlagged: false,
+          severity: null,
+          reason: null,
+          matchedCategories: [],
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('shouldAutoReport', () => {
+    it('should return true for CRITICAL violations', () => {
+      expect(
+        ContentModerationService.shouldAutoReport({
+          isFlagged: true,
+          severity: ScanSeverity.CRITICAL,
+          reason: 'animal_trafficking_or_abuse',
+          matchedCategories: [],
+        })
+      ).toBe(true);
+    });
+
+    it('should return true for HIGH violations', () => {
+      expect(
+        ContentModerationService.shouldAutoReport({
+          isFlagged: true,
+          severity: ScanSeverity.HIGH,
+          reason: 'financial_fraud_or_threats',
+          matchedCategories: [],
+        })
+      ).toBe(true);
+    });
+
+    it('should return false for MEDIUM violations', () => {
+      expect(
+        ContentModerationService.shouldAutoReport({
+          isFlagged: true,
+          severity: ScanSeverity.MEDIUM,
+          reason: 'spam_or_harassment',
+          matchedCategories: [],
+        })
+      ).toBe(false);
+    });
+
+    it('should return false for LOW violations', () => {
+      expect(
+        ContentModerationService.shouldAutoReport({
+          isFlagged: true,
+          severity: ScanSeverity.LOW,
+          reason: 'off_platform_contact',
+          matchedCategories: [],
+        })
+      ).toBe(false);
+    });
+
+    it('should return false for clean messages', () => {
+      expect(
+        ContentModerationService.shouldAutoReport({
+          isFlagged: false,
+          severity: null,
+          reason: null,
+          matchedCategories: [],
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/__tests__/services/content-moderation.service.test.ts
+++ b/service.backend/src/__tests__/services/content-moderation.service.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  ContentModerationService,
-  ScanSeverity,
-} from '../../services/content-moderation.service';
+import { ContentModerationService, ScanSeverity } from '../../services/content-moderation.service';
 
 describe('ContentModerationService', () => {
   describe('scanContent', () => {
@@ -28,9 +25,7 @@ describe('ContentModerationService', () => {
 
     describe('CRITICAL severity — animal trafficking and abuse', () => {
       it('should flag selling a pet for money', () => {
-        const result = ContentModerationService.scanContent(
-          'I am selling a puppy for $500'
-        );
+        const result = ContentModerationService.scanContent('I am selling a puppy for $500');
 
         expect(result.isFlagged).toBe(true);
         expect(result.severity).toBe(ScanSeverity.CRITICAL);
@@ -47,9 +42,7 @@ describe('ContentModerationService', () => {
       });
 
       it('should flag Western Union mentions', () => {
-        const result = ContentModerationService.scanContent(
-          'Send payment via Western Union'
-        );
+        const result = ContentModerationService.scanContent('Send payment via Western Union');
 
         expect(result.isFlagged).toBe(true);
         expect(result.severity).toBe(ScanSeverity.CRITICAL);
@@ -95,9 +88,7 @@ describe('ContentModerationService', () => {
       });
 
       it('should flag threats of physical harm', () => {
-        const result = ContentModerationService.scanContent(
-          "I'll hurt you if you don't comply"
-        );
+        const result = ContentModerationService.scanContent("I'll hurt you if you don't comply");
 
         expect(result.isFlagged).toBe(true);
         expect(result.severity).toBe(ScanSeverity.HIGH);
@@ -125,9 +116,7 @@ describe('ContentModerationService', () => {
       });
 
       it('should flag scammer accusations', () => {
-        const result = ContentModerationService.scanContent(
-          'You are a scammer, I know it'
-        );
+        const result = ContentModerationService.scanContent('You are a scammer, I know it');
 
         expect(result.isFlagged).toBe(true);
         expect(result.severity).toBe(ScanSeverity.MEDIUM);
@@ -145,9 +134,7 @@ describe('ContentModerationService', () => {
 
     describe('LOW severity — off-platform contact attempts', () => {
       it('should flag phone number sharing', () => {
-        const result = ContentModerationService.scanContent(
-          'Call me at 555-123-4567 anytime'
-        );
+        const result = ContentModerationService.scanContent('Call me at 555-123-4567 anytime');
 
         expect(result.isFlagged).toBe(true);
         expect(result.severity).toBe(ScanSeverity.LOW);

--- a/service.backend/src/controllers/auth.controller.ts
+++ b/service.backend/src/controllers/auth.controller.ts
@@ -6,6 +6,14 @@ import User from '../models/User';
 import { AuthenticatedRequest } from '../types';
 import { logger } from '../utils/logger';
 
+const REFRESH_TOKEN_COOKIE = 'refreshToken';
+const REFRESH_TOKEN_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict' as const,
+  maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+};
+
 // Validation rules
 export const authValidation = {
   register: [
@@ -121,7 +129,11 @@ export class AuthController {
   async register(req: Request, res: Response): Promise<void> {
     try {
       const result = await AuthService.register(req.body);
-      res.status(201).json(result);
+
+      res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
+
+      const { refreshToken: _, ...responseBody } = result;
+      res.status(201).json(responseBody);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Registration failed:', error);
@@ -141,7 +153,11 @@ export class AuthController {
   async login(req: Request, res: Response): Promise<void> {
     try {
       const result = await AuthService.login(req.body);
-      res.json(result);
+
+      res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
+
+      const { refreshToken: _, ...responseBody } = result;
+      res.json(responseBody);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Login failed:', error);
@@ -164,11 +180,19 @@ export class AuthController {
    */
   async logout(req: AuthenticatedRequest, res: Response): Promise<void> {
     try {
-      const refreshToken = req.body.refreshToken;
-      const result = await AuthService.logout(refreshToken);
-      res.json(result);
+      const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE] ?? req.body.refreshToken;
+      const accessToken = req.headers.authorization?.split(' ')[1];
+
+      await AuthService.logout(refreshToken, accessToken);
+
+      res.clearCookie(REFRESH_TOKEN_COOKIE, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+      });
+
+      res.json({ message: 'Logged out successfully' });
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Logout failed:', error);
       res.status(500).json({ error: 'Logout failed' });
     }
@@ -179,7 +203,7 @@ export class AuthController {
    */
   async refreshToken(req: Request, res: Response): Promise<void> {
     try {
-      const { refreshToken } = req.body;
+      const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE] ?? req.body.refreshToken;
 
       if (!refreshToken) {
         res.status(400).json({ error: 'Refresh token required' });
@@ -187,9 +211,12 @@ export class AuthController {
       }
 
       const result = await AuthService.refreshToken(refreshToken);
-      res.json(result);
+
+      res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
+
+      const { refreshToken: _, ...responseBody } = result;
+      res.json(responseBody);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Token refresh failed:', error);
       res.status(401).json({ error: 'Invalid refresh token' });
     }

--- a/service.backend/src/controllers/moderation.controller.ts
+++ b/service.backend/src/controllers/moderation.controller.ts
@@ -313,6 +313,32 @@ export class ModerationController {
       });
     }
   }
+
+  async getFlaggedMessages(req: AuthenticatedRequest, res: Response): Promise<void> {
+    try {
+      const page = req.query.page ? parseInt(String(req.query.page), 10) : 1;
+      const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : 20;
+      const severity = req.query.severity ? String(req.query.severity) : undefined;
+      const moderationStatus = req.query.moderationStatus
+        ? String(req.query.moderationStatus)
+        : undefined;
+
+      const result = await ModerationService.getFlaggedMessages({
+        page,
+        limit,
+        severity,
+        moderationStatus,
+      });
+
+      res.json({ success: true, data: result });
+    } catch (error) {
+      logger.error('Error fetching flagged messages:', error);
+      res.status(500).json({
+        success: false,
+        message: error instanceof Error ? error.message : 'Failed to fetch flagged messages',
+      });
+    }
+  }
 }
 
 export default new ModerationController();

--- a/service.backend/src/middleware/auth.ts
+++ b/service.backend/src/middleware/auth.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import User from '../models/User';
 import Role from '../models/Role';
 import Permission from '../models/Permission';
+import RevokedToken from '../models/RevokedToken';
 import { AuthenticatedRequest } from '../types/auth';
 import { logger, loggerHelpers } from '../utils/logger';
 import { env } from '../config/env';
@@ -11,6 +12,7 @@ export interface JWTPayload {
   userId: string;
   email: string;
   userType?: string;
+  jti?: string;
   iat?: number;
   exp?: number;
 }
@@ -39,6 +41,25 @@ export const authenticateToken = async (
     }
 
     const decoded = jwt.verify(token, env.JWT_SECRET) as JWTPayload;
+
+    // Check if access token has been revoked (e.g. post-logout blacklist)
+    if (decoded.jti) {
+      const revoked = await RevokedToken.findByPk(decoded.jti);
+      if (revoked) {
+        loggerHelpers.logSecurity(
+          'Authentication failed - token has been revoked',
+          {
+            userId: decoded.userId,
+            jti: decoded.jti,
+            ip: req.ip,
+            userAgent: req.get('User-Agent'),
+          },
+          req
+        );
+        res.status(401).json({ error: 'Token has been revoked' });
+        return;
+      }
+    }
 
     // Fetch user from database to ensure they still exist and are active
     const user = await User.findByPk(decoded.userId, {

--- a/service.backend/src/migrations/35-create-revoked-tokens.ts
+++ b/service.backend/src/migrations/35-create-revoked-tokens.ts
@@ -1,0 +1,34 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.createTable('revoked_tokens', {
+    jti: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+    },
+    user_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    expires_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    revoked_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  });
+
+  await queryInterface.addIndex('revoked_tokens', ['expires_at'], {
+    name: 'revoked_tokens_expires_at_idx',
+  });
+  await queryInterface.addIndex('revoked_tokens', ['user_id'], {
+    name: 'revoked_tokens_user_id_idx',
+  });
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.dropTable('revoked_tokens');
+}

--- a/service.backend/src/migrations/36-add-message-moderation-fields.ts
+++ b/service.backend/src/migrations/36-add-message-moderation-fields.ts
@@ -1,0 +1,55 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.addColumn('messages', 'is_flagged', {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  });
+
+  await queryInterface.addColumn('messages', 'flag_reason', {
+    type: DataTypes.STRING,
+    allowNull: true,
+  });
+
+  await queryInterface.addColumn('messages', 'flag_severity', {
+    type: DataTypes.ENUM('low', 'medium', 'high', 'critical'),
+    allowNull: true,
+  });
+
+  await queryInterface.addColumn('messages', 'moderation_status', {
+    type: DataTypes.ENUM('pending_review', 'approved', 'rejected'),
+    allowNull: true,
+  });
+
+  await queryInterface.addColumn('messages', 'flagged_at', {
+    type: DataTypes.DATE,
+    allowNull: true,
+  });
+
+  await queryInterface.addIndex('messages', ['is_flagged'], {
+    name: 'messages_is_flagged_idx',
+  });
+  await queryInterface.addIndex('messages', ['flag_severity'], {
+    name: 'messages_flag_severity_idx',
+  });
+  await queryInterface.addIndex('messages', ['moderation_status'], {
+    name: 'messages_moderation_status_idx',
+  });
+  await queryInterface.addIndex('messages', ['is_flagged', 'moderation_status'], {
+    name: 'messages_flagged_queue_idx',
+  });
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.removeIndex('messages', 'messages_flagged_queue_idx');
+  await queryInterface.removeIndex('messages', 'messages_moderation_status_idx');
+  await queryInterface.removeIndex('messages', 'messages_flag_severity_idx');
+  await queryInterface.removeIndex('messages', 'messages_is_flagged_idx');
+
+  await queryInterface.removeColumn('messages', 'flagged_at');
+  await queryInterface.removeColumn('messages', 'moderation_status');
+  await queryInterface.removeColumn('messages', 'flag_severity');
+  await queryInterface.removeColumn('messages', 'flag_reason');
+  await queryInterface.removeColumn('messages', 'is_flagged');
+}

--- a/service.backend/src/models/Message.ts
+++ b/service.backend/src/models/Message.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Op, Optional, QueryTypes } from 'sequelize';
 import sequelize, { getJsonType } from '../sequelize';
 import { MessageContentFormat } from '../types/chat';
+import { ScanSeverity, MessageModerationStatus } from '../services/content-moderation.service';
 import Chat from './Chat';
 import { generateReadableId, getReadableIdSqlLiteral } from '../utils/readable-id';
 
@@ -34,6 +35,12 @@ interface MessageAttributes {
   reactions?: MessageReaction[];
   read_status?: MessageReadStatus[];
   search_vector?: unknown; // tsvector type for full-text search
+  // Content moderation fields
+  is_flagged?: boolean;
+  flag_reason?: string | null;
+  flag_severity?: ScanSeverity | null;
+  moderation_status?: MessageModerationStatus | null;
+  flagged_at?: Date | null;
   created_at?: Date;
   updated_at?: Date;
   Chat?: Chat;
@@ -50,6 +57,11 @@ interface MessageCreationAttributes
     | 'Chat'
     | 'reactions'
     | 'read_status'
+    | 'is_flagged'
+    | 'flag_reason'
+    | 'flag_severity'
+    | 'moderation_status'
+    | 'flagged_at'
   > {}
 
 export class Message
@@ -65,6 +77,11 @@ export class Message
   public reactions?: MessageReaction[];
   public read_status?: MessageReadStatus[];
   public search_vector?: unknown;
+  public is_flagged?: boolean;
+  public flag_reason?: string | null;
+  public flag_severity?: ScanSeverity | null;
+  public moderation_status?: MessageModerationStatus | null;
+  public flagged_at?: Date | null;
   public readonly created_at!: Date;
   public readonly updated_at!: Date;
   public length!: number;
@@ -262,6 +279,27 @@ Message.init(
     },
     search_vector: {
       type: DataTypes.TSVECTOR,
+      allowNull: true,
+    },
+    is_flagged: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    flag_reason: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    flag_severity: {
+      type: DataTypes.ENUM(...Object.values(ScanSeverity)),
+      allowNull: true,
+    },
+    moderation_status: {
+      type: DataTypes.ENUM(...Object.values(MessageModerationStatus)),
+      allowNull: true,
+    },
+    flagged_at: {
+      type: DataTypes.DATE,
       allowNull: true,
     },
   },

--- a/service.backend/src/models/RevokedToken.ts
+++ b/service.backend/src/models/RevokedToken.ts
@@ -1,0 +1,55 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize from '../sequelize';
+
+type RevokedTokenAttributes = {
+  jti: string;
+  user_id: string;
+  expires_at: Date;
+  revoked_at: Date;
+};
+
+type RevokedTokenCreationAttributes = Optional<RevokedTokenAttributes, 'revoked_at'>;
+
+class RevokedToken
+  extends Model<RevokedTokenAttributes, RevokedTokenCreationAttributes>
+  implements RevokedTokenAttributes
+{
+  public jti!: string;
+  public user_id!: string;
+  public expires_at!: Date;
+  public revoked_at!: Date;
+}
+
+RevokedToken.init(
+  {
+    jti: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+    },
+    user_id: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    expires_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    revoked_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'revoked_tokens',
+    modelName: 'RevokedToken',
+    timestamps: false,
+    indexes: [
+      { fields: ['expires_at'], name: 'revoked_tokens_expires_at_idx' },
+      { fields: ['user_id'], name: 'revoked_tokens_user_id_idx' },
+    ],
+  }
+);
+
+export default RevokedToken;

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -19,6 +19,7 @@ import Notification from './Notification';
 // Auth & Permissions Models
 import Permission from './Permission';
 import RefreshToken from './RefreshToken';
+import RevokedToken from './RevokedToken';
 import Role from './Role';
 import RolePermission from './RolePermission';
 import UserRole from './UserRole';
@@ -68,6 +69,7 @@ const models = {
   Notification,
   DeviceToken,
   RefreshToken,
+  RevokedToken,
   Role,
   Permission,
   RolePermission,
@@ -342,6 +344,7 @@ export {
   ChatParticipant,
   DeviceToken,
   RefreshToken,
+  RevokedToken,
   EmailPreference,
   EmailQueue,
   EmailTemplate,

--- a/service.backend/src/routes/field-permissions.routes.ts
+++ b/service.backend/src/routes/field-permissions.routes.ts
@@ -60,7 +60,9 @@ const validateBulkFieldName = (
   { req, path }: { req: { body?: unknown }; path?: string }
 ): true => {
   const match = /overrides\[(\d+)\]/.exec(path ?? '');
-  if (!match) return true;
+  if (!match) {
+    return true;
+  }
   const index = parseInt(match[1], 10);
   const overridesArr = (req.body as { overrides?: Array<{ resource?: string }> })?.overrides;
   const resource = overridesArr?.[index]?.resource;

--- a/service.backend/src/routes/moderation.routes.ts
+++ b/service.backend/src/routes/moderation.routes.ts
@@ -406,4 +406,44 @@ router.get(
   moderationController.getModerationMetrics.bind(moderationController)
 );
 
+/**
+ * @swagger
+ * /api/v1/admin/moderation/flagged-messages:
+ *   get:
+ *     tags: [Moderation]
+ *     summary: Get flagged messages pending review
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: severity
+ *         schema:
+ *           type: string
+ *           enum: [low, medium, high, critical]
+ *         description: Filter by flag severity
+ *       - in: query
+ *         name: moderationStatus
+ *         schema:
+ *           type: string
+ *           enum: [pending_review, approved, rejected]
+ *         description: Filter by moderation status
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Flagged messages retrieved successfully
+ */
+router.get(
+  '/flagged-messages',
+  requirePermission(PERMISSIONS.MODERATION_REPORTS_READ),
+  generalLimiter,
+  moderationController.getFlaggedMessages.bind(moderationController)
+);
+
 export default router;

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -6,6 +6,7 @@ import speakeasy from 'speakeasy';
 import qrcode from 'qrcode';
 import User, { UserStatus, UserType } from '../models/User';
 import RefreshToken from '../models/RefreshToken';
+import RevokedToken from '../models/RevokedToken';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
 import { env } from '../config/env';
@@ -568,7 +569,27 @@ Need help? Contact us at support@adoptdontshop.com
     }
   }
 
-  static async logout(refreshToken?: string): Promise<void> {
+  static async logout(refreshToken?: string, accessToken?: string): Promise<void> {
+    if (accessToken) {
+      try {
+        const decoded = jwt.decode(accessToken) as {
+          jti?: string;
+          userId?: string;
+          exp?: number;
+        } | null;
+        if (decoded?.jti && decoded?.userId && decoded?.exp) {
+          await RevokedToken.create({
+            jti: decoded.jti,
+            user_id: decoded.userId,
+            expires_at: new Date(decoded.exp * 1000),
+          });
+          logger.info('Access token blacklisted on logout', { jti: decoded.jti });
+        }
+      } catch {
+        logger.warn('Failed to blacklist access token on logout');
+      }
+    }
+
     if (!refreshToken) {
       return;
     }
@@ -660,7 +681,8 @@ Need help? Contact us at support@adoptdontshop.com
       throw new Error('JWT secrets not configured');
     }
 
-    const token = jwt.sign(payload, jwtSecret, {
+    const accessTokenJti = crypto.randomUUID();
+    const token = jwt.sign({ ...payload, jti: accessTokenJti }, jwtSecret, {
       expiresIn: this.JWT_EXPIRES_IN,
     } as SignOptions);
 

--- a/service.backend/src/services/chat.service.ts
+++ b/service.backend/src/services/chat.service.ts
@@ -4,6 +4,7 @@ import { NotificationPriority, NotificationType } from '../models/Notification';
 import sequelize from '../sequelize';
 import {
   ContentModerationService,
+  MessageModerationStatus,
   ScanSeverity,
 } from './content-moderation.service';
 import moderationService, { ReportCategory, ReportSeverity } from './moderation.service';
@@ -559,7 +560,7 @@ export class ChatService {
             is_flagged: true,
             flag_reason: scanResult.reason,
             flag_severity: scanResult.severity,
-            moderation_status: 'pending_review' as const,
+            moderation_status: MessageModerationStatus.PENDING_REVIEW,
             flagged_at: new Date(),
           }
         : {};

--- a/service.backend/src/services/chat.service.ts
+++ b/service.backend/src/services/chat.service.ts
@@ -3,6 +3,11 @@ import { Chat, ChatParticipant, Message, User } from '../models';
 import { NotificationPriority, NotificationType } from '../models/Notification';
 import sequelize from '../sequelize';
 import {
+  ContentModerationService,
+  ScanSeverity,
+} from './content-moderation.service';
+import moderationService, { ReportCategory, ReportSeverity } from './moderation.service';
+import {
   ChatListResponse,
   ChatMessage,
   ChatStatistics,
@@ -542,6 +547,23 @@ export class ChatService {
         }
       }
 
+      // Scan content for policy violations before saving
+      const scanResult = ContentModerationService.scanContent(data.content);
+
+      if (ContentModerationService.isMessageBlocked(scanResult)) {
+        throw new Error('Message blocked: content violates platform policy');
+      }
+
+      const moderationFields = scanResult.isFlagged
+        ? {
+            is_flagged: true,
+            flag_reason: scanResult.reason,
+            flag_severity: scanResult.severity,
+            moderation_status: 'pending_review' as const,
+            flagged_at: new Date(),
+          }
+        : {};
+
       // Create the message with proper field names
       const message = await Message.create(
         {
@@ -551,6 +573,7 @@ export class ChatService {
           content_format: MessageContentFormat.PLAIN,
           attachments: data.attachments || [],
           created_at: new Date(),
+          ...moderationFields,
         },
         { transaction }
       );
@@ -578,6 +601,28 @@ export class ChatService {
       );
 
       await transaction.commit();
+
+      // Auto-report HIGH/CRITICAL violations after commit
+      if (ContentModerationService.shouldAutoReport(scanResult)) {
+        try {
+          const reportSeverity =
+            scanResult.severity === ScanSeverity.CRITICAL
+              ? ReportSeverity.CRITICAL
+              : ReportSeverity.HIGH;
+
+          await moderationService.submitReport('system', {
+            reportedEntityType: 'message',
+            reportedEntityId: messageWithSender.message_id,
+            reportedUserId: data.senderId,
+            category: ReportCategory.INAPPROPRIATE_CONTENT,
+            severity: reportSeverity,
+            title: `Auto-flagged: ${scanResult.reason}`,
+            description: `Message automatically flagged for: ${scanResult.reason}. Severity: ${scanResult.severity}`,
+          });
+        } catch (reportError) {
+          logger.warn('Failed to auto-create moderation report:', reportError);
+        }
+      }
 
       // Send real-time notifications to other participants
       try {

--- a/service.backend/src/services/content-moderation.service.ts
+++ b/service.backend/src/services/content-moderation.service.ts
@@ -1,0 +1,126 @@
+import { logger } from '../utils/logger';
+
+export enum ScanSeverity {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  CRITICAL = 'critical',
+}
+
+export enum MessageModerationStatus {
+  PENDING_REVIEW = 'pending_review',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}
+
+export type ScanResult = {
+  isFlagged: boolean;
+  severity: ScanSeverity | null;
+  reason: string | null;
+  matchedCategories: string[];
+};
+
+type PatternRule = {
+  label: string;
+  patterns: RegExp[];
+};
+
+// Rules ordered from most severe to least — first match wins
+const SEVERITY_RULES: Array<{ severity: ScanSeverity } & PatternRule> = [
+  {
+    severity: ScanSeverity.CRITICAL,
+    label: 'animal_trafficking_or_abuse',
+    patterns: [
+      /\b(sell|selling|buy|buying|purchase|purchasing)\s+(a\s+)?(dog|puppy|puppies|kitten|kittens|cat|cats|animal|pet|breed|litter)\s+(for|at)\s+\$?\d+/i,
+      /\b(animal|pet)\s+(abuse|cruelty|harm|torture|kill|killing)\b/i,
+      /\bwire\s+transfer\b.*\b(dog|puppy|cat|kitten|pet|animal)\b/i,
+      /\b(dog|puppy|cat|kitten|pet|animal)\b.*\bwire\s+transfer\b/i,
+      /\bwestern\s+union\b/i,
+      /\bmoney\s+gram\b/i,
+    ],
+  },
+  {
+    severity: ScanSeverity.HIGH,
+    label: 'financial_fraud_or_threats',
+    patterns: [
+      /\b(send|transfer|pay|wire)\s+(me\s+)?\$?\d{2,}/i,
+      /\b(advance\s+fee|upfront\s+payment|shipping\s+fee|insurance\s+fee)\b/i,
+      /\b(gift\s+card|bitcoin|crypto|cryptocurrency|paypal\s+me|venmo\s+me|cash\s+app)\b/i,
+      /\b(i('ll|\s+will)\s+(hurt|harm|kill|find|come\s+after|destroy))\s+you\b/i,
+      /\b(know\s+where\s+you\s+live|come\s+to\s+your\s+(house|home|address))\b/i,
+      /\b(credit\s+card\s+number|bank\s+account\s+number|routing\s+number|social\s+security\s+number|ssn)\b/i,
+    ],
+  },
+  {
+    severity: ScanSeverity.MEDIUM,
+    label: 'spam_or_harassment',
+    patterns: [
+      /\b(click\s+here\s+to|free\s+(offer|gift|prize)|you\s+have\s+won|claim\s+your)\b/i,
+      /\b(idiot|moron|stupid|dumb|loser|worthless|trash|garbage)\b/i,
+      /\b(scam(mer)?|fraud(ster)?|liar|cheater|thief)\b/i,
+      /https?:\/\/(?!adopt-dont-shop\.com|localhost)/i, // External links other than the platform
+    ],
+  },
+  {
+    severity: ScanSeverity.LOW,
+    label: 'off_platform_contact',
+    patterns: [
+      /\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/, // Phone number pattern
+      /\b(call|text|reach)\s+me\s+at\b/i,
+      /\b(my\s+email\s+is|email\s+me\s+at|contact\s+me\s+at)\b/i,
+      /\b(whatsapp|telegram|signal|snapchat|instagram|facebook)\s+(me|us|number)\b/i,
+    ],
+  },
+];
+
+export class ContentModerationService {
+  /**
+   * Scan message content for policy violations.
+   * Returns the first (highest severity) match found.
+   */
+  static scanContent(content: string): ScanResult {
+    for (const rule of SEVERITY_RULES) {
+      const matched = rule.patterns.some(pattern => pattern.test(content));
+      if (matched) {
+        logger.debug('Content flagged by moderation scanner', {
+          severity: rule.severity,
+          category: rule.label,
+          contentLength: content.length,
+        });
+
+        return {
+          isFlagged: true,
+          severity: rule.severity,
+          reason: rule.label,
+          matchedCategories: [rule.label],
+        };
+      }
+    }
+
+    return {
+      isFlagged: false,
+      severity: null,
+      reason: null,
+      matchedCategories: [],
+    };
+  }
+
+  /**
+   * Returns true when the message should be blocked entirely (not stored).
+   * Only CRITICAL severity warrants an outright block.
+   */
+  static isMessageBlocked(scanResult: ScanResult): boolean {
+    return scanResult.isFlagged && scanResult.severity === ScanSeverity.CRITICAL;
+  }
+
+  /**
+   * Returns true when a Report should be automatically created.
+   * HIGH and CRITICAL violations warrant automatic escalation.
+   */
+  static shouldAutoReport(scanResult: ScanResult): boolean {
+    return (
+      scanResult.isFlagged &&
+      (scanResult.severity === ScanSeverity.HIGH || scanResult.severity === ScanSeverity.CRITICAL)
+    );
+  }
+}

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -994,6 +994,43 @@ class ModerationService {
       pagination: result.pagination,
     };
   }
+
+  async getFlaggedMessages(options: {
+    severity?: string;
+    moderationStatus?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    messages: import('../models/Message').Message[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const { Op } = await import('sequelize');
+    const { default: Message } = await import('../models/Message');
+    const { page = 1, limit = 20, severity, moderationStatus } = options;
+
+    const where: Record<string, unknown> = { is_flagged: true };
+
+    if (severity) {
+      where['flag_severity'] = severity;
+    }
+    if (moderationStatus) {
+      where['moderation_status'] = moderationStatus;
+    } else {
+      where['moderation_status'] = { [Op.ne]: 'rejected' };
+    }
+
+    const { rows: messages, count: total } = await Message.findAndCountAll({
+      where,
+      order: [['flagged_at', 'DESC']],
+      limit,
+      offset: (page - 1) * limit,
+    });
+
+    return {
+      messages,
+      pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+    };
+  }
 }
 
 export default new ModerationService();


### PR DESCRIPTION
## Summary

### ENG-143 — Token Management Security Fixes

- **Token blacklisting**: Access tokens are immediately revoked on logout via a `revoked_tokens` DB table. Tokens now include a `jti` claim; `authenticateToken` middleware rejects blacklisted tokens with `401 Token has been revoked`.
- **httpOnly cookies for refresh tokens**: Refresh tokens no longer stored in `localStorage` (XSS-vulnerable). Backend sets them as `httpOnly`, `sameSite=strict`, `secure` cookies. Frontend moved access tokens to `sessionStorage`; refresh token handling is fully cookie-based.

### ENG-96 — Chat Content Moderation Integration

- **Pre-send content scanning**: `ChatService.sendMessage` scans every message with `ContentModerationService` before saving.
- **CRITICAL severity**: message is blocked entirely (not saved), sender receives an error.
- **HIGH/MEDIUM/LOW severity**: message saved with `is_flagged=true`, `flag_severity`, `flag_reason`, `moderation_status=pending_review`, and `flagged_at`.
- **Auto-reporting**: HIGH and CRITICAL violations automatically create a `Report` via `ModerationService`.
- **Moderation queue endpoint**: `GET /api/v1/admin/moderation/flagged-messages` returns paginated flagged messages with severity/status filters.

## Changes

### Backend (ENG-143)
- `RevokedToken` model + migration `35-create-revoked-tokens`
- `auth.service.ts`: adds `jti` to access tokens; `logout()` blacklists the access token
- `middleware/auth.ts`: checks `RevokedToken` table after JWT verification
- `auth.controller.ts`: sets/clears `refreshToken` httpOnly cookie on login, register, refresh, logout

### Backend (ENG-96)
- `ContentModerationService` with four severity tiers and ordered pattern rules
- Migration `36-add-message-moderation-fields` — adds 5 moderation columns + indexes to `messages`
- `Message` model updated with moderation fields
- `ChatService.sendMessage` integrated with content scanning and auto-report escalation
- `ModerationService.getFlaggedMessages` — paginated flagged message query with filters
- `GET /api/v1/admin/moderation/flagged-messages` route and controller method

### Frontend (`lib.auth`) (ENG-143)
- `auth-service.ts`: stores access token in `sessionStorage`, no longer reads/stores refresh token
- `auth.ts` types: `refreshToken` optional; `REFRESH_TOKEN` removed from `STORAGE_KEYS`

## Test plan

- [ ] All backend tests pass (43 test files, 1185+ tests)
- [ ] Logout blacklists access token — subsequent requests receive `401 Token has been revoked`
- [ ] Refresh token cookie is httpOnly and not readable via `document.cookie`
- [ ] Token refresh works without sending refresh token in body
- [ ] Messages containing CRITICAL content (animal trafficking) are blocked and not saved
- [ ] Messages with HIGH content (payment fraud) are saved as flagged and auto-reported
- [ ] Messages with LOW content (phone number) are saved as flagged, no auto-report
- [ ] `GET /api/v1/admin/moderation/flagged-messages` returns paginated results with filters

https://claude.ai/code/session_014K5twANwp11iqRkqYqFTia