### PR TITLE
chore(vscode): add settings.json for format-on-save, ESLint, workspace TS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "eslint.workingDirectories": [
+    { "pattern": "app.*" },
+    { "pattern": "lib.*" },
+    { "pattern": "service.backend" }
+  ],
+  "search.exclude": {
+    "**/dist": true,
+    "**/coverage": true,
+    "**/.turbo": true,
+    "package-lock.json": true
+  },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "tsconfig.json": "tsconfig.*.json",
+    "package.json": "package-lock.json, .npmrc, .nvmrc",
+    "*.ts": "${capture}.test.ts, ${capture}.spec.ts"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.vscode/settings.json` with format-on-save (Prettier), ESLint auto-fix on save, and workspace TypeScript SDK defaults
- Updates `.gitignore` to track `.vscode/settings.json` alongside the existing `.vscode/extensions.json` exception
- Wires up the 14 extensions already recommended in `.vscode/extensions.json` so new contributors get consistent tooling out of the box

Linear: https://linear.app/ideasquared/issue/ADS-377

## Test plan

- [ ] Open the repo in VS Code — confirm you are prompted to use the workspace TypeScript version
- [ ] Edit a `.ts` file with a formatting issue — confirm Prettier formats on save
- [ ] Introduce an ESLint error — confirm it is auto-fixed on save
- [ ] Confirm `git check-ignore .vscode/settings.json` exits with code 1 (file is tracked)
- [ ] Confirm no other files were modified

https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY)_