### PR TITLE
Phase 4 (slice 5.6 cont.): user_application_prefs typed table

### DIFF
--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -81,7 +81,7 @@ interface UserAttributes {
   termsAcceptedAt?: Date | null;
   privacyPolicyAcceptedAt?: Date | null;
   applicationDefaults?: JsonObject | null;
-  applicationPreferences?: JsonObject;
+  // applicationPreferences moved to user_application_prefs (plan 5.6).
   profileCompletionStatus?: JsonObject;
   applicationTemplateVersion?: number;
   Roles?: Role[];
@@ -146,7 +146,6 @@ class User extends Model<UserAttributes, UserCreationAttributes> implements User
   public termsAcceptedAt!: Date | null;
   public privacyPolicyAcceptedAt!: Date | null;
   public applicationDefaults!: JsonObject | null;
-  public applicationPreferences!: JsonObject;
   public profileCompletionStatus!: JsonObject;
   public applicationTemplateVersion!: number;
 
@@ -426,16 +425,9 @@ User.init(
       field: 'application_defaults',
       defaultValue: null,
     },
-    applicationPreferences: {
-      type: getJsonType(),
-      allowNull: true,
-      field: 'application_preferences',
-      defaultValue: {
-        auto_populate: true,
-        quick_apply_enabled: false,
-        completion_reminders: true,
-      },
-    },
+    // applicationPreferences moved to user_application_prefs (plan 5.6).
+    // Auto-created via the User.afterCreate hook below. applicationDefaults
+    // (the rich profile snapshot) stays as JSONB — separate larger slice.
     profileCompletionStatus: {
       type: getJsonType(),
       allowNull: true,
@@ -536,12 +528,18 @@ User.init(
       afterCreate: async (user: User, options) => {
         const { default: UserNotificationPrefs } = await import('./UserNotificationPrefs');
         const { default: UserPrivacyPrefs } = await import('./UserPrivacyPrefs');
+        const { default: UserApplicationPrefs } = await import('./UserApplicationPrefs');
         await UserNotificationPrefs.findOrCreate({
           where: { user_id: user.userId },
           defaults: { user_id: user.userId },
           transaction: options.transaction,
         });
         await UserPrivacyPrefs.findOrCreate({
+          where: { user_id: user.userId },
+          defaults: { user_id: user.userId },
+          transaction: options.transaction,
+        });
+        await UserApplicationPrefs.findOrCreate({
           where: { user_id: user.userId },
           defaults: { user_id: user.userId },
           transaction: options.transaction,

--- a/service.backend/src/models/UserApplicationPrefs.ts
+++ b/service.backend/src/models/UserApplicationPrefs.ts
@@ -1,0 +1,88 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+/**
+ * Per-user application-flow preferences (plan 5.6 — typed preference
+ * table replacing the User.applicationPreferences JSONB blob).
+ *
+ * 1:1 with User. Auto-created via User.afterCreate so consumers can
+ * always assume the row exists.
+ *
+ * The legacy JSONB used three keys (`auto_populate`,
+ * `quick_apply_enabled`, `completion_reminders`); this table maps them
+ * to plan-spec column names plus two new fields the plan calls for
+ * (`share_with_rescues`, `default_household_size`).
+ *
+ * Note: User.applicationDefaults (the rich profile snapshot —
+ * personalInfo, livingSituation, references) stays as JSONB for now.
+ * Splitting it into typed sub-tables is a separate larger slice.
+ */
+interface UserApplicationPrefsAttributes {
+  user_id: string;
+  auto_fill_profile: boolean;
+  remember_answers: boolean;
+  share_with_rescues: boolean;
+  completion_reminders: boolean;
+  default_household_size: number | null;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface UserApplicationPrefsCreationAttributes
+  extends Optional<
+    UserApplicationPrefsAttributes,
+    | 'auto_fill_profile'
+    | 'remember_answers'
+    | 'share_with_rescues'
+    | 'completion_reminders'
+    | 'default_household_size'
+    | 'created_at'
+    | 'updated_at'
+  > {}
+
+class UserApplicationPrefs
+  extends Model<UserApplicationPrefsAttributes, UserApplicationPrefsCreationAttributes>
+  implements UserApplicationPrefsAttributes
+{
+  public user_id!: string;
+  public auto_fill_profile!: boolean;
+  public remember_answers!: boolean;
+  public share_with_rescues!: boolean;
+  public completion_reminders!: boolean;
+  public default_household_size!: number | null;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+UserApplicationPrefs.init(
+  {
+    user_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      references: { model: 'users', key: 'user_id' },
+      onDelete: 'CASCADE',
+    },
+    auto_fill_profile: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    remember_answers: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    share_with_rescues: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    completion_reminders: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    default_household_size: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      validate: { min: 1, max: 50 },
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    tableName: 'user_application_prefs',
+    modelName: 'UserApplicationPrefs',
+    timestamps: true,
+    underscored: true,
+    paranoid: false,
+    indexes: [...auditIndexes('user_application_prefs')],
+  })
+);
+
+export default UserApplicationPrefs;

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -7,6 +7,7 @@ import PetStatusTransition from './PetStatusTransition';
 import Rescue from './Rescue';
 import User from './User';
 import UserFavorite from './UserFavorite';
+import UserApplicationPrefs from './UserApplicationPrefs';
 import UserNotificationPrefs from './UserNotificationPrefs';
 import UserPrivacyPrefs from './UserPrivacyPrefs';
 
@@ -70,6 +71,7 @@ const models = {
   UserFavorite,
   UserNotificationPrefs,
   UserPrivacyPrefs,
+  UserApplicationPrefs,
   Rescue,
   Pet,
   PetStatusTransition,
@@ -409,6 +411,11 @@ try {
   User.hasOne(UserPrivacyPrefs, { foreignKey: 'user_id', as: 'PrivacyPrefs' });
   UserPrivacyPrefs.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
 
+  // UserApplicationPrefs association (1:1, auto-created via
+  // User.afterCreate hook). Plan 5.6.
+  User.hasOne(UserApplicationPrefs, { foreignKey: 'user_id', as: 'ApplicationPrefs' });
+  UserApplicationPrefs.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
+
   // UserFavorite associations
   User.hasMany(UserFavorite, { foreignKey: 'user_id', as: 'Favorites' });
   UserFavorite.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
@@ -478,6 +485,7 @@ export {
   UserFavorite,
   UserNotificationPrefs,
   UserPrivacyPrefs,
+  UserApplicationPrefs,
   UserRole,
   UserSanction,
   Content,

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -283,16 +283,8 @@ export async function seedUsers() {
                 })
               )
             : null,
-        applicationPreferences:
-          userData.userType === UserType.ADOPTER
-            ? JSON.parse(
-                JSON.stringify({
-                  auto_populate: true,
-                  quick_apply_enabled: true,
-                  completion_reminders: true,
-                })
-              )
-            : undefined,
+        // applicationPreferences moved to user_application_prefs (plan
+        // 5.6) — auto-created by User.afterCreate hook; defaults stand in.
         profileCompletionStatus:
           userData.userType === UserType.ADOPTER
             ? JSON.parse(

--- a/service.backend/src/services/application-profile.service.ts
+++ b/service.backend/src/services/application-profile.service.ts
@@ -1,4 +1,5 @@
 import User from '../models/User';
+import UserApplicationPrefs from '../models/UserApplicationPrefs';
 import {
   ApplicationDefaults,
   ApplicationPreferences,
@@ -108,21 +109,18 @@ export class ApplicationProfileService {
    */
   static async getApplicationPreferences(userId: string): Promise<ApplicationPreferences> {
     try {
-      const user = await User.findByPk(userId, {
-        attributes: ['applicationPreferences'],
-      });
-
+      const user = await User.findByPk(userId, { attributes: ['userId'] });
       if (!user) {
         throw new Error('User not found');
       }
-
-      return (
-        (user.applicationPreferences as unknown as ApplicationPreferences) || {
-          auto_populate: true,
-          quick_apply_enabled: false,
-          completion_reminders: true,
-        }
-      );
+      // Plan 5.6: prefs live in user_application_prefs. Auto-created
+      // by User.afterCreate; findOrCreate is defensive against
+      // pre-existing users.
+      const [row] = await UserApplicationPrefs.findOrCreate({
+        where: { user_id: userId },
+        defaults: { user_id: userId },
+      });
+      return prefsRowToApi(row);
     } catch (error) {
       logger.error('Error getting application preferences:', error);
       throw error;
@@ -151,23 +149,20 @@ export class ApplicationProfileService {
     request: UpdateApplicationPreferencesRequest
   ): Promise<ApplicationPreferences> {
     try {
-      const user = await User.findByPk(userId);
-
+      const user = await User.findByPk(userId, { attributes: ['userId'] });
       if (!user) {
         throw new Error('User not found');
       }
 
-      // Merge with existing preferences
-      const currentPreferences =
-        (user.applicationPreferences as unknown as ApplicationPreferences) || {};
-      const updatedPreferences = { ...currentPreferences, ...request.applicationPreferences };
-
-      await user.update({
-        applicationPreferences: updatedPreferences,
+      const [row] = await UserApplicationPrefs.findOrCreate({
+        where: { user_id: userId },
+        defaults: { user_id: userId },
       });
+      await row.update(apiPatchToPrefsRow(request.applicationPreferences));
+      await row.reload();
 
       logger.info('Application preferences updated successfully', { userId });
-      return updatedPreferences;
+      return prefsRowToApi(row);
     } catch (error) {
       logger.error('Error updating application preferences:', error);
       throw error;
@@ -559,4 +554,50 @@ export class ApplicationProfileService {
 
     return nextSteps;
   }
+}
+
+/**
+ * Project a UserApplicationPrefs row into the legacy API shape (which
+ * uses the old JSONB key names).
+ */
+function prefsRowToApi(row: UserApplicationPrefs): ApplicationPreferences {
+  return {
+    auto_populate: row.auto_fill_profile,
+    quick_apply_enabled: row.remember_answers,
+    completion_reminders: row.completion_reminders,
+  } as ApplicationPreferences;
+}
+
+/**
+ * Map an API-side preferences patch to the column-named partial accepted
+ * by UserApplicationPrefs.update(). New plan-spec fields
+ * (share_with_rescues, default_household_size) aren't yet in the API
+ * contract — they'll get added in a follow-up alongside the
+ * applicationDefaults split.
+ */
+function apiPatchToPrefsRow(input: Partial<ApplicationPreferences>): Partial<{
+  auto_fill_profile: boolean;
+  remember_answers: boolean;
+  completion_reminders: boolean;
+}> {
+  const out: Partial<{
+    auto_fill_profile: boolean;
+    remember_answers: boolean;
+    completion_reminders: boolean;
+  }> = {};
+  const i = input as {
+    auto_populate?: boolean;
+    quick_apply_enabled?: boolean;
+    completion_reminders?: boolean;
+  };
+  if (i.auto_populate !== undefined) {
+    out.auto_fill_profile = i.auto_populate;
+  }
+  if (i.quick_apply_enabled !== undefined) {
+    out.remember_answers = i.quick_apply_enabled;
+  }
+  if (i.completion_reminders !== undefined) {
+    out.completion_reminders = i.completion_reminders;
+  }
+  return out;
 }


### PR DESCRIPTION
Third of four typed-pref tables. Replaces User.applicationPreferences JSONB with the typed schema; the rich User.applicationDefaults blob (personalInfo, livingSituation, references) stays JSONB for now — splitting it into typed sub-tables is a separate larger slice.

  user_application_prefs
    user_id                UUID PK FK→users CASCADE
    auto_fill_profile      BOOLEAN NOT NULL DEFAULT true
    remember_answers       BOOLEAN NOT NULL DEFAULT true
    share_with_rescues     BOOLEAN NOT NULL DEFAULT false
    completion_reminders   BOOLEAN NOT NULL DEFAULT true
    default_household_size INTEGER NULL

Same shape as #145/#146: 1:1 with User, auto-created via User.afterCreate, projection helpers map between the legacy JSONB key names (auto_populate / quick_apply_enabled / completion_reminders) and the typed columns so the API contract is preserved. The two new plan-spec fields (share_with_rescues, default_household_size) get defaults but aren't yet exposed via the API — they'll surface in a follow-up that also tackles the applicationDefaults split.

User.applicationPreferences column removed; seeders updated.