### PR TITLE
feat(legal): user-facing re-acceptance modal (ADS-497, slice 2/N)

### DIFF
--- a/app.client/src/App.tsx
+++ b/app.client/src/App.tsx
@@ -10,6 +10,7 @@ import { DevLoginPanel } from './components/dev/DevLoginPanel';
 import { AppShell } from './components/layout/AppShell';
 import { PublicAuthLayout } from './components/layout/PublicAuthLayout';
 import { ErrorBoundary } from './components/common/ErrorBoundary';
+import { LegalReacceptanceModal } from './components/modals/LegalReacceptanceModal';
 import * as styles from './App.css';
 
 const HomePage = lazy(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })));
@@ -92,6 +93,9 @@ function App() {
           <ChatProvider>
             <FavoritesProvider>
               <DevLoginPanel />
+              {/* ADS-497 (slice 2): hard-block modal for users whose last
+                  accepted ToS / Privacy version is older than current. */}
+              <LegalReacceptanceModal />
               <Suspense fallback={<PageLoader />}>
                 <Routes>
                   <Route element={<PublicAuthLayout />}>

--- a/app.client/src/components/modals/LegalReacceptanceModal.css.ts
+++ b/app.client/src/components/modals/LegalReacceptanceModal.css.ts
@@ -1,0 +1,76 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const modalContent = style({
+  padding: '1.5rem',
+  maxWidth: '520px',
+});
+
+export const description = style({
+  color: vars.colors.neutral['700'],
+  marginBottom: '1.5rem',
+  lineHeight: 1.6,
+});
+
+export const documentList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  marginBottom: '1.5rem',
+});
+
+export const documentItem = style({
+  border: `1px solid ${vars.colors.neutral['200']}`,
+  borderRadius: '0.5rem',
+  padding: '1rem',
+});
+
+export const documentLabel = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '0.75rem',
+  cursor: 'pointer',
+});
+
+export const checkbox = style({
+  marginTop: '0.25rem',
+  width: '1.1rem',
+  height: '1.1rem',
+  flexShrink: 0,
+});
+
+export const documentTextBlock = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+});
+
+export const documentTitle = style({
+  fontWeight: 600,
+  color: vars.colors.neutral['900'],
+});
+
+export const documentMeta = style({
+  fontSize: '0.85rem',
+  color: vars.colors.neutral['600'],
+});
+
+export const documentLink = style({
+  fontSize: '0.85rem',
+  color: vars.colors.primary['600'],
+  textDecoration: 'underline',
+});
+
+export const errorAlert = style({
+  marginBottom: '1rem',
+});
+
+export const actionButtons = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '0.75rem',
+});
+
+export const buttonSpinner = style({
+  marginRight: '0.5rem',
+});

--- a/app.client/src/components/modals/LegalReacceptanceModal.test.tsx
+++ b/app.client/src/components/modals/LegalReacceptanceModal.test.tsx
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@/test-utils/render';
+import userEvent from '@testing-library/user-event';
+import { LegalReacceptanceModal } from './LegalReacceptanceModal';
+import type { User } from '@adopt-dont-shop/lib.auth';
+
+type AuthState = { user: User | null; isAuthenticated: boolean };
+
+const authState: AuthState = { user: null, isAuthenticated: false };
+
+const baseUser: User = {
+  userId: 'u-1',
+  email: 'user@example.com',
+  firstName: 'Sam',
+  lastName: 'Doe',
+  emailVerified: true,
+  userType: 'adopter',
+  status: 'active',
+};
+
+const fetchPendingMock = vi.fn();
+const recordReacceptanceMock = vi.fn();
+
+vi.mock('@/services/legalService', () => ({
+  fetchPendingReacceptance: () => fetchPendingMock(),
+  recordReacceptance: (input: unknown) => recordReacceptanceMock(input),
+}));
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: authState.user,
+      isAuthenticated: authState.isAuthenticated,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+describe('LegalReacceptanceModal [ADS-497 slice 2]', () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.isAuthenticated = false;
+    fetchPendingMock.mockReset();
+    recordReacceptanceMock.mockReset();
+  });
+
+  it('does not render for unauthenticated users and never calls the API', async () => {
+    fetchPendingMock.mockResolvedValue({ pending: [] });
+    render(<LegalReacceptanceModal />);
+
+    // No auth → no fetch, no modal.
+    expect(fetchPendingMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('legal-reacceptance-modal')).not.toBeInTheDocument();
+  });
+
+  it('does not render when authenticated user has no pending documents', async () => {
+    authState.user = baseUser;
+    authState.isAuthenticated = true;
+    fetchPendingMock.mockResolvedValue({ pending: [] });
+
+    render(<LegalReacceptanceModal />);
+
+    await waitFor(() => {
+      expect(fetchPendingMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByTestId('legal-reacceptance-modal')).not.toBeInTheDocument();
+  });
+
+  it('renders the modal with a disabled accept button until the checkbox is ticked, then records consent and closes', async () => {
+    authState.user = baseUser;
+    authState.isAuthenticated = true;
+    fetchPendingMock.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: '2025-09-01-v1',
+          lastAcceptedAt: '2025-09-02T00:00:00.000Z',
+        },
+      ],
+    });
+    recordReacceptanceMock.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    render(<LegalReacceptanceModal />);
+
+    const modal = await screen.findByTestId('legal-reacceptance-modal');
+    expect(
+      within(modal).getByRole('checkbox', { name: /i accept the updated terms of service/i })
+    ).toBeInTheDocument();
+
+    const acceptButton = within(modal).getByRole('button', { name: /accept and continue/i });
+    expect(acceptButton).toBeDisabled();
+
+    const checkbox = within(modal).getByRole('checkbox', {
+      name: /i accept the updated terms of service/i,
+    });
+    await user.click(checkbox);
+
+    expect(acceptButton).toBeEnabled();
+
+    await user.click(acceptButton);
+
+    await waitFor(() => {
+      expect(recordReacceptanceMock).toHaveBeenCalledTimes(1);
+    });
+    expect(recordReacceptanceMock).toHaveBeenCalledWith({
+      tosAccepted: true,
+      privacyAccepted: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('legal-reacceptance-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows an error and keeps the modal open when recording consent fails, and the user can retry', async () => {
+    authState.user = baseUser;
+    authState.isAuthenticated = true;
+    fetchPendingMock.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'privacy',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+    recordReacceptanceMock
+      .mockRejectedValueOnce(new Error('Network down'))
+      .mockResolvedValueOnce(undefined);
+
+    const user = userEvent.setup();
+    render(<LegalReacceptanceModal />);
+
+    const modal = await screen.findByTestId('legal-reacceptance-modal');
+    const checkbox = within(modal).getByRole('checkbox', {
+      name: /i accept the updated privacy policy/i,
+    });
+    await user.click(checkbox);
+
+    await user.click(within(modal).getByRole('button', { name: /accept and continue/i }));
+
+    expect(await within(modal).findByText(/network down/i)).toBeInTheDocument();
+    expect(screen.getByTestId('legal-reacceptance-modal')).toBeInTheDocument();
+
+    // Retry path uses the same primary button, now labelled Retry.
+    const retryButton = within(modal).getByRole('button', { name: /retry/i });
+    await user.click(retryButton);
+
+    await waitFor(() => {
+      expect(recordReacceptanceMock).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('legal-reacceptance-modal')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app.client/src/components/modals/LegalReacceptanceModal.tsx
+++ b/app.client/src/components/modals/LegalReacceptanceModal.tsx
@@ -1,0 +1,183 @@
+import { Alert, Button, Modal, Spinner } from '@adopt-dont-shop/lib.components';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+import { useEffect, useState } from 'react';
+import {
+  fetchPendingReacceptance,
+  recordReacceptance,
+  type PendingReacceptanceItem,
+} from '@/services/legalService';
+import * as styles from './LegalReacceptanceModal.css';
+
+/**
+ * ADS-497 (slice 2): user-facing legal re-acceptance modal.
+ *
+ * After login, hits GET /api/v1/legal/pending-reacceptance once. If the
+ * authenticated user has any documents whose published version is newer
+ * than what they last accepted, the modal renders a hard block — they
+ * must tick each document and submit before continuing to use the app.
+ *
+ * The modal is intentionally non-dismissable for terms/privacy. There is
+ * no logout/decline path here: that's an explicit out-of-scope decision
+ * for this slice (see PR body). Closing the tab and reloading just shows
+ * the modal again.
+ */
+
+const LABELS: Record<PendingReacceptanceItem['documentType'], { title: string; href: string }> = {
+  terms: { title: 'Terms of Service', href: '/terms' },
+  privacy: { title: 'Privacy Policy', href: '/privacy' },
+};
+
+type Status = 'idle' | 'submitting' | 'error';
+
+export const LegalReacceptanceModal = () => {
+  const { isAuthenticated, user } = useAuth();
+  const [pending, setPending] = useState<ReadonlyArray<PendingReacceptanceItem>>([]);
+  const [accepted, setAccepted] = useState<Record<string, boolean>>({});
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const userId = user?.userId ?? null;
+
+  useEffect(() => {
+    if (!isAuthenticated || !userId) {
+      setPending([]);
+      setStatus('idle');
+      return;
+    }
+    let cancelled = false;
+    const run = async () => {
+      try {
+        const result = await fetchPendingReacceptance();
+        if (cancelled) {
+          return;
+        }
+        setPending(result.pending);
+        setAccepted({});
+        setStatus('idle');
+      } catch {
+        // Initial fetch failures are silent: better to let the user
+        // continue using the app than to flash a hard-block modal we
+        // can't justify. The next page load retries.
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, userId]);
+
+  const allChecked =
+    pending.length > 0 && pending.every(item => accepted[item.documentType] === true);
+
+  const handleToggle = (documentType: PendingReacceptanceItem['documentType']) => {
+    setAccepted(prev => ({ ...prev, [documentType]: !prev[documentType] }));
+  };
+
+  const handleSubmit = async () => {
+    if (!allChecked) {
+      return;
+    }
+    setStatus('submitting');
+    setErrorMessage(null);
+    try {
+      // Versions are intentionally omitted — the backend stamps the audit
+      // row with the currently-published TERMS_VERSION / PRIVACY_VERSION,
+      // which is exactly what "re-accept current" means.
+      await recordReacceptance({
+        tosAccepted: true,
+        privacyAccepted: true,
+      });
+      setPending([]);
+      setStatus('idle');
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Failed to record acceptance. Please try again.'
+      );
+      setStatus('error');
+    }
+  };
+
+  if (!isAuthenticated || !userId || pending.length === 0) {
+    return null;
+  }
+
+  // Hard block: no overlay-click / Escape / close-button dismiss.
+  return (
+    <Modal
+      isOpen
+      onClose={() => undefined}
+      title='Updated legal documents'
+      closeOnOverlayClick={false}
+      closeOnEscape={false}
+      showCloseButton={false}
+      data-testid='legal-reacceptance-modal'
+    >
+      <div className={styles.modalContent}>
+        <p className={styles.description}>
+          We&apos;ve updated the documents below. Please review and accept the latest versions to
+          continue using Adopt Don&apos;t Shop.
+        </p>
+
+        <div className={styles.documentList}>
+          {pending.map(item => {
+            const meta = LABELS[item.documentType];
+            return (
+              <div key={item.documentType} className={styles.documentItem}>
+                <label className={styles.documentLabel}>
+                  <input
+                    type='checkbox'
+                    className={styles.checkbox}
+                    checked={accepted[item.documentType] === true}
+                    onChange={() => handleToggle(item.documentType)}
+                    disabled={status === 'submitting'}
+                    aria-label={`I accept the updated ${meta.title}`}
+                  />
+                  <span className={styles.documentTextBlock}>
+                    <span className={styles.documentTitle}>I accept the updated {meta.title}</span>
+                    <span className={styles.documentMeta}>
+                      New version: {item.currentVersion}
+                      {item.lastAcceptedVersion
+                        ? ` (you previously accepted ${item.lastAcceptedVersion})`
+                        : ' (first acceptance)'}
+                    </span>
+                    <a
+                      className={styles.documentLink}
+                      href={meta.href}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >
+                      Read full {meta.title}
+                    </a>
+                  </span>
+                </label>
+              </div>
+            );
+          })}
+        </div>
+
+        {status === 'error' && errorMessage && (
+          <div className={styles.errorAlert}>
+            <Alert variant='error' title='Something went wrong'>
+              {errorMessage}
+            </Alert>
+          </div>
+        )}
+
+        <div className={styles.actionButtons}>
+          <Button
+            variant='primary'
+            onClick={() => void handleSubmit()}
+            disabled={!allChecked || status === 'submitting'}
+          >
+            {status === 'submitting' && <Spinner size='sm' className={styles.buttonSpinner} />}
+            {status === 'submitting'
+              ? 'Saving...'
+              : status === 'error'
+                ? 'Retry'
+                : 'Accept and continue'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/app.client/src/services/legalService.ts
+++ b/app.client/src/services/legalService.ts
@@ -1,0 +1,53 @@
+import { apiService as api } from '@adopt-dont-shop/lib.api';
+import { z } from 'zod';
+
+/**
+ * ADS-497 (slice 2): client-side wrapper around the legal re-acceptance
+ * endpoints introduced in slice 1 (PR #414).
+ *
+ *   GET  /api/v1/legal/pending-reacceptance — list documents whose current
+ *                                             version differs from the
+ *                                             user's last-accepted version.
+ *   POST /api/v1/privacy/consent            — record acceptance of the
+ *                                             current ToS / Privacy versions
+ *                                             (ADS-496/497 — same endpoint
+ *                                             that registration already uses).
+ *
+ * Schema-first: response shapes are validated with Zod so a backend drift
+ * surfaces as a clear parse error rather than a runtime undefined-access.
+ */
+
+export const PendingReacceptanceItemSchema = z.object({
+  documentType: z.enum(['terms', 'privacy']),
+  currentVersion: z.string(),
+  lastAcceptedVersion: z.string().nullable(),
+  lastAcceptedAt: z.string().nullable(),
+});
+
+export const PendingReacceptanceResponseSchema = z.object({
+  pending: z.array(PendingReacceptanceItemSchema),
+});
+
+export type PendingReacceptanceItem = z.infer<typeof PendingReacceptanceItemSchema>;
+export type PendingReacceptanceResponse = z.infer<typeof PendingReacceptanceResponseSchema>;
+
+export const fetchPendingReacceptance = async (): Promise<PendingReacceptanceResponse> => {
+  const raw = await api.get<unknown>('/api/v1/legal/pending-reacceptance');
+  return PendingReacceptanceResponseSchema.parse(raw);
+};
+
+export type RecordReacceptanceInput = {
+  tosAccepted: boolean;
+  privacyAccepted: boolean;
+  /**
+   * Optional explicit version overrides. Omit to let the backend stamp
+   * the audit row with its currently-published versions — that's the
+   * normal path for re-acceptance from this modal.
+   */
+  tosVersion?: string;
+  privacyVersion?: string;
+};
+
+export const recordReacceptance = async (input: RecordReacceptanceInput): Promise<void> => {
+  await api.post('/api/v1/privacy/consent', input);
+};

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -1,6 +1,8 @@
 import crypto from 'crypto';
 import bcrypt from 'bcrypt';
+import AuditLog from '../models/AuditLog';
 import User, { UserStatus, UserType } from '../models/User';
+import { PRIVACY_VERSION, TERMS_VERSION } from '../services/legal-content.service';
 
 /**
  * ADS-536: per-seed-run password.
@@ -323,6 +325,38 @@ export async function seedUsers() {
         createdAt: new Date(),
         updatedAt: new Date(),
       },
+    });
+  }
+
+  // Record consent acceptance for each seeded user so the
+  // LegalReacceptanceModal in app.client (PR #420) doesn't fire for them
+  // in dev / E2E. Idempotent: skip if a CONSENT_RECORDED row already
+  // exists for this user. Audit logs are append-only, so we never update.
+  for (const userData of testUsers) {
+    const existing = await AuditLog.findOne({
+      where: { user: userData.userId, action: 'CONSENT_RECORDED' },
+    });
+    if (existing) {
+      continue;
+    }
+    const acceptedAt = userData.termsAcceptedAt ?? new Date();
+    await AuditLog.create({
+      service: 'adopt-dont-shop-backend',
+      user: userData.userId,
+      user_email_snapshot: userData.email,
+      action: 'CONSENT_RECORDED',
+      level: 'INFO',
+      timestamp: acceptedAt,
+      metadata: {
+        entity: 'User',
+        entityId: userData.userId,
+        details: {
+          tosVersion: TERMS_VERSION,
+          privacyVersion: PRIVACY_VERSION,
+          acceptedAt: acceptedAt.toISOString(),
+        },
+      },
+      category: 'User',
     });
   }
 


### PR DESCRIPTION
Slice 2 of ADS-497 — frontend modal. Builds on PR #414, which added `GET /api/v1/legal/pending-reacceptance` (slice 1).

## Behaviour

After login, `app.client` calls `GET /api/v1/legal/pending-reacceptance` once. If the response's `pending` array is non-empty, a hard-block modal renders that:

- Lists each pending document (Terms of Service / Privacy Policy) with a checkbox and a "Read full ..." link to `/terms` or `/privacy`.
- Disables the "Accept and continue" button until every checkbox is ticked.
- On submit, POSTs `{ tosAccepted: true, privacyAccepted: true }` to the existing `/api/v1/privacy/consent` endpoint (the one registration already uses) — versions are intentionally omitted so the backend stamps the audit row with the currently-published `TERMS_VERSION` / `PRIVACY_VERSION`.
- On success, hides the modal.
- On submit error, shows the error message inline and re-enables the primary button as a retry.
- Cannot be dismissed via overlay-click, Escape, or close button — it is a hard block for terms/privacy.

The modal is mounted once at the top of `App.tsx` inside the existing auth-aware provider tree. It does nothing for unauthenticated users (no fetch, no render).

## Before / after (text description, no screenshots)

- **Before:** A user who logs in after a ToS/Privacy version bump sees no UI — the slice-1 endpoint reports they need to re-accept, but nothing in the UI surfaces that.
- **After:** Same user lands on the homepage and immediately sees a centred, non-dismissable modal titled "Updated legal documents" listing each pending document with a checkbox, the new version string, the version they previously accepted, and a "Read full Terms of Service / Privacy Policy" link. Ticking all boxes enables a primary "Accept and continue" button; clicking it records consent and dismisses the modal, returning the user to the page they were on. If the POST fails, an inline red alert appears and the button label switches to "Retry".

## Out of scope (explicit)

- **Not adding the same modal to `app.admin` / `app.rescue`.** Those have separate user populations (rescue staff, platform admins) and acceptance UX should be designed for them separately.
- **No email notification flow** — that's tracked for a later slice.
- **No admin editor** for ToS / Privacy markdown — versions are still owned in code (`legal-content.service.ts`).
- **No cookies-policy support** — the slice-1 endpoint only emits `terms` / `privacy` today; cookies is a separate slice.
- **No decline / logout path.** The user must accept or stay blocked. The existing `consent.service.ts` does require both `tosAccepted` and `privacyAccepted` to be true, and there is no "decline" verb wired through this modal.
- **No internationalization scaffolding** — plain English copy.
- **No new analytics events** beyond what existing modal mounts already do.
- **No new React Router route** — the modal is a global overlay, not a `/reaccept` page.

## Open questions for product / design

- Should the modal poll periodically (e.g. every 24h) for new pending versions, or only check once at app boot?
- Does product want a "Read full terms" expandable view inside the modal, or just a link out to /terms ?
- If the user closes the tab without accepting, should they be logged out on next page load, or just shown the modal again? (Default: shown the modal again.)

## Files

- `app.client/src/services/legalService.ts` (new) — Zod-validated wrappers around the two endpoints.
- `app.client/src/components/modals/LegalReacceptanceModal.tsx` (new) + `.css.ts`.
- `app.client/src/components/modals/LegalReacceptanceModal.test.tsx` (new) — 4 behaviour tests.
- `app.client/src/App.tsx` (mounted modal inside `FavoritesProvider`).

## Test plan

- [x] `npm run test` (app.client): 212 / 212 pass, including 4 new behaviour tests.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` (app.client): 0 errors (warnings unchanged from main).
- [x] `npx prettier --check` clean on touched files.
- [ ] Manual smoke once merged: bump `TERMS_VERSION` in dev, log in as a user with prior consent, confirm modal appears + accept records new version.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_