### PR TITLE
Phase 4 (slice 16 follow-up): immutable created_at via boot-script call

### DIFF
--- a/service.backend/src/__tests__/models/immutable-created-at.test.ts
+++ b/service.backend/src/__tests__/models/immutable-created-at.test.ts
@@ -1,17 +1,16 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { QueryTypes } from 'sequelize';
 import sequelize from '../../sequelize';
-import '../../models/index';
+import models from '../../models/index';
 import User from '../../models/User';
+import { installImmutableCreatedAtTriggers } from '../../models/immutable-created-at';
 
 /**
  * The BEFORE UPDATE trigger that locks created_at (plan 5.5.10) only
  * exists on Postgres — installImmutableCreatedAtTriggers short-circuits
- * on SQLite to keep the in-memory test path simple. The trigger contract
- * is exercised by the Postgres branch below, gated on the dialect; the
- * SQLite branch just confirms the helper installs cleanly (a thrown
- * error during afterSync would have failed every other test in the
- * file). Both paths share the bootstrap.
+ * on SQLite to keep the in-memory test path simple. Helper is called
+ * explicitly from the boot script after sequelize.sync() returns; tests
+ * call it explicitly here to mirror that flow.
  */
 const isPostgres = sequelize.getDialect() === 'postgres';
 const describePg = isPostgres ? describe : describe.skip;
@@ -19,6 +18,7 @@ const describePg = isPostgres ? describe : describe.skip;
 describe('immutable created_at trigger', () => {
   beforeEach(async () => {
     await sequelize.sync({ force: true });
+    await installImmutableCreatedAtTriggers(Object.values(models));
   });
 
   it('SQLite path is a no-op — UPDATE may rewrite created_at', async () => {

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -454,6 +454,13 @@ const startServer = async () => {
             );
           }
         }
+
+        // DB-level invariants that aren't expressible in Sequelize models.
+        // Idempotent and Postgres-gated; safe to run on every boot path
+        // (force-seed, fresh DB, warm reload).
+        const { installImmutableCreatedAtTriggers } = await import('./models/immutable-created-at');
+        const models = (await import('./models')).default;
+        await installImmutableCreatedAtTriggers(Object.values(models));
       } catch (error) {
         logger.error('Failed to sync database models:', error);
         throw error;

--- a/service.backend/src/models/immutable-created-at.ts
+++ b/service.backend/src/models/immutable-created-at.ts
@@ -1,86 +1,84 @@
 import { QueryTypes, ModelStatic, Model } from 'sequelize';
 import sequelize from '../sequelize';
+import logger from '../utils/logger';
 
 /**
  * Install BEFORE UPDATE triggers that reject any UPDATE which mutates
  * `created_at`. Defence in depth against bad hooks, raw SQL, and
  * migration mistakes — the row's birthday should never change.
  *
- * Plan 5.5.10. Postgres-only. SQLite tests no-op the whole helper.
+ * Plan 5.5.10. Postgres-only. SQLite tests no-op.
  *
- * Implemented as a single sequelize-level afterSync hook (rather than
- * one per model) so the shared trigger function is created exactly once
- * and the per-table installation walks the model registry in a single
- * pass. The WHEN clause means normal UPDATEs pay only dispatch overhead;
- * only created_at-touching UPDATEs raise.
- *
- * Idempotent: pg_trigger lookup short-circuits if the trigger already
- * exists, so repeat sync() calls don't churn.
+ * Called explicitly from the boot script after sequelize.sync() returns
+ * — not as a Sequelize afterSync hook. Two reasons:
+ *   - Boot-time setup runs once at a known point. Hooks fire on every
+ *     sync (incl. dev HMR resyncs) and any mistake there blocks boot
+ *     before the HTTP server comes up, which is a hard failure mode to
+ *     diagnose without log access.
+ *   - The intent ("after the schema exists, install DB-level
+ *     invariants") reads naturally as boot-script code; an afterSync
+ *     hook obscures it.
  *
  * Errors during installation are logged but not re-thrown — the trigger
- * is defence in depth, not a hard correctness requirement; we don't want
- * a hook bug to take down backend boot.
+ * is defence in depth, not a hard correctness requirement; we'd rather
+ * boot without it and surface the error than wedge boot.
  */
-export const installImmutableCreatedAtTriggers = (
+export const installImmutableCreatedAtTriggers = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   models: ReadonlyArray<ModelStatic<Model<any, any>>>
-): void => {
-  sequelize.afterSync(async () => {
-    if (sequelize.getDialect() !== 'postgres') {
-      return;
+): Promise<void> => {
+  if (sequelize.getDialect() !== 'postgres') {
+    return;
+  }
+
+  try {
+    await sequelize.query(`
+      CREATE OR REPLACE FUNCTION raise_immutable_created_at() RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'created_at is immutable on table %', TG_TABLE_NAME
+          USING ERRCODE = 'integrity_constraint_violation';
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+  } catch (err) {
+    logger.error('[immutable-created-at] failed to create function', { err });
+    return;
+  }
+
+  for (const model of models) {
+    // Models with timestamps:false (audit_logs, *_status_transitions)
+    // don't have a created_at column — they use purpose-specific names
+    // like `timestamp` or `transitioned_at`. Skip them.
+    if (model.options.timestamps === false) {
+      continue;
     }
+
+    const rawTable = model.getTableName();
+    const tableName = typeof rawTable === 'string' ? rawTable : rawTable.tableName;
+    const triggerName = `${tableName}_created_at_immutable`;
 
     try {
-      await sequelize.query(`
-        CREATE OR REPLACE FUNCTION raise_immutable_created_at() RETURNS trigger AS $$
-        BEGIN
-          RAISE EXCEPTION 'created_at is immutable on table %', TG_TABLE_NAME
-            USING ERRCODE = 'integrity_constraint_violation';
-        END;
-        $$ LANGUAGE plpgsql;
-      `);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error('[immutable-created-at] failed to create function:', err);
-      return;
-    }
-
-    for (const model of models) {
-      // Models with timestamps:false (audit_logs, *_status_transitions)
-      // don't have a created_at column — they use purpose-specific names
-      // like `timestamp` or `transitioned_at`. Skip them.
-      if (model.options.timestamps === false) {
+      const existing = await sequelize.query<{ tgname: string }>(
+        `SELECT t.tgname FROM pg_trigger t
+         JOIN pg_class c ON c.oid = t.tgrelid
+         WHERE c.relname = :table AND t.tgname = :trigger`,
+        {
+          replacements: { table: tableName, trigger: triggerName },
+          type: QueryTypes.SELECT,
+        }
+      );
+      if (existing.length > 0) {
         continue;
       }
 
-      const rawTable = model.getTableName();
-      const tableName = typeof rawTable === 'string' ? rawTable : rawTable.tableName;
-      const triggerName = `${tableName}_created_at_immutable`;
-
-      try {
-        const existing = await sequelize.query<{ tgname: string }>(
-          `SELECT t.tgname FROM pg_trigger t
-           JOIN pg_class c ON c.oid = t.tgrelid
-           WHERE c.relname = :table AND t.tgname = :trigger`,
-          {
-            replacements: { table: tableName, trigger: triggerName },
-            type: QueryTypes.SELECT,
-          }
-        );
-        if (existing.length > 0) {
-          continue;
-        }
-
-        await sequelize.query(`
-          CREATE TRIGGER ${triggerName}
-          BEFORE UPDATE ON "${tableName}"
-          FOR EACH ROW WHEN (OLD."created_at" IS DISTINCT FROM NEW."created_at")
-          EXECUTE FUNCTION raise_immutable_created_at();
-        `);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(`[immutable-created-at] failed on ${tableName}:`, err);
-      }
+      await sequelize.query(`
+        CREATE TRIGGER ${triggerName}
+        BEFORE UPDATE ON "${tableName}"
+        FOR EACH ROW WHEN (OLD."created_at" IS DISTINCT FROM NEW."created_at")
+        EXECUTE FUNCTION raise_immutable_created_at();
+      `);
+    } catch (err) {
+      logger.error(`[immutable-created-at] failed on ${tableName}`, { err });
     }
-  });
+  }
 };

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -61,8 +61,6 @@ import FieldPermission from './FieldPermission';
 import Content from './Content';
 import NavigationMenu from './NavigationMenu';
 
-import { installImmutableCreatedAtTriggers } from './immutable-created-at';
-
 // Define all models
 const models = {
   User,
@@ -106,14 +104,6 @@ const models = {
   Content,
   NavigationMenu,
 };
-
-// Install the BEFORE UPDATE trigger that locks created_at on every model
-// that has timestamps enabled. Postgres-only; SQLite tests no-op. See
-// plan 5.5.10 — defence in depth so a stray hook or raw UPDATE can't
-// rewrite a row's birthday.
-// TEMPORARILY DISABLED to bisect Test Docker Compose Stack failure (PR #131).
-// installImmutableCreatedAtTriggers(Object.values(models));
-void installImmutableCreatedAtTriggers;
 
 // Setup associations (done explicitly below instead of using associate methods)
 // Wrapped in try-catch to handle cases where associations are set up multiple times (e.g., in tests with mocks)


### PR DESCRIPTION
PR #131 landed the helper but kept the install call disabled as a bisect to isolate why Test Docker Compose Stack was timing out during backend boot. This re-enables the trigger via the standard "explicit boot-script call after sync" shape.

## Summary

- Helper is now a plain async function — no Sequelize `afterSync` hook. Errors are logged through the app logger and not re-thrown; the trigger is defence in depth, not a hard correctness requirement, so a hook bug shouldn't take down boot.
- Install runs from `service.backend/src/index.ts` immediately after the dev-mode sync block, inside the same try/catch that wraps sync. Idempotent and Postgres-gated, safe on every boot path (force-seed, fresh DB, warm reload). Production path (migrations, when slice 1.1 lands) will own its own ordering.
- Removed the bisect-disabled wiring from `models/index.ts`.
- Test calls `installImmutableCreatedAtTriggers` explicitly in `beforeEach` so the SQLite no-op path and the Postgres contract path both mirror the real boot flow.

## Why explicit > afterSync hook

Boot-time invariant setup is the standard shape in production codebases for "after sync, install DB-level invariants that aren't expressible in the ORM." `afterSync` hooks are implicit, fire on every sync (incl. dev HMR resyncs), and any failure there blocks boot before the HTTP server comes up — that was the PR #131 timeout I couldn't diagnose without log access. Explicit boot-script call runs once at a known point with logging and a try/catch, so any future failure shows up in `service-backend` logs instead of an opaque healthcheck timeout.

## Test plan

- [x] `npm test` — 1355 passed, 7 skipped (3 of which are the Postgres-gated trigger contract suite).
- [x] `npm run lint` clean (0 errors).
- [x] `npm run build` clean.
- [x] Trigger test exercises both paths: SQLite asserts the helper is a no-op (UPDATE may rewrite `created_at`); Postgres-gated suite asserts the trigger raises on tamper, allows untouched UPDATEs, and is installed on `users`/`pets`/`rescues`/`applications` but absent from `audit_logs`/`application_status_transitions`.
- [ ] Test Docker Compose Stack passes — this is the real signal we were missing on PR #131.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_