### PR TITLE
docs(frontend,infra): fix wrong constants, broken links, and stale env examples

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -141,14 +141,16 @@ npm run db:reset
 
 ### Debugging
 
-**Backend** — add to `docker-compose.override.yml`:
+**Backend** — add to `docker-compose.override.yml` (the repo doesn't ship a dedicated `dev:debug` script, so override the command to enable Node's `--inspect`):
 
 ```yaml
 services:
   service-backend:
     ports:
       - "9229:9229"
-    command: npm run dev:debug
+    command: >
+      npx ts-node-dev --inspect=0.0.0.0:9229 --respawn --transpile-only --poll
+      --watch src src/index.ts
 ```
 
 Attach your IDE debugger to `localhost:9229`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,7 +109,7 @@ Reusable packages and utilities across the platform.
 - **ESM-Only Architecture**: Modern module system throughout
 - **TypeScript Strict Mode**: Enforced across all packages
 - **Docker**: Multi-stage builds with BuildKit
-- **Testing**: Jest + React Testing Library with behaviour-focused tests
+- **Testing**: Vitest (apps + service.backend) and Jest (Node libraries) with behaviour-focused tests
 
 ## Contributing
 

--- a/docs/frontend/RESCUE_CONFIG_AND_WORKFLOW_COMPLETE.md
+++ b/docs/frontend/RESCUE_CONFIG_AND_WORKFLOW_COMPLETE.md
@@ -32,7 +32,7 @@ import styled from 'styled-components';
 import { useAuth } from '../contexts/AuthContext';
 import { usePermissions } from '../contexts/PermissionsContext';
 import { apiService } from '../services/libraryServices';
-import { RESCUE_UPDATE } from '@adopt-dont-shop/lib.permissions';
+import { RESCUE_SETTINGS_UPDATE } from '@adopt-dont-shop/lib.permissions';
 import RescueProfileForm from '../components/rescue/RescueProfileForm';
 import AdoptionPolicyForm from '../components/rescue/AdoptionPolicyForm';
 import type { RescueProfile, AdoptionPolicy } from '../types/rescue';
@@ -149,7 +149,7 @@ const RescueSettings: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const canEdit = hasPermission(RESCUE_UPDATE);
+  const canEdit = hasPermission(RESCUE_SETTINGS_UPDATE);
 
   useEffect(() => {
     loadRescueData();
@@ -188,7 +188,7 @@ const RescueSettings: React.FC = () => {
     if (!rescue) return;
 
     await apiService.put(
-      `http://localhost:5000/api/v1/rescues/${rescue.rescue_id}`,
+      `http://localhost:5000/api/v1/rescues/${rescue.rescueId}`,
       profileData
     );
 
@@ -199,7 +199,7 @@ const RescueSettings: React.FC = () => {
     if (!rescue) return;
 
     await apiService.put(
-      `http://localhost:5000/api/v1/rescues/${rescue.rescue_id}`,
+      `http://localhost:5000/api/v1/rescues/${rescue.rescueId}`,
       {
         adoptionPolicies: policies,
       }

--- a/docs/frontend/app-client-prd.md
+++ b/docs/frontend/app-client-prd.md
@@ -281,5 +281,5 @@ The Client App is the public-facing React application for potential pet adopters
 
 - **Implementation Plan**: [implementation-plan.md](./implementation-plan.md)
 - **Technical Architecture**: [technical-architecture.md](./technical-architecture.md)
-- **Swipe Interface Plan**: [swipe-interface-implementation-plan.md](./swipe-interface-implementation-plan.md)
+- **Implementation Status**: [IMPLEMENTATION_STATUS.md](./IMPLEMENTATION_STATUS.md)
 - **API Documentation**: [../backend/api-endpoints.md](../backend/api-endpoints.md)

--- a/docs/infrastructure/docker-setup.md
+++ b/docs/infrastructure/docker-setup.md
@@ -64,26 +64,35 @@ Modern browsers automatically resolve `*.localhost` subdomains to `127.0.0.1`, s
 
 ### Required Environment Variables
 
+The authoritative example lives in [`.env.example`](../../.env.example) at the repo root. The minimum dev set looks like:
+
 ```env
-# Development Environment Variables
 NODE_ENV=development
 
-# Database Configuration
-POSTGRES_USER=user
-POSTGRES_PASSWORD=password
-POSTGRES_DB=adopt_dont_shop
+# Database
+POSTGRES_USER=adopt_user
+POSTGRES_PASSWORD=CHANGE_THIS_SECURE_PASSWORD_IMMEDIATELY
+POSTGRES_DB=adopt_dont_shop_dev
 
-# Application URLs
-API_URL=http://api.localhost
-VITE_API_URL=http://api.localhost
-VITE_WS_URL=ws://api.localhost
+# Redis
+REDIS_HOST=redis
+REDIS_PORT=6379
 
-# JWT Configuration
-JWT_SECRET=your-super-secret-jwt-key-change-in-production-at-least-32-chars
+# Secrets — generate fresh values via `npm run secrets:generate`
+JWT_SECRET=...
+JWT_REFRESH_SECRET=...
+SESSION_SECRET=...
+CSRF_SECRET=...
 
-# Development specific
-DB_LOGGING=true
+# Frontend → backend
+VITE_API_BASE_URL=http://localhost:5000
+VITE_WS_BASE_URL=ws://localhost:5000
+
+# CORS (comma-separated list of allowed origins)
+CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost,http://admin.localhost,http://rescue.localhost,http://api.localhost,http://localhost:5000
 ```
+
+Generate strong secrets and append them to your `.env` with `npm run secrets:generate >> .env`.
 
 ## Common Issues & Solutions
 


### PR DESCRIPTION
## Summary

Final batch of documentation accuracy fixes — frontend docs, the Docker docs, the infrastructure setup guide, and the docs index. Each change verified against the corresponding source file or `.env.example`.

### `docs/frontend/RESCUE_CONFIG_AND_WORKFLOW_COMPLETE.md`
- Imported `RESCUE_UPDATE` does not exist in `@adopt-dont-shop/lib.permissions`. Real constant used by `app.rescue/src/pages/RescueSettings.tsx:6` is **`RESCUE_SETTINGS_UPDATE`**. Updated the example accordingly (both the import and the `hasPermission(...)` call).
- Replaced `${rescue.rescue_id}` with **`${rescue.rescueId}`** — the real model uses camelCase (`app.rescue/src/pages/RescueSettings.tsx:197, 207`).

### `docs/frontend/app-client-prd.md`
- Removed the broken link to `swipe-interface-implementation-plan.md` (file does not exist anywhere in `docs/frontend/`). Replaced with a working link to the existing `IMPLEMENTATION_STATUS.md`.

### `docs/README.md`
- "**Testing**: Jest + React Testing Library" → "**Testing**: Vitest (apps + service.backend) and Jest (Node libraries)". Verified by inspecting the `test` script in each package's `package.json`: apps and `service.backend` use `vitest run`; Node libraries (e.g. `lib.auth`, `lib.api`) use Jest.

### `docs/DOCKER.md`
- Replaced `command: npm run dev:debug` (no such script in `service.backend/package.json`) with an inline `npx ts-node-dev --inspect=...` override that actually works against the real dev script.

### `docs/infrastructure/docker-setup.md`
- The "Required Environment Variables" example listed `POSTGRES_USER=user`, `POSTGRES_DB=adopt_dont_shop`, `VITE_API_URL`, `VITE_WS_URL` — none of which match `.env.example`. Updated the section to mirror `.env.example` (`POSTGRES_USER=adopt_user`, `POSTGRES_DB=adopt_dont_shop_dev`, `VITE_API_BASE_URL`, `VITE_WS_BASE_URL`, `CORS_ORIGIN`, the four secret variables) and pointed readers at the canonical file. Added a note about `npm run secrets:generate >> .env`.

## Test plan
- [ ] Open each updated doc and verify code/env snippets match the referenced source.
- [ ] Confirm no remaining links to the deleted `swipe-interface-implementation-plan.md`.
- [ ] Confirm no remaining `dev:debug` reference in `docs/DOCKER.md`.

## Related PRs
- #110 — backend docs accuracy
- #111 — library docs accuracy

https://claude.ai/code/session_013RBaP8WTo6XSBbMcGV8A5p

---
_Generated by [Claude Code](https://claude.ai/code/session_013RBaP8WTo6XSBbMcGV8A5p)_