### PR TITLE
Phase 4 (slice 4.5 cont.): timeline actor email snapshot

### DIFF
--- a/service.backend/src/models/ApplicationTimeline.ts
+++ b/service.backend/src/models/ApplicationTimeline.ts
@@ -36,6 +36,14 @@ export interface ApplicationTimelineAttributes {
   description?: string | null;
   metadata?: Record<string, unknown> | null;
   created_by?: string | null; // user_id of staff member who triggered the event
+  // Snapshot of the actor's email at the moment the timeline event
+  // was written. created_by is a soft reference (no FK enforcement)
+  // — the user may be deleted before the timeline is read, at which
+  // point the live lookup returns null. Snapshot keeps the history
+  // readable forever ("admin@x.test approved this application"
+  // instead of "[deleted user] approved this application"). Mirrors
+  // AuditLog.user_email_snapshot (plan 4.5).
+  created_by_email_snapshot?: string | null;
   created_by_system?: boolean; // true for automated events
   created_at?: Date;
   updated_at?: Date;
@@ -61,6 +69,7 @@ class ApplicationTimeline
   public description?: string | null;
   public metadata?: Record<string, unknown> | null;
   public created_by?: string | null;
+  public created_by_email_snapshot?: string | null;
   public created_by_system?: boolean;
   public created_at?: Date;
   public updated_at?: Date;
@@ -107,6 +116,12 @@ ApplicationTimeline.init(
       // FK relationship defined at association level with constraints: false
       // (see models/index.ts) so timeline events can be created in tests
       // without requiring the user row to exist.
+    },
+    // See the field comment on the attribute interface — display
+    // safety-net for when the actor is later deleted. Plan 4.5.
+    created_by_email_snapshot: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     created_by_system: {
       type: DataTypes.BOOLEAN,

--- a/service.backend/src/services/applicationTimeline.service.ts
+++ b/service.backend/src/services/applicationTimeline.service.ts
@@ -21,9 +21,25 @@ export class ApplicationTimelineService {
    * Create a new timeline event
    */
   static async createEvent(data: CreateTimelineEventData): Promise<ApplicationTimeline> {
+    // Snapshot the actor's email so the timeline stays readable if
+    // the user is later deleted (plan 4.5). The lookup is best-effort
+    // — if the user can't be resolved (e.g. test fixtures with mocked
+    // user IDs that don't exist in the DB), the snapshot stays null
+    // and the timeline degrades gracefully on display.
+    let created_by_email_snapshot: string | null = null;
+    if (data.created_by) {
+      try {
+        const actor = await User.findByPk(data.created_by, { attributes: ['email'] });
+        created_by_email_snapshot = actor?.email ?? null;
+      } catch {
+        // Soft-fail — the snapshot is a display hint, not a guarantee.
+      }
+    }
+
     return ApplicationTimeline.create({
       timeline_id: undefined, // Will be auto-generated
       ...data,
+      created_by_email_snapshot,
       created_at: new Date(),
       updated_at: new Date(),
     });


### PR DESCRIPTION
## Summary

Plan 4.5 (cont.) — `ApplicationTimeline` mirrors the same display-safety problem `AuditLog` already addressed. The `created_by` FK is declared `constraints: false` so timeline rows survive the user being deleted — but without a snapshot, the rendered timeline degrades to "[deleted user] approved this application" and the audit trail becomes opaque.

## Schema

```
application_timeline
  + created_by_email_snapshot  TEXT NULL
```

Existing rows stay `NULL` — the display layer can fall back to a live `User` join with the snapshot as a backup.

## Service refactor

- **`ApplicationTimelineService.createEvent`**: best-effort `User.findByPk` on `created_by`, snapshot the email at creation. Soft-fails when the actor can't be resolved (test fixtures with mocked user IDs that don't exist in the DB) so the existing test surface keeps passing.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 1385 tests passing across 62 files (11 skipped, 0 failures)
- [x] `npx eslint --max-warnings=0 'src/**/*.ts'` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_