### PR TITLE
DevEx [ADS-198]: add CODEOWNERS, PR template, and issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Global fallback
+*                           @paragonjenko
+
+# Frontend apps
+/app.admin/                 @paragonjenko
+/app.client/                @paragonjenko
+/app.rescue/                @paragonjenko
+
+# Backend
+/service.backend/           @paragonjenko
+
+# Shared libraries
+/lib.*/                     @paragonjenko
+
+# Infrastructure & CI
+/.github/                   @paragonjenko
+/docker-compose*.yml        @paragonjenko
+/Dockerfile*                @paragonjenko
+/nginx/                     @paragonjenko
+/turbo.json                 @paragonjenko
+
+# Documentation
+/docs/                      @paragonjenko
+/README.md                  @paragonjenko

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as possible.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - app.client
+        - app.admin
+        - app.rescue
+        - service.backend
+        - lib (shared library)
+        - Infrastructure / Docker
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - Node version:
+        - Browser:
+        - OS:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest an improvement or new feature
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for the suggestion!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what opportunity does it address?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you thought about?
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - app.client
+        - app.admin
+        - app.rescue
+        - service.backend
+        - lib (shared library)
+        - Infrastructure / Docker
+        - Developer experience
+        - Other
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+-
+
+## Changes
+
+<!-- List the key files/areas changed. -->
+
+-
+
+## Test plan
+
+<!-- How did you verify this works? Check off items as you go. -->
+
+- [ ] Existing tests pass (`npm test`)
+- [ ] New behaviour is covered by tests
+- [ ] Tested manually (describe how)
+- [ ] No TypeScript errors (`npm run type-check`)
+- [ ] Lint passes (`npm run lint`)
+
+## Screenshots / recordings
+
+<!-- For UI changes, attach a screenshot or recording. Delete if not applicable. -->
+
+## Related
+
+<!-- Link to Linear ticket, related PRs, or issues. -->


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` so PRs auto-request review from `@paragonjenko`
- Adds `.github/pull_request_template.md` with Summary / Changes / Test plan / Screenshots sections
- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` with structured forms

## Why
Every PR was manually assigned and had no standard shape. This gives a consistent starting point.

## Test plan
- [ ] Opening a new PR pre-fills the template
- [ ] Changes to tracked paths auto-assign `@paragonjenko` as reviewer

Closes ADS-198

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG5PgsX626Mpzw6C4mThHv)_