### PR TITLE
fix(rescue): timeout external verification + run outside DB transaction [ADS-365, ADS-368]

### DIFF
--- a/service.backend/src/__tests__/services/external-verification-timeout.test.ts
+++ b/service.backend/src/__tests__/services/external-verification-timeout.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Behaviour tests for the timeout/abort handling in
+ * companies-house.service.ts and charity-commission.service.ts.
+ *
+ * Drives the real services with `global.fetch` stubbed out so we can
+ * simulate slow/never-resolving responses without hitting the network.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logBusiness: vi.fn(), logExternalService: vi.fn() },
+}));
+
+import { verifyCompaniesHouseNumber } from '../../services/companies-house.service';
+import { verifyCharityRegistrationNumber } from '../../services/charity-commission.service';
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {
+  process.env.COMPANIES_HOUSE_API_KEY = 'test-ch-key';
+  process.env.CHARITY_COMMISSION_API_KEY = 'test-cc-key';
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+  delete process.env.COMPANIES_HOUSE_API_KEY;
+  delete process.env.CHARITY_COMMISSION_API_KEY;
+});
+
+describe('verifyCompaniesHouseNumber timeout handling', () => {
+  it('returns a structured timeout result when fetch never resolves', async () => {
+    // fetch that respects the abort signal but otherwise never resolves
+    global.fetch = vi.fn().mockImplementation((_url: string, opts?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = opts?.signal;
+        signal?.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const start = Date.now();
+    const result = await verifyCompaniesHouseNumber('00000001');
+    const elapsed = Date.now() - start;
+
+    expect(result).toEqual({ verified: false, reason: 'Companies House API timeout' });
+    // The total budget is 7s; the per-request timeout is 5s. Either way we
+    // must NOT exceed the total budget by more than a small skew.
+    expect(elapsed).toBeLessThan(8_000);
+  }, 10_000);
+
+  it('does not retry on transport errors (only on 429)', async () => {
+    let calls = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      calls += 1;
+      return Promise.reject(new Error('ECONNREFUSED'));
+    }) as unknown as typeof fetch;
+
+    const result = await verifyCompaniesHouseNumber('00000001');
+    expect(result.verified).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  it('returns "API key not configured" when env var missing', async () => {
+    delete process.env.COMPANIES_HOUSE_API_KEY;
+    const result = await verifyCompaniesHouseNumber('00000001');
+    expect(result).toEqual({
+      verified: false,
+      reason: 'Companies House API key not configured',
+    });
+  });
+});
+
+describe('verifyCharityRegistrationNumber timeout handling', () => {
+  it('returns a structured timeout result when fetch never resolves', async () => {
+    global.fetch = vi.fn().mockImplementation((_url: string, opts?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = opts?.signal;
+        signal?.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const start = Date.now();
+    const result = await verifyCharityRegistrationNumber('1234567');
+    const elapsed = Date.now() - start;
+
+    expect(result).toEqual({ verified: false, reason: 'Charity Commission API timeout' });
+    expect(elapsed).toBeLessThan(8_000);
+  }, 10_000);
+
+  it('returns "API key not configured" when env var missing', async () => {
+    delete process.env.CHARITY_COMMISSION_API_KEY;
+    const result = await verifyCharityRegistrationNumber('1234567');
+    expect(result).toEqual({
+      verified: false,
+      reason: 'Charity Commission API key not configured',
+    });
+  });
+});

--- a/service.backend/src/services/charity-commission.service.ts
+++ b/service.backend/src/services/charity-commission.service.ts
@@ -42,6 +42,10 @@ export type CharityCommissionResult =
   | { verified: true; charityName: string }
   | { verified: false; reason: string };
 
+// See companies-house.service.ts for the rationale on these constants.
+const REQUEST_TIMEOUT_MS = 5_000;
+const TOTAL_BUDGET_MS = 7_000;
+
 const isAnimalRelated = (charity: CharityDetails): boolean => {
   const text = [
     charity.charity_name,
@@ -53,22 +57,74 @@ const isAnimalRelated = (charity: CharityDetails): boolean => {
   return ANIMAL_KEYWORDS.some(kw => text.includes(kw));
 };
 
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+
+class TimeoutError extends Error {
+  constructor() {
+    super('Charity Commission API timeout');
+    this.name = 'TimeoutError';
+  }
+}
+
+const fetchWithTimeout = async (
+  url: string,
+  subscriptionKey: string,
+  budgetSignal: AbortSignal
+): Promise<Response> => {
+  const requestSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const signal = AbortSignal.any([requestSignal, budgetSignal]);
+  return fetch(url, {
+    headers: { 'Ocp-Apim-Subscription-Key': subscriptionKey },
+    signal,
+  });
+};
+
 const fetchWithRetry = async (
   url: string,
   subscriptionKey: string,
-  attempt = 0
+  budgetSignal: AbortSignal
 ): Promise<Response> => {
-  const res = await fetch(url, {
-    headers: { 'Ocp-Apim-Subscription-Key': subscriptionKey },
-  });
+  let attempt = 0;
+  // Bail conditions are explicit at the bottom of the loop body. ESLint's
+  // no-constant-condition rule is overly cautious here.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (budgetSignal.aborted) {
+      throw new TimeoutError();
+    }
 
-  if (res.status === 429 && attempt < 3) {
+    let res: Response;
+    try {
+      res = await fetchWithTimeout(url, subscriptionKey, budgetSignal);
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw new TimeoutError();
+      }
+      throw error;
+    }
+
+    if (res.status !== 429 || attempt >= 3) {
+      return res;
+    }
+
     const delay = Math.pow(2, attempt) * 1000;
-    await new Promise(resolve => setTimeout(resolve, delay));
-    return fetchWithRetry(url, subscriptionKey, attempt + 1);
+    if (budgetSignal.aborted) {
+      throw new TimeoutError();
+    }
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(resolve, delay);
+      budgetSignal.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(t);
+          reject(new TimeoutError());
+        },
+        { once: true }
+      );
+    });
+    attempt += 1;
   }
-
-  return res;
 };
 
 // Strip the sub-charity suffix for the API lookup (e.g. "1234567-1" → "1234567").
@@ -84,11 +140,13 @@ export const verifyCharityRegistrationNumber = async (
   }
 
   const regno = baseRegistrationNumber(number);
+  const budgetSignal = AbortSignal.timeout(TOTAL_BUDGET_MS);
 
   try {
     const res = await fetchWithRetry(
       `${BASE_URL}/allcharitydetails/${encodeURIComponent(regno)}/0`,
-      subscriptionKey
+      subscriptionKey,
+      budgetSignal
     );
 
     if (res.status === 404) {
@@ -122,6 +180,10 @@ export const verifyCharityRegistrationNumber = async (
 
     return { verified: true, charityName: charity.charity_name };
   } catch (error) {
+    if (error instanceof TimeoutError || isAbortError(error)) {
+      logger.warn('Charity Commission verification timed out', { number });
+      return { verified: false, reason: 'Charity Commission API timeout' };
+    }
     logger.error('Charity Commission verification failed', { error, number });
     return { verified: false, reason: 'Failed to contact Charity Commission API' };
   }

--- a/service.backend/src/services/companies-house.service.ts
+++ b/service.backend/src/services/companies-house.service.ts
@@ -69,6 +69,17 @@ export type CompaniesHouseResult =
   | { verified: true; companyName: string }
   | { verified: false; reason: string };
 
+// Per-request fetch timeout. Companies House response times are sub-second in
+// the steady state; a 5s ceiling absorbs incident-period latency without
+// pinning DB connections (ADS-368).
+const REQUEST_TIMEOUT_MS = 5_000;
+
+// Hard cap on total wall-clock time across retries. With REQUEST_TIMEOUT_MS=5s
+// and up to 3 attempts the worst case is 5+1+5+2+5 = 18s — too long. This
+// budget is the absolute upper bound; the retry loop bails as soon as it's
+// exceeded so the verification helper can never take longer than this.
+const TOTAL_BUDGET_MS = 7_000;
+
 const isAnimalRelated = (company: CompaniesHouseCompany): boolean => {
   if (company.sic_codes?.some(code => ANIMAL_RELATED_SIC_CODES.has(code))) {
     return true;
@@ -77,20 +88,84 @@ const isAnimalRelated = (company: CompaniesHouseCompany): boolean => {
   return ANIMAL_KEYWORDS.some(kw => nameLower.includes(kw));
 };
 
-const fetchWithRetry = async (url: string, apiKey: string, attempt = 0): Promise<Response> => {
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}`,
-    },
-  });
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
 
-  if (res.status === 429 && attempt < 3) {
-    const delay = Math.pow(2, attempt) * 1000;
-    await new Promise(resolve => setTimeout(resolve, delay));
-    return fetchWithRetry(url, apiKey, attempt + 1);
+class TimeoutError extends Error {
+  constructor() {
+    super('Companies House API timeout');
+    this.name = 'TimeoutError';
   }
+}
 
-  return res;
+/**
+ * `fetch` with a per-request timeout. Composes the caller-supplied abort
+ * signal (the wall-clock budget) with a per-request `AbortSignal.timeout`
+ * so whichever fires first wins.
+ */
+const fetchWithTimeout = async (
+  url: string,
+  apiKey: string,
+  budgetSignal: AbortSignal
+): Promise<Response> => {
+  const requestSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const signal = AbortSignal.any([requestSignal, budgetSignal]);
+  return fetch(url, {
+    headers: { Authorization: `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}` },
+    signal,
+  });
+};
+
+/**
+ * Fetches the URL, retrying on HTTP 429 with exponential backoff. Bails early
+ * if the wall-clock budget is exhausted. Throws TimeoutError when either the
+ * per-request or total-budget signal fires.
+ */
+const fetchWithRetry = async (
+  url: string,
+  apiKey: string,
+  budgetSignal: AbortSignal
+): Promise<Response> => {
+  let attempt = 0;
+  // Bail conditions are explicit at the bottom of the loop body. ESLint's
+  // no-constant-condition rule is overly cautious here.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (budgetSignal.aborted) {
+      throw new TimeoutError();
+    }
+
+    let res: Response;
+    try {
+      res = await fetchWithTimeout(url, apiKey, budgetSignal);
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw new TimeoutError();
+      }
+      throw error;
+    }
+
+    if (res.status !== 429 || attempt >= 3) {
+      return res;
+    }
+
+    const delay = Math.pow(2, attempt) * 1000;
+    if (budgetSignal.aborted) {
+      throw new TimeoutError();
+    }
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(resolve, delay);
+      budgetSignal.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(t);
+          reject(new TimeoutError());
+        },
+        { once: true }
+      );
+    });
+    attempt += 1;
+  }
 };
 
 export const verifyCompaniesHouseNumber = async (number: string): Promise<CompaniesHouseResult> => {
@@ -100,8 +175,14 @@ export const verifyCompaniesHouseNumber = async (number: string): Promise<Compan
     return { verified: false, reason: 'Companies House API key not configured' };
   }
 
+  const budgetSignal = AbortSignal.timeout(TOTAL_BUDGET_MS);
+
   try {
-    const res = await fetchWithRetry(`${BASE_URL}/company/${encodeURIComponent(number)}`, apiKey);
+    const res = await fetchWithRetry(
+      `${BASE_URL}/company/${encodeURIComponent(number)}`,
+      apiKey,
+      budgetSignal
+    );
 
     if (res.status === 404) {
       return { verified: false, reason: `No company found with number ${number}` };
@@ -131,6 +212,10 @@ export const verifyCompaniesHouseNumber = async (number: string): Promise<Compan
 
     return { verified: true, companyName: company.company_name };
   } catch (error) {
+    if (error instanceof TimeoutError || isAbortError(error)) {
+      logger.warn('Companies House verification timed out', { number });
+      return { verified: false, reason: 'Companies House API timeout' };
+    }
     logger.error('Companies House verification failed', { error, number });
     return { verified: false, reason: 'Failed to contact Companies House API' };
   }

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -289,8 +289,13 @@ export class RescueService {
   static async createRescue(rescueData: CreateRescueRequest, createdBy: string): Promise<Rescue> {
     const startTime = Date.now();
 
+    // Phase 1: persist the rescue inside a transaction. Duplicate-checks plus
+    // the create-in-pending-state. External verification HTTP is deliberately
+    // NOT called here — it would hold a DB connection during arbitrary network
+    // I/O and exhaust the pool under load. See ADS-365.
     const transaction = await Rescue.sequelize!.transaction();
 
+    let rescue: Rescue;
     try {
       // Check for duplicate email
       const existingByEmail = await Rescue.findOne({
@@ -321,8 +326,8 @@ export class RescueService {
         }
       }
 
-      // Create the rescue in pending state — verification runs after
-      const rescue = await Rescue.create(
+      // Create the rescue in pending state — verification runs after commit.
+      rescue = await Rescue.create(
         {
           ...rescueData,
           status: 'pending',
@@ -330,58 +335,7 @@ export class RescueService {
         { transaction }
       );
 
-      // Attempt automated external verification
-      const verificationUpdate = await RescueService.attemptExternalVerification(
-        rescue.rescueId,
-        rescueData.companiesHouseNumber,
-        rescueData.charityRegistrationNumber
-      );
-
-      if (Object.keys(verificationUpdate).length > 0) {
-        await rescue.update(verificationUpdate, { transaction });
-      }
-
-      // Log the action
-      await AuditLogService.log({
-        userId: createdBy,
-        action: 'create',
-        entity: 'rescue',
-        entityId: rescue.rescueId,
-        details: {
-          rescueId: rescue.rescueId,
-          name: rescue.name,
-          email: rescue.email,
-          verificationStatus: verificationUpdate.status ?? 'pending',
-        },
-      });
-
-      loggerHelpers.logBusiness(
-        'Rescue Created',
-        {
-          rescueId: rescue.rescueId,
-          name: rescue.name,
-          createdBy,
-          verificationStatus: verificationUpdate.status ?? 'pending',
-          duration: Date.now() - startTime,
-        },
-        createdBy
-      );
-
       await transaction.commit();
-
-      // Send manual verification email outside the transaction so a send failure
-      // does not roll back the rescue creation.
-      if (verificationUpdate.manualVerificationRequestedAt) {
-        await RescueService.sendManualVerificationEmail(rescue.name, rescue.email).catch(err =>
-          logger.error('Failed to send manual verification email', {
-            err,
-            rescueId: rescue.rescueId,
-          })
-        );
-      }
-
-      logger.info(`Created new rescue: ${rescue.rescueId}`);
-      return rescue;
     } catch (error) {
       await transaction.rollback();
       logger.error('Error creating rescue:', {
@@ -395,6 +349,76 @@ export class RescueService {
       }
       throw new Error('Failed to create rescue');
     }
+
+    // Phase 2: verification runs AFTER commit, so the upstream API latency
+    // never holds a DB connection. The rescue already exists in the database
+    // with status='pending'; this update transitions it to verified or
+    // routes it to manual review. If anything in this phase fails, the
+    // rescue is still safely created and an admin can re-run verification.
+    let verificationUpdate: Awaited<ReturnType<typeof RescueService.attemptExternalVerification>> =
+      {};
+    try {
+      verificationUpdate = await RescueService.attemptExternalVerification(
+        rescue.rescueId,
+        rescueData.companiesHouseNumber,
+        rescueData.charityRegistrationNumber
+      );
+
+      if (Object.keys(verificationUpdate).length > 0) {
+        await rescue.update(verificationUpdate);
+      }
+    } catch (err) {
+      logger.error('External verification step failed (rescue already created)', {
+        err,
+        rescueId: rescue.rescueId,
+      });
+      // Don't throw — the rescue exists in pending state and can be
+      // verified manually by an admin.
+    }
+
+    try {
+      await AuditLogService.log({
+        userId: createdBy,
+        action: 'create',
+        entity: 'rescue',
+        entityId: rescue.rescueId,
+        details: {
+          rescueId: rescue.rescueId,
+          name: rescue.name,
+          email: rescue.email,
+          verificationStatus: verificationUpdate.status ?? 'pending',
+        },
+      });
+    } catch (err) {
+      logger.error('Failed to write audit log for rescue create', {
+        err,
+        rescueId: rescue.rescueId,
+      });
+    }
+
+    loggerHelpers.logBusiness(
+      'Rescue Created',
+      {
+        rescueId: rescue.rescueId,
+        name: rescue.name,
+        createdBy,
+        verificationStatus: verificationUpdate.status ?? 'pending',
+        duration: Date.now() - startTime,
+      },
+      createdBy
+    );
+
+    if (verificationUpdate.manualVerificationRequestedAt) {
+      await RescueService.sendManualVerificationEmail(rescue.name, rescue.email).catch(err =>
+        logger.error('Failed to send manual verification email', {
+          err,
+          rescueId: rescue.rescueId,
+        })
+      );
+    }
+
+    logger.info(`Created new rescue: ${rescue.rescueId}`);
+    return rescue;
   }
 
   /**


### PR DESCRIPTION
Closes ADS-365, ADS-368.

## Summary

- Add per-request fetch timeout (5s) + total wall-clock budget (7s) to both `companies-house.service.ts` and `charity-commission.service.ts` — neither helper can hang indefinitely on a slow upstream API any more (ADS-368).
- Move external verification HTTP out of the `createRescue` DB transaction — the transaction commits first with `status='pending'`, verification runs after and applies the result via a second update (ADS-365).

## Why

**ADS-368**: The two services called `fetch()` with no `AbortController` / `signal` and no timeout. The retry helper only triggered on HTTP 429, so a connection that never returned was *not* retried — it just hung. Combined with the retry budget this was a denial-of-availability vector against our own backend.

**ADS-365**: `RescueService.createRescue` opened a Sequelize transaction and then performed synchronous external HTTP inside it (via `attemptExternalVerification`). The verification helpers retry on 429 with exponential backoff (1s, 2s, 4s), so a single rescue creation could hold the transaction open for 7+ seconds plus the actual response time, with no upper bound. Under load this exhausted the connection pool and stalled unrelated requests.

## Changes

### `service.backend/src/services/companies-house.service.ts` + `charity-commission.service.ts`
- New `fetchWithTimeout` helper composes `AbortSignal.any([requestSignal, budgetSignal])` so whichever signal fires first wins.
- New wall-clock `budgetSignal = AbortSignal.timeout(7_000)` is created at the top of `verifyCompaniesHouseNumber` / `verifyCharityRegistrationNumber` and threaded into `fetchWithRetry`.
- Retry loop now bails as soon as the budget signal fires; the 1s/2s/4s sleep between retries also aborts on budget exhaustion.
- Aborted fetches are caught and rethrown as a typed `TimeoutError`; the public function maps that to `{ verified: false, reason: '<service> API timeout' }` which routes the rescue to manual review through the existing fallback path.

### `service.backend/src/services/rescue.service.ts` — `createRescue`
- Phase 1 (transaction): duplicate-checks + `Rescue.create({...rescueData, status: 'pending'})`, commit.
- Phase 2 (post-commit): `attemptExternalVerification` runs; the result is applied via a second `rescue.update(verificationUpdate)`. Failures here are logged but do **not** roll back the create — the rescue exists in `pending` and an admin can re-verify manually.
- Audit log + business log + manual-verification email all happen in phase 2 too, so nothing is gated on the upstream API.

## Test plan

- [x] `service.backend/src/__tests__/services/external-verification-timeout.test.ts` — new suite:
  - Companies House: never-resolving fetch produces `{ verified: false, reason: 'Companies House API timeout' }` within 8s
  - Charity Commission: same, with the matching reason string
  - Transport error (e.g. ECONNREFUSED) is NOT retried (only 429 is)
  - Missing API key returns the existing structured "key not configured" result
- [x] Existing `rescue.service.test.ts` `createRescue` tests still pass — phase split preserves observable behaviour
- [ ] CI green on this branch

## Risks / considerations

- The phase-1 transaction is shorter, but if phase 2 fails the audit log entry never lands. The original code had the same property when an exception thrown by `attemptExternalVerification` happened mid-transaction. Mitigated by best-effort audit log inside its own try/catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA