### PR TITLE
fix(security): add unsubscribe-token rotation endpoint [ADS-301]

### DIFF
--- a/service.backend/src/__tests__/services/email-unsubscribe-token-rotation.test.ts
+++ b/service.backend/src/__tests__/services/email-unsubscribe-token-rotation.test.ts
@@ -1,0 +1,73 @@
+/**
+ * ADS-301 — explicit revocation path for unsubscribe tokens.
+ *
+ * The token itself is intentionally not auto-expired (links must keep
+ * working in archived emails for CAN-SPAM / consumer-trust reasons), but
+ * operators / users must be able to invalidate one on demand. These tests
+ * verify the rotation method actually replaces the column with a new
+ * crypto-strong value.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logBusiness: vi.fn(), logExternalService: vi.fn() },
+}));
+
+import { EmailService } from '../../services/email.service';
+import EmailPreference from '../../models/EmailPreference';
+
+vi.mock('../../models/EmailPreference');
+
+const MockedEmailPreference = EmailPreference as unknown as {
+  findOne: ReturnType<typeof vi.fn>;
+  generateUnsubscribeToken: ReturnType<typeof vi.fn>;
+};
+
+describe('rotateUnsubscribeToken [ADS-301]', () => {
+  const service = new EmailService();
+  let updateMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateMock = vi.fn().mockResolvedValue(undefined);
+    MockedEmailPreference.findOne = vi.fn();
+    MockedEmailPreference.generateUnsubscribeToken = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a fresh token and persists it to the row', async () => {
+    MockedEmailPreference.findOne.mockResolvedValue({ update: updateMock });
+    MockedEmailPreference.generateUnsubscribeToken.mockReturnValue('new-token-base64url');
+
+    const newToken = await service.rotateUnsubscribeToken('user-123');
+
+    expect(newToken).toBe('new-token-base64url');
+    expect(updateMock).toHaveBeenCalledWith({ unsubscribeToken: 'new-token-base64url' });
+    expect(MockedEmailPreference.findOne).toHaveBeenCalledWith({ where: { userId: 'user-123' } });
+  });
+
+  it('throws when the user has no preferences row', async () => {
+    MockedEmailPreference.findOne.mockResolvedValue(null);
+
+    await expect(service.rotateUnsubscribeToken('user-456')).rejects.toThrow(
+      'Email preferences not found'
+    );
+  });
+
+  it('returns a different token on each call (crypto-strong)', async () => {
+    MockedEmailPreference.findOne.mockResolvedValue({ update: updateMock });
+    let counter = 0;
+    MockedEmailPreference.generateUnsubscribeToken.mockImplementation(() => `token-${counter++}`);
+
+    const a = await service.rotateUnsubscribeToken('user-1');
+    const b = await service.rotateUnsubscribeToken('user-1');
+
+    expect(a).not.toBe(b);
+  });
+});

--- a/service.backend/src/__tests__/services/email-unsubscribe-token-rotation.test.ts
+++ b/service.backend/src/__tests__/services/email-unsubscribe-token-rotation.test.ts
@@ -40,6 +40,17 @@ vi.mock('../../models/EmailPreference', () => ({
   },
 }));
 
+// setup-tests.ts globally mocks './services/email.service' to a stub that
+// only exports a default singleton — the EmailService named-export comes
+// back undefined under that mock, so we can't `new EmailService()` here.
+// Re-import the real module on top of the global mock.
+vi.mock('../../services/email.service', async () => {
+  const actual = await vi.importActual<typeof import('../../services/email.service')>(
+    '../../services/email.service'
+  );
+  return actual;
+});
+
 import EmailPreference from '../../models/EmailPreference';
 import { EmailService } from '../../services/email.service';
 

--- a/service.backend/src/__tests__/services/email-unsubscribe-token-rotation.test.ts
+++ b/service.backend/src/__tests__/services/email-unsubscribe-token-rotation.test.ts
@@ -7,19 +7,41 @@
  * verify the rotation method actually replaces the column with a new
  * crypto-strong value.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../utils/logger', () => ({
   __esModule: true,
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-  loggerHelpers: { logBusiness: vi.fn(), logExternalService: vi.fn() },
+  loggerHelpers: {
+    logBusiness: vi.fn(),
+    logDatabase: vi.fn(),
+    logPerformance: vi.fn(),
+    logExternalService: vi.fn(),
+  },
 }));
 
-import { EmailService } from '../../services/email.service';
-import EmailPreference from '../../models/EmailPreference';
+// Avoid the EmailService constructor's async ethereal-provider init
+// (network call to ethereal.email) by stubbing both providers.
+vi.mock('../../services/email-providers/ethereal-provider', () => ({
+  EtherealProvider: class {
+    initialize = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn();
+    getName = vi.fn().mockReturnValue('ethereal');
+    getPreviewInfo = vi.fn().mockReturnValue(null);
+  },
+}));
 
-vi.mock('../../models/EmailPreference');
+vi.mock('../../models/EmailPreference', () => ({
+  __esModule: true,
+  default: {
+    findOne: vi.fn(),
+    generateUnsubscribeToken: vi.fn(),
+  },
+}));
+
+import EmailPreference from '../../models/EmailPreference';
+import { EmailService } from '../../services/email.service';
 
 const MockedEmailPreference = EmailPreference as unknown as {
   findOne: ReturnType<typeof vi.fn>;
@@ -27,18 +49,13 @@ const MockedEmailPreference = EmailPreference as unknown as {
 };
 
 describe('rotateUnsubscribeToken [ADS-301]', () => {
-  const service = new EmailService();
+  let service: EmailService;
   let updateMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    service = new EmailService();
     updateMock = vi.fn().mockResolvedValue(undefined);
-    MockedEmailPreference.findOne = vi.fn();
-    MockedEmailPreference.generateUnsubscribeToken = vi.fn();
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
   });
 
   it('returns a fresh token and persists it to the row', async () => {

--- a/service.backend/src/controllers/email.controller.ts
+++ b/service.backend/src/controllers/email.controller.ts
@@ -374,6 +374,40 @@ export const updateUserPreferences = async (
   }
 };
 
+/**
+ * Rotate the authenticated user's unsubscribe token (ADS-301).
+ *
+ * Use cases:
+ *   - User suspects their email was forwarded / their mailbox was breached.
+ *   - Routine token hygiene.
+ *
+ * After rotation, any previously-sent email's unsubscribe link stops
+ * working — the response includes the new token so the caller can
+ * preview / log it if needed.
+ */
+export const rotateUnsubscribeToken = async (
+  req: AuthenticatedRequest,
+  res: Response
+): Promise<void> => {
+  try {
+    const userId = req.user?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+    const newToken = await emailService.rotateUnsubscribeToken(userId);
+    res.json({
+      message: 'Unsubscribe token rotated',
+      data: { unsubscribeToken: newToken },
+    });
+  } catch (error) {
+    logger.error('Failed to rotate unsubscribe token:', error);
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Failed to rotate unsubscribe token',
+    });
+  }
+};
+
 // Public endpoints
 export const unsubscribeUser = async (req: Request, res: Response): Promise<void> => {
   try {

--- a/service.backend/src/routes/email.routes.ts
+++ b/service.backend/src/routes/email.routes.ts
@@ -1312,6 +1312,30 @@ router.put(
   emailController.updateUserPreferences
 );
 
+/**
+ * @swagger
+ * /api/v1/email/preferences/unsubscribe-token/rotate:
+ *   post:
+ *     tags: [Email Management]
+ *     summary: Rotate the authenticated user's unsubscribe token (ADS-301)
+ *     description: |
+ *       Generates a new unsubscribe token for the caller and invalidates
+ *       the old one. Use when a token may have leaked (forwarded email,
+ *       mailbox compromise) — old emails' unsubscribe links will stop
+ *       working until a fresh email is sent.
+ *     security:
+ *       - bearerAuth: []
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: Token rotated successfully
+ */
+router.post(
+  '/preferences/unsubscribe-token/rotate',
+  authenticateToken,
+  emailController.rotateUnsubscribeToken
+);
+
 // Public Unsubscribe (No authentication required)
 
 /**

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -783,6 +783,36 @@ class EmailService {
     }
   }
 
+  /**
+   * Rotate a user's unsubscribe token. Use cases:
+   *
+   *   - Operator response to suspected token compromise (e.g. mailbox
+   *     breach, accidental forwarding to a wide list).
+   *   - Routine periodic rotation as part of a hygiene policy.
+   *
+   * After rotation:
+   *   - Old token immediately stops working (the column has a unique
+   *     index; the old plaintext value no longer matches any row).
+   *   - All previously-sent emails carrying the old token in their
+   *     unsubscribe footer will produce 'Invalid or expired unsubscribe
+   *     token' until they're re-sent or the user finds a recent email.
+   *
+   * This is the explicit revocation path for ADS-301 — `unsubscribeToken`
+   * is intentionally not auto-expired (links must keep working in
+   * archived emails for CAN-SPAM / consumer-trust reasons), but the
+   * operator must be able to invalidate one on demand.
+   */
+  public async rotateUnsubscribeToken(userId: string): Promise<string> {
+    const preference = await EmailPreference.findOne({ where: { userId } });
+    if (!preference) {
+      throw new Error('Email preferences not found');
+    }
+    const fresh = EmailPreference.generateUnsubscribeToken();
+    await preference.update({ unsubscribeToken: fresh });
+    logger.info(`Unsubscribe token rotated for user: ${userId}`);
+    return fresh;
+  }
+
   // Analytics and Reporting
   public async getEmailAnalytics(
     filters: {


### PR DESCRIPTION
Closes ADS-301.

## Summary

The worst issues in ADS-301 — reversibility (base64-encoded `${userId}:${Date.now()}:${Math.random()}`) and `Math.random` predictability — were already fixed: `EmailPreference.generateUnsubscribeToken` is now `randomBytes(32).toString('base64url')`, 256 bits of crypto-strong randomness.

The remaining real gap was **no path to revoke a leaked token**. `unsubscribeToken` is intentionally NOT auto-expired (the link lives in every email's footer; CAN-SPAM and consumer-trust require those links to keep working long after delivery). So a leaked token (forwarded email, mailbox breach) was previously valid until the user was deleted.

## Changes

- `EmailService.rotateUnsubscribeToken(userId)` — replaces the column with a fresh value, immediately invalidating the old one.
- `POST /api/v1/email/preferences/unsubscribe-token/rotate` (auth required) — caller can rotate their own token from the prefs page or via support tooling.
- `email-unsubscribe-token-rotation.test.ts` — happy path, missing-preferences error, distinct tokens on successive rotations.

## Out of scope (architectural trade-offs accepted)

- **Hashed-at-rest storage**. Would force re-architecting email composition: the template embeds the raw token in the unsubscribe URL, and if we only store the hash we lose the one-stable-link-per-user property. The blast radius of a leaked token is bounded to "user gets fewer emails" — not auth bypass or data leak. Combined with the new rotation path, residual risk is acceptable.
- **Auto-expiration**. Same trade-off — links must keep working in archived emails for compliance.

## Test plan

- [x] Unit tests pass for the new rotation method.
- [ ] CI green.
- [ ] Manual verification: rotate a token, confirm old link returns "Invalid or expired" while new link succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA

---
_Generated by [Claude Code](https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA)_