### PR TITLE
fix(rescue): preserve approve/verify operator intent in audit log [ADS-378]

### DIFF
--- a/service.backend/src/__tests__/services/rescue-business-logic.test.ts
+++ b/service.backend/src/__tests__/services/rescue-business-logic.test.ts
@@ -530,6 +530,58 @@ describe('RescueService - Business Logic Tests', () => {
         error: 'Rescue is already suspended',
       });
     });
+
+    it('preserves the operator action verb (approve vs verify) in the audit log [ADS-378]', async () => {
+      // Given: A pending rescue
+      const rescueId = 'aaa11111-e89b-12d3-a456-426614174a01';
+      const mockRescue = createMockRescue({ rescueId, status: 'pending' });
+      const mockTransaction = {
+        commit: vi.fn().mockResolvedValue(undefined),
+        rollback: vi.fn().mockResolvedValue(undefined),
+      };
+
+      MockedRescue.findByPk = vi.fn().mockResolvedValue(mockRescue as unknown);
+      (MockedRescue as unknown).sequelize = {
+        transaction: vi.fn().mockResolvedValue(mockTransaction),
+      };
+
+      // When: Bulk-approving (rather than bulk-verifying) the rescue
+      await RescueService.bulkUpdateRescues([rescueId], 'approve', mockUserId, 'Bulk approval');
+
+      // Then: The audit log entry records the 'approve' verb, not 'verify' —
+      // operator intent is preserved per ADS-378.
+      expect(MockedAuditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'approve',
+          entity: 'rescue',
+          entityId: rescueId,
+        })
+      );
+    });
+
+    it('logs the verify verb when bulk action is verify [ADS-378]', async () => {
+      const rescueId = 'bbb22222-e89b-12d3-a456-426614174b01';
+      const mockRescue = createMockRescue({ rescueId, status: 'pending' });
+      const mockTransaction = {
+        commit: vi.fn().mockResolvedValue(undefined),
+        rollback: vi.fn().mockResolvedValue(undefined),
+      };
+
+      MockedRescue.findByPk = vi.fn().mockResolvedValue(mockRescue as unknown);
+      (MockedRescue as unknown).sequelize = {
+        transaction: vi.fn().mockResolvedValue(mockTransaction),
+      };
+
+      await RescueService.bulkUpdateRescues([rescueId], 'verify', mockUserId);
+
+      expect(MockedAuditLogService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'verify',
+          entity: 'rescue',
+          entityId: rescueId,
+        })
+      );
+    });
   });
 
   describe('Staff Management', () => {

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -488,7 +488,13 @@ export class RescueService {
     rescueId: string,
     verifiedBy: string,
     notes?: string,
-    verificationSource: 'companies_house' | 'charity_commission' | 'manual' = 'manual'
+    verificationSource: 'companies_house' | 'charity_commission' | 'manual' = 'manual',
+    /**
+     * Operator intent verb recorded in the audit log. Defaults to `'verify'`.
+     * `bulkUpdateRescues` passes the caller's original action ('approve' or
+     * 'verify') so audit entries preserve the chosen verb — see ADS-378.
+     */
+    auditAction: 'verify' | 'approve' = 'verify'
   ): Promise<Rescue> {
     const startTime = Date.now();
 
@@ -517,10 +523,11 @@ export class RescueService {
         { transaction }
       );
 
-      // Log the action
+      // Log the action — `auditAction` lets bulk callers preserve their
+      // original verb ('approve' vs 'verify') rather than collapsing them.
       await AuditLogService.log({
         userId: verifiedBy,
-        action: 'verify',
+        action: auditAction,
         entity: 'rescue',
         entityId: rescueId,
         details: {
@@ -1454,7 +1461,11 @@ export class RescueService {
     for (const rescueId of rescueIds) {
       try {
         if (action === 'approve' || action === 'verify') {
-          await RescueService.verifyRescue(rescueId, performedBy, reason);
+          // Both actions perform identical state transitions, but operator
+          // intent must be preserved in the audit log. Pass the original
+          // action verb through so the audit entry records 'approve' vs
+          // 'verify' rather than collapsing them — see ADS-378.
+          await RescueService.verifyRescue(rescueId, performedBy, reason, 'manual', action);
         } else if (action === 'suspend') {
           await RescueService.suspendRescue(rescueId, performedBy, reason);
         }


### PR DESCRIPTION
Closes ADS-378.

## Summary

`bulkUpdateRescues` previously routed both `'approve'` and `'verify'` actions through `RescueService.verifyRescue` (rescue.service.ts:1456) and accepted the default audit-log verb (`'verify'`). The two actions remain functionally identical (same state transition: `pending` → `verified`) but operator intent was lost — a manual approval and an externally-confirmed verification both showed up in the audit log as `action='verify'`.

## Fix

`verifyRescue` now accepts an optional `auditAction: 'verify' | 'approve'` parameter (default `'verify'`) that overrides only the audit-log entry's action verb. `bulkUpdateRescues` passes the caller's original verb through, so `'approve'` and `'verify'` are recorded distinctly. Per-rescue `verifyRescue` callers (controllers, internal post-create verification) keep the default `'verify'` label — no behaviour change there.

This is the lower-risk of the two paths the ticket proposes: it preserves operator intent without breaking the public API contract on `RescueBulkActionSchema`. If product later decides the two actions should be true synonyms, dropping `'approve'` is a follow-up that becomes trivial once the audit log distinction is in place.

## Changes

### `service.backend/src/services/rescue.service.ts`
- `verifyRescue` signature gains an optional 5th param `auditAction`.
- `bulkUpdateRescues` passes the user-supplied action through:
  ```ts
  await RescueService.verifyRescue(rescueId, performedBy, reason, 'manual', action);
  ```

## Test plan

- [x] Two new cases in `service.backend/src/__tests__/services/rescue-business-logic.test.ts`:
  - `bulkUpdateRescues([id], 'approve', ...)` → audit log records `action: 'approve'`
  - `bulkUpdateRescues([id], 'verify', ...)` → audit log records `action: 'verify'`
- [x] Existing `verifyRescue` tests still pass — default audit verb unchanged
- [ ] CI green on this branch

## Out of scope

- Distinct semantic divergence (e.g. approve = clear pending without external verification, verify = ratify external check). The ticket flags this as a product question; this PR captures intent without making that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA