### PR TITLE
Phase 4 (slice 2.1 cont.): application_answers typed table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,4 @@ docker-compose.override.yml
 
 ### Build artifacts ###
 *.tsbuildinfo
-*.timestamp-*.mjs
+*.timestamp-*.mjs.claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,5 @@ docker-compose.override.yml
 
 ### Build artifacts ###
 *.tsbuildinfo
-*.timestamp-*.mjs.claude/worktrees/
+*.timestamp-*.mjs
+.claude/worktrees/

--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../config/env', () => ({
 
 import { generateCryptoUuid as uuidv4 } from '../../utils/uuid-helpers';
 import Application, { ApplicationPriority, ApplicationStatus } from '../../models/Application';
+import ApplicationAnswer from '../../models/ApplicationAnswer';
 import ApplicationReferenceModel, {
   ApplicationReferenceStatus,
 } from '../../models/ApplicationReference';
@@ -32,6 +33,7 @@ import { JsonObject } from '../../types/common';
 
 // Mock dependencies
 vi.mock('../../models/Application');
+vi.mock('../../models/ApplicationAnswer');
 vi.mock('../../models/ApplicationReference');
 vi.mock('../../models/ApplicationStatusTransition');
 vi.mock('../../models/Pet');
@@ -48,6 +50,7 @@ vi.mock('../../services/email.service', () => ({
 }));
 
 const MockedApplication = Application as vi.MockedObject<Application>;
+const MockedApplicationAnswer = ApplicationAnswer as vi.MockedObject<typeof ApplicationAnswer>;
 const MockedApplicationReference = ApplicationReferenceModel as vi.MockedObject<
   typeof ApplicationReferenceModel
 >;
@@ -90,6 +93,12 @@ describe('Application Submission Workflow Integration Tests', () => {
     MockedApplicationReference.bulkCreate = vi.fn().mockResolvedValue([] as never);
     MockedApplicationReference.findAll = vi.fn().mockResolvedValue([] as never);
     MockedApplicationReference.destroy = vi.fn().mockResolvedValue(0 as never);
+
+    // Same reasoning for the application_answers typed table — answers
+    // were extracted from JSONB to a typed model in this slice.
+    MockedApplicationAnswer.bulkCreate = vi.fn().mockResolvedValue([] as never);
+    MockedApplicationAnswer.findAll = vi.fn().mockResolvedValue([] as never);
+    MockedApplicationAnswer.destroy = vi.fn().mockResolvedValue(0 as never);
   });
 
   // Build a minimal ApplicationReference row instance — used by the
@@ -1650,7 +1659,9 @@ function createMockApplication(overrides: Partial<Application> = {}): vi.Mocked<
     rescueId: 'rescue-123',
     status: ApplicationStatus.SUBMITTED,
     priority: ApplicationPriority.NORMAL,
-    answers: {},
+    // answers moved to application_answers (plan 2.1) — no longer a
+    // column on Application; the test mocks the model directly where
+    // assertions are needed.
     // references[] moved to application_references (plan 2.1) — no
     // longer a column on Application; the test mocks the model directly
     // where assertions are needed.
@@ -1683,7 +1694,6 @@ function createMockApplication(overrides: Partial<Application> = {}): vi.Mocked<
       rescueId: overrides.rescueId ?? 'rescue-123',
       status: overrides.status ?? ApplicationStatus.SUBMITTED,
       priority: overrides.priority ?? ApplicationPriority.NORMAL,
-      answers: overrides.answers ?? {},
       documents: overrides.documents ?? [],
     }),
     update: vi.fn().mockResolvedValue(undefined),

--- a/service.backend/src/__tests__/models/ApplicationStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/ApplicationStatusTransition.test.ts
@@ -100,7 +100,6 @@ describe('ApplicationStatusTransition', () => {
         status,
         priority: 'normal',
         stage: 'questionnaire',
-        answers: '{}',
         documents: '[]',
         tags: '[]',
         created_at: new Date(),

--- a/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
+++ b/service.backend/src/__tests__/models/HomeVisitStatusTransition.test.ts
@@ -78,7 +78,6 @@ describe('HomeVisitStatusTransition', () => {
         status: ApplicationStatus.SUBMITTED,
         priority: 'normal',
         stage: 'questionnaire',
-        answers: '{}',
         documents: '[]',
         tags: '[]',
         created_at: new Date(),

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -8,6 +8,7 @@ import { vi } from 'vitest';
 
 import { ApplicationService } from '../../services/application.service';
 import Application, { ApplicationStatus, ApplicationPriority } from '../../models/Application';
+import ApplicationAnswer from '../../models/ApplicationAnswer';
 import ApplicationReferenceModel from '../../models/ApplicationReference';
 import ApplicationStatusTransition from '../../models/ApplicationStatusTransition';
 import Pet, { PetStatus } from '../../models/Pet';
@@ -16,6 +17,7 @@ import { CreateApplicationRequest, ApplicationStatusUpdateRequest } from '../../
 
 // Cast models to mocked versions
 const MockedApplication = Application as vi.MockedObject<Application>;
+const MockedApplicationAnswer = ApplicationAnswer as vi.MockedObject<typeof ApplicationAnswer>;
 const MockedApplicationReference = ApplicationReferenceModel as vi.MockedObject<
   typeof ApplicationReferenceModel
 >;
@@ -61,7 +63,9 @@ describe('ApplicationService - Business Logic', () => {
     petId: mockPetId,
     rescueId: mockRescueId,
     status,
-    answers: { experience: 'yes', has_yard: 'yes' },
+    // answers moved to application_answers (plan 2.1) — no longer a
+    // column on Application; tests that need answer rows mock
+    // ApplicationAnswer.findAll / bulkCreate directly.
     // references[] moved to application_references (plan 2.1) — no
     // longer a column on Application.
     priority: ApplicationPriority.NORMAL,
@@ -109,6 +113,10 @@ describe('ApplicationService - Business Logic', () => {
     MockedApplicationReference.bulkCreate = vi.fn().mockResolvedValue([] as never);
     MockedApplicationReference.findAll = vi.fn().mockResolvedValue([] as never);
     MockedApplicationReference.destroy = vi.fn().mockResolvedValue(0 as never);
+    // Same reasoning for the application_answers typed table (plan 2.1).
+    MockedApplicationAnswer.bulkCreate = vi.fn().mockResolvedValue([] as never);
+    MockedApplicationAnswer.findAll = vi.fn().mockResolvedValue([] as never);
+    MockedApplicationAnswer.destroy = vi.fn().mockResolvedValue(0 as never);
   });
 
   describe('Business Rule: Application Creation', () => {
@@ -138,14 +146,23 @@ describe('ApplicationService - Business Logic', () => {
           }),
         })
       );
+      // Answers are persisted to the application_answers typed table
+      // now (plan 2.1), not the parent Application row.
       expect(MockedApplication.create).toHaveBeenCalledWith(
         expect.objectContaining({
           userId: mockUserId,
           petId: mockPetId,
           rescueId: mockRescueId,
           status: ApplicationStatus.SUBMITTED,
-          answers: request.answers,
         })
+      );
+      expect(MockedApplicationAnswer.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            application_id: mockApplicationId,
+            question_key: 'experience',
+          }),
+        ])
       );
       expect(result).toBeDefined();
     });
@@ -395,11 +412,25 @@ describe('ApplicationService - Business Logic', () => {
 
       await ApplicationService.updateApplication(mockApplicationId, updates, mockUserId);
 
-      // Then: Application is updated
-      expect(mockApplication.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          answers: updates.answers,
-        })
+      // Then: answers are persisted to the typed table (plan 2.1).
+      // The parent Application.update no longer carries the answers
+      // field — replace-all semantics destroy + bulkCreate the rows.
+      expect(MockedApplicationAnswer.destroy).toHaveBeenCalledWith({
+        where: { application_id: mockApplicationId },
+      });
+      expect(MockedApplicationAnswer.bulkCreate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            application_id: mockApplicationId,
+            question_key: 'experience',
+            answer_value: 'Updated experience details',
+          }),
+          expect.objectContaining({
+            application_id: mockApplicationId,
+            question_key: 'has_yard',
+            answer_value: 'yes',
+          }),
+        ])
       );
     });
 

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -79,8 +79,20 @@ export class ApplicationController extends BaseController {
     const User = applicationModel.User as Record<string, unknown> | undefined;
     const Pet = applicationModel.Pet as Record<string, unknown> | undefined;
 
-    // Extract personal info from answers (common pattern in adoption forms)
-    const answers = (applicationModel.answers as Record<string, unknown>) || {};
+    // Extract personal info from answers (common pattern in adoption forms).
+    // Answers live in the application_answers typed table now (plan 2.1).
+    // The service layer projects them back into the legacy JsonObject
+    // shape on `applicationModel.answers`, but eager-loaded reads can
+    // also surface them via the `Answers` association — fall back to that
+    // shape when the projected object isn't present.
+    let answers = (applicationModel.answers as Record<string, unknown>) || {};
+    if (Object.keys(answers).length === 0 && Array.isArray(applicationModel.Answers)) {
+      const rows = applicationModel.Answers as Array<{
+        question_key: string;
+        answer_value: unknown;
+      }>;
+      answers = Object.fromEntries(rows.map(r => [r.question_key, r.answer_value]));
+    }
 
     const personalInfo = {
       firstName:

--- a/service.backend/src/models/Application.ts
+++ b/service.backend/src/models/Application.ts
@@ -1,6 +1,5 @@
 import { DataTypes, Model, Op, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
-import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
@@ -58,7 +57,8 @@ interface ApplicationAttributes {
   // Action tracking
   actionedBy?: string | null;
   actionedAt?: Date | null;
-  answers: JsonObject;
+  // answers moved to the application_answers table (plan 2.1) — see
+  // ApplicationAnswer. Application.hasMany(ApplicationAnswer, as: 'Answers').
   // references moved to the application_references table (plan 2.1) —
   // see ApplicationReference. Application.hasMany(ApplicationReference).
   documents: Array<{
@@ -114,7 +114,7 @@ class Application
   // Action tracking
   public actionedBy!: string | null;
   public actionedAt!: Date | null;
-  public answers!: JsonObject;
+  // answers moved to application_answers (plan 2.1).
   // references moved to application_references (plan 2.1).
   public documents!: Array<{
     documentId: string;
@@ -181,12 +181,6 @@ class Application
     };
 
     return statusWeights[this.status] || 0;
-  }
-
-  isValidAnswers(value: JsonObject) {
-    if (typeof value !== 'object' || value === null) {
-      throw new Error('Answers must be a valid object');
-    }
   }
 }
 
@@ -300,14 +294,7 @@ Application.init(
       allowNull: true,
       field: 'actioned_at',
     },
-    answers: {
-      type: getJsonType(),
-      allowNull: false,
-      defaultValue: {},
-      validate: {
-        isValidAnswers: Application.prototype.isValidAnswers,
-      },
-    },
+    // answers moved to the application_answers table (plan 2.1).
     // references moved to the application_references table (plan 2.1).
     documents: {
       type: getJsonType(),

--- a/service.backend/src/models/ApplicationAnswer.ts
+++ b/service.backend/src/models/ApplicationAnswer.ts
@@ -1,0 +1,116 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getJsonType, getUuidType } from '../sequelize';
+import { JsonValue } from '../types/common';
+import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+// Plan 2.1 — Application.answers JSONB extracted to a typed table.
+// One row per (application, question_key). The legacy JSONB shape
+// stored every adopter response on the application row, which made
+// per-question analytics and cross-application reporting impossible
+// without scanning every JSONB blob. With a dedicated table the hot
+// paths (gallery-style "all answers for this application", analytics
+// like "how many adopters have a yard") are simple SQL keyed on
+// indexes.
+//
+// `question_key` is the same identifier ApplicationQuestion uses, so
+// downstream analytics can join on the key. There's no DB-level FK
+// because ApplicationQuestion is rescue-scoped (and some legacy answer
+// keys may not have a configured question), but the application code
+// keeps the contract: one answer per question per application.
+
+interface ApplicationAnswerAttributes {
+  answer_id: string;
+  application_id: string;
+  question_key: string;
+  answer_value: JsonValue;
+  answered_at: Date;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface ApplicationAnswerCreationAttributes
+  extends Optional<
+    ApplicationAnswerAttributes,
+    'answer_id' | 'answered_at' | 'created_at' | 'updated_at'
+  > {}
+
+export class ApplicationAnswer
+  extends Model<ApplicationAnswerAttributes, ApplicationAnswerCreationAttributes>
+  implements ApplicationAnswerAttributes
+{
+  public answer_id!: string;
+  public application_id!: string;
+  public question_key!: string;
+  public answer_value!: JsonValue;
+  public answered_at!: Date;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+ApplicationAnswer.init(
+  {
+    answer_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      defaultValue: () => generateUuidV7(),
+    },
+    application_id: {
+      type: getUuidType(),
+      allowNull: false,
+      references: {
+        model: 'applications',
+        key: 'application_id',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    },
+    question_key: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    answer_value: {
+      type: getJsonType(),
+      allowNull: false,
+    },
+    answered_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    modelName: 'ApplicationAnswer',
+    tableName: 'application_answers',
+    timestamps: true,
+    underscored: true,
+    indexes: [
+      // One answer per question per application. Replaces the implicit
+      // single-key invariant of the JSONB shape.
+      {
+        fields: ['application_id', 'question_key'],
+        name: 'application_answers_app_question_unique',
+        unique: true,
+      },
+      // Gallery-style "all answers for this application" reads.
+      {
+        fields: ['application_id'],
+        name: 'application_answers_app_idx',
+      },
+      // Analytics — "how many adopters have a yard" — scan by
+      // question_key without touching the parent row.
+      {
+        fields: ['question_key'],
+        name: 'application_answers_question_key_idx',
+      },
+      ...auditIndexes('application_answers'),
+    ],
+  })
+);
+
+export default ApplicationAnswer;

--- a/service.backend/src/models/ApplicationAnswer.ts
+++ b/service.backend/src/models/ApplicationAnswer.ts
@@ -23,7 +23,11 @@ interface ApplicationAnswerAttributes {
   answer_id: string;
   application_id: string;
   question_key: string;
-  answer_value: JsonValue;
+  // Nullable: a user can legitimately answer "no value" to an
+  // optional question (e.g. yard_size on an apartment-dweller's
+  // form). The presence of the row signals "this question was
+  // answered"; the value carries the answer, including null.
+  answer_value: JsonValue | null;
   answered_at: Date;
   created_at?: Date;
   updated_at?: Date;
@@ -42,7 +46,7 @@ export class ApplicationAnswer
   public answer_id!: string;
   public application_id!: string;
   public question_key!: string;
-  public answer_value!: JsonValue;
+  public answer_value!: JsonValue | null;
   public answered_at!: Date;
   public readonly created_at!: Date;
   public readonly updated_at!: Date;
@@ -74,7 +78,8 @@ ApplicationAnswer.init(
     },
     answer_value: {
       type: getJsonType(),
-      allowNull: false,
+      // See the attribute interface — null is a valid answer.
+      allowNull: true,
     },
     answered_at: {
       type: DataTypes.DATE,

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -1,4 +1,5 @@
 import Application from './Application';
+import ApplicationAnswer from './ApplicationAnswer';
 import ApplicationQuestion from './ApplicationQuestion';
 import ApplicationReference from './ApplicationReference';
 import ApplicationStatusTransition from './ApplicationStatusTransition';
@@ -86,6 +87,7 @@ const models = {
   PetMedia,
   PetStatusTransition,
   Application,
+  ApplicationAnswer,
   ApplicationQuestion,
   ApplicationReference,
   ApplicationStatusTransition,
@@ -252,6 +254,18 @@ try {
     foreignKey: 'contacted_by',
     as: 'ContactedBy',
     constraints: false,
+  });
+
+  // ApplicationAnswer association (plan 2.1 — Application.answers JSONB
+  // extracted to a typed table). Cascade so deleting an application
+  // removes its answers.
+  Application.hasMany(ApplicationAnswer, {
+    foreignKey: 'application_id',
+    as: 'Answers',
+  });
+  ApplicationAnswer.belongsTo(Application, {
+    foreignKey: 'application_id',
+    as: 'Application',
   });
 
   // RescueSettings association (1:1, auto-created via Rescue.afterCreate
@@ -592,6 +606,7 @@ try {
 // Export all models
 export {
   Application,
+  ApplicationAnswer,
   ApplicationQuestion,
   ApplicationReference,
   ApplicationStatusTransition,

--- a/service.backend/src/seeders/09-applications.ts
+++ b/service.backend/src/seeders/09-applications.ts
@@ -848,22 +848,26 @@ export async function seedApplications() {
       defaults: defaults as any,
     });
 
-    for (const [question_key, answer_value] of Object.entries(answers ?? {})) {
-      await ApplicationAnswer.findOrCreate({
-        where: { application_id: appData.applicationId, question_key },
-        defaults: {
+    // Bulk-insert with ignoreDuplicates instead of per-row findOrCreate.
+    // 240 sequential round-trips (16 apps × ~15 answers) was tipping
+    // the CI backend health check past its 90s budget on cold starts.
+    // The (application_id, question_key) unique index keeps the seeder
+    // idempotent — duplicates from a re-run are dropped by Postgres.
+    const answerEntries = Object.entries(answers ?? {});
+    if (answerEntries.length > 0) {
+      await ApplicationAnswer.bulkCreate(
+        answerEntries.map(([question_key, answer_value]) => ({
           application_id: appData.applicationId,
           question_key,
           answer_value: answer_value as JsonValue,
-        },
-      });
+        })),
+        { ignoreDuplicates: true }
+      );
     }
 
-    for (let index = 0; index < references.length; index++) {
-      const ref = references[index];
-      await ApplicationReference.findOrCreate({
-        where: { application_id: appData.applicationId, legacy_id: ref.id },
-        defaults: {
+    if (references.length > 0) {
+      await ApplicationReference.bulkCreate(
+        references.map((ref, index) => ({
           application_id: appData.applicationId,
           legacy_id: ref.id,
           name: ref.name,
@@ -875,8 +879,9 @@ export async function seedApplications() {
           contacted_by: null,
           notes: ref.notes ?? null,
           order_index: index,
-        },
-      });
+        })),
+        { ignoreDuplicates: true }
+      );
     }
   }
 

--- a/service.backend/src/seeders/09-applications.ts
+++ b/service.backend/src/seeders/09-applications.ts
@@ -4,12 +4,15 @@ import Application, {
   ApplicationStage,
   ApplicationOutcome,
 } from '../models/Application';
+import ApplicationAnswer from '../models/ApplicationAnswer';
 import ApplicationReference, { ApplicationReferenceStatus } from '../models/ApplicationReference';
+import { JsonValue } from '../types/common';
 
-// Application.references[] moved to the application_references table
-// (plan 2.1). seedApplications() now does Application.findOrCreate first
-// and then ApplicationReference.findOrCreate per reference, keyed on
-// (application_id, legacy_id) to keep the seeder idempotent.
+// Application.answers / Application.references[] moved to typed tables
+// (plan 2.1). seedApplications() now does Application.findOrCreate
+// first and then ApplicationAnswer.findOrCreate per question_key /
+// ApplicationReference.findOrCreate per reference to keep the seeder
+// idempotent.
 type SeedReference = {
   id: string;
   name: string;
@@ -825,8 +828,9 @@ const applicationData = [
 
 export async function seedApplications() {
   for (const appData of applicationData) {
-    const { references, ...applicationFields } = appData as typeof appData & {
+    const { references, answers, ...applicationFields } = appData as typeof appData & {
       references: SeedReference[];
+      answers: Record<string, JsonValue>;
     };
 
     const defaults = {
@@ -843,6 +847,17 @@ export async function seedApplications() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       defaults: defaults as any,
     });
+
+    for (const [question_key, answer_value] of Object.entries(answers ?? {})) {
+      await ApplicationAnswer.findOrCreate({
+        where: { application_id: appData.applicationId, question_key },
+        defaults: {
+          application_id: appData.applicationId,
+          question_key,
+          answer_value: answer_value as JsonValue,
+        },
+      });
+    }
 
     for (let index = 0; index < references.length; index++) {
       const ref = references[index];

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1,6 +1,7 @@
 import { Includeable, Op, Order, WhereOptions } from 'sequelize';
 import { generateCryptoUuid as uuidv4 } from '../utils/uuid-helpers';
 import Application, { ApplicationPriority, ApplicationStatus } from '../models/Application';
+import ApplicationAnswer from '../models/ApplicationAnswer';
 import ApplicationReferenceModel, {
   ApplicationReferenceStatus,
 } from '../models/ApplicationReference';
@@ -35,6 +36,27 @@ import {
   ReferenceUpdateRequest,
   UpdateApplicationRequest,
 } from '../types/application';
+
+// Project a list of ApplicationAnswer rows back into the legacy
+// JsonObject shape (key -> value). Stable wire shape — callers that
+// used to read `application.answers` keep the same contract; the
+// answers now come from the typed table via the `Answers` association
+// (plan 2.1).
+const answersToJson = (rows: ApplicationAnswer[] | undefined | null): JsonObject => {
+  if (!rows || rows.length === 0) {
+    return {};
+  }
+  return Object.fromEntries(rows.map(row => [row.question_key, row.answer_value])) as JsonObject;
+};
+
+// Load all answer rows for an application and project to JsonObject.
+// Used by hot read paths that need the legacy `answers` shape.
+const loadAnswersJson = async (applicationId: string): Promise<JsonObject> => {
+  const rows = await ApplicationAnswer.findAll({
+    where: { application_id: applicationId },
+  });
+  return answersToJson(rows);
+};
 
 export class ApplicationService {
   /**
@@ -90,19 +112,33 @@ export class ApplicationService {
         );
       }
 
-      // Create application — references are persisted to the
-      // application_references typed table after creation (plan 2.1).
+      // Create application — answers and references are persisted to
+      // their typed tables after creation (plan 2.1).
       const application = await Application.create({
         userId: userId,
         petId: applicationData.petId,
         rescueId: pet.rescueId,
         status: ApplicationStatus.SUBMITTED,
         priority: applicationData.priority || ApplicationPriority.NORMAL,
-        answers: applicationData.answers,
         documents: [],
         notes: applicationData.notes,
         tags: applicationData.tags || [],
       });
+
+      // Persist answers to the application_answers typed table — one
+      // row per (application, question_key). The legacy JSONB shape
+      // becomes a row-per-key projection.
+      const incomingAnswers = applicationData.answers ?? {};
+      const answerEntries = Object.entries(incomingAnswers);
+      if (answerEntries.length > 0) {
+        await ApplicationAnswer.bulkCreate(
+          answerEntries.map(([question_key, answer_value]) => ({
+            application_id: application.applicationId,
+            question_key,
+            answer_value: answer_value as JsonValue,
+          }))
+        );
+      }
 
       const incomingReferences = applicationData.references ?? [];
       if (incomingReferences.length > 0) {
@@ -180,7 +216,12 @@ export class ApplicationService {
         userId
       );
 
-      return application.toJSON() as ApplicationData;
+      // Project the typed answer rows back onto the wire shape so
+      // callers continue to see `answers` as a JsonObject (plan 2.1).
+      return {
+        ...(application.toJSON() as ApplicationData),
+        answers: incomingAnswers,
+      };
     } catch (error) {
       logger.error('Failed to create application:', {
         error: error instanceof Error ? error.message : String(error),
@@ -235,6 +276,10 @@ export class ApplicationService {
             'status',
           ],
         },
+        // Eager-load the typed answer rows so the projected
+        // `answers` JsonObject is available without a second query
+        // (plan 2.1).
+        { model: ApplicationAnswer, as: 'Answers' },
       ];
 
       const application = await Application.findOne({
@@ -262,7 +307,11 @@ export class ApplicationService {
         // Additional rescue staff permission check would go here
       }
 
-      return application.toJSON() as ApplicationData;
+      const answerRows = (application as Application & { Answers?: ApplicationAnswer[] }).Answers;
+      return {
+        ...(application.toJSON() as ApplicationData),
+        answers: answersToJson(answerRows),
+      };
     } catch (error) {
       logger.error('Failed to get application by ID:', {
         error: error instanceof Error ? error.message : String(error),
@@ -460,6 +509,9 @@ export class ApplicationService {
           ],
         });
       }
+      // Always eager-load answer rows so the projected `answers`
+      // JsonObject is populated on every result (plan 2.1).
+      includeOptions.push({ model: ApplicationAnswer, as: 'Answers' });
 
       // Build order
       const safeSortBy = validateSortField(sortBy, APPLICATION_SORT_FIELDS, 'createdAt');
@@ -489,7 +541,13 @@ export class ApplicationService {
       });
 
       return {
-        applications: applications.map(app => app.toJSON()),
+        applications: applications.map(app => {
+          const answerRows = (app as Application & { Answers?: ApplicationAnswer[] }).Answers;
+          return {
+            ...(app.toJSON() as ApplicationData),
+            answers: answersToJson(answerRows),
+          };
+        }),
         pagination: {
           page,
           limit,
@@ -537,27 +595,50 @@ export class ApplicationService {
         throw new Error('Application cannot be updated once processed');
       }
 
-      // References are persisted to the application_references table
-      // (plan 2.1) — strip them off the parent update payload and apply
-      // them separately below.
-      const { references: incomingReferences, ...applicationUpdate } = updateData;
+      // Answers and references live in their typed tables (plan 2.1)
+      // — strip them off the parent update payload and apply them
+      // separately below.
+      const {
+        answers: incomingAnswers,
+        references: incomingReferences,
+        ...applicationUpdate
+      } = updateData;
 
       // Store original data for audit
       const existingReferences = await ApplicationReferenceModel.findAll({
         where: { application_id: applicationId },
         order: [['order_index', 'ASC']],
       });
+      const existingAnswerRows = await ApplicationAnswer.findAll({
+        where: { application_id: applicationId },
+      });
       const originalData = {
-        answers: application.answers,
+        answers: answersToJson(existingAnswerRows),
         references: existingReferences.map(r => r.toJSON()),
         priority: application.priority,
         notes: application.notes,
         tags: application.tags,
       };
 
-      // Update application — replace-all semantics for references
-      // mirror the JSONB era's array-overwrite behaviour.
+      // Update application — replace-all semantics for answers and
+      // references mirror the JSONB era's overwrite behaviour.
       await application.update(applicationUpdate);
+
+      if (incomingAnswers !== undefined) {
+        await ApplicationAnswer.destroy({
+          where: { application_id: applicationId },
+        });
+        const answerEntries = Object.entries(incomingAnswers);
+        if (answerEntries.length > 0) {
+          await ApplicationAnswer.bulkCreate(
+            answerEntries.map(([question_key, answer_value]) => ({
+              application_id: applicationId,
+              question_key,
+              answer_value: answer_value as JsonValue,
+            }))
+          );
+        }
+      }
 
       if (incomingReferences !== undefined) {
         await ApplicationReferenceModel.destroy({
@@ -620,7 +701,11 @@ export class ApplicationService {
         userId
       );
 
-      return (await application.reload()) as ApplicationData;
+      await application.reload();
+      return {
+        ...(application.toJSON() as ApplicationData),
+        answers: await loadAnswersJson(applicationId),
+      };
     } catch (error) {
       logger.error('Failed to update application:', {
         error: error instanceof Error ? error.message : String(error),
@@ -653,9 +738,12 @@ export class ApplicationService {
         throw new Error('Application is not in a valid state');
       }
 
-      // Validate application completeness
+      // Validate application completeness — answers live in the typed
+      // table now (plan 2.1); load them and project to the JsonObject
+      // shape the validator expects.
+      const currentAnswers = await loadAnswersJson(application.applicationId);
       const validationResult = await this.validateApplicationAnswers(
-        application.answers,
+        currentAnswers,
         application.rescueId
       );
 
@@ -682,7 +770,11 @@ export class ApplicationService {
 
       logger.info('Application submitted successfully', { applicationId, userId });
 
-      return (await application.reload()) as ApplicationData;
+      await application.reload();
+      return {
+        ...(application.toJSON() as ApplicationData),
+        answers: currentAnswers,
+      };
     } catch (error) {
       logger.error('Submit application failed:', error);
       throw error;
@@ -796,7 +888,11 @@ export class ApplicationService {
         actionedBy,
       });
 
-      return (await application.reload()) as ApplicationData;
+      await application.reload();
+      return {
+        ...(application.toJSON() as ApplicationData),
+        answers: await loadAnswersJson(applicationId),
+      };
     } catch (error) {
       logger.error('Update application status failed:', error);
       throw error;
@@ -868,7 +964,11 @@ export class ApplicationService {
 
       logger.info('Application withdrawn', { applicationId, userId });
 
-      return (await application.reload()) as ApplicationData;
+      await application.reload();
+      return {
+        ...(application.toJSON() as ApplicationData),
+        answers: await loadAnswersJson(applicationId),
+      };
     } catch (error) {
       logger.error('Withdraw application failed:', error);
       throw error;
@@ -938,7 +1038,11 @@ export class ApplicationService {
         userId,
       });
 
-      return (await application.reload()) as ApplicationData;
+      await application.reload();
+      return {
+        ...(application.toJSON() as ApplicationData),
+        answers: await loadAnswersJson(applicationId),
+      };
     } catch (error) {
       logger.error('Add document failed:', error);
       throw error;
@@ -1046,9 +1150,12 @@ export class ApplicationService {
 
       // If references are empty but we have reference data in the
       // application answers, seed the typed table from the client data.
-      if (referenceRows.length === 0 && application.answers) {
+      // Answers live in the application_answers table now (plan 2.1) —
+      // load them via the typed table rather than reading a column.
+      const answers =
+        referenceRows.length === 0 ? await loadAnswersJson(applicationId) : ({} as JsonObject);
+      if (referenceRows.length === 0 && Object.keys(answers).length > 0) {
         logger.info('Initializing references array from client data');
-        const answers = application.answers as JsonObject;
         const seeds: Array<{
           name: string;
           relationship: string;
@@ -1212,7 +1319,11 @@ export class ApplicationService {
         userId,
       });
 
-      return (await application.reload()) as ApplicationData;
+      await application.reload();
+      return {
+        ...(application.toJSON() as ApplicationData),
+        answers: await loadAnswersJson(applicationId),
+      };
     } catch (error) {
       logger.error('Update reference failed:', error);
       throw error;


### PR DESCRIPTION
## Summary

Plan 2.1 — `Application.answers` JSONB extracted to a typed `application_answers` table. One row per `(application, question_key)`. Wire shape preserved: `ApplicationData.answers` and `CreateApplicationRequest.answers` stay `JsonObject`; the service projects rows back into the legacy shape on every read path.

## Schema

```
application_answers
  answer_id        UUID PK
  application_id   UUID FK→applications CASCADE
  question_key     VARCHAR(128) NOT NULL    -- matches ApplicationQuestion.question_key
  answer_value     JSONB NOT NULL
  + audit columns
```

Indexes:
- `(application_id, question_key)` UNIQUE — one row per (app, key)
- `(application_id)` — load-all-answers query path

## Service refactors

- **`createApplication`**: persists answers via `ApplicationAnswer.bulkCreate` after `Application.create`.
- **`updateApplication`**: replace-all semantics via `destroy + bulkCreate`.
- **`getApplicationById` / `searchApplications`**: eager-load via `{ model: ApplicationAnswer, as: 'Answers' }`; project to `JsonObject` via `answersToJson(rows)`.
- **`submitApplication` / `withdrawApplication` / `addDocument` / `updateReference`**: don't use eager-loaded includes, so use `loadAnswersJson(applicationId)` post-update.
- `Application.isValidAnswers` instance method removed (validator on the dropped column).

## Tests

- `application-workflow` / `application.service`: `createMockApplication` no longer carries an `answers: {}` field. Reference assertions use `MockedApplicationAnswer.bulkCreate / destroy / findAll` mocks.
- The "allow user to update SUBMITTED" test now asserts `ApplicationAnswer.destroy + bulkCreate` instead of `application.update({ answers })`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 1385 tests passing across 62 files
- [x] `models/standards.test.ts` — 68 tests including FK / index / TIMESTAMPTZ checks
- [x] `npx eslint --max-warnings=0 'src/**/*.ts'` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_