### PR TITLE
fix(csrf): fix three bugs in CSRF token flow

### DIFF
--- a/service.backend/src/__tests__/middleware/csrf.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/csrf.middleware.test.ts
@@ -140,7 +140,9 @@ describe('CSRF Middleware', () => {
 
         getCsrfToken(mockRequest as Request, mockResponse as Response, mockNext);
 
-        expect(mockGenerateToken).toHaveBeenCalledWith(mockRequest, mockResponse, { overwrite: true });
+        expect(mockGenerateToken).toHaveBeenCalledWith(mockRequest, mockResponse, {
+          overwrite: true,
+        });
         expect(mockResponse.json).toHaveBeenCalledWith({
           csrfToken: generatedToken,
         });

--- a/service.backend/src/__tests__/middleware/csrf.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/csrf.middleware.test.ts
@@ -140,7 +140,7 @@ describe('CSRF Middleware', () => {
 
         getCsrfToken(mockRequest as Request, mockResponse as Response, mockNext);
 
-        expect(mockGenerateToken).toHaveBeenCalledWith(mockRequest, mockResponse);
+        expect(mockGenerateToken).toHaveBeenCalledWith(mockRequest, mockResponse, { overwrite: true });
         expect(mockResponse.json).toHaveBeenCalledWith({
           csrfToken: generatedToken,
         });

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -160,8 +160,9 @@ app.get('/api/v1/csrf-token', getCsrfToken);
 
 // Apply CSRF protection to all API routes except token endpoint and health checks
 app.use('/api', (req, res, next) => {
-  // Skip CSRF for health checks and read-only endpoints
-  const skipPaths = ['/api/v1/csrf-token', '/health', '/api/v1/health'];
+  // Within app.use('/api', ...) req.path is relative to the /api mount point,
+  // so paths here start with /v1/... not /api/v1/...
+  const skipPaths = ['/v1/csrf-token', '/v1/health'];
   if (skipPaths.some(path => req.path.startsWith(path)) || req.method === 'GET') {
     return next();
   }

--- a/service.backend/src/middleware/csrf.ts
+++ b/service.backend/src/middleware/csrf.ts
@@ -62,7 +62,10 @@ export const csrfProtection = doubleCsrfProtection;
  */
 export const getCsrfToken = (req: Request, res: Response, next: NextFunction): void => {
   try {
-    const token = generateCsrfToken(req, res);
+    // overwrite: true ensures a fresh token+cookie pair is always issued when
+    // this endpoint is called explicitly, preventing stale tokens from being
+    // re-used if a browser cookie has become out of sync with the cached token.
+    const token = generateCsrfToken(req, res, { overwrite: true });
     res.json({
       csrfToken: token,
     });
@@ -81,7 +84,7 @@ export const csrfErrorHandler = (
   res: Response,
   next: NextFunction
 ): void => {
-  if (err.code === 'EBADCSRFTOKEN' || err.message?.includes('CSRF')) {
+  if (err.code === 'EBADCSRFTOKEN' || err.message?.toLowerCase().includes('csrf')) {
     logger.warn('CSRF token validation failed', {
       method: req.method,
       path: req.path,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Three bugs were found in the CSRF token flow by reading the `csrf-csrf` v4 library source against our implementation:

- **`skipPaths` wrong path format** — inside `app.use('/api', ...)`, Express strips the mount prefix so `req.path` is `/v1/csrf-token`, not `/api/v1/csrf-token`. The skip check never matched any path. All currently-listed paths are GET requests (already skipped by the method check) so this was silent, but any future non-GET exemption would have silently failed.

- **`getCsrfToken` handler missing `overwrite: true`** — `csrf-csrf` v4 reuses any existing valid browser cookie when `overwrite` is omitted. If a browser's HttpOnly cookie drifts out of sync with the frontend's cached token (e.g. after a server restart or session edge case), calling `/csrf-token` would echo back the stale cookie value rather than issuing a fresh pair, leaving the client stuck with a token that fails validation.

- **`csrfErrorHandler` case-sensitive message fallback** — `err.message?.includes('CSRF')` used an uppercase match, but `csrf-csrf` v4's default error message is `"invalid csrf token"` (lowercase). The fallback never fired; fixed with `.toLowerCase()`.

## Test plan

- [ ] Existing CSRF middleware unit tests pass (`npx turbo test --filter=@adopt-dont-shop/service-backend`)
- [ ] Updated test assertion for `getCsrfToken` now expects `{ overwrite: true }` as the third argument
- [ ] Manual: open the app, submit a form — no CSRF 403 errors in the network tab

https://claude.ai/code/session_01Ss6eubuUC9Vh8n6P8NzLtE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss6eubuUC9Vh8n6P8NzLtE)_