### PR TITLE
Phase 4 (slice 5.5): drop User.applicationTemplateVersion orphan field

### DIFF
--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -1421,7 +1421,6 @@ function createMockUser(overrides: Partial<User> = {}): vi.Mocked<User> {
     applicationDefaults: null,
     applicationPreferences: {},
     profileCompletionStatus: {},
-    applicationTemplateVersion: 1,
     Roles: [],
     isAccountLocked: vi.fn().mockReturnValue(false),
     getFullName: vi.fn().mockReturnValue('Mock User'),

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -83,7 +83,9 @@ interface UserAttributes {
   applicationDefaults?: JsonObject | null;
   // applicationPreferences moved to user_application_prefs (plan 5.6).
   profileCompletionStatus?: JsonObject;
-  applicationTemplateVersion?: number;
+  // applicationTemplateVersion column removed (plan 5.5) — there was
+  // no backing application_templates table, so the field tracked
+  // nothing and was a known dead-end.
   Roles?: Role[];
 }
 
@@ -147,7 +149,7 @@ class User extends Model<UserAttributes, UserCreationAttributes> implements User
   public privacyPolicyAcceptedAt!: Date | null;
   public applicationDefaults!: JsonObject | null;
   public profileCompletionStatus!: JsonObject;
-  public applicationTemplateVersion!: number;
+  // applicationTemplateVersion removed (plan 5.5).
 
   // Optional Roles property
   public Roles?: Role[];
@@ -441,12 +443,8 @@ User.init(
         last_updated: null,
       },
     },
-    applicationTemplateVersion: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      field: 'application_template_version',
-      defaultValue: 1,
-    },
+    // applicationTemplateVersion column removed (plan 5.5) — orphan
+    // field with no backing application_templates table.
     ...auditColumns,
   },
   withAuditHooks({

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -295,7 +295,6 @@ export async function seedUsers() {
                 })
               )
             : undefined,
-        applicationTemplateVersion: 1,
         createdAt: new Date(),
         updatedAt: new Date(),
       },


### PR DESCRIPTION
Plan 5.5 — User.applicationTemplateVersion was an orphan: the column incremented but there was no application_templates table backing it, so the value referenced nothing. Either build the table or remove the field; nothing in the service layer reads it, so removing is the cheap path.

Surface:
  - User.ts: drop the column attribute, the public class field, and the init definition.
  - 04-users.ts seeder: stop passing applicationTemplateVersion: 1.
  - auth-flow.test.ts: drop the same field from the User mock.