### PR TITLE
Phase 3 (slice 5): status transition log rolled out to Pet, HomeVisit, Report

### DIFF
--- a/service.backend/src/__tests__/integration/admin-moderation-flow.test.ts
+++ b/service.backend/src/__tests__/integration/admin-moderation-flow.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../sequelize', async importOriginal => {
 
 import { Op } from 'sequelize';
 import Report, { ReportCategory, ReportStatus, ReportSeverity } from '../../models/Report';
+import ReportStatusTransition from '../../models/ReportStatusTransition';
 import ModeratorAction, { ActionType, ActionSeverity } from '../../models/ModeratorAction';
 import User, { UserStatus, UserType } from '../../models/User';
 import Rescue from '../../models/Rescue';
@@ -36,6 +37,7 @@ import { AuditLogService } from '../../services/auditLog.service';
 
 // Mock dependencies
 vi.mock('../../models/Report');
+vi.mock('../../models/ReportStatusTransition');
 vi.mock('../../models/ModeratorAction');
 vi.mock('../../models/User');
 vi.mock('../../models/Rescue');
@@ -43,6 +45,9 @@ vi.mock('../../services/auditLog.service');
 vi.mock('../../utils/logger');
 
 const MockedReport = Report as vi.MockedObject<Report>;
+const MockedReportStatusTransition = ReportStatusTransition as vi.MockedObject<
+  typeof ReportStatusTransition
+>;
 const MockedModeratorAction = ModeratorAction as vi.MockedObject<ModeratorAction>;
 const MockedUser = User as vi.MockedObject<User>;
 const MockedRescue = Rescue as vi.MockedObject<Rescue>;
@@ -59,6 +64,10 @@ describe('Admin Moderation Workflow Integration Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     MockedAuditLogService.log = vi.fn().mockResolvedValue(undefined as never);
+    // Stub the transition log so the mocked Report.create / report.update
+    // path doesn't try to write a transition row against a non-existent
+    // parent (FK fails). The trigger / hook plumbing has its own tests.
+    MockedReportStatusTransition.create = vi.fn().mockResolvedValue({} as never);
   });
 
   describe('Report Submission Workflow', () => {
@@ -329,7 +338,16 @@ describe('Admin Moderation Workflow Integration Tests', () => {
         const result = await ModerationService.assignReport('report-assign', moderatorId, adminId);
 
         expect(result.assignedModerator).toBe(moderatorId);
-        expect(result.status).toBe(ReportStatus.UNDER_REVIEW);
+        // Status is moved by the transition log; assert that, not the
+        // mocked parent row which never sees the trigger / hook.
+        expect(MockedReportStatusTransition.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reportId: 'report-assign',
+            toStatus: ReportStatus.UNDER_REVIEW,
+            transitionedBy: adminId,
+          }),
+          expect.anything()
+        );
         expect(MockedAuditLogService.log).toHaveBeenCalledWith(
           expect.objectContaining({
             action: 'REPORT_ASSIGNED',
@@ -564,7 +582,16 @@ describe('Admin Moderation Workflow Integration Tests', () => {
           'Requires administrative review'
         );
 
-        expect(result.status).toBe(ReportStatus.ESCALATED);
+        // Status moves via the transition log; the parent row is mocked
+        // here so the trigger / hook path doesn't run.
+        expect(MockedReportStatusTransition.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reportId: 'report-escalate-1',
+            toStatus: ReportStatus.ESCALATED,
+            metadata: { escalatedTo: adminId },
+          }),
+          expect.anything()
+        );
         expect(result.escalatedTo).toBe(adminId);
         expect(MockedAuditLogService.log).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import sequelize from '../../sequelize';
+import '../../models/index';
+import Application, { ApplicationStatus } from '../../models/Application';
+import HomeVisit, { HomeVisitStatus } from '../../models/HomeVisit';
+import HomeVisitStatusTransition from '../../models/HomeVisitStatusTransition';
+import Rescue from '../../models/Rescue';
+import User from '../../models/User';
+
+describe('HomeVisitStatusTransition', () => {
+  let userId: string;
+  let rescueId: string;
+  let petId: string;
+  let applicationId: string;
+  let visitId: string;
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+
+    const user = await User.create({
+      userId: 'cccccccc-cccc-4ccc-cccc-cccccccccccc',
+      email: 'visit@audit.local',
+      password: 'long-enough-password-123',
+      firstName: 'A',
+      lastName: 'B',
+      userType: 'adopter',
+      status: 'active',
+      emailVerified: true,
+    } as never);
+    userId = user.userId;
+
+    const rescue = await Rescue.create({
+      name: 'Test Rescue',
+      email: 'r2@test.local',
+      address: '1 Lane',
+      city: 'Town',
+      postcode: 'AB1 2CD',
+      country: 'GB',
+      contactPerson: 'X',
+      status: 'pending',
+      isDeleted: false,
+    } as never);
+    rescueId = rescue.rescueId;
+
+    petId = '33333333-3333-4333-a333-333333333333';
+    await sequelize.getQueryInterface().bulkInsert('pets', [
+      {
+        pet_id: petId,
+        name: 'Visitor',
+        rescue_id: rescueId,
+        type: 'dog',
+        status: 'available',
+        gender: 'male',
+        age_group: 'adult',
+        adoption_fee: 0,
+        archived: false,
+        featured: false,
+        priority_listing: false,
+        special_needs: false,
+        house_trained: false,
+        view_count: 0,
+        favorite_count: 0,
+        application_count: 0,
+        images: '[]',
+        videos: '[]',
+        tags: '[]',
+        created_at: new Date(),
+        updated_at: new Date(),
+        version: 0,
+      },
+    ]);
+
+    applicationId = '44444444-4444-4444-a444-444444444444';
+    await sequelize.getQueryInterface().bulkInsert('applications', [
+      {
+        application_id: applicationId,
+        user_id: userId,
+        pet_id: petId,
+        rescue_id: rescueId,
+        status: ApplicationStatus.SUBMITTED,
+        priority: 'normal',
+        stage: 'questionnaire',
+        answers: '{}',
+        documents: '[]',
+        tags: '[]',
+        references: '[]',
+        created_at: new Date(),
+        updated_at: new Date(),
+        version: 0,
+      },
+    ]);
+
+    visitId = '55555555-5555-4555-a555-555555555555';
+    await HomeVisit.create({
+      visit_id: visitId,
+      application_id: applicationId,
+      scheduled_date: '2026-05-10',
+      scheduled_time: '14:00:00',
+      assigned_staff: userId,
+      status: HomeVisitStatus.SCHEDULED,
+    } as never);
+  });
+
+  it('inserting a transition updates home_visits.status', async () => {
+    await HomeVisitStatusTransition.create({
+      visitId,
+      fromStatus: HomeVisitStatus.SCHEDULED,
+      toStatus: HomeVisitStatus.IN_PROGRESS,
+      transitionedBy: userId,
+    });
+
+    const reloaded = await HomeVisit.findByPk(visitId);
+    expect(reloaded?.status).toBe(HomeVisitStatus.IN_PROGRESS);
+  });
+
+  it('records cancellation reason in the transition log', async () => {
+    await HomeVisitStatusTransition.create({
+      visitId,
+      fromStatus: HomeVisitStatus.SCHEDULED,
+      toStatus: HomeVisitStatus.CANCELLED,
+      transitionedBy: userId,
+      reason: 'Adopter unavailable',
+    });
+
+    const t = await HomeVisitStatusTransition.findOne({
+      where: { visitId, toStatus: HomeVisitStatus.CANCELLED },
+    });
+    expect(t?.reason).toBe('Adopter unavailable');
+
+    const reloaded = await HomeVisit.findByPk(visitId);
+    expect(reloaded?.status).toBe(HomeVisitStatus.CANCELLED);
+  });
+});

--- a/service.backend/src/__tests__/models/PetStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/PetStatusTransition.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import sequelize from '../../sequelize';
+import '../../models/index';
+import Pet, { PetStatus } from '../../models/Pet';
+import PetStatusTransition from '../../models/PetStatusTransition';
+import Rescue from '../../models/Rescue';
+
+/**
+ * Pet status is owned by the transition log. Same dual-path setup as the
+ * Application case (Postgres trigger / SQLite afterCreate hook). These
+ * tests exercise the SQLite path; the Postgres path is verified manually
+ * in the dev stack.
+ */
+describe('PetStatusTransition', () => {
+  let rescueId: string;
+  let petId: string;
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+
+    const rescue = await Rescue.create({
+      name: 'Test Rescue',
+      email: 'r@test.local',
+      address: '1 Lane',
+      city: 'Town',
+      postcode: 'AB1 2CD',
+      country: 'GB',
+      contactPerson: 'X',
+      status: 'pending',
+      isDeleted: false,
+    } as never);
+    rescueId = rescue.rescueId;
+
+    // Same array-column workaround as the Application transition test —
+    // SQLite vs Postgres mismatch on Pet.images / .videos / .tags.
+    petId = '22222222-2222-4222-a222-222222222222';
+    await sequelize.getQueryInterface().bulkInsert('pets', [
+      {
+        pet_id: petId,
+        name: 'Buddy',
+        rescue_id: rescueId,
+        type: 'dog',
+        status: PetStatus.AVAILABLE,
+        gender: 'male',
+        age_group: 'adult',
+        adoption_fee: 0,
+        archived: false,
+        featured: false,
+        priority_listing: false,
+        special_needs: false,
+        house_trained: false,
+        view_count: 0,
+        favorite_count: 0,
+        application_count: 0,
+        images: '[]',
+        videos: '[]',
+        tags: '[]',
+        created_at: new Date(),
+        updated_at: new Date(),
+        version: 0,
+      },
+    ]);
+  });
+
+  it('inserting a transition updates pets.status', async () => {
+    await PetStatusTransition.create({
+      petId,
+      fromStatus: PetStatus.AVAILABLE,
+      toStatus: PetStatus.PENDING,
+      transitionedBy: null,
+      reason: 'Application submitted',
+    });
+
+    const reloaded = await Pet.findByPk(petId);
+    expect(reloaded?.status).toBe(PetStatus.PENDING);
+  });
+
+  it('preserves chronological history including operational pauses', async () => {
+    await PetStatusTransition.create({
+      petId,
+      fromStatus: PetStatus.AVAILABLE,
+      toStatus: PetStatus.MEDICAL_HOLD,
+      transitionedBy: null,
+      reason: 'Vet check needed',
+    });
+    await PetStatusTransition.create({
+      petId,
+      fromStatus: PetStatus.MEDICAL_HOLD,
+      toStatus: PetStatus.AVAILABLE,
+      transitionedBy: null,
+      reason: 'Cleared by vet',
+    });
+    await PetStatusTransition.create({
+      petId,
+      fromStatus: PetStatus.AVAILABLE,
+      toStatus: PetStatus.ADOPTED,
+      transitionedBy: null,
+    });
+
+    const history = await PetStatusTransition.findAll({
+      where: { petId },
+      order: [['transitionedAt', 'ASC']],
+    });
+    expect(history.map(t => t.toStatus)).toEqual([
+      PetStatus.MEDICAL_HOLD,
+      PetStatus.AVAILABLE,
+      PetStatus.ADOPTED,
+    ]);
+
+    const reloaded = await Pet.findByPk(petId);
+    expect(reloaded?.status).toBe(PetStatus.ADOPTED);
+  });
+});

--- a/service.backend/src/__tests__/models/ReportStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/ReportStatusTransition.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import sequelize from '../../sequelize';
+import '../../models/index';
+import Report, { ReportCategory, ReportSeverity, ReportStatus } from '../../models/Report';
+import ReportStatusTransition from '../../models/ReportStatusTransition';
+import User from '../../models/User';
+
+describe('ReportStatusTransition', () => {
+  let reporterId: string;
+  let moderatorId: string;
+  let reportId: string;
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+
+    const reporter = await User.create({
+      userId: 'dddddddd-dddd-4ddd-dddd-dddddddddd11',
+      email: 'reporter@audit.local',
+      password: 'long-enough-password-123',
+      firstName: 'A',
+      lastName: 'B',
+      userType: 'adopter',
+      status: 'active',
+      emailVerified: true,
+    } as never);
+    reporterId = reporter.userId;
+
+    const moderator = await User.create({
+      userId: 'dddddddd-dddd-4ddd-dddd-dddddddddd22',
+      email: 'mod@audit.local',
+      password: 'long-enough-password-123',
+      firstName: 'M',
+      lastName: 'M',
+      userType: 'moderator',
+      status: 'active',
+      emailVerified: true,
+    } as never);
+    moderatorId = moderator.userId;
+
+    const report = await Report.create({
+      reporterId,
+      reportedEntityId: 'eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee',
+      reportedEntityType: 'user',
+      category: ReportCategory.HARASSMENT,
+      severity: ReportSeverity.MEDIUM,
+      title: 'Test report',
+      description: 'A test report for transition coverage',
+      status: ReportStatus.PENDING,
+      evidence: [],
+      metadata: {},
+    } as never);
+    reportId = report.reportId;
+  });
+
+  it('inserting a transition updates reports.status', async () => {
+    await ReportStatusTransition.create({
+      reportId,
+      fromStatus: ReportStatus.PENDING,
+      toStatus: ReportStatus.UNDER_REVIEW,
+      transitionedBy: moderatorId,
+      reason: 'Assigned to moderator',
+    });
+
+    const reloaded = await Report.findByPk(reportId);
+    expect(reloaded?.status).toBe(ReportStatus.UNDER_REVIEW);
+  });
+
+  it('captures the resolution path with metadata', async () => {
+    await ReportStatusTransition.create({
+      reportId,
+      fromStatus: ReportStatus.PENDING,
+      toStatus: ReportStatus.UNDER_REVIEW,
+      transitionedBy: moderatorId,
+    });
+    await ReportStatusTransition.create({
+      reportId,
+      fromStatus: ReportStatus.UNDER_REVIEW,
+      toStatus: ReportStatus.RESOLVED,
+      transitionedBy: moderatorId,
+      reason: 'Content removed',
+      metadata: { actionType: 'content_removed' },
+    });
+
+    const history = await ReportStatusTransition.findAll({
+      where: { reportId },
+      order: [['transitionedAt', 'ASC']],
+    });
+    expect(history.map(t => t.toStatus)).toEqual([
+      ReportStatus.UNDER_REVIEW,
+      ReportStatus.RESOLVED,
+    ]);
+    expect(history[1].metadata).toMatchObject({ actionType: 'content_removed' });
+
+    const reloaded = await Report.findByPk(reportId);
+    expect(reloaded?.status).toBe(ReportStatus.RESOLVED);
+  });
+});

--- a/service.backend/src/__tests__/services/pet-business-logic.test.ts
+++ b/service.backend/src/__tests__/services/pet-business-logic.test.ts
@@ -20,6 +20,7 @@ import Pet, {
   SpayNeuterStatus,
   VaccinationStatus,
 } from '../../models/Pet';
+import PetStatusTransition from '../../models/PetStatusTransition';
 import Application, { ApplicationStatus } from '../../models/Application';
 import { PetService } from '../../services/pet.service';
 import { PetCreateData, PetStatusUpdate, PetUpdateData } from '../../types/pet';
@@ -27,6 +28,9 @@ import { PetCreateData, PetStatusUpdate, PetUpdateData } from '../../types/pet';
 // Mocked dependencies
 const MockedPet = Pet as vi.MockedObject<Pet>;
 const MockedApplication = Application as vi.MockedObject<Application>;
+const MockedPetStatusTransition = PetStatusTransition as vi.MockedObject<
+  typeof PetStatusTransition
+>;
 
 // Test constants
 const mockRescueId = 'rescue-123';
@@ -94,6 +98,11 @@ const createValidPetData = (overrides = {}): PetCreateData => ({
 describe('PetService - Business Logic', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The status-transition log is a real model. The mocked Pet.create
+    // returns a fake row that doesn't exist in the DB, so a real
+    // transition insert would trip the FK. Stub it — the trigger/hook
+    // path has its own dedicated tests.
+    MockedPetStatusTransition.create = vi.fn().mockResolvedValue({} as never);
   });
 
   // ==========================================================================
@@ -115,10 +124,12 @@ describe('PetService - Business Logic', () => {
       // When: Status is updated to PENDING
       const result = await PetService.updatePetStatus(mockPetId, statusUpdate, mockUserId);
 
-      // Then: Status is updated successfully
-      expect(mockPet.update).toHaveBeenCalledWith(
+      // Then: a transition is logged with toStatus = PENDING. The status
+      // itself is denormalized onto pets.status by the trigger / hook.
+      expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: PetStatus.PENDING,
+          petId: mockPetId,
+          toStatus: PetStatus.PENDING,
         })
       );
       expect(result).toBeDefined();
@@ -138,11 +149,17 @@ describe('PetService - Business Logic', () => {
       // When: Status is updated to ADOPTED
       await PetService.updatePetStatus(mockPetId, statusUpdate, mockUserId);
 
-      // Then: Adopted date is automatically set
+      // Then: Adopted date is set on the pet, and the transition log
+      // captures the status change.
       expect(mockPet.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: PetStatus.ADOPTED,
           adoptedDate: expect.any(Date),
+        })
+      );
+      expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          petId: mockPetId,
+          toStatus: PetStatus.ADOPTED,
         })
       );
     });
@@ -161,11 +178,16 @@ describe('PetService - Business Logic', () => {
       // When: Status is updated to FOSTER
       await PetService.updatePetStatus(mockPetId, statusUpdate, mockUserId);
 
-      // Then: Foster start date is automatically set
+      // Then: Foster start date is set on the pet, status moves via the log.
       expect(mockPet.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: PetStatus.FOSTER,
           fosterStartDate: expect.any(Date),
+        })
+      );
+      expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          petId: mockPetId,
+          toStatus: PetStatus.FOSTER,
         })
       );
     });
@@ -184,10 +206,11 @@ describe('PetService - Business Logic', () => {
       // When: Status is updated to MEDICAL_HOLD
       const result = await PetService.updatePetStatus(mockPetId, statusUpdate, mockUserId);
 
-      // Then: Status is updated successfully
-      expect(mockPet.update).toHaveBeenCalledWith(
+      // Then: a transition is logged with toStatus = MEDICAL_HOLD.
+      expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: PetStatus.MEDICAL_HOLD,
+          petId: mockPetId,
+          toStatus: PetStatus.MEDICAL_HOLD,
         })
       );
       expect(result).toBeDefined();
@@ -208,11 +231,16 @@ describe('PetService - Business Logic', () => {
       // When: Status is updated back to AVAILABLE
       await PetService.updatePetStatus(mockPetId, statusUpdate, mockUserId);
 
-      // Then: Available since date is updated
+      // Then: Available since date is updated and a transition is logged.
       expect(mockPet.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: PetStatus.AVAILABLE,
           availableSince: expect.any(Date),
+        })
+      );
+      expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          petId: mockPetId,
+          toStatus: PetStatus.AVAILABLE,
         })
       );
     });
@@ -231,11 +259,16 @@ describe('PetService - Business Logic', () => {
       // When: Foster becomes adoption
       await PetService.updatePetStatus(mockPetId, statusUpdate, mockUserId);
 
-      // Then: Adopted date is set
+      // Then: Adopted date is set and the transition log captures the change.
       expect(mockPet.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: PetStatus.ADOPTED,
           adoptedDate: expect.any(Date),
+        })
+      );
+      expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          petId: mockPetId,
+          toStatus: PetStatus.ADOPTED,
         })
       );
     });

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -1215,6 +1215,8 @@ export class ApplicationController extends BaseController {
       }
 
       const HomeVisit = (await import('../models/HomeVisit')).default;
+      const HomeVisitStatusTransition = (await import('../models/HomeVisitStatusTransition'))
+        .default;
 
       // Generate a unique visit_id
       const visitId = `visit_${applicationId}_${Date.now()}`;
@@ -1227,6 +1229,15 @@ export class ApplicationController extends BaseController {
         assigned_staff,
         notes,
         status: HomeVisitStatus.SCHEDULED,
+      });
+
+      // Seed the transition log with the initial status.
+      await HomeVisitStatusTransition.create({
+        visitId: visit.visit_id,
+        fromStatus: null,
+        toStatus: visit.status,
+        transitionedBy: req.user?.userId ?? null,
+        reason: 'Visit scheduled',
       });
 
       // Update application status to indicate scheduling progress
@@ -1276,7 +1287,9 @@ export class ApplicationController extends BaseController {
         });
       }
 
-      // Convert frontend camelCase to backend snake_case
+      // Convert frontend camelCase to backend snake_case. Note: status is
+      // handled separately via the transition log (below); we never write
+      // it to the parent row directly.
       const dbUpdateData: Record<string, string | Date | null> = {};
       if (updateData.scheduledDate) {
         dbUpdateData.scheduled_date = updateData.scheduledDate;
@@ -1286,9 +1299,6 @@ export class ApplicationController extends BaseController {
       }
       if (updateData.assignedStaff) {
         dbUpdateData.assigned_staff = updateData.assignedStaff;
-      }
-      if (updateData.status) {
-        dbUpdateData.status = updateData.status;
       }
       if (updateData.notes !== undefined) {
         dbUpdateData.notes = updateData.notes;
@@ -1311,7 +1321,23 @@ export class ApplicationController extends BaseController {
         dbUpdateData.completed_at = new Date();
       }
 
-      await visit.update(dbUpdateData);
+      if (Object.keys(dbUpdateData).length > 0) {
+        await visit.update(dbUpdateData);
+      }
+
+      // Append a transition row for the status change; the trigger / hook
+      // updates home_visits.status.
+      if (updateData.status && updateData.status !== visit.status) {
+        const HomeVisitStatusTransition = (await import('../models/HomeVisitStatusTransition'))
+          .default;
+        await HomeVisitStatusTransition.create({
+          visitId: visit.visit_id,
+          fromStatus: visit.status,
+          toStatus: updateData.status,
+          transitionedBy: req.user?.userId ?? null,
+          reason: updateData.cancelledReason || updateData.rescheduleReason || null,
+        });
+      }
 
       // Update application status based on visit outcome
       if (updateData.status === 'completed' && updateData.outcome) {

--- a/service.backend/src/models/HomeVisitStatusTransition.ts
+++ b/service.backend/src/models/HomeVisitStatusTransition.ts
@@ -1,0 +1,143 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getJsonType, getUuidType } from '../sequelize';
+import { JsonObject } from '../types/common';
+import { generateUuidV7 } from '../utils/uuid';
+import { HomeVisitStatus } from './HomeVisit';
+import { installStatusTransitionTrigger } from './status-transitions';
+
+/**
+ * Append-only event log of every status change on a HomeVisit.
+ *
+ * Same shape and rationale as ApplicationStatusTransition — see that file
+ * for the full pattern explanation. The trigger denormalizes to_status
+ * onto home_visits.status; the SQLite afterCreate hook is the JS fallback.
+ *
+ * Visits transition through:
+ *   scheduled → in_progress → completed (or cancelled at any point)
+ *
+ * The first transition for a visit has from_status = NULL.
+ */
+
+interface HomeVisitStatusTransitionAttributes {
+  transitionId: string;
+  visitId: string;
+  fromStatus: HomeVisitStatus | null;
+  toStatus: HomeVisitStatus;
+  transitionedAt: Date;
+  transitionedBy: string | null;
+  reason: string | null;
+  metadata: JsonObject | null;
+}
+
+interface HomeVisitStatusTransitionCreationAttributes
+  extends Optional<
+    HomeVisitStatusTransitionAttributes,
+    'transitionId' | 'transitionedAt' | 'fromStatus' | 'transitionedBy' | 'reason' | 'metadata'
+  > {}
+
+class HomeVisitStatusTransition
+  extends Model<HomeVisitStatusTransitionAttributes, HomeVisitStatusTransitionCreationAttributes>
+  implements HomeVisitStatusTransitionAttributes
+{
+  public transitionId!: string;
+  public visitId!: string;
+  public fromStatus!: HomeVisitStatus | null;
+  public toStatus!: HomeVisitStatus;
+  public transitionedAt!: Date;
+  public transitionedBy!: string | null;
+  public reason!: string | null;
+  public metadata!: JsonObject | null;
+}
+
+HomeVisitStatusTransition.init(
+  {
+    transitionId: {
+      type: getUuidType(),
+      primaryKey: true,
+      field: 'transition_id',
+      defaultValue: () => generateUuidV7(),
+    },
+    visitId: {
+      type: getUuidType(),
+      allowNull: false,
+      field: 'visit_id',
+      references: { model: 'home_visits', key: 'visit_id' },
+      onDelete: 'CASCADE',
+    },
+    fromStatus: {
+      type: DataTypes.ENUM(...Object.values(HomeVisitStatus)),
+      allowNull: true,
+      field: 'from_status',
+    },
+    toStatus: {
+      type: DataTypes.ENUM(...Object.values(HomeVisitStatus)),
+      allowNull: false,
+      field: 'to_status',
+    },
+    transitionedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'transitioned_at',
+      defaultValue: DataTypes.NOW,
+    },
+    transitionedBy: {
+      // No FK enforcement on the actor — same pattern as AuditLog.user.
+      // Forensic metadata that should survive user deletion; the
+      // parent-side FK (visit_id, CASCADE) is what enforces lifecycle
+      // integrity. Association in models/index.ts uses constraints: false.
+      type: getUuidType(),
+      allowNull: true,
+      field: 'transitioned_by',
+    },
+    reason: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    metadata: {
+      type: getJsonType(),
+      allowNull: true,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'home_visit_status_transitions',
+    modelName: 'HomeVisitStatusTransition',
+    underscored: true,
+    timestamps: false,
+    indexes: [
+      {
+        fields: ['visit_id', 'transitioned_at'],
+        name: 'home_visit_status_transitions_visit_id_at_idx',
+      },
+      {
+        fields: ['transitioned_by'],
+        name: 'home_visit_status_transitions_transitioned_by_idx',
+      },
+    ],
+    hooks: {
+      afterCreate: async (transition: HomeVisitStatusTransition) => {
+        if (sequelize.getDialect() === 'postgres') {
+          return;
+        }
+        const { HomeVisit } = sequelize.models;
+        if (!HomeVisit) {
+          return;
+        }
+        await HomeVisit.update(
+          { status: transition.toStatus },
+          { where: { visit_id: transition.visitId }, hooks: false }
+        );
+      },
+    },
+  }
+);
+
+installStatusTransitionTrigger(HomeVisitStatusTransition, {
+  parentTable: 'home_visits',
+  transitionTable: 'home_visit_status_transitions',
+  parentFkColumn: 'visit_id',
+  parentPkColumn: 'visit_id',
+  statusColumn: 'status',
+});
+
+export default HomeVisitStatusTransition;

--- a/service.backend/src/models/PetStatusTransition.ts
+++ b/service.backend/src/models/PetStatusTransition.ts
@@ -1,0 +1,147 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getJsonType, getUuidType } from '../sequelize';
+import { JsonObject } from '../types/common';
+import { generateUuidV7 } from '../utils/uuid';
+import { PetStatus } from './Pet';
+import { installStatusTransitionTrigger } from './status-transitions';
+
+/**
+ * Append-only event log of every status change on a Pet.
+ *
+ * Same shape and rationale as ApplicationStatusTransition — see that file
+ * for the full pattern explanation. The trigger denormalizes to_status
+ * onto pets.status; the SQLite afterCreate hook is the JS fallback.
+ *
+ * Pets transition through:
+ *   available → pending → adopted (the happy path)
+ *   available ↔ medical_hold / behavioral_hold (operational pauses)
+ *   adopted → deceased / not_available (terminal states)
+ *
+ * The first transition for a pet has from_status = NULL.
+ */
+
+interface PetStatusTransitionAttributes {
+  transitionId: string;
+  petId: string;
+  fromStatus: PetStatus | null;
+  toStatus: PetStatus;
+  transitionedAt: Date;
+  transitionedBy: string | null;
+  reason: string | null;
+  metadata: JsonObject | null;
+}
+
+interface PetStatusTransitionCreationAttributes
+  extends Optional<
+    PetStatusTransitionAttributes,
+    'transitionId' | 'transitionedAt' | 'fromStatus' | 'transitionedBy' | 'reason' | 'metadata'
+  > {}
+
+class PetStatusTransition
+  extends Model<PetStatusTransitionAttributes, PetStatusTransitionCreationAttributes>
+  implements PetStatusTransitionAttributes
+{
+  public transitionId!: string;
+  public petId!: string;
+  public fromStatus!: PetStatus | null;
+  public toStatus!: PetStatus;
+  public transitionedAt!: Date;
+  public transitionedBy!: string | null;
+  public reason!: string | null;
+  public metadata!: JsonObject | null;
+}
+
+PetStatusTransition.init(
+  {
+    transitionId: {
+      type: getUuidType(),
+      primaryKey: true,
+      field: 'transition_id',
+      defaultValue: () => generateUuidV7(),
+    },
+    petId: {
+      type: getUuidType(),
+      allowNull: false,
+      field: 'pet_id',
+      references: { model: 'pets', key: 'pet_id' },
+      onDelete: 'CASCADE',
+    },
+    fromStatus: {
+      type: DataTypes.ENUM(...Object.values(PetStatus)),
+      allowNull: true,
+      field: 'from_status',
+    },
+    toStatus: {
+      type: DataTypes.ENUM(...Object.values(PetStatus)),
+      allowNull: false,
+      field: 'to_status',
+    },
+    transitionedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'transitioned_at',
+      defaultValue: DataTypes.NOW,
+    },
+    transitionedBy: {
+      // No FK enforcement on the actor — same pattern as AuditLog.user.
+      // Forensic metadata that should survive user deletion; the
+      // parent-side FK (pet_id, CASCADE) is what enforces lifecycle
+      // integrity. Association in models/index.ts uses constraints: false.
+      type: getUuidType(),
+      allowNull: true,
+      field: 'transitioned_by',
+    },
+    reason: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    metadata: {
+      type: getJsonType(),
+      allowNull: true,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'pet_status_transitions',
+    modelName: 'PetStatusTransition',
+    underscored: true,
+    timestamps: false,
+    indexes: [
+      {
+        fields: ['pet_id', 'transitioned_at'],
+        name: 'pet_status_transitions_pet_id_at_idx',
+      },
+      {
+        fields: ['transitioned_by'],
+        name: 'pet_status_transitions_transitioned_by_idx',
+      },
+    ],
+    hooks: {
+      // SQLite (test) fallback for the Postgres trigger below — see
+      // ApplicationStatusTransition for the rationale.
+      afterCreate: async (transition: PetStatusTransition) => {
+        if (sequelize.getDialect() === 'postgres') {
+          return;
+        }
+        const { Pet } = sequelize.models;
+        if (!Pet) {
+          return;
+        }
+        await Pet.update(
+          { status: transition.toStatus },
+          { where: { pet_id: transition.petId }, hooks: false }
+        );
+      },
+    },
+  }
+);
+
+installStatusTransitionTrigger(PetStatusTransition, {
+  parentTable: 'pets',
+  transitionTable: 'pet_status_transitions',
+  parentFkColumn: 'pet_id',
+  parentPkColumn: 'pet_id',
+  statusColumn: 'status',
+});
+
+export default PetStatusTransition;

--- a/service.backend/src/models/ReportStatusTransition.ts
+++ b/service.backend/src/models/ReportStatusTransition.ts
@@ -1,0 +1,143 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getJsonType, getUuidType } from '../sequelize';
+import { JsonObject } from '../types/common';
+import { generateUuidV7 } from '../utils/uuid';
+import { ReportStatus } from './Report';
+import { installStatusTransitionTrigger } from './status-transitions';
+
+/**
+ * Append-only event log of every status change on a Report.
+ *
+ * Same shape and rationale as ApplicationStatusTransition — see that file
+ * for the full pattern explanation. The trigger denormalizes to_status
+ * onto reports.status; the SQLite afterCreate hook is the JS fallback.
+ *
+ * Reports transition through:
+ *   pending → under_review → resolved | dismissed | escalated
+ *
+ * The first transition for a report has from_status = NULL.
+ */
+
+interface ReportStatusTransitionAttributes {
+  transitionId: string;
+  reportId: string;
+  fromStatus: ReportStatus | null;
+  toStatus: ReportStatus;
+  transitionedAt: Date;
+  transitionedBy: string | null;
+  reason: string | null;
+  metadata: JsonObject | null;
+}
+
+interface ReportStatusTransitionCreationAttributes
+  extends Optional<
+    ReportStatusTransitionAttributes,
+    'transitionId' | 'transitionedAt' | 'fromStatus' | 'transitionedBy' | 'reason' | 'metadata'
+  > {}
+
+class ReportStatusTransition
+  extends Model<ReportStatusTransitionAttributes, ReportStatusTransitionCreationAttributes>
+  implements ReportStatusTransitionAttributes
+{
+  public transitionId!: string;
+  public reportId!: string;
+  public fromStatus!: ReportStatus | null;
+  public toStatus!: ReportStatus;
+  public transitionedAt!: Date;
+  public transitionedBy!: string | null;
+  public reason!: string | null;
+  public metadata!: JsonObject | null;
+}
+
+ReportStatusTransition.init(
+  {
+    transitionId: {
+      type: getUuidType(),
+      primaryKey: true,
+      field: 'transition_id',
+      defaultValue: () => generateUuidV7(),
+    },
+    reportId: {
+      type: getUuidType(),
+      allowNull: false,
+      field: 'report_id',
+      references: { model: 'reports', key: 'report_id' },
+      onDelete: 'CASCADE',
+    },
+    fromStatus: {
+      type: DataTypes.ENUM(...Object.values(ReportStatus)),
+      allowNull: true,
+      field: 'from_status',
+    },
+    toStatus: {
+      type: DataTypes.ENUM(...Object.values(ReportStatus)),
+      allowNull: false,
+      field: 'to_status',
+    },
+    transitionedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'transitioned_at',
+      defaultValue: DataTypes.NOW,
+    },
+    transitionedBy: {
+      // No FK enforcement on the actor — same pattern as AuditLog.user.
+      // Forensic metadata that should survive user deletion; the
+      // parent-side FK (report_id, CASCADE) is what enforces lifecycle
+      // integrity. Association in models/index.ts uses constraints: false.
+      type: getUuidType(),
+      allowNull: true,
+      field: 'transitioned_by',
+    },
+    reason: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    metadata: {
+      type: getJsonType(),
+      allowNull: true,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'report_status_transitions',
+    modelName: 'ReportStatusTransition',
+    underscored: true,
+    timestamps: false,
+    indexes: [
+      {
+        fields: ['report_id', 'transitioned_at'],
+        name: 'report_status_transitions_report_id_at_idx',
+      },
+      {
+        fields: ['transitioned_by'],
+        name: 'report_status_transitions_transitioned_by_idx',
+      },
+    ],
+    hooks: {
+      afterCreate: async (transition: ReportStatusTransition) => {
+        if (sequelize.getDialect() === 'postgres') {
+          return;
+        }
+        const { Report } = sequelize.models;
+        if (!Report) {
+          return;
+        }
+        await Report.update(
+          { status: transition.toStatus },
+          { where: { report_id: transition.reportId }, hooks: false }
+        );
+      },
+    },
+  }
+);
+
+installStatusTransitionTrigger(ReportStatusTransition, {
+  parentTable: 'reports',
+  transitionTable: 'report_status_transitions',
+  parentFkColumn: 'report_id',
+  parentPkColumn: 'report_id',
+  statusColumn: 'status',
+});
+
+export default ReportStatusTransition;

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -3,6 +3,7 @@ import ApplicationQuestion from './ApplicationQuestion';
 import ApplicationStatusTransition from './ApplicationStatusTransition';
 import ApplicationTimeline from './ApplicationTimeline';
 import Pet from './Pet';
+import PetStatusTransition from './PetStatusTransition';
 import Rescue from './Rescue';
 import User from './User';
 import UserFavorite from './UserFavorite';
@@ -33,6 +34,7 @@ import StaffMember from './StaffMember';
 // Content Moderation Models
 import ModeratorAction from './ModeratorAction';
 import Report from './Report';
+import ReportStatusTransition from './ReportStatusTransition';
 import UserSanction from './UserSanction';
 
 // Support System Models
@@ -50,6 +52,7 @@ import { SwipeSession } from './SwipeSession';
 
 // Application Management Models
 import HomeVisit from './HomeVisit';
+import HomeVisitStatusTransition from './HomeVisitStatusTransition';
 
 // Field-Level Permissions
 import FieldPermission from './FieldPermission';
@@ -64,6 +67,7 @@ const models = {
   UserFavorite,
   Rescue,
   Pet,
+  PetStatusTransition,
   Application,
   ApplicationQuestion,
   ApplicationStatusTransition,
@@ -84,6 +88,7 @@ const models = {
   Invitation,
   ModeratorAction,
   Report,
+  ReportStatusTransition,
   UserSanction,
   SupportTicket,
   SupportTicketResponse,
@@ -95,6 +100,7 @@ const models = {
   FieldPermission,
   FileUpload,
   HomeVisit,
+  HomeVisitStatusTransition,
   Content,
   NavigationMenu,
 };
@@ -128,6 +134,53 @@ try {
   ApplicationStatusTransition.belongsTo(User, {
     foreignKey: 'transitioned_by',
     as: 'TransitionedBy',
+  });
+
+  // Pet, HomeVisit, and Report status-transition logs follow the same
+  // pattern as ApplicationStatusTransition (see above for the rationale).
+  // The actor (transitioned_by) is declared without a DB-level FK
+  // constraint (matching AuditLog.user) — it's forensic metadata that
+  // outlives the user; lifecycle integrity is enforced by the parent FK.
+  Pet.hasMany(PetStatusTransition, { foreignKey: 'pet_id', as: 'StatusTransitions' });
+  PetStatusTransition.belongsTo(Pet, { foreignKey: 'pet_id', as: 'Pet' });
+  User.hasMany(PetStatusTransition, {
+    foreignKey: 'transitioned_by',
+    as: 'AppliedPetStatusTransitions',
+    constraints: false,
+  });
+  PetStatusTransition.belongsTo(User, {
+    foreignKey: 'transitioned_by',
+    as: 'TransitionedBy',
+    constraints: false,
+  });
+
+  HomeVisit.hasMany(HomeVisitStatusTransition, {
+    foreignKey: 'visit_id',
+    as: 'StatusTransitions',
+  });
+  HomeVisitStatusTransition.belongsTo(HomeVisit, { foreignKey: 'visit_id', as: 'HomeVisit' });
+  User.hasMany(HomeVisitStatusTransition, {
+    foreignKey: 'transitioned_by',
+    as: 'AppliedHomeVisitStatusTransitions',
+    constraints: false,
+  });
+  HomeVisitStatusTransition.belongsTo(User, {
+    foreignKey: 'transitioned_by',
+    as: 'TransitionedBy',
+    constraints: false,
+  });
+
+  Report.hasMany(ReportStatusTransition, { foreignKey: 'report_id', as: 'StatusTransitions' });
+  ReportStatusTransition.belongsTo(Report, { foreignKey: 'report_id', as: 'Report' });
+  User.hasMany(ReportStatusTransition, {
+    foreignKey: 'transitioned_by',
+    as: 'AppliedReportStatusTransitions',
+    constraints: false,
+  });
+  ReportStatusTransition.belongsTo(User, {
+    foreignKey: 'transitioned_by',
+    as: 'TransitionedBy',
+    constraints: false,
   });
 
   // Application Timeline associations
@@ -385,14 +438,17 @@ export {
   FieldPermission,
   FileUpload,
   HomeVisit,
+  HomeVisitStatusTransition,
   Invitation,
   Message,
   ModeratorAction,
   Notification,
   Permission,
   Pet,
+  PetStatusTransition,
   Rating,
   Report,
+  ReportStatusTransition,
   Rescue,
   Role,
   RolePermission,

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -1,6 +1,7 @@
 import { Op, Transaction, WhereOptions } from 'sequelize';
 import ModeratorAction, { ActionSeverity, ActionType } from '../models/ModeratorAction';
 import Report, { ReportCategory, ReportSeverity, ReportStatus } from '../models/Report';
+import ReportStatusTransition from '../models/ReportStatusTransition';
 import User from '../models/User';
 import Pet from '../models/Pet';
 import Rescue from '../models/Rescue';
@@ -117,6 +118,19 @@ class ModerationService {
             submissionContext: requestContext || null,
             autoDetected: false,
           },
+        },
+        { transaction }
+      );
+
+      // Seed the transition log with the initial status — same shape as
+      // ApplicationStatusTransition's `null → SUBMITTED` row.
+      await ReportStatusTransition.create(
+        {
+          reportId: report.reportId,
+          fromStatus: null,
+          toStatus: ReportStatus.PENDING,
+          transitionedBy: reporterId,
+          reason: 'Initial submission',
         },
         { transaction }
       );
@@ -310,11 +324,22 @@ class ModerationService {
         throw new Error('Report cannot be assigned in its current status');
       }
 
+      const previousStatus = report.status;
       await report.update(
         {
           assignedModerator: moderatorId,
           assignedAt: new Date(),
-          status: ReportStatus.UNDER_REVIEW,
+        },
+        { transaction }
+      );
+      await ReportStatusTransition.create(
+        {
+          reportId,
+          fromStatus: previousStatus,
+          toStatus: ReportStatus.UNDER_REVIEW,
+          transitionedBy: assignedBy,
+          reason: 'Assigned to moderator',
+          metadata: { moderatorId },
         },
         { transaction }
       );
@@ -364,17 +389,29 @@ class ModerationService {
       if (actionData.reportId) {
         const report = await Report.findByPk(actionData.reportId, { transaction });
         if (report) {
+          const previousStatus = report.status;
+          const newStatus =
+            actionData.actionType === ActionType.NO_ACTION ||
+            actionData.actionType === ActionType.REPORT_DISMISSED
+              ? ReportStatus.DISMISSED
+              : ReportStatus.RESOLVED;
           await report.update(
             {
-              status:
-                actionData.actionType === ActionType.NO_ACTION ||
-                actionData.actionType === ActionType.REPORT_DISMISSED
-                  ? ReportStatus.DISMISSED
-                  : ReportStatus.RESOLVED,
               resolvedBy: moderatorId,
               resolvedAt: new Date(),
               resolution: actionData.actionType,
               resolutionNotes: actionData.description,
+            },
+            { transaction }
+          );
+          await ReportStatusTransition.create(
+            {
+              reportId: report.reportId,
+              fromStatus: previousStatus,
+              toStatus: newStatus,
+              transitionedBy: moderatorId,
+              reason: actionData.description || actionData.actionType,
+              metadata: { actionType: actionData.actionType },
             },
             { transaction }
           );
@@ -632,12 +669,23 @@ class ModerationService {
         throw new Error('Report cannot be escalated in its current status');
       }
 
+      const previousStatus = report.status;
       await report.update(
         {
-          status: ReportStatus.ESCALATED,
           escalatedTo,
           escalatedAt: new Date(),
           escalationReason: reason,
+        },
+        { transaction }
+      );
+      await ReportStatusTransition.create(
+        {
+          reportId,
+          fromStatus: previousStatus,
+          toStatus: ReportStatus.ESCALATED,
+          transitionedBy: escalatedBy,
+          reason,
+          metadata: { escalatedTo },
         },
         { transaction }
       );
@@ -695,15 +743,25 @@ class ModerationService {
           throw new Error(`Report ${reportId} not found`);
         }
 
+        const previousStatus = report.status;
         switch (action) {
           case 'resolve':
             if ([ReportStatus.UNDER_REVIEW, ReportStatus.ESCALATED].includes(report.status)) {
               await report.update(
                 {
-                  status: ReportStatus.RESOLVED,
                   resolvedBy: moderatorId,
                   resolvedAt: new Date(),
                   resolutionNotes,
+                },
+                { transaction }
+              );
+              await ReportStatusTransition.create(
+                {
+                  reportId: report.reportId,
+                  fromStatus: previousStatus,
+                  toStatus: ReportStatus.RESOLVED,
+                  transitionedBy: moderatorId,
+                  reason: resolutionNotes || 'Bulk resolve',
                 },
                 { transaction }
               );
@@ -715,10 +773,19 @@ class ModerationService {
             if (report.status !== ReportStatus.RESOLVED) {
               await report.update(
                 {
-                  status: ReportStatus.DISMISSED,
                   resolvedBy: moderatorId,
                   resolvedAt: new Date(),
                   resolutionNotes,
+                },
+                { transaction }
+              );
+              await ReportStatusTransition.create(
+                {
+                  reportId: report.reportId,
+                  fromStatus: previousStatus,
+                  toStatus: ReportStatus.DISMISSED,
+                  transitionedBy: moderatorId,
+                  reason: resolutionNotes || 'Bulk dismiss',
                 },
                 { transaction }
               );
@@ -735,7 +802,17 @@ class ModerationService {
                 {
                   assignedModerator: assignTo,
                   assignedAt: new Date(),
-                  status: ReportStatus.UNDER_REVIEW,
+                },
+                { transaction }
+              );
+              await ReportStatusTransition.create(
+                {
+                  reportId: report.reportId,
+                  fromStatus: previousStatus,
+                  toStatus: ReportStatus.UNDER_REVIEW,
+                  transitionedBy: moderatorId,
+                  reason: 'Bulk assign',
+                  metadata: { assignedTo: assignTo },
                 },
                 { transaction }
               );
@@ -750,10 +827,20 @@ class ModerationService {
             if ([ReportStatus.PENDING, ReportStatus.UNDER_REVIEW].includes(report.status)) {
               await report.update(
                 {
-                  status: ReportStatus.ESCALATED,
                   escalatedTo: escalateTo,
                   escalatedAt: new Date(),
                   escalationReason: escalationReason || 'Bulk escalation',
+                },
+                { transaction }
+              );
+              await ReportStatusTransition.create(
+                {
+                  reportId: report.reportId,
+                  fromStatus: previousStatus,
+                  toStatus: ReportStatus.ESCALATED,
+                  transitionedBy: moderatorId,
+                  reason: escalationReason || 'Bulk escalation',
+                  metadata: { escalatedTo: escalateTo },
                 },
                 { transaction }
               );
@@ -811,16 +898,28 @@ class ModerationService {
     });
 
     if (moderators.length > 0) {
+      const assignedTo = moderators[0].userId;
       await Report.update(
         {
-          assignedModerator: moderators[0].userId,
+          assignedModerator: assignedTo,
           assignedAt: new Date(),
-          status: ReportStatus.UNDER_REVIEW,
         },
         {
           where: { reportId },
           transaction,
         }
+      );
+      // System-driven transition: transitionedBy is null (no actor).
+      await ReportStatusTransition.create(
+        {
+          reportId,
+          fromStatus: ReportStatus.PENDING,
+          toStatus: ReportStatus.UNDER_REVIEW,
+          transitionedBy: null,
+          reason: 'Auto-assigned',
+          metadata: { assignedTo },
+        },
+        { transaction }
       );
     }
   }

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -1,5 +1,6 @@
 import { col, fn, literal, Op, WhereOptions } from 'sequelize';
 import Pet, { AgeGroup, PetStatus, PetType, Size } from '../models/Pet';
+import PetStatusTransition from '../models/PetStatusTransition';
 import Rescue from '../models/Rescue';
 import UserFavorite from '../models/UserFavorite';
 import Report, { ReportCategory, ReportStatus, ReportSeverity } from '../models/Report';
@@ -393,6 +394,17 @@ export class PetService {
         videos,
       });
 
+      // Seed the transition log with the initial status. The trigger /
+      // hook would otherwise re-set pets.status to its default — a no-op
+      // here, but the row is what makes "history complete" structural.
+      await PetStatusTransition.create({
+        petId: pet.petId,
+        fromStatus: null,
+        toStatus: pet.status,
+        transitionedBy: createdBy,
+        reason: 'Initial listing',
+      });
+
       // Log pet creation with performance metrics
       await AuditLogService.log({
         action: 'CREATE',
@@ -669,12 +681,30 @@ export class PetService {
 
       const originalStatus = pet.status;
 
-      // Update status and related fields
-      await pet.update({
-        status: statusUpdate.status,
-        ...(statusUpdate.effectiveDate && { availableSince: statusUpdate.effectiveDate }),
-        ...(statusUpdate.status === PetStatus.ADOPTED && { adoptedDate: new Date() }),
-        ...(statusUpdate.status === PetStatus.FOSTER && { fosterStartDate: new Date() }),
+      // Update side-effect columns directly; the status itself is owned by
+      // the transition log + trigger / hook (see PetStatusTransition).
+      const sideEffects: Record<string, unknown> = {};
+      if (statusUpdate.effectiveDate) {
+        sideEffects.availableSince = statusUpdate.effectiveDate;
+      }
+      if (statusUpdate.status === PetStatus.ADOPTED) {
+        sideEffects.adoptedDate = new Date();
+      }
+      if (statusUpdate.status === PetStatus.FOSTER) {
+        sideEffects.fosterStartDate = new Date();
+      }
+      if (Object.keys(sideEffects).length > 0) {
+        await pet.update(sideEffects);
+      }
+
+      // Append the transition; the AFTER INSERT trigger (Postgres) /
+      // afterCreate hook (SQLite) propagates to_status onto pets.status.
+      await PetStatusTransition.create({
+        petId,
+        fromStatus: originalStatus,
+        toStatus: statusUpdate.status,
+        transitionedBy: updatedBy,
+        reason: statusUpdate.reason || null,
       });
 
       // Log status update


### PR DESCRIPTION
## Summary

Slice 5 of phase 3. Replicates the `ApplicationStatusTransition` pattern from slice 4 across three more workflow-heavy entities — Pet, HomeVisit, and Report — using the existing `installStatusTransitionTrigger` helper. Each gets an append-only `*_status_transitions` table with a Postgres `AFTER INSERT` trigger and a Sequelize `afterCreate` hook for SQLite.

```
pet_status_transitions        → drives  pets.status
home_visit_status_transitions → drives  home_visits.status
report_status_transitions     → drives  reports.status
```

Application code never writes a parent's status column directly any more — it inserts a transition; the trigger / hook denormalizes `to_status` onto the parent. Reads stay O(1) and unchanged.

## Why these three (and what's deferred)

Pet, HomeVisit, and Report all have clean status enums and well-defined write sites, so the refactor is mechanical. **UserSanction is intentionally deferred** — it uses `isActive` + lifecycle timestamps rather than a discrete status enum. Fitting it to the transition pattern needs a derived status redesign first; that's its own slice.

## What changed

**New models / tests**
- `PetStatusTransition`, `HomeVisitStatusTransition`, `ReportStatusTransition` — same shape as `ApplicationStatusTransition`. Indexes on `(parent_id, transitioned_at)`.
- One model test per entity covering the SQLite path (insert → parent.status updates; chronological history; reason / metadata captured).

**Service / controller refactors**
- `pet.service.createPet` seeds the initial `null → AVAILABLE` transition.
- `pet.service.updatePetStatus` writes side-effect cols (`adoptedDate`, `fosterStartDate`, `availableSince`) directly; status moves via the log.
- `moderation.service`: `submitReport`, `assignReport`, `takeModerationAction`, `escalateReport`, `bulkUpdateReports`, `autoAssignReport` all stop writing `reports.status` and append a transition row instead, with `reason`, `metadata`, and `transitioned_by` populated.
- `application.controller.scheduleHomeVisit` seeds the initial transition; `updateHomeVisit` writes side-effect cols and appends a transition only when the requested status differs from the current one.

**Actor FK**
- `transitioned_by` on each new model is intentionally **not** a DB-enforced FK to users (matches `AuditLog.user`). It's forensic metadata that should outlive user deletion; the parent FK with `CASCADE` is what enforces lifecycle integrity. Associations declare `constraints: false`.

**Test surgery**
- Mocks-based service tests (`pet.service`, `pet-business-logic`, `admin-moderation-flow`) switched from `mockEntity.update({ status })` assertions to `MockedXStatusTransition.create({ toStatus })`, matching the new contract.

## Test plan

- [x] `npx vitest run` — 1332 passed / 4 skipped, 0 failed
- [x] `npm run lint` — 0 errors (163 pre-existing warnings)
- [x] `npx tsc --noEmit` — clean
- [ ] Verify in dev Postgres: insert a transition for each new table; confirm parent's status updates via trigger
- [ ] Smoke-test the `bulkUpdateReports` path end-to-end to confirm transitions are inserted under the same `BEGIN`/`COMMIT`

## Out of scope (next slice)

- `UserSanction` status transitions (needs a derived-status design first)
- Optional state-machine validator triggers per entity (defer until each state machine stabilizes)
- Convenience views like `pet_status_timestamps` / `report_status_timestamps`

https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_