### PR TITLE
Phase 4 (slice 5.5.9 follow-up): BCP 47 ISO codes for language columns

### DIFF
--- a/service.backend/src/__tests__/models/iso-check-constraints.test.ts
+++ b/service.backend/src/__tests__/models/iso-check-constraints.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, beforeEach } from 'vitest';
 import { QueryTypes } from 'sequelize';
 import sequelize from '../../sequelize';
 import '../../models/index';
+import EmailPreference from '../../models/EmailPreference';
+import User from '../../models/User';
 import { installIsoCheckConstraints } from '../../models/iso-check-constraints';
 
 const isPostgres = sequelize.getDialect() === 'postgres';
@@ -44,6 +46,45 @@ describe('iso check constraints', () => {
       await expect(sequelize.query(sql, { type: QueryTypes.INSERT })).rejects.toThrow(
         new RegExp(constraint)
       );
+    });
+
+    // The language columns sit on tables (users, email_preferences) with
+    // many other required fields, so testing the CHECK via INSERT means
+    // copy-pasting a long column list. Easier: create a valid row through
+    // Sequelize, then UPDATE only the language column via raw SQL to
+    // bypass the JS-side validator and prove the DB CHECK fires.
+    it('rejects a non-BCP-47 language on users via UPDATE', async () => {
+      const user = await User.create({
+        email: 'lang@x.test',
+        password: 'x',
+        firstName: 'A',
+        lastName: 'B',
+      } as never);
+      await expect(
+        sequelize.query(`UPDATE users SET language = 'EN_US' WHERE user_id = :id`, {
+          replacements: { id: user.userId },
+          type: QueryTypes.UPDATE,
+        })
+      ).rejects.toThrow(/users_language_bcp47_check/);
+    });
+
+    it('rejects a non-BCP-47 language on email_preferences via UPDATE', async () => {
+      const user = await User.create({
+        email: 'pref@x.test',
+        password: 'x',
+        firstName: 'A',
+        lastName: 'B',
+      } as never);
+      const pref = await EmailPreference.create({ userId: user.userId } as never);
+      await expect(
+        sequelize.query(
+          `UPDATE email_preferences SET language = 'english' WHERE preference_id = :id`,
+          {
+            replacements: { id: (pref as unknown as { preferenceId: string }).preferenceId },
+            type: QueryTypes.UPDATE,
+          }
+        )
+      ).rejects.toThrow(/email_preferences_language_bcp47_check/);
     });
   });
 });

--- a/service.backend/src/models/EmailPreference.ts
+++ b/service.backend/src/models/EmailPreference.ts
@@ -364,7 +364,10 @@ EmailPreference.init(
       allowNull: false,
       defaultValue: 'en',
       validate: {
-        isIn: [['en', 'es', 'fr', 'de', 'it', 'pt', 'zh', 'ja', 'ko']],
+        is: {
+          args: /^[a-z]{2,3}(-[A-Z]{2})?$/,
+          msg: 'Language must be a BCP 47 simple form (e.g. en, en-GB, pt-BR)',
+        },
       },
     },
     timezone: {

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -365,6 +365,12 @@ User.init(
       type: DataTypes.STRING(10),
       allowNull: true,
       defaultValue: 'en',
+      validate: {
+        is: {
+          args: /^[a-z]{2,3}(-[A-Z]{2})?$/,
+          msg: 'Language must be a BCP 47 simple form (e.g. en, en-GB, pt-BR)',
+        },
+      },
     },
     country: {
       type: DataTypes.STRING(100),

--- a/service.backend/src/models/iso-check-constraints.ts
+++ b/service.backend/src/models/iso-check-constraints.ts
@@ -26,6 +26,11 @@ type IsoCheck = {
   nullable: boolean;
 };
 
+// BCP 47 simple form covers ISO 639-1 / 639-3 with optional ISO 3166-1
+// region: e.g. en, eng, en-GB, pt-BR, zh-CN. Doesn't cover script subtags
+// (zh-Hant) or extended language tags — out of scope for product copy.
+const BCP_47_SIMPLE = '^[a-z]{2,3}(-[A-Z]{2})?$';
+
 const ISO_CHECKS: readonly IsoCheck[] = [
   {
     table: 'pets',
@@ -39,6 +44,20 @@ const ISO_CHECKS: readonly IsoCheck[] = [
     column: 'country',
     name: 'rescues_country_iso_check',
     regex: '^[A-Z]{2}$',
+    nullable: false,
+  },
+  {
+    table: 'users',
+    column: 'language',
+    name: 'users_language_bcp47_check',
+    regex: BCP_47_SIMPLE,
+    nullable: true,
+  },
+  {
+    table: 'email_preferences',
+    column: 'language',
+    name: 'email_preferences_language_bcp47_check',
+    regex: BCP_47_SIMPLE,
     nullable: false,
   },
 ];


### PR DESCRIPTION
Extends slice 5.5.9 to cover the two `language` columns we have today.

## Summary

- `User.language` (`STRING(10)`, nullable, default `'en'`) — gains a Sequelize `validate.is` regex; previously had no validator at all.
- `EmailPreference.language` (`STRING(10)`, default `'en'`) — the hardcoded `isIn` allowlist of 9 codes is replaced with the broader BCP 47 simple form, matching the plan and removing a deploy-friction point when product wants to add a language.
- `ISO_CHECKS` gains two entries (`users_language_bcp47_check`, `email_preferences_language_bcp47_check`) sharing one regex constant: `^[a-z]{2,3}(-[A-Z]{2})?$`. Covers `en`, `eng`, `en-GB`, `pt-BR`, `zh-CN`. Deliberately doesn't cover script subtags like `zh-Hant` — out of scope for product copy.

## Test plan

- [x] `npm test` — 1356 passed, 11 skipped (4 of which are the new Postgres-gated CHECK tests on SQLite).
- [x] `npm run lint` clean.
- [x] Type-check + build clean.
- [x] Postgres-gated test extends the parameterized rejection table for INSERT-friendly cases (pets/rescues), plus two UPDATE-based cases for `users.language` and `email_preferences.language` (whose tables have many required fields, so an UPDATE on a Sequelize-created row is cleaner than a hand-written INSERT).
- [x] Each test asserts the constraint name appears in the rejection error.
- [ ] Test Docker Compose Stack green — confirms the boot-script call still lands cleanly with the four constraints.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_