### PR TITLE
chore(deps): bump zod 3 -> 4

### DIFF
--- a/app.admin/package.json
+++ b/app.admin/package.json
@@ -60,7 +60,7 @@
     "recharts": "^2.12.6",
     "socket.io-client": "^4.7.5",
     "styled-components": "^6.1.12",
-    "zod": "^3.23.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-react": "*",

--- a/app.client/package.json
+++ b/app.client/package.json
@@ -56,7 +56,7 @@
     "react-spring": "^10.0.1",
     "socket.io-client": "^4.7.5",
     "styled-components": "^6.1.12",
-    "zod": "^3.23.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-react": "*",

--- a/app.client/src/utils/validation.ts
+++ b/app.client/src/utils/validation.ts
@@ -84,7 +84,7 @@ export const personalInfoSchema = z.object({
 export const livingSituationSchema = z
   .object({
     housingType: z.enum(['house', 'apartment', 'flat', 'farm', 'other'], {
-      errorMap: () => ({ message: 'Please select a housing type' }),
+      error: () => 'Please select a housing type',
     }),
 
     isOwned: z.boolean(),
@@ -104,7 +104,7 @@ export const livingSituationSchema = z
     yardFenced: z.boolean().optional(),
 
     allowsPets: z.boolean({
-      errorMap: () => ({ message: 'Please confirm if pets are allowed' }),
+      error: () => 'Please confirm if pets are allowed',
     }),
 
     landlordContact: z
@@ -144,7 +144,7 @@ export const petExperienceSchema = z.object({
   hasPetsCurrently: z.boolean(),
 
   experienceLevel: z.enum(['beginner', 'some', 'experienced', 'expert'], {
-    errorMap: () => ({ message: 'Please select your experience level' }),
+    error: () => 'Please select your experience level',
   }),
 
   willingToTrain: z.boolean(),
@@ -282,7 +282,7 @@ export function validateStep(
   }
 
   const errors: Record<string, string> = {};
-  result.error.errors.forEach(error => {
+  result.error.issues.forEach(error => {
     const path = error.path.join('.');
     errors[path] = error.message;
   });
@@ -333,7 +333,7 @@ export function validateField(
           return { isValid: true };
         }
 
-        const error = result.error.errors[0];
+        const error = result.error.issues[0];
         return { isValid: false, error: error?.message || 'Invalid value' };
       }
     }

--- a/app.rescue/package.json
+++ b/app.rescue/package.json
@@ -61,7 +61,7 @@
     "react-spring": "^10.0.1",
     "socket.io-client": "^4.7.5",
     "styled-components": "^6.1.19",
-    "zod": "^3.23.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-react": "*",

--- a/lib.analytics/package.json
+++ b/lib.analytics/package.json
@@ -40,7 +40,7 @@
     "@adopt-dont-shop/lib.types": "*",
     "@types/node": "^20.19.0",
     "socket.io-client": "^4.7.5",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/lib.auth/package.json
+++ b/lib.auth/package.json
@@ -43,7 +43,7 @@
     "@vanilla-extract/css": "^1.20.1",
     "@vanilla-extract/recipes": "^0.5.7",
     "react": "^18.3.1",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "*",

--- a/lib.auth/src/components/LoginForm.tsx
+++ b/lib.auth/src/components/LoginForm.tsx
@@ -60,7 +60,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
     const result = loginSchema.safeParse(formData);
     if (!result.success) {
       const errors: Record<string, string> = {};
-      result.error.errors.forEach((err) => {
+      result.error.issues.forEach((err) => {
         if (err.path[0]) {
           errors[err.path[0].toString()] = err.message;
         }

--- a/lib.auth/src/components/RegisterForm.tsx
+++ b/lib.auth/src/components/RegisterForm.tsx
@@ -87,7 +87,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
     const result = registerSchema.safeParse(formData);
     if (!result.success) {
       const errors: Record<string, string> = {};
-      result.error.errors.forEach((err) => {
+      result.error.issues.forEach((err) => {
         if (err.path[0]) {
           errors[err.path[0].toString()] = err.message;
         }

--- a/lib.moderation/package.json
+++ b/lib.moderation/package.json
@@ -41,7 +41,7 @@
     "@adopt-dont-shop/lib.api": "*",
     "@types/node": "^20.19.0",
     "react": "^18.3.1",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "*",

--- a/lib.moderation/src/schemas.ts
+++ b/lib.moderation/src/schemas.ts
@@ -78,7 +78,7 @@ export const ReportSchema = z.object({
   title: z.string().min(3).max(255),
   description: z.string().min(10).max(5000),
   evidence: z.array(EvidenceItemSchema).default([]),
-  metadata: z.record(z.unknown()).default({}),
+  metadata: z.record(z.string(), z.unknown()).default({}),
   assignedModerator: z.string().nullable().optional(),
   assignedAt: z.coerce.date().nullable().optional(),
   resolvedBy: z.string().nullable().optional(),
@@ -101,7 +101,7 @@ export const CreateReportRequestSchema = z.object({
   title: z.string().min(3).max(255),
   description: z.string().min(10).max(5000),
   evidence: z.array(EvidenceItemSchema).optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 // Update report status request schema
@@ -142,7 +142,7 @@ export const ModeratorActionSchema = z.object({
   severity: ActionSeveritySchema,
   reason: z.string().min(3).max(500),
   description: z.string().optional(),
-  metadata: z.record(z.unknown()).default({}),
+  metadata: z.record(z.string(), z.unknown()).default({}),
   duration: z.number().int().min(1).max(8760).optional(),
   expiresAt: z.coerce.date().optional(),
   isActive: z.boolean().default(true),

--- a/lib.support-tickets/package.json
+++ b/lib.support-tickets/package.json
@@ -41,7 +41,7 @@
     "@adopt-dont-shop/lib.api": "*",
     "@types/node": "^20.19.0",
     "react": "^18.3.1",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "*",

--- a/lib.support-tickets/src/schemas.ts
+++ b/lib.support-tickets/src/schemas.ts
@@ -62,7 +62,7 @@ export const SupportTicketSchema = z.object({
   tags: z.array(z.string()).default([]),
   responses: z.array(TicketResponseSchema).default([]),
   attachments: z.array(AttachmentSchema).default([]),
-  metadata: z.record(z.unknown()).default({}),
+  metadata: z.record(z.string(), z.unknown()).default({}),
   firstResponseAt: z.coerce.date().nullable().optional(),
   lastResponseAt: z.coerce.date().nullable().optional(),
   resolvedAt: z.coerce.date().nullable().optional(),
@@ -91,7 +91,7 @@ export const CreateTicketRequestSchema = z.object({
   description: z.string().min(10).max(10000),
   tags: z.array(z.string()).optional(),
   attachments: z.array(AttachmentSchema).optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 // Update ticket request schema

--- a/lib.validation/package.json
+++ b/lib.validation/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@adopt-dont-shop/lib.types": "*",
     "@types/node": "^20.19.0",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "*",

--- a/lib.validation/src/schemas/rescue.ts
+++ b/lib.validation/src/schemas/rescue.ts
@@ -202,7 +202,7 @@ export const RescueUpdateRequestSchema = z
     contactTitle: ContactTitleSchema.optional(),
     contactEmail: EmailSchema.optional(),
     contactPhone: UkPhoneNumberSchema.optional(),
-    settings: z.record(z.unknown()).optional(),
+    settings: z.record(z.string(), z.unknown()).optional(),
   })
   .strip();
 export type RescueUpdateRequest = z.infer<typeof RescueUpdateRequestSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "recharts": "^2.12.6",
         "socket.io-client": "^4.7.5",
         "styled-components": "^6.1.12",
-        "zod": "^3.23.6"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-react": "*",
@@ -304,6 +304,15 @@
         }
       }
     },
+    "app.admin/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "app.client": {
       "name": "@adopt-dont-shop/app.client",
       "version": "1.0.0",
@@ -346,7 +355,7 @@
         "react-spring": "^10.0.1",
         "socket.io-client": "^4.7.5",
         "styled-components": "^6.1.12",
-        "zod": "^3.23.6"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-react": "*",
@@ -540,6 +549,15 @@
         }
       }
     },
+    "app.client/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "app.rescue": {
       "name": "@adopt-dont-shop/app.rescue",
       "version": "1.0.0",
@@ -585,7 +603,7 @@
         "react-spring": "^10.0.1",
         "socket.io-client": "^4.7.5",
         "styled-components": "^6.1.19",
-        "zod": "^3.23.6"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-react": "*",
@@ -777,6 +795,15 @@
         }
       }
     },
+    "app.rescue/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "e2e": {
       "name": "@adopt-dont-shop/e2e",
       "version": "1.0.0",
@@ -836,7 +863,7 @@
         "@adopt-dont-shop/lib.types": "*",
         "@types/node": "^20.19.0",
         "socket.io-client": "^4.7.5",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-base": "*",
@@ -863,6 +890,15 @@
         "react-query": {
           "optional": true
         }
+      }
+    },
+    "lib.analytics/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "lib.api": {
@@ -943,7 +979,7 @@
         "@vanilla-extract/css": "^1.20.1",
         "@vanilla-extract/recipes": "^0.5.7",
         "react": "^18.3.1",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-base": "*",
@@ -960,6 +996,15 @@
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
+      }
+    },
+    "lib.auth/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "lib.chat": {
@@ -1771,7 +1816,7 @@
         "@adopt-dont-shop/lib.api": "*",
         "@types/node": "^20.19.0",
         "react": "^18.3.1",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-base": "*",
@@ -1817,6 +1862,15 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "lib.moderation/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "lib.notifications": {
@@ -1982,7 +2036,7 @@
         "@adopt-dont-shop/lib.api": "*",
         "@types/node": "^20.19.0",
         "react": "^18.3.1",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-base": "*",
@@ -2028,6 +2082,15 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "lib.support-tickets/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "lib.types": {
@@ -2095,7 +2158,7 @@
       "dependencies": {
         "@adopt-dont-shop/lib.types": "*",
         "@types/node": "^20.19.0",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-base": "*",
@@ -2112,6 +2175,15 @@
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
+      }
+    },
+    "lib.validation/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -18107,13 +18179,6 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "service.backend": {
       "name": "@adopt-dont-shop/service-backend",
       "version": "1.0.0",
@@ -18164,7 +18229,7 @@
         "uuid": "^14.0.0",
         "winston": "^3.17.0",
         "yamljs": "^0.3.0",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-node": "*",
@@ -18446,6 +18511,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "service.backend/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -81,7 +81,7 @@
     "uuid": "^14.0.0",
     "winston": "^3.17.0",
     "yamljs": "^0.3.0",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-node": "*",

--- a/service.backend/src/__tests__/routes/rescue.routes.test.ts
+++ b/service.backend/src/__tests__/routes/rescue.routes.test.ts
@@ -137,7 +137,7 @@ const mockAdminUser = {
   ],
 };
 
-const rescueId = '11111111-1111-1111-1111-111111111111';
+const rescueId = '11111111-1111-4111-8111-111111111111';
 
 const buildApp = () => {
   const app = express();

--- a/service.backend/src/utils/validate-env.ts
+++ b/service.backend/src/utils/validate-env.ts
@@ -25,7 +25,7 @@ const placeholderMessage = 'must not use the default placeholder value';
 
 const secretField = (name: string) =>
   z
-    .string({ required_error: `${name} is required` })
+    .string({ error: `${name} is required` })
     .min(MIN_SECRET_LENGTH, {
       message: `${name} must be at least ${MIN_SECRET_LENGTH} characters long for security`,
     })
@@ -47,7 +47,7 @@ const numericString = (name: string) =>
 
 const booleanString = (name: string) =>
   z.enum(['true', 'false'], {
-    errorMap: () => ({ message: `${name} must be 'true' or 'false'` }),
+    error: () => `${name} must be 'true' or 'false'`,
   });
 
 const urlField = (name: string) =>
@@ -84,7 +84,7 @@ const baseSchema = z.object({
   SESSION_SECRET: secretField('SESSION_SECRET'),
   CSRF_SECRET: secretField('CSRF_SECRET'),
   ENCRYPTION_KEY: z
-    .string({ required_error: 'ENCRYPTION_KEY is required' })
+    .string({ error: 'ENCRYPTION_KEY is required' })
     .length(ENCRYPTION_KEY_HEX_LEN, {
       message:
         `ENCRYPTION_KEY must be exactly ${ENCRYPTION_KEY_HEX_LEN} hex characters (32 bytes). ` +


### PR DESCRIPTION
## Summary

Upgrades zod from 3.25.76 to 4.4.3 across the monorepo. Supersedes #372 (dependabot).

## Breaking-change fixes by category

- **`z.record(value)` -> `z.record(key, value)`** — 6 callsites
  - `lib.moderation/src/schemas.ts` (3)
  - `lib.support-tickets/src/schemas.ts` (2)
  - `lib.validation/src/schemas/rescue.ts` (1; remaining `settings: z.record(z.unknown())` site)
- **`ZodError.errors` -> `ZodError.issues`** — 4 callsites
  - `lib.auth/src/components/LoginForm.tsx`
  - `lib.auth/src/components/RegisterForm.tsx`
  - `app.client/src/utils/validation.ts` (2)
- **`errorMap` option removed -> use `error` callback** — 4 callsites
  - `service.backend/src/utils/validate-env.ts` (booleanString helper)
  - `app.client/src/utils/validation.ts` (3 enums/booleans)
- **`required_error` removed -> use `error` string** — 2 callsites in `service.backend/src/utils/validate-env.ts`
- **UUID validation tightened**: zod 4 enforces RFC 4122 version + variant bits. Updated the `rescueId` test fixture in `service.backend/src/__tests__/routes/rescue.routes.test.ts` from `11111111-1111-1111-1111-111111111111` (variant bits invalid) to a valid v4 UUID.

No `email`, `url`, `discriminatedUnion`, or `deepPartial` callsites needed migration; existing `z.string().uuid()` callsites kept their string-method form (still supported in 4.x).

## Test plan

- [x] `npx turbo type-check` clean
- [x] `npx turbo lint` clean (warnings only, pre-existing)
- [x] `service.backend` vitest: 2040 passed / 36 skipped
- [x] `lib.validation`, `lib.auth`, `lib.moderation`, `lib.support-tickets`, `lib.analytics` tests pass
- [ ] e2e (`@adopt-dont-shop/e2e`) requires `docker:dev:detach`; not runnable in this environment

Supersedes #372.

https://claude.ai/code/session_01PuGRtWaEBMjLFLMiW4cKXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuGRtWaEBMjLFLMiW4cKXQ)_