### PR TITLE
Phase 3 (slice 2): audit columns rollout to remaining transactional models

### DIFF
--- a/service.backend/src/__tests__/models/standards.test.ts
+++ b/service.backend/src/__tests__/models/standards.test.ts
@@ -140,10 +140,42 @@ describe('Model Standards', () => {
   });
 
   describe('audit columns', () => {
-    // Models that have been migrated to the audit-columns helper. The set
-    // grows as we roll out audit columns to the rest of the transactional
-    // models (separate PR per the Phase 3 plan).
-    const HAS_AUDIT_COLUMNS = ['User', 'Pet', 'Application', 'Rescue', 'Message'];
+    // Every transactional model gets created_by / updated_by / version.
+    // The set excludes:
+    //   - reference / config tables (Role, Permission, RolePermission,
+    //     UserRole, FieldPermission)
+    //   - append-only event logs (AuditLog, ApplicationTimeline)
+    //   - high-volume user-activity rows already keyed by user_id
+    //     (SwipeAction, SwipeSession, RefreshToken, DeviceToken)
+    const HAS_AUDIT_COLUMNS = [
+      // Slice 1
+      'User',
+      'Pet',
+      'Application',
+      'Rescue',
+      'Message',
+      // Slice 2 (this PR)
+      'Notification',
+      'Chat',
+      'ChatParticipant',
+      'Invitation',
+      'HomeVisit',
+      'Report',
+      'ModeratorAction',
+      'UserSanction',
+      'SupportTicket',
+      'SupportTicketResponse',
+      'Rating',
+      'EmailQueue',
+      'EmailTemplate',
+      'EmailPreference',
+      'StaffMember',
+      'Content',
+      'NavigationMenu',
+      'FileUpload',
+      'UserFavorite',
+      'ApplicationQuestion',
+    ];
 
     it.each(HAS_AUDIT_COLUMNS)('%s has created_by, updated_by, version', name => {
       const model = sequelize.models[name];

--- a/service.backend/src/__tests__/services/cms.service.test.ts
+++ b/service.backend/src/__tests__/services/cms.service.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../utils/logger', () => ({
 
 import User, { UserStatus, UserType } from '../../models/User';
 import Content, { ContentType, ContentStatus } from '../../models/Content';
+import { runWithContext } from '../../utils/request-context';
 import NavigationMenu, { MenuLocation } from '../../models/NavigationMenu';
 import CmsService from '../../services/cms.service';
 
@@ -323,22 +324,26 @@ describe('CmsService – navigation menus', () => {
   });
 
   it('updates a navigation menu with new items', async () => {
-    await makeUser();
-    const menu = await CmsService.createNavigationMenu({
-      name: 'Footer',
-      location: MenuLocation.FOOTER,
-      createdBy: 'author-1',
-    });
+    const author = await makeUser();
+    // Authoring runs inside the request context so the audit hook stamps
+    // created_by / updated_by from the actor (replaces the old explicit
+    // createdBy / modifiedBy args, which were dropped when the menu model
+    // adopted the audit-columns helper).
+    const menu = await runWithContext({ userId: author.userId }, () =>
+      CmsService.createNavigationMenu({
+        name: 'Footer',
+        location: MenuLocation.FOOTER,
+      })
+    );
     const items = [
       { id: '1', label: 'Home', url: '/', openInNewTab: false, order: 1 },
       { id: '2', label: 'About', url: '/about', openInNewTab: false, order: 2 },
     ];
-    const updated = await CmsService.updateNavigationMenu(menu.menuId, {
-      items,
-      modifiedBy: 'author-1',
-    });
+    const updated = await runWithContext({ userId: author.userId }, () =>
+      CmsService.updateNavigationMenu(menu.menuId, { items })
+    );
     expect(updated.items).toHaveLength(2);
-    expect(updated.lastModifiedBy).toBe('author-1');
+    expect((updated as unknown as { updated_by: string }).updated_by).toBe(author.userId);
   });
 
   it('deletes a navigation menu', async () => {

--- a/service.backend/src/controllers/cms.controller.ts
+++ b/service.backend/src/controllers/cms.controller.ts
@@ -137,17 +137,15 @@ export const getMenu = async (req: AuthenticatedRequest, res: Response): Promise
 };
 
 export const createMenu = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  const userId = req.user!.userId;
-  const menu = await CmsService.createNavigationMenu({ ...req.body, createdBy: userId });
+  // created_by stamped automatically from the request context (auth.middleware
+  // sets userId; the audit hook on NavigationMenu reads it).
+  const menu = await CmsService.createNavigationMenu(req.body);
   res.status(201).json({ success: true, message: 'Navigation menu created successfully', menu });
 };
 
 export const updateMenu = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  const userId = req.user!.userId;
-  const menu = await CmsService.updateNavigationMenu(req.params.menuId, {
-    ...req.body,
-    modifiedBy: userId,
-  });
+  // updated_by stamped automatically from the request context.
+  const menu = await CmsService.updateNavigationMenu(req.params.menuId, req.body);
   res.json({ success: true, message: 'Navigation menu updated successfully', menu });
 };
 

--- a/service.backend/src/models/ApplicationQuestion.ts
+++ b/service.backend/src/models/ApplicationQuestion.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Op, Optional, WhereOptions } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
 import { JsonObject, JsonValue } from '../types/common';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum QuestionCategory {
   PERSONAL_INFORMATION = 'personal_information',
@@ -338,8 +339,9 @@ ApplicationQuestion.init(
       type: DataTypes.DATE,
       allowNull: true,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'application_questions',
     modelName: 'ApplicationQuestion',
@@ -388,6 +390,7 @@ ApplicationQuestion.init(
           deleted_at: null,
         },
       },
+      ...auditIndexes('application_questions'),
     ],
     hooks: {
       beforeValidate: (question: ApplicationQuestion) => {
@@ -429,7 +432,7 @@ ApplicationQuestion.init(
         where: { is_required: true },
       },
     },
-  }
+  })
 );
 
 export default ApplicationQuestion;

--- a/service.backend/src/models/Chat.ts
+++ b/service.backend/src/models/Chat.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { ChatStatus } from '../types/chat';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 import { ChatParticipant } from './ChatParticipant';
 import { Message } from './Message';
@@ -101,8 +102,9 @@ Chat.init(
         isIn: [Object.values(ChatStatus)],
       },
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'chats',
     modelName: 'Chat',
@@ -125,8 +127,9 @@ Chat.init(
       {
         fields: ['status'],
       },
+      ...auditIndexes('chats'),
     ],
-  }
+  })
 );
 
 export default Chat;

--- a/service.backend/src/models/ChatParticipant.ts
+++ b/service.backend/src/models/ChatParticipant.ts
@@ -3,6 +3,7 @@ import sequelize, { getUuidType } from '../sequelize';
 import { ParticipantRole } from '../types/chat';
 import { generateUuidV7 } from '../utils/uuid';
 import Chat from './Chat';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 interface ChatParticipantAttributes {
   chat_participant_id: string;
@@ -88,8 +89,9 @@ ChatParticipant.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'chat_participants',
     modelName: 'ChatParticipant',
@@ -109,8 +111,9 @@ ChatParticipant.init(
       {
         fields: ['role'],
       },
+      ...auditIndexes('chat_participants'),
     ],
-  }
+  })
 );
 
 export default ChatParticipant;

--- a/service.backend/src/models/Content.ts
+++ b/service.backend/src/models/Content.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getArrayType, getUuidType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum ContentType {
   PAGE = 'page',
@@ -261,8 +262,9 @@ Content.init(
       allowNull: true,
       field: 'deleted_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'cms_content',
     timestamps: true,
@@ -276,8 +278,9 @@ Content.init(
       { fields: ['last_modified_by'] },
       { fields: ['published_at'] },
       { fields: ['scheduled_publish_at'] },
+      ...auditIndexes('cms_content'),
     ],
-  }
+  })
 );
 
 export default Content;

--- a/service.backend/src/models/EmailPreference.ts
+++ b/service.backend/src/models/EmailPreference.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum EmailFrequency {
   IMMEDIATE = 'immediate',
@@ -451,8 +452,9 @@ EmailPreference.init(
       defaultValue: DataTypes.NOW,
       field: 'updated_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'email_preferences',
     timestamps: true,
@@ -483,6 +485,7 @@ EmailPreference.init(
       {
         fields: ['last_digest_sent'],
       },
+      ...auditIndexes('email_preferences'),
     ],
     // TODO (Phase 3 — secrets-at-rest): unsubscribeToken should be hashed on
     // write, but the current emitter (email.service.generateUnsubscribeToken)
@@ -490,7 +493,7 @@ EmailPreference.init(
     // endpoint decodes that blob rather than doing an equality lookup. Hashing
     // without rewriting both sides would break the flow — deferred until the
     // token is switched to crypto.randomBytes(32).
-  }
+  })
 );
 
 export default EmailPreference;

--- a/service.backend/src/models/EmailQueue.ts
+++ b/service.backend/src/models/EmailQueue.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum EmailStatus {
   QUEUED = 'queued',
@@ -87,7 +88,7 @@ interface EmailQueueAttributes {
   metadata?: JsonObject;
   campaignId?: string;
   userId?: string;
-  createdBy?: string;
+  // createdBy removed — provided by auditColumns helper as `created_by`.
   tags?: string[];
   createdAt: Date;
   updatedAt: Date;
@@ -129,7 +130,6 @@ class EmailQueue
   public metadata?: JsonObject;
   public campaignId?: string;
   public userId?: string;
-  public createdBy?: string;
   public tags?: string[];
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
@@ -503,16 +503,8 @@ EmailQueue.init(
       },
       onDelete: 'SET NULL',
     },
-    createdBy: {
-      type: getUuidType(),
-      allowNull: true,
-      field: 'created_by',
-      references: {
-        model: 'users',
-        key: 'user_id',
-      },
-      onDelete: 'SET NULL',
-    },
+    // createdBy column dropped — superseded by auditColumns.created_by
+    // (see ../models/audit-columns.ts). Hook stamps it from request context.
     tags: {
       type: getArrayType(DataTypes.STRING),
       allowNull: false,
@@ -552,8 +544,9 @@ EmailQueue.init(
       defaultValue: DataTypes.NOW,
       field: 'updated_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'email_queue',
     timestamps: true,
@@ -579,10 +572,7 @@ EmailQueue.init(
         name: 'email_queue_template_id_idx',
         fields: ['template_id'],
       },
-      {
-        name: 'email_queue_created_by_idx',
-        fields: ['created_by'],
-      },
+      // created_by index now provided by auditIndexes('email_queue').
       {
         fields: ['campaign_id'],
       },
@@ -603,8 +593,9 @@ EmailQueue.init(
         fields: ['status', 'priority', 'scheduled_for'],
         name: 'email_queue_processing_idx',
       },
+      ...auditIndexes('email_queue'),
     ],
-  }
+  })
 );
 
 export default EmailQueue;

--- a/service.backend/src/models/EmailTemplate.ts
+++ b/service.backend/src/models/EmailTemplate.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum TemplateType {
   TRANSACTIONAL = 'transactional',
@@ -77,7 +78,7 @@ interface EmailTemplateAttributes {
   isDefault: boolean;
   priority: number;
   tags?: string[];
-  createdBy: string;
+  // createdBy removed — provided by auditColumns helper as `created_by`.
   lastModifiedBy?: string;
   lastUsedAt?: Date;
   usageCount: number;
@@ -112,7 +113,6 @@ class EmailTemplate
   public isDefault!: boolean;
   public priority!: number;
   public tags?: string[];
-  public createdBy!: string;
   public lastModifiedBy?: string;
   public lastUsedAt?: Date;
   public usageCount!: number;
@@ -164,8 +164,12 @@ class EmailTemplate
   }
 
   public async incrementUsage(): Promise<void> {
-    // Atomic — parallel email sends can all use the same template.
+    // Atomic — parallel email sends can all use the same template. We have
+    // to reload after .increment() because version: true on this model
+    // means the in-memory `version` is stale once the increment hits the DB,
+    // and the subsequent .save() would fail with a stale-instance error.
     await this.increment('usageCount');
+    await this.reload();
     this.lastUsedAt = new Date();
     await this.save();
   }
@@ -419,16 +423,10 @@ EmailTemplate.init(
         }
       },
     },
-    createdBy: {
-      type: getUuidType(),
-      allowNull: false,
-      field: 'created_by',
-      references: {
-        model: 'users',
-        key: 'user_id',
-      },
-      onDelete: 'SET NULL',
-    },
+    // createdBy column dropped — superseded by auditColumns.created_by.
+    // lastModifiedBy is a distinct column (last_modified_by) used by the
+    // template version history — kept separate from updated_by which tracks
+    // any row mutation.
     lastModifiedBy: {
       type: getUuidType(),
       allowNull: true,
@@ -479,8 +477,9 @@ EmailTemplate.init(
       allowNull: true,
       field: 'deleted_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'email_templates',
     timestamps: true,
@@ -506,10 +505,7 @@ EmailTemplate.init(
       {
         fields: ['is_default'],
       },
-      {
-        name: 'email_templates_created_by_idx',
-        fields: ['created_by'],
-      },
+      // created_by index now provided by auditIndexes('email_templates').
       {
         name: 'email_templates_last_modified_by_idx',
         fields: ['last_modified_by'],
@@ -525,8 +521,9 @@ EmailTemplate.init(
         fields: ['tags'],
         using: 'gin',
       },
+      ...auditIndexes('email_templates'),
     ],
-  }
+  })
 );
 
 export default EmailTemplate;

--- a/service.backend/src/models/FileUpload.ts
+++ b/service.backend/src/models/FileUpload.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import { generateUuidV7 } from '../utils/uuid';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { JsonObject } from '../types/common';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 interface FileUploadAttributes {
   upload_id: string;
@@ -152,8 +153,9 @@ FileUpload.init(
         },
       },
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'file_uploads',
     timestamps: true,
@@ -180,8 +182,9 @@ FileUpload.init(
         unique: true,
         name: 'file_uploads_stored_filename_unique',
       },
+      ...auditIndexes('file_uploads'),
     ],
-  }
+  })
 );
 
 export default FileUpload;

--- a/service.backend/src/models/HomeVisit.ts
+++ b/service.backend/src/models/HomeVisit.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getUuidType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum HomeVisitStatus {
   SCHEDULED = 'scheduled',
@@ -114,8 +115,9 @@ HomeVisit.init(
       type: DataTypes.DATE,
       allowNull: true,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     modelName: 'HomeVisit',
     tableName: 'home_visits',
@@ -135,8 +137,9 @@ HomeVisit.init(
       {
         fields: ['scheduled_date'],
       },
+      ...auditIndexes('home_visits'),
     ],
-  }
+  })
 );
 
 export default HomeVisit;

--- a/service.backend/src/models/Invitation.ts
+++ b/service.backend/src/models/Invitation.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { hashToken } from '../utils/secrets';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 interface InvitationAttributes {
   invitation_id: string;
@@ -102,8 +103,9 @@ Invitation.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'invitations',
     timestamps: true,
@@ -117,6 +119,7 @@ Invitation.init(
         fields: ['user_id'],
         name: 'invitations_user_id_idx',
       },
+      ...auditIndexes('invitations'),
     ],
     hooks: {
       beforeSave: (invitation: Invitation) => {
@@ -128,7 +131,7 @@ Invitation.init(
         }
       },
     },
-  }
+  })
 );
 
 export default Invitation;

--- a/service.backend/src/models/ModeratorAction.ts
+++ b/service.backend/src/models/ModeratorAction.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum ActionType {
   WARNING_ISSUED = 'warning_issued',
@@ -256,8 +257,9 @@ ModeratorAction.init(
       defaultValue: DataTypes.NOW,
       field: 'updated_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'moderator_actions',
     timestamps: true,
@@ -299,8 +301,9 @@ ModeratorAction.init(
       {
         fields: ['created_at'],
       },
+      ...auditIndexes('moderator_actions'),
     ],
-  }
+  })
 );
 
 export default ModeratorAction;

--- a/service.backend/src/models/NavigationMenu.ts
+++ b/service.backend/src/models/NavigationMenu.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum MenuLocation {
   HEADER = 'header',
@@ -23,8 +24,8 @@ type NavigationMenuAttributes = {
   location: MenuLocation;
   items: NavigationItem[];
   isActive: boolean;
-  createdBy: string;
-  lastModifiedBy?: string;
+  // createdBy / lastModifiedBy removed — provided by auditColumns
+  // (created_by / updated_by). Hook stamps from request context.
   createdAt: Date;
   updatedAt: Date;
 };
@@ -43,8 +44,6 @@ class NavigationMenu
   public location!: MenuLocation;
   public items!: NavigationItem[];
   public isActive!: boolean;
-  public createdBy!: string;
-  public lastModifiedBy?: string;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
 }
@@ -80,20 +79,8 @@ NavigationMenu.init(
       defaultValue: true,
       field: 'is_active',
     },
-    createdBy: {
-      type: getUuidType(),
-      allowNull: false,
-      field: 'created_by',
-      references: { model: 'users', key: 'user_id' },
-      onDelete: 'SET NULL',
-    },
-    lastModifiedBy: {
-      type: getUuidType(),
-      allowNull: true,
-      field: 'last_modified_by',
-      references: { model: 'users', key: 'user_id' },
-      onDelete: 'SET NULL',
-    },
+    // createdBy / lastModifiedBy dropped — superseded by auditColumns
+    // (created_by / updated_by). Hook stamps them from request context.
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -106,8 +93,9 @@ NavigationMenu.init(
       defaultValue: DataTypes.NOW,
       field: 'updated_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'cms_navigation_menus',
     timestamps: true,
@@ -115,10 +103,11 @@ NavigationMenu.init(
     indexes: [
       { fields: ['location'] },
       { fields: ['is_active'] },
-      { fields: ['created_by'] },
-      { fields: ['last_modified_by'] },
+      // created_by index now provided by auditIndexes('cms_navigation_menus').
+      // last_modified_by column was dropped (replaced by updated_by).
+      ...auditIndexes('cms_navigation_menus'),
     ],
-  }
+  })
 );
 
 export default NavigationMenu;

--- a/service.backend/src/models/Notification.ts
+++ b/service.backend/src/models/Notification.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Op, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
 import { JsonObject } from '../types/common';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 // Notification type enum
 export enum NotificationType {
@@ -332,8 +333,9 @@ Notification.init(
       type: DataTypes.DATE,
       allowNull: true,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'notifications',
     modelName: 'Notification',
@@ -391,6 +393,7 @@ Notification.init(
           external_id: { [Op.ne]: null },
         },
       },
+      ...auditIndexes('notifications'),
     ],
     hooks: {
       beforeValidate: (notification: Notification) => {
@@ -478,7 +481,7 @@ Notification.init(
         where: { channel },
       }),
     },
-  }
+  })
 );
 
 export default Notification;

--- a/service.backend/src/models/Rating.ts
+++ b/service.backend/src/models/Rating.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional, WhereOptions } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum RatingType {
   PET = 'pet',
@@ -395,8 +396,9 @@ Rating.init(
       type: DataTypes.DATE,
       defaultValue: DataTypes.NOW,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'ratings',
     timestamps: true,
@@ -439,8 +441,9 @@ Rating.init(
       {
         fields: ['created_at'],
       },
+      ...auditIndexes('ratings'),
     ],
-  }
+  })
 );
 
 export default Rating;

--- a/service.backend/src/models/Report.ts
+++ b/service.backend/src/models/Report.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum ReportCategory {
   INAPPROPRIATE_CONTENT = 'inappropriate_content',
@@ -285,8 +286,9 @@ Report.init(
       defaultValue: DataTypes.NOW,
       field: 'updated_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'reports',
     timestamps: true,
@@ -329,8 +331,9 @@ Report.init(
       {
         fields: ['created_at'],
       },
+      ...auditIndexes('reports'),
     ],
-  }
+  })
 );
 
 export default Report;

--- a/service.backend/src/models/StaffMember.ts
+++ b/service.backend/src/models/StaffMember.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 interface StaffMemberAttributes {
   staffMemberId: string;
@@ -159,8 +160,9 @@ StaffMember.init(
       defaultValue: DataTypes.NOW,
       field: 'updated_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'staff_members',
     timestamps: true,
@@ -186,6 +188,7 @@ StaffMember.init(
         fields: ['deleted_by'],
         name: 'staff_members_deleted_by_idx',
       },
+      ...auditIndexes('staff_members'),
     ],
     defaultScope: {
       where: {
@@ -202,7 +205,7 @@ StaffMember.init(
         },
       },
     },
-  }
+  })
 );
 
 export default StaffMember;

--- a/service.backend/src/models/SupportTicket.ts
+++ b/service.backend/src/models/SupportTicket.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum TicketStatus {
   OPEN = 'open',
@@ -322,8 +323,9 @@ SupportTicket.init(
       field: 'updated_at',
       defaultValue: DataTypes.NOW,
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'support_tickets',
     timestamps: true,
@@ -363,8 +365,9 @@ SupportTicket.init(
         fields: ['tags'],
         using: 'gin',
       },
+      ...auditIndexes('support_tickets'),
     ],
-  }
+  })
 );
 
 export default SupportTicket;

--- a/service.backend/src/models/SupportTicketResponse.ts
+++ b/service.backend/src/models/SupportTicketResponse.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum ResponderType {
   STAFF = 'staff',
@@ -132,8 +133,9 @@ SupportTicketResponse.init(
       allowNull: true,
       field: 'deleted_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'support_ticket_responses',
     timestamps: true,
@@ -159,8 +161,9 @@ SupportTicketResponse.init(
         // Composite index for common queries
         fields: ['ticket_id', 'created_at'],
       },
+      ...auditIndexes('support_ticket_responses'),
     ],
-  }
+  })
 );
 
 export default SupportTicketResponse;

--- a/service.backend/src/models/UserFavorite.ts
+++ b/service.backend/src/models/UserFavorite.ts
@@ -13,6 +13,7 @@ import sequelize, { getUuidType, getArrayType, getGeometryType } from '../sequel
 import { generateUuidV7 } from '../utils/uuid';
 import Pet from './Pet';
 import User from './User';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 class UserFavorite extends Model<
   InferAttributes<UserFavorite>,
@@ -82,8 +83,9 @@ UserFavorite.init(
       allowNull: true,
       field: 'deleted_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     modelName: 'UserFavorite',
     tableName: 'user_favorites',
@@ -111,8 +113,9 @@ UserFavorite.init(
         fields: ['created_at'],
         name: 'idx_user_favorites_created_at',
       },
+      ...auditIndexes('user_favorites'),
     ],
-  }
+  })
 );
 
 export default UserFavorite;

--- a/service.backend/src/models/UserSanction.ts
+++ b/service.backend/src/models/UserSanction.ts
@@ -2,6 +2,7 @@ import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType } from '../sequelize';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
 export enum SanctionType {
   WARNING = 'warning',
@@ -344,8 +345,9 @@ UserSanction.init(
       defaultValue: DataTypes.NOW,
       field: 'updated_at',
     },
+    ...auditColumns,
   },
-  {
+  withAuditHooks({
     sequelize,
     tableName: 'user_sanctions',
     timestamps: true,
@@ -401,8 +403,9 @@ UserSanction.init(
       {
         fields: ['user_id', 'is_active', 'end_date'],
       },
+      ...auditIndexes('user_sanctions'),
     ],
-  }
+  })
 );
 
 export default UserSanction;

--- a/service.backend/src/services/cms.service.ts
+++ b/service.backend/src/services/cms.service.ts
@@ -50,12 +50,13 @@ type UpdateContentInput = {
   modifiedBy: string;
 };
 
+// createdBy / modifiedBy removed — the audit-columns hook stamps
+// created_by / updated_by from the request context.
 type NavigationMenuInput = {
   name: string;
   location: MenuLocation;
   items?: NavigationMenu['items'];
   isActive?: boolean;
-  createdBy: string;
 };
 
 type UpdateNavigationMenuInput = {
@@ -63,7 +64,6 @@ type UpdateNavigationMenuInput = {
   location?: MenuLocation;
   items?: NavigationMenu['items'];
   isActive?: boolean;
-  modifiedBy: string;
 };
 
 const generateSlug = (title: string): string =>
@@ -358,7 +358,7 @@ class CmsService {
       location: input.location,
       items: input.items ?? [],
       isActive: input.isActive ?? true,
-      createdBy: input.createdBy,
+      // created_by stamped by the audit hook from request context.
     });
     logger.info('Navigation menu created', { menuId: menu.menuId });
     return menu;
@@ -382,7 +382,7 @@ class CmsService {
     if (input.isActive !== undefined) {
       menu.isActive = input.isActive;
     }
-    menu.lastModifiedBy = input.modifiedBy;
+    // updated_by stamped by the audit hook on save from request context.
 
     await menu.save();
     logger.info('Navigation menu updated', { menuId });

--- a/service.backend/src/services/email-template.service.ts
+++ b/service.backend/src/services/email-template.service.ts
@@ -521,7 +521,7 @@ The {{system.appName}} Team
           currentVersion: 1,
           usageCount: 0,
           testEmailsSent: 0,
-          createdBy,
+          // created_by stamped by audit hook from request context.
         });
 
         createdTemplates.push(template);


### PR DESCRIPTION
## Summary

Finishes the audit-columns rollout started in #109. Every transactional model now has `created_by` / `updated_by` + `version: true` via the helper from `models/audit-columns.ts`.

### Migrated in this PR (20 models)

`Notification`, `Chat`, `ChatParticipant`, `Invitation`, `HomeVisit`, `Report`, `ModeratorAction`, `UserSanction`, `SupportTicket`, `SupportTicketResponse`, `Rating`, `EmailQueue`, `EmailTemplate`, `EmailPreference`, `StaffMember`, `Content`, `NavigationMenu`, `FileUpload`, `UserFavorite`, `ApplicationQuestion`.

### Skipped (per slice-1 classification)

- **Reference / config:** `Role`, `Permission`, `RolePermission`, `UserRole`, `FieldPermission`
- **Append-only event logs:** `AuditLog`, `ApplicationTimeline`
- **High-volume user-activity / token rows already keyed by `user_id`:** `SwipeAction`, `SwipeSession`, `RefreshToken`, `DeviceToken`

### Conflicts cleared

`EmailQueue`, `EmailTemplate`, `NavigationMenu` had their own pre-existing `createdBy` / `lastModifiedBy` attributes mapping to the same DB columns the helper wants. Dropped the duplicates (column attribute, TS interface entry, and any explicitly-named index) so `auditColumns` / `auditIndexes` own the names. `NavigationMenu.lastModifiedBy` semantics fold into `updated_by`; `EmailTemplate` keeps a separate `last_modified_by` column for template-version history (a distinct concept from row mutation).

### Caller updates

- `cms.controller.createMenu` / `updateMenu` — dropped explicit `createdBy` / `modifiedBy` passes; the audit hook reads `userId` from the request context.
- `cms.service.NavigationMenuInput` / `UpdateNavigationMenuInput` — dropped the `createdBy` / `modifiedBy` fields from the input types.
- `email-template.service.bulkCreateTemplates` — stopped passing `createdBy`.

### Bug fix uncovered by the rollout

`EmailTemplate.incrementUsage()` was doing:
```ts
await this.increment('usageCount');
…
await this.save();
```
With `version: true` now active, the in-memory `version` is stale immediately after `.increment()` bumps it in the DB, and the subsequent `.save()` failed with `"stale model instance"`. Added an explicit `.reload()` between the two — the same pattern `Notification.incrementRetry` and `EmailPreference.recordBounce` already use.

### Tests

- `standards.test` `HAS_AUDIT_COLUMNS` now lists all 25 audited models (5 from slice 1 + 20 here). Each has assertions for column presence + FK indexes.
- `cms.service.test` `"updates a navigation menu"` rewritten to use `runWithContext()` and assert `updated_by` (replacing the dropped `lastModifiedBy` assertion).

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm test` — 1314 passed, 4 skipped (1274 prior + 40 new audit-column assertions)
- [ ] Smoke: with the dev stack up, edit a pet / send a chat / submit a support ticket, confirm `created_by` / `updated_by` populate correctly

https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_