### PR TITLE
docs(backend): align backend docs with current code

### DIFF
--- a/docs/backend/api-endpoints.md
+++ b/docs/backend/api-endpoints.md
@@ -19,20 +19,26 @@ The Adopt Don't Shop Backend API provides RESTful endpoints for managing users, 
 1. **Register**: `POST /api/v1/auth/register`
 2. **Login**: `POST /api/v1/auth/login` (returns JWT tokens)
 3. **Use Token**: Include in Authorization header: `Authorization: Bearer <token>`
-4. **Refresh**: `POST /api/v1/auth/refresh` (when token expires)
+4. **Refresh**: `POST /api/v1/auth/refresh-token` (when token expires)
 
 ### Auth Endpoints
 
-| Method | Endpoint                       | Description                 | Auth Required       |
-| ------ | ------------------------------ | --------------------------- | ------------------- |
-| POST   | `/api/v1/auth/register`        | Create new user account     | No                  |
-| POST   | `/api/v1/auth/login`           | Authenticate and get tokens | No                  |
-| POST   | `/api/v1/auth/logout`          | Invalidate current session  | Yes                 |
-| POST   | `/api/v1/auth/refresh`         | Refresh access token        | Yes (refresh token) |
-| POST   | `/api/v1/auth/password/forgot` | Request password reset      | No                  |
-| POST   | `/api/v1/auth/password/reset`  | Reset password with token   | No                  |
-| POST   | `/api/v1/auth/email/verify`    | Verify email address        | No                  |
-| GET    | `/api/v1/auth/me`              | Get current user profile    | Yes                 |
+| Method | Endpoint                              | Description                            | Auth Required       |
+| ------ | ------------------------------------- | -------------------------------------- | ------------------- |
+| POST   | `/api/v1/auth/register`               | Create new user account                | No                  |
+| POST   | `/api/v1/auth/login`                  | Authenticate and get tokens            | No                  |
+| POST   | `/api/v1/auth/logout`                 | Invalidate current session             | Yes                 |
+| POST   | `/api/v1/auth/refresh-token`          | Refresh access token                   | Yes (refresh token) |
+| POST   | `/api/v1/auth/forgot-password`        | Request password reset                 | No                  |
+| POST   | `/api/v1/auth/reset-password`         | Reset password with token              | No                  |
+| GET    | `/api/v1/auth/verify-email/:token`    | Verify email address                   | No                  |
+| POST   | `/api/v1/auth/resend-verification`    | Resend verification email              | No                  |
+| GET    | `/api/v1/auth/me`                     | Get current user profile               | Yes                 |
+| PUT    | `/api/v1/auth/me`                     | Update current user profile            | Yes                 |
+| POST   | `/api/v1/auth/2fa/setup`              | Begin two-factor enrolment             | Yes                 |
+| POST   | `/api/v1/auth/2fa/enable`             | Enable two-factor (verify OTP)         | Yes                 |
+| POST   | `/api/v1/auth/2fa/disable`            | Disable two-factor                     | Yes                 |
+| POST   | `/api/v1/auth/2fa/backup-codes`       | Regenerate backup codes                | Yes                 |
 
 ## Core Resources
 

--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -297,15 +297,16 @@ Most tables use soft delete (deleted_at timestamp) instead of hard delete for:
 
 ### Migration Management
 
-```bash
-# Create migration
-npm run migration:create -- --name add-new-field
+Migrations live in `service.backend/src/migrations/` as numbered TypeScript files (e.g. `30-create-file-uploads.ts`). Create a new one by adding the next sequential file following the existing pattern — the repo doesn't ship a `migration:create` npm script.
 
-# Run migrations
+```bash
+# Run migrations (from repo root, while the dev stack is running)
 npm run db:migrate
 
-# Rollback
-npm run db:migrate:undo
+# Rollback / status — shell into the backend container and use sequelize-cli directly
+npm run docker:shell:backend
+npx sequelize-cli db:migrate:undo
+npx sequelize-cli db:migrate:status
 ```
 
 ### Best Practices

--- a/docs/backend/deployment.md
+++ b/docs/backend/deployment.md
@@ -10,18 +10,18 @@ This guide covers deploying the Adopt Don't Shop Backend Service across differen
 
 **Production Environment:**
 
-- Node.js 18+ LTS
-- PostgreSQL 13+
-- Redis 6+ (for session storage and caching)
+- Node.js 20+ LTS
+- PostgreSQL 16+ with PostGIS
+- Redis 7+ (for session storage and caching)
 - 2+ CPU cores, 4GB+ RAM
 - 20GB+ disk space
 
 **Development Environment:**
 
-- Node.js 18+
-- PostgreSQL 13+
+- Node.js 20+
+- PostgreSQL 16+
 - Git
-- Docker (optional)
+- Docker Desktop (recommended)
 
 ### Required Services
 


### PR DESCRIPTION
## Summary

Fact-checked the backend documentation against the actual code in `service.backend/` and corrected concrete inaccuracies. Each change was verified against the source file referenced.

### `docs/backend/api-endpoints.md`
- Corrected the **Authentication** quick-start and table to match `service.backend/src/routes/auth.routes.ts`:
  - `POST /api/v1/auth/refresh` → `POST /api/v1/auth/refresh-token`
  - `POST /api/v1/auth/password/forgot` → `POST /api/v1/auth/forgot-password`
  - `POST /api/v1/auth/password/reset` → `POST /api/v1/auth/reset-password`
  - `POST /api/v1/auth/email/verify` → `GET /api/v1/auth/verify-email/:token`
- Added missing endpoints that exist in code: `POST /resend-verification`, `PUT /me`, `POST /2fa/setup`, `POST /2fa/enable`, `POST /2fa/disable`, `POST /2fa/backup-codes`.

### `docs/backend/testing.md`
- Replaced **Jest** references with **Vitest** (matches `service.backend/package.json` — `"test": "vitest run"`).
- Removed non-existent commands: `npm run test:integration`, `npm run test:e2e`, `npm run db:create:test`, `npm run db:reset:test`.
- Replaced the `jest.config.js` block with an illustrative `vitest.config.ts` snippet pointing to the real config file location.
- Updated mock examples to use `vi.fn()` and updated debugger invocation for Vitest.

### `docs/backend/implementation-guide.md`
- Replaced bogus `npm run db:create / db:migrate / db:seed / db:migrate:undo / seed:create / migration:create` calls with the real script names from `service.backend/package.json`: `migrate`, `seed`, `seed:dev`, `seed:clear`. Documented the `db:migrate` / `db:seed` aliases that exist at the repo root for the Docker workflow.
- Removed non-existent `test:load`, `test:stress`, `profile`, `db:log`, `db:drop` scripts; replaced with accurate guidance.
- Updated "Add Database Model" to describe the actual numbered-file convention used in `src/migrations/`.

### `docs/backend/database-schema.md`
- Replaced the `npm run migration:create` command (which doesn't exist) with the actual numbered-file pattern under `service.backend/src/migrations/`. Pointed at `sequelize-cli` directly for `undo` / `status`.

### `docs/backend/deployment.md`
- Bumped the prerequisite versions to match the real stack (Node 20 LTS, PostgreSQL 16 with PostGIS, Redis 7) — the previous text said Node 18 / Postgres 13 / Redis 6.
- Replaced the illustrative Dockerfile so it uses `npm run start` (the real script in `service.backend/package.json`) instead of the non-existent `npm run start:prod`. Pointed readers at the real multi-stage Dockerfile in `service.backend/Dockerfile`.

## Test plan
- [ ] Visual diff of each updated doc reads cleanly.
- [ ] Spot-check a few links in the table of contents still resolve.
- [ ] No content was removed beyond the listed inaccuracies.

https://claude.ai/code/session_013RBaP8WTo6XSBbMcGV8A5p

---
_Generated by [Claude Code](https://claude.ai/code/session_013RBaP8WTo6XSBbMcGV8A5p)_