### PR TITLE
fix: guard toISOString on undefined timestamps and allow admin access to all chats

### DIFF
--- a/service.backend/src/__tests__/controllers/chat.controller.test.ts
+++ b/service.backend/src/__tests__/controllers/chat.controller.test.ts
@@ -315,6 +315,36 @@ describe('ChatController', () => {
       });
     });
 
+    describe('when the caller is an admin', () => {
+      it('should pass undefined userId to the service (bypass participant check)', async () => {
+        mockRequest.params = { chatId: 'chat-001' };
+        mockRequest.user = { ...mockUser, userType: UserType.ADMIN } as User;
+
+        const mockChat = {
+          toJSON: () => ({
+            chat_id: 'chat-001',
+            type: 'application',
+            status: 'active',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            Participants: [],
+          }),
+        };
+
+        (ChatService.getChatById as Mock).mockResolvedValue(mockChat);
+
+        await ChatController.getChatById(
+          mockRequest as AuthenticatedRequest,
+          mockResponse as Response
+        );
+
+        expect(ChatService.getChatById).toHaveBeenCalledWith('chat-001', undefined);
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({ success: true })
+        );
+      });
+    });
+
     describe('when user is not a participant', () => {
       it('should return chat data (no access control implemented)', async () => {
         mockRequest.params = { chatId: 'chat-001' };
@@ -568,6 +598,34 @@ describe('ChatController', () => {
               }),
             }),
           })
+        );
+      });
+    });
+
+    describe('when the caller is an admin', () => {
+      it('should pass undefined userId to the service (bypass participant check)', async () => {
+        mockRequest.params = { chatId: 'chat-001' };
+        mockRequest.query = { page: '1', limit: '50' };
+        mockRequest.user = { ...mockUser, userType: UserType.ADMIN } as User;
+
+        (ChatService.getMessages as Mock).mockResolvedValue({
+          messages: [],
+          page: 1,
+          total: 0,
+          totalPages: 0,
+        });
+
+        await ChatController.getMessages(
+          mockRequest as AuthenticatedRequest,
+          mockResponse as Response
+        );
+
+        expect(ChatService.getMessages).toHaveBeenCalledWith(
+          'chat-001',
+          expect.objectContaining({ userId: undefined })
+        );
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({ success: true })
         );
       });
     });

--- a/service.backend/src/__tests__/controllers/chat.controller.test.ts
+++ b/service.backend/src/__tests__/controllers/chat.controller.test.ts
@@ -339,9 +339,7 @@ describe('ChatController', () => {
         );
 
         expect(ChatService.getChatById).toHaveBeenCalledWith('chat-001', undefined);
-        expect(mockResponse.json).toHaveBeenCalledWith(
-          expect.objectContaining({ success: true })
-        );
+        expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
       });
     });
 
@@ -624,9 +622,7 @@ describe('ChatController', () => {
           'chat-001',
           expect.objectContaining({ userId: undefined })
         );
-        expect(mockResponse.json).toHaveBeenCalledWith(
-          expect.objectContaining({ success: true })
-        );
+        expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
       });
     });
 

--- a/service.backend/src/__tests__/services/chat.service.test.ts
+++ b/service.backend/src/__tests__/services/chat.service.test.ts
@@ -401,6 +401,29 @@ describe('ChatService', () => {
         await ChatService.getMessages(chatId);
         expect(MockedChatParticipant.findOne).not.toHaveBeenCalled();
       });
+
+      it('does not crash when a message has undefined created_at or updated_at', async () => {
+        (MockedMessage.findAndCountAll as vi.Mock).mockResolvedValue({
+          rows: [
+            {
+              message_id: 'msg-001',
+              chat_id: chatId,
+              sender_id: 'user-1',
+              content: 'hello',
+              content_format: 'text',
+              attachments: [],
+              created_at: undefined,
+              updated_at: undefined,
+              Sender: { userId: 'user-1', firstName: 'A', lastName: 'B' },
+            },
+          ],
+          count: 1,
+        });
+        (MockedChatParticipant.findOne as vi.Mock).mockReset();
+        const result = await ChatService.getMessages(chatId);
+        expect(result.messages).toHaveLength(1);
+        expect(result.messages[0].created_at).toBeDefined();
+      });
     });
 
     describe('markMessagesAsRead', () => {

--- a/service.backend/src/controllers/chat.controller.ts
+++ b/service.backend/src/controllers/chat.controller.ts
@@ -223,8 +223,9 @@ export class ChatController {
     try {
       const { chatId } = req.params;
       const userId = req.user!.userId;
+      const isAdmin = req.user!.userType === UserType.ADMIN;
 
-      const chat = await ChatService.getChatById(chatId, userId);
+      const chat = await ChatService.getChatById(chatId, isAdmin ? undefined : userId);
 
       if (!chat) {
         return res.status(404).json({

--- a/service.backend/src/services/chat.service.ts
+++ b/service.backend/src/services/chat.service.ts
@@ -826,8 +826,8 @@ export class ChatService {
           mimeType: att.mimeType,
           size: att.size,
         })),
-        created_at: msg.created_at.toISOString(),
-        updated_at: msg.updated_at.toISOString(),
+        created_at: msg.created_at ? msg.created_at.toISOString() : new Date(0).toISOString(),
+        updated_at: msg.updated_at ? msg.updated_at.toISOString() : new Date(0).toISOString(),
         Sender: msg.Sender,
       })) as unknown as ChatMessage[];
 


### PR DESCRIPTION
## Summary

- **`toISOString` crash**: `chat.service.ts` `getMessages` called `.toISOString()` directly on `msg.created_at` / `msg.updated_at`, which are `undefined` on some rows, causing a 500 error. Fixed with a null-guard (`msg.created_at ? ... : new Date(0).toISOString()`).
- **Admin blocked from chats**: `getChatById` controller always passed the admin's `userId` to the service, which ran the participant check and threw "User is not a participant in this chat". Fixed by passing `undefined` when `userType === UserType.ADMIN`, matching the existing pattern already used in `getMessages`.

## Test plan

- [ ] New service test: `getMessages` does not crash when a message has `undefined` `created_at`/`updated_at`
- [ ] New controller tests: `getChatById` and `getMessages` pass `userId: undefined` to the service when the caller is an admin
- [ ] Existing chat service and controller tests continue to pass

https://claude.ai/code/session_01TMKcyjjVpZmWS13NmUxJHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMKcyjjVpZmWS13NmUxJHQ)_