### PR TITLE
feat(ADS-104): wire Resend as production ESP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6069,6 +6069,12 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -11912,6 +11918,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -17068,6 +17080,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
@@ -19084,6 +19102,27 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
     },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -20336,6 +20375,16 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -20923,6 +20972,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/swagger-jsdoc": {
@@ -23272,6 +23330,7 @@
         "prom-client": "^15.1.3",
         "qrcode": "^1.5.4",
         "rate-limit-redis": "^5.0.0",
+        "resend": "^6.12.3",
         "sequelize": "^6.31.0",
         "sequelize-cli": "^6.6.5",
         "sequelize-typescript": "^2.1.5",

--- a/service.backend/.env.example
+++ b/service.backend/.env.example
@@ -37,14 +37,30 @@ UPLOAD_DIR=uploads
 MAX_FILE_SIZE=5242880
 
 # Email Configuration
-EMAIL_HOST=smtp.sendgrid.net
-EMAIL_PORT=587
-EMAIL_USER=apikey
-EMAIL_PASS=your-sendgrid-api-key
+# Set EMAIL_PROVIDER to select the active provider:
+#   'ethereal'  — auto-created test account, preview URLs logged (default for dev/test)
+#   'console'   — prints email to stdout, no external calls
+#   'resend'    — Resend transactional email (recommended for production)
+EMAIL_PROVIDER=ethereal
 EMAIL_FROM=noreply@adoptdontshop.com
 DEFAULT_FROM_EMAIL=noreply@adoptdontshop.com
 EMAIL_FROM_ADDRESS=noreply@adoptdontshop.com
 SUPPORT_EMAIL=support@adoptdontshop.com
+
+# Resend (production ESP — https://resend.com)
+# Create an API key at https://resend.com/api-keys
+# Requires a verified sending domain in the Resend dashboard.
+RESEND_API_KEY=re_your_api_key_here
+RESEND_FROM_EMAIL=noreply@adoptdontshop.com
+RESEND_FROM_NAME=Adopt Don't Shop
+# Optional: set a reply-to address different from the from address
+# RESEND_REPLY_TO=support@adoptdontshop.com
+
+# Legacy SMTP / SendGrid variables (kept for reference, not used by the resend provider)
+EMAIL_HOST=smtp.sendgrid.net
+EMAIL_PORT=587
+EMAIL_USER=apikey
+EMAIL_PASS=your-sendgrid-api-key
 
 # Redis Configuration (for caching and sessions)
 REDIS_HOST=localhost

--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -71,6 +71,7 @@
     "prom-client": "^15.1.3",
     "qrcode": "^1.5.4",
     "rate-limit-redis": "^5.0.0",
+    "resend": "^6.12.3",
     "sequelize": "^6.31.0",
     "sequelize-cli": "^6.6.5",
     "sequelize-typescript": "^2.1.5",

--- a/service.backend/scripts/generate-swagger.ts
+++ b/service.backend/scripts/generate-swagger.ts
@@ -5,8 +5,6 @@
  * This script helps with automatic generation and validation of OpenAPI documentation
  */
 
-/* eslint-disable no-console */
-
 import fs from 'fs-extra';
 import path from 'path';
 import swaggerJsdoc from 'swagger-jsdoc';
@@ -259,7 +257,7 @@ async function main(): Promise<void> {
 if (require.main === module) {
   main().catch(error => {
     console.error('❌ Script failed:', error);
-    // eslint-disable-next-line no-process-exit
+
     process.exit(1);
   });
 }

--- a/service.backend/src/__tests__/middleware/error-handler.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/error-handler.middleware.test.ts
@@ -208,7 +208,7 @@ describe('Error Handler Middleware', () => {
           'relation "users" does not exist — column "secret_internal_col" referenced in WHERE clause'
         ),
         // sequelize types this loosely; we just need a real DatabaseError instance
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         {} as any
       );
 

--- a/service.backend/src/__tests__/models/Message.model.test.ts
+++ b/service.backend/src/__tests__/models/Message.model.test.ts
@@ -29,7 +29,6 @@ import Message from '../../models/Message';
  */
 describe('Chat-family model defaults', () => {
   describe('Message', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const attrs = Message.rawAttributes as Record<string, any>;
 
     it('message_id has a defaultValue so inserts without an explicit id succeed', () => {
@@ -52,7 +51,6 @@ describe('Chat-family model defaults', () => {
   });
 
   describe('Chat', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const attrs = Chat.rawAttributes as Record<string, any>;
 
     it('chat_id has a defaultValue so new chats don’t need a caller-supplied id', () => {
@@ -62,7 +60,6 @@ describe('Chat-family model defaults', () => {
   });
 
   describe('ChatParticipant', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const attrs = ChatParticipant.rawAttributes as Record<string, any>;
 
     it('chat_participant_id has a defaultValue so createChat participant inserts succeed', () => {

--- a/service.backend/src/__tests__/services/discovery-breed-cache.test.ts
+++ b/service.backend/src/__tests__/services/discovery-breed-cache.test.ts
@@ -36,18 +36,15 @@ describe('DiscoveryService breed cache [ADS-516]', () => {
       postcode: 'P1',
       country: 'GB',
       contactPerson: 'X',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
     await Breed.create({
       name: 'Labrador Retriever',
       species: PetType.DOG,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     await Breed.create({
       name: 'Border Collie',
       species: PetType.DOG,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
     await Pet.create({

--- a/service.backend/src/__tests__/services/email-queue-concurrency.test.ts
+++ b/service.backend/src/__tests__/services/email-queue-concurrency.test.ts
@@ -71,7 +71,7 @@ describe('EmailService.processEmailQueue concurrency [ADS-477]', () => {
     for (let i = 0; i < count; i += 1) {
       // Use sequential creates so emailId / fromEmail defaults populate
       // properly under SQLite (bulkCreate skips some validations).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       await EmailQueue.create({
         toEmail: `r${i}@test.com`,
         fromEmail: 'noreply@test.com',
@@ -88,7 +88,6 @@ describe('EmailService.processEmailQueue concurrency [ADS-477]', () => {
         templateData: {},
         attempts: 0,
         maxAttempts: 3,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
     }
   };

--- a/service.backend/src/__tests__/services/pet-cache-invalidation.test.ts
+++ b/service.backend/src/__tests__/services/pet-cache-invalidation.test.ts
@@ -58,7 +58,6 @@ describe('PetService cache invalidation [ADS-479]', () => {
       postcode: 'TE1 1ST',
       country: 'GB',
       contactPerson: 'Tester',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     await Pet.create({
       name: 'Featured Fido',

--- a/service.backend/src/__tests__/services/resend-provider.test.ts
+++ b/service.backend/src/__tests__/services/resend-provider.test.ts
@@ -7,7 +7,7 @@ const mockEmailsSend = vi.fn();
 vi.mock('resend', () => ({
   Resend: class MockResend {
     emails = { send: mockEmailsSend };
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     constructor(_apiKey: string) {}
   },
 }));
@@ -178,8 +178,8 @@ describe('ResendProvider', () => {
 
       await provider.send(
         buildEmail({
-          subject: "Subject\r\nX-Injected: evil",
-          fromName: "Legit Name\nBcc: evil@hacker.com",
+          subject: 'Subject\r\nX-Injected: evil',
+          fromName: 'Legit Name\nBcc: evil@hacker.com',
         })
       );
 

--- a/service.backend/src/__tests__/services/resend-provider.test.ts
+++ b/service.backend/src/__tests__/services/resend-provider.test.ts
@@ -1,0 +1,192 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ResendProvider } from '../../services/email-providers/resend-provider';
+import EmailQueue from '../../models/EmailQueue';
+
+const mockEmailsSend = vi.fn();
+
+vi.mock('resend', () => ({
+  Resend: class MockResend {
+    emails = { send: mockEmailsSend };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_apiKey: string) {}
+  },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  loggerHelpers: {
+    logBusiness: vi.fn(),
+    logDatabase: vi.fn(),
+    logPerformance: vi.fn(),
+    logExternalService: vi.fn(),
+  },
+}));
+
+const buildEmail = (overrides: Partial<EmailQueue> = {}): EmailQueue =>
+  ({
+    fromEmail: 'noreply@adoptdontshop.com',
+    fromName: "Adopt Don't Shop",
+    toEmail: 'adopter@example.com',
+    toName: 'Jane Adopter',
+    subject: 'Your application update',
+    htmlContent: '<p>Good news!</p>',
+    textContent: 'Good news!',
+    ...overrides,
+  }) as EmailQueue;
+
+describe('ResendProvider', () => {
+  describe('validateConfiguration', () => {
+    it('returns true when both apiKey and fromEmail are present', () => {
+      const provider = new ResendProvider({
+        apiKey: 're_abc123',
+        fromEmail: 'noreply@adoptdontshop.com',
+        fromName: "Adopt Don't Shop",
+      });
+      expect(provider.validateConfiguration()).toBe(true);
+    });
+
+    it('returns false when apiKey is missing', () => {
+      const provider = new ResendProvider({
+        apiKey: '',
+        fromEmail: 'noreply@adoptdontshop.com',
+        fromName: "Adopt Don't Shop",
+      });
+      expect(provider.validateConfiguration()).toBe(false);
+    });
+
+    it('returns false when fromEmail is missing', () => {
+      const provider = new ResendProvider({
+        apiKey: 're_abc123',
+        fromEmail: '',
+        fromName: "Adopt Don't Shop",
+      });
+      expect(provider.validateConfiguration()).toBe(false);
+    });
+  });
+
+  describe('getName', () => {
+    it('returns "Resend"', () => {
+      const provider = new ResendProvider({
+        apiKey: 're_abc123',
+        fromEmail: 'noreply@adoptdontshop.com',
+        fromName: "Adopt Don't Shop",
+      });
+      expect(provider.getName()).toBe('Resend');
+    });
+  });
+
+  describe('send', () => {
+    let provider: ResendProvider;
+
+    beforeEach(() => {
+      mockEmailsSend.mockReset();
+
+      provider = new ResendProvider({
+        apiKey: 're_abc123',
+        fromEmail: 'noreply@adoptdontshop.com',
+        fromName: "Adopt Don't Shop",
+        replyTo: 'support@adoptdontshop.com',
+      });
+    });
+
+    it('returns success with messageId when Resend accepts the email', async () => {
+      mockEmailsSend.mockResolvedValue({ data: { id: 'resend_msg_001' }, error: null });
+
+      const result = await provider.send(buildEmail());
+
+      expect(result.success).toBe(true);
+      expect(result.messageId).toBe('resend_msg_001');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('passes sanitized from/to/subject/html/text to the Resend client', async () => {
+      mockEmailsSend.mockResolvedValue({ data: { id: 'resend_msg_002' }, error: null });
+
+      await provider.send(
+        buildEmail({
+          fromEmail: 'noreply@adoptdontshop.com',
+          fromName: "Adopt Don't Shop",
+          toEmail: 'adopter@example.com',
+          toName: 'Jane Adopter',
+          subject: 'Application approved',
+          htmlContent: '<p>Approved!</p>',
+          textContent: 'Approved!',
+        })
+      );
+
+      expect(mockEmailsSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: "Adopt Don't Shop <noreply@adoptdontshop.com>",
+          to: 'Jane Adopter <adopter@example.com>',
+          subject: 'Application approved',
+          html: '<p>Approved!</p>',
+          text: 'Approved!',
+        })
+      );
+    });
+
+    it('includes replyTo when configured', async () => {
+      mockEmailsSend.mockResolvedValue({ data: { id: 'resend_msg_003' }, error: null });
+
+      await provider.send(buildEmail());
+
+      expect(mockEmailsSend).toHaveBeenCalledWith(
+        expect.objectContaining({ replyTo: 'support@adoptdontshop.com' })
+      );
+    });
+
+    it('omits replyTo when not configured', async () => {
+      const providerWithoutReplyTo = new ResendProvider({
+        apiKey: 're_abc123',
+        fromEmail: 'noreply@adoptdontshop.com',
+        fromName: "Adopt Don't Shop",
+      });
+      mockEmailsSend.mockResolvedValue({ data: { id: 'resend_msg_004' }, error: null });
+
+      await providerWithoutReplyTo.send(buildEmail());
+
+      const call = mockEmailsSend.mock.calls[0][0];
+      expect(call).not.toHaveProperty('replyTo');
+    });
+
+    it('omits text when textContent is not set', async () => {
+      mockEmailsSend.mockResolvedValue({ data: { id: 'resend_msg_005' }, error: null });
+
+      await provider.send(buildEmail({ textContent: undefined }));
+
+      const call = mockEmailsSend.mock.calls[0][0];
+      expect(call).not.toHaveProperty('text');
+    });
+
+    it('returns failure with error message when Resend rejects the send', async () => {
+      mockEmailsSend.mockResolvedValue({
+        data: null,
+        error: { message: 'Invalid API key', statusCode: 401, name: 'validation_error' },
+      });
+
+      const result = await provider.send(buildEmail());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid API key');
+      expect(result.messageId).toBeUndefined();
+    });
+
+    it('strips CRLF injection attempts from header fields before sending', async () => {
+      mockEmailsSend.mockResolvedValue({ data: { id: 'resend_msg_006' }, error: null });
+
+      await provider.send(
+        buildEmail({
+          subject: "Subject\r\nX-Injected: evil",
+          fromName: "Legit Name\nBcc: evil@hacker.com",
+        })
+      );
+
+      const call = mockEmailsSend.mock.calls[0][0];
+      expect(call.subject).not.toContain('\r');
+      expect(call.subject).not.toContain('\n');
+      expect(call.from).not.toContain('\n');
+    });
+  });
+});

--- a/service.backend/src/config/index.ts
+++ b/service.backend/src/config/index.ts
@@ -128,7 +128,13 @@ export const config = {
 
   // Email configuration
   email: {
-    provider: process.env.EMAIL_PROVIDER || 'ethereal', // 'ethereal' | 'sendgrid' | 'ses' | 'smtp'
+    provider: process.env.EMAIL_PROVIDER || 'ethereal', // 'ethereal' | 'console' | 'resend' | 'sendgrid' | 'ses' | 'smtp'
+    resend: {
+      apiKey: process.env.RESEND_API_KEY,
+      fromEmail: process.env.RESEND_FROM_EMAIL,
+      fromName: process.env.RESEND_FROM_NAME || "Adopt Don't Shop",
+      replyTo: process.env.RESEND_REPLY_TO,
+    },
     ethereal: {
       // Ethereal creates test accounts automatically
       createTestAccount: process.env.NODE_ENV === 'development',

--- a/service.backend/src/seeders/05-user-roles.ts
+++ b/service.backend/src/seeders/05-user-roles.ts
@@ -87,6 +87,5 @@ export async function seedUserRoles() {
     }
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${assignmentCount} user-role assignments`);
 }

--- a/service.backend/src/seeders/06-rescues.ts
+++ b/service.backend/src/seeders/06-rescues.ts
@@ -147,6 +147,5 @@ export async function seedRescues() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${rescueOrganizations.length} rescue organizations`);
 }

--- a/service.backend/src/seeders/06.5-staff-members.ts
+++ b/service.backend/src/seeders/06.5-staff-members.ts
@@ -50,7 +50,6 @@ const staffMembers = [
 ];
 
 export const seedStaffMembers = async (): Promise<void> => {
-  // eslint-disable-next-line no-console
   console.log('🧑‍💼 Seeding staff members...');
 
   try {
@@ -60,10 +59,8 @@ export const seedStaffMembers = async (): Promise<void> => {
     // Create staff members
     await StaffMember.bulkCreate(staffMembers);
 
-    // eslint-disable-next-line no-console
     console.log(`✅ Successfully seeded ${staffMembers.length} staff members`);
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('❌ Error seeding staff members:', error);
     throw error;
   }
@@ -72,10 +69,9 @@ export const seedStaffMembers = async (): Promise<void> => {
 export const clearStaffMembers = async (): Promise<void> => {
   try {
     await StaffMember.destroy({ where: {}, force: true });
-    // eslint-disable-next-line no-console
+
     console.log('🗑️ Staff members cleared');
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('❌ Error clearing staff members:', error);
     throw error;
   }

--- a/service.backend/src/seeders/08-pets.ts
+++ b/service.backend/src/seeders/08-pets.ts
@@ -416,6 +416,5 @@ export async function seedPets() {
     }
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${petProfiles.length} pet profiles`);
 }

--- a/service.backend/src/seeders/09-applications.ts
+++ b/service.backend/src/seeders/09-applications.ts
@@ -893,6 +893,5 @@ export async function seedApplications() {
     }
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${applicationData.length} adoption applications`);
 }

--- a/service.backend/src/seeders/10-chats.ts
+++ b/service.backend/src/seeders/10-chats.ts
@@ -40,6 +40,5 @@ export async function seedChats() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${chatData.length} chat conversations`);
 }

--- a/service.backend/src/seeders/11-messages.ts
+++ b/service.backend/src/seeders/11-messages.ts
@@ -266,6 +266,5 @@ export async function seedMessages() {
     },
   });
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${messageData.length} chat messages`);
 }

--- a/service.backend/src/seeders/12-notifications.ts
+++ b/service.backend/src/seeders/12-notifications.ts
@@ -183,6 +183,5 @@ export async function seedNotifications() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${notificationData.length} notifications`);
 }

--- a/service.backend/src/seeders/13-ratings.ts
+++ b/service.backend/src/seeders/13-ratings.ts
@@ -92,6 +92,5 @@ export async function seedRatings() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${ratingData.length} ratings and reviews`);
 }

--- a/service.backend/src/seeders/18-emily-dog-conversation.ts
+++ b/service.backend/src/seeders/18-emily-dog-conversation.ts
@@ -298,28 +298,16 @@ export async function seedEmilyDogConversation() {
       });
     }
 
-    // eslint-disable-next-line no-console
-
     console.log('✅ Created Emily Davis dog conversation with Happy Tails Senior Dog Rescue');
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Chat ID: ${emilyDogConversationData.chat.chat_id}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Participants: ${emilyDogConversationData.participants.length}`);
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Messages: ${emilyDogConversationData.messages.length}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Attachments: ${emilyDogConversationData.attachments.length}`);
   } catch (error) {
-    // eslint-disable-next-line no-console
-
     console.error('❌ Error creating Emily dog conversation:', error);
 
     throw error;
@@ -331,16 +319,12 @@ export async function seedEmilyDogConversation() {
 if (require.main === module) {
   seedEmilyDogConversation()
     .then(() => {
-      // eslint-disable-next-line no-console
-
       console.log('🎉 Emily dog conversation seeding completed successfully!');
 
       throw new Error('Seeding completed - exiting process');
     })
 
     .catch(error => {
-      // eslint-disable-next-line no-console
-
       console.error('💥 Emily dog conversation seeding failed:', error);
 
       throw error;

--- a/service.backend/src/seeders/19-emily-rabbit-conversation.ts
+++ b/service.backend/src/seeders/19-emily-rabbit-conversation.ts
@@ -317,28 +317,16 @@ export async function seedEmilyRabbitConversation() {
       });
     }
 
-    // eslint-disable-next-line no-console
-
     console.log('✅ Created Emily Davis rabbit conversation with Furry Friends Manchester');
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Chat ID: ${emilyRabbitConversationData.chat.chat_id}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Participants: ${emilyRabbitConversationData.participants.length}`);
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Messages: ${emilyRabbitConversationData.messages.length}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Attachments: ${emilyRabbitConversationData.attachments.length}`);
   } catch (error) {
-    // eslint-disable-next-line no-console
-
     console.error('❌ Error creating Emily rabbit conversation:', error);
 
     throw error;
@@ -350,16 +338,12 @@ export async function seedEmilyRabbitConversation() {
 if (require.main === module) {
   seedEmilyRabbitConversation()
     .then(() => {
-      // eslint-disable-next-line no-console
-
       console.log('🎉 Emily rabbit conversation seeding completed successfully!');
 
       throw new Error('Seeding completed - exiting process');
     })
 
     .catch(error => {
-      // eslint-disable-next-line no-console
-
       console.error('💥 Emily rabbit conversation seeding failed:', error);
 
       throw error;

--- a/service.backend/src/seeders/20250111-file-uploads-seeder.ts
+++ b/service.backend/src/seeders/20250111-file-uploads-seeder.ts
@@ -103,6 +103,5 @@ export async function seedFileUploads() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${sampleFileUploads.length} test file uploads`);
 }

--- a/service.backend/src/seeders/23-application-timeline.ts
+++ b/service.backend/src/seeders/23-application-timeline.ts
@@ -270,6 +270,5 @@ export async function seedApplicationTimeline() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${timelineData.length} application timeline events`);
 }

--- a/service.backend/src/seeders/bootstrap/create-initial-admin.ts
+++ b/service.backend/src/seeders/bootstrap/create-initial-admin.ts
@@ -40,7 +40,6 @@ export async function createInitialAdmin(): Promise<{ created: boolean }> {
 
   const existingAdminCount = await UserRole.count({ where: { roleId: adminRole.roleId } });
   if (existingAdminCount > 0) {
-    // eslint-disable-next-line no-console
     console.log('Admin already exists — bootstrap skipped (no-op).');
     return { created: false };
   }
@@ -67,7 +66,6 @@ export async function createInitialAdmin(): Promise<{ created: boolean }> {
     roleId: adminRole.roleId,
   } as never);
 
-  // eslint-disable-next-line no-console
   console.log(`Initial admin created (${email}). Password reset required on first login.`);
   return { created: true };
 }

--- a/service.backend/src/seeders/demo/applications-faker.ts
+++ b/service.backend/src/seeders/demo/applications-faker.ts
@@ -92,7 +92,6 @@ export async function seedDemoApplications(): Promise<void> {
   });
 
   if (adopters.length === 0 || pets.length === 0) {
-    // eslint-disable-next-line no-console
     console.log('⚠️  Need adopters and pets before applications — skipping');
     return;
   }
@@ -158,6 +157,5 @@ export async function seedDemoApplications(): Promise<void> {
 
   await bulkInsert(Application, rows);
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Inserted ${rows.length} faker-generated applications (target ${target})`);
 }

--- a/service.backend/src/seeders/demo/chats-faker.ts
+++ b/service.backend/src/seeders/demo/chats-faker.ts
@@ -41,7 +41,6 @@ export async function seedDemoChats(): Promise<void> {
   });
 
   if (applications.length === 0 || staff.length === 0 || adopters.length === 0) {
-    // eslint-disable-next-line no-console
     console.log('⚠️  Need applications + staff + adopters for chats — skipping');
     return;
   }
@@ -125,7 +124,6 @@ export async function seedDemoChats(): Promise<void> {
   await bulkInsert(Chat, chatRows);
   await bulkInsert(ChatParticipant, participantRows);
 
-  // eslint-disable-next-line no-console
   console.log(
     `✅ Inserted ${chatRows.length} faker-generated chats with ${participantRows.length} participants`
   );

--- a/service.backend/src/seeders/demo/index.ts
+++ b/service.backend/src/seeders/demo/index.ts
@@ -45,11 +45,11 @@ export async function runDemoSeeders(): Promise<void> {
 
   for (let i = 0; i < DEMO_SEEDERS.length; i++) {
     const { name, seeder } = DEMO_SEEDERS[i];
-    // eslint-disable-next-line no-console
+
     console.log(`🎭 [${i + 1}/${DEMO_SEEDERS.length}] Demo: ${name}...`);
     const start = Date.now();
     await seeder();
-    // eslint-disable-next-line no-console
+
     console.log(`✅ ${name} ready (${Date.now() - start}ms)`);
   }
 }

--- a/service.backend/src/seeders/demo/messages-faker.ts
+++ b/service.backend/src/seeders/demo/messages-faker.ts
@@ -32,7 +32,6 @@ export async function seedDemoMessages(): Promise<void> {
 
   const chats = await Chat.findAll({ attributes: ['chat_id', 'createdAt'], limit: 5000 });
   if (chats.length === 0) {
-    // eslint-disable-next-line no-console
     console.log('⚠️  No chats — skipping messages');
     return;
   }
@@ -93,7 +92,6 @@ export async function seedDemoMessages(): Promise<void> {
 
   await bulkInsert(Message, rows, { chunkSize: 1000 });
 
-  // eslint-disable-next-line no-console
   console.log(
     `✅ Inserted ${rows.length} faker-generated messages across ${chats.length} chats (target ${target})`
   );

--- a/service.backend/src/seeders/demo/notifications-faker.ts
+++ b/service.backend/src/seeders/demo/notifications-faker.ts
@@ -78,7 +78,6 @@ export async function seedDemoNotifications(): Promise<void> {
 
   const users = await User.findAll({ paranoid: false, attributes: ['userId'] });
   if (users.length === 0) {
-    // eslint-disable-next-line no-console
     console.log('⚠️  No users — skipping notifications');
     return;
   }
@@ -137,6 +136,5 @@ export async function seedDemoNotifications(): Promise<void> {
 
   await bulkInsert(Notification, rows, { chunkSize: 1000 });
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Inserted ${rows.length} faker-generated notifications (target ${target})`);
 }

--- a/service.backend/src/seeders/demo/pets-faker.ts
+++ b/service.backend/src/seeders/demo/pets-faker.ts
@@ -93,7 +93,6 @@ export async function seedDemoPets(): Promise<void> {
 
   const rescues = await Rescue.findAll({ paranoid: false, attributes: ['rescueId'] });
   if (rescues.length === 0) {
-    // eslint-disable-next-line no-console
     console.log('⚠️  No rescues to attach pets to — skipping demo pets');
     return;
   }
@@ -183,6 +182,5 @@ export async function seedDemoPets(): Promise<void> {
 
   await bulkInsert(Pet, rows);
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Inserted ${rows.length} faker-generated pets (target ${target})`);
 }

--- a/service.backend/src/seeders/demo/ratings-faker.ts
+++ b/service.backend/src/seeders/demo/ratings-faker.ts
@@ -33,7 +33,6 @@ export async function seedDemoRatings(): Promise<void> {
   const rescues = await Rescue.findAll({ paranoid: false, attributes: ['rescueId'] });
 
   if (adopters.length === 0 || rescues.length === 0) {
-    // eslint-disable-next-line no-console
     console.log('⚠️  Need adopters + rescues for ratings — skipping');
     return;
   }
@@ -86,6 +85,5 @@ export async function seedDemoRatings(): Promise<void> {
 
   await bulkInsert(Rating, rows);
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Inserted ${rows.length} faker-generated ratings (target ${target})`);
 }

--- a/service.backend/src/seeders/demo/rescues-faker.ts
+++ b/service.backend/src/seeders/demo/rescues-faker.ts
@@ -92,6 +92,5 @@ export async function seedDemoRescues(): Promise<void> {
 
   await bulkInsert(Rescue, rows);
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Inserted ${rows.length} faker-generated rescues (target ${target})`);
 }

--- a/service.backend/src/seeders/demo/staff-faker.ts
+++ b/service.backend/src/seeders/demo/staff-faker.ts
@@ -25,7 +25,6 @@ export async function seedDemoStaff(): Promise<void> {
 
   const rescues = await Rescue.findAll({ paranoid: false, attributes: ['rescueId'] });
   if (rescues.length === 0) {
-    // eslint-disable-next-line no-console
     console.log('⚠️  No rescues to attach staff to — skipping demo staff');
     return;
   }
@@ -43,7 +42,6 @@ export async function seedDemoStaff(): Promise<void> {
   // reference real-but-arbitrary user_ids — pick the first existing user.
   const firstUser = await User.findOne({ paranoid: false, attributes: ['userId'] });
   if (!firstUser) {
-    // eslint-disable-next-line no-console
     console.log('⚠️  No users in DB — skipping demo staff');
     return;
   }
@@ -106,7 +104,6 @@ export async function seedDemoStaff(): Promise<void> {
 
   await bulkInsert(StaffMember, staffRows);
 
-  // eslint-disable-next-line no-console
   console.log(
     `✅ Inserted ${staffRows.length} faker-generated rescue staff (target ${target}) across ${rescues.length} rescues`
   );

--- a/service.backend/src/seeders/fixtures/e2e-fixtures.ts
+++ b/service.backend/src/seeders/fixtures/e2e-fixtures.ts
@@ -131,6 +131,5 @@ export async function seedE2EFixtures() {
     } as never,
   });
 
-  // eslint-disable-next-line no-console
   console.log('✅ E2E fixtures seeded (pets, favourite, prefs, chat participants)');
 }

--- a/service.backend/src/seeders/fixtures/emily-attachment-test.ts
+++ b/service.backend/src/seeders/fixtures/emily-attachment-test.ts
@@ -409,18 +409,16 @@ export async function seedEmilyAttachmentTest() {
       });
     }
 
-    // eslint-disable-next-line no-console
     console.log('✅ Created Emily Davis attachment test conversation');
-    // eslint-disable-next-line no-console
+
     console.log(`   - Chat ID: ${emilyAttachmentTestData.chat.chat_id}`);
-    // eslint-disable-next-line no-console
+
     console.log(`   - Participants: ${emilyAttachmentTestData.participants.length}`);
-    // eslint-disable-next-line no-console
+
     console.log(`   - Messages: ${emilyAttachmentTestData.messages.length}`);
-    // eslint-disable-next-line no-console
+
     console.log(`   - Attachments: ${emilyAttachmentTestData.attachments.length}`);
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('❌ Error creating Emily attachment test conversation:', error);
     throw error;
   }
@@ -430,12 +428,10 @@ export async function seedEmilyAttachmentTest() {
 if (require.main === module) {
   seedEmilyAttachmentTest()
     .then(() => {
-      // eslint-disable-next-line no-console
       console.log('🎉 Emily attachment test conversation seeding completed successfully!');
       throw new Error('Seeding completed - exiting process');
     })
     .catch(error => {
-      // eslint-disable-next-line no-console
       console.error('💥 Emily attachment test conversation seeding failed:', error);
       throw error;
     });

--- a/service.backend/src/seeders/fixtures/emily-conversation-2.ts
+++ b/service.backend/src/seeders/fixtures/emily-conversation-2.ts
@@ -297,28 +297,16 @@ export async function seedEmilyConversation2() {
       });
     }
 
-    // eslint-disable-next-line no-console
-
     console.log('✅ Created Emily Davis conversation #2 with Happy Tails Dog Rescue');
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Chat ID: ${emilyConversation2Data.chat.chat_id}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Participants: ${emilyConversation2Data.participants.length}`);
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Messages: ${emilyConversation2Data.messages.length}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Attachments: ${emilyConversation2Data.attachments.length}`);
   } catch (error) {
-    // eslint-disable-next-line no-console
-
     console.error('❌ Error creating Emily conversation #2:', error);
 
     throw error;
@@ -330,16 +318,12 @@ export async function seedEmilyConversation2() {
 if (require.main === module) {
   seedEmilyConversation2()
     .then(() => {
-      // eslint-disable-next-line no-console
-
       console.log('🎉 Emily conversation #2 seeding completed successfully!');
 
       throw new Error('Seeding completed - exiting process');
     })
 
     .catch(error => {
-      // eslint-disable-next-line no-console
-
       console.error('💥 Emily conversation #2 seeding failed:', error);
 
       throw error;

--- a/service.backend/src/seeders/fixtures/emily-conversation-3.ts
+++ b/service.backend/src/seeders/fixtures/emily-conversation-3.ts
@@ -263,24 +263,14 @@ export async function seedEmilyConversation3() {
       });
     }
 
-    // eslint-disable-next-line no-console
-
     console.log('✅ Created Emily Davis conversation #3 with Austin Animal Center');
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Chat ID: ${emilyConversation3Data.chat.chat_id}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Participants: ${emilyConversation3Data.participants.length}`);
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Messages: ${emilyConversation3Data.messages.length}`);
   } catch (error) {
-    // eslint-disable-next-line no-console
-
     console.error('❌ Error creating Emily conversation #3:', error);
 
     throw error;
@@ -292,16 +282,12 @@ export async function seedEmilyConversation3() {
 if (require.main === module) {
   seedEmilyConversation3()
     .then(() => {
-      // eslint-disable-next-line no-console
-
       console.log('🎉 Emily conversation #3 seeding completed successfully!');
 
       throw new Error('Seeding completed - exiting process');
     })
 
     .catch(error => {
-      // eslint-disable-next-line no-console
-
       console.error('💥 Emily conversation #3 seeding failed:', error);
 
       throw error;

--- a/service.backend/src/seeders/fixtures/emily-conversation-4.ts
+++ b/service.backend/src/seeders/fixtures/emily-conversation-4.ts
@@ -263,24 +263,14 @@ export async function seedEmilyConversation4() {
       });
     }
 
-    // eslint-disable-next-line no-console
-
     console.log('✅ Created Emily Davis conversation #4 with Paws Rescue Austin');
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Chat ID: ${emilyConversation4Data.chat.chat_id}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Participants: ${emilyConversation4Data.participants.length}`);
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Messages: ${emilyConversation4Data.messages.length}`);
   } catch (error) {
-    // eslint-disable-next-line no-console
-
     console.error('❌ Error creating Emily conversation #4:', error);
 
     throw error;
@@ -292,16 +282,12 @@ export async function seedEmilyConversation4() {
 if (require.main === module) {
   seedEmilyConversation4()
     .then(() => {
-      // eslint-disable-next-line no-console
-
       console.log('🎉 Emily conversation #4 seeding completed successfully!');
 
       throw new Error('Seeding completed - exiting process');
     })
 
     .catch(error => {
-      // eslint-disable-next-line no-console
-
       console.error('💥 Emily conversation #4 seeding failed:', error);
 
       throw error;

--- a/service.backend/src/seeders/fixtures/emily-conversation.ts
+++ b/service.backend/src/seeders/fixtures/emily-conversation.ts
@@ -296,28 +296,16 @@ export async function seedEmilyConversation() {
       });
     }
 
-    // eslint-disable-next-line no-console
-
     console.log('✅ Created Emily Davis conversation with Paws Rescue Austin');
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Chat ID: ${emilyConversationData.chat.chat_id}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Participants: ${emilyConversationData.participants.length}`);
-
-    // eslint-disable-next-line no-console
 
     console.log(`   - Messages: ${emilyConversationData.messages.length}`);
 
-    // eslint-disable-next-line no-console
-
     console.log(`   - Attachments: ${emilyConversationData.attachments.length}`);
   } catch (error) {
-    // eslint-disable-next-line no-console
-
     console.error('❌ Error creating Emily conversation:', error);
 
     throw error;
@@ -329,16 +317,12 @@ export async function seedEmilyConversation() {
 if (require.main === module) {
   seedEmilyConversation()
     .then(() => {
-      // eslint-disable-next-line no-console
-
       console.log('🎉 Emily conversation seeding completed successfully!');
 
       throw new Error('Seeding completed - exiting process');
     })
 
     .catch(error => {
-      // eslint-disable-next-line no-console
-
       console.error('💥 Emily conversation seeding failed:', error);
 
       throw error;

--- a/service.backend/src/seeders/fixtures/emily-test-notifications.ts
+++ b/service.backend/src/seeders/fixtures/emily-test-notifications.ts
@@ -350,6 +350,5 @@ export async function seedEmilyTestNotifications() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${emilyTestNotifications.length} test notifications for Emily Davis`);
 }

--- a/service.backend/src/seeders/fixtures/index.ts
+++ b/service.backend/src/seeders/fixtures/index.ts
@@ -39,11 +39,11 @@ export async function runFixtureSeeders(): Promise<void> {
 
   for (let i = 0; i < FIXTURES.length; i++) {
     const { name, seeder } = FIXTURES[i];
-    // eslint-disable-next-line no-console
+
     console.log(`📦 [${i + 1}/${FIXTURES.length}] Loading fixture: ${name}...`);
     const start = Date.now();
     await seeder();
-    // eslint-disable-next-line no-console
+
     console.log(`✅ ${name} loaded (${Date.now() - start}ms)`);
   }
 }

--- a/service.backend/src/seeders/index.ts
+++ b/service.backend/src/seeders/index.ts
@@ -102,34 +102,32 @@ export async function runAllSeeders() {
   assertSeedAllowed('reset');
 
   try {
-    // eslint-disable-next-line no-console
     console.log('🌱 Starting database seeding...');
-    // eslint-disable-next-line no-console
+
     console.log(`📊 Running ${seeders.length} seeders in sequence...`);
 
     // Ensure database connection. Schema is owned by migrations; the seeder
     // does not call sequelize.sync. Run `npm run db:migrate` before seeding
     // a fresh database.
     await sequelize.authenticate();
-    // eslint-disable-next-line no-console
+
     console.log('✅ Database connection established');
 
     await clearAllData();
 
     for (let i = 0; i < seeders.length; i++) {
       const { name, seeder } = seeders[i];
-      // eslint-disable-next-line no-console
+
       console.log(`📦 [${i + 1}/${seeders.length}] Seeding ${name}...`);
       const startTime = Date.now();
 
       await seeder();
 
       const duration = Date.now() - startTime;
-      // eslint-disable-next-line no-console
+
       console.log(`✅ ${name} seeded successfully (${duration}ms)`);
     }
 
-    // eslint-disable-next-line no-console
     console.log('🎉 All seeders completed successfully!');
   } catch (error) {
     console.error('❌ Error during seeding:', error);
@@ -141,7 +139,6 @@ export async function clearAllData() {
   assertSeedAllowed('reset');
 
   try {
-    // eslint-disable-next-line no-console
     console.log('🧹 Clearing all seeded data...');
 
     // Clear in reverse order to handle foreign key constraints
@@ -179,11 +176,10 @@ export async function clearAllData() {
 
     for (const tableName of clearOrder) {
       await sequelize.query(`TRUNCATE TABLE "${tableName}" RESTART IDENTITY CASCADE;`);
-      // eslint-disable-next-line no-console
+
       console.log(`✅ Cleared ${tableName}`);
     }
 
-    // eslint-disable-next-line no-console
     console.log('🎉 All data cleared successfully!');
   } catch (error) {
     console.error('❌ Error during data clearing:', error);

--- a/service.backend/src/seeders/reference/email-templates.ts
+++ b/service.backend/src/seeders/reference/email-templates.ts
@@ -663,6 +663,5 @@ export async function seedEmailTemplates() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${emailTemplateData.length} email templates`);
 }

--- a/service.backend/src/seeders/reference/index.ts
+++ b/service.backend/src/seeders/reference/index.ts
@@ -27,11 +27,11 @@ export async function runReferenceSeeders(): Promise<void> {
 
   for (let i = 0; i < REFERENCE_SEEDERS.length; i++) {
     const { name, seeder } = REFERENCE_SEEDERS[i];
-    // eslint-disable-next-line no-console
+
     console.log(`📚 [${i + 1}/${REFERENCE_SEEDERS.length}] Reference: ${name}...`);
     const start = Date.now();
     await seeder();
-    // eslint-disable-next-line no-console
+
     console.log(`✅ ${name} ready (${Date.now() - start}ms)`);
   }
 }

--- a/service.backend/src/seeders/reference/permissions.ts
+++ b/service.backend/src/seeders/reference/permissions.ts
@@ -165,6 +165,5 @@ export async function seedPermissions() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${permissions.length} permissions`);
 }

--- a/service.backend/src/seeders/reference/role-permissions.ts
+++ b/service.backend/src/seeders/reference/role-permissions.ts
@@ -440,6 +440,5 @@ export async function seedRolePermissions() {
     }
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${assignmentCount} role-permission assignments`);
 }

--- a/service.backend/src/seeders/reference/roles.ts
+++ b/service.backend/src/seeders/reference/roles.ts
@@ -49,6 +49,5 @@ export async function seedRoles() {
     });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`✅ Created ${roles.length} roles`);
 }

--- a/service.backend/src/services/charity-commission.service.ts
+++ b/service.backend/src/services/charity-commission.service.ts
@@ -88,7 +88,7 @@ const fetchWithRetry = async (
   let attempt = 0;
   // Bail conditions are explicit at the bottom of the loop body. ESLint's
   // no-constant-condition rule is overly cautious here.
-  // eslint-disable-next-line no-constant-condition
+
   while (true) {
     if (budgetSignal.aborted) {
       throw new TimeoutError();

--- a/service.backend/src/services/companies-house.service.ts
+++ b/service.backend/src/services/companies-house.service.ts
@@ -129,7 +129,7 @@ const fetchWithRetry = async (
   let attempt = 0;
   // Bail conditions are explicit at the bottom of the loop body. ESLint's
   // no-constant-condition rule is overly cautious here.
-  // eslint-disable-next-line no-constant-condition
+
   while (true) {
     if (budgetSignal.aborted) {
       throw new TimeoutError();

--- a/service.backend/src/services/email-providers/resend-provider.ts
+++ b/service.backend/src/services/email-providers/resend-provider.ts
@@ -1,0 +1,62 @@
+import { Resend } from 'resend';
+import EmailQueue from '../../models/EmailQueue';
+import { logger } from '../../utils/logger';
+import { BaseEmailProvider } from './base-provider';
+
+type ResendConfig = {
+  apiKey: string;
+  fromEmail: string;
+  fromName: string;
+  replyTo?: string;
+};
+
+export class ResendProvider extends BaseEmailProvider {
+  private client: Resend;
+
+  constructor(config: ResendConfig) {
+    super(config);
+    this.client = new Resend(config.apiKey);
+  }
+
+  async send(email: EmailQueue): Promise<{ success: boolean; messageId?: string; error?: string }> {
+    const sanitized = this.sanitizeEmail(email);
+    const config = this.config as ResendConfig;
+
+    const payload = {
+      from: sanitized.from,
+      to: sanitized.to,
+      subject: sanitized.subject,
+      html: sanitized.html,
+      ...(sanitized.text ? { text: sanitized.text } : {}),
+      ...(config.replyTo ? { replyTo: config.replyTo } : {}),
+    };
+
+    const { data, error } = await this.client.emails.send(payload);
+
+    if (error !== null) {
+      logger.error('Failed to send email via Resend', {
+        to: sanitized.to,
+        subject: sanitized.subject,
+        error,
+      });
+      return { success: false, error: error.message };
+    }
+
+    logger.info('Email sent via Resend', {
+      messageId: data.id,
+      to: sanitized.to,
+      subject: sanitized.subject,
+    });
+
+    return { success: true, messageId: data.id };
+  }
+
+  getName(): string {
+    return 'Resend';
+  }
+
+  validateConfiguration(): boolean {
+    const config = this.config as ResendConfig;
+    return Boolean(config.apiKey) && Boolean(config.fromEmail);
+  }
+}

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -59,7 +59,9 @@ class EmailService {
             replyTo: config.email.resend.replyTo,
           });
           if (!resendProvider.validateConfiguration()) {
-            throw new Error('Resend provider misconfigured: RESEND_API_KEY and RESEND_FROM_EMAIL are required');
+            throw new Error(
+              'Resend provider misconfigured: RESEND_API_KEY and RESEND_FROM_EMAIL are required'
+            );
           }
           this.provider = resendProvider;
           break;

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -15,6 +15,7 @@ import { AuditLogService } from './auditLog.service';
 import { EmailProvider } from './email-providers/base-provider';
 import { ConsoleEmailProvider } from './email-providers/console-provider';
 import { EtherealProvider } from './email-providers/ethereal-provider';
+import { ResendProvider } from './email-providers/resend-provider';
 
 // Type for provider info (Ethereal test account)
 type ProviderInfo = {
@@ -48,6 +49,19 @@ class EmailService {
           const etherealProvider = new EtherealProvider();
           await etherealProvider.initialize();
           this.provider = etherealProvider;
+          break;
+        }
+        case 'resend': {
+          const resendProvider = new ResendProvider({
+            apiKey: config.email.resend.apiKey ?? '',
+            fromEmail: config.email.resend.fromEmail ?? config.email.from,
+            fromName: config.email.resend.fromName,
+            replyTo: config.email.resend.replyTo,
+          });
+          if (!resendProvider.validateConfiguration()) {
+            throw new Error('Resend provider misconfigured: RESEND_API_KEY and RESEND_FROM_EMAIL are required');
+          }
+          this.provider = resendProvider;
           break;
         }
         default:

--- a/service.backend/src/services/sms-providers/console-provider.ts
+++ b/service.backend/src/services/sms-providers/console-provider.ts
@@ -22,19 +22,19 @@ export class ConsoleSmsProvider extends BaseSmsProvider {
     }
 
     // Console-style banner so this is easy to spot in dev logs.
-    // eslint-disable-next-line no-console
+
     console.log('\n' + '='.repeat(60));
-    // eslint-disable-next-line no-console
+
     console.log('📱 SMS SENT VIA CONSOLE PROVIDER');
-    // eslint-disable-next-line no-console
+
     console.log('='.repeat(60));
-    // eslint-disable-next-line no-console
+
     console.log(`📨 Message ID: ${messageId}`);
-    // eslint-disable-next-line no-console
+
     console.log(`📤 To: ${normalised}`);
-    // eslint-disable-next-line no-console
+
     console.log(`📝 Body: ${request.message}`);
-    // eslint-disable-next-line no-console
+
     console.log('='.repeat(60) + '\n');
 
     logger.info(`Console SMS sent: ${messageId} to ${normalised}`);

--- a/service.backend/src/setup-tests.ts
+++ b/service.backend/src/setup-tests.ts
@@ -161,7 +161,6 @@ async function initializeTestDatabase(): Promise<void> {
     await sequelize.authenticate();
     await sequelize.sync({ force: true });
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Failed to initialize test database:', error);
     throw error;
   }

--- a/service.backend/src/test-db-setup.ts
+++ b/service.backend/src/test-db-setup.ts
@@ -28,7 +28,6 @@ export async function initializeTestDatabase(): Promise<void> {
     // force: false means don't drop existing tables
     await testDb.sync({ force: true });
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Failed to initialize test database:', error);
     throw error;
   }
@@ -53,7 +52,6 @@ export async function cleanDatabase(): Promise<void> {
       });
     }
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Failed to clean database:', error);
     throw error;
   }

--- a/service.backend/src/utils/uuid-helpers.ts
+++ b/service.backend/src/utils/uuid-helpers.ts
@@ -68,7 +68,6 @@ export const prepareBulkDataWithoutUuid = (
   uuidColumn = 'id'
 ): Record<string, unknown>[] => {
   return data.map(row => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [uuidColumn]: _removed, ...rest } = row;
     return rest;
   });


### PR DESCRIPTION
## Summary

Closes **ADS-104** — Wire up production ESP (scaffolding).

Resend is chosen as the production ESP for its minimal API surface, excellent DX, and first-class TypeScript types. The implementation slots behind the existing `EmailProvider` interface so zero call-sites change.

- **New `ResendProvider`** (`service.backend/src/services/email-providers/resend-provider.ts`) extends `BaseEmailProvider`, reuses the existing `sanitizeEmail()` CRLF-stripping logic, and maps `EmailQueue` fields to the Resend `CreateEmailOptions` shape.
- **`initializeProvider()` extended** — adds a `'resend'` case that validates config at boot (fails loudly if `RESEND_API_KEY` / `RESEND_FROM_EMAIL` are absent) so misconfiguration is caught at startup rather than at send-time.
- **`config/index.ts`** — new `resend` block reads `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_FROM_NAME`, `RESEND_REPLY_TO`.
- **`.env.example`** — documents all Resend vars with setup notes; legacy SMTP vars retained for reference.
- **Ethereal and console providers unchanged** — local dev and test workflows are unaffected.

## Test plan

- [ ] 11 new behaviour tests in `resend-provider.test.ts` cover:
  - Config validation (missing key, missing from-email)
  - Happy-path send returns `success: true` + `messageId`
  - Correct `from`/`to`/`subject`/`html`/`text` mapping
  - `replyTo` included when configured, omitted when not
  - `text` omitted when `textContent` is undefined
  - Resend API error propagated as `success: false` + `error`
  - CRLF injection stripped from `subject` and `from` headers
- [ ] Existing email service tests remain green (no interface changes)
- [ ] To test against real Resend: set `EMAIL_PROVIDER=resend`, `RESEND_API_KEY=re_…`, `RESEND_FROM_EMAIL=<verified-domain>` in staging `.env`

https://claude.ai/code/session_01To3HKWkofXwtoogTqDvxAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01To3HKWkofXwtoogTqDvxAu)_