### PR TITLE
[DevEx] ADS-203: Replace lib.types docker-compose hack with entrypoint script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,17 +63,8 @@ services:
       - /app/service.backend/node_modules
       - lib_types_node_modules:/app/lib.types/node_modules
       - ./uploads:/app/service.backend/uploads
-    # Build lib.types from bind-mounted source at startup, then COPY (not symlink)
-    # the built package into backend node_modules. Symlinks across Windows bind
-    # mounts into Linux containers are flaky; copy is reliable. Re-run via
-    # `npm run docker:rebuild:types` when lib.types source changes.
-    command: >
-      sh -c "set -e &&
-             cd /app/lib.types && npm run build &&
-             mkdir -p /app/service.backend/node_modules/@adopt-dont-shop &&
-             rm -rf /app/service.backend/node_modules/@adopt-dont-shop/lib.types &&
-             cp -r /app/lib.types /app/service.backend/node_modules/@adopt-dont-shop/lib.types &&
-             cd /app/service.backend && npm run dev"
+    entrypoint: ./service.backend/docker-entrypoint.sh
+    command: npm run dev
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 5000

--- a/service.backend/Dockerfile
+++ b/service.backend/Dockerfile
@@ -55,8 +55,11 @@ COPY eslint-config-node/ eslint-config-node/
 COPY lib.types/ lib.types/
 COPY lib.validation/ lib.validation/
 
-# Copy backend service
+# Copy backend service (including entrypoint script)
 COPY service.backend/ service.backend/
+
+# Make entrypoint script executable
+RUN chmod +x /app/service.backend/docker-entrypoint.sh
 
 # Build shared libraries first
 WORKDIR /app/lib.types
@@ -108,8 +111,11 @@ COPY eslint-config-node/ eslint-config-node/
 COPY lib.types/ lib.types/
 COPY lib.validation/ lib.validation/
 
-# Copy backend service
+# Copy backend service (including entrypoint script)
 COPY service.backend/ service.backend/
+
+# Make entrypoint script executable
+RUN chmod +x /app/service.backend/docker-entrypoint.sh
 
 # Build shared libraries first (required for backend TypeScript compilation)
 WORKDIR /app/lib.types

--- a/service.backend/docker-entrypoint.sh
+++ b/service.backend/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# Build lib.types if not already built
+if [ ! -d "/app/lib.types/dist" ]; then
+  echo "Building lib.types..."
+  cd /app/lib.types && npm run build
+fi
+
+# Ensure lib.types is in node_modules
+mkdir -p /app/service.backend/node_modules/@adopt-dont-shop
+if [ ! -d "/app/service.backend/node_modules/@adopt-dont-shop/lib.types" ] || [ ! -f "/app/service.backend/node_modules/@adopt-dont-shop/lib.types/package.json" ]; then
+  echo "Copying lib.types to node_modules..."
+  rm -rf /app/service.backend/node_modules/@adopt-dont-shop/lib.types
+  mkdir -p /app/service.backend/node_modules/@adopt-dont-shop/lib.types
+  cp /app/lib.types/package.json /app/service.backend/node_modules/@adopt-dont-shop/lib.types/
+  cp -r /app/lib.types/dist /app/service.backend/node_modules/@adopt-dont-shop/lib.types/
+fi
+
+cd /app/service.backend
+exec "$@"


### PR DESCRIPTION
## Problem

The current docker-compose configuration for the backend service rebuilds lib.types on every container start with a complex shell command embedded in the `command` field:

```yaml
command: >
  sh -c "set -e &&
         cd /app/lib.types && npm run build &&
         mkdir -p /app/service.backend/node_modules/@adopt-dont-shop &&
         rm -rf /app/service.backend/node_modules/@adopt-dont-shop/lib.types &&
         cp -r /app/lib.types /app/service.backend/node_modules/@adopt-dont-shop/lib.types &&
         cd /app/service.backend && npm run dev"
```

Issues with this approach:
- Rebuilds lib.types unnecessarily on every container start
- Hides the real startup command (`npm run dev`) in shell scripting
- Mixes build logic with docker-compose configuration
- Not maintainable or extensible

## Solution

Implemented a proper Docker entrypoint script that:
1. Only builds lib.types if the dist directory doesn't exist (idempotent)
2. Copies the built lib.types to node_modules (avoiding symlink issues across Windows/Docker bind mounts)
3. Cleanly executes the passed command

### Changes
- **Created**: `service.backend/docker-entrypoint.sh` - Smart entrypoint script
- **Updated**: `docker-compose.yml` - Now uses entrypoint and simple command
- **Updated**: `service.backend/Dockerfile` - Copies and makes entrypoint executable

This follows Docker best practices and makes the container startup logic more transparent and maintainable.

https://claude.ai/code/session_01VG5PgsX626Mpzw6C4mThHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG5PgsX626Mpzw6C4mThHv)_