### PR TITLE
fix(security): per-iteration ownership check in bulkUpdatePets [ADS-372]

### DIFF
--- a/service.backend/src/__tests__/services/pet.service.test.ts
+++ b/service.backend/src/__tests__/services/pet.service.test.ts
@@ -859,9 +859,103 @@ describe('PetService', () => {
 
       const result = await PetService.bulkUpdatePets(operation, testCallerId);
 
-      // Service archives both successfully (nonexistent just doesn't do anything)
-      expect(result.successCount).toBe(2);
-      expect(result.failedCount).toBe(0);
+      // ADS-372: archive now runs assertCallerOwnsPet per pet, which loads
+      // the row and throws 404 for missing IDs — surfacing the failure
+      // instead of silently no-op-ing the Pet.update against zero rows.
+      expect(result.successCount).toBe(1);
+      expect(result.failedCount).toBe(1);
+      expect(result.errors[0]).toMatchObject({ petId: 'nonexistent' });
+    });
+
+    it('rejects bulk archive of pets owned by another rescue [ADS-372]', async () => {
+      // Set up a second rescue with its own pet, then attempt to archive it
+      // from testCallerId (who is staff of testRescue, not the second one).
+      const otherRescue = await Rescue.create({
+        rescueId: uniqueId('rescue-other'),
+        name: 'Other Rescue',
+        email: `other-${Date.now()}@test.com`,
+        address: '999 Other St',
+        city: 'Other City',
+        postcode: 'OTHER1',
+        contactPerson: 'Other Contact',
+        status: 'verified',
+        country: 'GB',
+      });
+      const foreignPetId = uniqueId('foreign-pet');
+      await Pet.create({
+        petId: foreignPetId,
+        name: 'Foreign Pet',
+        type: PetType.DOG,
+        status: PetStatus.AVAILABLE,
+        breed: 'Mixed',
+        size: Size.MEDIUM,
+        ageGroup: AgeGroup.ADULT,
+        gender: Gender.MALE,
+        energyLevel: EnergyLevel.MEDIUM,
+        vaccinationStatus: VaccinationStatus.UP_TO_DATE,
+        spayNeuterStatus: SpayNeuterStatus.NEUTERED,
+        rescueId: otherRescue.rescueId,
+        archived: false,
+      });
+
+      const operation: BulkPetOperation = {
+        petIds: [foreignPetId],
+        operation: 'archive',
+      };
+
+      // The pre-flight ownership check on the bulk operation rejects the
+      // whole batch — the caller should not be able to archive a pet they
+      // don't own.
+      await expect(PetService.bulkUpdatePets(operation, testCallerId)).rejects.toThrow(
+        /Access denied/
+      );
+
+      const foreign = await Pet.findByPk(foreignPetId);
+      expect(foreign?.archived).toBe(false);
+    });
+
+    it('rejects bulk feature toggle on pets owned by another rescue [ADS-372]', async () => {
+      const otherRescue = await Rescue.create({
+        rescueId: uniqueId('rescue-other-2'),
+        name: 'Other Rescue 2',
+        email: `other2-${Date.now()}@test.com`,
+        address: '888 Other St',
+        city: 'Other City',
+        postcode: 'OTHER2',
+        contactPerson: 'Other Contact 2',
+        status: 'verified',
+        country: 'GB',
+      });
+      const foreignPetId = uniqueId('foreign-pet-feature');
+      await Pet.create({
+        petId: foreignPetId,
+        name: 'Foreign Featured Pet',
+        type: PetType.CAT,
+        status: PetStatus.AVAILABLE,
+        breed: 'Mixed',
+        size: Size.SMALL,
+        ageGroup: AgeGroup.ADULT,
+        gender: Gender.FEMALE,
+        energyLevel: EnergyLevel.LOW,
+        vaccinationStatus: VaccinationStatus.UP_TO_DATE,
+        spayNeuterStatus: SpayNeuterStatus.SPAYED,
+        rescueId: otherRescue.rescueId,
+        archived: false,
+        featured: false,
+      });
+
+      const operation: BulkPetOperation = {
+        petIds: [foreignPetId],
+        operation: 'feature',
+        data: { featured: true },
+      };
+
+      await expect(PetService.bulkUpdatePets(operation, testCallerId)).rejects.toThrow(
+        /Access denied/
+      );
+
+      const foreign = await Pet.findByPk(foreignPetId);
+      expect(foreign?.featured).toBe(false);
     });
 
     it('should handle unsupported operation by returning error result', async () => {

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -1292,14 +1292,22 @@ export class PetService {
                 await this.updatePetStatus(petId, data as unknown as PetStatusUpdate, updatedBy);
               }
               break;
-            case 'archive':
+            case 'archive': {
+              // ADS-372: per-iteration ownership check defends against TOCTOU
+              // (a pet moved to a different rescue between pre-flight and the
+              // update) and prevents future bulk operation types from
+              // accidentally bypassing the pre-flight by forgetting it.
+              await PetService.assertCallerOwnsPet(petId, updatedBy);
               await Pet.update({ archived: true }, { where: { petId } });
               break;
-            case 'feature':
+            }
+            case 'feature': {
               if (data && typeof data.featured === 'boolean') {
+                await PetService.assertCallerOwnsPet(petId, updatedBy);
                 await Pet.update({ featured: data.featured }, { where: { petId } });
               }
               break;
+            }
             case 'delete':
               await this.deletePet(petId, updatedBy, reason);
               break;


### PR DESCRIPTION
Closes ADS-372.

## Summary

The pre-flight ownership check on `bulkUpdatePets` covers the common case, but the `archive` and `feature` switch branches were issuing `Pet.update` directly with only the pre-flight as protection.

Two concerns this addresses:

1. **TOCTOU.** A pet moved to a different rescue between the pre-flight SELECT and the per-iteration UPDATE would still get archived/featured by the original caller.
2. **Forward compatibility.** New bulk operation types added to the switch could trivially forget the pre-flight precondition. Calling `assertCallerOwnsPet` inside each privileged branch makes the security boundary local to the write rather than depending on a distant pre-flight invariant.

The `update_status` and `delete` branches already delegate to `updatePetStatus` / `deletePet`, both of which call `assertCallerOwnsPet`. So this PR only needed to add it to `archive` and `feature`.

## Test plan

- [x] Updated existing "should handle partial failures" test — with the per-iteration check, archive of a non-existent petId now surfaces as a 1/1 partial failure (the prior behavior silently no-op'd `Pet.update` against zero rows, which was masking the real problem).
- [x] New cross-rescue archive test (foreign rescue's pet → 403, archived flag unchanged).
- [x] New cross-rescue feature test (foreign rescue's pet → 403, featured flag unchanged).
- [ ] CI green on this branch.

## Note on coverage

The current cross-rescue tests are caught by the **pre-flight** check (line 1246) rather than the new per-iteration check, because the pre-flight runs first and short-circuits the entire batch. The per-iteration check is genuinely defense-in-depth — its value is forward-compatibility for new operation types and TOCTOU resistance, neither of which is comfortably reproducible in a real-DB integration test. PR text should make this explicit so reviewers understand why the test names look "redundant."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA

---
_Generated by [Claude Code](https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA)_