### PR TITLE
Phase 4 (slice 10): Pet.birthDate + isBirthDateEstimate

### DIFF
--- a/lib.validation/src/schemas/__tests__/pet.test.ts
+++ b/lib.validation/src/schemas/__tests__/pet.test.ts
@@ -82,6 +82,47 @@ describe('Pet schemas', () => {
     });
   });
 
+  describe('birthDate', () => {
+    it('coerces ISO date strings to Date in PetCreateRequestSchema', () => {
+      const parsed = PetCreateRequestSchema.parse({
+        name: 'Buddy',
+        type: 'dog',
+        gender: 'male',
+        size: 'large',
+        ageGroup: 'adult',
+        birthDate: '2024-04-15',
+      });
+      expect(parsed.birthDate).toBeInstanceOf(Date);
+    });
+
+    it('rejects a future birthDate', () => {
+      const future = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+      expect(() =>
+        PetCreateRequestSchema.parse({
+          name: 'Buddy',
+          type: 'dog',
+          gender: 'male',
+          size: 'large',
+          ageGroup: 'adult',
+          birthDate: future,
+        })
+      ).toThrow(/future/);
+    });
+
+    it('accepts isBirthDateEstimate as a boolean flag', () => {
+      const parsed = PetCreateRequestSchema.parse({
+        name: 'Buddy',
+        type: 'dog',
+        gender: 'male',
+        size: 'large',
+        ageGroup: 'adult',
+        birthDate: '2024-01-01',
+        isBirthDateEstimate: true,
+      });
+      expect(parsed.isBirthDateEstimate).toBe(true);
+    });
+  });
+
   describe('PetStatusUpdateRequestSchema', () => {
     it('requires status; reason and notes are optional', () => {
       const parsed = PetStatusUpdateRequestSchema.parse({ status: 'pending' });

--- a/lib.validation/src/schemas/pet.ts
+++ b/lib.validation/src/schemas/pet.ts
@@ -93,6 +93,16 @@ const WeightKgSchema = z.coerce.number().min(0.1).max(200);
 const AdoptionFeeSchema = z.coerce.number().min(0).max(10_000);
 
 /**
+ * Birth date — coerce-on-input (accepts ISO strings or Date), refuse
+ * future dates. Pet.birthDate is DATEONLY in Postgres, so the time-of-
+ * day component is meaningless; downstream code treats it as a calendar
+ * date.
+ */
+const BirthDateSchema = z.coerce
+  .date()
+  .refine((d) => d.getTime() <= Date.now(), 'Birth date cannot be in the future');
+
+/**
  * Image / video shapes — kept JSON-style for now to avoid churning the
  * Pet.images / Pet.videos columns. The plan (2.1) will move these into
  * dedicated tables; the schema rebases at that point.
@@ -136,6 +146,12 @@ export const PetCreateRequestSchema = z.object({
   ageGroup: AgeGroupSchema,
   ageYears: AgeYearsSchema.optional(),
   ageMonths: AgeMonthsSchema.optional(),
+  // birthDate is the canonical age input — when set, the model's
+  // getAgeDisplay() / getAgeInMonths() prefer it over ageYears/ageMonths
+  // so age doesn't drift over time. Many rescues only have an estimate;
+  // isBirthDateEstimate records that.
+  birthDate: BirthDateSchema.optional(),
+  isBirthDateEstimate: z.boolean().optional(),
   weightKg: WeightKgSchema.optional(),
   shortDescription: ShortDescriptionSchema.optional(),
   longDescription: LongDescriptionSchema.optional(),
@@ -288,6 +304,8 @@ export const PetProfileSchema = z.object({
   status: PetStatusSchema,
   ageYears: AgeYearsSchema.nullable().optional(),
   ageMonths: AgeMonthsSchema.nullable().optional(),
+  birthDate: BirthDateSchema.nullable().optional(),
+  isBirthDateEstimate: z.boolean().optional(),
   weightKg: WeightKgSchema.nullable().optional(),
   shortDescription: ShortDescriptionSchema.nullable().optional(),
   longDescription: LongDescriptionSchema.nullable().optional(),

--- a/service.backend/src/__tests__/models/Pet.birthDate.test.ts
+++ b/service.backend/src/__tests__/models/Pet.birthDate.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import sequelize from '../../sequelize';
+import '../../models/index';
+import Pet from '../../models/Pet';
+import Rescue from '../../models/Rescue';
+
+/**
+ * Pet.birthDate + isBirthDateEstimate (plan 3.1).
+ *
+ * The point of birthDate is that age computed from a fixed date doesn't
+ * drift over time the way ageYears/ageMonths do. These tests pin down the
+ * resulting display behaviour (preference, estimate prefix, fallback to
+ * legacy fields, future-date rejection).
+ *
+ * Pets are inserted via raw queryInterface.bulkInsert to side-step the
+ * SQLite/Postgres array column type mismatch (Pet.tags is STRING in
+ * tests but ARRAY in prod) — same workaround used elsewhere.
+ */
+describe('Pet.birthDate + getAgeDisplay', () => {
+  let rescueId: string;
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    const rescue = await Rescue.create({
+      name: 'Test Rescue',
+      email: 'r@test.local',
+      address: '1 Lane',
+      city: 'Town',
+      postcode: 'AB1 2CD',
+      country: 'GB',
+      contactPerson: 'X',
+      status: 'pending',
+      isDeleted: false,
+    } as never);
+    rescueId = rescue.rescueId;
+  });
+
+  let counter = 0;
+  const insertPet = async (overrides: Record<string, unknown> = {}) => {
+    counter += 1;
+    const petId = `birthdate-pet-${counter}`;
+    await sequelize.getQueryInterface().bulkInsert('pets', [
+      {
+        pet_id: petId,
+        name: 'Buddy',
+        rescue_id: rescueId,
+        type: 'dog',
+        status: 'available',
+        gender: 'male',
+        size: 'medium',
+        age_group: 'adult',
+        adoption_fee: 0,
+        archived: false,
+        featured: false,
+        priority_listing: false,
+        special_needs: false,
+        house_trained: false,
+        view_count: 0,
+        favorite_count: 0,
+        application_count: 0,
+        is_birth_date_estimate: false,
+        images: '[]',
+        videos: '[]',
+        tags: '[]',
+        created_at: new Date(),
+        updated_at: new Date(),
+        version: 0,
+        ...overrides,
+      },
+    ]);
+    const pet = await Pet.findByPk(petId);
+    if (!pet) {
+      throw new Error('failed to seed pet');
+    }
+    return pet;
+  };
+
+  it('prefers birthDate over ageYears/ageMonths when both are set', async () => {
+    const now = new Date('2026-04-15');
+    const pet = await insertPet({
+      age_years: 8,
+      age_months: 0,
+      birth_date: '2024-04-15',
+    });
+    // 2024-04-15 → 2026-04-15 = exactly 24 months. The legacy 8-year
+    // value should be ignored.
+    expect(pet.getAgeInMonths(now)).toBe(24);
+    expect(pet.getAgeDisplay(now)).toBe('2 years');
+  });
+
+  it('prefixes the estimate marker when isBirthDateEstimate is true', async () => {
+    const now = new Date('2026-04-15');
+    const pet = await insertPet({
+      birth_date: '2025-01-15',
+      is_birth_date_estimate: true,
+    });
+    expect(pet.getAgeDisplay(now)).toBe('~1 year, 3 months');
+  });
+
+  it('falls back to ageYears/ageMonths when birthDate is null', async () => {
+    const pet = await insertPet({
+      age_years: 3,
+      age_months: 6,
+      birth_date: null,
+    });
+    expect(pet.getAgeDisplay()).toBe('3 years, 6 months');
+  });
+
+  it('returns "Age unknown" when nothing is set', async () => {
+    const pet = await insertPet({
+      age_years: null,
+      age_months: null,
+      birth_date: null,
+    });
+    expect(pet.getAgeInMonths()).toBeNull();
+    expect(pet.getAgeDisplay()).toBe('Age unknown');
+  });
+
+  it('handles a birthDate within the last month with the <1 month string', async () => {
+    const now = new Date('2026-04-25');
+    const pet = await insertPet({ birth_date: '2026-04-10' });
+    expect(pet.getAgeInMonths(now)).toBe(0);
+    expect(pet.getAgeDisplay(now)).toBe('<1 month');
+  });
+
+  it('rejects a future birth date via the model validator', async () => {
+    const future = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const pet = await insertPet({});
+    await expect(pet.update({ birthDate: future } as never)).rejects.toThrow(
+      /Birth date cannot be in the future/
+    );
+  });
+});

--- a/service.backend/src/models/Pet.ts
+++ b/service.backend/src/models/Pet.ts
@@ -101,6 +101,14 @@ export interface PetAttributes {
   longDescription?: string | null;
   ageYears?: number | null;
   ageMonths?: number | null;
+  /**
+   * Optional date of birth — preferred over ageYears/ageMonths when set,
+   * since age computed from a fixed date doesn't drift over time. Many
+   * rescues only have an estimate, in which case isBirthDateEstimate
+   * records that the value is approximate.
+   */
+  birthDate?: Date | null;
+  isBirthDateEstimate?: boolean;
   ageGroup: AgeGroup;
   gender: Gender;
   status: PetStatus;
@@ -195,6 +203,8 @@ class Pet extends Model<PetAttributes, PetCreationAttributes> implements PetAttr
   public longDescription!: string | null;
   public ageYears!: number | null;
   public ageMonths!: number | null;
+  public birthDate!: Date | null;
+  public isBirthDateEstimate!: boolean;
   public ageGroup!: AgeGroup;
   public gender!: Gender;
   public status!: PetStatus;
@@ -276,7 +286,22 @@ class Pet extends Model<PetAttributes, PetCreationAttributes> implements PetAttr
     return primaryImage?.url || this.images?.[0]?.url || null;
   }
 
-  public getAgeInMonths(): number | null {
+  public getAgeInMonths(now: Date = new Date()): number | null {
+    // Prefer birthDate when set — age computed from a fixed date doesn't
+    // drift over time. Falls back to the legacy ageYears/ageMonths fields
+    // for rescues that haven't backfilled birthDate yet.
+    //
+    // DATEONLY columns surface as 'YYYY-MM-DD' strings on Postgres and
+    // sometimes as Date on SQLite; normalize either form to Date here.
+    if (this.birthDate) {
+      const birth =
+        this.birthDate instanceof Date ? this.birthDate : new Date(this.birthDate as string);
+      const months =
+        (now.getFullYear() - birth.getFullYear()) * 12 +
+        (now.getMonth() - birth.getMonth()) -
+        (now.getDate() < birth.getDate() ? 1 : 0);
+      return Math.max(0, months);
+    }
     if (this.ageYears !== null && this.ageMonths !== null) {
       return this.ageYears * 12 + this.ageMonths;
     }
@@ -286,17 +311,27 @@ class Pet extends Model<PetAttributes, PetCreationAttributes> implements PetAttr
     return this.ageMonths;
   }
 
-  public getAgeDisplay(): string {
-    if (this.ageYears && this.ageMonths) {
-      return `${this.ageYears} years, ${this.ageMonths} months`;
+  public getAgeDisplay(now: Date = new Date()): string {
+    const totalMonths = this.getAgeInMonths(now);
+    if (totalMonths === null) {
+      return 'Age unknown';
     }
-    if (this.ageYears) {
-      return this.ageYears === 1 ? '1 year' : `${this.ageYears} years`;
+    const years = Math.floor(totalMonths / 12);
+    const months = totalMonths % 12;
+    const prefix = this.isBirthDateEstimate ? '~' : '';
+    if (years > 0 && months > 0) {
+      return `${prefix}${years} ${years === 1 ? 'year' : 'years'}, ${months} ${
+        months === 1 ? 'month' : 'months'
+      }`;
     }
-    if (this.ageMonths) {
-      return this.ageMonths === 1 ? '1 month' : `${this.ageMonths} months`;
+    if (years > 0) {
+      return `${prefix}${years} ${years === 1 ? 'year' : 'years'}`;
     }
-    return 'Age unknown';
+    if (months > 0) {
+      return `${prefix}${months} ${months === 1 ? 'month' : 'months'}`;
+    }
+    // Newborn / under one month
+    return `${prefix}<1 month`;
   }
 
   public async incrementViewCount(): Promise<void> {
@@ -410,6 +445,28 @@ Pet.init(
         min: 0,
         max: 11,
       },
+    },
+    birthDate: {
+      // DATEONLY: a calendar date with no time-of-day component. Pets
+      // don't have a meaningful birth time, and storing one would imply
+      // a precision the data doesn't have.
+      type: DataTypes.DATEONLY,
+      allowNull: true,
+      field: 'birth_date',
+      validate: {
+        isDate: true,
+        isNotInFuture(value: string | null) {
+          if (value && new Date(value) > new Date()) {
+            throw new Error('Birth date cannot be in the future');
+          }
+        },
+      },
+    },
+    isBirthDateEstimate: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      field: 'is_birth_date_estimate',
+      defaultValue: false,
     },
     ageGroup: {
       type: DataTypes.ENUM(...Object.values(AgeGroup)),


### PR DESCRIPTION
## Summary

First Phase 4 slice. Plan 3.1: **store the date, compute the age** — instead of storing the age and watching it drift. A pet entered as "3 years old" in 2026 is still "3 years old" in 2029 unless someone re-enters it. `birthDate` turns age into a derived value that stays accurate.

## Model changes (`service.backend/src/models/Pet.ts`)

- **`birthDate: DATEONLY`** (nullable) and **`isBirthDateEstimate: BOOLEAN`** (default `false`). `DATEONLY` because pets don't have a meaningful birth time — storing one would imply precision the data doesn't have.
- Validator on `birthDate` rejects future dates.
- `getAgeInMonths(now?)` and `getAgeDisplay(now?)` **prefer** `birthDate` when set; the legacy `ageYears` / `ageMonths` fields stay as a fallback so existing data keeps working until a backfill.
- **`~` prefix** on the display string when `isBirthDateEstimate` is true, signalling approximation (`~1 year, 3 months`).
- Edge case fixed: a `birthDate` within the same calendar month as `now` now returns `<1 month` rather than the prior empty fallthrough.

## Schema changes (`lib.validation/src/schemas/pet.ts`)

- New `BirthDateSchema` primitive — `z.coerce.date()` with a `refine()` that rejects future dates (mirrors the model validator).
- `birthDate` + `isBirthDateEstimate` added to `PetCreateRequestSchema` and `PetProfileSchema`. `PetUpdateRequestSchema` picks them up via the existing `.partial()` pattern.

## Test plan

- [x] **6 new model tests** — preference over legacy fields, estimate prefix, fallback when `birthDate` is null, "Age unknown" path, `<1 month` boundary, future-date rejection
- [x] **3 new schema tests** — string→Date coercion, future rejection, `isBirthDateEstimate` boolean acceptance
- [x] `service.backend` full suite: **1349 passed / 4 skipped, 0 failed**
- [x] `lib.validation` full suite: **118 passed**
- [x] `npm run lint` (lib.validation, service.backend): 0 errors
- [x] `npx tsc --noEmit` — only the two pre-existing `super_admin` errors on main; none introduced here
- [ ] Smoke-test against dev: create a pet with `birthDate`, verify `getAgeDisplay()` shows the prefix when `isBirthDateEstimate` is true

## Out of scope (follow-up)

- **Backfilling existing rows** from `ageYears` / `ageMonths`. The fallback behaviour means existing pets keep displaying correctly while new listings adopt `birthDate`.
- **Computing `ageGroup` from `birthDate`** (today still set explicitly by the rescue). Worth doing once we have a clean rollover dataset.

https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_