### PR TITLE
fix(rbac): correct permission field in requirePermissionOrOwnership (ADS-312)

### DIFF
--- a/service.backend/src/__tests__/middleware/rbac.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/rbac.middleware.test.ts
@@ -447,13 +447,57 @@ describe('RBAC Middleware', () => {
           Roles: [
             {
               name: 'admin',
-              Permissions: [{ name: 'pets:update' }],
+              Permissions: [{ permissionName: 'pets:update' }],
             },
           ],
         } as unknown as AuthenticatedRequest['user'];
         mockRequest.params = { petId: 'pet-456' };
 
         const middleware = requirePermissionOrOwnership('pets:update', 'petId');
+        middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockResponse.status).not.toHaveBeenCalled();
+      });
+
+      it('should allow access when user has permission on a different resource they do not own', () => {
+        mockRequest.user = {
+          userId: 'admin-123',
+          userType: UserType.ADMIN,
+          Roles: [
+            {
+              name: 'admin',
+              Permissions: [{ permissionName: 'users:read' }],
+            },
+          ],
+        } as unknown as AuthenticatedRequest['user'];
+        mockRequest.params = { userId: 'other-user-456' };
+
+        const middleware = requirePermissionOrOwnership('users:read', 'userId');
+        middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockResponse.status).not.toHaveBeenCalled();
+      });
+
+      it('should allow access when permission is found across multiple roles', () => {
+        mockRequest.user = {
+          userId: 'user-123',
+          userType: UserType.RESCUE_STAFF,
+          Roles: [
+            {
+              name: 'basic',
+              Permissions: [],
+            },
+            {
+              name: 'advanced',
+              Permissions: [{ permissionName: 'users:read' }],
+            },
+          ],
+        } as unknown as AuthenticatedRequest['user'];
+        mockRequest.params = { userId: 'other-user-456' };
+
+        const middleware = requirePermissionOrOwnership('users:read', 'userId');
         middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
 
         expect(mockNext).toHaveBeenCalled();

--- a/service.backend/src/middleware/rbac.ts
+++ b/service.backend/src/middleware/rbac.ts
@@ -128,8 +128,12 @@ export const requirePermissionOrOwnership = (
     }
 
     // Check if user has the required permission
+    // Type assertion justified: Sequelize associations don't always properly infer Permission type
     const hasPermission = req.user.Roles?.some(role =>
-      role.Permissions?.some(perm => perm.name === permission)
+      role.Permissions?.some(permission_obj => {
+        const perm = permission_obj as unknown as Permission;
+        return perm.permissionName === permission;
+      })
     );
 
     if (hasPermission) {


### PR DESCRIPTION
## Summary

- **Bug**: `requirePermissionOrOwnership` compared against `perm.name`, a field that does not exist on the `Permission` Sequelize model (the actual field is `permissionName`). The permission branch therefore always evaluated to `false`, and access was granted only via the ownership branch.
- **Fix**: Align with the existing `requirePermission` implementation — cast to `Permission` and read `permissionName` instead of `name`.
- **Test fix**: The existing "when user has permission" test used `{ name: 'pets:update' }` in the mock, which coincidentally matched the broken implementation and masked the bug in CI. Updated to `{ permissionName: 'pets:update' }`.
- **New tests**: Added cases for (a) permission match without ownership, (b) permission found across multiple roles, matching the acceptance criteria in ADS-312.

## Affected files

- `service.backend/src/middleware/rbac.ts` — one-line production fix
- `service.backend/src/__tests__/middleware/rbac.middleware.test.ts` — fix broken mock + 2 new test cases

## Test plan

- [x] All 44 RBAC middleware tests pass locally
- [x] `requirePermissionOrOwnership` now correctly grants access when user has the named permission but does not own the resource
- [x] Ownership-only path continues to work unchanged
- [x] 403 is still returned when neither permission nor ownership is satisfied

Closes ADS-312

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBRCYtkNwcRechV2f5Ab5s)_