### PR TITLE
chore(deps): bump otplib 12 -> 13 and dotenv 16 -> 17

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@playwright/test": "^1.49.0",
     "@types/node": "^20.19.0",
-    "otplib": "^12.0.1",
+    "otplib": "^13.4.0",
     "typescript": "^5.4.5"
   }
 }

--- a/e2e/tests/admin/2fa-enrollment.spec.ts
+++ b/e2e/tests/admin/2fa-enrollment.spec.ts
@@ -1,4 +1,4 @@
-import { authenticator } from 'otplib';
+import { generateSync } from 'otplib';
 
 import { test, expect } from '../../fixtures';
 import { postWithCsrf } from '../../helpers/seeds';
@@ -41,7 +41,7 @@ test.describe('admin 2FA enrollment', () => {
     // Confirm we can generate a valid 6-digit code from the secret.
     // This is the contract that actually matters — that the server
     // hands out a secret otplib can drive.
-    const code = authenticator.generate(secret!);
+    const code = generateSync({ secret: secret! });
     expect(code).toMatch(/^\d{6}$/);
 
     // Best-effort enable + disable.  If the server rejects (e.g. the
@@ -55,7 +55,7 @@ test.describe('admin 2FA enrollment', () => {
     if (!enableRes.ok()) {
       return;
     }
-    const disableCode = authenticator.generate(secret!);
+    const disableCode = generateSync({ secret: secret! });
     await postWithCsrf(adminApi.context, '/api/v1/auth/2fa/disable', {
       token: disableCode,
     }).catch(() => undefined);

--- a/package-lock.json
+++ b/package-lock.json
@@ -783,8 +783,30 @@
       "devDependencies": {
         "@playwright/test": "^1.49.0",
         "@types/node": "^20.19.0",
-        "otplib": "^12.0.1",
+        "otplib": "^13.4.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "e2e/node_modules/@otplib/core": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.0.tgz",
+      "integrity": "sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "e2e/node_modules/otplib": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-13.4.0.tgz",
+      "integrity": "sha512-RUcYcRMCgRWhUE/XabRppXpUwCwaWBNHe5iPXhdvP8wwDGpGpsIf/kxX/ec3zFsOaM1Oq8lEhUqDwk6W7DHkwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.0",
+        "@otplib/hotp": "13.4.0",
+        "@otplib/plugin-base32-scure": "13.4.0",
+        "@otplib/plugin-crypto-noble": "13.4.0",
+        "@otplib/totp": "13.4.0",
+        "@otplib/uri": "13.4.0"
       }
     },
     "eslint-config-base": {
@@ -4248,47 +4270,108 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
-    "node_modules/@otplib/core": {
-      "version": "12.0.1",
+    "node_modules/@otplib/hotp": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/hotp/-/hotp-13.4.0.tgz",
+      "integrity": "sha512-MJjE0x06mn2ptymz5qZmQveb+vWFuaIftqE0b5/TZZqUOK7l97cV8lRTmid5BpAQMwJDNLW6RnYxGeCRiNdekw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.0",
+        "@otplib/uri": "13.4.0"
+      }
+    },
+    "node_modules/@otplib/hotp/node_modules/@otplib/core": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.0.tgz",
+      "integrity": "sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@otplib/plugin-crypto": {
-      "version": "12.0.1",
+    "node_modules/@otplib/plugin-base32-scure": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-base32-scure/-/plugin-base32-scure-13.4.0.tgz",
+      "integrity": "sha512-/t9YWJmMbB8bF5z8mXrBZc2FXBe8B/3hG5FhWr9K8cFwFhyxScbPysmZe8s1UTzSA6N+s8Uv8aIfCtVXPNjJWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@otplib/core": "^12.0.1"
+        "@otplib/core": "13.4.0",
+        "@scure/base": "^2.0.0"
       }
     },
-    "node_modules/@otplib/plugin-thirty-two": {
-      "version": "12.0.1",
+    "node_modules/@otplib/plugin-base32-scure/node_modules/@otplib/core": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.0.tgz",
+      "integrity": "sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto-noble": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto-noble/-/plugin-crypto-noble-13.4.0.tgz",
+      "integrity": "sha512-KrvE4m7Zv+TT1944HzgqFJWJpKb6AyoxDbvhPStmBqdMlv5Gekb80d66cuFRL08kkPgJ5gXUSb5SFpYeB+bACg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@otplib/core": "^12.0.1",
-        "thirty-two": "^1.0.2"
+        "@noble/hashes": "^2.0.1",
+        "@otplib/core": "13.4.0"
       }
     },
-    "node_modules/@otplib/preset-default": {
-      "version": "12.0.1",
+    "node_modules/@otplib/plugin-crypto-noble/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@otplib/core": "^12.0.1",
-        "@otplib/plugin-crypto": "^12.0.1",
-        "@otplib/plugin-thirty-two": "^12.0.1"
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@otplib/preset-v11": {
-      "version": "12.0.1",
+    "node_modules/@otplib/plugin-crypto-noble/node_modules/@otplib/core": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.0.tgz",
+      "integrity": "sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@otplib/totp": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/totp/-/totp-13.4.0.tgz",
+      "integrity": "sha512-dK+vl0f0ekzf6mCENRI9AKS2NJUC7OjI3+X8e7QSnhQ2WM7I+i4PGpb3QxKi5hxjTtwVuoZwXR2CFtXdcRtNdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@otplib/core": "^12.0.1",
-        "@otplib/plugin-crypto": "^12.0.1",
-        "@otplib/plugin-thirty-two": "^12.0.1"
+        "@otplib/core": "13.4.0",
+        "@otplib/hotp": "13.4.0",
+        "@otplib/uri": "13.4.0"
       }
+    },
+    "node_modules/@otplib/totp/node_modules/@otplib/core": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.0.tgz",
+      "integrity": "sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@otplib/uri": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/uri/-/uri-13.4.0.tgz",
+      "integrity": "sha512-x1ozBa5bPbdZCrrTL/HK21qchiK7jYElTu+0ft22abeEhiLYgH1+SIULvOcVk3CK8YwF4kdcidvkq4ciejucJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.0"
+      }
+    },
+    "node_modules/@otplib/uri/node_modules/@otplib/core": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.0.tgz",
+      "integrity": "sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
@@ -5162,6 +5245,16 @@
       "version": "1.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sentry-internal/browser-utils": {
       "version": "10.52.0",
@@ -8674,16 +8767,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.7",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dottie": {
@@ -13011,16 +13094,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/otplib": {
-      "version": "12.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@otplib/core": "^12.0.1",
-        "@otplib/preset-default": "^12.0.1",
-        "@otplib/preset-v11": "^12.0.1"
-      }
-    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "dev": true,
@@ -16495,13 +16568,6 @@
         "utrie": "^1.0.2"
       }
     },
-    "node_modules/thirty-two": {
-      "version": "1.0.2",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.6"
-      }
-    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "license": "MIT"
@@ -18131,7 +18197,7 @@
         "cors": "^2.8.5",
         "cron-parser": "^4.9.0",
         "csrf-csrf": "^4.0.3",
-        "dotenv": "^16.0.3",
+        "dotenv": "^17.4.2",
         "express": "^4.18.2",
         "express-rate-limit": "^6.10.0",
         "express-validator": "^7.2.1",
@@ -18261,6 +18327,18 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "service.backend/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "service.backend/node_modules/file-type": {

--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -48,7 +48,7 @@
     "cors": "^2.8.5",
     "cron-parser": "^4.9.0",
     "csrf-csrf": "^4.0.3",
-    "dotenv": "^16.0.3",
+    "dotenv": "^17.4.2",
     "express": "^4.18.2",
     "express-rate-limit": "^6.10.0",
     "express-validator": "^7.2.1",


### PR DESCRIPTION
## Summary

Bundles the two breaking dependency bumps from #376 and #377:

- **otplib 12.0.1 -> 13.4.0** (e2e devDependency)
- **dotenv 16.0.3 -> 17.4.2** (service.backend dependency)

## Code changes

### otplib
v13 removed the `authenticator` named export and replaced the class-based API with a functional one. The only consumer is `e2e/tests/admin/2fa-enrollment.spec.ts`, updated to:

- import `generateSync` from `otplib` instead of `authenticator`
- call `generateSync({ secret })` instead of `authenticator.generate(secret)` for both setup-verify and disable code generation

### dotenv
v17 drops Node <18 (we run Node 22 LTS) and removed `parse(buf)` returning Buffer. service.backend only uses `dotenv.config()` / `config({ path })`, both unchanged in v17, so no code changes were required. Note: v17 prints helpful "tip:" messages to stdout by default but tests still pass cleanly.

## Test plan

- [x] `npx turbo type-check` green across all 46 tasks
- [x] `cd service.backend && npx vitest run` -> 2040 passed / 36 skipped / 0 failed
- [x] `npx turbo lint` -> 0 errors (pre-existing warnings only)

Supersedes #376 and #377.

https://claude.ai/code/session_01PuGRtWaEBMjLFLMiW4cKXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuGRtWaEBMjLFLMiW4cKXQ)_