### PR TITLE
Phase 3 (slice 3.4 final): unguessable unsubscribe token

### DIFF
--- a/service.backend/src/__tests__/services/email.service.test.ts
+++ b/service.backend/src/__tests__/services/email.service.test.ts
@@ -356,6 +356,47 @@ describe('EmailService - Real Database Testing', () => {
     });
   });
 
+  describe('Unsubscribe via token', () => {
+    it('mints a 32-byte base64url token, stores it, and looks it up on unsubscribe', async () => {
+      const preference = await emailService.createUserPreferences('user-123');
+
+      // 32 bytes base64url-encoded → exactly 43 chars, no padding, URL-safe
+      // alphabet only.
+      expect(preference.unsubscribeToken).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+      await emailService.unsubscribeUser(preference.unsubscribeToken);
+
+      const reloaded = await EmailPreference.findOne({ where: { userId: 'user-123' } });
+      expect(reloaded?.globalUnsubscribe).toBe(true);
+    });
+
+    it('rejects an unknown / forged token', async () => {
+      await emailService.createUserPreferences('user-123');
+
+      await expect(emailService.unsubscribeUser('not-a-real-token')).rejects.toThrow(
+        /Invalid or expired unsubscribe token|Failed to unsubscribe/
+      );
+    });
+
+    it('mints a unique token per user', async () => {
+      await User.create({
+        userId: 'user-456',
+        email: 'second@example.com',
+        password: 'hashedpassword',
+        firstName: 'Second',
+        lastName: 'User',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+        emailVerified: true,
+      });
+
+      const a = await emailService.createUserPreferences('user-123');
+      const b = await emailService.createUserPreferences('user-456');
+
+      expect(a.unsubscribeToken).not.toBe(b.unsubscribeToken);
+    });
+  });
+
   describe('Bulk email sending', () => {
     describe('when sending to multiple recipients', () => {
       it('should batch emails and add delays', async () => {

--- a/service.backend/src/models/EmailPreference.ts
+++ b/service.backend/src/models/EmailPreference.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType } from '../sequelize';
 import { JsonObject } from '../types/common';
@@ -247,8 +248,14 @@ class EmailPreference
       .map(p => p.type);
   }
 
+  // 32 bytes (256 bits) of randomness, base64url-encoded → 43 chars, URL-safe
+  // (no `+`/`/`/`=`). Brute-forcing the column is computationally infeasible,
+  // so the value is stored as-is and the unsubscribe endpoint matches on
+  // equality. The same token is reused across every email we send to a user
+  // (it lives in the unsubscribe footer link), so per-send hashing isn't
+  // viable — the email template would have no way to recover the raw value.
   public static generateUnsubscribeToken(): string {
-    return generateUuidV7();
+    return randomBytes(32).toString('base64url');
   }
 
   public static getDefaultPreferences(): NotificationPreference[] {
@@ -490,12 +497,6 @@ EmailPreference.init(
       },
       ...auditIndexes('email_preferences'),
     ],
-    // TODO (Phase 3 — secrets-at-rest): unsubscribeToken should be hashed on
-    // write, but the current emitter (email.service.generateUnsubscribeToken)
-    // produces a base64-encoded `userId:ts:random` and the unsubscribe
-    // endpoint decodes that blob rather than doing an equality lookup. Hashing
-    // without rewriting both sides would break the flow — deferred until the
-    // token is switched to crypto.randomBytes(32).
   })
 );
 

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -700,7 +700,7 @@ class EmailService {
         digestTime: '09:00',
         bounceCount: 0,
         isBlacklisted: false,
-        unsubscribeToken: this.generateUnsubscribeToken(userId),
+        unsubscribeToken: EmailPreference.generateUnsubscribeToken(),
       });
 
       logger.info(`Email preferences created for user: ${userId}`);
@@ -711,11 +711,6 @@ class EmailService {
         `Failed to create email preferences: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
-  }
-
-  private generateUnsubscribeToken(userId: string): string {
-    // Generate a secure unsubscribe token
-    return Buffer.from(`${userId}:${Date.now()}:${Math.random()}`).toString('base64');
   }
 
   public async updateUserPreferences(
@@ -751,13 +746,15 @@ class EmailService {
 
   public async unsubscribeUser(token: string, type?: NotificationType): Promise<void> {
     try {
-      // Decode token to get userId
-      const decoded = Buffer.from(token, 'base64').toString();
-      const [userId] = decoded.split(':');
-
-      const preference = await EmailPreference.findOne({ where: { userId } });
+      // Look up the preference row by the token's exact value. The token is
+      // a 32-byte random string (see EmailPreference.generateUnsubscribeToken)
+      // and the column has a unique index, so the lookup is O(1) and a single
+      // valid token can only ever address one user.
+      const preference = await EmailPreference.findOne({
+        where: { unsubscribeToken: token },
+      });
       if (!preference) {
-        throw new Error('Email preferences not found');
+        throw new Error('Invalid or expired unsubscribe token');
       }
 
       if (type) {
@@ -769,7 +766,7 @@ class EmailService {
         await preference.update({ globalUnsubscribe: true });
       }
 
-      logger.info(`User unsubscribed: ${userId} ${type ? `from ${type}` : 'globally'}`);
+      logger.info(`User unsubscribed: ${preference.userId} ${type ? `from ${type}` : 'globally'}`);
     } catch (error: unknown) {
       logger.error('Failed to unsubscribe user:', error);
       throw new Error(


### PR DESCRIPTION
Closes the last open item in plan 3.4 (encrypt/secure secrets at rest). Other one-shot tokens (verification, reset, invitation, 2FA secret, backup codes) were already hashed/encrypted at write — only the EmailPreference.unsubscribeToken still emitted a guessable `base64(userId:Date.now():Math.random())` and "looked it up" by decoding the userId out of the token rather than matching the column. Anyone who knew a user's userId could globally unsubscribe them.

This swaps in `crypto.randomBytes(32).toString('base64url')` (43 chars, URL-safe alphabet, 256 bits of entropy) and rewrites unsubscribeUser to match against the column directly via the existing unique index. The token is reused across every email's footer, so per-send hashing isn't viable — the email template would have no way to recover the raw value. 32 bytes of randomness makes brute force infeasible regardless.