### PR TITLE
fix: address 7 urgent security tickets (ADS-165, 209, 232, 233, 250, 251, 293)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,9 @@
       "Bash(find ./docs -name \"*.md\" -exec wc -l {})",
       "Bash(cat:*)",
       "Bash(test:*)",
-      "Bash(timeout /t 30 npm test -- email.service.test.ts --maxWorkers=1)"
+      "Bash(timeout /t 30 npm test -- email.service.test.ts --maxWorkers=1)",
+      "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__list_issues",
+      "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__get_issue"
     ],
     "deny": [],
     "ask": []

--- a/app.admin/src/services/authService.ts
+++ b/app.admin/src/services/authService.ts
@@ -9,17 +9,9 @@ import {
 import { apiService } from './libraryServices';
 
 class AuthService {
-  // Token management helpers
-  private setToken(token: string): void {
-    localStorage.setItem('authToken', token);
-    localStorage.setItem('accessToken', token); // Keep both for compatibility
-  }
-
-  private clearToken(): void {
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+  private clearUserData(): void {
     localStorage.removeItem('user');
+    localStorage.removeItem('impersonating');
   }
 
   // Login admin user
@@ -29,16 +21,8 @@ class AuthService {
 
     const response = await apiService.post<AuthResponse>('/api/v1/auth/admin/login', credentials);
 
-    // Store tokens and user data
-    localStorage.setItem('authToken', response.token);
-    localStorage.setItem('accessToken', response.token); // Keep both for compatibility
-    if (response.refreshToken) {
-      localStorage.setItem('refreshToken', response.refreshToken);
-    }
+    // Store only non-sensitive user data; tokens are in HttpOnly cookies
     localStorage.setItem('user', JSON.stringify(response.user));
-
-    // Set token in API service
-    this.setToken(response.token);
 
     return response;
   }
@@ -47,16 +31,8 @@ class AuthService {
   async register(userData: RegisterRequest): Promise<AuthResponse> {
     const response = await apiService.post<AuthResponse>('/api/v1/auth/admin/register', userData);
 
-    // Store tokens and user data
-    localStorage.setItem('authToken', response.token);
-    localStorage.setItem('accessToken', response.token); // Keep both for compatibility
-    if (response.refreshToken) {
-      localStorage.setItem('refreshToken', response.refreshToken);
-    }
+    // Store only non-sensitive user data; tokens are in HttpOnly cookies
     localStorage.setItem('user', JSON.stringify(response.user));
-
-    // Set token in API service
-    this.setToken(response.token);
 
     return response;
   }
@@ -69,14 +45,7 @@ class AuthService {
       // Continue with logout even if API call fails
       console.error('Logout API call failed:', error);
     } finally {
-      // Clear local storage
-      localStorage.removeItem('authToken');
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
-      localStorage.removeItem('user');
-
-      // Clear token from API service
-      this.clearToken();
+      this.clearUserData();
     }
   }
 
@@ -95,12 +64,9 @@ class AuthService {
     }
   }
 
-  // Check if admin is authenticated
+  // Check if admin is authenticated (user data present; token is in HttpOnly cookie)
   isAuthenticated(): boolean {
-    return (
-      !!(localStorage.getItem('authToken') || localStorage.getItem('accessToken')) &&
-      !!this.getCurrentUser()
-    );
+    return !!this.getCurrentUser();
   }
 
   // Check if current user has specific admin role
@@ -120,29 +86,9 @@ class AuthService {
     return user !== null && (ADMIN_USER_TYPES as readonly string[]).includes(user.userType);
   }
 
-  // Refresh access token
-  async refreshToken(): Promise<string> {
-    const refreshToken = localStorage.getItem('refreshToken');
-    if (!refreshToken) {
-      throw new Error('No refresh token available');
-    }
-
-    const response = await apiService.post<{ token: string; refreshToken: string }>(
-      '/api/v1/auth/admin/refresh-token',
-      {
-        refreshToken,
-      }
-    );
-
-    // Update stored tokens
-    localStorage.setItem('authToken', response.token);
-    localStorage.setItem('accessToken', response.token); // Keep both for compatibility
-    localStorage.setItem('refreshToken', response.refreshToken);
-
-    // Set token in API service
-    this.setToken(response.token);
-
-    return response.token;
+  // Refresh access token (cookie-based — no body token needed)
+  async refreshToken(): Promise<void> {
+    await apiService.post('/api/v1/auth/admin/refresh-token', {});
   }
 
   // Update admin profile
@@ -186,53 +132,35 @@ class AuthService {
   }
 
   // Impersonate user (super admin only)
-  async impersonateUser(userId: string): Promise<{ originalToken: string }> {
+  async impersonateUser(userId: string): Promise<void> {
     if (!this.isSuperAdmin()) {
       throw new Error('Only super admins can impersonate users');
     }
 
-    const originalToken = localStorage.getItem('authToken') || '';
-
-    const response = await apiService.post<{ token: string; user: User }>(
+    const response = await apiService.post<{ user: User }>(
       '/api/v1/admin/impersonate',
       { userId: userId }
     );
 
-    // Store impersonation token
-    localStorage.setItem('authToken', response.token);
-    localStorage.setItem('accessToken', response.token);
-    localStorage.setItem('impersonation_original_token', originalToken);
+    // Track impersonation state; token is managed via HttpOnly cookie by the server
+    localStorage.setItem('impersonating', 'true');
     localStorage.setItem('user', JSON.stringify(response.user));
-
-    // Set token in API service
-    this.setToken(response.token);
-
-    return { originalToken };
   }
 
   // Stop impersonation
   async stopImpersonation(): Promise<void> {
-    const originalToken = localStorage.getItem('impersonation_original_token');
-    if (!originalToken) {
-      throw new Error('No impersonation session found');
-    }
+    await apiService.post('/api/v1/admin/impersonate/stop', {});
 
-    // Restore original token
-    localStorage.setItem('authToken', originalToken);
-    localStorage.setItem('accessToken', originalToken);
-    localStorage.removeItem('impersonation_original_token');
+    localStorage.removeItem('impersonating');
 
-    // Get original user data
+    // Refresh user data from server
     const response = await apiService.get<User>('/api/v1/admin/profile');
     localStorage.setItem('user', JSON.stringify(response));
-
-    // Set token in API service
-    this.setToken(originalToken);
   }
 
   // Check if currently impersonating
   isImpersonating(): boolean {
-    return !!localStorage.getItem('impersonation_original_token');
+    return !!localStorage.getItem('impersonating');
   }
 }
 

--- a/app.admin/src/services/authService.ts
+++ b/app.admin/src/services/authService.ts
@@ -137,10 +137,9 @@ class AuthService {
       throw new Error('Only super admins can impersonate users');
     }
 
-    const response = await apiService.post<{ user: User }>(
-      '/api/v1/admin/impersonate',
-      { userId: userId }
-    );
+    const response = await apiService.post<{ user: User }>('/api/v1/admin/impersonate', {
+      userId: userId,
+    });
 
     // Track impersonation state; token is managed via HttpOnly cookie by the server
     localStorage.setItem('impersonating', 'true');

--- a/app.admin/src/services/libraryServices.ts
+++ b/app.admin/src/services/libraryServices.ts
@@ -1,13 +1,9 @@
 import { ApiService, AuthenticationError } from '@adopt-dont-shop/lib.api';
 
-// Create the global API service instance with auth token function
+// Create the global API service instance (tokens are in HttpOnly cookies)
 export const globalApiService = new ApiService({
   apiUrl: import.meta.env.VITE_API_BASE_URL ?? '',
   debug: import.meta.env.DEV,
-  // Provide function to get auth token from localStorage
-  getAuthToken: () => {
-    return localStorage.getItem('authToken') || localStorage.getItem('accessToken');
-  },
 });
 
 // Add error interceptor for handling 401 responses
@@ -16,9 +12,7 @@ globalApiService.interceptors.addErrorInterceptor((error: unknown) => {
     error instanceof AuthenticationError ||
     (error as { response?: { status?: number } })?.response?.status === 401
   ) {
-    // Clear authentication token
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('accessToken');
+    // Clear non-sensitive user data
     localStorage.removeItem('user');
 
     // Redirect to login page

--- a/app.client/src/contexts/base/devUtils.ts
+++ b/app.client/src/contexts/base/devUtils.ts
@@ -108,6 +108,5 @@ export const devAuthUtils: DevAuthUtils = {
   setDevUser,
   clearDevUser,
   createMockToken,
-  isDevTokenValid,
   clearDevTokens,
 };

--- a/app.client/src/contexts/base/devUtils.ts
+++ b/app.client/src/contexts/base/devUtils.ts
@@ -10,13 +10,10 @@ export interface DevAuthUtils {
   setDevUser: (user: User) => void;
   clearDevUser: () => void;
   createMockToken: (userId: string) => string;
-  isDevTokenValid: (token: string | null) => boolean;
   clearDevTokens: () => void;
 }
 
 const DEV_USER_KEY = 'dev_user';
-const ACCESS_TOKEN_KEY = 'accessToken';
-const AUTH_TOKEN_KEY = 'authToken';
 
 /**
  * Get development user from localStorage
@@ -43,13 +40,8 @@ export const setDevUser = (user: User): void => {
     return;
   }
 
-  // Store dev user
+  // Store dev user data (tokens are in HttpOnly cookies)
   localStorage.setItem(DEV_USER_KEY, JSON.stringify(user));
-
-  // Create and store mock token
-  const mockToken = createMockToken(user.userId);
-  localStorage.setItem(ACCESS_TOKEN_KEY, mockToken);
-  localStorage.setItem(AUTH_TOKEN_KEY, mockToken);
 };
 
 /**
@@ -72,28 +64,10 @@ export const createMockToken = (userId: string): string => {
 };
 
 /**
- * Check if a token is a valid dev token
- */
-export const isDevTokenValid = (token: string | null): boolean => {
-  if (!import.meta.env.DEV || !token) {
-    return false;
-  }
-  return token.startsWith('dev-token-');
-};
-
-/**
- * Clear development tokens
+ * Clear development tokens (no-op: tokens are in HttpOnly cookies)
  */
 export const clearDevTokens = (): void => {
-  if (!import.meta.env.DEV) {
-    return;
-  }
-
-  const token = localStorage.getItem(ACCESS_TOKEN_KEY);
-  if (isDevTokenValid(token)) {
-    localStorage.removeItem(ACCESS_TOKEN_KEY);
-    localStorage.removeItem(AUTH_TOKEN_KEY);
-  }
+  // Tokens are stored in HttpOnly cookies — nothing to clear from localStorage
 };
 
 /**
@@ -108,14 +82,6 @@ export const initializeDevAuth = (): User | null => {
   const devUser = getDevUser();
   if (!devUser) {
     return null;
-  }
-
-  // Ensure dev user has a mock token
-  const existingToken = localStorage.getItem(ACCESS_TOKEN_KEY);
-  if (!isDevTokenValid(existingToken)) {
-    const mockToken = createMockToken(devUser.userId);
-    localStorage.setItem(ACCESS_TOKEN_KEY, mockToken);
-    localStorage.setItem(AUTH_TOKEN_KEY, mockToken);
   }
 
   return devUser;

--- a/app.client/src/pages/ProfilePage.tsx
+++ b/app.client/src/pages/ProfilePage.tsx
@@ -321,20 +321,6 @@ export const ProfilePage: React.FC = () => {
     try {
       setError(null);
 
-      // In dev mode, check if using dev token before calling API
-      if (import.meta.env.DEV) {
-        const token = localStorage.getItem('accessToken');
-        if (token?.startsWith('dev-token-')) {
-          // Clear dev mode data
-          localStorage.removeItem('dev_user');
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('authToken');
-          localStorage.removeItem('user_settings');
-          navigate('/');
-          return;
-        }
-      }
-
       // Call the API to delete account
       await authService.deleteAccount('User requested account deletion');
 

--- a/app.rescue/src/__mocks__/components.tsx
+++ b/app.rescue/src/__mocks__/components.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => <>{children}</>;
-export const Container = ({ children, ...props }: any) => <div {...props}>{children}</div>;
-export const Card = ({ children, ...props }: any) => <div {...props}>{children}</div>;
-export const Button = ({ children, ...props }: any) => <button {...props}>{children}</button>;
-export const Text = ({ children, ...props }: any) => <span {...props}>{children}</span>;
-export const Heading = ({ children, ...props }: any) => <h1 {...props}>{children}</h1>;
+export const Container = (props: React.ComponentPropsWithoutRef<'div'>) => <div {...props} />;
+export const Card = (props: React.ComponentPropsWithoutRef<'div'>) => <div {...props} />;
+export const Button = (props: React.ComponentPropsWithoutRef<'button'>) => <button {...props} />;
+export const Text = (props: React.ComponentPropsWithoutRef<'span'>) => <span {...props} />;
+export const Heading = (props: React.ComponentPropsWithoutRef<'h1'>) => <h1 {...props} />;

--- a/app.rescue/src/__mocks__/components.tsx
+++ b/app.rescue/src/__mocks__/components.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
 
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => <>{children}</>;
-export const Container = (props: React.ComponentPropsWithoutRef<'div'>) => <div {...props} />;
-export const Card = (props: React.ComponentPropsWithoutRef<'div'>) => <div {...props} />;
-export const Button = (props: React.ComponentPropsWithoutRef<'button'>) => <button {...props} />;
-export const Text = (props: React.ComponentPropsWithoutRef<'span'>) => <span {...props} />;
-export const Heading = (props: React.ComponentPropsWithoutRef<'h1'>) => <h1 {...props} />;
+export const Container = ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
+  <div {...props}>{children}</div>
+);
+export const Card = ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) => (
+  <div {...props}>{children}</div>
+);
+export const Button = ({ children, ...props }: React.ComponentPropsWithoutRef<'button'>) => (
+  <button {...props}>{children}</button>
+);
+export const Text = ({ children, ...props }: React.ComponentPropsWithoutRef<'span'>) => (
+  <span {...props}>{children}</span>
+);
+export const Heading = ({ children, ...props }: React.ComponentPropsWithoutRef<'h1'>) => (
+  <h1 {...props}>{children}</h1>
+);

--- a/app.rescue/src/__tests__/application-review.behavior.test.tsx
+++ b/app.rescue/src/__tests__/application-review.behavior.test.tsx
@@ -245,7 +245,7 @@ const server = setupServer(
 
   // Approve application
   http.patch('/api/v1/applications/:applicationId/approve', async ({ params, request }) => {
-    const body = (await request.json()) as { notes?: string };
+    const _body = (await request.json()) as { notes?: string };
     const application = mockApplications.find(a => a.applicationId === params.applicationId);
 
     if (!application) {

--- a/app.rescue/src/__tests__/pet-management.behavior.test.tsx
+++ b/app.rescue/src/__tests__/pet-management.behavior.test.tsx
@@ -10,7 +10,6 @@
  * - Staff experiences graceful error handling
  */
 
-import { renderWithProviders, screen, waitFor, userEvent } from '../test-utils';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { mswHandlers } from '../test-utils/msw-handlers';

--- a/app.rescue/src/components/ApplicationTimeline.tsx
+++ b/app.rescue/src/components/ApplicationTimeline.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { formatDateTime } from '@adopt-dont-shop/lib.utils';
 
 // Timeline Event Types (matching backend)
+// eslint-disable-next-line react-refresh/only-export-components
 export enum TimelineEventType {
   STAGE_CHANGE = 'stage_change',
   STATUS_UPDATE = 'status_update',
@@ -34,7 +35,7 @@ export interface TimelineEvent {
   event_type: TimelineEventType;
   title: string;
   description?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   created_by?: string;
   created_by_system?: boolean;
   created_at: string;

--- a/app.rescue/src/components/ErrorBoundary.tsx
+++ b/app.rescue/src/components/ErrorBoundary.tsx
@@ -182,7 +182,8 @@ class ErrorBoundary extends Component<Props, State> {
             <ErrorTitle>Oops! Something went wrong</ErrorTitle>
 
             <ErrorMessage>
-              We're sorry, but something unexpected happened. Don't worry, your data is safe.
+              We&apos;re sorry, but something unexpected happened. Don&apos;t worry, your data is
+              safe.
             </ErrorMessage>
 
             <ButtonContainer>

--- a/app.rescue/src/components/applications/ApplicationList.tsx
+++ b/app.rescue/src/components/applications/ApplicationList.tsx
@@ -6,6 +6,7 @@ import type {
   ApplicationFilter,
   ApplicationSort,
 } from '../../types/applications';
+import { ApplicationStatus } from '@adopt-dont-shop/lib.applications';
 import ApplicationStats from './ApplicationStats';
 import ApplicationFilters from './ApplicationFilters';
 
@@ -561,7 +562,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
         newFilter.searchQuery = value || undefined;
         break;
       case 'status':
-        newFilter.status = value ? [value as any] : undefined;
+        newFilter.status = value ? [value as ApplicationStatus] : undefined;
         break;
       case 'priority':
         newFilter.priority = value ? [value] : undefined;
@@ -662,7 +663,10 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
             value={`${sort.field}-${sort.direction}`}
             onChange={e => {
               const [field, direction] = e.target.value.split('-');
-              onSortChange({ field: field as any, direction: direction as 'asc' | 'desc' });
+              onSortChange({
+                field: field as ApplicationSort['field'],
+                direction: direction as 'asc' | 'desc',
+              });
             }}
           >
             <option value="submittedAt-desc">Newest First</option>

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -983,7 +983,7 @@ type ApplicationData = {
   userName?: string;
   submittedDaysAgo?: number;
   submittedAt?: string;
-  stage?: string;
+  stage?: ApplicationStage;
   references?: ApplicationReference[];
   data?: Record<string, unknown>;
 };
@@ -993,7 +993,8 @@ type ApplicationReference = {
   name?: string;
   relationship?: string;
   phone?: string;
-  status?: string;
+  clinicName?: string;
+  status?: 'pending' | 'contacted' | 'completed' | 'failed';
   notes?: string;
   contacted_at?: string;
   contacted_by?: string;
@@ -1222,16 +1223,19 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
   };
 
   // Helper function to safely extract data from both legacy nested and current flat structures
-  const getData = (path: string) => {
-    // Try current flat structure first: application.data.personalInfo
-    const flatPath = path.split('.').reduce((obj, key) => obj?.[key], application?.data);
-    if (flatPath !== undefined) {
-      return flatPath;
-    }
-
-    // Fallback to legacy nested structure: application.data.data.personalInfo
-    const nestedPath = path.split('.').reduce((obj, key) => obj?.[key], application?.data?.data);
-    return nestedPath;
+  const getData = (path: string): unknown => {
+    const keys = path.split('.');
+    const traverse = (start: unknown): unknown => {
+      let current = start;
+      for (const key of keys) {
+        if (current === null || current === undefined || typeof current !== 'object')
+          return undefined;
+        current = (current as Record<string, unknown>)[key];
+      }
+      return current;
+    };
+    const flat = traverse(application?.data);
+    return flat !== undefined ? flat : traverse(application?.data?.['data']);
   };
 
   // Extract references from application data
@@ -1256,9 +1260,11 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
       });
     } else {
       // Fallback: try to get references from nested client data structure
-      const clientRefs = getData('references') || {};
-      const personalRefs = clientRefs.personal || [];
-      const vetRef = clientRefs.veterinarian;
+      const clientRefs = (getData('references') ?? {}) as Record<string, unknown>;
+      const personalRefs = Array.isArray(clientRefs['personal'])
+        ? (clientRefs['personal'] as ApplicationReference[])
+        : [];
+      const vetRef = clientRefs['veterinarian'] as ApplicationReference | undefined;
 
       let referenceIndex = 0;
 
@@ -1300,6 +1306,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
     // References found and processed
 
     return allRefs;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- getData depends only on application, which is already listed
   }, [application]);
 
   const handleReferenceUpdate = async (referenceId: string, status: string, notes: string) => {
@@ -1575,7 +1582,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                 Submitted by{' '}
                 {application.applicantName ||
                   application.userName ||
-                  `${application.data?.personalInfo?.firstName || application.data?.data?.personalInfo?.firstName || 'Unknown'} ${application.data?.personalInfo?.lastName || application.data?.data?.personalInfo?.lastName || ''}`.trim() ||
+                  `${(getData('personalInfo.firstName') as string) || 'Unknown'} ${(getData('personalInfo.lastName') as string) || ''}`.trim() ||
                   'Unknown Applicant'}{' '}
                 •{' '}
                 {application.submittedDaysAgo !== undefined
@@ -2103,8 +2110,8 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                 <EmptyVisits>
                   <p>No home visits scheduled yet.</p>
                   <p>
-                    Schedule a home visit to assess the applicant's living situation and suitability
-                    for pet adoption.
+                    Schedule a home visit to assess the applicant&apos;s living situation and
+                    suitability for pet adoption.
                   </p>
                 </EmptyVisits>
               ) : (

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -975,8 +975,32 @@ const VisitDetailsHeader = styled.div`
   }
 `;
 
+type ApplicationData = {
+  id: string;
+  status: string;
+  petName?: string;
+  applicantName?: string;
+  userName?: string;
+  submittedDaysAgo?: number;
+  submittedAt?: string;
+  stage?: string;
+  references?: ApplicationReference[];
+  data?: Record<string, unknown>;
+};
+
+type ApplicationReference = {
+  id?: string;
+  name?: string;
+  relationship?: string;
+  phone?: string;
+  status?: string;
+  notes?: string;
+  contacted_at?: string;
+  contacted_by?: string;
+};
+
 interface ApplicationReviewProps {
-  application: any;
+  application: ApplicationData;
   references: ReferenceCheck[];
   homeVisits: HomeVisit[];
   timeline: ApplicationTimeline[];
@@ -992,9 +1016,9 @@ interface ApplicationReviewProps {
     assignedStaff: string;
     notes?: string;
   }) => void;
-  onUpdateVisit: (visitId: string, updateData: any) => void;
-  onAddTimelineEvent: (event: string, description: string, data?: any) => void;
-  onRefresh?: () => void; // Optional refresh function to update application data
+  onUpdateVisit: (visitId: string, updateData: Record<string, unknown>) => void;
+  onAddTimelineEvent: (event: string, description: string, data?: Record<string, unknown>) => void;
+  onRefresh?: () => void;
 }
 
 const ApplicationReview: React.FC<ApplicationReviewProps> = ({
@@ -1217,7 +1241,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
     // First, try to get references from the main references array (backend format)
     const directReferences = application?.references || [];
     if (Array.isArray(directReferences) && directReferences.length > 0) {
-      directReferences.forEach((ref: any, index: number) => {
+      directReferences.forEach((ref: ApplicationReference, index: number) => {
         allRefs.push({
           id: ref.id || `ref-${index}`, // Use the reference ID if available, fallback to index-based ID
           applicationId: application.id,
@@ -1255,7 +1279,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
       }
 
       // Add personal references
-      personalRefs.forEach((ref: any) => {
+      personalRefs.forEach((ref: ApplicationReference) => {
         if (ref.name) {
           allRefs.push({
             id: `ref-${referenceIndex}`,
@@ -1402,7 +1426,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
 
   const handleCompleteVisit = async (visitId: string) => {
     try {
-      const updateData: any = {
+      const updateData: Record<string, unknown> = {
         status: 'completed',
         outcome: completeForm.outcome,
         notes: completeForm.notes,
@@ -1826,7 +1850,13 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
               <Section>
                 <SectionTitle>Previous Pet Experience</SectionTitle>
                 <Grid>
-                  {getData('answers.previous_pets').map((pet: any, index: number) => (
+                  {(
+                    getData('answers.previous_pets') as Array<{
+                      type?: string;
+                      breed?: string;
+                      years_owned?: string;
+                    }>
+                  ).map((pet, index) => (
                     <Card key={index}>
                       <CardTitle>Previous Pet #{index + 1}</CardTitle>
                       <Field>

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -1238,6 +1238,12 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
     return flat !== undefined ? flat : traverse(application?.data?.['data']);
   };
 
+  const getStr = (path: string): string => (getData(path) as string | null | undefined) ?? '';
+  const getArr = (path: string): unknown[] => {
+    const val = getData(path);
+    return Array.isArray(val) ? val : [];
+  };
+
   // Extract references from application data
   const extractedReferences: ReferenceCheck[] = useMemo(() => {
     const allRefs: ReferenceCheck[] = [];
@@ -1250,7 +1256,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
           id: ref.id || `ref-${index}`, // Use the reference ID if available, fallback to index-based ID
           applicationId: application.id,
           type: ref.relationship?.toLowerCase().includes('vet') ? 'veterinarian' : 'personal',
-          contactName: ref.name,
+          contactName: ref.name ?? '',
           contactInfo: `${ref.phone} - ${ref.relationship}`,
           status: ref.status || 'pending',
           notes: ref.notes || '',
@@ -1582,7 +1588,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                 Submitted by{' '}
                 {application.applicantName ||
                   application.userName ||
-                  `${(getData('personalInfo.firstName') as string) || 'Unknown'} ${(getData('personalInfo.lastName') as string) || ''}`.trim() ||
+                  `${getStr('personalInfo.firstName') || 'Unknown'} ${getStr('personalInfo.lastName') || ''}`.trim() ||
                   'Unknown Applicant'}{' '}
                 •{' '}
                 {application.submittedDaysAgo !== undefined
@@ -1693,33 +1699,33 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   <Field>
                     <FieldLabel>Name</FieldLabel>
                     <FieldValue>
-                      {getData('personalInfo.firstName') || 'N/A'}{' '}
-                      {getData('personalInfo.lastName') || ''}
+                      {getStr('personalInfo.firstName') || 'N/A'}{' '}
+                      {getStr('personalInfo.lastName') || ''}
                     </FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Email</FieldLabel>
-                    <FieldValue>{getData('personalInfo.email') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('personalInfo.email') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Phone</FieldLabel>
-                    <FieldValue>{getData('personalInfo.phone') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('personalInfo.phone') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Address</FieldLabel>
                     <FieldValue>
-                      {getData('personalInfo.address') || 'N/A'}
+                      {getStr('personalInfo.address') || 'N/A'}
                       <br />
-                      {getData('personalInfo.city') || 'N/A'},{' '}
-                      {getData('personalInfo.state') || 'N/A'}{' '}
-                      {getData('personalInfo.zipCode') || 'N/A'}
+                      {getStr('personalInfo.city') || 'N/A'},{' '}
+                      {getStr('personalInfo.state') || 'N/A'}{' '}
+                      {getStr('personalInfo.zipCode') || 'N/A'}
                     </FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Date of Birth</FieldLabel>
                     <FieldValue>
-                      {getData('personalInfo.dateOfBirth')
-                        ? new Date(getData('personalInfo.dateOfBirth')).toLocaleDateString()
+                      {getStr('personalInfo.dateOfBirth')
+                        ? new Date(getStr('personalInfo.dateOfBirth')).toLocaleDateString()
                         : 'N/A'}
                     </FieldValue>
                   </Field>
@@ -1729,11 +1735,11 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   <CardTitle>Household</CardTitle>
                   <Field>
                     <FieldLabel>Household Size</FieldLabel>
-                    <FieldValue>{getData('livingsituation.householdSize') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('livingsituation.householdSize') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Housing Type</FieldLabel>
-                    <FieldValue>{getData('livingsituation.housingType') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('livingsituation.housingType') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Own/Rent</FieldLabel>
@@ -1752,7 +1758,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   <Field>
                     <FieldLabel>Household Members</FieldLabel>
                     <FieldValue>
-                      {getData('answers.household_members')?.length || 0} members
+                      {getArr('answers.household_members').length || 0} members
                     </FieldValue>
                   </Field>
                 </Card>
@@ -1766,7 +1772,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   <CardTitle>Experience & Preferences</CardTitle>
                   <Field>
                     <FieldLabel>Experience Level</FieldLabel>
-                    <FieldValue>{getData('petExperience.experienceLevel') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('petExperience.experienceLevel') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Willing to Train</FieldLabel>
@@ -1776,11 +1782,11 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   </Field>
                   <Field>
                     <FieldLabel>Hours Alone Daily</FieldLabel>
-                    <FieldValue>{getData('petExperience.hoursAloneDaily') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('petExperience.hoursAloneDaily') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Exercise Plans</FieldLabel>
-                    <FieldValue>{getData('petExperience.exercisePlans') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('petExperience.exercisePlans') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Currently Has Pets</FieldLabel>
@@ -1795,18 +1801,18 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   <Field>
                     <FieldLabel>Veterinarian</FieldLabel>
                     <FieldValue>
-                      {getData('references.veterinarian.name') || 'N/A'}
-                      {getData('references.veterinarian.clinicName') &&
-                        ` - ${getData('references.veterinarian.clinicName')}`}
+                      {getStr('references.veterinarian.name') || 'N/A'}
+                      {getStr('references.veterinarian.clinicName') &&
+                        ` - ${getStr('references.veterinarian.clinicName')}`}
                     </FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Vet Phone</FieldLabel>
-                    <FieldValue>{getData('references.veterinarian.phone') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('references.veterinarian.phone') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Personal References</FieldLabel>
-                    <FieldValue>{getData('references.personal')?.length || 0} provided</FieldValue>
+                    <FieldValue>{getArr('references.personal').length || 0} provided</FieldValue>
                   </Field>
                 </Card>
               </Grid>
@@ -1820,13 +1826,13 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   <FieldVertical>
                     <FieldLabel>Why Adopt</FieldLabel>
                     <FieldValueFullWidth>
-                      {getData('answers.why_adopt') || 'N/A'}
+                      {getStr('answers.why_adopt') || 'N/A'}
                     </FieldValueFullWidth>
                   </FieldVertical>
                   <FieldVertical>
                     <FieldLabel>Exercise Plan</FieldLabel>
                     <FieldValueFullWidth>
-                      {getData('answers.exercise_plan') || 'N/A'}
+                      {getStr('answers.exercise_plan') || 'N/A'}
                     </FieldValueFullWidth>
                   </FieldVertical>
                 </Card>
@@ -1835,7 +1841,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   <CardTitle>Home Details</CardTitle>
                   <Field>
                     <FieldLabel>Yard Size</FieldLabel>
-                    <FieldValue>{getData('answers.yard_size') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('answers.yard_size') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Yard Fenced</FieldLabel>
@@ -1843,25 +1849,26 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                   </Field>
                   <Field>
                     <FieldLabel>Hours Pet Alone</FieldLabel>
-                    <FieldValue>{getData('answers.hours_alone') || 'N/A'}</FieldValue>
+                    <FieldValue>{getStr('answers.hours_alone') || 'N/A'}</FieldValue>
                   </Field>
                   <Field>
                     <FieldLabel>Current Pets</FieldLabel>
-                    <FieldValue>{getData('answers.current_pets')?.length || 0} pets</FieldValue>
+                    <FieldValue>{getArr('answers.current_pets').length || 0} pets</FieldValue>
                   </Field>
                 </Card>
               </Grid>
             </Section>
 
-            {getData('answers.previous_pets')?.length > 0 && (
+            {getArr('answers.previous_pets').length > 0 && (
               <Section>
                 <SectionTitle>Previous Pet Experience</SectionTitle>
                 <Grid>
                   {(
-                    getData('answers.previous_pets') as Array<{
+                    getArr('answers.previous_pets') as Array<{
                       type?: string;
                       breed?: string;
                       years_owned?: string;
+                      what_happened?: string;
                     }>
                   ).map((pet, index) => (
                     <Card key={index}>

--- a/app.rescue/src/components/applications/ApplicationStageCard.tsx
+++ b/app.rescue/src/components/applications/ApplicationStageCard.tsx
@@ -9,7 +9,7 @@ interface ApplicationStageCardProps {
   stage: ApplicationStage;
   availableActions: StageAction[];
   onClick: () => void;
-  onAction: (action: string, data?: any) => void;
+  onAction: (action: string, data?: Record<string, unknown>) => void;
 }
 
 const CardContainer = styled.div`

--- a/app.rescue/src/components/pets/PetFormModal.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.tsx
@@ -205,8 +205,8 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
     setErrors({});
   }, [pet, isOpen]);
 
-  const handleInputChange = (field: string, value: any) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+  const handleInputChange = (field: string, value: unknown) => {
+    setFormData(prev => ({ ...prev, [field]: value }) as typeof prev);
     if (errors[field]) {
       setErrors(prev => ({ ...prev, [field]: '' }));
     }
@@ -463,7 +463,9 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
               <select
                 id="goodWithChildren"
                 value={
-                  formData.goodWithChildren == null ? '' : formData.goodWithChildren.toString()
+                  formData.goodWithChildren === null || formData.goodWithChildren === undefined
+                    ? ''
+                    : formData.goodWithChildren.toString()
                 }
                 onChange={e =>
                   handleInputChange(
@@ -482,7 +484,11 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
               <label htmlFor="goodWithDogs">Good with Dogs</label>
               <select
                 id="goodWithDogs"
-                value={formData.goodWithDogs == null ? '' : formData.goodWithDogs.toString()}
+                value={
+                  formData.goodWithDogs === null || formData.goodWithDogs === undefined
+                    ? ''
+                    : formData.goodWithDogs.toString()
+                }
                 onChange={e =>
                   handleInputChange(
                     'goodWithDogs',
@@ -500,7 +506,11 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
               <label htmlFor="goodWithCats">Good with Cats</label>
               <select
                 id="goodWithCats"
-                value={formData.goodWithCats == null ? '' : formData.goodWithCats.toString()}
+                value={
+                  formData.goodWithCats === null || formData.goodWithCats === undefined
+                    ? ''
+                    : formData.goodWithCats.toString()
+                }
                 onChange={e =>
                   handleInputChange(
                     'goodWithCats',

--- a/app.rescue/src/components/rescue/AdoptionPolicyForm.tsx
+++ b/app.rescue/src/components/rescue/AdoptionPolicyForm.tsx
@@ -154,11 +154,11 @@ const AdoptionPolicyForm: React.FC<AdoptionPolicyFormProps> = ({
     }
   }, [policy]);
 
-  const handleChange = (field: keyof AdoptionPolicy, value: any) => {
+  const handleChange = (field: keyof AdoptionPolicy, value: unknown) => {
     setHasChanges(true);
     setSuccessMessage(null);
     setErrorMessage(null);
-    setFormData(prev => ({ ...prev, [field]: value }));
+    setFormData(prev => ({ ...prev, [field]: value }) as AdoptionPolicy);
   };
 
   const handleFeeChange = (type: 'min' | 'max', value: string) => {

--- a/app.rescue/src/components/rescue/RescueProfileForm.tsx
+++ b/app.rescue/src/components/rescue/RescueProfileForm.tsx
@@ -126,7 +126,7 @@ const RescueProfileForm: React.FC<RescueProfileFormProps> = ({
     }
   }, [rescue]);
 
-  const handleChange = (field: keyof RescueProfile | string, value: any) => {
+  const handleChange = (field: keyof RescueProfile | string, value: unknown) => {
     setHasChanges(true);
     setSuccessMessage(null);
     setErrorMessage(null);
@@ -141,10 +141,13 @@ const RescueProfileForm: React.FC<RescueProfileFormProps> = ({
         } as RescueAddress,
       }));
     } else {
-      setFormData(prev => ({
-        ...prev,
-        [field]: value,
-      }));
+      setFormData(
+        prev =>
+          ({
+            ...prev,
+            [field]: value,
+          }) as RescueProfile
+      );
     }
   };
 

--- a/app.rescue/src/components/staff/InviteStaffModal.tsx
+++ b/app.rescue/src/components/staff/InviteStaffModal.tsx
@@ -315,7 +315,6 @@ const InviteStaffModal: React.FC<InviteStaffModalProps> = ({
               placeholder="staff@example.com"
               disabled={loading}
               required
-              autoFocus
             />
             {errors.email && <FormError>{errors.email}</FormError>}
             <FormHelp>Enter the email address of the person you want to invite</FormHelp>

--- a/app.rescue/src/services/dashboardService.ts
+++ b/app.rescue/src/services/dashboardService.ts
@@ -37,14 +37,7 @@ export class DashboardService {
    */
   async getRescueDashboardData(): Promise<RescueDashboardData> {
     try {
-      // Debug: Log authentication status
-      const token = localStorage.getItem('accessToken') || localStorage.getItem('authToken');
       if (isDevelopment()) {
-        console.log('🔐 Dashboard API Call - Token exists:', !!token);
-        console.log(
-          '🔐 Dashboard API Call - Token preview:',
-          token ? `${token.substring(0, 20)}...` : 'none'
-        );
         console.log('🐋 Docker Environment - API Base URL:', getApiBaseUrl());
       }
 

--- a/app.rescue/src/services/libraryServices.ts
+++ b/app.rescue/src/services/libraryServices.ts
@@ -24,9 +24,7 @@ const baseUrl = getApiBaseUrl();
 globalApiService.updateConfig({
   apiUrl: baseUrl,
   debug: isDevelopment(),
-  getAuthToken: () => {
-    return localStorage.getItem('accessToken') || localStorage.getItem('authToken');
-  },
+  // Tokens are stored in HttpOnly cookies — no localStorage fallback needed
 });
 
 // Add 401 error interceptor for automatic logout and redirect
@@ -36,10 +34,7 @@ globalApiService.interceptors.addErrorInterceptor(async error => {
     error instanceof AuthenticationError ||
     (error instanceof Error && error.message.includes('401'))
   ) {
-    // Clear authentication tokens
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+    // Clear non-sensitive user data
     localStorage.removeItem('user');
 
     // Redirect to homepage

--- a/app.rescue/src/utils/devAuth.ts
+++ b/app.rescue/src/utils/devAuth.ts
@@ -15,11 +15,8 @@ export function setDevUserToken(user: {
   // Create mock dev token (same pattern as app.client)
   const mockToken = `dev-token-${user.userId}-${Date.now()}`;
 
-  // Store both token formats for compatibility
-  localStorage.setItem('authToken', mockToken);
-  localStorage.setItem('accessToken', mockToken);
-
-  console.log('🔧 Dev token generated and stored:', mockToken);
+  // In dev mode, tokens are still cookie-based. Log for diagnostics only.
+  console.log('🔧 Dev token generated (cookie-based auth):', mockToken);
 
   return mockToken;
 }

--- a/lib.api/src/__tests__/api-service.test.ts
+++ b/lib.api/src/__tests__/api-service.test.ts
@@ -266,24 +266,10 @@ describe('ApiService', () => {
       );
     });
 
-    it('should fallback to localStorage for auth token', async () => {
-      // Mock a scenario where localStorage is available but getAuthToken is not configured
-      // We need to override the private getAuthToken method to test the localStorage fallback
+    it('should not set Authorization header when no getAuthToken is configured (tokens are in HttpOnly cookies)', async () => {
+      // Tokens are now in HttpOnly cookies — no localStorage fallback
       apiService = new ApiService({ debug: false });
-
-      // Override the config to remove the getAuthToken function to test localStorage fallback
       (apiService as any).config.getAuthToken = null;
-
-      // Mock localStorage.getItem to return a token
-      mockLocalStorage.getItem.mockImplementation((key: string) => {
-        if (key === 'authToken') {
-          return 'localStorage-token';
-        }
-        if (key === 'accessToken') {
-          return 'localStorage-token';
-        }
-        return null;
-      });
 
       const mockHeaders = new Headers([['content-type', 'application/json']]);
 
@@ -295,13 +281,13 @@ describe('ApiService', () => {
 
       await apiService.fetchWithAuth('/test');
 
-      // Verify localStorage was checked for authToken
-      expect(mockLocalStorage.getItem).toHaveBeenCalledWith('authToken');
+      // No Authorization header should be set; cookie is sent automatically by the browser
+      expect(mockLocalStorage.getItem).not.toHaveBeenCalledWith('authToken');
       expect(mockFetch).toHaveBeenCalledWith(
         '/test',
         expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer localStorage-token',
+          headers: expect.not.objectContaining({
+            Authorization: expect.any(String),
           }),
         })
       );

--- a/lib.api/src/services/api-service.ts
+++ b/lib.api/src/services/api-service.ts
@@ -180,11 +180,7 @@ export class ApiService {
       return this.config.getAuthToken();
     }
 
-    // Fallback to localStorage if available
-    if (typeof localStorage !== 'undefined') {
-      return localStorage.getItem('authToken') || localStorage.getItem('accessToken');
-    }
-
+    // Tokens are now stored in HttpOnly cookies — do not read from localStorage.
     return null;
   }
 

--- a/lib.components/src/components/ui/Modal.tsx
+++ b/lib.components/src/components/ui/Modal.tsx
@@ -48,7 +48,9 @@ export const Modal: React.FC<ModalProps> = ({
 
   const handleEscape = useCallback(
     (event: KeyboardEvent) => {
-      if (closeOnEscape && event.key === 'Escape') onClose();
+      if (closeOnEscape && event.key === 'Escape') {
+        onClose();
+      }
     },
     [closeOnEscape, onClose]
   );
@@ -64,16 +66,22 @@ export const Modal: React.FC<ModalProps> = ({
             const focusable = modalRef.current.querySelectorAll<HTMLElement>(
               'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
             );
-            if (focusable.length > 0) focusable[0].focus();
+            if (focusable.length > 0) {
+              focusable[0].focus();
+            }
           }
         }, 0);
       }
 
-      if (closeOnEscape) document.addEventListener('keydown', handleEscape);
+      if (closeOnEscape) {
+        document.addEventListener('keydown', handleEscape);
+      }
 
       return () => {
         document.body.style.overflow = '';
-        if (closeOnEscape) document.removeEventListener('keydown', handleEscape);
+        if (closeOnEscape) {
+          document.removeEventListener('keydown', handleEscape);
+        }
       };
     } else {
       isInitialOpen.current = false;
@@ -81,7 +89,9 @@ export const Modal: React.FC<ModalProps> = ({
   }, [isOpen, closeOnEscape, handleEscape]);
 
   const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (closeOnOverlayClick && event.target === event.currentTarget) onClose();
+    if (closeOnOverlayClick && event.target === event.currentTarget) {
+      onClose();
+    }
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -93,7 +103,9 @@ export const Modal: React.FC<ModalProps> = ({
       const focusable = modalRef.current.querySelectorAll<HTMLElement>(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
       );
-      if (focusable.length === 0) return;
+      if (focusable.length === 0) {
+        return;
+      }
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
       const active = document.activeElement;
@@ -107,7 +119,9 @@ export const Modal: React.FC<ModalProps> = ({
     }
   };
 
-  if (!isOpen) return null;
+  if (!isOpen) {
+    return null;
+  }
 
   const modalContent = (
     <div

--- a/lib.utils/src/services/utils-service.ts
+++ b/lib.utils/src/services/utils-service.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import {
   UtilsServiceConfig,
   DateFormatOptions,
@@ -275,10 +276,11 @@ export class UtilsService {
     };
 
     const chars = charsets[opts.charset];
+    const randomBuffer = randomBytes(opts.length);
     let id = '';
 
     for (let i = 0; i < opts.length; i++) {
-      id += chars.charAt(Math.floor(Math.random() * chars.length));
+      id += chars.charAt(randomBuffer[i] % chars.length);
     }
 
     if (opts.includeTimestamp) {

--- a/lib.utils/src/services/utils-service.ts
+++ b/lib.utils/src/services/utils-service.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from 'crypto';
 import {
   UtilsServiceConfig,
   DateFormatOptions,
@@ -276,7 +275,8 @@ export class UtilsService {
     };
 
     const chars = charsets[opts.charset];
-    const randomBuffer = randomBytes(opts.length);
+    const randomBuffer = new Uint8Array(opts.length);
+    globalThis.crypto.getRandomValues(randomBuffer);
     let id = '';
 
     for (let i = 0; i < opts.length; i++) {

--- a/service.backend/src/__tests__/controllers/chat.controller.test.ts
+++ b/service.backend/src/__tests__/controllers/chat.controller.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach, afterEach, Mock } from 'vitest';
+import { vi, describe, it, expect, beforeEach, Mock } from 'vitest';
 
 // Mock services and models before importing
 vi.mock('../../services/chat.service');
@@ -433,17 +433,6 @@ describe('ChatController', () => {
       it('should include sender info in request', async () => {
         mockRequest.params = { chatId: 'chat-001' };
         mockRequest.body = { content: 'Test', messageType: 'text' };
-
-        const mockMessage = {
-          toJSON: () => ({
-            message_id: 'msg-002',
-            chat_id: 'chat-001',
-            sender_id: 'user-123',
-            content: 'Test',
-            created_at: new Date().toISOString(),
-          }),
-          Sender: { userId: 'user-123', firstName: 'John', lastName: 'Doe' },
-        };
 
         (ChatService.sendMessage as Mock).mockResolvedValue({});
 

--- a/service.backend/src/__tests__/helpers/test-database.ts
+++ b/service.backend/src/__tests__/helpers/test-database.ts
@@ -47,15 +47,15 @@ export function createTestDatabase(logging = false): Sequelize {
  * @param sequelize - Test database instance
  */
 export async function initializeTestModels(sequelize: Sequelize): Promise<void> {
-  // Import all models
-  const User = (await import('../../models/User')).default;
-  const Pet = (await import('../../models/Pet')).default;
-  const Application = (await import('../../models/Application')).default;
-  const ApplicationQuestion = (await import('../../models/ApplicationQuestion')).default;
-  const ApplicationTimeline = (await import('../../models/ApplicationTimeline')).default;
-  const Rescue = (await import('../../models/Rescue')).default;
-  const SwipeAction = (await import('../../models/SwipeAction')).default;
-  const Rating = (await import('../../models/Rating')).default;
+  // Import all models (side-effect: registers them with their sequelize instance)
+  await import('../../models/User');
+  await import('../../models/Pet');
+  await import('../../models/Application');
+  await import('../../models/ApplicationQuestion');
+  await import('../../models/ApplicationTimeline');
+  await import('../../models/Rescue');
+  await import('../../models/SwipeAction');
+  await import('../../models/Rating');
 
   // Note: Models are already initialized with their original sequelize instance
   // For integration tests, we need to re-initialize them with our test database

--- a/service.backend/src/__tests__/integration/admin-moderation-flow.test.ts
+++ b/service.backend/src/__tests__/integration/admin-moderation-flow.test.ts
@@ -26,7 +26,6 @@ vi.mock('../../sequelize', async importOriginal => {
   };
 });
 
-import { Op } from 'sequelize';
 import Report, { ReportCategory, ReportStatus, ReportSeverity } from '../../models/Report';
 import ReportStatusTransition from '../../models/ReportStatusTransition';
 import ModeratorAction, { ActionType, ActionSeverity } from '../../models/ModeratorAction';
@@ -51,7 +50,7 @@ const MockedReportStatusTransition = ReportStatusTransition as vi.MockedObject<
 >;
 const MockedModeratorAction = ModeratorAction as vi.MockedObject<ModeratorAction>;
 const MockedUser = User as vi.MockedObject<User>;
-const MockedRescue = Rescue as vi.MockedObject<Rescue>;
+const _MockedRescue = Rescue as vi.MockedObject<Rescue>;
 const MockedAuditLogService = AuditLogService as vi.MockedObject<AuditLogService>;
 
 describe('Admin Moderation Workflow Integration Tests', () => {
@@ -322,7 +321,7 @@ describe('Admin Moderation Workflow Integration Tests', () => {
           assignedModerator: undefined,
         });
 
-        const updatedReport = createMockReport({
+        const _updatedReport = createMockReport({
           reportId: 'report-assign',
           status: ReportStatus.UNDER_REVIEW,
           assignedModerator: moderatorId as string | undefined,

--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -10,7 +10,6 @@ vi.mock('../../config/env', () => ({
   getDatabaseName: () => 'test_db',
 }));
 
-import { generateCryptoUuid as uuidv4 } from '../../utils/uuid-helpers';
 import Application, { ApplicationPriority, ApplicationStatus } from '../../models/Application';
 import ApplicationAnswer from '../../models/ApplicationAnswer';
 import ApplicationReferenceModel, {
@@ -18,6 +17,7 @@ import ApplicationReferenceModel, {
 } from '../../models/ApplicationReference';
 import ApplicationStatusTransition from '../../models/ApplicationStatusTransition';
 import Pet, { PetStatus, PetType, AgeGroup, Gender } from '../../models/Pet';
+import StaffMember from '../../models/StaffMember';
 import User, { UserStatus, UserType } from '../../models/User';
 import { ApplicationService } from '../../services/application.service';
 import { PetService } from '../../services/pet.service';
@@ -27,7 +27,6 @@ import {
   CreateApplicationRequest,
   ApplicationStatusUpdateRequest,
   ReferenceUpdateRequest,
-  ApplicationReference,
 } from '../../types/application';
 import { JsonObject } from '../../types/common';
 
@@ -37,6 +36,7 @@ vi.mock('../../models/ApplicationAnswer');
 vi.mock('../../models/ApplicationReference');
 vi.mock('../../models/ApplicationStatusTransition');
 vi.mock('../../models/Pet');
+vi.mock('../../models/StaffMember');
 vi.mock('../../models/User');
 vi.mock('../../services/auditLog.service');
 vi.mock('../../services/applicationTimeline.service');
@@ -58,6 +58,7 @@ const MockedApplicationStatusTransition = ApplicationStatusTransition as vi.Mock
   typeof ApplicationStatusTransition
 >;
 const MockedPet = Pet as vi.MockedObject<Pet>;
+const MockedStaffMember = StaffMember as vi.MockedObject<typeof StaffMember>;
 const MockedUser = User as vi.MockedObject<User>;
 const MockedAuditLogService = AuditLogService as vi.MockedObject<AuditLogService>;
 const MockedApplicationTimelineService = ApplicationTimelineService as vi.Mocked<
@@ -523,9 +524,13 @@ describe('Application Submission Workflow Integration Tests', () => {
         const mockApplication = createMockApplication({
           applicationId: applicationId,
           userId: adopterId,
+          rescueId: rescueId,
         });
 
         MockedApplication.findOne = vi.fn().mockResolvedValue(mockApplication as never);
+        MockedStaffMember.findOne = vi
+          .fn()
+          .mockResolvedValue({ userId: rescueStaffId, rescueId: rescueId });
 
         const result = await ApplicationService.getApplicationById(
           applicationId,
@@ -587,7 +592,7 @@ describe('Application Submission Workflow Integration Tests', () => {
           actionedBy: rescueStaffId,
         };
 
-        const result = await ApplicationService.updateApplicationStatus(
+        const _result = await ApplicationService.updateApplicationStatus(
           applicationId,
           statusUpdate,
           rescueStaffId
@@ -625,7 +630,7 @@ describe('Application Submission Workflow Integration Tests', () => {
           rejectionReason: 'Not suitable for high-energy dog',
         };
 
-        const result = await ApplicationService.updateApplicationStatus(
+        const _result = await ApplicationService.updateApplicationStatus(
           applicationId,
           statusUpdate,
           rescueStaffId
@@ -940,7 +945,7 @@ describe('Application Submission Workflow Integration Tests', () => {
           notes: 'Great fit for our dog!',
         };
 
-        const result = await ApplicationService.updateApplicationStatus(
+        const _result = await ApplicationService.updateApplicationStatus(
           applicationId,
           statusUpdate,
           rescueStaffId
@@ -1064,7 +1069,7 @@ describe('Application Submission Workflow Integration Tests', () => {
           rejectionReason: 'Not suitable living conditions for this pet',
         };
 
-        const result = await ApplicationService.updateApplicationStatus(
+        const _result = await ApplicationService.updateApplicationStatus(
           applicationId,
           statusUpdate,
           rescueStaffId
@@ -1219,7 +1224,7 @@ describe('Application Submission Workflow Integration Tests', () => {
 
         MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication as never);
 
-        const result = await ApplicationService.withdrawApplication(applicationId, adopterId);
+        const _result = await ApplicationService.withdrawApplication(applicationId, adopterId);
 
         expect(MockedApplicationStatusTransition.create).toHaveBeenCalledWith(
           expect.objectContaining({

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -12,6 +12,7 @@ import ApplicationAnswer from '../../models/ApplicationAnswer';
 import ApplicationReferenceModel from '../../models/ApplicationReference';
 import ApplicationStatusTransition from '../../models/ApplicationStatusTransition';
 import Pet, { PetStatus } from '../../models/Pet';
+import StaffMember from '../../models/StaffMember';
 import User, { UserType } from '../../models/User';
 import { CreateApplicationRequest, ApplicationStatusUpdateRequest } from '../../types/application';
 
@@ -22,6 +23,7 @@ const MockedApplicationReference = ApplicationReferenceModel as vi.MockedObject<
   typeof ApplicationReferenceModel
 >;
 const MockedPet = Pet as vi.MockedObject<Pet>;
+const MockedStaffMember = StaffMember as vi.MockedObject<typeof StaffMember>;
 const MockedUser = User as vi.MockedObject<User>;
 const MockedApplicationStatusTransition = ApplicationStatusTransition as vi.MockedObject<
   typeof ApplicationStatusTransition
@@ -531,6 +533,9 @@ describe('ApplicationService - Business Logic', () => {
       mockApplication.rescueId = mockRescueId;
 
       MockedApplication.findOne = vi.fn().mockResolvedValue(mockApplication);
+      MockedStaffMember.findOne = vi
+        .fn()
+        .mockResolvedValue({ userId: 'rescue-staff-123', rescueId: mockRescueId });
 
       // When: Rescue staff views application
       const result = await ApplicationService.getApplicationById(

--- a/service.backend/src/__tests__/services/file-upload.service.test.ts
+++ b/service.backend/src/__tests__/services/file-upload.service.test.ts
@@ -112,6 +112,31 @@ const setupSuccessfulUpload = (mimetype = 'image/jpeg') => {
 // ──── Tests ───────────────────────────────────────────────────────────────────
 
 describe('FileUploadService', () => {
+  beforeEach(() => {
+    // scanForMalware is a private method; spy on it so upload tests exercise
+    // validation/processing logic independently of the AV scanner state.
+    vi.spyOn(
+      FileUploadService as unknown as { scanForMalware: (path: string) => Promise<boolean> },
+      'scanForMalware'
+    ).mockResolvedValue(true);
+  });
+
+  describe('malware scan (fail-closed)', () => {
+    it('rejects upload when scanner reports file as infected', async () => {
+      vi.spyOn(
+        FileUploadService as unknown as { scanForMalware: (path: string) => Promise<boolean> },
+        'scanForMalware'
+      ).mockResolvedValue(false);
+
+      const file = makeFile();
+      setupSuccessfulUpload();
+
+      await expect(
+        FileUploadService.uploadFile(file, 'pets', { uploadedBy: 'user-456' })
+      ).rejects.toThrow('File failed malware scan');
+    });
+  });
+
   describe('validateFile() — file size enforcement', () => {
     it('rejects a file that exceeds the 10 MB size limit', async () => {
       const file = makeFile({ size: 10 * 1024 * 1024 + 1 });

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -841,7 +841,21 @@ export class ApplicationController extends BaseController {
   // Get application statistics
   getApplicationStatistics = async (req: AuthenticatedRequest, res: Response) => {
     try {
-      const rescueId = req.query.rescueId as string;
+      const userType = req.user!.userType as UserType;
+      const userId = req.user!.userId;
+
+      let rescueId: string | undefined;
+      if (userType === UserType.ADMIN || userType === UserType.MODERATOR) {
+        rescueId = req.query.rescueId as string | undefined;
+      } else {
+        const StaffMember = (await import('../models/StaffMember')).default;
+        const membership = await StaffMember.findOne({ where: { userId } });
+        if (!membership) {
+          return res.status(403).json({ success: false, message: 'Access denied' });
+        }
+        rescueId = membership.rescueId;
+      }
+
       const statistics = await ApplicationService.getApplicationStatistics(rescueId);
 
       res.status(200).json({

--- a/service.backend/src/controllers/auth.controller.ts
+++ b/service.backend/src/controllers/auth.controller.ts
@@ -23,6 +23,14 @@ const REFRESH_TOKEN_COOKIE_OPTIONS = {
   maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
 };
 
+const ACCESS_TOKEN_COOKIE = 'accessToken';
+const ACCESS_TOKEN_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict' as const,
+  maxAge: 15 * 60 * 1000, // 15 minutes
+};
+
 export const authValidation = {
   register: validateBody(RegisterRequestSchema),
   login: validateBody(LoginRequestSchema),
@@ -55,8 +63,9 @@ export class AuthController {
       const result = await AuthService.register(req.body);
 
       res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
+      res.cookie(ACCESS_TOKEN_COOKIE, result.token, ACCESS_TOKEN_COOKIE_OPTIONS);
 
-      const { refreshToken: _, ...responseBody } = result;
+      const { refreshToken: _, token: __, ...responseBody } = result;
       res.status(201).json(responseBody);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -79,8 +88,9 @@ export class AuthController {
       const result = await AuthService.login(req.body);
 
       res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
+      res.cookie(ACCESS_TOKEN_COOKIE, result.token, ACCESS_TOKEN_COOKIE_OPTIONS);
 
-      const { refreshToken: _, ...responseBody } = result;
+      const { refreshToken: _, token: __, ...responseBody } = result;
       res.json(responseBody);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -114,6 +124,11 @@ export class AuthController {
         secure: process.env.NODE_ENV === 'production',
         sameSite: 'strict',
       });
+      res.clearCookie(ACCESS_TOKEN_COOKIE, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+      });
 
       res.json({ message: 'Logged out successfully' });
     } catch (error) {
@@ -137,8 +152,9 @@ export class AuthController {
       const result = await AuthService.refreshToken(refreshToken);
 
       res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
+      res.cookie(ACCESS_TOKEN_COOKIE, result.token, ACCESS_TOKEN_COOKIE_OPTIONS);
 
-      const { refreshToken: _, ...responseBody } = result;
+      const { refreshToken: _, token: __, ...responseBody } = result;
       res.json(responseBody);
     } catch (error) {
       logger.error('Token refresh failed:', error);

--- a/service.backend/src/controllers/rescue.controller.ts
+++ b/service.backend/src/controllers/rescue.controller.ts
@@ -8,6 +8,8 @@ import { logger } from '../utils/logger';
 import { AdoptionPolicy } from '../types/rescue';
 import EmailService from '../services/email.service';
 import { EmailType, EmailPriority } from '../models/EmailQueue';
+import { UserType } from '../models/User';
+import StaffMember from '../models/StaffMember';
 
 export class RescueController {
   /**
@@ -573,7 +575,7 @@ export class RescueController {
   /**
    * Get rescue analytics and statistics
    */
-  getRescueAnalytics = async (req: Request, res: Response) => {
+  getRescueAnalytics = async (req: AuthenticatedRequest, res: Response) => {
     try {
       const errors = validationResult(req);
       if (!errors.isEmpty()) {
@@ -585,6 +587,15 @@ export class RescueController {
       }
 
       const { rescueId } = req.params;
+      const userType = req.user!.userType as UserType;
+      const userId = req.user!.userId;
+
+      if (userType !== UserType.ADMIN && userType !== UserType.MODERATOR) {
+        const membership = await StaffMember.findOne({ where: { userId, rescueId } });
+        if (!membership) {
+          return res.status(403).json({ success: false, message: 'Access denied' });
+        }
+      }
 
       const statistics = await RescueService.getRescueStatistics(rescueId);
 

--- a/service.backend/src/middleware/auth.ts
+++ b/service.backend/src/middleware/auth.ts
@@ -25,7 +25,9 @@ export const authenticateToken = async (
 ): Promise<void> => {
   try {
     const authHeader = req.headers.authorization;
-    const token = authHeader && authHeader.split(' ')[1];
+    const token =
+      (authHeader && authHeader.split(' ')[1]) ||
+      (req.cookies as Record<string, string> | undefined)?.['accessToken'];
 
     if (!token) {
       loggerHelpers.logSecurity(
@@ -165,7 +167,9 @@ export const optionalAuth = async (
 ): Promise<void> => {
   try {
     const authHeader = req.headers.authorization;
-    const token = authHeader && authHeader.split(' ')[1];
+    const token =
+      (authHeader && authHeader.split(' ')[1]) ||
+      (req.cookies as Record<string, string> | undefined)?.['accessToken'];
 
     if (!token) {
       // No token provided, continue without authentication
@@ -282,7 +286,9 @@ export const authenticateOptionalToken = async (
 ): Promise<void> => {
   try {
     const authHeader = req.headers.authorization;
-    const token = authHeader && authHeader.split(' ')[1];
+    const token =
+      (authHeader && authHeader.split(' ')[1]) ||
+      (req.cookies as Record<string, string> | undefined)?.['accessToken'];
 
     if (!token) {
       // No token provided, continue without authentication

--- a/service.backend/src/sequelize.ts
+++ b/service.backend/src/sequelize.ts
@@ -40,10 +40,10 @@ const getDatabaseUrl = (): string => {
   }
 };
 
-const databaseUrl = getDatabaseUrl();
-
 // Use SQLite in-memory for tests (industry standard approach)
 const isTestEnvironment = process.env.NODE_ENV === 'test';
+
+const databaseUrl = isTestEnvironment ? '' : getDatabaseUrl();
 
 const sequelize = isTestEnvironment
   ? new Sequelize('sqlite::memory:', {

--- a/service.backend/src/sequelize.ts
+++ b/service.backend/src/sequelize.ts
@@ -4,15 +4,16 @@ import { env, getDatabaseName } from './config/env';
 
 dotenv.config();
 
-/**
- * Build a PostgreSQL connection string from individual environment variables
- * Follows the format: postgresql://username:password@host:port/database
- */
 const buildConnectionString = (database: string): string => {
-  const username = process.env.DB_USERNAME || 'user';
-  const password = process.env.DB_PASSWORD || 'password';
-  const host = process.env.DB_HOST || 'localhost';
-  const port = process.env.DB_PORT || '5432';
+  const username = process.env.DB_USERNAME;
+  const password = process.env.DB_PASSWORD;
+  const host = process.env.DB_HOST;
+  const port = process.env.DB_PORT;
+
+  if (!username) throw new Error('DB_USERNAME environment variable is not set');
+  if (!password) throw new Error('DB_PASSWORD environment variable is not set');
+  if (!host) throw new Error('DB_HOST environment variable is not set');
+  if (!port) throw new Error('DB_PORT environment variable is not set');
 
   return `postgresql://${username}:${password}@${host}:${port}/${database}`;
 };

--- a/service.backend/src/sequelize.ts
+++ b/service.backend/src/sequelize.ts
@@ -10,10 +10,18 @@ const buildConnectionString = (database: string): string => {
   const host = process.env.DB_HOST;
   const port = process.env.DB_PORT;
 
-  if (!username) throw new Error('DB_USERNAME environment variable is not set');
-  if (!password) throw new Error('DB_PASSWORD environment variable is not set');
-  if (!host) throw new Error('DB_HOST environment variable is not set');
-  if (!port) throw new Error('DB_PORT environment variable is not set');
+  if (!username) {
+    throw new Error('DB_USERNAME environment variable is not set');
+  }
+  if (!password) {
+    throw new Error('DB_PASSWORD environment variable is not set');
+  }
+  if (!host) {
+    throw new Error('DB_HOST environment variable is not set');
+  }
+  if (!port) {
+    throw new Error('DB_PORT environment variable is not set');
+  }
 
   return `postgresql://${username}:${password}@${host}:${port}/${database}`;
 };

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -305,13 +305,17 @@ export class ApplicationService {
       }
 
       // Check permissions
-      if (userId && userType !== UserType.ADMIN) {
-        // Users can only see their own applications
-        // Rescue staff can see applications for their rescue
+      if (userId && userType !== UserType.ADMIN && userType !== UserType.MODERATOR) {
         if (userType === UserType.ADOPTER && application.userId !== userId) {
           throw new Error('Access denied');
         }
-        // Additional rescue staff permission check would go here
+        if (userType === UserType.RESCUE_STAFF) {
+          const StaffMember = (await import('../models/StaffMember')).default;
+          const membership = await StaffMember.findOne({ where: { userId } });
+          if (!membership || membership.rescueId !== application.rescueId) {
+            throw new Error('Access denied');
+          }
+        }
       }
 
       const answerRows = (application as Application & { Answers?: ApplicationAnswer[] }).Answers;

--- a/service.backend/src/services/discovery.service.ts
+++ b/service.backend/src/services/discovery.service.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import { Op, fn, literal } from 'sequelize';
 import Breed from '../models/Breed';
 import Pet, { AgeGroup, Gender, PetStatus, PetType, Size } from '../models/Pet';
@@ -315,7 +316,7 @@ export class DiscoveryService {
       };
 
       // Ensure petId is never undefined
-      const petId = pet.petId || `pet_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      const petId = pet.petId || `pet_${Date.now()}_${randomBytes(5).toString('hex')}`;
 
       // Get image URLs - only return valid URLs, let frontend handle placeholders.
       // Sort by order_index so the gallery surfaces images in the rescue's
@@ -384,6 +385,6 @@ export class DiscoveryService {
    * Generate a unique session ID
    */
   private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `session_${Date.now()}_${randomBytes(5).toString('hex')}`;
   }
 }

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -508,40 +508,11 @@ export class FileUploadService {
    * - [ ] Document scanning configuration in deployment docs
    */
   private static async scanForMalware(filePath: string): Promise<boolean> {
-    // TODO: Implement actual malware scanning
-    // For now, return true (safe) but log that scanning is not implemented
-    logger.warn('Malware scanning not yet implemented - file accepted without scan', {
-      filePath,
-    });
-
-    // Example ClamAV integration (commented out until implemented):
-    /*
-    try {
-      const ClamScan = require('clamscan');
-      const clamscan = await new ClamScan().init({
-        clamdscan: {
-          socket: '/var/run/clamav/clamd.ctl',
-          timeout: 60000,
-        },
-      });
-
-      const { isInfected, viruses } = await clamscan.isInfected(filePath);
-
-      if (isInfected) {
-        logger.error('Malware detected in file', { filePath, viruses });
-        return false;
-      }
-
-      logger.info('File passed malware scan', { filePath });
-      return true;
-    } catch (error) {
-      logger.error('Malware scan failed:', error);
-      // Fail-safe: reject file if scan fails
-      return false;
-    }
-    */
-
-    return true; // Placeholder - returns safe by default
+    // AV scanning is not yet integrated. Fail closed: reject all uploads until
+    // a real scanner (e.g. ClamAV) is wired in. Remove this guard and wire up
+    // clamscan.isInfected(filePath) when the scanner is available.
+    logger.error('Malware scanning not implemented — upload rejected (fail-closed)', { filePath });
+    return false;
   }
 
   /**

--- a/service.backend/src/services/invitation.service.ts
+++ b/service.backend/src/services/invitation.service.ts
@@ -192,9 +192,7 @@ export class InvitationService {
       // Generate unique user ID
       const userIdPrefix = 'user_rescue_staff_';
       const timestamp = Date.now().toString().slice(-6);
-      const randomSuffix = Math.floor(Math.random() * 1000)
-        .toString()
-        .padStart(3, '0');
+      const randomSuffix = crypto.randomBytes(2).readUInt16BE(0).toString().slice(-3).padStart(3, '0');
       const userId = `${userIdPrefix}${timestamp}${randomSuffix}`;
 
       // Create user account

--- a/service.backend/src/services/invitation.service.ts
+++ b/service.backend/src/services/invitation.service.ts
@@ -192,7 +192,12 @@ export class InvitationService {
       // Generate unique user ID
       const userIdPrefix = 'user_rescue_staff_';
       const timestamp = Date.now().toString().slice(-6);
-      const randomSuffix = crypto.randomBytes(2).readUInt16BE(0).toString().slice(-3).padStart(3, '0');
+      const randomSuffix = crypto
+        .randomBytes(2)
+        .readUInt16BE(0)
+        .toString()
+        .slice(-3)
+        .padStart(3, '0');
       const userId = `${userIdPrefix}${timestamp}${randomSuffix}`;
 
       // Create user account

--- a/service.backend/src/services/messageBroker.service.ts
+++ b/service.backend/src/services/messageBroker.service.ts
@@ -4,6 +4,7 @@
  * Part of Phase 3 - Message Broker Integration
  */
 
+import { randomBytes } from 'crypto';
 import { logger } from '../utils/logger';
 
 export interface BrokerMessage {
@@ -48,7 +49,7 @@ class MessageBroker {
   constructor(config: MessageBrokerConfig = {}) {
     this.config = config;
     this.serverId =
-      config.serverId || `server-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      config.serverId || `server-${Date.now()}-${randomBytes(5).toString('hex')}`;
   }
 
   /**

--- a/service.backend/src/services/messageBroker.service.ts
+++ b/service.backend/src/services/messageBroker.service.ts
@@ -48,8 +48,7 @@ class MessageBroker {
 
   constructor(config: MessageBrokerConfig = {}) {
     this.config = config;
-    this.serverId =
-      config.serverId || `server-${Date.now()}-${randomBytes(5).toString('hex')}`;
+    this.serverId = config.serverId || `server-${Date.now()}-${randomBytes(5).toString('hex')}`;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes all 7 open Urgent tickets from Linear.

- **ADS-165** — Remove hardcoded DB credential fallbacks in `sequelize.ts`; now throws on missing `DB_USERNAME`/`DB_PASSWORD`/`DB_HOST`/`DB_PORT` instead of silently using `user`/`password` defaults
- **ADS-232** — Already fixed (`UpdateProfileSchema.parse` whitelist was in place); no code change needed
- **ADS-293** — Replace all `Math.random()` in security-sensitive paths with `crypto.randomBytes`: `invitation.service.ts` userId suffix, `messageBroker.service.ts` serverId, `discovery.service.ts` pet/session IDs, `lib.utils` `generateId()` helper
- **ADS-250** — `scanForMalware()` now fails closed (returns `false`, rejecting uploads) instead of the previous stub that always returned `true`; must be replaced with a real AV integration before file uploads can work
- **ADS-251** — `getRescueAnalytics` controller now verifies the requesting user is a member of the requested rescue (or admin/moderator) before returning stats
- **ADS-209** — `getApplicationById` now enforces rescue-staff ownership check (the TODO comment); `getApplicationStatistics` now derives `rescueId` from the authenticated session for non-admin users instead of accepting it from query string
- **ADS-233** — Tokens migrated from `localStorage` to `HttpOnly` cookies: backend sets `accessToken` as `HttpOnly; Secure; SameSite=Strict` cookie on login/register/refresh; auth middleware accepts token from cookie in addition to `Authorization` header; all frontend apps remove localStorage token storage

## Test plan

- [ ] Login/register flow works end-to-end with cookies (no tokens visible in localStorage)
- [ ] Logout clears both `accessToken` and `refreshToken` cookies
- [ ] A rescue staff member cannot call `GET /api/v1/rescues/:otherRescueId/analytics` and receive 200
- [ ] A rescue staff member calling `GET /api/v1/applications/statistics` gets stats scoped to their own rescue only
- [ ] A rescue staff member cannot read an application belonging to another rescue via `GET /api/v1/applications/:id`
- [ ] File uploads are rejected with "File failed malware scan" until AV integration is added
- [ ] Starting the backend with missing `DB_PASSWORD` env var throws a clear error message at boot
- [ ] No `authToken`/`accessToken`/`refreshToken` keys appear in `localStorage` after login

https://claude.ai/code/session_01PcC5WBX8dqb2FkgK7og4xT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcC5WBX8dqb2FkgK7og4xT)_