### PR TITLE
fix(api): split makeRequest into JSON + fetchRaw, drop unsound `as unknown as T` (ADS-261)

### DIFF
--- a/lib.api/src/__tests__/api-service.test.ts
+++ b/lib.api/src/__tests__/api-service.test.ts
@@ -503,6 +503,63 @@ describe('ApiService', () => {
     });
   });
 
+  describe('JSON contract [ADS-261]', () => {
+    beforeEach(() => {
+      apiService = new ApiService();
+    });
+
+    it('returns undefined for 204 No Content responses (callers type T as void)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        headers: new Headers(),
+        json: () => Promise.reject(new Error('should not parse')),
+      } as Response);
+
+      // Use GET to avoid the CSRF preflight; the contract is method-agnostic.
+      const result = await apiService.fetch('/users/account');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for empty 200 responses with no Content-Type', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () => Promise.reject(new Error('should not parse')),
+      } as Response);
+
+      const result = await apiService.fetch('/empty');
+      expect(result).toBeUndefined();
+    });
+
+    it('throws when an OK response has a non-JSON Content-Type', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers([['content-type', 'text/html']]),
+        text: () => Promise.resolve('<html />'),
+      } as Response);
+
+      await expect(apiService.fetch('/legacy-page')).rejects.toThrow(
+        /Use fetchRaw\(\) if you need the raw Response/
+      );
+    });
+
+    it('fetchRaw returns the underlying Response untouched', async () => {
+      const rawResponse = {
+        ok: true,
+        status: 200,
+        headers: new Headers([['content-type', 'application/octet-stream']]),
+      } as Response;
+      mockFetch.mockResolvedValueOnce(rawResponse);
+
+      const result = await apiService.fetchRaw('/download/file.zip');
+      expect(result).toBe(rawResponse);
+    });
+  });
+
   describe('Environment Variable Handling', () => {
     it('should use default URL when no environment variables are set', () => {
       apiService = new ApiService();

--- a/lib.api/src/services/api-service.ts
+++ b/lib.api/src/services/api-service.ts
@@ -270,8 +270,44 @@ export class ApiService {
     }
   }
 
-  // Core request method
+  // Core request method.
+  //
+  // ADS-261: this used to return `response as unknown as T` for any non-JSON
+  // response, which lied about the runtime shape and pushed callers into
+  // double-casting. Now `makeRequest` always parses JSON (or returns
+  // `undefined` for empty-body responses like 204 No Content). Callers
+  // wanting the raw `Response` use `fetchRaw()` instead.
   private async makeRequest<T>(url: string, options: FetchOptions = {}): Promise<T> {
+    const response = await this.executeFetch(url, options);
+
+    // 204 No Content / explicit empty body — `T` is expected to be `void`.
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    const contentType = response.headers.get('content-type');
+    if (!contentType || !contentType.includes('application/json')) {
+      // Empty body with no Content-Type (some 200/202 responses) is
+      // treated like 204 — there's nothing to parse.
+      const contentLength = response.headers.get('content-length');
+      if (
+        contentLength === '0' ||
+        (!contentType && response.status >= 200 && response.status < 300)
+      ) {
+        return undefined as T;
+      }
+      throw new Error(
+        `makeRequest expected JSON but received '${contentType ?? 'no Content-Type'}'. ` +
+          `Use fetchRaw() if you need the raw Response object.`
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  // Issue the HTTP request and return the raw `Response`. Internally shared
+  // by `makeRequest` (which then parses JSON) and `fetchRaw` (which doesn't).
+  private async executeFetch(url: string, options: FetchOptions = {}): Promise<Response> {
     const { method = 'GET', headers = {}, body, timeout = this.config.timeout } = options;
 
     // Build full URL
@@ -332,15 +368,7 @@ export class ApiService {
       // Apply response interceptors
       response = await this.interceptors.applyResponseInterceptors(response);
 
-      // Parse response
-      const contentType = response.headers.get('content-type');
-      if (contentType && contentType.includes('application/json')) {
-        const jsonResponse = (await response.json()) as T;
-        return jsonResponse;
-      }
-
-      // For non-JSON responses, return the response as-is
-      return response as unknown as T;
+      return response;
     } catch (error) {
       clearTimeout(timeoutId);
 
@@ -369,6 +397,23 @@ export class ApiService {
     };
 
     return this.makeRequest<T>(url, { ...options, headers });
+  }
+
+  // ADS-261: escape hatch for callers that genuinely need the raw `Response`
+  // (binary downloads, custom Content-Types, etc.). Going through this entry
+  // point keeps them honest — the call site uses `Response`, not a typed
+  // payload that doesn't exist.
+  async fetchRaw(url: string, options: FetchOptions = {}): Promise<Response> {
+    return this.executeFetch(url, options);
+  }
+
+  async fetchRawWithAuth(url: string, options: FetchOptions = {}): Promise<Response> {
+    const token = this.getAuthToken();
+    const headers = {
+      ...options.headers,
+      ...(token && { Authorization: `Bearer ${token}` }),
+    };
+    return this.executeFetch(url, { ...options, headers });
   }
 
   // Generic HTTP methods with authentication


### PR DESCRIPTION
## Summary

`ApiService.makeRequest<T>` promised a `T`, but for any non-JSON response it returned the raw `Response` object cast through `unknown` — every caller that hit that path silently violated its own type contract. The CLAUDE.md rule against `as unknown as X` called this out specifically, and it's the root pattern behind a lot of `as any` / `as unknown as X` growth in lib.chat / lib.applications consumers.

This PR follows ticket Option A: `makeRequest` always parses JSON; a new `fetchRaw` returns the `Response`.

## Changes

- **`makeRequest<T>`** always parses JSON. Empty bodies (204 No Content, or 2xx with no `Content-Type` and no payload) return `undefined` — callers type `T` as `void` for those paths. Any other non-JSON Content-Type now throws with a message pointing the caller at `fetchRaw`.
- **New `fetchRaw(url, options)` / `fetchRawWithAuth(url, options)`** return the raw `Response` for genuine non-JSON consumers (binary downloads, HTML, custom Content-Types).
- **Extracted private `executeFetch`** so `makeRequest` and `fetchRaw` share one code path (fetch + interceptors + timeout/abort).

## Caller audit

No existing call site consumed the old `Response` cast:
- `apiService.fetch('/api/v1/health/simple')` (offlineManager) — awaits and discards.
- `apiService.fetchWithAuth('/api/v1/users/account', { method: 'DELETE' })` (auth-service) — awaits and discards (returns 204).
- Internal `this.fetch('/api/v1/health')` (healthCheck) — awaits and discards.

So consumers keep getting what they always got — just without the lie in the type.

## Tests

Four new behavior cases in `api-service.test.ts > JSON contract [ADS-261]`:
- 204 → `undefined`
- empty 2xx (no Content-Type, no body) → `undefined`
- non-JSON 2xx (e.g. `text/html`) throws with a `fetchRaw()` hint
- `fetchRaw` returns the underlying `Response` untouched

## Test plan

- [x] `npx turbo build type-check lint --filter '!@adopt-dont-shop/e2e'` — 71/71 pass
- [x] `npx turbo test --filter '!@adopt-dont-shop/e2e'` — 46/46 pass (lib.api 31/31)

https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb)_