### PR TITLE
Phase 2 (slice 5.5.13 sweep): apply idempotency to remaining content-creation endpoints

### DIFF
--- a/service.backend/src/routes/chat.routes.ts
+++ b/service.backend/src/routes/chat.routes.ts
@@ -156,6 +156,7 @@ router.use(authenticateToken);
 router.post(
   '/',
   authLimiter,
+  idempotency,
   chatValidation.createChat,
   handleValidationErrors,
   ChatController.createChat
@@ -827,6 +828,7 @@ router.get(
 router.post(
   '/:chatId/participants',
   authLimiter,
+  idempotency,
   chatValidation.addParticipant,
   handleValidationErrors,
   ChatController.addParticipant
@@ -916,6 +918,7 @@ router.delete(
 router.post(
   '/messages/:messageId/reactions',
   generalLimiter,
+  idempotency,
   chatValidation.addReaction,
   handleValidationErrors,
   ChatController.addReaction

--- a/service.backend/src/routes/moderation.routes.ts
+++ b/service.backend/src/routes/moderation.routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { ModerationController } from '../controllers/moderation.controller';
 import { authenticateToken } from '../middleware/auth';
+import { idempotency } from '../middleware/idempotency';
 import { requirePermission } from '../middleware/rbac';
 import { generalLimiter } from '../middleware/rate-limiter';
 import { handleValidationErrors } from '../middleware/validation';
@@ -145,6 +146,7 @@ router.post(
   '/reports',
   requirePermission(PERMISSIONS.MODERATION_REPORTS_CREATE),
   generalLimiter,
+  idempotency,
   moderationValidation.submitReport,
   handleValidationErrors,
   moderationController.submitReport.bind(moderationController)

--- a/service.backend/src/routes/pet.routes.ts
+++ b/service.backend/src/routes/pet.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { PetController } from '../controllers/pet.controller';
 import { authenticateToken, authenticateOptionalToken } from '../middleware/auth';
 import { fieldMask, fieldWriteGuard } from '../middleware/field-permissions';
+import { idempotency } from '../middleware/idempotency';
 import { requirePermission } from '../middleware/rbac';
 import { handleValidationErrors } from '../middleware/validation';
 import { petValidation } from '../validation/pet.validation';
@@ -1339,6 +1340,7 @@ router.post(
   '/',
   authenticateToken,
   requirePermission('pets.create'),
+  idempotency,
   fieldWriteGuard('pets', { audit: true }),
   PetController.validateCreatePet,
   petController.createPet
@@ -1398,6 +1400,7 @@ router.patch(
 router.post(
   '/:petId/favorite',
   authenticateToken,
+  idempotency,
   PetController.validatePetId,
   petController.addToFavorites
 );
@@ -1419,6 +1422,7 @@ router.get(
 router.post(
   '/:petId/report',
   authenticateToken,
+  idempotency,
   PetController.validateReportPet,
   petController.reportPet
 );

--- a/service.backend/src/routes/supportTicket.routes.ts
+++ b/service.backend/src/routes/supportTicket.routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { SupportTicketController } from '../controllers/supportTicket.controller';
 import { authenticateToken } from '../middleware/auth';
+import { idempotency } from '../middleware/idempotency';
 import { requirePermission } from '../middleware/rbac';
 import { PERMISSIONS } from '../types/rbac';
 import { generalLimiter } from '../middleware/rate-limiter';
@@ -180,6 +181,7 @@ router.post(
   '/tickets',
   requirePermission(PERMISSIONS.SUPPORT_TICKET_CREATE),
   generalLimiter,
+  idempotency,
   SupportTicketController.createTicket
 );
 
@@ -287,6 +289,7 @@ router.post(
   '/tickets/:ticketId/reply',
   requirePermission(PERMISSIONS.SUPPORT_TICKET_REPLY),
   generalLimiter,
+  idempotency,
   SupportTicketController.addResponse
 );
 

--- a/service.backend/src/routes/userSupport.routes.ts
+++ b/service.backend/src/routes/userSupport.routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { UserSupportController } from '../controllers/userSupport.controller';
 import { authenticateToken } from '../middleware/auth';
+import { idempotency } from '../middleware/idempotency';
 import { requirePermission } from '../middleware/rbac';
 import { PERMISSIONS } from '../types/rbac';
 import { generalLimiter } from '../middleware/rate-limiter';
@@ -54,6 +55,7 @@ router.post(
   '/tickets',
   requirePermission(PERMISSIONS.SUPPORT_TICKET_MANAGE_OWN),
   generalLimiter,
+  idempotency,
   UserSupportController.createMyTicket
 );
 
@@ -161,6 +163,7 @@ router.post(
   '/tickets/:ticketId/reply',
   requirePermission(PERMISSIONS.SUPPORT_TICKET_MANAGE_OWN),
   generalLimiter,
+  idempotency,
   UserSupportController.replyToMyTicket
 );
 


### PR DESCRIPTION


Per the plan, idempotency on "every state-changing API endpoint called from a mobile/web client". The middleware itself landed in PR #135 and the canonical three (submit application, send message, swipe) are live. This sweep covers the remaining
content-creation routes where a network blip + naive client retry would create a duplicate:

  POST /api/v1/chats                          create chat
  POST /api/v1/chats/:chatId/participants     add participant
  POST /api/v1/chats/messages/:id/reactions   add reaction
  POST /api/v1/pets                           create pet (rescue)
  POST /api/v1/pets/:petId/favorite           favourite
  POST /api/v1/pets/:petId/report             report a pet
  POST /api/v1/support-tickets/tickets        create ticket (admin)
  POST /api/v1/support-tickets/tickets/:id/reply  add response
  POST /api/v1/users/support/tickets          create user ticket
  POST /api/v1/users/support/tickets/:id/reply    user ticket reply
  POST /api/v1/moderation/reports             create report

Header is optional — clients without an Idempotency-Key are unchanged. Cache key is sha256(client-key) + METHOD + path so a key reused against a different chat/pet/ticket doesn't replay the wrong response.

Skipped (intentional):
  - file-upload routes (own dedup via blob hashing)
  - admin actions (assign/escalate/bulk-update — low retry risk, audit log captures intent regardless)
  - mark-as-read (already naturally idempotent)
  - POST /invitations/accept (single-use token rejects retry with 409 already-been-used; native idempotency)
  - auth routes (have their own retry/replay protections — register/login/2FA shouldn't dedupe via this generic cache)

Tests in PR #135 cover the middleware behaviour end-to-end; this sweep is mechanical wiring — one import + one line per route.