### PR TITLE
fix(admin): wire pagination on list tables

### DIFF
--- a/app.admin/src/pages/Applications.tsx
+++ b/app.admin/src/pages/Applications.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Heading, Text, Input } from '@adopt-dont-shop/lib.components';
 import { FiSearch } from 'react-icons/fi';
 import { DataTable, type Column } from '../components/data';
@@ -33,15 +33,23 @@ const formatDate = (dateString: string) =>
 const Applications: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [page, setPage] = useState(1);
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<BulkApplicationActionType | null>(null);
   const [bulkResult, setBulkResult] = useState<{ succeeded: number; failed: number } | null>(null);
 
+  useEffect(() => {
+    setPage(1);
+  }, [searchQuery, statusFilter]);
+
   const { data, isLoading, error } = useApplications({
     search: searchQuery || undefined,
     status: statusFilter !== 'all' ? (statusFilter as ApplicationStatus) : undefined,
+    page,
     limit: 20,
   });
+
+  const totalPages = data?.pagination?.pages ?? 1;
 
   const bulkUpdateApplications = useBulkUpdateApplications();
 
@@ -177,6 +185,9 @@ const Applications: React.FC = () => {
         data={applications}
         loading={isLoading}
         emptyMessage='No applications found matching your criteria'
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
         selectable
         selectedRows={selectedRows}
         onSelectionChange={setSelectedRows}

--- a/app.admin/src/pages/Audit.tsx
+++ b/app.admin/src/pages/Audit.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { useQuery } from 'react-query';
 import { Heading, Text, Button, Input } from '@adopt-dont-shop/lib.components';
 import {
@@ -57,6 +57,10 @@ const Audit: React.FC = () => {
   const [page, setPage] = useState(1);
   const [selectedLog, setSelectedLog] = useState<AuditLog | null>(null);
 
+  useEffect(() => {
+    setPage(1);
+  }, [actionFilter, resourceFilter, statusFilter]);
+
   const sevenDaysAgo = useMemo(() => {
     const date = new Date();
     date.setDate(date.getDate() - 7);
@@ -89,6 +93,7 @@ const Audit: React.FC = () => {
   );
 
   const logs = data?.data || [];
+  const totalPages = data?.pagination?.pages ?? 1;
 
   const filteredLogs = useMemo(() => {
     if (!searchQuery) {
@@ -327,6 +332,9 @@ const Audit: React.FC = () => {
         loading={isLoading}
         emptyMessage='No audit logs found matching your criteria'
         onRowClick={log => setSelectedLog(log)}
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
         getRowId={log => log.id.toString()}
       />
 

--- a/app.admin/src/pages/Pets.tsx
+++ b/app.admin/src/pages/Pets.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Heading, Text, Input } from '@adopt-dont-shop/lib.components';
 import { FiSearch, FiPackage } from 'react-icons/fi';
 import { DataTable, type Column } from '../components/data';
@@ -36,15 +36,23 @@ const formatDate = (dateString: string) =>
 const Pets: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [page, setPage] = useState(1);
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<BulkPetActionType | null>(null);
   const [bulkResult, setBulkResult] = useState<{ succeeded: number; failed: number } | null>(null);
 
+  useEffect(() => {
+    setPage(1);
+  }, [searchQuery, statusFilter]);
+
   const { data, isLoading, error } = usePets({
     search: searchQuery || undefined,
     status: statusFilter !== 'all' ? (statusFilter as PetStatus) : undefined,
+    page,
     limit: 20,
   });
+
+  const totalPages = data?.pagination?.pages ?? 1;
 
   const bulkUpdatePets = useBulkUpdatePets();
 
@@ -198,6 +206,9 @@ const Pets: React.FC = () => {
         data={pets}
         loading={isLoading}
         emptyMessage='No pets found matching your criteria'
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
         selectable
         selectedRows={selectedRows}
         onSelectionChange={setSelectedRows}

--- a/app.admin/src/pages/Rescues.tsx
+++ b/app.admin/src/pages/Rescues.tsx
@@ -51,12 +51,17 @@ const Rescues: React.FC = () => {
   const navigate = useNavigate();
 
   const [rescues, setRescues] = useState<AdminRescue[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
-  const [currentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(20);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, statusFilter]);
 
   const [selectedRescue, setSelectedRescue] = useState<AdminRescue | null>(null);
   const [showDetailModal, setShowDetailModal] = useState(false);
@@ -85,9 +90,11 @@ const Rescues: React.FC = () => {
       });
 
       setRescues(result.data);
+      setTotalPages(result.pagination?.pages ?? 1);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch rescues');
       setRescues([]);
+      setTotalPages(1);
     } finally {
       setLoading(false);
     }
@@ -341,6 +348,9 @@ const Rescues: React.FC = () => {
         loading={loading}
         emptyMessage='No rescue organizations found matching your criteria'
         onRowClick={rescue => handleViewDetails(rescue.rescueId)}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
         selectable
         selectedRows={selectedRows}
         onSelectionChange={setSelectedRows}

--- a/app.admin/src/pages/Support.tsx
+++ b/app.admin/src/pages/Support.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { Heading, Text, Input } from '@adopt-dont-shop/lib.components';
 import { FiSearch, FiMessageSquare, FiClock, FiCheckCircle, FiAlertCircle } from 'react-icons/fi';
 import { DataTable, type Column } from '../components/data';
@@ -57,7 +57,12 @@ const Support: React.FC = () => {
   const [statusFilter, setStatusFilter] = useState<TicketStatus | 'all'>('all');
   const [priorityFilter, setPriorityFilter] = useState<TicketPriority | 'all'>('all');
   const [categoryFilter, setCategoryFilter] = useState<TicketCategory | 'all'>('all');
+  const [page, setPage] = useState(1);
   const [selectedTicket, setSelectedTicket] = useState<SupportTicket | null>(null);
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchQuery, statusFilter, priorityFilter, categoryFilter]);
 
   // Build filters for API
   const filters = useMemo(() => {
@@ -71,7 +76,7 @@ const Support: React.FC = () => {
       sortBy: 'createdAt' | 'updatedAt' | 'priority' | 'dueDate';
       sortOrder: 'asc' | 'desc';
     } = {
-      page: 1,
+      page,
       limit: 20,
       sortBy: 'createdAt',
       sortOrder: 'desc',
@@ -91,7 +96,7 @@ const Support: React.FC = () => {
     }
 
     return apiFilters;
-  }, [statusFilter, priorityFilter, categoryFilter, searchQuery]);
+  }, [statusFilter, priorityFilter, categoryFilter, searchQuery, page]);
 
   // Fetch tickets and stats using hooks
   const {
@@ -104,6 +109,7 @@ const Support: React.FC = () => {
   const { addResponse } = useTicketMutations();
 
   const tickets = ticketsData?.data || [];
+  const totalPages = ticketsData?.pagination?.totalPages ?? 1;
   const loading = ticketsLoading;
 
   // Stats from API
@@ -400,6 +406,9 @@ const Support: React.FC = () => {
         loading={loading}
         emptyMessage='No support tickets found matching your criteria'
         onRowClick={ticket => setSelectedTicket(ticket)}
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
         getRowId={ticket => ticket.ticketId}
       />
 

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -89,6 +89,11 @@ const Users: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [userTypeFilter, setUserTypeFilter] = useState<string>('all');
   const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchQuery, userTypeFilter, statusFilter]);
 
   // Modal state
   const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
@@ -106,9 +111,11 @@ const Users: React.FC = () => {
     search: searchQuery,
     userType: userTypeFilter !== 'all' ? userTypeFilter : undefined,
     status: statusFilter !== 'all' ? statusFilter : undefined,
-    page: 1,
+    page,
     limit: 20,
   });
+
+  const totalPages = data?.pagination?.pages ?? data?.pagination?.totalPages ?? 1;
 
   const suspendUser = useSuspendUser();
   const unsuspendUser = useUnsuspendUser();
@@ -525,6 +532,9 @@ const Users: React.FC = () => {
         loading={isLoading}
         emptyMessage='No users found matching your criteria'
         onRowClick={handleRowClick}
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
         selectable
         selectedRows={selectedRows}
         onSelectionChange={setSelectedRows}

--- a/app.admin/src/types/index.ts
+++ b/app.admin/src/types/index.ts
@@ -42,6 +42,10 @@ export interface PaginatedResponse<T> {
     totalPages?: number;
   };
   pagination?: {
+    page?: number;
+    limit?: number;
+    total?: number;
+    pages?: number;
     currentPage?: number;
     totalItems?: number;
     itemsPerPage?: number;


### PR DESCRIPTION
## Summary

The `DataTable` component already rendered pagination controls when `onPageChange` and `totalPages > 1` were supplied, but every admin list page hardcoded `page=1` and never read the `pagination` metadata back from the API — so users could only ever see the first 20 records, regardless of how many existed.

This PR wires pagination on every list page in `app.admin`:

- **Users**, **Pets**, **Applications** — added `page` state, passed to the `useUsers` / `usePets` / `useApplications` hooks, total pages read from `data.pagination.pages`.
- **Rescues** — `currentPage` was already declared but never settable; made it stateful, captured `pagination.pages` from the service response.
- **Support** — `page` was hardcoded to `1` inside the filters memo; replaced with state.
- **Audit** — page state existed and was sent to the API, but `data.pagination` was discarded; now wired into the table.
- All pages reset to page 1 when filters/search change.
- Updated `PaginatedResponse<T>` in `app.admin/src/types/index.ts` to include the `{ page, limit, total, pages }` fields the backend actually returns (additive, backwards-compatible).

## Test plan

- [ ] Open Users / Pets / Rescues / Applications / Support / Audit with > 20 records and verify pagination controls render and navigation works
- [ ] Apply a filter or change the search query and verify the table jumps back to page 1
- [ ] Confirm row selection / bulk actions still work on each paginated page

https://claude.ai/code/session_019fzy6ZY9eg23xTKmr1p1uz

---
_Generated by [Claude Code](https://claude.ai/code/session_019fzy6ZY9eg23xTKmr1p1uz)_