### PR TITLE
feat(legal): replace cookies policy placeholder with live UK ICO-aligned content

### DIFF
--- a/docs/legal/cookies.md
+++ b/docs/legal/cookies.md
@@ -1,7 +1,111 @@
 # Cookies Policy
 
-> **PLACEHOLDER — DO NOT SHIP.** This document needs legal review before
-> the cookies type is exposed to users. Replace this entire body with the
-> approved cookies policy before merging the PR that consumes it.
+**Version:** 2026-05-09-v1
+**Last updated:** 9 May 2026
 
-_Version: 2026-05-09-v0-PLACEHOLDER_
+This policy explains how Adopt Don't Shop uses cookies and similar
+technologies on our websites and apps. It sits alongside the
+[Privacy Policy](./privacy.md) and the [Terms of Service](./terms.md).
+
+## 1. Who we are
+
+Adopt Don't Shop is the data controller for the cookies described in
+this notice. Contact our Data Protection Officer at
+privacy@adoptdontshop.example.
+
+## 2. What cookies are
+
+Cookies are small text files that a website places on your device when
+you visit. We use them to keep you signed in, to protect your account
+from cross-site request forgery, and — only with your consent — to
+measure how the platform performs.
+
+## 3. Lawful basis
+
+We rely on two lawful bases under the UK GDPR and the Privacy and
+Electronic Communications Regulations (PECR):
+
+- **Strictly necessary cookies** — set without consent under PECR
+  reg. 6(4), because they are required to deliver the service you have
+  asked for (signing in, staying signed in, submitting forms safely).
+  Lawful basis under UK GDPR is performance of a contract (Art. 6(1)(b))
+  and our legitimate interest in securing the platform (Art. 6(1)(f)).
+- **Analytics and performance cookies and similar technologies** — set
+  only after you give explicit, prior consent (UK GDPR Art. 6(1)(a) and
+  PECR reg. 6). You can withdraw consent at any time; withdrawing is as
+  easy as granting it.
+
+We do not use marketing or advertising cookies.
+
+## 4. Cookies we set
+
+The table below lists every cookie set by Adopt Don't Shop today. If
+this changes we will update this policy and bump the version.
+
+| Name                                            | Category            | Purpose                                                                                                | Retention                  | Set by                       |
+|-------------------------------------------------|---------------------|--------------------------------------------------------------------------------------------------------|----------------------------|------------------------------|
+| `accessToken`                                   | Strictly necessary  | Short-lived authentication token. Keeps you signed in between requests.                                | 15 minutes                 | First-party (this service)   |
+| `refreshToken`                                  | Strictly necessary  | Long-lived authentication token. Lets us issue a new `accessToken` without forcing you to sign in.     | 3 days                     | First-party (this service)   |
+| `__Host-psifi.x-csrf-token` (production) / `psifi.x-csrf-token` (development) | Strictly necessary | CSRF (cross-site request forgery) defence. Pairs with a request header so other sites cannot act as you. | Session (cleared on browser close) | First-party (this service)   |
+
+All three cookies are set with the `HttpOnly`, `SameSite=Strict`, and
+(in production) `Secure` flags so that they cannot be read by
+JavaScript and are never sent on cross-site requests.
+
+## 5. Analytics, performance, and error monitoring
+
+We use **Statsig** for product analytics, feature experimentation, and
+optional session replay, and **Sentry** for error and performance
+monitoring. Both are loaded only after you grant analytics consent
+through the on-site banner.
+
+Statsig stores its identifiers in your browser's `localStorage` rather
+than in a cookie; Sentry transmits events over HTTPS without setting
+cookies. Neither tool runs before consent is granted, and no
+identifiable data is sent to either tool while consent is denied or
+unknown.
+
+If consent is later withdrawn, the third-party SDKs stop on your next
+page load and the local identifiers can be cleared from your browser's
+site-data settings.
+
+## 6. Marketing and advertising
+
+We do not set marketing or advertising cookies, and we do not share
+data with ad networks. If this changes we will update this policy and
+ask for fresh consent before any such cookie is set.
+
+## 7. Managing your choices
+
+You can manage cookies in two ways:
+
+- **In our app.** Use the cookie banner shown on first visit to grant
+  or deny analytics consent. The banner returns when consent has not
+  been recorded; you can also withdraw consent at any time from the
+  same control once it has been granted.
+- **In your browser.** Every modern browser lets you view, block, or
+  delete cookies from settings. Blocking strictly necessary cookies
+  will sign you out and prevent forms from submitting.
+
+The on-site cookie banner is being rolled out; until it is live in
+your app, withdraw analytics consent by clearing site data for
+`adoptdontshop.example` in your browser's settings. The strictly
+necessary cookies are unaffected by analytics consent.
+
+## 8. Your rights
+
+You have the same rights over cookie-derived personal data as over
+any other personal data we hold about you, including the right to
+access, rectify, erase, restrict, object, and complain to the
+Information Commissioner's Office (ico.org.uk). See the
+[Privacy Policy](./privacy.md) for how to exercise these rights.
+
+## 9. Changes
+
+We may update this policy from time to time. The version string above
+identifies the version each user accepted; material changes will be
+notified through the in-app re-acceptance flow on next sign-in.
+
+## 10. Contact
+
+Questions about cookies or this policy: privacy@adoptdontshop.example.

--- a/service.backend/src/__tests__/services/legal-content.test.ts
+++ b/service.backend/src/__tests__/services/legal-content.test.ts
@@ -54,13 +54,6 @@ describe('legal content service', () => {
     expect(doc.content).toContain('Cookies Policy');
   });
 
-  it('flags the cookies version as a placeholder so it is obvious in audit/pending output', () => {
-    // The cookies markdown is a stand-in awaiting legal review. The
-    // version constant carries that signal so any consent record or
-    // pending-reacceptance row that surfaces it is easy to spot.
-    expect(COOKIES_VERSION).toContain('PLACEHOLDER');
-  });
-
   it('versions follow a date-based identifier so consent records can be replayed', () => {
     expect(TERMS_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);
     expect(PRIVACY_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}/);

--- a/service.backend/src/routes/legal.routes.ts
+++ b/service.backend/src/routes/legal.routes.ts
@@ -47,11 +47,6 @@ router.get('/privacy', (_req, res) => {
   }
 });
 
-// NOTE: the cookies document body is currently a clearly-marked
-// placeholder pending legal review. The endpoint is wired so the
-// version constant + markdown source can be referenced end-to-end, but
-// the response body must not be linked from any user-facing UI until
-// `docs/legal/cookies.md` is replaced with approved copy.
 router.get('/cookies', (_req, res) => {
   try {
     const doc = getCookiesDocument();

--- a/service.backend/src/services/legal-content.service.ts
+++ b/service.backend/src/services/legal-content.service.ts
@@ -19,12 +19,7 @@ import AuditLog from '../models/AuditLog';
 
 export const TERMS_VERSION = '2026-05-08-v1';
 export const PRIVACY_VERSION = '2026-05-08-v1';
-// The `-PLACEHOLDER` suffix is intentional and load-bearing: any cookies
-// row surfaced by `getPendingReacceptance` (or written into an audit log)
-// is obviously not-yet-legally-reviewed. Replace this constant — and the
-// version line in `docs/legal/cookies.md` — when the real cookies policy
-// lands.
-export const COOKIES_VERSION = '2026-05-09-v0-PLACEHOLDER';
+export const COOKIES_VERSION = '2026-05-09-v1';
 
 const DOCS_DIR = path.resolve(__dirname, '..', '..', '..', 'docs', 'legal');
 
@@ -73,14 +68,13 @@ export const getCookiesDocument = (): LegalDocument => ({
  * per pending doc.
  *
  * Notes:
- *   - `terms`, `privacy`, and `cookies` are tracked. The cookies copy
- *     and version are currently a clearly-marked placeholder
- *     (`COOKIES_VERSION` ends in `-PLACEHOLDER`) and the consent service
- *     does not yet capture a `cookiesVersion`, so until both land
- *     `getPendingReacceptance` will always return `cookies` as pending
- *     for every user. That is intentional for the wiring slice and
- *     should be addressed before the cookies type is shown in the
- *     re-acceptance modal.
+ *   - `terms`, `privacy`, and `cookies` are tracked. The consent
+ *     service does not yet capture a `cookiesVersion`, so until that
+ *     gap is closed `getPendingReacceptance` will always return
+ *     `cookies` as pending for every existing user. That is
+ *     intentional for this slice and is tracked as a follow-up to be
+ *     addressed before the cookies type is shown in the re-acceptance
+ *     modal.
  *   - Consent capture writes to `audit_logs` (see
  *     `consent.service.ts`), so this read also goes there. Migrating
  *     to a dedicated consent-acceptance table is a separate decision.


### PR DESCRIPTION
## Summary

Follow-up to #419. Replaces the deliberate placeholder body with a production-deployable cookies policy drafted from the UK GDPR / PECR / ICO baseline, mirrored on the structure and tone of `privacy.md`. Bumps `COOKIES_VERSION` from `2026-05-09-v0-PLACEHOLDER` to `2026-05-09-v1` so the load-bearing placeholder marker no longer surfaces in audit logs or pending-reacceptance output.

## Cookies inventory (factually accurate to this codebase as of HEAD)

Inventoried by grepping for `res.cookie` / `res.clearCookie` in `service.backend/src` and reading the auth, csrf, and session middleware. No frontend code sets cookies via `document.cookie`. No `express-session` / `connect.sid` exists.

| Name | Category | Set by | Source |
|---|---|---|---|
| `accessToken` | Strictly necessary | First-party | `service.backend/src/controllers/auth.controller.ts` |
| `refreshToken` | Strictly necessary | First-party | `service.backend/src/controllers/auth.controller.ts` |
| `__Host-psifi.x-csrf-token` (prod) / `psifi.x-csrf-token` (dev) | Strictly necessary | First-party | `service.backend/src/middleware/csrf.ts` |

All three are `HttpOnly` + `SameSite=Strict` + `Secure` (in production).

**Third-party SDKs wired but cookie-free as configured:** Sentry (HTTP transport, no cookies) and Statsig (`localStorage` for stable ID, no cookies). Both gated behind explicit analytics consent via `lib.observability/src/consent.ts` — Statsig auto-capture and session-replay plugins are only mounted after consent is granted.

## Version bump

- `COOKIES_VERSION`: `2026-05-09-v0-PLACEHOLDER` -> `2026-05-09-v1`
- `docs/legal/cookies.md` body: full rewrite (was a 7-line placeholder block).
- Stale comments on `getPendingReacceptance` and the `/cookies` route handler are updated to drop the "placeholder" / "must not be linked from any user-facing UI" language that no longer applies.
- `legal-content.test.ts`: removed the `expect(COOKIES_VERSION).toContain('PLACEHOLDER')` test (the assertion no longer holds). Date-format regex test continues to assert shape stability.

## What was deliberately NOT included (and why)

- **No marketing / advertising cookies section beyond a one-paragraph "we don't set them".** The codebase has no GA / GTM / Meta pixel / ad network integration. Adding fake `_ga` rows would be misleading.
- **No "manage in your account settings" link.** No cookies-management page exists in any of the three apps yet. The policy points to the on-page banner (forthcoming) and browser settings as the two real withdrawal paths.
- **No CCPA / "Do Not Sell" language.** Policy is UK-shaped to match `terms.md` / `privacy.md` jurisdiction. Add a regional addendum if/when the service expands beyond the UK.
- **No frontend code, no banner UI, no consent service changes.** Slice is scoped to the policy + version bump exactly as the task brief specifies. The consent-side gap (`consent.service.ts` not capturing `cookiesVersion` so every authed user surfaces cookies as pending) is unchanged and remains tracked as the open item from #419.
- **No new tests beyond removing the placeholder assertion.** There is no version-bump comparison test pattern for terms/privacy to mirror, so the existing date-format + content-shape tests continue to cover the cookies document.

## Open questions for product / legal review

Defaults were chosen so the file is mergeable; please confirm or correct:

1. **DPO / data-controller contact.** Re-uses `privacy@adoptdontshop.example` from `privacy.md` (and `legal@adoptdontshop.example` is referenced in `terms.md`). If the production contact has changed, update `privacy.md` first and this file will follow on the next bump.
2. **Sentry classification.** This policy treats Sentry as analytics/performance gated behind consent (matches the existing `lib.observability/src/consent.ts` gate). An equally defensible position is that error tracking is strictly necessary for service security/reliability and could run pre-consent — but that is a posture change versus today's code, so the policy describes what the code does today, not what it could do.
3. **Cookies-management endpoint.** The policy references the on-site banner generically ("being rolled out; until it is live in your app, withdraw analytics consent by clearing site data"). It does not link a settings page (none exists). Once the banner ships, a one-line update here can replace that paragraph.

## Verification

- [x] `service.backend` lint: 0 errors (167 pre-existing warnings)
- [x] `service.backend` `tsc --noEmit`: only pre-existing errors in `resend-provider.ts` + `legal-reminder.service.ts` (introduced by #424 / #425, unchanged here)
- [x] Targeted: `legal-content.test.ts` (10 tests) + `legal.routes.test.ts` (5 tests) + `legal-reminder.test.ts` (8 tests) all green
- [x] Full vitest run: 2086 passed; same 3 pre-existing `resend`-related test files fail on `origin/main` without these changes
- [x] No placeholder strings remain in `docs/legal/cookies.md` or `COOKIES_VERSION`

## Test plan

- [ ] Confirm DPO contact + jurisdiction wording with legal
- [ ] Confirm Sentry classification (open question 2)
- [ ] After the cookie banner UI lands, update section 7 to point at the in-app control
- [ ] Close the consent-side capture gap (file or link the follow-up ticket from #419) so existing users stop surfacing cookies as pending after a no-op acceptance

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_