### PR TITLE
fix(security): atomic refresh-token rotation, fresh verification reminders, CORS wildcard guard

### DIFF
--- a/service.backend/src/__tests__/config/cors-wildcard-guard.test.ts
+++ b/service.backend/src/__tests__/config/cors-wildcard-guard.test.ts
@@ -1,0 +1,64 @@
+/**
+ * ADS-215 — when credentials are enabled (`credentials: true`) the browser
+ * already disallows wildcard `Access-Control-Allow-Origin: *`, but we want
+ * to fail loudly at startup rather than silently break the browser. Tests
+ * exercise the CORS_ORIGIN parsing IIFE in `config/index.ts` indirectly by
+ * loading the module under different env values via `vi.resetModules`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logBusiness: vi.fn(), logExternalService: vi.fn() },
+}));
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.resetModules();
+  // Reset env between cases so module-load reads the value we set here.
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+const loadConfig = async () => (await import('../../config/index')).config;
+
+describe('CORS_ORIGIN wildcard guard [ADS-215]', () => {
+  it('accepts a single explicit origin', async () => {
+    process.env.CORS_ORIGIN = 'https://app.example.com';
+    const config = await loadConfig();
+    expect(config.cors.origin).toBe('https://app.example.com');
+    expect(config.cors.credentials).toBe(true);
+  });
+
+  it('accepts a comma-separated explicit allowlist', async () => {
+    process.env.CORS_ORIGIN = 'https://app.example.com,https://admin.example.com';
+    const config = await loadConfig();
+    expect(config.cors.origin).toEqual(['https://app.example.com', 'https://admin.example.com']);
+  });
+
+  it('rejects a bare wildcard', async () => {
+    process.env.CORS_ORIGIN = '*';
+    await expect(loadConfig()).rejects.toThrow(/wildcard/);
+  });
+
+  it('rejects "null" as an origin', async () => {
+    process.env.CORS_ORIGIN = 'null';
+    await expect(loadConfig()).rejects.toThrow(/wildcard|unsafe/);
+  });
+
+  it('rejects a wildcard mixed into the allowlist', async () => {
+    process.env.CORS_ORIGIN = 'https://app.example.com,*';
+    await expect(loadConfig()).rejects.toThrow(/wildcard/);
+  });
+
+  it('rejects a glob-style wildcard host', async () => {
+    process.env.CORS_ORIGIN = 'https://*.example.com';
+    await expect(loadConfig()).rejects.toThrow(/wildcard|unsafe/);
+  });
+});

--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -110,6 +110,16 @@ describe('Authentication Flow Integration Tests', () => {
     (MockedUser as unknown as { sequelize: unknown }).sequelize = {
       transaction: vi.fn().mockResolvedValue(mockTransaction),
     };
+
+    // ADS-169: refreshToken now wraps revoke/rotate in a sequelize
+    // transaction on RefreshToken.sequelize. Provide a pass-through.
+    (MockedRefreshToken as unknown as { sequelize: unknown }).sequelize = {
+      transaction: vi.fn().mockImplementation(async (cb: (t: unknown) => Promise<unknown>) =>
+        cb({
+          /* sentinel transaction */
+        })
+      ),
+    };
   });
 
   describe('User Registration and Email Verification', () => {

--- a/service.backend/src/__tests__/services/auth-security.test.ts
+++ b/service.backend/src/__tests__/services/auth-security.test.ts
@@ -153,6 +153,16 @@ describe('AuthService - Security Business Logic', () => {
     MockedRefreshToken.update = vi.fn().mockResolvedValue([0]);
     MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(null);
 
+    // ADS-169: refreshToken now wraps revoke/rotate in a sequelize
+    // transaction. Provide a pass-through so the inner callback runs.
+    (MockedRefreshToken as unknown as { sequelize: unknown }).sequelize = {
+      transaction: vi.fn().mockImplementation(async (cb: (t: unknown) => Promise<unknown>) =>
+        cb({
+          /* sentinel transaction */
+        })
+      ),
+    };
+
     // Setup speakeasy mocks
     if (!MockedSpeakeasy.totp) {
       MockedSpeakeasy.totp = {} as typeof speakeasy.totp;

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -384,6 +384,21 @@ describe('AuthService', () => {
   });
 
   describe('refreshToken', () => {
+    // ADS-169: refreshToken now performs the rotation/revoke writes inside a
+    // sequelize transaction. Tests mock the transaction wrapper to a pass-
+    // through so the assertions stay focused on the model calls.
+    const buildPassThroughTransaction = () => {
+      const txMock = vi.fn().mockImplementation(async (cb: (t: unknown) => Promise<unknown>) =>
+        cb({
+          /* fake transaction object — only its identity matters */
+        })
+      );
+      (MockedRefreshToken as unknown as { sequelize: unknown }).sequelize = {
+        transaction: txMock,
+      };
+      return txMock;
+    };
+
     it('should refresh token successfully', async () => {
       const refreshToken = 'valid-refresh-token';
       const mockPayload = { userId: 'user-123', jti: 'token-123' };
@@ -412,7 +427,9 @@ describe('AuthService', () => {
 
       mockedJwt.verify = vi.fn().mockReturnValue(mockPayload);
       MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(mockStoredToken);
+      MockedRefreshToken.create = vi.fn().mockResolvedValue(undefined);
       MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser);
+      const txMock = buildPassThroughTransaction();
 
       const result = await AuthService.refreshToken(refreshToken);
 
@@ -423,6 +440,8 @@ describe('AuthService', () => {
       );
       expect(MockedRefreshToken.findByPk).toHaveBeenCalledWith(mockPayload.jti);
       expect(MockedUser.findByPk).toHaveBeenCalledWith(mockPayload.userId, expect.any(Object));
+      // ADS-169: rotation must run inside a transaction
+      expect(txMock).toHaveBeenCalled();
       expect(result.user).toBeDefined();
       expect(result.token).toBe('mocked-access-token');
     });
@@ -435,6 +454,36 @@ describe('AuthService', () => {
       });
 
       await expect(AuthService.refreshToken(invalidToken)).rejects.toThrow('Invalid refresh token');
+    });
+
+    it('revokes the entire token family inside a single transaction on reuse [ADS-169]', async () => {
+      const refreshToken = 'reused-refresh-token';
+      const mockPayload = { userId: 'user-123', jti: 'token-reused' };
+
+      const mockStoredToken = {
+        token_id: 'token-reused',
+        user_id: 'user-123',
+        family_id: 'family-abc',
+        is_revoked: true,
+        isExpired: vi.fn().mockReturnValue(false),
+        update: vi.fn().mockResolvedValue(undefined),
+      };
+
+      mockedJwt.verify = vi.fn().mockReturnValue(mockPayload);
+      MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(mockStoredToken);
+      MockedRefreshToken.update = vi.fn().mockResolvedValue([1]);
+      const txMock = buildPassThroughTransaction();
+
+      await expect(AuthService.refreshToken(refreshToken)).rejects.toThrow('Invalid refresh token');
+
+      expect(txMock).toHaveBeenCalled();
+      expect(MockedRefreshToken.update).toHaveBeenCalledWith(
+        { is_revoked: true },
+        expect.objectContaining({
+          where: { family_id: 'family-abc', user_id: 'user-123' },
+          transaction: expect.anything(),
+        })
+      );
     });
   });
 

--- a/service.backend/src/__tests__/services/refresh-token-rotation.test.ts
+++ b/service.backend/src/__tests__/services/refresh-token-rotation.test.ts
@@ -53,6 +53,17 @@ describe('Refresh token rotation', () => {
       transaction: vi.fn().mockResolvedValue(mockTransaction),
     };
 
+    // ADS-169: refreshToken now wraps revoke/rotate writes in
+    // RefreshToken.sequelize.transaction(async cb => ...). Provide a
+    // pass-through so the callback runs and the inner model calls execute.
+    (MockedRefreshToken as unknown as { sequelize: unknown }).sequelize = {
+      transaction: vi.fn().mockImplementation(async (cb: (t: unknown) => Promise<unknown>) =>
+        cb({
+          /* sentinel transaction */
+        })
+      ),
+    };
+
     vi.spyOn(AuthService as unknown, 'generateTokens').mockResolvedValue({
       token: 'new-access-token',
       refreshToken: 'new-refresh-token',
@@ -145,8 +156,11 @@ describe('Refresh token rotation', () => {
 
       await AuthService.refreshToken('valid.refresh.jwt');
 
+      // ADS-169: rotation happens inside a sequelize transaction, so the
+      // update is called with both the data and a transaction option.
       expect(storedToken.update).toHaveBeenCalledWith(
-        expect.objectContaining({ is_revoked: true })
+        expect.objectContaining({ is_revoked: true }),
+        expect.objectContaining({ transaction: expect.anything() })
       );
     });
 
@@ -160,10 +174,13 @@ describe('Refresh token rotation', () => {
 
       await AuthService.refreshToken('valid.refresh.jwt');
 
+      // ADS-169: storeRefreshToken now also receives the rotation transaction
+      // so it participates in the same atomic write.
       expect(storeRefreshTokenSpy).toHaveBeenCalledWith(
         'user-123',
         expect.any(String),
-        'family-abc'
+        'family-abc',
+        expect.anything()
       );
     });
 
@@ -189,7 +206,11 @@ describe('Refresh token rotation', () => {
         'Invalid refresh token'
       );
 
-      expect(storedToken.update).toHaveBeenCalledWith({ is_revoked: true });
+      // ADS-169: storedToken.update now runs inside a sequelize transaction
+      expect(storedToken.update).toHaveBeenCalledWith(
+        { is_revoked: true },
+        expect.objectContaining({ transaction: expect.anything() })
+      );
     });
   });
 
@@ -215,7 +236,10 @@ describe('Refresh token rotation', () => {
 
       expect(MockedRefreshToken.update).toHaveBeenCalledWith(
         { is_revoked: true },
-        { where: { family_id: 'family-abc', user_id: 'user-123' } }
+        expect.objectContaining({
+          where: { family_id: 'family-abc', user_id: 'user-123' },
+          transaction: expect.anything(),
+        })
       );
     });
 

--- a/service.backend/src/config/index.ts
+++ b/service.backend/src/config/index.ts
@@ -46,11 +46,26 @@ export const config = {
     origin: (() => {
       const corsOrigin = process.env.CORS_ORIGIN;
       if (corsOrigin) {
-        // Handle multiple origins (comma-separated)
-        if (corsOrigin.includes(',')) {
-          return corsOrigin.split(',').map(origin => origin.trim());
+        // ADS-215: with `credentials: true` the browser already disallows
+        // wildcard (`*`) Access-Control-Allow-Origin, but reject it here
+        // explicitly so the misconfiguration fails at startup with a
+        // clearer error than CORS-blocked-in-the-browser noise. Same for
+        // `null` and bare wildcards inside the comma-list.
+        const origins = corsOrigin.includes(',')
+          ? corsOrigin
+              .split(',')
+              .map(origin => origin.trim())
+              .filter(Boolean)
+          : [corsOrigin.trim()];
+        const wildcards = origins.filter(o => o === '*' || o === 'null' || o.includes('*'));
+        if (wildcards.length > 0) {
+          throw new Error(
+            `CORS_ORIGIN must be an explicit allowlist when credentials are enabled. ` +
+              `Got wildcard/unsafe entries: ${wildcards.join(', ')}. ` +
+              `List exact origins, comma-separated.`
+          );
         }
-        return corsOrigin;
+        return origins.length === 1 ? origins[0] : origins;
       }
       if (process.env.NODE_ENV === 'production') {
         throw new Error('CORS_ORIGIN environment variable is required in production');

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -328,12 +328,28 @@ export class AuthService {
         throw new Error('Invalid refresh token');
       }
 
+      // Refresh-token rotation is security-critical: a partial write on the
+      // reuse-detection path leaves a stolen token still usable; a partial
+      // write on rotation creates a new token without revoking the old one,
+      // turning a normal reuse path into a stolen-token replay vector.
+      // Wrap both branches in a single transaction so they're atomic.
+      // See ADS-169.
+      const sequelize = RefreshToken.sequelize;
+      if (!sequelize) {
+        throw new Error('RefreshToken model has no Sequelize instance');
+      }
+
       if (storedToken.is_revoked) {
-        // Reuse detected: revoke entire token family to protect the account
-        await RefreshToken.update(
-          { is_revoked: true },
-          { where: { family_id: storedToken.family_id, user_id: storedToken.user_id } }
-        );
+        // Reuse detected: revoke entire token family to protect the account.
+        await sequelize.transaction(async transaction => {
+          await RefreshToken.update(
+            { is_revoked: true },
+            {
+              where: { family_id: storedToken.family_id, user_id: storedToken.user_id },
+              transaction,
+            }
+          );
+        });
         loggerHelpers.logSecurity('Refresh token reuse detected – family revoked', {
           userId: storedToken.user_id,
           familyId: storedToken.family_id,
@@ -342,7 +358,9 @@ export class AuthService {
       }
 
       if (storedToken.isExpired()) {
-        await storedToken.update({ is_revoked: true });
+        await sequelize.transaction(async transaction => {
+          await storedToken.update({ is_revoked: true }, { transaction });
+        });
         throw new Error('Invalid refresh token');
       }
 
@@ -364,8 +382,15 @@ export class AuthService {
         { userId: user.userId, email: user.email, userType: user.userType },
         newTokenId
       );
-      await this.storeRefreshToken(user.userId, newTokenId, storedToken.family_id);
-      await storedToken.update({ is_revoked: true, replaced_by_token_id: newTokenId });
+      // Atomically: store the new token AND revoke the old one. Either both
+      // happen or neither does — no half-rotated state is observable.
+      await sequelize.transaction(async transaction => {
+        await this.storeRefreshToken(user.userId, newTokenId, storedToken.family_id, transaction);
+        await storedToken.update(
+          { is_revoked: true, replaced_by_token_id: newTokenId },
+          { transaction }
+        );
+      });
 
       return {
         user: this.sanitizeUser(user),
@@ -771,17 +796,21 @@ Need help? Contact us at support@adoptdontshop.com
   private static async storeRefreshToken(
     userId: string,
     tokenId: string,
-    familyId: string
+    familyId: string,
+    transaction?: Transaction
   ): Promise<void> {
     const expiresAt = new Date(Date.now() + this.parseExpirationTime(this.JWT_REFRESH_EXPIRES_IN));
-    await RefreshToken.create({
-      token_id: tokenId,
-      user_id: userId,
-      family_id: familyId,
-      is_revoked: false,
-      expires_at: expiresAt,
-      replaced_by_token_id: null,
-    });
+    await RefreshToken.create(
+      {
+        token_id: tokenId,
+        user_id: userId,
+        family_id: familyId,
+        is_revoked: false,
+        expires_at: expiresAt,
+        replaced_by_token_id: null,
+      },
+      { transaction }
+    );
   }
 
   private static parseExpirationTime(expiresIn: string): number {
@@ -1036,15 +1065,27 @@ Need help? Contact us at support@adoptdontshop.com
             continue;
           }
 
-          const verificationUrl = `${frontendUrl}/verify-email?token=${user.verificationToken}`;
+          // ADS-352: never email the stored `user.verificationToken` value —
+          // it's already SHA-256-hashed by the User model's
+          // `protectSecretsIfChanged` hook before persistence. Mailing the
+          // hash produces a permanently-broken verification link (the
+          // re-hash on inbound verification can't match the already-hashed
+          // value). Issue a fresh raw token, save (the hook hashes it), and
+          // email the raw value the same way `resendVerificationEmail` does.
+          const rawToken = crypto.randomBytes(32).toString('hex');
+          user.verificationToken = rawToken;
+          user.verificationTokenExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h
+          await user.save();
+
+          const verificationUrl = `${frontendUrl}/verify-email?token=${rawToken}`;
 
           await emailService.sendEmail({
             toEmail: user.email,
             templateData: {
               firstName: user.firstName,
-              verificationToken: user.verificationToken,
+              verificationToken: rawToken,
               verificationUrl,
-              expiresAt: user.verificationTokenExpiresAt?.toISOString() ?? null,
+              expiresAt: user.verificationTokenExpiresAt.toISOString(),
             },
             type: 'notification',
             priority: 'medium',


### PR DESCRIPTION
Closes ADS-169, ADS-352, ADS-215.

## Summary

Three independent auth/secret hardening fixes — kept in one PR because they touch overlapping files (`auth.service.ts` + `config/index.ts`).

### ADS-169 (High) — refresh-token rotation is now atomic

`AuthService.refreshToken` previously performed family-revocation and rotation writes without a transaction. A crash mid-operation left:
- **Reuse-detection path**: part of the family revoked, part not — stolen tokens still usable.
- **Rotation path**: new token live without old token revoked — turned legitimate reuse paths into stolen-token replay vectors.

Both branches now run inside `RefreshToken.sequelize.transaction(...)`. `storeRefreshToken` accepts an optional transaction so it can participate in the rotation transaction.

### ADS-352 (Medium) — verification reminder no longer mails the SHA-256 hash

`User.protectSecretsIfChanged` hashes `verificationToken` before persistence. Re-emailing `user.verificationToken` from the DB sent the **hash** — the inbound verification re-hashes the token and compares to the stored value, so the hash-of-hash never matched. **Every reminder link was permanently invalid.**

`sendVerificationReminders` now mirrors `resendVerificationEmail`: generate a fresh raw token, save (the hook hashes it), email the raw value. Reminder window is also re-anchored to 24h from the reminder send.

### ADS-215 (High) — CORS wildcard guard

`env.ts` already validates that JWT/refresh/session/CSRF secrets are pairwise distinct (lines 146-193) and `utils/password.ts` already enforces `BCRYPT_ROUNDS >= 10`. Last AC item: reject wildcard `CORS_ORIGIN` values (`*`, `null`, `https://*.example.com`) at startup. With `credentials: true` the browser disallows them anyway, but failing fast at startup beats silent CORS-blocked-in-the-browser noise.

## Test plan

- [x] `auth.service.test.ts` — new "revokes the entire token family inside a single transaction on reuse [ADS-169]" assertion + updated happy-path test asserts `txMock` is called.
- [x] `cors-wildcard-guard.test.ts` — new suite covers explicit-origin, comma-list, bare wildcard, `null` origin, and glob-host (`https://*.example.com`).
- [ ] CI green on this branch.
- [ ] Manual verification of ADS-352: trigger `sendVerificationReminders` cron, observe link works (deferrable until staging deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA

---
_Generated by [Claude Code](https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA)_