### PR TITLE
fix(lint): fix prettier formatting and duplicate import for PR 284

### DIFF
--- a/lib.validation/src/schemas/__tests__/user.test.ts
+++ b/lib.validation/src/schemas/__tests__/user.test.ts
@@ -1,4 +1,5 @@
 import {
+  BulkUserUpdateRequestSchema,
   EmailSchema,
   LoginRequestSchema,
   PhoneNumberSchema,
@@ -153,6 +154,106 @@ describe('User schemas', () => {
         location: { city: 'London', country: 'GB' },
       });
       expect(parsed.location?.city).toBe('London');
+    });
+  });
+
+  describe('BulkUserUpdateRequestSchema', () => {
+    const validUserIds = [
+      '550e8400-e29b-41d4-a716-446655440000',
+      '550e8400-e29b-41d4-a716-446655440001',
+    ];
+
+    it('accepts a valid bulk status update', () => {
+      const parsed = BulkUserUpdateRequestSchema.parse({
+        userIds: validUserIds,
+        updateData: { status: 'active' },
+      });
+      expect(parsed.userIds).toHaveLength(2);
+      expect(parsed.updateData.status).toBe('active');
+    });
+
+    it('accepts updateData with no fields (no-op update)', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({ userIds: validUserIds, updateData: {} })
+      ).not.toThrow();
+    });
+
+    it('rejects userType — privilege escalation vector', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: validUserIds,
+          updateData: { userType: 'admin' },
+        })
+      ).toThrow();
+    });
+
+    it('rejects emailVerified — bypasses email verification gate', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: validUserIds,
+          updateData: { emailVerified: true },
+        })
+      ).toThrow();
+    });
+
+    it('rejects twoFactorEnabled — disables 2FA on victim accounts', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: validUserIds,
+          updateData: { twoFactorEnabled: false },
+        })
+      ).toThrow();
+    });
+
+    it('rejects password — prevents silent credential reset', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: validUserIds,
+          updateData: { password: 'NewPass1!' },
+        })
+      ).toThrow();
+    });
+
+    it('rejects loginAttempts — defeats account lockout policy', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: validUserIds,
+          updateData: { loginAttempts: 0 },
+        })
+      ).toThrow();
+    });
+
+    it('rejects empty userIds array', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({ userIds: [], updateData: { status: 'active' } })
+      ).toThrow();
+    });
+
+    it('rejects non-UUID entries in userIds', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: ['not-a-uuid'],
+          updateData: { status: 'active' },
+        })
+      ).toThrow();
+    });
+
+    it('rejects more than 100 user IDs', () => {
+      const tooMany = Array.from({ length: 101 }, (_, i) =>
+        `550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`
+      );
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({ userIds: tooMany, updateData: {} })
+      ).toThrow();
+    });
+
+    it('rejects an invalid status value', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: validUserIds,
+          updateData: { status: 'ACTIVE' },
+        })
+      ).toThrow();
     });
   });
 });

--- a/lib.validation/src/schemas/__tests__/user.test.ts
+++ b/lib.validation/src/schemas/__tests__/user.test.ts
@@ -239,8 +239,9 @@ describe('User schemas', () => {
     });
 
     it('rejects more than 100 user IDs', () => {
-      const tooMany = Array.from({ length: 101 }, (_, i) =>
-        `550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`
+      const tooMany = Array.from(
+        { length: 101 },
+        (_, i) => `550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`
       );
       expect(() =>
         BulkUserUpdateRequestSchema.parse({ userIds: tooMany, updateData: {} })

--- a/lib.validation/src/schemas/user.ts
+++ b/lib.validation/src/schemas/user.ts
@@ -181,3 +181,28 @@ export const UserModelShapeSchema = UserProfileSchema.partial().extend({
   password: z.string().min(1).optional(),
 });
 export type UserModelShape = z.infer<typeof UserModelShapeSchema>;
+
+/**
+ * POST /api/v1/users/bulk-update — admin bulk operation.
+ *
+ * `updateData` is intentionally a strict allowlist: only `status` may be
+ * changed in bulk. Privilege-sensitive fields (userType, emailVerified,
+ * twoFactorEnabled, twoFactorSecret, password, loginAttempts, lockedUntil,
+ * roles) are excluded to prevent mass privilege-escalation. .strict() causes
+ * Zod to reject any key not listed here with a clear validation error.
+ */
+export const BulkUserUpdateDataSchema = z
+  .object({
+    status: UserStatusSchema.optional(),
+  })
+  .strict();
+export type BulkUserUpdateData = z.infer<typeof BulkUserUpdateDataSchema>;
+
+export const BulkUserUpdateRequestSchema = z.object({
+  userIds: z
+    .array(z.string().uuid('Each user ID must be a valid UUID'))
+    .min(1, 'At least one user ID is required')
+    .max(100, 'Cannot update more than 100 users at a time'),
+  updateData: BulkUserUpdateDataSchema,
+});
+export type BulkUserUpdateRequest = z.infer<typeof BulkUserUpdateRequestSchema>;

--- a/service.backend/src/__tests__/controllers/user.controller.test.ts
+++ b/service.backend/src/__tests__/controllers/user.controller.test.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 import { Response } from 'express';
-import { UserController } from '../../controllers/user.controller';
+import { NextFunction, Request } from 'express';
+import { UserController, userValidation } from '../../controllers/user.controller';
 import { UserType } from '../../models/User';
 import UserService from '../../services/user.service';
 import { AuthenticatedRequest } from '../../types';
@@ -156,14 +157,15 @@ describe('UserController', () => {
   });
 
   describe('bulkUpdateUsers', () => {
-    it('should call UserService.bulkUpdateUsers with provided data', async () => {
-      const validUserIds = [
-        '550e8400-e29b-41d4-a716-446655440000',
-        '550e8400-e29b-41d4-a716-446655440001',
-      ];
+    const validUserIds = [
+      '550e8400-e29b-41d4-a716-446655440000',
+      '550e8400-e29b-41d4-a716-446655440001',
+    ];
+
+    it('should call UserService.bulkUpdateUsers with the validated body', async () => {
       req.body = {
         userIds: validUserIds,
-        updateData: { status: 'ACTIVE' },
+        updateData: { status: 'active' },
       };
 
       MockedUserService.bulkUpdateUsers = vi.fn().mockResolvedValue(2);
@@ -171,32 +173,16 @@ describe('UserController', () => {
       await controller.bulkUpdateUsers(req as AuthenticatedRequest, res as Response);
 
       expect(MockedUserService.bulkUpdateUsers).toHaveBeenCalledWith(
-        [{ userIds: validUserIds, updates: { status: 'ACTIVE' } }],
+        [{ userIds: validUserIds, updates: { status: 'active' } }],
         'user-123'
       );
       expect(res.json).toHaveBeenCalledWith(2);
     });
 
-    it('should reject bulk update with non-array userIds', async () => {
-      req.body = {
-        userIds: 'not-an-array',
-        updateData: { status: 'ACTIVE' },
-      };
-
-      MockedUserService.bulkUpdateUsers = vi.fn().mockResolvedValue(0);
-
-      await controller.bulkUpdateUsers(req as AuthenticatedRequest, res as Response);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'userIds must be a non-empty array',
-      });
-    });
-
     it('should handle service errors', async () => {
       req.body = {
-        userIds: ['550e8400-e29b-41d4-a716-446655440000'],
-        updateData: { status: 'ACTIVE' },
+        userIds: [validUserIds[0]],
+        updateData: { status: 'active' },
       };
 
       MockedUserService.bulkUpdateUsers = vi.fn().mockRejectedValue(new Error('Database error'));
@@ -207,6 +193,60 @@ describe('UserController', () => {
       expect(res.json).toHaveBeenCalledWith({
         error: 'Failed to bulk update users',
       });
+    });
+  });
+
+  describe('userValidation.bulkUpdate middleware', () => {
+    const validUserIds = [
+      '550e8400-e29b-41d4-a716-446655440000',
+      '550e8400-e29b-41d4-a716-446655440001',
+    ];
+
+    const runMiddleware = (body: unknown) =>
+      new Promise<{ status?: number; body?: unknown }>((resolve) => {
+        const mockReq = { body } as Request;
+        const mockRes = {
+          status: vi.fn().mockReturnThis(),
+          json: vi.fn((payload) => resolve({ status: (mockRes.status as ReturnType<typeof vi.fn>).mock.calls[0]?.[0], body: payload })),
+        } as unknown as Response;
+        const next: NextFunction = () => resolve({ body: mockReq.body });
+        userValidation.bulkUpdate(mockReq, mockRes, next);
+      });
+
+    it('accepts a valid status update', async () => {
+      const result = await runMiddleware({ userIds: validUserIds, updateData: { status: 'active' } });
+      expect(result.status).toBeUndefined();
+      expect((result.body as { userIds: string[] }).userIds).toEqual(validUserIds);
+    });
+
+    it('rejects userType — privilege escalation vector', async () => {
+      const result = await runMiddleware({ userIds: validUserIds, updateData: { userType: 'admin' } });
+      expect(result.status).toBe(400);
+    });
+
+    it('rejects emailVerified — bypasses email verification gate', async () => {
+      const result = await runMiddleware({ userIds: validUserIds, updateData: { emailVerified: true } });
+      expect(result.status).toBe(400);
+    });
+
+    it('rejects twoFactorEnabled — disables 2FA on victim accounts', async () => {
+      const result = await runMiddleware({ userIds: validUserIds, updateData: { twoFactorEnabled: false } });
+      expect(result.status).toBe(400);
+    });
+
+    it('rejects password field', async () => {
+      const result = await runMiddleware({ userIds: validUserIds, updateData: { password: 'NewPass1!' } });
+      expect(result.status).toBe(400);
+    });
+
+    it('rejects empty userIds array', async () => {
+      const result = await runMiddleware({ userIds: [], updateData: { status: 'active' } });
+      expect(result.status).toBe(400);
+    });
+
+    it('rejects non-UUID entries in userIds', async () => {
+      const result = await runMiddleware({ userIds: ['not-a-uuid'], updateData: {} });
+      expect(result.status).toBe(400);
     });
   });
 });

--- a/service.backend/src/__tests__/controllers/user.controller.test.ts
+++ b/service.backend/src/__tests__/controllers/user.controller.test.ts
@@ -1,6 +1,5 @@
 import { vi } from 'vitest';
-import { Response } from 'express';
-import { NextFunction, Request } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import { UserController, userValidation } from '../../controllers/user.controller';
 import { UserType } from '../../models/User';
 import UserService from '../../services/user.service';
@@ -203,39 +202,59 @@ describe('UserController', () => {
     ];
 
     const runMiddleware = (body: unknown) =>
-      new Promise<{ status?: number; body?: unknown }>((resolve) => {
+      new Promise<{ status?: number; body?: unknown }>(resolve => {
         const mockReq = { body } as Request;
         const mockRes = {
           status: vi.fn().mockReturnThis(),
-          json: vi.fn((payload) => resolve({ status: (mockRes.status as ReturnType<typeof vi.fn>).mock.calls[0]?.[0], body: payload })),
+          json: vi.fn(payload =>
+            resolve({
+              status: (mockRes.status as ReturnType<typeof vi.fn>).mock.calls[0]?.[0],
+              body: payload,
+            })
+          ),
         } as unknown as Response;
         const next: NextFunction = () => resolve({ body: mockReq.body });
         userValidation.bulkUpdate(mockReq, mockRes, next);
       });
 
     it('accepts a valid status update', async () => {
-      const result = await runMiddleware({ userIds: validUserIds, updateData: { status: 'active' } });
+      const result = await runMiddleware({
+        userIds: validUserIds,
+        updateData: { status: 'active' },
+      });
       expect(result.status).toBeUndefined();
       expect((result.body as { userIds: string[] }).userIds).toEqual(validUserIds);
     });
 
     it('rejects userType — privilege escalation vector', async () => {
-      const result = await runMiddleware({ userIds: validUserIds, updateData: { userType: 'admin' } });
+      const result = await runMiddleware({
+        userIds: validUserIds,
+        updateData: { userType: 'admin' },
+      });
       expect(result.status).toBe(400);
     });
 
     it('rejects emailVerified — bypasses email verification gate', async () => {
-      const result = await runMiddleware({ userIds: validUserIds, updateData: { emailVerified: true } });
+      const result = await runMiddleware({
+        userIds: validUserIds,
+        updateData: { emailVerified: true },
+      });
       expect(result.status).toBe(400);
     });
 
     it('rejects twoFactorEnabled — disables 2FA on victim accounts', async () => {
-      const result = await runMiddleware({ userIds: validUserIds, updateData: { twoFactorEnabled: false } });
+      const result = await runMiddleware({
+        userIds: validUserIds,
+        updateData: { twoFactorEnabled: false },
+      });
       expect(result.status).toBe(400);
     });
 
     it('rejects password field', async () => {
-      const result = await runMiddleware({ userIds: validUserIds, updateData: { password: 'NewPass1!' } });
+      const result = await runMiddleware({
+        userIds: validUserIds,
+        updateData: { password: 'NewPass1!' },
+      });
       expect(result.status).toBe(400);
     });
 

--- a/service.backend/src/controllers/user.controller.ts
+++ b/service.backend/src/controllers/user.controller.ts
@@ -1,9 +1,11 @@
 import { Response } from 'express';
 import { body, query } from 'express-validator';
+import { BulkUserUpdateRequestSchema } from '@adopt-dont-shop/lib.validation';
 import { UserType } from '../models/User';
 import UserService from '../services/user.service';
 import { AuthenticatedRequest } from '../types';
 import { logger } from '../utils/logger';
+import { validateBody } from '../middleware/zod-validate';
 
 // Validation rules
 export const userValidation = {
@@ -68,21 +70,7 @@ export const userValidation = {
     body('user_type').isIn(['ADOPTER', 'RESCUE_STAFF', 'ADMIN']).withMessage('Invalid user type'),
   ],
 
-  bulkUpdate: [
-    body('userIds')
-      .isArray({ min: 1, max: 100 })
-      .withMessage('User IDs must be an array with 1-100 items'),
-    body('userIds.*').isUUID().withMessage('Each user ID must be a valid UUID'),
-    body('updateData').isObject().withMessage('Update data must be an object'),
-    body('updateData.status')
-      .optional()
-      .isIn(['ACTIVE', 'INACTIVE', 'PENDING_VERIFICATION', 'SUSPENDED'])
-      .withMessage('Invalid status'),
-    body('updateData.user_type')
-      .optional()
-      .isIn(['ADOPTER', 'RESCUE_STAFF', 'ADMIN'])
-      .withMessage('Invalid user type'),
-  ],
+  bulkUpdate: validateBody(BulkUserUpdateRequestSchema),
 };
 
 export class UserController {
@@ -259,11 +247,6 @@ export class UserController {
     try {
       const { userIds, updateData } = req.body;
       const requestingUserId = req.user!.userId;
-
-      if (!Array.isArray(userIds) || userIds.length === 0) {
-        res.status(400).json({ error: 'userIds must be a non-empty array' });
-        return;
-      }
 
       // Prevent including own account in bulk operations
       UserService.validateBulkOperation(requestingUserId, userIds, 'update');


### PR DESCRIPTION
## Summary

- Merges the changes from PR #284 (mass-assignment fix in `bulkUpdateUsers`)
- Fixes two linting issues that caused "Library Tests" and "Backend Tests" CI checks to fail:
  - Merged duplicate `import { Response } from 'express'` and `import { NextFunction, Request } from 'express'` into a single import in `user.controller.test.ts`
  - Fixed prettier formatting violations (long lines > 100 chars) in both test files

## Test plan

- [ ] Library Tests CI check passes
- [ ] Backend Tests CI check passes

https://claude.ai/code/session_017WcVfjrCtBTJw9jggw8cuv

---
_Generated by [Claude Code](https://claude.ai/code/session_017WcVfjrCtBTJw9jggw8cuv)_