### PR TITLE
fix: add missing Sequelize association aliases in analytics service

### DIFF
--- a/service.backend/src/services/analytics.service.ts
+++ b/service.backend/src/services/analytics.service.ts
@@ -187,6 +187,7 @@ export class AnalyticsService {
         include: [
           {
             model: Message,
+            as: 'SentMessages',
             where: { created_at: dateFilter as unknown as Date },
             required: true,
           },
@@ -198,6 +199,7 @@ export class AnalyticsService {
         include: [
           {
             model: Application,
+            as: 'UserApplications',
             where: { created_at: dateFilter as unknown as Date },
             required: true,
           },
@@ -867,6 +869,7 @@ export class AnalyticsService {
         include: [
           {
             model: Chat,
+            as: 'Chat',
             where: rescueId ? { rescue_id: rescueId } : {},
           },
         ],
@@ -922,6 +925,7 @@ export class AnalyticsService {
           ? [
               {
                 model: Chat,
+                as: 'Chat',
                 where: { rescue_id: rescueId },
               },
             ]
@@ -1034,6 +1038,7 @@ export class AnalyticsService {
           include: [
             {
               model: AuditLog,
+              as: 'AuditLogs',
               where: { created_at: { [Op.gte]: lastHour } },
               required: true,
             },
@@ -1416,6 +1421,7 @@ export class AnalyticsService {
         include: [
           {
             model: Chat,
+            as: 'Chat',
             where: rescueId ? { rescue_id: rescueId } : {},
           },
         ],
@@ -1430,6 +1436,7 @@ export class AnalyticsService {
           ? [
               {
                 model: Chat,
+                as: 'Chat',
                 where: { rescue_id: rescueId },
               },
             ]


### PR DESCRIPTION
## Summary

- Fixes `SequelizeEagerLoadingError` thrown from `getUserBehaviorMetrics` and `getDashboardAnalytics` when counting active users and messages
- Adds the required `as` alias to every `include` block in `analytics.service.ts` where the association was defined with one: `Message` → `'SentMessages'`, `Application` → `'UserApplications'`, `Chat` → `'Chat'`, `AuditLog` → `'AuditLogs'`

## Test plan

- [ ] Confirm the admin dashboard analytics endpoint no longer returns a 500 with `SequelizeEagerLoadingError`
- [ ] Verify user behavior metrics (active users, message counts) are returned correctly
- [ ] Check real-time metrics endpoint (active users in last hour) works without error

https://claude.ai/code/session_01K7MebdEtojSFwAtgXmECq5

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7MebdEtojSFwAtgXmECq5)_