### PR TITLE
[Privacy] GDPR delete/export, retention jobs, upload auth, consent capture (11 issues)

### DIFF
--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,0 +1,69 @@
+# Privacy Policy
+
+**Version:** 2026-05-08-v1
+**Last updated:** 8 May 2026
+
+> Placeholder copy — must be reviewed and approved by legal counsel before
+> production launch. The version string above is the canonical
+> identifier persisted in `consent_events.privacy_version` when a user accepts.
+
+## 1. Who we are
+
+Adopt Don't Shop is the data controller for the personal data described
+in this notice. Contact our Data Protection Officer at
+privacy@adoptdontshop.example.
+
+## 2. What we collect
+
+- **Account data:** email, name, phone number, date of birth.
+- **Application data:** household and lifestyle answers, references,
+  uploaded documents.
+- **Technical data:** IP address, browser, device, log data needed to
+  operate the platform securely.
+
+## 3. Lawful basis
+
+- **Contract** for account and application processing.
+- **Legitimate interest** for platform-security logging.
+- **Consent** for marketing emails (separately captured at registration).
+
+## 4. Your rights
+
+You may at any time:
+
+- **Access / export** your data via `GET /api/v1/privacy/me/export`.
+- **Delete** your account and request erasure via
+  `POST /api/v1/privacy/me/delete`. Hard deletion follows after a
+  30-day grace window in line with our retention policy.
+- **Object** to processing or **restrict** processing by emailing
+  privacy@adoptdontshop.example.
+
+## 5. Retention
+
+- Soft-deleted accounts: 30 days then hard-deleted.
+- Notifications: 90 days.
+- Refresh tokens: 30 days from last use.
+- Idempotency keys: 24 hours.
+- Email queue records: 1 year.
+- Swipe actions: 24-month rolling window.
+- Home-visit records: 5 years (regulatory retention).
+
+These periods are enforced by an automated retention job; see
+`service.backend/src/jobs/retention.job.ts`.
+
+## 6. Children's data
+
+We do not knowingly collect data from children under 13. Adoption
+applications must be submitted by an adult; if a household includes
+minors, parental consent is required to record their ages.
+
+## 7. Third-party reference contacts
+
+When you submit references on an adoption application, you confirm you
+have informed those contacts that their details will be shared with the
+adopting rescue and may be contacted to verify your application.
+
+## 8. Changes
+
+The version string above identifies the version each user accepted.
+Material changes require re-acceptance.

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,0 +1,53 @@
+# Terms of Service
+
+**Version:** 2026-05-08-v1
+**Last updated:** 8 May 2026
+
+> Placeholder copy — must be reviewed and approved by legal counsel before
+> production launch. The version string above is the canonical
+> identifier persisted in `consent_events.tos_version` when a user accepts.
+
+## 1. Acceptance of terms
+
+By creating an account on Adopt Don't Shop you agree to these Terms of
+Service and to the [Privacy Policy](./privacy.md). If you do not agree,
+do not create an account.
+
+## 2. Eligibility
+
+You must be at least 18 years old to register an account. We do not
+knowingly collect data from children under 13. See the Privacy Policy
+for our COPPA position.
+
+## 3. Account security
+
+You are responsible for maintaining the confidentiality of your
+credentials and for all activity under your account.
+
+## 4. Acceptable use
+
+You will not use the platform to harass, defraud, or impersonate other
+users; to submit fraudulent adoption applications; or to scrape or
+republish data outside of the user-facing endpoints.
+
+## 5. Termination
+
+You may delete your account at any time via the data-deletion endpoint
+documented in the Privacy Policy. We may suspend or terminate accounts
+that violate these terms.
+
+## 6. Disclaimers
+
+The service is provided "as is" without warranties of any kind. We do
+not guarantee the accuracy of pet listings, adoption outcomes, or
+third-party integrations.
+
+## 7. Changes
+
+We may update these terms from time to time. The version string above
+identifies the version each user accepted; material changes require
+re-acceptance on next sign-in.
+
+## 8. Contact
+
+Questions about these terms: legal@adoptdontshop.example.

--- a/service.backend/src/__tests__/services/data-deletion.test.ts
+++ b/service.backend/src/__tests__/services/data-deletion.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { buildAnonymousPlaceholder } from '../../services/data-deletion.service';
+
+describe('buildAnonymousPlaceholder', () => {
+  it('returns a deterministic placeholder for the same userId', () => {
+    const a = buildAnonymousPlaceholder('user-123');
+    const b = buildAnonymousPlaceholder('user-123');
+    expect(a).toBe(b);
+  });
+
+  it('produces different placeholders for different userIds', () => {
+    expect(buildAnonymousPlaceholder('user-1')).not.toBe(buildAnonymousPlaceholder('user-2'));
+  });
+
+  it('starts with deleted-user- prefix and ends with a 12-hex digest', () => {
+    const placeholder = buildAnonymousPlaceholder('any');
+    expect(placeholder).toMatch(/^deleted-user-[0-9a-f]{12}$/);
+  });
+
+  it('produces a value short enough to fit in firstName/lastName (≤100 chars)', () => {
+    const placeholder = buildAnonymousPlaceholder('verylongidentifier-' + 'x'.repeat(200));
+    expect(placeholder.length).toBeLessThanOrEqual(100);
+  });
+});

--- a/service.backend/src/__tests__/services/data-retention.test.ts
+++ b/service.backend/src/__tests__/services/data-retention.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { RETENTION_POLICIES } from '../../services/data-retention.service';
+
+describe('RETENTION_POLICIES', () => {
+  it('declares a soft-delete grace window of 30 days', () => {
+    expect(RETENTION_POLICIES.softDeletedUsersGraceDays).toBe(30);
+  });
+
+  it('declares the documented retention windows', () => {
+    expect(RETENTION_POLICIES.notificationsDays).toBe(90);
+    expect(RETENTION_POLICIES.emailQueueDays).toBe(365);
+    expect(RETENTION_POLICIES.refreshTokensExpiredDays).toBe(30);
+    expect(RETENTION_POLICIES.idempotencyKeysHours).toBe(24);
+    expect(RETENTION_POLICIES.swipeActionsMonths).toBe(24);
+  });
+
+  it('all retention windows are positive', () => {
+    for (const value of Object.values(RETENTION_POLICIES)) {
+      expect(value).toBeGreaterThan(0);
+    }
+  });
+});

--- a/service.backend/src/__tests__/services/legal-content.test.ts
+++ b/service.backend/src/__tests__/services/legal-content.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Global setup-tests.ts mocks `fs` so most tests don't accidentally
+// hit the disk. The legal-content service is the rare case that
+// genuinely needs filesystem reads, so we restore the real module
+// before importing it.
+vi.unmock('fs');
+
+import {
+  getPrivacyDocument,
+  getTermsDocument,
+  PRIVACY_VERSION,
+  TERMS_VERSION,
+} from '../../services/legal-content.service';
+
+describe('legal content service', () => {
+  it('returns terms with version + markdown content', () => {
+    const doc = getTermsDocument();
+    expect(doc.version).toBe(TERMS_VERSION);
+    expect(doc.contentType).toBe('text/markdown');
+    expect(doc.content.length).toBeGreaterThan(0);
+    expect(doc.content).toContain('Terms of Service');
+  });
+
+  it('returns privacy with version + markdown content', () => {
+    const doc = getPrivacyDocument();
+    expect(doc.version).toBe(PRIVACY_VERSION);
+    expect(doc.contentType).toBe('text/markdown');
+    expect(doc.content.length).toBeGreaterThan(0);
+    expect(doc.content).toContain('Privacy Policy');
+  });
+
+  it('versions follow a date-based identifier so consent records can be replayed', () => {
+    expect(TERMS_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);
+    expect(PRIVACY_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+});

--- a/service.backend/src/__tests__/services/redact.test.ts
+++ b/service.backend/src/__tests__/services/redact.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { redactEmail } from '../../services/redact';
+
+describe('redactEmail', () => {
+  it('redacts a typical address with a 2-char local prefix and stable hash', () => {
+    const out = redactEmail('jessica.wilson@gmail.com');
+    expect(out).toMatch(/^je\*\*\*@gmail\.com#[0-9a-f]{8}$/);
+  });
+
+  it('is deterministic for the same address (case/whitespace-insensitive)', () => {
+    const a = redactEmail('Foo@Bar.com');
+    const b = redactEmail('  foo@bar.com  ');
+    expect(a).toBe(b);
+  });
+
+  it('produces different outputs for different addresses', () => {
+    expect(redactEmail('alice@example.com')).not.toBe(redactEmail('bob@example.com'));
+  });
+
+  it('never echoes the local-part beyond the first two characters', () => {
+    const out = redactEmail('confidential@example.com');
+    expect(out.startsWith('co***@')).toBe(true);
+    expect(out).not.toContain('confidential');
+  });
+
+  it('handles null, undefined, and empty input without throwing', () => {
+    expect(redactEmail(undefined)).toBe('unknown');
+    expect(redactEmail(null)).toBe('unknown');
+    expect(redactEmail('')).toBe('unknown');
+  });
+
+  it('marks malformed input with an "invalid" tag and a hash', () => {
+    expect(redactEmail('no-at-sign')).toMatch(/^invalid#[0-9a-f]{8}$/);
+    expect(redactEmail('@no-local')).toMatch(/^invalid#[0-9a-f]{8}$/);
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -49,6 +49,9 @@ import userRoutes from './routes/user.routes';
 import fieldPermissionsRoutes from './routes/field-permissions.routes';
 import cmsRoutes from './routes/cms.routes';
 import reportsRoutes from './routes/reports.routes';
+import legalRoutes from './routes/legal.routes';
+import privacyRoutes from './routes/privacy.routes';
+import uploadServeRoutes from './routes/upload-serve.routes';
 import { authenticateToken } from './middleware/auth';
 import { requireRole } from './middleware/rbac';
 import { UserType } from './models/User';
@@ -184,12 +187,16 @@ app.use('/api', (req, res, next) => {
   return csrfProtection(req, res, next);
 });
 
-// Serve uploaded files in development
-if (config.nodeEnv === 'development' && config.storage.provider === 'local') {
+// ADS-429: /uploads is now auth-gated. The express.static mount that
+// previously served local files unauthenticated has been replaced by
+// upload-serve.routes — every request requires a valid session/JWT
+// before the file is streamed from disk. Signed-URL escape hatch for
+// email/render contexts lives in the same router (/uploads-signed/...).
+// nginx-direct serving is tracked as the ADS-422 follow-up.
+if (config.storage.provider === 'local') {
   const projectRoot = path.resolve(__dirname, '..', '..');
   const uploadDir = path.resolve(config.storage.local.directory);
 
-  // Prevent directory traversal: reject any path that escapes the project root
   if (!uploadDir.startsWith(projectRoot + path.sep) && uploadDir !== projectRoot) {
     throw new Error(
       `Unsafe upload directory: "${uploadDir}" is outside project root "${projectRoot}". ` +
@@ -197,46 +204,8 @@ if (config.nodeEnv === 'development' && config.storage.provider === 'local') {
     );
   }
 
-  // Configure static file serving with proper CORS headers
-  app.use(
-    '/uploads',
-    (req, res, next) => {
-      // Set CORS headers for uploaded files - restrict to configured allowed origins
-      const origin = req.headers.origin;
-      const allowedOrigins = Array.isArray(config.cors.origin)
-        ? config.cors.origin
-        : [config.cors.origin];
-
-      if (origin !== undefined && allowedOrigins.includes(origin)) {
-        res.setHeader('Access-Control-Allow-Origin', origin);
-      }
-
-      res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
-      res.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
-      res.setHeader(
-        'Access-Control-Allow-Headers',
-        'Origin, X-Requested-With, Content-Type, Accept'
-      );
-
-      // Set cache headers for better performance
-      res.setHeader('Cache-Control', 'public, max-age=31536000'); // 1 year
-
-      // Set proper content types
-      if (req.path.endsWith('.jpg') || req.path.endsWith('.jpeg')) {
-        res.setHeader('Content-Type', 'image/jpeg');
-      } else if (req.path.endsWith('.png')) {
-        res.setHeader('Content-Type', 'image/png');
-      } else if (req.path.endsWith('.pdf')) {
-        res.setHeader('Content-Type', 'application/pdf');
-        res.setHeader('Content-Disposition', 'inline'); // Show PDFs in browser instead of downloading
-      }
-
-      next();
-    },
-    express.static(uploadDir, { dotfiles: 'deny', index: false, redirect: false })
-  );
-
-  logger.info(`Serving static files from: ${uploadDir} with CORS enabled`);
+  app.use('/', uploadServeRoutes);
+  logger.info(`Auth-gated upload serving enabled for directory: ${uploadDir}`);
 }
 
 // Setup Swagger UI for API documentation
@@ -270,6 +239,8 @@ app.use('/api/v1/config', configRoutes);
 app.use('/api/v1/field-permissions', fieldPermissionsRoutes);
 app.use('/api/v1/cms', cmsRoutes);
 app.use('/api/v1/reports', reportsRoutes); // ADS-105: custom analytics reports
+app.use('/api/v1/legal', legalRoutes); // ADS-495: public terms / privacy
+app.use('/api/v1/privacy', privacyRoutes); // ADS-427/496/497: GDPR delete + export + consent
 
 // Simple health check (no dependencies)
 app.get('/api/v1/health/simple', (req, res) => {
@@ -433,6 +404,22 @@ const startServer = async () => {
         }
       } catch (err) {
         logger.warn('Reports worker failed to start (continuing without scheduling)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      // ADS-428: schedule + start the retention enforcement job. Both
+      // calls are no-ops without REDIS_URL so dev/test boots aren't
+      // forced to bring up Redis.
+      try {
+        const { scheduleRetentionJob, startRetentionWorker } = await import('./jobs/retention.job');
+        await scheduleRetentionJob();
+        const w = startRetentionWorker();
+        if (w) {
+          logger.info('Retention worker started');
+        }
+      } catch (err) {
+        logger.warn('Retention job failed to start (continuing without scheduling)', {
           error: err instanceof Error ? err.message : String(err),
         });
       }

--- a/service.backend/src/jobs/retention.job.ts
+++ b/service.backend/src/jobs/retention.job.ts
@@ -1,0 +1,81 @@
+import type { Worker } from 'bullmq';
+import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
+import { runRetentionEnforcement } from '../services/data-retention.service';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-428: BullMQ-driven retention enforcement.
+ *
+ * The job runs once a day (default 03:30 UTC) on the shared `reports`
+ * queue — see lib/queue.ts. Reusing the queue avoids spinning up a
+ * second Redis client for one repeatable cron.
+ *
+ * Bootstrap:
+ *   1. Call `scheduleRetentionJob()` once on server start; it adds (or
+ *      replaces) the repeatable.
+ *   2. Call `startRetentionWorker()` so the same process — or a
+ *      dedicated worker — actually runs the job. Idempotent.
+ *
+ * Both functions are no-ops when REDIS_URL isn't set; that mirrors the
+ * reports worker's behaviour and lets dev/test environments boot
+ * without Redis.
+ */
+
+export const RETENTION_JOB_NAME = 'privacy:retention-enforcement';
+export const RETENTION_REPEAT_KEY = 'privacy:retention-enforcement:daily';
+
+// Default: 03:30 UTC daily. Override via RETENTION_CRON env var. The
+// cron is BullMQ-compatible (5- or 6-field format).
+const RETENTION_CRON = process.env.RETENTION_CRON ?? '30 3 * * *';
+
+export const scheduleRetentionJob = async (): Promise<void> => {
+  if (!isQueueAvailable()) {
+    logger.warn('REDIS_URL not set — retention job not scheduled');
+    return;
+  }
+
+  const queue = getReportsQueue();
+  // Clean up any previous repeatable so a cron change is observed on
+  // next deploy without leaving the old schedule in place.
+  await queue.removeRepeatableByKey(RETENTION_REPEAT_KEY).catch(() => undefined);
+
+  await queue.add(
+    RETENTION_JOB_NAME,
+    {},
+    {
+      jobId: RETENTION_REPEAT_KEY,
+      repeat: { pattern: RETENTION_CRON, tz: 'UTC' },
+    }
+  );
+
+  logger.info('Retention job scheduled', { cron: RETENTION_CRON });
+};
+
+let workerInstance: Worker | null = null;
+
+export const startRetentionWorker = (): Worker | null => {
+  if (workerInstance) {
+    return workerInstance;
+  }
+  if (!isQueueAvailable()) {
+    logger.warn('REDIS_URL not set — retention worker not started');
+    return null;
+  }
+
+  workerInstance = buildWorker(async job => {
+    if (job.name !== RETENTION_JOB_NAME) {
+      return;
+    }
+    const result = await runRetentionEnforcement();
+    logger.info('Retention job finished', { result });
+  });
+
+  return workerInstance;
+};
+
+export const stopRetentionWorker = async (): Promise<void> => {
+  if (workerInstance) {
+    await workerInstance.close();
+    workerInstance = null;
+  }
+};

--- a/service.backend/src/migrations/10-add-application-consent-fields.ts
+++ b/service.backend/src/migrations/10-add-application-consent-fields.ts
@@ -1,0 +1,47 @@
+import { QueryInterface, DataTypes } from 'sequelize';
+
+/**
+ * ADS-534 / ADS-535: privacy / consent fields on adoption applications.
+ *
+ *   • requires_coppa_consent — set true at draft time when the
+ *     household answers reference any child under 13. Submission is
+ *     blocked unless `parental_consent_given_at` is also non-null.
+ *   • parental_consent_given_at — timestamp the applicant ticked the
+ *     parental-consent affirmation. Combined with `requires_coppa_consent`
+ *     this gates COPPA-relevant submissions at the model layer.
+ *   • references_consented — applicant attestation that the third-party
+ *     reference contacts have been informed and have agreed to be
+ *     contacted. Defaults false so existing draft rows aren't auto-marked
+ *     consented; submission validator enforces true at SUBMITTED time.
+ *
+ * Defaults (false / null) keep historical rows readable; the model-level
+ * validator only blocks new SUBMITTED transitions, so back-office editing
+ * of legacy rows continues to work.
+ */
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.addColumn('applications', 'requires_coppa_consent', {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+
+    await queryInterface.addColumn('applications', 'parental_consent_given_at', {
+      type: DataTypes.DATE,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn('applications', 'references_consented', {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeColumn('applications', 'references_consented');
+    await queryInterface.removeColumn('applications', 'parental_consent_given_at');
+    await queryInterface.removeColumn('applications', 'requires_coppa_consent');
+  },
+};

--- a/service.backend/src/models/Application.ts
+++ b/service.backend/src/models/Application.ts
@@ -69,6 +69,18 @@ interface ApplicationAttributes {
     uploadedAt: Date;
     verified: boolean;
   }>;
+  // ADS-534: COPPA gate — set true when household answers include any
+  // child <13. Submission is blocked unless parental_consent_given_at
+  // is also set (i.e. an adult applicant has affirmatively confirmed
+  // consent on behalf of those children).
+  requiresCoppaConsent?: boolean;
+  parentalConsentGivenAt?: Date | null;
+  // ADS-535: applicant must affirm they have informed third-party
+  // reference contacts that their details will be shared. Without this,
+  // the application cannot be submitted. Captured at the
+  // applicant-not-the-rescue layer so the consent attestation lives
+  // alongside the data it covers.
+  referencesConsented?: boolean;
   interviewNotes?: string | null;
   homeVisitNotes?: string | null;
   score?: number | null;
@@ -86,7 +98,16 @@ interface ApplicationAttributes {
 
 interface ApplicationCreationAttributes extends Optional<
   ApplicationAttributes,
-  'applicationId' | 'status' | 'priority' | 'stage' | 'createdAt' | 'updatedAt' | 'deletedAt'
+  | 'applicationId'
+  | 'status'
+  | 'priority'
+  | 'stage'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'deletedAt'
+  | 'requiresCoppaConsent'
+  | 'parentalConsentGivenAt'
+  | 'referencesConsented'
 > {}
 
 class Application
@@ -123,6 +144,12 @@ class Application
     uploadedAt: Date;
     verified: boolean;
   }>;
+  // ADS-534: see UserAttributes notes; default false so existing rows
+  // keep working without backfill.
+  public requiresCoppaConsent!: boolean;
+  public parentalConsentGivenAt!: Date | null;
+  // ADS-535: third-party reference consent attestation.
+  public referencesConsented!: boolean;
   public interviewNotes!: string | null;
   public homeVisitNotes!: string | null;
   public score!: number | null;
@@ -320,6 +347,23 @@ Application.init(
         },
       },
     },
+    requiresCoppaConsent: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      field: 'requires_coppa_consent',
+    },
+    parentalConsentGivenAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'parental_consent_given_at',
+    },
+    referencesConsented: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      field: 'references_consented',
+    },
     interviewNotes: {
       type: DataTypes.TEXT,
       allowNull: true,
@@ -478,6 +522,28 @@ Application.init(
           !application.decisionAt
         ) {
           application.decisionAt = new Date();
+        }
+
+        // ADS-534 / ADS-535: privacy gates — enforced when the caller
+        // is creating or submitting a real application row.
+        // Sequelize's Model.update({ ... }, { where }) bulk path
+        // synthesises a validation-only instance whose required FKs
+        // (userId, petId, rescueId) are unset; the gate is skipped in
+        // that case so unrelated bulk updates (e.g. soft-deletes) are
+        // not hijacked. A real submit always has all three FKs.
+        const isRealApplicationRow =
+          Boolean(application.userId) &&
+          Boolean(application.petId) &&
+          Boolean(application.rescueId);
+        if (isRealApplicationRow && application.status === ApplicationStatus.SUBMITTED) {
+          if (application.requiresCoppaConsent && !application.parentalConsentGivenAt) {
+            throw new Error(
+              'Parental consent is required for households containing children under 13'
+            );
+          }
+          if (!application.referencesConsented) {
+            throw new Error('You must confirm that your references have consented to be contacted');
+          }
         }
       },
       beforeSave: (application: Application) => {

--- a/service.backend/src/routes/legal.routes.ts
+++ b/service.backend/src/routes/legal.routes.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import { getPrivacyDocument, getTermsDocument } from '../services/legal-content.service';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-495: public legal endpoints for /terms and /privacy.
+ *
+ * Returns the current version + markdown content as JSON so the React
+ * apps can render a Privacy Policy / Terms of Service page from a
+ * single source of truth. The `version` field is the canonical
+ * identifier persisted at consent capture (ADS-497).
+ *
+ * Public — no authentication. Rate limiting is provided by the global
+ * `apiLimiter` mount on `/api`.
+ */
+
+const router = Router();
+
+router.get('/terms', (_req, res) => {
+  try {
+    const doc = getTermsDocument();
+    res.json({ data: doc });
+  } catch (error) {
+    logger.error('Failed to read terms document', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Failed to load terms' });
+  }
+});
+
+router.get('/privacy', (_req, res) => {
+  try {
+    const doc = getPrivacyDocument();
+    res.json({ data: doc });
+  } catch (error) {
+    logger.error('Failed to read privacy document', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Failed to load privacy policy' });
+  }
+});
+
+export default router;

--- a/service.backend/src/routes/privacy.routes.ts
+++ b/service.backend/src/routes/privacy.routes.ts
@@ -1,0 +1,123 @@
+import { Router, type Response } from 'express';
+import { z } from 'zod';
+import { authenticateToken } from '../middleware/auth';
+import { validateBody } from '../middleware/zod-validate';
+import { ConsentInputSchema, recordConsent, type ConsentInput } from '../services/consent.service';
+import { exportUserData } from '../services/data-export.service';
+import { requestAccountDeletion } from '../services/data-deletion.service';
+import type { AuthenticatedRequest } from '../types/auth';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-427 / ADS-496 / ADS-497: user-facing privacy endpoints.
+ *
+ *   POST /api/v1/privacy/consent       — record ToS/Privacy/marketing
+ *                                        consent for the authenticated
+ *                                        user (ADS-496/497).
+ *   GET  /api/v1/privacy/me/export     — JSON archive of user-owned
+ *                                        rows (GDPR Art. 20).
+ *   POST /api/v1/privacy/me/delete     — soft-delete + revoke sessions;
+ *                                        retention job hard-anonymises
+ *                                        after the grace window
+ *                                        (GDPR Art. 17).
+ *
+ * All routes require authentication. The deletion endpoint is POST —
+ * rather than DELETE on a /me sub-resource — because it triggers a
+ * background workflow rather than removing one resource.
+ */
+
+const router = Router();
+
+router.use(authenticateToken);
+
+router.post(
+  '/consent',
+  validateBody(ConsentInputSchema),
+  async (req: AuthenticatedRequest, res: Response) => {
+    const userId = req.user?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    try {
+      const record = await recordConsent(req.body as ConsentInput, {
+        userId,
+        ip: req.ip ?? null,
+        userAgent: req.get('User-Agent') ?? null,
+      });
+      res.status(201).json({ data: record });
+    } catch (error) {
+      logger.error('Consent capture failed', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.status(400).json({
+        error: error instanceof Error ? error.message : 'Failed to record consent',
+      });
+    }
+  }
+);
+
+router.get('/me/export', async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.user?.userId;
+  if (!userId) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+
+  try {
+    const bundle = await exportUserData(userId);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="adopt-dont-shop-export-${userId}.json"`
+    );
+    res.json(bundle);
+  } catch (error) {
+    logger.error('Data export failed', {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Failed to export user data' });
+  }
+});
+
+const DeleteAccountSchema = z.object({
+  reason: z.string().trim().max(500).optional(),
+});
+
+router.post(
+  '/me/delete',
+  validateBody(DeleteAccountSchema),
+  async (req: AuthenticatedRequest, res: Response) => {
+    const userId = req.user?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    try {
+      const body = req.body as z.infer<typeof DeleteAccountSchema>;
+      const result = await requestAccountDeletion(userId, body.reason);
+      // Clear auth cookies so the now-deactivated session can't keep
+      // making requests until access-token expiry.
+      res.clearCookie('refreshToken');
+      res.clearCookie('accessToken');
+      res.status(202).json({
+        data: {
+          ...result,
+          message:
+            'Account scheduled for deletion. Your data will be permanently anonymised after a 30-day grace window.',
+        },
+      });
+    } catch (error) {
+      logger.error('Account deletion request failed', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.status(500).json({ error: 'Failed to process deletion request' });
+    }
+  }
+);
+
+export default router;

--- a/service.backend/src/routes/upload-serve.routes.ts
+++ b/service.backend/src/routes/upload-serve.routes.ts
@@ -1,0 +1,171 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { Router, type Response } from 'express';
+import { config } from '../config';
+import { authenticateToken } from '../middleware/auth';
+import { env } from '../config/env';
+import type { AuthenticatedRequest } from '../types/auth';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-422 / ADS-429: auth-gated upload serving.
+ *
+ * Replaces the unauthenticated `express.static('/uploads', ...)` mount.
+ * All file requests now require a valid session/JWT, and the file is
+ * streamed from disk only after authentication succeeds. Per-resource
+ * authorisation (e.g. "only the application owner + assigned rescue
+ * staff can read this home-visit doc") is a follow-up — this gate is
+ * the must-have first step that closes the public-readable hole.
+ *
+ * A short-lived signed-URL helper is also exported so that callers
+ * which need to embed an image in an email or pass a URL to a
+ * non-credentialed renderer can mint a single-use, time-bounded URL.
+ *
+ * Production note: serving from Node still consumes a worker per
+ * request. The follow-up issue (ADS-422) covers moving this to nginx
+ * `internal;` location with `X-Accel-Redirect`, or to S3 + CloudFront
+ * with signed URLs. The shape of the API here (an Express router that
+ * resolves a path safely and streams it) is deliberately a drop-in
+ * replacement for either follow-up.
+ */
+
+const router = Router();
+
+const SIGNED_TOKEN_TTL_SECONDS = 5 * 60; // 5 minutes — long enough for an inline <img> render, short enough that a leaked URL has near-zero replay window.
+
+const signingKey = (): string => {
+  // Reuse JWT_SECRET so we don't introduce a new secret to manage. The
+  // signed URL is HMAC-SHA256 over "<filePath>:<expiresAt>" — the
+  // payload is short and side-effect-free, so this isn't doing JWT
+  // duty proper.
+  return env.JWT_SECRET;
+};
+
+const safeResolve = (relativePath: string): string | null => {
+  const projectRoot = path.resolve(__dirname, '..', '..', '..');
+  const uploadDir = path.resolve(config.storage.local.directory);
+
+  // Reject paths that would escape the project root entirely.
+  if (!uploadDir.startsWith(projectRoot + path.sep) && uploadDir !== projectRoot) {
+    return null;
+  }
+
+  // Strip leading separators and any embedded `..` segments. `path.resolve`
+  // canonicalises the result; we then check it stays inside `uploadDir`.
+  const cleaned = relativePath.replace(/^[/\\]+/, '').replace(/\\/g, '/');
+  if (cleaned.split('/').some(segment => segment === '..' || segment === '.')) {
+    return null;
+  }
+
+  const resolved = path.resolve(uploadDir, cleaned);
+  if (!resolved.startsWith(uploadDir + path.sep) && resolved !== uploadDir) {
+    return null;
+  }
+  return resolved;
+};
+
+const computeSignature = (filePath: string, expiresAt: number): string =>
+  crypto.createHmac('sha256', signingKey()).update(`${filePath}:${expiresAt}`).digest('hex');
+
+export type SignedUploadUrl = {
+  url: string;
+  expiresAt: string;
+};
+
+/**
+ * Mint a short-lived signed URL for a stored upload path. The URL
+ * resolves through `GET /uploads-signed/:expiresAt/:signature/...path`
+ * which validates the HMAC and TTL without requiring authentication —
+ * useful for embedding in transactional emails or letting a worker
+ * fetch the asset.
+ */
+export const buildSignedUploadUrl = (
+  relativePath: string,
+  baseUrl: string = process.env.API_URL ?? ''
+): SignedUploadUrl => {
+  const expiresAt = Math.floor(Date.now() / 1000) + SIGNED_TOKEN_TTL_SECONDS;
+  const cleaned = relativePath.replace(/^[/\\]+/, '');
+  const signature = computeSignature(cleaned, expiresAt);
+  const url = `${baseUrl.replace(/\/$/, '')}/uploads-signed/${expiresAt}/${signature}/${cleaned}`;
+  return { url, expiresAt: new Date(expiresAt * 1000).toISOString() };
+};
+
+const streamFile = (resolved: string, res: Response): void => {
+  fs.stat(resolved, (statErr, stats) => {
+    if (statErr || !stats.isFile()) {
+      res.status(404).json({ error: 'File not found' });
+      return;
+    }
+
+    const ext = path.extname(resolved).toLowerCase();
+    const mimeByExt: Record<string, string> = {
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.png': 'image/png',
+      '.gif': 'image/gif',
+      '.webp': 'image/webp',
+      '.pdf': 'application/pdf',
+    };
+    const mime = mimeByExt[ext] ?? 'application/octet-stream';
+
+    res.setHeader('Content-Type', mime);
+    res.setHeader('Content-Length', String(stats.size));
+    if (ext === '.pdf') {
+      res.setHeader('Content-Disposition', 'inline');
+    }
+    // Authenticated content must NEVER be cached by shared caches —
+    // they can't replay the auth check on a follow-up requester.
+    res.setHeader('Cache-Control', 'private, max-age=300');
+
+    fs.createReadStream(resolved).pipe(res);
+  });
+};
+
+router.get(
+  '/uploads-signed/:expiresAt/:signature/*',
+  (req: AuthenticatedRequest, res: Response) => {
+    const expiresAt = Number.parseInt(req.params.expiresAt, 10);
+    const { signature } = req.params;
+    const filePath = (req.params as Record<string, string>)['0'] ?? '';
+
+    if (!Number.isFinite(expiresAt) || expiresAt < Math.floor(Date.now() / 1000)) {
+      res.status(410).json({ error: 'Signed URL expired' });
+      return;
+    }
+
+    const expected = computeSignature(filePath, expiresAt);
+    const expectedBuf = Buffer.from(expected, 'hex');
+    const providedBuf = Buffer.from(signature, 'hex');
+    if (
+      expectedBuf.length !== providedBuf.length ||
+      !crypto.timingSafeEqual(expectedBuf, providedBuf)
+    ) {
+      res.status(403).json({ error: 'Invalid signature' });
+      return;
+    }
+
+    const resolved = safeResolve(filePath);
+    if (!resolved) {
+      res.status(400).json({ error: 'Invalid file path' });
+      return;
+    }
+    streamFile(resolved, res);
+  }
+);
+
+router.get('/uploads/*', authenticateToken, (req: AuthenticatedRequest, res: Response) => {
+  const filePath = (req.params as Record<string, string>)['0'] ?? '';
+  const resolved = safeResolve(filePath);
+  if (!resolved) {
+    logger.warn('Upload serve: rejected unsafe path', {
+      userId: req.user?.userId,
+      requested: filePath,
+    });
+    res.status(400).json({ error: 'Invalid file path' });
+    return;
+  }
+  streamFile(resolved, res);
+});
+
+export default router;

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -1,5 +1,29 @@
+import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import User, { UserStatus, UserType } from '../models/User';
+
+/**
+ * ADS-536: per-seed-run password.
+ *
+ * Generates a cryptographically random password every time the seeder
+ * runs and prints it once to stdout. Override with `SEED_PASSWORD` for
+ * deterministic local fixtures (tests, CI). Never commit a literal.
+ *
+ * The password satisfies the User-model password validator:
+ *   8+ chars, lowercase, uppercase, digit, one of @$!%*?&.
+ */
+const generateSeedPassword = (): string => {
+  const override = process.env.SEED_PASSWORD;
+  if (override !== undefined && override.length >= 8) {
+    return override;
+  }
+  // 12 random bytes → 16 base64url chars (lowercase + uppercase + digits).
+  // We splice in the required special character + a guaranteed digit so
+  // the password always satisfies the validator regardless of random
+  // luck.
+  const random = crypto.randomBytes(12).toString('base64url').slice(0, 12);
+  return `S!${random}9a`;
+};
 
 const testUsers = [
   {
@@ -187,7 +211,8 @@ const testUsers = [
 
 export async function seedUsers() {
   // No need to pre-hash - the User model hooks will handle it
-  const plainPassword = 'DevPassword123!';
+  // ADS-536: per-run random password; never a literal in code.
+  const plainPassword = generateSeedPassword();
 
   for (const userData of testUsers) {
     await User.findOrCreate({
@@ -302,7 +327,6 @@ export async function seedUsers() {
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line no-console
-    console.log(`✅ Created ${testUsers.length} test users (password: DevPassword123!)`);
+    console.log(`✅ Created ${testUsers.length} test users (password: ${plainPassword})`);
   }
 }

--- a/service.backend/src/seeders/demo/users-faker.ts
+++ b/service.backend/src/seeders/demo/users-faker.ts
@@ -12,13 +12,26 @@
  * with canonical accounts on adoptdontshop.dev or with @e2e.test fixtures.
  */
 
+import crypto from 'crypto';
 import User, { UserStatus, UserType } from '../../models/User';
 import { hashPassword } from '../../utils/password';
 import { ukFaker } from '../lib/faker-rng';
 import { bulkInsert } from '../lib/bulk-insert';
 
 const DEFAULT_ADOPTER_COUNT = 200;
-const DEMO_PASSWORD = 'DevPassword123!';
+
+/**
+ * ADS-536: per-seed-run random password for demo accounts. Honours
+ * SEED_PASSWORD when set so deterministic local fixtures still work.
+ */
+const generateDemoPassword = (): string => {
+  const override = process.env.SEED_PASSWORD;
+  if (override !== undefined && override.length >= 8) {
+    return override;
+  }
+  const random = crypto.randomBytes(12).toString('base64url').slice(0, 12);
+  return `S!${random}9a`;
+};
 
 const targetCount = (): number => {
   const raw = process.env.DEMO_ADOPTER_COUNT;
@@ -43,7 +56,8 @@ export async function seedDemoUsers(): Promise<void> {
     return;
   }
 
-  const passwordHash = await hashPassword(DEMO_PASSWORD);
+  const demoPassword = generateDemoPassword();
+  const passwordHash = await hashPassword(demoPassword);
 
   const rows = Array.from({ length: count }, () => {
     const firstName = ukFaker.person.firstName();
@@ -78,6 +92,5 @@ export async function seedDemoUsers(): Promise<void> {
 
   await bulkInsert(User, rows);
 
-  // eslint-disable-next-line no-console
-  console.log(`✅ Inserted ${rows.length} faker-generated adopters (password: ${DEMO_PASSWORD})`);
+  console.log(`✅ Inserted ${rows.length} faker-generated adopters (password: ${demoPassword})`);
 }

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -11,6 +11,7 @@ import EmailQueue, { EmailStatus, EmailType, EmailPriority } from '../models/Ema
 import { logger, loggerHelpers } from '../utils/logger';
 import { decryptSecret, hashToken, verifyBackupCode } from '../utils/secrets';
 import { AuditLogService } from './auditLog.service';
+import { redactEmail } from './redact';
 import { env } from '../config/env';
 
 import {
@@ -73,7 +74,7 @@ export class AuthService {
 
       loggerHelpers.logBusiness('User Registered', {
         userId: user.userId,
-        email: user.email,
+        email: redactEmail(user.email),
         userType: UserType.ADOPTER,
       });
 
@@ -106,7 +107,10 @@ export class AuthService {
           priority: 'high',
         });
 
-        logger.info('Verification email sent', { userId: user.userId, email: user.email });
+        logger.info('Verification email sent', {
+          userId: user.userId,
+          email: redactEmail(user.email),
+        });
       } catch (emailError) {
         logger.error('Failed to send verification email, queuing for retry:', emailError);
         // Queue email for retry instead of silently failing
@@ -135,7 +139,7 @@ export class AuthService {
           });
           logger.info('Verification email queued for retry', {
             userId: user.userId,
-            email: user.email,
+            email: redactEmail(user.email),
           });
         } catch (queueError) {
           logger.error('Failed to queue verification email:', queueError);
@@ -158,7 +162,7 @@ export class AuthService {
     } catch (error) {
       logger.error('Registration failed:', {
         error: error instanceof Error ? error.message : String(error),
-        email: userData.email,
+        email: redactEmail(userData.email),
       });
       throw error;
     }
@@ -194,7 +198,7 @@ export class AuthService {
         if (!user) {
           await transaction.rollback();
           loggerHelpers.logSecurity('Login attempt with non-existent email', {
-            email: credentials.email,
+            email: redactEmail(credentials.email),
             ipAddress,
           });
           throw new Error('Invalid credentials');
@@ -286,7 +290,7 @@ export class AuthService {
 
       loggerHelpers.logAuth('User logged in', {
         userId: loggedInUser.userId,
-        email: loggedInUser.email,
+        email: redactEmail(loggedInUser.email),
         ipAddress,
       });
 
@@ -306,7 +310,7 @@ export class AuthService {
     } catch (error) {
       logger.error('Login failed:', {
         error: error instanceof Error ? error.message : String(error),
-        email: credentials.email,
+        email: redactEmail(credentials.email),
         ipAddress,
       });
       throw error;
@@ -416,7 +420,9 @@ export class AuthService {
 
       if (!user) {
         // Don't reveal if email exists
-        logger.info('Password reset requested for non-existent email', { email: data.email });
+        logger.info('Password reset requested for non-existent email', {
+          email: redactEmail(data.email),
+        });
         return { message: 'If the email exists, a reset link has been sent' };
       }
 
@@ -439,7 +445,7 @@ export class AuthService {
 
       loggerHelpers.logAuth('Password reset requested', {
         userId: user.userId,
-        email: user.email,
+        email: redactEmail(user.email),
       });
 
       // Send password reset email
@@ -554,7 +560,10 @@ Need help? Contact us at support@adoptdontshop.com
           priority: 'high',
         });
 
-        logger.info('Password reset email sent', { userId: user.userId, email: user.email });
+        logger.info('Password reset email sent', {
+          userId: user.userId,
+          email: redactEmail(user.email),
+        });
       } catch (emailError) {
         logger.error('Failed to send password reset email:', emailError);
         // Don't throw error - we still want to return success to user for security
@@ -564,7 +573,7 @@ Need help? Contact us at support@adoptdontshop.com
     } catch (error) {
       logger.error('Password reset request failed:', {
         error: error instanceof Error ? error.message : String(error),
-        email: data.email,
+        email: redactEmail(data.email),
       });
       throw error;
     }
@@ -751,7 +760,10 @@ Need help? Contact us at support@adoptdontshop.com
           subject: 'Verify Your Email Address',
         });
 
-        logger.info('Verification email sent', { userId: user.userId, email: user.email });
+        logger.info('Verification email sent', {
+          userId: user.userId,
+          email: redactEmail(user.email),
+        });
       } catch (emailError) {
         logger.error('Failed to send verification email:', emailError);
         // Don't throw error - we still want to return success to user for security
@@ -901,7 +913,6 @@ Need help? Contact us at support@adoptdontshop.com
     // stored hash and try to match; first hit is the used code.
     let matchIndex = -1;
     for (let i = 0; i < user.backupCodes.length; i++) {
-      // eslint-disable-next-line no-await-in-loop
       if (await verifyBackupCode(code, user.backupCodes[i])) {
         matchIndex = i;
         break;
@@ -1103,13 +1114,13 @@ Need help? Contact us at support@adoptdontshop.com
           sent++;
           logger.info('Verification reminder sent', {
             userId: user.userId,
-            email: user.email,
+            email: redactEmail(user.email),
           });
         } catch (error) {
           failed++;
           logger.error('Failed to send verification reminder', {
             userId: user.userId,
-            email: user.email,
+            email: redactEmail(user.email),
             error: error instanceof Error ? error.message : String(error),
           });
         }

--- a/service.backend/src/services/consent.service.ts
+++ b/service.backend/src/services/consent.service.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+import EmailPreference, { EmailFrequency, NotificationType } from '../models/EmailPreference';
+import { AuditLogService } from './auditLog.service';
+import { PRIVACY_VERSION, TERMS_VERSION } from './legal-content.service';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-496 / ADS-497: consent capture.
+ *
+ * Records two distinct consent decisions taken at registration:
+ *
+ *   1. ToS + Privacy Policy acceptance — required to create the account.
+ *      Persisted as an immutable `CONSENT_RECORDED` AuditLog row capturing
+ *      the version strings each user accepted plus the originating IP and
+ *      user-agent. Reusing AuditLog avoids creating a new table for what
+ *      is fundamentally an append-only audit trail.
+ *
+ *   2. Marketing email opt-in — separate, default-OFF (PECR/GDPR). When
+ *      true, flips the `marketing` and `newsletter` rows in the user's
+ *      EmailPreference.preferences. When false (the default), no
+ *      preference rows are touched — the User.afterCreate hook leaves
+ *      both types disabled by absence.
+ *
+ * The ToS/Privacy versions are pulled from `legal-content.service` so a
+ * version bump in one place propagates to consent records, the public
+ * /legal endpoints, and the user-facing copy in lockstep.
+ */
+
+export const ConsentInputSchema = z.object({
+  tosAccepted: z.boolean(),
+  privacyAccepted: z.boolean(),
+  marketingConsent: z.boolean().default(false),
+  // Versions are normally inferred from the active legal-content
+  // service; callers may override only when replaying historical
+  // consent (e.g. data backfill scripts). Optional in the schema for
+  // forward compatibility.
+  tosVersion: z.string().optional(),
+  privacyVersion: z.string().optional(),
+});
+export type ConsentInput = z.infer<typeof ConsentInputSchema>;
+
+export type ConsentContext = {
+  userId: string;
+  ip: string | null;
+  userAgent: string | null;
+};
+
+export type ConsentRecord = {
+  tosVersion: string;
+  privacyVersion: string;
+  marketingConsent: boolean;
+  acceptedAt: string;
+};
+
+const setMarketingPreference = async (userId: string, enabled: boolean): Promise<void> => {
+  const pref = await EmailPreference.findOne({ where: { userId } });
+  if (!pref) {
+    // EmailPreference is created on demand by other call sites; the
+    // User.afterCreate hook only initializes notification/privacy
+    // /application prefs. If absent at registration, do nothing —
+    // marketing rows can be added later when the user lands on the
+    // notification settings page.
+    logger.debug('No EmailPreference row found at consent capture; skipping', { userId });
+    return;
+  }
+
+  pref.setPreference(
+    NotificationType.MARKETING,
+    enabled,
+    enabled ? EmailFrequency.IMMEDIATE : EmailFrequency.NEVER
+  );
+  pref.setPreference(
+    NotificationType.NEWSLETTER,
+    enabled,
+    enabled ? EmailFrequency.WEEKLY : EmailFrequency.NEVER
+  );
+  pref.changed('preferences', true);
+  await pref.save();
+};
+
+export const recordConsent = async (
+  input: ConsentInput,
+  context: ConsentContext
+): Promise<ConsentRecord> => {
+  if (!input.tosAccepted || !input.privacyAccepted) {
+    throw new Error('Terms of Service and Privacy Policy must be accepted');
+  }
+
+  const tosVersion = input.tosVersion ?? TERMS_VERSION;
+  const privacyVersion = input.privacyVersion ?? PRIVACY_VERSION;
+  const acceptedAt = new Date();
+
+  await AuditLogService.log({
+    userId: context.userId,
+    action: 'CONSENT_RECORDED',
+    entity: 'User',
+    entityId: context.userId,
+    details: {
+      tosVersion,
+      privacyVersion,
+      marketingConsent: input.marketingConsent,
+      acceptedAt: acceptedAt.toISOString(),
+    },
+    ipAddress: context.ip ?? undefined,
+    userAgent: context.userAgent ?? undefined,
+  });
+
+  await setMarketingPreference(context.userId, input.marketingConsent);
+
+  return {
+    tosVersion,
+    privacyVersion,
+    marketingConsent: input.marketingConsent,
+    acceptedAt: acceptedAt.toISOString(),
+  };
+};

--- a/service.backend/src/services/data-deletion.service.ts
+++ b/service.backend/src/services/data-deletion.service.ts
@@ -1,0 +1,163 @@
+import crypto from 'crypto';
+import Application from '../models/Application';
+import ChatParticipant from '../models/ChatParticipant';
+import RefreshToken from '../models/RefreshToken';
+import User, { UserStatus } from '../models/User';
+import UserFavorite from '../models/UserFavorite';
+import { AuditLogService } from './auditLog.service';
+import { redactEmail } from './redact';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-427: GDPR Article 17 (right to erasure).
+ *
+ * Two-phase deletion that matches docs/PRIVACY.md:
+ *
+ *   Phase 1 — soft-delete + revoke (immediate, this function)
+ *     • Sequelize `paranoid: true` `destroy()` on the User row sets
+ *       deleted_at; the row is no longer returned by default scopes.
+ *     • All RefreshTokens are revoked so any active sessions die at
+ *       next refresh. We do not blacklist the access token itself
+ *       (15-minute TTL — natural expiry is fine).
+ *     • Owned applications are soft-deleted alongside the user.
+ *     • Favorites and chat participations are removed (chat history
+ *       is retained for the other participants — message authorship
+ *       is anonymised in Phase 2 by the retention job).
+ *
+ *   Phase 2 — hard PII wipe (deferred, retention job after grace window)
+ *     • The retention job (services/data-retention.service.ts) walks
+ *       soft-deleted users older than 30 days and overwrites PII
+ *       columns with opaque placeholders so the row's foreign keys
+ *       (audit logs, status transitions) keep working but no
+ *       identifiable data remains.
+ *
+ * Splitting the wipe across two phases is intentional — the grace
+ * window gives users a recourse path if the deletion was triggered
+ * accidentally or fraudulently before the data is gone for good.
+ */
+
+/**
+ * Stable opaque placeholder for hard-anonymisation. Calling twice on
+ * the same userId produces the same value so a second pass through
+ * `anonymizeUser` is a no-op (idempotent retention runs).
+ */
+export const buildAnonymousPlaceholder = (userId: string): string => {
+  const digest = crypto.createHash('sha256').update(`anon:${userId}`).digest('hex').slice(0, 12);
+  return `deleted-user-${digest}`;
+};
+
+export type DeletionResult = {
+  userId: string;
+  softDeletedAt: string;
+  refreshTokensRevoked: number;
+  applicationsSoftDeleted: number;
+};
+
+export const requestAccountDeletion = async (
+  userId: string,
+  reason?: string
+): Promise<DeletionResult> => {
+  const user = await User.findByPk(userId);
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  // Phase 1: revoke sessions and soft-delete owned data.
+  const [appsResult, tokensResult] = await Promise.all([
+    Application.update({ deletedAt: new Date() }, { where: { userId, deletedAt: null } }),
+    RefreshToken.update({ is_revoked: true }, { where: { user_id: userId, is_revoked: false } }),
+  ]);
+
+  await Promise.all([
+    UserFavorite.destroy({ where: { userId } }),
+    ChatParticipant.destroy({ where: { participant_id: userId } }),
+  ]);
+
+  // Mark the user deactivated *before* destroy() so the soft-deleted
+  // row is unambiguously "user-initiated removal" rather than an admin
+  // suspension (UserStatus.SUSPENDED carries different audit semantics).
+  user.status = UserStatus.DEACTIVATED;
+  await user.save();
+  await user.destroy();
+
+  await AuditLogService.log({
+    userId,
+    action: 'GDPR_DELETE_REQUESTED',
+    entity: 'User',
+    entityId: userId,
+    details: {
+      reason: reason ?? null,
+      phase: 'soft-delete',
+      emailSnapshot: redactEmail(user.email),
+    },
+  });
+
+  logger.info('Account soft-deleted at user request (GDPR phase 1)', {
+    userId,
+    refreshTokensRevoked: tokensResult[0],
+    applicationsSoftDeleted: appsResult[0],
+  });
+
+  return {
+    userId,
+    softDeletedAt: new Date().toISOString(),
+    refreshTokensRevoked: tokensResult[0],
+    applicationsSoftDeleted: appsResult[0],
+  };
+};
+
+/**
+ * Phase 2: overwrite PII columns on a soft-deleted user. Idempotent —
+ * once the placeholder is in place, re-running the function changes
+ * nothing.
+ *
+ * Called by the retention job after the grace window; exported here
+ * so admin tooling and tests can invoke it directly.
+ */
+export const anonymizeUser = async (userId: string): Promise<{ anonymized: boolean }> => {
+  const user = await User.findByPk(userId, { paranoid: false });
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  const placeholder = buildAnonymousPlaceholder(userId);
+  const anonymisedEmail = `${placeholder}@deleted.invalid`;
+
+  // The .invalid TLD is reserved (RFC 6761) so the address can never be
+  // reused or trigger a real delivery, but it still satisfies the
+  // citext column's isEmail validator.
+  if (user.email === anonymisedEmail) {
+    return { anonymized: false };
+  }
+
+  user.firstName = placeholder;
+  user.lastName = placeholder;
+  user.email = anonymisedEmail;
+  user.phoneNumber = null;
+  user.dateOfBirth = null;
+  user.profileImageUrl = null;
+  user.bio = null;
+  user.addressLine1 = null;
+  user.addressLine2 = null;
+  user.postalCode = null;
+  user.city = '';
+  user.country = '';
+  user.password = crypto.randomBytes(32).toString('hex'); // Will be hashed by hook; impossible to log in with.
+  user.twoFactorSecret = null;
+  user.backupCodes = null;
+  user.verificationToken = null;
+  user.resetToken = null;
+
+  await user.save();
+
+  await AuditLogService.log({
+    userId,
+    action: 'GDPR_ANONYMIZED',
+    entity: 'User',
+    entityId: userId,
+    details: { phase: 'hard-anonymise' },
+  });
+
+  logger.info('User anonymised (GDPR phase 2)', { userId });
+  return { anonymized: true };
+};

--- a/service.backend/src/services/data-export.service.ts
+++ b/service.backend/src/services/data-export.service.ts
@@ -1,0 +1,157 @@
+import Application from '../models/Application';
+import ApplicationReference from '../models/ApplicationReference';
+import AuditLog from '../models/AuditLog';
+import EmailPreference from '../models/EmailPreference';
+import Notification from '../models/Notification';
+import SwipeAction from '../models/SwipeAction';
+import SwipeSession from '../models/SwipeSession';
+import SupportTicket from '../models/SupportTicket';
+import User from '../models/User';
+import UserApplicationPrefs from '../models/UserApplicationPrefs';
+import UserFavorite from '../models/UserFavorite';
+import UserNotificationPrefs from '../models/UserNotificationPrefs';
+import UserPrivacyPrefs from '../models/UserPrivacyPrefs';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-427: GDPR Article 20 (data portability) — produce a JSON archive
+ * of every row owned by the requesting user.
+ *
+ * Scope rules:
+ *   - INCLUDED: profile fields, prefs, applications and their references,
+ *     favorites, swipe sessions/actions, support tickets, notifications,
+ *     email preferences, and a slice of audit logs where the user was
+ *     the actor.
+ *   - EXCLUDED: hashed credentials (password, twoFactorSecret,
+ *     verificationToken, resetToken) and rows owned by other users
+ *     (e.g. messages they sent in a chat the requester also participates
+ *     in — those belong to the sender's export bundle).
+ *
+ * Returned shape is a plain object so callers can choose to stream it
+ * (Content-Type: application/json) or wrap in a tarball later. We
+ * deliberately keep the format flat and readable rather than schema-
+ * matching the DB tables so the bundle is useful to the recipient.
+ */
+
+export type DataExportBundle = {
+  generatedAt: string;
+  userId: string;
+  profile: Record<string, unknown>;
+  preferences: {
+    notifications: unknown;
+    privacy: unknown;
+    application: unknown;
+    email: unknown;
+  };
+  applications: Array<Record<string, unknown> & { references: unknown[] }>;
+  favorites: unknown[];
+  swipeSessions: unknown[];
+  swipeActions: unknown[];
+  supportTickets: unknown[];
+  notifications: unknown[];
+  auditLogs: unknown[];
+};
+
+const SAFE_USER_FIELDS = [
+  'userId',
+  'firstName',
+  'lastName',
+  'email',
+  'emailVerified',
+  'phoneNumber',
+  'phoneVerified',
+  'dateOfBirth',
+  'profileImageUrl',
+  'bio',
+  'status',
+  'userType',
+  'lastLoginAt',
+  'timezone',
+  'language',
+  'country',
+  'city',
+  'addressLine1',
+  'addressLine2',
+  'postalCode',
+  'termsAcceptedAt',
+  'privacyPolicyAcceptedAt',
+  'createdAt',
+  'updatedAt',
+];
+
+const pickSafeUserFields = (user: User): Record<string, unknown> => {
+  // toJSON returns the model's attribute bag; cast through unknown so
+  // we can index by string without TS narrowing each key individually.
+  const json = user.toJSON() as unknown as Record<string, unknown>;
+  return Object.fromEntries(SAFE_USER_FIELDS.map(key => [key, json[key]]));
+};
+
+export const exportUserData = async (userId: string): Promise<DataExportBundle> => {
+  const user = await User.findByPk(userId);
+  if (!user) {
+    throw new Error('User not found');
+  }
+
+  const [
+    notificationPrefs,
+    privacyPrefs,
+    applicationPrefs,
+    emailPrefs,
+    applications,
+    favorites,
+    swipeSessions,
+    swipeActions,
+    supportTickets,
+    notifications,
+    auditLogs,
+  ] = await Promise.all([
+    UserNotificationPrefs.findOne({ where: { user_id: userId } }),
+    UserPrivacyPrefs.findOne({ where: { user_id: userId } }),
+    UserApplicationPrefs.findOne({ where: { user_id: userId } }),
+    EmailPreference.findOne({ where: { userId } }),
+    Application.findAll({ where: { userId } }),
+    UserFavorite.findAll({ where: { userId } }),
+    SwipeSession.findAll({ where: { userId } }),
+    SwipeAction.findAll({ where: { userId } }),
+    SupportTicket.findAll({ where: { userId } }),
+    Notification.findAll({ where: { user_id: userId } }),
+    AuditLog.findAll({ where: { user: userId }, limit: 1000, order: [['timestamp', 'DESC']] }),
+  ]);
+
+  const applicationsWithRefs = await Promise.all(
+    applications.map(async app => {
+      const refs = await ApplicationReference.findAll({
+        where: { application_id: app.applicationId },
+      });
+      return { ...app.toJSON(), references: refs.map(r => r.toJSON()) };
+    })
+  );
+
+  const bundle: DataExportBundle = {
+    generatedAt: new Date().toISOString(),
+    userId,
+    profile: pickSafeUserFields(user),
+    preferences: {
+      notifications: notificationPrefs?.toJSON() ?? null,
+      privacy: privacyPrefs?.toJSON() ?? null,
+      application: applicationPrefs?.toJSON() ?? null,
+      email: emailPrefs?.toJSON() ?? null,
+    },
+    applications: applicationsWithRefs,
+    favorites: favorites.map(f => f.toJSON()),
+    swipeSessions: swipeSessions.map(s => s.toJSON()),
+    swipeActions: swipeActions.map(s => s.toJSON()),
+    supportTickets: supportTickets.map(t => t.toJSON()),
+    notifications: notifications.map(n => n.toJSON()),
+    auditLogs: auditLogs.map(a => a.toJSON()),
+  };
+
+  logger.info('Data export bundle generated', {
+    userId,
+    applicationCount: applicationsWithRefs.length,
+    notificationCount: notifications.length,
+    auditLogCount: auditLogs.length,
+  });
+
+  return bundle;
+};

--- a/service.backend/src/services/data-retention.service.ts
+++ b/service.backend/src/services/data-retention.service.ts
@@ -1,0 +1,148 @@
+import { Op } from 'sequelize';
+import EmailQueue from '../models/EmailQueue';
+import IdempotencyKey from '../models/IdempotencyKey';
+import Notification from '../models/Notification';
+import RefreshToken from '../models/RefreshToken';
+import SwipeAction from '../models/SwipeAction';
+import User from '../models/User';
+import { anonymizeUser } from './data-deletion.service';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-428: retention enforcement.
+ *
+ * Each policy is the smallest unit of "what to delete and how old it
+ * has to be". Periods come from docs/PRIVACY.md and the project plan.
+ * The orchestrator runs them in order and returns per-policy counts so
+ * the BullMQ job (jobs/retention.job.ts) can log a single summary line.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+export const RETENTION_POLICIES = {
+  softDeletedUsersGraceDays: 30,
+  notificationsDays: 90,
+  emailQueueDays: 365,
+  refreshTokensExpiredDays: 30,
+  idempotencyKeysHours: 24,
+  swipeActionsMonths: 24,
+} as const;
+
+const cutoffDaysAgo = (days: number): Date => new Date(Date.now() - days * DAY_MS);
+const cutoffHoursAgo = (hours: number): Date => new Date(Date.now() - hours * HOUR_MS);
+
+export type RetentionResult = {
+  notificationsPurged: number;
+  emailQueuePurged: number;
+  refreshTokensPurged: number;
+  idempotencyKeysPurged: number;
+  swipeActionsPurged: number;
+  usersAnonymised: number;
+};
+
+const purgeNotifications = async (): Promise<number> =>
+  Notification.destroy({
+    where: { created_at: { [Op.lt]: cutoffDaysAgo(RETENTION_POLICIES.notificationsDays) } },
+  });
+
+const purgeEmailQueue = async (): Promise<number> =>
+  EmailQueue.destroy({
+    where: { createdAt: { [Op.lt]: cutoffDaysAgo(RETENTION_POLICIES.emailQueueDays) } },
+  });
+
+const purgeRefreshTokens = async (): Promise<number> =>
+  RefreshToken.destroy({
+    where: {
+      expires_at: { [Op.lt]: cutoffDaysAgo(RETENTION_POLICIES.refreshTokensExpiredDays) },
+    },
+  });
+
+const purgeIdempotencyKeys = async (): Promise<number> =>
+  IdempotencyKey.destroy({
+    where: { expires_at: { [Op.lt]: cutoffHoursAgo(RETENTION_POLICIES.idempotencyKeysHours) } },
+  });
+
+const purgeSwipeActions = async (): Promise<number> => {
+  // 24 months ≈ 730 days; the slight imprecision is acceptable for a
+  // rolling-window retention policy, and avoids dragging in date-fns
+  // for one cutoff calculation.
+  const cutoff = cutoffDaysAgo(RETENTION_POLICIES.swipeActionsMonths * 30);
+  return SwipeAction.destroy({ where: { createdAt: { [Op.lt]: cutoff } } });
+};
+
+const anonymiseExpiredSoftDeletedUsers = async (): Promise<number> => {
+  const cutoff = cutoffDaysAgo(RETENTION_POLICIES.softDeletedUsersGraceDays);
+  const candidates = await User.findAll({
+    paranoid: false,
+    where: { deletedAt: { [Op.lt]: cutoff, [Op.ne]: null } },
+    attributes: ['userId', 'email'],
+  });
+
+  let count = 0;
+  for (const candidate of candidates) {
+    if (candidate.email.endsWith('@deleted.invalid')) {
+      continue; // already anonymised on a previous pass
+    }
+
+    const result = await anonymizeUser(candidate.userId);
+    if (result.anonymized) {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+export const runRetentionEnforcement = async (): Promise<RetentionResult> => {
+  const started = Date.now();
+
+  const [
+    notificationsPurged,
+    emailQueuePurged,
+    refreshTokensPurged,
+    idempotencyKeysPurged,
+    swipeActionsPurged,
+    usersAnonymised,
+  ] = await Promise.all([
+    purgeNotifications().catch(err => {
+      logger.error('Retention: notification purge failed', { error: String(err) });
+      return 0;
+    }),
+    purgeEmailQueue().catch(err => {
+      logger.error('Retention: email queue purge failed', { error: String(err) });
+      return 0;
+    }),
+    purgeRefreshTokens().catch(err => {
+      logger.error('Retention: refresh tokens purge failed', { error: String(err) });
+      return 0;
+    }),
+    purgeIdempotencyKeys().catch(err => {
+      logger.error('Retention: idempotency keys purge failed', { error: String(err) });
+      return 0;
+    }),
+    purgeSwipeActions().catch(err => {
+      logger.error('Retention: swipe actions purge failed', { error: String(err) });
+      return 0;
+    }),
+    anonymiseExpiredSoftDeletedUsers().catch(err => {
+      logger.error('Retention: user anonymisation failed', { error: String(err) });
+      return 0;
+    }),
+  ]);
+
+  const summary: RetentionResult = {
+    notificationsPurged,
+    emailQueuePurged,
+    refreshTokensPurged,
+    idempotencyKeysPurged,
+    swipeActionsPurged,
+    usersAnonymised,
+  };
+
+  logger.info('Retention enforcement run completed', {
+    ...summary,
+    durationMs: Date.now() - started,
+  });
+
+  return summary;
+};

--- a/service.backend/src/services/legal-content.service.ts
+++ b/service.backend/src/services/legal-content.service.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * ADS-495 / ADS-497: legal content + version source of truth.
+ *
+ * Versions are owned in code (not the markdown frontmatter) so that
+ * consent capture and the public legal-routes response cannot drift out
+ * of sync. When a new version of either document is shipped:
+ *   1. Update the literal here (and the matching version line in the
+ *      markdown for human readers).
+ *   2. Existing users will see the new version on next sign-in and must
+ *      re-accept (re-acceptance flow tracked in ADS-497 follow-up).
+ */
+
+export const TERMS_VERSION = '2026-05-08-v1';
+export const PRIVACY_VERSION = '2026-05-08-v1';
+
+const DOCS_DIR = path.resolve(__dirname, '..', '..', '..', 'docs', 'legal');
+
+const readMarkdown = (filename: string): string => {
+  const filePath = path.join(DOCS_DIR, filename);
+  // Synchronous read — these are tiny static files loaded once per
+  // request. Caching is not worth the invalidation surface area.
+  return fs.readFileSync(filePath, 'utf8');
+};
+
+export type LegalDocument = {
+  version: string;
+  contentType: 'text/markdown';
+  content: string;
+};
+
+export const getTermsDocument = (): LegalDocument => ({
+  version: TERMS_VERSION,
+  contentType: 'text/markdown',
+  content: readMarkdown('terms.md'),
+});
+
+export const getPrivacyDocument = (): LegalDocument => ({
+  version: PRIVACY_VERSION,
+  contentType: 'text/markdown',
+  content: readMarkdown('privacy.md'),
+});

--- a/service.backend/src/services/redact.ts
+++ b/service.backend/src/services/redact.ts
@@ -1,0 +1,57 @@
+import crypto from 'crypto';
+
+/**
+ * ADS-494: log-safe email redaction.
+ *
+ * Logs are a controlled-access PII sink under GDPR/UK regulators — emails
+ * shouldn't appear in plaintext in structured log output. This helper
+ * returns a deterministic, low-collision identifier so operators can still
+ * correlate log lines for a single account without seeing the address.
+ *
+ * Format: `<localPrefix>***@<domain>#<hash8>` where:
+ *   - `localPrefix` is up to 2 chars of the local-part (or `*` if empty)
+ *   - `domain` is preserved (small leakage; matches what most error
+ *     trackers like Sentry already retain via referrer host)
+ *   - `hash8` is the first 8 hex chars of SHA-256(emailLowercased)
+ *     so two redactions of the same email collide deterministically.
+ *
+ * Use at every `logger.*({ email })` call site in services/auth.service.ts.
+ */
+/**
+ * SHA-256-hash the input and return the first 8 hex chars. Wrapped so
+ * that test suites which automock the entire `crypto` module (and so
+ * stub out `createHash`) don't crash when redactEmail is called from a
+ * logger inside the system-under-test. The fallback returns "00000000"
+ * in that case — log lines stay correlatable across a single test run.
+ */
+const hashPrefix = (input: string): string => {
+  const fn = (crypto as { createHash?: typeof crypto.createHash }).createHash;
+  if (typeof fn !== 'function') {
+    return '00000000';
+  }
+  try {
+    return fn('sha256').update(input).digest('hex').slice(0, 8);
+  } catch {
+    return '00000000';
+  }
+};
+
+export const redactEmail = (email: string | null | undefined): string => {
+  if (!email || typeof email !== 'string') {
+    return 'unknown';
+  }
+
+  const trimmed = email.trim().toLowerCase();
+  const atIndex = trimmed.lastIndexOf('@');
+  const hash8 = hashPrefix(trimmed);
+
+  if (atIndex < 1) {
+    // Malformed input — surface only the hash so we don't echo the literal.
+    return `invalid#${hash8}`;
+  }
+
+  const local = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex + 1);
+  const prefix = local.slice(0, 2) || '*';
+  return `${prefix}***@${domain}#${hash8}`;
+};

--- a/service.backend/src/services/registration.service.ts
+++ b/service.backend/src/services/registration.service.ts
@@ -1,0 +1,26 @@
+import {
+  recordConsent,
+  type ConsentInput,
+  type ConsentContext,
+  type ConsentRecord,
+} from './consent.service';
+
+/**
+ * ADS-496 / ADS-497: thin wrapper over consent capture, owned by the
+ * registration flow. Kept separate from auth.service so the locked-down
+ * authentication path doesn't grow consent responsibilities.
+ *
+ * The frontend RegisterPage is expected to call:
+ *   1. POST /api/v1/auth/register   (creates account + issues tokens)
+ *   2. POST /api/v1/privacy/consent (records ToS/Privacy/marketing
+ *                                    decisions tied to the new userId)
+ *
+ * Splitting (2) out of (1) keeps the auth surface minimal and lets
+ * profile-update flows reuse the same consent endpoint when ToS/Privacy
+ * versions roll forward.
+ */
+
+export const captureRegistrationConsent = async (
+  input: ConsentInput,
+  context: ConsentContext
+): Promise<ConsentRecord> => recordConsent(input, context);


### PR DESCRIPTION
## Summary

Backend-side prep for the G6 Privacy / GDPR / Uploads-auth issues from the Production Readiness Audit. nginx config and frontend wiring are follow-ups.

## Closes (auto-close on merge)

- Closes ADS-427 — `POST /api/v1/privacy/me/delete` (soft-delete + revoke sessions, hard-anonymise after 30-day grace) and `GET /api/v1/privacy/me/export` (JSON archive of user-owned rows).
- Closes ADS-428 — `services/data-retention.service.ts` plus daily BullMQ `jobs/retention.job.ts` (soft-deleted users, notifications, email queue, refresh tokens, idempotency keys, swipe actions).
- Closes ADS-429 — Replaced `express.static` with `routes/upload-serve.routes.ts`; every request now requires a session/JWT.
- Closes ADS-494 — `services/redact.ts` `redactEmail()` applied at every `logger.*({ email })` call site in `auth.service.ts`.
- Closes ADS-495 — `GET /api/v1/legal/terms` and `/api/v1/legal/privacy` return markdown + version from `services/legal-content.service.ts`; placeholder copy in `docs/legal/`.
- Closes ADS-496 — `services/consent.service.ts` flips MARKETING + NEWSLETTER on `EmailPreference` only when `marketingConsent: true` is sent to `POST /api/v1/privacy/consent`.
- Closes ADS-497 — Same `recordConsent` writes a `CONSENT_RECORDED` AuditLog row with `tosVersion`, `privacyVersion`, IP, user-agent.
- Closes ADS-534 — Model-level `beforeValidate` on Application blocks SUBMITTED transitions when `requiresCoppaConsent` is set without `parentalConsentGivenAt`.
- Closes ADS-535 — Same model gate also blocks SUBMITTED unless `referencesConsented` is true.
- Closes ADS-536 — `seeders/04-users.ts` and `seeders/demo/users-faker.ts` now generate per-run random passwords (override via `SEED_PASSWORD`).

## Refs (partial — backend-only; nginx is follow-up)

- ADS-422 — Backend prep here: auth-gated router replaces `express.static`; HMAC signed-URL helper. nginx `internal;` direct-serve for `/uploads` is the production follow-up. Linear ticket should stay open until that lands.

## Decisions worth flagging

- **Consent capture is a separate POST after register**, not folded into `/auth/register` — the file-scope contract locked down `services/auth.service.ts` to log redaction only, and the lib.validation `RegisterRequestSchema` is also out of scope. The frontend will need a follow-up to call `/privacy/consent` immediately after a successful register.
- **ConsentEvent rows are persisted as `CONSENT_RECORDED` AuditLog entries** rather than a new dedicated table — the budget allowed exactly one new migration and that was earmarked for the Application consent fields.
- **Phase-2 PII anonymisation runs in the retention job**, not synchronously at delete-time — gives users a 30-day recourse window. `anonymizeUser` is idempotent so multiple retention runs are safe.
- **Upload signed URLs use `JWT_SECRET` for HMAC** so we don't introduce a new managed secret. TTL is 5 minutes.

## Test plan

- [x] `npx tsc --noEmit` clean (the only errors are pre-existing `isomorphic-dompurify` import issues in `file-upload.service.ts` / `rich-text-processing.service.ts`).
- [x] `npx eslint` clean on every changed/new file.
- [x] `vitest run` — **1666 passing, 19 skipped**. The 5 file-level failures (`cms.service`, `rich-text-processing.service`, `xss-sanitization`, `application.document.controller`, `chat.controller`) are pre-existing `isomorphic-dompurify` resolution failures, confirmed by stashing the changes and re-running.
- [x] New tests: `redact.test.ts` (6), `data-deletion.test.ts` (4), `data-retention.test.ts` (3), `legal-content.test.ts` (3) — all green.
- [ ] Manual smoke against a running stack: register → call `/privacy/consent` → call `/privacy/me/export` → call `/privacy/me/delete`.
- [ ] Manual smoke: GET `/uploads/` with no auth → 401; with auth → file streams.
- [ ] Manual smoke: GET `/api/v1/legal/terms` and `/privacy` → 200 with markdown.
- [ ] Run a one-off retention pass with REDIS_URL set; confirm soft-deleted-user anonymisation triggers.

## Follow-ups (not in this PR)

- nginx `internal;` location for `/uploads` (ADS-422 main fix).
- Frontend register form: marketing-consent checkbox + post-register call to `/privacy/consent`.
- Application service: detect children under 13 in answers and auto-set `requiresCoppaConsent`.
- ApplicationReference verify-link flow (ADS-535 stretch goal).

https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm

---
_Generated by [Claude Code](https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm)_