### PR TITLE
[Perf] Streaming export, queue concurrency, N+1 fix, caching, image processing (6 issues)

### DIFF
--- a/service.backend/src/__tests__/cache/redis-cache.test.ts
+++ b/service.backend/src/__tests__/cache/redis-cache.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the redis module before importing the cache module so the
+// mocks are wired in before any module-level Redis access.
+vi.mock('../../lib/redis', () => {
+  const store = new Map<string, string>();
+  const fakeRedis = {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    set: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+      return 'OK';
+    }),
+    incr: vi.fn(async (key: string) => {
+      const current = parseInt(store.get(key) ?? '1', 10);
+      const next = String(current + 1);
+      store.set(key, next);
+      return next;
+    }),
+    __store: store,
+  };
+  return {
+    getRedis: vi.fn(() => fakeRedis),
+    isRedisReady: vi.fn(() => true),
+    ensureRedisReady: vi.fn(async () => true),
+    __fakeRedis: fakeRedis,
+  };
+});
+
+import { cached, invalidateNamespace, __test__ } from '../../cache/redis-cache';
+import * as redisModule from '../../lib/redis';
+
+const fakeRedis = (redisModule as unknown as { __fakeRedis: { __store: Map<string, string> } })
+  .__fakeRedis;
+
+describe('redis-cache [ADS-479]', () => {
+  beforeEach(() => {
+    fakeRedis.__store.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fakeRedis.__store.clear();
+  });
+
+  it('produces stable keys regardless of arg property order', () => {
+    const a = __test__.hashArgs({ rescueId: 'r1', page: 2 });
+    const b = __test__.hashArgs({ page: 2, rescueId: 'r1' });
+    expect(a).toBe(b);
+  });
+
+  it('returns the loader result on cache miss and writes through', async () => {
+    const loader = vi.fn(async () => ({ items: [1, 2, 3] }));
+
+    const first = await cached({ namespace: 'pets:list', args: { page: 1 } }, loader);
+    expect(first).toEqual({ items: [1, 2, 3] });
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    const second = await cached({ namespace: 'pets:list', args: { page: 1 } }, loader);
+    expect(second).toEqual({ items: [1, 2, 3] });
+    // Second call should be served from cache.
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats different namespaces as independent', async () => {
+    const loaderA = vi.fn(async () => ({ kind: 'a' }));
+    const loaderB = vi.fn(async () => ({ kind: 'b' }));
+
+    await cached({ namespace: 'pets:list', args: { page: 1 } }, loaderA);
+    await cached({ namespace: 'rescues:list', args: { page: 1 } }, loaderB);
+
+    expect(loaderA).toHaveBeenCalledTimes(1);
+    expect(loaderB).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates a namespace by bumping the version stamp', async () => {
+    const loader = vi.fn(async () => ({ items: [1] }));
+    await cached({ namespace: 'pets:list', args: { page: 1 } }, loader);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    await invalidateNamespace('pets:list');
+
+    await cached({ namespace: 'pets:list', args: { page: 1 } }, loader);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls through to the loader when Redis is not ready', async () => {
+    vi.mocked(redisModule.ensureRedisReady).mockResolvedValueOnce(false);
+    const loader = vi.fn(async () => ({ items: [42] }));
+
+    const result = await cached({ namespace: 'discovery:queue', args: {} }, loader);
+    expect(result).toEqual({ items: [42] });
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+});

--- a/service.backend/src/__tests__/services/discovery-breed-cache.test.ts
+++ b/service.backend/src/__tests__/services/discovery-breed-cache.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../lib/redis', () => ({
+  getRedis: vi.fn(() => null),
+  isRedisReady: vi.fn(() => false),
+  ensureRedisReady: vi.fn(async () => false),
+}));
+
+import sequelize from '../../sequelize';
+import Breed from '../../models/Breed';
+import Pet, { AgeGroup, Gender, PetStatus, PetType, Size } from '../../models/Pet';
+import Rescue from '../../models/Rescue';
+import { DiscoveryService, __resetBreedCacheForTests } from '../../services/discovery.service';
+
+describe('DiscoveryService breed cache [ADS-516]', () => {
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    __resetBreedCacheForTests();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    __resetBreedCacheForTests();
+    await Pet.destroy({ where: {}, truncate: true, cascade: true });
+    await Rescue.destroy({ where: {}, truncate: true, cascade: true });
+    await Breed.destroy({ where: {}, truncate: true, cascade: true });
+  });
+
+  it('fetches the breed catalogue once and reuses it across requests', async () => {
+    const rescue = await Rescue.create({
+      name: 'R',
+      email: 'r@test.com',
+      status: 'verified',
+      address: '1 Test',
+      city: 'C',
+      postcode: 'P1',
+      country: 'GB',
+      contactPerson: 'X',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    await Breed.create({
+      name: 'Labrador Retriever',
+      species: PetType.DOG,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    await Breed.create({
+      name: 'Border Collie',
+      species: PetType.DOG,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    await Pet.create({
+      name: 'Rex',
+      type: PetType.DOG,
+      status: PetStatus.AVAILABLE,
+      gender: Gender.MALE,
+      size: Size.MEDIUM,
+      ageGroup: AgeGroup.ADULT,
+      archived: false,
+      rescueId: rescue.rescueId,
+    });
+
+    const findAllSpy = vi.spyOn(Breed, 'findAll');
+
+    const svc = new DiscoveryService();
+    // We don't care if pet hydration fails (the SQLite test schema
+    // doesn't include all the includes the smart-sort needs); only
+    // that the breed catalogue is fetched at most once across calls.
+    const ignore = (p: Promise<unknown>) => p.catch(() => undefined);
+    await ignore(svc.getDiscoveryQueue({ breed: 'Labrador' }, 5));
+    await ignore(svc.getDiscoveryQueue({ breed: 'Border' }, 5));
+    await ignore(svc.getDiscoveryQueue({ breed: 'Labrador' }, 5));
+
+    // The breed catalogue should have been fetched once for the cache.
+    // We allow up to 1 (and any extra calls are unrelated includes
+    // — in practice only the catalogue fetch hits findAll for Breed
+    // outside includes, so we assert on the count of catalogue-shaped
+    // calls).
+    const catalogueCalls = findAllSpy.mock.calls.filter(call => {
+      const opts = call[0] as { attributes?: string[] } | undefined;
+      return Array.isArray(opts?.attributes) && opts.attributes.includes('breed_id');
+    });
+    expect(catalogueCalls.length).toBe(1);
+
+    findAllSpy.mockRestore();
+  });
+});

--- a/service.backend/src/__tests__/services/file-upload-image-processing.test.ts
+++ b/service.backend/src/__tests__/services/file-upload-image-processing.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// The shared test setup stubs `fs` for upstream service tests. This
+// suite needs the real disk to write JPEG fixtures, so undo the mock.
+vi.unmock('fs');
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import sharp from 'sharp';
+
+import { FileUploadService } from '../../services/file-upload.service';
+
+const TMP_ROOT = path.join(os.tmpdir(), `ads-518-${Date.now()}`);
+
+let counter = 0;
+
+const buildSyntheticUpload = async (
+  originalWidth: number,
+  originalHeight: number
+): Promise<Express.Multer.File> => {
+  await fs.promises.mkdir(TMP_ROOT, { recursive: true });
+  counter += 1;
+  const filename = `large-${Date.now()}-${counter}.jpg`;
+  const filePath = path.join(TMP_ROOT, filename);
+  // Synthesize a large solid-colour JPEG. JPEG of a flat colour
+  // compresses to a small file, which is fine — we only care about
+  // dimensions for the resize assertion. The point is that the
+  // *input* dimensions exceed the 1600px bound.
+  await sharp({
+    create: {
+      width: originalWidth,
+      height: originalHeight,
+      channels: 3,
+      background: { r: 80, g: 120, b: 200 },
+    },
+  })
+    .jpeg({ quality: 100 })
+    .toFile(filePath);
+
+  return {
+    fieldname: 'file',
+    originalname: filename,
+    encoding: '7bit',
+    mimetype: 'image/jpeg',
+    size: (await fs.promises.stat(filePath)).size,
+    destination: TMP_ROOT,
+    filename,
+    path: filePath,
+    buffer: Buffer.alloc(0),
+    stream: null as never,
+  };
+};
+
+describe('FileUploadService image processing [ADS-518]', () => {
+  beforeAll(async () => {
+    await fs.promises.mkdir(TMP_ROOT, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.promises.rm(TMP_ROOT, { recursive: true, force: true });
+  });
+
+  it('resizes images larger than 1600px and writes a thumbnail', async () => {
+    const file = await buildSyntheticUpload(3200, 2400);
+
+    const result = await FileUploadService.__processImageForTests(file);
+
+    expect(result).not.toBeNull();
+    if (!result) return;
+
+    // The processed file replaces the original path; original is kept under .original.
+    expect(result.processedPath).toBe(file.path);
+    expect(result.originalPath).toBe(`${file.path}.original`);
+    expect(result.thumbnailPath).toBeDefined();
+
+    // Verify the resized image dimensions stay within the 1600px bound.
+    const resizedMeta = await sharp(result.processedPath).metadata();
+    expect(resizedMeta.width).toBeLessThanOrEqual(1600);
+    expect(resizedMeta.height).toBeLessThanOrEqual(1600);
+
+    // Thumbnail stays within 320px.
+    if (result.thumbnailPath) {
+      const thumbMeta = await sharp(result.thumbnailPath).metadata();
+      expect(thumbMeta.width).toBeLessThanOrEqual(320);
+      expect(thumbMeta.height).toBeLessThanOrEqual(320);
+    }
+
+    // The original is preserved on disk for re-derivation later.
+    await fs.promises.access(result.originalPath);
+  });
+
+  it('does not enlarge images smaller than 1600px', async () => {
+    const file = await buildSyntheticUpload(800, 600);
+
+    const result = await FileUploadService.__processImageForTests(file);
+    expect(result).not.toBeNull();
+    if (!result) return;
+
+    const meta = await sharp(result.processedPath).metadata();
+    // Should remain at the original dimensions.
+    expect(meta.width).toBe(800);
+    expect(meta.height).toBe(600);
+  });
+});

--- a/service.backend/src/__tests__/services/pet-cache-invalidation.test.ts
+++ b/service.backend/src/__tests__/services/pet-cache-invalidation.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock Redis with an in-memory store, then assert the cache helper is
+// exercised correctly by the service layer.
+vi.mock('../../lib/redis', () => {
+  const store = new Map<string, string>();
+  const fakeRedis = {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    set: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+      return 'OK';
+    }),
+    incr: vi.fn(async (key: string) => {
+      const current = parseInt(store.get(key) ?? '1', 10);
+      const next = String(current + 1);
+      store.set(key, next);
+      return next;
+    }),
+    __store: store,
+  };
+  return {
+    getRedis: vi.fn(() => fakeRedis),
+    isRedisReady: vi.fn(() => true),
+    ensureRedisReady: vi.fn(async () => true),
+    __fakeRedis: fakeRedis,
+  };
+});
+
+import sequelize from '../../sequelize';
+import Pet, { AgeGroup, Gender, PetStatus, PetType, Size } from '../../models/Pet';
+import Rescue from '../../models/Rescue';
+import { PetService } from '../../services/pet.service';
+import * as redisModule from '../../lib/redis';
+
+const fakeRedis = (redisModule as unknown as { __fakeRedis: { __store: Map<string, string> } })
+  .__fakeRedis;
+
+describe('PetService cache invalidation [ADS-479]', () => {
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    fakeRedis.__store.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    fakeRedis.__store.clear();
+    await Pet.destroy({ where: {}, truncate: true, cascade: true });
+    await Rescue.destroy({ where: {}, truncate: true, cascade: true });
+  });
+
+  it('serves getFeaturedPets from cache on the second call', async () => {
+    const rescue = await Rescue.create({
+      name: 'Cache Rescue',
+      email: 'cache@test.com',
+      status: 'verified',
+      address: '1 Test Lane',
+      city: 'Testville',
+      postcode: 'TE1 1ST',
+      country: 'GB',
+      contactPerson: 'Tester',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    await Pet.create({
+      name: 'Featured Fido',
+      type: PetType.DOG,
+      status: PetStatus.AVAILABLE,
+      gender: Gender.MALE,
+      size: Size.MEDIUM,
+      ageGroup: AgeGroup.ADULT,
+      featured: true,
+      archived: false,
+      rescueId: rescue.rescueId,
+    });
+
+    const findAllSpy = vi.spyOn(Pet, 'findAll');
+
+    const first = await PetService.getFeaturedPets(5);
+    const second = await PetService.getFeaturedPets(5);
+
+    expect(first.length).toBe(1);
+    expect(second.length).toBe(1);
+    // First call hits the DB, second is served from the cache.
+    expect(findAllSpy).toHaveBeenCalledTimes(1);
+
+    findAllSpy.mockRestore();
+  });
+});

--- a/service.backend/src/cache/redis-cache.ts
+++ b/service.backend/src/cache/redis-cache.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'crypto';
+import { ensureRedisReady, getRedis, isRedisReady } from '../lib/redis';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-479 / ADS-516: Read-through Redis cache helper for hot read paths.
+ *
+ * Behaviour:
+ * - Wraps a fetch function. On a hit, returns the cached value. On a
+ *   miss (or any Redis failure), falls through to the loader and
+ *   best-effort writes the result back.
+ * - Keys are namespaced (`namespace:hash`) and the args are SHA-1
+ *   hashed so long argument blobs don't blow the key length.
+ * - A versioned namespace lets writes invalidate an entire group by
+ *   bumping the version, so we don't have to track every key.
+ * - Redis is optional. When it isn't ready, the helper is a no-op
+ *   passthrough. Errors are swallowed and logged at debug; we never
+ *   surface cache failures to the caller.
+ */
+
+const DEFAULT_TTL_SECONDS = 60;
+
+const VERSION_KEY_PREFIX = 'cache:version:';
+
+/**
+ * Stable JSON stringifier so `{a:1,b:2}` and `{b:2,a:1}` produce the same key.
+ * Recurses into nested objects, leaves primitives/arrays as-is.
+ */
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(',')}}`;
+};
+
+const hashArgs = (args: unknown): string => {
+  const serialized = stableStringify(args);
+  return createHash('sha1').update(serialized).digest('hex');
+};
+
+const versionKey = (namespace: string): string => `${VERSION_KEY_PREFIX}${namespace}`;
+
+/** Get the current version stamp for a namespace (defaults to '1'). */
+const getNamespaceVersion = async (namespace: string): Promise<string> => {
+  const redis = getRedis();
+  if (!redis || !isRedisReady()) {
+    return '1';
+  }
+  try {
+    const v = await redis.get(versionKey(namespace));
+    return v ?? '1';
+  } catch (error) {
+    logger.debug('Cache version lookup failed', {
+      namespace,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return '1';
+  }
+};
+
+const buildKey = (namespace: string, version: string, args: unknown): string =>
+  `cache:${namespace}:v${version}:${hashArgs(args)}`;
+
+export type CacheOptions = {
+  /** Cache namespace, e.g. 'pets:list'. */
+  namespace: string;
+  /** Anything that varies the result — included in the key hash. */
+  args: unknown;
+  /** TTL in seconds. Default 60s. */
+  ttlSeconds?: number;
+};
+
+/**
+ * Read-through cache wrapper. Always falls through to `loader` if the
+ * cache is unavailable or the entry is missing. Best-effort writes.
+ */
+export const cached = async <T>(opts: CacheOptions, loader: () => Promise<T>): Promise<T> => {
+  const ttl = opts.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const ready = await ensureRedisReady();
+  if (!ready) {
+    return loader();
+  }
+
+  const redis = getRedis();
+  if (!redis) {
+    return loader();
+  }
+
+  const version = await getNamespaceVersion(opts.namespace);
+  const key = buildKey(opts.namespace, version, opts.args);
+
+  try {
+    const hit = await redis.get(key);
+    if (hit !== null) {
+      return JSON.parse(hit) as T;
+    }
+  } catch (error) {
+    logger.debug('Cache read failed — falling through', {
+      namespace: opts.namespace,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const value = await loader();
+
+  // Best-effort write. Skip undefined / non-serializable returns.
+  if (value !== undefined) {
+    try {
+      await redis.set(key, JSON.stringify(value), 'EX', ttl);
+    } catch (error) {
+      logger.debug('Cache write failed', {
+        namespace: opts.namespace,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return value;
+};
+
+/**
+ * Bump the version stamp for a namespace so all existing keys become
+ * unreachable. Used by write paths to invalidate listing caches.
+ * No-op if Redis isn't available.
+ */
+export const invalidateNamespace = async (namespace: string): Promise<void> => {
+  const ready = await ensureRedisReady();
+  if (!ready) {
+    return;
+  }
+  const redis = getRedis();
+  if (!redis) {
+    return;
+  }
+  try {
+    await redis.incr(versionKey(namespace));
+  } catch (error) {
+    logger.debug('Cache invalidation failed', {
+      namespace,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+/** Test seam — exposed for unit tests to assert key shape. */
+export const __test__ = { hashArgs, stableStringify, buildKey };

--- a/service.backend/src/services/discovery.service.ts
+++ b/service.backend/src/services/discovery.service.ts
@@ -8,6 +8,48 @@ import Rescue from '../models/Rescue';
 import sequelize from '../sequelize';
 import { logger } from '../utils/logger';
 
+/**
+ * ADS-516: In-process cache for the breed catalogue.
+ *
+ * Discovery's breed-filter path was firing a second `Breed.findAll`
+ * on every breed-filter request before the main pet query. Breed
+ * data is effectively static (admins rarely add new breeds), so we
+ * hold the catalogue in memory per process for an hour and resolve
+ * the LIKE-style filter against the cached array.
+ */
+type CachedBreed = { breed_id: string; name: string };
+
+let breedCache: { rows: CachedBreed[]; expiresAt: number } | null = null;
+const BREED_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const getCachedBreeds = async (): Promise<CachedBreed[]> => {
+  if (breedCache && breedCache.expiresAt > Date.now()) {
+    return breedCache.rows;
+  }
+  const rows = await Breed.findAll({ attributes: ['breed_id', 'name'] });
+  const flattened: CachedBreed[] = rows
+    .map(b => ({ breed_id: b.breed_id, name: b.name }))
+    .filter(b => Boolean(b.breed_id) && Boolean(b.name));
+  breedCache = { rows: flattened, expiresAt: Date.now() + BREED_CACHE_TTL_MS };
+  return flattened;
+};
+
+/**
+ * Resolve a free-form breed name to a list of breed IDs using the
+ * cached catalogue. Case-insensitive substring match — equivalent
+ * to the previous `iLike` SQL filter.
+ */
+const resolveBreedIdsFromCache = async (name: string): Promise<string[]> => {
+  const breeds = await getCachedBreeds();
+  const needle = name.toLowerCase();
+  return breeds.filter(b => b.name.toLowerCase().includes(needle)).map(b => b.breed_id);
+};
+
+/** Test seam — drop the in-process cache so a test can exercise the fetch path. */
+export const __resetBreedCacheForTests = (): void => {
+  breedCache = null;
+};
+
 // Pet.images / Pet.videos are no longer JSONB on the pet row (plan
 // 2.1) — they're rows in pet_media. Inside discovery we only ever look
 // at images, so we narrow the typed Pet to the shape we project below.
@@ -185,13 +227,10 @@ export class DiscoveryService {
       }
       // Plan 2.4 — breed is an FK; resolve free-form name to ids and
       // filter on the FK columns instead of a string LIKE on the pet row.
+      // ADS-516 — resolve via the in-process breed cache so we don't
+      // double-fetch on every discovery request.
       if (filters.breed) {
-        const likeOp = sequelize.getDialect() === 'postgres' ? Op.iLike : Op.like;
-        const breedRows = await Breed.findAll({
-          where: { name: { [likeOp]: `%${filters.breed}%` } },
-          attributes: ['breed_id'],
-        });
-        const breedIds = breedRows.map(b => b.breed_id);
+        const breedIds = await resolveBreedIdsFromCache(filters.breed);
         if (breedIds.length === 0) {
           whereConditions.breedId = '__never_matches__';
         } else {

--- a/service.backend/src/services/discovery.service.ts
+++ b/service.backend/src/services/discovery.service.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'crypto';
 import { Op, fn, literal } from 'sequelize';
+import { cached } from '../cache/redis-cache';
 import Breed from '../models/Breed';
 import Pet, { AgeGroup, Gender, PetStatus, PetType, Size } from '../models/Pet';
 import PetMedia, { PetMediaType } from '../models/PetMedia';
@@ -53,9 +54,33 @@ export interface DiscoveryQueue {
 
 export class DiscoveryService {
   /**
-   * Get discovery queue with smart sorting algorithm
+   * Get discovery queue with smart sorting algorithm.
+   *
+   * ADS-479: cached for 60s. The discovery feed is the hottest read
+   * path on the swipe UI; without caching, every drag triggers a full
+   * smart-sort recompute. Pet writes invalidate the `discovery:queue`
+   * namespace via `pet.service.ts`.
+   *
+   * Note: `sessionId` is per-request (random) and intentionally
+   * excluded from the cache key — only filter/limit/user matters
+   * for the actual pet shortlist.
    */
   async getDiscoveryQueue(
+    filters: DiscoveryFilters,
+    limit: number = 20,
+    userId?: string
+  ): Promise<DiscoveryQueue> {
+    return cached(
+      {
+        namespace: 'discovery:queue',
+        args: { filters, limit, userId: userId ?? null },
+        ttlSeconds: 60,
+      },
+      () => this.getDiscoveryQueueUncached(filters, limit, userId)
+    );
+  }
+
+  private async getDiscoveryQueueUncached(
     filters: DiscoveryFilters,
     limit: number = 20,
     userId?: string

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -533,11 +533,23 @@ export class FileUploadService {
   }
 
   /**
-   * Process file after upload (resize images, generate thumbnails, etc.)
+   * Process file after upload (resize images, generate thumbnails, etc.).
+   *
+   * ADS-518: previously a stub. Raw multi-megabyte uploads were
+   * being stored and served as-is, bloating storage and slowing
+   * client load times. Now we use `sharp` to:
+   *   - resize the main image to a max of 1600px on its longest
+   *     side (preserving aspect ratio) and re-encode at JPEG q=85
+   *   - emit a 320px thumbnail next to it
+   *
+   * The original is kept on disk under a `.original` suffix so we
+   * can re-derive at higher quality later if we change defaults.
+   * If `sharp` isn't loadable in the runtime (rare — listed in
+   * dependencies) we fall back to the original file unchanged.
    */
   private static async processFile(
     file: Express.Multer.File,
-    uploadType: keyof typeof UPLOAD_CONFIG.directories
+    _uploadType: keyof typeof UPLOAD_CONFIG.directories
   ): Promise<ProcessedFileInfo> {
     const processedInfo: ProcessedFileInfo = {
       originalPath: file.path,
@@ -546,20 +558,109 @@ export class FileUploadService {
       metadata: {},
     };
 
-    // Process images
     if (file.mimetype === 'image/svg+xml') {
       await this.sanitizeSvgFile(file);
-    } else if (UPLOAD_CONFIG.allowedMimeTypes.images.includes(file.mimetype)) {
-      // Add image processing logic here (resize, compress, generate thumbnails)
-      // This would use a library like sharp or jimp
+      return processedInfo;
     }
 
-    // Process videos
-    if (UPLOAD_CONFIG.allowedMimeTypes.videos.includes(file.mimetype)) {
-      // Add video processing logic here (generate thumbnails, extract metadata)
+    if (UPLOAD_CONFIG.allowedMimeTypes.images.includes(file.mimetype)) {
+      const result = await this.processImageWithSharp(file);
+      if (result) {
+        return result;
+      }
+      // Sharp unavailable / failed — fall back to the original file.
     }
 
     return processedInfo;
+  }
+
+  /**
+   * Test seam — exposed so tests can drive image processing without
+   * standing up the whole upload pipeline. Production callers use
+   * `processFile`.
+   */
+  public static async __processImageForTests(
+    file: Express.Multer.File
+  ): Promise<ProcessedFileInfo | null> {
+    return this.processImageWithSharp(file);
+  }
+
+  /**
+   * Sharp-backed image resize + thumbnail. Returns null if sharp
+   * isn't loadable or processing fails — callers fall back to the
+   * original file.
+   */
+  private static async processImageWithSharp(
+    file: Express.Multer.File
+  ): Promise<ProcessedFileInfo | null> {
+    let sharp: typeof import('sharp');
+    try {
+      const mod = await import('sharp');
+      // sharp ships both as ESM default and CJS bare; normalise.
+      const candidate = (mod as unknown as { default?: typeof import('sharp') }).default;
+      sharp = candidate ?? (mod as unknown as typeof import('sharp'));
+    } catch (error) {
+      logger.warn('sharp not available — image will be stored unprocessed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+
+    try {
+      const originalPath = file.path;
+      const ext = path.extname(originalPath);
+      const dir = path.dirname(originalPath);
+      const base = path.basename(originalPath, ext);
+
+      // Keep the original around under a .original suffix so we can
+      // re-derive at higher quality later if defaults change.
+      const keepOriginalPath = path.join(dir, `${base}${ext}.original`);
+      await fs.promises.copyFile(originalPath, keepOriginalPath);
+
+      // Resize the primary asset in place: max 1600px on the longest
+      // side, JPEG q=85 (mozjpeg). withoutEnlargement so we never up-scale.
+      const resizedTmpPath = path.join(dir, `${base}.resized${ext}`);
+      const meta = await sharp(originalPath).metadata();
+      const resizedInfo = await sharp(originalPath)
+        .resize({ width: 1600, height: 1600, fit: 'inside', withoutEnlargement: true })
+        .jpeg({ quality: 85, mozjpeg: true })
+        .toFile(resizedTmpPath);
+      await fs.promises.rename(resizedTmpPath, originalPath);
+
+      // 320px thumbnail next to it.
+      const thumbPath = path.join(dir, `${base}.thumb.jpg`);
+      await sharp(keepOriginalPath)
+        .resize({ width: 320, height: 320, fit: 'inside', withoutEnlargement: true })
+        .jpeg({ quality: 80, mozjpeg: true })
+        .toFile(thumbPath);
+
+      const originalStats = await fs.promises.stat(keepOriginalPath);
+      const processedStats = await fs.promises.stat(originalPath);
+
+      return {
+        originalPath: keepOriginalPath,
+        processedPath: originalPath,
+        thumbnailPath: thumbPath,
+        metadata: {
+          processedAt: new Date().toISOString(),
+          dimensions: {
+            width: resizedInfo.width ?? meta.width ?? 0,
+            height: resizedInfo.height ?? meta.height ?? 0,
+          },
+          thumbnailGenerated: true,
+          compressionRatio:
+            originalStats.size > 0
+              ? Number((processedStats.size / originalStats.size).toFixed(3))
+              : 0,
+        },
+      };
+    } catch (error) {
+      logger.error('Sharp image processing failed — keeping original', {
+        error: error instanceof Error ? error.message : String(error),
+        path: file.path,
+      });
+      return null;
+    }
   }
 
   /**

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -1,4 +1,5 @@
 import { col, fn, literal, Op, WhereOptions } from 'sequelize';
+import { cached, invalidateNamespace } from '../cache/redis-cache';
 import Breed from '../models/Breed';
 import Pet, { AgeGroup, PetStatus, PetType, Size } from '../models/Pet';
 import PetMedia, { PetMediaType } from '../models/PetMedia';
@@ -58,6 +59,23 @@ const PET_RESCUE_LIST_SORT_FIELDS = [
  */
 const getLikeOp = () => {
   return sequelize.getDialect() === 'postgres' ? Op.iLike : Op.like;
+};
+
+/**
+ * ADS-479: Cache namespaces for pet listings. Centralised so writes
+ * can fan out invalidation across every read path that might surface
+ * the mutated row.
+ */
+const PET_CACHE_NAMESPACES = [
+  'pets:list',
+  'pets:featured',
+  'pets:recent',
+  'pets:rescue-list',
+  'discovery:queue',
+] as const;
+
+const invalidatePetCaches = async (): Promise<void> => {
+  await Promise.all(PET_CACHE_NAMESPACES.map(ns => invalidateNamespace(ns)));
 };
 
 /**
@@ -557,6 +575,10 @@ export class PetService {
         );
       }
 
+      // ADS-479: bust cached pet listings + discovery feed so the
+      // newly-created pet shows up on the next read.
+      await invalidatePetCaches();
+
       return pet;
     } catch (error) {
       logger.error('Pet creation failed:', {
@@ -752,6 +774,9 @@ export class PetService {
         );
       }
 
+      // ADS-479: bust cached listings now that the row has changed.
+      await invalidatePetCaches();
+
       return pet.reload();
     } catch (error) {
       logger.error('Pet update failed:', {
@@ -833,6 +858,9 @@ export class PetService {
         );
       }
 
+      // ADS-479: cached listings filter on status, so invalidate.
+      await invalidatePetCaches();
+
       return pet.reload();
     } catch (error) {
       logger.error('Pet status update failed:', {
@@ -886,6 +914,9 @@ export class PetService {
           deletedBy
         );
       }
+
+      // ADS-479: drop the deleted pet from cached listings.
+      await invalidatePetCaches();
 
       return { message: 'Pet deleted successfully' };
     } catch (error) {
@@ -1084,30 +1115,37 @@ export class PetService {
   }
 
   /**
-   * Get featured pets
+   * Get featured pets.
+   *
+   * ADS-479: cached for 60s. The featured set is small and fanned
+   * out on every home-page render, so this is one of the hottest
+   * read paths. Writes (`createPet` / `updatePet` / `deletePet`)
+   * bump the namespace version to invalidate.
    */
   static async getFeaturedPets(limit: number = 10): Promise<Pet[]> {
-    try {
-      const pets = await Pet.findAll({
-        where: {
-          featured: true,
-          archived: false,
-          status: { [Op.in]: [PetStatus.AVAILABLE, PetStatus.FOSTER] },
-        },
-        order: [
-          ['priorityListing', 'DESC'],
-          ['createdAt', 'DESC'],
-        ],
-        limit,
-      });
+    return cached({ namespace: 'pets:featured', args: { limit }, ttlSeconds: 60 }, async () => {
+      try {
+        const pets = await Pet.findAll({
+          where: {
+            featured: true,
+            archived: false,
+            status: { [Op.in]: [PetStatus.AVAILABLE, PetStatus.FOSTER] },
+          },
+          order: [
+            ['priorityListing', 'DESC'],
+            ['createdAt', 'DESC'],
+          ],
+          limit,
+        });
 
-      logger.info('Featured pets retrieved successfully', { count: pets.length });
+        logger.info('Featured pets retrieved successfully', { count: pets.length });
 
-      return pets;
-    } catch (error) {
-      logger.error('Get featured pets failed:', error);
-      throw new Error('Failed to retrieve featured pets');
-    }
+        return pets;
+      } catch (error) {
+        logger.error('Get featured pets failed:', error);
+        throw new Error('Failed to retrieve featured pets');
+      }
+    });
   }
 
   /**
@@ -1752,32 +1790,36 @@ export class PetService {
   }
 
   /**
-   * Get recent pets (recently added)
+   * Get recent pets (recently added).
+   *
+   * ADS-479: cached for 60s. Same invalidation rules as featured.
    */
   static async getRecentPets(limit: number = 12): Promise<Pet[]> {
-    try {
-      const pets = await Pet.findAll({
-        where: {
-          status: PetStatus.AVAILABLE,
-          archived: false,
-        },
-        include: [
-          {
-            model: Rescue,
-            as: 'Rescue',
-            attributes: ['rescueId', 'name', 'city', 'state'],
+    return cached({ namespace: 'pets:recent', args: { limit }, ttlSeconds: 60 }, async () => {
+      try {
+        const pets = await Pet.findAll({
+          where: {
+            status: PetStatus.AVAILABLE,
+            archived: false,
           },
-        ],
-        order: [['createdAt', 'DESC']],
-        limit,
-      });
+          include: [
+            {
+              model: Rescue,
+              as: 'Rescue',
+              attributes: ['rescueId', 'name', 'city', 'state'],
+            },
+          ],
+          order: [['createdAt', 'DESC']],
+          limit,
+        });
 
-      logger.info(`Retrieved ${pets.length} recent pets`);
-      return pets;
-    } catch (error) {
-      logger.error('Error getting recent pets:', error);
-      throw new Error('Failed to retrieve recent pets');
-    }
+        logger.info(`Retrieved ${pets.length} recent pets`);
+        return pets;
+      } catch (error) {
+        logger.error('Error getting recent pets:', error);
+        throw new Error('Failed to retrieve recent pets');
+      }
+    });
   }
 
   /**

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -4,6 +4,7 @@ import { EmailType, EmailPriority } from '../models/EmailQueue';
 import { Application, Pet, Rescue, StaffMember, User, Role, UserRole } from '../models';
 import { logger, loggerHelpers } from '../utils/logger';
 import { invalidateAuthCache } from '../lib/auth-cache';
+import { cached, invalidateNamespace } from '../cache/redis-cache';
 import { AuditLogService } from './auditLog.service';
 import { validateSortField } from '../utils/sort-validation';
 import { verifyCompaniesHouseNumber } from './companies-house.service';
@@ -95,11 +96,38 @@ export type RescueWithStatistics = ReturnType<Rescue['toJSON']> & {
 // `RescueWithStatistics`.
 export type RescuePlain = ReturnType<Rescue['toJSON']>;
 
+/**
+ * ADS-479: cache namespaces touched by rescue writes. Invalidated by
+ * `createRescue` / `updateRescue` etc. so listings reflect the new
+ * state on the next read.
+ */
+const RESCUE_CACHE_NAMESPACES = ['rescues:search'] as const;
+
+const invalidateRescueCaches = async (): Promise<void> => {
+  await Promise.all(RESCUE_CACHE_NAMESPACES.map(ns => invalidateNamespace(ns)));
+};
+
 export class RescueService {
   /**
    * Search and filter rescues with pagination
    */
   static async searchRescues(options: RescueSearchOptions = {}): Promise<{
+    rescues: RescuePlain[];
+    pagination: {
+      page: number;
+      limit: number;
+      total: number;
+      pages: number;
+    };
+  }> {
+    // ADS-479: rescue search is fanned out from public-facing pages;
+    // cache for 60s with the full options blob in the key.
+    return cached({ namespace: 'rescues:search', args: options, ttlSeconds: 60 }, () =>
+      RescueService.searchRescuesUncached(options)
+    );
+  }
+
+  private static async searchRescuesUncached(options: RescueSearchOptions = {}): Promise<{
     rescues: RescuePlain[];
     pagination: {
       page: number;
@@ -425,6 +453,10 @@ export class RescueService {
       );
     }
 
+    // ADS-479: bust cached rescue search results so the new rescue
+    // surfaces on the next read.
+    await invalidateRescueCaches();
+
     logger.info(`Created new rescue: ${rescue.rescueId}`);
     return rescue;
   }
@@ -495,6 +527,9 @@ export class RescueService {
       );
 
       await transaction.commit();
+
+      // ADS-479: bust cached rescue search results.
+      await invalidateRescueCaches();
 
       logger.info(`Updated rescue: ${rescueId}`);
       return rescue.toJSON();


### PR DESCRIPTION
## Summary

Backend Performance group from the Production Readiness Audit. Six commits, one per Linear issue.

## Closes (auto-close on merge)

- Closes ADS-421 — Stream paginated admin exports instead of buffering whole tables. New `streamExport` walks the table 1000 rows at a time and emits JSON / JSONL / CSV; controller pipes the Readable straight to the response.
- Closes ADS-477 — Bounded parallel send in the email queue processor. Sequential `for...of await` replaced with a `Promise.all` worker pool; concurrency configurable via `EMAIL_QUEUE_CONCURRENCY` (default 5, capped at 50). Per-email failures isolated.
- Closes ADS-478 — Replace N+1 in `moderation.enrichReportsWithContext` with a single batched IN-query per entity type (user / pet / rescue), preserving input order.
- Closes ADS-479 — New `cache/redis-cache.ts` read-through helper with versioned namespaces. 60s caching applied to `PetService.getFeaturedPets` / `getRecentPets`, `RescueService.searchRescues`, `DiscoveryService.getDiscoveryQueue`. Pet/rescue writes bump namespace versions to invalidate. No-op passthrough when Redis isn't ready.
- Closes ADS-516 — Cache the breed catalogue in process for an hour; discovery breed-filter resolves against the cached array instead of refetching on every request.
- Closes ADS-518 — Wire `sharp` into `processFile`: resize images to a 1600px bounding box at JPEG q=85 (mozjpeg), emit a 320px thumbnail, preserve the original under `.original`. Falls back to the unprocessed file if sharp isn't loadable.

20 new tests added; all 150 existing tests in the touched service test files still pass. `npm run type-check` clean.

Linear project: https://linear.app/ideasquared/project/production-readiness-audit-db9e431277b9

## Test plan

- [ ] CI passes type-check, lint, tests
- [ ] Smoke: admin export endpoint streams large dataset without OOM
- [ ] Smoke: email queue processes a batch faster under EMAIL_QUEUE_CONCURRENCY=10
- [ ] Smoke: moderation reports page issues a single IN-query per entity type
- [ ] Smoke: pet listing repeated calls hit Redis cache; create/update/delete invalidate
- [ ] Smoke: discovery breed-filter does not re-fetch the catalogue per request
- [ ] Smoke: uploaded image is resized + thumbnail generated; `.original` preserved

https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm

---
_Generated by [Claude Code](https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm)_