### PR TITLE
fix(rescue): correct searchRescues return type to plain objects (ADS-373)

### DIFF
--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -87,12 +87,19 @@ export type RescueWithStatistics = ReturnType<Rescue['toJSON']> & {
   statistics: RescueStatsResponse;
 };
 
+// ADS-373: `searchRescues` maps each row through `toJSON()` before
+// returning, so the array contains plain objects — Sequelize-instance
+// methods (`.update()`, association accessors) are not present.
+// Mirrors the pattern already used by `getRescueById` and
+// `RescueWithStatistics`.
+export type RescuePlain = ReturnType<Rescue['toJSON']>;
+
 export class RescueService {
   /**
    * Search and filter rescues with pagination
    */
   static async searchRescues(options: RescueSearchOptions = {}): Promise<{
-    rescues: Rescue[];
+    rescues: RescuePlain[];
     pagination: {
       page: number;
       limit: number;


### PR DESCRIPTION
## Summary

`RescueService.searchRescues` was typed `Promise<{ rescues: Rescue[]; ... }>` but actually returned `rescues.map(rescue => rescue.toJSON())` — plain objects without the Sequelize `Model` methods (`.update()`, association accessors). Any consumer that trusted the type and called a `Model` API on a result element would fail at runtime. Same class of bug that #281 fixed for `getRescueById`; this finishes the cleanup.

## Fix

- Introduce a shared `RescuePlain = ReturnType<Rescue['toJSON']>` alias (mirrors the existing `RescueWithStatistics`) and use it as the `rescues` element type in `searchRescues`.
- The current consumer (`rescue.controller.searchRescues`) already passes the array straight to `res.json` — no behaviour change, just an honest type.

## Test plan

- [x] `npx turbo build lint --filter service-backend` — clean (0 errors)
- [x] `npx vitest run src/__tests__/services/rescue.service.test.ts` — 34 passed, 2 skipped (no regressions)

https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcYu5nD9eqpqbHGG7C18wb)_