### PR TITLE
fix(ci): make docker.yml parseable by Dependabot

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -180,18 +180,18 @@ jobs:
 
       - name: Create environment file
         run: |
-          cat > .env << 'ENVEOF'
-NODE_ENV=development
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=${{ steps.secrets.outputs.POSTGRES_PASSWORD }}
-POSTGRES_DB=adopt_dont_shop_dev
-JWT_SECRET=${{ steps.secrets.outputs.JWT_SECRET }}
-JWT_REFRESH_SECRET=${{ steps.secrets.outputs.JWT_REFRESH_SECRET }}
-SESSION_SECRET=${{ steps.secrets.outputs.SESSION_SECRET }}
-CSRF_SECRET=${{ steps.secrets.outputs.CSRF_SECRET }}
-ENCRYPTION_KEY=${{ steps.secrets.outputs.ENCRYPTION_KEY }}
-CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002
-ENVEOF
+          {
+            echo "NODE_ENV=development"
+            echo "POSTGRES_USER=postgres"
+            echo "POSTGRES_PASSWORD=${{ steps.secrets.outputs.POSTGRES_PASSWORD }}"
+            echo "POSTGRES_DB=adopt_dont_shop_dev"
+            echo "JWT_SECRET=${{ steps.secrets.outputs.JWT_SECRET }}"
+            echo "JWT_REFRESH_SECRET=${{ steps.secrets.outputs.JWT_REFRESH_SECRET }}"
+            echo "SESSION_SECRET=${{ steps.secrets.outputs.SESSION_SECRET }}"
+            echo "CSRF_SECRET=${{ steps.secrets.outputs.CSRF_SECRET }}"
+            echo "ENCRYPTION_KEY=${{ steps.secrets.outputs.ENCRYPTION_KEY }}"
+            echo "CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002"
+          } > .env
 
       - name: Start database and cache
         run: |


### PR DESCRIPTION
## Summary

Dependabot was failing to update `.github/workflows/docker.yml` with `dependency_file_not_parseable` (job 1345860694), which blocked the open dependency-update PRs (e.g. #180 for `docker/setup-buildx-action`).

Root cause: the `Create environment file` step used a heredoc whose body sat at column 0, while the enclosing `run: |` block scalar started at column 10. Strict YAML parsers treat that dedent as ending the block scalar, leaving the file structurally invalid. GitHub Actions tolerates it, which is why CI still ran.

Fix: replace the heredoc with a grouped `echo` redirect so every line stays inside the block scalar's indentation. The produced `.env` is unchanged.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker.yml'))"` succeeds
- [ ] Dependabot can re-run and recreate PRs (e.g. #180) without the parse error
- [ ] `test-compose` job in CI still produces a valid `.env` and the backend container becomes healthy

---
_Generated by [Claude Code](https://claude.ai/code/session_012npwpuiFcA2CtbezpGxNJ2)_