### PR TITLE
chore(deps): bump GitHub Actions group (codeql v4, deploy-pages v5)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # security-extended adds queries beyond the default set; this is
@@ -46,6 +46,6 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -42,4 +42,4 @@ jobs:
     environment:
       name: github-pages
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Bundles two trivial GitHub Actions version bumps to reduce review surface.

- `github/codeql-action` v3 → v4 (init + analyze) — aligns with `github/codeql-action/upload-sarif@v4` already used in `docker.yml`
- `actions/deploy-pages` v4 → v5

Supersedes #365 and #366.

## Test plan

- [ ] CodeQL workflow runs green on this PR
- [ ] No other workflow regressions

https://claude.ai/code/session_01PuGRtWaEBMjLFLMiW4cKXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuGRtWaEBMjLFLMiW4cKXQ)_