### PR TITLE
Phase 4 (slice 4.4 follow-up): deleted_at indexes on every paranoid m…

### DIFF
--- a/service.backend/src/__tests__/models/standards.test.ts
+++ b/service.backend/src/__tests__/models/standards.test.ts
@@ -158,6 +158,45 @@ describe('Model Standards', () => {
         `Models with both paranoid and isDeleted — ${failures.join(', ')}`
       ).toHaveLength(0);
     });
+
+    // paranoid: true filters every find on `deleted_at IS NULL`. Without
+    // an index Postgres can't use it to skip soft-deleted rows; the
+    // alternative is a sequential scan on every lookup (plan 4.4).
+    //
+    // The check is whitelist-driven rather than blanket because the global
+    // sequelize.define.paranoid: true gives every model a deleted_at
+    // column it might not actually want. The whitelist tracks the models
+    // that explicitly opt into soft-delete and need the index to back it;
+    // sorting which inherited-paranoid models truly want soft-delete vs
+    // which should opt out via paranoid: false is a separate slice.
+    const PARANOID_MODELS = [
+      'User',
+      'Pet',
+      'Application',
+      'ApplicationQuestion',
+      'Rescue',
+      'Notification',
+      'DeviceToken',
+      'Content',
+      'EmailTemplate',
+      'StaffMember',
+      'SupportTicketResponse',
+      'UserFavorite',
+    ];
+
+    it.each(PARANOID_MODELS)('%s has a deleted_at index', name => {
+      const model = sequelize.models[name];
+      expect(model, `${name} not registered`).toBeDefined();
+      const opts = (
+        model as unknown as {
+          options: { indexes?: Array<{ fields: Array<string | { name: string }> }> };
+        }
+      ).options;
+      const indexedCols = new Set(
+        (opts.indexes ?? []).flatMap(i => i.fields.map(f => (typeof f === 'string' ? f : f.name)))
+      );
+      expect(indexedCols.has('deleted_at'), `${name} missing deleted_at index`).toBe(true);
+    });
   });
 
   describe('audit columns', () => {

--- a/service.backend/src/models/Application.ts
+++ b/service.backend/src/models/Application.ts
@@ -518,6 +518,7 @@ Application.init(
         fields: ['rescue_id', 'status', { name: 'created_at', order: 'DESC' }],
         name: 'applications_rescue_status_created_idx',
       },
+      { fields: ['deleted_at'], name: 'applications_deleted_at_idx' },
       ...auditIndexes('applications'),
     ],
     hooks: {

--- a/service.backend/src/models/ApplicationQuestion.ts
+++ b/service.backend/src/models/ApplicationQuestion.ts
@@ -390,6 +390,7 @@ ApplicationQuestion.init(
           deleted_at: null,
         },
       },
+      { fields: ['deleted_at'], name: 'application_questions_deleted_at_idx' },
       ...auditIndexes('application_questions'),
     ],
     hooks: {

--- a/service.backend/src/models/Content.ts
+++ b/service.backend/src/models/Content.ts
@@ -278,6 +278,7 @@ Content.init(
       { fields: ['last_modified_by'] },
       { fields: ['published_at'] },
       { fields: ['scheduled_publish_at'] },
+      { fields: ['deleted_at'], name: 'cms_content_deleted_at_idx' },
       ...auditIndexes('cms_content'),
     ],
   })

--- a/service.backend/src/models/DeviceToken.ts
+++ b/service.backend/src/models/DeviceToken.ts
@@ -182,6 +182,7 @@ DeviceToken.init(
           deleted_at: null,
         },
       },
+      { fields: ['deleted_at'], name: 'device_tokens_deleted_at_idx' },
     ],
     hooks: {
       beforeValidate: (deviceToken: DeviceToken) => {

--- a/service.backend/src/models/EmailTemplate.ts
+++ b/service.backend/src/models/EmailTemplate.ts
@@ -521,6 +521,7 @@ EmailTemplate.init(
         fields: ['tags'],
         using: 'gin',
       },
+      { fields: ['deleted_at'], name: 'email_templates_deleted_at_idx' },
       ...auditIndexes('email_templates'),
     ],
   })

--- a/service.backend/src/models/Notification.ts
+++ b/service.backend/src/models/Notification.ts
@@ -401,6 +401,7 @@ Notification.init(
         fields: ['user_id', 'status', { name: 'created_at', order: 'DESC' }],
         name: 'notifications_user_status_created_idx',
       },
+      { fields: ['deleted_at'], name: 'notifications_deleted_at_idx' },
       ...auditIndexes('notifications'),
     ],
     hooks: {

--- a/service.backend/src/models/Pet.ts
+++ b/service.backend/src/models/Pet.ts
@@ -897,6 +897,7 @@ Pet.init(
         fields: ['status', 'type', 'size'],
         name: 'pets_status_type_size_idx',
       },
+      { fields: ['deleted_at'], name: 'pets_deleted_at_idx' },
       ...auditIndexes('pets'),
     ],
     hooks: {

--- a/service.backend/src/models/Rescue.ts
+++ b/service.backend/src/models/Rescue.ts
@@ -234,6 +234,7 @@ Rescue.init(
         fields: ['verified_by'],
         name: 'rescues_verified_by_idx',
       },
+      { fields: ['deleted_at'], name: 'rescues_deleted_at_idx' },
       ...auditIndexes('rescues'),
     ],
   })

--- a/service.backend/src/models/StaffMember.ts
+++ b/service.backend/src/models/StaffMember.ts
@@ -154,6 +154,7 @@ StaffMember.init(
         fields: ['added_by'],
         name: 'staff_members_added_by_idx',
       },
+      { fields: ['deleted_at'], name: 'staff_members_deleted_at_idx' },
       ...auditIndexes('staff_members'),
     ],
     // Soft-delete via Sequelize paranoid (plan 3.5). `destroy()`

--- a/service.backend/src/models/SupportTicketResponse.ts
+++ b/service.backend/src/models/SupportTicketResponse.ts
@@ -161,6 +161,7 @@ SupportTicketResponse.init(
         // Composite index for common queries
         fields: ['ticket_id', 'created_at'],
       },
+      { fields: ['deleted_at'], name: 'support_ticket_responses_deleted_at_idx' },
       ...auditIndexes('support_ticket_responses'),
     ],
   })

--- a/service.backend/src/models/UserFavorite.ts
+++ b/service.backend/src/models/UserFavorite.ts
@@ -113,6 +113,7 @@ UserFavorite.init(
         fields: ['created_at'],
         name: 'idx_user_favorites_created_at',
       },
+      { fields: ['deleted_at'], name: 'user_favorites_deleted_at_idx' },
       ...auditIndexes('user_favorites'),
     ],
   })


### PR DESCRIPTION
…odel

User got its deleted_at index in slice 4.4 (composite indexes). Same treatment for the other 11 models that explicitly opt into paranoid: true — without the index every find scans the full table to filter `deleted_at IS NULL` (the soft-delete predicate Sequelize inserts on every read).

  Application                applications_deleted_at_idx
  ApplicationQuestion        application_questions_deleted_at_idx
  Content                    cms_content_deleted_at_idx
  DeviceToken                device_tokens_deleted_at_idx
  EmailTemplate              email_templates_deleted_at_idx
  Notification               notifications_deleted_at_idx
  Pet                        pets_deleted_at_idx
  Rescue                     rescues_deleted_at_idx
  StaffMember                staff_members_deleted_at_idx
  SupportTicketResponse      support_ticket_responses_deleted_at_idx
  UserFavorite               user_favorites_deleted_at_idx

Plus a standards.test.ts whitelist rule that asserts each of the 12 intentionally-paranoid models has the index. The check is whitelist-driven, not blanket: the global sequelize.define.paranoid: true gives many models a deleted_at column they don't really want, so the rule tracks the models that explicitly opt into soft-delete rather than every model that happens to have the column. Sorting which inherited-paranoid models truly want soft-delete vs which should opt out via paranoid: false is a separate slice.