### PR TITLE
[DB] Connection pool/timeouts, idempotent seeders, backup runbook (4 issues)

### DIFF
--- a/docs/db-backup-runbook.md
+++ b/docs/db-backup-runbook.md
@@ -1,0 +1,151 @@
+# Database Backup & Restore Runbook (ADS-443)
+
+This runbook covers how the Adopt Don't Shop production PostgreSQL database is
+backed up, how to restore it, and the drill cadence required to keep that
+restore path trustworthy.
+
+The two scripts that implement this runbook live alongside the backend:
+
+- `service.backend/scripts/db-backup.sh` — date-stamped, gzipped `pg_dump`.
+- `service.backend/scripts/db-restore.sh` — interactive `pg_restore` with a
+  destructive-action confirmation gate.
+
+## Why this exists
+
+Migration `05` notes that its rollback path is "not recoverable" — and several
+later migrations are similarly forward-only. Without a known-good backup +
+rehearsed restore, every prod schema change is a one-way door. This runbook
+closes that gap.
+
+## What gets backed up
+
+- **In scope**: the application database (schema + data) referenced by
+  `DATABASE_URL` / `PROD_DB_NAME`.
+- **Out of scope (handled separately)**: object storage (uploads), Redis
+  (transient queues + caches), application secrets (managed in the secrets
+  store, not the DB).
+
+## Schedule
+
+| Job                      | Cadence       | Retention         |
+| ------------------------ | ------------- | ----------------- |
+| Nightly automated dump   | Daily 02:00 UTC | 14 days local + 30 days off-site |
+| Pre-migration manual dump | Before every prod migration | 30 days off-site |
+| Restore drill            | Quarterly     | Drill log retained 1 year |
+
+Nightly dumps are produced by running `db-backup.sh` from a scheduled job
+(cron / Kubernetes CronJob). The default local retention is 14 days; the
+off-site copy in object storage uses a longer lifecycle policy.
+
+## Required environment variables
+
+Both scripts authenticate using either:
+
+- `DATABASE_URL=postgresql://user:pass@host:5432/dbname`, **or**
+- The standard libpq vars: `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`,
+  `PGDATABASE`.
+
+Backup-only:
+
+- `BACKUP_DIR` — output directory (default `./backups`).
+- `BACKUP_RETENTION_DAYS` — local prune horizon (default `14`).
+
+Restore-only:
+
+- `CONFIRM_RESTORE=I_UNDERSTAND` — skips the interactive prompt for drills.
+- `RESTORE_JOBS` — parallel `pg_restore` workers (default `2`).
+
+## Running a backup
+
+```bash
+# Local
+DATABASE_URL=postgresql://app:pw@db.internal:5432/adopt_prod \
+BACKUP_DIR=/var/backups/adopt-dont-shop \
+./service.backend/scripts/db-backup.sh
+```
+
+Successful output looks like:
+
+```
+[db-backup] starting dump -> /var/backups/adopt-dont-shop/adopt-dont-shop-20260508T020000Z.dump.gz
+[db-backup] wrote /var/backups/adopt-dont-shop/adopt-dont-shop-20260508T020000Z.dump.gz (84231244 bytes)
+[db-backup] done
+```
+
+After every successful local dump, copy the file to the off-site bucket
+(e.g. `aws s3 cp ... s3://adopt-dont-shop-backups/`). Object storage retention
+is set by the bucket's lifecycle rule, **not** by this script.
+
+## Pre-migration backup checklist
+
+Before running any production migration:
+
+1. Verify last nightly backup completed (check job logs / monitoring).
+2. Run an ad-hoc backup with the migration tag in the filename:
+   ```bash
+   BACKUP_DIR=/var/backups/adopt-dont-shop ./db-backup.sh
+   ```
+3. Confirm the new file exists and is non-zero in size.
+4. Copy the file off-site.
+5. Note the backup filename in the migration change ticket.
+6. Only then run `npm run db:migrate`.
+
+If the migration fails or produces unexpected results, restore from the
+ad-hoc backup using the procedure below before any further writes occur.
+
+## Restoring
+
+`db-restore.sh` is **destructive**: it drops and recreates objects in the
+target database. Restore into a scratch DB first, verify, then repoint the
+application.
+
+```bash
+# 1. Provision a scratch DB
+createdb adopt_restore_check
+
+# 2. Restore into it
+DATABASE_URL=postgresql://app:pw@db.internal:5432/adopt_restore_check \
+./service.backend/scripts/db-restore.sh /var/backups/adopt-dont-shop/adopt-dont-shop-20260508T020000Z.dump.gz
+
+# Type 'restore' at the prompt, or set CONFIRM_RESTORE=I_UNDERSTAND for
+# unattended drills.
+
+# 3. Verify row counts on critical tables
+psql "$DATABASE_URL" -c 'select count(*) from users; select count(*) from rescues;'
+
+# 4. Repoint the application by updating its DATABASE_URL secret and
+#    restarting, only after verification passes.
+```
+
+For an in-place restore (after a migration disaster), make sure the app is
+stopped first; otherwise concurrent writes will collide with the restore.
+
+## Quarterly restore drill
+
+Pick a date each quarter to exercise the full path end-to-end:
+
+1. Pick a backup at random from the last 30 days.
+2. Provision a scratch DB.
+3. Run `db-restore.sh` with `CONFIRM_RESTORE=I_UNDERSTAND`.
+4. Run a smoke-test query set (row counts on `users`, `rescues`, `pets`,
+   `applications`, `audit_logs`).
+5. Record:
+   - Backup file used.
+   - Restore wall-clock time.
+   - Any errors encountered + remediation.
+6. File the drill log in the ops channel; archive it for at least one year.
+
+A drill that fails to complete cleanly is itself the highest-priority finding
+— fix the failure before the next scheduled migration.
+
+## Troubleshooting
+
+- **`pg_dump: error: connection to server`** — check `DATABASE_URL` /
+  `PGHOST` etc. The script does not retry; cron should.
+- **`pg_restore: error: could not execute query`** — almost always a role /
+  extension mismatch. The scripts pass `--no-owner --no-acl` to minimise
+  this; if it still fires, ensure the target DB has the same extensions
+  (`pg_trgm`, `citext`, `postgis`) installed.
+- **Backup file is suspiciously small** — verify the source DSN points at
+  the right database. The script reports the byte count on stdout; alert
+  if it drops below the expected floor for two consecutive nights.

--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -26,6 +26,8 @@
     "db:seed:fixtures": "ts-node src/seeders/cli.ts --fixtures",
     "db:seed:reset": "cross-env ALLOW_DEMO_SEED=true ts-node src/seeders/cli.ts --reset",
     "db:bootstrap": "cross-env ALLOW_BOOTSTRAP=true ts-node src/seeders/cli.ts --bootstrap",
+    "db:backup": "bash scripts/db-backup.sh",
+    "db:restore": "bash scripts/db-restore.sh",
     "security:validate": "node scripts/validate-security.js",
     "docs:generate": "ts-node scripts/generate-swagger.ts generate",
     "docs:validate": "ts-node scripts/generate-swagger.ts validate",

--- a/service.backend/scripts/db-backup.sh
+++ b/service.backend/scripts/db-backup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# db-backup.sh — Date-stamped pg_dump for the AdoptDontShop database.
+#
+# Produces a gzipped custom-format dump that pg_restore can parallelise,
+# named after the timestamp so successive backups don't overwrite each
+# other. Designed to run from cron; emits a single line per run on stdout
+# for log scraping.
+#
+# Required env (any one of these patterns):
+#   - DATABASE_URL=postgresql://user:pass@host:5432/dbname
+#   - or PGHOST / PGPORT / PGUSER / PGPASSWORD / PGDATABASE
+#
+# Optional env:
+#   - BACKUP_DIR        Output directory (default: ./backups)
+#   - BACKUP_RETENTION_DAYS  Files older than this are pruned (default: 14)
+#
+# Exits non-zero on any failure so a cron wrapper / monitor can alert.
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
+TIMESTAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
+
+if ! command -v pg_dump >/dev/null 2>&1; then
+  echo "[db-backup] pg_dump not found in PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+DUMP_FILE="$BACKUP_DIR/adopt-dont-shop-$TIMESTAMP.dump.gz"
+
+echo "[db-backup] starting dump -> $DUMP_FILE"
+
+# Custom format (-Fc) keeps schema + data together and is faster to restore
+# than plain SQL. Pipe to gzip so we don't pay the disk cost twice.
+if [ -n "${DATABASE_URL:-}" ]; then
+  pg_dump --no-owner --no-acl -Fc "$DATABASE_URL" | gzip -9 > "$DUMP_FILE"
+else
+  pg_dump --no-owner --no-acl -Fc | gzip -9 > "$DUMP_FILE"
+fi
+
+SIZE_BYTES="$(stat -c '%s' "$DUMP_FILE" 2>/dev/null || stat -f '%z' "$DUMP_FILE")"
+echo "[db-backup] wrote $DUMP_FILE ($SIZE_BYTES bytes)"
+
+# Retention: prune anything older than RETENTION_DAYS. -mtime is a no-op for
+# new files so this is safe to run on every backup. Off-site copies (S3 etc.)
+# are managed separately — see docs/db-backup-runbook.md.
+find "$BACKUP_DIR" -maxdepth 1 -type f -name 'adopt-dont-shop-*.dump.gz' \
+  -mtime +"$RETENTION_DAYS" -print -delete \
+  | sed 's/^/[db-backup] pruned /' || true
+
+echo "[db-backup] done"

--- a/service.backend/scripts/db-restore.sh
+++ b/service.backend/scripts/db-restore.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# db-restore.sh — Restore a pg_dump into a target database.
+#
+# DESTRUCTIVE. This script will overwrite existing schema and data in the
+# target database. Always restore into a scratch DB first, verify, then
+# repoint the application — see docs/db-backup-runbook.md.
+#
+# Usage:
+#   ./db-restore.sh path/to/backup.dump.gz
+#   DATABASE_URL=postgresql://... ./db-restore.sh path/to/backup.dump.gz
+#
+# Required env (any one of these patterns):
+#   - DATABASE_URL=postgresql://user:pass@host:5432/dbname
+#   - or PGHOST / PGPORT / PGUSER / PGPASSWORD / PGDATABASE
+#
+# Optional env:
+#   - CONFIRM_RESTORE=I_UNDERSTAND   Skips the interactive prompt for
+#                                    automated drills.
+#   - RESTORE_JOBS=N                 Parallel pg_restore workers (default 2).
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <backup-file.dump.gz>" >&2
+  exit 64
+fi
+
+BACKUP_FILE="$1"
+JOBS="${RESTORE_JOBS:-2}"
+
+if [ ! -f "$BACKUP_FILE" ]; then
+  echo "[db-restore] backup file not found: $BACKUP_FILE" >&2
+  exit 1
+fi
+
+if ! command -v pg_restore >/dev/null 2>&1; then
+  echo "[db-restore] pg_restore not found in PATH" >&2
+  exit 1
+fi
+
+TARGET_DESC="${DATABASE_URL:-${PGDATABASE:-<env>}}"
+echo "[db-restore] WARNING: this will overwrite schema + data in: $TARGET_DESC"
+echo "[db-restore] backup: $BACKUP_FILE"
+
+if [ "${CONFIRM_RESTORE:-}" != "I_UNDERSTAND" ]; then
+  read -r -p "[db-restore] type 'restore' to proceed: " REPLY
+  if [ "$REPLY" != "restore" ]; then
+    echo "[db-restore] aborted by user"
+    exit 1
+  fi
+fi
+
+echo "[db-restore] starting restore (jobs=$JOBS)"
+
+# --clean drops objects before recreating; --if-exists silences harmless
+# "object does not exist" errors for fresh targets. Use --no-owner /
+# --no-acl so the dump can land in an environment with different roles.
+if [ -n "${DATABASE_URL:-}" ]; then
+  gunzip -c "$BACKUP_FILE" \
+    | pg_restore --clean --if-exists --no-owner --no-acl \
+        --jobs="$JOBS" --dbname="$DATABASE_URL"
+else
+  gunzip -c "$BACKUP_FILE" \
+    | pg_restore --clean --if-exists --no-owner --no-acl \
+        --jobs="$JOBS"
+fi
+
+echo "[db-restore] done"

--- a/service.backend/src/__tests__/config/db-pool-config.test.ts
+++ b/service.backend/src/__tests__/config/db-pool-config.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ADS-401 — Connection pool, statement_timeout, lock_timeout config.
+ *
+ * These tests verify the env-driven defaults and overrides for the Sequelize
+ * pool and PostgreSQL session-level timeouts. The Sequelize instance itself
+ * is constructed with sqlite in tests, so we exercise the pure helper
+ * functions rather than introspecting the live connection.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildPoolConfig, buildTimeoutConfig, logEffectiveDbConfig } from '../../sequelize';
+
+const POOL_VARS = ['DB_POOL_MAX', 'DB_POOL_MIN', 'DB_POOL_ACQUIRE_MS', 'DB_POOL_IDLE_MS'] as const;
+
+const TIMEOUT_VARS = [
+  'DB_STATEMENT_TIMEOUT_MS',
+  'DB_LOCK_TIMEOUT_MS',
+  'DB_IDLE_IN_TRANSACTION_TIMEOUT_MS',
+] as const;
+
+const clearVars = () => {
+  for (const name of [...POOL_VARS, ...TIMEOUT_VARS]) {
+    delete process.env[name];
+  }
+};
+
+describe('database pool + timeout config [ADS-401]', () => {
+  beforeEach(() => {
+    clearVars();
+  });
+
+  afterEach(() => {
+    clearVars();
+  });
+
+  it('returns sane defaults when no env vars are set', () => {
+    expect(buildPoolConfig()).toEqual({
+      max: 20,
+      min: 2,
+      acquire: 30000,
+      idle: 10000,
+    });
+
+    expect(buildTimeoutConfig()).toEqual({
+      statementTimeoutMs: 30000,
+      lockTimeoutMs: 10000,
+      idleInTransactionSessionTimeoutMs: 60000,
+    });
+  });
+
+  it('honours numeric overrides from env', () => {
+    process.env.DB_POOL_MAX = '50';
+    process.env.DB_POOL_MIN = '5';
+    process.env.DB_POOL_ACQUIRE_MS = '15000';
+    process.env.DB_POOL_IDLE_MS = '5000';
+    process.env.DB_STATEMENT_TIMEOUT_MS = '45000';
+    process.env.DB_LOCK_TIMEOUT_MS = '7500';
+    process.env.DB_IDLE_IN_TRANSACTION_TIMEOUT_MS = '90000';
+
+    expect(buildPoolConfig()).toEqual({
+      max: 50,
+      min: 5,
+      acquire: 15000,
+      idle: 5000,
+    });
+
+    expect(buildTimeoutConfig()).toEqual({
+      statementTimeoutMs: 45000,
+      lockTimeoutMs: 7500,
+      idleInTransactionSessionTimeoutMs: 90000,
+    });
+  });
+
+  it('falls back to defaults when env values are non-numeric or negative', () => {
+    process.env.DB_POOL_MAX = 'not-a-number';
+    process.env.DB_POOL_MIN = '-1';
+    process.env.DB_STATEMENT_TIMEOUT_MS = 'NaN';
+
+    expect(buildPoolConfig().max).toBe(20);
+    expect(buildPoolConfig().min).toBe(2);
+    expect(buildTimeoutConfig().statementTimeoutMs).toBe(30000);
+  });
+
+  it('logs effective values so the running config is visible in ops', () => {
+    const log = vi.fn();
+
+    logEffectiveDbConfig(
+      { max: 20, min: 2, acquire: 30000, idle: 10000 },
+      {
+        statementTimeoutMs: 30000,
+        lockTimeoutMs: 10000,
+        idleInTransactionSessionTimeoutMs: 60000,
+      },
+      log
+    );
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const [message] = log.mock.calls[0];
+    expect(message).toContain('pool max=20');
+    expect(message).toContain('statementTimeoutMs=30000');
+    expect(message).toContain('lockTimeoutMs=10000');
+    expect(message).toContain('idleInTransactionSessionTimeoutMs=60000');
+  });
+});

--- a/service.backend/src/__tests__/seeders/env-guard.test.ts
+++ b/service.backend/src/__tests__/seeders/env-guard.test.ts
@@ -1,0 +1,85 @@
+/**
+ * ADS-506 — Reference seed target requires an explicit confirmation flag in prod.
+ *
+ * Reference data is allowed in every environment by NODE_ENV policy. Until
+ * this fix, that meant a misconfigured deploy could quietly overwrite
+ * production reference rows. The guard now demands ALLOW_REFERENCE_SEED_PROD
+ * when NODE_ENV=production.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { assertSeedAllowed } from '../../seeders/lib/env-guard';
+
+const FLAGS_TO_RESET = [
+  'NODE_ENV',
+  'ALLOW_REFERENCE_SEED_PROD',
+  'ALLOW_DEMO_SEED',
+  'ALLOW_BOOTSTRAP',
+] as const;
+
+const snapshotEnv = (): Record<string, string | undefined> => {
+  const snapshot: Record<string, string | undefined> = {};
+  for (const key of FLAGS_TO_RESET) {
+    snapshot[key] = process.env[key];
+  }
+  return snapshot;
+};
+
+const restoreEnv = (snapshot: Record<string, string | undefined>): void => {
+  for (const key of FLAGS_TO_RESET) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+};
+
+describe('seed env-guard reference target [ADS-506]', () => {
+  let snapshot: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    snapshot = snapshotEnv();
+  });
+
+  afterEach(() => {
+    restoreEnv(snapshot);
+  });
+
+  it('allows reference seeding in development without any flag', () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.ALLOW_REFERENCE_SEED_PROD;
+
+    expect(() => assertSeedAllowed('reference')).not.toThrow();
+  });
+
+  it('allows reference seeding in staging without any flag', () => {
+    process.env.NODE_ENV = 'staging';
+    delete process.env.ALLOW_REFERENCE_SEED_PROD;
+
+    expect(() => assertSeedAllowed('reference')).not.toThrow();
+  });
+
+  it('rejects reference seeding in production without ALLOW_REFERENCE_SEED_PROD', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.ALLOW_REFERENCE_SEED_PROD;
+
+    expect(() => assertSeedAllowed('reference')).toThrow(
+      /ALLOW_REFERENCE_SEED_PROD=true when NODE_ENV=production/
+    );
+  });
+
+  it('rejects reference seeding in production when the flag is set to a wrong value', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ALLOW_REFERENCE_SEED_PROD = 'yes';
+
+    expect(() => assertSeedAllowed('reference')).toThrow(/ALLOW_REFERENCE_SEED_PROD=true/);
+  });
+
+  it('allows reference seeding in production when ALLOW_REFERENCE_SEED_PROD=true', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ALLOW_REFERENCE_SEED_PROD = 'true';
+
+    expect(() => assertSeedAllowed('reference')).not.toThrow();
+  });
+});

--- a/service.backend/src/__tests__/seeders/invitations-idempotency.test.ts
+++ b/service.backend/src/__tests__/seeders/invitations-idempotency.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ADS-441 — Demo seeders must be re-run safe.
+ *
+ * The invitations seeder builds rows with a unique `token`. Before the fix,
+ * a re-run after a partial failure would crash on the unique constraint;
+ * the bulk-insert helper now uses `ignoreDuplicates: true`. We assert here
+ * that running the seeder twice in a row throws nothing and leaves the
+ * table in a consistent state.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import sequelize from '../../sequelize';
+import { Invitation, Rescue, User } from '../../models';
+import { UserStatus, UserType } from '../../models/User';
+import { seedInvitations } from '../../seeders/24-invitations';
+
+vi.mock('../../services/auditLog.service', () => ({
+  AuditLogService: { log: vi.fn().mockResolvedValue(undefined) },
+}));
+
+const NUM_RESCUES = 3;
+const NUM_USERS = 2;
+
+const seedDependencies = async (): Promise<void> => {
+  for (let i = 0; i < NUM_RESCUES; i++) {
+    await Rescue.create({
+      name: `Rescue ${i}`,
+      email: `rescue${i}@test.com`,
+      address: `${i} Main St`,
+      city: 'London',
+      postcode: 'SW1A 1AA',
+      country: 'GB',
+      contactPerson: 'Contact Person',
+      status: 'pending',
+    });
+  }
+
+  for (let i = 0; i < NUM_USERS; i++) {
+    await User.create({
+      userId: `seed-user-${i}`,
+      email: `seed${i}@test.com`,
+      password: 'hashedpassword',
+      firstName: 'Seed',
+      lastName: `User${i}`,
+      userType: UserType.ADOPTER,
+      status: UserStatus.ACTIVE,
+      emailVerified: true,
+    });
+  }
+};
+
+describe('invitations seeder idempotency [ADS-441]', () => {
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    await seedDependencies();
+  });
+
+  it('does not throw when run a second time', async () => {
+    await seedInvitations();
+    await expect(seedInvitations()).resolves.not.toThrow();
+  });
+
+  it('settles to a stable, non-empty row count across repeated runs', async () => {
+    await seedInvitations();
+    const firstRunCount = await Invitation.count();
+    expect(firstRunCount).toBeGreaterThan(0);
+
+    await seedInvitations();
+    const secondRunCount = await Invitation.count();
+
+    // The seeder clears + reinserts on each run, so the count must match
+    // exactly. The behavioural guarantee is "re-running is safe and
+    // converges" — not "every re-run is a strict no-op".
+    expect(secondRunCount).toBe(firstRunCount);
+  });
+});

--- a/service.backend/src/seeders/24-invitations.ts
+++ b/service.backend/src/seeders/24-invitations.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import Invitation from '../models/Invitation';
 import Rescue from '../models/Rescue';
 import User from '../models/User';
+import { bulkInsert } from './lib/bulk-insert';
 
 export async function seedInvitations() {
   console.log('🔑 Seeding invitations...');
@@ -87,8 +88,9 @@ export async function seedInvitations() {
       return;
     }
 
-    // Create invitations
-    await Invitation.bulkCreate(invitations);
+    // Create invitations idempotently — re-runs (e.g. after a partial seed
+    // failure) must not throw on the unique `token` constraint (ADS-441).
+    await bulkInsert(Invitation, invitations);
 
     const count = await Invitation.count();
     console.log(`✅ Successfully seeded ${count} invitations`);

--- a/service.backend/src/seeders/26-reports.ts
+++ b/service.backend/src/seeders/26-reports.ts
@@ -7,6 +7,7 @@ import Chat from '../models/Chat';
 import Message from '../models/Message';
 import { generateUuidV7 } from '../utils/uuid';
 import { JsonObject, JsonValue } from '../types/common';
+import { bulkInsert } from './lib/bulk-insert';
 
 export async function seedReports() {
   try {
@@ -309,7 +310,12 @@ export async function seedReports() {
           }>) || [],
       };
     });
-    await Report.bulkCreate(reportsWithEvidence.map(r => ({ ...r.fields, reportId: r.reportId })));
+    // Idempotent inserts — re-runs after a partial failure must not throw
+    // on duplicate primary keys (ADS-441).
+    await bulkInsert(
+      Report,
+      reportsWithEvidence.map(r => ({ ...r.fields, reportId: r.reportId }))
+    );
     const evidenceRows = reportsWithEvidence.flatMap(r =>
       r.evidence.map(e => ({
         parent_type: EvidenceParentType.REPORT,
@@ -320,9 +326,7 @@ export async function seedReports() {
         uploaded_at: new Date(),
       }))
     );
-    if (evidenceRows.length > 0) {
-      await ModerationEvidence.bulkCreate(evidenceRows);
-    }
+    await bulkInsert(ModerationEvidence, evidenceRows);
     console.log(
       `✅ Created ${validReports.length} moderation reports + ${evidenceRows.length} evidence rows`
     );

--- a/service.backend/src/seeders/29-audit-logs.ts
+++ b/service.backend/src/seeders/29-audit-logs.ts
@@ -1,4 +1,5 @@
 import AuditLog from '../models/AuditLog';
+import { bulkInsert } from './lib/bulk-insert';
 
 const auditLogs = [
   // Admin actions
@@ -347,7 +348,8 @@ export async function up() {
   console.log('🌱 Seeding audit logs...');
 
   try {
-    await AuditLog.bulkCreate(auditLogs);
+    // Idempotent — see ADS-441. A partial seed must be safe to re-run.
+    await bulkInsert(AuditLog, auditLogs);
     console.log(`✅ Created ${auditLogs.length} audit log entries`);
   } catch (error) {
     console.error('❌ Error seeding audit logs:', error);

--- a/service.backend/src/seeders/lib/env-guard.ts
+++ b/service.backend/src/seeders/lib/env-guard.ts
@@ -29,6 +29,18 @@ const FLAG_REQUIREMENTS: Partial<Record<SeedTarget, { var: string; value: string
   bootstrap: { var: 'ALLOW_BOOTSTRAP', value: 'true' },
 };
 
+/**
+ * Production-only flag requirements (ADS-506).
+ *
+ * Targets in this map are allowed in production by NODE_ENV policy but still
+ * require a per-invocation confirmation flag when NODE_ENV=production. This
+ * stops `npm run db:seed:reference` from silently overwriting reference data
+ * if it is accidentally pointed at a prod DSN.
+ */
+const PROD_ONLY_FLAG_REQUIREMENTS: Partial<Record<SeedTarget, { var: string; value: string }>> = {
+  reference: { var: 'ALLOW_REFERENCE_SEED_PROD', value: 'true' },
+};
+
 const isNodeEnv = (value: string): value is NodeEnv =>
   value === 'development' || value === 'test' || value === 'staging' || value === 'production';
 
@@ -49,5 +61,15 @@ export function assertSeedAllowed(target: SeedTarget): void {
       `Seed target "${target}" requires ${flag.var}=${flag.value} to confirm. ` +
         `This double-gate prevents accidental destructive operations.`
     );
+  }
+
+  if (env === 'production') {
+    const prodFlag = PROD_ONLY_FLAG_REQUIREMENTS[target];
+    if (prodFlag && process.env[prodFlag.var] !== prodFlag.value) {
+      throw new Error(
+        `Seed target "${target}" requires ${prodFlag.var}=${prodFlag.value} when NODE_ENV=production. ` +
+          `This guards against accidental seed runs against a production database.`
+      );
+    }
   }
 }

--- a/service.backend/src/sequelize.ts
+++ b/service.backend/src/sequelize.ts
@@ -4,6 +4,67 @@ import { env, getDatabaseName } from './config/env';
 
 dotenv.config();
 
+/**
+ * Connection pool + statement/lock timeouts (ADS-401).
+ *
+ * Sequelize defaults to a 5-connection pool with no per-query timeout, which
+ * lets a single slow query exhaust the pool and cascade to 500s. The values
+ * below are env-overridable so ops can tune per instance count.
+ */
+type PoolConfig = {
+  max: number;
+  min: number;
+  acquire: number;
+  idle: number;
+};
+
+type TimeoutConfig = {
+  statementTimeoutMs: number;
+  lockTimeoutMs: number;
+  idleInTransactionSessionTimeoutMs: number;
+};
+
+const parseIntEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+};
+
+export const buildPoolConfig = (): PoolConfig => ({
+  max: parseIntEnv('DB_POOL_MAX', 20),
+  min: parseIntEnv('DB_POOL_MIN', 2),
+  acquire: parseIntEnv('DB_POOL_ACQUIRE_MS', 30000),
+  idle: parseIntEnv('DB_POOL_IDLE_MS', 10000),
+});
+
+export const buildTimeoutConfig = (): TimeoutConfig => ({
+  statementTimeoutMs: parseIntEnv('DB_STATEMENT_TIMEOUT_MS', 30000),
+  lockTimeoutMs: parseIntEnv('DB_LOCK_TIMEOUT_MS', 10000),
+  idleInTransactionSessionTimeoutMs: parseIntEnv('DB_IDLE_IN_TRANSACTION_TIMEOUT_MS', 60000),
+});
+
+export const logEffectiveDbConfig = (
+  pool: PoolConfig,
+  timeouts: TimeoutConfig,
+  log: (message: string) => void = msg => {
+    // eslint-disable-next-line no-console
+    console.log(msg);
+  }
+): void => {
+  log(
+    `[db] pool max=${pool.max} min=${pool.min} acquireMs=${pool.acquire} idleMs=${pool.idle} ` +
+      `statementTimeoutMs=${timeouts.statementTimeoutMs} ` +
+      `lockTimeoutMs=${timeouts.lockTimeoutMs} ` +
+      `idleInTransactionSessionTimeoutMs=${timeouts.idleInTransactionSessionTimeoutMs}`
+  );
+};
+
 const buildConnectionString = (database: string): string => {
   const username = process.env.DB_USERNAME;
   const password = process.env.DB_PASSWORD;
@@ -62,6 +123,9 @@ const isTestEnvironment = process.env.NODE_ENV === 'test';
 
 const databaseUrl = isTestEnvironment ? '' : getDatabaseUrl();
 
+const poolConfig = buildPoolConfig();
+const timeoutConfig = buildTimeoutConfig();
+
 const sequelize = isTestEnvironment
   ? new Sequelize('sqlite::memory:', {
       dialect: 'sqlite',
@@ -92,6 +156,19 @@ const sequelize = isTestEnvironment
         // Enable paranoid (soft delete) by default
         paranoid: true,
       },
+      pool: {
+        max: poolConfig.max,
+        min: poolConfig.min,
+        acquire: poolConfig.acquire,
+        idle: poolConfig.idle,
+      },
+      dialectOptions: {
+        // Per-query and per-lock-wait ceilings keep a single misbehaving
+        // query from holding a connection forever. Values are in ms.
+        statement_timeout: timeoutConfig.statementTimeoutMs,
+        lock_timeout: timeoutConfig.lockTimeoutMs,
+        idle_in_transaction_session_timeout: timeoutConfig.idleInTransactionSessionTimeoutMs,
+      },
       logging:
         process.env.NODE_ENV === 'development' && process.env.DB_LOGGING === 'true'
           ? (sql: string) => {
@@ -100,6 +177,10 @@ const sequelize = isTestEnvironment
             }
           : false,
     });
+
+if (!isTestEnvironment) {
+  logEffectiveDbConfig(poolConfig, timeoutConfig);
+}
 
 /**
  * Get the appropriate JSON data type based on the database dialect


### PR DESCRIPTION
Production Readiness Audit — Group G2 (DB Operational). Each commit traces back to one Linear issue; tests added per fix.

## Closes (auto-close on merge)

- Closes ADS-401 — `service.backend/src/sequelize.ts` configures env-driven connection pool (max=20, min=2, acquire=30s, idle=10s) plus PostgreSQL `statement_timeout=30s`, `lock_timeout=10s`, `idle_in_transaction_session_timeout=60s`. Effective values logged on startup. Vitest covers defaults, env overrides, malformed-input fallback, and the log shape.
- Closes ADS-441 — `seeders/24-invitations.ts`, `26-reports.ts`, and `29-audit-logs.ts` now route bulk inserts through the existing `bulkInsert` helper (`ignoreDuplicates: true`, transactional). New `invitations-idempotency.test.ts` runs the seeder twice and asserts no errors and a stable row count.
- Closes ADS-443 — Adds `service.backend/scripts/db-backup.sh` (date-stamped gzipped `pg_dump` with retention pruning), `db-restore.sh` (interactive destructive-action gate, supports `CONFIRM_RESTORE=I_UNDERSTAND` for drills), `npm run db:backup` / `db:restore` aliases, and `docs/db-backup-runbook.md` covering schedule, retention, env vars, pre-migration checklist, restore drill, and troubleshooting.
- Closes ADS-506 — `seeders/lib/env-guard.ts` now requires `ALLOW_REFERENCE_SEED_PROD=true` for the `reference` target whenever `NODE_ENV=production`, mirroring the existing `ALLOW_BOOTSTRAP` gate. Non-prod environments unaffected.

## Notes

- All 11 new Vitests pass locally. The 5 pre-existing failures in the wider suite (`isomorphic-dompurify` not installed) are unrelated and pre-date this branch.
- No new dependencies; no changes to migrations, models, routes, services, controllers, middleware, frontend, root `package.json`, `.env.example`, docker, or nginx (per scope).

## Test plan

- [ ] CI on this branch runs the new tests (`db-pool-config.test.ts`, `invitations-idempotency.test.ts`, `env-guard.test.ts`).
- [ ] Verify backend startup log shows the new `[db] pool ...` line in a dev container.
- [ ] Smoke `bash service.backend/scripts/db-backup.sh` against a dev DB and confirm the resulting `.dump.gz` is non-empty.
- [ ] Confirm `npm run db:seed:reference` still works in dev (no flag required) and fails loudly in a `NODE_ENV=production` shell without `ALLOW_REFERENCE_SEED_PROD=true`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm)_