### PR TITLE
fix(auth): initialize notifications for rehydrated session

### DIFF
--- a/lib.auth/src/contexts/AuthContext.tsx
+++ b/lib.auth/src/contexts/AuthContext.tsx
@@ -50,6 +50,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Fire a single post-authentication signal so consuming apps can run
+  // session-scoped setup (e.g. initialize notifications) for both fresh
+  // logins and rehydrated sessions through one hook.
+  const initializeForAuthenticatedUser = (authenticatedUser: User) => {
+    onAuthEvent?.('auth_session_authenticated', {
+      user_id: authenticatedUser.userId,
+      user_type: authenticatedUser.userType,
+      email: authenticatedUser.email,
+    });
+  };
+
   // Initialize auth state from localStorage
   useEffect(() => {
     const initializeAuth = async () => {
@@ -70,6 +81,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
             }
 
             setUser(parsedUser);
+            initializeForAuthenticatedUser(parsedUser);
             setIsLoading(false);
             return;
           }
@@ -90,9 +102,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
           }
 
           setUser(freshUser);
-
-          // TODO: Initialize notifications for existing authenticated user
-          // Notifications should be initialized by the consuming app if needed
+          if (freshUser) {
+            initializeForAuthenticatedUser(freshUser);
+          }
         }
       } catch (error) {
         console.error('Failed to initialize auth:', error);
@@ -176,6 +188,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         user_type: response.user.userType,
         email: response.user.email,
       });
+
+      initializeForAuthenticatedUser(response.user);
     } catch (error) {
       console.error('Login error:', error);
       setUser(null);


### PR DESCRIPTION
## Summary

- Resolves the long-standing TODO in `lib.auth/src/contexts/AuthContext.tsx` about initializing notifications for users whose session is rehydrated on mount (e.g. page reload while logged in).
- Adds a tiny `initializeForAuthenticatedUser(user)` helper inside `AuthProvider` that fires a single `auth_session_authenticated` event via the existing `onAuthEvent` callback. Both the fresh-login path and the on-mount rehydrate path (real users and dev users) now call it, so consuming apps have one symmetric hook to drive post-auth setup such as notifications subscribe/fetch.
- No new dependencies; `lib.auth` does not (and should not) import `lib.notifications`. The helper preserves the existing inversion: lib.auth signals, the consuming app reacts.

## Before / After

**Before:** `login()` fired `auth_login_successful` and consumers could initialize notifications from that. The mount-time rehydrate effect did nothing equivalent — a user who reloaded the page while logged in never got their notifications kicked off until the next route navigation triggered something. The TODO at line 94 acknowledged the gap.

**After:** Both paths call `initializeForAuthenticatedUser(user)`, which emits `auth_session_authenticated` with `{ user_id, user_type, email }`. Consumers subscribe once to that event (in addition to or instead of `auth_login_successful`) and get notified for both fresh logins and rehydrated sessions. TODO removed.

## Test Plan

- [x] `cd lib.auth && npx tsc --noEmit` — passes
- [x] `cd lib.auth && npx vitest run` — 20/20 pass
- [x] `cd lib.notifications && npx vitest run` — 16/16 pass
- [ ] Manual: log in, reload the page, confirm `auth_session_authenticated` fires once on mount with the rehydrated user (verifiable via app analytics handler).

## Notes for reviewers

- **No AuthContext test was added.** Per the task brief, adding a brand-new React-rendering test scaffold for `AuthProvider` is out of scope (no existing AuthContext test file exists; the closest existing test, `__tests__/auth-service.test.ts`, exercises the `AuthService` class and is the wrong abstraction for an `AuthProvider` mount-behaviour test). Filing this as a follow-up gap: a `lib.auth/src/contexts/AuthContext.test.tsx` should be added with React Testing Library to cover both login and rehydrate paths. This PR is intentionally a behaviour-preserving wiring change.
- **Surprise during investigation:** the original TODO comment claimed "Notifications should be initialized by the consuming app if needed", but in practice no path in `lib.auth` ever called any notifications init — the login flow only fired analytics events. Consuming apps' `NotificationsProvider` (e.g. `app.client/src/contexts/NotificationsContext.tsx`) is mounted without a `userId` prop, so it never reacts to auth state at all today. Adding the symmetric event hook unblocks that wiring without changing app behaviour until a consumer subscribes.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_