### PR TITLE
Fixes eslint errors and runs eslint auto unblocking PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ docker-compose.override.yml
 *.tsbuildinfo
 *.timestamp-*.mjs
 .claude/worktrees/
+storybook-static/

--- a/app.admin/src/pages/ContentManagement.tsx
+++ b/app.admin/src/pages/ContentManagement.tsx
@@ -159,15 +159,27 @@ const StatusBadge = styled.span<{ $status: string }>`
   font-size: 0.75rem;
   font-weight: 500;
   background: ${p => {
-    if (p.$status === 'published') return '#d1fae5';
-    if (p.$status === 'draft') return '#fef3c7';
-    if (p.$status === 'scheduled') return '#dbeafe';
+    if (p.$status === 'published') {
+      return '#d1fae5';
+    }
+    if (p.$status === 'draft') {
+      return '#fef3c7';
+    }
+    if (p.$status === 'scheduled') {
+      return '#dbeafe';
+    }
     return '#f3f4f6';
   }};
   color: ${p => {
-    if (p.$status === 'published') return '#065f46';
-    if (p.$status === 'draft') return '#92400e';
-    if (p.$status === 'scheduled') return '#1e40af';
+    if (p.$status === 'published') {
+      return '#065f46';
+    }
+    if (p.$status === 'draft') {
+      return '#92400e';
+    }
+    if (p.$status === 'scheduled') {
+      return '#1e40af';
+    }
     return '#374151';
   }};
 `;
@@ -186,8 +198,12 @@ const IconButton = styled.button<{ $variant?: 'danger' | 'primary' | 'default' }
   border-radius: 6px;
   border: 1px solid
     ${p => {
-      if (p.$variant === 'danger') return '#fca5a5';
-      if (p.$variant === 'primary') return '#93c5fd';
+      if (p.$variant === 'danger') {
+        return '#fca5a5';
+      }
+      if (p.$variant === 'primary') {
+        return '#93c5fd';
+      }
       return '#e5e7eb';
     }};
   background: ${p =>
@@ -470,7 +486,9 @@ const ContentManagement: React.FC = () => {
   }, [fetchContent]);
 
   useEffect(() => {
-    if (activeTab === 'menus') fetchMenus();
+    if (activeTab === 'menus') {
+      fetchMenus();
+    }
   }, [activeTab, fetchMenus]);
 
   const openCreateContent = () => {
@@ -501,7 +519,9 @@ const ContentManagement: React.FC = () => {
   };
 
   const handleSlugGenerate = async () => {
-    if (!contentForm.title) return;
+    if (!contentForm.title) {
+      return;
+    }
     try {
       const slug = await cmsService.generateSlug(contentForm.title);
       setContentForm(f => ({ ...f, slug }));
@@ -583,7 +603,9 @@ const ContentManagement: React.FC = () => {
   };
 
   const handleArchive = async (item: Content) => {
-    if (!window.confirm(`Archive "${item.title}"?`)) return;
+    if (!window.confirm(`Archive "${item.title}"?`)) {
+      return;
+    }
     try {
       await cmsService.archiveContent(item.contentId);
       fetchContent();
@@ -593,7 +615,9 @@ const ContentManagement: React.FC = () => {
   };
 
   const handleDeleteContent = async (item: Content) => {
-    if (!window.confirm(`Permanently delete "${item.title}"?`)) return;
+    if (!window.confirm(`Permanently delete "${item.title}"?`)) {
+      return;
+    }
     try {
       await cmsService.deleteContent(item.contentId);
       fetchContent();
@@ -615,7 +639,9 @@ const ContentManagement: React.FC = () => {
   };
 
   const handleSaveMenu = async () => {
-    if (!menuForm.name.trim()) return;
+    if (!menuForm.name.trim()) {
+      return;
+    }
     setSaving(true);
     try {
       if (editingMenu) {
@@ -637,7 +663,9 @@ const ContentManagement: React.FC = () => {
   };
 
   const handleDeleteMenu = async (menu: NavigationMenu) => {
-    if (!window.confirm(`Delete menu "${menu.name}"?`)) return;
+    if (!window.confirm(`Delete menu "${menu.name}"?`)) {
+      return;
+    }
     try {
       await cmsService.deleteMenu(menu.menuId);
       fetchMenus();

--- a/lib.api/src/services/api-service.ts
+++ b/lib.api/src/services/api-service.ts
@@ -334,12 +334,7 @@ export class ApiService {
       clearTimeout(timeoutId);
 
       // Apply response interceptors
-      try {
-        response = await this.interceptors.applyResponseInterceptors(response);
-      } catch (interceptorError) {
-        // Response interceptor threw an error (e.g., due to !response.ok)
-        throw interceptorError;
-      }
+      response = await this.interceptors.applyResponseInterceptors(response);
 
       // Parse response
       const contentType = response.headers.get('content-type');

--- a/lib.components/.storybook/main.ts
+++ b/lib.components/.storybook/main.ts
@@ -1,13 +1,18 @@
+import path from 'path';
 import type { StorybookConfig } from '@storybook/react-vite';
 
+// In an npm workspace monorepo the storybook binary lives at the root while
+// @storybook/react-vite is installed under lib.components/node_modules.
+// Resolving the package directory from this config file's location ensures
+// storybook can find the preset regardless of hoisting.
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx)'],
-  addons: [
-    '@storybook/addon-essentials',
-    '@storybook/addon-a11y',
-  ],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-a11y'],
   framework: {
-    name: '@storybook/react-vite',
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    name: path.dirname(
+      require.resolve('@storybook/react-vite/package.json')
+    ) as '@storybook/react-vite',
     options: {},
   },
   docs: {

--- a/lib.permissions/src/config/__tests__/field-permission-defaults.test.ts
+++ b/lib.permissions/src/config/__tests__/field-permission-defaults.test.ts
@@ -121,12 +121,8 @@ describe('Field Permission Defaults', () => {
 
   describe('rescue staff access', () => {
     it('should allow rescue staff to write application internal notes', () => {
-      expect(getDefaultFieldAccess('applications', 'rescue_staff', 'interviewNotes')).toBe(
-        'write'
-      );
-      expect(getDefaultFieldAccess('applications', 'rescue_staff', 'homeVisitNotes')).toBe(
-        'write'
-      );
+      expect(getDefaultFieldAccess('applications', 'rescue_staff', 'interviewNotes')).toBe('write');
+      expect(getDefaultFieldAccess('applications', 'rescue_staff', 'homeVisitNotes')).toBe('write');
       expect(getDefaultFieldAccess('applications', 'rescue_staff', 'score')).toBe('write');
     });
 

--- a/lib.permissions/src/services/__tests__/field-permissions-service.test.ts
+++ b/lib.permissions/src/services/__tests__/field-permissions-service.test.ts
@@ -340,11 +340,7 @@ describe('FieldPermissionsService', () => {
     });
 
     it('should allow rescue staff to see and edit internal notes', async () => {
-      const result = await service.getFieldAccess(
-        'applications',
-        'rescue_staff',
-        'interviewNotes'
-      );
+      const result = await service.getFieldAccess('applications', 'rescue_staff', 'interviewNotes');
 
       expect(result.effectiveLevel).toBe('write');
       expect(result.allowed).toBe(true);

--- a/service.backend/src/services/notification.service.ts
+++ b/service.backend/src/services/notification.service.ts
@@ -912,13 +912,29 @@ type PrefsRowPatch = Partial<{
 
 function apiPatchToPrefsRow(input: Partial<NotificationPreferences>): PrefsRowPatch {
   const out: PrefsRowPatch = {};
-  if (input.email !== undefined) out.email_enabled = input.email;
-  if (input.push !== undefined) out.push_enabled = input.push;
-  if (input.sms !== undefined) out.sms_enabled = input.sms;
-  if (input.applications !== undefined) out.application_updates = input.applications;
-  if (input.messages !== undefined) out.chat_messages = input.messages;
-  if (input.quietHoursStart !== undefined) out.quiet_hours_start = input.quietHoursStart || null;
-  if (input.quietHoursEnd !== undefined) out.quiet_hours_end = input.quietHoursEnd || null;
-  if (input.timezone !== undefined) out.timezone = input.timezone;
+  if (input.email !== undefined) {
+    out.email_enabled = input.email;
+  }
+  if (input.push !== undefined) {
+    out.push_enabled = input.push;
+  }
+  if (input.sms !== undefined) {
+    out.sms_enabled = input.sms;
+  }
+  if (input.applications !== undefined) {
+    out.application_updates = input.applications;
+  }
+  if (input.messages !== undefined) {
+    out.chat_messages = input.messages;
+  }
+  if (input.quietHoursStart !== undefined) {
+    out.quiet_hours_start = input.quietHoursStart || null;
+  }
+  if (input.quietHoursEnd !== undefined) {
+    out.quiet_hours_end = input.quietHoursEnd || null;
+  }
+  if (input.timezone !== undefined) {
+    out.timezone = input.timezone;
+  }
   return out;
 }

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -1606,7 +1606,9 @@ function privacyPatchToPrefsRow(input: NonNullable<UserPreferences['privacySetti
         break;
     }
   }
-  if (input.showLocation !== undefined) out.show_location = input.showLocation;
+  if (input.showLocation !== undefined) {
+    out.show_location = input.showLocation;
+  }
   return out;
 }
 


### PR DESCRIPTION
This pull request primarily refactors several code blocks across the codebase to use explicit curly braces and multi-line formatting for conditional statements, improving code readability and consistency. There are also minor test formatting updates and a fix for Storybook configuration resolution in a monorepo environment.

**Code readability and consistency improvements:**

* Updated all single-line `if` statements in `app.admin/src/pages/ContentManagement.tsx`, `service.backend/src/services/notification.service.ts`, and `service.backend/src/services/user.service.ts` to use curly braces and multi-line formatting for better clarity and maintainability. [[1]](diffhunk://#diff-b9d71b9f43ab68d6cb865d4035cac825a82fc7199f7b3bf053badbe6eba56f8cL162-R182) [[2]](diffhunk://#diff-b9d71b9f43ab68d6cb865d4035cac825a82fc7199f7b3bf053badbe6eba56f8cL189-R206) [[3]](diffhunk://#diff-b9d71b9f43ab68d6cb865d4035cac825a82fc7199f7b3bf053badbe6eba56f8cL473-R491) [[4]](diffhunk://#diff-b9d71b9f43ab68d6cb865d4035cac825a82fc7199f7b3bf053badbe6eba56f8cL504-R524) [[5]](diffhunk://#diff-b9d71b9f43ab68d6cb865d4035cac825a82fc7199f7b3bf053badbe6eba56f8cL586-R608) [[6]](diffhunk://#diff-b9d71b9f43ab68d6cb865d4035cac825a82fc7199f7b3bf053badbe6eba56f8cL596-R620) [[7]](diffhunk://#diff-b9d71b9f43ab68d6cb865d4035cac825a82fc7199f7b3bf053badbe6eba56f8cL618-R644) [[8]](diffhunk://#diff-b9d71b9f43ab68d6cb865d4035cac825a82fc7199f7b3bf053badbe6eba56f8cL640-R668) [[9]](diffhunk://#diff-51a225b15b1518b1af514604914054210453aeed9aa65cee9b59ce0cd1ba3ec7L915-R938) [[10]](diffhunk://#diff-e85a9355eb10ee1deaa798f70945edd8ed7fd094409dd4e2d9cfa62050ea70eaL1609-R1611)

**Build and configuration improvements:**

* Modified Storybook configuration in `lib.components/.storybook/main.ts` to resolve the Storybook framework path relative to the config file, ensuring compatibility in npm workspace monorepos.

**Testing and minor cleanup:**

* Reformatted long test assertions to single lines for improved readability in `lib.permissions/src/config/__tests__/field-permission-defaults.test.ts` and `lib.permissions/src/services/__tests__/field-permissions-service.test.ts`. [[1]](diffhunk://#diff-7a26598fe76ca32948a6a9477af1a11cd49aae9b74c245f5dc317b0e56666120L124-R125) [[2]](diffhunk://#diff-cc5233df912aa1cfad5ea4ece7debf25ff765bbc48542b89353709ab535dbc42L343-R343)
* Removed unnecessary try/catch block around response interceptors in `lib.api/src/services/api-service.ts` for cleaner error handling.