### PR TITLE
ci: tolerate transient GHA cache export failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,7 +71,7 @@ jobs:
           push: false
           tags: paragonjenko/adoptdontshop:service-backend-dev-${{ github.sha }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
           build-args: BUILDKIT_INLINE_CACHE=1
 
       - name: Build production image
@@ -85,7 +85,7 @@ jobs:
           load: true
           tags: paragonjenko/adoptdontshop:service-backend-prod-${{ github.sha }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
           build-args: BUILDKIT_INLINE_CACHE=1
 
       - name: Run Trivy vulnerability scanner
@@ -143,7 +143,7 @@ jobs:
           push: false
           tags: paragonjenko/adoptdontshop:${{ matrix.app }}-dev-${{ github.sha }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Build production image
         uses: docker/build-push-action@v7
@@ -157,7 +157,7 @@ jobs:
           push: false
           tags: paragonjenko/adoptdontshop:${{ matrix.app }}-prod-${{ github.sha }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
   # ============================================================================
   # INTEGRATION TEST — verify the backend container starts and is healthy.


### PR DESCRIPTION
## Summary

The `Build app.client Image` job on main failed with a 502 from GitHub Actions Cache during the `cache-to` export step, after every Docker layer had built cleanly:

```
#65 ERROR: error writing layer blob: failed to parse error response 502: <!DOCTYPE html>
...
<title>Unicorn! &middot; GitHub</title>
```

The "Unicorn" page is GitHub's classic transient-infra error — nothing was wrong with the Dockerfile, the code, or the build itself. Just the cache upload bombed.

## Fix

Add `ignore-error=true` to every `cache-to: type=gha,mode=max` spec in `.github/workflows/docker.yml` (4 occurrences across the backend dev/prod and matrixed app dev/prod builds). BuildKit treats cache export errors as non-fatal under that flag, so a 502 from the GHA cache service no longer fails an otherwise-green build. Cache is still written when GHA is healthy.

## Test plan

- [ ] CI runs green on this PR
- [ ] Confirm cache hits on subsequent runs (cache-from still pulls when available)
- [ ] If GHA cache hits another 502, the build now succeeds and a warning appears in the build summary instead of a hard fail

---
_Generated by [Claude Code](https://claude.ai/code/session_019EyxvbsGgGoAZ3GH12ssNs)_