### PR TITLE
fix: remove root eslint.config.js that broke all workspace lint in CI

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,0 @@
-// ESLint flat config (v9+) for the monorepo root.
-// Individual packages under lib.*/app.*/service.backend/ maintain their own
-// .eslintrc.* configs and are linted from within those package directories.
-// This root config satisfies ESLint v9+ tooling (e.g. lint-staged) without
-// duplicating package-level rules.
-export default [];


### PR DESCRIPTION
## Problem

The root `eslint.config.js` (added in #183) put ESLint into flat-config mode for the entire monorepo. This caused every workspace lint script that uses `--ext ts,tsx` to fail with:

```
Invalid option '--ext' - perhaps you meant '-c'?
You're using eslint.config.js, some command line flags are no longer available.
```

This broke `npm run lint` in `service.backend`, all `app.*`, and all `lib.*` packages — causing CI failures on `main` after the DevEx PRs were merged.

## Fix

Delete the root `eslint.config.js`. Every workspace already has its own `.eslintrc.cjs` and is linted from within its own directory. No root flat config is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VG5PgsX626Mpzw6C4mThHv)_