### PR TITLE
fix(pet): unstick snake_case updates + multi-rescue createPet selection

### DIFF
--- a/service.backend/src/__tests__/controllers/pet.controller.test.ts
+++ b/service.backend/src/__tests__/controllers/pet.controller.test.ts
@@ -1,0 +1,114 @@
+import { vi } from 'vitest';
+import { Response } from 'express';
+import { PetController } from '../../controllers/pet.controller';
+import StaffMember from '../../models/StaffMember';
+import { UserType } from '../../models/User';
+import PetService from '../../services/pet.service';
+import { AuthenticatedRequest } from '../../types';
+
+vi.mock('../../models/StaffMember');
+vi.mock('../../services/pet.service', () => ({
+  default: {
+    createPet: vi.fn(),
+  },
+}));
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+vi.mock('express-validator', () => ({
+  validationResult: () => ({ isEmpty: () => true, array: () => [] }),
+}));
+
+const MockedStaffMember = StaffMember as unknown as { findAll: ReturnType<typeof vi.fn> };
+const MockedPetService = PetService as unknown as { createPet: ReturnType<typeof vi.fn> };
+
+describe('PetController.createPet — rescueId resolution [ADS-376]', () => {
+  let controller: PetController;
+  let req: Partial<AuthenticatedRequest>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PetController();
+    req = {
+      user: {
+        userId: 'user-1',
+        email: 'staff@example.com',
+        userType: UserType.RESCUE_STAFF,
+        firstName: 'Staff',
+        lastName: 'Member',
+      } as AuthenticatedRequest['user'],
+      body: { name: 'Buddy' },
+      query: {},
+    };
+    res = {
+      json: vi.fn().mockReturnThis(),
+      status: vi.fn().mockReturnThis(),
+    };
+    MockedPetService.createPet.mockResolvedValue({ petId: 'pet-1', name: 'Buddy' });
+  });
+
+  it('uses the single verified rescue implicitly when the user belongs to one rescue', async () => {
+    MockedStaffMember.findAll = vi.fn().mockResolvedValue([{ rescueId: 'rescue-A' }]);
+
+    await controller.createPet(req as AuthenticatedRequest, res as Response);
+
+    expect(MockedPetService.createPet).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Buddy' }),
+      'rescue-A',
+      'user-1'
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('returns 400 when the user is verified at multiple rescues and no selector is provided', async () => {
+    MockedStaffMember.findAll = vi
+      .fn()
+      .mockResolvedValue([{ rescueId: 'rescue-A' }, { rescueId: 'rescue-B' }]);
+
+    await controller.createPet(req as AuthenticatedRequest, res as Response);
+
+    expect(MockedPetService.createPet).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        rescueIds: ['rescue-A', 'rescue-B'],
+      })
+    );
+  });
+
+  it('uses the explicit ?rescueId when the user is verified at multiple rescues and the id matches one', async () => {
+    MockedStaffMember.findAll = vi
+      .fn()
+      .mockResolvedValue([{ rescueId: 'rescue-A' }, { rescueId: 'rescue-B' }]);
+    req.query = { rescueId: 'rescue-B' };
+
+    await controller.createPet(req as AuthenticatedRequest, res as Response);
+
+    expect(MockedPetService.createPet).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Buddy' }),
+      'rescue-B',
+      'user-1'
+    );
+  });
+
+  it('returns 403 when ?rescueId points at a rescue the user is not verified staff at', async () => {
+    MockedStaffMember.findAll = vi.fn().mockResolvedValue([{ rescueId: 'rescue-A' }]);
+    req.query = { rescueId: 'rescue-Z' };
+
+    await controller.createPet(req as AuthenticatedRequest, res as Response);
+
+    expect(MockedPetService.createPet).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 403 when the user has no verified rescue association', async () => {
+    MockedStaffMember.findAll = vi.fn().mockResolvedValue([]);
+
+    await controller.createPet(req as AuthenticatedRequest, res as Response);
+
+    expect(MockedPetService.createPet).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});

--- a/service.backend/src/__tests__/services/pet.service.test.ts
+++ b/service.backend/src/__tests__/services/pet.service.test.ts
@@ -444,6 +444,36 @@ describe('PetService', () => {
       expect(result).toBeDefined();
       expect(result.name).toBe('Updated Name');
     });
+
+    // ADS-367: previously the snake_case → camelCase mapping was a
+    // tautological no-op (identical key/value strings) and snake_case
+    // input was silently dropped before reaching the DB write whitelist.
+    it('writes through snake_case keys for snake-cased clients [ADS-367]', async () => {
+      const snakeUpdate = {
+        short_description: 'Snake case wrote through',
+        age_years: 7,
+        good_with_children: true,
+        spay_neuter_status: SpayNeuterStatus.NEUTERED,
+      } as unknown as PetUpdateData;
+
+      const result = await PetService.updatePet(petId, snakeUpdate, testCallerId);
+
+      expect(result.shortDescription).toBe('Snake case wrote through');
+      expect(result.ageYears).toBe(7);
+      expect(result.goodWithChildren).toBe(true);
+      expect(result.spayNeuterStatus).toBe(SpayNeuterStatus.NEUTERED);
+    });
+
+    it('prefers the camelCase value when both casings are sent [ADS-367]', async () => {
+      const mixed = {
+        shortDescription: 'camel wins',
+        short_description: 'should be ignored',
+      } as unknown as PetUpdateData;
+
+      const result = await PetService.updatePet(petId, mixed, testCallerId);
+
+      expect(result.shortDescription).toBe('camel wins');
+    });
   });
 
   describe('updatePetStatus', () => {

--- a/service.backend/src/controllers/pet.controller.ts
+++ b/service.backend/src/controllers/pet.controller.ts
@@ -215,22 +215,54 @@ export class PetController {
       // Import StaffMember model to get rescue ID
       const StaffMember = (await import('../models/StaffMember')).default;
 
-      // Find the user's rescue association
-      const staffMember = await StaffMember.findOne({
+      // ADS-376: a user can be verified staff at multiple rescues. Listing
+      // all verified rows lets us (a) keep the single-rescue UX implicit
+      // and (b) require an explicit selection when ambiguous. Explicit
+      // rescueId travels via the query string because `fieldWriteGuard`
+      // marks `pets.rescueId` as READ-only for rescue_staff and would
+      // reject it on the body.
+      const verifiedStaff = await StaffMember.findAll({
         where: {
           userId: user.userId,
           isVerified: true,
         },
+        attributes: ['rescueId'],
       });
 
-      if (!staffMember) {
+      if (verifiedStaff.length === 0) {
         return res.status(403).json({
           success: false,
           message: 'User is not associated with a rescue organization',
         });
       }
 
-      logger.info('Creating pet for rescue', { rescueId: staffMember.rescueId });
+      const requestedRescueId =
+        typeof req.query.rescueId === 'string' && req.query.rescueId.trim() !== ''
+          ? req.query.rescueId
+          : null;
+
+      let resolvedRescueId: string;
+      if (requestedRescueId) {
+        const match = verifiedStaff.find(s => s.rescueId === requestedRescueId);
+        if (!match) {
+          return res.status(403).json({
+            success: false,
+            message: 'You are not verified staff at the requested rescue',
+          });
+        }
+        resolvedRescueId = match.rescueId;
+      } else if (verifiedStaff.length === 1) {
+        resolvedRescueId = verifiedStaff[0].rescueId;
+      } else {
+        return res.status(400).json({
+          success: false,
+          message:
+            'You are verified staff at multiple rescues. Specify ?rescueId=<id> to indicate which rescue this pet belongs to.',
+          rescueIds: verifiedStaff.map(s => s.rescueId),
+        });
+      }
+
+      logger.info('Creating pet for rescue', { rescueId: resolvedRescueId });
 
       // Sanitize request body - convert empty strings to null for numeric fields
       const sanitizedBody = { ...req.body };
@@ -247,10 +279,10 @@ export class PetController {
         }
       });
 
-      // Use the rescue ID from the staff member association
+      // Use the rescue ID resolved from the staff member association(s)
       const pet = await this.petService.createPet(
         sanitizedBody,
-        staffMember.rescueId,
+        resolvedRescueId,
         req.user!.userId
       );
 

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -585,51 +585,24 @@ export class PetService {
       // Store original data for audit
       const originalData = pet.toJSON();
 
-      // Normalize input: the API accepts both camelCase and snake_case field names.
-      // The frontend service sends snake_case, so we normalize to camelCase first,
-      // then convert to snake_case for the database.
-      const snakeToCamelMapping: Record<string, string> = {
-        shortDescription: 'shortDescription',
-        longDescription: 'longDescription',
-        ageYears: 'ageYears',
-        ageMonths: 'ageMonths',
-        ageGroup: 'ageGroup',
-        secondaryBreedId: 'secondaryBreedId',
-        weightKg: 'weightKg',
-        microchipId: 'microchipId',
-        priorityListing: 'priorityListing',
-        adoptionFeeMinor: 'adoptionFeeMinor',
-        adoptionFeeCurrency: 'adoptionFeeCurrency',
-        specialNeeds: 'specialNeeds',
-        specialNeedsDescription: 'specialNeedsDescription',
-        houseTrained: 'houseTrained',
-        goodWithChildren: 'goodWithChildren',
-        goodWithDogs: 'goodWithDogs',
-        goodWithCats: 'goodWithCats',
-        goodWithSmallAnimals: 'goodWithSmallAnimals',
-        energyLevel: 'energyLevel',
-        exerciseNeeds: 'exerciseNeeds',
-        groomingNeeds: 'groomingNeeds',
-        trainingNotes: 'trainingNotes',
-        medicalNotes: 'medicalNotes',
-        behavioralNotes: 'behavioralNotes',
-        surrenderReason: 'surrenderReason',
-        intakeDate: 'intakeDate',
-        vaccinationStatus: 'vaccinationStatus',
-        vaccinationDate: 'vaccinationDate',
-        spayNeuterStatus: 'spayNeuterStatus',
-        spayNeuterDate: 'spayNeuterDate',
-        lastVetCheckup: 'lastVetCheckup',
-      };
-
+      // Normalize input: the API contract is camelCase, but defend against
+      // snake_case slipping in (e.g. integration callers that bypass the
+      // Zod validator). Mirrors the regex `fieldWriteGuard` uses for
+      // permission lookups so the two layers agree on key shape.
+      // ADS-367: the previous Record<string,string> map had identical key
+      // and value strings, so the conversion loop was a tautological no-op
+      // and snake_case inputs were silently dropped.
       const rawData = updateData as Record<string, unknown>;
       const normalizedData: Record<string, unknown> = { ...rawData };
-
-      for (const [snakeKey, camelKey] of Object.entries(snakeToCamelMapping)) {
-        if (rawData[snakeKey] !== undefined && rawData[camelKey] === undefined) {
-          normalizedData[camelKey] = rawData[snakeKey];
-          delete normalizedData[snakeKey];
+      for (const key of Object.keys(rawData)) {
+        if (!key.includes('_')) {
+          continue;
         }
+        const camelKey = key.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+        if (rawData[camelKey] === undefined) {
+          normalizedData[camelKey] = rawData[key];
+        }
+        delete normalizedData[key];
       }
 
       // Build update data using camelCase attribute names (Sequelize maps to DB columns via field:)


### PR DESCRIPTION
## Summary

Two daily-code-review bugs in the pet write path, both touching `pet.controller.ts` / `pet.service.ts`.

- **ADS-367** (High): `PetService.updatePet`'s `snakeToCamelMapping` had identical key/value strings (e.g. `shortDescription: 'shortDescription'`), so the conversion loop's `rawData[snakeKey] !== undefined && rawData[camelKey] === undefined` check was a tautological no-op. Any snake_case field slipping past the Zod validator (integration callers, future passthrough configs) was silently dropped before the downstream camelCase whitelist — the request returned `200 OK` with an audit log, but no DB write happened. Replaced the dead map with a generic regex normalizer that mirrors `fieldWriteGuard`'s lookup.
- **ADS-376** (Low): `createPet` derived the caller's rescue via `StaffMember.findOne({ userId, isVerified: true })`. A user verified at multiple rescues silently inherited whichever row Sequelize returned first. Switched to `findAll`: single match keeps the implicit UX, zero matches still 403s, and 2+ matches require `?rescueId=<id>` (resolved against the verified-staff list, 403 on mismatch). `rescueId` travels via query string because `fieldWriteGuard` marks `pets.rescueId` READ-only for `rescue_staff`.

## Audit (per ADS-367 acceptance criteria)

`updatePetStatus`, `bulkUpdatePets`, and `createPet` (service-layer) do **not** have the same bug — they each operate on validated camelCase shapes, and the Zod validator strips unknown keys before the body reaches them. Confirmed in code review; left unchanged.

## Test plan

- [x] `pet.service.test.ts` — new behavior tests:
  - snake_case keys (`short_description`, `age_years`, `good_with_children`, `spay_neuter_status`) write through to the DB
  - camelCase wins when both casings are sent for the same field
- [x] `pet.controller.test.ts` (new file) — five rescueId resolution paths:
  - single verified rescue → implicit, back-compat
  - multi-rescue + no selector → 400 with `rescueIds` payload
  - multi-rescue + valid `?rescueId` → uses the matched rescue
  - any verification + non-matching `?rescueId` → 403
  - no verified rescue → 403 (existing behavior preserved)
- [x] Full `service.backend` vitest suite (1731 / 1750 passing, 19 pre-existing skips)
- [x] `turbo build --filter=service-backend` (tsc) clean
- [x] `turbo lint --filter=service-backend` clean (0 errors)

https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb)_