### PR TITLE
Phase 3 (slice 3.5 follow-up): explicit paranoid:false on append-only models

### DIFF
--- a/service.backend/src/models/ApplicationTimeline.ts
+++ b/service.backend/src/models/ApplicationTimeline.ts
@@ -142,6 +142,9 @@ ApplicationTimeline.init(
     tableName: 'application_timeline',
     timestamps: true,
     underscored: true,
+    // Append-only event log (timeline rows are immutable history). No
+    // soft-delete — opts out of the global define.paranoid: true.
+    paranoid: false,
     indexes: [
       {
         fields: ['application_id', 'created_at'],

--- a/service.backend/src/models/EmailQueue.ts
+++ b/service.backend/src/models/EmailQueue.ts
@@ -551,6 +551,9 @@ EmailQueue.init(
     tableName: 'email_queue',
     timestamps: true,
     underscored: true,
+    // Append-only delivery queue with its own status field; sent rows
+    // get hard-archived by the retention job. No soft-delete.
+    paranoid: false,
     indexes: [
       {
         fields: ['status'],

--- a/service.backend/src/models/ModeratorAction.ts
+++ b/service.backend/src/models/ModeratorAction.ts
@@ -264,6 +264,9 @@ ModeratorAction.init(
     tableName: 'moderator_actions',
     timestamps: true,
     underscored: true,
+    // Audit-like append-only log of moderator decisions. The action row
+    // itself is immutable history; reversals are new rows. No soft-delete.
+    paranoid: false,
     indexes: [
       {
         name: 'moderator_actions_moderator_id_idx',

--- a/service.backend/src/models/SwipeAction.ts
+++ b/service.backend/src/models/SwipeAction.ts
@@ -283,6 +283,9 @@ SwipeAction.init(
     modelName: 'SwipeAction',
     timestamps: true,
     underscored: true,
+    // High-volume behavioural log; partitioned + retention per plan 4.2
+    // (24-month rolling window). Hard-deleted; no soft-delete semantics.
+    paranoid: false,
     indexes: [
       {
         fields: ['session_id'],

--- a/service.backend/src/models/SwipeSession.ts
+++ b/service.backend/src/models/SwipeSession.ts
@@ -230,6 +230,9 @@ SwipeSession.init(
     modelName: 'SwipeSession',
     timestamps: true,
     underscored: true,
+    // Behavioural session log; same retention story as swipe_actions.
+    // No soft-delete.
+    paranoid: false,
     indexes: [
       {
         fields: ['user_id', 'is_active'],

--- a/service.backend/src/models/UserSanction.ts
+++ b/service.backend/src/models/UserSanction.ts
@@ -352,6 +352,9 @@ UserSanction.init(
     tableName: 'user_sanctions',
     timestamps: true,
     underscored: true,
+    // Append-only sanction history. Lifting a sanction is a new row
+    // (reversal), not a soft-delete on the original. No paranoid.
+    paranoid: false,
     indexes: [
       {
         name: 'user_sanctions_user_id_idx',


### PR DESCRIPTION
Continues PR #143 (which closed the obvious reference/junction/TTL cases) with the append-only event-log tables. These rows are immutable history by design — reversals/retractions are new rows, not soft-deletes — so the global `define.paranoid: true` was giving them a `deleted_at` column that nothing legitimately writes to.

## Models opting out

| Model | Why no soft-delete |
|---|---|
| `ApplicationTimeline` | Timeline events are immutable history |
| `ModeratorAction` | Reversals are new rows, not soft-deletes |
| `UserSanction` | Lifting a sanction is a new row |
| `EmailQueue` | Send queue with own `status`; sent rows hard-archived by retention job |
| `SwipeAction` | High-volume behavioural; partition + retention per plan 4.2 |
| `SwipeSession` | Same retention story as `SwipeAction` |

## Remaining (intentionally kept paranoid)

Judgment calls left for now — these are user-authored data where soft-delete is the right call so an accidental destroy doesn't lose history: `Chat`, `ChatParticipant`, `FileUpload`, `Invitation`, `Rating`, `Report`, `SupportTicket`, `EmailPreference`, `HomeVisit`, `NavigationMenu`, `Message`.

## Test plan

- [x] `npm test` — 1380 passed, 11 skipped (no change from #143; this slice is additive options).
- [x] `npm run lint` clean.
- [x] Type-check + build clean.
- [ ] Test Docker Compose Stack green — confirms the table schemas re-sync without `deleted_at` on these tables.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_