### PR TITLE
fix(security): enforce rescue ownership in updateApplicationStatus [ADS-234 partial]

### DIFF
--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -399,6 +399,59 @@ describe('ApplicationService - Business Logic', () => {
         ApplicationService.updateApplicationStatus(mockApplicationId, updateRequest, mockUserId)
       ).rejects.toThrow('Cannot transition from approved to withdrawn');
     });
+
+    it('rejects status update when caller is rescue staff at a different rescue [ADS-234]', async () => {
+      // Given: application owned by rescue-789, caller is staff at a DIFFERENT rescue.
+      const mockApplication = createMockApplication(ApplicationStatus.SUBMITTED);
+      MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication);
+      MockedStaffMember.findOne = vi.fn().mockResolvedValue({
+        userId: 'foreign-staff-id',
+        rescueId: 'rescue-OTHER',
+        isVerified: true,
+      });
+
+      const updateRequest: ApplicationStatusUpdateRequest = {
+        status: ApplicationStatus.APPROVED,
+        actionedBy: 'foreign-staff-id',
+      };
+
+      await expect(
+        ApplicationService.updateApplicationStatus(
+          mockApplicationId,
+          updateRequest,
+          'foreign-staff-id',
+          UserType.RESCUE_STAFF
+        )
+      ).rejects.toThrow(/Access denied/);
+
+      // The status transition row must NOT be created — the IDOR attempt
+      // is rejected before any side-effects.
+      expect(MockedApplicationStatusTransition.create).not.toHaveBeenCalled();
+    });
+
+    it('allows status update when admin caller has no staff membership [ADS-234]', async () => {
+      // Given: admin caller, no StaffMember row needed.
+      const mockApplication = createMockApplication(ApplicationStatus.SUBMITTED);
+      (mockApplication.canTransitionTo as vi.Mock).mockReturnValue(true);
+      MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication);
+      MockedStaffMember.findOne = vi.fn().mockResolvedValue(null);
+
+      const updateRequest: ApplicationStatusUpdateRequest = {
+        status: ApplicationStatus.APPROVED,
+        actionedBy: 'admin-user-id',
+      };
+
+      await expect(
+        ApplicationService.updateApplicationStatus(
+          mockApplicationId,
+          updateRequest,
+          'admin-user-id',
+          UserType.ADMIN
+        )
+      ).resolves.toBeDefined();
+
+      expect(MockedApplicationStatusTransition.create).toHaveBeenCalled();
+    });
   });
 
   describe('Business Rule: Application Modification', () => {

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -556,7 +556,8 @@ export class ApplicationController extends BaseController {
       const application = await ApplicationService.updateApplicationStatus(
         applicationId,
         statusUpdate,
-        req.user!.userId
+        req.user!.userId,
+        req.user!.userType as UserType
       );
 
       res.status(200).json({

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -821,12 +821,34 @@ export class ApplicationService {
   static async updateApplicationStatus(
     applicationId: string,
     statusUpdate: ApplicationStatusUpdateRequest,
-    actionedBy: string
+    actionedBy: string,
+    actionedByUserType?: UserType
   ): Promise<ApplicationData> {
     try {
       const application = await Application.findByPk(applicationId);
       if (!application) {
         throw new Error('Application not found');
+      }
+
+      // ADS-234: enforce rescue ownership. The route already checks the
+      // caller has the RESCUE_STAFF or ADMIN role, but does NOT verify
+      // that a staff caller belongs to THIS application's rescue. Without
+      // this check, staff at rescue A could approve/reject applications
+      // submitted to rescue B (cross-rescue IDOR).
+      if (
+        actionedByUserType !== undefined &&
+        actionedByUserType !== UserType.ADMIN &&
+        actionedByUserType !== UserType.MODERATOR
+      ) {
+        const StaffMember = (await import('../models/StaffMember')).default;
+        const membership = await StaffMember.findOne({
+          where: { userId: actionedBy, isVerified: true },
+        });
+        if (!membership || membership.rescueId !== application.rescueId) {
+          throw Object.assign(new Error('Access denied: application belongs to another rescue'), {
+            statusCode: 403,
+          });
+        }
       }
 
       // Validate status transition


### PR DESCRIPTION
Partial close on ADS-234.

## Summary

`PATCH /applications/:applicationId/status` was protected by `requireRole(RESCUE_STAFF, ADMIN)` at the route level, but the service itself never verified that a staff caller actually belonged to **this** application's rescue. Staff at rescue A could approve, reject, or shortlist applications submitted to rescue B by guessing or enumerating `applicationId`s — a classic cross-tenant IDOR.

The path is high-risk: it lets an attacker (a verified rescue staff account) silently rubber-stamp competitor applications, force rejections that the real owners never see, or attach forged notes to other rescues' application timelines.

## Fix

Added a `StaffMember.findOne({ where: { userId, isVerified: true } })` check inside `updateApplicationStatus`. The check fires only when the caller is non-privileged (admin/moderator bypass) and `userType` is provided — existing test cases that don't pass userType keep working without modification.

Companion controller change passes `req.user.userType` through.

## Tests added

- Cross-rescue staff caller → 403, no transition row created, no side-effects.
- Admin caller without staff membership → still works.

## Why this is partial

The full ADS-234 ticket calls for an inventory of all `:applicationId` / `:rescueId` / `:chatId` routes plus generic `requireOwnership` / `requireChatParticipant` middleware. The status-update path was the highest-PII gap discovered during the initial audit pass; scoping the rest as separate tickets so each can be reviewed in isolation.

What's still uncovered (recommend separate tickets):

- `PUT /rescues/:rescueId` — verify staff membership at the modified rescue, not just any rescue.
- `chat.routes.ts` `:chatId` endpoints — verify caller is a participant of the chat.
- `bulkUpdateApplications` — already takes userId, but should be audited for the same staff-rescue-binding check.
- Application document upload/delete (`/:applicationId/documents`) — likely OK at service layer, worth verifying.
- Reference update (`/:applicationId/references`) — same.

## Test plan

- [ ] CI green on this branch.
- [ ] Manual: as rescue-staff at rescue A, attempt `PATCH /applications/{appAtRescueB}/status` and confirm 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA

---
_Generated by [Claude Code](https://claude.ai/code/session_0136qTFVh3mBqPnvinks4zqA)_