### PR TITLE
feat(legal): pending re-acceptance detection endpoint (ADS-497, slice 1/N)

### DIFF
--- a/service.backend/src/__tests__/routes/legal.routes.test.ts
+++ b/service.backend/src/__tests__/routes/legal.routes.test.ts
@@ -24,10 +24,9 @@ vi.mock('../../config/env', () => ({
 }));
 
 vi.mock('../../services/legal-content.service', async () => {
-  const actual =
-    await vi.importActual<typeof import('../../services/legal-content.service')>(
-      '../../services/legal-content.service'
-    );
+  const actual = await vi.importActual<typeof import('../../services/legal-content.service')>(
+    '../../services/legal-content.service'
+  );
   return {
     ...actual,
     getPendingReacceptance: vi.fn(),

--- a/service.backend/src/__tests__/routes/legal.routes.test.ts
+++ b/service.backend/src/__tests__/routes/legal.routes.test.ts
@@ -24,9 +24,10 @@ vi.mock('../../config/env', () => ({
 }));
 
 vi.mock('../../services/legal-content.service', async () => {
-  const actual = await vi.importActual<
-    typeof import('../../services/legal-content.service')
-  >('../../services/legal-content.service');
+  const actual =
+    await vi.importActual<typeof import('../../services/legal-content.service')>(
+      '../../services/legal-content.service'
+    );
   return {
     ...actual,
     getPendingReacceptance: vi.fn(),

--- a/service.backend/src/__tests__/routes/legal.routes.test.ts
+++ b/service.backend/src/__tests__/routes/legal.routes.test.ts
@@ -1,0 +1,145 @@
+/**
+ * ADS-497 (slice 1): route-level behaviour for the pending re-acceptance
+ * endpoint. The legal-content service has its own behaviour tests for the
+ * detection logic; these tests cover the HTTP contract — auth gating,
+ * response shape, and error mapping.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { NextFunction, Response } from 'express';
+import request from 'supertest';
+import { AuthenticatedRequest } from '../../types/api';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn() },
+}));
+
+vi.mock('../../config/env', () => ({
+  env: {
+    JWT_SECRET: 'test-secret-min-32-characters-long-12345',
+    JWT_REFRESH_SECRET: 'test-refresh-secret-min-32-chars-12345',
+    SESSION_SECRET: 'test-session-secret',
+    CSRF_SECRET: 'test-csrf-secret',
+  },
+}));
+
+vi.mock('../../services/legal-content.service', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../services/legal-content.service')
+  >('../../services/legal-content.service');
+  return {
+    ...actual,
+    getPendingReacceptance: vi.fn(),
+  };
+});
+
+const authenticateTokenMock = vi.fn();
+
+vi.mock('../../middleware/auth', () => ({
+  authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authenticateTokenMock(req, res, next),
+}));
+
+import legalRouter from '../../routes/legal.routes';
+import { getPendingReacceptance } from '../../services/legal-content.service';
+
+const mockGetPending = vi.mocked(getPendingReacceptance);
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/legal', legalRouter);
+  return app;
+};
+
+const mockUser = { userId: 'user-1', email: 'user@example.com' };
+
+describe('GET /api/v1/legal/pending-reacceptance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateTokenMock.mockImplementation(
+      (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+        req.user = mockUser as AuthenticatedRequest['user'];
+        next();
+      }
+    );
+  });
+
+  it('returns 401 when the request is unauthenticated', async () => {
+    authenticateTokenMock.mockImplementation((_req, res: Response) => {
+      res.status(401).json({ error: 'Access token required' });
+    });
+
+    const res = await request(buildApp()).get('/api/v1/legal/pending-reacceptance');
+
+    expect(res.status).toBe(401);
+    expect(mockGetPending).not.toHaveBeenCalled();
+  });
+
+  it('returns the full pending list for a user with no prior acceptance', async () => {
+    mockGetPending.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+        {
+          documentType: 'privacy',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+
+    const res = await request(buildApp()).get('/api/v1/legal/pending-reacceptance');
+
+    expect(res.status).toBe(200);
+    expect(res.body.pending).toHaveLength(2);
+    expect(mockGetPending).toHaveBeenCalledWith(mockUser.userId);
+  });
+
+  it('returns an empty pending array when the user is fully up to date', async () => {
+    mockGetPending.mockResolvedValue({ pending: [] });
+
+    const res = await request(buildApp()).get('/api/v1/legal/pending-reacceptance');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ pending: [] });
+  });
+
+  it('returns only the stale document when the user accepted an older version', async () => {
+    mockGetPending.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: '2025-01-01-v1',
+          lastAcceptedAt: '2025-02-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const res = await request(buildApp()).get('/api/v1/legal/pending-reacceptance');
+
+    expect(res.status).toBe(200);
+    expect(res.body.pending).toEqual([
+      {
+        documentType: 'terms',
+        currentVersion: '2026-05-08-v1',
+        lastAcceptedVersion: '2025-01-01-v1',
+        lastAcceptedAt: '2025-02-01T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('returns 500 when the service throws', async () => {
+    mockGetPending.mockRejectedValue(new Error('db down'));
+
+    const res = await request(buildApp()).get('/api/v1/legal/pending-reacceptance');
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/service.backend/src/__tests__/services/legal-content.test.ts
+++ b/service.backend/src/__tests__/services/legal-content.test.ts
@@ -55,7 +55,10 @@ describe('legal content service — getPendingReacceptance', () => {
     mockFindOne.mockReset();
   });
 
-  const buildAuditRow = (details: Record<string, unknown>, timestamp = new Date('2026-01-01T00:00:00Z')) => ({
+  const buildAuditRow = (
+    details: Record<string, unknown>,
+    timestamp = new Date('2026-01-01T00:00:00Z')
+  ) => ({
     metadata: { details },
     timestamp,
   });

--- a/service.backend/src/__tests__/services/legal-content.test.ts
+++ b/service.backend/src/__tests__/services/legal-content.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 
 // Global setup-tests.ts mocks `fs` so most tests don't accidentally
 // hit the disk. The legal-content service is the rare case that
@@ -6,12 +6,26 @@ import { describe, it, expect, vi } from 'vitest';
 // before importing it.
 vi.unmock('fs');
 
+// AuditLog is the storage for ToS / Privacy acceptance (see
+// consent.service.ts). The pending-re-acceptance behaviour is purely
+// derived from the latest CONSENT_RECORDED row, so a mocked findOne
+// is sufficient and keeps the test free of DB setup.
+vi.mock('../../models/AuditLog', () => ({
+  default: { findOne: vi.fn() },
+  AuditLog: { findOne: vi.fn() },
+  withAuditMutationAllowed: vi.fn(),
+}));
+
+import AuditLog from '../../models/AuditLog';
 import {
+  getPendingReacceptance,
   getPrivacyDocument,
   getTermsDocument,
   PRIVACY_VERSION,
   TERMS_VERSION,
 } from '../../services/legal-content.service';
+
+const mockFindOne = vi.mocked(AuditLog.findOne);
 
 describe('legal content service', () => {
   it('returns terms with version + markdown content', () => {
@@ -33,5 +47,93 @@ describe('legal content service', () => {
   it('versions follow a date-based identifier so consent records can be replayed', () => {
     expect(TERMS_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);
     expect(PRIVACY_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+});
+
+describe('legal content service — getPendingReacceptance', () => {
+  beforeEach(() => {
+    mockFindOne.mockReset();
+  });
+
+  const buildAuditRow = (details: Record<string, unknown>, timestamp = new Date('2026-01-01T00:00:00Z')) => ({
+    metadata: { details },
+    timestamp,
+  });
+
+  it('returns both terms and privacy as pending when the user has never recorded consent', async () => {
+    mockFindOne.mockResolvedValue(null);
+
+    const result = await getPendingReacceptance('user-without-history');
+
+    expect(result.pending).toHaveLength(2);
+    const types = result.pending.map(p => p.documentType).sort();
+    expect(types).toEqual(['privacy', 'terms']);
+    result.pending.forEach(item => {
+      expect(item.lastAcceptedVersion).toBeNull();
+      expect(item.lastAcceptedAt).toBeNull();
+    });
+  });
+
+  it('returns an empty list when the user accepted the exact current versions', async () => {
+    mockFindOne.mockResolvedValue(
+      buildAuditRow({
+        tosVersion: TERMS_VERSION,
+        privacyVersion: PRIVACY_VERSION,
+        acceptedAt: '2026-04-01T12:00:00Z',
+      })
+    );
+
+    const result = await getPendingReacceptance('user-up-to-date');
+
+    expect(result.pending).toEqual([]);
+  });
+
+  it('flags only the documents whose accepted version is older than the current version', async () => {
+    mockFindOne.mockResolvedValue(
+      buildAuditRow({
+        tosVersion: '2025-01-01-v1',
+        privacyVersion: PRIVACY_VERSION,
+        acceptedAt: '2025-02-01T00:00:00Z',
+      })
+    );
+
+    const result = await getPendingReacceptance('user-stale-tos');
+
+    expect(result.pending).toHaveLength(1);
+    expect(result.pending[0]).toEqual({
+      documentType: 'terms',
+      currentVersion: TERMS_VERSION,
+      lastAcceptedVersion: '2025-01-01-v1',
+      lastAcceptedAt: '2025-02-01T00:00:00Z',
+    });
+  });
+
+  it('falls back to the audit row timestamp when acceptedAt is missing from the details', async () => {
+    const ts = new Date('2025-06-15T10:30:00Z');
+    mockFindOne.mockResolvedValue(
+      buildAuditRow(
+        {
+          tosVersion: '2025-01-01-v1',
+          privacyVersion: PRIVACY_VERSION,
+        },
+        ts
+      )
+    );
+
+    const result = await getPendingReacceptance('user-no-acceptedAt');
+
+    expect(result.pending).toHaveLength(1);
+    expect(result.pending[0].lastAcceptedAt).toBe(ts.toISOString());
+  });
+
+  it('treats malformed audit metadata as no prior acceptance', async () => {
+    mockFindOne.mockResolvedValue({ metadata: 'not-an-object', timestamp: new Date() });
+
+    const result = await getPendingReacceptance('user-broken-metadata');
+
+    expect(result.pending).toHaveLength(2);
+    result.pending.forEach(item => {
+      expect(item.lastAcceptedVersion).toBeNull();
+    });
   });
 });

--- a/service.backend/src/routes/legal.routes.ts
+++ b/service.backend/src/routes/legal.routes.ts
@@ -1,5 +1,11 @@
-import { Router } from 'express';
-import { getPrivacyDocument, getTermsDocument } from '../services/legal-content.service';
+import { Response, Router } from 'express';
+import {
+  getPendingReacceptance,
+  getPrivacyDocument,
+  getTermsDocument,
+} from '../services/legal-content.service';
+import { authenticateToken } from '../middleware/auth';
+import { AuthenticatedRequest } from '../types/api';
 import { logger } from '../utils/logger';
 
 /**
@@ -39,5 +45,37 @@ router.get('/privacy', (_req, res) => {
     res.status(500).json({ error: 'Failed to load privacy policy' });
   }
 });
+
+/**
+ * ADS-497 (slice 1): which legal documents does this user need to
+ * re-accept because the published version is newer than the version
+ * they last accepted? Returns an empty `pending` array when the user
+ * is fully up to date. Authenticated — anonymous callers can't have
+ * pending re-acceptance.
+ */
+router.get(
+  '/pending-reacceptance',
+  authenticateToken,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const userId = req.user?.userId;
+    if (!userId) {
+      // authenticateToken already 401s when no token is present, but
+      // be defensive in case middleware ever changes shape.
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    try {
+      const result = await getPendingReacceptance(userId);
+      res.json(result);
+    } catch (error) {
+      logger.error('Failed to compute pending re-acceptance', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.status(500).json({ error: 'Failed to load pending re-acceptance' });
+    }
+  }
+);
 
 export default router;

--- a/service.backend/src/services/legal-content.service.ts
+++ b/service.backend/src/services/legal-content.service.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { z } from 'zod';
+import AuditLog from '../models/AuditLog';
 
 /**
  * ADS-495 / ADS-497: legal content + version source of truth.
@@ -10,7 +12,9 @@ import path from 'path';
  *   1. Update the literal here (and the matching version line in the
  *      markdown for human readers).
  *   2. Existing users will see the new version on next sign-in and must
- *      re-accept (re-acceptance flow tracked in ADS-497 follow-up).
+ *      re-accept — the detection side of that flow is
+ *      `getPendingReacceptance` below; the user-facing modal and any
+ *      email notification are tracked in follow-up ADS-497 slices.
  */
 
 export const TERMS_VERSION = '2026-05-08-v1';
@@ -42,3 +46,99 @@ export const getPrivacyDocument = (): LegalDocument => ({
   contentType: 'text/markdown',
   content: readMarkdown('privacy.md'),
 });
+
+/**
+ * ADS-497 (slice 1): pending re-acceptance detection.
+ *
+ * Looks at the user's most recent `CONSENT_RECORDED` audit log row and
+ * compares the recorded ToS / Privacy version strings to the currently
+ * published versions. Any document whose current version differs from
+ * the user's last accepted version (or where the user has never
+ * accepted) is returned as pending.
+ *
+ * Returning a list (not a boolean) keeps the response useful when more
+ * document types are added — the frontend modal can render one section
+ * per pending doc.
+ *
+ * Notes:
+ *   - Only `terms` and `privacy` are tracked today; the `cookies`
+ *     document type from the broader ADS-497 spec does not yet exist
+ *     in `legal-content.service` and is intentionally out of scope for
+ *     this slice.
+ *   - Consent capture writes to `audit_logs` (see
+ *     `consent.service.ts`), so this read also goes there. Migrating
+ *     to a dedicated consent-acceptance table is a separate decision.
+ */
+
+export type LegalDocumentType = 'terms' | 'privacy';
+
+const PendingReacceptanceItemSchema = z.object({
+  documentType: z.enum(['terms', 'privacy']),
+  currentVersion: z.string(),
+  lastAcceptedVersion: z.string().nullable(),
+  lastAcceptedAt: z.string().nullable(),
+});
+
+export const PendingReacceptanceSchema = z.object({
+  pending: z.array(PendingReacceptanceItemSchema),
+});
+
+export type PendingReacceptanceItem = z.infer<typeof PendingReacceptanceItemSchema>;
+export type PendingReacceptance = z.infer<typeof PendingReacceptanceSchema>;
+
+const ConsentDetailsSchema = z.object({
+  tosVersion: z.string().optional(),
+  privacyVersion: z.string().optional(),
+  acceptedAt: z.string().optional(),
+});
+
+const extractConsentDetails = (
+  metadata: unknown
+): z.infer<typeof ConsentDetailsSchema> => {
+  if (!metadata || typeof metadata !== 'object') {
+    return {};
+  }
+  const details = (metadata as { details?: unknown }).details;
+  const parsed = ConsentDetailsSchema.safeParse(details);
+  return parsed.success ? parsed.data : {};
+};
+
+export const getPendingReacceptance = async (
+  userId: string
+): Promise<PendingReacceptance> => {
+  const latest = await AuditLog.findOne({
+    where: { user: userId, action: 'CONSENT_RECORDED' },
+    order: [['timestamp', 'DESC']],
+  });
+
+  const details = latest ? extractConsentDetails(latest.metadata) : {};
+  const lastAcceptedAt = details.acceptedAt ?? latest?.timestamp?.toISOString() ?? null;
+
+  const candidates: ReadonlyArray<{
+    documentType: LegalDocumentType;
+    currentVersion: string;
+    lastAcceptedVersion: string | null;
+  }> = [
+    {
+      documentType: 'terms',
+      currentVersion: TERMS_VERSION,
+      lastAcceptedVersion: details.tosVersion ?? null,
+    },
+    {
+      documentType: 'privacy',
+      currentVersion: PRIVACY_VERSION,
+      lastAcceptedVersion: details.privacyVersion ?? null,
+    },
+  ];
+
+  const pending = candidates
+    .filter(c => c.lastAcceptedVersion !== c.currentVersion)
+    .map(c => ({
+      documentType: c.documentType,
+      currentVersion: c.currentVersion,
+      lastAcceptedVersion: c.lastAcceptedVersion,
+      lastAcceptedAt: c.lastAcceptedVersion ? lastAcceptedAt : null,
+    }));
+
+  return { pending };
+};

--- a/service.backend/src/services/legal-content.service.ts
+++ b/service.backend/src/services/legal-content.service.ts
@@ -92,9 +92,7 @@ const ConsentDetailsSchema = z.object({
   acceptedAt: z.string().optional(),
 });
 
-const extractConsentDetails = (
-  metadata: unknown
-): z.infer<typeof ConsentDetailsSchema> => {
+const extractConsentDetails = (metadata: unknown): z.infer<typeof ConsentDetailsSchema> => {
   if (!metadata || typeof metadata !== 'object') {
     return {};
   }
@@ -103,9 +101,7 @@ const extractConsentDetails = (
   return parsed.success ? parsed.data : {};
 };
 
-export const getPendingReacceptance = async (
-  userId: string
-): Promise<PendingReacceptance> => {
+export const getPendingReacceptance = async (userId: string): Promise<PendingReacceptance> => {
   const latest = await AuditLog.findOne({
     where: { user: userId, action: 'CONSENT_RECORDED' },
     order: [['timestamp', 'DESC']],


### PR DESCRIPTION
## Summary

This is the **backend detection slice** of ADS-497 (re-acceptance of legal content when terms / privacy versions change). It surfaces a single signal the frontend will later consume; the user-facing modal and any email-notification flow are explicitly **out of scope** and will land in follow-up PRs.

### What this PR adds

- `GET /api/v1/legal/pending-reacceptance` (auth-required) returns:

  ```ts
  { pending: Array<{
      documentType: 'terms' | 'privacy';
      currentVersion: string;
      lastAcceptedVersion: string | null;
      lastAcceptedAt: string | null;
  }> }
  ```

- `getPendingReacceptance(userId)` in `legal-content.service.ts` does the comparison: it reads the user's most recent `CONSENT_RECORDED` audit-log row and returns one entry per document whose current published version (`TERMS_VERSION` / `PRIVACY_VERSION`) differs from the version the user last accepted (or where the user has never accepted).

### Behaviour test coverage

Service (`__tests__/services/legal-content.test.ts`):
- never-accepted user → both terms + privacy returned
- exact-current acceptance → empty array
- accepted older terms only → only terms returned, with the stale version + acceptedAt
- audit row present but missing `acceptedAt` field → falls back to row timestamp
- malformed audit metadata → treated as no prior acceptance

Route (`__tests__/routes/legal.routes.test.ts`):
- unauthenticated → 401, service not called
- never-accepted → 200 with full list, called with the right userId
- fully up to date → 200 with `{ pending: [] }`
- stale terms only → 200 with the single stale entry
- service throws → 500

13 tests pass; full backend `tsc --noEmit` shows the same 9 pre-existing errors as `main` (none in changed files).

## Open questions / things called out for reviewers

1. **No dedicated consent-acceptance table.** ToS / Privacy acceptance is currently persisted as a `CONSENT_RECORDED` row in `audit_logs` (see `consent.service.ts`), so the detection logic reads from there too. Migrating to a first-class table is a bigger decision and was intentionally **not** done in this slice — the spec said not to change the consent model schema here.
2. **No `cookies` document type.** The original task spec mentioned `'terms' | 'privacy' | 'cookies'`, but `legal-content.service` today only ships `terms` and `privacy` markdown + version constants. The endpoint returns those two only. If a cookies policy is in scope for ADS-497, that's a separate "publish a cookies document" change and the enum here can be widened in lockstep.
3. **Frontend integration / modal / email notification:** deferred to subsequent slices.

## Test plan

- [ ] CI runs `service.backend` vitest suite green
- [ ] Manual: hit `GET /api/v1/legal/pending-reacceptance` unauthenticated → 401
- [ ] Manual: as a freshly-registered user (just accepted current versions) → `{ pending: [] }`
- [ ] Manual: bump `TERMS_VERSION` locally, hit the endpoint → terms appears in `pending` with the previous version as `lastAcceptedVersion`

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_