### PR TITLE
fix(security): set trust proxy so req.ip reflects real client [ADS-347]

### DIFF
--- a/service.backend/src/__tests__/security/trust-proxy.test.ts
+++ b/service.backend/src/__tests__/security/trust-proxy.test.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import request from 'supertest';
+
+describe('Trust proxy configuration', () => {
+  it('resolves req.ip from X-Forwarded-For when trust proxy is set to 1', async () => {
+    const app = express();
+    app.set('trust proxy', 1);
+    app.get('/ip', (req, res) => res.json({ ip: req.ip }));
+
+    const response = await request(app).get('/ip').set('X-Forwarded-For', '203.0.113.42');
+
+    expect(response.status).toBe(200);
+    expect(response.body.ip).toBe('203.0.113.42');
+  });
+
+  it('ignores X-Forwarded-For when trust proxy is not set (regression guard)', async () => {
+    const app = express();
+    app.get('/ip', (req, res) => res.json({ ip: req.ip }));
+
+    const response = await request(app).get('/ip').set('X-Forwarded-For', '203.0.113.42');
+
+    expect(response.status).toBe(200);
+    expect(response.body.ip).not.toBe('203.0.113.42');
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -73,6 +73,12 @@ configRoutes.get('/', async (req, res) => {
 
 // Initialize express app
 const app = express();
+
+// Trust the first proxy hop (nginx in our deploy). Without this, req.ip resolves
+// to the proxy container, so per-IP rate limits collapse to a global bucket and
+// security logs / audit IP fields lose forensic value.
+app.set('trust proxy', 1);
+
 const server = createServer(app);
 
 // Initialize Socket.IO


### PR DESCRIPTION
## Summary

- Adds `app.set('trust proxy', 1)` immediately after the Express app is created so `req.ip` reflects the upstream client (via `X-Forwarded-For`) instead of the nginx container address.
- Without this, every per-IP rate limiter (`apiLimiter`, `authLimiter`, `passwordResetLimiter`, `loginEmailLimiter`, `emailResendLimiter`, `uploadLimiter`) collapses to a single global bucket — one attacker can lock the whole app out of password resets/login. CSRF session identification and security/audit logs are also affected.
- Adds a regression test that verifies `X-Forwarded-For` propagates to `req.ip` when the setting is in place and is ignored when it is not.

## Acceptance criteria
- [x] `app.set('trust proxy', ...)` is set with a hop count justified for the deployment topology (nginx is the only hop; bump to a list if a CDN/ALB is added)
- [x] Test exercises a proxied request (`X-Forwarded-For`) and asserts `req.ip` reflects the forwarded address
- [x] Negative-case test confirms the previous (broken) behaviour without the setting

## Test plan
- [ ] CI runs `service.backend` tests (local install not available in this environment)
- [ ] Manual verification post-deploy: `loggerHelpers.logSecurity` emits the real client IP for a request that came through nginx

Closes [ADS-347](https://linear.app/ideasquared/issue/ADS-347)


---
_Generated by [Claude Code](https://claude.ai/code/session_013ABjfErrFasVHKf7Z7u5fe)_