### PR TITLE
[DevEx] ADS-196: Enable Turborepo remote caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
 
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
     services:
       postgres:
         image: postgres:15
@@ -105,6 +109,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     strategy:
       matrix:

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "enabled": true
+  },
   "globalDependencies": ["**/.env.*local"],
   "globalEnv": ["NODE_ENV", "CI", "DOCKER"],
   "tasks": {


### PR DESCRIPTION
## Overview

This PR enables Turborepo remote caching in CI, allowing GitHub Actions workflows to benefit from cached build artifacts across runs and jobs.

## Changes

- Added `remoteCache` configuration to `turbo.json` to enable remote caching
- Added `TURBO_TOKEN` and `TURBO_TEAM` environment variables to CI jobs that run turbo commands:
  - `test-backend` job
  - `test-frontend-apps` job

## Remote Cache Setup

To enable remote caching, you need to set up GitHub repository secrets:

1. **Create a Vercel Remote Cache account or organization**:
   - Visit [Vercel](https://vercel.com)
   - Create or use an existing Vercel account
   - Go to Account Settings → Tokens (in Vercel dashboard)

2. **Generate TURBO_TOKEN**:
   - In Vercel Account Settings, create a new API token
   - Give it a meaningful name (e.g., "Turborepo CI")
   - Copy the token value

3. **Get TURBO_TEAM**:
   - Navigate to your Vercel team settings
   - Find the Team Slug (visible in the URL, e.g., `vercel-team-slug` from `vercel.com/dashboard/teams/vercel-team-slug`)
   - Or use your username as the team ID if using a personal account

4. **Add GitHub Secrets**:
   - Go to repository Settings → Secrets and variables → Actions
   - Click "New repository secret"
   - Add `TURBO_TOKEN` with the Vercel API token
   - Add `TURBO_TEAM` with the Vercel team slug
   
5. **Verify Configuration**:
   - Once secrets are added, CI runs should automatically use remote caching
   - Cache hits will be indicated in workflow logs as `CACHE HIT` messages

## Benefits

- Faster CI builds by reusing cached artifacts across runs
- Reduced build times for PRs that don't modify dependencies or build outputs
- Improved developer experience with quicker feedback loops
- Cost savings from reduced CI compute usage

## Notes

- This configuration requires valid `TURBO_TOKEN` and `TURBO_TEAM` secrets in GitHub repository settings
- Without these secrets, builds will still succeed but will bypass remote caching
- Remote cache is only used in CI; local development uses local cache


---
_Generated by [Claude Code](https://claude.ai/code/session_01VG5PgsX626Mpzw6C4mThHv)_