### PR TITLE
Phase 4 (slice 5.5.11): addresses as a first-class entity

### DIFF
--- a/service.backend/src/__tests__/models/Address.model.test.ts
+++ b/service.backend/src/__tests__/models/Address.model.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import sequelize from '../../sequelize';
+import '../../models/index';
+import Address, { AddressOwnerType } from '../../models/Address';
+import Rescue from '../../models/Rescue';
+import User from '../../models/User';
+
+/**
+ * Plan 5.5.11 — addresses are a polymorphic typed table. The legacy
+ * shape lived inline on User and Rescue. These tests lock in the
+ * model invariants that matter to the schema (FK semantics, primary
+ * uniqueness, ISO country format) — the migration of the inline
+ * columns is a separate slice.
+ */
+describe('Address model', () => {
+  let userId: string;
+  let rescueId: string;
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+
+    const user = await User.create({
+      userId: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaa1',
+      email: 'address-test@example.local',
+      password: 'long-enough-password-123',
+      firstName: 'A',
+      lastName: 'B',
+      userType: 'adopter',
+      status: 'active',
+      emailVerified: true,
+    } as never);
+    userId = user.userId;
+
+    const rescue = await Rescue.create({
+      name: 'Address Test Rescue',
+      email: 'rescue@test.local',
+      address: '1 Lane',
+      city: 'Town',
+      postcode: 'AB1 2CD',
+      country: 'GB',
+      contactPerson: 'X',
+      status: 'pending',
+    } as never);
+    rescueId = rescue.rescueId;
+  });
+
+  it('persists a user address with required fields', async () => {
+    const address = await Address.create({
+      owner_type: AddressOwnerType.USER,
+      owner_id: userId,
+      label: 'home',
+      line_1: '10 Downing Street',
+      city: 'London',
+      postal_code: 'SW1A 2AA',
+      country: 'GB',
+      is_primary: true,
+    });
+
+    const reloaded = await Address.findByPk(address.address_id);
+    expect(reloaded?.owner_type).toBe(AddressOwnerType.USER);
+    expect(reloaded?.owner_id).toBe(userId);
+    expect(reloaded?.line_1).toBe('10 Downing Street');
+    expect(reloaded?.is_primary).toBe(true);
+  });
+
+  it('persists a rescue address scoped under the rescue owner_type', async () => {
+    const address = await Address.create({
+      owner_type: AddressOwnerType.RESCUE,
+      owner_id: rescueId,
+      label: 'head office',
+      line_1: '42 Galaxy Way',
+      city: 'Bristol',
+      postal_code: 'BS1 4DJ',
+      country: 'GB',
+      is_primary: true,
+    });
+
+    const reloaded = await Address.findByPk(address.address_id);
+    expect(reloaded?.owner_type).toBe(AddressOwnerType.RESCUE);
+    expect(reloaded?.owner_id).toBe(rescueId);
+  });
+
+  it('rejects a malformed country code', async () => {
+    await expect(
+      Address.create({
+        owner_type: AddressOwnerType.USER,
+        owner_id: userId,
+        line_1: '1 Place',
+        city: 'Town',
+        postal_code: 'AB1 2CD',
+        // Lowercase / wrong length — fails the ISO 3166-1 alpha-2 check.
+        country: 'gb',
+      } as never)
+    ).rejects.toThrow();
+  });
+
+  it('allows multiple non-primary addresses for the same owner', async () => {
+    await Address.create({
+      owner_type: AddressOwnerType.USER,
+      owner_id: userId,
+      line_1: '1 Place',
+      city: 'Town',
+      postal_code: 'AB1 2CD',
+      country: 'GB',
+      is_primary: false,
+    });
+    await Address.create({
+      owner_type: AddressOwnerType.USER,
+      owner_id: userId,
+      line_1: '2 Place',
+      city: 'Town',
+      postal_code: 'AB1 2CE',
+      country: 'GB',
+      is_primary: false,
+    });
+
+    const all = await Address.findAll({
+      where: { owner_type: AddressOwnerType.USER, owner_id: userId },
+    });
+    expect(all).toHaveLength(2);
+  });
+
+  it('enforces a single primary address per owner via the partial unique index', async () => {
+    await Address.create({
+      owner_type: AddressOwnerType.USER,
+      owner_id: userId,
+      line_1: '1 Place',
+      city: 'Town',
+      postal_code: 'AB1 2CD',
+      country: 'GB',
+      is_primary: true,
+    });
+
+    await expect(
+      Address.create({
+        owner_type: AddressOwnerType.USER,
+        owner_id: userId,
+        line_1: '2 Place',
+        city: 'Town',
+        postal_code: 'AB1 2CE',
+        country: 'GB',
+        is_primary: true,
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/service.backend/src/models/Address.ts
+++ b/service.backend/src/models/Address.ts
@@ -1,0 +1,189 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+// Plan 5.5.11 — addresses as a first-class entity. Both users and
+// rescues today store their addresses inline as columns on the parent
+// row. Users typically have multiple addresses over time (home →
+// shipping for a home-visit → new home post-move) and rescues can
+// have a head office plus regional intake locations, so the inline
+// shape doesn't model the domain. This table is the destination for
+// that migration; existing inline columns continue to work in
+// parallel for now (the cutover is a separate slice).
+//
+// Polymorphic FK: the owner_type discriminator + owner_id pair points
+// at either a user_id or a rescue_id. Both columns share the UUID
+// shape, so a single owner_id column is sufficient. The plan's
+// rationale: "polymorphic, acceptable here because the shape is
+// identical" — the alternative (two nullable FKs) clutters the schema
+// without adding query power. A trigger can enforce the parent
+// existence at the DB level later; for now the application layer is
+// responsible.
+
+export enum AddressOwnerType {
+  USER = 'user',
+  RESCUE = 'rescue',
+}
+
+interface AddressAttributes {
+  address_id: string;
+  owner_type: AddressOwnerType;
+  owner_id: string;
+  // Optional human-readable label — "home", "mailing", "intake-london",
+  // etc. Free-form so rescues can categorise as they please.
+  label: string | null;
+  line_1: string;
+  line_2: string | null;
+  city: string;
+  // State / county / province — naming varies by country, so use the
+  // generic "region" label. Optional because some addresses (UK
+  // postcodes, city-states) don't have a meaningful region.
+  region: string | null;
+  postal_code: string;
+  // ISO 3166-1 alpha-2 (plan 5.5.9). CHAR(2), uppercase.
+  country: string;
+  // Exactly one address per owner can be marked primary. Enforced via
+  // a partial unique index below — `WHERE is_primary = true`.
+  is_primary: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface AddressCreationAttributes
+  extends Optional<
+    AddressAttributes,
+    'address_id' | 'label' | 'line_2' | 'region' | 'is_primary' | 'created_at' | 'updated_at'
+  > {}
+
+export class Address
+  extends Model<AddressAttributes, AddressCreationAttributes>
+  implements AddressAttributes
+{
+  public address_id!: string;
+  public owner_type!: AddressOwnerType;
+  public owner_id!: string;
+  public label!: string | null;
+  public line_1!: string;
+  public line_2!: string | null;
+  public city!: string;
+  public region!: string | null;
+  public postal_code!: string;
+  public country!: string;
+  public is_primary!: boolean;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+Address.init(
+  {
+    address_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      defaultValue: () => generateUuidV7(),
+    },
+    owner_type: {
+      type: DataTypes.ENUM(...Object.values(AddressOwnerType)),
+      allowNull: false,
+    },
+    owner_id: {
+      type: getUuidType(),
+      allowNull: false,
+    },
+    label: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+    },
+    line_1: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    line_2: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+    city: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    region: {
+      type: DataTypes.STRING(128),
+      allowNull: true,
+    },
+    postal_code: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    country: {
+      type: DataTypes.CHAR(2),
+      allowNull: false,
+      validate: {
+        // Plan 5.5.9 — ISO 3166-1 alpha-2, uppercase.
+        is: /^[A-Z]{2}$/,
+      },
+    },
+    is_primary: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    modelName: 'Address',
+    tableName: 'addresses',
+    timestamps: true,
+    underscored: true,
+    indexes: [
+      // Most reads load all addresses for a single owner (e.g. "show
+      // all of this user's addresses"). Composite (owner_type,
+      // owner_id) supports both polymorphic-resolution and per-owner
+      // listings.
+      {
+        fields: ['owner_type', 'owner_id'],
+        name: 'addresses_owner_idx',
+      },
+      // Exactly one primary per owner — partial unique index on
+      // is_primary so non-primary rows don't conflict with each other.
+      {
+        fields: ['owner_type', 'owner_id'],
+        name: 'addresses_one_primary_per_owner',
+        unique: true,
+        where: { is_primary: true },
+      },
+      // Country + postal_code lookups support "find rescues near this
+      // postcode" queries that don't go through the geo-indexed
+      // location column.
+      {
+        fields: ['country', 'postal_code'],
+        name: 'addresses_country_postal_idx',
+      },
+      ...auditIndexes('addresses'),
+    ],
+    validate: {
+      // Owner_id has the right shape for either user or rescue (same
+      // UUID type), but enforce that one of the discriminators is
+      // chosen — if the application layer ever forgets to set
+      // owner_type the row would silently float. Belt + braces.
+      ownerTypeIsKnown(this: Address) {
+        if (!Object.values(AddressOwnerType).includes(this.owner_type)) {
+          throw new Error(
+            `addresses.owner_type must be one of: ${Object.values(AddressOwnerType).join(', ')}`
+          );
+        }
+      },
+    },
+  })
+);
+
+export default Address;

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -32,6 +32,7 @@ import RolePermission from './RolePermission';
 import UserRole from './UserRole';
 
 // Additional Models
+import Address from './Address';
 import AuditLog from './AuditLog';
 import IdempotencyKey from './IdempotencyKey';
 import Invitation from './Invitation';
@@ -96,6 +97,7 @@ const models = {
   Permission,
   RolePermission,
   UserRole,
+  Address,
   AuditLog,
   IdempotencyKey,
   Rating,
@@ -232,6 +234,25 @@ try {
   Application.belongsTo(Rescue, { foreignKey: 'rescue_id', as: 'Rescue' });
 
   Rescue.hasMany(Pet, { foreignKey: 'rescue_id', as: 'Pets' });
+
+  // Address (plan 5.5.11) — typed table for the addresses entity.
+  // Polymorphic via (owner_type, owner_id), so the FK isn't enforced
+  // at the DB level — Sequelize honours the `scope` shorthand by
+  // appending `owner_type = 'user' / 'rescue'` to every read through
+  // the association. Constraints disabled for the same reason as
+  // ModerationEvidence: there's no single referenced table.
+  User.hasMany(Address, {
+    foreignKey: 'owner_id',
+    as: 'Addresses',
+    scope: { owner_type: 'user' },
+    constraints: false,
+  });
+  Rescue.hasMany(Address, {
+    foreignKey: 'owner_id',
+    as: 'Addresses',
+    scope: { owner_type: 'rescue' },
+    constraints: false,
+  });
   Pet.belongsTo(Rescue, { foreignKey: 'rescue_id', as: 'Rescue' });
 
   // Application Questions associations
@@ -505,6 +526,7 @@ export {
   ApplicationQuestion,
   ApplicationStatusTransition,
   ApplicationTimeline,
+  Address,
   AuditLog,
   Chat,
   ChatParticipant,


### PR DESCRIPTION
## Summary

Plan 5.5.11 — addresses as a first-class entity. Both users and rescues today store their address inline as columns on the parent row; users typically have multiple addresses over time (home → shipping for a home-visit → new home post-move) and rescues can have a head office plus regional intake locations, so the inline shape doesn't model the domain.

This slice introduces the new table **additively** — `User.hasMany` / `Rescue.hasMany` associations make addresses available for new use cases. Migrating the existing inline columns to read/write through this table is a separate slice; for now both shapes coexist.

## Schema

```
addresses
  address_id    UUID PK
  owner_type    ENUM(user|rescue)            -- polymorphic discriminator
  owner_id      UUID NOT NULL                -- soft FK enforced in the app
  label         VARCHAR(64) NULL             -- 'home', 'mailing', etc.
  line_1        VARCHAR(255) NOT NULL
  line_2        VARCHAR(255) NULL
  city          VARCHAR(128) NOT NULL
  region        VARCHAR(128) NULL            -- state/county/province
  postal_code   VARCHAR(32) NOT NULL
  country       CHAR(2) NOT NULL             -- ISO 3166-1 alpha-2
  is_primary    BOOLEAN NOT NULL DEFAULT false
  + audit columns
```

Indexes:
- `(owner_type, owner_id)` — composite for polymorphic-resolution and per-owner listings
- partial unique on `(owner_type, owner_id) WHERE is_primary = true` — exactly one primary address per owner
- `(country, postal_code)` — supports "find by postcode" lookups that don't go through a geo-indexed location column

## Validations

- `country` matches `/^[A-Z]{2}$/` (ISO 3166-1 alpha-2)
- `owner_type` must be one of the known discriminator values
- `city` / `line_1` / `postal_code` are `notEmpty`

## Tests

- `models/Address.model.test`: persists user / rescue addresses with the right `owner_type`, rejects malformed country codes, allows multiple non-primary addresses, enforces the partial unique index on `is_primary`.
- `models/standards.test`: passes — the polymorphic `owner_id` has no `references` declaration (matching `ModerationEvidence`'s pattern) so the FK-on-everything check skips it.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 1385 tests passing across 62 files (5 new Address tests, 11 skipped, 0 failures)
- [x] `models/standards.test.ts` — 68 tests including FK / index / TIMESTAMPTZ checks for the new table
- [x] `npx eslint --max-warnings=0 'src/**/*.ts'` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_