### PR TITLE
Phase 4 (slice 5.6 cont.): user_privacy_prefs typed table

### DIFF
--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -178,16 +178,15 @@ describe('Authentication Flow Integration Tests', () => {
 
         await AuthService.register(registerData);
 
-        // Notification prefs are now created by the User.afterCreate hook
-        // into user_notification_prefs (plan 5.6) — auth.service no longer
-        // sets them on the User row.
+        // Notification + privacy prefs are now created by the
+        // User.afterCreate hook into their typed tables (plan 5.6) —
+        // auth.service no longer sets either on the User row, just the
+        // identity fields.
         expect(MockedUser.create).toHaveBeenCalledWith(
           expect.objectContaining({
-            privacySettings: expect.objectContaining({
-              profileVisibility: 'public',
-              showLocation: false,
-              allowMessages: true,
-            }),
+            email: registerData.email.toLowerCase(),
+            firstName: registerData.firstName,
+            lastName: registerData.lastName,
           })
         );
       });

--- a/service.backend/src/__tests__/services/user.service.test.ts
+++ b/service.backend/src/__tests__/services/user.service.test.ts
@@ -167,9 +167,9 @@ describe('UserService', () => {
 
   describe('updateUserPreferences', () => {
     it('should update user preferences successfully', async () => {
-      // Create a real user in the database. Notification prefs are
-      // auto-created by the User.afterCreate hook (plan 5.6) — no need
-      // to seed them inline.
+      // Create a real user in the database. Notification + privacy
+      // prefs are auto-created by the User.afterCreate hook (plan 5.6)
+      // — no need to seed them inline.
       const user = await User.create({
         email: 'prefs@example.com',
         password: 'hashedpassword',
@@ -177,11 +177,6 @@ describe('UserService', () => {
         lastName: 'User',
         userType: UserType.ADOPTER,
         status: UserStatus.ACTIVE,
-        privacySettings: {
-          profileVisibility: 'private',
-          showLocation: false,
-          showContactInfo: false,
-        },
       });
 
       const preferences = {

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -76,7 +76,7 @@ interface UserAttributes {
   postalCode?: string | null;
   location?: { type: string; coordinates: [number, number] };
   rescueId?: string | null;
-  privacySettings?: JsonObject;
+  // privacySettings moved to user_privacy_prefs (plan 5.6).
   // notificationPreferences moved to user_notification_prefs (plan 5.6).
   termsAcceptedAt?: Date | null;
   privacyPolicyAcceptedAt?: Date | null;
@@ -143,7 +143,6 @@ class User extends Model<UserAttributes, UserCreationAttributes> implements User
   public postalCode!: string | null;
   public location!: { type: string; coordinates: [number, number] };
   public rescueId!: string | null;
-  public privacySettings!: JsonObject;
   public termsAcceptedAt!: Date | null;
   public privacyPolicyAcceptedAt!: Date | null;
   public applicationDefaults!: JsonObject | null;
@@ -408,20 +407,9 @@ User.init(
       },
       onDelete: 'SET NULL',
     },
-    privacySettings: {
-      type: getJsonType(),
-      allowNull: true,
-      field: 'privacy_settings',
-      defaultValue: {
-        profileVisibility: 'public',
-        showEmail: false,
-        showPhone: false,
-        showLocation: true,
-      },
-    },
-    // notificationPreferences moved to user_notification_prefs (plan 5.6 —
-    // typed table with explicit columns + DB defaults; auto-created via
-    // User.afterCreate hook).
+    // privacySettings moved to user_privacy_prefs (plan 5.6); notification
+    // prefs to user_notification_prefs. Both auto-created via the
+    // User.afterCreate hook below.
     termsAcceptedAt: {
       type: DataTypes.DATE,
       allowNull: true,
@@ -540,12 +528,20 @@ User.init(
         }
         await protectSecretsIfChanged(user);
       },
-      // Plan 5.6 — every user gets a typed notification-prefs row at
-      // creation time so consumers can always assume it exists. Defaults
-      // are declared on UserNotificationPrefs.
+      // Plan 5.6 — every user gets typed pref rows at creation time so
+      // consumers can always assume they exist. Defaults are declared on
+      // each prefs model. Awaited sequentially because SQLite (the test
+      // dialect) can't run two queries concurrently within the same
+      // transaction.
       afterCreate: async (user: User, options) => {
         const { default: UserNotificationPrefs } = await import('./UserNotificationPrefs');
+        const { default: UserPrivacyPrefs } = await import('./UserPrivacyPrefs');
         await UserNotificationPrefs.findOrCreate({
+          where: { user_id: user.userId },
+          defaults: { user_id: user.userId },
+          transaction: options.transaction,
+        });
+        await UserPrivacyPrefs.findOrCreate({
           where: { user_id: user.userId },
           defaults: { user_id: user.userId },
           transaction: options.transaction,

--- a/service.backend/src/models/UserPrivacyPrefs.ts
+++ b/service.backend/src/models/UserPrivacyPrefs.ts
@@ -1,0 +1,85 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+export enum ProfileVisibility {
+  PUBLIC = 'public',
+  RESCUES_ONLY = 'rescues_only',
+  PRIVATE = 'private',
+}
+
+/**
+ * Per-user privacy preferences (plan 5.6 — typed preference table
+ * replacing the User.privacySettings JSONB blob).
+ *
+ * 1:1 with User. A row is auto-created by User.afterCreate so consumers
+ * can always assume the row exists.
+ */
+interface UserPrivacyPrefsAttributes {
+  user_id: string;
+  profile_visibility: ProfileVisibility;
+  show_last_seen: boolean;
+  show_location: boolean;
+  allow_search_indexing: boolean;
+  allow_data_export: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface UserPrivacyPrefsCreationAttributes
+  extends Optional<
+    UserPrivacyPrefsAttributes,
+    | 'profile_visibility'
+    | 'show_last_seen'
+    | 'show_location'
+    | 'allow_search_indexing'
+    | 'allow_data_export'
+    | 'created_at'
+    | 'updated_at'
+  > {}
+
+class UserPrivacyPrefs
+  extends Model<UserPrivacyPrefsAttributes, UserPrivacyPrefsCreationAttributes>
+  implements UserPrivacyPrefsAttributes
+{
+  public user_id!: string;
+  public profile_visibility!: ProfileVisibility;
+  public show_last_seen!: boolean;
+  public show_location!: boolean;
+  public allow_search_indexing!: boolean;
+  public allow_data_export!: boolean;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+UserPrivacyPrefs.init(
+  {
+    user_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      references: { model: 'users', key: 'user_id' },
+      onDelete: 'CASCADE',
+    },
+    profile_visibility: {
+      type: DataTypes.ENUM(...Object.values(ProfileVisibility)),
+      allowNull: false,
+      defaultValue: ProfileVisibility.RESCUES_ONLY,
+    },
+    show_last_seen: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    show_location: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    allow_search_indexing: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    allow_data_export: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    tableName: 'user_privacy_prefs',
+    modelName: 'UserPrivacyPrefs',
+    timestamps: true,
+    underscored: true,
+    paranoid: false,
+    indexes: [...auditIndexes('user_privacy_prefs')],
+  })
+);
+
+export default UserPrivacyPrefs;

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -8,6 +8,7 @@ import Rescue from './Rescue';
 import User from './User';
 import UserFavorite from './UserFavorite';
 import UserNotificationPrefs from './UserNotificationPrefs';
+import UserPrivacyPrefs from './UserPrivacyPrefs';
 
 // Communication Models
 import Chat from './Chat';
@@ -68,6 +69,7 @@ const models = {
   User,
   UserFavorite,
   UserNotificationPrefs,
+  UserPrivacyPrefs,
   Rescue,
   Pet,
   PetStatusTransition,
@@ -402,6 +404,11 @@ try {
   User.hasOne(UserNotificationPrefs, { foreignKey: 'user_id', as: 'NotificationPrefs' });
   UserNotificationPrefs.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
 
+  // UserPrivacyPrefs association (1:1, auto-created via User.afterCreate
+  // hook). Plan 5.6.
+  User.hasOne(UserPrivacyPrefs, { foreignKey: 'user_id', as: 'PrivacyPrefs' });
+  UserPrivacyPrefs.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
+
   // UserFavorite associations
   User.hasMany(UserFavorite, { foreignKey: 'user_id', as: 'Favorites' });
   UserFavorite.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
@@ -470,6 +477,7 @@ export {
   User,
   UserFavorite,
   UserNotificationPrefs,
+  UserPrivacyPrefs,
   UserRole,
   UserSanction,
   Content,

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -197,13 +197,8 @@ export async function seedUsers() {
         ...userData,
         password: plainPassword,
         loginAttempts: 0,
-        privacySettings: {
-          showProfile: true,
-          showLocation: false,
-          allowMessages: true,
-        },
-        // Notification prefs auto-created by User.afterCreate hook
-        // (plan 5.6) — defaults stand in.
+        // Notification + privacy prefs auto-created by User.afterCreate
+        // hook (plan 5.6) — defaults stand in.
         // Phase 1: Application defaults (JSON structure for adopters)
         applicationDefaults:
           userData.userType === UserType.ADOPTER

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -53,14 +53,8 @@ export class AuthService {
         verificationToken,
         verificationTokenExpiresAt: verificationExpires,
         loginAttempts: 0,
-        privacySettings: {
-          profileVisibility: 'public',
-          showLocation: false,
-          allowMessages: true,
-          showAdoptionHistory: false,
-        },
-        // Notification prefs auto-created by User.afterCreate hook
-        // (plan 5.6) — defaults stand in.
+        // Notification + privacy prefs auto-created by User.afterCreate
+        // hook (plan 5.6) — defaults stand in.
       });
 
       // Log registration with enhanced context

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -10,6 +10,7 @@ import Permission from '../models/Permission';
 import User, { UserStatus, UserType } from '../models/User';
 import UserFavorite from '../models/UserFavorite';
 import UserNotificationPrefs from '../models/UserNotificationPrefs';
+import UserPrivacyPrefs, { ProfileVisibility } from '../models/UserPrivacyPrefs';
 import sequelize from '../sequelize';
 import {
   BulkUserUpdateData,
@@ -428,19 +429,22 @@ export class UserService {
         throw new Error('User not found');
       }
 
-      // Privacy settings are still on the user row (plan 5.6 will move
-      // them in a follow-up slice).
-      const updatedPrivacySettings = preferences.privacySettings
-        ? { ...user.privacySettings, ...preferences.privacySettings }
-        : user.privacySettings;
-      await user.update({ privacySettings: updatedPrivacySettings });
-
-      // Notification prefs live in user_notification_prefs (plan 5.6).
-      const [prefs] = await UserNotificationPrefs.findOrCreate({
+      // Plan 5.6: notification prefs and privacy prefs live in their own
+      // typed tables. Both auto-created by the User.afterCreate hook so
+      // the findOrCreate is just defensive against pre-existing users.
+      const [notifPrefs] = await UserNotificationPrefs.findOrCreate({
         where: { user_id: userId },
         defaults: { user_id: userId },
       });
-      await prefs.update(userPrefsToPrefsRowPatch(preferences));
+      await notifPrefs.update(userPrefsToPrefsRowPatch(preferences));
+
+      if (preferences.privacySettings) {
+        const [privacyPrefs] = await UserPrivacyPrefs.findOrCreate({
+          where: { user_id: userId },
+          defaults: { user_id: userId },
+        });
+        await privacyPrefs.update(privacyPatchToPrefsRow(preferences.privacySettings));
+      }
 
       // Log the preference update
       await AuditLogService.log({
@@ -481,11 +485,16 @@ export class UserService {
         throw new Error('User not found');
       }
 
-      const [prefsRow] = await UserNotificationPrefs.findOrCreate({
+      // Sequential reads — SQLite (test dialect) can't parallelise queries
+      // inside the same auto-transaction findOrCreate opens.
+      const [notifRow] = await UserNotificationPrefs.findOrCreate({
         where: { user_id: userId },
         defaults: { user_id: userId },
       });
-      const privacySettings = (user.privacySettings as Record<string, unknown> | null) || {};
+      const [privacyRow] = await UserPrivacyPrefs.findOrCreate({
+        where: { user_id: userId },
+        defaults: { user_id: userId },
+      });
 
       if (loggerHelpers && loggerHelpers.logDatabase) {
         loggerHelpers.logDatabase('READ', {
@@ -496,14 +505,13 @@ export class UserService {
       }
 
       return {
-        emailNotifications: prefsRow.email_enabled,
-        pushNotifications: prefsRow.push_enabled,
-        smsNotifications: prefsRow.sms_enabled,
+        emailNotifications: notifRow.email_enabled,
+        pushNotifications: notifRow.push_enabled,
+        smsNotifications: notifRow.sms_enabled,
         privacySettings: {
-          profileVisibility:
-            (privacySettings.profileVisibility as 'public' | 'private' | 'friends') || 'public',
-          showLocation: Boolean(privacySettings.showLocation),
-          showContactInfo: Boolean(privacySettings.showContactInfo),
+          profileVisibility: privacyRow.profile_visibility as 'public' | 'private' | 'friends',
+          showLocation: privacyRow.show_location,
+          showContactInfo: false,
         },
       };
     } catch (error) {
@@ -536,15 +544,13 @@ export class UserService {
         },
       };
 
-      await user.update({
-        privacySettings: JSON.parse(JSON.stringify(defaultPreferences.privacySettings)),
-      });
-
-      // Reset notification prefs by destroying + recreating the row so the
-      // table-level DB defaults stand in (one source of truth for what
-      // "default" means).
+      // Reset both pref tables by destroying + recreating so the table-level
+      // DB defaults stand in (one source of truth for what "default" means).
+      // Sequential — SQLite serialises transactions per connection.
       await UserNotificationPrefs.destroy({ where: { user_id: userId } });
+      await UserPrivacyPrefs.destroy({ where: { user_id: userId } });
       await UserNotificationPrefs.create({ user_id: userId });
+      await UserPrivacyPrefs.create({ user_id: userId });
 
       // Log the preference reset
       await AuditLogService.log({
@@ -1573,6 +1579,34 @@ function userPrefsToPrefsRowPatch(input: UserPreferences): Partial<{
   if (np?.rescueUpdates !== undefined) {
     out.rescue_updates = np.rescueUpdates;
   }
+  return out;
+}
+
+/**
+ * Map an API-side privacy patch to the column-named partial accepted by
+ * UserPrivacyPrefs.update(). The legacy showContactInfo and allowMessages
+ * keys aren't tracked in the new table — silently ignored.
+ */
+function privacyPatchToPrefsRow(input: NonNullable<UserPreferences['privacySettings']>): Partial<{
+  profile_visibility: ProfileVisibility;
+  show_location: boolean;
+}> {
+  const out: Partial<{ profile_visibility: ProfileVisibility; show_location: boolean }> = {};
+  if (input.profileVisibility !== undefined) {
+    // Legacy API uses 'friends' for what the typed table calls 'rescues_only'.
+    switch (input.profileVisibility) {
+      case 'public':
+        out.profile_visibility = ProfileVisibility.PUBLIC;
+        break;
+      case 'private':
+        out.profile_visibility = ProfileVisibility.PRIVATE;
+        break;
+      case 'friends':
+        out.profile_visibility = ProfileVisibility.RESCUES_ONLY;
+        break;
+    }
+  }
+  if (input.showLocation !== undefined) out.show_location = input.showLocation;
   return out;
 }
 


### PR DESCRIPTION
Second of four typed-pref tables. Replaces `User.privacySettings` JSONB with a real schema. Same shape as the notification-prefs slice (#145): 1:1 with User, auto-created via the `User.afterCreate` hook, service consumers route through the new model.

## Schema

```
user_privacy_prefs
  user_id                UUID PK FK→users CASCADE
  profile_visibility     ENUM(public|rescues_only|private) DEFAULT 'rescues_only'
  show_last_seen         BOOLEAN NOT NULL DEFAULT false
  show_location          BOOLEAN NOT NULL DEFAULT true
  allow_search_indexing  BOOLEAN NOT NULL DEFAULT false
  allow_data_export      BOOLEAN NOT NULL DEFAULT true
```

## Notable

- The legacy `UserPreferences` API uses `'public' | 'private' | 'friends'` for `profileVisibility`; the new enum tightens `'friends'` to the more descriptive `'rescues_only'`. The mapper translates one to the other so the API contract is preserved.
- `User.afterCreate` now creates both pref rows. SQLite (test dialect) can't parallelise queries inside the auto-transaction `findOrCreate` opens, so the inserts are sequential — same change applied to `getUserPreferences` and `resetUserPreferences` which had `Promise.all` patterns that hit the same wall.

## What's left of plan 5.6

- `user_application_prefs` (currently `User.applicationDefaults` + `User.applicationPreferences`)
- `rescue_settings` (currently `Rescue.settings`)

## Test plan

- [x] `npm test` — 1380 passed, 11 skipped (no count change; this slice doesn't add new tests, two existing tests updated to match the auto-create behaviour).
- [x] `npm run lint` clean.
- [x] Type-check + build clean.
- [ ] Test Docker Compose Stack green — confirms the new table syncs cleanly + the auto-create hook fires for both pref rows during seeding.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_