### PR TITLE
fix(backend): URL-encode DB credentials in buildConnectionString

### DIFF
--- a/service.backend/src/__tests__/utils/connection-string.test.ts
+++ b/service.backend/src/__tests__/utils/connection-string.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildConnectionString } from '../../sequelize';
 
+const ENV_KEYS = ['DB_HOST', 'DB_PORT', 'DB_USERNAME', 'DB_PASSWORD'] as const;
+
 describe('buildConnectionString', () => {
-  const originalEnv = {
-    DB_HOST: process.env.DB_HOST,
-    DB_PORT: process.env.DB_PORT,
-    DB_USERNAME: process.env.DB_USERNAME,
-    DB_PASSWORD: process.env.DB_PASSWORD,
-  };
+  const originalEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      originalEnv[k] = process.env[k];
+    }
     process.env.DB_HOST = 'database';
     process.env.DB_PORT = '5432';
     process.env.DB_USERNAME = 'postgres';
@@ -17,7 +17,8 @@ describe('buildConnectionString', () => {
   });
 
   afterEach(() => {
-    for (const [k, v] of Object.entries(originalEnv)) {
+    for (const k of ENV_KEYS) {
+      const v = originalEnv[k];
       if (v === undefined) {
         delete process.env[k];
       } else {
@@ -54,11 +55,23 @@ describe('buildConnectionString', () => {
     expect(decodeURIComponent(url.pathname.slice(1))).toBe('db/with/slashes');
   });
 
-  it.each(['DB_USERNAME', 'DB_PASSWORD', 'DB_HOST', 'DB_PORT'])(
-    'throws if %s is not set',
-    (key) => {
-      delete process.env[key];
-      expect(() => buildConnectionString('any')).toThrow(key);
-    }
-  );
+  it('throws when DB_USERNAME is not set', () => {
+    process.env.DB_USERNAME = '';
+    expect(() => buildConnectionString('any')).toThrow('DB_USERNAME');
+  });
+
+  it('throws when DB_PASSWORD is not set', () => {
+    process.env.DB_PASSWORD = '';
+    expect(() => buildConnectionString('any')).toThrow('DB_PASSWORD');
+  });
+
+  it('throws when DB_HOST is not set', () => {
+    process.env.DB_HOST = '';
+    expect(() => buildConnectionString('any')).toThrow('DB_HOST');
+  });
+
+  it('throws when DB_PORT is not set', () => {
+    process.env.DB_PORT = '';
+    expect(() => buildConnectionString('any')).toThrow('DB_PORT');
+  });
 });

--- a/service.backend/src/__tests__/utils/connection-string.test.ts
+++ b/service.backend/src/__tests__/utils/connection-string.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildConnectionString } from '../../sequelize';
+
+describe('buildConnectionString', () => {
+  const originalEnv = {
+    DB_HOST: process.env.DB_HOST,
+    DB_PORT: process.env.DB_PORT,
+    DB_USERNAME: process.env.DB_USERNAME,
+    DB_PASSWORD: process.env.DB_PASSWORD,
+  };
+
+  beforeEach(() => {
+    process.env.DB_HOST = 'database';
+    process.env.DB_PORT = '5432';
+    process.env.DB_USERNAME = 'postgres';
+    process.env.DB_PASSWORD = 'simple';
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  });
+
+  it('produces a postgresql URL parseable by the WHATWG URL parser', () => {
+    const url = new URL(buildConnectionString('mydb'));
+    expect(url.protocol).toBe('postgresql:');
+    expect(url.username).toBe('postgres');
+    expect(url.password).toBe('simple');
+    expect(url.hostname).toBe('database');
+    expect(url.port).toBe('5432');
+    expect(url.pathname).toBe('/mydb');
+  });
+
+  it('encodes passwords containing reserved URI characters', () => {
+    // Real-world breakage: openssl rand -base64 32 emits passwords with '/',
+    // '+', and '='. Without encoding, the '/' terminates the authority and
+    // the URL parser ends up reading the username as the hostname.
+    process.env.DB_PASSWORD = '/PrZComp+Vi/E=';
+    const url = new URL(buildConnectionString('adopt_dont_shop_dev'));
+    expect(url.hostname).toBe('database');
+    expect(decodeURIComponent(url.password)).toBe('/PrZComp+Vi/E=');
+  });
+
+  it('encodes usernames and database names with reserved characters', () => {
+    process.env.DB_USERNAME = 'user@with:special';
+    const url = new URL(buildConnectionString('db/with/slashes'));
+    expect(url.hostname).toBe('database');
+    expect(decodeURIComponent(url.username)).toBe('user@with:special');
+    expect(decodeURIComponent(url.pathname.slice(1))).toBe('db/with/slashes');
+  });
+
+  it.each(['DB_USERNAME', 'DB_PASSWORD', 'DB_HOST', 'DB_PORT'])(
+    'throws if %s is not set',
+    (key) => {
+      delete process.env[key];
+      expect(() => buildConnectionString('any')).toThrow(key);
+    }
+  );
+});

--- a/service.backend/src/sequelize.ts
+++ b/service.backend/src/sequelize.ts
@@ -23,8 +23,17 @@ const buildConnectionString = (database: string): string => {
     throw new Error('DB_PORT environment variable is not set');
   }
 
-  return `postgresql://${username}:${password}@${host}:${port}/${database}`;
+  // URL-encode userinfo and database name. Random passwords (e.g. base64) can
+  // contain '/', '+', '=', and other characters that are reserved in URI
+  // userinfo; without encoding, the URL parser misreads the authority and
+  // ends up resolving the username as the host.
+  const u = encodeURIComponent(username);
+  const p = encodeURIComponent(password);
+  const db = encodeURIComponent(database);
+  return `postgresql://${u}:${p}@${host}:${port}/${db}`;
 };
+
+export { buildConnectionString };
 
 /**
  * Get the appropriate database connection string based on NODE_ENV


### PR DESCRIPTION
## Summary

Fixes the docker-compose CI job that's been timing out with `getaddrinfo EAI_AGAIN postgres`. Root cause is a URL-encoding bug in `buildConnectionString`, not infrastructure flakiness.

## Repro / observed failure

From the failing job log on PR #247:

```
01:30:44.420 [error]: Failed to start server: getaddrinfo EAI_AGAIN postgres
   "code":"EAI_AGAIN","syscall":"getaddrinfo","hostname":"postgres"
```

The backend retries the DB connection 4 times, then dies. The compose `until curl /health` loop hits its 90s timeout and the job exits 124.

## Root cause

`service.backend/src/sequelize.ts:26` builds the Postgres URL by raw string interpolation:

```ts
return `postgresql://${username}:${password}@${host}:${port}/${database}`;
```

The CI workflow generates `POSTGRES_PASSWORD=$(openssl rand -base64 32)`. base64 alphabet includes `/`, `+`, and `=`. With a password like `/PrZComp.../EUZQkY=`, the resulting URL is

```
postgresql://postgres:/PrZComp.../EUZQkY=@database:5432/adopt_dont_shop_dev
```

The `/` immediately after the `:` ends the URL authority. The parser ends up reading `postgres` (the username from compose's `${POSTGRES_USER:-adopt_user}` → `DB_USERNAME`) as the hostname. DNS lookup of `postgres` fails — that's the `EAI_AGAIN postgres` we see.

This isn't CI-only: any developer with a `/`, `+`, `=`, `@`, or `:` in their `DB_PASSWORD` would hit the same issue.

## Fix

`encodeURIComponent` username, password, and database name before assembling the URL (`service.backend/src/sequelize.ts`). `host` and `port` don't need encoding — host is a DNS name / IP, port is numeric.

`DEV_DATABASE_URL` / `DATABASE_URL` overrides bypass `buildConnectionString` entirely (see lines 40, 42, 45) and are unaffected — production stays on its existing pre-formatted-URL path.

Also exports `buildConnectionString` and adds `__tests__/utils/connection-string.test.ts` covering:

- Round-trip parse with WHATWG `URL` for the simple case
- The exact CI password shape (`/PrZComp+Vi/E=`) — asserts hostname stays `database`
- Usernames with `@` / `:` and database names with `/`
- Each `DB_*` env var being required

## Test plan

- [ ] CI's `Test Docker Compose Stack` goes green on this PR
- [ ] New `connection-string.test.ts` runs in the backend Vitest suite

## Notes

- Backwards compatible: `encodeURIComponent` on alphanumeric/`-_.!~*'()` is a no-op, so passwords without reserved chars get the same URL.
- Doesn't change the DEV_DATABASE_URL / DATABASE_URL flow; users supplying a pre-formatted URL are responsible for encoding their own credentials, same as today.

https://claude.ai/code/session_01EvkjwrdsjyG9RmbCvC9jBg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvkjwrdsjyG9RmbCvC9jBg)_