### PR TITLE
chore(lint): forbid console.log in src; clean up existing violations (ADS-488)

### DIFF
--- a/app.admin/src/components/modals/RescueDetailModal.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal.tsx
@@ -102,8 +102,6 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
         rescueService.getInvitations(rescueId),
       ]);
 
-      console.log('Fetched staff:', staffData.data);
-      console.log('Fetched invitations:', invitationsData);
       setStaff(staffData.data);
       setInvitations(invitationsData);
     } catch (err) {
@@ -130,8 +128,7 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
         title: inviteTitle.trim() || undefined,
       };
 
-      const newInvitation = await rescueService.inviteStaff(rescueId, payload);
-      console.log('Invitation sent:', newInvitation);
+      await rescueService.inviteStaff(rescueId, payload);
 
       // Reset form
       setInviteEmail('');
@@ -140,7 +137,6 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
 
       // Refresh staff list (don't show loading, we're already in loading state)
       await fetchStaff(false);
-      console.log('Staff and invitations refreshed');
     } catch (err) {
       setStaffError(err instanceof Error ? err.message : 'Failed to send invitation');
     } finally {

--- a/app.admin/src/services/authService.ts
+++ b/app.admin/src/services/authService.ts
@@ -17,9 +17,6 @@ class AuthService {
 
   // Login admin user
   async login(credentials: LoginRequest): Promise<AuthResponse> {
-    // eslint-disable-next-line no-console
-    console.log('🔐 AuthService: Attempting admin login for:', credentials.email);
-
     const response = await apiService.post<AuthResponse>('/api/v1/auth/admin/login', credentials);
 
     // Store only non-sensitive user data; tokens are in HttpOnly cookies

--- a/app.admin/src/services/rescueService.ts
+++ b/app.admin/src/services/rescueService.ts
@@ -238,8 +238,6 @@ class AdminRescueService {
       data: StaffInvitation[];
     }>(`${this.baseUrl}/${rescueId}/invitations`);
 
-    console.log('getInvitations response:', response);
-
     if (!response.success) {
       throw new Error('Failed to fetch invitations');
     }
@@ -256,8 +254,6 @@ class AdminRescueService {
       message: string;
       data: StaffInvitation;
     }>(`${this.baseUrl}/${rescueId}/invitations`, payload);
-
-    console.log('inviteStaff response:', response);
 
     if (!response.success) {
       throw new Error(response.message || 'Failed to send invitation');

--- a/app.client/src/components/application/steps/AdditionalInfoStep.tsx
+++ b/app.client/src/components/application/steps/AdditionalInfoStep.tsx
@@ -43,10 +43,6 @@ export const AdditionalInfoStep: React.FC<AdditionalInfoStepProps> = ({
   }, [watch, onChange]);
 
   const onSubmit = (formData: AdditionalInfoFormData) => {
-    if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
-      console.log('AdditionalInfoStep onSubmit called with:', formData);
-    }
     onComplete(formData as ApplicationData['additionalInfo']);
   };
 

--- a/app.client/src/utils/performanceMonitor.ts
+++ b/app.client/src/utils/performanceMonitor.ts
@@ -232,17 +232,6 @@ class PerformanceMonitor {
     }
   }
 
-  // Determine which metrics to log in development
-  private shouldLogMetric(name: string): boolean {
-    const importantMetrics = [
-      'message_delivery_time',
-      'socket_connection_time',
-      'api_response_time',
-      'message_retry',
-    ];
-    return importantMetrics.includes(name);
-  }
-
   // Get performance statistics
   getStats(): {
     totalMetrics: number;

--- a/app.client/src/utils/performanceMonitor.ts
+++ b/app.client/src/utils/performanceMonitor.ts
@@ -230,12 +230,6 @@ class PerformanceMonitor {
         console.warn('Analytics callback failed:', error);
       }
     }
-
-    // Log important metrics in development
-    if (import.meta.env.DEV && this.shouldLogMetric(name)) {
-      // eslint-disable-next-line no-console
-      console.log(`[Performance] ${name}:`, value, metadata);
-    }
   }
 
   // Determine which metrics to log in development

--- a/app.rescue/src/pages/Events.tsx
+++ b/app.rescue/src/pages/Events.tsx
@@ -138,8 +138,6 @@ const Events: React.FC = () => {
       const newEvent = await eventsService.createEvent(eventData);
       setEvents(prev => [newEvent, ...prev]);
       setShowCreateModal(false);
-      // Show success message (you could add a toast notification here)
-      console.log('Event created successfully:', newEvent);
     } catch (err) {
       console.error('Failed to create event:', err);
       alert('Failed to create event. Please try again.');
@@ -170,8 +168,6 @@ const Events: React.FC = () => {
       if (selectedEvent?.id === updatedEvent.id) {
         setSelectedEvent(updatedEvent);
       }
-
-      console.log('Event updated successfully:', updatedEvent);
     } catch (err) {
       console.error('Failed to update event:', err);
       alert('Failed to update event. Please try again.');
@@ -197,7 +193,6 @@ const Events: React.FC = () => {
       setEvents(prev => prev.filter(event => event.id !== eventId));
       setShowDetailsModal(false);
       setSelectedEvent(null);
-      console.log('Event deleted successfully');
     } catch (err) {
       console.error('Failed to delete event:', err);
       alert('Failed to delete event. Please try again.');
@@ -218,8 +213,6 @@ const Events: React.FC = () => {
       if (selectedEvent?.id === updatedEvent.id) {
         setSelectedEvent(updatedEvent);
       }
-
-      console.log('Event status updated:', status);
     } catch (err) {
       console.error('Failed to update event status:', err);
       alert('Failed to update event status. Please try again.');
@@ -269,7 +262,6 @@ const Events: React.FC = () => {
       // Refresh attendees list
       const updatedAttendees = await eventsService.getEventAttendees(selectedEvent.id);
       setEventAttendees(updatedAttendees);
-      console.log('Attendee checked in successfully');
     } catch (err) {
       console.error('Failed to check in attendee:', err);
       alert('Failed to check in attendee. Please try again.');

--- a/app.rescue/src/services/applicationService.ts
+++ b/app.rescue/src/services/applicationService.ts
@@ -209,9 +209,6 @@ export class RescueApplicationService {
 
         // Check for redundant transition
         if (currentStatus === targetStatus) {
-          console.log(
-            `Application ${id} is already in status ${currentApp.status}, skipping redundant update`
-          );
           return { success: true, message: `Application is already ${currentApp.status}` };
         }
 
@@ -386,7 +383,6 @@ export class RescueApplicationService {
               application.decision_at || application.reviewed_at || new Date().toISOString(),
           };
 
-          console.log(`Found legacy home visit notes for application ${applicationId}:`, homeVisit);
           return [homeVisit];
         }
 
@@ -522,8 +518,6 @@ export class RescueApplicationService {
       const response = await this.apiService.get<any>(
         `/api/v1/applications/${applicationId}/timeline`
       );
-
-      console.log('Timeline API response:', response); // Debug log
 
       // Handle different possible response formats
       let timelineArray = [];

--- a/app.rescue/src/utils/devAuth.ts
+++ b/app.rescue/src/utils/devAuth.ts
@@ -15,8 +15,5 @@ export function setDevUserToken(user: {
   // Create mock dev token (same pattern as app.client)
   const mockToken = `dev-token-${user.userId}-${Date.now()}`;
 
-  // In dev mode, tokens are still cookie-based. Log for diagnostics only.
-  console.log('🔧 Dev token generated (cookie-based auth):', mockToken);
-
   return mockToken;
 }

--- a/eslint-config-base/index.js
+++ b/eslint-config-base/index.js
@@ -27,9 +27,9 @@ export default tseslint.config(
 
       // General JavaScript/TypeScript rules
       'no-console': [
-        'warn',
+        'error',
         {
-          allow: ['warn', 'error', 'info'],
+          allow: ['warn', 'error'],
         },
       ],
       'no-debugger': 'warn',

--- a/eslint-config-react/index.js
+++ b/eslint-config-react/index.js
@@ -39,8 +39,8 @@ export default [
       // Security: disallow unsanitized dangerouslySetInnerHTML
       'react/no-danger': 'error',
 
-      // Override base config for React apps
-      'no-console': 'off',
+      // Override base config for React apps — allow only warn/error
+      'no-console': ['error', { allow: ['warn', 'error'] }],
     },
   },
 ];

--- a/lib.analytics/src/services/analytics-service.ts
+++ b/lib.analytics/src/services/analytics-service.ts
@@ -38,10 +38,6 @@ export class AnalyticsService {
     this.apiService = apiService || new ApiService();
     this.sessionId = this.generateSessionId();
 
-    if (this.config.debug) {
-      console.log(`${AnalyticsService.name} initialized with config:`, this.config);
-    }
-
     this.initializeAnalytics();
   }
 
@@ -153,10 +149,6 @@ export class AnalyticsService {
         events,
         sessionId: this.sessionId,
       });
-
-      if (this.config.debug) {
-        console.log(`${AnalyticsService.name} flushed ${events.length} events`);
-      }
     } catch (error) {
       // Re-queue events on failure
       this.eventQueue.unshift(...events);
@@ -186,10 +178,6 @@ export class AnalyticsService {
    */
   public updateConfig(updates: Partial<AnalyticsServiceConfig>): void {
     this.config = { ...this.config, ...updates };
-
-    if (this.config.debug) {
-      console.log(`${AnalyticsService.name} config updated:`, this.config);
-    }
   }
 
   /**
@@ -218,10 +206,6 @@ export class AnalyticsService {
     if (event.category === 'critical' || event.action === 'error') {
       await this.flushEventQueue();
     }
-
-    if (this.config.debug) {
-      console.log(`${AnalyticsService.name} tracked event:`, fullEvent);
-    }
   }
 
   /**
@@ -242,10 +226,6 @@ export class AnalyticsService {
 
     try {
       await this.apiService.post('/api/v1/analytics/pageviews', fullPageView);
-
-      if (this.config.debug) {
-        console.log(`${AnalyticsService.name} tracked page view:`, fullPageView);
-      }
     } catch (error) {
       if (this.config.debug) {
         console.error(`${AnalyticsService.name} failed to track page view:`, error);
@@ -259,10 +239,6 @@ export class AnalyticsService {
   public async trackUserJourney(journey: UserJourney): Promise<void> {
     try {
       await this.apiService.post('/api/v1/analytics/journeys', journey);
-
-      if (this.config.debug) {
-        console.log(`${AnalyticsService.name} tracked user journey:`, journey.journeyId);
-      }
     } catch (error) {
       if (this.config.debug) {
         console.error(`${AnalyticsService.name} failed to track user journey:`, error);
@@ -291,10 +267,6 @@ export class AnalyticsService {
         `/api/v1/analytics/engagement?${params}`
       )) as EngagementMetrics;
 
-      if (this.config.debug) {
-        console.log(`${AnalyticsService.name} retrieved engagement metrics for period:`, timeRange);
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -322,13 +294,6 @@ export class AnalyticsService {
       const response = (await this.apiService.get(
         `/api/v1/analytics/performance?${params}`
       )) as SystemPerformanceMetrics;
-
-      if (this.config.debug) {
-        console.log(
-          `${AnalyticsService.name} retrieved performance metrics for period:`,
-          timeRange
-        );
-      }
 
       return response;
     } catch (error) {
@@ -359,10 +324,6 @@ export class AnalyticsService {
         requestData
       )) as AnalyticsReport;
 
-      if (this.config.debug) {
-        console.log(`${AnalyticsService.name} generated ${type} report:`, response.id);
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -391,10 +352,6 @@ export class AnalyticsService {
         `/api/v1/analytics/funnels?${params}`
       )) as ConversionFunnel;
 
-      if (this.config.debug) {
-        console.log(`${AnalyticsService.name} retrieved funnel analysis:`, funnelName);
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -412,10 +369,6 @@ export class AnalyticsService {
       const response = (await this.apiService.get(
         `/api/v1/analytics/ab-tests/${testId}`
       )) as ABTestResults;
-
-      if (this.config.debug) {
-        console.log(`${AnalyticsService.name} retrieved A/B test results:`, testId);
-      }
 
       return response;
     } catch (error) {
@@ -495,10 +448,6 @@ export class AnalyticsService {
    */
   public startNewSession(): void {
     this.sessionId = this.generateSessionId();
-
-    if (this.config.debug) {
-      console.log(`${AnalyticsService.name} started new session:`, this.sessionId);
-    }
   }
 
   /**
@@ -527,9 +476,5 @@ export class AnalyticsService {
 
     // Flush any remaining events
     this.flushEventQueue();
-
-    if (this.config.debug) {
-      console.log(`${AnalyticsService.name} destroyed`);
-    }
   }
 }

--- a/lib.api/src/services/api-service.ts
+++ b/lib.api/src/services/api-service.ts
@@ -30,10 +30,6 @@ export class ApiService {
 
     this.interceptors = new InterceptorManager();
     this.setupDefaultInterceptors();
-
-    if (this.config.debug) {
-      console.log(`${ApiService.name} initialized with config:`, this.config);
-    }
   }
 
   private setupDefaultInterceptors(): void {
@@ -148,11 +144,6 @@ export class ApiService {
       this.baseURL = config.apiUrl;
       this.config.apiUrl = config.apiUrl;
     }
-
-    if (this.config.debug) {
-      console.log(`${ApiService.name} config updated:`, this.config);
-      console.log(`${ApiService.name} baseURL updated to:`, this.baseURL);
-    }
   }
 
   /**
@@ -167,10 +158,6 @@ export class ApiService {
    */
   clearCache(): void {
     this.cache.clear();
-
-    if (this.config.debug) {
-      console.log(`${ApiService.name} cache cleared`);
-    }
   }
 
   // Auth token management (delegated to external auth service)
@@ -222,10 +209,6 @@ export class ApiService {
   private async fetchCsrfToken(): Promise<string> {
     const url = `${this.baseURL}/api/v1/csrf-token`;
 
-    if (this.config.debug) {
-      console.log('🔒 Fetching CSRF token from:', url);
-    }
-
     try {
       const response = await fetch(url, {
         method: 'GET',
@@ -245,10 +228,6 @@ export class ApiService {
         throw new Error('CSRF token not found in response');
       }
 
-      if (this.config.debug) {
-        console.log('🔒 CSRF token received');
-      }
-
       return data.csrfToken;
     } catch (error) {
       if (this.config.debug) {
@@ -264,10 +243,6 @@ export class ApiService {
   public clearCsrfToken(): void {
     this.csrfToken = null;
     this.csrfTokenPromise = null;
-
-    if (this.config.debug) {
-      console.log('🔒 CSRF token cleared');
-    }
   }
 
   // Core request method.
@@ -312,13 +287,6 @@ export class ApiService {
 
     // Build full URL
     const fullUrl = url.startsWith('http') ? url : `${this.baseURL}${url}`;
-
-    if (this.config.debug) {
-      console.log(`🌐 API: ${method} ${fullUrl}`);
-      if (body && this.config.debug) {
-        console.log('📤 API: Request body:', body);
-      }
-    }
 
     // Prepare headers
     let requestHeaders: Record<string, string> = {

--- a/lib.applications/src/services/applications-service.ts
+++ b/lib.applications/src/services/applications-service.ts
@@ -360,11 +360,6 @@ export class ApplicationsService {
         };
       }>(url);
 
-      if (this.config.debug) {
-        console.log('Rescue applications retrieved:', response.data?.length || 0);
-        console.log('Response meta:', response.meta);
-      }
-
       // Return the applications array from the standardized response
       return response.data || [];
     } catch (error) {

--- a/lib.chat/src/services/chat-service.ts
+++ b/lib.chat/src/services/chat-service.ts
@@ -78,10 +78,6 @@ export class ChatService {
       csrfToken: config.csrfToken,
       ...config,
     };
-
-    if (this.config.debug) {
-      console.log(`${ChatService.name} initialized with config:`, this.config);
-    }
   }
 
   /**
@@ -133,12 +129,6 @@ export class ChatService {
       });
 
       this.setupSocketEventHandlers();
-
-      if (this.config.debug) {
-        console.log(
-          `${ChatService.name} connecting to ${this.config.socketUrl} for user ${userId}`
-        );
-      }
     } catch (error) {
       this.handleConnectionError(error as Error);
     }
@@ -277,10 +267,6 @@ export class ChatService {
     this.updateConnectionStatus('connected');
     this.reconnectionAttempts = 0;
 
-    if (this.config.debug) {
-      console.log(`${ChatService.name} connected successfully`);
-    }
-
     // Process queued messages
     this.processMessageQueue();
   }
@@ -290,10 +276,6 @@ export class ChatService {
    */
   private handleDisconnect(reason: string): void {
     this.updateConnectionStatus('disconnected');
-
-    if (this.config.debug) {
-      console.log(`${ChatService.name} disconnected: ${reason}`);
-    }
 
     // Attempt reconnection if enabled and not a manual disconnect
     if (
@@ -334,9 +316,6 @@ export class ChatService {
     };
 
     if (this.reconnectionAttempts >= reconnectionConfig.maxAttempts) {
-      if (this.config.debug) {
-        console.log(`${ChatService.name} max reconnection attempts reached`);
-      }
       return;
     }
 
@@ -349,12 +328,6 @@ export class ChatService {
         Math.pow(reconnectionConfig.backoffMultiplier, this.reconnectionAttempts - 1),
       reconnectionConfig.maxDelay
     );
-
-    if (this.config.debug) {
-      console.log(
-        `${ChatService.name} attempting reconnection ${this.reconnectionAttempts}/${reconnectionConfig.maxAttempts} in ${delay}ms`
-      );
-    }
 
     this.reconnectionTimer = setTimeout(() => {
       if (this.currentUserId && this.currentToken) {
@@ -597,10 +570,6 @@ export class ChatService {
           timestamp: new Date().toISOString(),
           retryCount: 0,
         });
-
-        if (this.config.debug) {
-          console.log(`${ChatService.name} message queued (disconnected)`);
-        }
       } else if (this.config.debug) {
         console.warn(`${ChatService.name} message queue full, dropping message`);
       }
@@ -873,10 +842,6 @@ export class ChatService {
    */
   updateConfig(config: Partial<ChatServiceConfig>): void {
     this.config = { ...this.config, ...config };
-
-    if (this.config.debug) {
-      console.log(`${ChatService.name} config updated:`, this.config);
-    }
   }
 
   /**
@@ -891,10 +856,6 @@ export class ChatService {
    */
   clearCache(): void {
     this.cache.clear();
-
-    if (this.config.debug) {
-      console.log(`${ChatService.name} cache cleared`);
-    }
   }
 
   // Test helper methods (for testing only)

--- a/lib.discovery/src/services/discovery-service.ts
+++ b/lib.discovery/src/services/discovery-service.ts
@@ -129,8 +129,7 @@ export class DiscoveryService {
       await this.apiService.post(`${this.API_BASE_URL}/swipe/action`, action);
     } catch (error) {
       if (this.config.debug) {
-        console.warn('Failed to record swipe action to backend, logging locally:', error);
-        console.info('Swipe action recorded (mock):', action);
+        console.warn('Failed to record swipe action to backend:', error);
       }
     }
   }

--- a/lib.invitations/src/services/invitations-service.ts
+++ b/lib.invitations/src/services/invitations-service.ts
@@ -29,10 +29,6 @@ export class InvitationsService {
       debug: false,
       ...config,
     };
-
-    if (this.config.debug) {
-      console.log(`${InvitationsService.name} initialized with config:`, this.config);
-    }
   }
 
   /**
@@ -64,10 +60,6 @@ export class InvitationsService {
         `/api/v1/rescues/${rescueId}/invitations`,
         payload
       );
-
-      if (this.config.debug) {
-        console.log(`Invitation sent to ${payload.email}`, response);
-      }
 
       return response;
     } catch (error) {
@@ -112,10 +104,6 @@ export class InvitationsService {
   async cancelInvitation(rescueId: string, invitationId: number): Promise<void> {
     try {
       await this.apiService.delete(`/api/v1/rescues/${rescueId}/invitations/${invitationId}`);
-
-      if (this.config.debug) {
-        console.log(`Invitation ${invitationId} cancelled`);
-      }
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to cancel invitation:', error);
@@ -156,10 +144,6 @@ export class InvitationsService {
         '/api/v1/invitations/accept',
         payload
       );
-
-      if (this.config.debug) {
-        console.log('Invitation accepted', response);
-      }
 
       return response;
     } catch (error) {

--- a/lib.notifications/src/services/notifications-service.ts
+++ b/lib.notifications/src/services/notifications-service.ts
@@ -28,10 +28,6 @@ export class NotificationsService {
     };
 
     this.apiService = apiService || new ApiService();
-
-    if (this.config.debug) {
-      console.log(`${NotificationsService.name} initialized with config:`, this.config);
-    }
   }
 
   /**
@@ -46,10 +42,6 @@ export class NotificationsService {
    */
   public updateConfig(updates: Partial<NotificationsServiceConfig>): void {
     this.config = { ...this.config, ...updates };
-
-    if (this.config.debug) {
-      console.log(`${NotificationsService.name} config updated:`, this.config);
-    }
   }
 
   // ===== NOTIFICATION DELIVERY =====
@@ -65,10 +57,6 @@ export class NotificationsService {
         '/api/v1/notifications',
         notification
       );
-
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} notification sent to user:`, notification.userId);
-      }
 
       return response;
     } catch (error) {
@@ -90,12 +78,6 @@ export class NotificationsService {
         '/api/v1/notifications/bulk',
         notification
       );
-
-      if (this.config.debug) {
-        console.log(
-          `${NotificationsService.name} bulk notification sent to ${notification.userIds.length} users`
-        );
-      }
 
       return response;
     } catch (error) {
@@ -123,10 +105,6 @@ export class NotificationsService {
         '/api/v1/notifications/schedule',
         scheduledNotification
       );
-
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} notification scheduled for:`, scheduledFor);
-      }
 
       return response;
     } catch (error) {
@@ -161,10 +139,6 @@ export class NotificationsService {
 
       const response = await this.apiService.get<PaginatedResponse<Notification>>(url);
 
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} retrieved notifications for user:`, userId);
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -182,10 +156,6 @@ export class NotificationsService {
       const response = await this.apiService.get<BaseResponse<Notification>>(
         `/api/v1/notifications/${notificationId}`
       );
-
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} retrieved notification:`, notificationId);
-      }
 
       return response;
     } catch (error) {
@@ -208,12 +178,6 @@ export class NotificationsService {
         }
       );
 
-      if (this.config.debug) {
-        console.log(
-          `${NotificationsService.name} marked ${notificationIds.length} notifications as read`
-        );
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -231,13 +195,6 @@ export class NotificationsService {
       const response = await this.apiService.patch<BaseResponse<{ updated: number }>>(
         `/api/v1/notifications/user/${userId}/mark-all-read`
       );
-
-      if (this.config.debug) {
-        console.log(
-          `${NotificationsService.name} marked all notifications as read for user:`,
-          userId
-        );
-      }
 
       return response;
     } catch (error) {
@@ -259,10 +216,6 @@ export class NotificationsService {
         `/api/v1/notifications/${notificationId}`
       );
 
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} deleted notification:`, notificationId);
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -282,10 +235,6 @@ export class NotificationsService {
       const response = await this.apiService.get<BaseResponse<NotificationPreferences>>(
         `/api/v1/notifications/preferences/${userId}`
       );
-
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} retrieved preferences for user:`, userId);
-      }
 
       return response;
     } catch (error) {
@@ -308,10 +257,6 @@ export class NotificationsService {
         `/api/v1/notifications/preferences/${userId}`,
         preferences
       );
-
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} updated preferences for user:`, userId);
-      }
 
       return response;
     } catch (error) {
@@ -342,12 +287,6 @@ export class NotificationsService {
         }
       );
 
-      if (this.config.debug) {
-        console.log(
-          `${NotificationsService.name} set DND for user ${userId}: ${startTime} - ${endTime}`
-        );
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -367,10 +306,6 @@ export class NotificationsService {
       const response = await this.apiService.get<BaseResponse<NotificationTemplate[]>>(
         '/api/v1/notifications/templates'
       );
-
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} retrieved notification templates`);
-      }
 
       return response;
     } catch (error) {
@@ -396,10 +331,6 @@ export class NotificationsService {
         }
       );
 
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} processed template:`, templateId);
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -423,10 +354,6 @@ export class NotificationsService {
         sampleData,
       });
 
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} previewed template:`, templateId);
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -449,10 +376,6 @@ export class NotificationsService {
 
       const response = await this.apiService.get<BaseResponse<NotificationStats>>(url);
 
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} retrieved notification stats`);
-      }
-
       return response;
     } catch (error) {
       if (this.config.debug) {
@@ -470,10 +393,6 @@ export class NotificationsService {
       const response = await this.apiService.get<BaseResponse<{ count: number }>>(
         `/api/v1/notifications/user/${userId}/unread-count`
       );
-
-      if (this.config.debug) {
-        console.log(`${NotificationsService.name} retrieved unread count for user:`, userId);
-      }
 
       return response;
     } catch (error) {

--- a/lib.permissions/src/services/field-permissions-service.ts
+++ b/lib.permissions/src/services/field-permissions-service.ts
@@ -221,11 +221,6 @@ export class FieldPermissionsService {
       await this.apiService.post('/api/v1/field-permissions', request);
       this.clearCache(request.resource, request.role);
 
-      if (this.config.debug) {
-        console.log(
-          `Updated field permission: ${request.resource}.${request.field_name} = ${request.access_level} for ${request.role}`
-        );
-      }
       return true;
     } catch (error) {
       if (this.config.debug) {

--- a/lib.permissions/src/services/permissions-service.ts
+++ b/lib.permissions/src/services/permissions-service.ts
@@ -30,10 +30,6 @@ export class PermissionsService {
     };
 
     this.apiService = apiService || new ApiService();
-
-    if (this.config.debug) {
-      console.log(`${PermissionsService.name} initialized with config:`, this.config);
-    }
   }
 
   /**
@@ -48,10 +44,6 @@ export class PermissionsService {
    */
   public updateConfig(updates: Partial<PermissionsServiceConfig>): void {
     this.config = { ...this.config, ...updates };
-
-    if (this.config.debug) {
-      console.log(`${PermissionsService.name} config updated:`, this.config);
-    }
   }
 
   /**
@@ -73,10 +65,6 @@ export class PermissionsService {
         '/api/v1/permissions/check',
         request
       )) as PermissionCheckResponse;
-
-      if (this.config.debug) {
-        console.log(`Permission check for ${userId}: ${permission} = ${response.hasPermission}`);
-      }
 
       return response.hasPermission;
     } catch (error) {
@@ -139,9 +127,6 @@ export class PermissionsService {
     if (useCache) {
       const cached = this.permissionsCache.get(userId);
       if (cached && Date.now() < cached.expires) {
-        if (this.config.debug) {
-          console.log(`Retrieved cached permissions for ${userId}`);
-        }
         return cached.permissions;
       }
     }
@@ -158,10 +143,6 @@ export class PermissionsService {
           permissions,
           expires: Date.now() + this.cacheTimeout,
         });
-      }
-
-      if (this.config.debug) {
-        console.log(`Retrieved ${permissions.length} permissions for ${userId}`);
       }
 
       return permissions;
@@ -181,10 +162,6 @@ export class PermissionsService {
       const response = (await this.apiService.get(
         `/api/v1/users/${userId}/with-permissions`
       )) as UserWithPermissions;
-
-      if (this.config.debug) {
-        console.log(`Retrieved user with permissions: ${userId}`);
-      }
 
       return response;
     } catch (error) {
@@ -235,10 +212,6 @@ export class PermissionsService {
       // Clear cache for the user
       this.permissionsCache.delete(request.userId);
 
-      if (this.config.debug) {
-        console.log(`Role ${request.role} assigned to user ${request.userId}`);
-      }
-
       return true;
     } catch (error) {
       if (this.config.debug) {
@@ -257,10 +230,6 @@ export class PermissionsService {
 
       // Clear cache for the user
       this.permissionsCache.delete(request.userId);
-
-      if (this.config.debug) {
-        console.log(`Granted ${request.permissions.length} permissions to user ${request.userId}`);
-      }
 
       return true;
     } catch (error) {
@@ -290,10 +259,6 @@ export class PermissionsService {
 
       // Clear cache for the user
       this.permissionsCache.delete(userId);
-
-      if (this.config.debug) {
-        console.log(`Revoked ${permissions.length} permissions from user ${userId}`);
-      }
 
       return true;
     } catch (error) {
@@ -326,10 +291,6 @@ export class PermissionsService {
         `/api/v1/permissions/audit-logs?${params}`
       )) as AuditLogsResponse;
 
-      if (this.config.debug) {
-        console.log(`Retrieved ${response.logs?.length || 0} audit log entries`);
-      }
-
       return response.logs || [];
     } catch (error) {
       if (this.config.debug) {
@@ -345,14 +306,8 @@ export class PermissionsService {
   public clearCache(userId?: string): void {
     if (userId) {
       this.permissionsCache.delete(userId);
-      if (this.config.debug) {
-        console.log(`Cleared permissions cache for user ${userId}`);
-      }
     } else {
       this.permissionsCache.clear();
-      if (this.config.debug) {
-        console.log('Cleared all permissions cache');
-      }
     }
   }
 
@@ -364,10 +319,6 @@ export class PermissionsService {
       const response = (await this.apiService.get(
         '/api/v1/permissions/list'
       )) as SystemPermissionsResponse;
-
-      if (this.config.debug) {
-        console.log(`Retrieved ${response.permissions?.length || 0} system permissions`);
-      }
 
       return response.permissions || [];
     } catch (error) {

--- a/lib.search/src/services/search-service.ts
+++ b/lib.search/src/services/search-service.ts
@@ -301,9 +301,6 @@ export class SearchService {
    */
   clearCache(): void {
     this.cache.clear();
-    if (this.config.debug) {
-      console.log('Search cache cleared');
-    }
   }
 
   /**
@@ -432,10 +429,6 @@ export class SearchService {
         .map(([key]) => key);
 
       expiredKeys.forEach((key) => this.cache.delete(key));
-
-      if (this.config.debug && expiredKeys.length > 0) {
-        console.log(`Cleaned up ${expiredKeys.length} expired cache entries`);
-      }
     }, 60000); // Run every minute
   }
 }

--- a/lib.utils/src/env.ts
+++ b/lib.utils/src/env.ts
@@ -123,10 +123,6 @@ export function getEnvironmentConfig(): EnvironmentConfig {
     ...urls,
   };
 
-  if (debug) {
-    console.log('🌍 Environment configuration loaded:', config);
-  }
-
   return config;
 }
 

--- a/lib.utils/src/services/utils-service.ts
+++ b/lib.utils/src/services/utils-service.ts
@@ -28,10 +28,6 @@ export class UtilsService {
       currency: 'USD',
       ...config,
     };
-
-    if (this.config.debug) {
-      console.log(`${UtilsService.name} initialized with config:`, this.config);
-    }
   }
 
   /**
@@ -46,10 +42,6 @@ export class UtilsService {
    */
   public updateConfig(updates: Partial<UtilsServiceConfig>): void {
     this.config = { ...this.config, ...updates };
-
-    if (this.config.debug) {
-      console.log(`${UtilsService.name} config updated:`, this.config);
-    }
   }
 
   // ===== DATE & TIME UTILITIES =====


### PR DESCRIPTION
## Summary

- Add `'no-console': ['error', { allow: ['warn', 'error'] }]` to `eslint-config-base` and `eslint-config-react`, replacing the previous looser/absent rule to prevent regressions
- Remove all `console.log/info/debug` calls from `src/` files across 10 lib packages and 3 app packages (346 lines deleted), fixing violations the new rule would surface
- `console.warn` and `console.error` are preserved throughout; test files are exempt via the existing override

## Test plan

- [ ] `npx turbo lint` passes with 0 errors across all 25 packages
- [ ] All previously-passing lib package tests continue to pass (lib.search, lib.analytics, lib.api, lib.applications, lib.invitations, lib.notifications, lib.permissions, lib.discovery, lib.utils — 25/25, 25/25, 31/31, 17/17, 10/10, 16/16, 75/75, 22/22, 55/55)
- [ ] No new TypeScript errors introduced (pre-existing failures in lib.components and lib.chat are unrelated to this change)

Closes ADS-488

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_