### PR TITLE
fix(uploads): align FileUpload.url with on-disk prefix + backfill migration

### DIFF
--- a/service.backend/src/__tests__/migrations/forward-fix-migrations.test.ts
+++ b/service.backend/src/__tests__/migrations/forward-fix-migrations.test.ts
@@ -5,6 +5,7 @@
  *   14 — revoked_tokens.updated_at           (ADS-502)
  *   15 — report_shares.token_hash UNIQUE     (ADS-505)
  *   16 — soft-delete partial indexes         (ADS-504)
+ *   17 — file_uploads.url prefix backfill    (PR #415 follow-up)
  *
  * Every test runs `up`, asserts the post-state, runs `down`, and asserts
  * the pre-state is restored. Postgres-only — the migration bodies use
@@ -23,10 +24,12 @@ import {
   Pet,
   Application,
 } from '../../models';
+import FileUpload from '../../models/FileUpload';
 import migration13 from '../../migrations/13-convert-ip-rules-cidr-to-native';
 import migration14 from '../../migrations/14-add-revoked-tokens-updated-at';
 import migration15 from '../../migrations/15-add-report-shares-token-hash-unique-index';
 import migration16 from '../../migrations/16-add-paranoid-partial-indexes';
+import migration17 from '../../migrations/17-fix-fileupload-url-prefix';
 
 // Reference models so they register with the Sequelize instance before
 // `sync()` runs.
@@ -38,6 +41,7 @@ void SavedReport;
 void User;
 void Pet;
 void Application;
+void FileUpload;
 
 const isPostgres = sequelize.getDialect() === 'postgres';
 const describeIfPostgres = isPostgres ? describe : describe.skip;
@@ -208,6 +212,177 @@ describeIfPostgres('forward-fix migrations — up/down round trip (ADS-484)', ()
         const idx = await findIndex(table, name);
         expect(idx).toBeUndefined();
       }
+    });
+  });
+
+  describe('14 — file_uploads.url prefix backfill (PR #415 follow-up)', () => {
+    let uploaderId: string;
+
+    const insertFileUpload = async (overrides: Record<string, unknown>) => {
+      const row = {
+        original_filename: 'photo.jpg',
+        stored_filename: `pets_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.jpg`,
+        file_path: 'pets/photo.jpg',
+        mime_type: 'image/jpeg',
+        file_size: 1024,
+        url: '/uploads/pets_1234_uuid.jpg',
+        uploaded_by: uploaderId,
+        metadata: '{}',
+        ...overrides,
+      };
+      const cols = Object.keys(row);
+      const placeholders = cols.map((_, i) => `$${i + 1}`).join(', ');
+      const values = cols.map(c => (row as Record<string, unknown>)[c]);
+      const [rows] = await sequelize.query(
+        `INSERT INTO file_uploads (${cols.join(', ')}, created_at, updated_at)
+           VALUES (${placeholders}, NOW(), NOW())
+           RETURNING upload_id, url, thumbnail_url`,
+        { bind: values as unknown as never }
+      );
+      return (rows as Array<Record<string, unknown>>)[0];
+    };
+
+    const readUrls = async (
+      uploadId: string
+    ): Promise<{ url: string; thumbnail_url: string | null }> => {
+      const [rows] = await sequelize.query(
+        `SELECT url, thumbnail_url FROM file_uploads WHERE upload_id = '${uploadId}'`
+      );
+      return (rows as Array<{ url: string; thumbnail_url: string | null }>)[0];
+    };
+
+    beforeEach(async () => {
+      // Insert a user for the uploaded_by FK. Re-uses sync()'d schema.
+      const [userRows] = await sequelize.query(
+        `INSERT INTO users (email, password, first_name, last_name, user_type, status, email_verified, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+           RETURNING user_id`,
+        {
+          bind: [
+            `uploader-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@example.com`,
+            'hashed-password',
+            'Up',
+            'Loader',
+            'adopter',
+            'active',
+            true,
+          ] as unknown as never,
+        }
+      );
+      uploaderId = (userRows as Array<{ user_id: string }>)[0].user_id;
+    });
+
+    it('up() rewrites a broken /uploads/<filename> to /uploads/<prefix>/<filename>', async () => {
+      const inserted = await insertFileUpload({
+        stored_filename: 'pets_1700000000000_abc123.jpg',
+        url: '/uploads/pets_1700000000000_abc123.jpg',
+      });
+
+      await migration17.up(queryInterface);
+
+      const after = await readUrls(inserted.upload_id as string);
+      expect(after.url).toBe('/uploads/pets/pets_1700000000000_abc123.jpg');
+    });
+
+    it('up() rewrites thumbnail_url with the same rule', async () => {
+      const inserted = await insertFileUpload({
+        stored_filename: 'applications_1700000000000_xyz789.pdf',
+        url: '/uploads/applications_1700000000000_xyz789.pdf',
+        thumbnail_url: '/uploads/applications_1700000000000_xyz789.thumb.jpg',
+      });
+
+      await migration17.up(queryInterface);
+
+      const after = await readUrls(inserted.upload_id as string);
+      expect(after.url).toBe('/uploads/applications/applications_1700000000000_xyz789.pdf');
+      expect(after.thumbnail_url).toBe(
+        '/uploads/applications/applications_1700000000000_xyz789.thumb.jpg'
+      );
+    });
+
+    it('up() leaves already-prefixed URLs alone (idempotent on correctly-shaped rows)', async () => {
+      const correctUrl = '/uploads/chat/chat_1700000000000_abc.jpg';
+      const inserted = await insertFileUpload({
+        stored_filename: 'chat_1700000000000_abc.jpg',
+        url: correctUrl,
+      });
+
+      await migration17.up(queryInterface);
+
+      const after = await readUrls(inserted.upload_id as string);
+      expect(after.url).toBe(correctUrl);
+    });
+
+    it('up() is safe to run twice (idempotent)', async () => {
+      const inserted = await insertFileUpload({
+        stored_filename: 'pets_1700000000000_dbl.jpg',
+        url: '/uploads/pets_1700000000000_dbl.jpg',
+      });
+
+      await migration17.up(queryInterface);
+      await migration17.up(queryInterface);
+
+      const after = await readUrls(inserted.upload_id as string);
+      expect(after.url).toBe('/uploads/pets/pets_1700000000000_dbl.jpg');
+    });
+
+    it('up() preserves CDN / external URL overrides', async () => {
+      const cdnUrl = 'https://cdn.example.com/pets/foo.jpg';
+      const inserted = await insertFileUpload({
+        stored_filename: 'pets_1700000000000_cdn.jpg',
+        url: cdnUrl,
+      });
+
+      await migration17.up(queryInterface);
+
+      const after = await readUrls(inserted.upload_id as string);
+      expect(after.url).toBe(cdnUrl);
+    });
+
+    it('up() leaves rows whose stored_filename does not match the writer convention', async () => {
+      // Hand-seeded shape (uses '-' instead of '_'). The seeder URL is
+      // already correctly shaped so there is nothing to fix; we should
+      // not silently rewrite to a wrong prefix.
+      const inserted = await insertFileUpload({
+        stored_filename: 'chat-1700000000000-abc.jpg',
+        url: '/uploads/chat-1700000000000-abc.jpg',
+      });
+
+      await migration17.up(queryInterface);
+
+      const after = await readUrls(inserted.upload_id as string);
+      expect(after.url).toBe('/uploads/chat-1700000000000-abc.jpg');
+    });
+
+    it('down() restores broken-shape URLs for rows up() rewrote', async () => {
+      const inserted = await insertFileUpload({
+        stored_filename: 'pets_1700000000000_round.jpg',
+        url: '/uploads/pets_1700000000000_round.jpg',
+        thumbnail_url: '/uploads/pets_1700000000000_round.thumb.jpg',
+      });
+
+      await migration17.up(queryInterface);
+      await migration17.down(queryInterface);
+
+      const after = await readUrls(inserted.upload_id as string);
+      expect(after.url).toBe('/uploads/pets_1700000000000_round.jpg');
+      expect(after.thumbnail_url).toBe('/uploads/pets_1700000000000_round.thumb.jpg');
+    });
+
+    it('down() leaves correctly-shaped rows it did not insert alone', async () => {
+      // A row where stored_filename does NOT match the URL's filename —
+      // down() must not strip the prefix because this row pre-dated the
+      // migration and was not produced by up().
+      const externalUrl = '/uploads/pets/some-other-name.jpg';
+      const inserted = await insertFileUpload({
+        stored_filename: 'pets_1700000000000_unmatched.jpg',
+        url: externalUrl,
+      });
+
+      await migration17.down(queryInterface);
+
+      const after = await readUrls(inserted.upload_id as string);
+      expect(after.url).toBe(externalUrl);
     });
   });
 });

--- a/service.backend/src/__tests__/services/file-upload.service.test.ts
+++ b/service.backend/src/__tests__/services/file-upload.service.test.ts
@@ -80,7 +80,7 @@ const makeMockRecord = (overrides: Record<string, unknown> = {}) => ({
   file_path: 'pets/photo_123.jpg',
   mime_type: 'image/jpeg',
   file_size: 1024,
-  url: '/uploads/pets_1234_uuid.jpg',
+  url: '/uploads/pets/pets_1234_uuid.jpg',
   thumbnail_url: undefined,
   uploaded_by: 'user-456',
   entity_id: undefined,
@@ -386,6 +386,39 @@ describe('FileUploadService', () => {
       expect(result.upload).toBeDefined();
       expect(result.file).toBeDefined();
       expect(result.file?.originalName).toBe('dog.jpg');
+    });
+
+    it('produces URLs that include the on-disk prefix segment', async () => {
+      // Regression: the writer used to emit `/uploads/<filename>` while
+      // multer placed the file at `<dir>/<prefix>/<filename>`, so the URL
+      // 404'd when the client followed it. Cover each upload type.
+      const cases: Array<{
+        uploadType: 'pets' | 'applications' | 'chat' | 'profiles' | 'documents';
+        expectedPrefix: string;
+      }> = [
+        { uploadType: 'pets', expectedPrefix: '/uploads/pets/' },
+        { uploadType: 'applications', expectedPrefix: '/uploads/applications/' },
+        { uploadType: 'chat', expectedPrefix: '/uploads/chat/' },
+        { uploadType: 'profiles', expectedPrefix: '/uploads/profiles/' },
+        { uploadType: 'documents', expectedPrefix: '/uploads/documents/' },
+      ];
+
+      for (const { uploadType, expectedPrefix } of cases) {
+        const file = makeFile({
+          originalname: 'doc.pdf',
+          mimetype: 'application/pdf',
+          filename: `${uploadType}_1234_uuid.pdf`,
+          path: `/test-uploads/${uploadType}/${uploadType}_1234_uuid.pdf`,
+        });
+        setupSuccessfulUpload('application/pdf');
+
+        const result = await FileUploadService.uploadFile(file, uploadType, {
+          uploadedBy: 'user-456',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.file?.url).toBe(`${expectedPrefix}${uploadType}_1234_uuid.pdf`);
+      }
     });
   });
 

--- a/service.backend/src/migrations/17-fix-fileupload-url-prefix.ts
+++ b/service.backend/src/migrations/17-fix-fileupload-url-prefix.ts
@@ -1,0 +1,93 @@
+import type { QueryInterface } from 'sequelize';
+import { runInTransaction } from './_helpers';
+
+/**
+ * Follow-up to ADS-422 (PR #415): align `file_uploads.url` with the
+ * on-disk prefix.
+ *
+ * The writer in `services/file-upload.service.ts` historically generated
+ * URLs as `/uploads/<filename>` while multer placed the file at
+ * `<uploadDir>/<prefix>/<filename>`. The `/uploads/*` route resolves the
+ * request path relative to `<uploadDir>`, so any consumer that used the
+ * stored URL got a 404 (or, worse, the wrong file if `<filename>`
+ * collided across prefixes). The writer is fixed to emit
+ * `/uploads/<prefix>/<filename>` for new rows; this migration backfills
+ * the prefix into rows already in the table.
+ *
+ * Strategy: derive the prefix from `stored_filename`, which follows the
+ * writer's convention `${uploadType}_${timestamp}_${uuid}${ext}`. This is
+ * more reliable than `entity_type` (which doesn't 1:1 map to the on-disk
+ * directory: `entity_type='application'` corresponds to prefix
+ * `applications`) and works without joining other tables.
+ *
+ * Safety:
+ *
+ *   - Idempotent. Only matches rows whose `url` (or `thumbnail_url`)
+ *     already lacks a prefix segment under `/uploads/`. A second run
+ *     finds nothing to update because the rewritten rows now include
+ *     the prefix.
+ *   - Skips CDN / external URLs (anything starting with `http://` or
+ *     `https://`) — those are explicit overrides we must preserve.
+ *   - Skips rows whose `stored_filename` doesn't match the writer's
+ *     `<prefix>_<...>` convention (e.g. legacy / hand-seeded rows whose
+ *     URL is already correctly shaped, or whose filename uses a
+ *     different naming scheme). These are left untouched rather than
+ *     silently rewritten to the wrong place.
+ *   - Wrapped in a single transaction (ADS-403). The table is small in
+ *     this codebase and a single UPDATE..WHERE is far simpler than
+ *     batched updates; if the table grows beyond ~100k rows the
+ *     migration should be re-shaped to chunk by `created_at`.
+ *
+ * Down-migration: reverses the rewrite by stripping the prefix segment
+ * from any URL whose path matches `/uploads/<prefix>/<filename>` and whose
+ * `stored_filename` equals `<filename>`. Down() is therefore a true
+ * inverse for rows this migration touched, and a no-op for rows it
+ * didn't.
+ */
+
+// Keep this list in lock-step with `UPLOAD_CONFIG.directories` in
+// `services/file-upload.service.ts`. New entries there require a new
+// migration to backfill any rows written via that prefix.
+const UPLOAD_PREFIXES = ['pets', 'applications', 'chat', 'profiles', 'documents', 'temp'] as const;
+
+/**
+ * SQL fragment that builds the corrected URL from the existing one. We
+ * derive `<prefix>` from `stored_filename` (the part before the first
+ * underscore — matches the writer's `${uploadType}_${timestamp}_...`
+ * naming) and slot it in between `/uploads/` and the filename.
+ *
+ * Postgres-flavoured: uses `~` for regex match and `regexp_replace` /
+ * `split_part` for extraction. Both are dialect-specific; the
+ * accompanying tests skip on non-postgres.
+ */
+const FIX_URL_SQL = (column: 'url' | 'thumbnail_url'): string => `
+  UPDATE file_uploads
+     SET ${column} = '/uploads/' || split_part(stored_filename, '_', 1) || '/' || regexp_replace(${column}, '^/uploads/', '')
+   WHERE ${column} IS NOT NULL
+     AND ${column} ~ '^/uploads/[^/]+$'
+     AND split_part(stored_filename, '_', 1) IN (${UPLOAD_PREFIXES.map(p => `'${p}'`).join(', ')})
+`;
+
+const REVERT_URL_SQL = (column: 'url' | 'thumbnail_url'): string => `
+  UPDATE file_uploads
+     SET ${column} = '/uploads/' || regexp_replace(${column}, '^/uploads/[^/]+/', '')
+   WHERE ${column} IS NOT NULL
+     AND ${column} ~ ('^/uploads/(' || '${UPLOAD_PREFIXES.join('|')}' || ')/[^/]+$')
+     AND regexp_replace(${column}, '^/uploads/[^/]+/', '') = stored_filename
+`;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.sequelize.query(FIX_URL_SQL('url'), { transaction: t });
+      await queryInterface.sequelize.query(FIX_URL_SQL('thumbnail_url'), { transaction: t });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.sequelize.query(REVERT_URL_SQL('thumbnail_url'), { transaction: t });
+      await queryInterface.sequelize.query(REVERT_URL_SQL('url'), { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -215,7 +215,7 @@ export class FileUploadService {
       const processedFile = await this.processFile(file, uploadType);
 
       // Generate file metadata
-      const fileMetadata = await this.generateFileMetadata(file, processedFile);
+      const fileMetadata = await this.generateFileMetadata(file, processedFile, uploadType);
 
       // Create database record
       const uploadRecord = await this.createUploadRecord(fileMetadata, metadata);
@@ -705,7 +705,8 @@ export class FileUploadService {
    */
   private static async generateFileMetadata(
     file: Express.Multer.File,
-    processedFile: ProcessedFileInfo
+    processedFile: ProcessedFileInfo,
+    uploadType: keyof typeof UPLOAD_CONFIG.directories
   ): Promise<FileMetadata> {
     const stats = await fs.promises.stat(this.safeResolveUploadPath(file.path));
 
@@ -715,9 +716,9 @@ export class FileUploadService {
       mimeType: file.mimetype,
       size: file.size,
       path: file.path,
-      url: this.generateFileUrl(file.filename),
+      url: this.generateFileUrl(uploadType, file.filename),
       thumbnailUrl: processedFile.thumbnailPath
-        ? this.generateFileUrl(path.basename(processedFile.thumbnailPath))
+        ? this.generateFileUrl(uploadType, path.basename(processedFile.thumbnailPath))
         : undefined,
       metadata: {
         ...processedFile.metadata,
@@ -729,10 +730,22 @@ export class FileUploadService {
   }
 
   /**
-   * Generate file URL
+   * Generate file URL.
+   *
+   * Multer writes uploaded files to `<uploadDir>/<prefix>/<filename>` (see
+   * `createStorage`), and the `/uploads/*` route resolves a request path
+   * relative to `<uploadDir>`. The URL therefore must include the same
+   * prefix segment, otherwise the file is served from the wrong directory
+   * (or 404s outright).
+   *
+   * Historic shape was `/uploads/<filename>` — see migration 17 which
+   * backfills `file_uploads.url` rows that match the broken pattern.
    */
-  private static generateFileUrl(filename: string): string {
-    return `/uploads/${filename}`;
+  private static generateFileUrl(
+    uploadType: keyof typeof UPLOAD_CONFIG.directories,
+    filename: string
+  ): string {
+    return `/uploads/${UPLOAD_CONFIG.directories[uploadType]}/${filename}`;
   }
 
   /**


### PR DESCRIPTION
Follow-up to #415, which flagged that `FileUpload.url` was generated as `/uploads/<filename>` while multer placed files at `<uploadDir>/<prefix>/<filename>`.

## Case identification: A — broken-shape, actively consumed

I traced every consumer of the field. The URL is on the hot path:

- `service.backend/src/controllers/application.controller.ts:699,711` — writes `uploadResult.upload.url` into `Application.documents[].fileUrl` (JSONB) and returns it on the response.
- `service.backend/src/controllers/chat.controller.ts:1108` — returns `uploadResult.upload.url` to the client; the client then sends it back inside `Message.attachments[].url` and the recipient renders it.
- `service.backend/src/services/file-upload.service.ts:775,791,826` — round-trips the value through `createUploadRecord` / `getUploadRecord` (so the value the controllers serialise comes from this).

The frontend resolves the URL via `app.client/src/utils/fileUtils.ts::resolveFileUrl`, which simply prepends `VITE_API_BASE_URL`. The auth-gated `GET /uploads/*` route in `service.backend/src/routes/upload-serve.routes.ts` resolves the request path against `config.storage.local.directory`, so a URL of `/uploads/<filename>` (no prefix) lands in the wrong directory and 404s. `MessageBubbleComponent` renders the result as `<img src=...>` / `<a href=...>` — broken in production today.

The ACL service (`upload-acl.service.ts`) is the one place that doesn't depend on the URL — it looks up rows by `stored_filename`. So #415's per-resource ACL still works correctly; only the user-visible URL is broken.

## Schema check (informs migration shape)

`file_uploads.url` is `NOT NULL`, `STRING(1000)`, **not unique, not indexed**. Safe to UPDATE in bulk. Same for `thumbnail_url` (nullable, otherwise identical).

## Changes

- **Writer fix** — `services/file-upload.service.ts::generateFileUrl` now takes `uploadType` and emits `/uploads/<prefix>/<filename>`. Threaded through `generateFileMetadata`. New rows written via the service will be correctly shaped from now on.
- **Migration 17** — `migrations/17-fix-fileupload-url-prefix.ts` backfills `file_uploads.url` and `file_uploads.thumbnail_url`. Strategy: derive the prefix from `stored_filename` (which the writer names `${uploadType}_${ts}_${uuid}${ext}`) using `split_part(stored_filename, '_', 1)`. Wrapped in `runInTransaction` per the project's `_helpers.ts` patterns.
- **Behaviour test** — file-upload service test covers all five upload types (`pets`, `applications`, `chat`, `profiles`, `documents`) and asserts the URL contains the on-disk prefix.
- **Migration round-trip test** — added to `forward-fix-migrations.test.ts` next to migrations 13–16, postgres-only via `describeIfPostgres`, covering: broken→fixed rewrite, thumbnail_url, idempotency on already-shaped rows, double-run idempotency, CDN/external URL preservation, non-conforming `stored_filename` left alone, and a true `down()` round-trip.

## Migration safety

- **Idempotent**. Match predicate is `url ~ '^/uploads/[^/]+$'` — only single-segment URLs are touched. After up() rewrites them, they have two segments and don't match again.
- **Reversible**. `down()` strips the prefix only when `regexp_replace(url, '^/uploads/[^/]+/', '') = stored_filename` — i.e. only for rows up() actually produced. Pre-existing correctly-shaped rows (e.g. seeded with `/uploads/chat/sample.jpg`) are not touched by down().
- **Preserves CDN URLs**. Anything starting with `http://` / `https://` doesn't match the `^/uploads/...` regex.
- **Skips non-conforming filenames**. The seeders use `chat-<ts>-name.jpg` (hyphen-separated). `split_part('chat-1700000000000-foo.jpg', '_', 1)` returns the whole filename, which isn't in `UPLOAD_PREFIXES`, so the row is skipped. The seeded rows are already correctly shaped, so this is the right behaviour.
- **Single transaction**. The table is small in this codebase. If it grows past ~100k rows the migration should be reshaped to chunk by `created_at` — noted in the migration body.

## Out of scope (intentional)

The same broken-shape URL is also stored in two JSONB columns:

- `messages.attachments[].url` — populated by the chat client which sent the broken URL it received from the upload endpoint.
- `applications.documents[].fileUrl` — populated by `application.controller.ts::addDocument` from the same source.

These are not touched by this PR. Reasoning: the brief was specific about scoping to `file_uploads.url`, the JSONB updates require joining on `attachment_id`/`upload_id` and would expand the migration considerably, and going forward all new writes will be correctly shaped. Existing chat messages with stale broken URLs will keep 404'ing for their attachments until either a new attachment is uploaded or a follow-up migration backfills the JSONB. Calling out for a separate ticket.

I could not determine the dev DB row count for `file_uploads` because Docker isn't running in this sandbox.

## Test plan

- [x] `npx vitest run` (service.backend) — 2070 passed, 44 skipped (postgres-only migration tests skip on sqlite, including the new one — same as existing migrations 13–16)
- [x] `npx vitest run src/__tests__/services/file-upload.service.test.ts` — 27 passed
- [x] `npx tsc --noEmit` (service.backend) — clean
- [x] `npx eslint .` (service.backend) — 0 errors (pre-existing 300 warnings unchanged)
- [ ] CI: postgres migration round-trip tests run (verifies up/down/idempotency against real Postgres)
- [ ] Manual: after merge, run `npm run db:migrate` against staging and spot-check `SELECT url FROM file_uploads LIMIT 10` shows prefixed URLs

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_