### PR TITLE
fix: replace removed Pet.breed column with breedId in application and swipe queries

### DIFF
--- a/service.backend/src/models/SwipeAction.ts
+++ b/service.backend/src/models/SwipeAction.ts
@@ -123,7 +123,7 @@ export class SwipeAction
       include: [
         {
           association: 'Pet',
-          attributes: ['pet_id', 'name', 'breed', 'type'],
+          attributes: ['pet_id', 'name', 'breed_id', 'type'],
         },
       ],
     });

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -270,7 +270,7 @@ export class ApplicationService {
             'petId',
             'name',
             'type',
-            'breed',
+            'breedId',
             'ageYears',
             'ageMonths',
             'ageGroup',


### PR DESCRIPTION
## Summary

- `GET /api/v1/applications/:id` was returning 500 errors because the `applications` service query included `'breed'` in the Pet attributes, but that column no longer exists — breeds were extracted to a lookup table (plan 2.4), leaving only `breed_id` / `breedId` as a FK
- Fixed `application.service.ts` line 273: `'breed'` → `'breedId'`
- Fixed `SwipeAction.ts` line 126 (identical stale reference): `'breed'` → `'breed_id'`

## Test plan

- [ ] Navigate to `/applications/:id` as a logged-in user — should return 200 with pet data instead of 500
- [ ] Confirm swipe session history endpoint does not error when pets are joined

https://claude.ai/code/session_017HtLA689htyFm4Df4faRPa

---
_Generated by [Claude Code](https://claude.ai/code/session_017HtLA689htyFm4Df4faRPa)_