### PR TITLE
docs(lib.discovery): fix inverted `@throws` JSDoc tags

### DIFF
--- a/lib.discovery/src/services/discovery-service.ts
+++ b/lib.discovery/src/services/discovery-service.ts
@@ -63,8 +63,9 @@ export class DiscoveryService {
    *
    * @param filters - Search filters to apply to the queue
    * @param userId - Optional user ID for personalization
-   * @returns Promise<PetDiscoveryQueue> - Initial queue with smart sorting
-   * @throws Will return empty queue if backend fails
+   * @returns Promise<PetDiscoveryQueue> - Initial queue with smart sorting.
+   *          Never throws: on backend failure the method logs (when `debug` is
+   *          enabled) and resolves with an empty queue.
    */
   async getDiscoveryQueue(
     filters: PetSearchFilters = {},
@@ -120,8 +121,8 @@ export class DiscoveryService {
    * - 'info': User views pet details (down swipe/tap) - interest indicator
    *
    * @param action - Swipe action object containing action type, pet ID, session info
-   * @returns Promise<void> - Resolves when action is recorded
-   * @throws Will log warning if backend fails but won't throw error
+   * @returns Promise<void> - Resolves when the action is recorded. Never throws:
+   *          backend failures are logged (when `debug` is enabled) and swallowed.
    */
   async recordSwipeAction(action: SwipeAction): Promise<void> {
     try {
@@ -145,8 +146,9 @@ export class DiscoveryService {
    * - Behavioral insights for personalization
    *
    * @param userId - User UUID to get statistics for
-   * @returns Promise<SwipeStats> - Comprehensive user analytics
-   * @throws Will return empty stats if backend fails
+   * @returns Promise<SwipeStats> - Comprehensive user analytics. Never throws:
+   *          on backend failure the method logs (when `debug` is enabled) and
+   *          resolves with a zeroed `SwipeStats` object.
    */
   async getSwipeStats(userId: string): Promise<SwipeStats> {
     try {


### PR DESCRIPTION
## Summary

`DiscoveryService.getDiscoveryQueue`, `recordSwipeAction`, and `getSwipeStats` each wrap their request in `try/catch` that swallows backend errors and resolves with a safe default (empty queue, `void`, zeroed stats respectively). Their JSDoc used `@throws` for sentences that actually describe non-throwing behaviour:

```diff
-   * @throws Will return empty queue if backend fails
+   * @returns Promise<PetDiscoveryQueue> - Initial queue with smart sorting.
+   *          Never throws: on backend failure the method logs (when `debug` is
+   *          enabled) and resolves with an empty queue.
```

IDE tooltips would mislead callers into wrapping the calls in try/catch; the whole point of the existing implementation is that callers don't need to.

### Not included

The JSDoc audit also flagged:

- **`service.backend/src/routes/*.ts`** — 167 auto-generated Swagger blocks across 9 route files contain placeholder paths/summaries (e.g. `/api/v1/:` with `summary: GET /api/v1/`). This is pervasive enough to warrant a dedicated effort rather than a piecemeal fix, and the generated OpenAPI is already consumed via `docs/backend/generated-openapi.yaml` — probably better addressed by regenerating the Swagger docs from the real route definitions. Not in scope here.
- **`service.backend/src/services/file-upload.service.ts` — `scanForMalware`** — the JSDoc block itself already prominently documents the TODO state, so the docs are accurate enough; the real issue is the missing feature, not the docs.

## Test plan

- [x] Each `@returns` edit verified by re-reading the method's try/catch to confirm it really never throws
- [x] No code behaviour changes — comments only

https://claude.ai/code/session_01Gm33J8uZZUVn9qdFNs4GAh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gm33J8uZZUVn9qdFNs4GAh)_