### PR TITLE
chore(devex): restructure CODEOWNERS into ownership areas (ADS-392)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,24 +1,58 @@
-# Global fallback
+# CODEOWNERS
+#
+# Teams are not yet created on the org. Once the following teams exist,
+# replace @paragonjenko in the matching sections with the team handle:
+#
+#   @adopt-dont-shop/backend   → /service.backend/, backend-facing libs
+#   @adopt-dont-shop/frontend  → /app.*/, /lib.components/
+#   @adopt-dont-shop/libs      → all other /lib.*/
+#   @adopt-dont-shop/infra     → /.github/, Docker/nginx/CI files
+#
+# See ADS-392: https://linear.app/ideasquared/issue/ADS-392
+#
+# When teams exist, also configure branch protection on `main` to require
+# a review from the relevant CODEOWNERS team (repo Settings → Branches).
+
+# ──────────────────────────────────────────────
+# Global fallback — catches anything not matched below
+# ──────────────────────────────────────────────
 *                           @paragonjenko
 
+# ──────────────────────────────────────────────
 # Frontend apps
+# Future owner: @adopt-dont-shop/frontend
+# ──────────────────────────────────────────────
 /app.admin/                 @paragonjenko
 /app.client/                @paragonjenko
 /app.rescue/                @paragonjenko
 
-# Backend
+# ──────────────────────────────────────────────
+# Backend service
+# Future owner: @adopt-dont-shop/backend
+# ──────────────────────────────────────────────
 /service.backend/           @paragonjenko
 
+# ──────────────────────────────────────────────
 # Shared libraries
+# Future owner: @adopt-dont-shop/frontend (lib.components)
+#               @adopt-dont-shop/backend  (lib.types, lib.validation)
+#               @adopt-dont-shop/libs     (all others)
+# ──────────────────────────────────────────────
 /lib.*/                     @paragonjenko
 
+# ──────────────────────────────────────────────
 # Infrastructure & CI
+# Future owner: @adopt-dont-shop/infra
+# ──────────────────────────────────────────────
 /.github/                   @paragonjenko
 /docker-compose*.yml        @paragonjenko
 /Dockerfile*                @paragonjenko
 /nginx/                     @paragonjenko
 /turbo.json                 @paragonjenko
 
+# ──────────────────────────────────────────────
 # Documentation
+# Future owner: @adopt-dont-shop/infra (or whole-team)
+# ──────────────────────────────────────────────
 /docs/                      @paragonjenko
 /README.md                  @paragonjenko


### PR DESCRIPTION
## Linear

https://linear.app/ideasquared/issue/ADS-392

## Summary

- Grouped all CODEOWNERS paths under clearly labelled sections: **Global fallback**, **Frontend apps**, **Backend service**, **Shared libraries**, **Infrastructure & CI**, and **Documentation**.
- Added a top-of-file comment block explaining the intended future team ownership per area (`@adopt-dont-shop/{backend,frontend,libs,infra}`) and linking back to ADS-392.
- All paths still resolve to `@paragonjenko` because the org teams do not exist yet — no team references have been added to the actual ownership lines, so CODEOWNERS remains valid and no PRs will be blocked.
- The structure is deliberately ready for a low-friction follow-up: once teams are created, a reviewer only needs to swap `@paragonjenko` for the annotated team handle in each section.

## What still needs human action (follow-ups)

1. **Create GitHub org teams** (repo admin required):
   - `@adopt-dont-shop/backend` — assign engineers owning `service.backend/`, `lib.types/`, `lib.validation/`
   - `@adopt-dont-shop/frontend` — assign engineers owning `app.*/`, `lib.components/`
   - `@adopt-dont-shop/libs` — assign engineers owning remaining `lib.*/`
   - `@adopt-dont-shop/infra` — assign engineers owning `.github/`, Docker/nginx/CI files

2. **Route paths to teams** — once teams exist, open a follow-up PR replacing `@paragonjenko` with the appropriate team handle in each section of `.github/CODEOWNERS`. Keep `@paragonjenko` only on the global `*` fallback.

3. **Configure branch protection on `main`** (repo Settings → Branches → Branch protection rules) — enable "Require a pull request before merging" and tick "Require review from Code Owners". This cannot be done via CODEOWNERS itself; it requires repo admin access in the GitHub UI.

4. **CONTRIBUTING.md** — ADS-371 is landing in a parallel PR to add a `CONTRIBUTING.md`. Once it merges, a follow-up should add a "Who reviews what" section listing each team's scope and review SLA.

https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY)_