### PR TITLE
fix(admin): use stable sliding window for pagination buttons

### DIFF
--- a/app.admin/src/components/data/DataTable.tsx
+++ b/app.admin/src/components/data/DataTable.tsx
@@ -114,6 +114,12 @@ export function DataTable<T extends object>({
 
   const allSelected = data.length > 0 && data.every(row => selectedRows.has(getRowId(row)));
 
+  const visiblePageCount = Math.min(5, totalPages);
+  const startPage = Math.max(
+    1,
+    Math.min(currentPage - 2, totalPages - visiblePageCount + 1)
+  );
+
   return (
     <div className={styles.tableContainer}>
       <div className={styles.tableWrapper}>
@@ -207,68 +213,61 @@ export function DataTable<T extends object>({
         </table>
       </div>
 
-      {onPageChange && totalPages > 1 && (() => {
-        const visiblePageCount = Math.min(5, totalPages);
-        const startPage = Math.max(
-          1,
-          Math.min(currentPage - 2, totalPages - visiblePageCount + 1)
-        );
-        return (
-          <div className={styles.paginationContainer}>
-            <div className={styles.paginationInfo}>
-              Page {currentPage} of {totalPages}
-            </div>
-            <div className={styles.paginationControls}>
-              <button
-                className={styles.pageButton({ active: false })}
-                onClick={() => onPageChange(1)}
-                disabled={currentPage === 1}
-                aria-label='First page'
-              >
-                <FiChevronsLeft />
-              </button>
-              <button
-                className={styles.pageButton({ active: false })}
-                onClick={() => onPageChange(currentPage - 1)}
-                disabled={currentPage === 1}
-                aria-label='Previous page'
-              >
-                <FiChevronLeft />
-              </button>
-
-              {Array.from({ length: visiblePageCount }, (_, i) => {
-                const pageNum = startPage + i;
-                return (
-                  <button
-                    key={pageNum}
-                    className={styles.pageButton({ active: currentPage === pageNum })}
-                    onClick={() => onPageChange(pageNum)}
-                  >
-                    {pageNum}
-                  </button>
-                );
-              })}
-
-              <button
-                className={styles.pageButton({ active: false })}
-                onClick={() => onPageChange(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                aria-label='Next page'
-              >
-                <FiChevronRight />
-              </button>
-              <button
-                className={styles.pageButton({ active: false })}
-                onClick={() => onPageChange(totalPages)}
-                disabled={currentPage === totalPages}
-                aria-label='Last page'
-              >
-                <FiChevronsRight />
-              </button>
-            </div>
+      {onPageChange && totalPages > 1 && (
+        <div className={styles.paginationContainer}>
+          <div className={styles.paginationInfo}>
+            Page {currentPage} of {totalPages}
           </div>
-        );
-      })()}
+          <div className={styles.paginationControls}>
+            <button
+              className={styles.pageButton({ active: false })}
+              onClick={() => onPageChange(1)}
+              disabled={currentPage === 1}
+              aria-label='First page'
+            >
+              <FiChevronsLeft />
+            </button>
+            <button
+              className={styles.pageButton({ active: false })}
+              onClick={() => onPageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              aria-label='Previous page'
+            >
+              <FiChevronLeft />
+            </button>
+
+            {Array.from({ length: visiblePageCount }, (_, i) => {
+              const pageNum = startPage + i;
+              return (
+                <button
+                  key={pageNum}
+                  className={styles.pageButton({ active: currentPage === pageNum })}
+                  onClick={() => onPageChange(pageNum)}
+                >
+                  {pageNum}
+                </button>
+              );
+            })}
+
+            <button
+              className={styles.pageButton({ active: false })}
+              onClick={() => onPageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              aria-label='Next page'
+            >
+              <FiChevronRight />
+            </button>
+            <button
+              className={styles.pageButton({ active: false })}
+              onClick={() => onPageChange(totalPages)}
+              disabled={currentPage === totalPages}
+              aria-label='Last page'
+            >
+              <FiChevronsRight />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app.admin/src/components/data/DataTable.tsx
+++ b/app.admin/src/components/data/DataTable.tsx
@@ -207,61 +207,68 @@ export function DataTable<T extends object>({
         </table>
       </div>
 
-      {onPageChange && totalPages > 1 && (
-        <div className={styles.paginationContainer}>
-          <div className={styles.paginationInfo}>
-            Page {currentPage} of {totalPages}
-          </div>
-          <div className={styles.paginationControls}>
-            <button
-              className={styles.pageButton({ active: false })}
-              onClick={() => onPageChange(1)}
-              disabled={currentPage === 1}
-              aria-label='First page'
-            >
-              <FiChevronsLeft />
-            </button>
-            <button
-              className={styles.pageButton({ active: false })}
-              onClick={() => onPageChange(currentPage - 1)}
-              disabled={currentPage === 1}
-              aria-label='Previous page'
-            >
-              <FiChevronLeft />
-            </button>
+      {onPageChange && totalPages > 1 && (() => {
+        const visiblePageCount = Math.min(5, totalPages);
+        const startPage = Math.max(
+          1,
+          Math.min(currentPage - 2, totalPages - visiblePageCount + 1)
+        );
+        return (
+          <div className={styles.paginationContainer}>
+            <div className={styles.paginationInfo}>
+              Page {currentPage} of {totalPages}
+            </div>
+            <div className={styles.paginationControls}>
+              <button
+                className={styles.pageButton({ active: false })}
+                onClick={() => onPageChange(1)}
+                disabled={currentPage === 1}
+                aria-label='First page'
+              >
+                <FiChevronsLeft />
+              </button>
+              <button
+                className={styles.pageButton({ active: false })}
+                onClick={() => onPageChange(currentPage - 1)}
+                disabled={currentPage === 1}
+                aria-label='Previous page'
+              >
+                <FiChevronLeft />
+              </button>
 
-            {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-              const pageNum = Math.max(1, Math.min(currentPage - 2 + i, totalPages - 4 + i));
-              return (
-                <button
-                  key={pageNum}
-                  className={styles.pageButton({ active: currentPage === pageNum })}
-                  onClick={() => onPageChange(pageNum)}
-                >
-                  {pageNum}
-                </button>
-              );
-            })}
+              {Array.from({ length: visiblePageCount }, (_, i) => {
+                const pageNum = startPage + i;
+                return (
+                  <button
+                    key={pageNum}
+                    className={styles.pageButton({ active: currentPage === pageNum })}
+                    onClick={() => onPageChange(pageNum)}
+                  >
+                    {pageNum}
+                  </button>
+                );
+              })}
 
-            <button
-              className={styles.pageButton({ active: false })}
-              onClick={() => onPageChange(currentPage + 1)}
-              disabled={currentPage === totalPages}
-              aria-label='Next page'
-            >
-              <FiChevronRight />
-            </button>
-            <button
-              className={styles.pageButton({ active: false })}
-              onClick={() => onPageChange(totalPages)}
-              disabled={currentPage === totalPages}
-              aria-label='Last page'
-            >
-              <FiChevronsRight />
-            </button>
+              <button
+                className={styles.pageButton({ active: false })}
+                onClick={() => onPageChange(currentPage + 1)}
+                disabled={currentPage === totalPages}
+                aria-label='Next page'
+              >
+                <FiChevronRight />
+              </button>
+              <button
+                className={styles.pageButton({ active: false })}
+                onClick={() => onPageChange(totalPages)}
+                disabled={currentPage === totalPages}
+                aria-label='Last page'
+              >
+                <FiChevronsRight />
+              </button>
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/app.admin/src/components/data/DataTable.tsx
+++ b/app.admin/src/components/data/DataTable.tsx
@@ -115,10 +115,7 @@ export function DataTable<T extends object>({
   const allSelected = data.length > 0 && data.every(row => selectedRows.has(getRowId(row)));
 
   const visiblePageCount = Math.min(5, totalPages);
-  const startPage = Math.max(
-    1,
-    Math.min(currentPage - 2, totalPages - visiblePageCount + 1)
-  );
+  const startPage = Math.max(1, Math.min(currentPage - 2, totalPages - visiblePageCount + 1));
 
   return (
     <div className={styles.tableContainer}>


### PR DESCRIPTION
## Summary

Follow-up to #297. The DataTable pagination buttons rendered duplicates near the edges — e.g. on page 1 of a 10-page list it produced `[1, 1, 1, 2, 3]` instead of `[1, 2, 3, 4, 5]`. The duplicates also caused React duplicate-key issues, leaving trailing buttons blank.

The old formula computed each button's number independently:

```ts
const pageNum = Math.max(1, Math.min(currentPage - 2 + i, totalPages - 4 + i));
```

Replaced with a single `startPage` plus a per-button offset, so the visible window slides as one unit and each button gets a unique page number.

## Test plan

- [x] On a list with > 5 pages, navigate to page 1 — pagination shows `1 2 3 4 5` with only `1` highlighted
- [x] Navigate to the last page — pagination shows the trailing 5 pages with the last one highlighted
- [x] Navigate to a middle page — current page is centered (~3rd slot)
- [x] On a list with 2-4 total pages, only that many buttons render and none are duplicated

https://claude.ai/code/session_019fzy6ZY9eg23xTKmr1p1uz

---
_Generated by [Claude Code](https://claude.ai/code/session_019fzy6ZY9eg23xTKmr1p1uz)_