### PR TITLE
chore: extract 'TBD' phone placeholder to named constant

### DIFF
--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -17,6 +17,15 @@ const APPLICATION_SORT_FIELDS = [
   'actioned_at',
   'submittedAt',
 ] as const;
+
+// The application_references.phone column is NOT NULL + notEmpty validated
+// (see ApplicationReference model). When the legacy reference shim seeds
+// rows from JSONB answers (or extends the list with synthetic placeholder
+// rows for an out-of-bounds index), a non-empty phone string is required.
+// This sentinel lets the rescue staff see at a glance that the value still
+// needs to be filled in. Producer-side only — no consumer code branches on
+// this literal.
+const LEGACY_PHONE_PLACEHOLDER = 'TBD';
 import ApplicationQuestion, { QuestionCategory } from '../models/ApplicationQuestion';
 import ApplicationStatusTransition from '../models/ApplicationStatusTransition';
 import Breed from '../models/Breed';
@@ -1444,7 +1453,7 @@ export class ApplicationService {
             seeds.push({
               name: clientRefs.veterinarian.name,
               relationship: 'Veterinarian',
-              phone: clientRefs.veterinarian.phone || 'TBD',
+              phone: clientRefs.veterinarian.phone || LEGACY_PHONE_PLACEHOLDER,
               email: clientRefs.veterinarian.email || '',
             });
           }
@@ -1454,7 +1463,7 @@ export class ApplicationService {
               seeds.push({
                 name: ref.name,
                 relationship: ref.relationship,
-                phone: ref.phone || 'TBD',
+                phone: ref.phone || LEGACY_PHONE_PLACEHOLDER,
                 email: ref.email || '',
               });
             });
@@ -1472,7 +1481,7 @@ export class ApplicationService {
             seeds.push({
               name: emergency.name,
               relationship: emergency.relationship || 'Emergency Contact',
-              phone: emergency.phone || 'TBD',
+              phone: emergency.phone || LEGACY_PHONE_PLACEHOLDER,
               email: emergency.email || '',
             });
           }
@@ -1512,7 +1521,7 @@ export class ApplicationService {
             legacy_id: `ref-${i}`,
             name: `Reference ${i + 1}`,
             relationship: 'Unknown',
-            phone: 'TBD',
+            phone: LEGACY_PHONE_PLACEHOLDER,
             email: '',
             status: ApplicationReferenceStatus.PENDING,
             contacted_at: null,


### PR DESCRIPTION
## Investigation findings

The audit flagged four `'TBD'` phone literals in `service.backend/src/services/application.service.ts` (lines 1447, 1457, 1475, 1515 in the original file). All four sit inside `ApplicationService.updateReference` — the legacy reference shim that seeds the typed `application_references` table from the JSONB-era `answers.references` / `answers.emergency_contact` payloads (and extends the row list with synthetic placeholder rows when the caller's index is out of bounds).

I evaluated each of the four interpretations from the brief:

| Interpretation | Verdict | Evidence |
|---|---|---|
| Sentinel value — downstream consumers branch on the literal `'TBD'` | **Ruled out** | `grep -rn "'TBD'\|\"TBD\"" service.backend/src lib.*/src app.*/src` returns only the four producer sites in `application.service.ts`. The two other matches in the repo are `'Location TBD'` strings in `app.rescue/src/components/events/EventCard.tsx` / `EventDetails.tsx` — unrelated to phone references. |
| Legacy data marker — production rows already contain `'TBD'` from a backfill | **Ruled out** | No migration under `service.backend/src/migrations` writes `'TBD'`. No seeder writes `'TBD'` either (the application seeder uses real phone numbers, plus a single `'N/A'`). |
| Genuine placeholder for a required column | **Confirmed** | `service.backend/src/models/ApplicationReference.ts` declares `phone` as `DataTypes.STRING(64)` with `allowNull: false` AND `validate: { notEmpty: true }`. Replacing `'TBD'` with `null` or `''` would fail Sequelize validation at runtime. |
| Dead code path | **Ruled out** | The shim runs whenever `updateReference` is called for an application whose typed-table rows haven't been seeded yet (or whose addressable index exceeds the seeded count). |

## Decision: Option B (extract to named constant)

Option A (replace with `null`) is unsafe — the field is required at the model layer and no consumer-side code is interpreting `'TBD'` as a "missing" sentinel either, so swapping it out silently would just trade a producer hack for a runtime crash.

Option C (no-code investigative PR) overstates the situation. The literal `'TBD'` works correctly today; it's just duplicated four times and unnamed. That's a low-risk, mechanical fix.

So Option B: extract the literal to a named constant `LEGACY_PHONE_PLACEHOLDER`, kept **module-local** to `application.service.ts`. The brief suggests a "shared location" for Option B, but that guideline applies when both producers AND consumers need to import the constant. There are zero consumers, so promoting it to a shared export would violate the "no abstractions for single-use code" rule in `CLAUDE.md`. If a consumer ever needs to recognise the sentinel, hoisting the constant up is trivial.

## Changes

- Added `const LEGACY_PHONE_PLACEHOLDER = 'TBD';` at module scope in `service.backend/src/services/application.service.ts`, alongside the existing `APPLICATION_SORT_FIELDS` constant, with a comment explaining why the value is required and that no consumer branches on it.
- Replaced all four `'TBD'` literals with `LEGACY_PHONE_PLACEHOLDER`.
- No behaviour change. No test changes (the literal's runtime value is identical).

## Consumer dependencies found

None. The full grep across `service.backend/src`, `lib.*/src`, and `app.*/src` returned only the four producer sites in `application.service.ts`.

## Test plan

- [x] `cd service.backend && npx vitest run application.service` — 32/32 passed
- [x] `npx tsc --noEmit` for `service.backend` — no new errors introduced (the file under change is clean; pre-existing errors in `file-upload.service.ts`, `rich-text-processing.service.ts`, and `validate-env.ts` are unrelated to this PR — missing `isomorphic-dompurify` dep and zod 4 migration friction)
- [ ] Manual smoke: hitting `PUT /applications/:id/references/:idx` on an application whose answers contain `references.veterinarian.phone = ''` should still seed a row (with `phone = 'TBD'`) and update its status

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_