### PR TITLE
feat(legal): admin-triggered re-acceptance reminder email (ADS-497, slice 3/N)

### DIFF
--- a/service.backend/src/__tests__/routes/admin-legal-reminder.routes.test.ts
+++ b/service.backend/src/__tests__/routes/admin-legal-reminder.routes.test.ts
@@ -1,0 +1,225 @@
+/**
+ * ADS-497 (slice 3): HTTP-contract tests for the admin-triggered legal
+ * re-acceptance reminder endpoint. Service-level behaviour (dedupe,
+ * rate-limit, missing-email) is covered in legal-reminder.test.ts;
+ * these tests cover auth gating, body validation, and error mapping.
+ */
+import { vi } from 'vitest';
+import express, { NextFunction, Response } from 'express';
+import request from 'supertest';
+import { AuthenticatedRequest } from '../../types';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn() },
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../config/env', () => ({
+  env: {
+    JWT_SECRET: 'test-secret-min-32-characters-long-12345',
+    JWT_REFRESH_SECRET: 'test-refresh-secret-min-32-chars-12345',
+    SESSION_SECRET: 'test-session-secret',
+    CSRF_SECRET: 'test-csrf-secret',
+  },
+}));
+
+vi.mock('../../middleware/rate-limiter', () => ({
+  authLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  generalLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../../services/admin.service', () => ({
+  default: {},
+}));
+
+vi.mock('../../services/security.service', () => ({
+  default: {},
+}));
+
+vi.mock('../../services/auditLog.service', () => ({
+  AuditLogService: { create: vi.fn(), getAuditLogs: vi.fn(), log: vi.fn() },
+}));
+
+vi.mock('../../services/legal-reminder.service', () => ({
+  sendReacceptanceReminder: vi.fn(),
+}));
+
+const authenticateTokenMock = vi.fn();
+const requireAdminMock = vi.fn();
+const requirePermissionMock = vi.fn();
+
+vi.mock('../../middleware/auth', () => ({
+  authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authenticateTokenMock(req, res, next),
+}));
+
+vi.mock('../../middleware/rbac', () => ({
+  requireAdmin: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    requireAdminMock(req, res, next),
+  requirePermission:
+    (perm: string) => (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+      requirePermissionMock(perm, req, res, next),
+  requireRole:
+    (..._roles: string[]) =>
+    (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>
+      next(),
+}));
+
+import adminRouter from '../../routes/admin.routes';
+import { sendReacceptanceReminder } from '../../services/legal-reminder.service';
+
+const mockSend = vi.mocked(sendReacceptanceReminder);
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/admin', adminRouter);
+  return app;
+};
+
+const mockAdminUser = {
+  userId: '827d8a69-a4a4-45a0-8dab-a5fc5ca89067',
+  email: 'admin@example.com',
+  userType: 'ADMIN',
+  role: 'ADMIN',
+};
+
+const targetUserId = '5e3a0eaa-79b1-4c46-b5b6-26f1a8b1c9a2';
+
+describe('POST /api/v1/admin/legal/send-reacceptance-reminder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateTokenMock.mockImplementation(
+      (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+        req.user = mockAdminUser as AuthenticatedRequest['user'];
+        next();
+      }
+    );
+    requireAdminMock.mockImplementation(
+      (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+    );
+    requirePermissionMock.mockImplementation(
+      (_perm: string, _req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+    );
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    authenticateTokenMock.mockImplementation((_req: AuthenticatedRequest, res: Response) => {
+      res.status(401).json({ error: 'Access token required' });
+    });
+
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: targetUserId });
+
+    expect(res.status).toBe(401);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when authenticated user is not an admin', async () => {
+    requireAdminMock.mockImplementation((_req: AuthenticatedRequest, res: Response) => {
+      res.status(403).json({ error: 'Access denied' });
+    });
+
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: targetUserId });
+
+    expect(res.status).toBe(403);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 when userId is missing', async () => {
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({});
+
+    expect(res.status).toBe(422);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 when userId is not a UUID', async () => {
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: 'not-a-uuid' });
+
+    expect(res.status).toBe(422);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with sent=true when the service queues an email', async () => {
+    mockSend.mockResolvedValue({
+      sent: true,
+      versions: [{ documentType: 'terms', currentVersion: '2026-05-08-v1' }],
+    });
+
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: targetUserId });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sent: true,
+      versions: [{ documentType: 'terms', currentVersion: '2026-05-08-v1' }],
+    });
+    expect(mockSend).toHaveBeenCalledWith({
+      userId: targetUserId,
+      triggeredBy: mockAdminUser.userId,
+    });
+  });
+
+  it('returns 200 with sent=false when the user is already up to date', async () => {
+    mockSend.mockResolvedValue({ sent: false, reason: 'no_pending_versions' });
+
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: targetUserId });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ sent: false, reason: 'no_pending_versions' });
+  });
+
+  it('returns 200 with sent=false when rate-limited', async () => {
+    mockSend.mockResolvedValue({ sent: false, reason: 'rate_limited' });
+
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: targetUserId });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ sent: false, reason: 'rate_limited' });
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    mockSend.mockRejectedValue(new Error('User not found'));
+
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: targetUserId });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'User not found' });
+  });
+
+  it('returns 422 when the target user has no email on file', async () => {
+    mockSend.mockRejectedValue(new Error('User has no email address on file'));
+
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: targetUserId });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual({ error: 'User has no email address on file' });
+  });
+
+  it('returns 500 on unexpected service errors', async () => {
+    mockSend.mockRejectedValue(new Error('db down'));
+
+    const res = await request(buildApp())
+      .post('/api/v1/admin/legal/send-reacceptance-reminder')
+      .send({ userId: targetUserId });
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/service.backend/src/__tests__/services/legal-reminder.test.ts
+++ b/service.backend/src/__tests__/services/legal-reminder.test.ts
@@ -1,0 +1,286 @@
+/**
+ * ADS-497 (slice 3): behaviour tests for the admin-triggered legal
+ * re-acceptance reminder service. The service itself is the only
+ * outbound-email path for this feature; tests cover the four documented
+ * outcomes (no pending, sent, rate-limited, missing email) plus the
+ * version-fingerprint dedupe semantics.
+ */
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logBusiness: vi.fn(), logExternalService: vi.fn(), logSecurity: vi.fn() },
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../models/AuditLog', () => ({
+  default: { findOne: vi.fn() },
+  AuditLog: { findOne: vi.fn() },
+  withAuditMutationAllowed: vi.fn(),
+}));
+
+vi.mock('../../models/User', () => ({
+  default: { findByPk: vi.fn() },
+}));
+
+vi.mock('../../services/email.service', () => ({
+  default: { sendEmail: vi.fn().mockResolvedValue('email-id-123') },
+}));
+
+vi.mock('../../services/auditLog.service', () => ({
+  AuditLogService: { log: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('../../services/legal-content.service', () => ({
+  getPendingReacceptance: vi.fn(),
+}));
+
+import AuditLog from '../../models/AuditLog';
+import User from '../../models/User';
+import { AuditLogService } from '../../services/auditLog.service';
+import emailService from '../../services/email.service';
+import {
+  LEGAL_REMINDER_SENT_ACTION,
+  REMINDER_RATE_LIMIT_HOURS,
+  sendReacceptanceReminder,
+} from '../../services/legal-reminder.service';
+import { getPendingReacceptance } from '../../services/legal-content.service';
+
+const mockUserFindByPk = vi.mocked(User.findByPk);
+const mockAuditFindOne = vi.mocked(AuditLog.findOne);
+const mockSendEmail = vi.mocked(emailService.sendEmail);
+const mockAuditLog = vi.mocked(AuditLogService.log);
+const mockGetPending = vi.mocked(getPendingReacceptance);
+
+const userRow = {
+  userId: 'user-1',
+  email: 'jane@example.com',
+  firstName: 'Jane',
+};
+
+describe('legal-reminder service - sendReacceptanceReminder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFindByPk.mockResolvedValue(userRow as never);
+    mockAuditFindOne.mockResolvedValue(null);
+  });
+
+  it('returns no_pending_versions when the user is already up to date', async () => {
+    mockGetPending.mockResolvedValue({ pending: [] });
+
+    const result = await sendReacceptanceReminder({ userId: 'user-1' });
+
+    expect(result).toEqual({ sent: false, reason: 'no_pending_versions' });
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('sends the email and writes an audit row when the user has pending docs and no recent reminder', async () => {
+    mockGetPending.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: '2025-01-01-v1',
+          lastAcceptedAt: '2025-02-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const result = await sendReacceptanceReminder({
+      userId: 'user-1',
+      triggeredBy: 'admin-7',
+    });
+
+    expect(result.sent).toBe(true);
+    if (result.sent) {
+      expect(result.versions).toEqual([{ documentType: 'terms', currentVersion: '2026-05-08-v1' }]);
+    }
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    const sendArgs = mockSendEmail.mock.calls[0][0];
+    expect(sendArgs.toEmail).toBe('jane@example.com');
+    expect(sendArgs.userId).toBe('user-1');
+    expect(sendArgs.subject).toContain('Terms of Service');
+    expect(sendArgs.htmlContent).toContain('2026-05-08-v1');
+    expect(sendArgs.textContent).toContain('Terms of Service');
+
+    expect(mockAuditLog).toHaveBeenCalledTimes(1);
+    const auditArgs = mockAuditLog.mock.calls[0][0];
+    expect(auditArgs.action).toBe(LEGAL_REMINDER_SENT_ACTION);
+    expect(auditArgs.entity).toBe('User');
+    expect(auditArgs.entityId).toBe('user-1');
+    expect(auditArgs.userId).toBe('user-1');
+    expect(auditArgs.details).toMatchObject({
+      versionFingerprint: 'terms:2026-05-08-v1',
+      versions: [{ documentType: 'terms', currentVersion: '2026-05-08-v1' }],
+      triggeredBy: 'admin-7',
+    });
+  });
+
+  it('rate-limits when an audit row exists for the same versions inside the window', async () => {
+    mockGetPending.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+        {
+          documentType: 'privacy',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+    mockAuditFindOne.mockResolvedValue({
+      metadata: {
+        details: {
+          versionFingerprint: 'privacy:2026-05-08-v1|terms:2026-05-08-v1',
+          versions: [
+            { documentType: 'terms', currentVersion: '2026-05-08-v1' },
+            { documentType: 'privacy', currentVersion: '2026-05-08-v1' },
+          ],
+          triggeredBy: 'admin-7',
+        },
+      },
+      timestamp: new Date(),
+    } as never);
+
+    const result = await sendReacceptanceReminder({ userId: 'user-1' });
+
+    expect(result).toEqual({ sent: false, reason: 'rate_limited' });
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('still sends when a previous audit row has a different version fingerprint (e.g. a newer version was published)', async () => {
+    mockGetPending.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+    mockAuditFindOne.mockResolvedValue({
+      metadata: {
+        details: {
+          versionFingerprint: 'terms:2025-01-01-v1',
+          versions: [{ documentType: 'terms', currentVersion: '2025-01-01-v1' }],
+          triggeredBy: null,
+        },
+      },
+      timestamp: new Date(),
+    } as never);
+
+    const result = await sendReacceptanceReminder({ userId: 'user-1' });
+
+    expect(result.sent).toBe(true);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('queries the audit log with a cutoff matching the rate-limit window', async () => {
+    mockGetPending.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+
+    const before = Date.now();
+    await sendReacceptanceReminder({ userId: 'user-1' });
+    const after = Date.now();
+
+    expect(mockAuditFindOne).toHaveBeenCalledTimes(1);
+    const where = mockAuditFindOne.mock.calls[0][0]?.where as Record<string, unknown>;
+    expect(where.user).toBe('user-1');
+    expect(where.action).toBe(LEGAL_REMINDER_SENT_ACTION);
+
+    const tsClause = where.timestamp as Record<symbol, Date>;
+    const symbols = Object.getOwnPropertySymbols(tsClause);
+    expect(symbols).toHaveLength(1);
+    const cutoff = tsClause[symbols[0]] as Date;
+    const expectedMin = before - REMINDER_RATE_LIMIT_HOURS * 60 * 60 * 1000;
+    const expectedMax = after - REMINDER_RATE_LIMIT_HOURS * 60 * 60 * 1000;
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(expectedMax);
+  });
+
+  it('throws when the user does not exist', async () => {
+    mockUserFindByPk.mockResolvedValue(null);
+
+    await expect(sendReacceptanceReminder({ userId: 'nope' })).rejects.toThrow('User not found');
+
+    expect(mockGetPending).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user has no email on file', async () => {
+    mockUserFindByPk.mockResolvedValue({ ...userRow, email: '' } as never);
+
+    await expect(sendReacceptanceReminder({ userId: 'user-1' })).rejects.toThrow(
+      'User has no email address on file'
+    );
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('produces a stable version fingerprint regardless of pending order', async () => {
+    // Order A: terms first
+    mockGetPending.mockResolvedValueOnce({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+        {
+          documentType: 'privacy',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+    await sendReacceptanceReminder({ userId: 'user-1' });
+    const fingerprintA = (mockAuditLog.mock.calls[0][0].details as { versionFingerprint: string })
+      .versionFingerprint;
+
+    vi.clearAllMocks();
+    mockUserFindByPk.mockResolvedValue(userRow as never);
+    mockAuditFindOne.mockResolvedValue(null);
+
+    // Order B: privacy first
+    mockGetPending.mockResolvedValueOnce({
+      pending: [
+        {
+          documentType: 'privacy',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+    await sendReacceptanceReminder({ userId: 'user-1' });
+    const fingerprintB = (mockAuditLog.mock.calls[0][0].details as { versionFingerprint: string })
+      .versionFingerprint;
+
+    expect(fingerprintA).toBe(fingerprintB);
+  });
+});

--- a/service.backend/src/routes/admin.routes.ts
+++ b/service.backend/src/routes/admin.routes.ts
@@ -1,11 +1,16 @@
-import express from 'express';
+import express, { Response } from 'express';
+import { z } from 'zod';
 import { AdminController } from '../controllers/admin.controller';
 import { SecurityController } from '../controllers/security.controller';
 import { authenticateToken } from '../middleware/auth';
 import { requireAdmin, requirePermission } from '../middleware/rbac';
 import { authLimiter, generalLimiter } from '../middleware/rate-limiter';
 import { handleValidationErrors } from '../middleware/validation';
+import { validateBody } from '../middleware/zod-validate';
+import { sendReacceptanceReminder } from '../services/legal-reminder.service';
+import { AuthenticatedRequest } from '../types/api';
 import { PERMISSIONS } from '../types/rbac';
+import { logger } from '../utils/logger';
 import { adminValidation } from '../validation/admin.validation';
 
 const router = express.Router();
@@ -1542,6 +1547,46 @@ router.get(
   requirePermission(PERMISSIONS.ADMIN_SECURITY_READ),
   generalLimiter,
   SecurityController.getSuspiciousActivity
+);
+
+// ADS-497 (slice 3): admin-triggered legal re-acceptance reminder.
+// Single user per request. No bulk-send. Per-user-per-version dedupe
+// is handled inside the service via the audit log; bulk fan-out is
+// deferred to slice 4.
+const SendReacceptanceReminderBodySchema = z.object({
+  userId: z.string().uuid(),
+});
+
+router.post(
+  '/legal/send-reacceptance-reminder',
+  authLimiter,
+  validateBody(SendReacceptanceReminderBodySchema),
+  async (req: AuthenticatedRequest, res: Response) => {
+    const { userId } = req.body as z.infer<typeof SendReacceptanceReminderBodySchema>;
+    try {
+      const result = await sendReacceptanceReminder({
+        userId,
+        triggeredBy: req.user?.userId ?? null,
+      });
+      res.status(200).json(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      if (message === 'User not found') {
+        res.status(404).json({ error: message });
+        return;
+      }
+      if (message === 'User has no email address on file') {
+        res.status(422).json({ error: message });
+        return;
+      }
+      logger.error('Failed to send legal re-acceptance reminder', {
+        userId,
+        triggeredBy: req.user?.userId,
+        error: message,
+      });
+      res.status(500).json({ error: 'Failed to send reminder' });
+    }
+  }
 );
 
 export default router;

--- a/service.backend/src/services/legal-reminder.service.ts
+++ b/service.backend/src/services/legal-reminder.service.ts
@@ -1,0 +1,256 @@
+import { Op } from 'sequelize';
+import { z } from 'zod';
+import AuditLog from '../models/AuditLog';
+import User from '../models/User';
+import { AuditLogService } from './auditLog.service';
+import emailService from './email.service';
+import { PendingReacceptanceItem, getPendingReacceptance } from './legal-content.service';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-497 (slice 3): admin-triggered re-acceptance reminder email.
+ *
+ * SCOPE — single user, manually triggered. There is intentionally no
+ * cron, no bulk-send, and no UI hook. The only entry point is the
+ * admin route `POST /api/v1/admin/legal/send-reacceptance-reminder`
+ * (see `admin.routes.ts`). Bulk fan-out is deferred to slice 4.
+ *
+ * Behaviour:
+ *   1. Look up which legal documents the user still has to re-accept
+ *      (`legal-content.service#getPendingReacceptance`). If nothing is
+ *      pending, return `{ sent: false, reason: 'no_pending_versions' }`
+ *      without emailing — version bumps shouldn't surprise users who
+ *      already accepted the latest copy.
+ *   2. Per-user-per-version dedupe via the audit log: if a
+ *      `LEGAL_REMINDER_SENT` row exists for this user with the same
+ *      pending-version fingerprint inside the rate-limit window, return
+ *      `{ sent: false, reason: 'rate_limited' }`. No new email, no new
+ *      audit row.
+ *   3. Otherwise, send a transactional email with subject + body that
+ *      lists the docs to review and links back to the app. Append a
+ *      `LEGAL_REMINDER_SENT` audit row capturing the version
+ *      fingerprint so subsequent calls can dedupe.
+ *
+ * Dedupe storage: reusing `audit_logs` (matches consent capture in
+ * `consent.service.ts`). Avoids a new table for what is effectively an
+ * append-only audit trail.
+ */
+
+export const REMINDER_RATE_LIMIT_HOURS = 24;
+export const LEGAL_REMINDER_SENT_ACTION = 'LEGAL_REMINDER_SENT';
+
+export const ReminderResultSchema = z.discriminatedUnion('sent', [
+  z.object({
+    sent: z.literal(true),
+    versions: z.array(
+      z.object({
+        documentType: z.enum(['terms', 'privacy']),
+        currentVersion: z.string(),
+      })
+    ),
+  }),
+  z.object({
+    sent: z.literal(false),
+    reason: z.enum(['no_pending_versions', 'rate_limited']),
+  }),
+]);
+export type ReminderResult = z.infer<typeof ReminderResultSchema>;
+
+const ReminderAuditDetailsSchema = z.object({
+  versionFingerprint: z.string(),
+  versions: z.array(
+    z.object({
+      documentType: z.enum(['terms', 'privacy']),
+      currentVersion: z.string(),
+    })
+  ),
+  triggeredBy: z.string().nullable(),
+});
+export type ReminderAuditDetails = z.infer<typeof ReminderAuditDetailsSchema>;
+
+/**
+ * Stable identifier for "the set of documents this reminder is about".
+ * Sorted so that {terms, privacy} and {privacy, terms} produce the
+ * same fingerprint regardless of upstream ordering.
+ */
+const buildVersionFingerprint = (pending: ReadonlyArray<PendingReacceptanceItem>): string => {
+  return pending
+    .map(p => `${p.documentType}:${p.currentVersion}`)
+    .sort()
+    .join('|');
+};
+
+const wasRecentlyReminded = async (userId: string, fingerprint: string): Promise<boolean> => {
+  const cutoff = new Date(Date.now() - REMINDER_RATE_LIMIT_HOURS * 60 * 60 * 1000);
+  const recent = await AuditLog.findOne({
+    where: {
+      user: userId,
+      action: LEGAL_REMINDER_SENT_ACTION,
+      timestamp: { [Op.gte]: cutoff },
+    },
+    order: [['timestamp', 'DESC']],
+  });
+  if (!recent) {
+    return false;
+  }
+  const parsed = ReminderAuditDetailsSchema.safeParse(
+    (recent.metadata as { details?: unknown } | null | undefined)?.details
+  );
+  if (!parsed.success) {
+    // Malformed metadata — treat as no record, but log so we notice.
+    logger.warn('LEGAL_REMINDER_SENT audit row had unparseable details', {
+      userId,
+    });
+    return false;
+  }
+  return parsed.data.versionFingerprint === fingerprint;
+};
+
+const documentLabel = (documentType: 'terms' | 'privacy'): string =>
+  documentType === 'terms' ? 'Terms of Service' : 'Privacy Policy';
+
+const renderReminderHtml = (
+  firstName: string | null,
+  pending: ReadonlyArray<PendingReacceptanceItem>
+): string => {
+  const baseUrl = process.env.FRONTEND_URL || 'https://adoptdontshop.com';
+  const supportEmail = process.env.SUPPORT_EMAIL || 'support@adoptdontshop.com';
+  const greeting = firstName ? `Hi ${firstName},` : 'Hi there,';
+  const items = pending
+    .map(p => `<li>${documentLabel(p.documentType)} (version ${p.currentVersion})</li>`)
+    .join('\n          ');
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Action required: review updated legal documents</title>
+</head>
+<body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h2>Please review our updated legal documents</h2>
+  <p>${greeting}</p>
+  <p>We've updated the following document(s) and need you to review and re-accept them the next time you sign in:</p>
+  <ul>
+          ${items}
+  </ul>
+  <p>
+    <a href="${baseUrl}" style="display: inline-block; background-color: #2563eb; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+      Open Adopt Don't Shop
+    </a>
+  </p>
+  <p>You won't be able to continue using your account until you've accepted the latest versions. If you have any questions, contact us at ${supportEmail}.</p>
+  <p>Thanks,<br>The Adopt Don't Shop team</p>
+</body>
+</html>`;
+};
+
+const renderReminderText = (
+  firstName: string | null,
+  pending: ReadonlyArray<PendingReacceptanceItem>
+): string => {
+  const baseUrl = process.env.FRONTEND_URL || 'https://adoptdontshop.com';
+  const supportEmail = process.env.SUPPORT_EMAIL || 'support@adoptdontshop.com';
+  const greeting = firstName ? `Hi ${firstName},` : 'Hi there,';
+  const items = pending
+    .map(p => `- ${documentLabel(p.documentType)} (version ${p.currentVersion})`)
+    .join('\n');
+
+  return `Please review our updated legal documents
+
+${greeting}
+
+We've updated the following document(s) and need you to review and re-accept them the next time you sign in:
+
+${items}
+
+Open Adopt Don't Shop: ${baseUrl}
+
+You won't be able to continue using your account until you've accepted the latest versions. If you have any questions, contact us at ${supportEmail}.
+
+Thanks,
+The Adopt Don't Shop team`;
+};
+
+const buildSubject = (pending: ReadonlyArray<PendingReacceptanceItem>): string => {
+  if (pending.length === 1) {
+    return `Action required: please review our updated ${documentLabel(pending[0].documentType)}`;
+  }
+  return 'Action required: please review our updated legal documents';
+};
+
+export type SendReminderOptions = {
+  userId: string;
+  triggeredBy?: string | null;
+};
+
+/**
+ * Send a legal-reacceptance reminder email to a single user.
+ *
+ * Throws when the user does not exist or has no email on file — the
+ * caller (admin route) translates these into 404 / 422. Returns a
+ * structured `{ sent }` result for the normal cases (already current
+ * or rate-limited) so the admin sees why nothing was sent.
+ */
+export const sendReacceptanceReminder = async (
+  options: SendReminderOptions
+): Promise<ReminderResult> => {
+  const { userId, triggeredBy = null } = options;
+
+  const user = await User.findByPk(userId, {
+    attributes: ['userId', 'email', 'firstName'],
+  });
+  if (!user) {
+    throw new Error('User not found');
+  }
+  if (!user.email) {
+    throw new Error('User has no email address on file');
+  }
+
+  const { pending } = await getPendingReacceptance(userId);
+  if (pending.length === 0) {
+    return { sent: false, reason: 'no_pending_versions' };
+  }
+
+  const fingerprint = buildVersionFingerprint(pending);
+
+  if (await wasRecentlyReminded(userId, fingerprint)) {
+    return { sent: false, reason: 'rate_limited' };
+  }
+
+  const versions = pending.map(p => ({
+    documentType: p.documentType,
+    currentVersion: p.currentVersion,
+  }));
+
+  await emailService.sendEmail({
+    toEmail: user.email,
+    toName: user.firstName ?? undefined,
+    userId,
+    subject: buildSubject(pending),
+    htmlContent: renderReminderHtml(user.firstName ?? null, pending),
+    textContent: renderReminderText(user.firstName ?? null, pending),
+    type: 'transactional',
+    priority: 'normal',
+    metadata: {
+      legalReminder: {
+        versionFingerprint: fingerprint,
+      },
+    },
+  });
+
+  const auditDetails: ReminderAuditDetails = {
+    versionFingerprint: fingerprint,
+    versions,
+    triggeredBy,
+  };
+
+  await AuditLogService.log({
+    userId,
+    action: LEGAL_REMINDER_SENT_ACTION,
+    entity: 'User',
+    entityId: userId,
+    details: auditDetails,
+  });
+
+  return { sent: true, versions };
+};


### PR DESCRIPTION
## Scope (read first — this PR sends email)

**Admin-triggered, single user, single email.** This PR introduces a NEW outbound-email path; blast radius has been deliberately constrained:

- **No cron/worker.** Nothing fires on its own.
- **No bulk-send.** The endpoint accepts exactly one `userId` per request.
- **No automatic firing on version bump.** Bumping `TERMS_VERSION` / `PRIVACY_VERSION` in `legal-content.service.ts` does not, by itself, email anyone.
- **No UI.** Admin endpoint only.
- **Per-user-per-version dedupe** via the audit log: the same user cannot be re-reminded for the same version-set inside a 24h window.

The bulk fan-out (cron, admin-UI batch action, scheduled job, retries beyond what `email.service` already provides) is **explicitly deferred to slice 4**.

## Summary

- New service `legal-reminder.service#sendReacceptanceReminder({ userId, triggeredBy })`:
  - Calls `getPendingReacceptance(userId)`. Returns `{ sent: false, reason: 'no_pending_versions' }` if nothing is pending — never emails an up-to-date user.
  - Computes a stable, order-independent **version fingerprint** (e.g. `privacy:2026-05-08-v1|terms:2026-05-08-v1`) and queries `audit_logs` for a `LEGAL_REMINDER_SENT` row with the same fingerprint inside the last 24h. If found, returns `{ sent: false, reason: 'rate_limited' }`.
  - Otherwise queues a transactional email via the existing `email.service` and writes a `LEGAL_REMINDER_SENT` audit row capturing `{ versionFingerprint, versions, triggeredBy }`.
  - Throws `User not found` / `User has no email address on file` for the route to translate to 404 / 422.
- New admin route `POST /api/v1/admin/legal/send-reacceptance-reminder` (body: `{ userId: uuid }`):
  - Authenticated + `requireAdmin` (inherited from `router.use` at the top of `admin.routes.ts`).
  - `validateBody` (Zod) → 422 on missing/non-UUID userId.
  - 200 with the structured service result for both "sent" and "not sent" cases (the not-sent variants tell the admin _why_).
  - 404 / 422 / 500 mapped from service-level errors.
- Subject + body rendered inline (matching the `sendStaffInvitation` pattern in `email-template.service.ts`) — no DB-template seed required, no new template engine. Plain HTML + plaintext fallback.

## Storage / dedupe choice

I considered a new `legal_reminder_sends` table but reused `audit_logs` instead — it matches `consent.service.ts` (which also persists immutable consent decisions there), is append-only by design (ADS-508), and avoids a migration for what is essentially an audit trail. The version fingerprint is the dedupe key; if a brand-new version ships, prior reminders for the old fingerprint will not block a fresh send.

## What I discovered about email infra (and how it shaped the design)

- `email.service.sendEmail()` already handles queueing, per-user preference checks (`canReceiveEmails` / type filtering), audit-logging the queue write (`EMAIL_QUEUED`), and provider dispatch. I rely on that and only add the legal-reminder-specific audit row on top.
- There is a `bulkEmail` path with concurrency / batching, but the task explicitly forbids using it here — the admin endpoint takes one `userId`.
- Templates can either be DB rows (categories: WELCOME, PASSWORD_RESET, …) or inline HTML/text passed to `sendEmail`. There is no existing `LEGAL_REMINDER` template category, and the staff-invitation flow already uses the inline pattern, so this PR does too — keeps the diff small and avoids needing a seed/migration to deploy.
- `User.findByPk` with `attributes: ['userId', 'email', 'firstName']` is enough for the recipient lookup; no need to touch joined associations.

## Open questions (please weigh in)

1. **Rate-limit window** — currently 24h (`REMINDER_RATE_LIMIT_HOURS = 24`). Should this be longer (e.g. 7 days) given that one nag per day is still arguably noisy for a legal-doc reminder?
2. **Audit action name** — I used `LEGAL_REMINDER_SENT`. The task suggested `TERMS_REACCEPTANCE_REMINDER` as an alternative. The chosen name is broader and survives if we ever add cookie-policy reminders; happy to rename if reviewers prefer the more specific one.
3. **Slice 4 trigger location** — should the eventual bulk-send be (a) an admin-UI batch action that pages through users, (b) a scheduled cron worker, or (c) a one-off CLI script run on demand by SRE? This PR doesn't choose; it just makes sure whatever slice 4 picks can call the same `sendReacceptanceReminder` function and inherit dedupe + audit logging for free.

## Files changed

- `service.backend/src/services/legal-reminder.service.ts` (new, ~270 LoC including comments)
- `service.backend/src/routes/admin.routes.ts` (new POST route + Zod schema + 4 imports)
- `service.backend/src/__tests__/services/legal-reminder.test.ts` (new — 8 behaviour tests)
- `service.backend/src/__tests__/routes/admin-legal-reminder.routes.test.ts` (new — 10 route tests)

## Test plan

- [x] Service tests (8): empty pending → not sent; pending + no recent reminder → sent + audit row + email payload contents; pending + matching audit row in window → rate-limited; pending + non-matching fingerprint in window → still sent; cutoff matches `REMINDER_RATE_LIMIT_HOURS`; missing user → throws; missing email → throws; fingerprint stable across pending-array order.
- [x] Route tests (10): 401 unauthed; 403 non-admin; 422 missing userId; 422 non-UUID userId; 200 sent=true; 200 sent=false `no_pending_versions`; 200 sent=false `rate_limited`; 404 user not found; 422 user has no email; 500 unexpected error.
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx prettier --check` on changed files — clean
- [x] Full backend `npx vitest run` — 2087 passed, 36 skipped, 0 failed (133 test files)

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_