### PR TITLE
Phase 4 (slice 2.1): moderation_evidence typed table (polymorphic)

### DIFF
--- a/service.backend/src/__tests__/integration/admin-moderation-flow.test.ts
+++ b/service.backend/src/__tests__/integration/admin-moderation-flow.test.ts
@@ -39,6 +39,7 @@ import { AuditLogService } from '../../services/auditLog.service';
 vi.mock('../../models/Report');
 vi.mock('../../models/ReportStatusTransition');
 vi.mock('../../models/ModeratorAction');
+vi.mock('../../models/ModerationEvidence');
 vi.mock('../../models/User');
 vi.mock('../../models/Rescue');
 vi.mock('../../services/auditLog.service');

--- a/service.backend/src/models/ModerationEvidence.ts
+++ b/service.backend/src/models/ModerationEvidence.ts
@@ -1,0 +1,113 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+export enum EvidenceType {
+  SCREENSHOT = 'screenshot',
+  URL = 'url',
+  TEXT = 'text',
+  FILE = 'file',
+}
+
+export enum EvidenceParentType {
+  REPORT = 'report',
+  MODERATOR_ACTION = 'moderator_action',
+}
+
+/**
+ * Evidence attached to a Report or a ModeratorAction (plan 2.1 — typed
+ * table replacing the JSONB `evidence[]` arrays on both parents).
+ *
+ * Polymorphic via (parent_type, parent_id). FK is not enforced at the
+ * DB level (no single referenced table), but the parent_type ENUM
+ * constrains the discriminator and a composite index covers the
+ * "evidence for parent X" lookup. Application code is the only writer
+ * — direct INSERTs without a valid parent are caught by code review,
+ * not the schema.
+ */
+interface ModerationEvidenceAttributes {
+  evidence_id: string;
+  parent_type: EvidenceParentType;
+  parent_id: string;
+  type: EvidenceType;
+  content: string;
+  description: string | null;
+  uploaded_at: Date;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface ModerationEvidenceCreationAttributes
+  extends Optional<
+    ModerationEvidenceAttributes,
+    'evidence_id' | 'description' | 'uploaded_at' | 'created_at' | 'updated_at'
+  > {}
+
+class ModerationEvidence
+  extends Model<ModerationEvidenceAttributes, ModerationEvidenceCreationAttributes>
+  implements ModerationEvidenceAttributes
+{
+  public evidence_id!: string;
+  public parent_type!: EvidenceParentType;
+  public parent_id!: string;
+  public type!: EvidenceType;
+  public content!: string;
+  public description!: string | null;
+  public uploaded_at!: Date;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+ModerationEvidence.init(
+  {
+    evidence_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      defaultValue: () => generateUuidV7(),
+    },
+    parent_type: {
+      type: DataTypes.ENUM(...Object.values(EvidenceParentType)),
+      allowNull: false,
+    },
+    parent_id: {
+      type: getUuidType(),
+      allowNull: false,
+    },
+    type: {
+      type: DataTypes.ENUM(...Object.values(EvidenceType)),
+      allowNull: false,
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    uploaded_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    tableName: 'moderation_evidence',
+    modelName: 'ModerationEvidence',
+    timestamps: true,
+    underscored: true,
+    paranoid: false,
+    indexes: [
+      {
+        fields: ['parent_type', 'parent_id'],
+        name: 'moderation_evidence_parent_idx',
+      },
+      ...auditIndexes('moderation_evidence'),
+    ],
+  })
+);
+
+export default ModerationEvidence;

--- a/service.backend/src/models/ModeratorAction.ts
+++ b/service.backend/src/models/ModeratorAction.ts
@@ -42,11 +42,7 @@ interface ModeratorActionAttributes {
   reversedBy?: string;
   reversedAt?: Date;
   reversalReason?: string;
-  evidence?: Array<{
-    type: 'screenshot' | 'url' | 'text' | 'file';
-    content: string;
-    description?: string;
-  }>;
+  // evidence moved to moderation_evidence (plan 2.1).
   notificationSent: boolean;
   internalNotes?: string;
   createdAt: Date;
@@ -77,11 +73,6 @@ class ModeratorAction
   public reversedBy?: string;
   public reversedAt?: Date;
   public reversalReason?: string;
-  public evidence?: Array<{
-    type: 'screenshot' | 'url' | 'text' | 'file';
-    content: string;
-    description?: string;
-  }>;
   public notificationSent!: boolean;
   public internalNotes?: string;
   public readonly createdAt!: Date;
@@ -230,10 +221,9 @@ ModeratorAction.init(
       allowNull: true,
       field: 'reversal_reason',
     },
-    evidence: {
-      type: getJsonType(),
-      allowNull: false,
-    },
+    // evidence moved to moderation_evidence (plan 2.1) —
+    // ModeratorAction.hasMany ModerationEvidence with scope:
+    // { parent_type: 'moderator_action' }.
     notificationSent: {
       type: DataTypes.BOOLEAN,
       allowNull: false,

--- a/service.backend/src/models/Report.ts
+++ b/service.backend/src/models/Report.ts
@@ -41,12 +41,7 @@ interface ReportAttributes {
   status: ReportStatus;
   title: string;
   description: string;
-  evidence?: Array<{
-    type: 'screenshot' | 'url' | 'text' | 'file';
-    content: string;
-    description?: string;
-    uploadedAt: Date;
-  }>;
+  // evidence moved to moderation_evidence (plan 2.1).
   metadata?: JsonObject;
   assignedModerator?: string;
   assignedAt?: Date;
@@ -81,12 +76,6 @@ class Report extends Model<ReportAttributes, ReportCreationAttributes> implement
   public status!: ReportStatus;
   public title!: string;
   public description!: string;
-  public evidence?: Array<{
-    type: 'screenshot' | 'url' | 'text' | 'file';
-    content: string;
-    description?: string;
-    uploadedAt: Date;
-  }>;
   public metadata?: JsonObject;
   public assignedModerator?: string;
   public assignedAt?: Date;
@@ -194,10 +183,8 @@ Report.init(
         len: [10, 5000],
       },
     },
-    evidence: {
-      type: getJsonType(),
-      allowNull: false,
-    },
+    // evidence moved to moderation_evidence (plan 2.1) — Report.hasMany
+    // ModerationEvidence with scope: { parent_type: 'report' }.
     metadata: {
       type: getJsonType(),
       allowNull: false,

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -38,6 +38,7 @@ import StaffMember from './StaffMember';
 
 // Content Moderation Models
 import ModeratorAction from './ModeratorAction';
+import ModerationEvidence from './ModerationEvidence';
 import Report from './Report';
 import ReportStatusTransition from './ReportStatusTransition';
 import UserSanction from './UserSanction';
@@ -97,6 +98,7 @@ const models = {
   StaffMember,
   Invitation,
   ModeratorAction,
+  ModerationEvidence,
   Report,
   ReportStatusTransition,
   UserSanction,
@@ -343,6 +345,34 @@ try {
   Report.hasMany(ModeratorAction, { foreignKey: 'reportId', as: 'Actions' });
   ModeratorAction.belongsTo(Report, { foreignKey: 'reportId', as: 'Report' });
 
+  // ModerationEvidence is polymorphic across Report and ModeratorAction
+  // (plan 2.1). The FK column `parent_id` doesn't have a single
+  // referenced table, so the Sequelize associations declare
+  // `constraints: false` and `scope: { parent_type }` so each parent
+  // sees only its own evidence rows.
+  Report.hasMany(ModerationEvidence, {
+    foreignKey: 'parent_id',
+    as: 'Evidence',
+    constraints: false,
+    scope: { parent_type: 'report' },
+  });
+  ModerationEvidence.belongsTo(Report, {
+    foreignKey: 'parent_id',
+    as: 'Report',
+    constraints: false,
+  });
+  ModeratorAction.hasMany(ModerationEvidence, {
+    foreignKey: 'parent_id',
+    as: 'Evidence',
+    constraints: false,
+    scope: { parent_type: 'moderator_action' },
+  });
+  ModerationEvidence.belongsTo(ModeratorAction, {
+    foreignKey: 'parent_id',
+    as: 'ModeratorAction',
+    constraints: false,
+  });
+
   // UserSanction associations
   User.hasMany(UserSanction, { foreignKey: 'userId', as: 'ReceivedSanctions' });
   UserSanction.belongsTo(User, { foreignKey: 'userId', as: 'User' });
@@ -473,6 +503,7 @@ export {
   Invitation,
   Message,
   ModeratorAction,
+  ModerationEvidence,
   Notification,
   Permission,
   Pet,

--- a/service.backend/src/seeders/26-reports.ts
+++ b/service.backend/src/seeders/26-reports.ts
@@ -1,9 +1,11 @@
 import Report, { ReportStatus, ReportCategory, ReportSeverity } from '../models/Report';
+import ModerationEvidence, { EvidenceParentType, EvidenceType } from '../models/ModerationEvidence';
 import User from '../models/User';
 import Pet from '../models/Pet';
 import Rescue from '../models/Rescue';
 import Chat from '../models/Chat';
 import Message from '../models/Message';
+import { generateUuidV7 } from '../utils/uuid';
 import { JsonObject, JsonValue } from '../types/common';
 
 export async function seedReports() {
@@ -291,14 +293,39 @@ export async function seedReports() {
       return cleaned;
     };
 
-    await Report.bulkCreate(
-      validReports.map(report => ({
-        ...report,
-        evidence: report.evidence || [],
-        metadata: cleanMetadata(report.metadata || {}),
+    // Evidence rows live in moderation_evidence (plan 2.1). Generate
+    // report IDs upfront so the evidence rows can reference them in
+    // the same bulk insert without a follow-up SELECT.
+    const reportsWithEvidence = validReports.map(report => {
+      const { evidence, ...rest } = report as typeof report & { evidence?: unknown[] };
+      return {
+        reportId: generateUuidV7(),
+        fields: { ...rest, metadata: cleanMetadata(report.metadata || {}) },
+        evidence:
+          (evidence as Array<{
+            type: string;
+            content: string;
+            description?: string;
+          }>) || [],
+      };
+    });
+    await Report.bulkCreate(reportsWithEvidence.map(r => ({ ...r.fields, reportId: r.reportId })));
+    const evidenceRows = reportsWithEvidence.flatMap(r =>
+      r.evidence.map(e => ({
+        parent_type: EvidenceParentType.REPORT,
+        parent_id: r.reportId,
+        type: e.type as EvidenceType,
+        content: e.content,
+        description: e.description ?? null,
+        uploaded_at: new Date(),
       }))
     );
-    console.log(`✅ Created ${validReports.length} moderation reports`);
+    if (evidenceRows.length > 0) {
+      await ModerationEvidence.bulkCreate(evidenceRows);
+    }
+    console.log(
+      `✅ Created ${validReports.length} moderation reports + ${evidenceRows.length} evidence rows`
+    );
   } catch (error) {
     console.error('Error seeding reports:', error);
     throw error;

--- a/service.backend/src/seeders/27-moderator-actions.ts
+++ b/service.backend/src/seeders/27-moderator-actions.ts
@@ -1,6 +1,8 @@
 import ModeratorAction, { ActionType, ActionSeverity } from '../models/ModeratorAction';
+import ModerationEvidence, { EvidenceParentType, EvidenceType } from '../models/ModerationEvidence';
 import User from '../models/User';
 import Report from '../models/Report';
+import { generateUuidV7 } from '../utils/uuid';
 import { JsonObject, JsonValue } from '../types/common';
 
 export async function seedModeratorActions() {
@@ -246,14 +248,40 @@ export async function seedModeratorActions() {
       return cleaned;
     };
 
+    // Evidence rows live in moderation_evidence (plan 2.1). Generate
+    // action IDs upfront so the evidence rows reference them.
+    const actionsWithEvidence = actions.map(action => {
+      const { evidence, ...rest } = action as typeof action & { evidence?: unknown[] };
+      return {
+        actionId: generateUuidV7(),
+        fields: { ...rest, metadata: cleanMetadata(action.metadata || {}) },
+        evidence:
+          (evidence as Array<{
+            type: string;
+            content: string;
+            description?: string;
+          }>) || [],
+      };
+    });
     await ModeratorAction.bulkCreate(
-      actions.map(action => ({
-        ...action,
-        evidence: action.evidence || [],
-        metadata: cleanMetadata(action.metadata || {}),
+      actionsWithEvidence.map(a => ({ ...a.fields, actionId: a.actionId }))
+    );
+    const evidenceRows = actionsWithEvidence.flatMap(a =>
+      a.evidence.map(e => ({
+        parent_type: EvidenceParentType.MODERATOR_ACTION,
+        parent_id: a.actionId,
+        type: e.type as EvidenceType,
+        content: e.content,
+        description: e.description ?? null,
+        uploaded_at: new Date(),
       }))
     );
-    console.log(`✅ Created ${actions.length} moderator actions`);
+    if (evidenceRows.length > 0) {
+      await ModerationEvidence.bulkCreate(evidenceRows);
+    }
+    console.log(
+      `✅ Created ${actions.length} moderator actions + ${evidenceRows.length} evidence rows`
+    );
   } catch (error) {
     console.error('Error seeding moderator actions:', error);
     throw error;

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -1,5 +1,6 @@
 import { Op, Transaction, WhereOptions } from 'sequelize';
 import ModeratorAction, { ActionSeverity, ActionType } from '../models/ModeratorAction';
+import ModerationEvidence, { EvidenceParentType, EvidenceType } from '../models/ModerationEvidence';
 import Report, { ReportCategory, ReportSeverity, ReportStatus } from '../models/Report';
 import ReportStatusTransition from '../models/ReportStatusTransition';
 import User from '../models/User';
@@ -110,11 +111,14 @@ class ModerationService {
         throw new Error('You have already submitted a report for this content');
       }
 
-      // Create the report
+      // Evidence rows live in moderation_evidence (plan 2.1) — pull
+      // them off the create payload and insert separately after the
+      // report is persisted.
+      const { evidence, ...reportFields } = reportData;
       const report = await Report.create(
         {
           reporterId,
-          ...reportData,
+          ...reportFields,
           status: ReportStatus.PENDING,
           severity: reportData.severity || ReportSeverity.MEDIUM,
           metadata: {
@@ -124,6 +128,20 @@ class ModerationService {
         },
         { transaction }
       );
+
+      if (evidence && evidence.length > 0) {
+        await ModerationEvidence.bulkCreate(
+          evidence.map(e => ({
+            parent_type: EvidenceParentType.REPORT,
+            parent_id: report.reportId,
+            type: e.type as EvidenceType,
+            content: e.content,
+            description: e.description ?? null,
+            uploaded_at: new Date(),
+          })),
+          { transaction }
+        );
+      }
 
       // Seed the transition log with the initial status — same shape as
       // ApplicationStatusTransition's `null → SUBMITTED` row.
@@ -382,16 +400,32 @@ class ModerationService {
         ? new Date(Date.now() + actionData.duration * 60 * 60 * 1000)
         : undefined;
 
+      // Evidence rows live in moderation_evidence (plan 2.1).
+      const { evidence, ...actionFields } = actionData;
       const action = await ModeratorAction.create(
         {
           moderatorId,
-          ...actionData,
+          ...actionFields,
           expiresAt,
           isActive: true,
           notificationSent: false,
         },
         { transaction }
       );
+
+      if (evidence && evidence.length > 0) {
+        await ModerationEvidence.bulkCreate(
+          evidence.map(e => ({
+            parent_type: EvidenceParentType.MODERATOR_ACTION,
+            parent_id: action.actionId,
+            type: e.type as EvidenceType,
+            content: e.content,
+            description: e.description ?? null,
+            uploaded_at: new Date(),
+          })),
+          { transaction }
+        );
+      }
 
       // Update related report if provided
       if (actionData.reportId) {

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -1771,7 +1771,8 @@ export class PetService {
         throw new Error('Pet not found');
       }
 
-      // Create the report
+      // Create the report. Evidence (if any) lives in moderation_evidence
+      // (plan 2.1) — the pet-flag flow currently doesn't attach any.
       const report = await Report.create({
         reportedEntityType: 'pet',
         reportedEntityId: petId,
@@ -1781,7 +1782,6 @@ export class PetService {
         description: description || 'No description provided',
         status: ReportStatus.PENDING,
         severity: ReportSeverity.MEDIUM, // Default severity
-        evidence: [], // Required field, empty array for now
       });
 
       logger.info(`Pet ${petId} reported by user ${reportedBy} for reason: ${reason}`);


### PR DESCRIPTION
First sub-slice of plan 2.1 — break out the JSONB `evidence[]` arrays on `Report` and `ModeratorAction` into a typed `moderation_evidence` table linked polymorphically (`parent_type` discriminator + `parent_id`).

## Schema

```
moderation_evidence
  evidence_id     UUID PK
  parent_type     ENUM('report' | 'moderator_action')
  parent_id       UUID
  type            ENUM('screenshot' | 'url' | 'text' | 'file')
  content         TEXT
  description     TEXT NULL
  uploaded_at     TIMESTAMPTZ NOT NULL
  + audit columns
  + index on (parent_type, parent_id)
```

The polymorphic FK isn't enforced at the DB level (no single referenced table); the Sequelize associations declare `constraints: false` and `scope: { parent_type }` so each parent (`Report`, `ModeratorAction`) sees only its own evidence rows via the same alias (`'Evidence'`).

## Consumers

- `ModerationService.submitReport` / `recordModerationAction` strip evidence off the create payload and `bulkCreate` the rows separately inside the same transaction.
- Pet flag flow (`pet.service.reportPet`) loses its `evidence: []` dummy — that path doesn't attach evidence anyway.
- Seeders (`26-reports`, `27-moderator-actions`) generate parent UUIDs upfront so evidence rows can reference them in one `bulkCreate` pass.

## Tests

`admin-moderation-flow.test.ts` mocks `ModerationEvidence` alongside the other mocked models; otherwise the `bulkCreate` hits a real model with no DB connection in the mocked test environment.

## What's left of plan 2.1

- `pet_media` (`Pet.images[]`, `Pet.videos[]`)
- `application_answers` (`Application.answers`)
- `application_references` (`Application.references[]`)
- `message_reactions` (`Message.reactions[]`)
- `message_reads` (`Message.read_status[]`)

## Test plan

- [x] `npm test` — 1380 passed, 11 skipped.
- [x] `npm run lint` clean (0 errors).
- [x] Type-check + build clean.
- [ ] Test Docker Compose Stack green — confirms the new table syncs cleanly + seeders create the polymorphic evidence rows correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_