### PR TITLE
fix: post-register check-your-email page + verification URL hygiene (#108)

### DIFF
--- a/app.client/src/App.tsx
+++ b/app.client/src/App.tsx
@@ -49,6 +49,9 @@ const RegisterPage = lazy(() =>
 const VerifyEmailPage = lazy(() =>
   import('@/pages/VerifyEmailPage').then(m => ({ default: m.VerifyEmailPage }))
 );
+const CheckYourEmailPage = lazy(() =>
+  import('@/pages/CheckYourEmailPage').then(m => ({ default: m.CheckYourEmailPage }))
+);
 const ForgotPasswordPage = lazy(() =>
   import('@/pages/ForgotPasswordPage').then(m => ({ default: m.ForgotPasswordPage }))
 );
@@ -91,6 +94,7 @@ function App() {
                     <Route path='/login' element={<LoginPage />} />
                     <Route path='/register' element={<RegisterPage />} />
                     <Route path='/verify-email' element={<VerifyEmailPage />} />
+                    <Route path='/check-your-email' element={<CheckYourEmailPage />} />
                     <Route path='/forgot-password' element={<ForgotPasswordPage />} />
                     <Route path='/reset-password' element={<ResetPasswordPage />} />
                   </Route>

--- a/app.client/src/pages/CheckYourEmailPage.css.ts
+++ b/app.client/src/pages/CheckYourEmailPage.css.ts
@@ -1,0 +1,59 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+export const container = style({
+  minHeight: 'calc(100vh - 200px)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '2rem',
+  background: 'linear-gradient(135deg, #ffffff 0%, #f9fafb 100%)',
+});
+
+export const card = style({
+  width: '100%',
+  maxWidth: '500px',
+  padding: '2.5rem',
+});
+
+export const iconContainer = style({
+  textAlign: 'center',
+  marginBottom: '1.5rem',
+  fontSize: '4rem',
+});
+
+export const header = style({
+  textAlign: 'center',
+  marginBottom: '2rem',
+});
+
+globalStyle(`${header} h1`, {
+  fontSize: '2rem',
+  marginBottom: '0.5rem',
+  color: '#111827',
+});
+
+globalStyle(`${header} p`, {
+  color: '#6b7280',
+  lineHeight: '1.6',
+  fontSize: '1rem',
+});
+
+export const buttonGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  marginTop: '2rem',
+});
+
+export const resendSection = style({
+  textAlign: 'center',
+  marginTop: '1.5rem',
+  paddingTop: '1.5rem',
+  borderTop: '1px solid #e5e7eb',
+});
+
+globalStyle(`${resendSection} p`, {
+  color: '#6b7280',
+  marginBottom: '1rem',
+  fontSize: '0.95rem',
+});

--- a/app.client/src/pages/CheckYourEmailPage.tsx
+++ b/app.client/src/pages/CheckYourEmailPage.tsx
@@ -1,0 +1,72 @@
+import { authService } from '@/services';
+import { Alert, Button, Card } from '@adopt-dont-shop/lib.components';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as styles from './CheckYourEmailPage.css';
+
+export const CheckYourEmailPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [isResending, setIsResending] = useState(false);
+  const [resendSuccess, setResendSuccess] = useState(false);
+  const [resendError, setResendError] = useState('');
+
+  const handleResend = async () => {
+    try {
+      setIsResending(true);
+      setResendSuccess(false);
+      setResendError('');
+      await authService.resendVerificationEmail();
+      setResendSuccess(true);
+    } catch (error) {
+      setResendError(
+        error instanceof Error ? error.message : 'Failed to resend verification email'
+      );
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <Card className={styles.card}>
+        <div className={styles.iconContainer}>📧</div>
+        <div className={styles.header}>
+          <h1>Check Your Email</h1>
+          <p>
+            We've sent a verification link to your email address. Click the link to activate your
+            account and access all features.
+          </p>
+        </div>
+
+        <Alert variant='info'>
+          The link expires after 24 hours. Check your spam folder if you don't see it.
+        </Alert>
+
+        <div className={styles.resendSection}>
+          <p>Didn't receive the email?</p>
+          <Button onClick={handleResend} disabled={isResending} isFullWidth>
+            {isResending ? 'Sending...' : 'Resend Verification Email'}
+          </Button>
+          {resendSuccess && (
+            <div style={{ marginTop: '1rem' }}>
+              <Alert variant='success'>Verification email sent! Please check your inbox.</Alert>
+            </div>
+          )}
+          {resendError && (
+            <div style={{ marginTop: '1rem' }}>
+              <Alert variant='error'>{resendError}</Alert>
+            </div>
+          )}
+        </div>
+
+        <div className={styles.buttonGroup}>
+          <Button variant='secondary' onClick={() => navigate('/login')} isFullWidth>
+            Back to Login
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default CheckYourEmailPage;

--- a/app.client/src/pages/RegisterPage.tsx
+++ b/app.client/src/pages/RegisterPage.tsx
@@ -7,7 +7,7 @@ export const RegisterPage: React.FC = () => {
   const navigate = useNavigate();
 
   const handleSuccess = () => {
-    navigate('/', { replace: true });
+    navigate('/check-your-email', { replace: true });
   };
 
   return (

--- a/app.client/src/pages/VerifyEmailPage.tsx
+++ b/app.client/src/pages/VerifyEmailPage.tsx
@@ -25,6 +25,9 @@ export const VerifyEmailPage: React.FC = () => {
       }
 
       try {
+        // Strip the token from browser history before the response arrives
+        // so it doesn't linger in address bar, history, or referer headers.
+        window.history.replaceState(null, '', window.location.pathname);
         await authService.verifyEmail(token);
         setStatus('success');
 

--- a/app.client/src/pages/index.ts
+++ b/app.client/src/pages/index.ts
@@ -1,5 +1,6 @@
 export { ApplicationDetailsPage } from './ApplicationDetailsPage';
 export { ApplicationPage } from './ApplicationPage';
+export { CheckYourEmailPage } from './CheckYourEmailPage';
 export { BlogPage } from './BlogPage';
 export { BlogPostPage } from './BlogPostPage';
 export { FavoritesPage } from './FavoritesPage';


### PR DESCRIPTION
## Summary

Addresses the two highest-impact remaining items from issue #108 (the structured 403 response and resend UI were already shipped in #107).

- **New page**: `CheckYourEmailPage` at `/check-your-email` — tells the user to check their inbox, shows expiry warning, and provides a "Resend verification email" CTA
- **Register redirect**: `RegisterPage` now navigates to `/check-your-email` instead of `/` after successful registration, so the user is never silently dumped into the app in a broken `pending_verification` state
- **URL hygiene**: `VerifyEmailPage` calls `history.replaceState` before dispatching the verify request, stripping the raw token from browser history, address bar, and referer headers immediately

## What was already done (not in this PR)

- Auth middleware returns 403 + `{ code: 'EMAIL_NOT_VERIFIED' }` for verified-only routes
- `VerifyEmailPage` handles expired/error states with a resend button
- `POST /auth/resend-verification` endpoint exists

## Files changed

- `app.client/src/pages/CheckYourEmailPage.tsx` — new page
- `app.client/src/pages/CheckYourEmailPage.css.ts` — styles (mirrors VerifyEmailPage layout)
- `app.client/src/pages/index.ts` — export new page
- `app.client/src/pages/RegisterPage.tsx` — redirect target changed
- `app.client/src/pages/VerifyEmailPage.tsx` — strip token from URL on verify
- `app.client/src/App.tsx` — register new route under PublicAuthLayout

## Test plan

- [ ] Register a new account → should land on `/check-your-email`, not `/`
- [ ] Click "Resend Verification Email" → confirm toast/alert appears
- [ ] Click the emailed verification link → token should be stripped from address bar immediately, page shows success/error state
- [ ] Navigate back to `/check-your-email` without being logged in — page renders correctly

Closes #108

https://claude.ai/code/session_0175PfPEVkF5zX56DFqT5tU6

---
_Generated by [Claude Code](https://claude.ai/code/session_0175PfPEVkF5zX56DFqT5tU6)_