### PR TITLE
Phase 4 (slice 1.2 cont.): unify polymorphic FK shape on UUID

### DIFF
--- a/service.backend/src/models/FileUpload.ts
+++ b/service.backend/src/models/FileUpload.ts
@@ -119,11 +119,12 @@ FileUpload.init(
       onDelete: 'SET NULL',
     },
     entity_id: {
-      type: DataTypes.STRING(255),
+      // Plan 1.2 — polymorphic FK pointing at a UUIDv7 PK
+      // (application_id, pet_id, etc.). Same shape across all parents
+      // means a single UUID column is sufficient; the parent existence
+      // is enforced at the application layer.
+      type: getUuidType(),
       allowNull: true,
-      validate: {
-        len: [0, 255],
-      },
     },
     /**
      * Polymorphic discriminator for entity_id. Postgres ENUM gives us

--- a/service.backend/src/models/Notification.ts
+++ b/service.backend/src/models/Notification.ts
@@ -268,7 +268,11 @@ Notification.init(
       allowNull: true,
     },
     related_entity_id: {
-      type: DataTypes.STRING,
+      // Plan 1.2 — polymorphic FK pointing at a UUIDv7 PK (pet_id,
+      // application_id, etc.). Stored as UUID so a typo won't pass
+      // through; the parent existence is enforced at the application
+      // layer (no single referenced table for a real FK).
+      type: getUuidType(),
       allowNull: true,
     },
     scheduled_for: {

--- a/service.backend/src/seeders/22-emily-test-notifications.ts
+++ b/service.backend/src/seeders/22-emily-test-notifications.ts
@@ -17,7 +17,9 @@ interface NotificationSeedData {
   status: NotificationStatus;
   data: JsonObject;
   related_entity_type: string;
-  related_entity_id: string;
+  // Optional now — campaign / system notifications don't point at a
+  // single entity; their action_url carries the routing.
+  related_entity_id: string | null;
   read_at?: Date;
   created_at: Date;
   updated_at: Date;
@@ -287,7 +289,10 @@ const emilyTestNotifications: NotificationSeedData[] = [
       pet_names: ['Mittens', 'Shadow', 'Princess'],
     },
     related_entity_type: 'pet',
-    related_entity_id: 'pet_cats_new',
+    // Campaign notification — points at a category page, not a single
+    // pet, so related_entity_id stays null. The action_url above
+    // carries the routing.
+    related_entity_id: null,
     created_at: new Date('2025-07-11T12:00:00Z'),
     updated_at: new Date('2025-07-11T12:00:00Z'),
   },
@@ -328,7 +333,9 @@ const emilyTestNotifications: NotificationSeedData[] = [
       discount_percentage: 50,
     },
     related_entity_type: 'rescue',
-    related_entity_id: 'clear-shelters-2025',
+    // Cross-rescue event notification — no single rescue id, the
+    // action_url above carries the routing.
+    related_entity_id: null,
     created_at: new Date('2025-07-10T14:00:00Z'),
     updated_at: new Date('2025-07-10T14:00:00Z'),
   },


### PR DESCRIPTION
Plan 1.2 standardised every PK and FK on UUIDv7, but two polymorphic FK columns slipped through with the legacy STRING type. Both store target ids that are themselves UUIDs in the new schema (pet_id, application_id, etc.), so unifying on the UUID type closes the gap.

Surface:
  - Notification.related_entity_id: STRING → getUuidType()
  - FileUpload.entity_id: STRING(255) → getUuidType()

No service-layer changes — values stored in these columns are already valid UUIDs from the Phase 1 migration; only the column type was out of sync.