### PR TITLE
chore: allow Linear save_issue MCP tool in local settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(test:*)",
       "Bash(timeout /t 30 npm test -- email.service.test.ts --maxWorkers=1)",
       "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__list_issues",
-      "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__get_issue"
+      "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__get_issue",
+      "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__save_issue"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary

Adds permission for the Linear `save_issue` MCP tool in local Claude settings. Used during a session that t-shirt sized 49 open Linear tickets (Backlog/Todo/In Progress) using Linear's estimate field (XS=1, S=2, M=3, L=5, XL=8). Sizing changes were made directly in Linear and are not part of this diff.

## Test plan
- [ ] Verify settings.local.json parses correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_015zZSHYNADMcAhUusF2NwUD)_