### PR TITLE
fix(applications): prevent duplicate active applications via partial unique index (ADS-168)

### DIFF
--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -1588,6 +1588,69 @@ describe('Application Submission Workflow Integration Tests', () => {
       });
     });
   });
+
+  describe('Concurrent Application Submission', () => {
+    it('allows exactly one application when two concurrent submits race for the same (userId, petId)', async () => {
+      // This test verifies the race-condition safety net introduced in ADS-168.
+      //
+      // Scenario: two browser tabs submit simultaneously. Both pass the
+      // pre-flight findOne check (because neither has committed yet). The DB
+      // partial unique index on (user_id, pet_id) then rejects the second
+      // INSERT with a UniqueConstraintError, which the service maps to the
+      // same "already have an active application" error as the guard.
+      const { UniqueConstraintError } = await import('sequelize');
+
+      const mockUser = createMockUser({ userId: adopterId });
+      const mockPet = createMockPet({ petId: petId, status: PetStatus.AVAILABLE });
+      const mockApplication = createMockApplication({
+        applicationId: applicationId,
+        userId: adopterId,
+        petId: petId,
+        status: ApplicationStatus.SUBMITTED,
+      });
+
+      const applicationData: CreateApplicationRequest = {
+        petId: petId,
+        answers: { experience: 'I have owned dogs for 10 years' },
+        references: [
+          { id: 'ref-0', name: 'Jane Smith', relationship: 'friend', phone: '555-0100' },
+        ],
+      };
+
+      MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser as never);
+      MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet as never);
+
+      // Both requests pass the pre-flight guard (findOne returns null for both)
+      MockedApplication.findOne = vi.fn().mockResolvedValue(null);
+
+      // First create succeeds; second throws UniqueConstraintError (DB index fires)
+      MockedApplication.create = vi
+        .fn()
+        .mockResolvedValueOnce(mockApplication as never)
+        .mockRejectedValueOnce(
+          new UniqueConstraintError({ message: 'applications_active_user_pet_uniq' })
+        );
+
+      const results = await Promise.allSettled([
+        ApplicationService.createApplication(applicationData, adopterId),
+        ApplicationService.createApplication(applicationData, adopterId),
+      ]);
+
+      const fulfilled = results.filter(r => r.status === 'fulfilled');
+      const rejected = results.filter(r => r.status === 'rejected');
+
+      // Exactly one succeeds
+      expect(fulfilled).toHaveLength(1);
+
+      // The other rejects with the conflict message
+      expect(rejected).toHaveLength(1);
+      const rejectedReason = (rejected[0] as PromiseRejectedResult).reason as Error;
+      expect(rejectedReason.message).toBe('You already have an active application for this pet');
+
+      // create was called twice (both requests got through the pre-flight guard)
+      expect(MockedApplication.create).toHaveBeenCalledTimes(2);
+    });
+  });
 });
 
 // Helper function to create mock user

--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -1598,6 +1598,17 @@ describe('Application Submission Workflow Integration Tests', () => {
       // partial unique index on (user_id, pet_id) then rejects the second
       // INSERT with a UniqueConstraintError, which the service maps to the
       // same "already have an active application" error as the guard.
+      //
+      // sequelize.transaction is mocked here because SQLite (used in tests)
+      // serialises concurrent writers: two real transactions racing to commit
+      // would both fail with SQLITE_BUSY rather than one succeeding and one
+      // getting a UniqueConstraintError. The mock isolates the service-layer
+      // UniqueConstraintError-handling logic from the SQLite concurrency model.
+      const sequelizeModule = await import('../../sequelize');
+      vi.spyOn(sequelizeModule.default, 'transaction').mockImplementation(((
+        cb: (t: unknown) => Promise<unknown>
+      ) => cb({ LOCK: { UPDATE: 'UPDATE' } })) as never);
+
       const { UniqueConstraintError } = await import('sequelize');
 
       const mockUser = createMockUser({ userId: adopterId });

--- a/service.backend/src/migrations/09-add-active-application-unique-index.ts
+++ b/service.backend/src/migrations/09-add-active-application-unique-index.ts
@@ -1,0 +1,84 @@
+import { QueryInterface, Op, QueryTypes } from 'sequelize';
+
+/**
+ * ADS-168: Prevent duplicate active applications for the same (user, pet) pair.
+ *
+ * Adds a partial unique index on applications(user_id, pet_id) scoped to
+ * non-terminal statuses (i.e. excluding 'rejected' and 'withdrawn'). Users MUST
+ * be allowed to apply again after a previous application is rejected or withdrawn,
+ * so a plain unique index on (user_id, pet_id) would be too restrictive.
+ *
+ * The application service already has a pre-flight findOne guard, but that guard
+ * has a TOCTOU race window (two concurrent requests both pass the check before
+ * either commit). This index closes the race: the second INSERT will fail with a
+ * UniqueConstraintError, which the service maps to a conflict error.
+ *
+ * Before creating the index, this migration detects any pre-existing duplicate
+ * active rows and marks the older ones as 'withdrawn' so the index creation
+ * does not fail on live data.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    // Detect and resolve pre-existing duplicate active applications before
+    // adding the unique constraint. For each (user_id, pet_id) pair that has
+    // more than one non-terminal application, keep the most recent one and mark
+    // the older duplicates as 'withdrawn'.
+    //
+    // This query finds all application_id values that are NOT the newest active
+    // row for their (user_id, pet_id) pair.
+    type DuplicateRow = { application_id: string };
+
+    const duplicates = (await queryInterface.sequelize.query(
+      `
+      SELECT a.application_id
+      FROM applications a
+      INNER JOIN (
+        SELECT user_id, pet_id, MAX(created_at) AS newest_created_at
+        FROM applications
+        WHERE status NOT IN ('rejected', 'withdrawn')
+          AND deleted_at IS NULL
+        GROUP BY user_id, pet_id
+        HAVING COUNT(*) > 1
+      ) dupes
+        ON a.user_id = dupes.user_id
+       AND a.pet_id = dupes.pet_id
+       AND a.created_at < dupes.newest_created_at
+      WHERE a.status NOT IN ('rejected', 'withdrawn')
+        AND a.deleted_at IS NULL
+      `,
+      { type: QueryTypes.SELECT }
+    )) as DuplicateRow[];
+
+    if (duplicates.length > 0) {
+      const duplicateIds = duplicates.map((row: DuplicateRow) => row.application_id);
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[migration 09] Marking ${duplicateIds.length} duplicate active application(s) as withdrawn before adding unique index.`
+      );
+
+      await queryInterface.sequelize.query(
+        `UPDATE applications
+         SET status = 'withdrawn', updated_at = NOW()
+         WHERE application_id IN (:ids)`,
+        { replacements: { ids: duplicateIds } }
+      );
+    }
+
+    // Partial unique index: only one active (non-rejected, non-withdrawn)
+    // application is allowed per (user_id, pet_id) pair at a time.
+    await queryInterface.addIndex('applications', ['user_id', 'pet_id'], {
+      name: 'applications_active_user_pet_uniq',
+      unique: true,
+      where: {
+        status: {
+          [Op.notIn]: ['rejected', 'withdrawn'],
+        },
+      },
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeIndex('applications', 'applications_active_user_pet_uniq');
+  },
+};

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1,4 +1,4 @@
-import { col, fn, Includeable, Op, Order, WhereOptions } from 'sequelize';
+import { col, fn, Includeable, Op, Order, UniqueConstraintError, WhereOptions } from 'sequelize';
 import { generateCryptoUuid as uuidv4 } from '../utils/uuid-helpers';
 import Application, { ApplicationPriority, ApplicationStatus } from '../models/Application';
 import ApplicationAnswer from '../models/ApplicationAnswer';
@@ -245,6 +245,13 @@ export class ApplicationService {
         };
       });
     } catch (error) {
+      // Race condition safety net: if two concurrent requests both pass the
+      // pre-flight findOne check, the DB unique index rejects the second
+      // INSERT. Map that to the same user-facing error as the pre-flight guard.
+      if (error instanceof UniqueConstraintError) {
+        throw new Error('You already have an active application for this pet');
+      }
+
       logger.error('Failed to create application:', {
         error: error instanceof Error ? error.message : String(error),
         applicationData: JSON.parse(JSON.stringify(applicationData)),


### PR DESCRIPTION
## Bug

`ApplicationService.createApplication` had a TOCTOU race condition: the "user already has an active application" guard did `findOne` followed by `Application.create` with no enforcement between them. Two concurrent submits (double-click, retry storm, two browser tabs) could both pass the guard and both create active `(userId, petId)` application rows.

## Fix

### 1. Migration: `09-add-active-application-unique-index.ts`

Adds a partial unique index at the DB layer:

```sql
CREATE UNIQUE INDEX applications_active_user_pet_uniq
  ON applications(user_id, pet_id)
  WHERE status NOT IN ('rejected', 'withdrawn');
```

**Why partial:** users must be able to re-apply after a previous application is rejected or withdrawn. The constraint only blocks while a prior application is in a non-terminal status (`submitted` or `approved`).

**Duplicate cleanup:** before creating the index the migration runs a query to detect any pre-existing duplicate active rows (those that would prevent the index from being created). For each `(user_id, pet_id)` pair with more than one non-terminal application, the older duplicates are marked `withdrawn` and the newest is kept. Zero duplicate rows were found/expected in normal operation, but the migration handles them safely rather than failing loudly.

### 2. Service change: `application.service.ts`

- Imported `UniqueConstraintError` from `sequelize`.
- Added a catch for `UniqueConstraintError` inside the outer `try/catch` of `createApplication`, mapping it to the same user-facing message as the pre-flight guard: `"You already have an active application for this pet"`.
- The pre-flight `findOne` guard is kept: it provides a clear immediate error for the normal (non-race) case without hitting the DB constraint path.

### 3. Concurrency test

Added to `src/__tests__/integration/application-workflow.test.ts` (describe: `"Concurrent Application Submission"`):

- Mocks `Application.create` to succeed on the first call and throw `UniqueConstraintError` on the second (simulating what the DB index does when both requests slip past the pre-flight guard).
- Runs both calls via `Promise.allSettled`.
- Asserts: 1 fulfilled, 1 rejected, rejected reason = `"You already have an active application for this pet"`, `create` called exactly 2 times.

## Files changed

| File | Change |
|---|---|
| `service.backend/src/migrations/09-add-active-application-unique-index.ts` | New migration (84 lines) |
| `service.backend/src/services/application.service.ts` | Import `UniqueConstraintError`; add catch block (7 lines) |
| `service.backend/src/__tests__/integration/application-workflow.test.ts` | Concurrency test (64 lines) |

## Notes

- The `ApplicationStatus` enum values used are lowercase (`'submitted'`, `'approved'`, `'rejected'`, `'withdrawn'`) from `src/models/Application.ts` — no cross-package type modifications.
- The model definition already has an `applications_user_pet_unique` index in its `indexes` array (used by `sequelize.sync()` for SQLite tests). The migration uses the canonical name `applications_active_user_pet_uniq` for the production PostgreSQL index. These are separate: the migration runs in production, the model annotation is for test SQLite sync.
- All 84 `service-backend` test files fail to start locally with `Could not locate the bindings file ... node_sqlite3.node` — this is a pre-existing `sqlite3` native-bindings issue (confirmed: all tests fail before any of my code runs). Type-check and lint both pass with 0 errors.
- `npm run db:migrate` must be run in the backend container (or against a live PostgreSQL instance) to apply the index to production/staging databases.

https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdk5P9yLQbJoeAAGt6jQfY)_