### PR TITLE
fix(security): strip CRLF from email header fields [ADS-221 partial]

### DIFF
--- a/service.backend/src/services/email-providers/base-provider.ts
+++ b/service.backend/src/services/email-providers/base-provider.ts
@@ -36,10 +36,21 @@ export abstract class BaseEmailProvider implements EmailProvider {
     html: string;
     text?: string;
   } {
+    // Strip CR/LF before composing header values. Nodemailer ≥ 8 also
+    // rejects CRLF in headers, but enforcing it at the boundary catches
+    // it earlier and protects providers that may be more permissive.
+    // [ADS-221]
+    const stripCrlf = (s: string) => s.replace(/[\r\n]+/g, ' ').trim();
+
+    const fromName = stripCrlf(email.fromName || "Adopt Don't Shop");
+    const fromEmail = stripCrlf(email.fromEmail);
+    const toName = email.toName ? stripCrlf(email.toName) : '';
+    const toEmail = stripCrlf(email.toEmail);
+
     return {
-      from: `${email.fromName || "Adopt Don't Shop"} <${email.fromEmail}>`,
-      to: email.toName ? `${email.toName} <${email.toEmail}>` : email.toEmail,
-      subject: email.subject,
+      from: `${fromName} <${fromEmail}>`,
+      to: toName ? `${toName} <${toEmail}>` : toEmail,
+      subject: stripCrlf(email.subject),
       html: email.htmlContent,
       text: email.textContent,
     };


### PR DESCRIPTION
Partial close on ADS-221 (low-severity bundle). One concrete fix here, scope notes below.

## Summary

`BaseEmailProvider.sanitizeEmail` interpolates user-controllable `fromName`, `toName`, `fromEmail`, `toEmail`, and `subject` directly into header-like strings:

```ts
from: `${email.fromName || "Adopt Don't Shop"} <${email.fromEmail}>`
```

If any field contains `\r` / `\n`, an attacker can inject SMTP headers — the classic vector being:

```
toName = "Victim\r\nBcc: attacker@evil.com"
```

resolving to a header that SMTP parses as `Bcc: attacker@evil.com`, copying the email to the attacker.

Nodemailer ≥ 8 also rejects CRLF in headers itself, so this is **defense-in-depth** — but enforcing it at the application boundary is cheap and protects any provider implementation that may be more permissive. The codebase has Console and Ethereal providers extending `BaseEmailProvider`, and providers are an obvious extension point for new vendors (SES, SendGrid, etc.).

Implementation: a single-line normalisation that replaces any run of CR/LF with a space and trims. Preserves multi-word names like "Mary Jane" while neutralising injection sequences.

## What ADS-221 ALSO covers (per ticket title) and why I didn't fix here

- **Error leakage.** Audited `src/middleware/error-handler.ts`. It already redacts to "Something went wrong" in production for unhandled errors; stack traces only included when `NODE_ENV === 'development'`. `ApiError` messages are developer-controlled. No leakage to fix.
- **JWT secret rotation.** This is a feature, not a fix — would require multi-key signing (kid header), parallel verification against an active set, deprecation TTL. Substantial architectural work, not a "low-severity bundle" item; needs its own ticket if you want it.

## Test plan

- [ ] CI green on this branch.
- [ ] Manual: send an email with `toName: "X\r\nBcc: y@z.com"` and confirm the rendered headers don't include the injected Bcc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA

---
_Generated by [Claude Code](https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA)_