### PR TITLE
fix(security): prevent mass assignment privilege escalation in updateUserProfile

### DIFF
--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -44,6 +44,7 @@
     "@types/uuid": "^9.0.0",
     "@types/validator": "^13.7.10",
     "bcrypt": "^5.1.0",
+    "zod": "^3.25.76",
     "bcryptjs": "^3.0.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/service.backend/src/__tests__/services/user.service.test.ts
+++ b/service.backend/src/__tests__/services/user.service.test.ts
@@ -93,6 +93,31 @@ describe('UserService', () => {
         'User not found'
       );
     });
+
+    it('should not allow privilege escalation via mass assignment of restricted fields', async () => {
+      const user = await User.create({
+        email: 'mass-assign@example.com',
+        password: 'hashedpassword',
+        firstName: 'John',
+        lastName: 'Doe',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+        emailVerified: false,
+      });
+
+      await UserService.updateUserProfile(user.userId, {
+        firstName: 'Jane',
+        userType: UserType.ADMIN,
+        emailVerified: true,
+        status: UserStatus.SUSPENDED,
+      });
+
+      const dbUser = await User.findByPk(user.userId);
+      expect(dbUser?.firstName).toBe('Jane');
+      expect(dbUser?.userType).toBe(UserType.ADOPTER);
+      expect(dbUser?.emailVerified).toBe(false);
+      expect(dbUser?.status).toBe(UserStatus.ACTIVE);
+    });
   });
 
   describe('searchUsers', () => {

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { JsonObject } from '../types/common';
 import { Op, QueryTypes, WhereOptions } from 'sequelize';
 import Application from '../models/Application';
@@ -12,7 +13,6 @@ import {
   BulkUserUpdateData,
   PaginationOptions,
   UserPreferences,
-  UserProfile,
   UserSearchFilters,
   UserSearchOptions,
   UserStatistics,
@@ -72,6 +72,47 @@ interface UserActivitySummary {
     profileCompleteness: number;
   };
 }
+
+const UpdateProfileSchema = z.object({
+  firstName: z.string().min(1).optional(),
+  lastName: z.string().min(1).optional(),
+  phoneNumber: z.string().optional(),
+  bio: z.string().optional(),
+  profileImageUrl: z.string().url().optional().nullable(),
+  location: z
+    .object({
+      type: z.string().optional(),
+      coordinates: z.tuple([z.number(), z.number()]).optional(),
+      country: z.string().optional(),
+      city: z.string().optional(),
+      addressLine1: z.string().optional(),
+      addressLine2: z.string().optional(),
+      postalCode: z.string().optional(),
+    })
+    .optional(),
+  privacySettings: z
+    .object({
+      profileVisibility: z.enum(['public', 'private', 'rescue_only']).optional(),
+      showLocation: z.boolean().optional(),
+      allowMessages: z.boolean().optional(),
+      showAdoptionHistory: z.boolean().optional(),
+      showContactInfo: z.boolean().optional(),
+      allowSearchIndexing: z.boolean().optional(),
+    })
+    .optional(),
+  notificationPreferences: z
+    .object({
+      emailNotifications: z.boolean().optional(),
+      pushNotifications: z.boolean().optional(),
+      smsNotifications: z.boolean().optional(),
+      marketingEmails: z.boolean().optional(),
+      applicationUpdates: z.boolean().optional(),
+      chatMessages: z.boolean().optional(),
+      petAlerts: z.boolean().optional(),
+      rescueUpdates: z.boolean().optional(),
+    })
+    .optional(),
+});
 
 export class UserService {
   static async getUserById(userId: string, includePrivate: boolean = false): Promise<User | null> {
@@ -156,7 +197,7 @@ export class UserService {
 
   static async updateUserProfile(
     userId: string,
-    updateData: Partial<UserProfile>,
+    updateData: Record<string, unknown>,
     updatedBy?: string
   ): Promise<User> {
     const startTime = Date.now();
@@ -170,12 +211,15 @@ export class UserService {
       // Store original data for audit
       const originalData = user.toJSON();
 
+      // Validate and whitelist allowed fields to prevent mass assignment
+      const safeData = UpdateProfileSchema.parse(updateData);
+
       // Process the update data to match the database model format
-      const processedUpdateData: Record<string, unknown> = { ...updateData };
+      const processedUpdateData: Record<string, unknown> = { ...safeData };
 
       // Handle location transformation if present
-      if (updateData.location) {
-        const { coordinates, type, ...locationData } = updateData.location;
+      if (safeData.location) {
+        const { coordinates, type, ...locationData } = safeData.location;
 
         // If we have coordinates, create a proper GeoJSON Point
         if (coordinates && Array.isArray(coordinates) && coordinates.length === 2) {
@@ -226,7 +270,7 @@ export class UserService {
           'User Profile Updated',
           {
             userId,
-            updatedFields: Object.keys(updateData),
+            updatedFields: Object.keys(safeData),
             duration: Date.now() - startTime,
           },
           userId


### PR DESCRIPTION
## Summary

Fixes **ENG-232** — Mass assignment in `updateUserProfile` allows privilege escalation.

- Adds a Zod `UpdateProfileSchema` that whitelists only the fields a user may update on their own profile (`firstName`, `lastName`, `phoneNumber`, `bio`, `profileImageUrl`, `location`, `privacySettings`, `notificationPreferences`)
- Applies the schema before `user.update()`, silently stripping any field not on the allowlist (e.g. `userType`, `status`, `emailVerified`, `twoFactorSecret`, `passwordHash`)
- Changes the `updateUserProfile` service parameter from `Partial<UserProfile>` to `Record<string, unknown>` to accurately reflect that raw client input is validated internally
- Adds `zod` as an explicit dependency of `service.backend`

## Security impact

Previously, an authenticated user could POST `{ "userType": "ADMIN", "emailVerified": true }` to their profile update endpoint and persist those values directly, escalating from `ADOPTER` to `ADMIN` and bypassing email verification. After this fix those fields are stripped at the service boundary before any database write.

## Test plan

- [x] Regression test added: submits `{ userType: ADMIN, emailVerified: true, status: SUSPENDED }` and asserts all three fields remain unchanged on the persisted record while the allowed field (`firstName`) updates correctly
- [x] All 1231 existing backend tests continue to pass

https://claude.ai/code/session_014K1ruba2eDNenWVQfpmxdY

---
_Generated by [Claude Code](https://claude.ai/code/session_014K1ruba2eDNenWVQfpmxdY)_