### PR TITLE
fix: allow sorting applications by submittedAt field

### DIFF
--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -742,6 +742,52 @@ describe('ApplicationService - Business Logic', () => {
     });
   });
 
+  describe('Business Rule: Application Search Sorting', () => {
+    const mockApplicationRow = () => {
+      const app = createMockApplication();
+      return {
+        ...app,
+        toJSON: vi.fn().mockReturnValue(app),
+        Answers: [],
+      };
+    };
+
+    beforeEach(() => {
+      MockedApplication.findAndCountAll = vi.fn().mockResolvedValue({
+        rows: [mockApplicationRow()],
+        count: 1,
+      });
+    });
+
+    it('allows sorting by submittedAt', async () => {
+      // Given: A request to sort by submittedAt (a valid Application column)
+      // When: searchApplications is called with sortBy=submittedAt
+      const result = await ApplicationService.searchApplications(
+        {},
+        { page: 1, limit: 10, sortBy: 'submittedAt', sortOrder: 'DESC' }
+      );
+
+      // Then: The query succeeds and returns results
+      expect(result.applications).toHaveLength(1);
+      expect(MockedApplication.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: [['submittedAt', 'DESC']],
+        })
+      );
+    });
+
+    it('rejects sorting by an unknown field', async () => {
+      // Given: A request with a non-existent sort field
+      // When & Then: An error is thrown
+      await expect(
+        ApplicationService.searchApplications(
+          {},
+          { page: 1, limit: 10, sortBy: 'notAField', sortOrder: 'DESC' }
+        )
+      ).rejects.toThrow('Failed to search applications');
+    });
+  });
+
   describe('Error Handling', () => {
     it('throws error when application not found', async () => {
       // Given: Application does not exist

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -7,7 +7,7 @@ import ApplicationReferenceModel, {
 } from '../models/ApplicationReference';
 import { validateSortField } from '../utils/sort-validation';
 
-const APPLICATION_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'actioned_at'] as const;
+const APPLICATION_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'actioned_at', 'submittedAt'] as const;
 import ApplicationQuestion, { QuestionCategory } from '../models/ApplicationQuestion';
 import ApplicationStatusTransition from '../models/ApplicationStatusTransition';
 import Breed from '../models/Breed';

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -7,7 +7,13 @@ import ApplicationReferenceModel, {
 } from '../models/ApplicationReference';
 import { validateSortField } from '../utils/sort-validation';
 
-const APPLICATION_SORT_FIELDS = ['createdAt', 'updatedAt', 'status', 'actioned_at', 'submittedAt'] as const;
+const APPLICATION_SORT_FIELDS = [
+  'createdAt',
+  'updatedAt',
+  'status',
+  'actioned_at',
+  'submittedAt',
+] as const;
 import ApplicationQuestion, { QuestionCategory } from '../models/ApplicationQuestion';
 import ApplicationStatusTransition from '../models/ApplicationStatusTransition';
 import Breed from '../models/Breed';


### PR DESCRIPTION
## Summary

- `submittedAt` is a valid column on the `Application` model but was missing from the `APPLICATION_SORT_FIELDS` allowlist in `application.service.ts`
- Any request with `sortBy=submittedAt` (e.g. from the rescue/admin application list UI) threw a 500 error instead of returning results
- Added `'submittedAt'` to the allowlist and added tests covering both the valid sort and rejection of unknown fields

## Test plan

- [ ] Confirm the two new tests in `application.service.test.ts` pass: one asserting `submittedAt` sorts work, one asserting unknown fields still throw
- [ ] Manually verify the applications list page loads without error when sorted by submitted date

https://claude.ai/code/session_01SDWap9irRwG5jkD7NRbUQH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDWap9irRwG5jkD7NRbUQH)_