### PR TITLE
docs: fact-check sweep across backend, libraries, and infra

### DIFF
--- a/docs/UK_LOCALIZATION.md
+++ b/docs/UK_LOCALIZATION.md
@@ -531,10 +531,10 @@ postcode: {
 
 ## 11. Related Documentation
 
-- [Shared Libraries Documentation](../docs/SHARED_LIBRARIES.md)
-- [lib.utils Documentation](../lib.utils/README.md)
-- Backend API Documentation
-- Frontend Component Library
+- [Shared libraries index](./libraries/README.md)
+- [lib.utils README](../lib.utils/README.md)
+- [Backend API endpoints](./backend/api-endpoints.md)
+- [lib.components README](../lib.components/README.md)
 
 ---
 

--- a/docs/backend/api-endpoints.md
+++ b/docs/backend/api-endpoints.md
@@ -101,20 +101,30 @@ The Adopt Don't Shop Backend API provides RESTful endpoints for managing users, 
 | GET    | `/api/v1/rescues/:rescueId/pets`          | Get rescue's pets               |
 | GET    | `/api/v1/rescues/:rescueId/analytics`     | Get rescue metrics (staff only) |
 
-### Conversations & Messaging
+### Chat & Messaging
 
-| Method | Endpoint                                                    | Description               |
-| ------ | ----------------------------------------------------------- | ------------------------- |
-| GET    | `/api/v1/conversations`                                     | List user's conversations |
-| POST   | `/api/v1/conversations`                                     | Create new conversation   |
-| GET    | `/api/v1/conversations/:conversationId`                     | Get conversation details  |
-| GET    | `/api/v1/conversations/:conversationId/messages`            | Get messages (paginated)  |
-| POST   | `/api/v1/conversations/:conversationId/messages`            | Send message              |
-| PUT    | `/api/v1/conversations/:conversationId/messages/:messageId` | Edit message              |
-| DELETE | `/api/v1/conversations/:conversationId/messages/:messageId` | Delete message            |
-| POST   | `/api/v1/conversations/:conversationId/read`                | Mark messages as read     |
-| POST   | `/api/v1/conversations/:conversationId/participants`        | Add participant           |
-| GET    | `/api/v1/conversations/:conversationId/search`              | Search messages           |
+Chat routes are mounted at `/api/v1/chats` (canonical). `/api/v1/conversations` is registered as an alias for backwards compatibility — prefer `chats` in new code. The schema field is `chat_id`.
+
+| Method | Endpoint                                            | Description                            |
+| ------ | --------------------------------------------------- | -------------------------------------- |
+| GET    | `/api/v1/chats`                                     | List user's chats                      |
+| POST   | `/api/v1/chats`                                     | Create new chat                        |
+| GET    | `/api/v1/chats/search`                              | Search chats                           |
+| GET    | `/api/v1/chats/analytics`                           | Chat analytics (rescue staff / admin)  |
+| GET    | `/api/v1/chats/:chatId`                             | Get chat details                       |
+| PUT    | `/api/v1/chats/:chatId`                             | Update chat metadata                   |
+| PATCH  | `/api/v1/chats/:chatId`                             | Lock/unlock or change status           |
+| DELETE | `/api/v1/chats/:chatId`                             | Archive/delete chat                    |
+| GET    | `/api/v1/chats/:chatId/messages`                    | Get messages (paginated)               |
+| POST   | `/api/v1/chats/:chatId/messages`                    | Send message                           |
+| DELETE | `/api/v1/chats/:chatId/messages/:messageId`         | Delete message                         |
+| POST   | `/api/v1/chats/:chatId/read`                        | Mark messages as read                  |
+| GET    | `/api/v1/chats/:chatId/unread-count`                | Get unread message count               |
+| POST   | `/api/v1/chats/:chatId/participants`                | Add participant                        |
+| DELETE | `/api/v1/chats/:chatId/participants/:userId`        | Remove participant                     |
+| POST   | `/api/v1/chats/messages/:messageId/reactions`       | Add reaction to a message              |
+| DELETE | `/api/v1/chats/messages/:messageId/reactions`       | Remove reaction                        |
+| POST   | `/api/v1/chats/:chatId/attachments/upload`          | Upload chat attachment                 |
 
 ### Notifications
 
@@ -198,14 +208,12 @@ Common HTTP status codes:
 
 ## Interactive API Documentation
 
-**Swagger UI**: Available at `/api-docs` in development mode
+**Swagger UI**: Available at `/api/docs` (e.g. http://localhost:5000/api/docs in dev).
 
 - Full endpoint documentation with request/response schemas
 - Interactive testing interface
 - Authentication token management
-- Real-time API exploration
-
-**Postman Collection**: Import from `/api/postman-collection.json`
+- Generated OpenAPI specs are also committed at `docs/backend/generated-openapi.json` / `.yaml`
 
 ## Rate Limiting
 
@@ -236,8 +244,7 @@ Connect to `/socket.io` with JWT authentication.
 
 ## Additional Resources
 
-- **Backend Architecture**: [architecture.md](./architecture.md)
+- **Implementation Guide**: [implementation-guide.md](./implementation-guide.md)
 - **Database Schema**: [database-schema.md](./database-schema.md)
-- **Authentication Guide**: [authentication.md](./authentication.md)
 - **Deployment Guide**: [deployment.md](./deployment.md)
 - **Troubleshooting**: [troubleshooting.md](./troubleshooting.md)

--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -24,8 +24,8 @@ erDiagram
     Application ||--o{ Timeline : tracks
     Application ||--o{ Message : generates
 
-    Conversation ||--o{ Message : contains
-    Conversation ||--o{ Participant : includes
+    Chat ||--o{ Message : contains
+    Chat ||--o{ ChatParticipant : includes
 ```
 
 ## Core Tables
@@ -132,33 +132,48 @@ erDiagram
 
 ## Communication Tables
 
-### Conversations
+### Chats
 
-**Purpose**: Message thread management
+**Purpose**: Chat thread management between adopters and rescues. Defined in `service.backend/src/models/Chat.ts`.
 
-| Field           | Type      | Description                    |
-| --------------- | --------- | ------------------------------ |
-| conversation_id | UUID (PK) | Primary identifier             |
-| application_id  | UUID (FK) | Related application (optional) |
-| title           | VARCHAR   | Conversation title             |
-| type            | ENUM      | DIRECT, GROUP, APPLICATION     |
-| created_at      | TIMESTAMP | Creation date                  |
+| Field          | Type      | Description                                |
+| -------------- | --------- | ------------------------------------------ |
+| chat_id        | UUID (PK) | Primary identifier                         |
+| rescue_id      | UUID (FK) | Owning rescue                              |
+| pet_id         | UUID (FK) | Pet that initiated the chat (optional)     |
+| application_id | UUID (FK) | Related application (optional)             |
+| status         | ENUM      | active, locked, archived                   |
+| created_at     | TIMESTAMP | Creation date                              |
+| updated_at     | TIMESTAMP | Last update                                |
+
+**Indexes**: rescue_id, pet_id, application_id, status
+
+### Chat Participants
+
+**Purpose**: Junction table linking users to chats. Defined in `ChatParticipant.ts`.
+
+| Field    | Type      | Description           |
+| -------- | --------- | --------------------- |
+| chat_id  | UUID (FK) | Parent chat           |
+| user_id  | UUID (FK) | Participant user      |
+| role     | ENUM      | Participant role      |
 
 ### Messages
 
-**Purpose**: Individual messages
+**Purpose**: Individual messages within a chat.
 
-| Field           | Type      | Description         |
-| --------------- | --------- | ------------------- |
-| message_id      | UUID (PK) | Primary identifier  |
-| conversation_id | UUID (FK) | Parent conversation |
-| sender_id       | UUID (FK) | Message sender      |
-| content         | TEXT      | Message content     |
-| attachments     | JSONB     | File attachments    |
-| read_by         | JSONB     | Read receipts       |
-| created_at      | TIMESTAMP | Send time           |
+| Field       | Type      | Description        |
+| ----------- | --------- | ------------------ |
+| message_id  | UUID (PK) | Primary identifier |
+| chat_id     | UUID (FK) | Parent chat        |
+| sender_id   | UUID (FK) | Message sender     |
+| content     | TEXT      | Message content    |
+| attachments | JSONB     | File attachments   |
+| created_at  | TIMESTAMP | Send time          |
 
-**Indexes**: conversation_id, sender_id, created_at
+Read receipts are tracked in a separate `MessageRead` table; reactions in `MessageReaction`.
+
+**Indexes**: chat_id, sender_id, created_at
 
 ### Notifications
 

--- a/docs/backend/deployment.md
+++ b/docs/backend/deployment.md
@@ -161,7 +161,7 @@ ENABLE_REQUEST_LOGGING=true
 
 The service includes a production-ready Dockerfile:
 
-The repository ships a multi-stage Dockerfile at `service.backend/Dockerfile` built against `node:20-alpine` with a non-root `backend` user. Build the production image via:
+The repository ships a multi-stage Dockerfile at `service.backend/Dockerfile` built against `node:22-alpine` with a non-root `backend` user. Build the production image via:
 
 ```bash
 docker build \

--- a/docs/backend/service-backend-prd.md
+++ b/docs/backend/service-backend-prd.md
@@ -308,6 +308,5 @@ The Backend Service is the core API and data management layer that powers all ap
 - **API Reference**: [api-endpoints.md](./api-endpoints.md)
 - **Implementation Guide**: [implementation-guide.md](./implementation-guide.md)
 - **Database Schema**: [database-schema.md](./database-schema.md)
-- **Architecture Details**: [architecture.md](./architecture.md)
 - **Deployment Guide**: [deployment.md](./deployment.md)
 - **Testing Strategy**: [testing.md](./testing.md)

--- a/docs/frontend/app-rescue-prd.md
+++ b/docs/frontend/app-rescue-prd.md
@@ -292,4 +292,3 @@ interface ApplicationAttributes {
 - **Implementation Plan**: [implementation-plan.md](./implementation-plan.md)
 - **Technical Architecture**: [technical-architecture.md](./technical-architecture.md)
 - **API Documentation**: [../backend/api-endpoints.md](../backend/api-endpoints.md)
-- **Staff Implementation**: [staff-workstream-implementation.md](./staff-workstream-implementation.md)

--- a/docs/frontend/implementation-plan.md
+++ b/docs/frontend/implementation-plan.md
@@ -373,6 +373,6 @@ Implementation roadmap for the Rescue App (app.rescue) - a comprehensive managem
 
 - **Technical Architecture**: [technical-architecture.md](./technical-architecture.md)
 - **App Rescue PRD**: [app-rescue-prd.md](./app-rescue-prd.md)
-- **Component Library**: [../libraries/components.md](../libraries/components.md)
+- **Component Library**: [../../lib.components/README.md](../../lib.components/README.md)
 - **API Documentation**: [../backend/api-endpoints.md](../backend/api-endpoints.md)
 - **Testing Guide**: [../backend/testing.md](../backend/testing.md)

--- a/docs/frontend/technical-architecture.md
+++ b/docs/frontend/technical-architecture.md
@@ -480,5 +480,5 @@ FROM nginx:alpine AS production
 - **Implementation Plan**: [implementation-plan.md](./implementation-plan.md)
 - **App Rescue PRD**: [app-rescue-prd.md](./app-rescue-prd.md)
 - **API Documentation**: [../backend/api-endpoints.md](../backend/api-endpoints.md)
-- **Component Library**: [../libraries/components.md](../libraries/components.md)
+- **Component Library**: [../../lib.components/README.md](../../lib.components/README.md)
 - **Testing Guide**: [../backend/testing.md](../backend/testing.md)

--- a/docs/infrastructure/MICROSERVICES-STANDARDS.md
+++ b/docs/infrastructure/MICROSERVICES-STANDARDS.md
@@ -36,10 +36,10 @@ The Adopt Don't Shop platform uses a hybrid microservices architecture combining
 
 **✅ Shared Libraries**
 
-- 16 libraries with consistent ESM architecture
+- 21 libraries with consistent ESM architecture
 - TypeScript-first with full type safety
-- Published as workspace dependencies
-- Versioned and tested independently
+- Linked as npm workspace dependencies (`"*"` version)
+- Tested independently
 
 **✅ Single Database**
 
@@ -61,11 +61,11 @@ The Adopt Don't Shop platform uses a hybrid microservices architecture combining
 
 All libraries follow these standards:
 
-- **Module System**: ES Modules only (no CommonJS)
-- **Build Tool**: TypeScript Compiler (tsc)
-- **Testing**: Jest with 8/8 tests per library
+- **Module System**: ES Modules first; a few libraries (`lib.api`, `lib.permissions`, `lib.types`, `lib.validation`) also emit a CJS bundle for backend consumers
+- **Build Tool**: TypeScript Compiler (`tsc`) for most libs; `lib.components` uses Vite to bundle assets and styles
+- **Testing**: Jest for Node libs, Vitest for libs co-located with apps and `service.backend`
 - **Code Quality**: ESLint + Prettier
-- **Documentation**: Comprehensive README with examples
+- **Documentation**: Each library has its own README next to the source
 
 ### Library Structure
 
@@ -87,30 +87,34 @@ lib.{name}/
 
 ### Library Categories
 
-**Core Services (3)**
+The canonical index with links is in [`docs/libraries/README.md`](../libraries/README.md). Categorised here for orientation:
 
-- lib.api - HTTP client wrapper
-- lib.auth - Authentication
-- lib.validation - Schema validation
+**Transport & data (3)**
 
-**Feature Libraries (11)**
+- `lib.api` — HTTP client, interceptors, auth-token plumbing
+- `lib.types` — shared types/constants (zero-dependency)
+- `lib.validation` — Zod schemas
 
-- lib.applications - Application management
-- lib.chat - Real-time messaging
-- lib.discovery - Pet discovery
-- lib.email - Email system
-- lib.invitations - Staff invitations
-- lib.notifications - Multi-channel notifications
-- lib.pets - Pet management
-- lib.rescues - Rescue organizations
-- lib.search - Advanced search
-- lib.storage - File storage
-- lib.users - User management
+**Auth & access (3)**
+
+- `lib.auth` — sessions, two-factor, `AuthProvider` / `useAuth`
+- `lib.permissions` — RBAC + field-level permissions
+- `lib.invitations` — staff/user invitations
+
+**Domain services (10)**
+
+- `lib.applications`, `lib.chat`, `lib.discovery`, `lib.notifications`, `lib.pets`, `lib.rescue`, `lib.search`, `lib.moderation`, `lib.support-tickets`, `lib.audit-logs`
+
+**UI & analytics (3)**
+
+- `lib.components` — shared React components
+- `lib.analytics` — event tracking
+- `lib.feature-flags` — Statsig types
 
 **Utilities (2)**
 
-- lib.analytics - Analytics tracking
-- lib.common - Shared utilities
+- `lib.utils` — formatters, locale, env helpers
+- `lib.dev-tools` — dev-only tooling
 
 ## Database Strategy
 

--- a/docs/infrastructure/docker-setup.md
+++ b/docs/infrastructure/docker-setup.md
@@ -85,7 +85,10 @@ SESSION_SECRET=...
 CSRF_SECRET=...
 
 # Frontend → backend
-VITE_API_BASE_URL=http://localhost:5000
+# Leave VITE_API_BASE_URL empty in Docker dev; the Vite dev server proxies
+# /api requests to the backend via docker-compose networking. Set an
+# absolute URL only when running the apps outside Docker.
+VITE_API_BASE_URL=
 VITE_WS_BASE_URL=ws://localhost:5000
 
 # CORS (comma-separated list of allowed origins)

--- a/lib.api/ARCHITECTURE.md
+++ b/lib.api/ARCHITECTURE.md
@@ -17,7 +17,7 @@
 
 ```typescript
 // lib.pets/src/pet-service.ts
-import { apiService, ApiError } from '@adopt-dont-shop/lib-api';
+import { apiService, ApiError } from '@adopt-dont-shop/lib.api';
 import type { Pet, PetSearchFilters, PaginatedResponse } from './types';
 
 export class PetService {
@@ -55,7 +55,7 @@ export const petService = new PetService();
 
 ```typescript
 // lib.auth/src/auth-service.ts
-import { apiService, AuthenticationError } from '@adopt-dont-shop/lib-api';
+import { apiService, AuthenticationError } from '@adopt-dont-shop/lib.api';
 import type { LoginRequest, AuthResponse, User } from './types';
 
 export class AuthService {
@@ -103,7 +103,7 @@ export const authService = new AuthService();
 
 ```typescript
 // App-specific setup
-import { apiService } from '@adopt-dont-shop/lib-api';
+import { apiService } from '@adopt-dont-shop/lib.api';
 
 // Add token refresh interceptor
 apiService.interceptors.addErrorInterceptor(async (error) => {
@@ -137,13 +137,13 @@ if (import.meta.env.DEV) {
 
 ```typescript
 // app.client/src/services/index.ts
-import { apiService } from '@adopt-dont-shop/lib-api';
-import { petService } from '@adopt-dont-shop/lib-pets';
-import { authService } from '@adopt-dont-shop/lib-auth';
+import { apiService } from '@adopt-dont-shop/lib.api';
+import { petService } from '@adopt-dont-shop/lib.pets';
+import { authService } from '@adopt-dont-shop/lib.auth';
 
 // Configure API for client app
 apiService.updateConfig({
-  apiUrl: import.meta.env.VITE_API_URL,
+  apiUrl: import.meta.env.VITE_API_BASE_URL,
   debug: import.meta.env.DEV,
 });
 
@@ -154,14 +154,14 @@ export { petService, authService };
 
 ```typescript
 // app.rescue/src/services/index.ts
-import { apiService } from '@adopt-dont-shop/lib-api';
-import { petService } from '@adopt-dont-shop/lib-pets';
-import { authService } from '@adopt-dont-shop/lib-auth';
-import { rescueService } from '@adopt-dont-shop/lib-rescue';
+import { apiService } from '@adopt-dont-shop/lib.api';
+import { petService } from '@adopt-dont-shop/lib.pets';
+import { authService } from '@adopt-dont-shop/lib.auth';
+import { rescueService } from '@adopt-dont-shop/lib.rescue';
 
 // Configure API for rescue app
 apiService.updateConfig({
-  apiUrl: import.meta.env.VITE_API_URL,
+  apiUrl: import.meta.env.VITE_API_BASE_URL,
   headers: { 'X-App': 'rescue' },
 });
 
@@ -172,18 +172,17 @@ export { petService, authService, rescueService };
 
 ```typescript
 // app.admin/src/services/index.ts
-import { apiService } from '@adopt-dont-shop/lib-api';
-import { authService } from '@adopt-dont-shop/lib-auth';
-import { adminService } from '@adopt-dont-shop/lib-admin';
+import { apiService } from '@adopt-dont-shop/lib.api';
+import { authService } from '@adopt-dont-shop/lib.auth';
 
 // Configure API for admin app with longer timeouts
 apiService.updateConfig({
-  apiUrl: import.meta.env.VITE_API_URL,
+  apiUrl: import.meta.env.VITE_API_BASE_URL,
   timeout: 30000,
   headers: { 'X-App': 'admin' },
 });
 
-export { authService, adminService };
+export { authService };
 ```
 
 ## Benefits

--- a/lib.components/README.md
+++ b/lib.components/README.md
@@ -1,63 +1,73 @@
-# Components Library
+# `@adopt-dont-shop/lib.components`
 
-Shared UI components and design system.
+Shared React component library and design system. Built with vanilla-extract (`.css.ts`) and bundled by Vite. Used by `app.client`, `app.admin`, and `app.rescue`.
 
-## Documentation
+## Install (workspace)
 
-## Installation
+Apps in this monorepo depend on it via `"@adopt-dont-shop/lib.components": "*"` in their `package.json` — no install command needed.
 
-```bash
-npm install @adopt-dont-shop/lib.components
+## Quick start
+
+```tsx
+import { ThemeProvider, Button, Card, TextInput } from '@adopt-dont-shop/lib.components';
+import '@adopt-dont-shop/lib.components/styles';
+
+export function App() {
+  return (
+    <ThemeProvider>
+      <Card>
+        <TextInput label="Email" />
+        <Button variant="primary">Submit</Button>
+      </Card>
+    </ThemeProvider>
+  );
+}
 ```
+
+## Exports
+
+The canonical list lives in [`src/index.ts`](./src/index.ts). Public surface, grouped:
+
+- **Theme**: `ThemeProvider`, `useTheme`, `darkTheme`, `lightTheme`, `vars`
+- **Foundation**: `Avatar`, `Badge`, `Button`, `DateTime`, `Heading`, `Spinner`, `DotSpinner`, `Text`
+- **Layout**: `Container`, `Stack`, `Card` (+ `CardHeader`/`CardContent`/`CardFooter`)
+- **Form**: `CheckboxInput`, `SelectInput`, `TextInput`, `TextArea`, `Input`, `FileUpload`
+- **Feedback**: `Alert`, `Modal`, `ConfirmDialog`, `Toast` / `ToastContainer`
+- **Navigation**: `Breadcrumbs`, `Footer`, `Header`, `Navbar`
+- **Hooks**: `useConfirm`, `useToast`
+
+Component-level READMEs live next to the source (e.g. `src/components/ui/Toast/README.md`).
 
 ## Structure
 
 ```
-lib.components/
-├── src/
-│   ├── components/
-│   │   ├── ui/          # Core UI components (Button, Input, Card, etc.)
-│   │   ├── forms/       # Form-related components
-│   │   ├── layout/      # Layout components
-│   │   ├── pet/         # Pet-related components
-│   │   ├── application/ # Application-related components
-│   │   ├── communication/ # Messaging components
-│   │   └── data/        # Data display components
-│   ├── hooks/           # Custom React hooks
-│   ├── utils/           # Utility functions
-│   ├── types/           # TypeScript type definitions
-│   └── index.ts         # Main export file
-├── package.json
-├── tsconfig.json
-└── vite.config.ts
+lib.components/src/
+├── components/
+│   ├── ui/          # Core UI: Button, Input, Card, Alert, Modal, Toast, ...
+│   ├── form/        # Form inputs: TextInput, CheckboxInput, SelectInput, FileUpload
+│   ├── layout/      # Container, Stack
+│   ├── data/        # ListGroup, Table
+│   └── navigation/  # Breadcrumbs, Header, Footer, Navbar
+├── hooks/           # useConfirm, useToast
+├── utils/           # cn(), shared helpers
+├── styles/          # theme + ThemeProvider (vanilla-extract)
+├── types/           # shared component prop types
+└── index.ts         # public entry point
 ```
 
-## Adding New Components
-
-1. Create the component in the appropriate directory
-2. Export it in the index.ts file
-3. Add appropriate tests
-4. Document the component with Storybook
-
-## Building
+## Scripts
 
 ```bash
-# Development (watch mode)
-npm run dev
-
-# Production build
-npm run build
+npm run dev               # vite build --watch
+npm run build             # vite build (lib + theme bundle)
+npm run test              # jest
+npm run storybook         # storybook dev server on :6006
+npm run build-storybook   # static storybook build
 ```
 
-## Testing
+## Conventions
 
-```bash
-npm run test
-```
-
-## Best Practices
-
-- Each component should have a corresponding TypeScript interface
-- Components should be properly typed with React.forwardRef where appropriate
-- Use the cn() utility for merging classes
-- Follow composition pattern for complex components
+- Each component owns its directory with `*.tsx`, `*.css.ts`, `*.test.tsx`, and (where present) `*.stories.tsx`.
+- Use the `cn()` utility from `src/utils/cn.ts` to merge class strings.
+- Theme values come from `vars` (vanilla-extract) — don't hardcode colours.
+- Forwarded refs where the underlying element makes sense as a ref target.

--- a/service.backend/README.md
+++ b/service.backend/README.md
@@ -242,10 +242,10 @@ RATE_LIMIT_MAX_REQUESTS=100
 
 ### Docker Deployment
 
-The production image is built by `service.backend/Dockerfile` against `node:20-alpine`. A minimal illustrative alternative:
+The production image is built by `service.backend/Dockerfile` against `node:22-alpine`. A minimal illustrative alternative:
 
 ```dockerfile
-FROM node:20-alpine
+FROM node:22-alpine
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Summary

Audit + fix sweep over the docs surface (89 markdown files / ~17.5k lines). Each change is fact-checked against the actual code/config; no new docs were authored where the existing ones were already correct. Organised into three focused commits so reviewers can take them piecemeal.

### Batch 1 — Backend (`80e14be`)

- **`docs/backend/api-endpoints.md`** — the "Conversations & Messaging" section was wrong: routes are mounted at `/api/v1/chats` (with `/api/v1/conversations` kept as a back-compat alias in `service.backend/src/index.ts:247-248`), the param is `:chatId`, and there's no `PUT` for editing messages. Renamed the section, added the missing endpoints (`unread-count`, `reactions`, `analytics`, `attachments/upload`, `PATCH chat`), and removed the non-existent edit route. Also fixed Swagger UI path (`/api-docs` → `/api/docs`, per `src/config/swagger.ts:247`) and dropped the broken Postman / `architecture.md` / `authentication.md` links.
- **`docs/backend/database-schema.md`** — `Conversation`/`conversation_id` doesn't exist in code; the model is `Chat`/`chat_id` (`service.backend/src/models/Chat.ts`). Renamed the table, swapped in the real columns (`rescue_id`, `pet_id`, `application_id`, `status`), added `ChatParticipant`, and fixed the Mermaid diagram + `Messages` table FK.
- **`docs/backend/deployment.md`, `service.backend/README.md`** — production Dockerfile is `node:22-alpine`, not `node:20-alpine` (`service.backend/Dockerfile:7,178`).

### Batch 2 — Libraries (`96cd99b`)

- **`lib.api/ARCHITECTURE.md`** — every code example used the hyphenated `@adopt-dont-shop/lib-api` / `lib-pets` / `lib-auth` / `lib-rescue`. Workspace packages are dotted (`lib.api`, etc.) — the old form fails to resolve. Also removed the `lib-admin` import (no such package) and replaced `VITE_API_URL` with `VITE_API_BASE_URL`, the canonical env var read in `lib.api/src/services/api-service.ts`.
- **`lib.components/README.md`** — the structure block listed folders that don't exist (`forms/`, `pet/`, `application/`, `communication/`) while omitting `form/`, `navigation/`, and `data/`. Rewrote with the real layout, added a quick-start, an exports list sourced from `src/index.ts`, and the storybook scripts that already exist in the package.

### Batch 3 — Infra & frontend (`bdb942c`)

- **`docs/infrastructure/MICROSERVICES-STANDARDS.md`** — claimed "16 libraries"; the workspaces array has 21. Replaced the stale category list (referenced removed packages: `lib.email`, `lib.rescues`, `lib.storage`, `lib.users`, `lib.common`) with the real one. Softened the "Build Tool: tsc" line because `lib.components` ships via Vite, and dropped the made-up "Jest with 8/8 tests per library" claim.
- **`docs/infrastructure/docker-setup.md`** — `VITE_API_BASE_URL` is empty in `docker-compose.yml` (apps proxy `/api` via Vite); doc said `http://localhost:5000`.
- **`docs/frontend/technical-architecture.md`, `docs/frontend/implementation-plan.md`** — repointed the "Component Library" link from the non-existent `../libraries/components.md` to `lib.components/README.md`.
- **Stale links cleanup** — removed dead refs in `frontend/app-rescue-prd.md` (`staff-workstream-implementation.md`), `backend/service-backend-prd.md` (`architecture.md`), and `UK_LOCALIZATION.md` (`../docs/SHARED_LIBRARIES.md`). After the sweep, **0 broken relative md links remain** anywhere under `docs/`, `lib.*`, or app READMEs.

## Test plan

- [ ] Spot-check an endpoint table row against `service.backend/src/routes/chat.routes.ts`
- [ ] Confirm `lib.components` README's structure matches `ls lib.components/src/components`
- [ ] Run a broken-link scan (`python3` script in PR conversation) and confirm 0 broken
- [ ] CI markdown lint / format passes

Out of scope (not changed, but noted during the audit): the rest of the lib READMEs were spot-checked against their `src/index.ts` and found accurate; the per-component READMEs under `lib.components/src/components/*/README.md` weren't touched.

https://claude.ai/code/session_01EvkjwrdsjyG9RmbCvC9jBg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvkjwrdsjyG9RmbCvC9jBg)_