### PR TITLE
Phase 2 (slice 5.5.13 rollout): idempotency on send-message and swipe

### DIFF
--- a/service.backend/src/routes/chat.routes.ts
+++ b/service.backend/src/routes/chat.routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { ChatController } from '../controllers/chat.controller';
 import { authenticateToken } from '../middleware/auth';
+import { idempotency } from '../middleware/idempotency';
 import { requirePermission } from '../middleware/rbac';
 import { authLimiter, generalLimiter, uploadLimiter } from '../middleware/rate-limiter';
 import { handleValidationErrors } from '../middleware/validation';
@@ -547,6 +548,7 @@ router.delete(
 router.post(
   '/:chatId/messages',
   authLimiter,
+  idempotency,
   chatValidation.sendMessage,
   handleValidationErrors,
   ChatController.sendMessage

--- a/service.backend/src/routes/discovery.routes.ts
+++ b/service.backend/src/routes/discovery.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { QueryTypes } from 'sequelize';
 import { DiscoveryController } from '../controllers/discovery.controller';
 import { authenticateToken } from '../middleware/auth';
+import { idempotency } from '../middleware/idempotency';
 import sequelize from '../sequelize';
 
 const router = Router();
@@ -459,6 +460,7 @@ router.post('/queue', discoveryController.addToQueue);
 // Swipe action routes
 router.post(
   '/swipe/action',
+  idempotency,
   DiscoveryController.validateSwipeAction,
   discoveryController.recordSwipeAction
 );


### PR DESCRIPTION
Plan 5.5.13 listed three canonical "double-submit-able" mutations: submit application (PR #135), send message, and swipe. This rolls the middleware out to the latter two.

## Summary

- `POST /api/v1/chats/:chatId/messages` — a network blip after the client sent a message would otherwise post it twice.
- `POST /api/v1/discovery/swipe/action` — same risk for likes/passes, which feed the recommendation engine.

Both routes accept the optional `Idempotency-Key` header now. Existing clients without the header are unaffected — the middleware passes through. Cache key is `sha256(client-key) + METHOD + path` so a key reused against a different chat or pet doesn't replay the wrong response.

## What's left

The plan calls out idempotency on "every state-changing API endpoint called from a mobile/web client." Remaining mutating endpoints (chat creation, reactions, file uploads, profile updates, …) are deferred to future slices as we touch each route for other reasons — not worth a single sweeping rollout.

## Test plan

- [x] `npm test` — 1362 passed, 11 skipped. PR #135 covers the middleware end-to-end; this slice is two route-level imports and is exercised transitively.
- [x] `npm run lint` clean.
- [x] Type-check + build clean.
- [ ] Test Docker Compose Stack green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_