### PR TITLE
chore(eslint): drop no-explicit-any 'error' override in eslint-config-node (ADS-282)

### DIFF
--- a/eslint-config-node/index.js
+++ b/eslint-config-node/index.js
@@ -4,8 +4,10 @@ export default [
   ...baseConfig,
   {
     rules: {
-      // Stricter rules for backend services
-      '@typescript-eslint/no-explicit-any': 'error',
+      // Stricter rules for backend services. ADS-282 leaves
+      // `@typescript-eslint/no-explicit-any` at the base 'warn' level so new
+      // `as any` introductions surface in PR checks/IDE without a CI-failing
+      // gate; the existing-site sweep stays deferred.
       'no-console': 'error',
       'no-process-exit': 'error',
       'no-process-env': 'off',


### PR DESCRIPTION
## Summary

After #329 landed the ESLint v9 flat-config migration, `eslint-config-base` correctly set `@typescript-eslint/no-explicit-any` to `'warn'`, but `eslint-config-node` was still re-escalating it to `'error'`. That made the base policy decision pointless for `service.backend` — new `as any` introductions blocked CI rather than surfacing as warnings, which is the exact failure mode ADS-282 wanted to fix.

This PR drops the override so the base `'warn'` applies to backend code too.

## Out of scope

- The existing-site sweep stays deferred (per ADS-282's "Out of Scope" — the original L scope was replaced with this S "set to warn" precursor).
- `@typescript-eslint/no-unsafe-assignment` requires typed linting (`parserOptions.project`) and is its own ticket.

## Test plan

- [x] `npx turbo lint --filter service-backend` — 0 errors, 297 warnings (the previously-error `as any` violations now surface as warnings)
- [x] `npx turbo lint` (full monorepo) — 24/24 pass, 0 errors

https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb)_