### PR TITLE
docs: add CONTRIBUTING.md consolidating contributor guide (ADS-371)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Before opening: make sure you've read [CONTRIBUTING.md](../CONTRIBUTING.md) and that all CI checks pass. -->
+
 ## Summary
 
 <!-- What does this PR do? 1-3 bullet points. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to Adopt Don't Shop
+
+Thanks for contributing! This guide covers everything you need to open a good PR.
+
+## Getting started
+
+Follow the Quick Start in [README.md](./README.md#quick-start) to get the stack running locally.
+
+## Development workflow
+
+### Branch naming
+
+```
+<owner>/<ticket>-<short-slug>
+# e.g. paragonjenko/ads-123-add-rescue-search
+```
+
+### Commits
+
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add rescue search endpoint
+fix: correct date format in profile
+refactor: extract validation logic
+test: add edge cases for registration
+docs: update API reference
+```
+
+### TDD loop
+
+This project follows strict Test-Driven Development — **no new behaviour without a test first**:
+
+1. **Red** — write a failing test that describes the desired behaviour
+2. **Green** — write the minimum code to make it pass
+3. **Refactor** — clean up while keeping tests green
+
+## Before opening a PR
+
+All four checks must pass locally before pushing:
+
+```bash
+npm run lint
+npm test
+npm run type-check
+npm run format:check
+```
+
+The CI workflow enforces these — PRs that fail CI will not be merged.
+
+## Code style
+
+Full guidelines are in [.claude/CLAUDE.md](./.claude/CLAUDE.md). Key rules:
+
+- TypeScript strict mode — no `any`, no type assertions without justification
+- Schema-first types: define a [Zod](https://zod.dev/) schema, then `z.infer<>` the type
+- Immutable data; pure functions; no nested if/else (use early returns)
+- Functional components only in React; no class components
+
+## Test requirements
+
+| Package scope | Test runner |
+|---|---|
+| `lib.*` shared libraries | Jest |
+| `app.*` React apps | Vitest + React Testing Library |
+| `service.backend` | Vitest |
+
+> Note: ADS-385 will consolidate all packages onto Vitest. Until then, use the runner already configured in the package.
+
+Tests must cover **behaviour**, not implementation. 100% coverage is expected but tests must always be grounded in business requirements, not internal structure.
+
+## Reporting bugs / proposing features
+
+Use the issue templates in [`.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE/):
+
+- [Bug report](./.github/ISSUE_TEMPLATE/bug_report.yml)
+- [Feature request](./.github/ISSUE_TEMPLATE/feature_request.yml)
+
+## Reviewing & code ownership
+
+Code ownership is defined in [`.github/CODEOWNERS`](./.github/CODEOWNERS). All PRs require at least one approved review before merge.

--- a/README.md
+++ b/README.md
@@ -171,11 +171,7 @@ Common issues:
 
 ## Contributing
 
-1. Fork and branch from `main`
-2. Follow TDD — write or modify tests first (see [.claude/CLAUDE.md](./.claude/CLAUDE.md))
-3. Run `npm run lint` and `npm run test` before opening a PR
-4. Use conventional commit messages
-5. Open a PR
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full contributor guide.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Creates `CONTRIBUTING.md` at the repo root so GitHub surfaces it on PR/issue pages
- Trims the duplicated "Contributing" section in `README.md` to a single link
- Adds a one-line `CONTRIBUTING.md` reference to the PR template

## Changes

- `CONTRIBUTING.md` — new file with sections: Getting started, Development workflow (branch naming, Conventional Commits, TDD loop), Before opening a PR (pre-flight checklist), Code style, Test requirements (Jest vs Vitest split + ADS-385 note), Reporting bugs/features, Reviewing & code ownership
- `README.md` — "Contributing" section replaced with a single link to `CONTRIBUTING.md`
- `.github/pull_request_template.md` — one-line reference to `CONTRIBUTING.md` added at the top

## Test plan

- [ ] `CONTRIBUTING.md` exists at repo root and renders correctly on GitHub
- [ ] README "Contributing" section is now a single link (no duplicated content)
- [ ] PR template references `CONTRIBUTING.md`
- [ ] `npm run lint` passes
- [ ] `npm run format:check` passes (Prettier ran via lint-staged on commit)

## Related

Linear: https://linear.app/ideasquared/issue/ADS-371

https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY