### PR TITLE
Phase 4 (slice 5.5.9): DB-level CHECK constraints for ISO-coded columns

### DIFF
--- a/service.backend/src/__tests__/models/iso-check-constraints.test.ts
+++ b/service.backend/src/__tests__/models/iso-check-constraints.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { QueryTypes } from 'sequelize';
+import sequelize from '../../sequelize';
+import '../../models/index';
+import { installIsoCheckConstraints } from '../../models/iso-check-constraints';
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describePg = isPostgres ? describe : describe.skip;
+
+describe('iso check constraints', () => {
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    await installIsoCheckConstraints();
+  });
+
+  it('SQLite path is a no-op', async () => {
+    if (isPostgres) {
+      return;
+    }
+    await expect(installIsoCheckConstraints()).resolves.toBeUndefined();
+  });
+
+  describePg('Postgres path', () => {
+    it.each([
+      {
+        constraint: 'pets_adoption_fee_currency_iso_check',
+        sql: `INSERT INTO pets (pet_id, name, rescue_id, type, status, gender, age_group,
+                                adoption_fee_minor, adoption_fee_currency, archived, featured,
+                                priority_listing, special_needs, house_trained, view_count,
+                                favorite_count, application_count, images, videos, tags,
+                                created_at, updated_at, version)
+              VALUES (gen_random_uuid(), 'X', gen_random_uuid(), 'dog', 'available', 'male',
+                      'adult', 0, 'gbp', false, false, false, false, false, 0, 0, 0,
+                      ARRAY[]::jsonb[], ARRAY[]::jsonb[], ARRAY[]::text[], now(), now(), 0)`,
+      },
+      {
+        constraint: 'rescues_country_iso_check',
+        sql: `INSERT INTO rescues (rescue_id, name, email, address, city, postcode, country,
+                                   contact_person, status, created_at, updated_at, version)
+              VALUES (gen_random_uuid(), 'X', 'x@x.test', '1 Lane', 'Town', 'AB1 2CD',
+                      'United Kingdom', 'X', 'pending', now(), now(), 0)`,
+      },
+    ])('rejects values that violate $constraint', async ({ sql, constraint }) => {
+      await expect(sequelize.query(sql, { type: QueryTypes.INSERT })).rejects.toThrow(
+        new RegExp(constraint)
+      );
+    });
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -21,7 +21,9 @@ import { logger } from './utils/logger';
 import { printEnvironmentInfo, validateEnvironment } from './utils/validate-env';
 
 // Import models to ensure they're loaded
-import './models';
+import models from './models';
+import { installImmutableCreatedAtTriggers } from './models/immutable-created-at';
+import { installIsoCheckConstraints } from './models/iso-check-constraints';
 
 // Import routes
 import adminRoutes from './routes/admin.routes';
@@ -457,10 +459,11 @@ const startServer = async () => {
 
         // DB-level invariants that aren't expressible in Sequelize models.
         // Idempotent and Postgres-gated; safe to run on every boot path
-        // (force-seed, fresh DB, warm reload).
-        const { installImmutableCreatedAtTriggers } = await import('./models/immutable-created-at');
-        const models = (await import('./models')).default;
-        await installImmutableCreatedAtTriggers(Object.values(models));
+        // (force-seed, fresh DB, warm reload). Independent — run in parallel.
+        await Promise.all([
+          installImmutableCreatedAtTriggers(Object.values(models)),
+          installIsoCheckConstraints(),
+        ]);
       } catch (error) {
         logger.error('Failed to sync database models:', error);
         throw error;

--- a/service.backend/src/models/iso-check-constraints.ts
+++ b/service.backend/src/models/iso-check-constraints.ts
@@ -1,0 +1,81 @@
+import { QueryTypes } from 'sequelize';
+import sequelize from '../sequelize';
+import logger from '../utils/logger';
+
+/**
+ * DB-level CHECK constraints for ISO-coded columns. Sequelize enforces
+ * the same regexes via per-column `validate.is`, but those are JS-side
+ * only — anything bypassing the ORM (raw bulkInsert, future migrations,
+ * COPY) gets no validation. The DB CHECK closes that escape hatch.
+ *
+ * Postgres-only; SQLite tests no-op. Errors are logged and not
+ * re-thrown — these are belt-and-braces invariants, not a hard
+ * correctness requirement, so a hook bug shouldn't take down boot.
+ *
+ * Idempotent via pg_constraint lookup. To add a new ISO column, append
+ * an entry to ISO_CHECKS and the next boot installs it.
+ */
+type IsoCheck = {
+  table: string;
+  column: string;
+  /** Constraint name; must be unique per schema. */
+  name: string;
+  /** ISO regex (e.g. '^[A-Z]{3}$'). Substituted as a SQL string literal. */
+  regex: string;
+  /** When true the predicate accepts NULL (column is nullable). */
+  nullable: boolean;
+};
+
+const ISO_CHECKS: readonly IsoCheck[] = [
+  {
+    table: 'pets',
+    column: 'adoption_fee_currency',
+    name: 'pets_adoption_fee_currency_iso_check',
+    regex: '^[A-Z]{3}$',
+    nullable: true,
+  },
+  {
+    table: 'rescues',
+    column: 'country',
+    name: 'rescues_country_iso_check',
+    regex: '^[A-Z]{2}$',
+    nullable: false,
+  },
+];
+
+const buildPredicate = (check: IsoCheck): string => {
+  const col = `"${check.column}"`;
+  const matches = `${col} ~ ${sequelize.escape(check.regex)}`;
+  return check.nullable ? `${col} IS NULL OR ${matches}` : matches;
+};
+
+export const installIsoCheckConstraints = async (): Promise<void> => {
+  if (sequelize.getDialect() !== 'postgres') {
+    return;
+  }
+
+  for (const check of ISO_CHECKS) {
+    try {
+      const existing = await sequelize.query<{ conname: string }>(
+        `SELECT c.conname FROM pg_constraint c
+         JOIN pg_class t ON t.oid = c.conrelid
+         WHERE t.relname = :table AND c.conname = :name`,
+        {
+          replacements: { table: check.table, name: check.name },
+          type: QueryTypes.SELECT,
+        }
+      );
+      if (existing.length > 0) {
+        continue;
+      }
+
+      await sequelize.query(
+        `ALTER TABLE "${check.table}"
+         ADD CONSTRAINT "${check.name}"
+         CHECK (${buildPredicate(check)});`
+      );
+    } catch (err) {
+      logger.error(`[iso-check] failed on ${check.table}.${check.column}`, { err });
+    }
+  }
+};


### PR DESCRIPTION
Plan 5.5.9 — DB-level CHECK constraints for the ISO-coded columns we already have. Sequelize enforces the same regexes via `validate.is`, but those are JS-side only; anything bypassing the ORM gets no validation. The DB CHECK closes that escape hatch.

## Summary

- `pets.adoption_fee_currency` must match `^[A-Z]{3}$` (or be NULL — the column is nullable for free pets).
- `rescues.country` must match `^[A-Z]{2}$`.
- New helper `installIsoCheckConstraints` runs from the boot script after sync, alongside `installImmutableCreatedAtTriggers` (slice 16). Same shape: plain async function, Postgres-only, idempotent via `pg_constraint` lookup, errors logged via app logger and not re-thrown.
- Both installers now run in parallel via `Promise.all` — they touch disjoint catalog objects.
- The dynamic `await import()` block in the boot script collapses into top-level static imports of `models`, `installImmutableCreatedAtTriggers`, and `installIsoCheckConstraints` (no code-splitting benefit, and `./models` was already loaded).
- Constraint metadata is `{ table, column, name, regex, nullable }`. The predicate is constructed inside the helper with `sequelize.escape(regex)`, so future contributors adding entries can't accidentally introduce SQL injection — only static literals make it into the actual `ALTER TABLE`.

## Adding a new ISO column

Append to `ISO_CHECKS` in `iso-check-constraints.ts` and the next boot installs it. Future candidates: `User.country`, `User.language`, `EmailPreference.language` — all currently free-form `STRING(N)`; deferred to a separate slice that also tightens the column type.

## Test plan

- [x] `npm test` — 1356 passed, 9 skipped (2 of which are the Postgres-gated CHECK tests on SQLite).
- [x] `npm run lint` clean (0 errors).
- [x] Type-check + build clean.
- [x] Postgres-gated test suite: parameterized over both constraints, asserts each rejects its canonical violation (`'gbp'` lowercase / `'United Kingdom'` for country) with the constraint name in the error message.
- [x] SQLite path confirms the helper is a callable no-op.
- [ ] Test Docker Compose Stack green — the real signal that the boot-script call lands cleanly against Postgres.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_