### PR TITLE
fix(security): stop logging raw invitation tokens in error handlers (ENG-155)

### DIFF
--- a/service.backend/src/__tests__/routes/invitation.routes.test.ts
+++ b/service.backend/src/__tests__/routes/invitation.routes.test.ts
@@ -1,0 +1,125 @@
+import { vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/invitation.service', () => ({
+  InvitationService: {
+    acceptInvitation: vi.fn(),
+    getInvitationDetails: vi.fn(),
+  },
+}));
+
+import { logger } from '../../utils/logger';
+import { InvitationService } from '../../services/invitation.service';
+import invitationRouter from '../../routes/invitation.routes';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/invitations', invitationRouter);
+  return app;
+};
+
+describe('Invitation routes — token safety in error logs', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = buildApp();
+  });
+
+  describe('POST /invitations/accept — error handling', () => {
+    const validBody = {
+      token: 'super-secret-invitation-token-abc123',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      password: 'SecurePass1!',
+    };
+
+    beforeEach(() => {
+      vi.mocked(InvitationService.acceptInvitation).mockRejectedValue(
+        new Error('Invitation not found')
+      );
+    });
+
+    it('returns a 404 when the invitation is not found', async () => {
+      const res = await request(app).post('/invitations/accept').send(validBody);
+      expect(res.status).toBe(404);
+    });
+
+    it('calls logger.error when the service throws', async () => {
+      await request(app).post('/invitations/accept').send(validBody);
+      expect(vi.mocked(logger.error)).toHaveBeenCalled();
+    });
+
+    it('does not include the raw invitation token in the error log metadata', async () => {
+      await request(app).post('/invitations/accept').send(validBody);
+
+      const calls = vi.mocked(logger.error).mock.calls;
+      for (const [, meta] of calls) {
+        if (meta && typeof meta === 'object') {
+          expect(meta).not.toHaveProperty('token', validBody.token);
+        }
+      }
+    });
+
+    it('does not serialize the raw token anywhere in the error log call arguments', async () => {
+      await request(app).post('/invitations/accept').send(validBody);
+
+      const serialised = JSON.stringify(vi.mocked(logger.error).mock.calls);
+      expect(serialised).not.toContain(validBody.token);
+    });
+  });
+
+  describe('GET /invitations/details/:token — error handling', () => {
+    const rawToken = 'super-secret-invitation-token-xyz789';
+
+    beforeEach(() => {
+      vi.mocked(InvitationService.getInvitationDetails).mockRejectedValue(
+        new Error('Database error')
+      );
+    });
+
+    it('returns a 500 when the service throws unexpectedly', async () => {
+      const res = await request(app).get(`/invitations/details/${rawToken}`);
+      expect(res.status).toBe(500);
+    });
+
+    it('calls logger.error when the service throws', async () => {
+      await request(app).get(`/invitations/details/${rawToken}`);
+      expect(vi.mocked(logger.error)).toHaveBeenCalled();
+    });
+
+    it('does not include the raw token in the error log metadata', async () => {
+      await request(app).get(`/invitations/details/${rawToken}`);
+
+      const calls = vi.mocked(logger.error).mock.calls;
+      for (const [, meta] of calls) {
+        if (meta && typeof meta === 'object') {
+          expect(meta).not.toHaveProperty('token', rawToken);
+        }
+      }
+    });
+
+    it('does not serialize the raw token anywhere in the error log call arguments', async () => {
+      await request(app).get(`/invitations/details/${rawToken}`);
+
+      const serialised = JSON.stringify(vi.mocked(logger.error).mock.calls);
+      expect(serialised).not.toContain(rawToken);
+    });
+  });
+});

--- a/service.backend/src/routes/invitation.routes.ts
+++ b/service.backend/src/routes/invitation.routes.ts
@@ -48,7 +48,7 @@ router.post(
       res.status(201).json(result);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Error accepting invitation:', { error: errorMessage, token: req.body.token });
+      logger.error('Error accepting invitation:', { error: errorMessage });
 
       if (errorMessage.includes('not found') || errorMessage.includes('expired')) {
         return res.status(404).json({
@@ -109,10 +109,7 @@ router.get(
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Error getting invitation details:', {
-        error: errorMessage,
-        token: req.params.token,
-      });
+      logger.error('Error getting invitation details:', { error: errorMessage });
 
       res.status(500).json({
         success: false,


### PR DESCRIPTION
## Summary

Fixes **ENG-155** — invitation tokens were being written verbatim to error logs in `service.backend/src/routes/invitation.routes.ts`.

- `POST /invitations/accept` error handler logged `{ token: req.body.token }` alongside the error message (line 51)
- `GET /invitations/details/:token` error handler logged `{ token: req.params.token }` (line 114)

Invitation tokens are bearer credentials that grant the ability to register as rescue staff. Anyone with read access to log aggregation (Datadog, Loki, rotating files) could have replayed these tokens against `/invitations/accept` until they expired.

**Changes:**
- Removed `token` from both `logger.error` calls — only the error message is now logged
- Added a new test file `service.backend/src/__tests__/routes/invitation.routes.test.ts` with 8 behaviour tests asserting:
  - Routes return the correct HTTP status codes on service errors
  - `logger.error` is called (errors are still observable)
  - The raw token value does **not** appear in any error log argument (checked both by property name and full serialisation)

No other token/credential leaks were found in a codebase-wide sweep of `logger.*` calls.

## Test plan

- [x] New tests are red before the fix, green after
- [x] All 8 new tests pass (`8 passed`)
- [x] Manually verified the diff removes only the `token` field from log metadata — error messages are preserved
- [ ] Run full backend test suite to confirm no regressions