### PR TITLE
feat(apps): wire authenticated userId into NotificationsProvider

### DIFF
--- a/app.client/src/App.test.tsx
+++ b/app.client/src/App.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+// Capture the userId prop NotificationsProvider receives, so we can assert
+// that App.tsx wires user.userId from useAuth() through to it. Mocking the
+// provider keeps this test focused on the wiring, not the provider's internals
+// (those have their own behaviour tests).
+const notificationsProviderUserIdSpy = vi.fn<(userId: string | undefined) => void>();
+
+vi.mock('@/contexts/NotificationsContext', () => ({
+  NotificationsProvider: ({ children, userId }: { children: ReactNode; userId?: string }) => {
+    notificationsProviderUserIdSpy(userId);
+    return <>{children}</>;
+  },
+}));
+
+// Stub the other context providers so App can render without their full deps.
+vi.mock('@/contexts/PermissionsContext', () => ({
+  PermissionsProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/contexts/AnalyticsContext', () => ({
+  AnalyticsProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/contexts/ChatContext', () => ({
+  ChatProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/contexts/FavoritesContext', () => ({
+  FavoritesProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+// AppShell pulls in heavy navigation/chat dependencies; replace it with a
+// minimal pass-through that renders the nested route via <Outlet />.
+vi.mock('./components/layout/AppShell', async () => {
+  const { Outlet } = await import('react-router-dom');
+  return { AppShell: () => <Outlet /> };
+});
+vi.mock('./components/layout/PublicAuthLayout', async () => {
+  const { Outlet } = await import('react-router-dom');
+  return { PublicAuthLayout: () => <Outlet /> };
+});
+
+vi.mock('./components/dev/DevLoginPanel', () => ({
+  DevLoginPanel: () => null,
+}));
+
+vi.mock('./components/common/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+// Stable mock for useAuth that we can reconfigure per test.
+const useAuthMock = vi.fn();
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => useAuthMock(),
+  };
+});
+
+import App from './App';
+
+const baseAuth = {
+  isLoading: false,
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  updateProfile: vi.fn(),
+  refreshUser: vi.fn(),
+};
+
+afterEach(() => {
+  notificationsProviderUserIdSpy.mockClear();
+  useAuthMock.mockReset();
+});
+
+const renderApp = () =>
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <App />
+    </MemoryRouter>
+  );
+
+describe('App notifications wiring', () => {
+  it('passes undefined userId to NotificationsProvider when no user is authenticated', async () => {
+    useAuthMock.mockReturnValue({ ...baseAuth, user: null, isAuthenticated: false });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(notificationsProviderUserIdSpy).toHaveBeenCalled();
+    });
+    expect(notificationsProviderUserIdSpy).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('passes user.userId to NotificationsProvider when AuthProvider has an authenticated user', async () => {
+    useAuthMock.mockReturnValue({
+      ...baseAuth,
+      user: {
+        userId: 'user-abc',
+        email: 'a@b.c',
+        firstName: 'A',
+        lastName: 'B',
+        userType: 'adopter',
+      },
+      isAuthenticated: true,
+    });
+
+    renderApp();
+
+    await waitFor(() => {
+      expect(notificationsProviderUserIdSpy).toHaveBeenCalled();
+    });
+    expect(notificationsProviderUserIdSpy).toHaveBeenLastCalledWith('user-abc');
+  });
+});

--- a/app.client/src/App.tsx
+++ b/app.client/src/App.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, lazy, Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { Spinner } from '@adopt-dont-shop/lib.components';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { PermissionsProvider } from '@/contexts/PermissionsContext';
 import { AnalyticsProvider } from '@/contexts/AnalyticsContext';
 import { NotificationsProvider } from '@/contexts/NotificationsContext';
@@ -85,10 +86,14 @@ const RouteBoundary = ({ name, children }: { name: string; children: ReactNode }
 );
 
 function App() {
+  // ADS: pass the authenticated user's id so NotificationsProvider initialises
+  // for both fresh logins and rehydrated sessions. The provider's useEffect
+  // re-runs whenever userId changes, so no event subscription is needed.
+  const { user } = useAuth();
   return (
     <PermissionsProvider>
       <AnalyticsProvider>
-        <NotificationsProvider>
+        <NotificationsProvider userId={user?.userId}>
           <ChatProvider>
             <FavoritesProvider>
               <DevLoginPanel />

--- a/app.client/src/contexts/__tests__/notifications-context-userid.behavior.test.tsx
+++ b/app.client/src/contexts/__tests__/notifications-context-userid.behavior.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, waitFor } from '@testing-library/react';
+
+import { NotificationsProvider } from '../NotificationsContext';
+
+// Hold a stable mock for getUserNotifications across renders so tests can
+// assert which userId it was called with.
+const getUserNotificationsMock = vi.fn(async () => ({ data: [] }));
+
+vi.mock('@adopt-dont-shop/lib.notifications', () => {
+  class NotificationsService {
+    getUserNotifications = getUserNotificationsMock;
+    markAsRead = vi.fn(async () => undefined);
+    markAllAsRead = vi.fn(async () => undefined);
+    deleteNotification = vi.fn(async () => undefined);
+  }
+  return { NotificationsService };
+});
+
+afterEach(() => {
+  getUserNotificationsMock.mockClear();
+});
+
+const renderWithProvider = (userId?: string) =>
+  render(
+    <MemoryRouter>
+      <NotificationsProvider userId={userId}>
+        <div>child</div>
+      </NotificationsProvider>
+    </MemoryRouter>
+  );
+
+describe('NotificationsProvider userId wiring', () => {
+  it('does not load notifications when no userId is provided', async () => {
+    renderWithProvider(undefined);
+    // Give the provider's effect a tick to run; it should bail out early.
+    await waitFor(() => {
+      // No call should have been made.
+      expect(getUserNotificationsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('loads notifications for the authenticated user when userId is provided', async () => {
+    renderWithProvider('user-123');
+    await waitFor(() => {
+      expect(getUserNotificationsMock).toHaveBeenCalledWith('user-123');
+    });
+  });
+
+  it('reloads notifications when the userId changes (e.g. login or rehydrate)', async () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <NotificationsProvider userId={undefined}>
+          <div>child</div>
+        </NotificationsProvider>
+      </MemoryRouter>
+    );
+
+    // Initially no userId -> no fetch.
+    expect(getUserNotificationsMock).not.toHaveBeenCalled();
+
+    // Simulate auth becoming available (login or rehydrate populating user).
+    rerender(
+      <MemoryRouter>
+        <NotificationsProvider userId='user-456'>
+          <div>child</div>
+        </NotificationsProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(getUserNotificationsMock).toHaveBeenCalledWith('user-456');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #411 (`lib.auth` `auth_session_authenticated` event). After that PR, the consuming apps still didn't actually drive notifications init — `app.client` mounted `<NotificationsProvider>` with no `userId` prop, so its `useEffect` short-circuited and `getUserNotifications` never ran.

This PR wires `user?.userId` from `useAuth()` down to `<NotificationsProvider>` in `app.client`. The provider's existing `useEffect([notificationsService, userId])` already re-runs when `userId` changes, so login and rehydrate paths are both covered without subscribing to the new event at all.

### Before
```tsx
function App() {
  return (
    <PermissionsProvider>
      <AnalyticsProvider>
        <NotificationsProvider>            // ← no userId; effect bails
          ...
```

### After
```tsx
function App() {
  const { user } = useAuth();
  return (
    <PermissionsProvider>
      <AnalyticsProvider>
        <NotificationsProvider userId={user?.userId}>
          ...
```

### Why the userId-prop path is enough (no event subscription needed)

`AuthProvider` populates `user` in two places that both flow through `useAuth()`:
- Fresh login: `setUser(response.user)` after a successful `login()`
- Rehydrate: `setUser(freshUser)` (or `setUser(parsedUser)` for dev users) inside the mount-time `initializeAuth()` effect

Either path triggers a re-render of `App`, which re-renders `<NotificationsProvider userId={user?.userId}>` with the new id. The provider's effect, which depends on `userId`, then runs `getUserNotifications`. The new `auth_session_authenticated` event from PR #411 remains valuable for analytics/logging consumers, but notifications init is naturally a function of "is there a userId in scope," so the simpler path wins.

### Files touched
- `app.client/src/App.tsx` — read `useAuth()`, pass `userId={user?.userId}` to `<NotificationsProvider>` (6 LOC change)
- `app.client/src/App.test.tsx` (new) — App-level wiring test
- `app.client/src/contexts/__tests__/notifications-context-userid.behavior.test.tsx` (new) — provider behaviour test

### Surprise: `app.rescue` was deliberately skipped

The task brief listed `app.rescue/src/App.tsx` as a second target. Investigation found:
- `app.rescue/src/contexts/NotificationsContext.tsx` exists but is **never mounted anywhere** (`grep` confirms)
- **Zero consumers** of `useNotifications` across `app.rescue`

Mounting a provider that has no consumers — purely so it can fire an API call no UI reads — would be speculative work outside the spirit of "surgical changes only." Recommend a separate ticket if/when `app.rescue` actually gains a notifications consumer (bell, page, etc.); at that point the same one-line `userId={user?.userId}` wiring used here applies.

`app.admin` was correctly skipped per the task (no NotificationsProvider).

## Test plan

Behaviour-driven tests added (Vitest + RTL):

- [x] `NotificationsProvider` does not call `getUserNotifications` when `userId` is undefined (rehydrate-not-yet-complete / signed-out case)
- [x] `NotificationsProvider` calls `getUserNotifications(userId)` when a userId is provided (login or rehydrate-complete case)
- [x] `NotificationsProvider` re-fetches when `userId` transitions from undefined to a value (the login/rehydrate transition)
- [x] `App` passes `undefined` to `NotificationsProvider` when `useAuth()` returns no user
- [x] `App` passes `user.userId` to `NotificationsProvider` when `useAuth()` returns an authenticated user

### Test counts (`@adopt-dont-shop/app.client`)
- Before: 22 files, 208 tests passing
- After: 24 files, 213 tests passing (+1 file with 3 tests, +1 file with 2 tests)

### Verification commands run locally
- `npx vitest run` in `app.client` — all 213 tests pass
- `npx tsc --noEmit` in `app.client` — clean
- `npx eslint` on changed files — clean

### Pre-existing flake (not introduced here)

`src/__tests__/distance-sorting.behavior.test.tsx` "Manual Location Entry" sub-suite occasionally fails when run alongside other tests but passes in isolation. Confirmed unrelated to this change by running the same suite on `main` — same intermittent behaviour. Worth a separate flake-tracker ticket.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_