### PR TITLE
chore(deps): limit dependabot to major + security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   # npm workspace — covers all packages via root lockfile
+  # Only major version bumps are surfaced here. Security advisories
+  # always bypass `ignore` rules, so security fixes still come through.
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -9,6 +11,11 @@ updates:
       time: "09:00"
       timezone: Europe/London
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
     groups:
       typescript-eslint:
         patterns:
@@ -48,6 +55,11 @@ updates:
       time: "09:00"
       timezone: Europe/London
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
 
   # Docker — backend
   - package-ecosystem: docker
@@ -56,6 +68,11 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
 
   # Docker — frontend app Dockerfile
   - package-ecosystem: docker
@@ -64,3 +81,8 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor


### PR DESCRIPTION
## Summary
- Limits Dependabot to major version bumps only across npm, github-actions, and docker ecosystems
- Security advisories still come through automatically — `ignore` rules don't apply to security updates
- Goal: cut PR noise so the queue is manageable

## Test plan
- [ ] Merge and observe the next Monday Dependabot run produces only major-version PRs
- [ ] Confirm any GitHub security advisory still creates a PR despite the ignore rules

https://claude.ai/code/session_01N8MZSUHq9CgiGySRUW3oz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8MZSUHq9CgiGySRUW3oz5)_