### PR TITLE
feat(5.5.7): switch email columns to CITEXT for DB-level case-insensi…

### DIFF
--- a/service.backend/src/__tests__/models/email-citext.test.ts
+++ b/service.backend/src/__tests__/models/email-citext.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import sequelize from '../../sequelize';
+import '../../models/index';
+import User from '../../models/User';
+import Rescue from '../../models/Rescue';
+
+/**
+ * Email columns use CITEXT (Postgres) / TEXT COLLATE NOCASE (SQLite) so
+ * the DB itself enforces case-insensitive uniqueness (plan 5.5.7).
+ *
+ * Before this change, the beforeValidate hook lowercased emails before the
+ * uniqueness check, which meant a raw INSERT bypassing the hook could store
+ * both Foo@x.com and foo@x.com as distinct rows. CITEXT closes that gap at
+ * the column level in both dialects.
+ */
+describe('Email case-insensitive uniqueness via CITEXT', () => {
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  describe('User.email', () => {
+    it('rejects a second user whose email differs only in case', async () => {
+      await User.create({
+        email: 'Foo@Example.com',
+        password: 'hunter2hunter2',
+        firstName: 'First',
+        lastName: 'User',
+      } as never);
+
+      await expect(
+        User.create({
+          email: 'foo@example.com',
+          password: 'hunter2hunter2',
+          firstName: 'Second',
+          lastName: 'User',
+        } as never)
+      ).rejects.toThrow();
+    });
+
+    it('accepts a user whose email is genuinely different', async () => {
+      await User.create({
+        email: 'alice@example.com',
+        password: 'hunter2hunter2',
+        firstName: 'Alice',
+        lastName: 'Smith',
+      } as never);
+
+      await expect(
+        User.create({
+          email: 'bob@example.com',
+          password: 'hunter2hunter2',
+          firstName: 'Bob',
+          lastName: 'Jones',
+        } as never)
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('Rescue.email', () => {
+    it('rejects a second rescue whose email differs only in case', async () => {
+      await Rescue.create({
+        name: 'First Rescue',
+        email: 'Rescue@Example.com',
+        address: '1 Lane',
+        city: 'Town',
+        postcode: 'AB1 2CD',
+        country: 'GB',
+        contactPerson: 'Alice',
+        status: 'pending',
+      } as never);
+
+      await expect(
+        Rescue.create({
+          name: 'Second Rescue',
+          email: 'rescue@example.com',
+          address: '2 Lane',
+          city: 'Town',
+          postcode: 'AB1 2CD',
+          country: 'GB',
+          contactPerson: 'Bob',
+          status: 'pending',
+        } as never)
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -418,6 +418,12 @@ const startServer = async () => {
         await sequelize.query('SELECT PostGIS_Version();');
         logger.info('PostGIS extension is ready.');
 
+        // Ensure citext extension is available (plan 5.5.7). CITEXT provides
+        // native case-insensitive uniqueness on email columns so the DB enforces
+        // the constraint even for raw INSERTs that bypass application hooks.
+        await sequelize.query('CREATE EXTENSION IF NOT EXISTS citext;');
+        logger.info('citext extension ready.');
+
         if (forceSeed) {
           // Force recreate database (drops all tables)
           await sequelize.sync({ force: true });

--- a/service.backend/src/models/Rescue.ts
+++ b/service.backend/src/models/Rescue.ts
@@ -1,5 +1,11 @@
 import { DataTypes, Model, Optional } from 'sequelize';
-import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType, getCitextType } from '../sequelize';
+import sequelize, {
+  getJsonType,
+  getUuidType,
+  getArrayType,
+  getGeometryType,
+  getCitextType,
+} from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 

--- a/service.backend/src/models/Rescue.ts
+++ b/service.backend/src/models/Rescue.ts
@@ -1,5 +1,5 @@
 import { DataTypes, Model, Optional } from 'sequelize';
-import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
+import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType, getCitextType } from '../sequelize';
 import { generateUuidV7 } from '../utils/uuid';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
@@ -85,7 +85,7 @@ Rescue.init(
       unique: true,
     },
     email: {
-      type: DataTypes.STRING,
+      type: getCitextType(),
       allowNull: false,
       unique: true,
       validate: {

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -1,5 +1,5 @@
 import { BelongsToManyAddAssociationMixin, DataTypes, Model, Optional } from 'sequelize';
-import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
+import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType, getCitextType } from '../sequelize';
 import { hashPassword, verifyPassword } from '../utils/password';
 import { encryptSecret, hashBackupCode, hashToken } from '../utils/secrets';
 import { JsonObject } from '../types/common';
@@ -214,7 +214,7 @@ User.init(
       },
     },
     email: {
-      type: DataTypes.STRING(255),
+      type: getCitextType(),
       unique: true,
       allowNull: false,
       validate: {
@@ -494,10 +494,11 @@ User.init(
     ],
     hooks: {
       // Normalize identifier fields before validation so uniqueness /
-      // isEmail checks see the canonical form (lowercase, trimmed).
+      // isEmail checks see the canonical form (trimmed). Case is now
+      // handled at the column level via CITEXT (plan 5.5.7).
       beforeValidate: (user: User) => {
         if (user.email && typeof user.email === 'string') {
-          user.email = user.email.trim().toLowerCase();
+          user.email = user.email.trim();
         }
         if (user.phoneNumber && typeof user.phoneNumber === 'string') {
           // Light normalization only — strip surrounding whitespace and the

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -1,5 +1,11 @@
 import { BelongsToManyAddAssociationMixin, DataTypes, Model, Optional } from 'sequelize';
-import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType, getCitextType } from '../sequelize';
+import sequelize, {
+  getJsonType,
+  getUuidType,
+  getArrayType,
+  getGeometryType,
+  getCitextType,
+} from '../sequelize';
 import { hashPassword, verifyPassword } from '../utils/password';
 import { encryptSecret, hashBackupCode, hashToken } from '../utils/secrets';
 import { JsonObject } from '../types/common';

--- a/service.backend/src/sequelize.ts
+++ b/service.backend/src/sequelize.ts
@@ -137,4 +137,14 @@ export const getTsVectorType = () => {
   return isTestEnvironment ? DataTypes.TEXT : DataTypes.TSVECTOR;
 };
 
+/**
+ * Get the appropriate case-insensitive text type based on the database dialect.
+ * PostgreSQL uses CITEXT (requires the citext extension).
+ * SQLite uses TEXT COLLATE NOCASE — Sequelize's built-in CITEXT shim handles this
+ * automatically when dialect === sqlite, so DataTypes.CITEXT is safe on both paths.
+ */
+export const getCitextType = () => {
+  return DataTypes.CITEXT;
+};
+
 export default sequelize;


### PR DESCRIPTION
…tive uniqueness

DB-level case-insensitive uniqueness replaces application-level normalization. Two users with `Foo@x.com` and `foo@x.com` could previously bypass the hook in raw INSERT paths; CITEXT closes that at the column level. SQLite tests use TEXT COLLATE NOCASE for parity (Sequelize's built-in CITEXT shim handles this automatically on the sqlite dialect — no custom DataType needed).

Changes:
- sequelize.ts: add getCitextType() helper following the getJsonType/getUuidType pattern
- User.ts: use getCitextType() for email; drop toLowerCase() from beforeValidate (trim kept)
- Rescue.ts: use getCitextType() for email
- index.ts: bootstrap `CREATE EXTENSION IF NOT EXISTS citext` on the Postgres dev path, alongside the existing PostGIS readiness check
- email-citext.test.ts: new behaviour test proving User.email and Rescue.email reject case-variant duplicates on both dialects

https://claude.ai/code/session_01T3qNRb5ShhGWzUwMRRkfga