### PR TITLE
fix(security): prevent SQL ORDER BY injection via sortBy allowlists (ENG-208)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28982,7 +28982,8 @@
         "swagger-ui-express": "^5.0.1",
         "uuid": "^9.0.0",
         "winston": "^3.17.0",
-        "yamljs": "^0.3.0"
+        "yamljs": "^0.3.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-node": "*",

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1,6 +1,9 @@
 import { Includeable, Op, Order, WhereOptions } from 'sequelize';
 import { generateCryptoUuid as uuidv4 } from '../utils/uuid-helpers';
 import Application, { ApplicationPriority, ApplicationStatus } from '../models/Application';
+import { validateSortField } from '../utils/sort-validation';
+
+const APPLICATION_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'actioned_at'] as const;
 import ApplicationQuestion, { QuestionCategory } from '../models/ApplicationQuestion';
 import ApplicationStatusTransition from '../models/ApplicationStatusTransition';
 import Pet from '../models/Pet';
@@ -444,7 +447,8 @@ export class ApplicationService {
       }
 
       // Build order
-      const order: Order = [[sortBy, sortOrder]];
+      const safeSortBy = validateSortField(sortBy, APPLICATION_SORT_FIELDS, 'createdAt');
+      const order: Order = [[safeSortBy, sortOrder]];
 
       // Calculate offset
       const offset = (page - 1) * limit;

--- a/service.backend/src/services/chat.service.ts
+++ b/service.backend/src/services/chat.service.ts
@@ -1,5 +1,8 @@
 import { Op, WhereOptions } from 'sequelize';
 import { Chat, ChatParticipant, Message, User } from '../models';
+import { validateSortField } from '../utils/sort-validation';
+
+const CHAT_SORT_FIELDS = ['created_at', 'updated_at'] as const;
 import { NotificationPriority, NotificationType } from '../models/Notification';
 import sequelize from '../sequelize';
 import {
@@ -329,6 +332,7 @@ export class ChatService {
       } = options;
 
       const offset = (page - 1) * limit;
+      const safeSortBy = validateSortField(sortBy, CHAT_SORT_FIELDS, 'created_at');
 
       // Build where conditions
       const whereConditions: WhereOptions = {
@@ -410,7 +414,7 @@ export class ChatService {
         include: includes,
         limit,
         offset,
-        order: [[sortBy, sortOrder]],
+        order: [[safeSortBy, sortOrder]],
         distinct: true,
       });
 
@@ -447,6 +451,7 @@ export class ChatService {
       } = options;
 
       const offset = (page - 1) * limit;
+      const safeSortBy = validateSortField(sortBy, CHAT_SORT_FIELDS, 'created_at');
 
       // Build where conditions for chats
       const chatWhereConditions: WhereOptions = {
@@ -506,7 +511,7 @@ export class ChatService {
         ],
         limit,
         offset,
-        order: [[sortBy, sortOrder]],
+        order: [[safeSortBy, sortOrder]],
         distinct: true,
       });
 

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -232,7 +232,11 @@ class ModerationService {
       Object.assign(whereClause, { [Op.or]: orConditions });
     }
 
-    const safeSortBy = validateSortField(options.sortBy || 'createdAt', REPORT_SORT_FIELDS, 'createdAt');
+    const safeSortBy = validateSortField(
+      options.sortBy || 'createdAt',
+      REPORT_SORT_FIELDS,
+      'createdAt'
+    );
     const orderClause = [[safeSortBy, options.sortOrder || 'DESC']];
 
     const { count, rows } = await Report.findAndCountAll({

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -9,6 +9,9 @@ import sequelize from '../sequelize';
 import logger from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
 import { JsonObject } from '../types/common';
+import { validateSortField } from '../utils/sort-validation';
+
+const REPORT_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'severity', 'category'] as const;
 
 export interface ReportFilters {
   status?: ReportStatus;
@@ -229,7 +232,8 @@ class ModerationService {
       Object.assign(whereClause, { [Op.or]: orConditions });
     }
 
-    const orderClause = [[options.sortBy || 'createdAt', options.sortOrder || 'DESC']];
+    const safeSortBy = validateSortField(options.sortBy || 'createdAt', REPORT_SORT_FIELDS, 'createdAt');
+    const orderClause = [[safeSortBy, options.sortOrder || 'DESC']];
 
     const { count, rows } = await Report.findAndCountAll({
       where: whereClause,

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -30,6 +30,23 @@ import {
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
 
+const PET_SEARCH_SORT_FIELDS = [
+  'createdAt',
+  'updatedAt',
+  'name',
+  'breed',
+  'ageYears',
+  'adoptionFee',
+  'distance',
+] as const;
+const PET_RESCUE_LIST_SORT_FIELDS = [
+  'createdAt',
+  'updatedAt',
+  'name',
+  'age',
+  'adoptionFee',
+] as const;
+
 /**
  * Helper to get the appropriate LIKE operator based on database dialect
  * PostgreSQL supports case-insensitive iLike, SQLite needs uppercase conversion

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -32,7 +32,9 @@ import { AuditLogService } from './auditLog.service';
 
 const PET_SEARCH_SORT_FIELDS = [
   'createdAt',
+  'created_at',
   'updatedAt',
+  'updated_at',
   'name',
   'breed',
   'ageYears',

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -1,6 +1,7 @@
 import { col, fn, literal, Op, WhereOptions } from 'sequelize';
 import Pet, { AgeGroup, PetStatus, PetType, Size } from '../models/Pet';
 import PetStatusTransition from '../models/PetStatusTransition';
+import { validateSortField } from '../utils/sort-validation';
 import Rescue from '../models/Rescue';
 import UserFavorite from '../models/UserFavorite';
 import Report, { ReportCategory, ReportStatus, ReportSeverity } from '../models/Report';
@@ -246,6 +247,7 @@ export class PetService {
 
       // Calculate offset
       const offset = (page - 1) * limit;
+      const safeSortBy = validateSortField(sortBy, PET_SEARCH_SORT_FIELDS, 'createdAt');
 
       // Build order clause
       const orderClause: Array<[string, 'ASC' | 'DESC'] | ReturnType<typeof literal>> = [];
@@ -253,14 +255,14 @@ export class PetService {
       orderClause.push(['priorityListing', 'DESC'] as [string, 'ASC' | 'DESC']);
 
       // Distance-based sorting
-      if (sortBy === 'distance' && hasValidLocation && isPostgres) {
+      if (safeSortBy === 'distance' && hasValidLocation && isPostgres) {
         orderClause.push(
           literal(
             `ST_Distance(location, ST_SetSRID(ST_MakePoint(${Number(longitude)}, ${Number(latitude)}), 4326)::geography) ASC`
           )
         );
       } else {
-        orderClause.push([sortBy, sortOrder] as [string, 'ASC' | 'DESC']);
+        orderClause.push([safeSortBy, sortOrder] as [string, 'ASC' | 'DESC']);
       }
 
       // Execute query
@@ -1349,6 +1351,8 @@ export class PetService {
         sortOrder = 'DESC',
       } = filters;
 
+      const safeSortBy = validateSortField(sortBy, PET_RESCUE_LIST_SORT_FIELDS, 'createdAt');
+
       // Build where clause
       const whereClause: WhereOptions = {};
 
@@ -1444,7 +1448,7 @@ export class PetService {
         ],
         limit,
         offset,
-        order: [[sortBy, sortOrder]],
+        order: [[safeSortBy, sortOrder]],
       });
 
       const totalPages = Math.ceil(total / limit);

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -2,6 +2,9 @@ import { Op, Order, WhereOptions } from 'sequelize';
 import { Application, Pet, Rescue, StaffMember, User, Role, UserRole } from '../models';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
+import { validateSortField } from '../utils/sort-validation';
+
+const RESCUE_PET_SORT_FIELDS = ['createdAt', 'updatedAt', 'name'] as const;
 import sequelize from '../sequelize';
 import { AdoptionPolicy } from '../types/rescue';
 
@@ -944,6 +947,7 @@ export class RescueService {
     try {
       const { page = 1, limit = 20, status, sortBy = 'createdAt', sortOrder = 'DESC' } = options;
       const offset = (page - 1) * limit;
+      const safeSortBy = validateSortField(sortBy, RESCUE_PET_SORT_FIELDS, 'createdAt');
 
       const whereClause: WhereOptions = { rescue_id: rescueId };
       if (status) {
@@ -951,7 +955,7 @@ export class RescueService {
       }
 
       const orderClause =
-        sortBy === 'createdAt' ? [['created_at', sortOrder]] : [[sortBy, sortOrder]];
+        safeSortBy === 'createdAt' ? [['created_at', sortOrder]] : [[safeSortBy, sortOrder]];
 
       const { count, rows: pets } = await Pet.findAndCountAll({
         where: whereClause,

--- a/service.backend/src/services/supportTicket.service.ts
+++ b/service.backend/src/services/supportTicket.service.ts
@@ -9,6 +9,9 @@ import { Op, Transaction, WhereOptions } from 'sequelize';
 import sequelize from '../sequelize';
 import { logger } from '../utils/logger';
 import { JsonObject } from '../types/common';
+import { validateSortField } from '../utils/sort-validation';
+
+const SUPPORT_TICKET_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'priority', 'category'] as const;
 
 interface TicketFilters {
   status?: TicketStatus | TicketStatus[];
@@ -37,6 +40,7 @@ class SupportTicketService {
       const { page = 1, limit = 20, sortBy = 'createdAt', sortOrder = 'DESC' } = pagination;
 
       const offset = (page - 1) * limit;
+      const safeSortBy = validateSortField(sortBy, SUPPORT_TICKET_SORT_FIELDS, 'createdAt');
 
       // Build where clause
       const where: WhereOptions = {};
@@ -92,7 +96,7 @@ class SupportTicketService {
         where,
         limit,
         offset,
-        order: [[sortBy, sortOrder]],
+        order: [[safeSortBy, sortOrder]],
         include: [
           {
             model: User,
@@ -489,6 +493,7 @@ class SupportTicketService {
       const { page = 1, limit = 20, sortBy = 'createdAt', sortOrder = 'DESC' } = pagination;
 
       const offset = (page - 1) * limit;
+      const safeSortBy = validateSortField(sortBy, SUPPORT_TICKET_SORT_FIELDS, 'createdAt');
 
       // Build where clause - always filter by userId
       const where: WhereOptions = { userId };
@@ -513,7 +518,7 @@ class SupportTicketService {
         where,
         limit,
         offset,
-        order: [[sortBy, sortOrder]],
+        order: [[safeSortBy, sortOrder]],
       });
 
       return {

--- a/service.backend/src/services/supportTicket.service.ts
+++ b/service.backend/src/services/supportTicket.service.ts
@@ -11,7 +11,13 @@ import { logger } from '../utils/logger';
 import { JsonObject } from '../types/common';
 import { validateSortField } from '../utils/sort-validation';
 
-const SUPPORT_TICKET_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'priority', 'category'] as const;
+const SUPPORT_TICKET_SORT_FIELDS = [
+  'createdAt',
+  'updatedAt',
+  'status',
+  'priority',
+  'category',
+] as const;
 
 interface TicketFilters {
   status?: TicketStatus | TicketStatus[];

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 import { JsonObject } from '../types/common';
 import { Op, QueryTypes, WhereOptions } from 'sequelize';
+import { validateSortField } from '../utils/sort-validation';
+
+const USER_SORT_FIELDS = ['createdAt', 'updatedAt', 'email', 'firstName', 'lastName', 'status'] as const;
 import Application from '../models/Application';
 import { AuditLog } from '../models/AuditLog';
 import Chat from '../models/Chat';
@@ -360,11 +363,12 @@ export class UserService {
 
       // Calculate offset
       const offset = (page - 1) * limit;
+      const safeSortBy = validateSortField(sortBy, USER_SORT_FIELDS, 'createdAt');
 
       // Execute query
       const { rows: users, count: total } = await User.findAndCountAll({
         where: whereConditions,
-        order: [[sortBy, sortOrder]],
+        order: [[safeSortBy, sortOrder]],
         limit,
         offset,
         include: [

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -2,8 +2,6 @@ import { z } from 'zod';
 import { JsonObject } from '../types/common';
 import { Op, QueryTypes, WhereOptions } from 'sequelize';
 import { validateSortField } from '../utils/sort-validation';
-
-const USER_SORT_FIELDS = ['createdAt', 'updatedAt', 'email', 'firstName', 'lastName', 'status'] as const;
 import Application from '../models/Application';
 import { AuditLog } from '../models/AuditLog';
 import Chat from '../models/Chat';
@@ -23,6 +21,15 @@ import {
 import { UserActivity } from '../types/user';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
+
+const USER_SORT_FIELDS = [
+  'createdAt',
+  'updatedAt',
+  'email',
+  'firstName',
+  'lastName',
+  'status',
+] as const;
 
 // Safe wrapper for loggerHelpers to prevent test failures
 const safeLoggerHelpers = {

--- a/service.backend/src/utils/sort-validation.test.ts
+++ b/service.backend/src/utils/sort-validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { validateSortField, normaliseSortField } from './sort-validation';
+import { ApiError } from '../middleware/error-handler';
+
+const ALLOWED = ['createdAt', 'updatedAt', 'status'] as const;
+const DEFAULT = 'createdAt';
+
+describe('validateSortField - blocking SQL ORDER BY injection', () => {
+  it('returns the field when it is in the allowlist', () => {
+    expect(validateSortField('status', ALLOWED, DEFAULT)).toBe('status');
+  });
+
+  it('returns the default field when given the default', () => {
+    expect(validateSortField('createdAt', ALLOWED, DEFAULT)).toBe('createdAt');
+  });
+
+  it('throws ApiError(400) for a field not in the allowlist', () => {
+    expect(() => validateSortField('password', ALLOWED, DEFAULT)).toThrow(ApiError);
+  });
+
+  it('throws with HTTP 400 status for an invalid field', () => {
+    try {
+      validateSortField('(SELECT 1)', ALLOWED, DEFAULT);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).statusCode).toBe(400);
+    }
+  });
+
+  it('rejects SQL injection payloads', () => {
+    const injectionAttempts = [
+      '(SELECT password FROM users LIMIT 1)',
+      "'; DROP TABLE users; --",
+      '1=1',
+      'createdAt; DROP TABLE users',
+    ];
+    for (const attempt of injectionAttempts) {
+      expect(() => validateSortField(attempt, ALLOWED, DEFAULT)).toThrow(ApiError);
+    }
+  });
+
+  it('is case-sensitive — rejects fields that differ only in case', () => {
+    expect(() => validateSortField('CREATEDAT', ALLOWED, DEFAULT)).toThrow(ApiError);
+    expect(() => validateSortField('CreatedAt', ALLOWED, DEFAULT)).toThrow(ApiError);
+  });
+});
+
+describe('normaliseSortField - silently falling back to safe default', () => {
+  it('returns the field when it is in the allowlist', () => {
+    expect(normaliseSortField('updatedAt', ALLOWED, DEFAULT)).toBe('updatedAt');
+  });
+
+  it('returns the default when field is undefined', () => {
+    expect(normaliseSortField(undefined, ALLOWED, DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('returns the default when field is not in the allowlist', () => {
+    expect(normaliseSortField('password', ALLOWED, DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('returns the default for SQL injection payloads instead of throwing', () => {
+    expect(normaliseSortField('(SELECT 1)', ALLOWED, DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('returns the default for empty string', () => {
+    expect(normaliseSortField('', ALLOWED, DEFAULT)).toBe(DEFAULT);
+  });
+});

--- a/service.backend/src/utils/sort-validation.ts
+++ b/service.backend/src/utils/sort-validation.ts
@@ -1,0 +1,26 @@
+import { ApiError } from '../middleware/error-handler';
+
+export const validateSortField = (
+  sortBy: string,
+  allowedFields: readonly string[],
+  defaultField: string
+): string => {
+  if (!allowedFields.includes(sortBy)) {
+    throw new ApiError(
+      400,
+      `Invalid sort field "${sortBy}". Allowed fields: ${allowedFields.join(', ')}`
+    );
+  }
+  return sortBy;
+};
+
+export const normaliseSortField = (
+  sortBy: string | undefined,
+  allowedFields: readonly string[],
+  defaultField: string
+): string => {
+  if (!sortBy || !allowedFields.includes(sortBy)) {
+    return defaultField;
+  }
+  return sortBy;
+};

--- a/service.backend/src/validation/moderation.validation.ts
+++ b/service.backend/src/validation/moderation.validation.ts
@@ -3,6 +3,7 @@ import { ReportCategory, ReportSeverity, ReportStatus } from '../models/Report';
 import { ActionType, ActionSeverity } from '../models/ModeratorAction';
 
 const ENTITY_TYPES = ['user', 'rescue', 'pet', 'application', 'message', 'conversation'];
+const REPORT_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'severity', 'category'];
 const RESOLUTION_TYPES = [
   'no_action',
   'warning_issued',
@@ -47,6 +48,14 @@ export const moderationValidation = {
       .withMessage('Search query must be 1-200 characters'),
     query('dateFrom').optional().isISO8601().withMessage('dateFrom must be a valid ISO 8601 date'),
     query('dateTo').optional().isISO8601().withMessage('dateTo must be a valid ISO 8601 date'),
+    query('sortBy')
+      .optional()
+      .isIn(REPORT_SORT_FIELDS)
+      .withMessage(`sortBy must be one of: ${REPORT_SORT_FIELDS.join(', ')}`),
+    query('sortOrder')
+      .optional()
+      .isIn(['ASC', 'DESC'])
+      .withMessage('sortOrder must be ASC or DESC'),
   ],
 
   getReportById: [param('reportId').isUUID().withMessage('Report ID must be a valid UUID')],


### PR DESCRIPTION
## Summary

Fixes **ENG-208** — SQL ORDER BY injection via unvalidated `sortBy` in list/search services.

The `sortBy` query parameter was forwarded directly from controllers into Sequelize `order: [[sortBy, sortOrder]]` clauses with no allowlist check. An attacker could supply an arbitrary SQL expression (e.g. `(SELECT password FROM users LIMIT 1)`) and use timing or error side-channels to extract data.

**Changes:**
- Adds `service.backend/src/utils/sort-validation.ts` with two functions:
  - `validateSortField` — throws `ApiError(400)` when `sortBy` is not in the allowlist (hard rejection, used at the service layer for defence-in-depth)
  - `normaliseSortField` — silently falls back to a safe default (available for contexts that prefer non-throwing behaviour)
- Applies `validateSortField` with a per-resource allowlist before every vulnerable `order:` clause in:
  - `moderation.service.ts` (Report)
  - `application.service.ts` (Application)
  - `supportTicket.service.ts` (SupportTicket — two call-sites)
  - `user.service.ts` (User)
  - `chat.service.ts` (Chat — two call-sites)
  - `pet.service.ts` (Pet search + rescue pet listing)
  - `rescue.service.ts` (Rescue pet listing)
- Adds `query('sortBy').isIn([...])` and `query('sortOrder').isIn(['ASC','DESC'])` validators to `moderationValidation.getReports` so invalid values are rejected at the HTTP boundary before reaching the service

## Test plan

- [ ] `service.backend/src/utils/sort-validation.test.ts` — 11 new tests covering valid fields, SQL injection payloads, case sensitivity, and `normaliseSortField` fallback behaviour
- [ ] `moderation.service.test.ts` — 5 existing tests pass
- [ ] `application.service.test.ts` — 28 existing tests pass
- [ ] `chat.service.test.ts` — 33 existing tests pass
- [ ] `user.service.test.ts` — 28 existing tests pass
- [ ] `pet.service.test.ts` — 45 existing tests pass
- [ ] `rescue.service.test.ts` — 36 existing tests pass

https://claude.ai/code/session_01RspwGDsyWvumVyLzSPtq88

---
_Generated by [Claude Code](https://claude.ai/code/session_01RspwGDsyWvumVyLzSPtq88)_