### PR TITLE
fix(security): drop unused export filters arg + validate chat sortOrder [ADS-350, ADS-351]

### DIFF
--- a/service.backend/src/__tests__/utils/sort-validation.test.ts
+++ b/service.backend/src/__tests__/utils/sort-validation.test.ts
@@ -1,0 +1,62 @@
+import {
+  validateSortField,
+  validateSortOrder,
+  normaliseSortField,
+} from '../../utils/sort-validation';
+import { ApiError } from '../../middleware/error-handler';
+
+describe('sort-validation', () => {
+  describe('validateSortField', () => {
+    const ALLOWED = ['createdAt', 'updatedAt'] as const;
+
+    it('returns the field when it is in the allowlist', () => {
+      expect(validateSortField('createdAt', ALLOWED, 'createdAt')).toBe('createdAt');
+    });
+
+    it('throws ApiError(400) when the field is not in the allowlist', () => {
+      try {
+        validateSortField('password', ALLOWED, 'createdAt');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ApiError);
+        expect((e as ApiError).statusCode).toBe(400);
+      }
+    });
+  });
+
+  describe('validateSortOrder', () => {
+    it('accepts ASC and DESC (any case) and uppercases', () => {
+      expect(validateSortOrder('ASC')).toBe('ASC');
+      expect(validateSortOrder('asc')).toBe('ASC');
+      expect(validateSortOrder('DESC')).toBe('DESC');
+      expect(validateSortOrder('desc')).toBe('DESC');
+    });
+
+    it('returns DESC default when input is not a string', () => {
+      expect(validateSortOrder(undefined)).toBe('DESC');
+      expect(validateSortOrder(null)).toBe('DESC');
+      expect(validateSortOrder(42)).toBe('DESC');
+    });
+
+    it('throws ApiError(400) on a non-ASC/DESC string (injection guard)', () => {
+      try {
+        validateSortOrder('ASC; DROP TABLE users');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ApiError);
+        expect((e as ApiError).statusCode).toBe(400);
+      }
+    });
+  });
+
+  describe('normaliseSortField', () => {
+    const ALLOWED = ['a', 'b'] as const;
+    it('returns the field when allowlisted', () => {
+      expect(normaliseSortField('a', ALLOWED, 'b')).toBe('a');
+    });
+    it('returns default for undefined or unknown', () => {
+      expect(normaliseSortField(undefined, ALLOWED, 'b')).toBe('b');
+      expect(normaliseSortField('z', ALLOWED, 'b')).toBe('b');
+    });
+  });
+});

--- a/service.backend/src/services/admin.service.ts
+++ b/service.backend/src/services/admin.service.ts
@@ -676,30 +676,37 @@ class AdminService {
   }
 
   /**
-   * Export data for compliance/backup
+   * Export data for compliance/backup.
+   *
+   * Filters are intentionally not accepted: forwarding caller-supplied
+   * objects into Sequelize `where` clauses lets a (compromised or
+   * malicious) admin construct arbitrary boolean queries via Sequelize
+   * operators (`$or`, `$gt`, `$jsonb` …) and exfiltrate filtered slices
+   * of audit logs and other sensitive tables. If filtered exports are
+   * needed, expose them as named query parameters with a per-entity Zod
+   * schema and translate to a `where` clause server-side.
    */
-  static async exportData(dataType: string, format = 'json', filters?: JsonObject) {
+  static async exportData(dataType: string, format = 'json') {
     try {
       let data;
 
       switch (dataType) {
         case 'users':
           data = await User.findAll({
-            where: filters || {},
             attributes: { exclude: ['password'] },
           });
           break;
         case 'rescues':
-          data = await Rescue.findAll({ where: filters || {} });
+          data = await Rescue.findAll();
           break;
         case 'pets':
-          data = await Pet.findAll({ where: filters || {} });
+          data = await Pet.findAll();
           break;
         case 'applications':
-          data = await Application.findAll({ where: filters || {} });
+          data = await Application.findAll();
           break;
         case 'audit_logs':
-          data = await AuditLog.findAll({ where: filters || {} });
+          data = await AuditLog.findAll();
           break;
         default:
           throw new Error('Invalid data type for export');

--- a/service.backend/src/services/chat.service.ts
+++ b/service.backend/src/services/chat.service.ts
@@ -4,7 +4,7 @@ import MessageReaction from '../models/MessageReaction';
 import MessageRead from '../models/MessageRead';
 import StaffMember from '../models/StaffMember';
 import Rescue from '../models/Rescue';
-import { validateSortField } from '../utils/sort-validation';
+import { validateSortField, validateSortOrder } from '../utils/sort-validation';
 
 const CHAT_SORT_FIELDS = ['created_at', 'updated_at'] as const;
 import { NotificationPriority, NotificationType } from '../models/Notification';
@@ -413,6 +413,7 @@ export class ChatService {
 
       const offset = (page - 1) * limit;
       const safeSortBy = validateSortField(sortBy, CHAT_SORT_FIELDS, 'created_at');
+      const safeSortOrder = validateSortOrder(sortOrder);
 
       // Build where conditions
       const whereConditions: WhereOptions = {
@@ -498,7 +499,7 @@ export class ChatService {
         include: includes,
         limit,
         offset,
-        order: [[safeSortBy, sortOrder]],
+        order: [[safeSortBy, safeSortOrder]],
         distinct: true,
       });
 
@@ -536,6 +537,7 @@ export class ChatService {
 
       const offset = (page - 1) * limit;
       const safeSortBy = validateSortField(sortBy, CHAT_SORT_FIELDS, 'created_at');
+      const safeSortOrder = validateSortOrder(sortOrder);
 
       // Build where conditions for chats
       const chatWhereConditions: WhereOptions = {
@@ -595,7 +597,7 @@ export class ChatService {
         ],
         limit,
         offset,
-        order: [[safeSortBy, sortOrder]],
+        order: [[safeSortBy, safeSortOrder]],
         distinct: true,
       });
 

--- a/service.backend/src/utils/sort-validation.ts
+++ b/service.backend/src/utils/sort-validation.ts
@@ -24,3 +24,16 @@ export const normaliseSortField = (
   }
   return sortBy;
 };
+
+export type SortOrder = 'ASC' | 'DESC';
+
+export const validateSortOrder = (sortOrder: unknown): SortOrder => {
+  if (typeof sortOrder !== 'string') {
+    return 'DESC';
+  }
+  const upper = sortOrder.toUpperCase();
+  if (upper !== 'ASC' && upper !== 'DESC') {
+    throw new ApiError(400, `Invalid sort order "${sortOrder}". Allowed: ASC, DESC`);
+  }
+  return upper;
+};


### PR DESCRIPTION
## Summary

Two related input-validation hardening fixes.

### ADS-350 — Admin export endpoint
`AdminService.exportData` accepted a third `filters` argument that was forwarded directly into a Sequelize `where: filters || {}` clause across every entity branch (`users`, `rescues`, `pets`, `applications`, `audit_logs`). The controller never actually passed this argument, so the parameter was a latent vulnerability — any future caller could have allowed an admin to author arbitrary boolean queries via Sequelize operators (`$or`, `$gt`, `$jsonb` …) and exfiltrate filtered slices of audit logs and other sensitive tables.

Fix: drop the parameter outright. If filtered exports are needed later, they should be implemented with a per-entity Zod schema that translates named query params to a server-built `where` clause — never by forwarding caller-supplied objects.

### ADS-351 — Chat search sort-order injection
`ChatService.searchChats` and `searchConversations` validated `sortBy` via `validateSortField` but passed `sortOrder` straight into the Sequelize order clause (`order: [[safeSortBy, sortOrder]]`). A crafted value would reach Sequelize and could surface as a 500 error (schema-discovery primitive) or, in some configurations, broken ordering.

Fix: add `validateSortOrder` helper alongside the existing `validateSortField`. Use it in both chat search paths so a non-ASC/DESC value rejects with 400 before reaching Sequelize.

## Files
- `services/admin.service.ts` — drop `filters` arg
- `services/chat.service.ts` — call `validateSortOrder` in both search paths
- `utils/sort-validation.ts` — new `validateSortOrder` helper (mirrors `validateSortField`)
- `__tests__/utils/sort-validation.test.ts` — unit tests covering allowlist, bad-value rejection, default-on-undefined

## Test plan
- [ ] `sort-validation.test.ts` covers ASC/DESC accept, default for non-string, ApiError(400) for bogus strings (e.g. `ASC; DROP …`)
- [ ] CI runs `service.backend` tests
- [ ] No remaining `sortOrder` argument forwarded to Sequelize from chat services without going through `validateSortOrder`

Closes [ADS-350](https://linear.app/ideasquared/issue/ADS-350) and [ADS-351](https://linear.app/ideasquared/issue/ADS-351)


---
_Generated by [Claude Code](https://claude.ai/code/session_013ABjfErrFasVHKf7Z7u5fe)_