### PR TITLE
Phase 4 (slice 2.1 cont.): pet_media typed table

### DIFF
--- a/service.backend/src/__tests__/integration/pet-discovery-flow.test.ts
+++ b/service.backend/src/__tests__/integration/pet-discovery-flow.test.ts
@@ -94,16 +94,12 @@ const createMockPet = (overrides: Partial<PetAttributes> = {}): Pet => {
     spayNeuterStatus: overrides.spayNeuterStatus || SpayNeuterStatus.UNKNOWN,
     spayNeuterDate: overrides.spayNeuterDate || new Date(),
     lastVetCheckup: overrides.lastVetCheckup || new Date(),
-    images: overrides.images || [
-      {
-        image_id: 'img-default',
-        url: 'https://example.com/pet.jpg',
-        is_primary: true,
-        order_index: 0,
-        uploaded_at: new Date(),
-      },
-    ],
-    videos: overrides.videos || [],
+    // Pet.images / Pet.videos moved to the pet_media table (plan 2.1).
+    // Tests that need media to flow through the service layer must
+    // mock PetMedia.findAll directly. Most discovery-flow tests don't
+    // assert on specific images, so we omit the field by default and
+    // surface the eager-loaded "Media" relation via overrides only.
+    Media: overrides.Media || [],
     location: overrides.location || { type: 'Point', coordinates: [-122.4194, 37.7749] },
     availableSince: overrides.availableSince || new Date('2024-01-01'),
     adoptedDate: overrides.adoptedDate || null,
@@ -125,7 +121,6 @@ const createMockPet = (overrides: Partial<PetAttributes> = {}): Pet => {
       .fn()
       .mockReturnValue(petData.status === PetStatus.AVAILABLE && !petData.archived),
     canBeAdopted: vi.fn().mockReturnValue(petData.status === PetStatus.AVAILABLE),
-    getPrimaryImage: vi.fn().mockReturnValue('https://example.com/pet.jpg'),
     getAgeDisplay: vi.fn().mockReturnValue(`${petData.ageYears} years`),
     increment: vi.fn().mockResolvedValue(undefined),
     toJSON: vi.fn().mockReturnValue(petData),
@@ -328,20 +323,26 @@ describe('Pet Discovery & Matching Flow Integration Tests', () => {
   describe('Workflow 2: View Pet Details', () => {
     describe('when user views a pet profile', () => {
       it('should retrieve complete pet details with images', async () => {
+        // Pet.images JSONB is now eager-loaded via the Media association
+        // (plan 2.1 — pet_media typed table).
         const mockPet = createMockPet({
           petId: 'pet-detail-1',
           name: 'Buddy',
           longDescription: 'Friendly and energetic dog',
-          images: [
+          Media: [
             {
-              image_id: 'img-buddy-1',
+              media_id: 'img-buddy-1',
+              pet_id: 'pet-detail-1',
+              type: 'image',
               url: 'https://example.com/buddy-1.jpg',
               is_primary: true,
               order_index: 0,
               uploaded_at: new Date(),
             },
             {
-              image_id: 'img-buddy-2',
+              media_id: 'img-buddy-2',
+              pet_id: 'pet-detail-1',
+              type: 'image',
               url: 'https://example.com/buddy-2.jpg',
               is_primary: false,
               order_index: 1,
@@ -356,7 +357,7 @@ describe('Pet Discovery & Matching Flow Integration Tests', () => {
 
         expect(result?.name).toBe('Buddy');
         expect(result?.longDescription).toBe('Friendly and energetic dog');
-        expect(result?.images).toHaveLength(2);
+        expect((result as Pet & { Media?: unknown[] })?.Media).toHaveLength(2);
       });
 
       it('should increment view count when pet is viewed', async () => {

--- a/service.backend/src/__tests__/integration/pet-discovery-matching.test.ts
+++ b/service.backend/src/__tests__/integration/pet-discovery-matching.test.ts
@@ -138,9 +138,13 @@ const createMockPet = (overrides: Partial<PetAttributes> = {}): Pet => {
     spayNeuterStatus: overrides.spayNeuterStatus || SpayNeuterStatus.NEUTERED,
     spayNeuterDate: overrides.spayNeuterDate || new Date('2024-01-10'),
     lastVetCheckup: overrides.lastVetCheckup || new Date('2024-01-20'),
-    images: overrides.images || [
+    // Pet.images / Pet.videos moved to the pet_media table (plan 2.1).
+    // Eager-loaded through the Media association.
+    Media: overrides.Media || [
       {
-        image_id: 'img_1',
+        media_id: 'img_1',
+        pet_id: overrides.petId || 'pet-123',
+        type: 'image',
         url: 'https://example.com/pet-image-1.jpg',
         thumbnail_url: 'https://example.com/pet-image-1-thumb.jpg',
         caption: 'Main photo',
@@ -149,7 +153,6 @@ const createMockPet = (overrides: Partial<PetAttributes> = {}): Pet => {
         uploaded_at: new Date(),
       },
     ],
-    videos: overrides.videos || [],
     location: overrides.location || { type: 'Point', coordinates: [-122.4194, 37.7749] },
     availableSince: overrides.availableSince || new Date('2024-01-01'),
     adoptedDate: overrides.adoptedDate || null,
@@ -171,7 +174,6 @@ const createMockPet = (overrides: Partial<PetAttributes> = {}): Pet => {
       .fn()
       .mockReturnValue(petData.status === PetStatus.AVAILABLE && !petData.archived),
     isAdopted: vi.fn().mockReturnValue(petData.status === PetStatus.ADOPTED),
-    getPrimaryImage: vi.fn().mockReturnValue(petData.images[0]?.url || null),
     getAgeInMonths: vi
       .fn()
       .mockReturnValue((petData.ageYears || 0) * 12 + (petData.ageMonths || 0)),
@@ -695,11 +697,15 @@ describe('Pet Discovery & Matching Integration Tests', () => {
       });
 
       it('should retrieve pet images in correct order', async () => {
+        // Pet.images JSONB extracted to the pet_media table (plan 2.1)
+        // and surfaced through the eager-loaded Media association.
         const mockPet = createMockPet({
           petId: 'pet-1',
-          images: [
+          Media: [
             {
-              image_id: 'img_1',
+              media_id: 'img_1',
+              pet_id: 'pet-1',
+              type: 'image',
               url: 'https://example.com/img1.jpg',
               thumbnail_url: 'https://example.com/img1-thumb.jpg',
               caption: 'First photo',
@@ -708,7 +714,9 @@ describe('Pet Discovery & Matching Integration Tests', () => {
               uploaded_at: new Date(),
             },
             {
-              image_id: 'img_2',
+              media_id: 'img_2',
+              pet_id: 'pet-1',
+              type: 'image',
               url: 'https://example.com/img2.jpg',
               thumbnail_url: 'https://example.com/img2-thumb.jpg',
               caption: 'Second photo',
@@ -723,9 +731,12 @@ describe('Pet Discovery & Matching Integration Tests', () => {
 
         const result = await PetService.getPetById('pet-1', userId);
 
-        expect(result?.images).toHaveLength(2);
-        expect(result?.images[0].is_primary).toBe(true);
-        expect(result?.images[0].order_index).toBe(0);
+        const media = (
+          result as Pet & { Media?: Array<{ is_primary: boolean; order_index: number }> }
+        )?.Media;
+        expect(media).toHaveLength(2);
+        expect(media?.[0].is_primary).toBe(true);
+        expect(media?.[0].order_index).toBe(0);
       });
     });
   });
@@ -978,10 +989,22 @@ describe('Pet Discovery & Matching Integration Tests', () => {
       });
 
       it('should filter out pets with no images', async () => {
+        // Pet.images JSONB extracted to pet_media (plan 2.1) — pets are
+        // checked by their eager-loaded Media association.
         const mockPets = [
           createMockPet({
             petId: 'pet-2',
-            images: [{ image_id: 'img_1', url: 'test.jpg' } as never],
+            Media: [
+              {
+                media_id: 'img_1',
+                pet_id: 'pet-2',
+                type: 'image',
+                url: 'test.jpg',
+                is_primary: true,
+                order_index: 0,
+                uploaded_at: new Date(),
+              },
+            ],
           }),
         ];
 
@@ -992,8 +1015,10 @@ describe('Pet Discovery & Matching Integration Tests', () => {
 
         const result = await PetService.searchPets({}, { page: 1, limit: 20 });
 
-        // All returned pets should have images
-        expect(result.pets.every(pet => pet.images && pet.images.length > 0)).toBe(true);
+        const allHaveImages = result.pets.every(
+          p => ((p as Pet & { Media?: unknown[] }).Media?.length ?? 0) > 0
+        );
+        expect(allHaveImages).toBe(true);
       });
     });
 

--- a/service.backend/src/__tests__/models/ApplicationStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/ApplicationStatusTransition.test.ts
@@ -71,8 +71,6 @@ describe('ApplicationStatusTransition', () => {
         view_count: 0,
         favorite_count: 0,
         application_count: 0,
-        images: '[]',
-        videos: '[]',
         tags: '[]',
         created_at: new Date(),
         updated_at: new Date(),

--- a/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
@@ -61,8 +61,6 @@ describe('HomeVisitStatusTransition', () => {
         view_count: 0,
         favorite_count: 0,
         application_count: 0,
-        images: '[]',
-        videos: '[]',
         tags: '[]',
         created_at: new Date(),
         updated_at: new Date(),

--- a/service.backend/src/__tests__/models/Pet.birthDate.test.ts
+++ b/service.backend/src/__tests__/models/Pet.birthDate.test.ts
@@ -59,8 +59,6 @@ describe('Pet.birthDate + getAgeDisplay', () => {
         favorite_count: 0,
         application_count: 0,
         is_birth_date_estimate: false,
-        images: '[]',
-        videos: '[]',
         tags: '[]',
         created_at: new Date(),
         updated_at: new Date(),

--- a/service.backend/src/__tests__/models/Pet.money.test.ts
+++ b/service.backend/src/__tests__/models/Pet.money.test.ts
@@ -50,8 +50,6 @@ describe('Pet.adoptionFee Money columns', () => {
         favorite_count: 0,
         application_count: 0,
         is_birth_date_estimate: false,
-        images: '[]',
-        videos: '[]',
         tags: '[]',
         created_at: new Date(),
         updated_at: new Date(),

--- a/service.backend/src/__tests__/models/PetStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/PetStatusTransition.test.ts
@@ -31,7 +31,8 @@ describe('PetStatusTransition', () => {
     rescueId = rescue.rescueId;
 
     // Same array-column workaround as the Application transition test —
-    // SQLite vs Postgres mismatch on Pet.images / .videos / .tags.
+    // SQLite vs Postgres mismatch on Pet.tags. (Pet.images / .videos
+    // were extracted to the pet_media table per plan 2.1.)
     petId = '22222222-2222-4222-a222-222222222222';
     await sequelize.getQueryInterface().bulkInsert('pets', [
       {
@@ -52,8 +53,6 @@ describe('PetStatusTransition', () => {
         view_count: 0,
         favorite_count: 0,
         application_count: 0,
-        images: '[]',
-        videos: '[]',
         tags: '[]',
         created_at: new Date(),
         updated_at: new Date(),

--- a/service.backend/src/__tests__/services/discovery.service.test.ts
+++ b/service.backend/src/__tests__/services/discovery.service.test.ts
@@ -1,11 +1,13 @@
 import { vi } from 'vitest';
 import { Op } from 'sequelize';
 import Pet, { AgeGroup, Gender, PetStatus, PetType, Size } from '../../models/Pet';
+import PetMedia, { PetMediaType } from '../../models/PetMedia';
 import Rescue from '../../models/Rescue';
 import { DiscoveryFilters, DiscoveryService } from '../../services/discovery.service';
 
 // Mock dependencies
 vi.mock('../../models/Pet');
+vi.mock('../../models/PetMedia');
 vi.mock('../../models/Rescue');
 vi.mock('../../utils/logger', () => ({
   logger: {
@@ -35,7 +37,10 @@ describe('DiscoveryService', () => {
         ageGroup: AgeGroup.ADULT,
         size: Size.LARGE,
         gender: Gender.MALE,
-        images: [{ url: 'image1.jpg' }, { url: 'image2.jpg' }],
+        Media: [
+          { type: 'image', url: 'image1.jpg' },
+          { type: 'image', url: 'image2.jpg' },
+        ],
         shortDescription: 'Friendly dog',
         status: PetStatus.AVAILABLE,
         createdAt: new Date(),
@@ -54,7 +59,7 @@ describe('DiscoveryService', () => {
         ageGroup: AgeGroup.YOUNG,
         size: Size.MEDIUM,
         gender: Gender.FEMALE,
-        images: [{ url: 'image3.jpg' }],
+        Media: [{ type: 'image', url: 'image3.jpg' }],
         shortDescription: 'Calm cat',
         status: PetStatus.AVAILABLE,
         createdAt: new Date(),
@@ -68,8 +73,9 @@ describe('DiscoveryService', () => {
     ];
 
     it('should generate discovery queue successfully with basic filters', async () => {
-      // Mock the smart filtering to return filtered pets
-      const filteredPets = mockPets.filter(pet => pet.images && pet.images.length > 0);
+      // Mock the smart filtering to return filtered pets — pet media is
+      // now the eager-loaded Media association (plan 2.1).
+      const filteredPets = mockPets.filter(pet => pet.Media && pet.Media.length > 0);
 
       // Spy on private methods to avoid complex mocking
       vi.spyOn(discoveryService as unknown, 'getSmartSortedPets').mockResolvedValue(filteredPets);
@@ -138,7 +144,10 @@ describe('DiscoveryService', () => {
         ageGroup: AgeGroup.YOUNG,
         size: Size.LARGE,
         gender: Gender.MALE,
-        images: [{ url: 'image4.jpg' }, { url: 'image5.jpg' }],
+        Media: [
+          { type: 'image', url: 'image4.jpg' },
+          { type: 'image', url: 'image5.jpg' },
+        ],
         shortDescription: 'Energetic pup',
         status: PetStatus.AVAILABLE,
         createdAt: new Date(),
@@ -168,6 +177,12 @@ describe('DiscoveryService', () => {
             model: Rescue,
             as: 'Rescue',
             attributes: ['rescue_id', 'name', 'status'],
+          },
+          {
+            model: PetMedia,
+            as: 'Media',
+            where: { type: PetMediaType.IMAGE },
+            required: false,
           },
         ],
         limit: 10,
@@ -206,15 +221,19 @@ describe('DiscoveryService', () => {
   });
 
   describe('calculateCompatibilityScore', () => {
+    // Pet.images JSONB extracted to pet_media (plan 2.1) — the score uses
+    // the eager-loaded Media association now.
+    const image = (i: number) => ({ type: 'image', url: `img${i}.jpg` });
+
     it('should calculate basic compatibility score', () => {
       const mockPet = {
-        images: [{ url: 'img1.jpg' }],
+        Media: [image(1)],
         longDescription: 'Short description',
         ageGroup: AgeGroup.ADULT,
         goodWithChildren: false,
         goodWithDogs: false,
         goodWithCats: false,
-      } as Pet;
+      } as unknown as Pet;
 
       const score = (discoveryService as unknown).calculateCompatibilityScore(mockPet);
 
@@ -223,14 +242,14 @@ describe('DiscoveryService', () => {
 
     it('should boost score for pets with good attributes', () => {
       const mockPet = {
-        images: [{ url: 'img1.jpg' }, { url: 'img2.jpg' }, { url: 'img3.jpg' }],
+        Media: [image(1), image(2), image(3)],
         longDescription:
           'This is a very long and detailed description about this wonderful pet that provides lots of useful information for potential adopters.',
         ageGroup: AgeGroup.YOUNG,
         goodWithChildren: true,
         goodWithDogs: true,
         goodWithCats: true,
-      } as Pet;
+      } as unknown as Pet;
 
       const score = (discoveryService as unknown).calculateCompatibilityScore(mockPet);
 
@@ -240,13 +259,13 @@ describe('DiscoveryService', () => {
 
     it('should cap score at 100', () => {
       const mockPet = {
-        images: Array(10).fill({ url: 'img.jpg' }),
+        Media: Array(10).fill(image(1)),
         longDescription: 'Very long description '.repeat(20),
         ageGroup: AgeGroup.BABY,
         goodWithChildren: true,
         goodWithDogs: true,
         goodWithCats: true,
-      } as Pet;
+      } as unknown as Pet;
 
       const score = (discoveryService as unknown).calculateCompatibilityScore(mockPet);
 

--- a/service.backend/src/__tests__/services/pet-business-logic.test.ts
+++ b/service.backend/src/__tests__/services/pet-business-logic.test.ts
@@ -20,6 +20,7 @@ import Pet, {
   SpayNeuterStatus,
   VaccinationStatus,
 } from '../../models/Pet';
+import PetMedia, { PetMediaType } from '../../models/PetMedia';
 import PetStatusTransition from '../../models/PetStatusTransition';
 import Application, { ApplicationStatus } from '../../models/Application';
 import { PetService } from '../../services/pet.service';
@@ -31,6 +32,7 @@ const MockedApplication = Application as vi.MockedObject<Application>;
 const MockedPetStatusTransition = PetStatusTransition as vi.MockedObject<
   typeof PetStatusTransition
 >;
+const MockedPetMedia = PetMedia as vi.MockedObject<typeof PetMedia>;
 
 // Test constants
 const mockRescueId = 'rescue-123';
@@ -43,7 +45,6 @@ const mockPetId = 'pet-789';
 
 const createMockPet = (overrides = {}) => ({
   petId: mockPetId,
-  petId: mockPetId,
   name: 'Buddy',
   type: PetType.DOG,
   breed: 'Golden Retriever',
@@ -55,14 +56,11 @@ const createMockPet = (overrides = {}) => ({
   vaccinationStatus: VaccinationStatus.UP_TO_DATE,
   spayNeuterStatus: SpayNeuterStatus.NEUTERED,
   rescueId: mockRescueId,
-  rescueId: mockRescueId,
   archived: false,
   featured: false,
   priorityListing: false,
   specialNeeds: false,
   houseTrained: true,
-  images: [],
-  videos: [],
   viewCount: 0,
   favoriteCount: 0,
   applicationCount: 0,
@@ -90,8 +88,6 @@ const createValidPetData = (overrides = {}): PetCreateData => ({
   vaccinationStatus: VaccinationStatus.UP_TO_DATE,
   spayNeuterStatus: SpayNeuterStatus.NEUTERED,
   rescueId: mockRescueId,
-  images: [],
-  videos: [],
   ...overrides,
 });
 
@@ -103,6 +99,12 @@ describe('PetService - Business Logic', () => {
     // transition insert would trip the FK. Stub it — the trigger/hook
     // path has its own dedicated tests.
     MockedPetStatusTransition.create = vi.fn().mockResolvedValue({} as never);
+    // Pet media writes go through PetMedia.bulkCreate / destroy / count
+    // (plan 2.1). Stub the typed-table writes here so the service code
+    // doesn't try to hit the real DB through the mocked Pet model.
+    MockedPetMedia.bulkCreate = vi.fn().mockResolvedValue([] as never);
+    MockedPetMedia.destroy = vi.fn().mockResolvedValue(0 as never);
+    MockedPetMedia.count = vi.fn().mockResolvedValue(0 as never);
   });
 
   // ==========================================================================
@@ -424,20 +426,25 @@ describe('PetService - Business Logic', () => {
       // When: Creating pet with images
       await PetService.createPet(petData, mockRescueId, mockUserId);
 
-      // Then: Images are properly formatted with required fields
-      expect(MockedPet.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          images: expect.arrayContaining([
-            expect.objectContaining({
-              image_id: expect.stringContaining('img_'),
-              url: 'https://example.com/image1.jpg',
-              thumbnail_url: 'https://example.com/thumb1.jpg',
-              is_primary: true,
-              order_index: 0,
-              uploaded_at: expect.any(Date),
-            }),
-          ]),
-        })
+      // Then: PetMedia rows are inserted with the right shape (plan 2.1
+      // — Pet.images JSONB extracted to the pet_media typed table).
+      expect(MockedPetMedia.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            pet_id: mockPetId,
+            type: PetMediaType.IMAGE,
+            url: 'https://example.com/image1.jpg',
+            thumbnail_url: 'https://example.com/thumb1.jpg',
+            is_primary: true,
+            order_index: 0,
+          }),
+          expect.objectContaining({
+            pet_id: mockPetId,
+            type: PetMediaType.IMAGE,
+            url: 'https://example.com/image2.jpg',
+            order_index: 1,
+          }),
+        ])
       );
     });
 
@@ -460,18 +467,16 @@ describe('PetService - Business Logic', () => {
       // When: Creating pet with videos
       await PetService.createPet(petData, mockRescueId, mockUserId);
 
-      // Then: Videos are properly formatted
-      expect(MockedPet.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          videos: expect.arrayContaining([
-            expect.objectContaining({
-              video_id: expect.stringContaining('vid_'),
-              url: 'https://example.com/video1.mp4',
-              duration_seconds: 30,
-              uploaded_at: expect.any(Date),
-            }),
-          ]),
-        })
+      // Then: PetMedia video row is inserted (plan 2.1).
+      expect(MockedPetMedia.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            pet_id: mockPetId,
+            type: PetMediaType.VIDEO,
+            url: 'https://example.com/video1.mp4',
+            duration_seconds: 30,
+          }),
+        ])
       );
     });
 
@@ -674,20 +679,11 @@ describe('PetService - Business Logic', () => {
 
   describe('Image Management', () => {
     it('should add images to pet', async () => {
-      // Given: Pet with existing images
-      const mockPet = createMockPet({
-        images: [
-          {
-            image_id: 'img_existing',
-            url: 'https://example.com/existing.jpg',
-            is_primary: true,
-            order_index: 0,
-            uploaded_at: new Date(),
-          },
-        ],
-      });
+      // Given: Pet with one existing image (count returns 1)
+      const mockPet = createMockPet();
       mockPet.reload.mockResolvedValue(mockPet);
       MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet);
+      MockedPetMedia.count = vi.fn().mockResolvedValue(1 as never);
 
       const newImages = [
         {
@@ -702,31 +698,23 @@ describe('PetService - Business Logic', () => {
       // When: Adding new images
       await PetService.addPetImages(mockPetId, newImages, mockUserId);
 
-      // Then: New images are appended to existing images
-      expect(mockPet.update).toHaveBeenCalledWith({
-        images: expect.arrayContaining([
-          expect.objectContaining({ image_id: 'img_existing' }),
+      // Then: New images are inserted into pet_media keyed to the pet
+      expect(MockedPetMedia.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
           expect.objectContaining({
-            image_id: expect.stringContaining('img_'),
+            pet_id: mockPetId,
+            type: PetMediaType.IMAGE,
             url: 'https://example.com/new1.jpg',
+            thumbnail_url: 'https://example.com/new1_thumb.jpg',
+            order_index: 1,
           }),
-        ]),
-      });
+        ])
+      );
     });
 
     it('should replace all images when updating', async () => {
       // Given: Pet with existing images
-      const mockPet = createMockPet({
-        images: [
-          {
-            image_id: 'old_img',
-            url: 'old.jpg',
-            is_primary: true,
-            order_index: 0,
-            uploaded_at: new Date(),
-          },
-        ],
-      });
+      const mockPet = createMockPet();
       mockPet.reload.mockResolvedValue(mockPet);
       MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet);
 
@@ -742,79 +730,46 @@ describe('PetService - Business Logic', () => {
       // When: Updating images (replaces all)
       await PetService.updatePetImages(mockPetId, newImages, mockUserId);
 
-      // Then: All images are replaced
-      expect(mockPet.update).toHaveBeenCalledWith({
-        images: expect.arrayContaining([
+      // Then: Existing images are deleted before new ones are inserted
+      expect(MockedPetMedia.destroy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            pet_id: mockPetId,
+            type: PetMediaType.IMAGE,
+          }),
+        })
+      );
+      expect(MockedPetMedia.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
           expect.objectContaining({
             url: 'https://example.com/new.jpg',
           }),
         ]),
-      });
-      // Old image should not be present
-      expect(mockPet.update).not.toHaveBeenCalledWith({
-        images: expect.arrayContaining([expect.objectContaining({ image_id: 'old_img' })]),
-      });
+        expect.anything()
+      );
     });
 
     it('should remove specific image by ID', async () => {
-      // Given: Pet with multiple images
-      const mockPet = createMockPet({
-        images: [
-          {
-            image_id: 'img1',
-            url: 'photo1.jpg',
-            is_primary: true,
-            order_index: 0,
-            uploaded_at: new Date(),
-          },
-          {
-            image_id: 'img2',
-            url: 'photo2.jpg',
-            is_primary: false,
-            order_index: 1,
-            uploaded_at: new Date(),
-          },
-          {
-            image_id: 'img3',
-            url: 'photo3.jpg',
-            is_primary: false,
-            order_index: 2,
-            uploaded_at: new Date(),
-          },
-        ],
-      });
+      // Given: Pet with the target image present (destroy returns 1)
+      const mockPet = createMockPet();
       mockPet.reload.mockResolvedValue(mockPet);
       MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet);
+      MockedPetMedia.destroy = vi.fn().mockResolvedValue(1 as never);
 
       // When: Removing specific image
       await PetService.removePetImage(mockPetId, 'img2', mockUserId);
 
-      // Then: Only specified image is removed
-      expect(mockPet.update).toHaveBeenCalledWith({
-        images: expect.arrayContaining([
-          expect.objectContaining({ image_id: 'img1' }),
-          expect.objectContaining({ image_id: 'img3' }),
-        ]),
-      });
-      expect(mockPet.update).toHaveBeenCalledWith({
-        images: expect.not.arrayContaining([expect.objectContaining({ image_id: 'img2' })]),
+      // Then: PetMedia.destroy is called for that image only
+      expect(MockedPetMedia.destroy).toHaveBeenCalledWith({
+        where: { media_id: 'img2', pet_id: mockPetId, type: PetMediaType.IMAGE },
       });
     });
 
     it('should throw error when removing non-existent image', async () => {
-      // Given: Pet without the specified image
-      const mockPet = createMockPet({
-        images: [
-          {
-            image_id: 'img1',
-            url: 'photo1.jpg',
-            is_primary: true,
-            order_index: 0,
-            uploaded_at: new Date(),
-          },
-        ],
-      });
+      // Given: Pet without the specified image (destroy returns 0)
+      const mockPet = createMockPet();
       MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet);
+      MockedPetMedia.destroy = vi.fn().mockResolvedValue(0 as never);
 
       // When & Then: Removing non-existent image fails
       await expect(PetService.removePetImage(mockPetId, 'nonexistent', mockUserId)).rejects.toThrow(
@@ -892,27 +847,12 @@ describe('PetService - Business Logic', () => {
     });
 
     it('should maintain image order_index integrity when adding images', async () => {
-      // Given: Pet with 2 existing images
-      const mockPet = createMockPet({
-        images: [
-          {
-            image_id: 'img1',
-            url: 'photo1.jpg',
-            is_primary: true,
-            order_index: 0,
-            uploaded_at: new Date(),
-          },
-          {
-            image_id: 'img2',
-            url: 'photo2.jpg',
-            is_primary: false,
-            order_index: 1,
-            uploaded_at: new Date(),
-          },
-        ],
-      });
+      // Given: Pet with 2 existing images — count() reports 2 so the
+      // next order_index for an image without an explicit position is 2.
+      const mockPet = createMockPet();
       mockPet.reload.mockResolvedValue(mockPet);
       MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet);
+      MockedPetMedia.count = vi.fn().mockResolvedValue(2 as never);
 
       const newImages = [
         {
@@ -925,14 +865,14 @@ describe('PetService - Business Logic', () => {
       await PetService.addPetImages(mockPetId, newImages, mockUserId);
 
       // Then: New image gets order_index = 2 (continuing sequence)
-      expect(mockPet.update).toHaveBeenCalledWith({
-        images: expect.arrayContaining([
+      expect(MockedPetMedia.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
           expect.objectContaining({
             url: 'photo3.jpg',
-            order_index: 2, // Continues from existing images
+            order_index: 2,
           }),
-        ]),
-      });
+        ])
+      );
     });
   });
 

--- a/service.backend/src/__tests__/services/pet.service.test.ts
+++ b/service.backend/src/__tests__/services/pet.service.test.ts
@@ -99,8 +99,6 @@ describe('PetService', () => {
         priorityListing: false,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
 
       await Pet.create({
@@ -119,8 +117,6 @@ describe('PetService', () => {
         priorityListing: true,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 
@@ -185,8 +181,6 @@ describe('PetService', () => {
           priorityListing: false,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         });
       }
 
@@ -228,8 +222,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
         viewCount: 0,
       });
     });
@@ -285,8 +277,6 @@ describe('PetService', () => {
         vaccinationStatus: VaccinationStatus.UP_TO_DATE,
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
-        images: [],
-        videos: [],
       };
 
       const result = await PetService.createPet(mockPetData, testRescue.rescueId, 'user1');
@@ -318,8 +308,6 @@ describe('PetService', () => {
         vaccinationStatus: VaccinationStatus.UP_TO_DATE,
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
-        images: [],
-        videos: [],
       };
 
       // The service doesn't validate empty names but the model does
@@ -340,8 +328,6 @@ describe('PetService', () => {
         vaccinationStatus: VaccinationStatus.UP_TO_DATE,
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
-        images: [],
-        videos: [],
       };
 
       // Force an error
@@ -377,8 +363,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 
@@ -438,8 +422,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 
@@ -498,8 +480,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 
@@ -558,8 +538,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 
@@ -574,11 +552,18 @@ describe('PetService', () => {
     ];
 
     it('should add images to pet successfully', async () => {
-      const result = await PetService.addPetImages(petId, newImages, 'user1');
+      // Pet.images JSONB extracted to pet_media (plan 2.1) — assert that
+      // the row was inserted into PetMedia rather than that the JSONB
+      // column on the pet was mutated.
+      const { default: PetMedia, PetMediaType } = await import('../../models/PetMedia');
 
-      expect(result.images).toHaveLength(1);
-      expect(result.images[0].url).toBe('https://example.com/image1.jpg');
-      expect(result.images[0].is_primary).toBe(true);
+      await PetService.addPetImages(petId, newImages, 'user1');
+
+      const rows = await PetMedia.findAll({ where: { pet_id: petId } });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].url).toBe('https://example.com/image1.jpg');
+      expect(rows[0].is_primary).toBe(true);
+      expect(rows[0].type).toBe(PetMediaType.IMAGE);
 
       expect(mockAuditLog).toHaveBeenCalled();
     });
@@ -613,8 +598,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
 
       await Pet.create({
@@ -631,8 +614,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.SPAYED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 
@@ -663,8 +644,6 @@ describe('PetService', () => {
         rescueId: testRescue.rescueId,
         featured: true,
         archived: false,
-        images: [],
-        videos: [],
       });
 
       await Pet.create({
@@ -682,8 +661,6 @@ describe('PetService', () => {
         rescueId: testRescue.rescueId,
         featured: true,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 
@@ -715,8 +692,6 @@ describe('PetService', () => {
           featured: true,
           specialNeeds: false,
           archived: false,
-          images: [],
-          videos: [],
         },
         {
           petId: uniqueId('stats-pet2'),
@@ -733,8 +708,6 @@ describe('PetService', () => {
           rescueId: testRescue.rescueId,
           specialNeeds: true,
           archived: false,
-          images: [],
-          videos: [],
         },
         {
           petId: uniqueId('stats-pet3'),
@@ -750,8 +723,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
       ]);
     });
@@ -795,8 +766,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
 
       pet2 = await Pet.create({
@@ -813,8 +782,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.SPAYED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 
@@ -889,8 +856,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
         viewCount: 50,
         favoriteCount: 10,
         applicationCount: 3,
@@ -933,8 +898,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
           createdAt: new Date('2025-07-08T10:00:00Z'),
         },
         {
@@ -951,8 +914,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.SPAYED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
           createdAt: new Date('2025-07-08T09:00:00Z'),
         },
       ]);
@@ -999,8 +960,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
         {
           petId: uniqueId('breeds-pet2'),
@@ -1016,8 +975,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
         {
           petId: uniqueId('breeds-pet3'),
@@ -1033,8 +990,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
       ]);
     });
@@ -1064,8 +1019,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
         {
           petId: uniqueId('breeds-pet5'),
@@ -1081,8 +1034,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
         {
           petId: uniqueId('breeds-pet6'),
@@ -1098,8 +1049,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
       ]);
 
@@ -1165,8 +1114,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
 
       await Pet.bulkCreate([
@@ -1184,8 +1131,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.SPAYED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
         {
           petId: uniqueId('similar-2'),
@@ -1201,8 +1146,6 @@ describe('PetService', () => {
           spayNeuterStatus: SpayNeuterStatus.NEUTERED,
           rescueId: testRescue.rescueId,
           archived: false,
-          images: [],
-          videos: [],
         },
       ]);
     });
@@ -1250,8 +1193,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
 
       // Should not throw - the SQL injection attempt is safely escaped
@@ -1301,8 +1242,6 @@ describe('PetService', () => {
         spayNeuterStatus: SpayNeuterStatus.NEUTERED,
         rescueId: testRescue.rescueId,
         archived: false,
-        images: [],
-        videos: [],
       });
     });
 

--- a/service.backend/src/__tests__/services/rescue.service.test.ts
+++ b/service.backend/src/__tests__/services/rescue.service.test.ts
@@ -274,8 +274,6 @@ describe('RescueService - Behavioral Testing', () => {
         gender: 'male',
         size: 'large',
         status: PetStatus.AVAILABLE,
-        images: [],
-        videos: [],
       });
 
       const result = await RescueService.getRescueById(rescue.rescueId, true);
@@ -632,8 +630,6 @@ describe('RescueService - Behavioral Testing', () => {
         gender: 'male',
         size: 'large',
         status: PetStatus.AVAILABLE,
-        images: [],
-        videos: [],
       });
 
       await Pet.create({
@@ -645,8 +641,6 @@ describe('RescueService - Behavioral Testing', () => {
         gender: 'male',
         size: 'large',
         status: PetStatus.ADOPTED,
-        images: [],
-        videos: [],
       });
 
       const result = await RescueService.getRescueStatistics(rescue.rescueId);
@@ -709,8 +703,6 @@ describe('RescueService - Behavioral Testing', () => {
         gender: 'male',
         size: 'large',
         status: PetStatus.AVAILABLE,
-        images: [],
-        videos: [],
       });
 
       const result = await RescueService.getRescuePets(rescue.rescueId);
@@ -741,8 +733,6 @@ describe('RescueService - Behavioral Testing', () => {
         gender: 'male',
         size: 'large',
         status: PetStatus.AVAILABLE,
-        images: [],
-        videos: [],
       });
 
       await Pet.create({
@@ -754,8 +744,6 @@ describe('RescueService - Behavioral Testing', () => {
         gender: 'male',
         size: 'large',
         status: PetStatus.ADOPTED,
-        images: [],
-        videos: [],
       });
 
       const result = await RescueService.getRescuePets(rescue.rescueId, {

--- a/service.backend/src/models/Pet.ts
+++ b/service.backend/src/models/Pet.ts
@@ -1,7 +1,6 @@
 // src/models/Pet.ts
 import { DataTypes, Model, Op, Optional, QueryTypes, WhereOptions } from 'sequelize';
 import sequelize, {
-  getJsonType,
   getUuidType,
   getArrayType,
   getGeometryType,
@@ -154,23 +153,7 @@ export interface PetAttributes {
   spayNeuterStatus: SpayNeuterStatus;
   spayNeuterDate?: Date | null;
   lastVetCheckup?: Date | null;
-  images: Array<{
-    image_id: string;
-    url: string;
-    thumbnail_url?: string;
-    caption?: string;
-    is_primary: boolean;
-    order_index: number;
-    uploaded_at: Date;
-  }>;
-  videos: Array<{
-    video_id: string;
-    url: string;
-    thumbnail_url?: string;
-    caption?: string;
-    duration_seconds?: number;
-    uploaded_at: Date;
-  }>;
+  // images / videos moved to the pet_media table (plan 2.1) — Pet.hasMany(PetMedia).
   location?: { type: string; coordinates: [number, number] };
   availableSince?: Date | null;
   adoptedDate?: Date | null;
@@ -195,7 +178,6 @@ export interface PetCreationAttributes
     | 'priorityListing'
     | 'specialNeeds'
     | 'houseTrained'
-    | 'videos'
     | 'viewCount'
     | 'favoriteCount'
     | 'applicationCount'
@@ -251,23 +233,7 @@ class Pet extends Model<PetAttributes, PetCreationAttributes> implements PetAttr
   public spayNeuterStatus!: SpayNeuterStatus;
   public spayNeuterDate!: Date | null;
   public lastVetCheckup!: Date | null;
-  public images!: Array<{
-    image_id: string;
-    url: string;
-    thumbnail_url?: string;
-    caption?: string;
-    is_primary: boolean;
-    order_index: number;
-    uploaded_at: Date;
-  }>;
-  public videos!: Array<{
-    video_id: string;
-    url: string;
-    thumbnail_url?: string;
-    caption?: string;
-    duration_seconds?: number;
-    uploaded_at: Date;
-  }>;
+  // images / videos moved to pet_media (plan 2.1).
   public location!: { type: string; coordinates: [number, number] };
   public availableSince!: Date | null;
   public adoptedDate!: Date | null;
@@ -289,11 +255,6 @@ class Pet extends Model<PetAttributes, PetCreationAttributes> implements PetAttr
 
   public isAdopted(): boolean {
     return this.status === PetStatus.ADOPTED;
-  }
-
-  public getPrimaryImage(): string | null {
-    const primaryImage = this.images?.find(img => img.is_primary);
-    return primaryImage?.url || this.images?.[0]?.url || null;
   }
 
   public getAgeInMonths(now: Date = new Date()): number | null {
@@ -702,32 +663,7 @@ Pet.init(
       allowNull: true,
       field: 'last_vet_checkup',
     },
-    images: {
-      type: getJsonType(),
-      allowNull: false,
-      validate: {
-        isValidImages(value: unknown) {
-          if (!Array.isArray(value)) {
-            throw new Error('Images must be an array');
-          }
-          value.forEach((img, index) => {
-            if (
-              typeof img !== 'object' ||
-              img === null ||
-              !('image_id' in img) ||
-              !('url' in img)
-            ) {
-              throw new Error(`Image at index ${index} must have image_id and url`);
-            }
-          });
-        },
-      },
-    },
-    videos: {
-      type: getJsonType(),
-      allowNull: false,
-      defaultValue: [],
-    },
+    // images / videos moved to pet_media (plan 2.1).
     location: {
       type: getGeometryType('POINT'),
       allowNull: true,

--- a/service.backend/src/models/PetMedia.ts
+++ b/service.backend/src/models/PetMedia.ts
@@ -1,0 +1,165 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+// Plan 2.1 — Pet.images[] / Pet.videos[] JSONB extracted to a typed
+// table. One row per image or video; `type` discriminates. Photo-only
+// fields (is_primary) and video-only fields (duration_seconds) live
+// alongside in the same row — they're sparse but the row count is small
+// (a handful per pet) and querying through a single relation is simpler
+// than two parallel tables.
+
+export enum PetMediaType {
+  IMAGE = 'image',
+  VIDEO = 'video',
+}
+
+interface PetMediaAttributes {
+  media_id: string;
+  pet_id: string;
+  type: PetMediaType;
+  url: string;
+  thumbnail_url: string | null;
+  caption: string | null;
+  // Display order within the parent pet's gallery, lowest first. Held as
+  // an integer rather than computed-at-read-time so the gallery order is
+  // stable across reads regardless of insert order.
+  order_index: number;
+  // Image-only. Exactly one image per pet should be primary; uniqueness
+  // is enforced via a partial index (see indexes below).
+  is_primary: boolean;
+  // Video-only. Null for images and for videos where duration is unknown
+  // (e.g. external-host videos we haven't probed).
+  duration_seconds: number | null;
+  uploaded_at: Date;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface PetMediaCreationAttributes
+  extends Optional<
+    PetMediaAttributes,
+    | 'media_id'
+    | 'thumbnail_url'
+    | 'caption'
+    | 'is_primary'
+    | 'duration_seconds'
+    | 'uploaded_at'
+    | 'created_at'
+    | 'updated_at'
+  > {}
+
+export class PetMedia
+  extends Model<PetMediaAttributes, PetMediaCreationAttributes>
+  implements PetMediaAttributes
+{
+  public media_id!: string;
+  public pet_id!: string;
+  public type!: PetMediaType;
+  public url!: string;
+  public thumbnail_url!: string | null;
+  public caption!: string | null;
+  public order_index!: number;
+  public is_primary!: boolean;
+  public duration_seconds!: number | null;
+  public uploaded_at!: Date;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+PetMedia.init(
+  {
+    media_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      defaultValue: () => generateUuidV7(),
+    },
+    pet_id: {
+      type: getUuidType(),
+      allowNull: false,
+      references: {
+        model: 'pets',
+        key: 'pet_id',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    },
+    type: {
+      type: DataTypes.ENUM(...Object.values(PetMediaType)),
+      allowNull: false,
+    },
+    url: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    thumbnail_url: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    caption: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    order_index: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+      validate: {
+        min: 0,
+      },
+    },
+    is_primary: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    duration_seconds: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      validate: {
+        min: 0,
+      },
+    },
+    uploaded_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    modelName: 'PetMedia',
+    tableName: 'pet_media',
+    timestamps: true,
+    underscored: true,
+    indexes: [
+      // Most reads load all media for a single pet, ordered by position.
+      // Composite (pet_id, order_index) supports both the where + order
+      // in one lookup.
+      {
+        fields: ['pet_id', 'order_index'],
+        name: 'pet_media_pet_order_idx',
+      },
+      {
+        fields: ['pet_id', 'type'],
+        name: 'pet_media_pet_type_idx',
+      },
+      // One primary image per pet. Partial index on is_primary so videos
+      // and non-primary images don't conflict.
+      {
+        fields: ['pet_id'],
+        name: 'pet_media_one_primary_per_pet',
+        unique: true,
+        where: { is_primary: true },
+      },
+      ...auditIndexes('pet_media'),
+    ],
+  })
+);
+
+export default PetMedia;

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -3,6 +3,7 @@ import ApplicationQuestion from './ApplicationQuestion';
 import ApplicationStatusTransition from './ApplicationStatusTransition';
 import ApplicationTimeline from './ApplicationTimeline';
 import Pet from './Pet';
+import PetMedia from './PetMedia';
 import PetStatusTransition from './PetStatusTransition';
 import Rescue from './Rescue';
 import RescueSettings from './RescueSettings';
@@ -76,6 +77,7 @@ const models = {
   Rescue,
   RescueSettings,
   Pet,
+  PetMedia,
   PetStatusTransition,
   Application,
   ApplicationQuestion,
@@ -405,6 +407,11 @@ try {
   Pet.hasMany(SwipeAction, { foreignKey: 'petId', as: 'SwipeActions' });
   SwipeAction.belongsTo(Pet, { foreignKey: 'petId', as: 'Pet' });
 
+  // Pet media (plan 2.1 — Pet.images / Pet.videos JSONB extracted to a
+  // typed table). Cascade so deleting a pet removes its media rows.
+  Pet.hasMany(PetMedia, { foreignKey: 'pet_id', as: 'Media' });
+  PetMedia.belongsTo(Pet, { foreignKey: 'pet_id', as: 'Pet' });
+
   User.hasOne(EmailPreference, { foreignKey: 'userId', as: 'EmailPreferences' });
   EmailPreference.belongsTo(User, { foreignKey: 'userId', as: 'User' });
 
@@ -476,6 +483,7 @@ export {
   Notification,
   Permission,
   Pet,
+  PetMedia,
   PetStatusTransition,
   Rating,
   Report,

--- a/service.backend/src/seeders/08-pets.ts
+++ b/service.backend/src/seeders/08-pets.ts
@@ -8,6 +8,21 @@ import Pet, {
   SpayNeuterStatus,
   VaccinationStatus,
 } from '../models/Pet';
+import PetMedia, { PetMediaType } from '../models/PetMedia';
+
+// Pet.images / Pet.videos moved to the pet_media table (plan 2.1).
+// The seeder still describes the gallery alongside each pet profile for
+// readability, but seedPets() now does Pet.findOrCreate first then
+// PetMedia.findOrCreate per image.
+type SeedImage = {
+  image_id: string;
+  url: string;
+  thumbnail_url?: string;
+  caption?: string;
+  is_primary: boolean;
+  order_index: number;
+  uploaded_at: Date;
+};
 
 const petProfiles = [
   {
@@ -335,15 +350,35 @@ const petProfiles = [
 
 export async function seedPets() {
   for (const petData of petProfiles) {
+    const { images, ...petAttributes } = petData as typeof petData & { images: SeedImage[] };
+
     await Pet.findOrCreate({
       paranoid: false,
       where: { petId: petData.petId },
       defaults: {
-        ...petData,
+        ...petAttributes,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
     });
+
+    for (const img of images) {
+      await PetMedia.findOrCreate({
+        where: { media_id: img.image_id },
+        defaults: {
+          media_id: img.image_id,
+          pet_id: petData.petId,
+          type: PetMediaType.IMAGE,
+          url: img.url,
+          thumbnail_url: img.thumbnail_url ?? null,
+          caption: img.caption ?? null,
+          is_primary: img.is_primary,
+          order_index: img.order_index,
+          duration_seconds: null,
+          uploaded_at: img.uploaded_at,
+        },
+      });
+    }
   }
 
   // eslint-disable-next-line no-console

--- a/service.backend/src/services/analytics.service.ts
+++ b/service.backend/src/services/analytics.service.ts
@@ -4,6 +4,7 @@ import AuditLog from '../models/AuditLog';
 import Chat from '../models/Chat';
 import Message from '../models/Message';
 import Pet from '../models/Pet';
+import PetMedia, { PetMediaType } from '../models/PetMedia';
 import Rescue from '../models/Rescue';
 import User from '../models/User';
 import sequelize from '../sequelize';
@@ -626,13 +627,24 @@ export class AnalyticsService {
       const previousPeriodStart = new Date(
         defaultStartDate.getTime() - (defaultEndDate.getTime() - defaultStartDate.getTime())
       );
+      // Pet.images JSONB extracted to pet_media (plan 2.1) — count
+      // distinct pets that have at least one image row in the period.
       const previousStorageCount = await Pet.count({
         where: {
           createdAt: {
             [Op.between]: [previousPeriodStart, defaultStartDate],
           } as unknown as Date,
-          images: { [Op.not]: null } as unknown as string[],
         },
+        include: [
+          {
+            model: PetMedia,
+            as: 'Media',
+            where: { type: PetMediaType.IMAGE },
+            required: true,
+          },
+        ],
+        distinct: true,
+        col: 'pet_id',
       });
 
       const currentStorageCount = await Pet.count({
@@ -640,8 +652,17 @@ export class AnalyticsService {
           createdAt: {
             [Op.between]: [defaultStartDate, defaultEndDate],
           } as unknown as Date,
-          images: { [Op.not]: null } as unknown as string[],
         },
+        include: [
+          {
+            model: PetMedia,
+            as: 'Media',
+            where: { type: PetMediaType.IMAGE },
+            required: true,
+          },
+        ],
+        distinct: true,
+        col: 'pet_id',
       });
 
       const storageGrowthRate =

--- a/service.backend/src/services/discovery.service.ts
+++ b/service.backend/src/services/discovery.service.ts
@@ -1,7 +1,16 @@
 import { Op, fn, literal } from 'sequelize';
 import Pet, { AgeGroup, Gender, PetStatus, PetType, Size } from '../models/Pet';
+import PetMedia, { PetMediaType } from '../models/PetMedia';
 import Rescue from '../models/Rescue';
 import { logger } from '../utils/logger';
+
+// Pet.images / Pet.videos are no longer JSONB on the pet row (plan
+// 2.1) — they're rows in pet_media. Inside discovery we only ever look
+// at images, so we narrow the typed Pet to the shape we project below.
+type PetWithMedia = Pet & { Media?: PetMedia[] };
+
+const getImages = (pet: PetWithMedia): PetMedia[] =>
+  (pet.Media ?? []).filter(m => m.type === PetMediaType.IMAGE);
 
 export interface DiscoveryFilters {
   type?: string;
@@ -101,6 +110,12 @@ export class DiscoveryService {
             as: 'Rescue',
             attributes: ['rescue_id', 'name', 'status'],
           },
+          {
+            model: PetMedia,
+            as: 'Media',
+            where: { type: PetMediaType.IMAGE },
+            required: false,
+          },
         ],
         limit,
         order: [['created_at', 'ASC']],
@@ -154,6 +169,12 @@ export class DiscoveryService {
             as: 'Rescue',
             attributes: ['rescue_id', 'name', 'status'],
           },
+          {
+            model: PetMedia,
+            as: 'Media',
+            where: { type: PetMediaType.IMAGE },
+            required: false,
+          },
         ],
         order: [
           // 1. Prioritize verified rescues
@@ -162,8 +183,12 @@ export class DiscoveryService {
           // 2. Prioritize recently added pets (within last 7 days)
           literal(`CASE WHEN "Pet"."created_at" > NOW() - INTERVAL '7 days' THEN 0 ELSE 1 END`),
 
-          // 3. Prioritize pets with good photos (more than 2 images)
-          literal(`CASE WHEN jsonb_array_length("Pet"."images") > 2 THEN 0 ELSE 1 END`),
+          // 3. Prioritize pets with good photos (more than 2 images).
+          // Counts the eager-loaded pet_media rows that are images —
+          // replaces the old jsonb_array_length on Pet.images (plan 2.1).
+          literal(
+            `CASE WHEN (SELECT COUNT(*) FROM pet_media WHERE pet_media.pet_id = "Pet"."pet_id" AND pet_media.type = 'image') > 2 THEN 0 ELSE 1 END`
+          ),
 
           // 4. Boost puppies and kittens (young pets are popular)
           literal(`CASE WHEN "Pet"."age_group" IN ('baby', 'young') THEN 0 ELSE 1 END`),
@@ -197,8 +222,9 @@ export class DiscoveryService {
     // For now, implement basic filtering
     // TODO: Implement ML-based filtering based on user behavior
 
-    // Remove pets with no images
-    const filtered = pets.filter(pet => pet.images && pet.images.length > 0);
+    // Remove pets with no images. Media is eager-loaded via PetMedia
+    // (plan 2.1).
+    const filtered = pets.filter(pet => getImages(pet).length > 0);
 
     // Implement diversity - don't show too many of the same breed in a row
     const diversified = this.diversifyBreeds(filtered);
@@ -255,13 +281,13 @@ export class DiscoveryService {
       // Ensure petId is never undefined
       const petId = pet.petId || `pet_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
-      // Get image URLs - only return valid URLs, let frontend handle placeholders
-      let imageUrls: string[] = [];
-      if (pet.images && Array.isArray(pet.images) && pet.images.length > 0) {
-        imageUrls = pet.images
-          .map(img => img.url)
-          .filter(url => url && !url.includes('placeholder') && !url.includes('via.placeholder'));
-      }
+      // Get image URLs - only return valid URLs, let frontend handle placeholders.
+      // Sort by order_index so the gallery surfaces images in the rescue's
+      // intended order (the eager-load doesn't impose ordering by default).
+      const images = [...getImages(pet)].sort((a, b) => a.order_index - b.order_index);
+      const imageUrls = images
+        .map(img => img.url)
+        .filter(url => url && !url.includes('placeholder') && !url.includes('via.placeholder'));
 
       return {
         petId,
@@ -289,7 +315,7 @@ export class DiscoveryService {
     let score = 50; // Base score
 
     // Boost for good photos
-    if (pet.images && pet.images.length >= 3) {
+    if (getImages(pet).length >= 3) {
       score += 15;
     }
 

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -1,5 +1,6 @@
 import { col, fn, literal, Op, WhereOptions } from 'sequelize';
 import Pet, { AgeGroup, PetStatus, PetType, Size } from '../models/Pet';
+import PetMedia, { PetMediaType } from '../models/PetMedia';
 import PetStatusTransition from '../models/PetStatusTransition';
 import { validateSortField } from '../utils/sort-validation';
 import Rescue from '../models/Rescue';
@@ -387,34 +388,45 @@ export class PetService {
     try {
       const { initialImages, initialVideos, ...petAttributes } = petData;
 
-      // Prepare images with required fields
-      const images = (initialImages || []).map((img, index) => ({
-        image_id: `img_${Date.now()}_${index}`,
-        url: img.url,
-        thumbnail_url: img.thumbnailUrl,
-        caption: img.caption,
-        is_primary: img.isPrimary || false,
-        order_index: img.orderIndex || index,
-        uploaded_at: new Date(),
-      }));
-
-      // Prepare videos with required fields
-      const videos = (initialVideos || []).map((vid, index) => ({
-        video_id: `vid_${Date.now()}_${index}`,
-        url: vid.url,
-        thumbnail_url: vid.thumbnailUrl,
-        caption: vid.caption,
-        duration_seconds: vid.durationSeconds,
-        uploaded_at: new Date(),
-      }));
-
-      // Create pet
+      // Create pet first; media rows reference the new pet_id (plan 2.1).
       const pet = await Pet.create({
         ...petAttributes,
         rescueId,
-        images,
-        videos,
       });
+
+      // Initial gallery — images and videos are rows in pet_media now,
+      // not JSONB on the parent.
+      if ((initialImages?.length ?? 0) > 0) {
+        await PetMedia.bulkCreate(
+          (initialImages ?? []).map((img, index) => ({
+            pet_id: pet.petId,
+            type: PetMediaType.IMAGE,
+            url: img.url,
+            thumbnail_url: img.thumbnailUrl ?? null,
+            caption: img.caption ?? null,
+            is_primary: img.isPrimary || false,
+            order_index: img.orderIndex ?? index,
+            duration_seconds: null,
+            uploaded_at: new Date(),
+          }))
+        );
+      }
+
+      if ((initialVideos?.length ?? 0) > 0) {
+        await PetMedia.bulkCreate(
+          (initialVideos ?? []).map((vid, index) => ({
+            pet_id: pet.petId,
+            type: PetMediaType.VIDEO,
+            url: vid.url,
+            thumbnail_url: vid.thumbnailUrl ?? null,
+            caption: vid.caption ?? null,
+            is_primary: false,
+            order_index: index,
+            duration_seconds: vid.durationSeconds ?? null,
+            uploaded_at: new Date(),
+          }))
+        );
+      }
 
       // Seed the transition log with the initial status. The trigger /
       // hook would otherwise re-set pets.status to its default — a no-op
@@ -840,21 +852,25 @@ export class PetService {
         throw new Error('Pet not found');
       }
 
-      // Generate image IDs and prepare image data
-      const newImages = images.map((img, index) => ({
-        image_id: `img_${Date.now()}_${index}`,
-        url: img.url,
-        thumbnail_url: img.thumbnailUrl,
-        caption: img.caption,
-        is_primary: img.isPrimary || false,
-        order_index: img.orderIndex || pet.images.length + index,
-        uploaded_at: new Date(),
-      }));
+      // Existing image count drives the default order_index for the
+      // appended rows so they fall after the current gallery (plan 2.1).
+      const existingCount = await PetMedia.count({
+        where: { pet_id: petId, type: PetMediaType.IMAGE },
+      });
 
-      // Add to existing images
-      const updatedImages = [...pet.images, ...newImages];
-
-      await pet.update({ images: updatedImages });
+      const created = await PetMedia.bulkCreate(
+        images.map((img, index) => ({
+          pet_id: petId,
+          type: PetMediaType.IMAGE,
+          url: img.url,
+          thumbnail_url: img.thumbnailUrl ?? null,
+          caption: img.caption ?? null,
+          is_primary: img.isPrimary || false,
+          order_index: img.orderIndex ?? existingCount + index,
+          duration_seconds: null,
+          uploaded_at: new Date(),
+        }))
+      );
 
       // Log image addition
       await AuditLogService.log({
@@ -862,7 +878,7 @@ export class PetService {
         entity: 'Pet',
         entityId: petId,
         details: {
-          addedImages: JSON.parse(JSON.stringify(newImages)),
+          addedImages: created.map(m => JSON.parse(JSON.stringify(m.toJSON()))),
           addedBy,
         },
         userId: addedBy,
@@ -891,18 +907,28 @@ export class PetService {
         throw new Error('Pet not found');
       }
 
-      // Replace all images
-      const newImages = images.map((img, index) => ({
-        image_id: img.imageId || `img_${Date.now()}_${index}`,
-        url: img.url,
-        thumbnail_url: img.thumbnailUrl,
-        caption: img.caption,
-        is_primary: img.isPrimary || false,
-        order_index: img.orderIndex || index,
-        uploaded_at: new Date(),
-      }));
-
-      await pet.update({ images: newImages });
+      // Replace all images: delete-then-insert inside a transaction so a
+      // failed bulkCreate doesn't leave the pet with no media.
+      const created = await sequelize.transaction(async tx => {
+        await PetMedia.destroy({
+          where: { pet_id: petId, type: PetMediaType.IMAGE },
+          transaction: tx,
+        });
+        return PetMedia.bulkCreate(
+          images.map((img, index) => ({
+            pet_id: petId,
+            type: PetMediaType.IMAGE,
+            url: img.url,
+            thumbnail_url: img.thumbnailUrl ?? null,
+            caption: img.caption ?? null,
+            is_primary: img.isPrimary || false,
+            order_index: img.orderIndex ?? index,
+            duration_seconds: null,
+            uploaded_at: new Date(),
+          })),
+          { transaction: tx }
+        );
+      });
 
       // Log image update
       await AuditLogService.log({
@@ -910,7 +936,7 @@ export class PetService {
         entity: 'Pet',
         entityId: petId,
         details: {
-          newImages: JSON.parse(JSON.stringify(newImages)),
+          newImages: created.map(m => JSON.parse(JSON.stringify(m.toJSON()))),
           updatedBy,
         },
         userId: updatedBy,
@@ -939,14 +965,13 @@ export class PetService {
         throw new Error('Pet not found');
       }
 
-      const originalImages = pet.images;
-      const updatedImages = pet.images.filter(img => img.image_id !== imageId);
+      const deleted = await PetMedia.destroy({
+        where: { media_id: imageId, pet_id: petId, type: PetMediaType.IMAGE },
+      });
 
-      if (originalImages.length === updatedImages.length) {
+      if (deleted === 0) {
         throw new Error('Image not found');
       }
-
-      await pet.update({ images: updatedImages });
 
       // Log image removal
       await AuditLogService.log({


### PR DESCRIPTION
## Summary

Plan 2.1 — `Pet.images` / `Pet.videos` JSONB extracted to a typed `pet_media` table. One row per image or video; `type` discriminates. The pet_media table replaces the JSONB blobs that used to live on `pets`, and all reads now go through `Pet.hasMany(PetMedia, { as: 'Media' })`.

## Schema

```
pet_media
  media_id          UUID PK
  pet_id            UUID FK→pets CASCADE
  type              ENUM('image' | 'video')
  url               TEXT NOT NULL
  thumbnail_url     TEXT NULL
  caption           TEXT NULL
  order_index       INTEGER NOT NULL DEFAULT 0
  is_primary        BOOLEAN NOT NULL DEFAULT false
  duration_seconds  INTEGER NULL    (videos only)
  uploaded_at       TIMESTAMPTZ NOT NULL
  + audit columns
```

Indexes:
- `(pet_id, order_index)` — gallery read pattern (where + order in one lookup)
- `(pet_id, type)` — image-only / video-only filters
- partial unique on `pet_id WHERE is_primary = true` — one primary image per pet

## Service refactors

- **Pet creation**: `initialImages` / `initialVideos` go through `PetMedia.bulkCreate` after `Pet.create` instead of being written into the JSONB column.
- **`addPetImages`**: `PetMedia.count` drives the default `order_index`; `bulkCreate` appends the new rows.
- **`updatePetImages`**: delete-then-insert inside a transaction so a failed `bulkCreate` can't leave the pet with no media.
- **`removePetImage`**: `PetMedia.destroy` keyed on `(media_id, pet_id, type)`.
- **DiscoveryService** eager-loads `Media`; the old `jsonb_array_length` sort factor becomes a correlated `COUNT` against `pet_media`.
- **AnalyticsService.count** uses an inner-join on `PetMedia` for the "pets that have at least one image" metric.

## Tests

- `pet-business-logic` / `discovery` / `pet-discovery-flow` / `pet-discovery-matching`: switched from `images: [...]` JSONB scaffolding to `Media: [...]` eager-load shape; assertions now check `PetMedia.bulkCreate` / `destroy` / `count` call sites.
- Status-transition tests no longer pass `images: '[]'` / `videos: '[]'` to the raw `bulkInsert` helper — those columns are gone.
- Seeder seeds `PetMedia` rows alongside each `Pet` via `findOrCreate` so the seed data preserves the existing `image_id` values.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 1380 tests passing across 61 files (11 skipped, 0 failures)
- [x] `models/standards.test.ts` — 68 tests, including FK / index / TIMESTAMPTZ checks for the new table
- [x] `npx eslint --max-warnings=0 'src/**/*.ts'` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_