### PR TITLE
refactor(types): delete dead duplicate domain types in lib.components and lib.auth (ADS-281)

### DIFF
--- a/lib.auth/src/index.ts
+++ b/lib.auth/src/index.ts
@@ -27,7 +27,6 @@ export type {
   LoginRequest,
   RegisterRequest,
   AuthResponse,
-  Rescue,
   ChangePasswordRequest,
   RefreshTokenRequest,
   RefreshTokenResponse,

--- a/lib.auth/src/types/auth.ts
+++ b/lib.auth/src/types/auth.ts
@@ -89,19 +89,12 @@ export enum Permission {
   RESCUE_SETTINGS_UPDATE = 'rescue_settings_update',
 }
 
-export interface Rescue {
-  rescueId: string;
-  rescueName: string;
-  rescueType: string;
-  contactEmail: string;
-  contactPhone?: string;
-  websiteUrl?: string;
-  description?: string;
-  logoUrl?: string;
-  isActive: boolean;
-  createdAt: string;
-  updatedAt: string;
-}
+// ADS-281: a `Rescue` interface used to live here with a different shape
+// from `lib.rescue/src/types/index.ts:Rescue` (rescueName/rescueType/
+// websiteUrl/logoUrl/isActive vs the canonical name/email/address/etc.).
+// It was unused outside lib.auth's barrel re-export, so removing it stops
+// the divergent shape from leaking into consumers — the canonical source
+// is `@adopt-dont-shop/lib.rescue`.
 
 // Permission mappings for role-based access control
 export const rolePermissions: Record<RescueRole, Permission[]> = {

--- a/lib.components/src/types/index.ts
+++ b/lib.components/src/types/index.ts
@@ -1,63 +1,11 @@
-export interface User {
-  id: string;
-  email: string;
-  firstName: string;
-  lastName: string;
-  role: UserRole;
-  isActive: boolean;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface Pet {
-  id: string;
-  name: string;
-  species: string;
-  breed: string;
-  age: number;
-  gender: string;
-  size: string;
-  description: string;
-  images: string[];
-  isAvailable: boolean;
-  rescueId: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface Application {
-  id: string;
-  petId: string;
-  userId: string;
-  status: ApplicationStatus;
-  answers: Record<string, unknown>;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface Message {
-  id: string;
-  conversationId: string;
-  senderId: string;
-  content: string;
-  attachments: string[];
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface Notification {
-  id: string;
-  userId: string;
-  title: string;
-  message: string;
-  type: NotificationType;
-  isRead: boolean;
-  createdAt: string;
-}
-
-export type UserRole = 'USER' | 'RESCUE_ADMIN' | 'RESCUE_STAFF' | 'ADMIN';
-export type ApplicationStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'WITHDRAWN';
-export type NotificationType = 'APPLICATION' | 'MESSAGE' | 'SYSTEM' | 'ADOPTION';
+// ADS-281: domain types (`User`, `Pet`, `Application`, `Message`,
+// `Notification`, `UserRole`, `ApplicationStatus`, `NotificationType`)
+// previously declared here used UPPERCASE literals incompatible with the
+// rest of the workspace (`lib.types`, `lib.applications`, etc.). They were
+// dead — no consumer imported them — so removing them rather than aligning
+// avoids resurrecting the wrong-cased literals as a public surface. The
+// real `NotificationType` enum used by the components lives in
+// `./notifications`.
 
 export type ButtonVariant =
   | 'primary'


### PR DESCRIPTION
## Summary

ADS-281 flagged four "incompatible cross-package duplicates" — `ApplicationStatus`, `UserRole`, `Pet`, and `Rescue` — defined with conflicting shapes across libs (lowercase vs UPPERCASE literals, snake_case vs camelCase fields, etc.). The ticket worried about a typed value flowing from backend → `lib.applications` → a `lib.components` `<StatusBadge>` and breaking at runtime because the literal sets don't overlap.

After surveying actual usage: most of the duplicates are **dead code with the wrong literals** that nothing imports, so the safest fix is to delete them rather than try to reconcile incompatible value sets.

## What's deleted

**`lib.components/src/types/index.ts`** — removed:
- `User`, `Pet`, `Application`, `Message`, `Notification` interfaces (UPPERCASE literal-using shapes never imported outside this file)
- `UserRole` (`'USER' | 'RESCUE_ADMIN' | 'RESCUE_STAFF' | 'ADMIN'`)
- `ApplicationStatus` (`'PENDING' | 'APPROVED' | 'REJECTED' | 'WITHDRAWN'`)
- `NotificationType` (`'APPLICATION' | 'MESSAGE' | 'SYSTEM' | 'ADOPTION'`) — note the *real* `NotificationType` enum used by lib.components lives in `./notifications` and is unaffected.

Kept: `ButtonVariant`, `ButtonSize`, `ButtonProps`, `InputProps`, `ModalProps` — these are real component types.

**`lib.auth/src/types/auth.ts`** — removed:
- `Rescue` interface (`{ rescueId, rescueName, rescueType, contactEmail, contactPhone?, websiteUrl?, description?, logoUrl?, isActive, createdAt, updatedAt }`) — different shape from the canonical `lib.rescue/src/types/index.ts:Rescue` and re-exported from the lib.auth barrel but never consumed.

Also removed the matching `Rescue` re-export from `lib.auth/src/index.ts`.

## Out of scope

The remaining "duplicates" the ticket lists are actually different views of the same domain:
- `lib.pets.Pet` (full snake_case API shape, used by `app.rescue` / `app.client` for full pet management) vs `lib.rescue.Pet` (minimal `{ id, name, type, breed?, age?, size?, rescueId, status? }` used internally for "pets at this rescue" listings).
- `lib.applications.ApplicationStatus` (`'submitted' | 'approved' | 'rejected' | 'withdrawn'`) vs `lib.validation.ApplicationStatusSchema` (same lowercase set, derived from Zod) — already aligned.

Collapsing those would be a deeper API change; the dead-code deletion here removes the *incompatible* shapes (the actual ADS-281 failure mode) without touching live code paths.

## Test plan

- [x] `npx turbo build type-check lint --filter '!@adopt-dont-shop/e2e'` — 71/71 pass (the type-check is the actual proof — TS would have caught any consumer that drifted onto the deleted types)
- [x] `npx turbo test --filter '!@adopt-dont-shop/e2e'` — 46/46 pass

https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb)_