### PR TITLE
fix: normalize snake_case body keys in fieldWriteGuard (#113)

### DIFF
--- a/service.backend/src/__tests__/middleware/field-permissions.test.ts
+++ b/service.backend/src/__tests__/middleware/field-permissions.test.ts
@@ -748,4 +748,45 @@ describe('Field Permissions Middleware - fieldWriteGuard (Express integration)',
     expect(mockNext).toHaveBeenCalled();
     expect(statusCode).toBeUndefined();
   });
+
+  it('should allow rescue_staff to POST pet fields sent as snake_case', async () => {
+    mockRequest.user = {
+      userId: 'staff-1',
+      userType: UserType.RESCUE_STAFF,
+    } as AuthenticatedRequest['user'];
+    // Frontend sends snake_case; defaults map uses camelCase — these must resolve
+    mockRequest.body = {
+      short_description: 'A friendly dog',
+      long_description: 'Very friendly',
+      adoption_fee: 50,
+      house_trained: true,
+      special_needs: false,
+      age_years: 2,
+      age_months: 0,
+      energy_level: 'medium',
+    };
+
+    const middleware = fieldWriteGuard('pets');
+    await middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(statusCode).toBeUndefined();
+  });
+
+  it('should still block a restricted snake_case field', async () => {
+    mockRequest.user = {
+      userId: 'adopter-1',
+      userType: UserType.ADOPTER,
+    } as AuthenticatedRequest['user'];
+    // Adopters cannot write any pet fields
+    mockRequest.body = {
+      short_description: 'Trying to write',
+    };
+
+    const middleware = fieldWriteGuard('pets');
+    await middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
+
+    expect(statusCode).toBe(403);
+    expect(mockNext).not.toHaveBeenCalled();
+  });
 });

--- a/service.backend/src/middleware/field-permissions.ts
+++ b/service.backend/src/middleware/field-permissions.ts
@@ -398,7 +398,8 @@ export const fieldWriteGuard = (
       const accessMap = await getEffectiveAccessMap(resource, role);
       const requestedFields = Object.keys(body);
       const blockedFields = requestedFields.filter(field => {
-        const level = accessMap[field];
+        const camelField = field.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+        const level = accessMap[camelField] ?? accessMap[field];
         return level !== 'write';
       });
 


### PR DESCRIPTION
## Summary

- Converts each request body key from snake_case to camelCase before looking it up in the field-permission access map
- Falls back to the original key so bodies already in camelCase continue to work
- Adds two new tests: `rescue_staff` POST with snake_case pet fields succeeds; a genuinely-restricted field still returns 403

## Root cause

The frontend sends snake_case body keys (`short_description`, `age_years`, `adoption_fee`, …) but the defaults map in `lib.types` is keyed camelCase (`shortDescription`, `ageYears`, `adoptionFee`). `accessMap[field]` returned `undefined` for every snake_case key, so all of them fell through to the "denied" branch and every `rescue_staff` pet write returned 403.

## Files changed

- `service.backend/src/middleware/field-permissions.ts` — two-line fix at the lookup site
- `service.backend/src/__tests__/middleware/field-permissions.test.ts` — two new behaviour tests

## Test plan

- [ ] Run `npm run test` in `service.backend` — all 34 field-permission tests pass
- [ ] POST `/api/v1/pets` as `rescue_staff` with snake_case body — expect 200, not 403
- [ ] POST with a field the role cannot write — expect 403 with `blockedFields`

Closes #113

https://claude.ai/code/session_0175PfPEVkF5zX56DFqT5tU6

---
_Generated by [Claude Code](https://claude.ai/code/session_0175PfPEVkF5zX56DFqT5tU6)_