### PR TITLE
Phase 4 (slice 5.6 final): rescue_settings typed table

### DIFF
--- a/service.backend/src/models/Rescue.ts
+++ b/service.backend/src/models/Rescue.ts
@@ -237,6 +237,18 @@ Rescue.init(
       { fields: ['deleted_at'], name: 'rescues_deleted_at_idx' },
       ...auditIndexes('rescues'),
     ],
+    hooks: {
+      // Plan 5.6 — every rescue gets a typed settings row at creation
+      // time so consumers can always assume it exists.
+      afterCreate: async (rescue: Rescue, options) => {
+        const { default: RescueSettings } = await import('./RescueSettings');
+        await RescueSettings.findOrCreate({
+          where: { rescue_id: rescue.rescueId },
+          defaults: { rescue_id: rescue.rescueId },
+          transaction: options.transaction,
+        });
+      },
+    },
   })
 );
 

--- a/service.backend/src/models/RescueSettings.ts
+++ b/service.backend/src/models/RescueSettings.ts
@@ -1,0 +1,98 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+/**
+ * Per-rescue operational settings (plan 5.6 — typed preference table
+ * complementing Rescue.settings JSONB).
+ *
+ * 1:1 with Rescue. Auto-created via Rescue.afterCreate so consumers
+ * can always assume the row exists.
+ *
+ * Scope note: Rescue.settings.adoptionPolicies (the rich nested
+ * AdoptionPolicy object — references count, fee range, requirements
+ * list, etc.) stays in the JSONB column for now. Splitting that into
+ * its own typed shape is a separate larger slice.
+ */
+interface RescueSettingsAttributes {
+  rescue_id: string;
+  auto_approve_applications: boolean;
+  require_home_visit: boolean;
+  require_references: boolean;
+  min_adopter_age: number;
+  allow_out_of_area_adoptions: boolean;
+  application_expiry_days: number;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface RescueSettingsCreationAttributes
+  extends Optional<
+    RescueSettingsAttributes,
+    | 'auto_approve_applications'
+    | 'require_home_visit'
+    | 'require_references'
+    | 'min_adopter_age'
+    | 'allow_out_of_area_adoptions'
+    | 'application_expiry_days'
+    | 'created_at'
+    | 'updated_at'
+  > {}
+
+class RescueSettings
+  extends Model<RescueSettingsAttributes, RescueSettingsCreationAttributes>
+  implements RescueSettingsAttributes
+{
+  public rescue_id!: string;
+  public auto_approve_applications!: boolean;
+  public require_home_visit!: boolean;
+  public require_references!: boolean;
+  public min_adopter_age!: number;
+  public allow_out_of_area_adoptions!: boolean;
+  public application_expiry_days!: number;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+RescueSettings.init(
+  {
+    rescue_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      references: { model: 'rescues', key: 'rescue_id' },
+      onDelete: 'CASCADE',
+    },
+    auto_approve_applications: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    require_home_visit: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    require_references: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    min_adopter_age: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 18,
+      validate: { min: 16, max: 99 },
+    },
+    allow_out_of_area_adoptions: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    application_expiry_days: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 30,
+      validate: { min: 1, max: 365 },
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    tableName: 'rescue_settings',
+    modelName: 'RescueSettings',
+    timestamps: true,
+    underscored: true,
+    paranoid: false,
+    indexes: [...auditIndexes('rescue_settings')],
+  })
+);
+
+export default RescueSettings;

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -81,7 +81,7 @@ interface UserAttributes {
   termsAcceptedAt?: Date | null;
   privacyPolicyAcceptedAt?: Date | null;
   applicationDefaults?: JsonObject | null;
-  applicationPreferences?: JsonObject;
+  // applicationPreferences moved to user_application_prefs (plan 5.6).
   profileCompletionStatus?: JsonObject;
   applicationTemplateVersion?: number;
   Roles?: Role[];
@@ -146,7 +146,6 @@ class User extends Model<UserAttributes, UserCreationAttributes> implements User
   public termsAcceptedAt!: Date | null;
   public privacyPolicyAcceptedAt!: Date | null;
   public applicationDefaults!: JsonObject | null;
-  public applicationPreferences!: JsonObject;
   public profileCompletionStatus!: JsonObject;
   public applicationTemplateVersion!: number;
 
@@ -426,16 +425,9 @@ User.init(
       field: 'application_defaults',
       defaultValue: null,
     },
-    applicationPreferences: {
-      type: getJsonType(),
-      allowNull: true,
-      field: 'application_preferences',
-      defaultValue: {
-        auto_populate: true,
-        quick_apply_enabled: false,
-        completion_reminders: true,
-      },
-    },
+    // applicationPreferences moved to user_application_prefs (plan 5.6).
+    // Auto-created via the User.afterCreate hook below. applicationDefaults
+    // (the rich profile snapshot) stays as JSONB — separate larger slice.
     profileCompletionStatus: {
       type: getJsonType(),
       allowNull: true,
@@ -536,12 +528,18 @@ User.init(
       afterCreate: async (user: User, options) => {
         const { default: UserNotificationPrefs } = await import('./UserNotificationPrefs');
         const { default: UserPrivacyPrefs } = await import('./UserPrivacyPrefs');
+        const { default: UserApplicationPrefs } = await import('./UserApplicationPrefs');
         await UserNotificationPrefs.findOrCreate({
           where: { user_id: user.userId },
           defaults: { user_id: user.userId },
           transaction: options.transaction,
         });
         await UserPrivacyPrefs.findOrCreate({
+          where: { user_id: user.userId },
+          defaults: { user_id: user.userId },
+          transaction: options.transaction,
+        });
+        await UserApplicationPrefs.findOrCreate({
           where: { user_id: user.userId },
           defaults: { user_id: user.userId },
           transaction: options.transaction,

--- a/service.backend/src/models/UserApplicationPrefs.ts
+++ b/service.backend/src/models/UserApplicationPrefs.ts
@@ -1,0 +1,88 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+/**
+ * Per-user application-flow preferences (plan 5.6 — typed preference
+ * table replacing the User.applicationPreferences JSONB blob).
+ *
+ * 1:1 with User. Auto-created via User.afterCreate so consumers can
+ * always assume the row exists.
+ *
+ * The legacy JSONB used three keys (`auto_populate`,
+ * `quick_apply_enabled`, `completion_reminders`); this table maps them
+ * to plan-spec column names plus two new fields the plan calls for
+ * (`share_with_rescues`, `default_household_size`).
+ *
+ * Note: User.applicationDefaults (the rich profile snapshot —
+ * personalInfo, livingSituation, references) stays as JSONB for now.
+ * Splitting it into typed sub-tables is a separate larger slice.
+ */
+interface UserApplicationPrefsAttributes {
+  user_id: string;
+  auto_fill_profile: boolean;
+  remember_answers: boolean;
+  share_with_rescues: boolean;
+  completion_reminders: boolean;
+  default_household_size: number | null;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface UserApplicationPrefsCreationAttributes
+  extends Optional<
+    UserApplicationPrefsAttributes,
+    | 'auto_fill_profile'
+    | 'remember_answers'
+    | 'share_with_rescues'
+    | 'completion_reminders'
+    | 'default_household_size'
+    | 'created_at'
+    | 'updated_at'
+  > {}
+
+class UserApplicationPrefs
+  extends Model<UserApplicationPrefsAttributes, UserApplicationPrefsCreationAttributes>
+  implements UserApplicationPrefsAttributes
+{
+  public user_id!: string;
+  public auto_fill_profile!: boolean;
+  public remember_answers!: boolean;
+  public share_with_rescues!: boolean;
+  public completion_reminders!: boolean;
+  public default_household_size!: number | null;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+UserApplicationPrefs.init(
+  {
+    user_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      references: { model: 'users', key: 'user_id' },
+      onDelete: 'CASCADE',
+    },
+    auto_fill_profile: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    remember_answers: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    share_with_rescues: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    completion_reminders: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    default_household_size: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      validate: { min: 1, max: 50 },
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    tableName: 'user_application_prefs',
+    modelName: 'UserApplicationPrefs',
+    timestamps: true,
+    underscored: true,
+    paranoid: false,
+    indexes: [...auditIndexes('user_application_prefs')],
+  })
+);
+
+export default UserApplicationPrefs;

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -7,6 +7,7 @@ import PetStatusTransition from './PetStatusTransition';
 import Rescue from './Rescue';
 import User from './User';
 import UserFavorite from './UserFavorite';
+import UserApplicationPrefs from './UserApplicationPrefs';
 import UserNotificationPrefs from './UserNotificationPrefs';
 import UserPrivacyPrefs from './UserPrivacyPrefs';
 
@@ -70,6 +71,7 @@ const models = {
   UserFavorite,
   UserNotificationPrefs,
   UserPrivacyPrefs,
+  UserApplicationPrefs,
   Rescue,
   Pet,
   PetStatusTransition,
@@ -409,6 +411,11 @@ try {
   User.hasOne(UserPrivacyPrefs, { foreignKey: 'user_id', as: 'PrivacyPrefs' });
   UserPrivacyPrefs.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
 
+  // UserApplicationPrefs association (1:1, auto-created via
+  // User.afterCreate hook). Plan 5.6.
+  User.hasOne(UserApplicationPrefs, { foreignKey: 'user_id', as: 'ApplicationPrefs' });
+  UserApplicationPrefs.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
+
   // UserFavorite associations
   User.hasMany(UserFavorite, { foreignKey: 'user_id', as: 'Favorites' });
   UserFavorite.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
@@ -478,6 +485,7 @@ export {
   UserFavorite,
   UserNotificationPrefs,
   UserPrivacyPrefs,
+  UserApplicationPrefs,
   UserRole,
   UserSanction,
   Content,

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -5,6 +5,7 @@ import ApplicationTimeline from './ApplicationTimeline';
 import Pet from './Pet';
 import PetStatusTransition from './PetStatusTransition';
 import Rescue from './Rescue';
+import RescueSettings from './RescueSettings';
 import User from './User';
 import UserFavorite from './UserFavorite';
 import UserApplicationPrefs from './UserApplicationPrefs';
@@ -73,6 +74,7 @@ const models = {
   UserPrivacyPrefs,
   UserApplicationPrefs,
   Rescue,
+  RescueSettings,
   Pet,
   PetStatusTransition,
   Application,
@@ -214,6 +216,11 @@ try {
     as: 'CreatedBy',
     constraints: false,
   });
+
+  // RescueSettings association (1:1, auto-created via Rescue.afterCreate
+  // hook). Plan 5.6.
+  Rescue.hasOne(RescueSettings, { foreignKey: 'rescue_id', as: 'Settings' });
+  RescueSettings.belongsTo(Rescue, { foreignKey: 'rescue_id', as: 'Rescue' });
 
   Rescue.hasMany(Application, { foreignKey: 'rescue_id', as: 'RescueApplications' });
   Application.belongsTo(Rescue, { foreignKey: 'rescue_id', as: 'Rescue' });
@@ -474,6 +481,7 @@ export {
   Report,
   ReportStatusTransition,
   Rescue,
+  RescueSettings,
   Role,
   RolePermission,
   StaffMember,

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -283,16 +283,8 @@ export async function seedUsers() {
                 })
               )
             : null,
-        applicationPreferences:
-          userData.userType === UserType.ADOPTER
-            ? JSON.parse(
-                JSON.stringify({
-                  auto_populate: true,
-                  quick_apply_enabled: true,
-                  completion_reminders: true,
-                })
-              )
-            : undefined,
+        // applicationPreferences moved to user_application_prefs (plan
+        // 5.6) — auto-created by User.afterCreate hook; defaults stand in.
         profileCompletionStatus:
           userData.userType === UserType.ADOPTER
             ? JSON.parse(

--- a/service.backend/src/seeders/06-rescues.ts
+++ b/service.backend/src/seeders/06-rescues.ts
@@ -24,11 +24,12 @@ const rescueOrganizations = [
     status: 'verified' as const,
     verifiedAt: new Date('2023-01-15'),
     verifiedBy: '0cbbd913-c94c-4254-a028-81b76df89c9f',
+    // Toggles like autoApproveApplications, requireHomeVisit live in
+    // rescue_settings now (plan 5.6 — auto-created via Rescue.afterCreate
+    // hook with table-level defaults). The JSONB only carries
+    // adoptionPolicies, which is the rich nested object that hasn't
+    // been split out yet.
     settings: {
-      autoApproveApplications: false,
-      requireHomeVisit: true,
-      allowPublicContact: true,
-      adoptionFeeRange: { min: 50, max: 300 },
       adoptionPolicies: {
         requireHomeVisit: true,
         requireReferences: true,
@@ -81,10 +82,6 @@ const rescueOrganizations = [
     verifiedAt: new Date('2023-02-20'),
     verifiedBy: '0cbbd913-c94c-4254-a028-81b76df89c9f',
     settings: {
-      autoApproveApplications: false,
-      requireHomeVisit: true,
-      allowPublicContact: true,
-      adoptionFeeRange: { min: 25, max: 150 },
       adoptionPolicies: {
         requireHomeVisit: true,
         requireReferences: true,
@@ -134,12 +131,9 @@ const rescueOrganizations = [
     contactEmail: 'coordinator@furryfriendspdx.dev',
     contactPhone: '(503) 555-0789',
     status: 'pending' as const,
-    settings: {
-      autoApproveApplications: false,
-      requireHomeVisit: false,
-      allowPublicContact: true,
-      adoptionFeeRange: { min: 75, max: 400 },
-    },
+    // Toggles live in rescue_settings (auto-created); JSONB stays empty
+    // until adoption policies are added.
+    settings: {},
   },
 ];
 

--- a/service.backend/src/services/application-profile.service.ts
+++ b/service.backend/src/services/application-profile.service.ts
@@ -1,4 +1,5 @@
 import User from '../models/User';
+import UserApplicationPrefs from '../models/UserApplicationPrefs';
 import {
   ApplicationDefaults,
   ApplicationPreferences,
@@ -108,21 +109,18 @@ export class ApplicationProfileService {
    */
   static async getApplicationPreferences(userId: string): Promise<ApplicationPreferences> {
     try {
-      const user = await User.findByPk(userId, {
-        attributes: ['applicationPreferences'],
-      });
-
+      const user = await User.findByPk(userId, { attributes: ['userId'] });
       if (!user) {
         throw new Error('User not found');
       }
-
-      return (
-        (user.applicationPreferences as unknown as ApplicationPreferences) || {
-          auto_populate: true,
-          quick_apply_enabled: false,
-          completion_reminders: true,
-        }
-      );
+      // Plan 5.6: prefs live in user_application_prefs. Auto-created
+      // by User.afterCreate; findOrCreate is defensive against
+      // pre-existing users.
+      const [row] = await UserApplicationPrefs.findOrCreate({
+        where: { user_id: userId },
+        defaults: { user_id: userId },
+      });
+      return prefsRowToApi(row);
     } catch (error) {
       logger.error('Error getting application preferences:', error);
       throw error;
@@ -151,23 +149,20 @@ export class ApplicationProfileService {
     request: UpdateApplicationPreferencesRequest
   ): Promise<ApplicationPreferences> {
     try {
-      const user = await User.findByPk(userId);
-
+      const user = await User.findByPk(userId, { attributes: ['userId'] });
       if (!user) {
         throw new Error('User not found');
       }
 
-      // Merge with existing preferences
-      const currentPreferences =
-        (user.applicationPreferences as unknown as ApplicationPreferences) || {};
-      const updatedPreferences = { ...currentPreferences, ...request.applicationPreferences };
-
-      await user.update({
-        applicationPreferences: updatedPreferences,
+      const [row] = await UserApplicationPrefs.findOrCreate({
+        where: { user_id: userId },
+        defaults: { user_id: userId },
       });
+      await row.update(apiPatchToPrefsRow(request.applicationPreferences));
+      await row.reload();
 
       logger.info('Application preferences updated successfully', { userId });
-      return updatedPreferences;
+      return prefsRowToApi(row);
     } catch (error) {
       logger.error('Error updating application preferences:', error);
       throw error;
@@ -559,4 +554,50 @@ export class ApplicationProfileService {
 
     return nextSteps;
   }
+}
+
+/**
+ * Project a UserApplicationPrefs row into the legacy API shape (which
+ * uses the old JSONB key names).
+ */
+function prefsRowToApi(row: UserApplicationPrefs): ApplicationPreferences {
+  return {
+    auto_populate: row.auto_fill_profile,
+    quick_apply_enabled: row.remember_answers,
+    completion_reminders: row.completion_reminders,
+  } as ApplicationPreferences;
+}
+
+/**
+ * Map an API-side preferences patch to the column-named partial accepted
+ * by UserApplicationPrefs.update(). New plan-spec fields
+ * (share_with_rescues, default_household_size) aren't yet in the API
+ * contract — they'll get added in a follow-up alongside the
+ * applicationDefaults split.
+ */
+function apiPatchToPrefsRow(input: Partial<ApplicationPreferences>): Partial<{
+  auto_fill_profile: boolean;
+  remember_answers: boolean;
+  completion_reminders: boolean;
+}> {
+  const out: Partial<{
+    auto_fill_profile: boolean;
+    remember_answers: boolean;
+    completion_reminders: boolean;
+  }> = {};
+  const i = input as {
+    auto_populate?: boolean;
+    quick_apply_enabled?: boolean;
+    completion_reminders?: boolean;
+  };
+  if (i.auto_populate !== undefined) {
+    out.auto_fill_profile = i.auto_populate;
+  }
+  if (i.quick_apply_enabled !== undefined) {
+    out.remember_answers = i.quick_apply_enabled;
+  }
+  if (i.completion_reminders !== undefined) {
+    out.completion_reminders = i.completion_reminders;
+  }
+  return out;
 }


### PR DESCRIPTION
Last of four typed-pref tables. Adds `rescue_settings` per the plan spec; complements (rather than replaces) `Rescue.settings` JSONB which keeps holding `adoptionPolicies` — that's a rich nested object whose typed split is a separate larger slice.

## Schema

```
rescue_settings
  rescue_id                    UUID PK FK→rescues CASCADE
  auto_approve_applications    BOOLEAN NOT NULL DEFAULT false
  require_home_visit           BOOLEAN NOT NULL DEFAULT true
  require_references           BOOLEAN NOT NULL DEFAULT true
  min_adopter_age              INTEGER NOT NULL DEFAULT 18
  allow_out_of_area_adoptions  BOOLEAN NOT NULL DEFAULT false
  application_expiry_days      INTEGER NOT NULL DEFAULT 30
```

## Pattern

Same shape as the three User pref tables (#145, #146, #148): 1:1 with parent, auto-created via `Rescue.afterCreate`, sequential awaits in the hook (SQLite test path).

Seeders trim dead JSONB keys (`autoApproveApplications`, `requireHomeVisit`, `allowPublicContact`, `adoptionFeeRange`) — those weren't read by any service code; the toggles now live in the typed table with their default values, and adoption fee range is part of `adoptionPolicies`.

## What's left

This closes plan 5.6 for the four-table sweep. The remaining preferences-related plan items are larger structural slices for later:

- `User.applicationDefaults` split into typed sub-tables (`personalInfo`, `livingSituation`, `petExperience`, `references`)
- `Rescue.settings.adoptionPolicies` split (or move into `rescue_settings` as additional columns)

## Test plan

- [x] `npm test` — 1380 passed, 11 skipped.
- [x] `npm run lint` clean (0 errors).
- [x] Type-check + build clean.
- [ ] Test Docker Compose Stack green — confirms the new table syncs cleanly + the auto-create hook fires for rescues during seeding.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_