### PR TITLE
Phase 3 (slice 1): audit columns + optimistic concurrency

### DIFF
--- a/service.backend/src/__tests__/models/standards.test.ts
+++ b/service.backend/src/__tests__/models/standards.test.ts
@@ -138,4 +138,35 @@ describe('Model Standards', () => {
       ).toHaveLength(0);
     });
   });
+
+  describe('audit columns', () => {
+    // Models that have been migrated to the audit-columns helper. The set
+    // grows as we roll out audit columns to the rest of the transactional
+    // models (separate PR per the Phase 3 plan).
+    const HAS_AUDIT_COLUMNS = ['User', 'Pet', 'Application', 'Rescue', 'Message'];
+
+    it.each(HAS_AUDIT_COLUMNS)('%s has created_by, updated_by, version', name => {
+      const model = sequelize.models[name];
+      expect(model, `${name} not registered`).toBeDefined();
+      const attrs = model.getAttributes() as Record<string, ModelAttribute>;
+      expect(attrs).toHaveProperty('created_by');
+      expect(attrs).toHaveProperty('updated_by');
+      // version: true makes Sequelize add the column under "version".
+      expect(attrs).toHaveProperty('version');
+    });
+
+    it.each(HAS_AUDIT_COLUMNS)('%s has indexes on created_by and updated_by', name => {
+      const model = sequelize.models[name];
+      const opts = (
+        model as unknown as {
+          options: { indexes?: Array<{ fields: Array<string | { name: string }> }> };
+        }
+      ).options;
+      const cols = new Set(
+        (opts.indexes ?? []).flatMap(i => i.fields.map(f => (typeof f === 'string' ? f : f.name)))
+      );
+      expect(cols.has('created_by'), `${name} missing created_by index`).toBe(true);
+      expect(cols.has('updated_by'), `${name} missing updated_by index`).toBe(true);
+    });
+  });
 });

--- a/service.backend/src/__tests__/utils/audit-columns.test.ts
+++ b/service.backend/src/__tests__/utils/audit-columns.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import '../../models/index';
+import Rescue from '../../models/Rescue';
+import User from '../../models/User';
+import { runWithContext } from '../../utils/request-context';
+
+const seedActor = async (id: string): Promise<void> => {
+  await User.create({
+    userId: id,
+    email: `actor-${id}@test.local`,
+    password: 'password-x',
+    firstName: 'Actor',
+    lastName: 'Tester',
+    userType: 'admin',
+    status: 'active',
+    emailVerified: true,
+  } as never);
+};
+
+/**
+ * End-to-end check of the audit-column wiring:
+ *   - context-aware created_by / updated_by stamping
+ *   - Sequelize version: true optimistic locking
+ *
+ * Uses Rescue against the in-memory test DB — it's the simplest of the
+ * audited models (no array / geometry columns that getArrayType / SQLite
+ * would reject in tests).
+ */
+describe('audit columns + request context', () => {
+  let rescueCounter = 0;
+
+  const makeRescue = (overrides: Record<string, unknown> = {}) => {
+    rescueCounter += 1;
+    return Rescue.create({
+      name: `Rescue ${rescueCounter}`,
+      email: `rescue${rescueCounter}@test.local`,
+      address: '1 Test Lane',
+      city: 'Testville',
+      postcode: 'AB1 2CD',
+      country: 'GB',
+      contactPerson: 'Test Person',
+      status: 'pending',
+      isDeleted: false,
+      ...overrides,
+    } as never);
+  };
+
+  it('stamps created_by from request context on insert', async () => {
+    await sequelize.sync({ force: true });
+    const actorId = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa1';
+    await seedActor(actorId);
+
+    const rescue = await runWithContext({ userId: actorId }, () => makeRescue());
+
+    const reloaded = (await Rescue.findByPk(rescue.rescueId)) as unknown as {
+      created_by: string;
+      updated_by: string;
+    };
+    expect(reloaded.created_by).toBe(actorId);
+    expect(reloaded.updated_by).toBe(actorId);
+  });
+
+  it('refreshes updated_by on save without touching created_by', async () => {
+    await sequelize.sync({ force: true });
+    const creatorId = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa2';
+    const editorId = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbb2';
+    await seedActor(creatorId);
+    await seedActor(editorId);
+
+    const rescue = await runWithContext({ userId: creatorId }, () => makeRescue());
+    await runWithContext({ userId: editorId }, async () => {
+      rescue.name = `${rescue.name} (renamed)`;
+      await rescue.save();
+    });
+
+    const reloaded = (await Rescue.findByPk(rescue.rescueId)) as unknown as {
+      created_by: string;
+      updated_by: string;
+    };
+    expect(reloaded.created_by).toBe(creatorId);
+    expect(reloaded.updated_by).toBe(editorId);
+  });
+
+  it('leaves created_by null when no context is active (e.g. seeders)', async () => {
+    await sequelize.sync({ force: true });
+    // No runWithContext wrapper -> getUserId() is undefined -> hook no-ops.
+    const rescue = await makeRescue();
+    const reloaded = (await Rescue.findByPk(rescue.rescueId)) as unknown as {
+      created_by: string | null;
+      updated_by: string | null;
+    };
+    expect(reloaded.created_by).toBeNull();
+    expect(reloaded.updated_by).toBeNull();
+  });
+
+  it('Sequelize version: true blocks stale updates', async () => {
+    await sequelize.sync({ force: true });
+    const rescue = await makeRescue();
+
+    // Two independent in-memory copies of the same row.
+    const a = (await Rescue.findByPk(rescue.rescueId)) as Rescue;
+    const b = (await Rescue.findByPk(rescue.rescueId)) as Rescue;
+
+    // First write wins, bumps version 0 -> 1.
+    a.name = 'A wrote first';
+    await a.save();
+
+    // Second write is stale (still has version 0) and should be rejected.
+    b.name = 'B writes stale';
+    await expect(b.save()).rejects.toThrow();
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -13,6 +13,7 @@ import { config } from './config';
 import { errorHandler } from './middleware/error-handler';
 import { csrfProtection, csrfErrorHandler, getCsrfToken } from './middleware/csrf';
 import { apiLimiter } from './middleware/rate-limiter';
+import { requestContextMiddleware } from './middleware/request-context';
 import sequelize from './sequelize';
 import { initializeMessageBroker } from './services/messageBroker.service';
 import { SocketHandlers } from './socket/socket-handlers';
@@ -138,6 +139,11 @@ app.use(
 app.use(express.json({ limit: '10mb' }));
 app.use(morgan(config.nodeEnv === 'production' ? 'combined' : 'dev'));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+
+// Establish AsyncLocalStorage context per-request so model hooks can read
+// the authenticated userId for created_by / updated_by stamping. Must come
+// before the auth middleware mount points (which fill in userId).
+app.use(requestContextMiddleware);
 
 // Cookie parser for CSRF tokens
 app.use(cookieParser());

--- a/service.backend/src/middleware/auth.ts
+++ b/service.backend/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import Role from '../models/Role';
 import Permission from '../models/Permission';
 import { AuthenticatedRequest } from '../types/auth';
 import { logger, loggerHelpers } from '../utils/logger';
+import { setUserId } from '../utils/request-context';
 import { env } from '../config/env';
 
 export interface JWTPayload {
@@ -92,8 +93,11 @@ export const authenticateToken = async (
       return;
     }
 
-    // Attach user to request
+    // Attach user to request and to the AsyncLocalStorage context so that
+    // Sequelize hooks (created_by / updated_by stamping) can read the actor
+    // without threading req through every call chain.
     req.user = user;
+    setUserId(user.userId);
 
     loggerHelpers.logAuth(
       'User authenticated',
@@ -166,6 +170,7 @@ export const optionalAuth = async (
 
     if (user && user.status === 'active') {
       req.user = user;
+      setUserId(user.userId);
       logger.debug('Optional authentication successful', {
         userId: user.userId,
         ip: req.ip,
@@ -290,6 +295,7 @@ export const authenticateOptionalToken = async (
 
     // Attach user to request if found
     req.user = user;
+    setUserId(user.userId);
 
     logger.info('Optional authentication successful', {
       userId: user.userId,

--- a/service.backend/src/middleware/request-context.ts
+++ b/service.backend/src/middleware/request-context.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from 'express';
+import { runWithContext } from '../utils/request-context';
+
+/**
+ * Establish a fresh AsyncLocalStorage context for the lifetime of one
+ * request. Mounted before auth so the auth middleware can fill in userId
+ * later. Without this, getUserId() in model hooks always returns undefined.
+ */
+export const requestContextMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  runWithContext({}, () => next());
+};

--- a/service.backend/src/models/Application.ts
+++ b/service.backend/src/models/Application.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Op, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 // Simple application status enum for small charities
 export enum ApplicationStatus {
@@ -448,8 +449,9 @@ Application.init(
       allowNull: true,
       field: 'deleted_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'applications',
     modelName: 'Application',
@@ -508,6 +510,7 @@ Application.init(
           },
         },
       },
+      ...auditIndexes('applications'),
     ],
     hooks: {
       beforeValidate: (application: Application) => {
@@ -570,7 +573,7 @@ Application.init(
         },
       },
     },
-  }
+  })
 );
 
 export default Application;

--- a/service.backend/src/models/Message.ts
+++ b/service.backend/src/models/Message.ts
@@ -3,6 +3,7 @@ import sequelize, { getJsonType, getUuidType, getTsVectorType, TsVector } from '
 import { MessageContentFormat } from '../types/chat';
 import Chat from './Chat';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export interface MessageReaction {
   user_id: string;
@@ -277,8 +278,9 @@ Message.init(
       type: getTsVectorType(),
       allowNull: true,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'messages',
     modelName: 'Message',
@@ -313,6 +315,7 @@ Message.init(
         using: 'gin',
         name: 'messages_read_status_gin_idx',
       },
+      ...auditIndexes('messages'),
     ],
     hooks: {
       beforeSave: async (message: Message) => {
@@ -326,7 +329,7 @@ Message.init(
         }
       },
     },
-  }
+  })
 );
 
 // Add class method for full-text search

--- a/service.backend/src/models/Pet.ts
+++ b/service.backend/src/models/Pet.ts
@@ -10,6 +10,7 @@ import sequelize, {
 } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 // Pet status enum
 export enum PetStatus {
@@ -703,8 +704,9 @@ Pet.init(
       allowNull: true,
       field: 'deleted_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'pets',
     modelName: 'Pet',
@@ -774,6 +776,7 @@ Pet.init(
         using: 'gist',
         name: 'pets_location_gist_idx',
       },
+      ...auditIndexes('pets'),
     ],
     hooks: {
       beforeValidate: (pet: Pet) => {
@@ -870,7 +873,7 @@ Pet.init(
         },
       },
     },
-  }
+  })
 );
 
 export default Pet;

--- a/service.backend/src/models/Rescue.ts
+++ b/service.backend/src/models/Rescue.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 interface RescueAttributes {
   rescueId: string;
@@ -227,8 +228,9 @@ Rescue.init(
       defaultValue: DataTypes.NOW,
       field: 'updated_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'rescues',
     timestamps: true,
@@ -244,6 +246,7 @@ Rescue.init(
         fields: ['deleted_by'],
         name: 'rescues_deleted_by_idx',
       },
+      ...auditIndexes('rescues'),
     ],
     defaultScope: {
       where: {
@@ -260,7 +263,7 @@ Rescue.init(
         },
       },
     },
-  }
+  })
 );
 
 export default Rescue;

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -4,6 +4,7 @@ import { hashPassword, verifyPassword } from '../utils/password';
 import { encryptSecret, hashBackupCode, hashToken } from '../utils/secrets';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 // Forward declarations to avoid circular imports
 interface Permission {
@@ -471,8 +472,9 @@ User.init(
       field: 'application_template_version',
       defaultValue: 1,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     modelName: 'User',
     tableName: 'users',
@@ -508,6 +510,7 @@ User.init(
       {
         fields: ['created_at'],
       },
+      ...auditIndexes('users'),
     ],
     hooks: {
       // Normalize identifier fields before validation so uniqueness /
@@ -536,7 +539,7 @@ User.init(
         await protectSecretsIfChanged(user);
       },
     },
-  }
+  })
 );
 
 /**

--- a/service.backend/src/models/audit-columns.ts
+++ b/service.backend/src/models/audit-columns.ts
@@ -1,0 +1,106 @@
+import { InitOptions, Model } from 'sequelize';
+import { getUuidType } from '../sequelize';
+import { getUserId } from '../utils/request-context';
+
+/**
+ * Standard audit columns added to every transactional model:
+ *
+ *   created_by  UUID NULL  — the userId of whoever inserted the row.
+ *                            Set automatically by the beforeCreate hook from
+ *                            the AsyncLocalStorage request context. Null for
+ *                            system-created rows (seeders, jobs).
+ *   updated_by  UUID NULL  — same idea, refreshed on every UPDATE.
+ *
+ * Plus model-level `version: true` for optimistic concurrency:
+ *   - Sequelize adds a `version` column (default 0) and rewrites every
+ *     model.save / model.update with `WHERE id = ? AND version = ?`.
+ *   - A stale write throws OptimisticLockError instead of silently winning.
+ *   - Keeps `Model.increment` callers honest too — they pass through the
+ *     same lock check.
+ *
+ * Helpers below let each model opt in with two lines: spread the column
+ * defs into init's first arg, spread the options into init's second arg.
+ */
+
+export const auditColumns = {
+  created_by: {
+    type: getUuidType(),
+    allowNull: true,
+    references: { model: 'users', key: 'user_id' },
+    onDelete: 'SET NULL' as const,
+  },
+  updated_by: {
+    type: getUuidType(),
+    allowNull: true,
+    references: { model: 'users', key: 'user_id' },
+    onDelete: 'SET NULL' as const,
+  },
+};
+
+/**
+ * Hooks that stamp created_by / updated_by from the request context.
+ * Composed (not replaced) with any model-specific hooks — Sequelize merges
+ * them by name when both define the same hook.
+ */
+const stampCreatedBy = (instance: Model): void => {
+  const userId = getUserId();
+  // Don't overwrite an explicitly-set value (services that need to attribute
+  // a create to a different actor — e.g. admin acting on behalf of a user —
+  // can pass created_by directly).
+  if (userId && !instance.getDataValue('created_by')) {
+    instance.setDataValue('created_by', userId);
+  }
+  if (userId && !instance.getDataValue('updated_by')) {
+    instance.setDataValue('updated_by', userId);
+  }
+};
+
+const stampUpdatedBy = (instance: Model): void => {
+  const userId = getUserId();
+  if (userId) {
+    instance.setDataValue('updated_by', userId);
+  }
+};
+
+/**
+ * Merge audit hooks into an existing init options block. Preserves any
+ * model-specific beforeCreate / beforeUpdate the model already declares.
+ *
+ * Typed as `InitOptions<any>` because Sequelize's hook callback types are
+ * generic over the model class — model-specific options literals widen
+ * cleanly to this signature on the way in and the way out.
+ */
+export const withAuditHooks = <M extends Model>(options: InitOptions<M>): InitOptions<M> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const existing: any = options.hooks ?? {};
+  return {
+    ...options,
+    version: true,
+    hooks: {
+      ...existing,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      beforeCreate: async (instance: Model, opts: any) => {
+        stampCreatedBy(instance);
+        if (existing.beforeCreate) {
+          await existing.beforeCreate(instance, opts);
+        }
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      beforeUpdate: async (instance: Model, opts: any) => {
+        stampUpdatedBy(instance);
+        if (existing.beforeUpdate) {
+          await existing.beforeUpdate(instance, opts);
+        }
+      },
+    },
+  };
+};
+
+/**
+ * Indexes covering the FK columns added above. Each transactional model
+ * spreads these into its `indexes` array.
+ */
+export const auditIndexes = (tableName: string) => [
+  { fields: ['created_by'], name: `${tableName}_created_by_idx` },
+  { fields: ['updated_by'], name: `${tableName}_updated_by_idx` },
+];

--- a/service.backend/src/utils/request-context.ts
+++ b/service.backend/src/utils/request-context.ts
@@ -1,0 +1,41 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+/**
+ * Request-scoped context. Lets Sequelize hooks (and any deeply-nested code
+ * path) read the authenticated user without threading the value through
+ * every function signature.
+ *
+ * The pattern:
+ *   - Auth middleware calls setUserId(req.user.userId) once auth resolves.
+ *   - Model beforeCreate / beforeUpdate hooks read getUserId() and stamp
+ *     created_by / updated_by.
+ *   - Outside a request (cron jobs, seeders, tests) the store is empty and
+ *     hooks fall through to null. The columns are nullable on purpose.
+ */
+type RequestContextStore = {
+  userId?: string;
+};
+
+const storage = new AsyncLocalStorage<RequestContextStore>();
+
+/**
+ * Establish a fresh context and run the callback inside it. Express
+ * middleware uses this for every request; tests/jobs can use it to simulate
+ * an actor.
+ */
+export const runWithContext = <T>(store: RequestContextStore, fn: () => T): T =>
+  storage.run(store, fn);
+
+export const getUserId = (): string | undefined => storage.getStore()?.userId;
+
+/**
+ * Mutate the current context. Used by the auth middleware to set userId
+ * once auth has resolved (the request-context middleware runs first to
+ * establish the empty store; auth fills it in).
+ */
+export const setUserId = (userId: string): void => {
+  const store = storage.getStore();
+  if (store) {
+    store.userId = userId;
+  }
+};


### PR DESCRIPTION
## Summary

Phase 3, slice 1. Establishes the wiring for `created_by` / `updated_by` audit stamping and Sequelize `version`-based optimistic concurrency, and applies it to **five core transactional models**. The remaining transactional models, status-transition tables, generated `search_vector`, and Zod schema rollout are separate follow-up PRs in Phase 3.

### What's wired up

**`utils/request-context.ts`** — AsyncLocalStorage store. `runWithContext()` establishes it for a code path; `setUserId()` writes into it; `getUserId()` reads it from anywhere downstream (no need to thread `req` through every call).

**`middleware/request-context.ts` + `index.ts`** — middleware that establishes the store at the start of every request. Mounted *before* the auth middleware so the auth handlers have somewhere to write.

**`middleware/auth.ts`** — calls `setUserId(user.userId)` at all three sites where `req.user` is populated (required-auth, optional+strict, optional+lenient).

**`models/audit-columns.ts`** — composable helper:
- `auditColumns` — `created_by` + `updated_by` columns (UUID, nullable, FK to `users` with `onDelete: 'SET NULL'`).
- `auditIndexes(tableName)` — named B-tree indexes for both FK columns.
- `withAuditHooks(opts)` — wraps a model's `init` options:
  - composes `beforeCreate` / `beforeUpdate` stamping with any existing hooks the model already declares (no clobbering);
  - turns on `version: true`, so Sequelize rewrites every `save()` with `WHERE id = ? AND version = ?` — stale writes throw `OptimisticLockError` instead of silently winning the last-write race.

### Applied to (in this PR)

- `User`, `Pet`, `Application`, `Rescue`, `Message`

Each model spreads `auditColumns` into its attributes, `auditIndexes` into the indexes array, and wraps init's second arg with `withAuditHooks`. Three lines per model.

### Out of scope (follow-ups)

- Roll out to remaining transactional models (`Notification`, `Chat`, `Invitation`, `HomeVisit`, `Report`, `ModeratorAction`, `UserSanction`, `SupportTicket`, `Rating`, `EmailQueue`, `EmailTemplate`, `EmailPreference`, `StaffMember`, `Content`, `NavigationMenu`, `FileUpload`, `UserFavorite`, `ApplicationQuestion`, `ChatParticipant`, `SupportTicketResponse`).
- Status-transition tables for `Application` / `Pet` / `HomeVisit` / `UserSanction` / `Report` (Phase 3.7).
- `search_vector` as `GENERATED ALWAYS AS ... STORED` for `Pet` and `Message` (Phase 3.5.5.6).
- Zod schema-first rollout (Phase 3.2.3).

### Tests

- **`__tests__/utils/audit-columns.test.ts`** — round-trip integration:
  - insert inside `runWithContext` stamps both `created_by` and `updated_by`;
  - update inside a *different* context refreshes only `updated_by`, leaves `created_by` alone;
  - insert with no context leaves both `null` (seeders / cron / system jobs);
  - stale-save raises (Sequelize `OptimisticLockError` via `version: true`).
- **`__tests__/models/standards.test.ts`** — extends the existing standards suite with per-model assertions that audited models have `created_by` + `updated_by` + `version` and indexes on both FK columns. The list grows as the rollout continues.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm test` — 1274 passed, 4 skipped (1260 prior + 14 new)
- [ ] Smoke: register a user, log in, create a pet under that login, confirm `pets.created_by` matches the actor in `psql`
- [ ] Smoke: open two tabs, edit the same record, confirm second tab gets a 409/error from the optimistic-lock failure

https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_