### PR TITLE
[Infra] Migrations runner, nginx prod conf, graceful shutdown, CI hardening, healthchecks (16 issues)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 updates:
-  # npm workspace — covers all packages via root lockfile
-  # Only major version bumps are surfaced here. Security advisories
-  # always bypass `ignore` rules, so security fixes still come through.
+  # npm workspace — covers all packages via root lockfile.
+  # Patch + minor updates surface here so security fixes that ship as
+  # patch releases are caught automatically. Major bumps still raise
+  # individual PRs; minor/patch are grouped to keep PR volume manageable. [ADS-499]
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -10,13 +11,18 @@ updates:
       day: monday
       time: "09:00"
       timezone: Europe/London
-    open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-patch
-          - version-update:semver-minor
+    open-pull-requests-limit: 15
     groups:
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - patch
+          - minor
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
       typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
@@ -46,7 +52,7 @@ updates:
         patterns:
           - "turbo"
 
-  # GitHub Actions
+  # GitHub Actions — keep workflow actions current; patch + minor allowed.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -55,11 +61,11 @@ updates:
       time: "09:00"
       timezone: Europe/London
     open-pull-requests-limit: 5
-    ignore:
-      - dependency-name: "*"
+    groups:
+      actions-minor-patch:
         update-types:
-          - version-update:semver-patch
-          - version-update:semver-minor
+          - patch
+          - minor
 
   # Docker — backend
   - package-ecosystem: docker
@@ -68,11 +74,6 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-patch
-          - version-update:semver-minor
 
   # Docker — frontend app Dockerfile
   - package-ecosystem: docker
@@ -81,8 +82,3 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 3
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-patch
-          - version-update:semver-minor

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# GitHub CodeQL static analysis for JavaScript / TypeScript.
+# Trivy in `docker.yml` covers container images; this covers source code.
+# Runs on every push to main, every PR, and weekly (catches new queries
+# released in the GitHub-managed query packs). [ADS-498]
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays at 06:00 UTC. Aligns with the Dependabot weekly schedule so
+    # security review happens in the same window.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended adds queries beyond the default set; this is
+          # the recommended config for production code.
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,10 +104,16 @@ jobs:
         with:
           images: paragonjenko/adoptdontshop
           flavor: prefix=service-backend-
+          # Tags are intentionally immutable so rollbacks are deterministic.
+          # `:latest` is only emitted on stable semver tags (v1.2.3) — it is
+          # NOT updated on every push to main. SHA + semver tags are the
+          # authoritative deploy targets. [ADS-396]
           tags: |
             type=ref,event=branch
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc') }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -153,10 +159,13 @@ jobs:
         with:
           images: paragonjenko/adoptdontshop
           flavor: prefix=${{ matrix.app }}-
+          # See backend job for tag-strategy rationale. [ADS-396]
           tags: |
             type=ref,event=branch
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc') }}
 
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/Dockerfile.app.optimized
+++ b/Dockerfile.app.optimized
@@ -113,15 +113,79 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["npm", "run", "dev"]
 
 # Build stage for production
+# Selective COPY discipline: workspace metadata first, then library
+# package.json files for layer-cache-friendly `npm ci`, then sources. This
+# mirrors the development stage above and keeps test files / storybook
+# configs / .git out of the build image. [ADS-433]
 FROM base AS build
 ARG APP_NAME
 
-# Copy entire workspace
-COPY . .
+COPY package*.json turbo.json ./
+COPY tsconfig.base.json tsconfig.cjs.base.json ./
+COPY eslint-config-base/ ./eslint-config-base/
+COPY eslint-config-react/ ./eslint-config-react/
+COPY eslint-config-node/ ./eslint-config-node/
+
+# Library package.json files (cache-friendly install layer).
+COPY lib.analytics/package.json ./lib.analytics/
+COPY lib.api/package.json ./lib.api/
+COPY lib.applications/package.json ./lib.applications/
+COPY lib.audit-logs/package.json ./lib.audit-logs/
+COPY lib.auth/package.json ./lib.auth/
+COPY lib.chat/package.json ./lib.chat/
+COPY lib.components/package.json ./lib.components/
+COPY lib.dev-tools/package.json ./lib.dev-tools/
+COPY lib.discovery/package.json ./lib.discovery/
+COPY lib.feature-flags/package.json ./lib.feature-flags/
+COPY lib.invitations/package.json ./lib.invitations/
+COPY lib.moderation/package.json ./lib.moderation/
+COPY lib.notifications/package.json ./lib.notifications/
+COPY lib.permissions/package.json ./lib.permissions/
+COPY lib.pets/package.json ./lib.pets/
+COPY lib.rescue/package.json ./lib.rescue/
+COPY lib.search/package.json ./lib.search/
+COPY lib.support-tickets/package.json ./lib.support-tickets/
+COPY lib.types/package.json ./lib.types/
+COPY lib.utils/package.json ./lib.utils/
+COPY lib.validation/package.json ./lib.validation/
+
+# Backend package.json — required for npm workspace resolution even though
+# we don't build it here (Turbo `--filter=...@adopt-dont-shop/${APP_NAME}`
+# only builds the app and its lib deps).
+COPY service.backend/package.json ./service.backend/
+
+# App package.json
+COPY ${APP_NAME}/package.json ./${APP_NAME}/
 
 # Install dependencies with cache mount
 RUN --mount=type=cache,target=/root/.npm \
     npm ci --prefer-offline
+
+# Library sources
+COPY lib.analytics/ ./lib.analytics/
+COPY lib.api/ ./lib.api/
+COPY lib.applications/ ./lib.applications/
+COPY lib.audit-logs/ ./lib.audit-logs/
+COPY lib.auth/ ./lib.auth/
+COPY lib.chat/ ./lib.chat/
+COPY lib.components/ ./lib.components/
+COPY lib.dev-tools/ ./lib.dev-tools/
+COPY lib.discovery/ ./lib.discovery/
+COPY lib.feature-flags/ ./lib.feature-flags/
+COPY lib.invitations/ ./lib.invitations/
+COPY lib.moderation/ ./lib.moderation/
+COPY lib.notifications/ ./lib.notifications/
+COPY lib.permissions/ ./lib.permissions/
+COPY lib.pets/ ./lib.pets/
+COPY lib.rescue/ ./lib.rescue/
+COPY lib.search/ ./lib.search/
+COPY lib.support-tickets/ ./lib.support-tickets/
+COPY lib.types/ ./lib.types/
+COPY lib.utils/ ./lib.utils/
+COPY lib.validation/ ./lib.validation/
+
+# App source
+COPY ${APP_NAME}/ ./${APP_NAME}/
 
 # Build libraries first, then the specific app using Turbo
 # Use cache mount for Turbo cache
@@ -181,7 +245,10 @@ http { \
         add_header Referrer-Policy "strict-origin-when-cross-origin" always; \
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always; \
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always; \
-        add_header Content-Security-Policy "default-src '"'"'self'"'"'; script-src '"'"'self'"'"' '"'"'unsafe-inline'"'"' '"'"'unsafe-eval'"'"'; style-src '"'"'self'"'"' '"'"'unsafe-inline'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"' data:; connect-src '"'"'self'"'"' ws: wss:;" always; \
+        # CSP without unsafe-inline / unsafe-eval on script-src. style-src \
+        # keeps unsafe-inline only because styled-components injects runtime \
+        # styles. [ADS-434] \
+        add_header Content-Security-Policy "default-src '"'"'self'"'"'; script-src '"'"'self'"'"'; style-src '"'"'self'"'"' '"'"'unsafe-inline'"'"'; img-src '"'"'self'"'"' data: https:; font-src '"'"'self'"'"' data:; connect-src '"'"'self'"'"' wss: https:; frame-ancestors '"'"'none'"'"'; object-src '"'"'none'"'"'; base-uri '"'"'self'"'"'; form-action '"'"'self'"'"'; upgrade-insecure-requests" always; \
         \
         # SPA routing - all routes to index.html \
         location / { \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,14 @@
 # 4. Consider using external secrets management (AWS Secrets Manager, Vault)
 # ============================================================================
 
+# Reusable JSON-file log driver with rotation. Without this Docker's default
+# json-file driver retains logs unboundedly and fills the host disk. [ADS-432]
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
+
 services:
   # Database - Production configuration
   database:
@@ -19,6 +27,15 @@ services:
     restart: always
     # Production: Don't expose database port to host
     ports: []
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2g
+        reservations:
+          cpus: '0.5'
+          memory: 512m
     # Optional: Use Docker secrets instead of environment variables
     # secrets:
     #   - postgres_password
@@ -30,6 +47,52 @@ services:
     restart: always
     ports: []  # Don't expose Redis port to host in production
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?Error: REDIS_PASSWORD required in production}
+    # Healthcheck so dependent services can wait for service_healthy. Without
+    # this the backend may start before Redis is ready and crash on first
+    # connection. [ADS-431]
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli -a "$$REDIS_PASSWORD" ping | grep -q PONG']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512m
+        reservations:
+          cpus: '0.25'
+          memory: 128m
+
+  # Migration runner - one-shot init container that applies pending migrations
+  # before the backend starts. Skipping this leaves the running service hitting
+  # a stale schema on every release. [ADS-393]
+  service-backend-migrate:
+    build:
+      context: .
+      dockerfile: ./service.backend/Dockerfile
+      target: build
+    restart: 'no'
+    command: ['npx', 'sequelize-cli', 'db:migrate']
+    working_dir: /app/service.backend
+    environment:
+      NODE_ENV: production
+      DB_HOST: database
+      DB_PORT: 5432
+      DB_USERNAME: ${POSTGRES_USER:?Error: POSTGRES_USER required}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:?Error: POSTGRES_PASSWORD required}
+      PROD_DB_NAME: ${POSTGRES_DB:?Error: POSTGRES_DB required}
+    depends_on:
+      database:
+        condition: service_healthy
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512m
 
   # Backend Service - Production
   service-backend:
@@ -89,7 +152,18 @@ services:
       database:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
+      service-backend-migrate:
+        condition: service_completed_successfully
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2g
+        reservations:
+          cpus: '0.5'
+          memory: 512m
 
   # Frontend Apps - Production
   app-admin:
@@ -111,6 +185,15 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
 
   app-client:
     build:
@@ -131,6 +214,15 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
 
   app-rescue:
     build:
@@ -151,6 +243,15 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
 
   # Nginx - Production with SSL
   nginx:
@@ -163,6 +264,15 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 256m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
 
 # ============================================================================
 # Production Volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,14 @@ services:
       redis:
         condition: service_started
     restart: unless-stopped
+    # Healthcheck so a crash-looping backend is caught by Docker health
+    # machinery and dependents can wait on service_healthy. [ADS-449, ADS-463]
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://localhost:5000/health || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     mem_limit: 1g
     memswap_limit: 1g
     cpus: '1.0'

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -1,0 +1,79 @@
+# Production Deploy Runbook
+
+Companion to `docker-compose.prod.yml` and `nginx/nginx.prod.conf`. Covers
+the operator-side steps that the compose file alone doesn't capture.
+
+## Prerequisites
+
+- Production host with Docker Engine ≥ 24 and Docker Compose v2.
+- TLS cert + key mounted at `nginx/ssl/fullchain.pem` and `nginx/ssl/privkey.pem`,
+  or a working letsencrypt volume populated by certbot.
+- All `${VAR:?}` env vars in `docker-compose.prod.yml` set in `.env`.
+
+## One-time setup
+
+1. Replace `__PROD_HOSTNAME__` in `nginx/nginx.prod.conf` with your real hostname
+   (e.g. `adoptdontshop.example`). nginx does not expand env vars in
+   `server_name`, so this is a build-time substitution. A simple `sed` works:
+
+   ```bash
+   sed -i.bak "s/__PROD_HOSTNAME__/${PROD_HOSTNAME}/g" nginx/nginx.prod.conf
+   ```
+
+2. Provision DNS A/AAAA records for `${PROD_HOSTNAME}`,
+   `api.${PROD_HOSTNAME}`, `admin.${PROD_HOSTNAME}`, `rescue.${PROD_HOSTNAME}`
+   pointing at the host.
+
+## Release deploy
+
+The `service-backend-migrate` init container runs `sequelize-cli db:migrate`
+once before `service-backend` starts. Compose's
+`service_completed_successfully` dependency gates the backend on a clean
+migration. [ADS-393]
+
+```bash
+# Pull immutable image tags (sha-prefixed or vX.Y.Z) — never :latest in
+# production deploys. See ADS-396 for the rationale.
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Verify:
+
+```bash
+docker compose -f docker-compose.prod.yml ps           # all healthy
+docker compose -f docker-compose.prod.yml logs service-backend-migrate
+curl -sf https://${PROD_HOSTNAME}/health
+```
+
+## Rollback
+
+Because release.yml emits immutable `:sha-<long>` and `:vX.Y.Z` tags, rollback
+is deterministic: pick the previous known-good tag and re-deploy. [ADS-396]
+
+```bash
+export IMAGE_TAG=v1.2.3   # previous good release
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+```
+
+If a migration introduced incompatible schema, run the corresponding `down`
+migration before rolling back the application image:
+
+```bash
+docker compose -f docker-compose.prod.yml run --rm service-backend-migrate \
+  npx sequelize-cli db:migrate:undo
+```
+
+## Backup / snapshot
+
+See [`snapshot-policy.md`](./snapshot-policy.md). [ADS-500]
+
+## Known limitations
+
+- nginx hostname substitution is manual (placeholder string). A future
+  iteration could ship a `docker-entrypoint` that runs `envsubst` over a
+  template, but that would change the compose volume mount.
+- `service-backend-migrate` runs single-instance. Multi-replica deploys must
+  wrap migrations in a Postgres advisory lock — tracked in ADS-393's
+  follow-up.

--- a/docs/operations/snapshot-policy.md
+++ b/docs/operations/snapshot-policy.md
@@ -1,0 +1,86 @@
+# Volume Backup & Snapshot Policy [ADS-500]
+
+This document captures the snapshot policy for the production stack. The
+production `docker-compose.prod.yml` declares three persistent stores; each
+has its own RPO / RTO and backup mechanism.
+
+## What gets backed up
+
+| Volume / Store        | Source                                 | Recovery class | Retention |
+|-----------------------|----------------------------------------|----------------|-----------|
+| `postgres_data`       | `database` service (Postgres 16+PostGIS) | Tier-1 (full)  | 30 days   |
+| `uploads`             | `service-backend` user uploads         | Tier-1 (full)  | 90 days   |
+| `letsencrypt`         | nginx TLS state                        | Regenerable — no backup |  N/A     |
+| Application images    | Docker registry (Docker Hub)           | Immutable tags | indefinite (per-tag) |
+
+## Postgres — `pg_dump` to S3
+
+Run `scripts/snapshot-postgres.sh` from a host that has docker access to the
+production stack. The script:
+
+1. Acquires a logical dump via `docker compose exec database pg_dump`
+   (no downtime; consistent snapshot using `--serializable-deferrable`).
+2. Compresses with `gzip -9`.
+3. Uploads to `s3://${BACKUP_BUCKET}/postgres/$(date -u +%Y/%m/%d)/dump.sql.gz`.
+4. Tags the object with `Class=tier1, Retention=30d` so the bucket lifecycle
+   policy auto-prunes after 30 days.
+
+### Cron snippet
+
+Daily at 02:00 UTC, hourly WAL is out of scope (see ADS-443 for streaming
+replication / PITR design).
+
+```cron
+# /etc/cron.d/adopt-dont-shop-backup
+SHELL=/bin/bash
+PATH=/usr/local/bin:/usr/bin:/bin
+BACKUP_BUCKET=adopt-dont-shop-prod-backups
+AWS_REGION=eu-west-2
+
+0 2 * * * deploy /opt/adopt-dont-shop/scripts/snapshot-postgres.sh >> /var/log/snapshot.log 2>&1
+```
+
+## Uploads — S3-native
+
+Move the `uploads` volume to S3 with versioning enabled. While the volume
+remains local-disk, the snapshot script `snapshot-uploads.sh` rsyncs to
+`s3://${BACKUP_BUCKET}/uploads/$(date -u +%Y/%m/%d)/` daily.
+
+Once the file-upload service is migrated to S3 directly (tracked separately),
+this script becomes obsolete and the bucket itself is the system of record;
+versioning + lifecycle policies replace daily snapshots.
+
+### Cron snippet
+
+```cron
+30 2 * * * deploy /opt/adopt-dont-shop/scripts/snapshot-uploads.sh >> /var/log/snapshot.log 2>&1
+```
+
+## letsencrypt — regenerable, no backup
+
+certbot renews on demand; backing up the state directory adds no resilience
+(rate-limit risk is low at our scale). If the volume is lost, the renewal
+hook re-issues certs at next nginx restart.
+
+## Restore procedure
+
+See `docs/operations/restore.md` (TODO — out of scope for ADS-500). The
+short version:
+
+```bash
+# Postgres
+gunzip -c dump.sql.gz | docker compose exec -T database psql -U "$POSTGRES_USER" "$POSTGRES_DB"
+
+# Uploads
+aws s3 sync "s3://${BACKUP_BUCKET}/uploads/$(date -u +%Y/%m/%d)/" /var/lib/docker/volumes/uploads/_data/
+```
+
+## Verification
+
+A monthly restore drill against a staging environment is required to keep
+this policy honest. Track outcomes in `docs/operations/restore-drills.md`.
+
+## Related
+
+- ADS-443 — streaming replication / PITR (out of scope here)
+- ADS-500 — volume backup automation (this document)

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -1,0 +1,289 @@
+# ============================================================================
+# Production nginx configuration — TLS-terminated, HTTPS-only.
+#
+# Differences from the dev `nginx.conf`:
+#   * HTTP/80 server is a redirect-only block; HSTS is emitted only on 443
+#     so browsers never see HSTS over plain HTTP. [ADS-435]
+#   * Content-Security-Policy drops `unsafe-inline` / `unsafe-eval` from
+#     script-src. style-src keeps `unsafe-inline` to support styled-components
+#     runtime style injection (matches helmet config in service.backend). [ADS-434]
+#   * Default-server returns 444 (no response) for unknown Host headers
+#     instead of catching `*.localhost`. [ADS-501]
+#
+# Cert provisioning is deployment-specific; mount your fullchain.pem +
+# privkey.pem at /etc/nginx/ssl/ or use the bundled letsencrypt volume.
+#
+# DEPLOYMENT: Replace every `__PROD_HOSTNAME__` placeholder with your prod
+# hostname (e.g. `adoptdontshop.example`) before mounting this file into the
+# nginx container. nginx does not perform variable expansion in server_name
+# directives, so this is a build-time substitution. See
+# `docs/operations/deploy.md` for the documented procedure.
+# ============================================================================
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                   '$status $body_bytes_sent "$http_referer" '
+                   '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    server_tokens off;
+
+    # Gzip — disabled for JSON API responses (BREACH attack mitigation).
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/xml+rss;
+
+    limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        "" close;
+    }
+
+    upstream backend { server service-backend:5000; }
+    upstream client  { server app-client:3000; }
+    upstream admin   { server app-admin:3000; }
+    upstream rescue  { server app-rescue:3000; }
+
+    # ------------------------------------------------------------------------
+    # Shared SSL settings
+    # ------------------------------------------------------------------------
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    ssl_certificate     /etc/nginx/ssl/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+    # ------------------------------------------------------------------------
+    # Default server — closes connections from unknown Host headers (ADS-501).
+    # 444 is nginx's "drop connection without response" sentinel.
+    # Listens on both 80 and 443 so unrecognised hosts are dropped uniformly.
+    # ------------------------------------------------------------------------
+    server {
+        listen 80 default_server;
+        listen 443 ssl default_server;
+        http2 on;
+        server_name _;
+        return 444;
+    }
+
+    # ------------------------------------------------------------------------
+    # HTTP -> HTTPS redirect for known hostnames. No HSTS here. [ADS-435]
+    # ------------------------------------------------------------------------
+    server {
+        listen 80;
+        server_name __PROD_HOSTNAME__ api.__PROD_HOSTNAME__ admin.__PROD_HOSTNAME__ rescue.__PROD_HOSTNAME__;
+        return 301 https://$host$request_uri;
+    }
+
+    # ------------------------------------------------------------------------
+    # Shared security-header snippet — applied inside every HTTPS server block.
+    # HSTS lives only here so plain-HTTP responses never carry it. [ADS-435]
+    # CSP without unsafe-inline / unsafe-eval on script-src. [ADS-434]
+    # ------------------------------------------------------------------------
+    # nginx has no `include`-time variable expansion for add_header, so the
+    # headers are repeated per server block. Keep them in sync.
+
+    # ------------------------------------------------------------------------
+    # Admin app
+    # ------------------------------------------------------------------------
+    server {
+        listen 443 ssl;
+        http2 on;
+        server_name admin.__PROD_HOSTNAME__;
+
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' wss: https:; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            proxy_pass http://admin;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            proxy_set_header Host $host;
+        }
+
+        location / {
+            proxy_pass http://admin;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 86400;
+        }
+    }
+
+    # ------------------------------------------------------------------------
+    # Rescue app
+    # ------------------------------------------------------------------------
+    server {
+        listen 443 ssl;
+        http2 on;
+        server_name rescue.__PROD_HOSTNAME__;
+
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' wss: https:; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            proxy_pass http://rescue;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            proxy_set_header Host $host;
+        }
+
+        location / {
+            proxy_pass http://rescue;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 86400;
+        }
+    }
+
+    # ------------------------------------------------------------------------
+    # API
+    # ------------------------------------------------------------------------
+    server {
+        listen 443 ssl;
+        http2 on;
+        server_name api.__PROD_HOSTNAME__;
+
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' wss: https:; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
+
+        location / {
+            limit_req zone=api burst=20 nodelay;
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 86400;
+        }
+
+        location /auth/ {
+            limit_req zone=login burst=5 nodelay;
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /socket.io/ {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400;
+        }
+    }
+
+    # ------------------------------------------------------------------------
+    # Main client app
+    # ------------------------------------------------------------------------
+    server {
+        listen 443 ssl;
+        http2 on;
+        server_name __PROD_HOSTNAME__;
+
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' wss: https:; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
+
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            proxy_pass http://client;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            proxy_set_header Host $host;
+        }
+
+        location /api/ {
+            limit_req zone=api burst=20 nodelay;
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 86400;
+        }
+
+        location / {
+            proxy_pass http://client;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 86400;
+        }
+    }
+}

--- a/scripts/snapshot-postgres.sh
+++ b/scripts/snapshot-postgres.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Daily Postgres snapshot — see docs/operations/snapshot-policy.md [ADS-500].
+# Runs `pg_dump` against the production database container and uploads the
+# compressed dump to S3. Designed to be invoked from cron on the prod host.
+#
+# Required env:
+#   BACKUP_BUCKET   S3 bucket for snapshots (no s3:// prefix)
+#   AWS_REGION      AWS region of the bucket
+#   POSTGRES_USER   superuser for pg_dump (read from .env or systemd unit)
+#   POSTGRES_DB     database name
+# Optional:
+#   COMPOSE_FILE    defaults to /opt/adopt-dont-shop/docker-compose.prod.yml
+
+set -euo pipefail
+
+: "${BACKUP_BUCKET:?BACKUP_BUCKET required}"
+: "${AWS_REGION:?AWS_REGION required}"
+: "${POSTGRES_USER:?POSTGRES_USER required}"
+: "${POSTGRES_DB:?POSTGRES_DB required}"
+
+COMPOSE_FILE="${COMPOSE_FILE:-/opt/adopt-dont-shop/docker-compose.prod.yml}"
+TIMESTAMP="$(date -u +%Y/%m/%d/%H%M%S)"
+S3_KEY="postgres/${TIMESTAMP}/dump.sql.gz"
+TMPFILE="$(mktemp -t pg-dump-XXXXXX.sql.gz)"
+
+cleanup() {
+  rm -f "$TMPFILE"
+}
+trap cleanup EXIT
+
+echo "[snapshot-postgres] dumping ${POSTGRES_DB} -> ${TMPFILE}"
+docker compose -f "$COMPOSE_FILE" exec -T database \
+  pg_dump --serializable-deferrable -U "$POSTGRES_USER" "$POSTGRES_DB" \
+  | gzip -9 > "$TMPFILE"
+
+DUMP_BYTES="$(stat -c%s "$TMPFILE")"
+if [[ "$DUMP_BYTES" -lt 1024 ]]; then
+  echo "[snapshot-postgres] ERROR: dump is suspiciously small (${DUMP_BYTES} bytes)" >&2
+  exit 1
+fi
+
+echo "[snapshot-postgres] uploading ${DUMP_BYTES} bytes -> s3://${BACKUP_BUCKET}/${S3_KEY}"
+aws s3 cp "$TMPFILE" "s3://${BACKUP_BUCKET}/${S3_KEY}" \
+  --region "$AWS_REGION" \
+  --metadata "Class=tier1,Retention=30d"
+
+echo "[snapshot-postgres] done"

--- a/scripts/snapshot-uploads.sh
+++ b/scripts/snapshot-uploads.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Daily uploads snapshot — see docs/operations/snapshot-policy.md [ADS-500].
+# rsyncs the `uploads` Docker volume to S3 with daily prefixing. Becomes
+# obsolete once file-upload.service.ts uses S3 as the system of record.
+#
+# Required env:
+#   BACKUP_BUCKET   S3 bucket for snapshots
+#   AWS_REGION      AWS region of the bucket
+# Optional:
+#   UPLOADS_PATH    defaults to /var/lib/docker/volumes/uploads/_data
+
+set -euo pipefail
+
+: "${BACKUP_BUCKET:?BACKUP_BUCKET required}"
+: "${AWS_REGION:?AWS_REGION required}"
+
+UPLOADS_PATH="${UPLOADS_PATH:-/var/lib/docker/volumes/uploads/_data}"
+
+if [[ ! -d "$UPLOADS_PATH" ]]; then
+  echo "[snapshot-uploads] ERROR: $UPLOADS_PATH does not exist" >&2
+  exit 1
+fi
+
+DAY="$(date -u +%Y/%m/%d)"
+DEST="s3://${BACKUP_BUCKET}/uploads/${DAY}/"
+
+echo "[snapshot-uploads] syncing ${UPLOADS_PATH}/ -> ${DEST}"
+aws s3 sync "$UPLOADS_PATH/" "$DEST" \
+  --region "$AWS_REGION" \
+  --metadata "Class=tier1,Retention=90d"
+
+echo "[snapshot-uploads] done"

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -561,17 +561,37 @@ const startServer = async () => {
     });
 
     // Graceful shutdown
+    // Without an explicit process.exit(), Socket.IO connections + timers keep
+    // the event loop alive after server.close(), so dumb-init eventually
+    // SIGKILLs the container. We exit cleanly after draining, with a 10s
+    // force-exit fallback for stuck connections. [ADS-395]
+    let shuttingDown = false;
     const gracefulShutdown = (signal: string) => {
+      if (shuttingDown) {
+        return;
+      }
+      shuttingDown = true;
       logger.info(`Received ${signal}. Starting graceful shutdown...`);
+
+      const forceExitTimer = setTimeout(() => {
+        logger.error('Graceful shutdown timed out after 10s — forcing exit.');
+        process.exit(1);
+      }, 10_000);
+      forceExitTimer.unref();
+
       server.close(async () => {
         logger.info('HTTP server closed.');
         try {
+          const { messageBroker } = await import('./services/messageBroker.service');
+          await messageBroker.disconnect();
+          logger.info('Message broker disconnected.');
           await sequelize.close();
           logger.info('Database connection closed.');
           logger.info('Graceful shutdown completed.');
+          process.exit(0);
         } catch (error) {
           logger.error('Error during graceful shutdown:', error);
-          throw error;
+          process.exit(1);
         }
       });
     };


### PR DESCRIPTION
Group **G11a — Infrastructure (Docker, nginx, CI workflows)** for the Production Readiness Audit. Each commit is scoped to one ADS-XXX cluster; the file scope stays inside docker/nginx/CI/docs as required.

## Closes (auto-close on merge)

### Urgent

- Closes ADS-393 — Added `service-backend-migrate` init container in `docker-compose.prod.yml` that runs `sequelize-cli db:migrate` once before the backend starts. Backend now depends on `service_completed_successfully` so prod releases cannot race the schema. Documented in `docs/operations/deploy.md`. Multi-replica advisory-lock work is flagged as a follow-up.
- Closes ADS-394 — Wrote `nginx/nginx.prod.conf` with TLS-only listeners, redirect-only HTTP block, hardened CSP, default_server returning 444. The compose mount no longer fails.
- Closes ADS-395 — `gracefulShutdown` in `service.backend/src/index.ts` now disconnects the message broker, closes Sequelize, and `process.exit(0)`s; a 10s `setTimeout` force-exit fallback covers stuck Socket.IO connections. Single additional handler — surrounding code untouched.
- Closes ADS-396 — `release.yml` now emits `:vX.Y.Z`, `:major.minor`, `:sha-`, and `:branch` tags. `:latest` is gated to stable semver tags only (no alpha/beta/rc).

### High

- Closes ADS-430 — `deploy.resources.limits` + `reservations` on every prod compose service.
- Closes ADS-431 — Redis `healthcheck: redis-cli ping`; backend dependency upgraded to `service_healthy`.
- Closes ADS-432 — Shared YAML anchor `x-logging` applies json-file driver with `max-size: 50m, max-file: 5` to every service.
- Closes ADS-433 — Build stage replaces `COPY . .` with explicit per-package COPYs mirroring the dev stage's layer-cache discipline.
- Closes ADS-434 — Removed `unsafe-inline` and `unsafe-eval` from script-src CSP in `nginx.prod.conf` and the embedded nginx config in `Dockerfile.app.optimized`. style-src keeps `unsafe-inline` for styled-components, matching the helmet config in `service.backend/src/index.ts`.
- Closes ADS-435 — HSTS only on HTTPS server blocks in `nginx.prod.conf`; the HTTP/80 block is a redirect-only stub. The dev `nginx.conf` is intentionally unchanged (dev runs over HTTP, scope-out per file-ownership rules).
- Closes ADS-449 — Added a `healthcheck` to `service-backend` in `docker-compose.yml` (dev). Prod compose already had one.
- Closes ADS-463 — Same fix as ADS-449 (audit dup).

### Medium

- Closes ADS-498 — New `.github/workflows/codeql.yml` running `javascript-typescript` analysis on push/PR/weekly with the `security-extended` query pack.
- Closes ADS-499 — Removed the patch+minor `ignore` blocks across npm / GitHub Actions / Docker ecosystems in `dependabot.yml`. Added grouped production / development minor-patch buckets to keep PR volume sane.
- Closes ADS-500 — Wrote `docs/operations/snapshot-policy.md` plus `scripts/snapshot-postgres.sh` and `scripts/snapshot-uploads.sh`. Cron snippets for daily 02:00 / 02:30 UTC included.
- Closes ADS-501 — `nginx.prod.conf` default_server returns 444 for unknown Host headers instead of catching `*.localhost`.

## Validation

- YAML parsed via Python `yaml.safe_load` for `codeql.yml`, `dependabot.yml`, `release.yml`.
- nginx config syntax-checked with `nginx -t` after substituting placeholders + upstreams + cert paths (`http2 on;` is correct for `nginx:alpine` ≥ 1.25).
- Shell scripts pass `bash -n`.
- Docker Compose YAML structure validated against a synthetic base file (the pre-existing `${VAR:?Error: ...}` colon-in-value YAML quirk is unrelated to this PR).

## Out of scope (other agents)

- env var contents (`.env.example`, `validate-env*`) — owned by G11b in PR #356.
- `package.json` updates — owned by G12 in PR #354.
- App / lib source changes beyond the single graceful-shutdown handler — other groups.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm)_