### PR TITLE
feat(lib.dev-tools): migrate styled-components to Vanilla Extract CSS

### DIFF
--- a/lib.dev-tools/jest.config.cjs
+++ b/lib.dev-tools/jest.config.cjs
@@ -2,6 +2,9 @@ const base = require('../jest.config.base.cjs');
 module.exports = {
   ...base,
   setupFilesAfterEnv: ['<rootDir>/src/test-utils/setup-tests.ts'],
+  moduleNameMapper: {
+    '\\.css\\.ts$': '<rootDir>/src/__mocks__/vanillaExtractMock.js',
+  },
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.d.ts',

--- a/lib.dev-tools/package.json
+++ b/lib.dev-tools/package.json
@@ -39,8 +39,9 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^20.0.0",
-    "react": "^18.2.0",
-    "styled-components": "^6.1.8"
+    "@vanilla-extract/css": "^1.20.1",
+    "@vanilla-extract/recipes": "^0.5.7",
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "*",
@@ -48,7 +49,6 @@
     "@typescript-eslint/parser": "^7.0.0",
     "@types/jest": "^29.4.0",
     "@types/react": "^18.2.0",
-    "@types/styled-components": "^5.1.26",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
@@ -60,7 +60,6 @@
   },
   "peerDependencies": {
     "react": ">=18.0.0",
-    "styled-components": ">=5.0.0",
     "typescript": "^5.0.0"
   },
   "repository": {

--- a/lib.dev-tools/src/__mocks__/vanillaExtractMock.js
+++ b/lib.dev-tools/src/__mocks__/vanillaExtractMock.js
@@ -1,0 +1,13 @@
+// Mock for Vanilla Extract .css.ts files in Jest
+// style() returns a string, recipe() returns a function returning a string,
+// styleVariants() returns an object with string values.
+const handler = {
+  get: (target, prop) => {
+    if (prop === '__esModule') return true;
+    // For recipe variants (functions), return a callable that returns ''
+    return new Proxy(() => '', handler);
+  },
+  apply: () => '',
+};
+
+module.exports = new Proxy({}, handler);

--- a/lib.dev-tools/src/components/DevPanel.css.ts
+++ b/lib.dev-tools/src/components/DevPanel.css.ts
@@ -1,0 +1,232 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const devToggle = style({
+  position: 'fixed',
+  top: '20px',
+  right: '20px',
+  zIndex: 10000,
+  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  color: 'white',
+  border: 'none',
+  padding: '0.75rem 1.25rem',
+  borderRadius: '12px',
+  fontWeight: 600,
+  fontSize: '0.875rem',
+  cursor: 'pointer',
+  boxShadow: '0 8px 25px -5px rgba(102, 126, 234, 0.4)',
+  transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+  backdropFilter: 'blur(10px)',
+  selectors: {
+    '&:hover': {
+      transform: 'translateY(-2px)',
+      boxShadow: '0 12px 32px -5px rgba(102, 126, 234, 0.6)',
+    },
+    '&:active': {
+      transform: 'translateY(0)',
+    },
+  },
+});
+
+export const devPanel = recipe({
+  base: {
+    position: 'fixed',
+    top: 0,
+    width: '420px',
+    height: '100vh',
+    background: 'linear-gradient(to bottom, #ffffff 0%, #f8fafc 100%)',
+    borderLeft: '1px solid #e2e8f0',
+    boxShadow: '-20px 0 40px -10px rgba(0, 0, 0, 0.15)',
+    zIndex: 9999,
+    transition: 'right 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+    backdropFilter: 'blur(10px)',
+  },
+  variants: {
+    isOpen: {
+      open: { right: '0' },
+      closed: { right: '-420px' },
+    },
+  },
+  defaultVariants: { isOpen: 'closed' },
+});
+
+export const devHeader = style({
+  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  color: 'white',
+  padding: '1.5rem',
+  fontWeight: 700,
+  fontSize: '1.1rem',
+  textAlign: 'center',
+  boxShadow: '0 4px 12px rgba(102, 126, 234, 0.2)',
+  position: 'relative',
+  selectors: {
+    '&::after': {
+      content: "''",
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      height: '1px',
+      background: 'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent)',
+    },
+  },
+});
+
+export const devContent = style({
+  padding: '1.5rem',
+  maxHeight: 'calc(100vh - 120px)',
+  overflowY: 'auto',
+  scrollbarWidth: 'thin',
+  scrollbarColor: '#cbd5e1 transparent',
+});
+
+globalStyle(`${devContent}::-webkit-scrollbar`, { width: '6px' });
+globalStyle(`${devContent}::-webkit-scrollbar-track`, { background: 'transparent' });
+globalStyle(`${devContent}::-webkit-scrollbar-thumb`, {
+  background: '#cbd5e1',
+  borderRadius: '3px',
+});
+globalStyle(`${devContent}::-webkit-scrollbar-thumb:hover`, { background: '#94a3b8' });
+
+export const userCard = style({
+  display: 'block',
+  width: '100%',
+  background: 'linear-gradient(135deg, #ffffff 0%, #f8fafc 100%)',
+  border: '1px solid #e2e8f0',
+  borderRadius: '12px',
+  padding: '1.25rem',
+  marginBottom: '1rem',
+  cursor: 'pointer',
+  transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+  textAlign: 'left',
+  position: 'relative',
+  overflow: 'hidden',
+  selectors: {
+    '&::before': {
+      content: "''",
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '4px',
+      height: '100%',
+      background: 'linear-gradient(to bottom, #667eea, #764ba2)',
+      transform: 'scaleY(0)',
+      transition: 'transform 0.3s ease',
+    },
+    '&:hover': {
+      borderColor: '#667eea',
+      background: 'linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%)',
+      transform: 'translateY(-2px)',
+      boxShadow: '0 12px 25px -5px rgba(102, 126, 234, 0.25)',
+    },
+    '&:hover::before': {
+      transform: 'scaleY(1)',
+    },
+    '&:active': {
+      transform: 'translateY(0)',
+    },
+    '&:disabled': {
+      opacity: 0.6,
+      cursor: 'not-allowed',
+      background: '#f1f5f9',
+    },
+    '&:disabled:hover': {
+      transform: 'none',
+      boxShadow: 'none',
+    },
+  },
+});
+
+export const userName = style({
+  fontWeight: 700,
+  color: '#1e293b',
+  marginBottom: '0.5rem',
+  fontSize: '1rem',
+  letterSpacing: '-0.025em',
+});
+
+export const userEmail = style({
+  color: '#64748b',
+  fontSize: '0.875rem',
+  marginBottom: '0.5rem',
+  fontFamily: "'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif",
+});
+
+export const userDescription = style({
+  color: '#475569',
+  fontSize: '0.8rem',
+  lineHeight: '1.4',
+  fontStyle: 'italic',
+  opacity: 0.9,
+});
+
+export const currentUserPanel = style({
+  background: 'linear-gradient(135deg, #ecfdf5 0%, #f0fdf4 100%)',
+  border: '1px solid #86efac',
+  borderRadius: '12px',
+  padding: '1.5rem',
+  marginBottom: '1.5rem',
+  boxShadow: '0 4px 12px rgba(34, 197, 94, 0.1)',
+});
+
+globalStyle(`${currentUserPanel} h4`, {
+  margin: '0 0 0.75rem 0',
+  color: '#166534',
+  fontSize: '1rem',
+  fontWeight: 700,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+});
+
+globalStyle(`${currentUserPanel} h4::before`, {
+  content: "'👤'",
+  fontSize: '1.2rem',
+});
+
+export const logoutButton = style({
+  width: '100%',
+  padding: '0.75rem 1rem',
+  background: 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)',
+  color: 'white',
+  border: 'none',
+  borderRadius: '8px',
+  cursor: 'pointer',
+  fontSize: '0.875rem',
+  fontWeight: 600,
+  marginTop: '0.75rem',
+  transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+  boxShadow: '0 4px 12px rgba(239, 68, 68, 0.3)',
+  selectors: {
+    '&:hover': {
+      transform: 'translateY(-1px)',
+      boxShadow: '0 8px 20px rgba(239, 68, 68, 0.4)',
+    },
+    '&:active': {
+      transform: 'translateY(0)',
+    },
+  },
+});
+
+export const warningBanner = style({
+  background: 'linear-gradient(135deg, #fef3c7 0%, #fef7cd 100%)',
+  color: '#92400e',
+  padding: '1rem',
+  borderRadius: '12px',
+  fontSize: '0.875rem',
+  marginBottom: '1.5rem',
+  border: '1px solid #fbbf24',
+  boxShadow: '0 4px 12px rgba(251, 191, 36, 0.15)',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  selectors: {
+    '&::before': {
+      content: "'⚠️'",
+      fontSize: '1.2rem',
+    },
+  },
+});

--- a/lib.dev-tools/src/components/DevPanel.tsx
+++ b/lib.dev-tools/src/components/DevPanel.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { EtherealCredentialsPanel } from './EtherealCredentialsPanel';
 import { isDevelopmentMode } from '../index';
 import { useSeededUsers } from '../hooks/useSeededUsers';
+import * as styles from './DevPanel.css';
 
 // Dev user interface extending base User type
 export interface DevUser {
@@ -46,244 +46,6 @@ export interface DevPanelProps {
   userTypes?: string[];
   useApiData?: boolean;
 }
-
-// Styled components
-const DevToggle = styled.button`
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  z-index: 10000;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border: none;
-  padding: 0.75rem 1.25rem;
-  border-radius: 12px;
-  font-weight: 600;
-  font-size: 0.875rem;
-  cursor: pointer;
-  box-shadow: 0 8px 25px -5px rgba(102, 126, 234, 0.4);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  backdrop-filter: blur(10px);
-
-  &:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 12px 32px -5px rgba(102, 126, 234, 0.6);
-  }
-
-  &:active {
-    transform: translateY(0);
-  }
-`;
-
-const DevPanel = styled.div<{ $isOpen: boolean }>`
-  position: fixed;
-  top: 0;
-  right: ${(props) => (props.$isOpen ? '0' : '-420px')};
-  width: 420px;
-  height: 100vh;
-  background: linear-gradient(to bottom, #ffffff 0%, #f8fafc 100%);
-  border-left: 1px solid #e2e8f0;
-  box-shadow: -20px 0 40px -10px rgba(0, 0, 0, 0.15);
-  z-index: 9999;
-  transition: right 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-  backdrop-filter: blur(10px);
-`;
-
-const DevHeader = styled.div`
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  padding: 1.5rem;
-  font-weight: 700;
-  font-size: 1.1rem;
-  text-align: center;
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
-  position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
-  }
-`;
-
-const DevContent = styled.div`
-  padding: 1.5rem;
-  max-height: calc(100vh - 120px);
-  overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: #cbd5e1 transparent;
-
-  &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: #cbd5e1;
-    border-radius: 3px;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background: #94a3b8;
-  }
-`;
-
-const UserCard = styled.button`
-  display: block;
-  width: 100%;
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 1.25rem;
-  margin-bottom: 1rem;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  text-align: left;
-  position: relative;
-  overflow: hidden;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 4px;
-    height: 100%;
-    background: linear-gradient(to bottom, #667eea, #764ba2);
-    transform: scaleY(0);
-    transition: transform 0.3s ease;
-  }
-
-  &:hover {
-    border-color: #667eea;
-    background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-    transform: translateY(-2px);
-    box-shadow: 0 12px 25px -5px rgba(102, 126, 234, 0.25);
-
-    &::before {
-      transform: scaleY(1);
-    }
-  }
-
-  &:active {
-    transform: translateY(0);
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-    background: #f1f5f9;
-
-    &:hover {
-      transform: none;
-      box-shadow: none;
-    }
-  }
-`;
-
-const UserName = styled.div`
-  font-weight: 700;
-  color: #1e293b;
-  margin-bottom: 0.5rem;
-  font-size: 1rem;
-  letter-spacing: -0.025em;
-`;
-
-const UserEmail = styled.div`
-  color: #64748b;
-  font-size: 0.875rem;
-  margin-bottom: 0.5rem;
-  font-family:
-    'Segoe UI',
-    -apple-system,
-    BlinkMacSystemFont,
-    sans-serif;
-`;
-
-const UserDescription = styled.div`
-  color: #475569;
-  font-size: 0.8rem;
-  line-height: 1.4;
-  font-style: italic;
-  opacity: 0.9;
-`;
-
-const CurrentUserPanel = styled.div`
-  background: linear-gradient(135deg, #ecfdf5 0%, #f0fdf4 100%);
-  border: 1px solid #86efac;
-  border-radius: 12px;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  box-shadow: 0 4px 12px rgba(34, 197, 94, 0.1);
-
-  h4 {
-    margin: 0 0 0.75rem 0;
-    color: #166534;
-    font-size: 1rem;
-    font-weight: 700;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-
-    &::before {
-      content: '👤';
-      font-size: 1.2rem;
-    }
-  }
-`;
-
-const LogoutButton = styled.button`
-  width: 100%;
-  padding: 0.75rem 1rem;
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 0.875rem;
-  font-weight: 600;
-  margin-top: 0.75rem;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
-
-  &:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 8px 20px rgba(239, 68, 68, 0.4);
-  }
-
-  &:active {
-    transform: translateY(0);
-  }
-`;
-
-const WarningBanner = styled.div`
-  background: linear-gradient(135deg, #fef3c7 0%, #fef7cd 100%);
-  color: #92400e;
-  padding: 1rem;
-  border-radius: 12px;
-  font-size: 0.875rem;
-  margin-bottom: 1.5rem;
-  border: 1px solid #fbbf24;
-  box-shadow: 0 4px 12px rgba(251, 191, 36, 0.15);
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-
-  &::before {
-    content: '⚠️';
-    font-size: 1.2rem;
-  }
-`;
 
 export const DevPanelComponent: React.FC<DevPanelProps> = ({
   title,
@@ -336,26 +98,30 @@ export const DevPanelComponent: React.FC<DevPanelProps> = ({
 
   return (
     <>
-      <DevToggle onClick={() => setIsOpen(!isOpen)}>🔧 DEV LOGIN</DevToggle>
+      <button className={styles.devToggle} onClick={() => setIsOpen(!isOpen)}>
+        🔧 DEV LOGIN
+      </button>
 
-      <DevPanel $isOpen={isOpen}>
-        <DevHeader>{title}</DevHeader>
+      <div className={styles.devPanel({ isOpen: isOpen ? 'open' : 'closed' })}>
+        <div className={styles.devHeader}>{title}</div>
 
-        <DevContent>
-          <WarningBanner>
+        <div className={styles.devContent}>
+          <div className={styles.warningBanner}>
             ⚠️ Development only - uses backend seeded users with real authentication
-          </WarningBanner>
+          </div>
 
           {isAuthenticated && user && (
-            <CurrentUserPanel>
+            <div className={styles.currentUserPanel}>
               <h4>Currently Logged In:</h4>
-              <UserName>
+              <div className={styles.userName}>
                 {user.firstName} {user.lastName}
-              </UserName>
-              <UserEmail>{user.email}</UserEmail>
-              <UserDescription>User Type: {user.userType}</UserDescription>
-              <LogoutButton onClick={handleLogout}>🚪 Logout</LogoutButton>
-            </CurrentUserPanel>
+              </div>
+              <div className={styles.userEmail}>{user.email}</div>
+              <div className={styles.userDescription}>User Type: {user.userType}</div>
+              <button className={styles.logoutButton} onClick={handleLogout}>
+                🚪 Logout
+              </button>
+            </div>
           )}
 
           {/* Ethereal Email Credentials */}
@@ -389,20 +155,21 @@ export const DevPanelComponent: React.FC<DevPanelProps> = ({
           )}
 
           {users.map((devUser: DevUser) => (
-            <UserCard
+            <button
+              className={styles.userCard}
               key={devUser.userId}
               onClick={() => handleUserLogin(devUser)}
               disabled={isAuthenticated && user?.email === devUser.email}
             >
-              <UserName>
+              <div className={styles.userName}>
                 {devUser.firstName} {devUser.lastName}
-              </UserName>
-              <UserEmail>{devUser.email}</UserEmail>
-              <UserDescription>{devUser.description}</UserDescription>
-            </UserCard>
+              </div>
+              <div className={styles.userEmail}>{devUser.email}</div>
+              <div className={styles.userDescription}>{devUser.description}</div>
+            </button>
           ))}
-        </DevContent>
-      </DevPanel>
+        </div>
+      </div>
     </>
   );
 };

--- a/lib.dev-tools/src/components/EtherealCredentialsPanel.css.ts
+++ b/lib.dev-tools/src/components/EtherealCredentialsPanel.css.ts
@@ -1,0 +1,90 @@
+import { style } from '@vanilla-extract/css';
+
+export const etherealSection = style({
+  background: 'linear-gradient(135deg, #eff6ff 0%, #f0f9ff 100%)',
+  border: '1px solid #7dd3fc',
+  borderRadius: '12px',
+  padding: '1.5rem',
+  marginBottom: '1.5rem',
+  boxShadow: '0 4px 12px rgba(14, 165, 233, 0.1)',
+  position: 'relative',
+  selectors: {
+    '&::before': {
+      content: "''",
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      height: '3px',
+      background: 'linear-gradient(90deg, #0ea5e9, #06b6d4)',
+      borderRadius: '12px 12px 0 0',
+    },
+  },
+});
+
+export const etherealHeader = style({
+  margin: '0 0 1rem 0',
+  color: '#0c4a6e',
+  fontSize: '1rem',
+  fontWeight: 700,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  selectors: {
+    '&::before': {
+      content: "'📧'",
+      fontSize: '1.2rem',
+    },
+  },
+});
+
+export const credentialRow = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: '0.5rem',
+  fontSize: '0.8rem',
+});
+
+export const credentialLabel = style({
+  color: '#64748b',
+  fontWeight: 500,
+});
+
+export const credentialValue = style({
+  color: '#1e293b',
+  fontFamily: "'Courier New', monospace",
+  background: 'rgba(255, 255, 255, 0.8)',
+  padding: '0.25rem 0.5rem',
+  borderRadius: '3px',
+  fontSize: '0.75rem',
+  cursor: 'pointer',
+  transition: 'background-color 0.2s ease',
+  selectors: {
+    '&:hover': {
+      background: 'rgba(255, 255, 255, 1)',
+    },
+  },
+});
+
+export const etherealButton = style({
+  background: '#0ea5e9',
+  color: 'white',
+  border: 'none',
+  padding: '0.5rem 1rem',
+  borderRadius: '4px',
+  fontSize: '0.8rem',
+  cursor: 'pointer',
+  marginRight: '0.5rem',
+  marginBottom: '0.5rem',
+  transition: 'background-color 0.2s ease',
+  selectors: {
+    '&:hover': {
+      background: '#0284c7',
+    },
+    '&:disabled': {
+      background: '#94a3b8',
+      cursor: 'not-allowed',
+    },
+  },
+});

--- a/lib.dev-tools/src/components/EtherealCredentialsPanel.tsx
+++ b/lib.dev-tools/src/components/EtherealCredentialsPanel.tsx
@@ -1,92 +1,6 @@
 import React from 'react';
-import styled from 'styled-components';
 import { useEtherealCredentials } from '../hooks/useEtherealCredentials';
-
-const EtherealSection = styled.div`
-  background: linear-gradient(135deg, #eff6ff 0%, #f0f9ff 100%);
-  border: 1px solid #7dd3fc;
-  border-radius: 12px;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  box-shadow: 0 4px 12px rgba(14, 165, 233, 0.1);
-  position: relative;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: linear-gradient(90deg, #0ea5e9, #06b6d4);
-    border-radius: 12px 12px 0 0;
-  }
-`;
-
-const EtherealHeader = styled.h4`
-  margin: 0 0 1rem 0;
-  color: #0c4a6e;
-  font-size: 1rem;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-
-  &::before {
-    content: '📧';
-    font-size: 1.2rem;
-  }
-`;
-
-const CredentialRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-  font-size: 0.8rem;
-`;
-
-const CredentialLabel = styled.span`
-  color: #64748b;
-  font-weight: 500;
-`;
-
-const CredentialValue = styled.span`
-  color: #1e293b;
-  font-family: 'Courier New', monospace;
-  background: rgba(255, 255, 255, 0.8);
-  padding: 0.25rem 0.5rem;
-  border-radius: 3px;
-  font-size: 0.75rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background: rgba(255, 255, 255, 1);
-  }
-`;
-
-const EtherealButton = styled.button`
-  background: #0ea5e9;
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  font-size: 0.8rem;
-  cursor: pointer;
-  margin-right: 0.5rem;
-  margin-bottom: 0.5rem;
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background: #0284c7;
-  }
-
-  &:disabled {
-    background: #94a3b8;
-    cursor: not-allowed;
-  }
-`;
+import * as styles from './EtherealCredentialsPanel.css';
 
 interface EtherealCredentialsPanelProps {
   className?: string;
@@ -123,37 +37,45 @@ export const EtherealCredentialsPanel: React.FC<EtherealCredentialsPanelProps> =
   };
 
   return (
-    <EtherealSection className={className}>
-      <EtherealHeader>📧 Ethereal Email Testing</EtherealHeader>
+    <div className={`${styles.etherealSection}${className ? ` ${className}` : ''}`}>
+      <h4 className={styles.etherealHeader}>📧 Ethereal Email Testing</h4>
       {loading ? (
         <div style={{ color: '#64748b', fontSize: '0.8rem' }}>Loading credentials...</div>
       ) : credentials ? (
         <>
-          <CredentialRow>
-            <CredentialLabel>Username:</CredentialLabel>
-            <CredentialValue
+          <div className={styles.credentialRow}>
+            <span className={styles.credentialLabel}>Username:</span>
+            <span
+              className={styles.credentialValue}
               onClick={() => copyToClipboard(credentials.user)}
               title="Click to copy"
             >
               {credentials.user}
-            </CredentialValue>
-          </CredentialRow>
-          <CredentialRow>
-            <CredentialLabel>Password:</CredentialLabel>
-            <CredentialValue
+            </span>
+          </div>
+          <div className={styles.credentialRow}>
+            <span className={styles.credentialLabel}>Password:</span>
+            <span
+              className={styles.credentialValue}
               onClick={() => copyToClipboard(credentials.pass)}
               title="Click to copy"
             >
               {credentials.pass}
-            </CredentialValue>
-          </CredentialRow>
+            </span>
+          </div>
           <div style={{ marginTop: '0.75rem' }}>
-            <EtherealButton onClick={() => window.open(credentials.loginUrl, '_blank')}>
+            <button
+              className={styles.etherealButton}
+              onClick={() => window.open(credentials.loginUrl, '_blank')}
+            >
               🔐 Login to Ethereal
-            </EtherealButton>
-            <EtherealButton onClick={() => window.open(credentials.messagesUrl, '_blank')}>
+            </button>
+            <button
+              className={styles.etherealButton}
+              onClick={() => window.open(credentials.messagesUrl, '_blank')}
+            >
               📬 View Messages
-            </EtherealButton>
+            </button>
           </div>
           <div style={{ marginTop: '0.5rem', fontSize: '0.75rem', color: '#64748b' }}>
             Use these credentials to access test emails on Ethereal.email
@@ -164,6 +86,6 @@ export const EtherealCredentialsPanel: React.FC<EtherealCredentialsPanelProps> =
           📧 Mock ethereal credentials loaded for development
         </div>
       )}
-    </EtherealSection>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary

- Replace all styled-components in `DevPanel.tsx` and `EtherealCredentialsPanel.tsx` with Vanilla Extract CSS
- Create `DevPanel.css.ts` and `EtherealCredentialsPanel.css.ts` with equivalent styles using `style()`, `recipe()`, and `globalStyle()`
- Add `src/__mocks__/vanillaExtractMock.js` so Jest can handle `.css.ts` imports
- Remove `styled-components` and `@types/styled-components` dependencies; add `@vanilla-extract/css` and `@vanilla-extract/recipes`
- Update `jest.config.cjs` with `moduleNameMapper` for `.css.ts` files

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/lib.dev-tools` passes
- [x] `tsc --noEmit` passes with no type errors
- [ ] Visual review: dev panel slides in/out correctly, user cards hover as expected

https://claude.ai/code/session_01J97yCAVnLEW9Hzv2QqdEHb

---
_Generated by [Claude Code](https://claude.ai/code/session_01J97yCAVnLEW9Hzv2QqdEHb)_