### PR TITLE
Streamline API service initialization and improve JWT error handling

### DIFF
--- a/lib.pets/src/services/pets-management-service.ts
+++ b/lib.pets/src/services/pets-management-service.ts
@@ -21,20 +21,8 @@ export class PetManagementService {
   private config: PetsServiceConfig;
 
   constructor(apiService?: ApiService, config: PetsServiceConfig = {}) {
-    this.apiService =
-      apiService ||
-      new ApiService({
-        apiUrl: 'http://localhost:5000',
-        getAuthToken: () => {
-          // Get token from localStorage, prioritizing authToken over accessToken
-          if (typeof localStorage !== 'undefined') {
-            return localStorage.getItem('authToken') || localStorage.getItem('accessToken');
-          }
-          return null;
-        },
-      });
+    this.apiService = apiService || new ApiService();
     this.config = {
-      apiUrl: 'http://localhost:5000',
       debug: false,
       ...config,
     };

--- a/service.backend/src/middleware/auth.ts
+++ b/service.backend/src/middleware/auth.ts
@@ -153,13 +153,16 @@ export const authenticateToken = async (
       req
     );
 
-    if (error instanceof jwt.JsonWebTokenError) {
-      res.status(401).json({ error: 'Invalid token' });
+    // TokenExpiredError must be checked before JsonWebTokenError because
+    // TokenExpiredError extends JsonWebTokenError — checking the parent first
+    // would mask expiry errors as generic "Invalid token" responses.
+    if (error instanceof jwt.TokenExpiredError) {
+      res.status(401).json({ error: 'Token expired' });
       return;
     }
 
-    if (error instanceof jwt.TokenExpiredError) {
-      res.status(401).json({ error: 'Token expired' });
+    if (error instanceof jwt.JsonWebTokenError) {
+      res.status(401).json({ error: 'Invalid token' });
       return;
     }
 


### PR DESCRIPTION
This pull request makes targeted improvements to authentication error handling and service configuration defaults. The main changes are:

**Authentication error handling improvements:**

* The order of error checks in the `authenticateToken` middleware was updated to ensure that token expiration errors are handled before generic JWT errors. This prevents expired tokens from being incorrectly reported as "Invalid token" instead of "Token expired".

**Service configuration simplification:**

* The `PetManagementService` constructor no longer sets a default `apiUrl` or custom `getAuthToken` logic for the `ApiService`. Instead, it uses the default configuration of `ApiService` unless an instance is provided fixing a bug where a rescue cant access pets.