### PR TITLE
Phase 3 (slice 8): Zod schema-first rollout for Rescue

### DIFF
--- a/lib.validation/src/index.ts
+++ b/lib.validation/src/index.ts
@@ -7,3 +7,4 @@ export * from './types';
 // frontend. Add one schema module per entity as the rollout progresses.
 export * from './schemas/user';
 export * from './schemas/pet';
+export * from './schemas/rescue';

--- a/lib.validation/src/schemas/__tests__/rescue.test.ts
+++ b/lib.validation/src/schemas/__tests__/rescue.test.ts
@@ -1,0 +1,201 @@
+import {
+  AdoptionPolicySchema,
+  AddStaffMemberRequestSchema,
+  RescueBulkUpdateRequestSchema,
+  RescueCreateRequestSchema,
+  RescueDeletionRequestSchema,
+  RescueRejectionRequestSchema,
+  RescueSearchQuerySchema,
+  RescueStatusSchema,
+  RescueUpdateRequestSchema,
+  RescueVerificationRequestSchema,
+  StaffInvitationRequestSchema,
+  UkPhoneNumberSchema,
+  UkPostcodeSchema,
+} from '../rescue';
+
+describe('Rescue schemas', () => {
+  describe('UkPostcodeSchema', () => {
+    it('uppercases and normalises whitespace', () => {
+      expect(UkPostcodeSchema.parse('  sw1a 1aa  ')).toBe('SW1A 1AA');
+    });
+
+    it('accepts the no-space form', () => {
+      expect(UkPostcodeSchema.parse('SW1A1AA')).toBe('SW1A1AA');
+    });
+
+    it('rejects garbage', () => {
+      expect(() => UkPostcodeSchema.parse('not a postcode')).toThrow();
+    });
+  });
+
+  describe('UkPhoneNumberSchema', () => {
+    it('strips separators and accepts +44 numbers', () => {
+      expect(UkPhoneNumberSchema.parse('+44 (20) 7946-0958')).toBe('+442079460958');
+    });
+
+    it('accepts a 0-prefixed UK number', () => {
+      expect(UkPhoneNumberSchema.parse('020 7946 0958')).toBe('02079460958');
+    });
+
+    it('rejects too-short input', () => {
+      expect(() => UkPhoneNumberSchema.parse('123')).toThrow();
+    });
+  });
+
+  describe('RescueStatusSchema', () => {
+    it('accepts the canonical statuses', () => {
+      expect(RescueStatusSchema.parse('verified')).toBe('verified');
+    });
+
+    it('rejects unknown statuses', () => {
+      expect(() => RescueStatusSchema.parse('archived')).toThrow();
+    });
+  });
+
+  describe('RescueCreateRequestSchema', () => {
+    const valid = {
+      name: 'Happy Tails Rescue',
+      email: 'hello@happytails.org',
+      address: '1 Lane',
+      city: 'London',
+      postcode: 'SW1A 1AA',
+      country: 'United Kingdom',
+      contactPerson: 'Jane Doe',
+    };
+
+    it('accepts a minimal valid create payload', () => {
+      const parsed = RescueCreateRequestSchema.parse(valid);
+      expect(parsed.email).toBe('hello@happytails.org');
+      expect(parsed.postcode).toBe('SW1A 1AA');
+    });
+
+    it('rejects names shorter than 2 chars after trim', () => {
+      expect(() => RescueCreateRequestSchema.parse({ ...valid, name: ' x ' })).toThrow();
+    });
+
+    it('rejects an invalid postcode', () => {
+      expect(() => RescueCreateRequestSchema.parse({ ...valid, postcode: '12345' })).toThrow();
+    });
+
+    it('rejects an EIN outside 9–10 chars', () => {
+      expect(() => RescueCreateRequestSchema.parse({ ...valid, ein: '12345678' })).toThrow();
+      expect(() => RescueCreateRequestSchema.parse({ ...valid, ein: '12345678901' })).toThrow();
+      expect(() => RescueCreateRequestSchema.parse({ ...valid, ein: '123456789' })).not.toThrow();
+    });
+
+    it('rejects descriptions over 1000 chars', () => {
+      expect(() =>
+        RescueCreateRequestSchema.parse({ ...valid, description: 'x'.repeat(1001) })
+      ).toThrow();
+    });
+
+    it('rejects an invalid contact email', () => {
+      expect(() =>
+        RescueCreateRequestSchema.parse({ ...valid, contactEmail: 'not-an-email' })
+      ).toThrow();
+    });
+  });
+
+  describe('RescueUpdateRequestSchema', () => {
+    it('accepts an empty update', () => {
+      const parsed = RescueUpdateRequestSchema.parse({});
+      expect(parsed).toEqual({});
+    });
+
+    it('still rejects an invalid email when present', () => {
+      expect(() => RescueUpdateRequestSchema.parse({ email: 'foo' })).toThrow();
+    });
+  });
+
+  describe('AdoptionPolicySchema', () => {
+    it('accepts a complete policy', () => {
+      const parsed = AdoptionPolicySchema.parse({
+        requireHomeVisit: true,
+        requireReferences: true,
+        minimumReferenceCount: 2,
+        adoptionFeeRange: { min: 50, max: 200 },
+        requirements: ['No children under 5'],
+        returnPolicy: 'Returns accepted within 30 days',
+      });
+      expect(parsed.adoptionFeeRange?.max).toBe(200);
+    });
+
+    it('rejects an inverted fee range', () => {
+      expect(() =>
+        AdoptionPolicySchema.parse({ adoptionFeeRange: { min: 300, max: 100 } })
+      ).toThrow();
+    });
+
+    it('rejects minimumReferenceCount outside 0–10', () => {
+      expect(() => AdoptionPolicySchema.parse({ minimumReferenceCount: 11 })).toThrow();
+    });
+  });
+
+  describe('RescueSearchQuerySchema', () => {
+    it('coerces query-string ints', () => {
+      const parsed = RescueSearchQuerySchema.parse({ page: '2', limit: '10' });
+      expect(parsed.page).toBe(2);
+      expect(parsed.limit).toBe(10);
+    });
+
+    it('clamps limit to 100', () => {
+      expect(() => RescueSearchQuerySchema.parse({ limit: '200' })).toThrow();
+    });
+
+    it('rejects unknown sortBy values', () => {
+      expect(() => RescueSearchQuerySchema.parse({ sortBy: 'mostPopular' })).toThrow();
+    });
+  });
+
+  describe('Staff schemas', () => {
+    it('StaffInvitationRequestSchema requires a valid email', () => {
+      expect(() => StaffInvitationRequestSchema.parse({ email: 'foo' })).toThrow();
+      expect(() => StaffInvitationRequestSchema.parse({ email: 'a@b.co' })).not.toThrow();
+    });
+
+    it('AddStaffMemberRequestSchema requires a userId', () => {
+      expect(() => AddStaffMemberRequestSchema.parse({})).toThrow();
+      expect(() => AddStaffMemberRequestSchema.parse({ userId: 'u1' })).not.toThrow();
+    });
+  });
+
+  describe('Verification / rejection / deletion shapes', () => {
+    it('cap notes / reason at 500 chars', () => {
+      expect(() => RescueVerificationRequestSchema.parse({ notes: 'x'.repeat(501) })).toThrow();
+      expect(() => RescueRejectionRequestSchema.parse({ reason: 'x'.repeat(501) })).toThrow();
+      expect(() => RescueDeletionRequestSchema.parse({ reason: 'x'.repeat(501) })).toThrow();
+    });
+  });
+
+  describe('RescueBulkUpdateRequestSchema', () => {
+    it('accepts a valid bulk update', () => {
+      const parsed = RescueBulkUpdateRequestSchema.parse({
+        rescueIds: ['aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa1', 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbb2'],
+        action: 'verify',
+      });
+      expect(parsed.rescueIds).toHaveLength(2);
+    });
+
+    it('rejects a non-UUID id', () => {
+      expect(() =>
+        RescueBulkUpdateRequestSchema.parse({ rescueIds: ['nope'], action: 'verify' })
+      ).toThrow();
+    });
+
+    it('rejects an empty rescueIds array', () => {
+      expect(() =>
+        RescueBulkUpdateRequestSchema.parse({ rescueIds: [], action: 'verify' })
+      ).toThrow();
+    });
+
+    it('rejects an unknown action', () => {
+      expect(() =>
+        RescueBulkUpdateRequestSchema.parse({
+          rescueIds: ['aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa1'],
+          action: 'destroy',
+        })
+      ).toThrow();
+    });
+  });
+});

--- a/lib.validation/src/schemas/pet.ts
+++ b/lib.validation/src/schemas/pet.ts
@@ -13,7 +13,6 @@ import type { PetId, RescueId } from '@adopt-dont-shop/lib.types';
  * to add a check here, it should also exist on the model — and vice
  * versa.
  */
-
 // ----- Enums (match the values exported from Pet.ts) ---------------------
 
 export const PetStatusSchema = z.enum([
@@ -71,12 +70,10 @@ export type GoodWithValue = z.infer<typeof GoodWithSchema>;
 export const PetIdSchema = z
   .string()
   .min(1, 'Pet ID is required')
-  .transform(v => v as PetId);
+  .transform((v) => v as PetId);
 
-export const RescueIdSchema = z
-  .string()
-  .min(1, 'Rescue ID is required')
-  .transform(v => v as RescueId);
+// RescueIdSchema lives in schemas/rescue.ts — Pet uses RescueId only
+// for FK references in shapes below.
 
 const PetNameSchema = z.string().trim().min(1, 'Name is required').max(100);
 const BreedSchema = z.string().trim().min(1).max(100);
@@ -254,12 +251,7 @@ export type ReportPetRequest = z.infer<typeof ReportPetRequestSchema>;
 /**
  * POST /api/v1/pets/bulk-update — admin bulk operation.
  */
-export const BulkPetOperationTypeSchema = z.enum([
-  'update_status',
-  'archive',
-  'feature',
-  'delete',
-]);
+export const BulkPetOperationTypeSchema = z.enum(['update_status', 'archive', 'feature', 'delete']);
 export type BulkPetOperationType = z.infer<typeof BulkPetOperationTypeSchema>;
 
 export const BulkPetOperationRequestSchema = z.object({
@@ -279,7 +271,12 @@ export type BulkPetOperationRequest = z.infer<typeof BulkPetOperationRequestSche
  */
 export const PetProfileSchema = z.object({
   petId: PetIdSchema,
-  rescueId: RescueIdSchema,
+  // FK to Rescue. Brand at the type level without dragging the rescue
+  // schema in as a runtime dep here.
+  rescueId: z
+    .string()
+    .min(1)
+    .transform((v) => v as RescueId),
   name: PetNameSchema,
   type: PetTypeSchema,
   breed: BreedSchema.nullable().optional(),

--- a/lib.validation/src/schemas/rescue.ts
+++ b/lib.validation/src/schemas/rescue.ts
@@ -1,0 +1,253 @@
+import { z } from 'zod';
+import type { RescueId } from '@adopt-dont-shop/lib.types';
+
+/**
+ * Canonical Zod schemas for the Rescue domain.
+ *
+ * Same role as schemas/user.ts and schemas/pet.ts: one source of truth
+ * for Rescue-shaped data, used by service.backend request validation
+ * and (over time) the rescue / admin frontends.
+ *
+ * The values mirror the validators in service.backend/src/models/Rescue.ts
+ * and the express-validator chains in service.backend/src/routes/rescue.routes.ts.
+ */
+
+// ----- Enums --------------------------------------------------------------
+
+export const RescueStatusSchema = z.enum(['pending', 'verified', 'suspended', 'inactive']);
+export type RescueStatusValue = z.infer<typeof RescueStatusSchema>;
+
+// ----- Primitives ---------------------------------------------------------
+
+export const RescueIdSchema = z
+  .string()
+  .min(1, 'Rescue ID is required')
+  .transform((v) => v as RescueId);
+
+/**
+ * UK postcode — case- and whitespace-insensitive. Mirrors the regex used
+ * by `isUKPostcode` in service.backend's UK validators middleware so the
+ * backend and the frontend agree on what counts as valid.
+ */
+const UkPostcodeRegex = /^[A-Z]{1,2}\d{1,2}[A-Z]?\s?\d[A-Z]{2}$/i;
+export const UkPostcodeSchema = z
+  .string()
+  .transform((v) => v.trim().toUpperCase().replace(/\s+/g, ' '))
+  .pipe(z.string().regex(UkPostcodeRegex, 'Please enter a valid UK postcode'));
+
+/**
+ * UK phone number — light normalization (strip whitespace and common
+ * separators) then a 10–15 digit check that mirrors the existing
+ * `isUKPhoneNumber` middleware. Full E.164 normalization is deferred
+ * (see plan 3.3, same caveat as User.PhoneNumberSchema).
+ */
+export const UkPhoneNumberSchema = z
+  .string()
+  .transform((v) => v.trim().replace(/[\s\-()]/g, ''))
+  .pipe(z.string().regex(/^(?:\+44|0)\d{9,10}$/, 'Please enter a valid UK phone number'));
+
+const NameSchema = z.string().trim().min(2, 'Name must be at least 2 characters').max(100);
+const ContactNameSchema = z
+  .string()
+  .trim()
+  .min(2, 'Contact person must be at least 2 characters')
+  .max(100);
+
+const EmailSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .min(5)
+  .max(255)
+  .email('Please enter a valid email address');
+
+const AddressSchema = z.string().trim().min(5, 'Address must be at least 5 characters').max(255);
+
+const CitySchema = z.string().trim().min(2).max(100);
+const CountySchema = z.string().trim().min(2).max(100);
+const CountrySchema = z.string().trim().min(2).max(100);
+
+const WebsiteSchema = z.string().url('Please enter a valid website URL');
+const DescriptionSchema = z.string().trim().max(1000);
+const MissionSchema = z.string().trim().max(500);
+
+const EinSchema = z
+  .string()
+  .trim()
+  .min(9, 'EIN must be 9–10 characters')
+  .max(10, 'EIN must be 9–10 characters');
+
+const RegistrationNumberSchema = z.string().trim().max(50);
+const ContactTitleSchema = z.string().trim().max(100);
+const NotesSchema = z.string().trim().max(500);
+const ReasonSchema = z.string().trim().max(500);
+
+// ----- Adoption policy ---------------------------------------------------
+
+/**
+ * Mirror of the adoption-policy validators in rescue.routes. Stored on
+ * Rescue.settings (JSONB today; will move to a typed table in Tier 5.6).
+ */
+export const AdoptionPolicySchema = z.object({
+  requireHomeVisit: z.boolean().optional(),
+  requireReferences: z.boolean().optional(),
+  requireVeterinarianReference: z.boolean().optional(),
+  minimumReferenceCount: z.coerce.number().int().min(0).max(10).optional(),
+  adoptionFeeRange: z
+    .object({
+      min: z.coerce.number().min(0),
+      max: z.coerce.number().min(0),
+    })
+    .refine((v) => v.max >= v.min, {
+      message: 'adoptionFeeRange.max must be ≥ adoptionFeeRange.min',
+      path: ['max'],
+    })
+    .optional(),
+  requirements: z.array(z.string().trim().min(1)).optional(),
+  policies: z.array(z.string().trim().min(1)).optional(),
+  returnPolicy: z.string().trim().max(1000).optional(),
+  spayNeuterPolicy: z.string().trim().max(1000).optional(),
+  followUpPolicy: z.string().trim().max(1000).optional(),
+});
+export type AdoptionPolicy = z.infer<typeof AdoptionPolicySchema>;
+
+// ----- Request shapes ----------------------------------------------------
+
+/**
+ * POST /api/v1/rescues — create a new rescue listing.
+ *
+ * Mirrors validateCreateRescue. Country has a sensible default in the
+ * model (`United Kingdom`), but the original validator made it required;
+ * we keep that contract here.
+ */
+export const RescueCreateRequestSchema = z.object({
+  name: NameSchema,
+  email: EmailSchema,
+  phone: UkPhoneNumberSchema.optional(),
+  address: AddressSchema,
+  city: CitySchema,
+  county: CountySchema.optional(),
+  postcode: UkPostcodeSchema,
+  country: CountrySchema,
+  website: WebsiteSchema.optional(),
+  description: DescriptionSchema.optional(),
+  mission: MissionSchema.optional(),
+  ein: EinSchema.optional(),
+  registrationNumber: RegistrationNumberSchema.optional(),
+  contactPerson: ContactNameSchema,
+  contactTitle: ContactTitleSchema.optional(),
+  contactEmail: EmailSchema.optional(),
+  contactPhone: UkPhoneNumberSchema.optional(),
+});
+export type RescueCreateRequest = z.infer<typeof RescueCreateRequestSchema>;
+
+/**
+ * PUT/PATCH /api/v1/rescues/:rescueId — same fields, all optional.
+ * Status moves through verifyRescue / rejectRescue / suspend flows
+ * rather than this generic update.
+ */
+export const RescueUpdateRequestSchema = RescueCreateRequestSchema.partial();
+export type RescueUpdateRequest = z.infer<typeof RescueUpdateRequestSchema>;
+
+/**
+ * GET /api/v1/rescues — search query.
+ */
+export const RescueSearchSortBySchema = z.enum(['name', 'createdAt', 'verifiedAt']);
+export type RescueSearchSortBy = z.infer<typeof RescueSearchSortBySchema>;
+
+export const RescueSearchQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  search: z.string().trim().max(100).optional(),
+  status: RescueStatusSchema.optional(),
+  location: z.string().trim().max(100).optional(),
+  sortBy: RescueSearchSortBySchema.optional(),
+  sortOrder: z.enum(['ASC', 'DESC']).optional(),
+});
+export type RescueSearchQuery = z.infer<typeof RescueSearchQuerySchema>;
+
+/**
+ * Staff invitation (POST /:rescueId/invitations) and add-staff
+ * (POST /:rescueId/staff).
+ */
+export const StaffInvitationRequestSchema = z.object({
+  email: EmailSchema,
+  title: ContactTitleSchema.optional(),
+});
+export type StaffInvitationRequest = z.infer<typeof StaffInvitationRequestSchema>;
+
+export const AddStaffMemberRequestSchema = z.object({
+  userId: z.string().min(1, 'User ID is required'),
+  title: ContactTitleSchema.optional(),
+});
+export type AddStaffMemberRequest = z.infer<typeof AddStaffMemberRequestSchema>;
+
+/**
+ * Verification / rejection / deletion bodies — all small.
+ */
+export const RescueVerificationRequestSchema = z.object({
+  notes: NotesSchema.optional(),
+});
+export type RescueVerificationRequest = z.infer<typeof RescueVerificationRequestSchema>;
+
+export const RescueRejectionRequestSchema = z.object({
+  reason: ReasonSchema.optional(),
+  notes: NotesSchema.optional(),
+});
+export type RescueRejectionRequest = z.infer<typeof RescueRejectionRequestSchema>;
+
+export const RescueDeletionRequestSchema = z.object({
+  reason: ReasonSchema.optional(),
+});
+export type RescueDeletionRequest = z.infer<typeof RescueDeletionRequestSchema>;
+
+/**
+ * POST /api/v1/rescues/bulk-update — admin bulk operation.
+ */
+export const RescueBulkActionSchema = z.enum(['approve', 'suspend', 'verify']);
+export type RescueBulkAction = z.infer<typeof RescueBulkActionSchema>;
+
+export const RescueBulkUpdateRequestSchema = z.object({
+  rescueIds: z
+    .array(z.string().uuid('Each rescue ID must be a UUID'))
+    .min(1, 'At least one rescue ID is required'),
+  action: RescueBulkActionSchema,
+  reason: ReasonSchema.optional(),
+});
+export type RescueBulkUpdateRequest = z.infer<typeof RescueBulkUpdateRequestSchema>;
+
+// ----- Read / model shape ------------------------------------------------
+
+export const RescueProfileSchema = z.object({
+  rescueId: RescueIdSchema,
+  name: NameSchema,
+  email: EmailSchema,
+  phone: UkPhoneNumberSchema.nullable().optional(),
+  address: AddressSchema,
+  city: CitySchema,
+  county: CountySchema.nullable().optional(),
+  postcode: UkPostcodeSchema,
+  country: CountrySchema,
+  website: WebsiteSchema.nullable().optional(),
+  description: DescriptionSchema.nullable().optional(),
+  mission: MissionSchema.nullable().optional(),
+  ein: EinSchema.nullable().optional(),
+  registrationNumber: RegistrationNumberSchema.nullable().optional(),
+  contactPerson: ContactNameSchema,
+  contactTitle: ContactTitleSchema.nullable().optional(),
+  contactEmail: EmailSchema.nullable().optional(),
+  contactPhone: UkPhoneNumberSchema.nullable().optional(),
+  status: RescueStatusSchema,
+  settings: z.record(z.string(), z.unknown()).optional(),
+  verifiedAt: z.coerce.date().nullable().optional(),
+  createdAt: z.coerce.date().optional(),
+  updatedAt: z.coerce.date().optional(),
+});
+export type RescueProfile = z.infer<typeof RescueProfileSchema>;
+
+/**
+ * Partial shape for the future Sequelize beforeValidate cross-check
+ * (parallel to UserModelShapeSchema / PetModelShapeSchema).
+ */
+export const RescueModelShapeSchema = RescueProfileSchema.partial();
+export type RescueModelShape = z.infer<typeof RescueModelShapeSchema>;

--- a/service.backend/src/routes/rescue.routes.ts
+++ b/service.backend/src/routes/rescue.routes.ts
@@ -1,193 +1,64 @@
 import { Router } from 'express';
-import { body, param, query } from 'express-validator';
+import { body, param } from 'express-validator';
+import { z } from 'zod';
+import {
+  AddStaffMemberRequestSchema,
+  AdoptionPolicySchema,
+  RescueBulkUpdateRequestSchema,
+  RescueCreateRequestSchema,
+  RescueDeletionRequestSchema,
+  RescueRejectionRequestSchema,
+  RescueSearchQuerySchema,
+  RescueUpdateRequestSchema,
+  RescueVerificationRequestSchema,
+  StaffInvitationRequestSchema,
+} from '@adopt-dont-shop/lib.validation';
 import { RescueController } from '../controllers/rescue.controller';
 import { QuestionController } from '../controllers/question.controller';
 import { authenticateToken } from '../middleware/auth';
 import { fieldMask, fieldWriteGuard } from '../middleware/field-permissions';
-import { isUKPostcode, isUKPhoneNumber } from '../utils/uk-validators-middleware';
+import { validateBody, validateParams, validateQuery } from '../middleware/zod-validate';
 import { requirePermission } from '../middleware/rbac';
 
 const router = Router();
 const rescueController = new RescueController();
 const questionController = new QuestionController();
 
-// Validation middleware
-const validateRescueId = param('rescueId').isUUID().withMessage('Invalid rescue ID format');
-const validateUserId = param('userId').notEmpty().withMessage('User ID is required');
+// Param schemas — kept here so the file is self-contained.
+const RescueIdParamSchema = z.object({
+  rescueId: z.string().uuid('Invalid rescue ID format'),
+});
+const RescueAndUserParamSchema = RescueIdParamSchema.extend({
+  userId: z.string().min(1, 'User ID is required'),
+});
 
-const validateCreateRescue = [
-  body('name').trim().isLength({ min: 2, max: 100 }).withMessage('Name must be 2-100 characters'),
-  body('email').isEmail().withMessage('Valid email is required'),
-  body('phone').optional().custom(isUKPhoneNumber).withMessage('Valid phone number required'),
-  body('address')
-    .trim()
-    .isLength({ min: 5, max: 255 })
-    .withMessage('Address must be 5-255 characters'),
-  body('city').trim().isLength({ min: 2, max: 100 }).withMessage('City must be 2-100 characters'),
-  body('county')
-    .optional()
-    .trim()
-    .isLength({ min: 2, max: 100 })
-    .withMessage('County must be 2-100 characters'),
-  body('postcode').trim().custom(isUKPostcode).withMessage('Please enter a valid UK postcode'),
-  body('country')
-    .trim()
-    .isLength({ min: 2, max: 100 })
-    .withMessage('Country must be 2-100 characters'),
-  body('website').optional().isURL().withMessage('Valid website URL required'),
-  body('description')
-    .optional()
-    .isLength({ max: 1000 })
-    .withMessage('Description must be max 1000 characters'),
-  body('mission')
-    .optional()
-    .isLength({ max: 500 })
-    .withMessage('Mission must be max 500 characters'),
-  body('ein').optional().isLength({ min: 9, max: 10 }).withMessage('EIN must be 9-10 characters'),
-  body('registrationNumber')
-    .optional()
-    .isLength({ max: 50 })
-    .withMessage('Registration number must be max 50 characters'),
-  body('contactPerson')
-    .trim()
-    .isLength({ min: 2, max: 100 })
-    .withMessage('Contact person must be 2-100 characters'),
-  body('contactTitle')
-    .optional()
-    .isLength({ max: 100 })
-    .withMessage('Contact title must be max 100 characters'),
-  body('contactEmail').optional().isEmail().withMessage('Valid contact email required'),
-  body('contactPhone')
-    .optional()
-    .custom(isUKPhoneNumber)
-    .withMessage('Valid contact phone required'),
-];
+const validateRescueId = validateParams(RescueIdParamSchema);
+const validateRescueAndUser = validateParams(RescueAndUserParamSchema);
 
-const validateUpdateRescue = [
-  body('name')
-    .optional()
-    .trim()
-    .isLength({ min: 2, max: 100 })
-    .withMessage('Name must be 2-100 characters'),
-  body('email').optional().isEmail().withMessage('Valid email is required'),
-  body('phone').optional().custom(isUKPhoneNumber).withMessage('Valid phone number required'),
-  body('address')
-    .optional()
-    .trim()
-    .isLength({ min: 5, max: 255 })
-    .withMessage('Address must be 5-255 characters'),
-  body('city')
-    .optional()
-    .trim()
-    .isLength({ min: 2, max: 100 })
-    .withMessage('City must be 2-100 characters'),
-  body('county')
-    .optional()
-    .trim()
-    .isLength({ min: 2, max: 100 })
-    .withMessage('County must be 2-100 characters'),
-  body('postcode')
-    .optional()
-    .trim()
-    .custom(isUKPostcode)
-    .withMessage('Please enter a valid UK postcode'),
-  body('country')
-    .optional()
-    .trim()
-    .isLength({ min: 2, max: 100 })
-    .withMessage('Country must be 2-100 characters'),
-  body('website').optional().isURL().withMessage('Valid website URL required'),
-  body('description')
-    .optional()
-    .isLength({ max: 1000 })
-    .withMessage('Description must be max 1000 characters'),
-  body('mission')
-    .optional()
-    .isLength({ max: 500 })
-    .withMessage('Mission must be max 500 characters'),
-  body('ein').optional().isLength({ min: 9, max: 10 }).withMessage('EIN must be 9-10 characters'),
-  body('registrationNumber')
-    .optional()
-    .isLength({ max: 50 })
-    .withMessage('Registration number must be max 50 characters'),
-  body('contactPerson')
-    .optional()
-    .trim()
-    .isLength({ min: 2, max: 100 })
-    .withMessage('Contact person must be 2-100 characters'),
-  body('contactTitle')
-    .optional()
-    .isLength({ max: 100 })
-    .withMessage('Contact title must be max 100 characters'),
-  body('contactEmail').optional().isEmail().withMessage('Valid contact email required'),
-  body('contactPhone')
-    .optional()
-    .custom(isUKPhoneNumber)
-    .withMessage('Valid contact phone required'),
-];
+// Body / query validators — backed by canonical Zod schemas in
+// @adopt-dont-shop/lib.validation. Same rules, same error response
+// shape (see middleware/zod-validate), one source of truth.
+const validateCreateRescue = validateBody(RescueCreateRequestSchema);
+const validateUpdateRescue = validateBody(RescueUpdateRequestSchema);
+const validateSearchQuery = validateQuery(RescueSearchQuerySchema);
+const validateAddStaff = validateBody(AddStaffMemberRequestSchema);
+const validateInviteStaff = validateBody(StaffInvitationRequestSchema);
+const validateVerification = validateBody(RescueVerificationRequestSchema);
+const validateRejection = validateBody(RescueRejectionRequestSchema);
+const validateDeletion = validateBody(RescueDeletionRequestSchema);
+const validateAdoptionPolicy = validateBody(AdoptionPolicySchema);
+const validateBulkUpdate = validateBody(RescueBulkUpdateRequestSchema);
 
-const validateSearchQuery = [
-  query('page').optional().isInt({ min: 1 }).withMessage('Page must be a positive integer'),
-  query('limit').optional().isInt({ min: 1, max: 100 }).withMessage('Limit must be 1-100'),
-  query('search')
-    .optional()
-    .trim()
-    .isLength({ max: 100 })
-    .withMessage('Search term max 100 characters'),
-  query('status')
-    .optional()
-    .isIn(['pending', 'verified', 'suspended', 'inactive'])
-    .withMessage('Invalid status'),
-  query('location')
-    .optional()
-    .trim()
-    .isLength({ max: 100 })
-    .withMessage('Location max 100 characters'),
-  query('sortBy')
-    .optional()
-    .isIn(['name', 'createdAt', 'verifiedAt'])
-    .withMessage('Invalid sort field'),
-  query('sortOrder').optional().isIn(['ASC', 'DESC']).withMessage('Sort order must be ASC or DESC'),
-];
-
-const validateStaffMember = [
-  body('userId').notEmpty().withMessage('User ID is required'),
-  body('title')
-    .optional()
-    .trim()
-    .isLength({ max: 100 })
-    .withMessage('Title must be max 100 characters'),
-];
-
-const validateVerification = [
-  body('notes').optional().isLength({ max: 500 }).withMessage('Notes must be max 500 characters'),
-];
-
-const validateRejection = [
-  body('reason').optional().isLength({ max: 500 }).withMessage('Reason must be max 500 characters'),
-  body('notes').optional().isLength({ max: 500 }).withMessage('Notes must be max 500 characters'),
-];
-const validateDeletion = [
-  body('reason').optional().isLength({ max: 500 }).withMessage('Reason must be max 500 characters'),
-];
-
-const validateSendEmail = [
-  body('templateId')
-    .optional()
-    .trim()
-    .isLength({ min: 1, max: 100 })
-    .withMessage('Template ID must be max 100 characters'),
-  body('subject')
-    .optional()
-    .trim()
-    .isLength({ min: 1, max: 200 })
-    .withMessage('Subject must be max 200 characters'),
-  body('body')
-    .optional()
-    .trim()
-    .isLength({ min: 1, max: 5000 })
-    .withMessage('Body must be max 5000 characters'),
-];
+// Send-email body — kept here for now since EmailTemplate-shaped payloads
+// haven't migrated to lib.validation yet; the rest of the rescue surface
+// is already on Zod above.
+const validateSendEmail = validateBody(
+  z.object({
+    templateId: z.string().trim().min(1).max(100).optional(),
+    subject: z.string().trim().min(1).max(200).optional(),
+    body: z.string().trim().min(1).max(5000).optional(),
+  })
+);
 
 // Public routes (no authentication required)
 
@@ -941,30 +812,22 @@ router.get(
 router.post(
   '/:rescueId/staff',
   validateRescueId,
-  validateStaffMember,
+  validateAddStaff,
   requirePermission('staff.create'),
   rescueController.addStaffMember
 );
 
 router.put(
   '/:rescueId/staff/:userId',
-  validateRescueId,
-  validateUserId,
-  [
-    body('title')
-      .optional()
-      .trim()
-      .isLength({ max: 100 })
-      .withMessage('Title must be max 100 characters'),
-  ],
+  validateRescueAndUser,
+  validateBody(z.object({ title: z.string().trim().max(100).optional() })),
   requirePermission('staff.update'),
   rescueController.updateStaffMember
 );
 
 router.delete(
   '/:rescueId/staff/:userId',
-  validateRescueId,
-  validateUserId,
+  validateRescueAndUser,
   requirePermission('staff.delete'),
   rescueController.removeStaffMember
 );
@@ -973,14 +836,7 @@ router.delete(
 router.post(
   '/:rescueId/invitations',
   validateRescueId,
-  [
-    body('email').isEmail().withMessage('Valid email is required'),
-    body('title')
-      .optional()
-      .trim()
-      .isLength({ max: 100 })
-      .withMessage('Title must be max 100 characters'),
-  ],
+  validateInviteStaff,
   requirePermission('staff.create'),
   rescueController.inviteStaffMember
 );
@@ -1012,39 +868,7 @@ router.get(
 router.put(
   '/:rescueId/adoption-policies',
   validateRescueId,
-  [
-    body('requireHomeVisit').isBoolean().withMessage('requireHomeVisit must be a boolean'),
-    body('requireReferences').isBoolean().withMessage('requireReferences must be a boolean'),
-    body('minimumReferenceCount')
-      .isInt({ min: 0, max: 10 })
-      .withMessage('minimumReferenceCount must be 0-10'),
-    body('requireVeterinarianReference')
-      .isBoolean()
-      .withMessage('requireVeterinarianReference must be a boolean'),
-    body('adoptionFeeRange.min')
-      .isFloat({ min: 0 })
-      .withMessage('Minimum fee must be 0 or greater'),
-    body('adoptionFeeRange.max')
-      .isFloat({ min: 0 })
-      .withMessage('Maximum fee must be 0 or greater'),
-    body('requirements').isArray().withMessage('requirements must be an array'),
-    body('policies').isArray().withMessage('policies must be an array'),
-    body('returnPolicy')
-      .optional()
-      .isString()
-      .isLength({ max: 1000 })
-      .withMessage('returnPolicy must be max 1000 characters'),
-    body('spayNeuterPolicy')
-      .optional()
-      .isString()
-      .isLength({ max: 1000 })
-      .withMessage('spayNeuterPolicy must be max 1000 characters'),
-    body('followUpPolicy')
-      .optional()
-      .isString()
-      .isLength({ max: 1000 })
-      .withMessage('followUpPolicy must be max 1000 characters'),
-  ],
+  validateAdoptionPolicy,
   requirePermission('rescues.update'),
   rescueController.updateAdoptionPolicies
 );
@@ -1087,14 +911,7 @@ router.post(
 router.post(
   '/bulk-update',
   authenticateToken,
-  [
-    body('rescueIds').isArray({ min: 1 }).withMessage('rescueIds must be a non-empty array'),
-    body('rescueIds.*').isUUID().withMessage('Each rescue ID must be a valid UUID'),
-    body('action')
-      .isIn(['approve', 'suspend', 'verify'])
-      .withMessage('Action must be approve, suspend, or verify'),
-    body('reason').optional().isString().isLength({ max: 500 }),
-  ],
+  validateBulkUpdate,
   requirePermission('rescues.verify'),
   rescueController.bulkUpdateRescues
 );


### PR DESCRIPTION
## Summary

Continuing the Zod schema-first rollout (plan 2.3). User (slice 6) and Pet (slice 7) shipped; Rescue is next. Add canonical Rescue schemas to `lib.validation` and wire them into `rescue.routes`, replacing the duplicated express-validator chains.

## What's new in `lib.validation`

`lib.validation/src/schemas/rescue.ts`:

- **`RescueStatusSchema`** — `pending` / `verified` / `suspended` / `inactive`, matching the Rescue.status ENUM column.
- **`RescueIdSchema`** (branded via `lib.types`) — moved here from `pet.ts` where it was a transitional export; Pet keeps an inline brand for the FK.
- **`UkPostcodeSchema`** + **`UkPhoneNumberSchema`** — mirror the `isUKPostcode` / `isUKPhoneNumber` middleware so frontend forms and backend agree on what counts as valid.
- **Reusable primitives** — name / address / city / contact / EIN bounds matching the existing rescue.routes express-validator chains.
- **`AdoptionPolicySchema`** — the Rescue.settings.adoptionPolicies block, including a `refine()` so `adoptionFeeRange.max ≥ min`.
- **Request shapes** — `RescueCreateRequestSchema`, `RescueUpdateRequestSchema`, `RescueSearchQuerySchema`, `StaffInvitationRequestSchema`, `AddStaffMemberRequestSchema`, Verification / Rejection / Deletion bodies, `RescueBulkUpdateRequestSchema`.
- **Read shape** — `RescueProfileSchema` and partial `RescueModelShapeSchema` (parallel to `UserModelShapeSchema` / `PetModelShapeSchema`).

## Wiring (service.backend)

- `rescue.routes`: every user-facing validator (`validateCreateRescue` / `validateUpdateRescue` / `validateSearchQuery` / `validateStaffMember` / `validateVerification` / `validateRejection` / `validateDeletion` and the inline staff-invitation / adoption-policies / bulk-update blocks) now uses `validateBody` / `validateQuery` / `validateParams` driven by the lib schemas.
- `/:rescueId/staff/:userId` routes get a single `validateRescueAndUser` param check instead of two stacked `param()` chains.
- `validateSendEmail` migrated to a Zod inline shape (kept local — EmailTemplate-shaped payloads haven't migrated yet).

## Pet schema cleanup

`pet.ts` no longer re-exports `RescueIdSchema` (it now lives only in `rescue.ts`). `PetProfileSchema.rescueId` uses an inline branded-string transform so we don't pull `rescue.ts` in as a runtime dep.

## Test plan

- [x] `lib.validation`: 85 tests / 4 files (30 new Rescue cases — UK postcode + phone normalization, EIN bounds, adoption-policy refine, query coercion, bulk-op constraints)
- [x] `service.backend`: 1343 passed / 4 skipped, 0 failed
- [x] `npm run lint` (lib.validation, service.backend): 0 errors
- [x] `npx tsc --noEmit` — only the two pre-existing `super_admin` errors on main (`field-permissions.ts:94`, `field-permissions.routes.ts:144`); none introduced by this slice
- [ ] Smoke-test against dev: create / update a rescue, search with mixed query params, invite a staff member, verify / reject / suspend, run a bulk update — confirm error responses match the prior shape

## Out of scope (follow-ups)

- Frontend form migration — `app.rescue/RescueProfileForm` still rolls its own validation; will move to `RescueCreateRequestSchema` in its own slice.
- Application schemas — final Phase 3 entity, next slice.
- The `super_admin` UserRole gap is unrelated to this rollout.

https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_