### PR TITLE
docs: fix inaccurate scripts, tooling, and stale file references

### DIFF
--- a/EMAIL_VERIFICATION.md
+++ b/EMAIL_VERIFICATION.md
@@ -386,13 +386,17 @@ Comprehensive test suite added to `service.backend/src/__tests__/services/auth.s
 
 ### Running Tests
 
+The backend uses Vitest. Run from `service.backend/`:
+
 ```bash
 # Run all backend tests
-npm run test:backend
+npm test
 
-# Run specific auth service tests
-npm run test:backend -- auth.service.test.ts
+# Run specific auth service tests (Vitest takes a substring filter)
+npm test auth.service.test.ts
 ```
+
+Or via Turbo at the repo root: `npx turbo test --filter=@adopt-dont-shop/service-backend`.
 
 ---
 

--- a/TEST_STATUS.md
+++ b/TEST_STATUS.md
@@ -259,20 +259,18 @@ http.get('/api/v1/rescues/stats', ...)
 
 ## Test Execution Commands
 
+> **Note**: this is a historical status snapshot. Per-app/per-library npm aliases (e.g. `test:libs`, `test:admin`) no longer exist — use Turbo's `--filter` flag against the real workspace names.
+
 ```bash
-# Run all library tests (currently passing)
-npm run test:libs
-
-# Run component tests (387 tests passing)
-npm run test:components
-
-# Run app tests (pending MSW config)
-npm run test:client
-npm run test:admin
-npm run test:rescue
-
-# Run all tests
+# All tests across the workspace
 npm test
+
+# Per-app / per-library (Turbo filters accept globs)
+npx turbo test --filter=@adopt-dont-shop/app.client
+npx turbo test --filter=@adopt-dont-shop/app.admin
+npx turbo test --filter=@adopt-dont-shop/app.rescue
+npx turbo test --filter=@adopt-dont-shop/lib.components
+npx turbo test --filter='@adopt-dont-shop/lib.*'
 ```
 
 ## 🎉 Conclusion: Migration Complete!

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -97,7 +97,7 @@ The dev stack is configured for HMR on Windows/macOS/Linux:
 
 | Layer | Mechanism | Latency |
 | --- | --- | --- |
-| Frontend apps (`app.*/src/**`) | Vite HMR with polling (`CHOKIDAR_USEPOLLING=true`, interval 100ms) | ~1-2s |
+| Frontend apps (`app.*/src/**`) | Vite HMR with polling (`CHOKIDAR_USEPOLLING=true`, `CHOKIDAR_INTERVAL=1000`) | ~1-2s |
 | Frontend libs (`lib.*/src/**` except `lib.types`) | Vite aliases point at lib `src/` — HMR picks them up | ~1-2s |
 | Backend (`service.backend/src/**`) | `ts-node-dev --poll` | ~2s |
 | `lib.types/src/**` | Built into backend `node_modules` at container start. Re-run via `npm run docker:rebuild:types` | manual |

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,9 +140,8 @@ Historical documentation moved to `_archive/` folder:
 
 ## Maintenance
 
-- **Last Major Cleanup**: October 2025
-- **Structure**: Organized by function
-- **Policy**: Archive historical docs, don't delete
+- **Structure**: Organized by function (infrastructure, backend, frontend, libraries)
+- **Policy**: Archive historical docs to `_archive/`, don't delete
 - **Duplicates**: Consolidated overlapping documentation
 
 ---

--- a/docs/backend/deployment.md
+++ b/docs/backend/deployment.md
@@ -161,38 +161,45 @@ ENABLE_REQUEST_LOGGING=true
 
 The service includes a production-ready Dockerfile:
 
+The repository ships a multi-stage Dockerfile at `service.backend/Dockerfile` built against `node:20-alpine` with a non-root `backend` user. Build the production image via:
+
+```bash
+docker build \
+  --target production \
+  -t adoptdontshop/backend:latest \
+  -f service.backend/Dockerfile .
+```
+
+An illustrative minimal alternative (equivalent shape):
+
 ```dockerfile
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --only=production
 
-FROM node:18-alpine AS runtime
+FROM node:20-alpine AS runtime
 
-# Security: Create non-root user
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nodejs -u 1001
+# Security: create non-root user
+RUN addgroup -g 1001 -S nodejs \
+ && adduser -S nodejs -u 1001
 
 WORKDIR /app
 
-# Copy dependencies
 COPY --from=builder /app/node_modules ./node_modules
 COPY --chown=nodejs:nodejs . .
 
-# Build application
 RUN npm run build
 
-# Switch to non-root user
 USER nodejs
 
 EXPOSE 5000
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node healthcheck.js
+  CMD wget --no-verbose --tries=1 --spider http://localhost:5000/health || exit 1
 
-CMD ["npm", "run", "start:prod"]
+CMD ["npm", "start"]
 ```
 
 ### Docker Compose

--- a/docs/backend/implementation-guide.md
+++ b/docs/backend/implementation-guide.md
@@ -4,16 +4,17 @@
 
 ### Prerequisites
 
-- Node.js 18+ and npm
-- PostgreSQL 15+
+- Node.js 20+ and npm
+- PostgreSQL 16+ with PostGIS (provided by the Docker stack)
 - Docker and Docker Compose (recommended)
 
 ### Development Setup
 
-1. **Clone and Install**
+From the repository root the typical workflow uses Docker — the container boots the database, Redis, and the backend in one command. See the [root README](../../README.md) for the full quick start.
+
+1. **Install workspace dependencies (from repo root)**
 
    ```bash
-   cd service.backend
    npm install
    ```
 
@@ -21,24 +22,40 @@
 
    ```bash
    cp .env.example .env
-   # Edit .env with your configuration
+   npm run secrets:generate >> .env
+   # Edit .env to set POSTGRES_PASSWORD and any third-party keys
    ```
 
-3. **Database Setup**
+3. **Start the stack**
 
    ```bash
-   npm run db:create
-   npm run db:migrate
-   npm run db:seed  # Optional: sample data
+   npm run docker:dev          # foreground
+   npm run docker:dev:detach   # or background
    ```
 
-4. **Start Development Server**
+4. **Initialize the database (first run, or after `docker:reset`)**
 
    ```bash
-   npm run dev
+   npm run db:migrate          # runs sequelize-cli db:migrate inside the backend container
+   npm run db:seed             # optional sample data
+   # or: npm run db:reset      # migrate + seed
    ```
 
-   Server will start at `http://localhost:5000`
+5. **Backend is reachable at**
+
+   ```
+   http://localhost:5000       # direct
+   http://api.localhost        # via the nginx reverse proxy
+   ```
+
+### Native (no-Docker) Development
+
+If you prefer to run the backend on the host (you must provide Postgres and Redis yourself):
+
+```bash
+cd service.backend
+npm run dev                  # ts-node-dev --respawn --transpile-only --poll --watch src src/index.ts
+```
 
 ## Environment Configuration
 
@@ -165,41 +182,45 @@ uploads/
 
 ## Database Management
 
+Migrations and seeders use `sequelize-cli`. From the repo root, `npm run db:migrate` and `npm run db:seed` are thin wrappers that shell into the backend container and call `sequelize-cli db:migrate` / `db:seed:all`. For commands that don't have an npm wrapper, shell into the container first:
+
+```bash
+npm run docker:shell:backend
+# then inside the container:
+npx sequelize-cli <command>
+```
+
 ### Migrations
 
 ```bash
-# Create new migration
-npm run migration:create -- --name add-user-fields
-
-# Run migrations
+# Run migrations (from repo root)
 npm run db:migrate
 
-# Undo last migration
-npm run db:migrate:undo
-
-# Undo all migrations
-npm run db:migrate:undo:all
+# Inside the backend container (npm run docker:shell:backend):
+npx sequelize-cli migration:generate --name add-user-fields
+npx sequelize-cli db:migrate:undo
+npx sequelize-cli db:migrate:undo:all
 ```
 
 ### Seeders
 
 ```bash
-# Create new seeder
-npm run seed:create -- --name demo-users
-
-# Run all seeders
+# Run all seeders (from repo root)
 npm run db:seed
 
-# Undo last seeder
-npm run db:seed:undo
-
-# Undo all seeders
-npm run db:seed:undo:all
+# Inside the backend container:
+npx sequelize-cli seed:generate --name demo-users
+npx sequelize-cli db:seed:undo
+npx sequelize-cli db:seed:undo:all
 ```
+
+Migrations live in `service.backend/src/migrations/` and seeders in `service.backend/src/seeders/`.
 
 ## Testing
 
 ### Run Tests
+
+The backend uses **Vitest**. Run from `service.backend/` (or via `npx turbo test --filter=@adopt-dont-shop/service-backend` at the root).
 
 ```bash
 # All tests
@@ -208,25 +229,17 @@ npm test
 # Watch mode
 npm run test:watch
 
+# Vitest UI
+npm run test:ui
+
 # Coverage report
 npm run test:coverage
 
 # Specific test file
-npm test src/services/__tests__/user.service.test.ts
+npm test -- src/__tests__/services/user.service.test.ts
 ```
 
-### Load Testing
-
-```bash
-# Basic load test
-npm run test:load
-
-# Stress test
-npm run test:stress
-
-# Performance profiling
-npm run profile
-```
+Load-testing and performance-profiling scripts are not yet set up.
 
 ## Health Monitoring
 
@@ -280,14 +293,19 @@ docker compose logs -f service-backend
 ### Production
 
 ```bash
-# Build production image
-docker build -t adoptdontshop/backend:latest -f Dockerfile.prod .
+# Build production image (multi-stage target in the shared Dockerfile)
+docker build \
+  --target production \
+  -t adoptdontshop/backend:latest \
+  -f service.backend/Dockerfile .
 
 # Run production container
 docker run -p 5000:5000 \
   --env-file .env.production \
   adoptdontshop/backend:latest
 ```
+
+The root `docker-compose.prod.yml` overlay exercises this path end-to-end — see [Deployment Guide](./deployment.md) and [Docker Infrastructure Guide](../DOCKER.md).
 
 ## Common Tasks
 
@@ -298,21 +316,22 @@ docker run -p 5000:5000 \
 3. **Create service** `src/services/myresource.service.ts`
 4. **Add model** (if needed) `src/models/MyResource.ts`
 5. **Register route** in `src/index.ts`
-6. **Add tests** `src/services/__tests__/myresource.service.test.ts`
+6. **Add tests** under `src/__tests__/services/myresource.service.test.ts`
 
 ### Add Database Model
 
-1. **Create migration**
+1. **Create migration** (inside the backend container):
 
    ```bash
-   npm run migration:create -- --name create-my-table
+   npm run docker:shell:backend
+   npx sequelize-cli migration:generate --name create-my-table
    ```
 
-2. **Define schema** in migration file
+2. **Define schema** in the migration file under `src/migrations/`
 3. **Create model** `src/models/MyModel.ts`
-4. **Run migration** `npm run db:migrate`
-5. **Add associations** in model file
-6. **Create seeder** (optional) for test data
+4. **Run migration** `npm run db:migrate` (from the repo root)
+5. **Add associations** in the model file
+6. **Create seeder** (optional) under `src/seeders/`
 
 ### Update Email Template
 
@@ -331,11 +350,10 @@ docker run -p 5000:5000 \
 # Check PostgreSQL is running
 docker compose ps database
 
-# Reset database
-npm run db:drop
-npm run db:create
-npm run db:migrate
-npm run db:seed
+# Nuclear reset (wipes the volume, then re-initializes)
+npm run docker:reset
+npm run docker:dev:detach
+npm run db:reset          # migrate + seed
 ```
 
 ### Email Not Sending

--- a/docs/backend/testing.md
+++ b/docs/backend/testing.md
@@ -2,20 +2,21 @@
 
 ## Overview
 
-Comprehensive testing strategy for the backend service using Jest. Follows the testing pyramid: 70% unit tests, 20% integration tests, 10% E2E tests.
-
-## Test Structure
+Comprehensive testing strategy for the backend service using **Vitest**. We follow a behaviour-driven pyramid: most tests exercise service-layer behaviour through public APIs, with a smaller ring of integration tests that hit the database and routes end-to-end.
 
 ```
 Testing Pyramid
-├── E2E Tests (10%) - Full API integration and user journeys
-├── Integration Tests (20%) - Database, services, external APIs
-└── Unit Tests (70%) - Services, controllers, utilities, models
+├── Integration Tests — Database + HTTP routes (src/__tests__/integration/, src/__tests__/controllers/)
+└── Service / behaviour tests — Services, utilities, middleware, models (src/__tests__/services/, etc.)
 ```
+
+Tests live under `service.backend/src/__tests__/` organised by layer (`services/`, `controllers/`, `integration/`, `middleware/`, `models/`, `security/`, `utils/`, `validation/`).
 
 ## Quick Start
 
 ### Running Tests
+
+From `service.backend/` (or via `npx turbo test --filter=@adopt-dont-shop/service-backend` at the repo root):
 
 ```bash
 # All tests
@@ -24,50 +25,25 @@ npm test
 # Watch mode
 npm run test:watch
 
+# Vitest UI
+npm run test:ui
+
 # Coverage report
 npm run test:coverage
 
-# Specific test file
+# Specific test file — Vitest takes a substring filter
 npm test user.service.test.ts
-
-# Integration tests only
-npm run test:integration
-
-# E2E tests only
-npm run test:e2e
 ```
 
-### Coverage Requirements
+There are no separate `test:integration` / `test:e2e` scripts; integration and route tests run in the same Vitest invocation. Target them via substring or file path.
 
-- Overall: 80%+ coverage
-- Services: 90%+ coverage
-- Controllers: 85%+ coverage
-- Critical paths: 100% coverage
+### Coverage Targets
+
+Follow the [project CLAUDE.md](../../.claude/CLAUDE.md) guidance: aim for 100% behavioural coverage, not per-line targets — add tests for the behaviours you care about, not to hit a number.
 
 ## Configuration
 
-### Jest Setup
-
-```javascript
-// jest.config.js
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.test.ts'],
-  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
-  coverageThreshold: {
-    global: {
-      branches: 80,
-      functions: 80,
-      lines: 80,
-      statements: 80,
-    },
-  },
-  testTimeout: 10000,
-  maxWorkers: 1,
-};
-```
+Vitest is configured in `service.backend/vitest.config.ts`. The service does not use Jest; any legacy `jest.config.js` should be treated as stale.
 
 ### Test Database
 
@@ -301,14 +277,16 @@ export const createTestPet = async (rescueId: string, overrides = {}) => {
 
 ```typescript
 // test-helpers/mocks.ts
+import { vi } from 'vitest';
+
 export const mockEmailService = {
-  sendEmail: jest.fn().mockResolvedValue({ success: true }),
-  sendTemplate: jest.fn().mockResolvedValue({ success: true }),
+  sendEmail: vi.fn().mockResolvedValue({ success: true }),
+  sendTemplate: vi.fn().mockResolvedValue({ success: true }),
 };
 
 export const mockStorageService = {
-  uploadFile: jest.fn().mockResolvedValue({ url: 'https://cdn.example.com/file.jpg' }),
-  deleteFile: jest.fn().mockResolvedValue({ success: true }),
+  uploadFile: vi.fn().mockResolvedValue({ url: 'https://cdn.example.com/file.jpg' }),
+  deleteFile: vi.fn().mockResolvedValue({ success: true }),
 };
 ```
 
@@ -347,26 +325,27 @@ export const mockStorageService = {
 ### Running Specific Tests
 
 ```bash
-# Single test file
+# Single test file (substring match)
 npm test user.service.test.ts
 
 # Single test case
-npm test -t "should create user"
+npm test -- -t "should create user"
 
-# With debugger
-node --inspect-brk node_modules/.bin/jest --runInBand
+# With Node debugger (Vitest)
+node --inspect-brk node_modules/.bin/vitest run --no-threads
 ```
 
 ### Common Issues
 
 **Database Connection Issues**
 
-```bash
-# Check test database exists
-npm run db:create:test
+Vitest uses the database configured via `DB_*` / `TEST_DB_NAME` env vars (see `.env.example`). If you're working in Docker, ensure the database container is healthy:
 
-# Reset test database
-npm run db:reset:test
+```bash
+docker compose ps database      # must be "healthy"
+npm run docker:reset            # last resort — wipes the volume
+npm run docker:dev:detach
+npm run db:reset
 ```
 
 **Timeout Errors**

--- a/docs/libraries/auth.md
+++ b/docs/libraries/auth.md
@@ -208,64 +208,27 @@ app.get('/api/auth/example', async (req, res) => {
 
 ## 🐳 Docker Integration
 
-### Development with Docker Compose
+The library is consumed as a workspace dependency; there is no per-library Dockerfile or `docker-compose.lib.yml`. In the Docker dev stack (`docker-compose.yml`), frontend containers bind-mount the repo root so Vite resolves `@adopt-dont-shop/lib.auth` straight from the library's `src/` via workspace aliases — hot reload works without a rebuild.
 
-1. **Build the library:**
+For the backend, `lib.types` is the only library that needs rebuilding (see `npm run docker:rebuild:types`). Every other library is picked up via npm workspaces on container start.
 
-```bash
-# From workspace root
-docker compose -f docker-compose.lib.yml up lib-auth
-```
-
-2. **Run tests:**
-
-```bash
-docker compose -f docker-compose.lib.yml run lib-auth-test
-```
-
-### Using in App Containers
-
-Add to your app's Dockerfile:
+In production app Dockerfiles, copy `lib.auth/` into the build context alongside the app and let Turbo handle the dependency graph:
 
 ```dockerfile
-# Copy shared libraries
-COPY lib.auth /workspace/lib.auth
-
-# Install dependencies
-RUN npm install @adopt-dont-shop/lib.auth
-```
-
-### Multi-stage Build for Production
-
-```dockerfile
-# In your app's Dockerfile
-FROM node:20-alpine AS deps
+# Production build — example for a frontend app
+FROM node:20-alpine AS build
 
 WORKDIR /app
+COPY package*.json turbo.json ./
+COPY lib.auth/ lib.auth/
+COPY lib.types/ lib.types/
+COPY app.client/ app.client/
 
-# Copy shared library
-COPY lib.auth ./lib.auth
-
-# Copy app package files
-COPY app.client/package*.json ./app.client/
-
-# Install dependencies
-RUN cd lib.auth && npm ci && npm run build
-RUN cd app.client && npm ci
-
-# Build stage
-FROM node:20-alpine AS builder
-
-WORKDIR /app
-
-COPY --from=deps /app ./
-
-# Copy app source
-COPY app.client ./app.client
-
-# Build app
-RUN cd app.client && npm run build
+RUN npm ci
+RUN npx turbo run build --filter=@adopt-dont-shop/app.client
 ```
+
+See `Dockerfile.app.optimized` at the repo root for the real recipe used by all three frontend apps.
 
 ## 🧪 Testing
 
@@ -328,21 +291,16 @@ npm run type-check
 lib.auth/
 ├── src/
 │   ├── services/
-│   │   ├── auth-service.ts     # Main service implementation
-│   │   └── __tests__/
-│   │       └── auth-service.test.ts
+│   │   └── auth-service.ts           # Main service implementation
 │   ├── types/
 │   │   └── index.ts                  # TypeScript type definitions
 │   └── index.ts                      # Main entry point
+├── __tests__/                        # Jest tests
 ├── dist/                             # Built output (generated)
-├── docker-compose.lib.yml           # Docker compose for development
-├── Dockerfile                       # Multi-stage Docker build
-├── jest.config.js                   # Jest test configuration
-├── package.json                     # Package configuration
-├── tsconfig.json                    # TypeScript configuration
-├── .eslintrc.json                   # ESLint configuration
-├── .prettierrc.json                 # Prettier configuration
-└── README.md                        # This file
+├── jest.config.cjs                   # Jest configuration
+├── package.json                      # Package configuration
+├── tsconfig.json                     # TypeScript configuration
+└── README.md                         # This file
 ```
 
 ## 🔗 Integration Examples

--- a/docs/libraries/validation.md
+++ b/docs/libraries/validation.md
@@ -208,64 +208,25 @@ app.get('/api/validation/example', async (req, res) => {
 
 ## 🐳 Docker Integration
 
-### Development with Docker Compose
+The library is consumed as a workspace dependency; there is no per-library Dockerfile or `docker-compose.lib.yml`. Frontend containers bind-mount the repo root so Vite resolves `@adopt-dont-shop/lib.validation` from the library's `src/` — hot reload works without a rebuild. The backend picks it up via npm workspaces on container start.
 
-1. **Build the library:**
-
-```bash
-# From workspace root
-docker compose -f docker-compose.lib.yml up lib-validation
-```
-
-2. **Run tests:**
-
-```bash
-docker compose -f docker-compose.lib.yml run lib-validation-test
-```
-
-### Using in App Containers
-
-Add to your app's Dockerfile:
+In production app Dockerfiles, copy `lib.validation/` into the build context and let Turbo handle the dependency graph:
 
 ```dockerfile
-# Copy shared libraries
-COPY lib.validation /workspace/lib.validation
-
-# Install dependencies
-RUN npm install @adopt-dont-shop/lib.validation
-```
-
-### Multi-stage Build for Production
-
-```dockerfile
-# In your app's Dockerfile
-FROM node:20-alpine AS deps
+# Production build — example for a frontend app
+FROM node:20-alpine AS build
 
 WORKDIR /app
+COPY package*.json turbo.json ./
+COPY lib.validation/ lib.validation/
+COPY lib.types/ lib.types/
+COPY app.client/ app.client/
 
-# Copy shared library
-COPY lib.validation ./lib.validation
-
-# Copy app package files
-COPY app.client/package*.json ./app.client/
-
-# Install dependencies
-RUN cd lib.validation && npm ci && npm run build
-RUN cd app.client && npm ci
-
-# Build stage
-FROM node:20-alpine AS builder
-
-WORKDIR /app
-
-COPY --from=deps /app ./
-
-# Copy app source
-COPY app.client ./app.client
-
-# Build app
-RUN cd app.client && npm run build
+RUN npm ci
+RUN npx turbo run build --filter=@adopt-dont-shop/app.client
 ```
+
+See `Dockerfile.app.optimized` at the repo root for the real recipe used by all three frontend apps.
 
 ## 🧪 Testing
 
@@ -328,21 +289,15 @@ npm run type-check
 lib.validation/
 ├── src/
 │   ├── services/
-│   │   ├── validation-service.ts     # Main service implementation
-│   │   └── __tests__/
-│   │       └── validation-service.test.ts
+│   │   └── validation-service.ts     # Main service implementation
 │   ├── types/
 │   │   └── index.ts                  # TypeScript type definitions
 │   └── index.ts                      # Main entry point
 ├── dist/                             # Built output (generated)
-├── docker-compose.lib.yml           # Docker compose for development
-├── Dockerfile                       # Multi-stage Docker build
-├── jest.config.js                   # Jest test configuration
-├── package.json                     # Package configuration
-├── tsconfig.json                    # TypeScript configuration
-├── .eslintrc.json                   # ESLint configuration
-├── .prettierrc.json                 # Prettier configuration
-└── README.md                        # This file
+├── jest.config.cjs                   # Jest configuration
+├── package.json                      # Package configuration
+├── tsconfig.json                     # TypeScript configuration
+└── README.md                         # This file
 ```
 
 ## 🔗 Integration Examples


### PR DESCRIPTION
## Summary

Fact-checking pass over the core developer-facing docs. Every change was verified against the actual `package.json` scripts, `docker-compose.yml`, and on-disk file layout.

### What's wrong and how it was fixed

| File | Issue | Fix |
| --- | --- | --- |
| `docs/DOCKER.md` | Said Vite polling interval is `100ms` | `docker-compose.yml` actually sets `CHOKIDAR_INTERVAL: 1000` |
| `docs/README.md` | Future-dated "Last Major Cleanup: October 2025" stamp | Removed — drift-prone, no substitute value |
| `docs/backend/testing.md` | Claimed Jest, referenced non-existent `test:integration` / `test:e2e` scripts, Jest config example | Backend uses Vitest (`service.backend/vitest.config.ts`). Scripts don't exist; removed. `jest.fn()` → `vi.fn()`. |
| `docs/backend/implementation-guide.md` | Referenced `db:create`, `db:drop`, `migration:create`, `db:migrate:undo`, `seed:create`, `db:seed:undo`, `test:load`, `test:stress`, `profile`, `Dockerfile.prod` | None exist. Replaced with the real Docker-based workflow + `sequelize-cli` invocations inside the backend container. Fixed Dockerfile path to `service.backend/Dockerfile`. |
| `docs/backend/deployment.md` | Node 18 Dockerfile, `CMD ["npm", "run", "start:prod"]` | Backend Dockerfile uses Node 20; `start:prod` doesn't exist — use `npm start`. |
| `docs/libraries/auth.md` & `docs/libraries/validation.md` | Referenced `docker-compose.lib.yml`, per-lib `Dockerfile`, `jest.config.js`, `.eslintrc.json`, `.prettierrc.json` | No per-library Docker files exist; libs use `jest.config.cjs`; ESLint/Prettier configs are inherited, not per-package. |
| `EMAIL_VERIFICATION.md` | `npm run test:backend` | No such script — use `npm test` from `service.backend/`. |
| `TEST_STATUS.md` | `test:libs`, `test:components`, `test:client`, `test:admin`, `test:rescue` | None exist. Replaced with `turbo --filter` commands that actually work. |

### Not addressed here (follow-up PRs)

- Library READMEs (malformed markdown in `lib.chat`, `lib.dev-tools`, `lib.analytics`; missing READMEs for `lib.discovery` and `lib.support-tickets`; stale `exampleMethod()` placeholders across multiple libs)
- Historical docs (FIX_SUMMARY.md, TEST_STATUS.md): considered for `_archive/` relocation but left in place for now.

## Test plan

- [x] Each removed script was grep'd against `package.json` files workspace-wide — none exist
- [x] Replacement scripts verified against root `package.json` and `service.backend/package.json`
- [x] Dockerfile claims (Node version, non-root user, CMD) verified against `service.backend/Dockerfile`
- [x] `docker-compose.yml` polling interval verified
- [x] `jest.config.cjs` existence confirmed in `lib.auth/` and `lib.validation/`

https://claude.ai/code/session_01Gm33J8uZZUVn9qdFNs4GAh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gm33J8uZZUVn9qdFNs4GAh)_