### PR TITLE
Phase 4 (slice 2.1 cont.): application_references typed table

### DIFF
--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -12,6 +12,9 @@ vi.mock('../../config/env', () => ({
 
 import { generateCryptoUuid as uuidv4 } from '../../utils/uuid-helpers';
 import Application, { ApplicationPriority, ApplicationStatus } from '../../models/Application';
+import ApplicationReferenceModel, {
+  ApplicationReferenceStatus,
+} from '../../models/ApplicationReference';
 import ApplicationStatusTransition from '../../models/ApplicationStatusTransition';
 import Pet, { PetStatus, PetType, AgeGroup, Gender } from '../../models/Pet';
 import User, { UserStatus, UserType } from '../../models/User';
@@ -29,6 +32,7 @@ import { JsonObject } from '../../types/common';
 
 // Mock dependencies
 vi.mock('../../models/Application');
+vi.mock('../../models/ApplicationReference');
 vi.mock('../../models/ApplicationStatusTransition');
 vi.mock('../../models/Pet');
 vi.mock('../../models/User');
@@ -44,6 +48,9 @@ vi.mock('../../services/email.service', () => ({
 }));
 
 const MockedApplication = Application as vi.MockedObject<Application>;
+const MockedApplicationReference = ApplicationReferenceModel as vi.MockedObject<
+  typeof ApplicationReferenceModel
+>;
 const MockedApplicationStatusTransition = ApplicationStatusTransition as vi.MockedObject<
   typeof ApplicationStatusTransition
 >;
@@ -75,7 +82,43 @@ describe('Application Submission Workflow Integration Tests', () => {
     // insert would trip the FK. Stub it — the trigger/hook path has its own
     // dedicated tests.
     MockedApplicationStatusTransition.create = vi.fn().mockResolvedValue({} as never);
+
+    // Application references are written to the application_references
+    // table now (plan 2.1). Stub the typed-table writes so the service
+    // code doesn't try to hit the real DB through the mocked
+    // Application model.
+    MockedApplicationReference.bulkCreate = vi.fn().mockResolvedValue([] as never);
+    MockedApplicationReference.findAll = vi.fn().mockResolvedValue([] as never);
+    MockedApplicationReference.destroy = vi.fn().mockResolvedValue(0 as never);
   });
+
+  // Build a minimal ApplicationReference row instance — used by the
+  // updateReference flow which calls `target.update(...)` on each
+  // row. (plan 2.1)
+  const mockReferenceRow = (
+    overrides: Partial<{
+      reference_id: string;
+      legacy_id: string;
+      name: string;
+      relationship: string;
+      phone: string;
+      status: 'pending' | 'contacted' | 'verified' | 'failed';
+      order_index: number;
+    }> = {}
+  ) => {
+    const row = {
+      reference_id: overrides.reference_id ?? 'ref-uuid-0',
+      legacy_id: overrides.legacy_id ?? 'ref-0',
+      name: overrides.name ?? 'John Doe',
+      relationship: overrides.relationship ?? 'Veterinarian',
+      phone: overrides.phone ?? '555-1234',
+      status: overrides.status ?? 'pending',
+      order_index: overrides.order_index ?? 0,
+      update: vi.fn().mockResolvedValue(undefined),
+      toJSON: vi.fn().mockReturnValue(overrides),
+    };
+    return row;
+  };
 
   describe('Browse and View Pets', () => {
     describe('when browsing available pets', () => {
@@ -272,11 +315,12 @@ describe('Application Submission Workflow Integration Tests', () => {
       });
 
       it('should initialize references with pending status', async () => {
+        // References live in the application_references typed table now
+        // (plan 2.1) — assert the bulkCreate payload rather than the
+        // Application model's removed `references` array column.
         const mockUser = createMockUser({ userId: adopterId });
         const mockPet = createMockPet({ petId: petId, status: PetStatus.AVAILABLE });
-        const mockApplication = createMockApplication({
-          references: validReferences.map(ref => ({ ...ref, status: 'pending' as const })),
-        });
+        const mockApplication = createMockApplication();
 
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
         MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet as never);
@@ -289,10 +333,17 @@ describe('Application Submission Workflow Integration Tests', () => {
           references: validReferences,
         };
 
-        const result = await ApplicationService.createApplication(applicationData, adopterId);
+        await ApplicationService.createApplication(applicationData, adopterId);
 
-        expect(result.references).toHaveLength(2);
-        expect(result.references[0].status).toBe('pending');
+        expect(MockedApplicationReference.bulkCreate).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              status: ApplicationReferenceStatus.PENDING,
+            }),
+          ])
+        );
+        const payload = (MockedApplicationReference.bulkCreate as vi.Mock).mock.calls[0][0];
+        expect(payload).toHaveLength(2);
       });
 
       it('should create timeline event when application is submitted', async () => {
@@ -672,56 +723,32 @@ describe('Application Submission Workflow Integration Tests', () => {
   describe('Reference Checks and Verification', () => {
     describe('when contacting references', () => {
       it('should update reference status to contacted', async () => {
-        const mockApplication = createMockApplication({
-          applicationId: applicationId,
-          references: [
-            {
-              id: 'ref-0',
-              name: 'John Doe',
-              relationship: 'Veterinarian',
-              phone: '555-1234',
-              status: 'pending',
-            },
-          ],
-        });
-
-        mockApplication.update = vi.fn().mockResolvedValue(mockApplication);
+        const mockApplication = createMockApplication({ applicationId: applicationId });
         mockApplication.reload = vi.fn().mockResolvedValue(mockApplication);
-
         MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication as never);
+
+        const refRow = mockReferenceRow({ status: 'pending' });
+        MockedApplicationReference.findAll = vi.fn().mockResolvedValue([refRow] as never);
 
         const referenceUpdate: ReferenceUpdateRequest = {
           referenceId: 'ref-0',
           status: 'contacted',
         };
 
-        const result = await ApplicationService.updateReference(
-          applicationId,
-          referenceUpdate,
-          rescueStaffId
-        );
+        await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
 
-        expect(mockApplication.update).toHaveBeenCalled();
+        expect(refRow.update).toHaveBeenCalledWith(
+          expect.objectContaining({ status: 'contacted' })
+        );
       });
 
       it('should update reference status to verified after successful check', async () => {
-        const mockApplication = createMockApplication({
-          applicationId: applicationId,
-          references: [
-            {
-              id: 'ref-0',
-              name: 'John Doe',
-              relationship: 'Veterinarian',
-              phone: '555-1234',
-              status: 'contacted',
-            },
-          ],
-        });
-
-        mockApplication.update = vi.fn().mockResolvedValue(mockApplication);
+        const mockApplication = createMockApplication({ applicationId: applicationId });
         mockApplication.reload = vi.fn().mockResolvedValue(mockApplication);
-
         MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication as never);
+
+        const refRow = mockReferenceRow({ status: 'contacted' });
+        MockedApplicationReference.findAll = vi.fn().mockResolvedValue([refRow] as never);
 
         const referenceUpdate: ReferenceUpdateRequest = {
           referenceId: 'ref-0',
@@ -731,27 +758,18 @@ describe('Application Submission Workflow Integration Tests', () => {
 
         await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
 
-        expect(mockApplication.update).toHaveBeenCalled();
+        expect(refRow.update).toHaveBeenCalledWith(
+          expect.objectContaining({ status: 'verified', notes: 'Confirmed excellent pet owner' })
+        );
       });
 
       it('should update reference status to failed if unreachable', async () => {
-        const mockApplication = createMockApplication({
-          applicationId: applicationId,
-          references: [
-            {
-              id: 'ref-0',
-              name: 'John Doe',
-              relationship: 'Veterinarian',
-              phone: '555-1234',
-              status: 'contacted',
-            },
-          ],
-        });
-
-        mockApplication.update = vi.fn().mockResolvedValue(mockApplication);
+        const mockApplication = createMockApplication({ applicationId: applicationId });
         mockApplication.reload = vi.fn().mockResolvedValue(mockApplication);
-
         MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication as never);
+
+        const refRow = mockReferenceRow({ status: 'contacted' });
+        MockedApplicationReference.findAll = vi.fn().mockResolvedValue([refRow] as never);
 
         const referenceUpdate: ReferenceUpdateRequest = {
           referenceId: 'ref-0',
@@ -761,57 +779,38 @@ describe('Application Submission Workflow Integration Tests', () => {
 
         await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
 
-        expect(mockApplication.update).toHaveBeenCalled();
+        expect(refRow.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
       });
 
       it('should track when reference was contacted', async () => {
-        const mockApplication = createMockApplication({
-          applicationId: applicationId,
-          references: [
-            {
-              id: 'ref-0',
-              name: 'John Doe',
-              relationship: 'Veterinarian',
-              phone: '555-1234',
-              status: 'pending',
-            },
-          ],
-        });
-
-        mockApplication.update = vi.fn().mockResolvedValue(mockApplication);
+        const mockApplication = createMockApplication({ applicationId: applicationId });
         mockApplication.reload = vi.fn().mockResolvedValue(mockApplication);
-
         MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication as never);
 
+        const refRow = mockReferenceRow({ status: 'pending' });
+        MockedApplicationReference.findAll = vi.fn().mockResolvedValue([refRow] as never);
+
+        const contactedAt = new Date();
         const referenceUpdate: ReferenceUpdateRequest = {
           referenceId: 'ref-0',
           status: 'contacted',
-          contactedAt: new Date(),
+          contactedAt,
         };
 
         await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
 
-        expect(mockApplication.update).toHaveBeenCalled();
+        expect(refRow.update).toHaveBeenCalledWith(
+          expect.objectContaining({ status: 'contacted', contacted_at: contactedAt })
+        );
       });
 
       it('should allow adding notes to reference checks', async () => {
-        const mockApplication = createMockApplication({
-          applicationId: applicationId,
-          references: [
-            {
-              id: 'ref-0',
-              name: 'John Doe',
-              relationship: 'Veterinarian',
-              phone: '555-1234',
-              status: 'contacted',
-            },
-          ],
-        });
-
-        mockApplication.update = vi.fn().mockResolvedValue(mockApplication);
+        const mockApplication = createMockApplication({ applicationId: applicationId });
         mockApplication.reload = vi.fn().mockResolvedValue(mockApplication);
-
         MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication as never);
+
+        const refRow = mockReferenceRow({ status: 'contacted' });
+        MockedApplicationReference.findAll = vi.fn().mockResolvedValue([refRow] as never);
 
         const referenceUpdate: ReferenceUpdateRequest = {
           referenceId: 'ref-0',
@@ -821,7 +820,9 @@ describe('Application Submission Workflow Integration Tests', () => {
 
         await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
 
-        expect(mockApplication.update).toHaveBeenCalled();
+        expect(refRow.update).toHaveBeenCalledWith(
+          expect.objectContaining({ notes: 'Very positive reference - highly recommended' })
+        );
       });
     });
   });
@@ -1412,15 +1413,6 @@ describe('Application Submission Workflow Integration Tests', () => {
           applicationId: applicationId,
           userId: adopterId,
           petId: petId,
-          references: [
-            {
-              id: 'ref-0',
-              name: 'John Doe',
-              relationship: 'Veterinarian',
-              phone: '555-1234',
-              status: 'pending',
-            },
-          ],
         });
 
         MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
@@ -1443,6 +1435,9 @@ describe('Application Submission Workflow Integration Tests', () => {
         mockApplication.reload = vi.fn().mockResolvedValue(mockApplication);
 
         MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication as never);
+
+        const refRow = mockReferenceRow({ status: 'pending' });
+        MockedApplicationReference.findAll = vi.fn().mockResolvedValue([refRow] as never);
 
         const referenceUpdate: ReferenceUpdateRequest = {
           referenceId: 'ref-0',
@@ -1656,7 +1651,9 @@ function createMockApplication(overrides: Partial<Application> = {}): vi.Mocked<
     status: ApplicationStatus.SUBMITTED,
     priority: ApplicationPriority.NORMAL,
     answers: {},
-    references: [],
+    // references[] moved to application_references (plan 2.1) — no
+    // longer a column on Application; the test mocks the model directly
+    // where assertions are needed.
     documents: [],
     interviewNotes: null,
     homeVisitNotes: null,
@@ -1687,7 +1684,6 @@ function createMockApplication(overrides: Partial<Application> = {}): vi.Mocked<
       status: overrides.status ?? ApplicationStatus.SUBMITTED,
       priority: overrides.priority ?? ApplicationPriority.NORMAL,
       answers: overrides.answers ?? {},
-      references: overrides.references ?? [],
       documents: overrides.documents ?? [],
     }),
     update: vi.fn().mockResolvedValue(undefined),

--- a/service.backend/src/__tests__/models/ApplicationStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/ApplicationStatusTransition.test.ts
@@ -103,7 +103,6 @@ describe('ApplicationStatusTransition', () => {
         answers: '{}',
         documents: '[]',
         tags: '[]',
-        references: '[]',
         created_at: new Date(),
         updated_at: new Date(),
         version: 0,

--- a/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
@@ -81,7 +81,6 @@ describe('HomeVisitStatusTransition', () => {
         answers: '{}',
         documents: '[]',
         tags: '[]',
-        references: '[]',
         created_at: new Date(),
         updated_at: new Date(),
         version: 0,

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -8,6 +8,7 @@ import { vi } from 'vitest';
 
 import { ApplicationService } from '../../services/application.service';
 import Application, { ApplicationStatus, ApplicationPriority } from '../../models/Application';
+import ApplicationReferenceModel from '../../models/ApplicationReference';
 import ApplicationStatusTransition from '../../models/ApplicationStatusTransition';
 import Pet, { PetStatus } from '../../models/Pet';
 import User, { UserType } from '../../models/User';
@@ -15,6 +16,9 @@ import { CreateApplicationRequest, ApplicationStatusUpdateRequest } from '../../
 
 // Cast models to mocked versions
 const MockedApplication = Application as vi.MockedObject<Application>;
+const MockedApplicationReference = ApplicationReferenceModel as vi.MockedObject<
+  typeof ApplicationReferenceModel
+>;
 const MockedPet = Pet as vi.MockedObject<Pet>;
 const MockedUser = User as vi.MockedObject<User>;
 const MockedApplicationStatusTransition = ApplicationStatusTransition as vi.MockedObject<
@@ -58,15 +62,8 @@ describe('ApplicationService - Business Logic', () => {
     rescueId: mockRescueId,
     status,
     answers: { experience: 'yes', has_yard: 'yes' },
-    references: [
-      {
-        id: 'ref-1',
-        name: 'Jane Doe',
-        email: 'jane@example.com',
-        phone: '555-0100',
-        relationship: 'friend',
-      },
-    ],
+    // references[] moved to application_references (plan 2.1) — no
+    // longer a column on Application.
     priority: ApplicationPriority.NORMAL,
     submittedAt: new Date(),
     update: vi.fn().mockResolvedValue(true),
@@ -106,6 +103,12 @@ describe('ApplicationService - Business Logic', () => {
     // care about service behaviour, not the trigger/hook plumbing, which has
     // its own dedicated tests.
     MockedApplicationStatusTransition.create = vi.fn().mockResolvedValue({} as never);
+    // Same reasoning as the transition stub: with mocked Application.create
+    // returning a fake row, ApplicationReference.bulkCreate would trip the
+    // FK on the SQLite test DB (plan 2.1).
+    MockedApplicationReference.bulkCreate = vi.fn().mockResolvedValue([] as never);
+    MockedApplicationReference.findAll = vi.fn().mockResolvedValue([] as never);
+    MockedApplicationReference.destroy = vi.fn().mockResolvedValue(0 as never);
   });
 
   describe('Business Rule: Application Creation', () => {

--- a/service.backend/src/models/Application.ts
+++ b/service.backend/src/models/Application.ts
@@ -59,17 +59,8 @@ interface ApplicationAttributes {
   actionedBy?: string | null;
   actionedAt?: Date | null;
   answers: JsonObject;
-  references: Array<{
-    id: string;
-    name: string;
-    relationship: string;
-    phone: string;
-    email?: string;
-    contacted_at?: Date;
-    status: 'pending' | 'contacted' | 'verified' | 'failed';
-    notes?: string;
-    contacted_by?: string;
-  }>;
+  // references moved to the application_references table (plan 2.1) —
+  // see ApplicationReference. Application.hasMany(ApplicationReference).
   documents: Array<{
     documentId: string;
     documentType: string;
@@ -124,17 +115,7 @@ class Application
   public actionedBy!: string | null;
   public actionedAt!: Date | null;
   public answers!: JsonObject;
-  public references!: Array<{
-    id: string;
-    name: string;
-    relationship: string;
-    phone: string;
-    email?: string;
-    contacted_at?: Date;
-    status: 'pending' | 'contacted' | 'verified' | 'failed';
-    notes?: string;
-    contacted_by?: string;
-  }>;
+  // references moved to application_references (plan 2.1).
   public documents!: Array<{
     documentId: string;
     documentType: string;
@@ -327,34 +308,7 @@ Application.init(
         isValidAnswers: Application.prototype.isValidAnswers,
       },
     },
-    references: {
-      type: getJsonType(),
-      allowNull: false,
-      validate: {
-        isValidReferences(
-          value: Array<{
-            id: string;
-            name: string;
-            relationship: string;
-            phone: string;
-            email?: string;
-            contacted_at?: Date;
-            status: 'pending' | 'contacted' | 'verified' | 'failed';
-            notes?: string;
-            contacted_by?: string;
-          }>
-        ) {
-          if (!Array.isArray(value)) {
-            throw new Error('References must be an array');
-          }
-          value.forEach(ref => {
-            if (!ref.id || !ref.name || !ref.relationship || !ref.phone) {
-              throw new Error('Each reference must have id, name, relationship, and phone');
-            }
-          });
-        },
-      },
-    },
+    // references moved to the application_references table (plan 2.1).
     documents: {
       type: getJsonType(),
       allowNull: false,

--- a/service.backend/src/models/ApplicationReference.ts
+++ b/service.backend/src/models/ApplicationReference.ts
@@ -1,0 +1,197 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+// Plan 2.1 — Application.references[] JSONB extracted to a typed table.
+// One row per personal/veterinary reference attached to an application.
+// Status moves through pending → contacted → verified | failed as the
+// rescue follows up. The legacy "ref-N" id format used in the JSONB
+// payload is preserved on a dedicated column (legacy_id) so the
+// existing ID-based `updateReference` path keeps working without a data
+// migration; new rows will set legacy_id to the same value as the row's
+// PK by default.
+
+export enum ApplicationReferenceStatus {
+  PENDING = 'pending',
+  CONTACTED = 'contacted',
+  VERIFIED = 'verified',
+  FAILED = 'failed',
+}
+
+interface ApplicationReferenceAttributes {
+  reference_id: string;
+  application_id: string;
+  // Legacy "ref-N" identifier from the JSONB shape — kept on the row so
+  // existing API calls that pass `referenceId` continue to resolve to a
+  // single row. Unique per application.
+  legacy_id: string;
+  name: string;
+  relationship: string;
+  phone: string;
+  email: string | null;
+  status: ApplicationReferenceStatus;
+  contacted_at: Date | null;
+  contacted_by: string | null;
+  notes: string | null;
+  // Display order within the parent application's reference list,
+  // lowest first. Replaces the implicit array-index ordering of the
+  // JSONB shape.
+  order_index: number;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface ApplicationReferenceCreationAttributes
+  extends Optional<
+    ApplicationReferenceAttributes,
+    | 'reference_id'
+    | 'email'
+    | 'status'
+    | 'contacted_at'
+    | 'contacted_by'
+    | 'notes'
+    | 'order_index'
+    | 'created_at'
+    | 'updated_at'
+  > {}
+
+export class ApplicationReference
+  extends Model<ApplicationReferenceAttributes, ApplicationReferenceCreationAttributes>
+  implements ApplicationReferenceAttributes
+{
+  public reference_id!: string;
+  public application_id!: string;
+  public legacy_id!: string;
+  public name!: string;
+  public relationship!: string;
+  public phone!: string;
+  public email!: string | null;
+  public status!: ApplicationReferenceStatus;
+  public contacted_at!: Date | null;
+  public contacted_by!: string | null;
+  public notes!: string | null;
+  public order_index!: number;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+ApplicationReference.init(
+  {
+    reference_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      defaultValue: () => generateUuidV7(),
+    },
+    application_id: {
+      type: getUuidType(),
+      allowNull: false,
+      references: {
+        model: 'applications',
+        key: 'application_id',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    },
+    legacy_id: {
+      type: DataTypes.STRING(64),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    relationship: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    phone: {
+      type: DataTypes.STRING(64),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    email: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+    status: {
+      type: DataTypes.ENUM(...Object.values(ApplicationReferenceStatus)),
+      allowNull: false,
+      defaultValue: ApplicationReferenceStatus.PENDING,
+    },
+    contacted_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    contacted_by: {
+      type: getUuidType(),
+      allowNull: true,
+      references: {
+        model: 'users',
+        key: 'user_id',
+      },
+      // Forensic — preserve the row even if the actor is removed. The
+      // audit trail still records who handled the reference.
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
+    },
+    notes: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    order_index: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+      validate: {
+        min: 0,
+      },
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    modelName: 'ApplicationReference',
+    tableName: 'application_references',
+    timestamps: true,
+    underscored: true,
+    indexes: [
+      // Most reads load all references for an application, ordered by
+      // position. Composite (application_id, order_index) covers the
+      // where + order in one lookup.
+      {
+        fields: ['application_id', 'order_index'],
+        name: 'application_references_app_order_idx',
+      },
+      // Look up a reference by its caller-supplied legacy_id (e.g. the
+      // "ref-0" string from the JSONB era).
+      {
+        fields: ['application_id', 'legacy_id'],
+        name: 'application_references_app_legacy_unique',
+        unique: true,
+      },
+      {
+        fields: ['status'],
+        name: 'application_references_status_idx',
+      },
+      {
+        fields: ['contacted_by'],
+        name: 'application_references_contacted_by_idx',
+      },
+      ...auditIndexes('application_references'),
+    ],
+  })
+);
+
+export default ApplicationReference;

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -1,5 +1,6 @@
 import Application from './Application';
 import ApplicationQuestion from './ApplicationQuestion';
+import ApplicationReference from './ApplicationReference';
 import ApplicationStatusTransition from './ApplicationStatusTransition';
 import ApplicationTimeline from './ApplicationTimeline';
 import Pet from './Pet';
@@ -83,6 +84,7 @@ const models = {
   PetStatusTransition,
   Application,
   ApplicationQuestion,
+  ApplicationReference,
   ApplicationStatusTransition,
   ApplicationTimeline,
   Chat,
@@ -220,6 +222,29 @@ try {
   ApplicationTimeline.belongsTo(User, {
     foreignKey: 'created_by',
     as: 'CreatedBy',
+    constraints: false,
+  });
+
+  // ApplicationReference association (plan 2.1 — Application.references
+  // JSONB extracted to a typed table). Cascade so deleting an
+  // application removes its references; references survive the
+  // contacted_by user being removed (SET NULL declared on the FK).
+  Application.hasMany(ApplicationReference, {
+    foreignKey: 'application_id',
+    as: 'References',
+  });
+  ApplicationReference.belongsTo(Application, {
+    foreignKey: 'application_id',
+    as: 'Application',
+  });
+  User.hasMany(ApplicationReference, {
+    foreignKey: 'contacted_by',
+    as: 'ContactedReferences',
+    constraints: false,
+  });
+  ApplicationReference.belongsTo(User, {
+    foreignKey: 'contacted_by',
+    as: 'ContactedBy',
     constraints: false,
   });
 
@@ -503,6 +528,7 @@ try {
 export {
   Application,
   ApplicationQuestion,
+  ApplicationReference,
   ApplicationStatusTransition,
   ApplicationTimeline,
   AuditLog,

--- a/service.backend/src/seeders/09-applications.ts
+++ b/service.backend/src/seeders/09-applications.ts
@@ -4,6 +4,22 @@ import Application, {
   ApplicationStage,
   ApplicationOutcome,
 } from '../models/Application';
+import ApplicationReference, { ApplicationReferenceStatus } from '../models/ApplicationReference';
+
+// Application.references[] moved to the application_references table
+// (plan 2.1). seedApplications() now does Application.findOrCreate first
+// and then ApplicationReference.findOrCreate per reference, keyed on
+// (application_id, legacy_id) to keep the seeder idempotent.
+type SeedReference = {
+  id: string;
+  name: string;
+  relationship: string;
+  phone: string;
+  email?: string;
+  status: 'pending' | 'contacted' | 'verified' | 'failed';
+  notes?: string;
+  contacted_at?: Date;
+};
 
 const applicationData = [
   {
@@ -809,10 +825,12 @@ const applicationData = [
 
 export async function seedApplications() {
   for (const appData of applicationData) {
-    // Type assertion justified: Application form data structure is intentionally flexible
-    // to support various rescue organization requirements
+    const { references, ...applicationFields } = appData as typeof appData & {
+      references: SeedReference[];
+    };
+
     const defaults = {
-      ...appData,
+      ...applicationFields,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -825,6 +843,26 @@ export async function seedApplications() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       defaults: defaults as any,
     });
+
+    for (let index = 0; index < references.length; index++) {
+      const ref = references[index];
+      await ApplicationReference.findOrCreate({
+        where: { application_id: appData.applicationId, legacy_id: ref.id },
+        defaults: {
+          application_id: appData.applicationId,
+          legacy_id: ref.id,
+          name: ref.name,
+          relationship: ref.relationship,
+          phone: ref.phone,
+          email: ref.email ?? null,
+          status: (ref.status as ApplicationReferenceStatus) ?? ApplicationReferenceStatus.PENDING,
+          contacted_at: ref.contacted_at ?? null,
+          contacted_by: null,
+          notes: ref.notes ?? null,
+          order_index: index,
+        },
+      });
+    }
   }
 
   // eslint-disable-next-line no-console

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1,6 +1,9 @@
 import { Includeable, Op, Order, WhereOptions } from 'sequelize';
 import { generateCryptoUuid as uuidv4 } from '../utils/uuid-helpers';
 import Application, { ApplicationPriority, ApplicationStatus } from '../models/Application';
+import ApplicationReferenceModel, {
+  ApplicationReferenceStatus,
+} from '../models/ApplicationReference';
 import { validateSortField } from '../utils/sort-validation';
 
 const APPLICATION_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'actioned_at'] as const;
@@ -87,16 +90,8 @@ export class ApplicationService {
         );
       }
 
-      // Prepare references with default status
-      const processedReferences: ApplicationReference[] = (applicationData.references ?? []).map(
-        ref => ({
-          ...ref,
-          status: 'pending' as const,
-          contacted_at: undefined,
-        })
-      );
-
-      // Create application
+      // Create application — references are persisted to the
+      // application_references typed table after creation (plan 2.1).
       const application = await Application.create({
         userId: userId,
         petId: applicationData.petId,
@@ -104,11 +99,32 @@ export class ApplicationService {
         status: ApplicationStatus.SUBMITTED,
         priority: applicationData.priority || ApplicationPriority.NORMAL,
         answers: applicationData.answers,
-        references: processedReferences,
         documents: [],
         notes: applicationData.notes,
         tags: applicationData.tags || [],
       });
+
+      const incomingReferences = applicationData.references ?? [];
+      if (incomingReferences.length > 0) {
+        await ApplicationReferenceModel.bulkCreate(
+          incomingReferences.map((ref, index) => ({
+            application_id: application.applicationId,
+            // Preserve the caller-supplied id (legacy "ref-N" or any
+            // other shape) for backwards compatibility with the
+            // ID-based update path below.
+            legacy_id: ref.id || `ref-${index}`,
+            name: ref.name,
+            relationship: ref.relationship,
+            phone: ref.phone,
+            email: ref.email ?? null,
+            status: ApplicationReferenceStatus.PENDING,
+            contacted_at: null,
+            contacted_by: null,
+            notes: null,
+            order_index: index,
+          }))
+        );
+      }
 
       // Record the initial transition (from_status = null encodes
       // "initial state assigned at creation"). The trigger / hook will
@@ -521,17 +537,51 @@ export class ApplicationService {
         throw new Error('Application cannot be updated once processed');
       }
 
+      // References are persisted to the application_references table
+      // (plan 2.1) — strip them off the parent update payload and apply
+      // them separately below.
+      const { references: incomingReferences, ...applicationUpdate } = updateData;
+
       // Store original data for audit
+      const existingReferences = await ApplicationReferenceModel.findAll({
+        where: { application_id: applicationId },
+        order: [['order_index', 'ASC']],
+      });
       const originalData = {
         answers: application.answers,
-        references: application.references,
+        references: existingReferences.map(r => r.toJSON()),
         priority: application.priority,
         notes: application.notes,
         tags: application.tags,
       };
 
-      // Update application
-      await application.update(updateData);
+      // Update application — replace-all semantics for references
+      // mirror the JSONB era's array-overwrite behaviour.
+      await application.update(applicationUpdate);
+
+      if (incomingReferences !== undefined) {
+        await ApplicationReferenceModel.destroy({
+          where: { application_id: applicationId },
+        });
+        if (incomingReferences.length > 0) {
+          await ApplicationReferenceModel.bulkCreate(
+            incomingReferences.map((ref, index) => ({
+              application_id: applicationId,
+              legacy_id: ref.id || `ref-${index}`,
+              name: ref.name,
+              relationship: ref.relationship,
+              phone: ref.phone,
+              email: ref.email ?? null,
+              status:
+                (ref.status as ApplicationReferenceStatus) ?? ApplicationReferenceStatus.PENDING,
+              contacted_at: ref.contacted_at ?? null,
+              contacted_by: ref.contacted_by ?? null,
+              notes: ref.notes ?? null,
+              order_index: index,
+            }))
+          );
+        }
+      }
 
       // Create timeline event for application update
       await ApplicationTimelineService.createEvent({
@@ -982,25 +1032,30 @@ export class ApplicationService {
         throw new Error('Either referenceId or reference_index must be provided');
       }
 
+      // References live in the application_references typed table now
+      // (plan 2.1). Treat order_index as the addressable position to
+      // preserve the legacy "update by index" contract.
+      let referenceRows = await ApplicationReferenceModel.findAll({
+        where: { application_id: applicationId },
+        order: [['order_index', 'ASC']],
+      });
+
       logger.info(
-        `Updating reference for application ${applicationId}, index ${referenceIndex}, current references count: ${application.references.length}`
+        `Updating reference for application ${applicationId}, index ${referenceIndex}, current references count: ${referenceRows.length}`
       );
 
-      // If references array is empty but we have reference data in the application answers,
-      // initialize the references array from the client data
-      if (application.references.length === 0 && application.answers) {
+      // If references are empty but we have reference data in the
+      // application answers, seed the typed table from the client data.
+      if (referenceRows.length === 0 && application.answers) {
         logger.info('Initializing references array from client data');
         const answers = application.answers as JsonObject;
-        const initializedReferences: Array<{
-          id: string;
+        const seeds: Array<{
           name: string;
           relationship: string;
           phone: string;
           email?: string;
-          status: 'pending' | 'contacted' | 'verified' | 'failed';
         }> = [];
 
-        // Check for references in answers.references
         if (answers.references) {
           const clientRefs = answers.references as {
             veterinarian?: { name: string; phone?: string; email?: string; clinicName?: string };
@@ -1012,34 +1067,27 @@ export class ApplicationService {
             }>;
           };
 
-          // Add veterinarian reference if exists
           if (clientRefs.veterinarian && clientRefs.veterinarian.name) {
-            initializedReferences.push({
-              id: `ref-${initializedReferences.length}`,
+            seeds.push({
               name: clientRefs.veterinarian.name,
               relationship: 'Veterinarian',
               phone: clientRefs.veterinarian.phone || 'TBD',
               email: clientRefs.veterinarian.email || '',
-              status: 'pending' as const,
             });
           }
 
-          // Add personal references
           if (Array.isArray(clientRefs.personal)) {
             clientRefs.personal.forEach(ref => {
-              initializedReferences.push({
-                id: `ref-${initializedReferences.length}`,
+              seeds.push({
                 name: ref.name,
                 relationship: ref.relationship,
                 phone: ref.phone || 'TBD',
                 email: ref.email || '',
-                status: 'pending' as const,
               });
             });
           }
         }
 
-        // Also check for emergency_contact in answers
         if (answers.emergency_contact && typeof answers.emergency_contact === 'object') {
           const emergency = answers.emergency_contact as {
             name?: string;
@@ -1048,55 +1096,75 @@ export class ApplicationService {
             relationship?: string;
           };
           if (emergency.name) {
-            initializedReferences.push({
-              id: `ref-${initializedReferences.length}`,
+            seeds.push({
               name: emergency.name,
               relationship: emergency.relationship || 'Emergency Contact',
               phone: emergency.phone || 'TBD',
               email: emergency.email || '',
-              status: 'pending' as const,
             });
           }
         }
 
-        // Update the application with initialized references
-        if (initializedReferences.length > 0) {
-          await application.update({ references: initializedReferences });
-          await application.reload(); // Reload to get updated data
-          logger.info(`Initialized ${initializedReferences.length} references from client data`);
+        if (seeds.length > 0) {
+          await ApplicationReferenceModel.bulkCreate(
+            seeds.map((seed, index) => ({
+              application_id: applicationId,
+              legacy_id: `ref-${index}`,
+              name: seed.name,
+              relationship: seed.relationship,
+              phone: seed.phone,
+              email: seed.email ?? null,
+              status: ApplicationReferenceStatus.PENDING,
+              contacted_at: null,
+              contacted_by: null,
+              notes: null,
+              order_index: index,
+            }))
+          );
+          referenceRows = await ApplicationReferenceModel.findAll({
+            where: { application_id: applicationId },
+            order: [['order_index', 'ASC']],
+          });
+          logger.info(`Initialized ${referenceRows.length} references from client data`);
         }
       }
 
-      // If still out of bounds after initialization, extend the array with placeholders
-      if (referenceIndex >= application.references.length) {
-        const currentRefs = [...application.references];
-
-        // Extend array to accommodate the requested index
-        while (currentRefs.length <= referenceIndex) {
-          currentRefs.push({
-            id: `ref-${currentRefs.length}`,
-            name: `Reference ${currentRefs.length + 1}`,
+      // If still out of bounds after initialization, extend the list
+      // with placeholder rows so the caller's index resolves to a row.
+      if (referenceIndex >= referenceRows.length) {
+        const placeholderRows = [];
+        for (let i = referenceRows.length; i <= referenceIndex; i++) {
+          placeholderRows.push({
+            application_id: applicationId,
+            legacy_id: `ref-${i}`,
+            name: `Reference ${i + 1}`,
             relationship: 'Unknown',
-            phone: 'TBD', // Provide a non-empty placeholder phone
+            phone: 'TBD',
             email: '',
-            status: 'pending' as const,
+            status: ApplicationReferenceStatus.PENDING,
+            contacted_at: null,
+            contacted_by: null,
+            notes: null,
+            order_index: i,
           });
         }
-
-        await application.update({ references: currentRefs });
-        await application.reload();
-        logger.info(`Extended references array to ${currentRefs.length} items`);
+        if (placeholderRows.length > 0) {
+          await ApplicationReferenceModel.bulkCreate(placeholderRows);
+          referenceRows = await ApplicationReferenceModel.findAll({
+            where: { application_id: applicationId },
+            order: [['order_index', 'ASC']],
+          });
+          logger.info(`Extended references list to ${referenceRows.length} items`);
+        }
       }
 
-      const updatedReferences = [...application.references];
-      updatedReferences[referenceIndex] = {
-        ...updatedReferences[referenceIndex],
-        status: referenceUpdate.status,
-        notes: referenceUpdate.notes,
-        contacted_at: referenceUpdate.contactedAt,
-      };
-
-      await application.update({ references: updatedReferences });
+      const target = referenceRows[referenceIndex];
+      await target.update({
+        status: referenceUpdate.status as ApplicationReferenceStatus,
+        notes: referenceUpdate.notes ?? null,
+        contacted_at: referenceUpdate.contactedAt ?? null,
+        contacted_by: userId,
+      });
 
       // Create timeline event for reference update
       const eventType =

--- a/service.backend/src/types/application.ts
+++ b/service.backend/src/types/application.ts
@@ -15,7 +15,11 @@ export interface ApplicationData {
   actionedAt?: Date | null;
   rejectionReason?: string | null;
   answers: JsonObject;
-  references: ApplicationReference[];
+  // references[] is sourced from the application_references table now
+  // (plan 2.1). Optional on the wire shape because most read paths
+  // don't eager-load it; populated by the routes that surface
+  // references explicitly.
+  references?: ApplicationReference[];
   documents: ApplicationDocument[];
   interviewNotes?: string | null;
   homeVisitNotes?: string | null;


### PR DESCRIPTION
## Summary

Plan 2.1 — `Application.references[]` JSONB extracted to a typed `application_references` table. One row per personal/veterinary reference attached to an application. Status moves through `pending → contacted → verified | failed` as the rescue follows up. `Application.hasMany(ApplicationReference, { as: 'References' })`.

## Schema

```
application_references
  reference_id      UUID PK
  application_id    UUID FK→applications CASCADE
  legacy_id         VARCHAR(64) NOT NULL    -- preserves "ref-N" ids
  name              VARCHAR(255) NOT NULL
  relationship      VARCHAR(255) NOT NULL
  phone             VARCHAR(64) NOT NULL
  email             VARCHAR(255) NULL
  status            ENUM(pending|contacted|verified|failed)
  contacted_at      TIMESTAMPTZ NULL
  contacted_by      UUID FK→users SET NULL  -- forensic
  notes             TEXT NULL
  order_index       INTEGER NOT NULL DEFAULT 0
  + audit columns
```

Indexes:
- `(application_id, order_index)` — gallery read pattern
- `(application_id, legacy_id)` UNIQUE — back-compat ID lookup
- `status`, `contacted_by`

## Service refactors

- **`createApplication`**: `ApplicationReference.bulkCreate` after `Application.create` instead of writing into the JSONB column. `legacy_id` preserved from the caller-supplied id (or `ref-N` by index).
- **`updateApplication`**: replace-all references via `destroy` + `bulkCreate` in a single update flow, mirroring the JSONB era's array overwrite.
- **`updateReference`**: `order_index` becomes the addressable position. Initialize-from-answers and extend-with-placeholders flows preserved so the legacy "update by index" contract continues to work; references are resolved via `findAll` then `target.update(...)` on the specific row.
- `ApplicationData.references` is now optional (sourced from the typed table, not eager-loaded by default).

## Tests

- `application-workflow` / `application.service`: switched from `references: [...]` JSONB scaffolding to `ApplicationReference` model mocks; reference assertions now check `bulkCreate` / `destroy` / `update` call sites on row instances.
- Status-transition tests no longer pass `references: '[]'` to the raw `bulkInsert` helper — that column is gone.
- Seeder seeds `ApplicationReference` rows alongside each `Application` via `findOrCreate` keyed on `(application_id, legacy_id)` so the seed data preserves the existing `ref-N` identifiers.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 1380 tests passing across 61 files (11 skipped, 0 failures)
- [x] `models/standards.test.ts` — 68 tests including FK / index / TIMESTAMPTZ checks for the new table
- [x] `npx eslint --max-warnings=0 'src/**/*.ts'` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_