### PR TITLE
fix(security): block cross-rescue IDOR in PetService mutation methods (ADS-348)

### DIFF
--- a/service.backend/src/__tests__/services/pet-business-logic.test.ts
+++ b/service.backend/src/__tests__/services/pet-business-logic.test.ts
@@ -25,6 +25,8 @@ import PetStatusTransition from '../../models/PetStatusTransition';
 import Application, { ApplicationStatus } from '../../models/Application';
 import { PetService } from '../../services/pet.service';
 import { PetCreateData, PetStatusUpdate, PetUpdateData } from '../../types/pet';
+import User, { UserType } from '../../models/User';
+import StaffMember from '../../models/StaffMember';
 
 // Mocked dependencies
 const MockedPet = Pet as vi.MockedObject<Pet>;
@@ -33,6 +35,8 @@ const MockedPetStatusTransition = PetStatusTransition as vi.MockedObject<
   typeof PetStatusTransition
 >;
 const MockedPetMedia = PetMedia as vi.MockedObject<typeof PetMedia>;
+const MockedUser = User as vi.MockedObject<typeof User>;
+const MockedStaffMember = StaffMember as vi.MockedObject<typeof StaffMember>;
 
 // Test constants
 const mockRescueId = 'rescue-123';
@@ -105,6 +109,12 @@ describe('PetService - Business Logic', () => {
     MockedPetMedia.bulkCreate = vi.fn().mockResolvedValue([] as never);
     MockedPetMedia.destroy = vi.fn().mockResolvedValue(0 as never);
     MockedPetMedia.count = vi.fn().mockResolvedValue(0 as never);
+    // Ownership checks in PetService mutation methods call User.findByPk and
+    // StaffMember.findOne. Return an admin user so the check is bypassed in
+    // these business-logic tests (the ownership enforcement is covered
+    // separately in pet.service.test.ts).
+    MockedUser.findByPk = vi.fn().mockResolvedValue({ userType: UserType.ADMIN } as never);
+    MockedStaffMember.findOne = vi.fn().mockResolvedValue(null as never);
   });
 
   // ==========================================================================

--- a/service.backend/src/__tests__/services/pet.service.test.ts
+++ b/service.backend/src/__tests__/services/pet.service.test.ts
@@ -34,12 +34,14 @@ vi.mock('../../services/auditLog.service', () => ({
 // Import Report model for real database operations
 import Report from '../../models/Report';
 import User, { UserStatus, UserType } from '../../models/User';
+import StaffMember from '../../models/StaffMember';
 
 import { AuditLogService } from '../../services/auditLog.service';
 const mockAuditLog = AuditLogService.log as vi.MockedFunction<typeof AuditLogService.log>;
 
 describe('PetService', () => {
   let testRescue: Rescue;
+  let testCallerId: string;
   let testCounter = 0;
 
   // Helper to generate unique IDs
@@ -85,6 +87,28 @@ describe('PetService', () => {
       contactPerson: 'Test Contact',
       status: 'verified',
       country: 'GB',
+    });
+
+    // Create a verified rescue-staff user and associate them with the test rescue.
+    // Mutating PetService methods enforce rescue ownership, so callers that
+    // are not admins must have a verified StaffMember row.
+    testCallerId = `caller-${timestamp}-${testCounter++}`;
+    await User.create({
+      userId: testCallerId,
+      email: `caller-${timestamp}@test.com`,
+      firstName: 'Test',
+      lastName: 'Caller',
+      password: 'hashed-password',
+      userType: UserType.RESCUE_STAFF,
+      emailVerified: true,
+      status: UserStatus.ACTIVE,
+    });
+    await StaffMember.create({
+      rescueId: testRescue.rescueId,
+      userId: testCallerId,
+      isVerified: true,
+      addedBy: testCallerId,
+      addedAt: new Date(),
     });
   });
 
@@ -392,7 +416,7 @@ describe('PetService', () => {
     };
 
     it('should update pet successfully', async () => {
-      const result = await PetService.updatePet(petId, updateData, 'user1');
+      const result = await PetService.updatePet(petId, updateData, testCallerId);
 
       expect(result.name).toBe('Updated Name');
       expect(result.shortDescription).toBe('Updated description');
@@ -402,7 +426,7 @@ describe('PetService', () => {
           action: 'UPDATE',
           entity: 'Pet',
           entityId: petId,
-          userId: 'user1',
+          userId: testCallerId,
         })
       );
     });
@@ -416,7 +440,7 @@ describe('PetService', () => {
     it('should allow updates to adopted pets (service permits it)', async () => {
       await testPet.update({ status: PetStatus.ADOPTED });
 
-      const result = await PetService.updatePet(petId, updateData, 'user1');
+      const result = await PetService.updatePet(petId, updateData, testCallerId);
       expect(result).toBeDefined();
       expect(result.name).toBe('Updated Name');
     });
@@ -452,7 +476,7 @@ describe('PetService', () => {
     };
 
     it('should update pet status successfully', async () => {
-      const result = await PetService.updatePetStatus(petId, statusUpdate, 'user1');
+      const result = await PetService.updatePetStatus(petId, statusUpdate, testCallerId);
 
       expect(result.status).toBe(PetStatus.ADOPTED);
       expect(result.adoptedDate).toBeDefined();
@@ -466,9 +490,9 @@ describe('PetService', () => {
             originalStatus: PetStatus.AVAILABLE,
             newStatus: PetStatus.ADOPTED,
             reason: statusUpdate.reason,
-            updatedBy: 'user1',
+            updatedBy: testCallerId,
           }),
-          userId: 'user1',
+          userId: testCallerId,
         })
       );
     });
@@ -504,7 +528,7 @@ describe('PetService', () => {
     });
 
     it('should soft delete pet successfully', async () => {
-      const result = await PetService.deletePet(petId, 'user1', 'No longer available');
+      const result = await PetService.deletePet(petId, testCallerId, 'No longer available');
 
       expect(result.message).toBe('Pet deleted successfully');
 
@@ -519,9 +543,9 @@ describe('PetService', () => {
           entityId: petId,
           details: expect.objectContaining({
             reason: 'No longer available',
-            deletedBy: 'user1',
+            deletedBy: testCallerId,
           }),
-          userId: 'user1',
+          userId: testCallerId,
         })
       );
     });
@@ -533,7 +557,7 @@ describe('PetService', () => {
     it('should delete adopted pets (service allows it)', async () => {
       await testPet.update({ status: PetStatus.ADOPTED });
 
-      const result = await PetService.deletePet(petId, 'user1');
+      const result = await PetService.deletePet(petId, testCallerId);
       expect(result.message).toBe('Pet deleted successfully');
     });
   });
@@ -813,7 +837,7 @@ describe('PetService', () => {
         reason: 'Bulk adoption',
       };
 
-      const result = await PetService.bulkUpdatePets(operation, 'user1');
+      const result = await PetService.bulkUpdatePets(operation, testCallerId);
 
       expect(result.successCount).toBe(2);
       expect(result.failedCount).toBe(0);
@@ -833,7 +857,7 @@ describe('PetService', () => {
         reason: 'Bulk archive',
       };
 
-      const result = await PetService.bulkUpdatePets(operation, 'user1');
+      const result = await PetService.bulkUpdatePets(operation, testCallerId);
 
       // Service archives both successfully (nonexistent just doesn't do anything)
       expect(result.successCount).toBe(2);
@@ -846,7 +870,7 @@ describe('PetService', () => {
         operation: 'invalid_operation' as 'archive',
       };
 
-      const result = await PetService.bulkUpdatePets(operation, 'user1');
+      const result = await PetService.bulkUpdatePets(operation, testCallerId);
 
       expect(result.successCount).toBe(0);
       expect(result.failedCount).toBe(1);
@@ -1239,6 +1263,198 @@ describe('PetService', () => {
 
       // Restore
       Report.create = originalCreate;
+    });
+  });
+
+  // ADS-348: Cross-rescue IDOR — staff of rescue A must not mutate pets
+  // belonging to rescue B. Every mutating PetService method must enforce this.
+  describe('cross-rescue ownership enforcement', () => {
+    let rescueA: Rescue;
+    let rescueB: Rescue;
+    let staffAUserId: string;
+    let petOfRescueB: Pet;
+    let petIdB: string;
+
+    beforeEach(async () => {
+      // testRescue is already created by the outer beforeEach; use it as rescue A
+      rescueA = testRescue;
+      staffAUserId = testCallerId; // verified staff of rescue A
+
+      const ts = Date.now();
+      const counter = testCounter++;
+
+      // Create a second rescue (rescue B)
+      rescueB = await Rescue.create({
+        rescueId: `rescue-b-${ts}-${counter}`,
+        name: `Rescue B ${ts}`,
+        email: `rescue-b-${ts}@test.com`,
+        address: '456 Other Street',
+        city: 'Other City',
+        postcode: 'OTH456',
+        contactPerson: 'Other Contact',
+        status: 'verified',
+        country: 'GB',
+      });
+
+      const goldenId = await breedIdFor(PetType.DOG, 'Golden Retriever');
+
+      // Create a pet that belongs to rescue B
+      petIdB = `pet-b-${ts}-${counter}`;
+      petOfRescueB = await Pet.create({
+        petId: petIdB,
+        name: 'Rescue B Pet',
+        type: PetType.DOG,
+        status: PetStatus.AVAILABLE,
+        breedId: goldenId,
+        size: Size.LARGE,
+        ageGroup: AgeGroup.ADULT,
+        gender: Gender.MALE,
+        energyLevel: EnergyLevel.MEDIUM,
+        vaccinationStatus: VaccinationStatus.UP_TO_DATE,
+        spayNeuterStatus: SpayNeuterStatus.NEUTERED,
+        rescueId: rescueB.rescueId,
+        archived: false,
+      });
+    });
+
+    it('updatePet: rescue A staff cannot update a rescue B pet', async () => {
+      await expect(
+        PetService.updatePet(petIdB, { name: 'Hacked Name' }, staffAUserId)
+      ).rejects.toMatchObject({ statusCode: 403 });
+
+      // The pet must be unchanged
+      await petOfRescueB.reload();
+      expect(petOfRescueB.name).toBe('Rescue B Pet');
+    });
+
+    it('updatePetStatus: rescue A staff cannot change status of a rescue B pet', async () => {
+      await expect(
+        PetService.updatePetStatus(
+          petIdB,
+          { status: PetStatus.ADOPTED, reason: 'IDOR attempt' },
+          staffAUserId
+        )
+      ).rejects.toMatchObject({ statusCode: 403 });
+
+      await petOfRescueB.reload();
+      expect(petOfRescueB.status).toBe(PetStatus.AVAILABLE);
+    });
+
+    it('deletePet: rescue A staff cannot delete a rescue B pet', async () => {
+      await expect(PetService.deletePet(petIdB, staffAUserId)).rejects.toMatchObject({
+        statusCode: 403,
+      });
+
+      // The pet must still exist (soft-delete was not applied)
+      const stillThere = await Pet.findByPk(petIdB);
+      expect(stillThere).not.toBeNull();
+    });
+
+    it('updatePetImages: rescue A staff cannot replace images of a rescue B pet', async () => {
+      await expect(
+        PetService.updatePetImages(
+          petIdB,
+          [{ url: 'https://evil.com/img.jpg', isPrimary: true }],
+          staffAUserId
+        )
+      ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    it('removePetImage: rescue A staff cannot remove an image from a rescue B pet', async () => {
+      await expect(
+        PetService.removePetImage(petIdB, 'some-image-id', staffAUserId)
+      ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    it('bulkUpdatePets: mixed-rescue payload is rejected with no mutations applied', async () => {
+      // pet of rescue A (belongs to staffA's rescue) + pet of rescue B
+      const petIdA = uniqueId('pet-a-bulk');
+      await Pet.create({
+        petId: petIdA,
+        name: 'Rescue A Pet',
+        type: PetType.DOG,
+        status: PetStatus.AVAILABLE,
+        breedId: await breedIdFor(PetType.DOG, 'Golden Retriever'),
+        size: Size.LARGE,
+        ageGroup: AgeGroup.ADULT,
+        gender: Gender.MALE,
+        energyLevel: EnergyLevel.MEDIUM,
+        vaccinationStatus: VaccinationStatus.UP_TO_DATE,
+        spayNeuterStatus: SpayNeuterStatus.NEUTERED,
+        rescueId: rescueA.rescueId,
+        archived: false,
+      });
+
+      await expect(
+        PetService.bulkUpdatePets({ petIds: [petIdA, petIdB], operation: 'archive' }, staffAUserId)
+      ).rejects.toMatchObject({ statusCode: 403 });
+
+      // Neither pet should have been archived
+      const petA = await Pet.findByPk(petIdA);
+      const petB = await Pet.findByPk(petIdB);
+      expect(petA?.archived).toBe(false);
+      expect(petB?.archived).toBe(false);
+    });
+
+    it('admin user bypasses cross-rescue check and can mutate any pet', async () => {
+      const ts = Date.now();
+      const adminId = `admin-${ts}-${testCounter++}`;
+      await User.create({
+        userId: adminId,
+        email: `admin-${ts}@test.com`,
+        firstName: 'Admin',
+        lastName: 'User',
+        password: 'hashed-password',
+        userType: UserType.ADMIN,
+        emailVerified: true,
+      });
+
+      const result = await PetService.updatePet(petIdB, { name: 'Admin Updated' }, adminId);
+      expect(result.name).toBe('Admin Updated');
+    });
+
+    it('unverified staff cannot mutate even their own rescue pets', async () => {
+      const ts = Date.now();
+      const unverifiedId = `unverified-${ts}-${testCounter++}`;
+      await User.create({
+        userId: unverifiedId,
+        email: `unverified-${ts}@test.com`,
+        firstName: 'Unverified',
+        lastName: 'Staff',
+        password: 'hashed-password',
+        userType: UserType.RESCUE_STAFF,
+        emailVerified: true,
+      });
+      // Staff member row for rescue A but isVerified = false
+      await StaffMember.create({
+        rescueId: rescueA.rescueId,
+        userId: unverifiedId,
+        isVerified: false,
+        addedBy: testCallerId,
+        addedAt: new Date(),
+      });
+
+      // Create a pet belonging to rescue A (the unverified user's own rescue)
+      const ownRescuePetId = uniqueId('own-rescue-pet');
+      await Pet.create({
+        petId: ownRescuePetId,
+        name: 'Own Rescue Pet',
+        type: PetType.DOG,
+        status: PetStatus.AVAILABLE,
+        breedId: await breedIdFor(PetType.DOG, 'Golden Retriever'),
+        size: Size.LARGE,
+        ageGroup: AgeGroup.ADULT,
+        gender: Gender.MALE,
+        energyLevel: EnergyLevel.MEDIUM,
+        vaccinationStatus: VaccinationStatus.UP_TO_DATE,
+        spayNeuterStatus: SpayNeuterStatus.NEUTERED,
+        rescueId: rescueA.rescueId,
+        archived: false,
+      });
+
+      await expect(
+        PetService.updatePet(ownRescuePetId, { name: 'Hacked' }, unverifiedId)
+      ).rejects.toMatchObject({ statusCode: 403 });
     });
   });
 });

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -31,6 +31,8 @@ import {
 } from '../types/pet';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
+import User, { UserType } from '../models/User';
+import StaffMember from '../models/StaffMember';
 
 const PET_SEARCH_SORT_FIELDS = [
   'createdAt',
@@ -79,6 +81,46 @@ const resolveBreedIdsByName = async (name: string): Promise<string[]> => {
 };
 
 export class PetService {
+  /**
+   * Verifies that the calling user owns the pet's rescue, then returns the
+   * loaded Pet. Admins and moderators bypass the check. Throws 403 for any
+   * cross-rescue attempt, or 404 when the pet doesn't exist.
+   */
+  private static async assertCallerOwnsPet(petId: string, callerUserId: string): Promise<Pet> {
+    const pet = await Pet.findByPk(petId);
+    if (!pet) {
+      throw Object.assign(new Error('Pet not found'), { statusCode: 404 });
+    }
+
+    const caller = await User.findByPk(callerUserId);
+    if (caller && (caller.userType === UserType.ADMIN || caller.userType === UserType.MODERATOR)) {
+      return pet;
+    }
+
+    const staff = await StaffMember.findOne({
+      where: { userId: callerUserId, isVerified: true },
+    });
+
+    if (!staff || staff.rescueId !== pet.rescueId) {
+      await AuditLogService.log({
+        action: 'UNAUTHORIZED_ACCESS_ATTEMPT',
+        entity: 'Pet',
+        entityId: petId,
+        details: {
+          callerUserId,
+          callerRescueId: staff?.rescueId ?? null,
+          petRescueId: pet.rescueId,
+        },
+        userId: callerUserId,
+      });
+      throw Object.assign(new Error('Access denied: pet belongs to another rescue'), {
+        statusCode: 403,
+      });
+    }
+
+    return pet;
+  }
+
   /**
    * Search pets with advanced filtering and sorting
    */
@@ -538,10 +580,7 @@ export class PetService {
     const startTime = Date.now();
 
     try {
-      const pet = await Pet.findByPk(petId);
-      if (!pet) {
-        throw new Error('Pet not found');
-      }
+      const pet = await PetService.assertCallerOwnsPet(petId, updatedBy);
 
       // Store original data for audit
       const originalData = pet.toJSON();
@@ -763,10 +802,7 @@ export class PetService {
     const startTime = Date.now();
 
     try {
-      const pet = await Pet.findByPk(petId);
-      if (!pet) {
-        throw new Error('Pet not found');
-      }
+      const pet = await PetService.assertCallerOwnsPet(petId, updatedBy);
 
       const originalStatus = pet.status;
 
@@ -847,10 +883,7 @@ export class PetService {
     const startTime = Date.now();
 
     try {
-      const pet = await Pet.findByPk(petId);
-      if (!pet) {
-        throw new Error('Pet not found');
-      }
+      const pet = await PetService.assertCallerOwnsPet(petId, deletedBy);
 
       // Soft delete the pet
       await pet.destroy();
@@ -953,10 +986,7 @@ export class PetService {
     updatedBy: string
   ): Promise<Pet> {
     try {
-      const pet = await Pet.findByPk(petId);
-      if (!pet) {
-        throw new Error('Pet not found');
-      }
+      const pet = await PetService.assertCallerOwnsPet(petId, updatedBy);
 
       // Replace all images: delete-then-insert inside a transaction so a
       // failed bulkCreate doesn't leave the pet with no media.
@@ -1011,10 +1041,7 @@ export class PetService {
    */
   static async removePetImage(petId: string, imageId: string, removedBy: string): Promise<Pet> {
     try {
-      const pet = await Pet.findByPk(petId);
-      if (!pet) {
-        throw new Error('Pet not found');
-      }
+      const pet = await PetService.assertCallerOwnsPet(petId, removedBy);
 
       const deleted = await PetMedia.destroy({
         where: { media_id: imageId, pet_id: petId, type: PetMediaType.IMAGE },
@@ -1209,6 +1236,48 @@ export class PetService {
   ): Promise<BulkPetOperationResult> {
     try {
       const { petIds, operation: operationType, data, reason } = operation;
+
+      // Pre-flight ownership check — all-or-nothing to prevent partial mutations
+      // across rescue boundaries. Admins/moderators bypass this.
+      const caller = await User.findByPk(updatedBy);
+      const isPrivileged =
+        caller && (caller.userType === UserType.ADMIN || caller.userType === UserType.MODERATOR);
+
+      if (!isPrivileged) {
+        const staff = await StaffMember.findOne({
+          where: { userId: updatedBy, isVerified: true },
+        });
+        if (!staff) {
+          throw Object.assign(new Error('Access denied: caller is not rescue staff'), {
+            statusCode: 403,
+          });
+        }
+        const pets = await Pet.findAll({
+          where: { petId: { [Op.in]: petIds } },
+          attributes: ['petId', 'rescueId'],
+        });
+        const crossRescuePet = pets.find(p => p.rescueId !== staff.rescueId);
+        if (crossRescuePet) {
+          await AuditLogService.log({
+            action: 'UNAUTHORIZED_ACCESS_ATTEMPT',
+            entity: 'Pet',
+            entityId: 'bulk',
+            details: {
+              callerUserId: updatedBy,
+              callerRescueId: staff.rescueId,
+              petIds,
+              firstCrossRescuePetId: crossRescuePet.petId,
+              firstCrossRescuePetRescueId: crossRescuePet.rescueId,
+            },
+            userId: updatedBy,
+          });
+          throw Object.assign(
+            new Error('Access denied: one or more pets belong to another rescue'),
+            { statusCode: 403 }
+          );
+        }
+      }
+
       const results: BulkPetOperationResult = {
         successCount: 0,
         failedCount: 0,


### PR DESCRIPTION
## Summary

Fixes ADS-348: horizontal privilege escalation across rescue tenant boundaries in `PetService`.

- **Root cause**: All six mutating `PetService` methods (`updatePet`, `updatePetStatus`, `deletePet`, `updatePetImages`, `removePetImage`, `bulkUpdatePets`) called `Pet.findByPk` without verifying the caller's rescue matches the pet's rescue. Any rescue staff member with `pets.update` / `pets.delete` permission could modify pets belonging to other rescues.
- **Fix**: Introduced a private `assertCallerOwnsPet` helper that loads the pet, checks if the caller is an admin/moderator (bypass allowed), then verifies the caller has a verified `StaffMember` row whose `rescueId` matches the pet's rescue. Throws 403 and writes an audit log entry on any cross-rescue attempt.
- **`bulkUpdatePets`**: Added an all-or-nothing pre-flight check — batch-loads all requested pet `rescueId`s and rejects the entire payload with 403 if any pet belongs to a different rescue (no partial mutations are applied).

## Test plan

- [ ] All 53 tests in `pet.service.test.ts` pass (8 new tests in `cross-rescue ownership enforcement` describe block)
- [ ] All 38 tests in `pet-business-logic.test.ts` pass (mocks updated to stub admin user for ownership check)
- [ ] All 645 tests in the full service test suite pass
- [ ] `updatePet`: rescue A staff → 403 on rescue B pet, pet unchanged
- [ ] `updatePetStatus`: rescue A staff → 403, status unchanged
- [ ] `deletePet`: rescue A staff → 403, pet still exists
- [ ] `updatePetImages`: rescue A staff → 403
- [ ] `removePetImage`: rescue A staff → 403
- [ ] `bulkUpdatePets`: mixed-rescue payload → 403, no pets archived
- [ ] Admin user bypasses check and can mutate any pet
- [ ] Unverified staff member blocked even on their own rescue's pets

https://claude.ai/code/session_01FUAFJSUazsT3QDNic6X21C

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUAFJSUazsT3QDNic6X21C)_