### PR TITLE
feat(legal): add cookies document type with placeholder text (ADS-497)

### DIFF
--- a/docs/legal/cookies.md
+++ b/docs/legal/cookies.md
@@ -1,0 +1,7 @@
+# Cookies Policy
+
+> **PLACEHOLDER — DO NOT SHIP.** This document needs legal review before
+> the cookies type is exposed to users. Replace this entire body with the
+> approved cookies policy before merging the PR that consumes it.
+
+_Version: 2026-05-09-v0-PLACEHOLDER_

--- a/service.backend/src/__tests__/services/legal-content.test.ts
+++ b/service.backend/src/__tests__/services/legal-content.test.ts
@@ -18,6 +18,8 @@ vi.mock('../../models/AuditLog', () => ({
 
 import AuditLog from '../../models/AuditLog';
 import {
+  COOKIES_VERSION,
+  getCookiesDocument,
   getPendingReacceptance,
   getPrivacyDocument,
   getTermsDocument,
@@ -44,9 +46,25 @@ describe('legal content service', () => {
     expect(doc.content).toContain('Privacy Policy');
   });
 
+  it('returns cookies with version + markdown content', () => {
+    const doc = getCookiesDocument();
+    expect(doc.version).toBe(COOKIES_VERSION);
+    expect(doc.contentType).toBe('text/markdown');
+    expect(doc.content.length).toBeGreaterThan(0);
+    expect(doc.content).toContain('Cookies Policy');
+  });
+
+  it('flags the cookies version as a placeholder so it is obvious in audit/pending output', () => {
+    // The cookies markdown is a stand-in awaiting legal review. The
+    // version constant carries that signal so any consent record or
+    // pending-reacceptance row that surfaces it is easy to spot.
+    expect(COOKIES_VERSION).toContain('PLACEHOLDER');
+  });
+
   it('versions follow a date-based identifier so consent records can be replayed', () => {
     expect(TERMS_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);
     expect(PRIVACY_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);
+    expect(COOKIES_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);
   });
 });
 
@@ -63,25 +81,26 @@ describe('legal content service — getPendingReacceptance', () => {
     timestamp,
   });
 
-  it('returns both terms and privacy as pending when the user has never recorded consent', async () => {
+  it('returns terms, privacy, and cookies as pending when the user has never recorded consent', async () => {
     mockFindOne.mockResolvedValue(null);
 
     const result = await getPendingReacceptance('user-without-history');
 
-    expect(result.pending).toHaveLength(2);
+    expect(result.pending).toHaveLength(3);
     const types = result.pending.map(p => p.documentType).sort();
-    expect(types).toEqual(['privacy', 'terms']);
+    expect(types).toEqual(['cookies', 'privacy', 'terms']);
     result.pending.forEach(item => {
       expect(item.lastAcceptedVersion).toBeNull();
       expect(item.lastAcceptedAt).toBeNull();
     });
   });
 
-  it('returns an empty list when the user accepted the exact current versions', async () => {
+  it('returns an empty list when the user accepted the exact current versions for every tracked document', async () => {
     mockFindOne.mockResolvedValue(
       buildAuditRow({
         tosVersion: TERMS_VERSION,
         privacyVersion: PRIVACY_VERSION,
+        cookiesVersion: COOKIES_VERSION,
         acceptedAt: '2026-04-01T12:00:00Z',
       })
     );
@@ -96,6 +115,7 @@ describe('legal content service — getPendingReacceptance', () => {
       buildAuditRow({
         tosVersion: '2025-01-01-v1',
         privacyVersion: PRIVACY_VERSION,
+        cookiesVersion: COOKIES_VERSION,
         acceptedAt: '2025-02-01T00:00:00Z',
       })
     );
@@ -111,6 +131,51 @@ describe('legal content service — getPendingReacceptance', () => {
     });
   });
 
+  it('flags cookies as pending when the user accepted an older cookies version', async () => {
+    mockFindOne.mockResolvedValue(
+      buildAuditRow({
+        tosVersion: TERMS_VERSION,
+        privacyVersion: PRIVACY_VERSION,
+        cookiesVersion: '2025-01-01-cookies-v1',
+        acceptedAt: '2025-02-01T00:00:00Z',
+      })
+    );
+
+    const result = await getPendingReacceptance('user-stale-cookies');
+
+    expect(result.pending).toHaveLength(1);
+    expect(result.pending[0]).toEqual({
+      documentType: 'cookies',
+      currentVersion: COOKIES_VERSION,
+      lastAcceptedVersion: '2025-01-01-cookies-v1',
+      lastAcceptedAt: '2025-02-01T00:00:00Z',
+    });
+  });
+
+  it('flags cookies as pending when consent was recorded without any cookiesVersion at all', async () => {
+    // Today's consent.service writes only tosVersion + privacyVersion.
+    // Until that gap is closed, every existing user will surface
+    // cookies as pending — this test pins that behaviour so the
+    // shape is stable for the frontend modal.
+    mockFindOne.mockResolvedValue(
+      buildAuditRow({
+        tosVersion: TERMS_VERSION,
+        privacyVersion: PRIVACY_VERSION,
+        acceptedAt: '2026-04-01T12:00:00Z',
+      })
+    );
+
+    const result = await getPendingReacceptance('user-pre-cookies-capture');
+
+    expect(result.pending).toHaveLength(1);
+    expect(result.pending[0]).toEqual({
+      documentType: 'cookies',
+      currentVersion: COOKIES_VERSION,
+      lastAcceptedVersion: null,
+      lastAcceptedAt: null,
+    });
+  });
+
   it('falls back to the audit row timestamp when acceptedAt is missing from the details', async () => {
     const ts = new Date('2025-06-15T10:30:00Z');
     mockFindOne.mockResolvedValue(
@@ -118,6 +183,7 @@ describe('legal content service — getPendingReacceptance', () => {
         {
           tosVersion: '2025-01-01-v1',
           privacyVersion: PRIVACY_VERSION,
+          cookiesVersion: COOKIES_VERSION,
         },
         ts
       )
@@ -134,7 +200,7 @@ describe('legal content service — getPendingReacceptance', () => {
 
     const result = await getPendingReacceptance('user-broken-metadata');
 
-    expect(result.pending).toHaveLength(2);
+    expect(result.pending).toHaveLength(3);
     result.pending.forEach(item => {
       expect(item.lastAcceptedVersion).toBeNull();
     });

--- a/service.backend/src/routes/legal.routes.ts
+++ b/service.backend/src/routes/legal.routes.ts
@@ -1,5 +1,6 @@
 import { Response, Router } from 'express';
 import {
+  getCookiesDocument,
   getPendingReacceptance,
   getPrivacyDocument,
   getTermsDocument,
@@ -43,6 +44,23 @@ router.get('/privacy', (_req, res) => {
       error: error instanceof Error ? error.message : String(error),
     });
     res.status(500).json({ error: 'Failed to load privacy policy' });
+  }
+});
+
+// NOTE: the cookies document body is currently a clearly-marked
+// placeholder pending legal review. The endpoint is wired so the
+// version constant + markdown source can be referenced end-to-end, but
+// the response body must not be linked from any user-facing UI until
+// `docs/legal/cookies.md` is replaced with approved copy.
+router.get('/cookies', (_req, res) => {
+  try {
+    const doc = getCookiesDocument();
+    res.json({ data: doc });
+  } catch (error) {
+    logger.error('Failed to read cookies document', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ error: 'Failed to load cookies policy' });
   }
 });
 

--- a/service.backend/src/services/legal-content.service.ts
+++ b/service.backend/src/services/legal-content.service.ts
@@ -19,6 +19,12 @@ import AuditLog from '../models/AuditLog';
 
 export const TERMS_VERSION = '2026-05-08-v1';
 export const PRIVACY_VERSION = '2026-05-08-v1';
+// The `-PLACEHOLDER` suffix is intentional and load-bearing: any cookies
+// row surfaced by `getPendingReacceptance` (or written into an audit log)
+// is obviously not-yet-legally-reviewed. Replace this constant — and the
+// version line in `docs/legal/cookies.md` — when the real cookies policy
+// lands.
+export const COOKIES_VERSION = '2026-05-09-v0-PLACEHOLDER';
 
 const DOCS_DIR = path.resolve(__dirname, '..', '..', '..', 'docs', 'legal');
 
@@ -47,6 +53,12 @@ export const getPrivacyDocument = (): LegalDocument => ({
   content: readMarkdown('privacy.md'),
 });
 
+export const getCookiesDocument = (): LegalDocument => ({
+  version: COOKIES_VERSION,
+  contentType: 'text/markdown',
+  content: readMarkdown('cookies.md'),
+});
+
 /**
  * ADS-497 (slice 1): pending re-acceptance detection.
  *
@@ -61,19 +73,23 @@ export const getPrivacyDocument = (): LegalDocument => ({
  * per pending doc.
  *
  * Notes:
- *   - Only `terms` and `privacy` are tracked today; the `cookies`
- *     document type from the broader ADS-497 spec does not yet exist
- *     in `legal-content.service` and is intentionally out of scope for
- *     this slice.
+ *   - `terms`, `privacy`, and `cookies` are tracked. The cookies copy
+ *     and version are currently a clearly-marked placeholder
+ *     (`COOKIES_VERSION` ends in `-PLACEHOLDER`) and the consent service
+ *     does not yet capture a `cookiesVersion`, so until both land
+ *     `getPendingReacceptance` will always return `cookies` as pending
+ *     for every user. That is intentional for the wiring slice and
+ *     should be addressed before the cookies type is shown in the
+ *     re-acceptance modal.
  *   - Consent capture writes to `audit_logs` (see
  *     `consent.service.ts`), so this read also goes there. Migrating
  *     to a dedicated consent-acceptance table is a separate decision.
  */
 
-export type LegalDocumentType = 'terms' | 'privacy';
+export type LegalDocumentType = 'terms' | 'privacy' | 'cookies';
 
 const PendingReacceptanceItemSchema = z.object({
-  documentType: z.enum(['terms', 'privacy']),
+  documentType: z.enum(['terms', 'privacy', 'cookies']),
   currentVersion: z.string(),
   lastAcceptedVersion: z.string().nullable(),
   lastAcceptedAt: z.string().nullable(),
@@ -89,6 +105,11 @@ export type PendingReacceptance = z.infer<typeof PendingReacceptanceSchema>;
 const ConsentDetailsSchema = z.object({
   tosVersion: z.string().optional(),
   privacyVersion: z.string().optional(),
+  // Forward-compatible: consent.service does not write this field today,
+  // so it will always be undefined and the cookies row will surface as
+  // pending. Once consent capture starts persisting it, this read picks
+  // it up automatically.
+  cookiesVersion: z.string().optional(),
   acceptedAt: z.string().optional(),
 });
 
@@ -124,6 +145,11 @@ export const getPendingReacceptance = async (userId: string): Promise<PendingRea
       documentType: 'privacy',
       currentVersion: PRIVACY_VERSION,
       lastAcceptedVersion: details.privacyVersion ?? null,
+    },
+    {
+      documentType: 'cookies',
+      currentVersion: COOKIES_VERSION,
+      lastAcceptedVersion: details.cookiesVersion ?? null,
     },
   ];
 


### PR DESCRIPTION
## Summary

Follow-up to #414. Wires a third legal document type (`cookies`) end-to-end through the existing ADS-495/ADS-497 plumbing so the version constant, public endpoint, and pending-reacceptance detection all know about it.

> **DO NOT MERGE WITHOUT LEGAL REVIEW.** `docs/legal/cookies.md` is a deliberate placeholder. The version constant `2026-05-09-v0-PLACEHOLDER` is load-bearing — it makes any cookies row that surfaces in audit logs or pending-reacceptance output obviously not-yet-legally-reviewed. Replace both before this PR is taken out of draft.

## Changes

- **`docs/legal/cookies.md`** (new) — placeholder body with a prominent "DO NOT SHIP" banner. Replace the entire body with approved cookies policy copy before merging.
- **`service.backend/src/services/legal-content.service.ts`**
  - Adds `COOKIES_VERSION = '2026-05-09-v0-PLACEHOLDER'` and `getCookiesDocument()` mirroring the existing two getters.
  - Widens `LegalDocumentType` and the pending-reacceptance Zod enum to include `'cookies'`.
  - Adds a third candidate to `getPendingReacceptance` reading from `details.cookiesVersion ?? null`.
- **`service.backend/src/routes/legal.routes.ts`** — adds `GET /api/v1/legal/cookies` returning `getCookiesDocument()`. Mirrors the existing `/terms` and `/privacy` handlers.
- **`service.backend/src/__tests__/services/legal-content.test.ts`** — extends behaviour tests to cover the cookies document and the third candidate in pending detection (never-accepted user gets all 3, exact-current acceptance returns empty, stale cookies version returns it, pre-cookies-capture audit row surfaces cookies as pending).

## Consent-side gap (intentional, follow-up)

`consent.service.ts` does **not** yet capture a `cookiesVersion` field on the `CONSENT_RECORDED` audit row — it still only writes `tosVersion` + `privacyVersion`. Until that side is updated, every existing user (and every newly-registered user) will surface `cookies` as pending in `getPendingReacceptance`. The new test `flags cookies as pending when consent was recorded without any cookiesVersion at all` pins that behaviour so it doesn't drift silently.

This is intentional for this slice — closing the consent-capture side is out of scope here.

## Open questions for the user

1. **Where should the cookies-acceptance signal come from on initial registration?** Today's consent service only writes `tosVersion` + `privacyVersion`. Does it need a third field on the registration consent payload, or do we treat cookies acceptance as implicit-on-signup (e.g. backfill `cookiesVersion = COOKIES_VERSION` at the same time as the other two) until a dedicated cookie-banner flow exists?
2. **Should `getPendingReacceptance` filter out the cookies entry while the version is still a `-PLACEHOLDER` string,** to avoid forcing a no-op acceptance from existing users when a frontend modal eventually consumes this list? Trade-off: filtering hides the wiring; not filtering is honest but every authed call returns at least one stale row until both gaps close.

## Scope guards (for review)

- No real cookies policy text — placeholder only.
- Consent-recording side unchanged (`tosVersion`/`privacyVersion` only).
- No frontend UI for cookies.
- `TERMS_VERSION` and `PRIVACY_VERSION` unchanged.

## Test plan

- [x] `service.backend` lint: 0 errors (300 pre-existing warnings)
- [x] `service.backend` `tsc --noEmit`: clean
- [x] `service.backend` full vitest suite: 2073 passed, 36 skipped (pre-existing)
- [x] Targeted: `legal-content.test.ts` (12 tests) + `legal.routes.test.ts` (5 tests) all green
- [ ] Replace `docs/legal/cookies.md` body with legally-reviewed copy before un-drafting
- [ ] Replace `COOKIES_VERSION` placeholder string with a dated, non-placeholder version before un-drafting
- [ ] Decide consent-side capture story (open question 1) and link/file the follow-up ticket
- [ ] Decide whether to filter placeholder versions from pending-reacceptance (open question 2)

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_