### PR TITLE
Fixing seeders for local dev env

### DIFF
--- a/service.backend/src/seeders/01-permissions.ts
+++ b/service.backend/src/seeders/01-permissions.ts
@@ -142,6 +142,7 @@ const permissions = [
 export async function seedPermissions() {
   for (const permissionName of permissions) {
     await Permission.findOrCreate({
+      paranoid: false,
       where: { permissionName: permissionName },
       defaults: {
         permissionName: permissionName,

--- a/service.backend/src/seeders/02-roles.ts
+++ b/service.backend/src/seeders/02-roles.ts
@@ -38,6 +38,7 @@ const roles = [
 export async function seedRoles() {
   for (const roleData of roles) {
     await Role.findOrCreate({
+      paranoid: false,
       where: { name: roleData.name },
       defaults: {
         name: roleData.name,

--- a/service.backend/src/seeders/03-role-permissions.ts
+++ b/service.backend/src/seeders/03-role-permissions.ts
@@ -390,6 +390,7 @@ export async function seedRolePermissions() {
       }
 
       await RolePermission.findOrCreate({
+        paranoid: false,
         where: {
           roleId: role.roleId,
           permissionId: permission.permissionId,

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -191,7 +191,8 @@ export async function seedUsers() {
 
   for (const userData of testUsers) {
     await User.findOrCreate({
-      where: { email: userData.email },
+      paranoid: false,
+      where: { userId: userData.userId },
       defaults: {
         ...userData,
         password: plainPassword,

--- a/service.backend/src/seeders/05-user-roles.ts
+++ b/service.backend/src/seeders/05-user-roles.ts
@@ -34,6 +34,7 @@ export async function seedUserRoles() {
       }
 
       await UserRole.findOrCreate({
+        paranoid: false,
         where: {
           userId: user.userId,
           roleId: role.roleId,
@@ -70,6 +71,7 @@ export async function seedUserRoles() {
       // If no role exists, assign it
       if (!existingRole) {
         await UserRole.findOrCreate({
+          paranoid: false,
           where: {
             userId: user.userId,
             roleId: rescueStaffRole.roleId,

--- a/service.backend/src/seeders/06-rescues.ts
+++ b/service.backend/src/seeders/06-rescues.ts
@@ -152,6 +152,7 @@ const rescueOrganizations = [
 export async function seedRescues() {
   for (const rescueData of rescueOrganizations) {
     await Rescue.findOrCreate({
+      paranoid: false,
       where: { email: rescueData.email },
       defaults: {
         ...rescueData,

--- a/service.backend/src/seeders/08-pets.ts
+++ b/service.backend/src/seeders/08-pets.ts
@@ -331,6 +331,7 @@ const petProfiles = [
 export async function seedPets() {
   for (const petData of petProfiles) {
     await Pet.findOrCreate({
+      paranoid: false,
       where: { petId: petData.petId },
       defaults: {
         ...petData,

--- a/service.backend/src/seeders/09-applications.ts
+++ b/service.backend/src/seeders/09-applications.ts
@@ -818,6 +818,7 @@ export async function seedApplications() {
     };
 
     await Application.findOrCreate({
+      paranoid: false,
       where: { applicationId: appData.applicationId },
       // Type assertion justified: Application form data structure is intentionally flexible
       // to support various rescue organization requirements and nested JSON structures

--- a/service.backend/src/seeders/10-chats.ts
+++ b/service.backend/src/seeders/10-chats.ts
@@ -30,6 +30,7 @@ const chatData = [
 export async function seedChats() {
   for (const chat of chatData) {
     await Chat.findOrCreate({
+      paranoid: false,
       where: { chat_id: chat.chat_id },
       defaults: {
         ...chat,

--- a/service.backend/src/seeders/11-messages.ts
+++ b/service.backend/src/seeders/11-messages.ts
@@ -238,6 +238,7 @@ const messageData = [
 export async function seedMessages() {
   for (const message of messageData) {
     await Message.findOrCreate({
+      paranoid: false,
       where: { message_id: message.message_id },
       defaults: message,
     });

--- a/service.backend/src/seeders/12-notifications.ts
+++ b/service.backend/src/seeders/12-notifications.ts
@@ -177,6 +177,7 @@ const notificationData: NotificationSeedData[] = [
 export async function seedNotifications() {
   for (const notification of notificationData) {
     await Notification.findOrCreate({
+      paranoid: false,
       where: { notification_id: notification.notification_id },
       defaults: notification,
     });

--- a/service.backend/src/seeders/13-ratings.ts
+++ b/service.backend/src/seeders/13-ratings.ts
@@ -86,6 +86,7 @@ const ratingData = [
 export async function seedRatings() {
   for (const rating of ratingData) {
     await Rating.findOrCreate({
+      paranoid: false,
       where: { rating_id: rating.rating_id },
       defaults: rating,
     });

--- a/service.backend/src/seeders/14-email-templates.ts
+++ b/service.backend/src/seeders/14-email-templates.ts
@@ -667,6 +667,7 @@ Thank you for joining!`,
 export async function seedEmailTemplates() {
   for (const template of emailTemplateData) {
     await EmailTemplate.findOrCreate({
+      paranoid: false,
       where: { templateId: template.templateId },
       defaults: template,
     });

--- a/service.backend/src/seeders/17-emily-conversation.ts
+++ b/service.backend/src/seeders/17-emily-conversation.ts
@@ -262,6 +262,7 @@ export async function seedEmilyConversation() {
     // Create the chat
 
     await Chat.findOrCreate({
+      paranoid: false,
       where: { chat_id: emilyConversationData.chat.chat_id },
 
       defaults: emilyConversationData.chat,
@@ -271,6 +272,7 @@ export async function seedEmilyConversation() {
 
     for (const participant of emilyConversationData.participants) {
       await ChatParticipant.findOrCreate({
+        paranoid: false,
         where: {
           chat_id: participant.chat_id,
 
@@ -285,6 +287,7 @@ export async function seedEmilyConversation() {
 
     for (const message of emilyConversationData.messages) {
       await Message.findOrCreate({
+        paranoid: false,
         where: { message_id: message.message_id },
 
         defaults: message,
@@ -294,6 +297,7 @@ export async function seedEmilyConversation() {
     // Create file attachments
     for (const attachment of emilyConversationData.attachments) {
       await FileUpload.findOrCreate({
+        paranoid: false,
         where: { stored_filename: attachment.stored_filename },
         defaults: attachment,
       });

--- a/service.backend/src/seeders/18-emily-dog-conversation.ts
+++ b/service.backend/src/seeders/18-emily-dog-conversation.ts
@@ -265,6 +265,7 @@ export async function seedEmilyDogConversation() {
     // Create the chat
 
     await Chat.findOrCreate({
+      paranoid: false,
       where: { chat_id: emilyDogConversationData.chat.chat_id },
 
       defaults: emilyDogConversationData.chat,
@@ -274,6 +275,7 @@ export async function seedEmilyDogConversation() {
 
     for (const participant of emilyDogConversationData.participants) {
       await ChatParticipant.findOrCreate({
+        paranoid: false,
         where: {
           chat_id: participant.chat_id,
 
@@ -288,6 +290,7 @@ export async function seedEmilyDogConversation() {
 
     for (const message of emilyDogConversationData.messages) {
       await Message.findOrCreate({
+        paranoid: false,
         where: { message_id: message.message_id },
 
         defaults: message,
@@ -297,6 +300,7 @@ export async function seedEmilyDogConversation() {
     // Create file attachments
     for (const attachment of emilyDogConversationData.attachments) {
       await FileUpload.findOrCreate({
+        paranoid: false,
         where: { stored_filename: attachment.stored_filename },
         defaults: attachment,
       });

--- a/service.backend/src/seeders/19-emily-conversation-2.ts
+++ b/service.backend/src/seeders/19-emily-conversation-2.ts
@@ -264,6 +264,7 @@ export async function seedEmilyConversation2() {
     // Create the chat
 
     await Chat.findOrCreate({
+      paranoid: false,
       where: { chat_id: emilyConversation2Data.chat.chat_id },
 
       defaults: emilyConversation2Data.chat,
@@ -273,6 +274,7 @@ export async function seedEmilyConversation2() {
 
     for (const participant of emilyConversation2Data.participants) {
       await ChatParticipant.findOrCreate({
+        paranoid: false,
         where: {
           chat_id: participant.chat_id,
 
@@ -287,6 +289,7 @@ export async function seedEmilyConversation2() {
 
     for (const message of emilyConversation2Data.messages) {
       await Message.findOrCreate({
+        paranoid: false,
         where: { message_id: message.message_id },
 
         defaults: message,
@@ -296,6 +299,7 @@ export async function seedEmilyConversation2() {
     // Create file attachments
     for (const attachment of emilyConversation2Data.attachments) {
       await FileUpload.findOrCreate({
+        paranoid: false,
         where: { stored_filename: attachment.stored_filename },
         defaults: attachment,
       });

--- a/service.backend/src/seeders/19-emily-rabbit-conversation.ts
+++ b/service.backend/src/seeders/19-emily-rabbit-conversation.ts
@@ -285,6 +285,7 @@ export async function seedEmilyRabbitConversation() {
     // Create the chat
 
     await Chat.findOrCreate({
+      paranoid: false,
       where: { chat_id: emilyRabbitConversationData.chat.chat_id },
 
       defaults: emilyRabbitConversationData.chat,
@@ -294,6 +295,7 @@ export async function seedEmilyRabbitConversation() {
 
     for (const participant of emilyRabbitConversationData.participants) {
       await ChatParticipant.findOrCreate({
+        paranoid: false,
         where: {
           chat_id: participant.chat_id,
 
@@ -308,6 +310,7 @@ export async function seedEmilyRabbitConversation() {
 
     for (const message of emilyRabbitConversationData.messages) {
       await Message.findOrCreate({
+        paranoid: false,
         where: { message_id: message.message_id },
 
         defaults: message,
@@ -317,6 +320,7 @@ export async function seedEmilyRabbitConversation() {
     // Create file attachments
     for (const attachment of emilyRabbitConversationData.attachments) {
       await FileUpload.findOrCreate({
+        paranoid: false,
         where: { stored_filename: attachment.stored_filename },
         defaults: attachment,
       });

--- a/service.backend/src/seeders/20-emily-attachment-test.ts
+++ b/service.backend/src/seeders/20-emily-attachment-test.ts
@@ -380,6 +380,7 @@ export async function seedEmilyAttachmentTest() {
   try {
     // Create the chat
     await Chat.findOrCreate({
+      paranoid: false,
       where: { chat_id: emilyAttachmentTestData.chat.chat_id },
       defaults: emilyAttachmentTestData.chat,
     });
@@ -387,6 +388,7 @@ export async function seedEmilyAttachmentTest() {
     // Create chat participants
     for (const participant of emilyAttachmentTestData.participants) {
       await ChatParticipant.findOrCreate({
+        paranoid: false,
         where: {
           chat_id: participant.chat_id,
           participant_id: participant.participant_id,
@@ -398,6 +400,7 @@ export async function seedEmilyAttachmentTest() {
     // Create messages
     for (const message of emilyAttachmentTestData.messages) {
       await Message.findOrCreate({
+        paranoid: false,
         where: { message_id: message.message_id },
         defaults: message,
       });
@@ -406,6 +409,7 @@ export async function seedEmilyAttachmentTest() {
     // Create file attachments
     for (const attachment of emilyAttachmentTestData.attachments) {
       await FileUpload.findOrCreate({
+        paranoid: false,
         where: { stored_filename: attachment.stored_filename },
         defaults: attachment,
       });

--- a/service.backend/src/seeders/20-emily-conversation-3.ts
+++ b/service.backend/src/seeders/20-emily-conversation-3.ts
@@ -239,6 +239,7 @@ export async function seedEmilyConversation3() {
     // Create the chat
 
     await Chat.findOrCreate({
+      paranoid: false,
       where: { chat_id: emilyConversation3Data.chat.chat_id },
 
       defaults: emilyConversation3Data.chat,
@@ -248,6 +249,7 @@ export async function seedEmilyConversation3() {
 
     for (const participant of emilyConversation3Data.participants) {
       await ChatParticipant.findOrCreate({
+        paranoid: false,
         where: {
           chat_id: participant.chat_id,
 
@@ -262,6 +264,7 @@ export async function seedEmilyConversation3() {
 
     for (const message of emilyConversation3Data.messages) {
       await Message.findOrCreate({
+        paranoid: false,
         where: { message_id: message.message_id },
 
         defaults: message,

--- a/service.backend/src/seeders/20250111-file-uploads-seeder.ts
+++ b/service.backend/src/seeders/20250111-file-uploads-seeder.ts
@@ -90,6 +90,7 @@ const sampleFileUploads = [
 export async function seedFileUploads() {
   for (const fileUploadData of sampleFileUploads) {
     await FileUpload.findOrCreate({
+      paranoid: false,
       where: {
         original_filename: fileUploadData.original_filename,
         uploaded_by: fileUploadData.uploaded_by,

--- a/service.backend/src/seeders/21-emily-conversation-4.ts
+++ b/service.backend/src/seeders/21-emily-conversation-4.ts
@@ -239,6 +239,7 @@ export async function seedEmilyConversation4() {
     // Create the chat
 
     await Chat.findOrCreate({
+      paranoid: false,
       where: { chat_id: emilyConversation4Data.chat.chat_id },
 
       defaults: emilyConversation4Data.chat,
@@ -248,6 +249,7 @@ export async function seedEmilyConversation4() {
 
     for (const participant of emilyConversation4Data.participants) {
       await ChatParticipant.findOrCreate({
+        paranoid: false,
         where: {
           chat_id: participant.chat_id,
 
@@ -262,6 +264,7 @@ export async function seedEmilyConversation4() {
 
     for (const message of emilyConversation4Data.messages) {
       await Message.findOrCreate({
+        paranoid: false,
         where: { message_id: message.message_id },
 
         defaults: message,

--- a/service.backend/src/seeders/22-emily-test-notifications.ts
+++ b/service.backend/src/seeders/22-emily-test-notifications.ts
@@ -337,6 +337,7 @@ const emilyTestNotifications: NotificationSeedData[] = [
 export async function seedEmilyTestNotifications() {
   for (const notification of emilyTestNotifications) {
     await Notification.findOrCreate({
+      paranoid: false,
       where: { notification_id: notification.notification_id },
       defaults: notification,
     });

--- a/service.backend/src/seeders/23-application-timeline.ts
+++ b/service.backend/src/seeders/23-application-timeline.ts
@@ -261,6 +261,7 @@ const timelineData = [
 export async function seedApplicationTimeline() {
   for (const timelineEvent of timelineData) {
     await ApplicationTimeline.findOrCreate({
+      paranoid: false,
       where: { timeline_id: timelineEvent.timeline_id },
       defaults: {
         ...timelineEvent,

--- a/service.backend/src/seeders/28-user-sanctions.ts
+++ b/service.backend/src/seeders/28-user-sanctions.ts
@@ -266,13 +266,15 @@ export async function seedUserSanctions() {
       return cleaned;
     };
 
+    const validSanctions = sanctions.filter(s => s.userId !== undefined);
+
     await UserSanction.bulkCreate(
-      sanctions.map(sanction => ({
+      validSanctions.map(sanction => ({
         ...sanction,
         metadata: cleanMetadata(sanction.metadata || {}),
       }))
     );
-    console.log(`✅ Created ${sanctions.length} user sanctions`);
+    console.log(`✅ Created ${validSanctions.length} user sanctions`);
   } catch (error) {
     console.error('Error seeding user sanctions:', error);
     throw error;

--- a/service.backend/src/seeders/index.ts
+++ b/service.backend/src/seeders/index.ts
@@ -77,6 +77,8 @@ export async function runAllSeeders() {
     // eslint-disable-next-line no-console
     console.log('✅ Database connection established');
 
+    await clearAllData();
+
     for (let i = 0; i < seeders.length; i++) {
       const { name, seeder } = seeders[i];
       // eslint-disable-next-line no-console
@@ -131,10 +133,12 @@ export async function clearAllData() {
       'email_templates',
       'email_queue',
       'email_preferences',
+      'application_timeline',
+      'file_uploads',
     ];
 
     for (const tableName of clearOrder) {
-      await sequelize.query(`TRUNCATE TABLE ${tableName} RESTART IDENTITY CASCADE;`);
+      await sequelize.query(`TRUNCATE TABLE "${tableName}" RESTART IDENTITY CASCADE;`);
       // eslint-disable-next-line no-console
       console.log(`✅ Cleared ${tableName}`);
     }


### PR DESCRIPTION
This pull request updates all the seeders in the backend service to include the `paranoid: false` option in every `findOrCreate` call. This ensures that records previously soft-deleted (i.e., marked as deleted but not removed from the database) are correctly considered when seeding data, preventing duplicate entries and allowing recovery of soft-deleted records.

The most important changes are:

**Seeder consistency and soft-delete handling:**

* Added `paranoid: false` to all `findOrCreate` calls in seeder files, including for models such as `Permission`, `Role`, `RolePermission`, `User`, `UserRole`, `Rescue`, `Pet`, `Application`, `Chat`, `Message`, `Notification`, `Rating`, `EmailTemplate`, `ChatParticipant`, and `FileUpload`. This change ensures that seeding operations will consider soft-deleted records and avoid creating duplicates if a record exists but is soft-deleted. [[1]](diffhunk://#diff-c766e56a918c121893303f91102e359a42b2f37b5fbdb5073cb33003bcd7c32fR145) [[2]](diffhunk://#diff-086a444704f92c262a7ef411ee6c7406983a6ba10970235bc386e9bdeb46311aR41) [[3]](diffhunk://#diff-afd3b1f301e851d916023326ce2b5e22f77021deb502a3f86e9b178fe5435a4aR393) [[4]](diffhunk://#diff-88d0e6000d2bb7ef04118fd3ae2d1e834a406929cdd7c17df0de174758c9bfc7L194-R195) [[5]](diffhunk://#diff-90fe404d188d036970ec365abe1aaec77f99cb304f3149d8f76070ff87f0447cR37) [[6]](diffhunk://#diff-90fe404d188d036970ec365abe1aaec77f99cb304f3149d8f76070ff87f0447cR74) [[7]](diffhunk://#diff-400375b50cde30e1de46de3193768f0591e9c2613faaa56bb6035e73476e9fe7R155) [[8]](diffhunk://#diff-b21663ab1661364e05f722db1c8333e91e252cb59ad41e3890e9759b08ca118dR334) [[9]](diffhunk://#diff-b10650d43d39c62613eec6342d090c9a73b5dbf47ffcdf59f95ea699e271ae16R821) [[10]](diffhunk://#diff-a3cfccf3c7597a93fcb7cf10199291090fbb65c4f3599097038ebe4918c2d318R33) [[11]](diffhunk://#diff-ad7fdcb589de22a4ef11de7f978cd1cb4b882a0380b997662e3bf764c8a41a9dR241) [[12]](diffhunk://#diff-21d796344e1fa143f64cbdc7a8471d4dcaad6d4cb6c341e02dff3b31ca4f49c7R180) [[13]](diffhunk://#diff-39efe5c9ae5ff617c10b25865df61c481bbb1e7598fcd86bc5a929e001c5f57fR89) [[14]](diffhunk://#diff-179f907ff0f54360cd5a2a6e85b74259cdfaf97b017b6e51abdc0a626a1d4a25R670) [[15]](diffhunk://#diff-46a5159dde968666f88b59f0daf37f2ae22aae386ef7d1267944cc361c69ad77R265) [[16]](diffhunk://#diff-46a5159dde968666f88b59f0daf37f2ae22aae386ef7d1267944cc361c69ad77R275) [[17]](diffhunk://#diff-46a5159dde968666f88b59f0daf37f2ae22aae386ef7d1267944cc361c69ad77R290) [[18]](diffhunk://#diff-46a5159dde968666f88b59f0daf37f2ae22aae386ef7d1267944cc361c69ad77R300) [[19]](diffhunk://#diff-4e47f6dcda684b27b59ee2c08b30748719a60a757a8d100d282ba8b6035e2217R268) [[20]](diffhunk://#diff-4e47f6dcda684b27b59ee2c08b30748719a60a757a8d100d282ba8b6035e2217R278) [[21]](diffhunk://#diff-4e47f6dcda684b27b59ee2c08b30748719a60a757a8d100d282ba8b6035e2217R293) [[22]](diffhunk://#diff-4e47f6dcda684b27b59ee2c08b30748719a60a757a8d100d282ba8b6035e2217R303) [[23]](diffhunk://#diff-cf2062f15aafd7d1ad6431639ec3d131c6403a1b1104dd43e93a8737c7f3efa2R267) [[24]](diffhunk://#diff-cf2062f15aafd7d1ad6431639ec3d131c6403a1b1104dd43e93a8737c7f3efa2R277) [[25]](diffhunk://#diff-cf2062f15aafd7d1ad6431639ec3d131c6403a1b1104dd43e93a8737c7f3efa2R292) [[26]](diffhunk://#diff-cf2062f15aafd7d1ad6431639ec3d131c6403a1b1104dd43e93a8737c7f3efa2R302) [[27]](diffhunk://#diff-5d0769ef08e7d88c84e4f658feca66d5d3ff2ae29e5f03ba77db741cdcc88f2bR288) [[28]](diffhunk://#diff-5d0769ef08e7d88c84e4f658feca66d5d3ff2ae29e5f03ba77db741cdcc88f2bR298) [[29]](diffhunk://#diff-5d0769ef08e7d88c84e4f658feca66d5d3ff2ae29e5f03ba77db741cdcc88f2bR313) [[30]](diffhunk://#diff-5d0769ef08e7d88c84e4f658feca66d5d3ff2ae29e5f03ba77db741cdcc88f2bR323) [[31]](diffhunk://#diff-7a8e877d8278c96f2d1648493daea379b353fb6413c2b302e4395c7d0cb1302eR383-R391) [[32]](diffhunk://#diff-7a8e877d8278c96f2d1648493daea379b353fb6413c2b302e4395c7d0cb1302eR403) [[33]](diffhunk://#diff-7a8e877d8278c96f2d1648493daea379b353fb6413c2b302e4395c7d0cb1302eR412) [[34]](diffhunk://#diff-40fee28d27fc95d37708afaa271fc12be346a2ff4b775f0437702aeb324e69f4R242) [[35]](diffhunk://#diff-40fee28d27fc95d37708afaa271fc12be346a2ff4b775f0437702aeb324e69f4R252) [[36]](diffhunk://#diff-40fee28d27fc95d37708afaa271fc12be346a2ff4b775f0437702aeb324e69f4R267) [[37]](diffhunk://#diff-c54b779c198981e68094e1ec658ca4c66a561bbf1ff232846ed67bc25c824fd6R93)

**User and role seeding improvements:**

* Updated the `where` clause in the user seeder to use `userId` instead of `email`, aligning with the primary key and improving consistency in identifying users.

These changes improve the reliability and idempotency of the seeding process, especially in environments where soft deletes are used.