### PR TITLE
Phase 4 (slice 4.4): composite indexes for the dominant query patterns

### DIFF
--- a/service.backend/src/models/Application.ts
+++ b/service.backend/src/models/Application.ts
@@ -510,6 +510,14 @@ Application.init(
           },
         },
       },
+      // Rescue dashboard's primary query: open applications for a rescue,
+      // newest first (plan 4.4). Covering shape — status + rescue_id let
+      // Postgres skip the heap for the filter, then created_at gives the
+      // ORDER BY a presorted scan.
+      {
+        fields: ['rescue_id', 'status', { name: 'created_at', order: 'DESC' }],
+        name: 'applications_rescue_status_created_idx',
+      },
       ...auditIndexes('applications'),
     ],
     hooks: {

--- a/service.backend/src/models/Message.ts
+++ b/service.backend/src/models/Message.ts
@@ -321,6 +321,13 @@ Message.init(
         using: 'gin',
         name: 'messages_read_status_gin_idx',
       },
+      // Messaging pagination is always "latest N messages in this chat,
+      // newest first" (plan 4.4) — composite covers the where + order
+      // in one index lookup.
+      {
+        fields: ['chat_id', { name: 'created_at', order: 'DESC' }],
+        name: 'messages_chat_created_idx',
+      },
       ...auditIndexes('messages'),
     ],
     // search_vector is now a stored generated column on Postgres

--- a/service.backend/src/models/Notification.ts
+++ b/service.backend/src/models/Notification.ts
@@ -393,6 +393,14 @@ Notification.init(
           external_id: { [Op.ne]: null },
         },
       },
+      // Notification center renders "my unread, newest first" (plan
+      // 4.4) — composite covers the where + order in one lookup. The
+      // pre-existing user_read_idx serves the "did I read this" path;
+      // this one serves the list query.
+      {
+        fields: ['user_id', 'status', { name: 'created_at', order: 'DESC' }],
+        name: 'notifications_user_status_created_idx',
+      },
       ...auditIndexes('notifications'),
     ],
     hooks: {

--- a/service.backend/src/models/Pet.ts
+++ b/service.backend/src/models/Pet.ts
@@ -885,6 +885,18 @@ Pet.init(
         using: 'gist',
         name: 'pets_location_gist_idx',
       },
+      // Composite indexes for the dominant access patterns (plan 4.4).
+      // Single-column indexes on status/type/size remain useful for the
+      // less common one-axis filters; these add covering shape for the
+      // queries we know are hot.
+      {
+        fields: ['status', 'rescue_id'],
+        name: 'pets_status_rescue_idx',
+      },
+      {
+        fields: ['status', 'type', 'size'],
+        name: 'pets_status_type_size_idx',
+      },
       ...auditIndexes('pets'),
     ],
     hooks: {

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -516,6 +516,13 @@ User.init(
       {
         fields: ['created_at'],
       },
+      // paranoid: true filters every find on `deleted_at IS NULL`. Without
+      // this index Postgres can't use it to skip soft-deleted rows; the
+      // alternative is a sequential scan on every user lookup (plan 4.4).
+      {
+        fields: ['deleted_at'],
+        name: 'users_deleted_at_idx',
+      },
       ...auditIndexes('users'),
     ],
     hooks: {


### PR DESCRIPTION
Plan 4.4 — add composite indexes that cover the where + order shape of the queries we know are hot, instead of relying on Postgres to combine multiple single-column indexes (slower bitmap-OR scans, worse stats).

Pre-existing single-column indexes stay — they're still useful for the less common one-axis filters. This slice is purely additive; no schema migration beyond `sync({ force: true })` on boot.

## Indexes added

| Name | Shape | Query it serves |
|---|---|---|
| `pets_status_rescue_idx` | `(status, rescue_id)` | Rescue dashboard "show me my pets in state X" |
| `pets_status_type_size_idx` | `(status, type, size)` | Main catalog browse — adopters filter by all three at once |
| `applications_rescue_status_created_idx` | `(rescue_id, status, created_at DESC)` | Rescue dashboard's primary view: open applications, newest first |
| `messages_chat_created_idx` | `(chat_id, created_at DESC)` | Messaging pagination ("latest N in this chat, newest first") |
| `notifications_user_status_created_idx` | `(user_id, status, created_at DESC)` | Notification center ("my unread, newest first") |
| `users_deleted_at_idx` | `(deleted_at)` | Required for `paranoid: true` to actually skip soft-deleted rows without a seq scan on every user lookup |

## Test plan

- [x] `npm test` — 1362 passed, 11 skipped. No behaviour change at the model layer.
- [x] `npm run lint` clean.
- [x] Type-check + build clean.
- [ ] Test Docker Compose Stack green — confirms the new indexes get created cleanly during `sync({ force: true })` against Postgres.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_