### PR TITLE
[Frontend] app.rescue: localhost URLs, ProtectedRoute, double-submit, meta (5 issues)

### DIFF
--- a/app.rescue/index.html
+++ b/app.rescue/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Rescue App</title>
+    <meta
+      name="description"
+      content="Adopt Don't Shop Rescue Portal — manage your rescue's pets, adoption applications, staff, events, and communications in one place."
+    />
+    <title>Rescue Portal | Adopt Don't Shop</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/app.rescue/src/App.tsx
+++ b/app.rescue/src/App.tsx
@@ -17,6 +17,7 @@ const RescueSettings = lazy(() => import('./pages/RescueSettings'));
 const Communication = lazy(() => import('./pages/Communication'));
 const Events = lazy(() => import('./pages/Events'));
 const AcceptInvitation = lazy(() => import('./pages/AcceptInvitation'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
 const Analytics = lazy(() => import('./pages/Analytics'));
 // Reports (ADS-105)
 const Reports = lazy(() => import('./pages/Reports'));
@@ -47,6 +48,7 @@ function App() {
       <Suspense fallback={<PageLoader />}>
         <Routes>
           <Route path="/accept-invitation" element={<AcceptInvitation />} />
+          <Route path="/login" element={<LoginPage />} />
 
           {/* Protected Routes */}
           <Route

--- a/app.rescue/src/components/ProtectedRoute.test.tsx
+++ b/app.rescue/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the css module so vanilla-extract style imports don't blow up.
+vi.mock('./ProtectedRoute.css', () => ({
+  loadingContainer: 'loading-container',
+  loadingCard: 'loading-card',
+  loadingSpinner: 'loading-spinner',
+}));
+
+// Mock lib.components — keep it minimal: just render children/text.
+vi.mock('@adopt-dont-shop/lib.components', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+// We use vi.hoisted so the mock factory can read this state without TDZ issues.
+const authState = vi.hoisted(() => ({
+  current: {
+    isAuthenticated: false,
+    isLoading: false,
+    user: null as { userId: string } | null,
+  },
+}));
+
+vi.mock('@adopt-dont-shop/lib.auth', () => ({
+  useAuth: () => authState.current,
+}));
+
+import { ProtectedRoute } from './ProtectedRoute';
+
+describe('ProtectedRoute', () => {
+  it('redirects unauthenticated users to /login instead of rendering protected content', () => {
+    authState.current = { isAuthenticated: false, isLoading: false, user: null };
+
+    render(
+      <MemoryRouter initialEntries={['/pets']}>
+        <Routes>
+          <Route
+            path="/pets"
+            element={
+              <ProtectedRoute>
+                <div>Protected Pet Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login Page Stand-In</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // The protected content must NOT be rendered in-place.
+    expect(screen.queryByText('Protected Pet Content')).not.toBeInTheDocument();
+    // The router should have navigated to /login.
+    expect(screen.getByText('Login Page Stand-In')).toBeInTheDocument();
+  });
+
+  it('renders protected content when the user is authenticated', () => {
+    authState.current = {
+      isAuthenticated: true,
+      isLoading: false,
+      user: { userId: 'user-1' },
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/pets']}>
+        <Routes>
+          <Route
+            path="/pets"
+            element={
+              <ProtectedRoute>
+                <div>Protected Pet Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login Page Stand-In</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Protected Pet Content')).toBeInTheDocument();
+    expect(screen.queryByText('Login Page Stand-In')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading state while authentication is being checked', () => {
+    authState.current = { isAuthenticated: false, isLoading: true, user: null };
+
+    render(
+      <MemoryRouter initialEntries={['/pets']}>
+        <Routes>
+          <Route
+            path="/pets"
+            element={
+              <ProtectedRoute>
+                <div>Protected Pet Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login Page Stand-In</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Protected Pet Content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Login Page Stand-In')).not.toBeInTheDocument();
+  });
+});

--- a/app.rescue/src/components/ProtectedRoute.tsx
+++ b/app.rescue/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
-import LoginPage from '../pages/LoginPage';
 import { Text, Card } from '@adopt-dont-shop/lib.components';
 import * as styles from './ProtectedRoute.css';
 
@@ -10,6 +10,7 @@ interface ProtectedRouteProps {
 
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const { isAuthenticated, isLoading, user } = useAuth();
+  const location = useLocation();
 
   // Show loading spinner while checking authentication
   if (isLoading) {
@@ -23,9 +24,10 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
     );
   }
 
-  // Show auth page if not authenticated
+  // Redirect to login if not authenticated, preserving the attempted
+  // location so the login page can return the user there after sign-in.
   if (!isAuthenticated || !user) {
-    return <LoginPage />;
+    return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   // Render protected content

--- a/app.rescue/src/components/events/EventForm.test.tsx
+++ b/app.rescue/src/components/events/EventForm.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the css module so vanilla-extract style imports don't blow up.
+vi.mock('./EventForm.css', () => ({
+  formContainer: 'form-container',
+  formTitle: 'form-title',
+  formGrid: 'form-grid',
+  formGroup: 'form-group',
+  formRow: 'form-row',
+  formActions: 'form-actions',
+  label: 'label',
+  input: 'input',
+  textArea: 'text-area',
+  select: 'select',
+  helperText: 'helper-text',
+  checkboxGroup: 'checkbox-group',
+  checkbox: 'checkbox',
+  button: ({ variant }: { variant: string }) => `button-${variant}`,
+}));
+
+import EventForm from './EventForm';
+
+const fillRequiredFields = () => {
+  fireEvent.change(screen.getByLabelText(/Event Name/i), {
+    target: { name: 'name', value: 'Spring Adoption' },
+  });
+  fireEvent.change(screen.getByLabelText(/Description/i), {
+    target: { name: 'description', value: 'Annual spring adoption fair' },
+  });
+  fireEvent.change(screen.getByLabelText(/Start Date & Time/i), {
+    target: { name: 'startDate', value: '2026-06-01T10:00' },
+  });
+  fireEvent.change(screen.getByLabelText(/End Date & Time/i), {
+    target: { name: 'endDate', value: '2026-06-01T16:00' },
+  });
+};
+
+describe('EventForm double-submit protection', () => {
+  it('only fires onSubmit once when the user clicks submit twice in quick succession', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    // The parent owns the in-flight flag and flips `submitting` on first submit.
+    const { rerender } = render(
+      <EventForm onSubmit={onSubmit} onCancel={onCancel} submitting={false} />
+    );
+
+    fillRequiredFields();
+
+    const submit = screen.getByRole('button', { name: /Create Event/i });
+
+    // First click — parent will set submitting=true after this fires.
+    fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // Re-render with submitting=true (mimics the parent's state update).
+    rerender(<EventForm onSubmit={onSubmit} onCancel={onCancel} submitting={true} />);
+
+    const submitWhileBusy = screen.getByRole('button', { name: /Saving/i });
+    expect(submitWhileBusy).toBeDisabled();
+
+    fireEvent.click(submitWhileBusy);
+    // Still only one call — second click was ignored.
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the cancel button while a submission is in flight', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<EventForm onSubmit={onSubmit} onCancel={onCancel} submitting={true} />);
+
+    expect(screen.getByRole('button', { name: /Cancel/i })).toBeDisabled();
+  });
+
+  it('shows a busy label on the submit button while submitting', () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <EventForm onSubmit={onSubmit} onCancel={onCancel} submitting={true} isEditing={false} />
+    );
+
+    expect(screen.getByRole('button', { name: /Saving/i })).toHaveAttribute('aria-busy', 'true');
+  });
+});

--- a/app.rescue/src/components/events/EventForm.tsx
+++ b/app.rescue/src/components/events/EventForm.tsx
@@ -7,9 +7,18 @@ interface EventFormProps {
   onSubmit: (data: CreateEventInput) => void;
   onCancel: () => void;
   isEditing?: boolean;
+  // Set to true while a parent-managed mutation is in flight so the submit
+  // button is disabled and double-submits are prevented (ADS-483).
+  submitting?: boolean;
 }
 
-const EventForm: React.FC<EventFormProps> = ({ initialData, onSubmit, onCancel, isEditing }) => {
+const EventForm: React.FC<EventFormProps> = ({
+  initialData,
+  onSubmit,
+  onCancel,
+  isEditing,
+  submitting = false,
+}) => {
   const [formData, setFormData] = useState<CreateEventInput>({
     name: initialData?.name || '',
     description: initialData?.description || '',
@@ -70,6 +79,9 @@ const EventForm: React.FC<EventFormProps> = ({ initialData, onSubmit, onCancel, 
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (submitting) {
+      return;
+    }
     onSubmit(formData);
   };
 
@@ -335,11 +347,17 @@ const EventForm: React.FC<EventFormProps> = ({ initialData, onSubmit, onCancel, 
             type="button"
             className={styles.button({ variant: 'secondary' })}
             onClick={onCancel}
+            disabled={submitting}
           >
             Cancel
           </button>
-          <button type="submit" className={styles.button({ variant: 'primary' })}>
-            {isEditing ? 'Update Event' : 'Create Event'}
+          <button
+            type="submit"
+            className={styles.button({ variant: 'primary' })}
+            disabled={submitting}
+            aria-busy={submitting}
+          >
+            {submitting ? 'Saving...' : isEditing ? 'Update Event' : 'Create Event'}
           </button>
         </div>
       </form>

--- a/app.rescue/src/pages/Events.tsx
+++ b/app.rescue/src/pages/Events.tsx
@@ -48,6 +48,8 @@ const Events: React.FC = () => {
   // State for loading and errors
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // In-flight flag to prevent duplicate create/update/delete submissions.
+  const [submitting, setSubmitting] = useState(false);
 
   // Fetch events on mount and when filters change
   useEffect(() => {
@@ -128,6 +130,10 @@ const Events: React.FC = () => {
    * Handle event creation
    */
   const handleCreateEvent = async (eventData: CreateEventInput) => {
+    if (submitting) {
+      return;
+    }
+    setSubmitting(true);
     try {
       const newEvent = await eventsService.createEvent(eventData);
       setEvents(prev => [newEvent, ...prev]);
@@ -137,6 +143,8 @@ const Events: React.FC = () => {
     } catch (err) {
       console.error('Failed to create event:', err);
       alert('Failed to create event. Please try again.');
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -144,10 +152,11 @@ const Events: React.FC = () => {
    * Handle event update
    */
   const handleUpdateEvent = async (eventData: CreateEventInput) => {
-    if (!eventToEdit) {
+    if (!eventToEdit || submitting) {
       return;
     }
 
+    setSubmitting(true);
     try {
       const updates: UpdateEventInput = {
         ...eventData,
@@ -166,6 +175,8 @@ const Events: React.FC = () => {
     } catch (err) {
       console.error('Failed to update event:', err);
       alert('Failed to update event. Please try again.');
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -173,10 +184,14 @@ const Events: React.FC = () => {
    * Handle event deletion
    */
   const handleDeleteEvent = async (eventId: string) => {
+    if (submitting) {
+      return;
+    }
     if (!confirm('Are you sure you want to delete this event? This action cannot be undone.')) {
       return;
     }
 
+    setSubmitting(true);
     try {
       await eventsService.deleteEvent(eventId);
       setEvents(prev => prev.filter(event => event.id !== eventId));
@@ -186,6 +201,8 @@ const Events: React.FC = () => {
     } catch (err) {
       console.error('Failed to delete event:', err);
       alert('Failed to delete event. Please try again.');
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -356,12 +373,10 @@ const Events: React.FC = () => {
       </div>
 
       {/* Create Event Modal */}
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
         className={clsx(styles.modal, showCreateModal ? styles.modalOpen : styles.modalClosed)}
         onClick={() => handleCloseModal('create')}
       >
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
           <div className={styles.modalHeader}>
             <h2 className={styles.modalTitle}>Create New Event</h2>
@@ -374,18 +389,17 @@ const Events: React.FC = () => {
               onSubmit={handleCreateEvent}
               onCancel={() => handleCloseModal('create')}
               isEditing={false}
+              submitting={submitting}
             />
           </div>
         </div>
       </div>
 
       {/* Edit Event Modal */}
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
         className={clsx(styles.modal, showEditModal ? styles.modalOpen : styles.modalClosed)}
         onClick={() => handleCloseModal('edit')}
       >
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
           <div className={styles.modalHeader}>
             <h2 className={styles.modalTitle}>Edit Event</h2>
@@ -413,6 +427,7 @@ const Events: React.FC = () => {
                 onSubmit={handleUpdateEvent}
                 onCancel={() => handleCloseModal('edit')}
                 isEditing={true}
+                submitting={submitting}
               />
             )}
           </div>
@@ -420,12 +435,10 @@ const Events: React.FC = () => {
       </div>
 
       {/* Event Details Modal */}
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
         className={clsx(styles.modal, showDetailsModal ? styles.modalOpen : styles.modalClosed)}
         onClick={() => handleCloseModal('details')}
       >
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
           <div className={styles.modalHeader}>
             <h2 className={styles.modalTitle}>Event Details</h2>

--- a/app.rescue/src/pages/LoginPage.tsx
+++ b/app.rescue/src/pages/LoginPage.tsx
@@ -1,12 +1,19 @@
 import { AuthLayout, LoginForm } from '@adopt-dont-shop/lib.auth';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import * as styles from './LoginPage.css';
+
+type LocationState = {
+  from?: { pathname?: string };
+};
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleSuccess = () => {
-    navigate('/', { replace: true });
+    const state = location.state as LocationState | null;
+    const redirectTo = state?.from?.pathname ?? '/';
+    navigate(redirectTo, { replace: true });
   };
 
   return (

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -39,14 +39,12 @@ const PetManagement: React.FC = () => {
         contactPhone: '555-0123',
       };
 
-      // Call the API using lib.api
-      const result = await apiService.post<any>(
-        'http://localhost:5000/api/v1/rescues',
-        demoRescueData
-      );
+      // Call the API using lib.api (relative path resolves against the
+      // configured API base URL, so this works in any environment).
+      const result = await apiService.post<any>('/api/v1/rescues', demoRescueData);
 
       // Now update the user with the rescue ID
-      await apiService.patch<any>(`http://localhost:5000/api/v1/users/${user?.userId}`, {
+      await apiService.patch<any>(`/api/v1/users/${user?.userId}`, {
         rescueId: result.data.rescueId,
       });
 
@@ -150,9 +148,7 @@ const PetManagement: React.FC = () => {
   const fetchStats = async () => {
     try {
       // Try to get stats using the dashboard endpoint which works
-      const dashboardData = await apiService.get<any>(
-        'http://localhost:5000/api/v1/dashboard/rescue'
-      );
+      const dashboardData = await apiService.get<any>('/api/v1/dashboard/rescue');
 
       // Map dashboard data to our stats format
       setStats({


### PR DESCRIPTION
## Summary

Production Readiness Audit fixes for `app.rescue`. Four code fixes plus a verified-already-fixed item.

## Closes (auto-close on merge)

- Closes ADS-415 — `app.rescue/src/pages/PetManagement.tsx` was making three direct calls to `http://localhost:5000/api/v1/...` via `apiService`, silently bypassing the configured base URL and breaking in any non-local environment. Switched to relative paths (`/api/v1/rescues`, `/api/v1/users/:userId`, `/api/v1/dashboard/rescue`) so `apiService` applies `VITE_API_BASE_URL` consistently.
- Closes ADS-416 — Verified the rescue dashboard frontend (`app.rescue/src/services/dashboardService.ts` → `getRecentActivities`) already calls the real `/api/v1/dashboard/rescue` endpoint and maps `response.data.recentActivity`. The backend stub was removed in commit `c8acd45 fix(dashboard): replace hardcoded mock activity with real rescue-scoped data (ADS-158)` already on the base branch. No frontend stub remained — issue is closed by upstream work.
- Closes ADS-424 — `ProtectedRoute` returned `<LoginPage />` in-place inside the protected layout subtree, leaking layout structure and losing the attempted location. Now uses `<Navigate to="/login" replace state={{ from: location }} />`, registers `/login` as a public route in `App.tsx`, and `LoginPage` honours `state.from` on successful login. Added `ProtectedRoute.test.tsx` covering: redirect when unauthenticated, pass-through when authenticated, and the loading state.
- Closes ADS-483 — Added a per-action `submitting` flag in `Events.tsx`, plumbed it into `EventForm`. Submit button shows a "Saving…" label, sets `aria-busy`, and disables itself (and Cancel) while a mutation is in flight; create/update/delete handlers early-return if already submitting. Added `EventForm.test.tsx` that simulates a double-click while busy and asserts only one `onSubmit` call fires. Also dropped six orphan `eslint-disable-next-line jsx-a11y/...` directives in `Events.tsx` — the rules they reference are not loaded by the root eslint config, so the directives suppressed nothing and were blocking the pre-commit lint hook.
- Closes ADS-520 — `app.rescue/index.html`: replaced the generic "Rescue App" title with `Rescue Portal | Adopt Don't Shop` and added a meaningful `<meta name="description">`.

## Test plan

- [x] `npx vitest run` in `app.rescue` — all 9 test files (123 tests) pass, including the two new test files
- [x] `npx tsc --noEmit` in `app.rescue` — clean
- [x] `npx eslint` on every touched file — only pre-existing warnings; zero new errors
- [ ] Manual: visit `/pets` while logged out and confirm browser navigates to `/login` (not in-place render); after login, confirm redirect back to `/pets`
- [ ] Manual: open Create/Edit Event modal, double-click "Create Event" — only one network request fires; button shows "Saving…"
- [ ] Manual: confirm pet management calls succeed against a non-localhost backend (uses configured `VITE_API_BASE_URL`)
- [ ] Manual: tab title reads "Rescue Portal | Adopt Don't Shop"; view-source shows the meta description

https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm

---
_Generated by [Claude Code](https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm)_