### PR TITLE
refactor(rescue): typed plain object from getRescueById when includeStats [ADS-361]

### DIFF
--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -224,10 +224,7 @@ export class RescueService {
    */
   static async getRescueById(rescueId: string): Promise<Rescue>;
   static async getRescueById(rescueId: string, includeStats: false): Promise<Rescue>;
-  static async getRescueById(
-    rescueId: string,
-    includeStats: true
-  ): Promise<RescueWithStatistics>;
+  static async getRescueById(rescueId: string, includeStats: true): Promise<RescueWithStatistics>;
   static async getRescueById(
     rescueId: string,
     includeStats?: boolean

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -83,6 +83,10 @@ export interface RescueStatsResponse {
   averageTimeToAdoption: number;
 }
 
+export type RescueWithStatistics = ReturnType<Rescue['toJSON']> & {
+  statistics: RescueStatsResponse;
+};
+
 export class RescueService {
   /**
    * Search and filter rescues with pagination
@@ -211,12 +215,27 @@ export class RescueService {
   }
 
   /**
-   * Get rescue by ID with full details
+   * Get rescue by ID with full details.
+   *
+   * When `includeStats` is true the return is a plain object (rescue
+   * attributes + statistics) rather than a Sequelize model instance — this
+   * avoids mutating the model with a non-column property and keeps the
+   * return type honest without any `as any` cast.
    */
+  static async getRescueById(rescueId: string): Promise<Rescue>;
+  static async getRescueById(rescueId: string, includeStats: false): Promise<Rescue>;
+  static async getRescueById(
+    rescueId: string,
+    includeStats: true
+  ): Promise<RescueWithStatistics>;
+  static async getRescueById(
+    rescueId: string,
+    includeStats?: boolean
+  ): Promise<Rescue | RescueWithStatistics>;
   static async getRescueById(
     rescueId: string,
     includeStats = false
-  ): Promise<Rescue & { statistics?: RescueStatsResponse }> {
+  ): Promise<Rescue | RescueWithStatistics> {
     const startTime = Date.now();
 
     try {
@@ -249,7 +268,7 @@ export class RescueService {
 
       if (includeStats) {
         const statistics = await this.getRescueStatistics(rescueId);
-        return Object.assign(rescue, { statistics });
+        return { ...rescue.toJSON(), statistics };
       }
 
       return rescue;


### PR DESCRIPTION
## Summary

`RescueService.getRescueById(id, true)` previously did `Object.assign(rescue, { statistics })`, mutating a Sequelize model instance with a non-column property. The original code used `(rescue as any).statistics = stats`, which violated the no-`any` policy; the current code drops the cast but still mutates the model.

This PR replaces the mutation with `{ ...rescue.toJSON(), statistics }` and adds typed overloads:
- `getRescueById(id)` / `getRescueById(id, false)` → `Rescue` (model instance, unchanged behaviour)
- `getRescueById(id, true)` → `RescueWithStatistics` (plain object)

No behaviour change for existing callers — controllers serialize via `res.json` which already calls `toJSON`. The return type is now honest without any cast.

## Test plan
- [ ] Existing `rescue.service.test.ts` tests for `getRescueById` continue to pass (they only assert on `result.name` / `result.statistics`)
- [ ] CI runs `service.backend` tests

Closes [ADS-361](https://linear.app/ideasquared/issue/ADS-361)


---
_Generated by [Claude Code](https://claude.ai/code/session_013ABjfErrFasVHKf7Z7u5fe)_