### PR TITLE
Phase 2 (slice 4.5): denormalised user_email_snapshot on AuditLog

### DIFF
--- a/service.backend/src/__tests__/services/auditLog.service.test.ts
+++ b/service.backend/src/__tests__/services/auditLog.service.test.ts
@@ -1,4 +1,5 @@
 import { AuditLog } from '../../models/AuditLog';
+import User from '../../models/User';
 import { AuditLogService } from '../../services/auditLog.service';
 import { Op } from 'sequelize';
 
@@ -117,6 +118,38 @@ describe('AuditLogService', () => {
 
       expect(result.level).toBe('WARNING');
       expect(result.status).toBe('failure');
+    });
+
+    it('captures user_email_snapshot from the actor at write time', async () => {
+      // Seed a real user; the snapshot reads from User.findByPk(userId).
+      const userId = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa01';
+      await User.create({
+        userId,
+        email: 'snapshot@audit.test',
+        password: 'TestPassword123!',
+        firstName: 'Snap',
+        lastName: 'Shot',
+      } as never);
+
+      const result = await AuditLogService.log({
+        userId,
+        action: 'CREATE_PET',
+        entity: 'Pet',
+        entityId: 'pet-1',
+      });
+
+      expect(result.user_email_snapshot).toBe('snapshot@audit.test');
+    });
+
+    it('leaves user_email_snapshot null when the actor is unknown', async () => {
+      const result = await AuditLogService.log({
+        userId: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa99',
+        action: 'CREATE_PET',
+        entity: 'Pet',
+        entityId: 'pet-1',
+      });
+
+      expect(result.user_email_snapshot).toBeNull();
     });
   });
 

--- a/service.backend/src/models/AuditLog.ts
+++ b/service.backend/src/models/AuditLog.ts
@@ -6,6 +6,7 @@ export class AuditLog extends Model {
   public id!: number;
   public service!: string;
   public user!: string | null;
+  public user_email_snapshot!: string | null;
   public action!: string;
   public level!: 'INFO' | 'WARNING' | 'ERROR';
   public status!: 'success' | 'failure' | null;
@@ -28,6 +29,18 @@ AuditLog.init(
       allowNull: false,
     },
     user: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    /**
+     * Snapshot of the user's email at the moment the log was written.
+     * AuditLog.user is a soft reference (no FK enforcement) — the user
+     * may be deleted before the log is read, at which point the live
+     * lookup returns null. The snapshot keeps the audit trail readable
+     * forever ("admin@x.test deleted Pet 12345" instead of
+     * "[deleted user]"). Plan 2.2 / 4.5.
+     */
+    user_email_snapshot: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/service.backend/src/services/auditLog.service.ts
+++ b/service.backend/src/services/auditLog.service.ts
@@ -38,9 +38,24 @@ export class AuditLogService {
    */
   static async log(data: AuditLogData): Promise<AuditLog> {
     try {
+      // Capture the actor's email at write time so the audit trail
+      // stays readable after the user is deleted (plan 2.2 / 4.5).
+      // Best-effort — a missing user (or a transient lookup failure)
+      // just leaves the snapshot null; the audit log still gets written.
+      let userEmailSnapshot: string | null = null;
+      if (data.userId) {
+        try {
+          const user = await User.findByPk(data.userId, { attributes: ['email'] });
+          userEmailSnapshot = user?.email ?? null;
+        } catch {
+          userEmailSnapshot = null;
+        }
+      }
+
       const auditLog = await AuditLog.create({
         service: data.service || 'adopt-dont-shop-backend',
         user: data.userId,
+        user_email_snapshot: userEmailSnapshot,
         action: data.action,
         level: data.level || 'INFO',
         status: data.status,


### PR DESCRIPTION
Plan 4.5 says to keep `AuditLog` rows readable after the actor is deleted by snapshotting their email at log-write time. Previously display lookups would either fail (FK enforced — but it isn't today) or return the ambiguous `[deleted user]` (no FK).

## Summary

- **`AuditLog.user_email_snapshot`** — `STRING`, nullable. Captured at write time so the audit trail stays readable forever (`"admin@x.test deleted Pet 12345"`) even after the user is deleted.
- **`AuditLogService.log()`** — looks up the actor via `User.findByPk(userId, { attributes: ['email'] })` and stamps the snapshot before the insert. Best-effort: a missing user or transient lookup failure leaves the snapshot `null`; the audit row still gets written.
- **`AuditLog.user`** stays a soft reference (no DB-level FK constraint). I tried adding the FK + SET NULL per plan 2.2 in the same slice, but it cascaded to 56 test failures across `application.service`, `pet-business-logic`, and `auth-security` — every test that exercises a service path which writes an audit log was passing made-up user IDs. That cleanup is its own slice.
- **Direct `AuditLog.create`** call sites (`middleware/field-permissions.ts`, `services/field-permission.service.ts`) fall through to `null` snapshot — refactoring them through `AuditLogService.log` for consistent capture is also out of scope here.

## Test plan

- [x] `npm test` — 1364 passed, 11 skipped (added 2 new audit-log tests for snapshot capture: positive case with seeded user, negative case with unknown actor UUID).
- [x] `npm run lint` clean.
- [x] Type-check + build clean.
- [ ] Test Docker Compose Stack green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_