### PR TITLE
feat: add loading skeletons throughout admin app

### DIFF
--- a/app.admin/src/__tests__/loading-states.behavior.test.tsx
+++ b/app.admin/src/__tests__/loading-states.behavior.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Behavioral tests for loading skeleton states (Admin App)
+ *
+ * Tests admin-facing behavior:
+ * - DataTable shows skeleton rows (not text) while data is loading
+ * - DataTable shows actual rows after data loads
+ * - DataTable shows empty state when data is empty
+ * - FieldPermissions shows skeleton while permissions are being fetched
+ * - FieldPermissions shows actual field data after load completes
+ * - MetricCard shows skeleton while loading
+ * - MetricCard shows actual values after data loads
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, screen, waitFor } from '../test-utils';
+import { DataTable, type Column } from '../components/data/DataTable';
+import { MetricCard } from '../components/ui/MetricCard';
+import FieldPermissions from '../pages/FieldPermissions';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@adopt-dont-shop/lib.auth', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}));
+
+const mockGet = vi.fn();
+vi.mock('../services/libraryServices', () => ({
+  apiService: {
+    get: (url: string) => mockGet(url),
+    post: vi.fn().mockResolvedValue({ success: true, data: [] }),
+    delete: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+type SimpleRow = { id: string; name: string; status: string };
+
+const simpleColumns: Column<SimpleRow>[] = [
+  { id: 'name', header: 'Name', accessor: 'name' },
+  { id: 'status', header: 'Status', accessor: 'status' },
+];
+
+const simpleRows: SimpleRow[] = [
+  { id: '1', name: 'Alice', status: 'active' },
+  { id: '2', name: 'Bob', status: 'pending' },
+];
+
+// ── DataTable loading states ──────────────────────────────────────────────────
+
+describe('DataTable loading states', () => {
+  describe('while loading', () => {
+    it('renders skeleton placeholder rows instead of actual data', () => {
+      const { container } = renderWithProviders(
+        <DataTable columns={simpleColumns} data={[]} loading={true} />
+      );
+      const skeletonRows = container.querySelectorAll('[data-testid="skeleton-row"]');
+      expect(skeletonRows.length).toBeGreaterThan(0);
+    });
+
+    it('does not show actual row data during loading', () => {
+      renderWithProviders(
+        <DataTable columns={simpleColumns} data={simpleRows} loading={true} />
+      );
+      expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+      expect(screen.queryByText('Bob')).not.toBeInTheDocument();
+    });
+
+    it('does not show the empty state message during loading', () => {
+      renderWithProviders(
+        <DataTable
+          columns={simpleColumns}
+          data={[]}
+          loading={true}
+          emptyMessage='No items found'
+        />
+      );
+      expect(screen.queryByText('No items found')).not.toBeInTheDocument();
+    });
+
+    it('shows skeleton rows for a selectable table', () => {
+      const { container } = renderWithProviders(
+        <DataTable
+          columns={simpleColumns}
+          data={[]}
+          loading={true}
+          selectable={true}
+        />
+      );
+      const skeletonRows = container.querySelectorAll('[data-testid="skeleton-row"]');
+      expect(skeletonRows.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('after data loads', () => {
+    it('shows actual row data once loading is complete', () => {
+      renderWithProviders(
+        <DataTable columns={simpleColumns} data={simpleRows} loading={false} />
+      );
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+    });
+
+    it('does not show skeleton rows once loading is complete', () => {
+      const { container } = renderWithProviders(
+        <DataTable columns={simpleColumns} data={simpleRows} loading={false} />
+      );
+      const skeletonRows = container.querySelectorAll('[data-testid="skeleton-row"]');
+      expect(skeletonRows.length).toBe(0);
+    });
+
+    it('shows empty state message when data is empty and not loading', () => {
+      renderWithProviders(
+        <DataTable
+          columns={simpleColumns}
+          data={[]}
+          loading={false}
+          emptyMessage='No items found'
+        />
+      );
+      expect(screen.getByText('No items found')).toBeInTheDocument();
+    });
+  });
+
+  describe('column headers', () => {
+    it('always shows column headers regardless of loading state', () => {
+      renderWithProviders(
+        <DataTable columns={simpleColumns} data={[]} loading={true} />
+      );
+      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
+    });
+  });
+});
+
+// ── MetricCard loading states ─────────────────────────────────────────────────
+
+describe('MetricCard loading states', () => {
+  describe('while loading', () => {
+    it('does not show the metric value while loading', () => {
+      renderWithProviders(
+        <MetricCard icon='👥' label='Total Users' value='12,543' loading={true} />
+      );
+      expect(screen.queryByText('12,543')).not.toBeInTheDocument();
+    });
+
+    it('still shows the label while loading', () => {
+      renderWithProviders(
+        <MetricCard icon='👥' label='Total Users' value='12,543' loading={true} />
+      );
+      expect(screen.getByText('Total Users')).toBeInTheDocument();
+    });
+  });
+
+  describe('after data loads', () => {
+    it('shows the metric value once loading is complete', () => {
+      renderWithProviders(
+        <MetricCard icon='👥' label='Total Users' value='12,543' loading={false} />
+      );
+      expect(screen.getByText('12,543')).toBeInTheDocument();
+    });
+
+    it('shows the change indicator when provided', () => {
+      renderWithProviders(
+        <MetricCard
+          icon='👥'
+          label='Total Users'
+          value='12,543'
+          change='+5% this month'
+          changePositive={true}
+          loading={false}
+        />
+      );
+      expect(screen.getByText(/5% this month/)).toBeInTheDocument();
+    });
+  });
+});
+
+// ── FieldPermissions loading states ──────────────────────────────────────────
+
+describe('FieldPermissions loading states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('while loading', () => {
+    it('shows a loading skeleton before field data arrives', () => {
+      mockGet.mockImplementation(() => new Promise(() => {}));
+      const { container } = renderWithProviders(<FieldPermissions />);
+      expect(
+        container.querySelector('[aria-label="Loading field permissions"]')
+      ).toBeInTheDocument();
+    });
+
+    it('does not show field names while loading', () => {
+      mockGet.mockImplementation(() => new Promise(() => {}));
+      renderWithProviders(<FieldPermissions />);
+      expect(screen.queryByText('email')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('after data loads', () => {
+    it('shows field names once data has loaded', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url.includes('/defaults/')) {
+          return Promise.resolve({ data: { email: 'read', first_name: 'read' } });
+        }
+        return Promise.resolve({ data: [] });
+      });
+
+      renderWithProviders(<FieldPermissions />);
+
+      await waitFor(() => {
+        expect(screen.getByText('email')).toBeInTheDocument();
+        expect(screen.getByText('first_name')).toBeInTheDocument();
+      });
+    });
+
+    it('hides the loading skeleton once data has loaded', async () => {
+      mockGet.mockImplementation((url: string) => {
+        if (url.includes('/defaults/')) {
+          return Promise.resolve({ data: { email: 'read' } });
+        }
+        return Promise.resolve({ data: [] });
+      });
+
+      const { container } = renderWithProviders(<FieldPermissions />);
+
+      await waitFor(() => {
+        expect(
+          container.querySelector('[aria-label="Loading field permissions"]')
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/app.admin/src/__tests__/loading-states.behavior.test.tsx
+++ b/app.admin/src/__tests__/loading-states.behavior.test.tsx
@@ -59,33 +59,21 @@ describe('DataTable loading states', () => {
     });
 
     it('does not show actual row data during loading', () => {
-      renderWithProviders(
-        <DataTable columns={simpleColumns} data={simpleRows} loading={true} />
-      );
+      renderWithProviders(<DataTable columns={simpleColumns} data={simpleRows} loading={true} />);
       expect(screen.queryByText('Alice')).not.toBeInTheDocument();
       expect(screen.queryByText('Bob')).not.toBeInTheDocument();
     });
 
     it('does not show the empty state message during loading', () => {
       renderWithProviders(
-        <DataTable
-          columns={simpleColumns}
-          data={[]}
-          loading={true}
-          emptyMessage='No items found'
-        />
+        <DataTable columns={simpleColumns} data={[]} loading={true} emptyMessage='No items found' />
       );
       expect(screen.queryByText('No items found')).not.toBeInTheDocument();
     });
 
     it('shows skeleton rows for a selectable table', () => {
       const { container } = renderWithProviders(
-        <DataTable
-          columns={simpleColumns}
-          data={[]}
-          loading={true}
-          selectable={true}
-        />
+        <DataTable columns={simpleColumns} data={[]} loading={true} selectable={true} />
       );
       const skeletonRows = container.querySelectorAll('[data-testid="skeleton-row"]');
       expect(skeletonRows.length).toBeGreaterThan(0);
@@ -94,9 +82,7 @@ describe('DataTable loading states', () => {
 
   describe('after data loads', () => {
     it('shows actual row data once loading is complete', () => {
-      renderWithProviders(
-        <DataTable columns={simpleColumns} data={simpleRows} loading={false} />
-      );
+      renderWithProviders(<DataTable columns={simpleColumns} data={simpleRows} loading={false} />);
       expect(screen.getByText('Alice')).toBeInTheDocument();
       expect(screen.getByText('Bob')).toBeInTheDocument();
     });
@@ -124,9 +110,7 @@ describe('DataTable loading states', () => {
 
   describe('column headers', () => {
     it('always shows column headers regardless of loading state', () => {
-      renderWithProviders(
-        <DataTable columns={simpleColumns} data={[]} loading={true} />
-      );
+      renderWithProviders(<DataTable columns={simpleColumns} data={[]} loading={true} />);
       expect(screen.getByText('Name')).toBeInTheDocument();
       expect(screen.getByText('Status')).toBeInTheDocument();
     });

--- a/app.admin/src/__tests__/moderation.behavior.test.tsx
+++ b/app.admin/src/__tests__/moderation.behavior.test.tsx
@@ -193,7 +193,7 @@ describe('Content Moderation page', () => {
   });
 
   describe('loading state', () => {
-    it('shows a loading indicator while fetching reports', () => {
+    it('shows skeleton rows while fetching reports', () => {
       mockUseReports.mockReturnValue({
         data: undefined,
         isLoading: true,
@@ -201,8 +201,9 @@ describe('Content Moderation page', () => {
         refetch: vi.fn(),
       });
 
-      renderWithProviders(<Moderation />);
-      expect(screen.getByText('Loading...')).toBeInTheDocument();
+      const { container } = renderWithProviders(<Moderation />);
+      const skeletonRows = container.querySelectorAll('[data-testid="skeleton-row"]');
+      expect(skeletonRows.length).toBeGreaterThan(0);
     });
   });
 

--- a/app.admin/src/__tests__/rescues.behavior.test.tsx
+++ b/app.admin/src/__tests__/rescues.behavior.test.tsx
@@ -193,10 +193,11 @@ describe('Rescue Management page', () => {
   });
 
   describe('loading state', () => {
-    it('shows a loading indicator while fetching rescues', () => {
+    it('shows skeleton rows while fetching rescues', () => {
       mockGetAll.mockReturnValue(new Promise(() => {}));
-      renderWithProviders(<Rescues />);
-      expect(screen.getByText('Loading...')).toBeInTheDocument();
+      const { container } = renderWithProviders(<Rescues />);
+      const skeletonRows = container.querySelectorAll('[data-testid="skeleton-row"]');
+      expect(skeletonRows.length).toBeGreaterThan(0);
     });
   });
 

--- a/app.admin/src/__tests__/user-management.behavior.test.tsx
+++ b/app.admin/src/__tests__/user-management.behavior.test.tsx
@@ -264,10 +264,17 @@ describe('User Management page', () => {
   });
 
   describe('loading state', () => {
-    it('shows a loading indicator while fetching users', () => {
+    it('shows skeleton rows while fetching users', () => {
+      setupLoadingState();
+      const { container } = renderWithProviders(<Users />);
+      const skeletonRows = container.querySelectorAll('[data-testid="skeleton-row"]');
+      expect(skeletonRows.length).toBeGreaterThan(0);
+    });
+
+    it('does not show user data while loading', () => {
       setupLoadingState();
       renderWithProviders(<Users />);
-      expect(screen.getByText('Loading...')).toBeInTheDocument();
+      expect(screen.queryByText('john.doe@example.com')).not.toBeInTheDocument();
     });
   });
 

--- a/app.admin/src/components/data/DataTable.tsx
+++ b/app.admin/src/components/data/DataTable.tsx
@@ -307,11 +307,7 @@ export function DataTable<T extends Record<string, any>>({
           <Tbody>
             {loading ? (
               Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
-                <SkeletonTableRow
-                  key={i}
-                  columnCount={columns.length}
-                  hasCheckbox={selectable}
-                />
+                <SkeletonTableRow key={i} columnCount={columns.length} hasCheckbox={selectable} />
               ))
             ) : data.length === 0 ? (
               <EmptyRow>

--- a/app.admin/src/components/data/DataTable.tsx
+++ b/app.admin/src/components/data/DataTable.tsx
@@ -8,6 +8,7 @@ import {
   FiChevronLeft,
   FiChevronRight,
 } from 'react-icons/fi';
+import { SkeletonTableRow } from '../ui/Skeleton';
 
 export interface Column<T> {
   id: string;
@@ -131,13 +132,7 @@ const Checkbox = styled.input.attrs({ type: 'checkbox' })`
   accent-color: ${props => props.theme.colors.primary[600]};
 `;
 
-const LoadingRow = styled.tr`
-  td {
-    padding: 3rem;
-    text-align: center;
-    color: #6b7280;
-  }
-`;
+const SKELETON_ROW_COUNT = 5;
 
 const EmptyRow = styled.tr`
   td {
@@ -311,9 +306,13 @@ export function DataTable<T extends Record<string, any>>({
           </Thead>
           <Tbody>
             {loading ? (
-              <LoadingRow>
-                <td colSpan={columns.length + (selectable ? 1 : 0)}>Loading...</td>
-              </LoadingRow>
+              Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
+                <SkeletonTableRow
+                  key={i}
+                  columnCount={columns.length}
+                  hasCheckbox={selectable}
+                />
+              ))
             ) : data.length === 0 ? (
               <EmptyRow>
                 <td colSpan={columns.length + (selectable ? 1 : 0)}>{emptyMessage}</td>

--- a/app.admin/src/components/modals/RescueDetailModal.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Button, Heading, Text, DateTime } from '@adopt-dont-shop/lib.components';
+import { Skeleton, SkeletonText } from '../ui/Skeleton';
 import {
   FiX,
   FiMail,
@@ -603,7 +604,19 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
         </TabContainer>
 
         <ModalBody>
-          {loading && <LoadingSpinner>Loading rescue details...</LoadingSpinner>}
+          {loading && (
+            <div aria-label='Loading rescue details' style={{ padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                <Skeleton width='4rem' height='4rem' radius='50%' />
+                <div style={{ flex: 1 }}>
+                  <Skeleton height='1.25rem' width='50%' style={{ marginBottom: '0.5rem' }} />
+                  <Skeleton height='0.875rem' width='30%' />
+                </div>
+              </div>
+              <SkeletonText lines={4} lastLineWidth='40%' />
+              <SkeletonText lines={3} lastLineWidth='55%' />
+            </div>
+          )}
 
           {error && <ErrorMessage>{error}</ErrorMessage>}
 
@@ -826,7 +839,19 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
                       </InviteForm>
                     )}
 
-                    {loadingStaff && <LoadingSpinner>Loading staff...</LoadingSpinner>}
+                    {loadingStaff && (
+                      <div aria-label='Loading staff' style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', padding: '1rem 0' }}>
+                        {Array.from({ length: 3 }, (_, i) => (
+                          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                            <Skeleton width='2.5rem' height='2.5rem' radius='50%' />
+                            <div style={{ flex: 1 }}>
+                              <Skeleton height='0.875rem' width='40%' style={{ marginBottom: '0.25rem' }} />
+                              <Skeleton height='0.75rem' width='60%' />
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
 
                     {!loadingStaff &&
                       (staff?.length || 0) === 0 &&

--- a/app.admin/src/components/modals/RescueDetailModal.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal.tsx
@@ -605,7 +605,10 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
 
         <ModalBody>
           {loading && (
-            <div aria-label='Loading rescue details' style={{ padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+            <div
+              aria-label='Loading rescue details'
+              style={{ padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.5rem' }}
+            >
               <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
                 <Skeleton width='4rem' height='4rem' radius='50%' />
                 <div style={{ flex: 1 }}>
@@ -840,12 +843,27 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
                     )}
 
                     {loadingStaff && (
-                      <div aria-label='Loading staff' style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', padding: '1rem 0' }}>
+                      <div
+                        aria-label='Loading staff'
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: '0.75rem',
+                          padding: '1rem 0',
+                        }}
+                      >
                         {Array.from({ length: 3 }, (_, i) => (
-                          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                          <div
+                            key={i}
+                            style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}
+                          >
                             <Skeleton width='2.5rem' height='2.5rem' radius='50%' />
                             <div style={{ flex: 1 }}>
-                              <Skeleton height='0.875rem' width='40%' style={{ marginBottom: '0.25rem' }} />
+                              <Skeleton
+                                height='0.875rem'
+                                width='40%'
+                                style={{ marginBottom: '0.25rem' }}
+                              />
                               <Skeleton height='0.75rem' width='60%' />
                             </div>
                           </div>

--- a/app.admin/src/components/ui/Skeleton.tsx
+++ b/app.admin/src/components/ui/Skeleton.tsx
@@ -24,7 +24,13 @@ type SkeletonProps = {
 };
 
 export const Skeleton: React.FC<SkeletonProps> = ({ width, height, radius, className, style }) => (
-  <SkeletonBase $width={width} $height={height} $radius={radius} className={className} style={style} />
+  <SkeletonBase
+    $width={width}
+    $height={height}
+    $radius={radius}
+    className={className}
+    style={style}
+  />
 );
 
 const TextLine = styled(SkeletonBase)`
@@ -43,11 +49,7 @@ type SkeletonTextProps = {
 export const SkeletonText: React.FC<SkeletonTextProps> = ({ lines = 3, lastLineWidth = '60%' }) => (
   <div>
     {Array.from({ length: lines }, (_, i) => (
-      <TextLine
-        key={i}
-        $height='0.875rem'
-        $width={i === lines - 1 ? lastLineWidth : '100%'}
-      />
+      <TextLine key={i} $height='0.875rem' $width={i === lines - 1 ? lastLineWidth : '100%'} />
     ))}
   </div>
 );

--- a/app.admin/src/components/ui/Skeleton.tsx
+++ b/app.admin/src/components/ui/Skeleton.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+const shimmer = keyframes`
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+`;
+
+const SkeletonBase = styled.div<{ $width?: string; $height?: string; $radius?: string }>`
+  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background-size: 200% 100%;
+  animation: ${shimmer} 1.5s ease-in-out infinite;
+  border-radius: ${props => props.$radius ?? '4px'};
+  width: ${props => props.$width ?? '100%'};
+  height: ${props => props.$height ?? '1rem'};
+`;
+
+type SkeletonProps = {
+  width?: string;
+  height?: string;
+  radius?: string;
+  className?: string;
+};
+
+export const Skeleton: React.FC<SkeletonProps> = ({ width, height, radius, className }) => (
+  <SkeletonBase $width={width} $height={height} $radius={radius} className={className} />
+);
+
+const TextLine = styled(SkeletonBase)`
+  margin-bottom: 0.5rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+type SkeletonTextProps = {
+  lines?: number;
+  lastLineWidth?: string;
+};
+
+export const SkeletonText: React.FC<SkeletonTextProps> = ({ lines = 3, lastLineWidth = '60%' }) => (
+  <div>
+    {Array.from({ length: lines }, (_, i) => (
+      <TextLine
+        key={i}
+        $height='0.875rem'
+        $width={i === lines - 1 ? lastLineWidth : '100%'}
+      />
+    ))}
+  </div>
+);
+
+const CellContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+type SkeletonTableRowProps = {
+  columnCount: number;
+  hasCheckbox?: boolean;
+};
+
+export const SkeletonTableRow: React.FC<SkeletonTableRowProps> = ({
+  columnCount,
+  hasCheckbox = false,
+}) => (
+  <tr aria-hidden='true' data-testid='skeleton-row'>
+    {hasCheckbox && (
+      <td style={{ padding: '1rem' }}>
+        <SkeletonBase $width='1rem' $height='1rem' $radius='2px' />
+      </td>
+    )}
+    {Array.from({ length: columnCount }, (_, i) => (
+      <td key={i} style={{ padding: '1rem' }}>
+        <CellContainer>
+          {i === 0 ? (
+            <>
+              <SkeletonBase $width='2rem' $height='2rem' $radius='50%' style={{ flexShrink: 0 }} />
+              <div style={{ flex: 1 }}>
+                <SkeletonBase $height='0.875rem' style={{ marginBottom: '0.25rem' }} />
+                <SkeletonBase $height='0.75rem' $width='70%' />
+              </div>
+            </>
+          ) : (
+            <SkeletonBase $height='0.875rem' $width={i % 3 === 0 ? '60%' : '80%'} />
+          )}
+        </CellContainer>
+      </td>
+    ))}
+  </tr>
+);
+
+const CardContainer = styled.div`
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+`;
+
+type SkeletonCardProps = {
+  lines?: number;
+  showAvatar?: boolean;
+};
+
+export const SkeletonCard: React.FC<SkeletonCardProps> = ({ lines = 3, showAvatar = false }) => (
+  <CardContainer aria-hidden='true'>
+    {showAvatar && (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1rem' }}>
+        <SkeletonBase $width='3rem' $height='3rem' $radius='50%' style={{ flexShrink: 0 }} />
+        <div style={{ flex: 1 }}>
+          <SkeletonBase $height='1rem' style={{ marginBottom: '0.375rem' }} />
+          <SkeletonBase $height='0.875rem' $width='60%' />
+        </div>
+      </div>
+    )}
+    <SkeletonText lines={lines} />
+  </CardContainer>
+);

--- a/app.admin/src/components/ui/Skeleton.tsx
+++ b/app.admin/src/components/ui/Skeleton.tsx
@@ -20,10 +20,11 @@ type SkeletonProps = {
   height?: string;
   radius?: string;
   className?: string;
+  style?: React.CSSProperties;
 };
 
-export const Skeleton: React.FC<SkeletonProps> = ({ width, height, radius, className }) => (
-  <SkeletonBase $width={width} $height={height} $radius={radius} className={className} />
+export const Skeleton: React.FC<SkeletonProps> = ({ width, height, radius, className, style }) => (
+  <SkeletonBase $width={width} $height={height} $radius={radius} className={className} style={style} />
 );
 
 const TextLine = styled(SkeletonBase)`

--- a/app.admin/src/components/ui/index.ts
+++ b/app.admin/src/components/ui/index.ts
@@ -9,4 +9,6 @@ export type { FilterOption } from './FilterPanel';
 export { ActionMenu } from './ActionMenu';
 export type { ActionMenuItem } from './ActionMenu';
 
+export { Skeleton, SkeletonText, SkeletonTableRow, SkeletonCard } from './Skeleton';
+
 export * from './SharedComponents';

--- a/app.admin/src/pages/FieldPermissions.tsx
+++ b/app.admin/src/pages/FieldPermissions.tsx
@@ -418,9 +418,20 @@ const FieldPermissions: React.FC = () => {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <div aria-label='Loading field permissions' style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+            <div
+              aria-label='Loading field permissions'
+              style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}
+            >
               {Array.from({ length: 6 }, (_, i) => (
-                <div key={i} style={{ display: 'grid', gridTemplateColumns: '2fr 1fr 1fr 1fr', gap: '1rem', alignItems: 'center' }}>
+                <div
+                  key={i}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '2fr 1fr 1fr 1fr',
+                    gap: '1rem',
+                    alignItems: 'center',
+                  }}
+                >
                   <Skeleton height='0.875rem' width={i % 2 === 0 ? '70%' : '50%'} />
                   <Skeleton height='1.5rem' width='80%' radius='6px' />
                   <Skeleton height='1.5rem' width='80%' radius='6px' />

--- a/app.admin/src/pages/FieldPermissions.tsx
+++ b/app.admin/src/pages/FieldPermissions.tsx
@@ -20,6 +20,7 @@ import {
   CardTitle,
   CardContent,
 } from '../components/ui';
+import { Skeleton } from '../components/ui/Skeleton';
 
 const RESOURCES: ReadonlyArray<FieldPermissionResource> = [
   'users',
@@ -417,7 +418,16 @@ const FieldPermissions: React.FC = () => {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <Text>Loading field permissions...</Text>
+            <div aria-label='Loading field permissions' style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              {Array.from({ length: 6 }, (_, i) => (
+                <div key={i} style={{ display: 'grid', gridTemplateColumns: '2fr 1fr 1fr 1fr', gap: '1rem', alignItems: 'center' }}>
+                  <Skeleton height='0.875rem' width={i % 2 === 0 ? '70%' : '50%'} />
+                  <Skeleton height='1.5rem' width='80%' radius='6px' />
+                  <Skeleton height='1.5rem' width='80%' radius='6px' />
+                  <Skeleton height='1rem' width='60%' />
+                </div>
+              ))}
+            </div>
           ) : fieldNames.length === 0 ? (
             <Text>No fields configured for this resource and role.</Text>
           ) : (


### PR DESCRIPTION
## Summary

- Creates reusable `Skeleton`, `SkeletonText`, `SkeletonTableRow`, and `SkeletonCard` components with shimmer animation
- Replaces `"Loading..."` text in `DataTable` with 5 skeleton rows that mirror the actual column structure
- Replaces `"Loading field permissions..."` text in `FieldPermissions` with a skeleton grid matching the field table layout
- Replaces `"Loading rescue details..."` and `"Loading staff..."` text in `RescueDetailModal` with structured skeleton placeholders
- Exports all skeleton variants from `components/ui/index.ts`

## Test plan

- [ ] All 188 existing tests pass (`vitest run --pool=threads` from `app.admin/`)
- [ ] New `loading-states.behavior.test.tsx` covers: DataTable skeleton rows during load, no data shown while loading, empty state not shown during load, MetricCard skeleton hides values, FieldPermissions skeleton appears/disappears correctly
- [ ] Updated `user-management`, `rescues`, and `moderation` behaviour tests to assert skeleton rows instead of `"Loading..."` text

Closes ENG-124

https://claude.ai/code/session_01CBFivjW3uVcE5ss3e7wYNT