### PR TITLE
[Types] ADS-414 partial: any/as-any cleanup in backend services, controllers, middleware

### DIFF
--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -72,11 +72,18 @@ export class ApplicationController extends BaseController {
   static validateBulkUpdate = [validateBody(ApplicationBulkUpdateRequestSchema)];
 
   /**
-   * Transform database Application model to frontend-compatible format
+   * Transform database Application model to frontend-compatible format.
+   *
+   * Accepts \`unknown\` so callers can pass in either a Sequelize model
+   * instance or the result of \`.toJSON()\` without sprinkling
+   * \`as unknown as Record<string, unknown>\` at every call site. The body
+   * narrows once and reads via the established Record-shape pattern.
    */
-  protected transformApplicationModel(
-    applicationModel: Record<string, unknown>
-  ): FrontendApplication {
+  protected transformApplicationModel(applicationModelInput: unknown): FrontendApplication {
+    const applicationModel: Record<string, unknown> =
+      applicationModelInput && typeof applicationModelInput === 'object'
+        ? (applicationModelInput as Record<string, unknown>)
+        : {};
     const User = applicationModel.User as Record<string, unknown> | undefined;
     const Pet = applicationModel.Pet as Record<string, unknown> | undefined;
 
@@ -260,7 +267,7 @@ export class ApplicationController extends BaseController {
 
       // Transform the applications to frontend format
       const transformedApplications = result.applications.map(app =>
-        this.transformApplicationModel(app as unknown as Record<string, unknown>)
+        this.transformApplicationModel(app)
       );
 
       return this.sendPaginatedSuccess(res, transformedApplications, {
@@ -377,9 +384,7 @@ export class ApplicationController extends BaseController {
       }
 
       // Transform the raw application data to frontend format
-      const transformedApplication = this.transformApplicationModel(
-        application as unknown as Record<string, unknown>
-      );
+      const transformedApplication = this.transformApplicationModel(application);
 
       res.status(200).json({
         success: true,

--- a/service.backend/src/controllers/chat.controller.ts
+++ b/service.backend/src/controllers/chat.controller.ts
@@ -66,15 +66,13 @@ type SerializedMessage = {
  * both shapes so a single field rename in the model can't silently
  * regress every chat timestamp.
  */
-const readTimestamp = (
-  obj: Record<string, unknown> | null | undefined,
-  ...keys: string[]
-): string | undefined => {
-  if (!obj) {
+const readTimestamp = (obj: unknown, ...keys: string[]): string | undefined => {
+  if (!obj || typeof obj !== 'object') {
     return undefined;
   }
+  const record = obj as Record<string, unknown>;
   for (const key of keys) {
-    const value = obj[key];
+    const value = record[key];
     if (value instanceof Date) {
       return value.toISOString();
     }
@@ -85,10 +83,10 @@ const readTimestamp = (
   return undefined;
 };
 
-const readCreatedAt = (obj: Record<string, unknown> | null | undefined): string | undefined =>
+const readCreatedAt = (obj: unknown): string | undefined =>
   readTimestamp(obj, 'createdAt', 'created_at');
 
-const readUpdatedAt = (obj: Record<string, unknown> | null | undefined): string | undefined =>
+const readUpdatedAt = (obj: unknown): string | undefined =>
   readTimestamp(obj, 'updatedAt', 'updated_at');
 
 /**
@@ -181,7 +179,7 @@ export const toFrontendMessage = (
     senderRole: isRescueStaff ? 'rescue_staff' : 'adopter',
     senderRescueName: isRescueStaff ? (context.rescueName ?? null) : null,
     content: msg.content || '',
-    timestamp: readCreatedAt(msg as unknown as Record<string, unknown>) ?? '',
+    timestamp: readCreatedAt(msg) ?? '',
     type: msg.content_format || 'text',
     status: 'sent',
     attachments: msg.attachments || [],
@@ -251,15 +249,15 @@ export class ChatController {
         participants: [], // Will be populated by frontend when needed
         unreadCount: 0, // New conversation starts with 0 unread
         isTyping: [], // Empty initially
-        createdAt: readCreatedAt(chat as unknown as Record<string, unknown>),
-        updatedAt: readUpdatedAt(chat as unknown as Record<string, unknown>),
+        createdAt: readCreatedAt(chat),
+        updatedAt: readUpdatedAt(chat),
         // Keep backward compatibility fields
         chat_id: chat.chat_id,
         rescue_id: chat.rescue_id,
         pet_id: chat.pet_id,
         application_id: chat.application_id,
-        created_at: readCreatedAt(chat as unknown as Record<string, unknown>),
-        updated_at: readUpdatedAt(chat as unknown as Record<string, unknown>),
+        created_at: readCreatedAt(chat),
+        updated_at: readUpdatedAt(chat),
       };
 
       res.json({
@@ -347,8 +345,8 @@ export class ChatController {
         chat_id: chatObj.chat_id,
         participants,
         unreadCount,
-        updatedAt: readUpdatedAt(chatObj as unknown as Record<string, unknown>),
-        createdAt: readCreatedAt(chatObj as unknown as Record<string, unknown>),
+        updatedAt: readUpdatedAt(chatObj),
+        createdAt: readCreatedAt(chatObj),
         isActive: chatObj.status === 'active',
         petId: chatObj.pet_id,
         rescueId: chatObj.rescue_id,
@@ -433,7 +431,7 @@ export class ChatController {
                   ? msg.content.slice(0, 120) + '...'
                   : msg.content,
               senderId: msg.sender_id,
-              createdAt: readCreatedAt(msg as unknown as Record<string, unknown>),
+              createdAt: readCreatedAt(msg),
             };
           }
 
@@ -469,8 +467,8 @@ export class ChatController {
             participants,
             unreadCount,
             isTyping: [],
-            createdAt: readCreatedAt(chatObj as unknown as Record<string, unknown>),
-            updatedAt: readUpdatedAt(chatObj as unknown as Record<string, unknown>),
+            createdAt: readCreatedAt(chatObj),
+            updatedAt: readUpdatedAt(chatObj),
             rescueName: chat.rescue?.name || null,
             lastMessage,
           };
@@ -536,7 +534,7 @@ export class ChatController {
                 ? msg.content.slice(0, 120) + '...'
                 : msg.content,
             senderId: msg.sender_id,
-            createdAt: readCreatedAt(msg as unknown as Record<string, unknown>),
+            createdAt: readCreatedAt(msg),
           };
         }
         return {

--- a/service.backend/src/controllers/email.controller.ts
+++ b/service.backend/src/controllers/email.controller.ts
@@ -133,12 +133,7 @@ export const previewTemplate = async (req: AuthenticatedRequest, res: Response):
     }
 
     // Process template with provided data
-    // Accessing private processTemplate method for preview functionality
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const processedContent = await (emailService as any).processTemplate(
-      template,
-      templateData || {}
-    );
+    const processedContent = await emailService.renderTemplatePreview(template, templateData || {});
 
     res.json({
       message: 'Template preview generated successfully',
@@ -237,9 +232,7 @@ export const getQueueStatus = async (req: AuthenticatedRequest, res: Response): 
 export const processQueue = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
   try {
     // Start queue processing
-    // Accessing private startQueueProcessor method
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (emailService as any).startQueueProcessor();
+    emailService.startQueueProcessor();
 
     res.json({
       message: 'Queue processing started successfully',

--- a/service.backend/src/controllers/pet.controller.ts
+++ b/service.backend/src/controllers/pet.controller.ts
@@ -154,10 +154,16 @@ export class PetController {
       const result = await this.petService.searchPets(filters, options);
 
       // Distance is computed by the service layer (Haversine). Preserve it through toJSON().
+      const readDistance = (value: unknown): number | undefined => {
+        if (!value || typeof value !== 'object') {
+          return undefined;
+        }
+        const candidate = (value as { distance?: unknown }).distance;
+        return typeof candidate === 'number' ? candidate : undefined;
+      };
       const petsData = result.pets.map(pet => {
-        const rawPet = pet as unknown as Record<string, unknown>;
-        const distance = typeof rawPet.distance === 'number' ? rawPet.distance : undefined;
-        const petJson = (pet.toJSON ? pet.toJSON() : pet) as unknown as Record<string, unknown>;
+        const distance = readDistance(pet);
+        const petJson: Record<string, unknown> = pet.toJSON() as Record<string, unknown>;
         return distance !== undefined ? { ...petJson, distance } : petJson;
       });
 

--- a/service.backend/src/middleware/rate-limiter.ts
+++ b/service.backend/src/middleware/rate-limiter.ts
@@ -13,6 +13,14 @@ interface RateLimitRequest extends Request {
   };
 }
 
+// Narrow shape for the authenticated user attached by upstream auth middleware.
+// Used here only to extract userId for per-user rate limiting; full
+// AuthenticatedRequest is over-broad for express-rate-limit's req parameter.
+type RequestWithMaybeUser = Request & { user?: { userId?: string } };
+
+const getUserIdOrIp = (req: RequestWithMaybeUser): string =>
+  req.user?.userId || req.ip || 'unknown';
+
 // Development rate limiter that tracks but doesn't block
 const createDevLimiter = (windowMs: number, max: number, name: string) => {
   return rateLimit({
@@ -151,18 +159,15 @@ export const twoFactorLimiter =
     : rateLimit({
         windowMs: 15 * 60 * 1000, // 15 minutes
         max: 5,
-        keyGenerator: req =>
-          (req as unknown as { user?: { userId?: string } }).user?.userId || req.ip || 'unknown',
+        keyGenerator: (req: RequestWithMaybeUser) => getUserIdOrIp(req),
         message: {
           error: 'Too many 2FA attempts, please try again later.',
           retryAfter: 900,
         },
         standardHeaders: true,
         legacyHeaders: false,
-        handler: (req, res) => {
-          logger.warn(
-            `2FA rate limit exceeded for user: ${(req as unknown as { user?: { userId?: string } }).user?.userId || req.ip}`
-          );
+        handler: (req: RequestWithMaybeUser, res) => {
+          logger.warn(`2FA rate limit exceeded for user: ${req.user?.userId || req.ip}`);
           res.status(429).json({
             error: 'Too many 2FA attempts, please try again later.',
             retryAfter: 900,

--- a/service.backend/src/middleware/rbac.ts
+++ b/service.backend/src/middleware/rbac.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Response } from 'express';
 import { UserType } from '../models/User';
-import Permission from '../models/Permission';
 import { AuthenticatedRequest, PERMISSIONS } from '../types';
 import { logger } from '../utils/logger';
 // Import the actual model types instead of defining local interfaces
@@ -50,12 +49,8 @@ export const requirePermission = (requiredPermission: string) => {
     }
 
     // Check if user has the required permission through roles
-    // Type assertion justified: Sequelize associations don't always properly infer Permission type
     const hasPermission = req.user.Roles?.some(role =>
-      role.Permissions?.some(permission => {
-        const perm = permission as unknown as Permission;
-        return perm.permissionName === requiredPermission;
-      })
+      role.Permissions?.some(permission => permission.permissionName === requiredPermission)
     );
 
     if (!hasPermission) {
@@ -128,12 +123,8 @@ export const requirePermissionOrOwnership = (
     }
 
     // Check if user has the required permission
-    // Type assertion justified: Sequelize associations don't always properly infer Permission type
     const hasPermission = req.user.Roles?.some(role =>
-      role.Permissions?.some(permission_obj => {
-        const perm = permission_obj as unknown as Permission;
-        return perm.permissionName === permission;
-      })
+      role.Permissions?.some(permission_obj => permission_obj.permissionName === permission)
     );
 
     if (hasPermission) {

--- a/service.backend/src/models/Role.ts
+++ b/service.backend/src/models/Role.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize from '../sequelize';
+import type Permission from './Permission';
 
 interface RoleAttributes {
   roleId: number;
@@ -17,6 +18,11 @@ class Role extends Model<RoleAttributes, RoleCreationAttributes> implements Role
   public description!: string;
   public createdAt!: Date;
   public updatedAt!: Date;
+
+  // Sequelize association — populated by Role.belongsToMany(Permission)
+  // declared in src/models/index.ts. Declared here so callers reading
+  // role.Permissions[i].permissionName don't need cast escapes.
+  public Permissions?: Permission[];
 }
 
 Role.init(

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -518,6 +518,21 @@ class EmailService {
   }
 
   // Template Processing
+  /**
+   * Public wrapper for processTemplate, used by preview endpoints to render
+   * a template with provided data without queueing/sending.
+   */
+  public async renderTemplatePreview(
+    template: EmailTemplate,
+    data: TemplateData
+  ): Promise<{
+    subject: string;
+    htmlContent: string;
+    textContent?: string;
+  }> {
+    return this.processTemplate(template, data);
+  }
+
   private async processTemplate(
     template: EmailTemplate,
     data: TemplateData

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -968,15 +968,15 @@ class ModerationService {
   }
 
   async getActiveActionsForUser(userId: string): Promise<ModeratorAction[]> {
-    // Split the query to avoid complex Op.or with null handling
-    // Type assertion needed: Sequelize doesn't allow null in where clause correctly
-    // This is a valid runtime pattern - checking for records where expiresAt is null
+    // Split the query to avoid complex Op.or with null handling.
+    // `[Op.is]: null` emits `IS NULL`, which is the SQL semantics we want
+    // for "never expires" and avoids casting null into a Date-shaped attribute.
     const [neverExpiringActions, futureExpiringActions] = await Promise.all([
       ModeratorAction.findAll({
         where: {
           targetUserId: userId,
           isActive: true,
-          expiresAt: null as unknown as undefined,
+          expiresAt: { [Op.is]: null },
         },
         order: [['createdAt', 'DESC']],
       }),

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -1178,14 +1178,14 @@ export class RescueService {
       });
 
       return {
-        totalPets: totalPets as unknown as number,
-        availablePets: availablePets as unknown as number,
-        adoptedPets: adoptedPets as unknown as number,
+        totalPets,
+        availablePets,
+        adoptedPets,
         pendingApplications,
         totalApplications,
         staffCount,
-        activeListings: availablePets as unknown as number,
-        monthlyAdoptions: monthlyAdoptions as unknown as number,
+        activeListings: availablePets,
+        monthlyAdoptions,
         averageTimeToAdoption,
       };
     } catch (error) {

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -6,7 +6,6 @@ import Application from '../models/Application';
 import { AuditLog } from '../models/AuditLog';
 import Chat from '../models/Chat';
 import ChatParticipant from '../models/ChatParticipant';
-import Permission from '../models/Permission';
 import User, { UserStatus, UserType } from '../models/User';
 import UserFavorite from '../models/UserFavorite';
 import UserNotificationPrefs from '../models/UserNotificationPrefs';
@@ -1434,9 +1433,7 @@ export class UserService {
         for (const role of user.Roles) {
           if (role.Permissions) {
             for (const permission of role.Permissions) {
-              // Type assertion needed: Sequelize associations don't always infer correctly
-              const perm = permission as unknown as Permission;
-              permissions.add(perm.permissionName);
+              permissions.add(permission.permissionName);
             }
           }
         }
@@ -1497,9 +1494,7 @@ export class UserService {
         for (const role of user.Roles) {
           if (role.Permissions) {
             for (const permission of role.Permissions) {
-              // Type assertion needed: Sequelize associations don't always infer correctly
-              const perm = permission as unknown as Permission;
-              permissions.add(perm.permissionName);
+              permissions.add(permission.permissionName);
             }
           }
         }


### PR DESCRIPTION
## Summary

Partial cleanup for ADS-414. Surgical, behaviour-preserving changes only.

Scope: service.backend/src/{services,controllers,middleware}, lib.api, lib.types, lib.auth, lib.validation (tests excluded).

- Total violations: 78 → 50 (28 removed)
- Pure any / as any: 3 → 1 (only remaining is a JSDoc comment)

## Refs (NOT auto-closed — 50 of 78 in-scope violations remain)

- ADS-414 — Partial cleanup. Linear issue should stay open until the remaining ~50 in-scope violations and the app-level / other lib.* violations are also fixed.

The audit issue cites 283 `any` / `as any` + 110 `as unknown as` violations across the full repo. This PR addresses 28 of the 78 in scope (services/controllers/middleware/lib.api/lib.types/lib.auth/lib.validation, tests excluded). App-level apps and other libs are explicitly out of scope.

## Commits (5)

1. `email.controller`: added public `EmailService.renderTemplatePreview` wrapper, removed both `(emailService as any)` reach-throughs.
2. `rbac` + `user.service`: declared `Role.Permissions?: Permission[]` on the model so callers traverse the existing `belongsToMany` association without casts (-4 casts). `rate-limiter.ts` got a narrow `RequestWithMaybeUser` shim (-2 casts).
3. `chat.controller`: widened `readTimestamp` helpers to `unknown` (-11 casts). Dropped 5 spurious `as unknown as number` casts in `rescue.service.ts` (`Pet.count()` already returns `Promise<number>`).
4. `moderation.service`: replaced `null as unknown as undefined` with `{ [Op.is]: null }` (same SQL).
5. `application.controller` + `pet.controller`: widened helpers to `unknown` and removed unreachable `pet.toJSON ?` branch (-4 casts).

## Deferred (50 remaining in scope)

Real Sequelize / library typing seams. `analytics.service.ts` (19), `moderation.service.ts` (6), `pet.service.ts` (5), `application.controller.ts` (3), `reports.service.ts` (3), `zod-validate.ts` (2), `application-profile.service.ts` (2), `chat.controller.ts` (2), and singletons in `chat.service.ts`, `supportTicket.{controller,service}.ts`, `base.controller.ts`, `user.service.ts`, `lib.api/services/api-service.ts`. App-level / other lib.* violations are out of scope.

## Validation

No `npm run type-check` was run; node_modules not installed in worktree. Manual review confirmed runtime behaviour preserved.

## Test plan

- [ ] Run `npm run type-check` in CI.
- [ ] Run `npm run test --filter=@adopt-dont-shop/service-backend`.
- [ ] Sanity-check email template preview endpoint.
- [ ] Sanity-check 2FA rate limiter keys per user.
- [ ] Sanity-check `getActiveActionsForUser` returns both never-expiring and future-expiring actions.

Linear: https://linear.app/ideasquared/issue/ADS-414

https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm

---
_Generated by [Claude Code](https://claude.ai/code/session_014KNBgjowyuvQKsT4AwfGVm)_