### PR TITLE
fix(security): add edge CSP to nginx reverse proxy [ADS-214 partial]

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,10 @@
+# TLS termination is expected at an upstream load balancer / CDN
+# (e.g. Cloudflare, AWS ALB, GCP HTTPS LB). This nginx receives
+# plaintext on port 80 over the internal network. If you intend to
+# terminate TLS here directly, add a `listen 443 ssl` block per
+# server and a `listen 80; return 301 https://...;` redirect block.
+# Cert provisioning is deployment-specific, hence not configured in-tree.
+# [ADS-214]
 events {
     worker_connections 1024;
 }
@@ -67,13 +74,16 @@ http {
         listen 80;
         server_name admin.localhost;
 
-        # Security headers
+        # Security headers — mirrored at the edge so they survive
+        # error responses and any path that bypasses the upstream app
+        # (maintenance pages, misrouted requests). [ADS-214]
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
 
         # Static asset caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
@@ -102,13 +112,16 @@ http {
         listen 80;
         server_name rescue.localhost;
 
-        # Security headers
+        # Security headers — mirrored at the edge so they survive
+        # error responses and any path that bypasses the upstream app
+        # (maintenance pages, misrouted requests). [ADS-214]
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
 
         # Static asset caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
@@ -137,13 +150,16 @@ http {
         listen 80;
         server_name api.localhost;
 
-        # Security headers
+        # Security headers — mirrored at the edge so they survive
+        # error responses and any path that bypasses the upstream app
+        # (maintenance pages, misrouted requests). [ADS-214]
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
 
         # API routes
         location / {
@@ -188,13 +204,16 @@ http {
         listen 80 default_server;
         server_name localhost *.localhost;
 
-        # Security headers
+        # Security headers — mirrored at the edge so they survive
+        # error responses and any path that bypasses the upstream app
+        # (maintenance pages, misrouted requests). [ADS-214]
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
 
         # Health check endpoint
         location /health {


### PR DESCRIPTION
Partial close on ADS-214.

## Summary

`nginx/nginx.conf` already emits HSTS, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` on each of its 4 server blocks. Missing: **Content-Security-Policy**. Without an edge CSP, error responses, maintenance pages, and any path that bypasses the upstream Node app reach clients without protection.

Add the same CSP the per-app nginxes already emit, on all 4 server blocks (admin, rescue, api, default-client).

## What's NOT in this PR

**TLS termination.** Real cert provisioning is deployment-specific — this config typically sits behind an upstream LB / CDN that handles TLS. If TLS is to be terminated here directly, the change is roughly:

```nginx
server {
  listen 80;
  server_name _;
  return 301 https://$host$request_uri;
}

server {
  listen 443 ssl http2;
  ssl_certificate     /etc/ssl/certs/server.crt;
  ssl_certificate_key /etc/ssl/private/server.key;
  # ... rest of existing block
}
```

Documented in a comment at the top of `nginx.conf` so the gap is at least captured in-tree.

## Test plan

- [ ] CI green.
- [ ] Manual: `curl -I http://localhost/admin.localhost` against a `docker:dev` stack, verify `Content-Security-Policy` header present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA

---
_Generated by [Claude Code](https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA)_