### PR TITLE
chore(deps): bump node from 22-alpine to 24-alpine in /service.backend

### DIFF
--- a/service.backend/Dockerfile
+++ b/service.backend/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================================================
 # BASE STAGE - Shared foundation for all stages
 # ============================================================================
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 
 # Install security updates and necessary packages
 # hadolint ignore=DL3018
@@ -175,7 +175,7 @@ RUN rm -rf node_modules/@adopt-dont-shop/lib.types && \
 # ============================================================================
 # PRODUCTION STAGE - Minimal image with only runtime dependencies
 # ============================================================================
-FROM node:22-alpine AS production
+FROM node:24-alpine AS production
 
 # Install only runtime essentials + security updates
 # hadolint ignore=DL3018


### PR DESCRIPTION
## Summary

Replaces dependabot PR #261 (which proposed bumping to `25-alpine`).

Pin to **Node 24-alpine** — the active LTS line — instead of `25-alpine`, which is the current/odd-numbered Node release and not suitable for long-running production. The original PR's `Test Docker Compose Stack` job also timed out on `25-alpine` (exit 124).

Root `package.json` already declares `"engines": { "node": ">=20.0.0" }`, so 24 satisfies the constraint. No code or lockfile changes needed.

## Test plan

- [ ] CI: `Test Docker Compose Stack` passes (was failing on `25-alpine` in #261)
- [ ] CI: `Build Backend Image` succeeds
- [ ] CI: backend tests pass on the new image

Once green, close #261 with `@dependabot ignore this major version` to stop future v25 PRs.

https://claude.ai/code/session_01F34VuTbVF2UjoR8vcpcuy5

---
_Generated by [Claude Code](https://claude.ai/code/session_01F34VuTbVF2UjoR8vcpcuy5)_