### PR TITLE
docs: add MIT LICENSE file (ADS-369)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present Adopt Don't Shop Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib.audit-logs/package.json
+++ b/lib.audit-logs/package.json
@@ -24,7 +24,7 @@
     "adopt-dont-shop"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@adopt-dont-shop/lib.api": "*"
   },


### PR DESCRIPTION
## Summary

- Adds `LICENSE` at the repo root with standard MIT license text and copyright `Copyright (c) 2024-present Adopt Don't Shop Team`, resolving the broken `[LICENSE](./LICENSE)` link in README.md
- Fixes `lib.audit-logs/package.json` which incorrectly declared `"license": "ISC"` — all workspace packages now consistently declare `"license": "MIT"`
- No functional code changes; documentation/compliance fix only

## Test plan

- [ ] `cat LICENSE` shows MIT text with correct copyright line
- [ ] Clicking `LICENSE` link in GitHub README renders the file (no 404)
- [ ] `grep '"license"' */package.json package.json` reports `MIT` for every workspace package (no `ISC` or other values)
- [ ] GitHub repo page detects and displays the MIT license badge

## Linear

https://linear.app/ideasquared/issue/ADS-369

https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY)_