### PR TITLE
feat(legal): scheduled cron for bulk re-acceptance reminders (ADS-497, slice 4/N)

### DIFF
--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -32,6 +32,7 @@
     "docs:generate": "ts-node scripts/generate-swagger.ts generate",
     "docs:validate": "ts-node scripts/generate-swagger.ts validate",
     "docs:watch": "ts-node scripts/generate-swagger.ts watch",
+    "legal-reminder:run": "ts-node src/workers/legal-reminder.cli.ts",
     "prestart": "npm run security:validate",
     "predeploy": "npm run lint && npm run test && npm run security:validate && npm run build"
   },

--- a/service.backend/src/__tests__/services/legal-reminder-cron.test.ts
+++ b/service.backend/src/__tests__/services/legal-reminder-cron.test.ts
@@ -1,0 +1,268 @@
+/**
+ * ADS-497 (slice 4): behaviour tests for the bulk legal-reminder cron.
+ *
+ * Covers the five operational outcomes the runbook calls out:
+ *   - empty backlog
+ *   - all eligible users get sent
+ *   - all candidates already inside the rate-limit window
+ *   - one user errors mid-batch (others still complete; error counted)
+ *   - dry-run does not invoke sendReacceptanceReminder
+ *   - batchSize cap honoured (over-supply of eligible users → cap)
+ *
+ * Service internals (audit log fingerprint dedupe, version rendering)
+ * are covered in legal-reminder.test.ts; this file treats
+ * `sendReacceptanceReminder` as a black box.
+ */
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logBusiness: vi.fn(), logExternalService: vi.fn(), logSecurity: vi.fn() },
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../models/AuditLog', () => ({
+  default: {
+    findAll: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockResolvedValue(undefined),
+  },
+  AuditLog: {
+    findAll: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockResolvedValue(undefined),
+  },
+  withAuditMutationAllowed: vi.fn(),
+}));
+
+vi.mock('../../models/User', () => ({
+  default: { findAll: vi.fn() },
+  UserStatus: {
+    ACTIVE: 'active',
+    INACTIVE: 'inactive',
+    SUSPENDED: 'suspended',
+    PENDING_VERIFICATION: 'pending_verification',
+    DEACTIVATED: 'deactivated',
+  },
+}));
+
+vi.mock('../../services/legal-reminder.service', () => ({
+  sendReacceptanceReminder: vi.fn(),
+  REMINDER_RATE_LIMIT_HOURS: 24,
+  LEGAL_REMINDER_SENT_ACTION: 'LEGAL_REMINDER_SENT',
+}));
+
+vi.mock('../../services/legal-content.service', () => ({
+  getPendingReacceptance: vi.fn(),
+}));
+
+import AuditLog from '../../models/AuditLog';
+import User from '../../models/User';
+import { sendReacceptanceReminder } from '../../services/legal-reminder.service';
+import { getPendingReacceptance } from '../../services/legal-content.service';
+import {
+  LEGAL_REMINDER_CRON_RAN_ACTION,
+  runLegalReminderCron,
+} from '../../workers/legal-reminder.worker';
+
+const mockUserFindAll = vi.mocked(User.findAll);
+const mockAuditFindAll = vi.mocked(AuditLog.findAll);
+const mockAuditCreate = vi.mocked(AuditLog.create);
+const mockSend = vi.mocked(sendReacceptanceReminder);
+const mockGetPending = vi.mocked(getPendingReacceptance);
+
+const userIdRow = (userId: string) => ({ userId }) as never;
+
+describe('legal reminder cron - runLegalReminderCron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuditFindAll.mockResolvedValue([]);
+    mockAuditCreate.mockResolvedValue(undefined as never);
+  });
+
+  it('returns a zero summary and writes the cron audit row when no users are eligible', async () => {
+    mockUserFindAll.mockResolvedValue([]);
+
+    const summary = await runLegalReminderCron({ dryRun: false });
+
+    expect(summary).toEqual({
+      totalEligible: 0,
+      sent: 0,
+      rateLimited: 0,
+      errors: 0,
+      dryRun: false,
+    });
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockAuditCreate).toHaveBeenCalledTimes(1);
+    const created = mockAuditCreate.mock.calls[0][0];
+    expect(created.action).toBe(LEGAL_REMINDER_CRON_RAN_ACTION);
+    expect(created.user).toBeNull();
+    const meta = created.metadata as { details: { totalEligible: number; dryRun: boolean } };
+    expect(meta.details.totalEligible).toBe(0);
+    expect(meta.details.dryRun).toBe(false);
+  });
+
+  it('sends to every eligible user when nobody is rate-limited', async () => {
+    mockUserFindAll.mockResolvedValue([userIdRow('u1'), userIdRow('u2'), userIdRow('u3')]);
+    mockSend.mockResolvedValue({
+      sent: true,
+      versions: [{ documentType: 'terms', currentVersion: '2026-05-08-v1' }],
+    });
+
+    const summary = await runLegalReminderCron({ dryRun: false });
+
+    expect(summary).toEqual({
+      totalEligible: 3,
+      sent: 3,
+      rateLimited: 0,
+      errors: 0,
+      dryRun: false,
+    });
+    expect(mockSend).toHaveBeenCalledTimes(3);
+    expect(mockSend.mock.calls.map(c => c[0].userId)).toEqual(['u1', 'u2', 'u3']);
+    expect(mockSend.mock.calls.every(c => c[0].triggeredBy === 'cron')).toBe(true);
+  });
+
+  it('aggregates rate_limited results when sendReacceptanceReminder reports the user was already reminded', async () => {
+    mockUserFindAll.mockResolvedValue([userIdRow('u1'), userIdRow('u2')]);
+    mockSend.mockResolvedValue({ sent: false, reason: 'rate_limited' });
+
+    const summary = await runLegalReminderCron({ dryRun: false });
+
+    expect(summary).toEqual({
+      totalEligible: 2,
+      sent: 0,
+      rateLimited: 2,
+      errors: 0,
+      dryRun: false,
+    });
+  });
+
+  it('does not count users with no pending versions toward the totals', async () => {
+    mockUserFindAll.mockResolvedValue([userIdRow('u1'), userIdRow('u2')]);
+    mockSend.mockResolvedValue({ sent: false, reason: 'no_pending_versions' });
+
+    const summary = await runLegalReminderCron({ dryRun: false });
+
+    expect(summary).toEqual({
+      totalEligible: 0,
+      sent: 0,
+      rateLimited: 0,
+      errors: 0,
+      dryRun: false,
+    });
+  });
+
+  it('continues processing when one user errors and counts the failure', async () => {
+    mockUserFindAll.mockResolvedValue([userIdRow('u1'), userIdRow('u2'), userIdRow('u3')]);
+    mockSend
+      .mockResolvedValueOnce({
+        sent: true,
+        versions: [{ documentType: 'terms', currentVersion: 'v1' }],
+      })
+      .mockRejectedValueOnce(new Error('email-provider-down'))
+      .mockResolvedValueOnce({
+        sent: true,
+        versions: [{ documentType: 'terms', currentVersion: 'v1' }],
+      });
+
+    const summary = await runLegalReminderCron({ dryRun: false });
+
+    expect(summary).toEqual({
+      totalEligible: 3,
+      sent: 2,
+      rateLimited: 0,
+      errors: 1,
+      dryRun: false,
+    });
+    expect(mockSend).toHaveBeenCalledTimes(3);
+    const audited = mockAuditCreate.mock.calls[0][0];
+    const details = (audited.metadata as { details: { errors: number } }).details;
+    expect(details.errors).toBe(1);
+  });
+
+  it('does NOT call sendReacceptanceReminder in dry-run mode and flags dryRun in the audit row', async () => {
+    mockUserFindAll.mockResolvedValue([userIdRow('u1'), userIdRow('u2')]);
+    mockGetPending.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: 'v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+
+    const summary = await runLegalReminderCron({ dryRun: true });
+
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(summary).toEqual({
+      totalEligible: 2,
+      sent: 0,
+      rateLimited: 0,
+      errors: 0,
+      dryRun: true,
+    });
+    const audited = mockAuditCreate.mock.calls[0][0];
+    const details = (audited.metadata as { details: { dryRun: boolean; totalEligible: number } })
+      .details;
+    expect(details.dryRun).toBe(true);
+    expect(details.totalEligible).toBe(2);
+  });
+
+  it('only counts users with pending docs as eligible during dry-run', async () => {
+    mockUserFindAll.mockResolvedValue([userIdRow('u1'), userIdRow('u2')]);
+    mockGetPending
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            documentType: 'terms',
+            currentVersion: 'v1',
+            lastAcceptedVersion: null,
+            lastAcceptedAt: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ pending: [] });
+
+    const summary = await runLegalReminderCron({ dryRun: true });
+
+    expect(summary.totalEligible).toBe(1);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('honours the batchSize cap even if more eligible users are returned by the candidate query', async () => {
+    const candidates = Array.from({ length: 150 }, (_, i) => userIdRow(`u${i}`));
+    mockUserFindAll.mockResolvedValue(candidates);
+    mockSend.mockResolvedValue({
+      sent: true,
+      versions: [{ documentType: 'terms', currentVersion: 'v1' }],
+    });
+
+    const summary = await runLegalReminderCron({ dryRun: false, batchSize: 100 });
+
+    expect(summary.totalEligible).toBe(100);
+    expect(summary.sent).toBe(100);
+    expect(mockSend).toHaveBeenCalledTimes(100);
+    // The first 100 (sorted oldest-first by the candidate query) win.
+    expect(mockSend.mock.calls[0][0].userId).toBe('u0');
+    expect(mockSend.mock.calls[99][0].userId).toBe('u99');
+  });
+
+  it('excludes users who were reminded inside the rate-limit window from the candidate query', async () => {
+    mockAuditFindAll.mockResolvedValue([
+      { user: 'recently-reminded-1' } as never,
+      { user: 'recently-reminded-2' } as never,
+    ]);
+    mockUserFindAll.mockResolvedValue([]);
+
+    await runLegalReminderCron({ dryRun: false });
+
+    const userWhereCall = mockUserFindAll.mock.calls[0][0];
+    const where = userWhereCall?.where as Record<string, unknown>;
+    const userIdClause = where.userId as Record<symbol, unknown[]>;
+    expect(userIdClause).toBeDefined();
+    const symbols = Object.getOwnPropertySymbols(userIdClause);
+    expect(symbols).toHaveLength(1);
+    expect(userIdClause[symbols[0]]).toEqual(['recently-reminded-1', 'recently-reminded-2']);
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -518,6 +518,24 @@ const startServer = async () => {
           error: err instanceof Error ? err.message : String(err),
         });
       }
+
+      // ADS-497 (slice 4): legal re-acceptance reminder cron. Gated
+      // behind LEGAL_REMINDER_CRON_ENABLED (default off) AND
+      // LEGAL_REMINDER_CRON_DRY_RUN (default on) — so the first deploy
+      // is observe-only and operators flip dry-run last.
+      try {
+        const { scheduleLegalReminderCron, startLegalReminderWorker } =
+          await import('./workers/legal-reminder.worker');
+        await scheduleLegalReminderCron();
+        const w = startLegalReminderWorker();
+        if (w) {
+          logger.info('Legal reminder worker started');
+        }
+      } catch (err) {
+        logger.warn('Legal reminder cron failed to start (continuing without scheduling)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     // Test database connection with retry mechanism

--- a/service.backend/src/workers/legal-reminder.cli.ts
+++ b/service.backend/src/workers/legal-reminder.cli.ts
@@ -1,0 +1,50 @@
+/**
+ * ADS-497 (slice 4): one-off CLI for the legal reminder cron.
+ *
+ *   npm run legal-reminder:run               # respects LEGAL_REMINDER_CRON_DRY_RUN
+ *   npm run legal-reminder:run -- --dry-run  # forces dry-run regardless of env
+ *   npm run legal-reminder:run -- --live     # forces live (sends emails)
+ *
+ * Useful for SRE: invoke once after deploy to observe the eligible
+ * count before flipping the cron's DRY_RUN env var. Closes the DB
+ * connection and exits non-zero on error so it's safe to chain in CI.
+ */
+
+import sequelize from '../sequelize';
+import { logger } from '../utils/logger';
+import { runLegalReminderCron } from './legal-reminder.worker';
+
+const parseDryRun = (argv: ReadonlyArray<string>): boolean => {
+  if (argv.includes('--live')) {
+    return false;
+  }
+  if (argv.includes('--dry-run')) {
+    return true;
+  }
+  return process.env.LEGAL_REMINDER_CRON_DRY_RUN !== 'false';
+};
+
+const main = async (): Promise<void> => {
+  const dryRun = parseDryRun(process.argv.slice(2));
+  logger.info('Running legal reminder cron via CLI', { dryRun });
+  const summary = await runLegalReminderCron({ dryRun });
+  // Mirror to stdout so SRE running this manually sees the result
+  // without grepping logs.
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(summary, null, 2));
+};
+
+main()
+  .then(async () => {
+    await sequelize.close();
+    // eslint-disable-next-line no-process-exit
+    process.exit(0);
+  })
+  .catch(async err => {
+    logger.error('Legal reminder cron CLI failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    await sequelize.close().catch(() => undefined);
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  });

--- a/service.backend/src/workers/legal-reminder.worker.ts
+++ b/service.backend/src/workers/legal-reminder.worker.ts
@@ -1,0 +1,256 @@
+import { Op } from 'sequelize';
+import type { Worker } from 'bullmq';
+import { z } from 'zod';
+import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
+import AuditLog from '../models/AuditLog';
+import User, { UserStatus } from '../models/User';
+import { getPendingReacceptance } from '../services/legal-content.service';
+import {
+  LEGAL_REMINDER_SENT_ACTION,
+  REMINDER_RATE_LIMIT_HOURS,
+  sendReacceptanceReminder,
+} from '../services/legal-reminder.service';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-497 (slice 4): scheduled cron for bulk re-acceptance reminders.
+ *
+ * Sequential loop over up to `batchSize` users-with-pending and a single
+ * summary audit row at the end. Per-user dedupe is delegated to
+ * `legal-reminder.service` (LEGAL_REMINDER_SENT fingerprint window) so
+ * this worker only does coarse pre-filtering and aggregation.
+ *
+ * Guardrails (also captured in the PR body):
+ *   - Hard batch cap (default 100). Bigger backlogs drain over multiple
+ *     daily runs.
+ *   - Daily, NOT hourly, schedule.
+ *   - Two env-var gates: registration (LEGAL_REMINDER_CRON_ENABLED) and
+ *     dry-run (LEGAL_REMINDER_CRON_DRY_RUN). Default OFF / dry-run.
+ *   - First deploy is observe-only: ENABLED=true alone still skips
+ *     sends; you must also set DRY_RUN=false to actually email users.
+ */
+
+export const LEGAL_REMINDER_CRON_RAN_ACTION = 'LEGAL_REMINDER_CRON_RAN';
+export const LEGAL_REMINDER_CRON_JOB_NAME = 'legal:reminder-cron';
+export const LEGAL_REMINDER_CRON_REPEAT_KEY = 'legal:reminder-cron:daily';
+export const DEFAULT_BATCH_SIZE = 100;
+
+// Default 02:00 UTC daily. Override via LEGAL_REMINDER_CRON env var. Cron
+// is BullMQ-compatible (5- or 6-field). Daily schedule is a hard rule —
+// see PR body — so the documented override is a different time of day,
+// not a different frequency.
+const LEGAL_REMINDER_CRON = process.env.LEGAL_REMINDER_CRON ?? '0 2 * * *';
+
+const isCronEnabled = (): boolean => process.env.LEGAL_REMINDER_CRON_ENABLED === 'true';
+
+// Default dry-run = TRUE. Operator must explicitly set DRY_RUN=false to
+// turn on sends. This makes the first deploy to any environment safe by
+// default — observe the summary audit row first, then flip the switch.
+const isDryRun = (): boolean => process.env.LEGAL_REMINDER_CRON_DRY_RUN !== 'false';
+
+export const RunSummarySchema = z.object({
+  totalEligible: z.number().int().nonnegative(),
+  sent: z.number().int().nonnegative(),
+  rateLimited: z.number().int().nonnegative(),
+  errors: z.number().int().nonnegative(),
+  dryRun: z.boolean(),
+});
+export type RunSummary = z.infer<typeof RunSummarySchema>;
+
+export type RunOptions = {
+  dryRun: boolean;
+  batchSize?: number;
+};
+
+/**
+ * Find users who plausibly need a reminder. We pull active, non-deleted
+ * users with an email, then exclude anyone who already received a
+ * LEGAL_REMINDER_SENT inside the rate-limit window (regardless of
+ * fingerprint — the per-fingerprint check still runs inside
+ * `sendReacceptanceReminder`).
+ *
+ * Returns up to `batchSize` userIds. Ordering is stable (createdAt ASC)
+ * so the same backlog drains the same way across runs and rotates
+ * deterministically.
+ */
+const findCandidateUserIds = async (batchSize: number): Promise<ReadonlyArray<string>> => {
+  const cutoff = new Date(Date.now() - REMINDER_RATE_LIMIT_HOURS * 60 * 60 * 1000);
+
+  const recentlyReminded = await AuditLog.findAll({
+    where: {
+      action: LEGAL_REMINDER_SENT_ACTION,
+      timestamp: { [Op.gte]: cutoff },
+    },
+    attributes: ['user'],
+  });
+  const excludedUserIds = recentlyReminded
+    .map(row => row.user)
+    .filter((u): u is string => typeof u === 'string' && u.length > 0);
+
+  const where: Record<string, unknown> = {
+    status: UserStatus.ACTIVE,
+  };
+  if (excludedUserIds.length > 0) {
+    where.userId = { [Op.notIn]: excludedUserIds };
+  }
+
+  // Over-fetch slightly so that `sendReacceptanceReminder` returning
+  // `no_pending_versions` (user is already up to date) doesn't shrink
+  // the effective batch below the cap. Keeping the multiplier small —
+  // we don't want to scan the whole user table.
+  const overFetch = Math.min(batchSize * 5, 500);
+  const users = await User.findAll({
+    where,
+    attributes: ['userId'],
+    order: [['createdAt', 'ASC']],
+    limit: overFetch,
+  });
+  return users.map(u => u.userId);
+};
+
+/**
+ * Run the cron once. Returns the same summary that gets persisted as a
+ * LEGAL_REMINDER_CRON_RAN audit row, so callers (including the CLI) can
+ * print it.
+ */
+export const runLegalReminderCron = async (options: RunOptions): Promise<RunSummary> => {
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const candidateIds = await findCandidateUserIds(batchSize);
+
+  let sent = 0;
+  let rateLimited = 0;
+  let errors = 0;
+  let totalEligible = 0;
+
+  for (const userId of candidateIds) {
+    if (totalEligible >= batchSize) {
+      break;
+    }
+
+    try {
+      if (options.dryRun) {
+        // Observe-only: count "would-be sends" without invoking the
+        // email path. We still check pending docs so the count
+        // reflects real eligibility, not just raw candidate volume.
+        const { pending } = await getPendingReacceptance(userId);
+        if (pending.length === 0) {
+          continue;
+        }
+        totalEligible += 1;
+        continue;
+      }
+
+      const result = await sendReacceptanceReminder({ userId, triggeredBy: 'cron' });
+      if (result.sent) {
+        totalEligible += 1;
+        sent += 1;
+        continue;
+      }
+      if (result.reason === 'rate_limited') {
+        totalEligible += 1;
+        rateLimited += 1;
+        continue;
+      }
+      // 'no_pending_versions' — not eligible, don't count toward the cap.
+    } catch (err) {
+      totalEligible += 1;
+      errors += 1;
+      logger.error('Legal reminder cron: send failed for user', {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const summary: RunSummary = {
+    totalEligible,
+    sent,
+    rateLimited,
+    errors,
+    dryRun: options.dryRun,
+  };
+
+  // System-level audit row — no user attribution. AuditLogService.log
+  // requires a userId, so write the row directly. This is append-only
+  // (the immutable-trigger only blocks UPDATE/DELETE), so direct
+  // creation is safe.
+  await AuditLog.create({
+    service: 'adopt-dont-shop-backend',
+    user: null,
+    user_email_snapshot: null,
+    action: LEGAL_REMINDER_CRON_RAN_ACTION,
+    level: 'INFO',
+    timestamp: new Date(),
+    metadata: {
+      entity: 'System',
+      entityId: 'legal-reminder-cron',
+      details: { ...summary },
+    },
+    category: 'System',
+  });
+
+  logger.info('Legal reminder cron finished', { summary });
+  return summary;
+};
+
+/**
+ * Schedule the daily repeatable. No-op when REDIS_URL is not set or the
+ * cron is not opted in via env var. Mirrors retention.job.ts.
+ */
+export const scheduleLegalReminderCron = async (): Promise<void> => {
+  if (!isCronEnabled()) {
+    logger.info('Legal reminder cron not enabled (LEGAL_REMINDER_CRON_ENABLED!=true)');
+    return;
+  }
+  if (!isQueueAvailable()) {
+    logger.warn('REDIS_URL not set — legal reminder cron not scheduled');
+    return;
+  }
+
+  const queue = getReportsQueue();
+  await queue.removeRepeatableByKey(LEGAL_REMINDER_CRON_REPEAT_KEY).catch(() => undefined);
+  await queue.add(
+    LEGAL_REMINDER_CRON_JOB_NAME,
+    {},
+    {
+      jobId: LEGAL_REMINDER_CRON_REPEAT_KEY,
+      repeat: { pattern: LEGAL_REMINDER_CRON, tz: 'UTC' },
+    }
+  );
+
+  logger.info('Legal reminder cron scheduled', {
+    cron: LEGAL_REMINDER_CRON,
+    dryRun: isDryRun(),
+  });
+};
+
+let workerInstance: Worker | null = null;
+
+export const startLegalReminderWorker = (): Worker | null => {
+  if (workerInstance) {
+    return workerInstance;
+  }
+  if (!isCronEnabled()) {
+    return null;
+  }
+  if (!isQueueAvailable()) {
+    logger.warn('REDIS_URL not set — legal reminder worker not started');
+    return null;
+  }
+
+  workerInstance = buildWorker(async job => {
+    if (job.name !== LEGAL_REMINDER_CRON_JOB_NAME) {
+      return;
+    }
+    await runLegalReminderCron({ dryRun: isDryRun() });
+  });
+
+  return workerInstance;
+};
+
+export const stopLegalReminderWorker = async (): Promise<void> => {
+  if (workerInstance) {
+    await workerInstance.close();
+    workerInstance = null;
+  }
+};


### PR DESCRIPTION
## Summary

Adds a daily BullMQ-driven cron that finds users with pending legal re-acceptance and emails reminders via the existing `legal-reminder.service` (slice 3, PR #424). Per-user dedupe is delegated to that service so this worker only does coarse pre-filtering, sequential dispatch, and aggregation.

Reuses the same `reports` BullMQ queue + worker scaffolding as `reports.worker.ts` and `retention.job.ts` — no new infrastructure.

## Scope guardrails (this is SCHEDULED background email — read carefully)

| Guardrail | Default | Override |
|---|---|---|
| Cron registration | **OFF** | `LEGAL_REMINDER_CRON_ENABLED=true` |
| Dry-run (no actual sends) | **ON** | `LEGAL_REMINDER_CRON_DRY_RUN=false` |
| Schedule | `0 2 * * *` (02:00 UTC, **once per day**) | `LEGAL_REMINDER_CRON` (BullMQ cron pattern; daily-only is a hard rule — change time-of-day, not frequency) |
| Hard batch cap | **100 users / run** | `runLegalReminderCron({ batchSize })` |
| Per-user-per-version dedupe | 24-hour window inherited from `legal-reminder.service` | n/a — see open question 1 below |

**First deploy is observe-only.** Setting `LEGAL_REMINDER_CRON_ENABLED=true` alone schedules the cron but the worker still skips sends (default dry-run). The summary audit row tells you how many users would have been emailed. Only then flip `LEGAL_REMINDER_CRON_DRY_RUN=false`.

## Production runbook

```
1. Deploy the change. Cron is OFF — nothing happens.
2. Set LEGAL_REMINDER_CRON_ENABLED=true. Cron now runs daily at 02:00 UTC
   in DRY-RUN mode. Each run writes a LEGAL_REMINDER_CRON_RAN audit row
   with totalEligible/sent/rateLimited/errors/dryRun=true.
3. Observe at least one run. Confirm totalEligible looks plausible.
4. Set LEGAL_REMINDER_CRON_DRY_RUN=false. Next run actually emails users
   (still capped at 100 per run; backlog drains over subsequent days).
5. To kill the feature: unset LEGAL_REMINDER_CRON_ENABLED, redeploy,
   and remove the repeatable from BullMQ.
```

For one-off manual runs (useful before step 3):

```
npm run legal-reminder:run -- --dry-run   # forces dry-run
npm run legal-reminder:run -- --live      # forces live (use with care)
npm run legal-reminder:run                # respects env
```

## Behaviour

`runLegalReminderCron({ dryRun, batchSize })`:

1. Pulls active, non-deleted users (oldest createdAt first for stable rotation), excluding anyone with a `LEGAL_REMINDER_SENT` audit row inside the rate-limit window. Coarse pre-filter — the per-user fingerprint check still runs inside `sendReacceptanceReminder`.
2. Iterates up to `batchSize` candidates with `pending.length > 0`. In live mode calls `sendReacceptanceReminder({ userId, triggeredBy: 'cron' })`; in dry-run only checks `getPendingReacceptance` and counts.
3. Aggregates `{ totalEligible, sent, rateLimited, errors, dryRun }`.
4. Writes ONE summary `LEGAL_REMINDER_CRON_RAN` audit row at the end (system-level, `user: null`).

Audit-row-per-send (`LEGAL_REMINDER_SENT`) is unchanged — written by `legal-reminder.service` per slice 3.

## What this PR explicitly does NOT do

- No retry logic beyond what `email.service` already provides.
- No bypass of `email.service.canReceiveEmails` opt-out check.
- No bulk fan-out engine — sequential loop with a hard cap.
- No tracking pixels.
- No new email templates — reuses slice 3's inline rendering.
- Does not write to a queue table — sends go through `sendReacceptanceReminder` to inherit audit + dedupe.

## Open questions

1. **Rate-limit window**: kept at the existing 24h `REMINDER_RATE_LIMIT_HOURS` from `legal-reminder.service`. The task brief mentioned "adjust to 7 days if requested" — not changed here because that affects the slice 3 admin endpoint too. If product wants 7 days for the cron specifically, we'd need a separate window param on the service rather than a constant change. Flagged for follow-up.
2. **Dry-run default**: chosen `LEGAL_REMINDER_CRON_DRY_RUN=true` (default opt-in to skipping sends). Rationale: blast-radius asymmetry. Forgetting to flip dry-run off is benign (no emails). Forgetting to flip it on would email the entire backlog on first deploy. Default-safe wins.
3. **Cron time**: hardcoded to 02:00 UTC with a `LEGAL_REMINDER_CRON` env override (matches `RETENTION_CRON` pattern). 02:00 UTC chosen as a low-traffic window for most users; SRE can override per env without a code change.
4. **Restart safety**: the cron is idempotent. If the worker crashes mid-run, the next scheduled run re-evaluates the candidate set. Already-sent users are excluded by the `LEGAL_REMINDER_SENT` window pre-filter, and the per-user fingerprint dedupe inside the service is the second line of defence. No DB transactions or partial-write recovery needed.
5. **Max-runtime cap**: not enforced. Sequential 100-send loop at typical email-API latencies (~200-500ms each) bounds at ~50s, well under the 24h next-run gap. If we ever raise the batch cap, we should add a wall-clock guard.
6. **Cookies placeholder**: `legal-content.service` currently flags `cookies` as pending for every user (the placeholder version doesn't match anyone's accepted version, by design). This is inherited from slice 3 — the cron will list `Cookies Policy` in reminder bodies. Pre-existing condition; should be addressed before the cookies type is shown to real users.

## Files

- **New**: `service.backend/src/workers/legal-reminder.worker.ts` — `runLegalReminderCron`, `scheduleLegalReminderCron`, `startLegalReminderWorker`, `stopLegalReminderWorker`.
- **New**: `service.backend/src/workers/legal-reminder.cli.ts` — one-off CLI wrapper.
- **New**: `service.backend/src/__tests__/services/legal-reminder-cron.test.ts` — 9 behaviour tests.
- **Modified**: `service.backend/src/index.ts` — registers cron + worker behind env-var gate (mirrors retention worker bootstrap).
- **Modified**: `service.backend/package.json` — adds `legal-reminder:run` npm script.

## Test plan

- [x] `vitest run src/__tests__/services/legal-reminder-cron.test.ts` — 9/9 pass
- [x] `vitest run src/__tests__/services/legal-reminder.test.ts` — slice 3 service tests still pass (8/8)
- [x] Full `vitest run` — 2096 pass; the 3 pre-existing failures (`email.service.test.ts`, `email-queue-concurrency.test.ts`, `email-unsubscribe-token-rotation.test.ts`) are unrelated and reproduce on `origin/main` without these changes (missing `resend` package — owned by ADS-104 / PR #425).
- [x] `eslint` clean on changed files (the 6 `index.ts` warnings are pre-existing in unrelated bootstrap blocks).
- [x] `tsc --noEmit` — no new errors. The 6 errors that show up reproduce on `origin/main` (slice 3 cookies-type widening + missing `resend` package).
- [ ] Manual smoke: `npm run legal-reminder:run -- --dry-run` against a dev DB — not executed in this environment (no DB / Redis available).
- [ ] Staging soak: deploy with `LEGAL_REMINDER_CRON_ENABLED=true` only, observe one daily run's `LEGAL_REMINDER_CRON_RAN` audit row before flipping `LEGAL_REMINDER_CRON_DRY_RUN=false`.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_