### PR TITLE
Phase 4 (slice 15): polymorphic entity_type as Postgres ENUM

### DIFF
--- a/service.backend/src/models/FileUpload.ts
+++ b/service.backend/src/models/FileUpload.ts
@@ -125,13 +125,15 @@ FileUpload.init(
         len: [0, 255],
       },
     },
+    /**
+     * Polymorphic discriminator for entity_id. Postgres ENUM gives us
+     * a DB-level CHECK so a typo can't silently rot the type (plan 2.2).
+     * Adding a value requires an enum-add migration, which is the right
+     * friction for "what kind of thing can have a file attached".
+     */
     entity_type: {
-      type: DataTypes.STRING(100),
+      type: DataTypes.ENUM('chat', 'message', 'application', 'pet', 'user', 'rescue'),
       allowNull: true,
-      validate: {
-        len: [0, 100],
-        isIn: [['chat', 'message', 'application', 'pet', 'user', 'rescue']],
-      },
     },
     purpose: {
       type: DataTypes.STRING(100),

--- a/service.backend/src/models/Notification.ts
+++ b/service.backend/src/models/Notification.ts
@@ -240,29 +240,32 @@ Notification.init(
       allowNull: false,
       defaultValue: {},
     },
+    /**
+     * Polymorphic discriminator for related_entity_id. Postgres ENUM
+     * gives us a DB-level CHECK constraint (plan 2.2) so a typo can't
+     * silently rot the type. The list mirrors the prior Sequelize
+     * `isIn` validator — adding a value means a new enum-add migration,
+     * which is the right friction for "what counts as a notifiable
+     * thing".
+     */
     related_entity_type: {
-      type: DataTypes.STRING(50),
+      type: DataTypes.ENUM(
+        'application',
+        'pet',
+        'message',
+        'user',
+        'rescue',
+        'conversation',
+        'interview',
+        'home_visit',
+        'reminder',
+        'announcement',
+        'adoption',
+        'event',
+        'reference',
+        'security'
+      ),
       allowNull: true,
-      validate: {
-        isIn: [
-          [
-            'application',
-            'pet',
-            'message',
-            'user',
-            'rescue',
-            'conversation',
-            'interview',
-            'home_visit',
-            'reminder',
-            'announcement',
-            'adoption',
-            'event',
-            'reference',
-            'security',
-          ],
-        ],
-      },
     },
     related_entity_id: {
       type: DataTypes.STRING,


### PR DESCRIPTION
## Summary

Plan 2.2: **polymorphic discriminator columns get DB-level CHECK constraints.**

`ModeratorAction.targetEntityType` and `Report.reportedEntityType` were already Postgres ENUMs. The two remaining loose-string columns weren't:

- `Notification.related_entity_type` — 14-value `STRING(50)` with a Sequelize `isIn` validator
- `FileUpload.entity_type` — 6-value `STRING(100)` with a Sequelize `isIn` validator

Sequelize-level `isIn` catches the typo at ORM write time but doesn't survive raw SQL paths or out-of-band data fixes. The constraint belongs at the DB.

## Changes

Both columns flip from `DataTypes.STRING(N)` + `validate.isIn` to `DataTypes.ENUM(...)`. Same value list — Postgres ENUM gives us the CHECK constraint. Adding a new value now requires an enum-add migration, which is the right friction for "what kind of thing can be notified about / have a file attached".

No code changes elsewhere — the runtime behaviour is identical, the test fixtures already use values from the whitelist.

## Test plan

- [x] `service.backend` full suite: **1354 passed / 4 skipped, 0 failed**
- [x] `npm run lint`: 0 errors
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke-test against dev: insert a Notification with `related_entity_type = 'unknown'` and confirm a Postgres CHECK error rather than the prior Sequelize-only validation error

## Out of scope (follow-up)

- Real FKs for `entity_id` would require either (a) breaking each polymorphic shape into a per-type table or (b) using a polymorphic FK pattern. Both are bigger than this slice; the plan suggests CHECK constraints are sufficient for now.

https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_