### PR TITLE
feat(app.client): redesign navbar and navigation for better UX

### DIFF
--- a/app.client/src/App.tsx
+++ b/app.client/src/App.tsx
@@ -6,6 +6,7 @@ import { AnalyticsProvider } from '@/contexts/AnalyticsContext';
 import { NotificationsProvider } from '@/contexts/NotificationsContext';
 import { ChatProvider } from '@/contexts/ChatContext';
 import { FavoritesProvider } from '@/contexts/FavoritesContext';
+import { DevLoginPanel } from './components/dev/DevLoginPanel';
 import { AppShell } from './components/layout/AppShell';
 import { PublicAuthLayout } from './components/layout/PublicAuthLayout';
 
@@ -83,6 +84,7 @@ function App() {
         <NotificationsProvider>
           <ChatProvider>
             <FavoritesProvider>
+              <DevLoginPanel />
               <Suspense fallback={<PageLoader />}>
                 <Routes>
                   <Route element={<PublicAuthLayout />}>

--- a/app.client/src/App.tsx
+++ b/app.client/src/App.tsx
@@ -1,15 +1,13 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { Footer, Spinner } from '@adopt-dont-shop/lib.components';
+import { Spinner } from '@adopt-dont-shop/lib.components';
 import { PermissionsProvider } from '@/contexts/PermissionsContext';
 import { AnalyticsProvider } from '@/contexts/AnalyticsContext';
 import { NotificationsProvider } from '@/contexts/NotificationsContext';
 import { ChatProvider } from '@/contexts/ChatContext';
 import { FavoritesProvider } from '@/contexts/FavoritesContext';
-import { DevLoginPanel } from './components/dev/DevLoginPanel';
-import { AppNavbar } from './components/navigation/AppNavbar';
-import { SwipeOnboarding } from './components/onboarding/SwipeOnboarding';
-import { SwipeFloatingButton } from './components/ui/SwipeFloatingButton';
+import { AppShell } from './components/layout/AppShell';
+import { PublicAuthLayout } from './components/layout/PublicAuthLayout';
 
 const HomePage = lazy(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })));
 const DiscoveryPage = lazy(() =>
@@ -24,6 +22,9 @@ const RescueDetailsPage = lazy(() =>
 );
 const ApplicationPage = lazy(() =>
   import('@/pages/ApplicationPage').then(m => ({ default: m.ApplicationPage }))
+);
+const ApplicationDashboard = lazy(() =>
+  import('@/pages/ApplicationDashboard').then(m => ({ default: m.ApplicationDashboard }))
 );
 const ApplicationDetailsPage = lazy(() =>
   import('@/pages/ApplicationDetailsPage').then(m => ({ default: m.ApplicationDetailsPage }))
@@ -76,48 +77,43 @@ const PageLoader = () => (
 );
 
 function App() {
-  const [showOnboarding, setShowOnboarding] = useState(true);
-
   return (
     <PermissionsProvider>
       <AnalyticsProvider>
         <NotificationsProvider>
           <ChatProvider>
             <FavoritesProvider>
-              <div className='app'>
-                <AppNavbar />
-                <main>
-                  <Suspense fallback={<PageLoader />}>
-                    <Routes>
-                      <Route path='/' element={<HomePage />} />
-                      <Route path='/discover' element={<DiscoveryPage />} />
-                      <Route path='/search' element={<SearchPage />} />
-                      <Route path='/pets/:id' element={<PetDetailsPage />} />
-                      <Route path='/rescues/:id' element={<RescueDetailsPage />} />
-                      <Route path='/apply/:petId' element={<ApplicationPage />} />
-                      <Route path='/applications/:id' element={<ApplicationDetailsPage />} />
-                      <Route path='/profile' element={<ProfilePage />} />
-                      <Route path='/favorites' element={<FavoritesPage />} />
-                      <Route path='/notifications' element={<NotificationsPage />} />
-                      <Route path='/chat' element={<ChatPage />} />
-                      <Route path='/chat/:conversationId' element={<ChatPage />} />
-                      <Route path='/login' element={<LoginPage />} />
-                      <Route path='/register' element={<RegisterPage />} />
-                      <Route path='/verify-email' element={<VerifyEmailPage />} />
-                      <Route path='/forgot-password' element={<ForgotPasswordPage />} />
-                      <Route path='/reset-password' element={<ResetPasswordPage />} />
-                      <Route path='/blog' element={<BlogPage />} />
-                      <Route path='/blog/:slug' element={<BlogPostPage />} />
-                      <Route path='/help' element={<HelpPage />} />
-                      <Route path='/help/:slug' element={<HelpArticlePage />} />
-                    </Routes>
-                  </Suspense>
-                </main>
-                <SwipeFloatingButton />
-                <DevLoginPanel />
-                {showOnboarding && <SwipeOnboarding onClose={() => setShowOnboarding(false)} />}
-                <Footer />
-              </div>
+              <Suspense fallback={<PageLoader />}>
+                <Routes>
+                  <Route element={<PublicAuthLayout />}>
+                    <Route path='/login' element={<LoginPage />} />
+                    <Route path='/register' element={<RegisterPage />} />
+                    <Route path='/verify-email' element={<VerifyEmailPage />} />
+                    <Route path='/forgot-password' element={<ForgotPasswordPage />} />
+                    <Route path='/reset-password' element={<ResetPasswordPage />} />
+                  </Route>
+
+                  <Route element={<AppShell />}>
+                    <Route path='/' element={<HomePage />} />
+                    <Route path='/discover' element={<DiscoveryPage />} />
+                    <Route path='/search' element={<SearchPage />} />
+                    <Route path='/pets/:id' element={<PetDetailsPage />} />
+                    <Route path='/rescues/:id' element={<RescueDetailsPage />} />
+                    <Route path='/apply/:petId' element={<ApplicationPage />} />
+                    <Route path='/applications' element={<ApplicationDashboard />} />
+                    <Route path='/applications/:id' element={<ApplicationDetailsPage />} />
+                    <Route path='/profile' element={<ProfilePage />} />
+                    <Route path='/favorites' element={<FavoritesPage />} />
+                    <Route path='/notifications' element={<NotificationsPage />} />
+                    <Route path='/chat' element={<ChatPage />} />
+                    <Route path='/chat/:conversationId' element={<ChatPage />} />
+                    <Route path='/blog' element={<BlogPage />} />
+                    <Route path='/blog/:slug' element={<BlogPostPage />} />
+                    <Route path='/help' element={<HelpPage />} />
+                    <Route path='/help/:slug' element={<HelpArticlePage />} />
+                  </Route>
+                </Routes>
+              </Suspense>
             </FavoritesProvider>
           </ChatProvider>
         </NotificationsProvider>

--- a/app.client/src/__tests__/application-routing.behavior.test.tsx
+++ b/app.client/src/__tests__/application-routing.behavior.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from '@adopt-dont-shop/lib.components';
+import { AppShell } from '@/components/layout/AppShell';
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/contexts/NotificationsContext', () => ({
+  useNotifications: () => ({ unreadCount: 0 }),
+}));
+
+vi.mock('@/contexts/ChatContext', () => ({
+  useChat: () => ({ unreadMessageCount: 0 }),
+}));
+
+vi.mock('@/components/ui/SwipeFloatingButton', () => ({
+  SwipeFloatingButton: () => null,
+}));
+
+vi.mock('@/components/dev/DevLoginPanel', () => ({ DevLoginPanel: () => null }));
+vi.mock('@/components/onboarding/SwipeOnboarding', () => ({ SwipeOnboarding: () => null }));
+
+vi.mock('@/pages/ApplicationDashboard', () => ({
+  ApplicationDashboard: () => <div>Application dashboard</div>,
+}));
+vi.mock('@/pages/ApplicationDetailsPage', () => ({
+  ApplicationDetailsPage: () => <div>Application details</div>,
+}));
+
+import { ApplicationDashboard } from '@/pages/ApplicationDashboard';
+import { ApplicationDetailsPage } from '@/pages/ApplicationDetailsPage';
+
+const renderAt = (path: string) =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route path='/applications' element={<ApplicationDashboard />} />
+            <Route path='/applications/:id' element={<ApplicationDetailsPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+
+describe('Application routing', () => {
+  it('renders ApplicationDashboard at /applications', () => {
+    renderAt('/applications');
+    expect(screen.getByText('Application dashboard')).toBeInTheDocument();
+  });
+
+  it('renders ApplicationDetailsPage at /applications/:id', () => {
+    renderAt('/applications/abc-123');
+    expect(screen.getByText('Application details')).toBeInTheDocument();
+  });
+});

--- a/app.client/src/__tests__/application-routing.behavior.test.tsx
+++ b/app.client/src/__tests__/application-routing.behavior.test.tsx
@@ -36,7 +36,6 @@ vi.mock('@/components/ui/SwipeFloatingButton', () => ({
   SwipeFloatingButton: () => null,
 }));
 
-vi.mock('@/components/dev/DevLoginPanel', () => ({ DevLoginPanel: () => null }));
 vi.mock('@/components/onboarding/SwipeOnboarding', () => ({ SwipeOnboarding: () => null }));
 
 vi.mock('@/pages/ApplicationDashboard', () => ({

--- a/app.client/src/components/layout/AppShell.test.tsx
+++ b/app.client/src/components/layout/AppShell.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from '@adopt-dont-shop/lib.components';
+import { AppShell } from './AppShell';
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/contexts/NotificationsContext', () => ({
+  useNotifications: () => ({ unreadCount: 0 }),
+}));
+
+vi.mock('@/contexts/ChatContext', () => ({
+  useChat: () => ({ unreadMessageCount: 0 }),
+}));
+
+vi.mock('@/components/ui/SwipeFloatingButton', () => ({
+  SwipeFloatingButton: () => <div data-testid='swipe-fab' />,
+}));
+
+vi.mock('@/components/dev/DevLoginPanel', () => ({
+  DevLoginPanel: () => null,
+}));
+
+vi.mock('@/components/onboarding/SwipeOnboarding', () => ({
+  SwipeOnboarding: () => null,
+}));
+
+const renderShell = () =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route path='/' element={<div>Home</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+
+describe('AppShell', () => {
+  it('renders the app navbar logo', () => {
+    renderShell();
+    expect(screen.getByRole('link', { name: /adopt don't shop/i })).toBeInTheDocument();
+  });
+
+  it('renders the nested route content in the main region', () => {
+    renderShell();
+    expect(screen.getByRole('main')).toContainElement(screen.getByText('Home'));
+  });
+
+  it('renders the floating swipe button', () => {
+    renderShell();
+    expect(screen.getByTestId('swipe-fab')).toBeInTheDocument();
+  });
+});

--- a/app.client/src/components/layout/AppShell.test.tsx
+++ b/app.client/src/components/layout/AppShell.test.tsx
@@ -36,10 +36,6 @@ vi.mock('@/components/ui/SwipeFloatingButton', () => ({
   SwipeFloatingButton: () => <div data-testid='swipe-fab' />,
 }));
 
-vi.mock('@/components/dev/DevLoginPanel', () => ({
-  DevLoginPanel: () => null,
-}));
-
 vi.mock('@/components/onboarding/SwipeOnboarding', () => ({
   SwipeOnboarding: () => null,
 }));

--- a/app.client/src/components/layout/AppShell.tsx
+++ b/app.client/src/components/layout/AppShell.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import styled from 'styled-components';
+import { Footer } from '@adopt-dont-shop/lib.components';
+import { AppNavbar } from '@/components/navigation/AppNavbar';
+import { BottomTabBar } from '@/components/navigation/BottomTabBar';
+import { DevLoginPanel } from '@/components/dev/DevLoginPanel';
+import { SwipeOnboarding } from '@/components/onboarding/SwipeOnboarding';
+import { SwipeFloatingButton } from '@/components/ui/SwipeFloatingButton';
+
+const Shell = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Main = styled.main`
+  flex: 1;
+`;
+
+export const AppShell: React.FC = () => {
+  const [showOnboarding, setShowOnboarding] = useState(true);
+
+  return (
+    <Shell>
+      <AppNavbar />
+      <Main>
+        <Outlet />
+      </Main>
+      <SwipeFloatingButton />
+      <BottomTabBar />
+      <DevLoginPanel />
+      {showOnboarding && <SwipeOnboarding onClose={() => setShowOnboarding(false)} />}
+      <Footer />
+    </Shell>
+  );
+};

--- a/app.client/src/components/layout/AppShell.tsx
+++ b/app.client/src/components/layout/AppShell.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { Footer } from '@adopt-dont-shop/lib.components';
 import { AppNavbar } from '@/components/navigation/AppNavbar';
 import { BottomTabBar } from '@/components/navigation/BottomTabBar';
-import { DevLoginPanel } from '@/components/dev/DevLoginPanel';
 import { SwipeOnboarding } from '@/components/onboarding/SwipeOnboarding';
 import { SwipeFloatingButton } from '@/components/ui/SwipeFloatingButton';
 
@@ -29,7 +28,6 @@ export const AppShell: React.FC = () => {
       </Main>
       <SwipeFloatingButton />
       <BottomTabBar />
-      <DevLoginPanel />
       {showOnboarding && <SwipeOnboarding onClose={() => setShowOnboarding(false)} />}
       <Footer />
     </Shell>

--- a/app.client/src/components/layout/PublicAuthLayout.test.tsx
+++ b/app.client/src/components/layout/PublicAuthLayout.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from '@adopt-dont-shop/lib.components';
+import { PublicAuthLayout } from './PublicAuthLayout';
+
+const renderAt = (path: string) =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route element={<PublicAuthLayout />}>
+            <Route path='/login' element={<div>Login page content</div>} />
+            <Route path='/register' element={<div>Register page content</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+
+describe('PublicAuthLayout', () => {
+  it('renders the logo linking back to home', () => {
+    renderAt('/login');
+    expect(screen.getByRole('link', { name: /adopt don't shop/i })).toHaveAttribute('href', '/');
+  });
+
+  it('shows a "Sign up" switch link on the /login route', () => {
+    renderAt('/login');
+    const switchLink = screen.getByRole('link', { name: /sign up/i });
+    expect(switchLink).toHaveAttribute('href', '/register');
+  });
+
+  it('shows a "Log in" switch link on the /register route', () => {
+    renderAt('/register');
+    const switchLink = screen.getByRole('link', { name: /log in/i });
+    expect(switchLink).toHaveAttribute('href', '/login');
+  });
+
+  it('renders the nested route content', () => {
+    renderAt('/login');
+    expect(screen.getByText('Login page content')).toBeInTheDocument();
+  });
+});

--- a/app.client/src/components/layout/PublicAuthLayout.tsx
+++ b/app.client/src/components/layout/PublicAuthLayout.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Link, Outlet, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Shell = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: ${({ theme }) => theme.background.primary};
+`;
+
+const Header = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+  padding: 0 ${({ theme }) => theme.spacing[4]};
+  border-bottom: 1px solid ${({ theme }) => theme.border.color.primary};
+`;
+
+const Logo = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing[2]};
+  font-weight: 700;
+  font-size: ${({ theme }) => theme.typography.size.lg};
+  color: ${({ theme }) => theme.text.primary};
+  text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.border.color.focus};
+    outline-offset: 2px;
+    border-radius: ${({ theme }) => theme.border.radius.sm};
+  }
+`;
+
+const LogoIcon = styled.span`
+  font-size: 1.5rem;
+  line-height: 1;
+`;
+
+const SwitchLink = styled(Link)`
+  color: ${({ theme }) => theme.colors.primary[600]};
+  text-decoration: none;
+  font-weight: 500;
+  font-size: ${({ theme }) => theme.typography.size.sm};
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.border.color.focus};
+    outline-offset: 2px;
+    border-radius: ${({ theme }) => theme.border.radius.sm};
+  }
+`;
+
+const Main = styled.main`
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: ${({ theme }) => theme.spacing[8]} ${({ theme }) => theme.spacing[4]};
+`;
+
+export const PublicAuthLayout: React.FC = () => {
+  const location = useLocation();
+  const onLogin = location.pathname.startsWith('/login');
+  const switchTo = onLogin ? '/register' : '/login';
+  const switchLabel = onLogin ? 'Sign up' : 'Log in';
+
+  return (
+    <Shell>
+      <Header>
+        <Logo to='/'>
+          <LogoIcon aria-hidden='true'>🐾</LogoIcon>
+          Adopt Don&apos;t Shop
+        </Logo>
+        <SwitchLink to={switchTo}>{switchLabel}</SwitchLink>
+      </Header>
+      <Main>
+        <Outlet />
+      </Main>
+    </Shell>
+  );
+};

--- a/app.client/src/components/navigation/AppNavbar.test.tsx
+++ b/app.client/src/components/navigation/AppNavbar.test.tsx
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, screen, within } from '@/test-utils/render';
+import { AppNavbar } from './AppNavbar';
+import type { User } from '@adopt-dont-shop/lib.auth';
+
+type AuthState = { user: User | null; isAuthenticated: boolean };
+
+const authState: AuthState = { user: null, isAuthenticated: false };
+const notificationsState = { unreadCount: 0 };
+const chatState = { unreadMessageCount: 0 };
+
+const baseUser: User = {
+  userId: 'u1',
+  email: 'alex@example.com',
+  firstName: 'Alex',
+  lastName: 'Rivera',
+  emailVerified: true,
+  userType: 'adopter',
+  status: 'active',
+};
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: authState.user,
+      isAuthenticated: authState.isAuthenticated,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/contexts/NotificationsContext', () => ({
+  useNotifications: () => notificationsState,
+}));
+
+vi.mock('@/contexts/ChatContext', () => ({
+  useChat: () => chatState,
+}));
+
+describe('AppNavbar', () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.isAuthenticated = false;
+    notificationsState.unreadCount = 0;
+    chatState.unreadMessageCount = 0;
+  });
+
+  describe('logged out', () => {
+    it('renders Log in and Sign up CTAs', () => {
+      renderWithProviders(<AppNavbar />);
+      expect(screen.getByRole('link', { name: /log in/i })).toHaveAttribute('href', '/login');
+      expect(screen.getByRole('link', { name: /sign up/i })).toHaveAttribute('href', '/register');
+    });
+
+    it('does not show Favorites / Messages / Notifications / user menu', () => {
+      renderWithProviders(<AppNavbar />);
+      expect(screen.queryByRole('link', { name: /favorites/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /messages/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /notifications/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /user menu/i })).not.toBeInTheDocument();
+    });
+
+    it('still shows Discover and Search so visitors can browse', () => {
+      renderWithProviders(<AppNavbar />);
+      expect(screen.getByRole('link', { name: /discover/i })).toHaveAttribute('href', '/discover');
+      expect(screen.getByRole('link', { name: /search/i })).toHaveAttribute('href', '/search');
+    });
+  });
+
+  describe('logged in', () => {
+    beforeEach(() => {
+      authState.user = baseUser;
+      authState.isAuthenticated = true;
+    });
+
+    it('renders the primary adopter links', () => {
+      renderWithProviders(<AppNavbar />);
+      expect(screen.getByRole('link', { name: /discover/i })).toHaveAttribute('href', '/discover');
+      expect(screen.getByRole('link', { name: /search/i })).toHaveAttribute('href', '/search');
+      expect(screen.getByRole('link', { name: /favorites/i })).toHaveAttribute(
+        'href',
+        '/favorites'
+      );
+    });
+
+    it('renders the user menu trigger', () => {
+      renderWithProviders(<AppNavbar />);
+      expect(screen.getByRole('button', { name: /user menu/i })).toBeInTheDocument();
+    });
+
+    it('hides the messages badge when there are no unread messages', () => {
+      chatState.unreadMessageCount = 0;
+      renderWithProviders(<AppNavbar />);
+      const messagesLink = screen.getByRole('link', { name: /messages/i });
+      expect(within(messagesLink).queryByText(/\d+/)).not.toBeInTheDocument();
+    });
+
+    it('shows the messages badge with the unread count', () => {
+      chatState.unreadMessageCount = 4;
+      renderWithProviders(<AppNavbar />);
+      const messagesLink = screen.getByRole('link', { name: /messages/i });
+      expect(within(messagesLink).getByText('4')).toBeInTheDocument();
+    });
+
+    it('shows the notifications badge with the unread count', () => {
+      notificationsState.unreadCount = 7;
+      renderWithProviders(<AppNavbar />);
+      const notificationsLink = screen.getByRole('link', { name: /notifications/i });
+      expect(within(notificationsLink).getByText('7')).toBeInTheDocument();
+    });
+
+    it('clamps notification counts over 99 to 99+', () => {
+      notificationsState.unreadCount = 145;
+      renderWithProviders(<AppNavbar />);
+      const notificationsLink = screen.getByRole('link', { name: /notifications/i });
+      expect(within(notificationsLink).getByText('99+')).toBeInTheDocument();
+    });
+
+    it('does not render the legacy swipe callout', () => {
+      renderWithProviders(<AppNavbar />);
+      expect(screen.queryByText(/try our new swipe feature/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('points the logo at the home route', () => {
+    renderWithProviders(<AppNavbar />);
+    const logo = screen.getByRole('link', { name: /adopt don't shop/i });
+    expect(logo).toHaveAttribute('href', '/');
+  });
+});

--- a/app.client/src/components/navigation/AppNavbar.tsx
+++ b/app.client/src/components/navigation/AppNavbar.tsx
@@ -1,327 +1,189 @@
-import React, { useState } from 'react';
-import {
-  MdAutoFixHigh,
-  MdChat,
-  MdClose,
-  MdFavorite,
-  MdMenu,
-  MdNotifications,
-  MdPerson,
-  MdSearch,
-  MdSwipe,
-} from 'react-icons/md';
+import React from 'react';
+import { MdChat, MdFavorite, MdNotifications, MdSearch, MdSwipe } from 'react-icons/md';
 import { Link, useLocation } from 'react-router-dom';
-import styled, { css, keyframes } from 'styled-components';
+import styled from 'styled-components';
+import { Badge } from '@adopt-dont-shop/lib.components';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+import { useChat } from '@/contexts/ChatContext';
 import { useNotifications } from '@/contexts/NotificationsContext';
-
-const pulseGlow = keyframes`
-  0%, 100% {
-    box-shadow: 0 0 5px rgba(255, 64, 129, 0.3);
-  }
-  50% {
-    box-shadow: 0 0 20px rgba(255, 64, 129, 0.6);
-  }
-`;
-
-const swipeAnimation = keyframes`
-  0% { transform: translateX(0) rotate(0deg); }
-  25% { transform: translateX(10px) rotate(5deg); }
-  75% { transform: translateX(-10px) rotate(-5deg); }
-  100% { transform: translateX(0) rotate(0deg); }
-`;
+import { AuthCtas } from './AuthCtas';
+import { NavLink } from './NavLink';
+import { NavUserMenu } from './NavUserMenu';
 
 const NavbarContainer = styled.nav`
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  padding: 0;
+  background: ${({ theme }) => theme.colors.gradients.primary};
   position: sticky;
   top: 0;
   z-index: 1000;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  box-shadow: ${({ theme }) => theme.shadows.md};
 `;
 
 const NavContent = styled.div`
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 ${({ theme }) => theme.spacing[4]};
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  height: 70px;
+  gap: ${({ theme }) => theme.spacing[4]};
+  height: 64px;
 
   @media (max-width: 768px) {
-    padding: 0 0.75rem;
-    height: 60px;
+    height: 56px;
+    padding: 0 ${({ theme }) => theme.spacing[3]};
+    gap: ${({ theme }) => theme.spacing[2]};
   }
 `;
 
 const Logo = styled(Link)`
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 1.5rem;
+  gap: ${({ theme }) => theme.spacing[2]};
+  font-size: ${({ theme }) => theme.typography.size.lg};
   font-weight: 700;
-  color: white;
+  color: #fff;
   text-decoration: none;
-  transition: transform 0.2s ease;
+  white-space: nowrap;
 
-  &:hover {
-    transform: scale(1.02);
-  }
-
-  @media (max-width: 768px) {
-    font-size: 1.25rem;
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+    border-radius: ${({ theme }) => theme.border.radius.sm};
   }
 `;
 
-const LogoIcon = styled.div`
-  font-size: 2rem;
-  color: #ff4081;
+const LogoIcon = styled.span`
+  font-size: 1.75rem;
+  line-height: 1;
 `;
 
-const NavItems = styled.div<{ $isOpen: boolean }>`
-  display: flex;
+const PrimaryLinks = styled.div`
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: ${({ theme }) => theme.spacing[1]};
 
   @media (max-width: 768px) {
-    position: fixed;
-    top: 60px;
-    left: 0;
-    right: 0;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    flex-direction: column;
-    padding: 1rem;
-    gap: 0.75rem;
-    transform: translateY(${({ $isOpen }) => ($isOpen ? '0' : '-100%')});
-    transition: transform 0.3s ease;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  }
-`;
-
-const NavLink = styled(Link)<{ $isActive?: boolean; $isPrimary?: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  border-radius: 12px;
-  font-weight: 500;
-  color: white;
-  text-decoration: none;
-  transition: all 0.2s ease;
-  position: relative;
-  overflow: hidden;
-
-  ${({ $isPrimary }) =>
-    $isPrimary &&
-    css`
-      background: linear-gradient(45deg, #ff4081, #ff6ec7);
-      box-shadow: 0 4px 15px rgba(255, 64, 129, 0.3);
-      animation: ${pulseGlow} 3s ease-in-out infinite;
-      font-weight: 600;
-
-      &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: -100%;
-        width: 100%;
-        height: 100%;
-        background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-        transition: left 0.6s;
-      }
-
-      &:hover::before {
-        left: 100%;
-      }
-
-      .swipe-icon {
-        animation: ${swipeAnimation} 2s ease-in-out infinite;
-      }
-    `}
-
-  ${({ $isActive, $isPrimary }) =>
-    $isActive &&
-    !$isPrimary &&
-    css`
-      background: rgba(255, 255, 255, 0.15);
-      backdrop-filter: blur(10px);
-    `}
-
-  &:hover {
-    background: ${({ $isPrimary }) =>
-      $isPrimary ? 'linear-gradient(45deg, #e91e63, #ff4081)' : 'rgba(255, 255, 255, 0.1)'};
-    transform: translateY(-2px);
-  }
-
-  .nav-icon {
-    font-size: 1.25rem;
-  }
-
-  @media (max-width: 768px) {
-    width: 100%;
-    justify-content: center;
-    padding: 1rem;
-  }
-`;
-
-const MobileMenuButton = styled.button`
-  display: none;
-  background: none;
-  border: none;
-  color: white;
-  font-size: 1.5rem;
-  cursor: pointer;
-  padding: 0.5rem;
-  border-radius: 8px;
-  transition: background 0.2s ease;
-
-  &:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-
-  @media (max-width: 768px) {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-`;
-
-const SwipeCallout = styled.div`
-  background: rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 20px;
-  padding: 0.5rem 1rem;
-  margin-left: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: white;
-  font-size: 0.875rem;
-  font-weight: 500;
-
-  .sparkle {
-    color: #ffd700;
-    animation: ${swipeAnimation} 1.5s ease-in-out infinite;
-  }
-
-  @media (max-width: 968px) {
     display: none;
   }
 `;
 
-interface AppNavbarProps {
+const RightSlot = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing[1]};
+  margin-left: auto;
+`;
+
+const IconLinkAnchor = styled(Link)<{ $active: boolean }>`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  color: #fff;
+  text-decoration: none;
+  transition: background ${({ theme }) => theme.transitions.fast};
+  background: ${({ $active }) => ($active ? 'rgba(255, 255, 255, 0.18)' : 'transparent')};
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+  }
+
+  svg {
+    font-size: 1.375rem;
+  }
+`;
+
+const BadgeOverlay = styled.span`
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  pointer-events: none;
+`;
+
+type IconLinkProps = {
+  to: string;
+  label: string;
+  icon: React.ReactNode;
+  count?: number;
+};
+
+const IconLink: React.FC<IconLinkProps> = ({ to, label, icon, count = 0 }) => {
+  const location = useLocation();
+  const active = location.pathname === to || location.pathname.startsWith(`${to}/`);
+  const ariaLabel = count > 0 ? `${label} (${count} unread)` : label;
+  return (
+    <IconLinkAnchor to={to} $active={active} aria-label={ariaLabel}>
+      {icon}
+      {count > 0 && (
+        <BadgeOverlay>
+          <Badge variant='count' max={99}>
+            {count}
+          </Badge>
+        </BadgeOverlay>
+      )}
+    </IconLinkAnchor>
+  );
+};
+
+export type AppNavbarProps = {
   className?: string;
-}
+};
 
 export const AppNavbar: React.FC<AppNavbarProps> = ({ className }) => {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const location = useLocation();
-  const { unreadCount } = useNotifications();
-
-  const isActive = (path: string) => location.pathname === path;
-
-  const toggleMobileMenu = () => {
-    setMobileMenuOpen(!mobileMenuOpen);
-  };
+  const { isAuthenticated } = useAuth();
+  const { unreadCount: notificationsUnread } = useNotifications();
+  const { unreadMessageCount } = useChat();
 
   return (
     <NavbarContainer className={className}>
       <NavContent>
         <Logo to='/'>
-          <LogoIcon>🐾</LogoIcon>
+          <LogoIcon aria-hidden='true'>🐾</LogoIcon>
           Adopt Don&apos;t Shop
         </Logo>
 
-        <NavItems $isOpen={mobileMenuOpen}>
-          <NavLink
-            to='/discover'
-            $isPrimary={true}
-            $isActive={isActive('/discover')}
-            onClick={() => setMobileMenuOpen(false)}
-          >
-            <MdSwipe className='nav-icon swipe-icon' />
-            Discover Pets
+        <PrimaryLinks>
+          <NavLink to='/discover' icon={<MdSwipe aria-hidden='true' />} primary>
+            Discover
           </NavLink>
-
-          <NavLink
-            to='/search'
-            $isActive={isActive('/search')}
-            onClick={() => setMobileMenuOpen(false)}
-          >
-            <MdSearch className='nav-icon' />
+          <NavLink to='/search' icon={<MdSearch aria-hidden='true' />}>
             Search
           </NavLink>
+          {isAuthenticated && (
+            <NavLink to='/favorites' icon={<MdFavorite aria-hidden='true' />}>
+              Favorites
+            </NavLink>
+          )}
+        </PrimaryLinks>
 
-          <NavLink
-            to='/favorites'
-            $isActive={isActive('/favorites')}
-            onClick={() => setMobileMenuOpen(false)}
-          >
-            <MdFavorite className='nav-icon' />
-            Favorites
-          </NavLink>
-
-          <NavLink
-            to='/chat'
-            $isActive={isActive('/chat')}
-            onClick={() => setMobileMenuOpen(false)}
-          >
-            <MdChat className='nav-icon' />
-            Messages
-          </NavLink>
-
-          <NavLink
-            to='/notifications'
-            $isActive={isActive('/notifications')}
-            onClick={() => setMobileMenuOpen(false)}
-            style={{ position: 'relative' }}
-          >
-            <MdNotifications className='nav-icon' />
-            Notifications
-            {unreadCount > 0 && (
-              <span
-                style={{
-                  position: 'absolute',
-                  top: '-2px',
-                  right: '8px',
-                  background: '#ff4081',
-                  color: 'white',
-                  borderRadius: '50%',
-                  width: '18px',
-                  height: '18px',
-                  fontSize: '12px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontWeight: 'bold',
-                }}
-              >
-                {unreadCount > 99 ? '99+' : unreadCount}
-              </span>
-            )}
-          </NavLink>
-
-          <NavLink
-            to='/profile'
-            $isActive={isActive('/profile')}
-            onClick={() => setMobileMenuOpen(false)}
-          >
-            <MdPerson className='nav-icon' />
-            Profile
-          </NavLink>
-        </NavItems>
-
-        <SwipeCallout>
-          <MdAutoFixHigh className='sparkle' />
-          Try our new swipe feature!
-        </SwipeCallout>
-
-        <MobileMenuButton onClick={toggleMobileMenu} aria-label='Toggle menu'>
-          {mobileMenuOpen ? <MdClose /> : <MdMenu />}
-        </MobileMenuButton>
+        <RightSlot>
+          {isAuthenticated ? (
+            <>
+              <IconLink
+                to='/chat'
+                label='Messages'
+                icon={<MdChat aria-hidden='true' />}
+                count={unreadMessageCount}
+              />
+              <IconLink
+                to='/notifications'
+                label='Notifications'
+                icon={<MdNotifications aria-hidden='true' />}
+                count={notificationsUnread}
+              />
+              <NavUserMenu />
+            </>
+          ) : (
+            <AuthCtas />
+          )}
+        </RightSlot>
       </NavContent>
     </NavbarContainer>
   );

--- a/app.client/src/components/navigation/AuthCtas.tsx
+++ b/app.client/src/components/navigation/AuthCtas.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Row = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing[2]};
+`;
+
+const GhostLink = styled(Link)`
+  color: #fff;
+  text-decoration: none;
+  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[3]}`};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  font-weight: 500;
+  font-size: ${({ theme }) => theme.typography.size.sm};
+  transition: background ${({ theme }) => theme.transitions.fast};
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+  }
+`;
+
+const SolidLink = styled(Link)`
+  color: ${({ theme }) => theme.colors.primary[700]};
+  background: #fff;
+  text-decoration: none;
+  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[4]}`};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  font-weight: 600;
+  font-size: ${({ theme }) => theme.typography.size.sm};
+  transition:
+    transform ${({ theme }) => theme.transitions.fast},
+    box-shadow ${({ theme }) => theme.transitions.fast};
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: ${({ theme }) => theme.shadows.md};
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+  }
+`;
+
+export const AuthCtas: React.FC = () => (
+  <Row>
+    <GhostLink to='/login'>Log in</GhostLink>
+    <SolidLink to='/register'>Sign up</SolidLink>
+  </Row>
+);

--- a/app.client/src/components/navigation/BottomTabBar.test.tsx
+++ b/app.client/src/components/navigation/BottomTabBar.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, screen, within } from '@/test-utils/render';
+import { BottomTabBar } from './BottomTabBar';
+import type { User } from '@adopt-dont-shop/lib.auth';
+
+const authState: { user: User | null; isAuthenticated: boolean } = {
+  user: null,
+  isAuthenticated: false,
+};
+const chatState = { unreadMessageCount: 0 };
+
+const baseUser: User = {
+  userId: 'u1',
+  email: 'alex@example.com',
+  firstName: 'Alex',
+  lastName: 'Rivera',
+  emailVerified: true,
+  userType: 'adopter',
+  status: 'active',
+};
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: authState.user,
+      isAuthenticated: authState.isAuthenticated,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/contexts/ChatContext', () => ({
+  useChat: () => chatState,
+}));
+
+describe('BottomTabBar', () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.isAuthenticated = false;
+    chatState.unreadMessageCount = 0;
+  });
+
+  it('does not render when the user is unauthenticated', () => {
+    const { container } = renderWithProviders(<BottomTabBar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a navigation region with 5 primary tabs when authenticated', () => {
+    authState.user = baseUser;
+    authState.isAuthenticated = true;
+    renderWithProviders(<BottomTabBar />);
+    const nav = screen.getByRole('navigation', { name: /primary/i });
+    expect(within(nav).getByRole('link', { name: /discover/i })).toHaveAttribute(
+      'href',
+      '/discover'
+    );
+    expect(within(nav).getByRole('link', { name: /search/i })).toHaveAttribute('href', '/search');
+    expect(within(nav).getByRole('link', { name: /favorites/i })).toHaveAttribute(
+      'href',
+      '/favorites'
+    );
+    expect(within(nav).getByRole('link', { name: /messages/i })).toHaveAttribute('href', '/chat');
+    expect(within(nav).getByRole('button', { name: /user menu/i })).toBeInTheDocument();
+  });
+
+  it('shows the unread-messages badge when unreadMessageCount > 0', () => {
+    authState.user = baseUser;
+    authState.isAuthenticated = true;
+    chatState.unreadMessageCount = 3;
+    renderWithProviders(<BottomTabBar />);
+    const messages = screen.getByRole('link', { name: /messages/i });
+    expect(within(messages).getByText('3')).toBeInTheDocument();
+  });
+});

--- a/app.client/src/components/navigation/BottomTabBar.tsx
+++ b/app.client/src/components/navigation/BottomTabBar.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  MdChat,
-  MdFavoriteBorder,
-  MdOutlineSearch,
-  MdSwipe,
-} from 'react-icons/md';
+import { MdChat, MdFavoriteBorder, MdOutlineSearch, MdSwipe } from 'react-icons/md';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { Badge } from '@adopt-dont-shop/lib.components';
@@ -93,7 +88,9 @@ export const BottomTabBar: React.FC = () => {
   const { unreadMessageCount } = useChat();
   const location = useLocation();
 
-  if (!isAuthenticated) return null;
+  if (!isAuthenticated) {
+    return null;
+  }
 
   const tabs: TabDef[] = [
     { to: '/discover', label: 'Discover', icon: <MdSwipe aria-hidden='true' /> },

--- a/app.client/src/components/navigation/BottomTabBar.tsx
+++ b/app.client/src/components/navigation/BottomTabBar.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import {
+  MdChat,
+  MdFavoriteBorder,
+  MdOutlineSearch,
+  MdSwipe,
+} from 'react-icons/md';
+import { Link, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import { Badge } from '@adopt-dont-shop/lib.components';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+import { useChat } from '@/contexts/ChatContext';
+import { NavUserMenu } from './NavUserMenu';
+
+const Bar = styled.nav`
+  display: flex;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background: ${({ theme }) => theme.background.primary};
+  border-top: 1px solid ${({ theme }) => theme.border.color.primary};
+  padding-bottom: env(safe-area-inset-bottom, 0);
+
+  @media (min-width: 769px) {
+    display: none;
+  }
+`;
+
+const Tabs = styled.ul`
+  display: flex;
+  justify-content: space-around;
+  align-items: stretch;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+`;
+
+const TabItem = styled.li`
+  flex: 1;
+  display: flex;
+`;
+
+const TabLink = styled(Link)<{ $active: boolean }>`
+  flex: 1;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: ${({ theme }) => theme.spacing[0.5]};
+  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[1]}`};
+  color: ${({ theme, $active }) => ($active ? theme.colors.primary[600] : theme.text.secondary)};
+  font-size: ${({ theme }) => theme.typography.size.xs};
+  text-decoration: none;
+  position: relative;
+  min-height: 56px;
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.border.color.focus};
+    outline-offset: -2px;
+  }
+
+  svg {
+    font-size: 1.5rem;
+  }
+`;
+
+const BadgeOverlay = styled.span`
+  position: absolute;
+  top: 6px;
+  right: calc(50% - 20px);
+  pointer-events: none;
+`;
+
+const MeTab = styled.li`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+type TabDef = {
+  to: string;
+  label: string;
+  icon: React.ReactNode;
+  badge?: number;
+};
+
+export const BottomTabBar: React.FC = () => {
+  const { isAuthenticated } = useAuth();
+  const { unreadMessageCount } = useChat();
+  const location = useLocation();
+
+  if (!isAuthenticated) return null;
+
+  const tabs: TabDef[] = [
+    { to: '/discover', label: 'Discover', icon: <MdSwipe aria-hidden='true' /> },
+    { to: '/search', label: 'Search', icon: <MdOutlineSearch aria-hidden='true' /> },
+    { to: '/favorites', label: 'Favorites', icon: <MdFavoriteBorder aria-hidden='true' /> },
+    {
+      to: '/chat',
+      label: 'Messages',
+      icon: <MdChat aria-hidden='true' />,
+      badge: unreadMessageCount,
+    },
+  ];
+
+  const isActive = (to: string) =>
+    location.pathname === to || location.pathname.startsWith(`${to}/`);
+
+  return (
+    <Bar aria-label='Primary'>
+      <Tabs>
+        {tabs.map(tab => {
+          const active = isActive(tab.to);
+          const ariaLabel =
+            tab.badge && tab.badge > 0 ? `${tab.label} (${tab.badge} unread)` : tab.label;
+          return (
+            <TabItem key={tab.to}>
+              <TabLink
+                to={tab.to}
+                $active={active}
+                aria-label={ariaLabel}
+                aria-current={active ? 'page' : undefined}
+              >
+                {tab.icon}
+                <span>{tab.label}</span>
+                {tab.badge && tab.badge > 0 ? (
+                  <BadgeOverlay>
+                    <Badge variant='count' max={99}>
+                      {tab.badge}
+                    </Badge>
+                  </BadgeOverlay>
+                ) : null}
+              </TabLink>
+            </TabItem>
+          );
+        })}
+        <MeTab>
+          <NavUserMenu />
+        </MeTab>
+      </Tabs>
+    </Bar>
+  );
+};

--- a/app.client/src/components/navigation/NavLink.tsx
+++ b/app.client/src/components/navigation/NavLink.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Link, useLocation, type LinkProps } from 'react-router-dom';
+import styled, { css } from 'styled-components';
+
+type StyledLinkProps = {
+  $active: boolean;
+  $primary: boolean;
+  $iconOnly: boolean;
+};
+
+const StyledLink = styled(Link)<StyledLinkProps>`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing[2]};
+  padding: ${({ theme, $iconOnly }) =>
+    $iconOnly ? theme.spacing[2] : `${theme.spacing[2]} ${theme.spacing[3]}`};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: ${({ theme }) => theme.typography.size.sm};
+  transition: background ${({ theme }) => theme.transitions.fast};
+  position: relative;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+  }
+
+  ${({ $active }) =>
+    $active &&
+    css`
+      background: rgba(255, 255, 255, 0.18);
+    `}
+
+  ${({ $primary }) =>
+    $primary &&
+    css`
+      background: rgba(255, 255, 255, 0.15);
+      font-weight: 600;
+    `}
+
+  .nav-icon {
+    font-size: 1.25rem;
+    display: inline-flex;
+  }
+`;
+
+export type NavLinkProps = Omit<LinkProps, 'to'> & {
+  to: string;
+  icon?: React.ReactNode;
+  primary?: boolean;
+  iconOnly?: boolean;
+  children?: React.ReactNode;
+};
+
+export const NavLink: React.FC<NavLinkProps> = ({
+  to,
+  icon,
+  primary = false,
+  iconOnly = false,
+  children,
+  ...rest
+}) => {
+  const location = useLocation();
+  const active = location.pathname === to || location.pathname.startsWith(`${to}/`);
+
+  return (
+    <StyledLink to={to} $active={active} $primary={primary} $iconOnly={iconOnly} {...rest}>
+      {icon && <span className='nav-icon'>{icon}</span>}
+      {!iconOnly && children}
+    </StyledLink>
+  );
+};

--- a/app.client/src/components/navigation/NavUserMenu.test.tsx
+++ b/app.client/src/components/navigation/NavUserMenu.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, screen } from '@/test-utils/render';
+import { NavUserMenu } from './NavUserMenu';
+import type { User } from '@adopt-dont-shop/lib.auth';
+
+const baseUser: User = {
+  userId: 'u1',
+  email: 'alex@example.com',
+  firstName: 'Alex',
+  lastName: 'Rivera',
+  emailVerified: true,
+  userType: 'adopter',
+  status: 'active',
+};
+
+const mockLogout = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: baseUser,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: mockLogout,
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('NavUserMenu', () => {
+  beforeEach(() => {
+    mockLogout.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it('renders an avatar trigger with the user initials', () => {
+    renderWithProviders(<NavUserMenu />);
+    const trigger = screen.getByRole('button', { name: /user menu/i });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveTextContent('AR');
+  });
+
+  it('opens the menu on click and shows user name and email', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NavUserMenu />);
+    await user.click(screen.getByRole('button', { name: /user menu/i }));
+    expect(await screen.findByText('Alex Rivera')).toBeInTheDocument();
+    expect(screen.getByText('alex@example.com')).toBeInTheDocument();
+  });
+
+  it('links each menu item to the correct route', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NavUserMenu />);
+    await user.click(screen.getByRole('button', { name: /user menu/i }));
+    expect(await screen.findByRole('menuitem', { name: /profile/i })).toHaveAttribute(
+      'href',
+      '/profile'
+    );
+    expect(screen.getByRole('menuitem', { name: /my applications/i })).toHaveAttribute(
+      'href',
+      '/applications'
+    );
+    expect(screen.getByRole('menuitem', { name: /settings/i })).toHaveAttribute(
+      'href',
+      '/profile?tab=settings'
+    );
+    expect(screen.getByRole('menuitem', { name: /help/i })).toHaveAttribute('href', '/help');
+  });
+
+  it('calls logout and navigates home when Log out is clicked', async () => {
+    mockLogout.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderWithProviders(<NavUserMenu />);
+    await user.click(screen.getByRole('button', { name: /user menu/i }));
+    const logout = await screen.findByRole('menuitem', { name: /log out/i });
+    await user.click(logout);
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('sets aria-expanded on the trigger when the menu is open', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NavUserMenu />);
+    const trigger = screen.getByRole('button', { name: /user menu/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await user.click(trigger);
+    await vi.waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+});

--- a/app.client/src/components/navigation/NavUserMenu.tsx
+++ b/app.client/src/components/navigation/NavUserMenu.tsx
@@ -1,0 +1,176 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import React from 'react';
+import {
+  MdHelpOutline,
+  MdLogout,
+  MdOutlineDescription,
+  MdOutlineSettings,
+  MdPersonOutline,
+} from 'react-icons/md';
+import { Link, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import { Avatar } from '@adopt-dont-shop/lib.components';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+
+const TriggerButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing[2]};
+  background: transparent;
+  border: none;
+  padding: ${({ theme }) => theme.spacing[1]};
+  border-radius: ${({ theme }) => theme.border.radius.full};
+  cursor: pointer;
+  color: inherit;
+  transition: background ${({ theme }) => theme.transitions.fast};
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+  }
+`;
+
+const Content = styled(DropdownMenu.Content)`
+  min-width: 240px;
+  background: ${({ theme }) => theme.background.primary};
+  color: ${({ theme }) => theme.text.primary};
+  border: 1px solid ${({ theme }) => theme.border.color.primary};
+  border-radius: ${({ theme }) => theme.border.radius.md};
+  box-shadow: ${({ theme }) => theme.shadows.md};
+  padding: ${({ theme }) => theme.spacing[1]} 0;
+  z-index: 1100;
+`;
+
+const Header = styled.div`
+  padding: ${({ theme }) => `${theme.spacing[3]} ${theme.spacing[4]} ${theme.spacing[2]}`};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing[0.5]};
+`;
+
+const Name = styled.span`
+  font-weight: 600;
+  color: ${({ theme }) => theme.text.primary};
+`;
+
+const Email = styled.span`
+  font-size: ${({ theme }) => theme.typography.size.sm};
+  color: ${({ theme }) => theme.text.secondary};
+`;
+
+const Separator = styled(DropdownMenu.Separator)`
+  height: 1px;
+  background: ${({ theme }) => theme.border.color.primary};
+  margin: ${({ theme }) => theme.spacing[1]} 0;
+`;
+
+const Item = styled(DropdownMenu.Item)`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing[2]};
+  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[4]}`};
+  color: ${({ theme }) => theme.text.primary};
+  text-decoration: none;
+  cursor: pointer;
+  outline: none;
+  font-size: ${({ theme }) => theme.typography.size.sm};
+
+  &[data-highlighted],
+  &:focus-visible {
+    background: ${({ theme }) => theme.background.tertiary};
+  }
+
+  svg {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+  }
+`;
+
+const DangerItem = styled(Item)`
+  color: ${({ theme }) => theme.colors.semantic.error[600]};
+
+  &[data-highlighted],
+  &:focus-visible {
+    background: ${({ theme }) => theme.colors.semantic.error[50]};
+    color: ${({ theme }) => theme.colors.semantic.error[700]};
+  }
+`;
+
+export type NavUserMenuProps = {
+  className?: string;
+};
+
+export const NavUserMenu: React.FC<NavUserMenuProps> = ({ className }) => {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  if (!user) return null;
+
+  const fullName = `${user.firstName} ${user.lastName}`.trim();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } finally {
+      navigate('/');
+    }
+  };
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <TriggerButton
+          type='button'
+          aria-label={`User menu for ${fullName}`}
+          className={className}
+        >
+          <Avatar name={fullName} src={user.profileImageUrl} size='sm' />
+        </TriggerButton>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <Content sideOffset={8} align='end'>
+          <Header>
+            <Name>{fullName}</Name>
+            <Email>{user.email}</Email>
+          </Header>
+          <Separator />
+          <Item asChild>
+            <Link to='/profile'>
+              <MdPersonOutline />
+              Profile
+            </Link>
+          </Item>
+          <Item asChild>
+            <Link to='/applications'>
+              <MdOutlineDescription />
+              My applications
+            </Link>
+          </Item>
+          <Item asChild>
+            <Link to='/profile?tab=settings'>
+              <MdOutlineSettings />
+              Settings
+            </Link>
+          </Item>
+          <Item asChild>
+            <Link to='/help'>
+              <MdHelpOutline />
+              Help
+            </Link>
+          </Item>
+          <Separator />
+          <DangerItem onSelect={handleLogout}>
+            <MdLogout />
+            Log out
+          </DangerItem>
+        </Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};
+

--- a/app.client/src/components/navigation/NavUserMenu.tsx
+++ b/app.client/src/components/navigation/NavUserMenu.tsx
@@ -109,7 +109,9 @@ export const NavUserMenu: React.FC<NavUserMenuProps> = ({ className }) => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
 
-  if (!user) return null;
+  if (!user) {
+    return null;
+  }
 
   const fullName = `${user.firstName} ${user.lastName}`.trim();
 
@@ -124,11 +126,7 @@ export const NavUserMenu: React.FC<NavUserMenuProps> = ({ className }) => {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
-        <TriggerButton
-          type='button'
-          aria-label={`User menu for ${fullName}`}
-          className={className}
-        >
+        <TriggerButton type='button' aria-label={`User menu for ${fullName}`} className={className}>
           <Avatar name={fullName} src={user.profileImageUrl} size='sm' />
         </TriggerButton>
       </DropdownMenu.Trigger>
@@ -173,4 +171,3 @@ export const NavUserMenu: React.FC<NavUserMenuProps> = ({ className }) => {
     </DropdownMenu.Root>
   );
 };
-

--- a/app.client/src/components/ui/SwipeFloatingButton.tsx
+++ b/app.client/src/components/ui/SwipeFloatingButton.tsx
@@ -52,9 +52,9 @@ const FloatingContainer = styled.div<{ $show: boolean }>`
   gap: 1rem;
   animation: ${slideUp} 0.5s ease-out;
 
+  /* Hidden on mobile — BottomTabBar already surfaces the Discover destination. */
   @media (max-width: 768px) {
-    bottom: 5rem;
-    right: 1rem;
+    display: none;
   }
 `;
 

--- a/app.client/src/contexts/ChatContext.tsx
+++ b/app.client/src/contexts/ChatContext.tsx
@@ -155,7 +155,9 @@ export function ChatProvider({ children }: ChatProviderProps) {
         // when the incoming message targets a conversation that is not currently active.
         setConversations(prev =>
           (prev || []).map(conv => {
-            if (conv.id !== message.conversationId) return conv;
+            if (conv.id !== message.conversationId) {
+              return conv;
+            }
             const isActive = activeConversationIdRef.current === conv.id;
             return {
               ...conv,
@@ -223,9 +225,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
         );
         // Zero out unread count on the conversation that was marked read.
         setConversations(prev =>
-          (prev || []).map(conv =>
-            conv.id === event.chatId ? { ...conv, unreadCount: 0 } : conv
-          )
+          (prev || []).map(conv => (conv.id === event.chatId ? { ...conv, unreadCount: 0 } : conv))
         );
       };
 

--- a/app.client/src/contexts/ChatContext.tsx
+++ b/app.client/src/contexts/ChatContext.tsx
@@ -22,6 +22,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -48,6 +49,9 @@ interface ChatContextType {
   isOnline: boolean;
   connectionQuality: 'excellent' | 'good' | 'poor' | 'offline';
   pendingMessageCount: number;
+
+  // Aggregate unread count across all conversations (excludes the active one).
+  unreadMessageCount: number;
 
   // Actions
   setActiveConversation: (conversation: Conversation | null) => void;
@@ -97,6 +101,11 @@ export function ChatProvider({ children }: ChatProviderProps) {
   const initializedRef = useRef<string | null>(null);
   const lastMarkedAsReadRef = useRef<string | null>(null);
   const lastLoadedMessagesRef = useRef<string | null>(null);
+  // Tracks the active conversation id for socket handlers that live across re-renders.
+  const activeConversationIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    activeConversationIdRef.current = activeConversation?.id ?? null;
+  }, [activeConversation]);
 
   const loadConversations = useCallback(async () => {
     if (!isAuthenticated) {
@@ -142,13 +151,19 @@ export function ChatProvider({ children }: ChatProviderProps) {
           return [...currentMessages, message];
         });
 
-        // Update conversation list with latest message
+        // Update conversation list with latest message and bump unread count
+        // when the incoming message targets a conversation that is not currently active.
         setConversations(prev =>
-          (prev || []).map(conv =>
-            conv.id === message.conversationId
-              ? { ...conv, lastMessage: message, updatedAt: message.timestamp }
-              : conv
-          )
+          (prev || []).map(conv => {
+            if (conv.id !== message.conversationId) return conv;
+            const isActive = activeConversationIdRef.current === conv.id;
+            return {
+              ...conv,
+              lastMessage: message,
+              updatedAt: message.timestamp,
+              unreadCount: isActive ? conv.unreadCount : (conv.unreadCount ?? 0) + 1,
+            };
+          })
         );
       };
 
@@ -204,6 +219,12 @@ export function ChatProvider({ children }: ChatProviderProps) {
                   ],
                 }
               : msg
+          )
+        );
+        // Zero out unread count on the conversation that was marked read.
+        setConversations(prev =>
+          (prev || []).map(conv =>
+            conv.id === event.chatId ? { ...conv, unreadCount: 0 } : conv
           )
         );
       };
@@ -590,6 +611,11 @@ export function ChatProvider({ children }: ChatProviderProps) {
     };
   }, []);
 
+  const unreadMessageCount = useMemo(
+    () => (conversations ?? []).reduce((sum, c) => sum + (c.unreadCount ?? 0), 0),
+    [conversations]
+  );
+
   const value: ChatContextType = {
     conversations,
     activeConversation,
@@ -606,6 +632,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     isOnline,
     connectionQuality,
     pendingMessageCount,
+    unreadMessageCount,
     setActiveConversation: handleSetActiveConversation,
     sendMessage,
     markAsRead,

--- a/app.client/src/contexts/__tests__/chat-context-unread.behavior.test.tsx
+++ b/app.client/src/contexts/__tests__/chat-context-unread.behavior.test.tsx
@@ -1,0 +1,172 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import type { Conversation, Message, ReadStatusUpdateEvent } from '@/services';
+import { ChatProvider, useChat } from '../ChatContext';
+
+type MessageHandler = (m: Message) => void;
+type ReadStatusHandler = (e: ReadStatusUpdateEvent) => void;
+
+const messageHandlers: MessageHandler[] = [];
+const readStatusHandlers: ReadStatusHandler[] = [];
+
+const buildConv = (id: string, unread: number): Conversation =>
+  ({
+    id,
+    chat_id: id,
+    participants: [],
+    unreadCount: unread,
+    updatedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    isActive: true,
+  }) as Conversation;
+
+const buildMessage = (conversationId: string, id: string): Message =>
+  ({
+    id,
+    conversationId,
+    senderId: 'other-user',
+    senderName: 'Other',
+    content: 'hello',
+    timestamp: new Date().toISOString(),
+    type: 'text',
+    status: 'delivered',
+  }) as Message;
+
+let seededConversations: Conversation[] = [];
+
+vi.mock('@/services', () => ({
+  chatService: {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    getConversations: vi.fn(async () => seededConversations),
+    getMessages: vi.fn(async () => ({ data: [] })),
+    markAsRead: vi.fn(async () => undefined),
+    onMessage: vi.fn((cb: MessageHandler) => {
+      messageHandlers.push(cb);
+    }),
+    onTyping: vi.fn(),
+    onReactionUpdate: vi.fn(),
+    onReadStatusUpdate: vi.fn((cb: ReadStatusHandler) => {
+      readStatusHandlers.push(cb);
+    }),
+    off: vi.fn(),
+  },
+  useConnectionStatus: () => ({
+    status: 'connected',
+    isConnected: true,
+    isReconnecting: false,
+    reconnectionAttempts: 0,
+  }),
+}));
+
+vi.mock('@/utils/offlineManager', () => ({
+  isCurrentlyOnline: () => true,
+  getConnectionQuality: () => 'excellent',
+  offlineManager: { setSyncCallback: vi.fn(), forceSync: vi.fn() },
+  onOfflineStateChange: vi.fn(),
+  removeOfflineStateListener: vi.fn(),
+  queueMessageForOffline: vi.fn(() => 'tmp-id'),
+}));
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: { userId: 'u1', email: 'a@b.c', firstName: 'A', lastName: 'B' },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+const wrapper = ({ children }: { children: ReactNode }) => <ChatProvider>{children}</ChatProvider>;
+
+describe('ChatContext unreadMessageCount', () => {
+  beforeEach(() => {
+    messageHandlers.length = 0;
+    readStatusHandlers.length = 0;
+    seededConversations = [buildConv('c1', 2), buildConv('c2', 3), buildConv('c3', 0)];
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sums unreadCount across conversations', async () => {
+    const { result } = renderHook(() => useChat(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.conversations).toHaveLength(3);
+    });
+    expect(result.current.unreadMessageCount).toBe(5);
+  });
+
+  it('increments unreadCount when a message arrives in an inactive conversation', async () => {
+    const { result } = renderHook(() => useChat(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.conversations).toHaveLength(3);
+    });
+    await waitFor(() => {
+      expect(messageHandlers.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      messageHandlers[0](buildMessage('c1', 'm-new'));
+    });
+
+    expect(result.current.unreadMessageCount).toBe(6);
+    expect(result.current.conversations.find(c => c.id === 'c1')?.unreadCount).toBe(3);
+  });
+
+  it('does not increment unreadCount when a message arrives in the active conversation', async () => {
+    const { result } = renderHook(() => useChat(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.conversations).toHaveLength(3);
+    });
+
+    act(() => {
+      const active = result.current.conversations.find(c => c.id === 'c1')!;
+      result.current.setActiveConversation(active);
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeConversation?.id).toBe('c1');
+    });
+
+    act(() => {
+      messageHandlers[0](buildMessage('c1', 'm-active'));
+    });
+
+    expect(result.current.conversations.find(c => c.id === 'c1')?.unreadCount).toBe(2);
+    expect(result.current.unreadMessageCount).toBe(5);
+  });
+
+  it('resets a conversation unreadCount to zero on readStatus update', async () => {
+    const { result } = renderHook(() => useChat(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.conversations).toHaveLength(3);
+    });
+    await waitFor(() => {
+      expect(readStatusHandlers.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      readStatusHandlers[0]({
+        chatId: 'c2',
+        userId: 'u1',
+        timestamp: new Date().toISOString(),
+      } as ReadStatusUpdateEvent);
+    });
+
+    expect(result.current.conversations.find(c => c.id === 'c2')?.unreadCount).toBe(0);
+    expect(result.current.unreadMessageCount).toBe(2);
+  });
+});

--- a/lib.components/src/components/ui/Badge.test.tsx
+++ b/lib.components/src/components/ui/Badge.test.tsx
@@ -107,4 +107,39 @@ describe('Badge', () => {
     const badge = screen.getByTestId('small-dot');
     expect(badge).toBeInTheDocument();
   });
+
+  describe('count variant', () => {
+    it('renders a numeric count', () => {
+      renderWithTheme(<Badge variant='count'>3</Badge>);
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('clamps numeric children above the max to "{max}+"', () => {
+      renderWithTheme(
+        <Badge variant='count' max={99}>
+          150
+        </Badge>
+      );
+      expect(screen.getByText('99+')).toBeInTheDocument();
+      expect(screen.queryByText('150')).not.toBeInTheDocument();
+    });
+
+    it('renders numeric children equal to max without clamping', () => {
+      renderWithTheme(
+        <Badge variant='count' max={99}>
+          99
+        </Badge>
+      );
+      expect(screen.getByText('99')).toBeInTheDocument();
+    });
+
+    it('ignores max when children is not numeric', () => {
+      renderWithTheme(
+        <Badge variant='count' max={5}>
+          NEW
+        </Badge>
+      );
+      expect(screen.getByText('NEW')).toBeInTheDocument();
+    });
+  });
 });

--- a/lib.components/src/components/ui/Badge.tsx
+++ b/lib.components/src/components/ui/Badge.tsx
@@ -38,7 +38,8 @@ export type BadgeVariant =
   | 'warning'
   | 'info'
   | 'neutral'
-  | 'outline';
+  | 'outline'
+  | 'count';
 
 export type BadgeSize = 'xs' | 'sm' | 'md' | 'lg';
 
@@ -63,6 +64,11 @@ export type BadgeProps = {
    * Whether the badge should have a dot indicator
    */
   dot?: boolean;
+  /**
+   * When children is a number, clamp values above max to "{max}+".
+   * Useful with variant="count" for unread-count bubbles.
+   */
+  max?: number;
 };
 
 const getSizeStyles = (size: BadgeSize, theme: Theme) => {
@@ -191,6 +197,17 @@ const getVariantStyles = (variant: BadgeVariant, theme: Theme) => {
         color: ${theme.text.secondary};
         border-color: ${theme.border.color.secondary};
       `}
+    `,
+    count: css`
+      background: ${theme.colors.semantic.error[500]};
+      color: #fff;
+      border: none;
+      border-radius: ${theme.border.radius.full};
+      font-weight: 700;
+      padding: 0 ${theme.spacing[1.5]};
+      min-width: ${theme.spacing[5]};
+      min-height: ${theme.spacing[5]};
+      justify-content: center;
     `,
   };
   return variants[variant];
@@ -365,6 +382,18 @@ const CloseIcon = () => (
   </svg>
 );
 
+const clampCount = (children: React.ReactNode, max: number | undefined): React.ReactNode => {
+  if (max === undefined) return children;
+  const numeric =
+    typeof children === 'number'
+      ? children
+      : typeof children === 'string' && /^-?\d+$/.test(children.trim())
+        ? Number(children)
+        : null;
+  if (numeric === null) return children;
+  return numeric > max ? `${max}+` : String(numeric);
+};
+
 export const Badge: React.FC<BadgeProps> = ({
   children,
   variant = 'neutral',
@@ -377,6 +406,7 @@ export const Badge: React.FC<BadgeProps> = ({
   icon,
   rounded = false,
   dot = false,
+  max,
 }) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleRemove = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -385,6 +415,8 @@ export const Badge: React.FC<BadgeProps> = ({
       onRemove();
     }
   };
+
+  const displayChildren = clampCount(children, max);
 
   return (
     <StyledBadge
@@ -397,11 +429,13 @@ export const Badge: React.FC<BadgeProps> = ({
       $dot={dot}
       data-testid={dataTestId}
       role='status'
-      aria-label={typeof children === 'string' ? children : undefined}
+      aria-label={typeof displayChildren === 'string' ? displayChildren : undefined}
     >
       {icon && <IconContainer $size={size}>{icon}</IconContainer>}
 
-      {children && <span>{children}</span>}
+      {displayChildren !== undefined && displayChildren !== null && displayChildren !== '' && (
+        <span>{displayChildren}</span>
+      )}
 
       {removable && (
         <RemoveButton


### PR DESCRIPTION
## Summary

Reshape `app.client`'s navigation so adopters always know who they are, where they can go, and what needs their attention — on desktop and mobile, logged in and out.

**Desktop (logged-in):** `Logo · Discover · Search · Favorites · 🔔 · 💬 · Avatar▾`
**Desktop (logged-out):** `Logo · Discover · Search · · · Log in · [Sign up]`
**Mobile (logged-in):** slim top bar (logo + avatar) + fixed bottom tab bar (Discover · Search · Favorites · Messages · Me)
**Mobile (logged-out):** slim top bar (logo + Log in + Sign up)
**Auth pages** (`/login`, `/register`, `/verify-email`, `/forgot-password`, `/reset-password`): minimal `PublicAuthLayout` with logo + Log in/Sign up switch link. No full navbar.

## What changed

- **`AppNavbar` rewrite** — auth-aware branches (Log in/Sign up CTAs when logged out; primary links + icon-badges + user menu when logged in), theme tokens throughout, drops the legacy pink pulsing-glow animation and the "Try our new swipe feature!" callout.
- **`NavUserMenu`** — avatar dropdown with full a11y (Escape, click-outside, arrow keys, focus return, `aria-expanded`) via `@radix-ui/react-dropdown-menu`. Items: Profile / My applications / Settings / Help / Log out.
- **`BottomTabBar`** — mobile-only fixed bottom tab (5 items), respects `env(safe-area-inset-bottom)`. `SwipeFloatingButton` is hidden on mobile to avoid overlap.
- **Layout split** — nested routes via `PublicAuthLayout` (auth pages) and `AppShell` (main app). Cleaner mental model, unlocks future `ProtectedRoute`.
- **`/applications` list route** — wraps the existing `ApplicationDashboard` so the user menu has a canonical target (existing `/applications/:id` detail route unchanged).
- **`ChatContext.unreadMessageCount`** — derived sum across `conversations[].unreadCount`, bumped when a message arrives in an inactive conversation, zeroed on `readStatus` events. No backend changes.
- **`lib.components/Badge`** — new `variant="count"` + `max` prop for unread-count pills. Available to `app.admin` and `app.rescue` going forward.

## Test plan

- [x] 32 new behaviour tests (TDD) across `NavUserMenu`, `AppNavbar`, `BottomTabBar`, `PublicAuthLayout`, `AppShell`, `ChatContext` unread count, application routing, and Badge count variant — all passing.
- [x] `lib.components` typechecks cleanly.
- [ ] Manual smoke — logged-out: confirm top bar shows only Discover/Search + Log in/Sign up; auth pages show minimal layout only.
- [ ] Manual smoke — logged-in (desktop): keyboard Tab order, avatar Enter/Space opens menu, Escape closes, Messages badge reacts to new unread chat, `/applications` renders.
- [ ] Manual smoke — mobile (390×844): slim top bar + bottom tab, active tab marked, `SwipeFloatingButton` hidden, safe-area padding respected.
- [ ] Manual smoke — screen reader: avatar announced as expanded/collapsed, badges announced via `aria-label` on the link.

https://claude.ai/code/session_01NymbjgrRCunwPoFkCf5mgz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NymbjgrRCunwPoFkCf5mgz)_