### PR TITLE
chore(test): ratchet backend coverage thresholds after ADS-417/490

### DIFF
--- a/service.backend/vitest.config.ts
+++ b/service.backend/vitest.config.ts
@@ -47,11 +47,12 @@ export default defineConfig({
       // PR that adds tests should ratchet these UP — never down.
       // Run via `npm run test:coverage`; the default `npm test` skips
       // coverage to keep watch-mode fast.
+      // Re-baselined post-ADS-417/490 to L=41/S=41/F=49/B=34
       thresholds: {
-        lines: 40,
-        statements: 40,
-        functions: 47,
-        branches: 33,
+        lines: 41,
+        statements: 41,
+        functions: 49,
+        branches: 34,
       },
     },
 


### PR DESCRIPTION
## Summary

Re-baseline `service.backend/vitest.config.ts` coverage thresholds upward to reflect the larger test surface added by recent merges (ADS-417 — 64 supertest route tests; ADS-490 — 94 service tests). Per the existing in-file policy, "Each new PR that adds tests should ratchet these UP — never down."

New floors are computed as `floor(actual - 1)` per metric so the gate keeps a small headroom against measurement noise.

## Measured coverage (this branch, v8 reporter)

```
=============================== Coverage summary ===============================
Statements   : 42.96% ( 6632/15435 )
Branches     : 35.85% ( 3203/8934 )
Functions    : 50.59% ( 1109/2192 )
Lines        : 42.7%  ( 6468/15145 )
================================================================================
```

## Threshold changes

| Metric | Old | New | Delta | Actual |
|---|---|---|---|---|
| Lines      | 40 | 41 | +1 | 42.7%  |
| Statements | 40 | 41 | +1 | 42.96% |
| Functions  | 47 | 49 | +2 | 50.59% |
| Branches   | 33 | 34 | +1 | 35.85% |

All four thresholds ratchet up; none decrease. Coverage passes with the new thresholds (no `ERROR: Coverage for ... does not meet global threshold` lines in the verification run).

## Notes

- Only the four threshold numbers (and a one-line provenance comment) were changed. Provider, reporters, exclude list, and surrounding policy comment block are untouched.
- The verification coverage run exits non-zero, but solely due to a pre-existing unrelated failing test in `src/utils/validate-env.test.ts` ("rejects non-boolean WORKER_ENABLED" — the assertion expects a custom error message but Zod is now emitting its default `Invalid enum value` message). This is not introduced by this PR and has no bearing on coverage thresholds. Worth a follow-up.

## Test plan

- [ ] CI runs `npm run test:coverage` for `service.backend` and the coverage gate passes against the new thresholds.
- [ ] Reviewer sanity-checks that no other vitest config option (provider/reporter/exclude/etc.) was modified.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_