### PR TITLE
fix(security): add HSTS + CSP parity across frontend nginx configs [ADS-353]

### DIFF
--- a/Dockerfile.app.optimized
+++ b/Dockerfile.app.optimized
@@ -167,11 +167,14 @@ http { \
         root /usr/share/nginx/html; \
         index index.html; \
         \
-        # Security headers (OWASP recommendations) \
+        # Security headers (OWASP recommendations + ADS-353 CSP/HSTS) \
         add_header X-Frame-Options "SAMEORIGIN" always; \
         add_header X-Content-Type-Options "nosniff" always; \
         add_header X-XSS-Protection "1; mode=block" always; \
         add_header Referrer-Policy "strict-origin-when-cross-origin" always; \
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always; \
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always; \
+        add_header Content-Security-Policy "default-src '"'"'self'"'"'; script-src '"'"'self'"'"' '"'"'unsafe-inline'"'"' '"'"'unsafe-eval'"'"'; style-src '"'"'self'"'"' '"'"'unsafe-inline'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"' data:; connect-src '"'"'self'"'"' ws: wss:;" always; \
         \
         # SPA routing - all routes to index.html \
         location / { \

--- a/app.admin/nginx.conf
+++ b/app.admin/nginx.conf
@@ -38,4 +38,9 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
-} 
+    # HSTS: served on HTTP too — browsers ignore it on plaintext connections
+    # but cache it after the first HTTPS hit. preload requires the apex
+    # domain to be added to the HSTS preload list separately (ADS-353).
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+}

--- a/app.client/nginx.conf
+++ b/app.client/nginx.conf
@@ -38,4 +38,6 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
-} 
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+}

--- a/app.rescue/nginx.conf
+++ b/app.rescue/nginx.conf
@@ -38,4 +38,6 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 }


### PR DESCRIPTION
Closes ADS-353.

## Summary

Three nginx configs and one production Dockerfile were each missing one or more of `Strict-Transport-Security`, `Content-Security-Policy`, `Permissions-Policy`. State before:

| Config | CSP | HSTS | Permissions-Policy |
|--|--|--|--|
| `nginx/nginx.conf` (reverse proxy) | ✗ | ✓ | ✓ |
| `app.admin/nginx.conf` | ✓ | ✗ | ✗ |
| `app.client/nginx.conf` | ✓ | ✗ | ✗ |
| `app.rescue/nginx.conf` | ✓ | ✗ | ✗ |
| `Dockerfile.app.optimized` (production) | ✗ | ✗ | ✗ |

After: all four serve `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`, `Content-Security-Policy: <existing permissive policy>`, and `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()`.

## Out of scope

- **CSP tightening.** The existing policy allows `'unsafe-inline'` and `'unsafe-eval'` for scripts. Removing those requires eliminating inline scripts/styles emitted by the bundled apps — much wider work, separate ticket if you want it.
- **HSTS preload list submission.** Adding the apex domain to https://hstspreload.org/ has to happen out-of-band; this PR only emits the header.
- **`nginx/nginx.conf` reverse-proxy CSP.** That config terminates at app proxies, where the per-app config already emits CSP. Left alone here to avoid duplicate `add_header` (only the most-specific block applies in nginx, which would actually drop the per-app CSP — counterproductive).

## Test plan

- [ ] CI green on this branch (build images, smoke-test compose stack).
- [ ] Manual: curl `-I` against a built image and verify all four headers are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA

---
_Generated by [Claude Code](https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA)_