### PR TITLE
security: remove dev-token bypass and eval('import.meta') from auth stack

### DIFF
--- a/app.admin/src/services/authService.ts
+++ b/app.admin/src/services/authService.ts
@@ -185,56 +185,6 @@ class AuthService {
     }
   }
 
-  // Development helper for admin
-  async loginWithDevToken(userType: UserType = 'admin'): Promise<void> {
-    if (!import.meta.env.DEV) {
-      throw new Error('Dev token login is only available in development mode');
-    }
-
-    const devToken = `dev-token-${userType}`;
-    const mockUser: User = {
-      userId: `dev-admin-${userType}`,
-      email: `${userType}@admin.dev.local`,
-      firstName: 'Dev',
-      lastName: 'Admin',
-      emailVerified: true,
-      phoneNumber: null,
-      phoneVerified: false,
-      status: 'active',
-      userType: userType,
-      profileImageUrl: null,
-      bio: null,
-      country: null,
-      city: null,
-      addressLine1: null,
-      addressLine2: null,
-      postalCode: null,
-      rescueId: null,
-      lastLoginAt: new Date().toISOString(),
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
-
-    // Store dev tokens and user data
-    localStorage.setItem('authToken', devToken);
-    localStorage.setItem('accessToken', devToken);
-    localStorage.setItem('refreshToken', `${devToken}-refresh`);
-    localStorage.setItem('user', JSON.stringify(mockUser));
-
-    // Set token in API service
-    this.setToken(devToken);
-
-    // eslint-disable-next-line no-console
-    console.log(`🛠️ Admin logged in with dev token as ${userType}`);
-  }
-
-  // Clear dev tokens
-  clearDevTokens(): void {
-    if (import.meta.env.DEV) {
-      this.logout();
-    }
-  }
-
   // Impersonate user (super admin only)
   async impersonateUser(userId: string): Promise<{ originalToken: string }> {
     if (!this.isSuperAdmin()) {

--- a/eslint-config-base/index.js
+++ b/eslint-config-base/index.js
@@ -45,6 +45,8 @@ module.exports = {
     'curly': ['warn', 'all'],
     'no-duplicate-imports': 'error',
     'no-unused-expressions': 'error',
+    'no-eval': 'error',
+    'no-new-func': 'error',
   },
   overrides: [
     {

--- a/lib.api/src/services/api-service.ts
+++ b/lib.api/src/services/api-service.ts
@@ -372,16 +372,6 @@ export class ApiService {
   async fetchWithAuth<T>(url: string, options: FetchOptions = {}): Promise<T> {
     const token = this.getAuthToken();
 
-    // In development mode, check if this is a dev token
-    if (this.config.debug && token?.startsWith('dev-token-')) {
-      // For dev tokens, make requests without authentication header
-      // The backend should handle missing auth gracefully in dev mode
-      if (this.config.debug) {
-        console.log('API: Using dev token, making request without auth header');
-      }
-      return this.makeRequest<T>(url, options);
-    }
-
     const headers = {
       ...options.headers,
       ...(token && { Authorization: `Bearer ${token}` }),
@@ -485,63 +475,19 @@ export class ApiService {
   }
 }
 
-// Get environment variables with proper type checking and improved fallback
 const getApiUrl = (): string | undefined => {
-  // In Vite environment (browser)
-  try {
-    if (typeof window !== 'undefined') {
-      // Use eval to avoid import.meta issues in Jest
-      const importMeta = eval('import.meta');
-      if (importMeta && importMeta.env) {
-        const viteEnv = importMeta.env as Record<string, string>;
-        const apiUrl = viteEnv.VITE_API_BASE_URL || viteEnv.VITE_API_URL; // VITE_API_URL for legacy support
-        if (apiUrl) {
-          console.log('🔧 DEBUG: Found API URL in import.meta.env:', apiUrl);
-          return apiUrl;
-        }
-      }
-    }
-  } catch {
-    // import.meta not available or eval failed (e.g., in test environment)
-  }
-
-  // In Node.js environment
   if (typeof process !== 'undefined' && process.env) {
-    const apiUrl = process.env.VITE_API_BASE_URL || process.env.VITE_API_URL; // VITE_API_URL for legacy support
-    if (apiUrl) {
-      console.log('🔧 DEBUG: Found API URL in process.env:', apiUrl);
-      return apiUrl;
-    }
+    return process.env.VITE_API_BASE_URL ?? process.env.VITE_API_URL ?? undefined;
   }
-  console.log('🔧 DEBUG: No API URL found in environment, will use getBaseUrl() fallback');
   return undefined;
 };
 
 const isDevelopment = (): boolean => {
-  // In Vite environment
-  try {
-    if (typeof window !== 'undefined') {
-      const importMeta = eval('import.meta');
-      if (importMeta && importMeta.env) {
-        const viteEnv = importMeta.env as Record<string, string>;
-        return viteEnv.MODE === 'development';
-      }
-    }
-  } catch {
-    // import.meta not available
-  }
-
-  // In Node.js environment
-  if (typeof process !== 'undefined' && process.env?.NODE_ENV) {
-    return process.env.NODE_ENV === 'development';
-  }
-  return false;
+  return typeof process !== 'undefined' && process.env?.NODE_ENV === 'development';
 };
 
-// Debug log the environment detection
 const apiUrl = getApiUrl();
 const debug = isDevelopment();
-console.log('🔧 DEBUG: Creating global apiService with:', { apiUrl, debug });
 
 // Export singleton instance with environment-aware configuration
 export const apiService = new ApiService({


### PR DESCRIPTION
## Summary

Closes ADS-299 and ADS-300.

- **ADS-299** — `loginWithDevToken()` and `clearDevTokens()` have been removed from `app.admin/src/services/authService.ts`. These methods minted predictable `dev-token-*` tokens and wrote them to `localStorage`, and while they were guarded by `import.meta.env.DEV`, the code still landed in the production bundle because Vite does not dead-code-eliminate exported class methods. They are now gone entirely.

- **ADS-300 (eval)** — `eval('import.meta')` has been removed from `lib.api/src/services/api-service.ts`. The two helper functions `getApiUrl` and `isDevelopment` now read from `process.env` only. This is sufficient for the module-level singleton: in Node.js/test environments `process.env` is real; in Vite browser builds `process.env` is defined as `{}` (see `app.admin/vite.config.ts`) and the constructor falls back to `getBaseUrl()` anyway. All Vite apps (including `app.admin`) create their own `ApiService` instance with `import.meta.env` directly in `libraryServices.ts`, so no functionality is lost.

- **ADS-300 (dev-token bypass)** — The branch in `fetchWithAuth()` that skipped the `Authorization` header for tokens starting with `dev-token-` has been deleted. All tokens now go through the standard Bearer path.

- **ESLint** — `no-eval` and `no-new-func` added to the shared `eslint-config-base` so neither pattern can be reintroduced silently.

## Test plan

- [ ] Confirm `loginWithDevToken` / `clearDevTokens` are absent from the admin app JS bundle (`grep loginWithDevToken dist/` returns nothing after `vite build`)
- [ ] Confirm `eval` is absent from the built bundle (`grep "eval(" dist/` returns nothing)
- [ ] Confirm `dev-token` is absent from the built bundle
- [ ] Run `npx turbo test --filter=@adopt-dont-shop/lib.api` — pre-existing 4 failures in `getBaseUrl` jsdom tests are unrelated to these changes (verified by running tests before and after the diff)
- [ ] Confirm ESLint blocks any future `eval(` usage: adding `eval('x')` to any TS file should fail `npm run lint`

https://claude.ai/code/session_01344oQKEzH8YzP1wxkfxFsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01344oQKEzH8YzP1wxkfxFsP)_