### PR TITLE
Phase 3 (slice 3.5): explicit paranoid:false on reference/junction/TTL tables

### DIFF
--- a/service.backend/src/models/IdempotencyKey.ts
+++ b/service.backend/src/models/IdempotencyKey.ts
@@ -92,6 +92,9 @@ IdempotencyKey.init(
     modelName: 'IdempotencyKey',
     timestamps: true,
     underscored: true,
+    // Per-request scratch with 24h TTL — drop expired rows hard via the
+    // cleanup job. No soft-delete.
+    paranoid: false,
     indexes: [
       { fields: ['user_id'], name: 'idempotency_keys_user_id_idx' },
       { fields: ['expires_at'], name: 'idempotency_keys_expires_at_idx' },

--- a/service.backend/src/models/Permission.ts
+++ b/service.backend/src/models/Permission.ts
@@ -50,6 +50,10 @@ Permission.init(
     tableName: 'permissions',
     timestamps: true,
     underscored: true,
+    // Reference data — never soft-deleted. Opts out of the global
+    // sequelize.define.paranoid: true so we don't carry an unused
+    // deleted_at column on this lookup table.
+    paranoid: false,
   }
 );
 

--- a/service.backend/src/models/RefreshToken.ts
+++ b/service.backend/src/models/RefreshToken.ts
@@ -88,6 +88,9 @@ RefreshToken.init(
     modelName: 'RefreshToken',
     timestamps: true,
     underscored: true,
+    // Hard expiration via expires_at + is_revoked. Hard-deleted on
+    // logout/cleanup; no soft-delete semantics needed.
+    paranoid: false,
     indexes: [
       { fields: ['user_id'], name: 'refresh_tokens_user_id_idx' },
       { fields: ['family_id'], name: 'refresh_tokens_family_id_idx' },

--- a/service.backend/src/models/Role.ts
+++ b/service.backend/src/models/Role.ts
@@ -54,6 +54,8 @@ Role.init(
     tableName: 'roles',
     timestamps: true,
     underscored: true,
+    // Reference data — see Permission.ts for rationale.
+    paranoid: false,
   }
 );
 

--- a/service.backend/src/models/RolePermission.ts
+++ b/service.backend/src/models/RolePermission.ts
@@ -55,6 +55,9 @@ RolePermission.init(
     tableName: 'role_permissions',
     timestamps: true,
     underscored: true,
+    // Junction table; remove the assignment outright when revoking
+    // (CASCADE FKs handle parent deletes). No soft-delete.
+    paranoid: false,
   }
 );
 

--- a/service.backend/src/models/UserRole.ts
+++ b/service.backend/src/models/UserRole.ts
@@ -48,6 +48,9 @@ UserRole.init(
     tableName: 'user_roles',
     timestamps: true,
     underscored: true,
+    // Junction table; revoke = remove the row (CASCADE handles parent
+    // deletes). No soft-delete.
+    paranoid: false,
   }
 );
 


### PR DESCRIPTION
The global `sequelize.define.paranoid: true` makes every model nominally paranoid — including reference data, junction tables, and tables with their own retention semantics. Sequelize then auto-adds a `deleted_at` column they don't really want, and every find filters on it.

This slice closes the obvious cases. The judgment-heavier ones (chat / message / report / etc.) are left for a follow-up where the soft-delete vs hard-delete decision needs more thought than a sweep can give it.

## Models opting out (paranoid: false)

| Model | Why no soft-delete |
|---|---|
| `Permission` | Reference data |
| `Role` | Reference data |
| `RolePermission` | Junction; CASCADE handles parent deletes |
| `UserRole` | Junction; CASCADE handles parent deletes |
| `RefreshToken` | Hard expiration via `expires_at` + `is_revoked` |
| `IdempotencyKey` | 24h TTL; cleanup job hard-deletes |

(`FieldPermission` already explicitly opts out.)

## Test plan

- [x] `npm test` — 1380 passed, 11 skipped.
- [x] `npm run lint` clean.
- [x] Type-check + build clean.
- [ ] Test Docker Compose Stack green — confirms the table schemas re-sync cleanly without the `deleted_at` column.

## Follow-up

A separate slice should sort the judgment cases — `Chat`, `Message`, `FileUpload`, `Invitation`, `Rating`, `Report`, `ModeratorAction`, `UserSanction`, `SupportTicket`, `EmailQueue`, `EmailPreference`, `HomeVisit`, `NavigationMenu`, `SwipeAction`, `SwipeSession`, `ApplicationTimeline`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_