### PR TITLE
DevEx [ADS-197]: add Dependabot for npm, Docker, and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+version: 2
+updates:
+  # npm workspace — covers all packages via root lockfile
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 10
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+      jest:
+        patterns:
+          - "jest"
+          - "ts-jest"
+          - "@types/jest"
+          - "jest-environment-*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "happy-dom"
+          - "jsdom"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+      turbo:
+        patterns:
+          - "turbo"
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+
+  # Docker — backend
+  - package-ecosystem: docker
+    directory: /service.backend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+
+  # Docker — frontend app Dockerfile
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering npm (workspace root), GitHub Actions, and Docker (backend + app Dockerfile)
- Groups related packages (TypeScript-ESLint, Jest, Vitest, React, Vite, Turbo) to reduce PR noise
- Weekly schedule on Monday mornings (Europe/London)

## Why
`quality.yml` ran `npm outdated` with `continue-on-error: true` — nobody saw the results. This replaces that with automated grouped PRs.

## Test plan
- [ ] Dependabot tab on GitHub shows scheduled checks after merge

Closes ADS-197

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG5PgsX626Mpzw6C4mThHv)_