### PR TITLE
fix: restrict uploads CORS to configured allowed origins (ENG-145)

### DIFF
--- a/service.backend/src/__tests__/security/security-headers.test.ts
+++ b/service.backend/src/__tests__/security/security-headers.test.ts
@@ -268,3 +268,59 @@ describe('Security Headers', () => {
     });
   });
 });
+
+describe('Uploads CORS Headers', () => {
+  const allowedOrigins = ['http://localhost:3000', 'http://localhost:3001'];
+  let uploadsApp: express.Application;
+
+  beforeEach(() => {
+    uploadsApp = express();
+
+    uploadsApp.use('/uploads', (req, res, next) => {
+      const origin = req.headers.origin;
+      const allowedOriginList = Array.isArray(allowedOrigins) ? allowedOrigins : [allowedOrigins];
+
+      if (origin !== undefined && allowedOriginList.includes(origin)) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+      }
+
+      res.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
+      next();
+    });
+
+    uploadsApp.get('/uploads/test.jpg', (_req, res) => {
+      res.json({ file: 'test' });
+    });
+  });
+
+  it('should set Access-Control-Allow-Origin to the specific allowed origin, not a wildcard', async () => {
+    const response = await request(uploadsApp)
+      .get('/uploads/test.jpg')
+      .set('Origin', 'http://localhost:3000');
+
+    expect(response.headers['access-control-allow-origin']).toBe('http://localhost:3000');
+    expect(response.headers['access-control-allow-origin']).not.toBe('*');
+  });
+
+  it('should reflect the specific allowed origin in the response header', async () => {
+    const response = await request(uploadsApp)
+      .get('/uploads/test.jpg')
+      .set('Origin', 'http://localhost:3001');
+
+    expect(response.headers['access-control-allow-origin']).toBe('http://localhost:3001');
+  });
+
+  it('should not set Access-Control-Allow-Origin for disallowed origins', async () => {
+    const response = await request(uploadsApp)
+      .get('/uploads/test.jpg')
+      .set('Origin', 'http://evil.com');
+
+    expect(response.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('should not set Access-Control-Allow-Origin when no origin header is provided', async () => {
+    const response = await request(uploadsApp).get('/uploads/test.jpg');
+
+    expect(response.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -166,9 +166,17 @@ if (config.nodeEnv === 'development' && config.storage.provider === 'local') {
   app.use(
     '/uploads',
     (req, res, next) => {
-      // Set CORS headers for uploaded files
+      // Set CORS headers for uploaded files - restrict to configured allowed origins
+      const origin = req.headers.origin;
+      const allowedOrigins = Array.isArray(config.cors.origin)
+        ? config.cors.origin
+        : [config.cors.origin];
+
+      if (origin !== undefined && allowedOrigins.includes(origin)) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+      }
+
       res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
-      res.setHeader('Access-Control-Allow-Origin', '*');
       res.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
       res.setHeader(
         'Access-Control-Allow-Headers',


### PR DESCRIPTION
## Summary

- Replaces wildcard `Access-Control-Allow-Origin: *` on the `/uploads` static file route with origin-specific validation against `config.cors.origin`
- Handles both string and array forms of `config.cors.origin` by normalising to an array before checking
- Adds 4 behaviour-driven tests covering: allowed origin reflected, second allowed origin reflected, disallowed origin rejected, and no-origin request rejected

## Test plan

- [ ] Allowed origins (from `CORS_ORIGIN` env or dev defaults) receive `Access-Control-Allow-Origin: <origin>` — never `*`
- [ ] Requests from unlisted origins receive no `Access-Control-Allow-Origin` header
- [ ] Requests with no `Origin` header receive no `Access-Control-Allow-Origin` header
- [ ] All existing security header tests continue to pass

Fixes: https://linear.app/ideasquared/issue/ENG-145/cors-configuration-issues

https://claude.ai/code/session_014JfAfwLvDwKbUdBCuvA4Dc