### PR TITLE
refactor(frontend): forbid inline style prop (warn); migrate priority offenders (ADS-522)

### DIFF
--- a/app.admin/src/components/ui/Skeleton.css.ts
+++ b/app.admin/src/components/ui/Skeleton.css.ts
@@ -32,3 +32,67 @@ export const cardContainer = style({
   borderRadius: '12px',
   padding: '1.5rem',
 });
+
+export const tableCell = style({
+  padding: '1rem',
+});
+
+export const checkboxSkeleton = style({
+  width: '1rem',
+  height: '1rem',
+  borderRadius: '2px',
+});
+
+export const avatarSkeleton = style({
+  width: '2rem',
+  height: '2rem',
+  borderRadius: '50%',
+  flexShrink: 0,
+});
+
+export const flexFill = style({
+  flex: 1,
+});
+
+export const textRowPrimary = style({
+  height: '0.875rem',
+  borderRadius: '4px',
+  marginBottom: '0.25rem',
+});
+
+export const textRowSecondary = style({
+  height: '0.75rem',
+  width: '70%',
+  borderRadius: '4px',
+});
+
+export const genericTextRow = style({
+  height: '0.875rem',
+  borderRadius: '4px',
+});
+
+export const avatarLarge = style({
+  width: '3rem',
+  height: '3rem',
+  borderRadius: '50%',
+  flexShrink: 0,
+});
+
+export const avatarRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  marginBottom: '1rem',
+});
+
+export const cardTextPrimary = style({
+  height: '1rem',
+  borderRadius: '4px',
+  marginBottom: '0.375rem',
+});
+
+export const cardTextSecondary = style({
+  height: '0.875rem',
+  width: '60%',
+  borderRadius: '4px',
+});

--- a/app.admin/src/components/ui/Skeleton.tsx
+++ b/app.admin/src/components/ui/Skeleton.tsx
@@ -32,12 +32,8 @@ export const SkeletonText: React.FC<SkeletonTextProps> = ({ lines = 3, lastLineW
     {Array.from({ length: lines }, (_, i) => (
       <div
         key={i}
-        className={clsx(styles.skeletonBase, styles.textLine)}
-        style={{
-          height: '0.875rem',
-          width: i === lines - 1 ? lastLineWidth : '100%',
-          borderRadius: '4px',
-        }}
+        className={clsx(styles.skeletonBase, styles.textLine, styles.genericTextRow)}
+        style={{ width: i === lines - 1 ? lastLineWidth : '100%' }}
       />
     ))}
   </div>
@@ -54,41 +50,25 @@ export const SkeletonTableRow: React.FC<SkeletonTableRowProps> = ({
 }) => (
   <tr aria-hidden='true' data-testid='skeleton-row'>
     {hasCheckbox && (
-      <td style={{ padding: '1rem' }}>
-        <div
-          className={styles.skeletonBase}
-          style={{ width: '1rem', height: '1rem', borderRadius: '2px' }}
-        />
+      <td className={styles.tableCell}>
+        <div className={clsx(styles.skeletonBase, styles.checkboxSkeleton)} />
       </td>
     )}
     {Array.from({ length: columnCount }, (_, i) => (
-      <td key={i} style={{ padding: '1rem' }}>
+      <td key={i} className={styles.tableCell}>
         <div className={styles.cellContainer}>
           {i === 0 ? (
             <>
-              <div
-                className={styles.skeletonBase}
-                style={{ width: '2rem', height: '2rem', borderRadius: '50%', flexShrink: 0 }}
-              />
-              <div style={{ flex: 1 }}>
-                <div
-                  className={styles.skeletonBase}
-                  style={{ height: '0.875rem', borderRadius: '4px', marginBottom: '0.25rem' }}
-                />
-                <div
-                  className={styles.skeletonBase}
-                  style={{ height: '0.75rem', width: '70%', borderRadius: '4px' }}
-                />
+              <div className={clsx(styles.skeletonBase, styles.avatarSkeleton)} />
+              <div className={styles.flexFill}>
+                <div className={clsx(styles.skeletonBase, styles.textRowPrimary)} />
+                <div className={clsx(styles.skeletonBase, styles.textRowSecondary)} />
               </div>
             </>
           ) : (
             <div
-              className={styles.skeletonBase}
-              style={{
-                height: '0.875rem',
-                width: i % 3 === 0 ? '60%' : '80%',
-                borderRadius: '4px',
-              }}
+              className={clsx(styles.skeletonBase, styles.genericTextRow)}
+              style={{ width: i % 3 === 0 ? '60%' : '80%' }}
             />
           )}
         </div>
@@ -105,20 +85,11 @@ type SkeletonCardProps = {
 export const SkeletonCard: React.FC<SkeletonCardProps> = ({ lines = 3, showAvatar = false }) => (
   <div className={styles.cardContainer} aria-hidden='true'>
     {showAvatar && (
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1rem' }}>
-        <div
-          className={styles.skeletonBase}
-          style={{ width: '3rem', height: '3rem', borderRadius: '50%', flexShrink: 0 }}
-        />
-        <div style={{ flex: 1 }}>
-          <div
-            className={styles.skeletonBase}
-            style={{ height: '1rem', borderRadius: '4px', marginBottom: '0.375rem' }}
-          />
-          <div
-            className={styles.skeletonBase}
-            style={{ height: '0.875rem', width: '60%', borderRadius: '4px' }}
-          />
+      <div className={styles.avatarRow}>
+        <div className={clsx(styles.skeletonBase, styles.avatarLarge)} />
+        <div className={styles.flexFill}>
+          <div className={clsx(styles.skeletonBase, styles.cardTextPrimary)} />
+          <div className={clsx(styles.skeletonBase, styles.cardTextSecondary)} />
         </div>
       </div>
     )}

--- a/app.client/src/pages/FavoritesPage.css.ts
+++ b/app.client/src/pages/FavoritesPage.css.ts
@@ -158,3 +158,17 @@ globalStyle(`${statCard} .label`, {
 export const errorAlert = style({
   margin: '2rem 0',
 });
+
+export const ctaButtonGreen = style({
+  background: '#48bb78',
+  ':hover': {
+    background: '#38a169',
+  },
+});
+
+export const ctaButtonRow = style({
+  display: 'flex',
+  gap: '1rem',
+  justifyContent: 'center',
+  flexWrap: 'wrap',
+});

--- a/app.client/src/pages/FavoritesPage.tsx
+++ b/app.client/src/pages/FavoritesPage.tsx
@@ -131,11 +131,11 @@ export const FavoritesPage: React.FC = () => {
             You haven&apos;t saved any pets to your favorites yet. Start exploring to find pets that
             steal your heart!
           </p>
-          <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+          <div className={styles.ctaButtonRow}>
             <Link to='/discover' className={styles.ctaButton}>
               🔍 Start Swiping
             </Link>
-            <Link to='/search' className={styles.ctaButton} style={{ background: '#48bb78' }}>
+            <Link to='/search' className={`${styles.ctaButton} ${styles.ctaButtonGreen}`}>
               📋 Browse All Pets
             </Link>
           </div>

--- a/app.client/src/pages/ProfilePage.tsx
+++ b/app.client/src/pages/ProfilePage.tsx
@@ -378,12 +378,12 @@ export const ProfilePage: React.FC = () => {
     <div className={styles.section}>
       <h2 className={styles.sectionTitle}>Settings</h2>
       {successMessage && (
-        <div style={{ marginBottom: '1rem' }}>
+        <div className={styles.sectionGap}>
           <Alert variant='success'>{successMessage}</Alert>
         </div>
       )}
       {error && (
-        <div style={{ marginBottom: '1rem' }} role='alert'>
+        <div className={styles.sectionGap} role='alert'>
           <Alert variant='error'>{error}</Alert>
         </div>
       )}

--- a/app.rescue/src/components/analytics/AdoptionTrendsChart.css.ts
+++ b/app.rescue/src/components/analytics/AdoptionTrendsChart.css.ts
@@ -120,3 +120,13 @@ export const loadingSkeleton = style({
     animation: `${shimmer} 1.5s infinite`,
   },
 });
+
+export const emptyState = style({
+  textAlign: 'center',
+  padding: '2rem',
+  color: '#6b7280',
+});
+
+export const chartWrapper = style({
+  position: 'relative',
+});

--- a/app.rescue/src/components/analytics/AdoptionTrendsChart.tsx
+++ b/app.rescue/src/components/analytics/AdoptionTrendsChart.tsx
@@ -25,11 +25,7 @@ const AdoptionTrendsChart: React.FC<AdoptionTrendsChartProps> = ({
   }
 
   if (!data || data.length === 0) {
-    return (
-      <div style={{ textAlign: 'center', padding: '2rem', color: '#6b7280' }}>
-        No trend data available
-      </div>
-    );
+    return <div className={styles.emptyState}>No trend data available</div>;
   }
 
   const padding = { top: 20, right: 20, bottom: 40, left: 50 };
@@ -88,7 +84,7 @@ const AdoptionTrendsChart: React.FC<AdoptionTrendsChartProps> = ({
 
   return (
     <div className={styles.chartContainer}>
-      <div style={{ position: 'relative' }}>
+      <div className={styles.chartWrapper}>
         <svg
           className={styles.svgContainer}
           height={chartHeight}

--- a/app.rescue/src/components/analytics/ConversionFunnelChart.css.ts
+++ b/app.rescue/src/components/analytics/ConversionFunnelChart.css.ts
@@ -158,3 +158,9 @@ export const loadingSkeletonRow = style({
     animation: `${shimmer} 1.5s infinite`,
   },
 });
+
+export const emptyState = style({
+  textAlign: 'center',
+  padding: '2rem',
+  color: '#6b7280',
+});

--- a/app.rescue/src/components/analytics/ConversionFunnelChart.tsx
+++ b/app.rescue/src/components/analytics/ConversionFunnelChart.tsx
@@ -45,11 +45,7 @@ const ConversionFunnelChart: React.FC<ConversionFunnelChartProps> = ({ data, loa
   }
 
   if (!data || data.length === 0) {
-    return (
-      <div style={{ textAlign: 'center', padding: '2rem', color: '#6b7280' }}>
-        No funnel data available
-      </div>
-    );
+    return <div className={styles.emptyState}>No funnel data available</div>;
   }
 
   const totalApplications = data[0]?.applicationsCount || 0;

--- a/app.rescue/src/components/analytics/ResponseTimeChart.css.ts
+++ b/app.rescue/src/components/analytics/ResponseTimeChart.css.ts
@@ -190,3 +190,21 @@ export const loadingSkeletonRow = style({
     animation: `${shimmer} 1.5s infinite`,
   },
 });
+
+export const emptyState = style({
+  textAlign: 'center',
+  padding: '2rem',
+  color: '#6b7280',
+});
+
+export const legendColorGreen = style({
+  background: '#10B981',
+});
+
+export const legendColorRed = style({
+  background: '#EF4444',
+});
+
+export const legendColorGray = style({
+  background: '#D1D5DB',
+});

--- a/app.rescue/src/components/analytics/ResponseTimeChart.tsx
+++ b/app.rescue/src/components/analytics/ResponseTimeChart.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import * as styles from './ResponseTimeChart.css';
 
 interface ResponseTimeData {
@@ -26,11 +27,7 @@ const ResponseTimeChart: React.FC<ResponseTimeChartProps> = ({ data, loading = f
   }
 
   if (!data || data.length === 0) {
-    return (
-      <div style={{ textAlign: 'center', padding: '2rem', color: '#6b7280' }}>
-        No response time data available
-      </div>
-    );
+    return <div className={styles.emptyState}>No response time data available</div>;
   }
 
   // Calculate max value for scaling
@@ -84,15 +81,15 @@ const ResponseTimeChart: React.FC<ResponseTimeChartProps> = ({ data, loading = f
 
       <div className={styles.legend}>
         <div className={styles.legendItem}>
-          <div className={styles.legendColor} style={{ background: '#10B981' }} />
+          <div className={clsx(styles.legendColor, styles.legendColorGreen)} />
           <span>Actual Response Time (Compliant)</span>
         </div>
         <div className={styles.legendItem}>
-          <div className={styles.legendColor} style={{ background: '#EF4444' }} />
+          <div className={clsx(styles.legendColor, styles.legendColorRed)} />
           <span>Actual Response Time (Over SLA)</span>
         </div>
         <div className={styles.legendItem}>
-          <div className={styles.legendColor} style={{ background: '#D1D5DB' }} />
+          <div className={clsx(styles.legendColor, styles.legendColorGray)} />
           <span>SLA Target</span>
         </div>
       </div>

--- a/app.rescue/src/components/analytics/StageDistributionChart.css.ts
+++ b/app.rescue/src/components/analytics/StageDistributionChart.css.ts
@@ -148,3 +148,9 @@ export const loadingSkeleton = style({
     animation: `${shimmer} 1.5s infinite`,
   },
 });
+
+export const emptyState = style({
+  textAlign: 'center',
+  padding: '2rem',
+  color: '#6b7280',
+});

--- a/app.rescue/src/components/analytics/StageDistributionChart.tsx
+++ b/app.rescue/src/components/analytics/StageDistributionChart.tsx
@@ -25,9 +25,7 @@ const StageDistributionChart: React.FC<StageDistributionChartProps> = ({
   if (!data || data.length === 0) {
     return (
       <div className={styles.chartContainer}>
-        <div style={{ textAlign: 'center', padding: '2rem', color: '#6b7280' }}>
-          No data available
-        </div>
+        <div className={styles.emptyState}>No data available</div>
       </div>
     );
   }

--- a/app.rescue/src/components/events/EventAnalytics.css.ts
+++ b/app.rescue/src/components/events/EventAnalytics.css.ts
@@ -123,3 +123,7 @@ export const emptyStateText = style({
   fontSize: '0.875rem',
   color: '#6b7280',
 });
+
+export const progressFillAmber = style({
+  background: '#f59e0b',
+});

--- a/app.rescue/src/components/events/EventAnalytics.tsx
+++ b/app.rescue/src/components/events/EventAnalytics.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import { EventAnalytics as EventAnalyticsType } from '../../types/events';
 import * as styles from './EventAnalytics.css';
 
@@ -101,11 +102,8 @@ const EventAnalytics: React.FC<EventAnalyticsProps> = ({ analytics, loading }) =
             <div className={styles.metricValue}>{analytics.feedbackScore}/5</div>
             <div className={styles.progressBar}>
               <div
-                className={styles.progressFill}
-                style={{
-                  width: `${(analytics.feedbackScore / 5) * 100}%`,
-                  background: '#f59e0b',
-                }}
+                className={clsx(styles.progressFill, styles.progressFillAmber)}
+                style={{ width: `${(analytics.feedbackScore / 5) * 100}%` }}
               />
             </div>
           </div>

--- a/app.rescue/src/components/pets/PetFormModal.css.ts
+++ b/app.rescue/src/components/pets/PetFormModal.css.ts
@@ -115,3 +115,8 @@ export const modalActions = style({
     },
   },
 });
+
+export const submitError = style({
+  color: '#ef4444',
+  marginBottom: '1rem',
+});

--- a/app.rescue/src/components/pets/PetFormModal.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.tsx
@@ -419,9 +419,7 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
             </div>
           </div>
 
-          {errors.submit && (
-            <div style={{ color: '#ef4444', marginBottom: '1rem' }}>{errors.submit}</div>
-          )}
+          {errors.submit && <div className={styles.submitError}>{errors.submit}</div>}
 
           <div className={styles.modalActions}>
             <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>

--- a/eslint-config-react/index.js
+++ b/eslint-config-react/index.js
@@ -36,6 +36,19 @@ export default [
       'jsx-a11y/anchor-is-valid': 'warn',
       'jsx-a11y/mouse-events-have-key-events': 'warn',
 
+      // ADS-522: discourage inline styles — prefer Vanilla Extract classes
+      'react/forbid-component-props': [
+        'warn',
+        {
+          forbid: [
+            {
+              propName: 'style',
+              message: 'Use a Vanilla Extract class instead of inline style — see ADS-522.',
+            },
+          ],
+        },
+      ],
+
       // Security: disallow unsanitized dangerouslySetInnerHTML
       'react/no-danger': 'error',
 

--- a/lib.components/src/components/data/Table/Table.css.ts
+++ b/lib.components/src/components/data/Table/Table.css.ts
@@ -252,3 +252,39 @@ export const loadingRowTd = style({
     },
   },
 });
+
+export const srOnly = style({
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+});
+
+export const loadingSkeletonCell = style({
+  height: '20px',
+  width: '100%',
+});
+
+export const emptyStateIcon = style({
+  marginBottom: '16px',
+  opacity: 0.5,
+});
+
+export const headerCellContentLeft = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+});
+
+export const headerCellContentCenter = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+export const headerCellContentRight = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+});

--- a/lib.components/src/components/data/Table/Table.tsx
+++ b/lib.components/src/components/data/Table/Table.tsx
@@ -2,9 +2,15 @@ import React, { useMemo, useState } from 'react';
 import clsx from 'clsx';
 import {
   emptyState,
+  emptyStateIcon,
+  headerCellContentCenter,
+  headerCellContentLeft,
+  headerCellContentRight,
   loadingRowTd,
+  loadingSkeletonCell,
   sortIconBase,
   sortIconVariants,
+  srOnly,
   stripedRow,
   styledTable,
   tableCell,
@@ -211,17 +217,7 @@ export const Table = <T,>({
     return (
       <div className={clsx(tableContainer({ responsive }), className)} style={containerStyle}>
         {/* Visually hidden spinner for a11y */}
-        <div
-          role='status'
-          aria-live='polite'
-          style={{
-            position: 'absolute',
-            width: 1,
-            height: 1,
-            overflow: 'hidden',
-            clip: 'rect(0 0 0 0)',
-          }}
-        >
+        <div role='status' aria-live='polite' className={srOnly}>
           Loading…
         </div>
         <table className={styledTable({ size, variant })} data-testid={dataTestId}>
@@ -247,7 +243,7 @@ export const Table = <T,>({
               <tr key={index}>
                 {columns.map(column => (
                   <td key={column.key} className={loadingRowTd}>
-                    <div style={{ height: '20px', width: '100%' }} />
+                    <div className={loadingSkeletonCell} />
                   </td>
                 ))}
               </tr>
@@ -269,7 +265,7 @@ export const Table = <T,>({
             fill='none'
             stroke='currentColor'
             strokeWidth='1'
-            style={{ marginBottom: '16px', opacity: 0.5 }}
+            className={emptyStateIcon}
           >
             <rect x='3' y='3' width='18' height='18' rx='2' ry='2' />
             <path d='M9 9h6v6H9z' />
@@ -317,16 +313,13 @@ export const Table = <T,>({
                 }
               >
                 <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent:
-                      column.align === 'center'
-                        ? 'center'
-                        : column.align === 'right'
-                          ? 'flex-end'
-                          : 'flex-start',
-                  }}
+                  className={clsx(
+                    column.align === 'center'
+                      ? headerCellContentCenter
+                      : column.align === 'right'
+                        ? headerCellContentRight
+                        : headerCellContentLeft
+                  )}
                 >
                   {column.headerRender ? column.headerRender() : column.header}
                   {(column.sortable || sortable) && (

--- a/lib.components/src/components/form/SelectInput/SelectInput.css.ts
+++ b/lib.components/src/components/form/SelectInput/SelectInput.css.ts
@@ -381,3 +381,15 @@ export const helperText = recipe({
   },
   defaultVariants: { state: 'default' },
 });
+
+export const iconRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+});
+
+export const emptyMessage = style({
+  padding: '8px',
+  textAlign: 'center',
+  color: '#9ca3af',
+});

--- a/lib.components/src/components/form/SelectInput/SelectInput.tsx
+++ b/lib.components/src/components/form/SelectInput/SelectInput.tsx
@@ -19,6 +19,8 @@ import {
   clearButton,
   placeholder,
   helperText,
+  iconRow,
+  emptyMessage,
 } from './SelectInput.css';
 
 export type SelectOption = {
@@ -230,7 +232,7 @@ export const SelectInput = forwardRef<HTMLButtonElement, SelectInputProps>(
               aria-label={label}
             >
               {renderValue()}
-              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+              <div className={iconRow}>
                 {clearable &&
                   (currentValue || (Array.isArray(currentValue) && currentValue.length > 0)) && (
                     <button
@@ -264,9 +266,7 @@ export const SelectInput = forwardRef<HTMLButtonElement, SelectInputProps>(
                 )}
                 <Select.Viewport className={viewport}>
                   {filteredOptions.length === 0 ? (
-                    <div style={{ padding: '8px', textAlign: 'center', color: '#9ca3af' }}>
-                      No options found
-                    </div>
+                    <div className={emptyMessage}>No options found</div>
                   ) : (
                     filteredOptions.map(option => (
                       <Select.Item

--- a/lib.components/src/components/reports/DrillDownModal.css.ts
+++ b/lib.components/src/components/reports/DrillDownModal.css.ts
@@ -1,0 +1,31 @@
+import { style } from '@vanilla-extract/css';
+
+export const overlay = style({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(15, 23, 42, 0.4)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 50,
+});
+
+export const panel = style({
+  background: 'var(--color-surface, #fff)',
+  borderRadius: '12px',
+  padding: '20px',
+  width: 'min(720px, 92vw)',
+  maxHeight: '85vh',
+  overflowY: 'auto',
+});
+
+export const header = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: '12px',
+});
+
+export const title = style({
+  margin: 0,
+});

--- a/lib.components/src/components/reports/DrillDownModal.tsx
+++ b/lib.components/src/components/reports/DrillDownModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import * as styles from './DrillDownModal.css';
 
 /**
  * ADS-105: Detail view shown when a widget supports drill-down and
@@ -18,25 +19,6 @@ export type DrillDownModalProps = {
   children: React.ReactNode;
 };
 
-const overlayStyle: React.CSSProperties = {
-  position: 'fixed',
-  inset: 0,
-  background: 'rgba(15, 23, 42, 0.4)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  zIndex: 50,
-};
-
-const panelStyle: React.CSSProperties = {
-  background: 'var(--color-surface, #fff)',
-  borderRadius: '12px',
-  padding: '20px',
-  width: 'min(720px, 92vw)',
-  maxHeight: '85vh',
-  overflowY: 'auto',
-};
-
 export const DrillDownModal: React.FC<DrillDownModalProps> = ({ title, onClose, children }) => {
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
@@ -49,17 +31,10 @@ export const DrillDownModal: React.FC<DrillDownModalProps> = ({ title, onClose, 
   }, [onClose]);
 
   return (
-    <div style={overlayStyle} role='presentation'>
-      <div style={panelStyle} role='dialog' aria-modal='true'>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginBottom: '12px',
-          }}
-        >
-          <h3 style={{ margin: 0 }}>{title}</h3>
+    <div className={styles.overlay} role='presentation'>
+      <div className={styles.panel} role='dialog' aria-modal='true'>
+        <div className={styles.header}>
+          <h3 className={styles.title}>{title}</h3>
           <button type='button' onClick={onClose} aria-label='Close'>
             ✕
           </button>


### PR DESCRIPTION
## Summary

- Adds `react/forbid-component-props` ESLint rule (severity: **warn**) to `eslint-config-react` so any new `style={{}}` prop surfaces immediately in CI output
- Migrates ~35 static inline-style occurrences across `app.admin`, `app.client`, `app.rescue`, and `lib.components` to colocated Vanilla Extract classes in `*.css.ts` files
- Dynamic values (percentage widths, runtime colours from data, configurable heights) are intentionally left as inline styles

## Files changed

| Package | Files |
|---|---|
| `eslint-config-react` | `index.js` — new lint rule |
| `app.admin` | `Skeleton.css.ts` / `Skeleton.tsx` |
| `app.client` | `FavoritesPage.css.ts` / `FavoritesPage.tsx`, `ProfilePage.tsx` |
| `app.rescue` | `AdoptionTrendsChart`, `ConversionFunnelChart`, `ResponseTimeChart`, `StageDistributionChart`, `EventAnalytics`, `PetFormModal` (`.css.ts` + `.tsx` each) |
| `lib.components` | `Table.css.ts` / `Table.tsx`, `SelectInput.css.ts` / `SelectInput.tsx`, new `DrillDownModal.css.ts` / `DrillDownModal.tsx` |

## Test plan

- [ ] `npx turbo lint --filter='@adopt-dont-shop/app.*' --filter='@adopt-dont-shop/lib.components'` — 0 errors (only pre-existing warnings + new ADS-522 warnings on remaining unmigrated sites)
- [ ] `npx turbo test --filter='@adopt-dont-shop/app.*' --filter='@adopt-dont-shop/lib.components'` — all 26 tasks pass
- [ ] `npx turbo type-check` — all tasks pass
- [ ] Visual smoke-test: Skeleton loaders, Table, SelectInput, analytics charts, PetFormModal, FavoritesPage all render correctly

Closes ADS-522

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_