### PR TITLE
Phase 4 (slice 12): unify soft-delete on paranoid

### DIFF
--- a/service.backend/src/__tests__/models/ApplicationStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/ApplicationStatusTransition.test.ts
@@ -45,7 +45,6 @@ describe('ApplicationStatusTransition', () => {
       country: 'GB',
       contactPerson: 'X',
       status: 'pending',
-      isDeleted: false,
     } as never);
     rescueId = rescue.rescueId;
     // Insert Pet via raw SQL to avoid the array-column SQLite vs Postgres

--- a/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
@@ -38,7 +38,6 @@ describe('HomeVisitStatusTransition', () => {
       country: 'GB',
       contactPerson: 'X',
       status: 'pending',
-      isDeleted: false,
     } as never);
     rescueId = rescue.rescueId;
 

--- a/service.backend/src/__tests__/models/Pet.birthDate.test.ts
+++ b/service.backend/src/__tests__/models/Pet.birthDate.test.ts
@@ -30,7 +30,6 @@ describe('Pet.birthDate + getAgeDisplay', () => {
       country: 'GB',
       contactPerson: 'X',
       status: 'pending',
-      isDeleted: false,
     } as never);
     rescueId = rescue.rescueId;
   });

--- a/service.backend/src/__tests__/models/Pet.money.test.ts
+++ b/service.backend/src/__tests__/models/Pet.money.test.ts
@@ -23,7 +23,6 @@ describe('Pet.adoptionFee Money columns', () => {
       country: 'GB',
       contactPerson: 'X',
       status: 'pending',
-      isDeleted: false,
     } as never);
     rescueId = rescue.rescueId;
   });

--- a/service.backend/src/__tests__/models/PetStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/PetStatusTransition.test.ts
@@ -27,7 +27,6 @@ describe('PetStatusTransition', () => {
       country: 'GB',
       contactPerson: 'X',
       status: 'pending',
-      isDeleted: false,
     } as never);
     rescueId = rescue.rescueId;
 

--- a/service.backend/src/__tests__/models/standards.test.ts
+++ b/service.backend/src/__tests__/models/standards.test.ts
@@ -117,15 +117,9 @@ describe('Model Standards', () => {
   });
 
   describe('soft-delete consistency', () => {
-    it('models that use paranoid do not also define a manual isDeleted column', () => {
+    it('no model carries a manual isDeleted column alongside paranoid', () => {
       const failures: string[] = [];
-      // Legacy models still carry manual isDeleted columns alongside the global
-      // paranoid default. Cleanup is tracked as a Phase 3 item.
-      const LEGACY_MANUAL_SOFT_DELETE = new Set(['Rescue', 'StaffMember']);
       Object.values(sequelize.models).forEach(model => {
-        if (LEGACY_MANUAL_SOFT_DELETE.has(model.name)) {
-          return;
-        }
         const opts = (model as unknown as { options: { paranoid?: boolean } }).options;
         const attrs = model.getAttributes() as Record<string, ModelAttribute>;
         if (opts.paranoid && 'isDeleted' in attrs) {

--- a/service.backend/src/__tests__/services/pet.service.test.ts
+++ b/service.backend/src/__tests__/services/pet.service.test.ts
@@ -71,7 +71,6 @@ describe('PetService', () => {
       contactPerson: 'Test Contact',
       status: 'verified',
       country: 'United Kingdom',
-      isDeleted: false,
     });
   });
 

--- a/service.backend/src/__tests__/services/question.service.test.ts
+++ b/service.backend/src/__tests__/services/question.service.test.ts
@@ -37,7 +37,6 @@ const createRescue = async (rescueId: string) => {
     country: 'UK',
     contactPerson: 'Test Contact',
     status: 'pending',
-    isDeleted: false,
   });
 };
 

--- a/service.backend/src/__tests__/services/rescue-business-logic.test.ts
+++ b/service.backend/src/__tests__/services/rescue-business-logic.test.ts
@@ -63,15 +63,15 @@ describe('RescueService - Business Logic Tests', () => {
     verifiedAt: null as Date | null,
     verifiedBy: null as string | null,
     settings: {},
-    isDeleted: false,
     deletedAt: null as Date | null,
-    deletedBy: null as string | null,
     createdAt: new Date(),
     updatedAt: new Date(),
     update: vi.fn().mockImplementation(function (this: unknown, data: unknown) {
       Object.assign(this, data);
       return Promise.resolve(this);
     }),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
     save: vi.fn().mockResolvedValue(undefined),
     toJSON: vi.fn().mockReturnThis(),
     sequelize: {
@@ -103,9 +103,7 @@ describe('RescueService - Business Logic Tests', () => {
     user_id: mockUserId,
     title: 'Coordinator',
     isVerified: false,
-    isDeleted: false,
     deletedAt: null as Date | null,
-    deletedBy: null as string | null,
     addedBy: mockUserId,
     addedAt: new Date(),
     user: createMockUser(),
@@ -113,6 +111,8 @@ describe('RescueService - Business Logic Tests', () => {
       Object.assign(this, data);
       return Promise.resolve(this);
     }),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
     toJSON: vi.fn().mockReturnThis(),
     ...overrides,
   });
@@ -171,12 +171,12 @@ describe('RescueService - Business Logic Tests', () => {
       // When: Creating a new rescue
       const result = await RescueService.createRescue(rescueData, mockUserId);
 
-      // Then: Rescue is created with pending status
+      // Then: Rescue is created with pending status. paranoid soft-delete
+      // is the model default; no isDeleted column on the create payload.
       expect(MockedRescue.create).toHaveBeenCalledWith(
         expect.objectContaining({
           ...rescueData,
           status: 'pending',
-          isDeleted: false,
         }),
         { transaction: mockTransaction }
       );
@@ -407,7 +407,6 @@ describe('RescueService - Business Logic Tests', () => {
           userId: mockUserId,
           title: 'Volunteer Coordinator',
           isVerified: false,
-          isDeleted: false,
         }),
         { transaction: mockTransaction }
       );
@@ -425,7 +424,7 @@ describe('RescueService - Business Logic Tests', () => {
       // Given: User is already an active staff member
       const mockRescue = createMockRescue();
       const mockUser = createMockUser();
-      const existingStaff = createMockStaffMember({ isDeleted: false });
+      const existingStaff = createMockStaffMember();
 
       const mockTransaction = {
         commit: vi.fn().mockResolvedValue(undefined),
@@ -452,9 +451,9 @@ describe('RescueService - Business Logic Tests', () => {
       const mockUser = createMockUser();
       const mockRole = createMockRole();
       const softDeletedStaff = createMockStaffMember({
-        isDeleted: true,
         deletedAt: new Date(),
         isVerified: true, // Was previously verified
+        restore: vi.fn().mockResolvedValue(undefined),
       });
 
       const mockTransaction = {
@@ -479,11 +478,13 @@ describe('RescueService - Business Logic Tests', () => {
       // When: Re-adding the staff member
       await RescueService.addStaffMember(mockRescueId, mockUserId, 'Manager', mockUserId);
 
-      // Then: Staff member is restored with verification status preserved
+      // Then: Staff member is restored (paranoid restore() clears
+      // deletedAt) with verification status preserved.
+      expect(softDeletedStaff.restore).toHaveBeenCalledWith({
+        transaction: mockTransaction,
+      });
       expect(softDeletedStaff.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          isDeleted: false,
-          deletedAt: undefined,
           isVerified: true, // Verification status preserved
           title: 'Manager',
         }),
@@ -494,7 +495,7 @@ describe('RescueService - Business Logic Tests', () => {
 
     it('should soft delete staff member on removal', async () => {
       // Given: An active staff member
-      const mockStaffMember = createMockStaffMember({ isDeleted: false });
+      const mockStaffMember = createMockStaffMember();
 
       const mockTransaction = {
         commit: vi.fn().mockResolvedValue(undefined),
@@ -509,15 +510,10 @@ describe('RescueService - Business Logic Tests', () => {
       // When: Removing the staff member
       await RescueService.removeStaffMember(mockRescueId, mockUserId, mockUserId);
 
-      // Then: Staff member is soft deleted
-      expect(mockStaffMember.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isDeleted: true,
-          deletedAt: expect.any(Date),
-          deletedBy: mockUserId,
-        }),
-        { transaction: mockTransaction }
-      );
+      // Then: Staff member is soft deleted via paranoid destroy().
+      expect(mockStaffMember.destroy).toHaveBeenCalledWith({
+        transaction: mockTransaction,
+      });
       expect(mockTransaction.commit).toHaveBeenCalled();
     });
 
@@ -653,8 +649,8 @@ describe('RescueService - Business Logic Tests', () => {
 
   describe('Soft Delete Functionality', () => {
     it('should soft delete rescue', async () => {
-      // Given: An active rescue
-      const mockRescue = createMockRescue({ isDeleted: false });
+      // Given: An active rescue (deletedAt is null while live).
+      const mockRescue = createMockRescue({ deletedAt: null });
 
       const mockTransaction = {
         commit: vi.fn().mockResolvedValue(undefined),
@@ -669,21 +665,16 @@ describe('RescueService - Business Logic Tests', () => {
       // When: Deleting the rescue
       await RescueService.deleteRescue(mockRescueId, mockUserId, 'Policy violation');
 
-      // Then: Rescue is soft deleted
-      expect(mockRescue.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isDeleted: true,
-          deletedAt: expect.any(Date),
-          deletedBy: mockUserId,
-        }),
-        { transaction: mockTransaction }
-      );
+      // Then: Rescue is soft deleted via paranoid destroy().
+      expect(mockRescue.destroy).toHaveBeenCalledWith({
+        transaction: mockTransaction,
+      });
       expect(mockTransaction.commit).toHaveBeenCalled();
     });
 
     it('should prevent soft deleting already deleted rescue', async () => {
-      // Given: An already deleted rescue
-      const mockRescue = createMockRescue({ isDeleted: true });
+      // Given: An already deleted rescue (deletedAt is non-null).
+      const mockRescue = createMockRescue({ deletedAt: new Date() });
 
       const mockTransaction = {
         commit: vi.fn().mockResolvedValue(undefined),

--- a/service.backend/src/__tests__/services/rescue.service.test.ts
+++ b/service.backend/src/__tests__/services/rescue.service.test.ts
@@ -791,9 +791,10 @@ describe('RescueService - Behavioral Testing', () => {
 
       await RescueService.deleteRescue(rescue.rescueId, 'admin-123');
 
-      const deleted = await Rescue.scope('withDeleted').findByPk(rescue.rescueId);
-      expect(deleted?.isDeleted).toBe(true);
-      expect(deleted?.deletedBy).toBe('admin-123');
+      // paranoid scope hides soft-deleted rows by default; opt in with
+      // paranoid: false to verify the row is still there with deletedAt.
+      const deleted = await Rescue.findByPk(rescue.rescueId, { paranoid: false });
+      expect(deleted?.deletedAt).toBeInstanceOf(Date);
     });
 
     it('should throw error when rescue not found', async () => {
@@ -811,10 +812,9 @@ describe('RescueService - Behavioral Testing', () => {
         country: 'UK',
         contactPerson: 'Jane Smith',
         status: 'verified',
-        isDeleted: true,
-        deletedBy: 'admin-123',
-        deletedAt: new Date(),
       });
+      // Soft-delete it first so the next deleteRescue throws.
+      await rescue.destroy();
 
       await expect(RescueService.deleteRescue(rescue.rescueId, 'admin-123')).rejects.toThrow();
     });

--- a/service.backend/src/__tests__/utils/audit-columns.test.ts
+++ b/service.backend/src/__tests__/utils/audit-columns.test.ts
@@ -41,7 +41,6 @@ describe('audit columns + request context', () => {
       country: 'GB',
       contactPerson: 'Test Person',
       status: 'pending',
-      isDeleted: false,
       ...overrides,
     } as never);
   };

--- a/service.backend/src/controllers/pet.controller.ts
+++ b/service.backend/src/controllers/pet.controller.ts
@@ -121,7 +121,6 @@ export class PetController {
           const staffMember = await StaffMember.findOne({
             where: {
               userId: authenticatedReq.user.userId,
-              isDeleted: false,
               isVerified: true,
             },
           });
@@ -216,7 +215,6 @@ export class PetController {
       const staffMember = await StaffMember.findOne({
         where: {
           userId: user.userId,
-          isDeleted: false,
           isVerified: true,
         },
       });
@@ -499,7 +497,6 @@ export class PetController {
       const staffMember = await StaffMember.findOne({
         where: {
           userId: user.userId,
-          isDeleted: false,
           isVerified: true,
         },
       });

--- a/service.backend/src/models/Rescue.ts
+++ b/service.backend/src/models/Rescue.ts
@@ -26,9 +26,8 @@ interface RescueAttributes {
   verifiedAt?: Date;
   verifiedBy?: string;
   settings?: object;
-  isDeleted: boolean;
-  deletedAt?: Date;
-  deletedBy?: string;
+  /** Managed by Sequelize paranoid; null when the row is live. */
+  deletedAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -36,7 +35,7 @@ interface RescueAttributes {
 export interface RescueCreationAttributes
   extends Optional<
     RescueAttributes,
-    'rescueId' | 'verifiedAt' | 'verifiedBy' | 'deletedAt' | 'deletedBy' | 'createdAt' | 'updatedAt'
+    'rescueId' | 'verifiedAt' | 'verifiedBy' | 'deletedAt' | 'createdAt' | 'updatedAt'
   > {}
 
 class Rescue extends Model<RescueAttributes, RescueCreationAttributes> implements RescueAttributes {
@@ -62,9 +61,7 @@ class Rescue extends Model<RescueAttributes, RescueCreationAttributes> implement
   public verifiedAt?: Date;
   public verifiedBy?: string;
   public settings?: object;
-  public isDeleted!: boolean;
-  public deletedAt?: Date;
-  public deletedBy?: string;
+  public deletedAt?: Date | null;
   public createdAt!: Date;
   public updatedAt!: Date;
 
@@ -195,27 +192,6 @@ Rescue.init(
       allowNull: true,
       defaultValue: {},
     },
-    isDeleted: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-      field: 'is_deleted',
-    },
-    deletedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-      field: 'deleted_at',
-    },
-    deletedBy: {
-      type: getUuidType(),
-      allowNull: true,
-      field: 'deleted_by',
-      references: {
-        model: 'users',
-        key: 'user_id',
-      },
-      onDelete: 'SET NULL',
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -237,32 +213,20 @@ Rescue.init(
     underscored: true,
     createdAt: 'createdAt',
     updatedAt: 'updatedAt',
+    // Soft-delete via Sequelize's paranoid mode (plan 3.5). `deletedAt`
+    // is managed automatically; `Rescue.destroy()` soft-deletes,
+    // `restore()` undeletes, and the default scope hides deleted rows.
+    // `paranoid: true` removes the need for the old isDeleted /
+    // deletedBy columns; the audit log captures who deleted.
+    paranoid: true,
+    deletedAt: 'deletedAt',
     indexes: [
       {
         fields: ['verified_by'],
         name: 'rescues_verified_by_idx',
       },
-      {
-        fields: ['deleted_by'],
-        name: 'rescues_deleted_by_idx',
-      },
       ...auditIndexes('rescues'),
     ],
-    defaultScope: {
-      where: {
-        isDeleted: false,
-      },
-    },
-    scopes: {
-      withDeleted: {
-        where: {},
-      },
-      deleted: {
-        where: {
-          isDeleted: true,
-        },
-      },
-    },
   })
 );
 

--- a/service.backend/src/models/StaffMember.ts
+++ b/service.backend/src/models/StaffMember.ts
@@ -13,9 +13,8 @@ interface StaffMemberAttributes {
   verifiedAt?: Date;
   addedBy: string;
   addedAt: Date;
-  isDeleted: boolean;
-  deletedAt?: Date;
-  deletedBy?: string;
+  /** Managed by Sequelize paranoid; null when the row is live. */
+  deletedAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -23,13 +22,7 @@ interface StaffMemberAttributes {
 interface StaffMemberCreationAttributes
   extends Optional<
     StaffMemberAttributes,
-    | 'staffMemberId'
-    | 'verifiedAt'
-    | 'verifiedBy'
-    | 'deletedAt'
-    | 'deletedBy'
-    | 'createdAt'
-    | 'updatedAt'
+    'staffMemberId' | 'verifiedAt' | 'verifiedBy' | 'deletedAt' | 'createdAt' | 'updatedAt'
   > {}
 
 class StaffMember
@@ -45,9 +38,7 @@ class StaffMember
   public verifiedAt?: Date;
   public addedBy!: string;
   public addedAt!: Date;
-  public isDeleted!: boolean;
-  public deletedAt?: Date;
-  public deletedBy?: string;
+  public deletedAt?: Date | null;
   public createdAt!: Date;
   public updatedAt!: Date;
 
@@ -127,27 +118,6 @@ StaffMember.init(
       defaultValue: DataTypes.NOW,
       field: 'added_at',
     },
-    isDeleted: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-      field: 'is_deleted',
-    },
-    deletedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-      field: 'deleted_at',
-    },
-    deletedBy: {
-      type: getUuidType(),
-      allowNull: true,
-      field: 'deleted_by',
-      references: {
-        model: 'users',
-        key: 'user_id',
-      },
-      onDelete: 'SET NULL',
-    },
     createdAt: {
       type: DataTypes.DATE,
       allowNull: false,
@@ -184,27 +154,12 @@ StaffMember.init(
         fields: ['added_by'],
         name: 'staff_members_added_by_idx',
       },
-      {
-        fields: ['deleted_by'],
-        name: 'staff_members_deleted_by_idx',
-      },
       ...auditIndexes('staff_members'),
     ],
-    defaultScope: {
-      where: {
-        isDeleted: false,
-      },
-    },
-    scopes: {
-      withDeleted: {
-        where: {},
-      },
-      deleted: {
-        where: {
-          isDeleted: true,
-        },
-      },
-    },
+    // Soft-delete via Sequelize paranoid (plan 3.5). `destroy()`
+    // sets deletedAt; the default scope hides deleted rows.
+    paranoid: true,
+    deletedAt: 'deletedAt',
   })
 );
 

--- a/service.backend/src/routes/dashboard.routes.ts
+++ b/service.backend/src/routes/dashboard.routes.ts
@@ -20,7 +20,6 @@ router.get('/rescue', async (req: AuthenticatedRequest, res) => {
     const staffMember = await StaffMember.findOne({
       where: {
         userId: user?.userId,
-        isDeleted: false,
         // Remove the isVerified requirement for now - let unverified staff see dashboard
         // isVerified: true,
       },
@@ -120,7 +119,6 @@ router.get('/activity', async (req: AuthenticatedRequest, res) => {
     const staffMember = await StaffMember.findOne({
       where: {
         userId: user?.userId,
-        isDeleted: false,
         // Remove the isVerified requirement for now - let unverified staff see dashboard
         // isVerified: true,
       },

--- a/service.backend/src/routes/staff.routes.ts
+++ b/service.backend/src/routes/staff.routes.ts
@@ -14,7 +14,7 @@ const router = express.Router();
     try {
       const userId = req.user!.userId;
       const staffMember = await StaffMember.findOne({
-        where: { userId: userId, isDeleted: false },
+        where: { userId: userId },
       });
       if (!staffMember) {
         return res
@@ -106,7 +106,6 @@ router.get(
       const currentUserStaff = await StaffMember.findOne({
         where: {
           userId: userId,
-          isDeleted: false,
           isVerified: true,
         },
       });
@@ -122,7 +121,6 @@ router.get(
       const colleagues = await StaffMember.findAll({
         where: {
           rescueId: currentUserStaff.rescueId,
-          isDeleted: false,
         },
         include: [
           {

--- a/service.backend/src/seeders/06-rescues.ts
+++ b/service.backend/src/seeders/06-rescues.ts
@@ -55,7 +55,6 @@ const rescueOrganizations = [
           'We conduct follow-up visits at 2 weeks, 1 month, and 3 months after adoption to ensure the pet is settling in well. Our team is always available for support and advice.',
       },
     },
-    isDeleted: false,
   },
   {
     rescueId: '550e8400-e29b-41d4-a716-446655440002',
@@ -112,7 +111,6 @@ const rescueOrganizations = [
           'Given the special needs of senior dogs, we maintain regular contact with adopters. We check in monthly for the first year and are available 24/7 for emergency support or advice.',
       },
     },
-    isDeleted: false,
   },
   {
     rescueId: '550e8400-e29b-41d4-a716-446655440003',
@@ -142,7 +140,6 @@ const rescueOrganizations = [
       allowPublicContact: true,
       adoptionFeeRange: { min: 75, max: 400 },
     },
-    isDeleted: false,
   },
 ];
 

--- a/service.backend/src/seeders/06.5-staff-members.ts
+++ b/service.backend/src/seeders/06.5-staff-members.ts
@@ -11,7 +11,6 @@ const staffMembers = [
     verifiedAt: new Date('2023-01-15'),
     addedBy: '0e394fc1-c11a-4148-a2c7-5dfc51798d8d',
     addedAt: new Date('2023-01-15'),
-    isDeleted: false,
   },
   {
     rescueId: '550e8400-e29b-41d4-a716-446655440001', // Paws Rescue Austin
@@ -22,7 +21,6 @@ const staffMembers = [
     verifiedAt: new Date('2023-01-20'),
     addedBy: '3d7065c5-82a3-4bba-a84e-78229365badd',
     addedAt: new Date('2023-01-20'),
-    isDeleted: false,
   },
   // Happy Tails Senior Dog Rescue staff
   {
@@ -34,7 +32,6 @@ const staffMembers = [
     verifiedAt: new Date('2023-02-20'),
     addedBy: '0e394fc1-c11a-4148-a2c7-5dfc51798d8d',
     addedAt: new Date('2023-02-20'),
-    isDeleted: false,
   },
   // Furry Friends Portland - let's add a staff member for the third rescue too
   {
@@ -46,7 +43,6 @@ const staffMembers = [
     verifiedAt: undefined,
     addedBy: '0e394fc1-c11a-4148-a2c7-5dfc51798d8d',
     addedAt: new Date('2024-01-10'),
-    isDeleted: false,
   },
 ];
 

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -294,7 +294,6 @@ export class ApplicationService {
           const staffMember = await StaffMember.findOne({
             where: {
               userId: userId,
-              isDeleted: false,
               isVerified: true,
             },
           });

--- a/service.backend/src/services/invitation.service.ts
+++ b/service.backend/src/services/invitation.service.ts
@@ -51,7 +51,7 @@ export class InvitationService {
 
       // Check if email is already associated with this rescue
       const existingStaff = await StaffMember.findOne({
-        where: { rescueId, isDeleted: false },
+        where: { rescueId },
         include: [
           {
             model: User,
@@ -224,7 +224,6 @@ export class InvitationService {
           verifiedAt: new Date(),
           addedBy: invitation.invited_by || user.userId,
           addedAt: new Date(),
-          isDeleted: false,
         },
         { transaction }
       );

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -286,7 +286,6 @@ export class RescueService {
         {
           ...rescueData,
           status: 'pending',
-          isDeleted: false,
         },
         { transaction }
       );
@@ -595,9 +594,10 @@ export class RescueService {
         throw new Error('User not found');
       }
 
-      // Check if user is already an active staff member
+      // Check if user is already an active staff member. paranoid scope
+      // hides soft-deleted rows by default.
       const existingActiveStaff = await StaffMember.findOne({
-        where: { rescueId, userId, isDeleted: false },
+        where: { rescueId, userId },
         transaction,
       });
 
@@ -605,27 +605,26 @@ export class RescueService {
         throw new Error('User is already a staff member of this rescue');
       }
 
-      // Check if user was previously a staff member (soft deleted)
+      // Check if user was previously a staff member (soft deleted) — opt
+      // in to including paranoid rows.
       const existingSoftDeletedStaff = await StaffMember.findOne({
-        where: { rescueId, userId, isDeleted: true },
+        where: { rescueId, userId },
+        paranoid: false,
         transaction,
       });
 
       let staffMember;
-      if (existingSoftDeletedStaff) {
-        // Restore the soft-deleted staff member
-        // Preserve verification status if they were previously verified
+      if (existingSoftDeletedStaff && existingSoftDeletedStaff.deletedAt) {
+        // Restore the soft-deleted staff member, preserving verification.
         const wasVerified = existingSoftDeletedStaff.isVerified;
 
+        await existingSoftDeletedStaff.restore({ transaction });
         await existingSoftDeletedStaff.update(
           {
             title,
-            isDeleted: false,
-            deletedAt: undefined,
-            deletedBy: undefined,
             addedBy,
             addedAt: new Date(),
-            isVerified: wasVerified, // Keep previous verification status
+            isVerified: wasVerified,
           },
           { transaction }
         );
@@ -643,7 +642,6 @@ export class RescueService {
             title,
             addedBy,
             isVerified: false,
-            isDeleted: false,
             addedAt: new Date(),
           },
           { transaction }
@@ -721,7 +719,7 @@ export class RescueService {
 
     try {
       const staffMember = await StaffMember.findOne({
-        where: { rescueId, userId, isDeleted: false },
+        where: { rescueId, userId },
         include: [
           {
             model: User,
@@ -738,15 +736,8 @@ export class RescueService {
 
       const user = staffMember.user!;
 
-      // Soft delete the staff member instead of hard delete
-      await staffMember.update(
-        {
-          isDeleted: true,
-          deletedAt: new Date(),
-          deletedBy: removedBy,
-        },
-        { transaction }
-      );
+      // paranoid soft-delete; the audit log captures who removed.
+      await staffMember.destroy({ transaction });
 
       // Keep the user's rescue_staff role intact
       // This allows them to be re-added easily and maintains their capability level
@@ -986,25 +977,23 @@ export class RescueService {
     const transaction = await Rescue.sequelize!.transaction();
 
     try {
-      const rescue = await Rescue.findByPk(rescueId, { transaction });
+      // paranoid scope hides already-soft-deleted rows by default;
+      // opt in so we can throw a clearer error if it's already gone.
+      const rescue = await Rescue.findByPk(rescueId, {
+        paranoid: false,
+        transaction,
+      });
 
       if (!rescue) {
         throw new Error('Rescue not found');
       }
 
-      if (rescue.isDeleted) {
+      if (rescue.deletedAt) {
         throw new Error('Rescue organization is already deleted');
       }
 
-      // Soft delete by updating status
-      await rescue.update(
-        {
-          isDeleted: true,
-          deletedAt: new Date(),
-          deletedBy,
-        },
-        { transaction }
-      );
+      // paranoid soft-delete sets deletedAt; the audit log captures who.
+      await rescue.destroy({ transaction });
 
       // Log the action
       await AuditLogService.log({
@@ -1054,9 +1043,9 @@ export class RescueService {
       const { page = 1, limit = 20, search, role } = options;
       const offset = (page - 1) * limit;
 
+      // paranoid scope hides soft-deleted rows automatically.
       const whereConditions: WhereOptions = {
         rescueId,
-        isDeleted: false, // Only get active staff members
       };
 
       // Build user search conditions for the included User model


### PR DESCRIPTION
## Summary

Plan 3.5: **unify soft-delete on Sequelize `paranoid: true`.**

Rescue and StaffMember were the last two models still using an ad-hoc `isDeleted` / `deletedBy` / manual `deletedAt` pattern — parallel to (and conflicting with) the global `paranoid` default. Drop the ad-hoc columns, switch both to paranoid, simplify every caller.

## What changed

**Models**
- `Rescue` — drop `isDeleted`, `deletedBy`, manual `deletedAt`; add `paranoid: true`; drop `rescues_deleted_by_idx` and the `defaultScope` / `scopes` (paranoid handles them).
- `StaffMember` — same shape: drop the three columns, drop `staff_members_deleted_by_idx`, drop the manual scope; add `paranoid: true`.

**Service refactor (`rescue.service`)**
- `deleteRescue` — replaces the manual `update({ isDeleted, deletedAt, deletedBy })` with `rescue.destroy()`. Reads via `paranoid: false` first so we can throw a clear "already deleted" error.
- `removeStaffMember` — `staffMember.destroy()` instead of manual update.
- `addStaffMember` — opts in to `paranoid: false` to find a soft-deleted row, then `restore()` + update for verification preservation.

**Caller cleanup**
- Strip every `isDeleted: false` filter from production code (paranoid scope handles it now): `pet.controller`, `dashboard.routes`, `staff.routes`, `invitation.service`, `application.service`, seeders.

**Audit trail**
- The standalone `deletedBy` column was redundant — `AuditLogService.log` already captures who deleted on every soft-delete path.

## Tests

- `rescue-business-logic` + `rescue.service` tests rewired to assert `destroy()` / `restore()` instead of `update({ isDeleted: true })`. Mock factories gain `destroy` / `restore` stubs.
- `standards.test.ts` no longer needs the `LEGACY_MANUAL_SOFT_DELETE` whitelist — the assertion now applies to every model.
- `audit-columns.test.ts` factory stops setting `isDeleted: false`.

## Test plan

- [x] `service.backend` full suite: **1354 passed / 4 skipped, 0 failed**
- [x] `npm run lint`: 0 errors
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke-test against dev: soft-delete a rescue + staff member, confirm the rows still exist with `paranoid: false`, confirm default queries hide them

## Out of scope

- The plan mentions a `paranoid`-compatible `deletedBy` hook. Audit logs already cover this case; not adding a column unless a downstream consumer needs it.

https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_