### PR TITLE
Phase 4 (slice 2.4): breeds lookup table

### DIFF
--- a/service.backend/src/__tests__/integration/pet-discovery-matching.test.ts
+++ b/service.backend/src/__tests__/integration/pet-discovery-matching.test.ts
@@ -385,7 +385,14 @@ describe('Pet Discovery & Matching Integration Tests', () => {
       });
 
       it('should filter pets by breed', async () => {
-        const mockPets = [createMockPet({ petId: 'pet-1', breed: 'Golden Retriever' })];
+        // Plan 2.4 — pets reference breeds by FK now; the service
+        // resolves the caller's free-form name to a list of breed_ids
+        // and adds them to the WHERE as either a `breedId` IN-list
+        // (when nothing else needs OR'ing) or an `[Op.or]` term
+        // covering breedId + secondaryBreedId. Either shape proves
+        // the filter wired through; assert the logical effect rather
+        // than the exact column name.
+        const mockPets = [createMockPet({ petId: 'pet-1' })];
 
         MockedPet.findAndCountAll = vi.fn().mockResolvedValue({
           rows: mockPets,
@@ -396,7 +403,15 @@ describe('Pet Discovery & Matching Integration Tests', () => {
 
         expect(result.pets).toHaveLength(1);
         const callArgs = (MockedPet.findAndCountAll as vi.Mock).mock.calls[0][0];
-        expect(callArgs.where.breed).toBeTruthy(); // Has a breed filter
+        // Plan 2.4 — pets reference breeds by FK now; the service
+        // resolves the caller's free-form name to a list of breed_ids.
+        // The breeds catalogue is empty in this mocked-Pet integration
+        // context, so the resolver returns []. The implementation
+        // treats that as "no breed in the catalogue matches" and sets
+        // a `breedId = '__never_matches__'` sentinel — proves the
+        // filter wired through. (The pre-2.4 string-LIKE path would
+        // have set `where.breed`; that key is gone.)
+        expect(callArgs.where.breedId).toBe('__never_matches__');
       });
 
       it('should filter pets good with children', async () => {

--- a/service.backend/src/__tests__/services/discovery.service.test.ts
+++ b/service.backend/src/__tests__/services/discovery.service.test.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import { Op } from 'sequelize';
+import Breed from '../../models/Breed';
 import Pet, { AgeGroup, Gender, PetStatus, PetType, Size } from '../../models/Pet';
 import PetMedia, { PetMediaType } from '../../models/PetMedia';
 import Rescue from '../../models/Rescue';
@@ -182,6 +183,15 @@ describe('DiscoveryService', () => {
             model: PetMedia,
             as: 'Media',
             where: { type: PetMediaType.IMAGE },
+            required: false,
+          },
+          // Plan 2.4 — breeds eager-loaded so the discovery transform
+          // can surface the human-readable breed name from the lookup
+          // table.
+          {
+            model: Breed,
+            as: 'Breed',
+            attributes: ['breed_id', 'name'],
             required: false,
           },
         ],

--- a/service.backend/src/__tests__/services/pet.service.test.ts
+++ b/service.backend/src/__tests__/services/pet.service.test.ts
@@ -1,6 +1,7 @@
 import { Op } from 'sequelize';
 import { vi } from 'vitest';
 import { AuditLog } from '../../models/AuditLog';
+import Breed from '../../models/Breed';
 import Pet, {
   AgeGroup,
   EnergyLevel,
@@ -44,6 +45,19 @@ describe('PetService', () => {
   // Helper to generate unique IDs
   const uniqueId = (prefix: string) => `${prefix}-${Date.now()}-${testCounter++}`;
 
+  // Plan 2.4 — pet.breed is now an FK into the breeds lookup table.
+  // Tests that previously created pets with `breed: 'Golden Retriever'`
+  // need to find-or-create the breed and use the FK. This helper
+  // returns the breed_id for a (species, name) pair, creating the row
+  // on first ask.
+  const breedIdFor = async (species: PetType, name: string): Promise<string> => {
+    const [row] = await Breed.findOrCreate({
+      where: { species, name },
+      defaults: { species, name },
+    });
+    return row.breed_id;
+  };
+
   beforeEach(async () => {
     vi.clearAllMocks();
     mockAuditLog.mockResolvedValue({
@@ -82,13 +96,16 @@ describe('PetService', () => {
       pet1Id = uniqueId('search-pet1');
       pet2Id = uniqueId('search-pet2');
 
+      const goldenId = await breedIdFor(PetType.DOG, 'Golden Retriever');
+      const persianId = await breedIdFor(PetType.CAT, 'Persian');
+
       // Create test pets
       await Pet.create({
         petId: pet1Id,
         name: 'Buddy',
         type: PetType.DOG,
         status: PetStatus.AVAILABLE,
-        breed: 'Golden Retriever',
+        breedId: goldenId,
         size: Size.LARGE,
         ageGroup: AgeGroup.ADULT,
         gender: Gender.MALE,
@@ -106,7 +123,7 @@ describe('PetService', () => {
         name: 'Whiskers',
         type: PetType.CAT,
         status: PetStatus.AVAILABLE,
-        breed: 'Persian',
+        breedId: persianId,
         size: Size.MEDIUM,
         ageGroup: AgeGroup.YOUNG,
         gender: Gender.FEMALE,
@@ -142,8 +159,11 @@ describe('PetService', () => {
 
       const result = await PetService.searchPets(filters);
 
+      // Plan 2.4 — search resolves the term against the breeds
+      // lookup, so a search for "Golden" finds the Buddy pet whose
+      // breedId points at the "Golden Retriever" breed row.
       expect(result.pets).toHaveLength(1);
-      expect(result.pets[0].breed).toContain('Golden');
+      expect(result.pets[0].name).toBe('Buddy');
     });
 
     it('should handle range filters', async () => {
@@ -944,54 +964,14 @@ describe('PetService', () => {
   });
 
   describe('getPetBreedsByType', () => {
+    // Plan 2.4 — breeds live in the typed table now. The endpoint
+    // returns the catalogue of breed names per species, so the test
+    // setup seeds the breeds table directly rather than seeding pets
+    // and inferring breeds from them.
     beforeEach(async () => {
-      await Pet.bulkCreate([
-        {
-          petId: uniqueId('breeds-pet1'),
-          name: 'Dog 1',
-          type: PetType.DOG,
-          breed: 'Golden Retriever',
-          status: PetStatus.AVAILABLE,
-          size: Size.LARGE,
-          ageGroup: AgeGroup.ADULT,
-          gender: Gender.MALE,
-          energyLevel: EnergyLevel.MEDIUM,
-          vaccinationStatus: VaccinationStatus.UP_TO_DATE,
-          spayNeuterStatus: SpayNeuterStatus.NEUTERED,
-          rescueId: testRescue.rescueId,
-          archived: false,
-        },
-        {
-          petId: uniqueId('breeds-pet2'),
-          name: 'Dog 2',
-          type: PetType.DOG,
-          breed: 'Labrador Retriever',
-          status: PetStatus.AVAILABLE,
-          size: Size.LARGE,
-          ageGroup: AgeGroup.ADULT,
-          gender: Gender.MALE,
-          energyLevel: EnergyLevel.HIGH,
-          vaccinationStatus: VaccinationStatus.UP_TO_DATE,
-          spayNeuterStatus: SpayNeuterStatus.NEUTERED,
-          rescueId: testRescue.rescueId,
-          archived: false,
-        },
-        {
-          petId: uniqueId('breeds-pet3'),
-          name: 'Dog 3',
-          type: PetType.DOG,
-          breed: 'German Shepherd',
-          status: PetStatus.AVAILABLE,
-          size: Size.LARGE,
-          ageGroup: AgeGroup.ADULT,
-          gender: Gender.MALE,
-          energyLevel: EnergyLevel.HIGH,
-          vaccinationStatus: VaccinationStatus.UP_TO_DATE,
-          spayNeuterStatus: SpayNeuterStatus.NEUTERED,
-          rescueId: testRescue.rescueId,
-          archived: false,
-        },
-      ]);
+      await breedIdFor(PetType.DOG, 'Golden Retriever');
+      await breedIdFor(PetType.DOG, 'Labrador Retriever');
+      await breedIdFor(PetType.DOG, 'German Shepherd');
     });
 
     it('should return breeds for valid pet type', async () => {
@@ -1003,60 +983,17 @@ describe('PetService', () => {
       expect(result).toContain('Labrador Retriever');
     });
 
-    it('should filter out null and empty breeds', async () => {
-      await Pet.bulkCreate([
-        {
-          petId: uniqueId('breeds-pet4'),
-          name: 'Dog 4',
-          type: PetType.DOG,
-          breed: null as unknown as string,
-          status: PetStatus.AVAILABLE,
-          size: Size.MEDIUM,
-          ageGroup: AgeGroup.ADULT,
-          gender: Gender.MALE,
-          energyLevel: EnergyLevel.MEDIUM,
-          vaccinationStatus: VaccinationStatus.UP_TO_DATE,
-          spayNeuterStatus: SpayNeuterStatus.NEUTERED,
-          rescueId: testRescue.rescueId,
-          archived: false,
-        },
-        {
-          petId: uniqueId('breeds-pet5'),
-          name: 'Dog 5',
-          type: PetType.DOG,
-          breed: '  ',
-          status: PetStatus.AVAILABLE,
-          size: Size.MEDIUM,
-          ageGroup: AgeGroup.ADULT,
-          gender: Gender.MALE,
-          energyLevel: EnergyLevel.MEDIUM,
-          vaccinationStatus: VaccinationStatus.UP_TO_DATE,
-          spayNeuterStatus: SpayNeuterStatus.NEUTERED,
-          rescueId: testRescue.rescueId,
-          archived: false,
-        },
-        {
-          petId: uniqueId('breeds-pet6'),
-          name: 'Dog 6',
-          type: PetType.DOG,
-          breed: 'Poodle',
-          status: PetStatus.AVAILABLE,
-          size: Size.MEDIUM,
-          ageGroup: AgeGroup.ADULT,
-          gender: Gender.MALE,
-          energyLevel: EnergyLevel.MEDIUM,
-          vaccinationStatus: VaccinationStatus.UP_TO_DATE,
-          spayNeuterStatus: SpayNeuterStatus.NEUTERED,
-          rescueId: testRescue.rescueId,
-          archived: false,
-        },
-      ]);
+    it('should not return breeds from other species', async () => {
+      // Cat breeds shouldn't leak into a dog query (plan 2.4 — the
+      // species discriminator gates the result set).
+      await breedIdFor(PetType.CAT, 'Persian');
+      await breedIdFor(PetType.CAT, 'Siamese');
 
       const result = await PetService.getPetBreedsByType('dog');
 
-      expect(result).toContain('Poodle');
-      expect(result).not.toContain('');
-      expect(result).not.toContain(null);
+      expect(result).not.toContain('Persian');
+      expect(result).not.toContain('Siamese');
+      expect(result).toHaveLength(3);
     });
 
     it('should throw error for invalid pet type', async () => {
@@ -1066,14 +1003,19 @@ describe('PetService', () => {
     });
 
     it('should handle database errors', async () => {
-      const originalFindAll = Pet.findAll;
-      Pet.findAll = vi.fn().mockRejectedValue(new Error('Database error'));
-
-      await expect(PetService.getPetBreedsByType('dog')).rejects.toThrow(
-        'Failed to retrieve breeds for pet type: dog'
-      );
-
-      Pet.findAll = originalFindAll;
+      // Mock the new lookup target — Breed.findAll, not Pet.findAll.
+      // Use try/finally so a failed assertion doesn't leak the mock
+      // into downstream tests (the previous version did, breaking
+      // every later test that called Pet.findAll).
+      const originalFindAll = Breed.findAll;
+      Breed.findAll = vi.fn().mockRejectedValue(new Error('Database error'));
+      try {
+        await expect(PetService.getPetBreedsByType('dog')).rejects.toThrow(
+          'Failed to retrieve breeds for pet type: dog'
+        );
+      } finally {
+        Breed.findAll = originalFindAll;
+      }
     });
   });
 
@@ -1097,14 +1039,21 @@ describe('PetService', () => {
   describe('getSimilarPets', () => {
     let referencePet: Pet;
     let refPetId: string;
+    let goldenId: string;
+    let labradorId: string;
 
     beforeEach(async () => {
+      // Plan 2.4 — pets reference breeds by FK; resolve names to ids
+      // first so the similarity query can match on breed_id.
+      goldenId = await breedIdFor(PetType.DOG, 'Golden Retriever');
+      labradorId = await breedIdFor(PetType.DOG, 'Labrador Retriever');
+
       refPetId = uniqueId('similar-ref');
       referencePet = await Pet.create({
         petId: refPetId,
         name: 'Reference Dog',
         type: PetType.DOG,
-        breed: 'Golden Retriever',
+        breedId: goldenId,
         status: PetStatus.AVAILABLE,
         size: Size.LARGE,
         ageGroup: AgeGroup.ADULT,
@@ -1121,7 +1070,7 @@ describe('PetService', () => {
           petId: uniqueId('similar-1'),
           name: 'Similar Dog 1',
           type: PetType.DOG,
-          breed: 'Golden Retriever',
+          breedId: goldenId,
           status: PetStatus.AVAILABLE,
           size: Size.LARGE,
           ageGroup: AgeGroup.ADULT,
@@ -1136,7 +1085,7 @@ describe('PetService', () => {
           petId: uniqueId('similar-2'),
           name: 'Similar Dog 2',
           type: PetType.DOG,
-          breed: 'Labrador Retriever',
+          breedId: labradorId,
           status: PetStatus.AVAILABLE,
           size: Size.LARGE,
           ageGroup: AgeGroup.YOUNG,
@@ -1163,27 +1112,36 @@ describe('PetService', () => {
     });
 
     it('should handle database errors', async () => {
+      // try/finally so a failed assertion doesn't leak mocks into
+      // downstream tests (the previous version did and broke
+      // unrelated tests downstream).
       const originalFindByPk = Pet.findByPk;
       const originalFindAll = Pet.findAll;
-
       Pet.findByPk = vi.fn().mockResolvedValue(referencePet);
       Pet.findAll = vi.fn().mockRejectedValue(new Error('Database error'));
-
-      await expect(PetService.getSimilarPets(refPetId)).rejects.toThrow(
-        'Failed to retrieve similar pets'
-      );
-
-      Pet.findByPk = originalFindByPk;
-      Pet.findAll = originalFindAll;
+      try {
+        await expect(PetService.getSimilarPets(refPetId)).rejects.toThrow(
+          'Failed to retrieve similar pets'
+        );
+      } finally {
+        Pet.findByPk = originalFindByPk;
+        Pet.findAll = originalFindAll;
+      }
     });
 
-    it('should safely handle breed values containing SQL injection characters', async () => {
-      const maliciousPetId = uniqueId('sqli-ref');
+    it('should safely handle pets whose breed has SQL-injection-y characters', async () => {
+      // The breed name itself can't contain malicious SQL anymore —
+      // it's a row in the breeds catalogue. The id is a UUID. So the
+      // SQL-injection vector from the JSONB era is structurally
+      // closed. This test now just sanity-checks that a pet with an
+      // exotic breed name doesn't break the similar-pets query.
+      const exoticBreedId = await breedIdFor(PetType.DOG, "O'Reilly's Hound");
+      const exoticPetId = uniqueId('sqli-ref');
       await Pet.create({
-        petId: maliciousPetId,
-        name: 'Malicious Pet',
+        petId: exoticPetId,
+        name: 'Exotic Pet',
         type: PetType.DOG,
-        breed: "'; DROP TABLE pets; --",
+        breedId: exoticBreedId,
         status: PetStatus.AVAILABLE,
         size: Size.LARGE,
         ageGroup: AgeGroup.ADULT,
@@ -1195,11 +1153,9 @@ describe('PetService', () => {
         archived: false,
       });
 
-      // Should not throw - the SQL injection attempt is safely escaped
-      const result = await PetService.getSimilarPets(maliciousPetId, 6);
+      const result = await PetService.getSimilarPets(exoticPetId, 6);
       expect(Array.isArray(result)).toBe(true);
 
-      // Verify the pets table still exists and is functional
       const petCount = await Pet.count();
       expect(petCount).toBeGreaterThan(0);
     });
@@ -1227,13 +1183,15 @@ describe('PetService', () => {
         rescueId: null,
       });
 
+      const goldenId = await breedIdFor(PetType.DOG, 'Golden Retriever');
+
       petId = uniqueId('report-pet');
       testPet = await Pet.create({
         petId: petId,
         name: 'Buddy',
         type: PetType.DOG,
         status: PetStatus.AVAILABLE,
-        breed: 'Golden Retriever',
+        breedId: goldenId,
         size: Size.LARGE,
         ageGroup: AgeGroup.ADULT,
         gender: Gender.MALE,

--- a/service.backend/src/__tests__/services/swipe.service.test.ts
+++ b/service.backend/src/__tests__/services/swipe.service.test.ts
@@ -94,9 +94,13 @@ describe('SwipeService', () => {
       await swipeService.recordSwipeAction(mockSwipeAction);
 
       expect(mockSequelize.query).toHaveBeenCalledTimes(3);
+      // Plan 2.4 — breed is now an FK; the pet preference probe joins
+      // through the breeds lookup to surface the breed name. Match
+      // the canonical column expression rather than the legacy
+      // bare-column shape.
       expect(mockSequelize.query).toHaveBeenNthCalledWith(
         2,
-        expect.stringContaining('SELECT type, breed, age_group'),
+        expect.stringContaining('b.name AS breed'),
         {
           replacements: { petId: 'pet123' },
         }

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -182,11 +182,13 @@ export class ApplicationController extends BaseController {
       updatedAt: applicationModel.updatedAt as string,
     };
 
-    // Add pet information if available
+    // Add pet information if available. Plan 2.4 — breed name lives
+    // on the eager-loaded Breed association, not directly on Pet.
     if (Pet) {
       transformed.petName = Pet.name as string;
       transformed.petType = Pet.type as string;
-      transformed.petBreed = Pet.breed as string;
+      const petBreed = Pet.Breed as { name?: string } | undefined;
+      transformed.petBreed = petBreed?.name ?? '';
     }
 
     // Add user information if available

--- a/service.backend/src/models/Breed.ts
+++ b/service.backend/src/models/Breed.ts
@@ -1,0 +1,89 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+import { PetType } from './Pet';
+
+// Plan 2.4 — breeds as a lookup table. Pet.breed / Pet.secondaryBreed
+// were free-form STRING columns; "Golden Retriever", "golden retriever",
+// "Goldie", "golden ret." all coexisted, which broke breed filters,
+// breed-popularity stats, and made canonicalisation impossible. This
+// table is the catalogue of canonical breeds; pets reference rows by
+// FK on breed_id / secondary_breed_id.
+//
+// Species mirrors the existing PetType union (dog | cat | rabbit | ...) so
+// breeds can't be miscategorised across species. The (species, name)
+// composite uniqueness lets the same name exist for different species
+// (e.g. "Persian" cat vs the unrelated "Persian" rabbit) without
+// collision.
+
+interface BreedAttributes {
+  breed_id: string;
+  species: PetType;
+  name: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+interface BreedCreationAttributes
+  extends Optional<BreedAttributes, 'breed_id' | 'created_at' | 'updated_at'> {}
+
+export class Breed
+  extends Model<BreedAttributes, BreedCreationAttributes>
+  implements BreedAttributes
+{
+  public breed_id!: string;
+  public species!: PetType;
+  public name!: string;
+  public readonly created_at!: Date;
+  public readonly updated_at!: Date;
+}
+
+Breed.init(
+  {
+    breed_id: {
+      type: getUuidType(),
+      primaryKey: true,
+      defaultValue: () => generateUuidV7(),
+    },
+    species: {
+      type: DataTypes.ENUM(...Object.values(PetType)),
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+      validate: { notEmpty: true, len: [1, 128] },
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    modelName: 'Breed',
+    tableName: 'breeds',
+    timestamps: true,
+    // Reference table — opt out of the global paranoid default. A
+    // soft-deleted breed leaves a deleted_at row behind that still
+    // collides on the (species, name) unique index, breaking
+    // findOrCreate after a test truncate. We never want to "softly
+    // remove" a breed anyway: archive via a flag instead, or hard-
+    // delete if it really is gone.
+    paranoid: false,
+    underscored: true,
+    indexes: [
+      // (species, name) unique — one canonical row per name per species.
+      {
+        fields: ['species', 'name'],
+        name: 'breeds_species_name_unique',
+        unique: true,
+      },
+      // Name-prefix lookups for the breed search filter (caller passes
+      // a free-form string; the service resolves it to one or more
+      // breed_ids before hitting pets).
+      { fields: ['name'], name: 'breeds_name_idx' },
+      ...auditIndexes('breeds'),
+    ],
+  })
+);
+
+export default Breed;

--- a/service.backend/src/models/Pet.ts
+++ b/service.backend/src/models/Pet.ts
@@ -113,8 +113,13 @@ export interface PetAttributes {
   gender: Gender;
   status: PetStatus;
   type: PetType;
-  breed?: string | null;
-  secondaryBreed?: string | null;
+  // Plan 2.4 — breeds extracted into the breeds lookup table. Both FKs
+  // are nullable: an unknown-breed pet is a real case (stray of mixed
+  // ancestry, etc.) and a single-breed pet has no secondary FK. Read
+  // the human-readable breed name through the Breed / SecondaryBreed
+  // associations.
+  breedId?: string | null;
+  secondaryBreedId?: string | null;
   weightKg?: number | null;
   size: Size;
   color?: string | null;
@@ -200,8 +205,8 @@ class Pet extends Model<PetAttributes, PetCreationAttributes> implements PetAttr
   public gender!: Gender;
   public status!: PetStatus;
   public type!: PetType;
-  public breed!: string | null;
-  public secondaryBreed!: string | null;
+  public breedId!: string | null;
+  public secondaryBreedId!: string | null;
   public weightKg!: number | null;
   public size!: Size;
   public color!: string | null;
@@ -470,14 +475,21 @@ Pet.init(
       type: DataTypes.ENUM(...Object.values(PetType)),
       allowNull: false,
     },
-    breed: {
-      type: DataTypes.STRING(100),
+    breedId: {
+      type: getUuidType(),
       allowNull: true,
+      field: 'breed_id',
+      references: { model: 'breeds', key: 'breed_id' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
     },
-    secondaryBreed: {
-      type: DataTypes.STRING(100),
+    secondaryBreedId: {
+      type: getUuidType(),
       allowNull: true,
-      field: 'secondary_breed',
+      field: 'secondary_breed_id',
+      references: { model: 'breeds', key: 'breed_id' },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE',
     },
     weightKg: {
       type: DataTypes.DECIMAL(5, 2),
@@ -784,8 +796,12 @@ Pet.init(
         name: 'pets_gender_idx',
       },
       {
-        fields: ['breed'],
-        name: 'pets_breed_idx',
+        fields: ['breed_id'],
+        name: 'pets_breed_id_idx',
+      },
+      {
+        fields: ['secondary_breed_id'],
+        name: 'pets_secondary_breed_id_idx',
       },
       {
         fields: ['featured'],
@@ -908,13 +924,18 @@ Pet.init(
 // Install a Postgres trigger that maintains search_vector from row content
 // so the DB owns the value and there's no JS hook to forget. Weight
 // reflects search intent: name > breed > description > temperament.
+//
+// Plan 2.4 — breed strings now live in the breeds lookup table. The
+// trigger looks them up via subquery so search by breed name still
+// works; the cost is a per-row lookup against breeds (small reference
+// table, indexed by PK), in exchange for the canonical-breeds win.
 installGeneratedSearchVector(Pet, {
   table: 'pets',
   indexName: 'pets_search_vector_gin_idx',
   expression: [
     "setweight(to_tsvector('english', coalesce(NEW.name, '')), 'A')",
-    "setweight(to_tsvector('english', coalesce(NEW.breed, '')), 'B')",
-    "setweight(to_tsvector('english', coalesce(NEW.secondary_breed, '')), 'B')",
+    "setweight(to_tsvector('english', coalesce((SELECT name FROM breeds WHERE breed_id = NEW.breed_id), '')), 'B')",
+    "setweight(to_tsvector('english', coalesce((SELECT name FROM breeds WHERE breed_id = NEW.secondary_breed_id), '')), 'B')",
     "setweight(to_tsvector('english', coalesce(NEW.short_description, '')), 'C')",
     "setweight(to_tsvector('english', coalesce(NEW.long_description, '')), 'C')",
     "setweight(to_tsvector('english', coalesce(array_to_string(NEW.temperament, ' '), '')), 'D')",

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -3,6 +3,7 @@ import ApplicationQuestion from './ApplicationQuestion';
 import ApplicationReference from './ApplicationReference';
 import ApplicationStatusTransition from './ApplicationStatusTransition';
 import ApplicationTimeline from './ApplicationTimeline';
+import Breed from './Breed';
 import Pet from './Pet';
 import PetMedia from './PetMedia';
 import PetStatusTransition from './PetStatusTransition';
@@ -82,6 +83,7 @@ const models = {
   UserApplicationPrefs,
   Rescue,
   RescueSettings,
+  Breed,
   Pet,
   PetMedia,
   PetStatusTransition,
@@ -543,6 +545,15 @@ try {
   Pet.hasMany(PetMedia, { foreignKey: 'pet_id', as: 'Media' });
   PetMedia.belongsTo(Pet, { foreignKey: 'pet_id', as: 'Pet' });
 
+  // Breed lookup (plan 2.4 — Pet.breed / Pet.secondaryBreed STRING
+  // columns extracted to the breeds typed table). Both FKs nullable;
+  // SET NULL on delete so a pet survives its breed row being removed.
+  // No reverse Breed.hasMany — the breed_id FK doesn't represent the
+  // pet's home in the breeds table (each pet has two distinct FKs into
+  // it), so the inverse association would be misleading.
+  Pet.belongsTo(Breed, { foreignKey: 'breed_id', as: 'Breed' });
+  Pet.belongsTo(Breed, { foreignKey: 'secondary_breed_id', as: 'SecondaryBreed' });
+
   User.hasOne(EmailPreference, { foreignKey: 'userId', as: 'EmailPreferences' });
   EmailPreference.belongsTo(User, { foreignKey: 'userId', as: 'User' });
 
@@ -598,6 +609,7 @@ export {
   ApplicationTimeline,
   Address,
   AuditLog,
+  Breed,
   Chat,
   ChatParticipant,
   IdempotencyKey,

--- a/service.backend/src/seeders/08-pets.ts
+++ b/service.backend/src/seeders/08-pets.ts
@@ -1,3 +1,4 @@
+import Breed from '../models/Breed';
 import Pet, {
   AgeGroup,
   EnergyLevel,
@@ -38,7 +39,7 @@ const petProfiles = [
     gender: Gender.MALE,
     status: PetStatus.AVAILABLE,
     type: PetType.DOG,
-    breed: 'Golden Retriever',
+    breedName: 'Golden Retriever',
     weightKg: 28.5,
     size: Size.LARGE,
     color: 'Golden',
@@ -109,7 +110,7 @@ const petProfiles = [
     gender: Gender.FEMALE,
     status: PetStatus.AVAILABLE,
     type: PetType.CAT,
-    breed: 'Domestic Shorthair',
+    breedName: 'Domestic Shorthair',
     weightKg: 4.2,
     size: Size.MEDIUM,
     color: 'Brown Tabby',
@@ -172,8 +173,8 @@ const petProfiles = [
     gender: Gender.MALE,
     status: PetStatus.AVAILABLE,
     type: PetType.DOG,
-    breed: 'Pit Bull Mix',
-    secondaryBreed: 'American Staffordshire Terrier',
+    breedName: 'Pit Bull Mix',
+    secondaryBreedName: 'American Staffordshire Terrier',
     weightKg: 32.2,
     size: Size.LARGE,
     color: 'Brindle',
@@ -235,7 +236,7 @@ const petProfiles = [
     gender: Gender.FEMALE,
     status: PetStatus.PENDING,
     type: PetType.CAT,
-    breed: 'Siamese Mix',
+    breedName: 'Siamese Mix',
     weightKg: 3.8,
     size: Size.MEDIUM,
     color: 'Seal Point',
@@ -297,7 +298,7 @@ const petProfiles = [
     gender: Gender.MALE,
     status: PetStatus.AVAILABLE,
     type: PetType.DOG,
-    breed: 'German Shepherd Mix',
+    breedName: 'German Shepherd Mix',
     weightKg: 22.7,
     size: Size.LARGE,
     color: 'Black and Tan',
@@ -349,14 +350,48 @@ const petProfiles = [
 ];
 
 export async function seedPets() {
+  // Plan 2.4 — pets reference the breeds lookup table by FK. Seed the
+  // (species, name) pairs that appear in the pet seed data first, then
+  // resolve each pet's breedName / secondaryBreedName to the matching
+  // breed_id when inserting the pet rows.
+  const requiredBreeds = new Set<string>();
+  for (const profile of petProfiles) {
+    requiredBreeds.add(`${profile.type}::${profile.breedName}`);
+    if ('secondaryBreedName' in profile && profile.secondaryBreedName) {
+      requiredBreeds.add(`${profile.type}::${profile.secondaryBreedName}`);
+    }
+  }
+
+  const breedIdsByKey = new Map<string, string>();
+  for (const key of requiredBreeds) {
+    const [species, name] = key.split('::');
+    const [row] = await Breed.findOrCreate({
+      where: { species: species as PetType, name },
+      defaults: { species: species as PetType, name },
+    });
+    breedIdsByKey.set(key, row.breed_id);
+  }
+
   for (const petData of petProfiles) {
-    const { images, ...petAttributes } = petData as typeof petData & { images: SeedImage[] };
+    const profile = petData as typeof petData & {
+      images: SeedImage[];
+      breedName: string;
+      secondaryBreedName?: string;
+    };
+    const { images, breedName, secondaryBreedName, ...petAttributes } = profile;
+
+    const breedId = breedIdsByKey.get(`${profile.type}::${breedName}`) ?? null;
+    const secondaryBreedId = secondaryBreedName
+      ? (breedIdsByKey.get(`${profile.type}::${secondaryBreedName}`) ?? null)
+      : null;
 
     await Pet.findOrCreate({
       paranoid: false,
       where: { petId: petData.petId },
       defaults: {
         ...petAttributes,
+        breedId,
+        secondaryBreedId,
         createdAt: new Date(),
         updatedAt: new Date(),
       },

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -9,6 +9,7 @@ import { validateSortField } from '../utils/sort-validation';
 const APPLICATION_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'actioned_at'] as const;
 import ApplicationQuestion, { QuestionCategory } from '../models/ApplicationQuestion';
 import ApplicationStatusTransition from '../models/ApplicationStatusTransition';
+import Breed from '../models/Breed';
 import Pet from '../models/Pet';
 import User, { UserType } from '../models/User';
 import { logger, loggerHelpers } from '../utils/logger';
@@ -423,9 +424,12 @@ export class ApplicationService {
           { '$User.first_name$': { [Op.iLike]: `%${filters.search}%` } },
           { '$User.last_name$': { [Op.iLike]: `%${filters.search}%` } },
           { '$User.email$': { [Op.iLike]: `%${filters.search}%` } },
-          // Search in pet fields
+          // Search in pet fields. Plan 2.4 — breed lives in the
+          // breeds lookup table; the `$Pet->Breed.name$` path follows
+          // the eager-loaded Breed association added to the include
+          // chain below.
           { '$Pet.name$': { [Op.iLike]: `%${filters.search}%` } },
-          { '$Pet.breed$': { [Op.iLike]: `%${filters.search}%` } },
+          { '$Pet->Breed.name$': { [Op.iLike]: `%${filters.search}%` } },
         ];
         (whereConditions as Record<string | symbol, unknown>)[Op.or] = searchConditions;
       }
@@ -445,6 +449,10 @@ export class ApplicationService {
         });
       }
       if (include_pet) {
+        // Plan 2.4 — breed extracted to the breeds lookup table.
+        // Eager-load Breed so callers see the canonical name without
+        // a second round-trip; the application-controller transform
+        // reads `Pet.Breed?.name`.
         includeOptions.push({
           model: Pet,
           as: 'Pet',
@@ -452,12 +460,13 @@ export class ApplicationService {
             'petId',
             'name',
             'type',
-            'breed',
+            'breedId',
             'ageYears',
             'ageMonths',
             'ageGroup',
             'status',
           ],
+          include: [{ model: Breed, as: 'Breed', attributes: ['breed_id', 'name'] }],
         });
       }
 

--- a/service.backend/src/services/discovery.service.ts
+++ b/service.backend/src/services/discovery.service.ts
@@ -1,13 +1,17 @@
 import { Op, fn, literal } from 'sequelize';
+import Breed from '../models/Breed';
 import Pet, { AgeGroup, Gender, PetStatus, PetType, Size } from '../models/Pet';
 import PetMedia, { PetMediaType } from '../models/PetMedia';
 import Rescue from '../models/Rescue';
+import sequelize from '../sequelize';
 import { logger } from '../utils/logger';
 
 // Pet.images / Pet.videos are no longer JSONB on the pet row (plan
 // 2.1) — they're rows in pet_media. Inside discovery we only ever look
 // at images, so we narrow the typed Pet to the shape we project below.
-type PetWithMedia = Pet & { Media?: PetMedia[] };
+// Plan 2.4 also added the Breed association (eager-loaded for the
+// breed-name read paths).
+type PetWithMedia = Pet & { Media?: PetMedia[]; Breed?: Breed | null };
 
 const getImages = (pet: PetWithMedia): PetMedia[] =>
   (pet.Media ?? []).filter(m => m.type === PetMediaType.IMAGE);
@@ -96,7 +100,9 @@ export class DiscoveryService {
     try {
       logger.info('Loading more pets', { sessionId, lastPetId, limit });
 
-      // Get pets after the last pet ID
+      // Get pets after the last pet ID. Eager-load Breed so the
+      // discovery transform can read the human-readable breed name
+      // from the lookup table (plan 2.4).
       const pets = await Pet.findAll({
         where: {
           petId: {
@@ -114,6 +120,12 @@ export class DiscoveryService {
             model: PetMedia,
             as: 'Media',
             where: { type: PetMediaType.IMAGE },
+            required: false,
+          },
+          {
+            model: Breed,
+            as: 'Breed',
+            attributes: ['breed_id', 'name'],
             required: false,
           },
         ],
@@ -145,10 +157,23 @@ export class DiscoveryService {
       if (filters.type) {
         whereConditions.type = filters.type;
       }
+      // Plan 2.4 — breed is an FK; resolve free-form name to ids and
+      // filter on the FK columns instead of a string LIKE on the pet row.
       if (filters.breed) {
-        whereConditions.breed = {
-          [Op.iLike]: `%${filters.breed}%`,
-        };
+        const likeOp = sequelize.getDialect() === 'postgres' ? Op.iLike : Op.like;
+        const breedRows = await Breed.findAll({
+          where: { name: { [likeOp]: `%${filters.breed}%` } },
+          attributes: ['breed_id'],
+        });
+        const breedIds = breedRows.map(b => b.breed_id);
+        if (breedIds.length === 0) {
+          whereConditions.breedId = '__never_matches__';
+        } else {
+          (whereConditions as Record<symbol, unknown>)[Op.or] = [
+            { breedId: { [Op.in]: breedIds } },
+            { secondaryBreedId: { [Op.in]: breedIds } },
+          ];
+        }
       }
       if (filters.ageGroup) {
         whereConditions.ageGroup = filters.ageGroup;
@@ -160,7 +185,9 @@ export class DiscoveryService {
         whereConditions.gender = filters.gender;
       }
 
-      // Smart sorting query with multiple factors
+      // Smart sorting query with multiple factors. Eager-load Breed
+      // so downstream transforms / dedup keys can read the canonical
+      // breed name (plan 2.4).
       const pets = await Pet.findAll({
         where: whereConditions,
         include: [
@@ -173,6 +200,12 @@ export class DiscoveryService {
             model: PetMedia,
             as: 'Media',
             where: { type: PetMediaType.IMAGE },
+            required: false,
+          },
+          {
+            model: Breed,
+            as: 'Breed',
+            attributes: ['breed_id', 'name'],
             required: false,
           },
         ],
@@ -241,7 +274,9 @@ export class DiscoveryService {
     const maxSameBreed = 2;
 
     for (const pet of pets) {
-      const breed = pet.breed || 'unknown';
+      // Plan 2.4 — dedupe on the breed FK so equal-breed pets are
+      // treated as same regardless of the human name resolution path.
+      const breed = pet.breedId || 'unknown';
       const recentBreedCount = recentBreeds.filter(b => b === breed).length;
 
       if (recentBreedCount < maxSameBreed) {
@@ -270,12 +305,13 @@ export class DiscoveryService {
    */
   private async transformToDiscoveryPets(pets: Pet[]): Promise<DiscoveryPet[]> {
     return pets.map(pet => {
-      // Type assertion to access included rescue data
-      const petWithRescue = pet as Pet & {
+      // Type assertion to access included rescue / breed data
+      const petWithIncludes = pet as Pet & {
         Rescue?: {
           name: string;
           status: 'pending' | 'verified' | 'suspended' | 'inactive';
         };
+        Breed?: { name: string } | null;
       };
 
       // Ensure petId is never undefined
@@ -293,7 +329,8 @@ export class DiscoveryService {
         petId,
         name: pet.name || 'Unknown',
         type: pet.type,
-        breed: pet.breed || undefined,
+        // Plan 2.4 — breed name comes from the eager-loaded Breed row.
+        breed: petWithIncludes.Breed?.name || undefined,
         ageGroup: pet.ageGroup,
         ageYears: pet.ageYears || undefined,
         ageMonths: pet.ageMonths || undefined,
@@ -301,8 +338,8 @@ export class DiscoveryService {
         gender: pet.gender,
         images: imageUrls,
         shortDescription: pet.shortDescription || undefined,
-        rescueName: petWithRescue.Rescue?.name || 'Unknown Rescue',
-        isSponsored: petWithRescue.Rescue?.status === 'verified' || false,
+        rescueName: petWithIncludes.Rescue?.name || 'Unknown Rescue',
+        isSponsored: petWithIncludes.Rescue?.status === 'verified' || false,
         compatibilityScore: this.calculateCompatibilityScore(pet),
       };
     });

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -4,6 +4,7 @@ import ModerationEvidence, { EvidenceParentType, EvidenceType } from '../models/
 import Report, { ReportCategory, ReportSeverity, ReportStatus } from '../models/Report';
 import ReportStatusTransition from '../models/ReportStatusTransition';
 import User from '../models/User';
+import Breed from '../models/Breed';
 import Pet from '../models/Pet';
 import Rescue from '../models/Rescue';
 import sequelize from '../sequelize';
@@ -1051,14 +1052,19 @@ class ModerationService {
               }
 
               case 'pet': {
-                const pet = await Pet.findByPk(report.reportedEntityId);
+                // Plan 2.4 — breed name lives in the breeds lookup
+                // table, eager-loaded via the Breed association.
+                const pet = await Pet.findByPk(report.reportedEntityId, {
+                  include: [{ model: Breed, as: 'Breed', attributes: ['name'] }],
+                });
+                const petWithBreed = pet as (Pet & { Breed?: { name: string } | null }) | null;
                 entityContext = pet
                   ? {
                       type: 'pet',
                       id: pet.petId,
                       displayName: pet.name,
                       petType: pet.type,
-                      breed: pet.breed,
+                      breed: petWithBreed?.Breed?.name ?? null,
                       rescueId: pet.rescueId,
                     }
                   : {

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -1,4 +1,5 @@
 import { col, fn, literal, Op, WhereOptions } from 'sequelize';
+import Breed from '../models/Breed';
 import Pet, { AgeGroup, PetStatus, PetType, Size } from '../models/Pet';
 import PetMedia, { PetMediaType } from '../models/PetMedia';
 import PetStatusTransition from '../models/PetStatusTransition';
@@ -37,7 +38,6 @@ const PET_SEARCH_SORT_FIELDS = [
   'updatedAt',
   'updated_at',
   'name',
-  'breed',
   'ageYears',
   'adoptionFeeMinor',
   'distance',
@@ -56,6 +56,26 @@ const PET_RESCUE_LIST_SORT_FIELDS = [
  */
 const getLikeOp = () => {
   return sequelize.getDialect() === 'postgres' ? Op.iLike : Op.like;
+};
+
+/**
+ * Plan 2.4 — breed is now an FK into the breeds lookup table. Callers
+ * still pass a free-form breed name (the API contract didn't change);
+ * resolve it to a list of breed_ids the service can use as an IN-list
+ * filter. Returns an empty array when no breeds match — the caller
+ * should treat that as "no results", not "no filter".
+ */
+const resolveBreedIdsByName = async (name: string): Promise<string[]> => {
+  const rows = await Breed.findAll({
+    where: { name: { [getLikeOp()]: `%${name}%` } },
+    attributes: ['breed_id'],
+  });
+  // Filter out undefined/null breed_ids defensively. In some integration
+  // test contexts Sequelize's auto-mock surfaces phantom rows whose
+  // attribute getters return undefined; we never want those in the
+  // IN-list (they'd render as `breedId IN (NULL, NULL)`, which matches
+  // nothing semantically but produces noise).
+  return rows.map(b => b.breed_id).filter((id): id is string => Boolean(id));
 };
 
 export class PetService {
@@ -127,9 +147,11 @@ export class PetService {
       if (size) {
         whereConditions.size = size;
       }
-      if (breed) {
-        whereConditions.breed = { [getLikeOp()]: `%${breed}%` };
-      }
+      // Plan 2.4 — breed is an FK into the breeds table. Resolve the
+      // caller's free-form name to breed_ids; the actual WHERE
+      // contribution is merged in after all simple filters so it can
+      // share the [Op.or] slot with the text search if both are set.
+      const breedIdsForFilter = breed ? await resolveBreedIdsByName(breed) : null;
       if (ageGroup) {
         whereConditions.ageGroup = ageGroup;
       }
@@ -219,24 +241,53 @@ export class PetService {
         whereConditions.tags = { [Op.overlap]: tags };
       }
 
-      // Text search (applied last as it changes the structure)
+      // Plan 2.4 — breed filter and the text-search OR may both want
+      // to set [Op.or] on the where; bundle them as separate AND-ed
+      // OR groups so they coexist instead of overwriting each other.
+      const andClauses: WhereOptions[] = [];
+
+      if (breedIdsForFilter !== null) {
+        if (breedIdsForFilter.length === 0) {
+          whereConditions.breedId = '__never_matches__';
+        } else {
+          andClauses.push({
+            [Op.or]: [
+              { breedId: { [Op.in]: breedIdsForFilter } },
+              { secondaryBreedId: { [Op.in]: breedIdsForFilter } },
+            ],
+          });
+        }
+      }
+
+      // Text search (applied last as it changes the structure).
+      // Plan 2.4 — breed names live in the breeds lookup table now.
+      // Resolve the search term against breed names up-front so the
+      // OR can include breedId / secondaryBreedId IN-lists alongside
+      // the name / description LIKE clauses.
       if (search) {
+        const searchBreedIds = await resolveBreedIdsByName(search);
         const searchConditions: WhereOptions[] = [
           { name: { [getLikeOp()]: `%${search}%` } },
-          { breed: { [getLikeOp()]: `%${search}%` } },
-          { secondaryBreed: { [getLikeOp()]: `%${search}%` } },
           { shortDescription: { [getLikeOp()]: `%${search}%` } },
           { longDescription: { [getLikeOp()]: `%${search}%` } },
         ];
+        if (searchBreedIds.length > 0) {
+          searchConditions.push({ breedId: { [Op.in]: searchBreedIds } });
+          searchConditions.push({ secondaryBreedId: { [Op.in]: searchBreedIds } });
+        }
 
         // Only add tags search for PostgreSQL (SQLite doesn't support overlap operator)
         if (sequelize.getDialect() === 'postgres') {
           searchConditions.push({ tags: { [Op.overlap]: [search] } });
         }
 
+        andClauses.push({ [Op.or]: searchConditions });
+      }
+
+      if (andClauses.length > 0) {
         whereConditions = {
           ...whereConditions,
-          [Op.or]: searchConditions,
+          [Op.and]: andClauses,
         };
       }
 
@@ -504,7 +555,7 @@ export class PetService {
         ageYears: 'ageYears',
         ageMonths: 'ageMonths',
         ageGroup: 'ageGroup',
-        secondaryBreed: 'secondaryBreed',
+        secondaryBreedId: 'secondaryBreedId',
         weightKg: 'weightKg',
         microchipId: 'microchipId',
         priorityListing: 'priorityListing',
@@ -559,8 +610,8 @@ export class PetService {
       if (normalizedData.ageGroup !== undefined) {
         dbUpdateData.ageGroup = normalizedData.ageGroup;
       }
-      if (normalizedData.secondaryBreed !== undefined) {
-        dbUpdateData.secondaryBreed = normalizedData.secondaryBreed;
+      if (normalizedData.secondaryBreedId !== undefined) {
+        dbUpdateData.secondaryBreedId = normalizedData.secondaryBreedId;
       }
       if (normalizedData.weightKg !== undefined) {
         dbUpdateData.weightKg = normalizedData.weightKg;
@@ -643,7 +694,7 @@ export class PetService {
         'name',
         'gender',
         'status',
-        'breed',
+        'breedId',
         'size',
         'color',
         'markings',
@@ -1414,8 +1465,17 @@ export class PetService {
       if (status) {
         whereClause.status = status;
       }
+      // Plan 2.4 — resolve free-form breed name to FK ids before filtering.
       if (breed) {
-        whereClause.breed = { [getLikeOp()]: `%${breed}%` };
+        const breedIds = await resolveBreedIdsByName(breed);
+        if (breedIds.length === 0) {
+          whereClause.breedId = '__never_matches__';
+        } else {
+          (whereClause as Record<symbol, unknown>)[Op.or] = [
+            { breedId: { [Op.in]: breedIds } },
+            { secondaryBreedId: { [Op.in]: breedIds } },
+          ];
+        }
       }
       if (size) {
         whereClause.size = size;
@@ -1475,14 +1535,21 @@ export class PetService {
         whereClause.createdAt = dateFilter;
       }
 
-      // Search functionality
+      // Search functionality. Plan 2.4 — breed names live in the
+      // breeds lookup table, so the OR resolves the search term to
+      // breed_ids and adds an FK IN-list term.
       if (search) {
-        (whereClause as Record<symbol, unknown>)[Op.or] = [
+        const searchBreedIds = await resolveBreedIdsByName(search);
+        const searchOr: WhereOptions[] = [
           { name: { [getLikeOp()]: `%${search}%` } },
-          { breed: { [getLikeOp()]: `%${search}%` } },
           { shortDescription: { [getLikeOp()]: `%${search}%` } },
           { longDescription: { [getLikeOp()]: `%${search}%` } },
         ];
+        if (searchBreedIds.length > 0) {
+          searchOr.push({ breedId: { [Op.in]: searchBreedIds } });
+          searchOr.push({ secondaryBreedId: { [Op.in]: searchBreedIds } });
+        }
+        (whereClause as Record<symbol, unknown>)[Op.or] = searchOr;
       }
 
       const offset = (page - 1) * limit;
@@ -1664,7 +1731,9 @@ export class PetService {
   }
 
   /**
-   * Get pet breeds by type
+   * Get pet breeds by type. Plan 2.4 — reads from the breeds lookup
+   * table directly instead of `SELECT DISTINCT breed FROM pets` so the
+   * catalogue isn't gated on a pet of that breed currently existing.
    */
   static async getPetBreedsByType(type: string): Promise<string[]> {
     try {
@@ -1675,20 +1744,15 @@ export class PetService {
         throw new Error(`Invalid pet type: ${type}`);
       }
 
-      const breeds = await Pet.findAll({
-        attributes: ['breed'],
-        where: {
-          type: validType,
-          archived: false,
-        },
-        group: ['breed'],
-        order: [['breed', 'ASC']],
+      const breeds = await Breed.findAll({
+        where: { species: validType as PetType },
+        attributes: ['name'],
+        order: [['name', 'ASC']],
       });
 
       const breedNames = breeds
-        .map(pet => pet.breed)
-        .filter((breed): breed is string => breed !== null && breed.trim() !== '')
-        .sort();
+        .map(b => b.name)
+        .filter((name): name is string => name !== null && name.trim() !== '');
 
       logger.info(`Retrieved ${breedNames.length} breeds for type ${type}`);
       return breedNames;
@@ -1727,14 +1791,15 @@ export class PetService {
         throw new Error('Pet not found');
       }
 
-      // Find similar pets with priority scoring
+      // Plan 2.4 — breed is an FK; "same breed" is now an FK
+      // comparison (simpler and faster than the old string match).
       const similarPets = await Pet.findAll({
         where: {
           petId: { [Op.ne]: petId }, // Exclude the reference pet
           status: PetStatus.AVAILABLE,
           archived: false,
           [Op.or]: [
-            { breed: referencePet.breed }, // Same breed (highest priority)
+            { breedId: referencePet.breedId }, // Same breed (highest priority)
             { type: referencePet.type }, // Same type
             { size: referencePet.size }, // Same size
             { ageGroup: referencePet.ageGroup }, // Same age group
@@ -1748,10 +1813,10 @@ export class PetService {
           },
         ],
         order: [
-          // Prioritize exact breed matches first
+          // Prioritize exact breed matches first (FK comparison)
           [
             sequelize.literal(
-              `CASE WHEN breed = ${sequelize.escape(referencePet.breed ?? '')} THEN 0 ELSE 1 END`
+              `CASE WHEN breed_id = ${sequelize.escape(referencePet.breedId ?? '')} THEN 0 ELSE 1 END`
             ),
             'ASC',
           ],

--- a/service.backend/src/services/swipe.service.ts
+++ b/service.backend/src/services/swipe.service.ts
@@ -184,16 +184,19 @@ export class SwipeService {
 
       const stats = (swipeResults as SwipeStatsRow[])[0];
 
-      // Get top breeds liked by user
+      // Get top breeds liked by user. Plan 2.4 — breed names live in
+      // the breeds lookup table, so the SQL joins through breeds and
+      // groups by the breed name from there.
       const [breedResults] = await sequelize.query(
         `
-        SELECT p.breed, COUNT(*) as count
+        SELECT b.name AS breed, COUNT(*) as count
         FROM swipe_actions sa
         JOIN pets p ON sa.pet_id = p.pet_id
+        LEFT JOIN breeds b ON p.breed_id = b.breed_id
         WHERE sa.user_id = :userId
           AND sa.action IN ('like', 'super_like')
-          AND p.breed IS NOT NULL
-        GROUP BY p.breed
+          AND b.name IS NOT NULL
+        GROUP BY b.name
         ORDER BY count DESC
         LIMIT 5
       `,
@@ -332,13 +335,17 @@ export class SwipeService {
     action: 'like' | 'super_like'
   ): Promise<void> {
     try {
-      // Get pet details for preference learning
+      // Get pet details for preference learning. Plan 2.4 — breed
+      // moved to the breeds lookup; LEFT JOIN through breeds so a pet
+      // with no breed still surfaces (breed comes back as null).
       const [petResults] = await sequelize.query(
         `
-        SELECT type, breed, age_group, size, gender, good_with_children,
-               good_with_dogs, good_with_cats, energy_level
-        FROM pets
-        WHERE pet_id = :petId
+        SELECT p.type, b.name AS breed, p.age_group, p.size, p.gender,
+               p.good_with_children, p.good_with_dogs, p.good_with_cats,
+               p.energy_level
+        FROM pets p
+        LEFT JOIN breeds b ON p.breed_id = b.breed_id
+        WHERE p.pet_id = :petId
       `,
         {
           replacements: { petId },

--- a/service.backend/src/types/pet.ts
+++ b/service.backend/src/types/pet.ts
@@ -22,6 +22,10 @@ export interface PetSearchFilters {
   size?: Size;
   ageGroup?: AgeGroup;
   energyLevel?: EnergyLevel;
+  // Plan 2.4 — caller-facing breed name (free-form). The pets table
+  // stores a breed_id FK; the service resolves the name to one or
+  // more breed_ids at the search boundary. Keep this a string so the
+  // public API stays human-typeable.
   breed?: string;
   rescueId?: string;
   goodWithChildren?: boolean;
@@ -74,8 +78,11 @@ export interface PetUpdateData {
   ageGroup?: AgeGroup;
   gender?: Gender;
   status?: PetStatus;
-  breed?: string;
-  secondaryBreed?: string;
+  // Plan 2.4 — direct FK references into the breeds table. Callers
+  // pass the breed_id (and secondary_breed_id) UUID; resolving from a
+  // free-form name lives one level up.
+  breedId?: string | null;
+  secondaryBreedId?: string | null;
   weightKg?: number;
   size?: Size;
   color?: string;


### PR DESCRIPTION
## Summary

Plan 2.4 — `Pet.breed` / `Pet.secondaryBreed` STRING columns extracted to a typed `breeds` lookup table. Free-form strings produced "Golden Retriever", "golden retriever", "Goldie", "golden ret." all coexisting in production data; canonicalising on a catalogue table makes breed filters and breed-popularity stats actually work, and gates breed names behind a foreign key.

## Schema

```
breeds
  breed_id     UUID PK
  species      ENUM(dog|cat|rabbit|bird|reptile|small_mammal|fish|other)
                                       -- mirrors PetType from Pet.ts
  name         VARCHAR(128) NOT NULL
  + audit columns

pets:
  breed              STRING        -> breedId             UUID FK→breeds SET NULL
  secondary_breed    STRING        -> secondary_breed_id  UUID FK→breeds SET NULL
```

Indexes:
- `breeds (species, name)` UNIQUE — one canonical row per name per species
- `breeds (name)` — name-prefix lookups for the breed search filter
- `pets (breed_id)`, `pets (secondary_breed_id)`

## Other model details

- `paranoid: false` on `Breed` — reference table; we never want to "softly remove" a breed and leave a `deleted_at` row colliding on the unique index. (This was a real test-cleanup bug found during integration.)
- Search-vector trigger updated to look up breed names via subquery on the breeds table.

## Service refactors (covers every read/write of `pet.breed`)

- **`pet.service.searchPets / searchByDistance`**: caller's free-form name resolved to a list of `breed_id`s (`resolveBreedIdsByName`); WHERE contributes either a `breedId` IN-list, an OR clause covering `breedId + secondaryBreedId`, or a `'__never_matches__'` sentinel when nothing in the catalogue matches.
- **`pet.service.getPetBreedsByType`**: switched from `SELECT DISTINCT breed FROM pets` to `Breed.findAll({ species })` — the catalogue isn't gated on a pet of that breed currently existing.
- **`pet.service.getSimilarPets`**: "same breed" comparison is now an FK equality (faster, simpler than the old string match).
- **`discovery.service.getDiscoveryQueue / loadMorePets`**: eager-load `Breed` so the transform can surface the human-readable name; the breed filter resolves names to IDs first.
- **`discovery.service.diversifyBreeds`**: uses `pet.breedId` as the dedup key (no name lookup needed).
- **`swipe.service.recordSwipeAction`**: raw SQL probe rewritten to `LEFT JOIN breeds` and select `b.name AS breed`.
- **`moderation.service`**: report context eager-loads `Breed` for display.

## Test refactors

- `pet.service.test`: `getPetBreedsByType` / `getSimilarPets` / `reportPet` now seed `Breed` rows via a `breedIdFor` helper and reference them by FK. The "should handle database errors" tests use `try/finally` and mock `Breed.findAll` instead of `Pet.findAll` (the original mock was leaking into downstream tests).
- `pet-discovery-matching`: filter test asserts the `breedId` sentinel instead of the now-gone `where.breed` string filter.
- `discovery.service.test`: `loadMorePets` expected args include the new `Breed` eager-load.
- `swipe.service.test`: SQL assertion looks for `b.name AS breed` instead of the bare `breed` column.

## Seeder

- `08-pets.ts`: seeds the canonical breeds first, then resolves breed names to `breed_id`s when creating each pet.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 1385 tests passing across 62 files (11 skipped, 0 failures)
- [x] `models/standards.test.ts` — 68 tests including FK / index / TIMESTAMPTZ checks for the new table
- [x] `npx eslint --max-warnings=0 'src/**/*.ts'` — 0 errors

## Notes

- The agent that started this slice ran out of usage quota mid-implementation. The model + service refactors landed cleanly; I picked up the test fixes (mock leakage, `breedIdFor` helper, the integration-test breed filter assertion) plus the `paranoid: false` fix on `Breed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga)_