### PR TITLE
feat(legal): cookies banner + localStorage + attach-on-signin (ADS-497, slice 5)

### DIFF
--- a/app.admin/src/App.test.tsx
+++ b/app.admin/src/App.test.tsx
@@ -16,10 +16,12 @@ vi.mock('@adopt-dont-shop/lib.auth', () => ({
   useAuth: () => useAuthMock(),
 }));
 
-// Replace the modal with a sentinel so the test asserts wiring without
-// pulling in the modal's full network behaviour.
+// Replace the modal + banner with sentinels so the test asserts wiring
+// without pulling in their full network behaviour.
 vi.mock('@adopt-dont-shop/lib.legal', () => ({
   LegalReacceptanceModal: () => <div data-testid='legal-reacceptance-modal-sentinel' />,
+  CookieBanner: () => <div data-testid='cookie-banner-sentinel' />,
+  attachStoredCookieConsent: vi.fn(),
 }));
 
 vi.mock('@adopt-dont-shop/lib.analytics', () => ({
@@ -63,5 +65,23 @@ describe('AdminApp [ADS-497 modal wiring]', () => {
     renderApp();
 
     expect(screen.queryByTestId('legal-reacceptance-modal-sentinel')).not.toBeInTheDocument();
+  });
+});
+
+describe('AdminApp [ADS-497 cookie banner wiring]', () => {
+  it('mounts the CookieBanner on the authenticated branch', () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: true, isLoading: false });
+
+    renderApp();
+
+    expect(screen.getByTestId('cookie-banner-sentinel')).toBeInTheDocument();
+  });
+
+  it('mounts the CookieBanner on the public/login branch (anonymous visitors decide too)', () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: false, isLoading: false });
+
+    renderApp();
+
+    expect(screen.getByTestId('cookie-banner-sentinel')).toBeInTheDocument();
   });
 });

--- a/app.admin/src/App.tsx
+++ b/app.admin/src/App.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { Spinner } from '@adopt-dont-shop/lib.components';
-import { LegalReacceptanceModal } from '@adopt-dont-shop/lib.legal';
+import { CookieBanner, LegalReacceptanceModal } from '@adopt-dont-shop/lib.legal';
 import { useAnalyticsInvalidator } from '@adopt-dont-shop/lib.analytics';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { AdminLayout } from './components/layout/AdminLayout';
@@ -70,6 +70,10 @@ const AdminApp: React.FC = () => {
         </Suspense>
 
         <DevLoginPanel />
+
+        {/* ADS-497 (slice 5): cookie banner is shown to anonymous visitors
+            too, so first-time choices are persisted before sign-in. */}
+        <CookieBanner />
       </>
     );
   }
@@ -186,6 +190,10 @@ const AdminApp: React.FC = () => {
 
       {/* Dev Login Panel - only shows in development */}
       <DevLoginPanel />
+
+      {/* ADS-497 (slice 5): on-page cookie banner. Mounted before the
+          re-acceptance modal so the modal stacks on top if both surface. */}
+      <CookieBanner />
 
       {/* ADS-497: hard-block re-acceptance modal for users whose last
           accepted ToS / Privacy version is older than current. Admins are

--- a/app.admin/src/main.tsx
+++ b/app.admin/src/main.tsx
@@ -1,5 +1,6 @@
 import { ThemeProvider } from '@adopt-dont-shop/lib.components';
 import { AuthProvider } from '@adopt-dont-shop/lib.auth';
+import { attachStoredCookieConsent } from '@adopt-dont-shop/lib.legal';
 import { captureException, initSentry, reportWebVitals } from '@adopt-dont-shop/lib.observability';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -44,11 +45,28 @@ const queryClient = new QueryClient({
   },
 });
 
+// ADS-497 (slice 5): on first sign-in OR rehydrate, replay an anonymous
+// cookie-banner choice (if any) against the user's account. Idempotent
+// per (userId, cookiesVersion).
+const handleAuthEvent = (event: string, data?: Record<string, unknown>) => {
+  if (event !== 'auth_session_authenticated') {
+    return;
+  }
+  const userId = typeof data?.user_id === 'string' ? data.user_id : null;
+  if (userId) {
+    void attachStoredCookieConsent(userId);
+  }
+};
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider allowedUserTypes={['admin', 'moderator']} appType='admin'>
+        <AuthProvider
+          allowedUserTypes={['admin', 'moderator']}
+          appType='admin'
+          onAuthEvent={handleAuthEvent}
+        >
           <StatsigWrapper>
             <ThemeProvider>
               <BrowserRouter>

--- a/app.client/src/App.test.tsx
+++ b/app.client/src/App.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
 // Capture the userId prop NotificationsProvider receives, so we can assert
@@ -47,6 +47,14 @@ vi.mock('./components/dev/DevLoginPanel', () => ({
 
 vi.mock('./components/common/ErrorBoundary', () => ({
   ErrorBoundary: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+// ADS-497: replace the legal modal + cookie banner with sentinels so the
+// App-level wiring tests don't pull in their network behaviour.
+vi.mock('@adopt-dont-shop/lib.legal', () => ({
+  LegalReacceptanceModal: () => <div data-testid='legal-reacceptance-modal-sentinel' />,
+  CookieBanner: () => <div data-testid='cookie-banner-sentinel' />,
+  attachStoredCookieConsent: vi.fn(),
 }));
 
 // Stable mock for useAuth that we can reconfigure per test.
@@ -115,5 +123,21 @@ describe('App notifications wiring', () => {
       expect(notificationsProviderUserIdSpy).toHaveBeenCalled();
     });
     expect(notificationsProviderUserIdSpy).toHaveBeenLastCalledWith('user-abc');
+  });
+});
+
+describe('App [ADS-497 slice 5] cookie banner wiring', () => {
+  it('mounts the CookieBanner alongside the LegalReacceptanceModal', async () => {
+    useAuthMock.mockReturnValue({ ...baseAuth, user: null, isAuthenticated: false });
+
+    renderApp();
+
+    // The banner + modal are sibling sentinels of the routed Suspense
+    // boundary, so they're available before the lazy LoginPage finishes
+    // loading. waitFor handles the React 19 act() flush.
+    await waitFor(() => {
+      expect(screen.getByTestId('cookie-banner-sentinel')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('legal-reacceptance-modal-sentinel')).toBeInTheDocument();
   });
 });

--- a/app.client/src/App.tsx
+++ b/app.client/src/App.tsx
@@ -11,7 +11,7 @@ import { DevLoginPanel } from './components/dev/DevLoginPanel';
 import { AppShell } from './components/layout/AppShell';
 import { PublicAuthLayout } from './components/layout/PublicAuthLayout';
 import { ErrorBoundary } from './components/common/ErrorBoundary';
-import { LegalReacceptanceModal } from '@adopt-dont-shop/lib.legal';
+import { CookieBanner, LegalReacceptanceModal } from '@adopt-dont-shop/lib.legal';
 import * as styles from './App.css';
 
 const HomePage = lazy(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })));
@@ -98,6 +98,10 @@ function App() {
           <ChatProvider>
             <FavoritesProvider>
               <DevLoginPanel />
+              {/* ADS-497 (slice 5): on-page cookie banner. Bottom-anchored, does
+                  not block the page. Mounted before the modal so the modal
+                  renders on top if both ever surface together. */}
+              <CookieBanner />
               {/* ADS-497 (slice 2): hard-block modal for users whose last
                   accepted ToS / Privacy version is older than current. */}
               <LegalReacceptanceModal />

--- a/app.client/src/components/AppWithAuth.tsx
+++ b/app.client/src/components/AppWithAuth.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { AuthProvider } from '@adopt-dont-shop/lib.auth';
+import { attachStoredCookieConsent } from '@adopt-dont-shop/lib.legal';
 import { useAnalytics } from '@/contexts/AnalyticsContext';
 
 interface AppWithAuthProps {
@@ -17,6 +18,16 @@ export const AppWithAuth = ({ children }: AppWithAuthProps) => {
       eventType: event,
       ...data,
     } as any);
+    // ADS-497 (slice 5): on first sign-in OR rehydrate, replay the
+    // anonymous cookie-banner choice (if any) against the user's
+    // account so the audit log captures their decision. Idempotent per
+    // (userId, cookiesVersion) — safe on every session event.
+    if (event === 'auth_session_authenticated') {
+      const userId = typeof data?.user_id === 'string' ? data.user_id : null;
+      if (userId) {
+        void attachStoredCookieConsent(userId);
+      }
+    }
   };
 
   return (

--- a/app.rescue/src/App.test.tsx
+++ b/app.rescue/src/App.test.tsx
@@ -12,6 +12,8 @@ import { render, screen } from '@testing-library/react';
 
 vi.mock('@adopt-dont-shop/lib.legal', () => ({
   LegalReacceptanceModal: () => <div data-testid="legal-reacceptance-modal-sentinel" />,
+  CookieBanner: () => <div data-testid="cookie-banner-sentinel" />,
+  attachStoredCookieConsent: vi.fn(),
 }));
 
 vi.mock('@adopt-dont-shop/lib.analytics', () => ({
@@ -42,5 +44,15 @@ describe('rescue App [ADS-497 modal wiring]', () => {
     );
 
     expect(screen.getByTestId('legal-reacceptance-modal-sentinel')).toBeInTheDocument();
+  });
+
+  it('mounts the CookieBanner at the App root (ADS-497 slice 5)', () => {
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('cookie-banner-sentinel')).toBeInTheDocument();
   });
 });

--- a/app.rescue/src/App.tsx
+++ b/app.rescue/src/App.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { Spinner } from '@adopt-dont-shop/lib.components';
-import { LegalReacceptanceModal } from '@adopt-dont-shop/lib.legal';
+import { CookieBanner, LegalReacceptanceModal } from '@adopt-dont-shop/lib.legal';
 import { useAnalyticsInvalidator } from '@adopt-dont-shop/lib.analytics';
 
 // Components
@@ -100,6 +100,10 @@ function App() {
 
       {/* Dev Login Panel - only shows in development */}
       <DevLoginPanel />
+
+      {/* ADS-497 (slice 5): on-page cookie banner. Mounted before the
+          re-acceptance modal so the modal stacks on top if both surface. */}
+      <CookieBanner />
 
       {/* ADS-497: hard-block re-acceptance modal for users whose last
           accepted ToS / Privacy version is older than current. Rescue

--- a/app.rescue/src/components/AppWithAuth.tsx
+++ b/app.rescue/src/components/AppWithAuth.tsx
@@ -1,16 +1,34 @@
 import { ReactNode } from 'react';
 import { AuthProvider } from '@adopt-dont-shop/lib.auth';
+import { attachStoredCookieConsent } from '@adopt-dont-shop/lib.legal';
 
 interface AppWithAuthProps {
   children: ReactNode;
 }
+
+// ADS-497 (slice 5): replay an anonymous cookie-banner choice against
+// the user's account on first session-auth event. Idempotent per
+// (userId, cookiesVersion).
+const handleAuthEvent = (event: string, data?: Record<string, unknown>) => {
+  if (event !== 'auth_session_authenticated') {
+    return;
+  }
+  const userId = typeof data?.user_id === 'string' ? data.user_id : null;
+  if (userId) {
+    void attachStoredCookieConsent(userId);
+  }
+};
 
 /**
  * Wrapper component that provides AuthProvider for rescue app
  */
 export const AppWithAuth = ({ children }: AppWithAuthProps) => {
   return (
-    <AuthProvider allowedUserTypes={['rescue_staff']} appType="rescue">
+    <AuthProvider
+      allowedUserTypes={['rescue_staff']}
+      appType="rescue"
+      onAuthEvent={handleAuthEvent}
+    >
       {children}
     </AuthProvider>
   );

--- a/lib.legal/package.json
+++ b/lib.legal/package.json
@@ -41,6 +41,7 @@
     "@adopt-dont-shop/lib.api": "*",
     "@adopt-dont-shop/lib.auth": "*",
     "@adopt-dont-shop/lib.components": "*",
+    "@adopt-dont-shop/lib.observability": "*",
     "@types/node": "^20.19.0",
     "@vanilla-extract/css": "^1.20.1",
     "react": "^19.0.0",

--- a/lib.legal/src/components/CookieBanner.css.ts
+++ b/lib.legal/src/components/CookieBanner.css.ts
@@ -1,0 +1,96 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const banner = style({
+  position: 'fixed',
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: 1000,
+  background: vars.colors.neutral['50'],
+  borderTop: `1px solid ${vars.colors.neutral['300']}`,
+  boxShadow: '0 -2px 8px rgba(0, 0, 0, 0.08)',
+  padding: '1rem 1.25rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+});
+
+export const headerRow = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+});
+
+export const title = style({
+  fontWeight: 600,
+  fontSize: '1rem',
+  color: vars.colors.neutral['900'],
+  margin: 0,
+});
+
+export const description = style({
+  margin: 0,
+  color: vars.colors.neutral['700'],
+  fontSize: '0.9rem',
+  lineHeight: 1.5,
+});
+
+export const policyLink = style({
+  color: vars.colors.primary['600'],
+  textDecoration: 'underline',
+});
+
+export const actionRow = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.75rem',
+  alignItems: 'center',
+});
+
+export const detailsBlock = style({
+  borderTop: `1px solid ${vars.colors.neutral['200']}`,
+  paddingTop: '0.75rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+});
+
+export const categoryRow = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+});
+
+export const categoryLabel = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  fontWeight: 600,
+  color: vars.colors.neutral['900'],
+});
+
+export const categoryMeta = style({
+  fontSize: '0.85rem',
+  color: vars.colors.neutral['600'],
+  fontWeight: 400,
+});
+
+export const categoryDescription = style({
+  margin: 0,
+  fontSize: '0.85rem',
+  color: vars.colors.neutral['700'],
+  lineHeight: 1.5,
+});
+
+export const checkbox = style({
+  width: '1.1rem',
+  height: '1.1rem',
+});
+
+export const togglesActions = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.75rem',
+  justifyContent: 'flex-end',
+});

--- a/lib.legal/src/components/CookieBanner.test.tsx
+++ b/lib.legal/src/components/CookieBanner.test.tsx
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { User } from '@adopt-dont-shop/lib.auth';
+import { CookieBanner } from './CookieBanner';
+import {
+  COOKIE_CONSENT_STORAGE_KEY,
+  type StoredCookieConsent,
+} from '../services/cookie-consent-storage';
+
+const CURRENT_VERSION = '2026-05-09-v1';
+
+type AuthState = { user: User | null; isAuthenticated: boolean };
+const authState: AuthState = { user: null, isAuthenticated: false };
+
+const baseUser: User = {
+  userId: 'u-1',
+  email: 'a@b.c',
+  firstName: 'Sam',
+  lastName: 'Doe',
+  emailVerified: true,
+  userType: 'adopter',
+  status: 'active',
+};
+
+const fetchCookiesVersionMock = vi.fn();
+const recordReacceptanceMock = vi.fn();
+const setAnalyticsConsentMock = vi.fn();
+
+vi.mock('../services/legal-service', () => ({
+  fetchCookiesVersion: () => fetchCookiesVersionMock(),
+  recordReacceptance: (input: unknown) => recordReacceptanceMock(input),
+  // The banner imports these too — keep the mock surface complete to
+  // avoid undefined-call traps during partial imports.
+  fetchPendingReacceptance: vi.fn(),
+}));
+
+vi.mock('@adopt-dont-shop/lib.observability', () => ({
+  setAnalyticsConsent: (state: unknown) => setAnalyticsConsentMock(state),
+}));
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: authState.user,
+      isAuthenticated: authState.isAuthenticated,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+const setStoredConsent = (record: StoredCookieConsent): void => {
+  window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(record));
+};
+
+const readStoredJson = (): StoredCookieConsent | null => {
+  const raw = window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+  return JSON.parse(raw) as StoredCookieConsent;
+};
+
+describe('CookieBanner [ADS-497 slice 5]', () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.isAuthenticated = false;
+    window.localStorage.clear();
+    fetchCookiesVersionMock.mockReset();
+    recordReacceptanceMock.mockReset();
+    setAnalyticsConsentMock.mockReset();
+    fetchCookiesVersionMock.mockResolvedValue(CURRENT_VERSION);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the bottom banner when no consent record exists for the current version', async () => {
+    render(<CookieBanner />);
+
+    expect(await screen.findByTestId('cookie-banner')).toBeInTheDocument();
+    // Both primary actions are visible up-front (manage preferences is closed by default).
+    expect(screen.getByTestId('cookie-banner-accept-all')).toBeInTheDocument();
+    expect(screen.getByTestId('cookie-banner-essentials-only')).toBeInTheDocument();
+    // The detailed analytics toggle is hidden until "Manage preferences" is clicked.
+    expect(screen.queryByTestId('cookie-banner-analytics-toggle')).not.toBeInTheDocument();
+  });
+
+  it('does not render when a consent record exists for the current version', async () => {
+    setStoredConsent({
+      cookiesVersion: CURRENT_VERSION,
+      analyticsConsent: false,
+      acceptedAt: '2026-05-10T08:00:00.000Z',
+    });
+
+    render(<CookieBanner />);
+
+    await waitFor(() => {
+      expect(fetchCookiesVersionMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+  });
+
+  it('re-shows when the stored record is for an OLDER cookies version', async () => {
+    setStoredConsent({
+      cookiesVersion: '2025-01-01-old',
+      analyticsConsent: true,
+      acceptedAt: '2025-01-02T00:00:00.000Z',
+    });
+
+    render(<CookieBanner />);
+
+    expect(await screen.findByTestId('cookie-banner')).toBeInTheDocument();
+  });
+
+  it('persists the choice to localStorage on "Accept all" and flips the observability gate', async () => {
+    const user = userEvent.setup();
+    render(<CookieBanner />);
+
+    await user.click(await screen.findByTestId('cookie-banner-accept-all'));
+
+    await waitFor(() => {
+      const stored = readStoredJson();
+      expect(stored).not.toBeNull();
+    });
+    const stored = readStoredJson();
+    expect(stored?.cookiesVersion).toBe(CURRENT_VERSION);
+    expect(stored?.analyticsConsent).toBe(true);
+    expect(setAnalyticsConsentMock).toHaveBeenCalledWith('granted');
+  });
+
+  it('persists analytics OFF on "Essentials only" and denies the observability gate', async () => {
+    const user = userEvent.setup();
+    render(<CookieBanner />);
+
+    await user.click(await screen.findByTestId('cookie-banner-essentials-only'));
+
+    await waitFor(() => {
+      const stored = readStoredJson();
+      expect(stored?.analyticsConsent).toBe(false);
+    });
+    expect(setAnalyticsConsentMock).toHaveBeenCalledWith('denied');
+  });
+
+  it('does NOT pre-check the analytics toggle in the disclosure (opt-in default)', async () => {
+    const user = userEvent.setup();
+    render(<CookieBanner />);
+
+    const banner = await screen.findByTestId('cookie-banner');
+    await user.click(within(banner).getByTestId('cookie-banner-manage-preferences'));
+
+    const toggle = await within(banner).findByTestId('cookie-banner-analytics-toggle');
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('records the explicit toggle state on "Save preferences" inside the disclosure', async () => {
+    const user = userEvent.setup();
+    render(<CookieBanner />);
+
+    const banner = await screen.findByTestId('cookie-banner');
+    await user.click(within(banner).getByTestId('cookie-banner-manage-preferences'));
+    await user.click(await within(banner).findByTestId('cookie-banner-analytics-toggle'));
+    await user.click(within(banner).getByTestId('cookie-banner-save-preferences'));
+
+    await waitFor(() => {
+      expect(readStoredJson()?.analyticsConsent).toBe(true);
+    });
+    expect(setAnalyticsConsentMock).toHaveBeenCalledWith('granted');
+  });
+
+  it('does not call the API for anonymous users', async () => {
+    const user = userEvent.setup();
+    render(<CookieBanner />);
+
+    await user.click(await screen.findByTestId('cookie-banner-accept-all'));
+
+    await waitFor(() => {
+      expect(setAnalyticsConsentMock).toHaveBeenCalled();
+    });
+    expect(recordReacceptanceMock).not.toHaveBeenCalled();
+  });
+
+  it('calls the consent API for authenticated users with the captured cookies version + analytics flag', async () => {
+    authState.user = baseUser;
+    authState.isAuthenticated = true;
+    recordReacceptanceMock.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    render(<CookieBanner />);
+
+    await user.click(await screen.findByTestId('cookie-banner-accept-all'));
+
+    await waitFor(() => {
+      expect(recordReacceptanceMock).toHaveBeenCalledTimes(1);
+    });
+    expect(recordReacceptanceMock).toHaveBeenCalledWith({
+      tosAccepted: true,
+      privacyAccepted: true,
+      cookiesVersion: CURRENT_VERSION,
+      analyticsConsent: true,
+    });
+  });
+
+  it('stays hidden when the cookies-version fetch fails (no stale write)', async () => {
+    fetchCookiesVersionMock.mockRejectedValue(new Error('network'));
+
+    render(<CookieBanner />);
+
+    // Wait long enough that the loading effect resolves into a no-op.
+    await waitFor(() => {
+      expect(fetchCookiesVersionMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/lib.legal/src/components/CookieBanner.tsx
+++ b/lib.legal/src/components/CookieBanner.tsx
@@ -1,0 +1,287 @@
+import { Button } from '@adopt-dont-shop/lib.components';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+import { setAnalyticsConsent } from '@adopt-dont-shop/lib.observability';
+import { useEffect, useState } from 'react';
+import { fetchCookiesVersion, recordReacceptance } from '../services/legal-service';
+import {
+  readStoredConsent,
+  writeStoredConsent,
+  type StoredCookieConsent,
+} from '../services/cookie-consent-storage';
+import * as styles from './CookieBanner.css';
+
+/**
+ * ADS-497 (slice 5): on-page cookie banner.
+ *
+ * Renders a bottom-anchored bar (NOT a modal — the page underneath stays
+ * usable) when the user has not yet decided for the currently published
+ * cookies policy version. Two primary actions:
+ *
+ *   - "Accept all" — analytics consent ON
+ *   - "Essentials only" — analytics consent OFF (default)
+ *
+ * A "Manage preferences" disclosure exposes per-category controls. Only
+ * two categories appear, matching docs/legal/cookies.md exactly:
+ *
+ *   - Strictly necessary (always on, no toggle)
+ *   - Analytics (toggleable, default off — opt-in)
+ *
+ * The choice is persisted to localStorage under `legal-consent-v1` so it
+ * survives reloads. For authenticated users it is also POSTed to
+ * /api/v1/privacy/consent so the audit log captures the decision against
+ * their account. Anonymous users persist only locally; their choice is
+ * later replayed against their account on first sign-in via
+ * `attachStoredCookieConsent`.
+ *
+ * The banner also flips the observability analytics gate so Sentry +
+ * Statsig auto-capture / session replay respect the choice on the same
+ * tab without a reload.
+ */
+
+const COOKIES_POLICY_HREF = '/cookies';
+
+type Status = 'loading' | 'idle' | 'submitting';
+
+const buildRecord = (cookiesVersion: string, analyticsConsent: boolean): StoredCookieConsent => ({
+  cookiesVersion,
+  analyticsConsent,
+  acceptedAt: new Date().toISOString(),
+});
+
+export const CookieBanner = () => {
+  const { isAuthenticated } = useAuth();
+  const [status, setStatus] = useState<Status>('loading');
+  const [cookiesVersion, setCookiesVersion] = useState<string | null>(null);
+  const [hasDecided, setHasDecided] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
+  const [analyticsToggle, setAnalyticsToggle] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      try {
+        const version = await fetchCookiesVersion();
+        if (cancelled) {
+          return;
+        }
+        setCookiesVersion(version);
+        const stored = readStoredConsent(version);
+        setHasDecided(stored !== null);
+        setAnalyticsToggle(stored?.analyticsConsent ?? false);
+        setStatus('idle');
+      } catch {
+        // Backend unreachable: we deliberately do NOT show the banner
+        // with a guessed version, because that would write a stale
+        // localStorage record. Banner stays hidden until the next page
+        // load retries.
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Re-open path: useCookieConsent().openPreferences() clears the stored
+  // record and dispatches this event so the banner returns without a
+  // page reload (slice 5b footer link).
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const handler = () => {
+      setHasDecided(false);
+      setShowDetails(true);
+      setAnalyticsToggle(false);
+    };
+    window.addEventListener('legal-consent-v1:cleared', handler);
+    return () => window.removeEventListener('legal-consent-v1:cleared', handler);
+  }, []);
+
+  const persistChoice = async (analyticsConsent: boolean): Promise<void> => {
+    if (!cookiesVersion) {
+      return;
+    }
+    setStatus('submitting');
+    const record = buildRecord(cookiesVersion, analyticsConsent);
+    writeStoredConsent(record);
+    setAnalyticsConsent(analyticsConsent ? 'granted' : 'denied');
+
+    if (isAuthenticated) {
+      try {
+        await recordReacceptance({
+          tosAccepted: true,
+          privacyAccepted: true,
+          cookiesVersion: record.cookiesVersion,
+          analyticsConsent: record.analyticsConsent,
+        });
+      } catch {
+        // Network failures are non-fatal: localStorage already captured
+        // the user's choice and the next sign-in will retry the attach.
+      }
+    }
+
+    setHasDecided(true);
+    setStatus('idle');
+  };
+
+  if (status === 'loading' || !cookiesVersion || hasDecided) {
+    return null;
+  }
+
+  return (
+    <div
+      role='region'
+      aria-label='Cookie consent'
+      className={styles.banner}
+      data-testid='cookie-banner'
+    >
+      <div className={styles.headerRow}>
+        <h2 className={styles.title}>We use cookies</h2>
+        <p className={styles.description}>
+          We use strictly necessary cookies to keep you signed in and to protect your account. With
+          your permission we also use analytics cookies to understand how the site is used so we can
+          improve it. Read our{' '}
+          <a className={styles.policyLink} href={COOKIES_POLICY_HREF}>
+            cookies policy
+          </a>
+          .
+        </p>
+      </div>
+
+      {showDetails && (
+        <div className={styles.detailsBlock}>
+          <div className={styles.categoryRow}>
+            <span className={styles.categoryLabel}>
+              Strictly necessary
+              <span className={styles.categoryMeta}>Always on</span>
+            </span>
+            <p className={styles.categoryDescription}>
+              Required to sign you in, keep you signed in, and protect forms from cross-site request
+              forgery. The platform cannot work without these.
+            </p>
+          </div>
+
+          <div className={styles.categoryRow}>
+            <label className={styles.categoryLabel}>
+              <input
+                type='checkbox'
+                className={styles.checkbox}
+                checked={analyticsToggle}
+                onChange={e => setAnalyticsToggle(e.target.checked)}
+                disabled={status === 'submitting'}
+                aria-label='Allow analytics cookies'
+                data-testid='cookie-banner-analytics-toggle'
+              />
+              Analytics
+              <span className={styles.categoryMeta}>Optional</span>
+            </label>
+            <p className={styles.categoryDescription}>
+              Helps us understand how the site is used so we can fix problems and improve features.
+              Off by default.
+            </p>
+          </div>
+
+          <div className={styles.togglesActions}>
+            <Button
+              variant='primary'
+              onClick={() => void persistChoice(analyticsToggle)}
+              disabled={status === 'submitting'}
+              data-testid='cookie-banner-save-preferences'
+            >
+              Save preferences
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className={styles.actionRow}>
+        <Button
+          variant='secondary'
+          onClick={() => void persistChoice(false)}
+          disabled={status === 'submitting'}
+          data-testid='cookie-banner-essentials-only'
+        >
+          Essentials only
+        </Button>
+        <Button
+          variant='outline'
+          onClick={() => setShowDetails(prev => !prev)}
+          disabled={status === 'submitting'}
+          aria-expanded={showDetails}
+          data-testid='cookie-banner-manage-preferences'
+        >
+          {showDetails ? 'Hide preferences' : 'Manage preferences'}
+        </Button>
+        <Button
+          variant='primary'
+          onClick={() => void persistChoice(true)}
+          disabled={status === 'submitting'}
+          data-testid='cookie-banner-accept-all'
+        >
+          Accept all
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Hook for components that need to read or re-open the cookie banner
+ * (e.g. a footer "Cookie preferences" link in slice 5b). Internal
+ * subscription pattern is intentionally minimal: we re-read localStorage
+ * lazily — banner choices are infrequent so polling is fine.
+ */
+export const useCookieConsent = (): {
+  analyticsConsent: boolean;
+  hasDecided: boolean;
+  openPreferences: () => void;
+} => {
+  // The `cookiesVersion` argument to readStoredConsent comes from a
+  // network fetch on banner mount; this hook intentionally only checks
+  // "has the user ever decided for SOME version" so it stays
+  // synchronous. Callers that need the current-version-only view should
+  // use the banner itself.
+  const stored = (() => {
+    try {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return null;
+      }
+      const raw = window.localStorage.getItem('legal-consent-v1');
+      if (!raw) {
+        return null;
+      }
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        'analyticsConsent' in parsed &&
+        typeof (parsed as { analyticsConsent: unknown }).analyticsConsent === 'boolean'
+      ) {
+        return parsed as StoredCookieConsent;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  })();
+
+  const openPreferences = () => {
+    try {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return;
+      }
+      window.localStorage.removeItem('legal-consent-v1');
+      // Force a synthetic event so any mounted CookieBanner re-evaluates.
+      window.dispatchEvent(new Event('legal-consent-v1:cleared'));
+    } catch {
+      // localStorage unavailable; nothing to do.
+    }
+  };
+
+  return {
+    analyticsConsent: stored?.analyticsConsent ?? false,
+    hasDecided: stored !== null,
+    openPreferences,
+  };
+};

--- a/lib.legal/src/components/LegalReacceptanceModal.tsx
+++ b/lib.legal/src/components/LegalReacceptanceModal.tsx
@@ -30,6 +30,7 @@ import * as styles from './LegalReacceptanceModal.css';
 const LABELS: Record<PendingReacceptanceItem['documentType'], { title: string; href: string }> = {
   terms: { title: 'Terms of Service', href: '/terms' },
   privacy: { title: 'Privacy Policy', href: '/privacy' },
+  cookies: { title: 'Cookies Policy', href: '/cookies' },
 };
 
 type Status = 'idle' | 'submitting' | 'error';

--- a/lib.legal/src/index.ts
+++ b/lib.legal/src/index.ts
@@ -2,10 +2,12 @@
 
 // Components
 export { LegalReacceptanceModal } from './components/LegalReacceptanceModal';
+export { CookieBanner, useCookieConsent } from './components/CookieBanner';
 
 // Service / schemas
 export {
   fetchPendingReacceptance,
+  fetchCookiesVersion,
   recordReacceptance,
   PendingReacceptanceItemSchema,
   PendingReacceptanceResponseSchema,
@@ -15,3 +17,14 @@ export type {
   PendingReacceptanceResponse,
   RecordReacceptanceInput,
 } from './services/legal-service';
+
+// Cookie banner storage + sign-in attach
+export {
+  COOKIE_CONSENT_STORAGE_KEY,
+  StoredCookieConsentSchema,
+  readStoredConsent,
+  writeStoredConsent,
+  clearStoredConsent,
+} from './services/cookie-consent-storage';
+export type { StoredCookieConsent } from './services/cookie-consent-storage';
+export { attachStoredCookieConsent } from './services/attach-stored-consent';

--- a/lib.legal/src/services/attach-stored-consent.test.ts
+++ b/lib.legal/src/services/attach-stored-consent.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { COOKIE_CONSENT_STORAGE_KEY } from './cookie-consent-storage';
+
+const CURRENT_VERSION = '2026-05-09-v1';
+
+const fetchCookiesVersionMock = vi.fn();
+const recordReacceptanceMock = vi.fn();
+
+vi.mock('./legal-service', () => ({
+  fetchCookiesVersion: () => fetchCookiesVersionMock(),
+  recordReacceptance: (input: unknown) => recordReacceptanceMock(input),
+  // Round out the partial mock so other importers stay safe.
+  fetchPendingReacceptance: vi.fn(),
+}));
+
+import { attachStoredCookieConsent } from './attach-stored-consent';
+
+const ATTACHED_KEY = 'legal-consent-v1:attached';
+
+describe('attachStoredCookieConsent', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    fetchCookiesVersionMock.mockReset();
+    recordReacceptanceMock.mockReset();
+    fetchCookiesVersionMock.mockResolvedValue(CURRENT_VERSION);
+    recordReacceptanceMock.mockResolvedValue(undefined);
+  });
+
+  const storeConsent = (analyticsConsent: boolean): void => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: CURRENT_VERSION,
+        analyticsConsent,
+        acceptedAt: '2026-05-10T09:00:00.000Z',
+      })
+    );
+  };
+
+  it('does nothing when no anonymous choice is stored', async () => {
+    await attachStoredCookieConsent('user-1');
+
+    expect(recordReacceptanceMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the stored choice is for an older cookies version', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2025-01-01-old',
+        analyticsConsent: true,
+        acceptedAt: '2025-01-02T00:00:00.000Z',
+      })
+    );
+
+    await attachStoredCookieConsent('user-1');
+
+    expect(recordReacceptanceMock).not.toHaveBeenCalled();
+  });
+
+  it('replays the stored choice to the consent endpoint on first attach', async () => {
+    storeConsent(true);
+
+    await attachStoredCookieConsent('user-1');
+
+    expect(recordReacceptanceMock).toHaveBeenCalledTimes(1);
+    expect(recordReacceptanceMock).toHaveBeenCalledWith({
+      tosAccepted: true,
+      privacyAccepted: true,
+      cookiesVersion: CURRENT_VERSION,
+      analyticsConsent: true,
+    });
+  });
+
+  it('is idempotent for the same userId + cookiesVersion (no duplicate audit row)', async () => {
+    storeConsent(false);
+
+    await attachStoredCookieConsent('user-1');
+    await attachStoredCookieConsent('user-1');
+    await attachStoredCookieConsent('user-1');
+
+    expect(recordReacceptanceMock).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(ATTACHED_KEY)).toBe(`user-1::${CURRENT_VERSION}`);
+  });
+
+  it('attaches once per userId — a different userId on the same browser still gets one call', async () => {
+    storeConsent(true);
+
+    await attachStoredCookieConsent('user-1');
+    await attachStoredCookieConsent('user-2');
+
+    expect(recordReacceptanceMock).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.getItem(ATTACHED_KEY)).toBe(`user-2::${CURRENT_VERSION}`);
+  });
+
+  it('retries on the next call when the previous attach failed (no dedupe key written)', async () => {
+    storeConsent(true);
+    recordReacceptanceMock.mockRejectedValueOnce(new Error('network'));
+
+    await attachStoredCookieConsent('user-1');
+    expect(window.localStorage.getItem(ATTACHED_KEY)).toBeNull();
+
+    recordReacceptanceMock.mockResolvedValueOnce(undefined);
+    await attachStoredCookieConsent('user-1');
+
+    expect(recordReacceptanceMock).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.getItem(ATTACHED_KEY)).toBe(`user-1::${CURRENT_VERSION}`);
+  });
+
+  it('skips silently when fetching the cookies version fails', async () => {
+    storeConsent(true);
+    fetchCookiesVersionMock.mockRejectedValue(new Error('backend down'));
+
+    await attachStoredCookieConsent('user-1');
+
+    expect(recordReacceptanceMock).not.toHaveBeenCalled();
+  });
+});

--- a/lib.legal/src/services/attach-stored-consent.ts
+++ b/lib.legal/src/services/attach-stored-consent.ts
@@ -1,0 +1,83 @@
+import { fetchCookiesVersion, recordReacceptance } from './legal-service';
+import { readStoredConsent } from './cookie-consent-storage';
+
+/**
+ * ADS-497 (slice 5): replay an anonymous cookie-banner choice against
+ * the user's account on first sign-in.
+ *
+ * The cookie banner persists the user's choice to localStorage even when
+ * they're not signed in. When `auth_session_authenticated` fires for the
+ * first time per `(userId, cookiesVersion)`, we POST the stored choice
+ * to /api/v1/privacy/consent so the audit log captures the decision
+ * against the account.
+ *
+ * Idempotency: a second key `legal-consent-v1:attached` records the
+ * `userId,cookiesVersion` tuple last attached. Subsequent calls with the
+ * same tuple are no-ops, so calling this on every rehydrate (or both
+ * fresh login + rehydrate within one tab life) does not produce
+ * duplicate audit rows.
+ *
+ * Failures are swallowed so a transient network error here cannot break
+ * sign-in. The next session-authenticated event will retry the attach,
+ * because the dedupe key is only written on success.
+ */
+
+const ATTACHED_STORAGE_KEY = 'legal-consent-v1:attached';
+
+const safeReadAttachKey = (): string | null => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null;
+    }
+    return window.localStorage.getItem(ATTACHED_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const safeWriteAttachKey = (value: string): void => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+    window.localStorage.setItem(ATTACHED_STORAGE_KEY, value);
+  } catch {
+    // localStorage unavailable; without persistence we accept that the
+    // attach call may run again on the next session event. Better than
+    // refusing to attach at all.
+  }
+};
+
+const buildAttachKey = (userId: string, cookiesVersion: string): string =>
+  `${userId}::${cookiesVersion}`;
+
+export const attachStoredCookieConsent = async (userId: string): Promise<void> => {
+  let currentCookiesVersion: string;
+  try {
+    currentCookiesVersion = await fetchCookiesVersion();
+  } catch {
+    // Backend unreachable — silently skip; the next session-auth event
+    // will retry. Refusing to authenticate over a transient outage in
+    // an audit-replay path would be worse.
+    return;
+  }
+  const stored = readStoredConsent(currentCookiesVersion);
+  if (!stored) {
+    return;
+  }
+  const attachKey = buildAttachKey(userId, stored.cookiesVersion);
+  if (safeReadAttachKey() === attachKey) {
+    return;
+  }
+  try {
+    await recordReacceptance({
+      tosAccepted: true,
+      privacyAccepted: true,
+      cookiesVersion: stored.cookiesVersion,
+      analyticsConsent: stored.analyticsConsent,
+    });
+    safeWriteAttachKey(attachKey);
+  } catch {
+    // Leave the dedupe key un-set so the next session event retries.
+  }
+};

--- a/lib.legal/src/services/cookie-consent-storage.test.ts
+++ b/lib.legal/src/services/cookie-consent-storage.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  COOKIE_CONSENT_STORAGE_KEY,
+  clearStoredConsent,
+  readStoredConsent,
+  writeStoredConsent,
+} from './cookie-consent-storage';
+
+const CURRENT_VERSION = '2026-05-09-v1';
+
+describe('cookie-consent-storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns null when nothing has been written', () => {
+    expect(readStoredConsent(CURRENT_VERSION)).toBeNull();
+  });
+
+  it('round-trips a valid record', () => {
+    const record = {
+      cookiesVersion: CURRENT_VERSION,
+      analyticsConsent: true,
+      acceptedAt: '2026-05-10T09:00:00.000Z',
+    };
+    writeStoredConsent(record);
+
+    expect(readStoredConsent(CURRENT_VERSION)).toEqual(record);
+  });
+
+  it('returns null when the stored cookiesVersion does not match the current version (forces re-prompt on bump)', () => {
+    writeStoredConsent({
+      cookiesVersion: '2025-01-01-old',
+      analyticsConsent: true,
+      acceptedAt: '2025-01-02T00:00:00.000Z',
+    });
+
+    expect(readStoredConsent(CURRENT_VERSION)).toBeNull();
+  });
+
+  it('returns null when the stored value is not valid JSON', () => {
+    window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, 'not-json{');
+
+    expect(readStoredConsent(CURRENT_VERSION)).toBeNull();
+  });
+
+  it('returns null when the stored value fails schema validation (missing fields)', () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({ cookiesVersion: CURRENT_VERSION })
+    );
+
+    expect(readStoredConsent(CURRENT_VERSION)).toBeNull();
+  });
+
+  it('returns null when the stored value has wrong types (analyticsConsent as string)', () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: CURRENT_VERSION,
+        analyticsConsent: 'yes',
+        acceptedAt: '2026-05-10T09:00:00.000Z',
+      })
+    );
+
+    expect(readStoredConsent(CURRENT_VERSION)).toBeNull();
+  });
+
+  it('clears the record', () => {
+    writeStoredConsent({
+      cookiesVersion: CURRENT_VERSION,
+      analyticsConsent: false,
+      acceptedAt: '2026-05-10T09:00:00.000Z',
+    });
+    clearStoredConsent();
+
+    expect(readStoredConsent(CURRENT_VERSION)).toBeNull();
+  });
+});

--- a/lib.legal/src/services/cookie-consent-storage.ts
+++ b/lib.legal/src/services/cookie-consent-storage.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+
+/**
+ * ADS-497 (slice 5): localStorage persistence for the on-page cookie
+ * banner choice.
+ *
+ * The banner stores a single record describing the user's last decision
+ * for the current published cookies policy version. When the policy
+ * version changes (`COOKIES_VERSION` bumped server-side and surfaced via
+ * the backend response), `readStoredConsent` returns null so the banner
+ * re-prompts. Anonymous users live entirely off this store; authenticated
+ * users additionally have their choice replayed to the consent endpoint
+ * via `attachStoredCookieConsent`.
+ *
+ * Schema-first via Zod so a malformed value (e.g. an older banner
+ * version, hand-edited storage) is treated the same as no decision.
+ */
+
+export const COOKIE_CONSENT_STORAGE_KEY = 'legal-consent-v1';
+
+export const StoredCookieConsentSchema = z.object({
+  cookiesVersion: z.string().min(1),
+  analyticsConsent: z.boolean(),
+  acceptedAt: z.string().min(1),
+});
+
+export type StoredCookieConsent = z.infer<typeof StoredCookieConsentSchema>;
+
+const safeReadRaw = (): string | null => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null;
+    }
+    return window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Returns the stored cookie-consent record only when it parses cleanly
+ * AND its `cookiesVersion` matches the caller's current version. Any
+ * mismatch — missing, malformed JSON, schema failure, or stale version —
+ * resolves to null so the caller treats the user as undecided and the
+ * banner re-prompts.
+ */
+export const readStoredConsent = (currentCookiesVersion: string): StoredCookieConsent | null => {
+  const raw = safeReadRaw();
+  if (!raw) {
+    return null;
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const result = StoredCookieConsentSchema.safeParse(parsedJson);
+  if (!result.success) {
+    return null;
+  }
+  if (result.data.cookiesVersion !== currentCookiesVersion) {
+    return null;
+  }
+  return result.data;
+};
+
+export const writeStoredConsent = (record: StoredCookieConsent): void => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+    window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(record));
+  } catch {
+    // localStorage unavailable (privacy mode, quota); fail silently.
+  }
+};
+
+export const clearStoredConsent = (): void => {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+    window.localStorage.removeItem(COOKIE_CONSENT_STORAGE_KEY);
+  } catch {
+    // localStorage unavailable; fail silently.
+  }
+};

--- a/lib.legal/src/services/legal-service.ts
+++ b/lib.legal/src/services/legal-service.ts
@@ -18,7 +18,7 @@ import { z } from 'zod';
  */
 
 export const PendingReacceptanceItemSchema = z.object({
-  documentType: z.enum(['terms', 'privacy']),
+  documentType: z.enum(['terms', 'privacy', 'cookies']),
   currentVersion: z.string(),
   lastAcceptedVersion: z.string().nullable(),
   lastAcceptedAt: z.string().nullable(),
@@ -46,8 +46,32 @@ export type RecordReacceptanceInput = {
    */
   tosVersion?: string;
   privacyVersion?: string;
+  /**
+   * ADS-497 (slice 5): cookies + analytics consent posted by the on-page
+   * cookie banner. `cookiesVersion` defaults to the backend's current
+   * COOKIES_VERSION when omitted; `analyticsConsent` is opt-in only.
+   */
+  cookiesVersion?: string;
+  analyticsConsent?: boolean;
 };
 
 export const recordReacceptance = async (input: RecordReacceptanceInput): Promise<void> => {
   await api.post('/api/v1/privacy/consent', input);
+};
+
+/**
+ * ADS-497 (slice 5): cookies-policy version snapshot for the on-page
+ * banner. Returns just the version string so a banner mount can be
+ * cheap; the full policy markdown is rendered on /cookies for users who
+ * click through.
+ */
+const CookiesDocumentResponseSchema = z.object({
+  data: z.object({
+    version: z.string().min(1),
+  }),
+});
+
+export const fetchCookiesVersion = async (): Promise<string> => {
+  const raw = await api.get<unknown>('/api/v1/legal/cookies');
+  return CookiesDocumentResponseSchema.parse(raw).data.version;
 };

--- a/lib.legal/vitest.config.ts
+++ b/lib.legal/vitest.config.ts
@@ -67,6 +67,10 @@ export default mergeConfig(
           __dirname,
           '../lib.components/src/theme.ts'
         ),
+        '@adopt-dont-shop/lib.observability': path.resolve(
+          __dirname,
+          '../lib.observability/src/index.ts'
+        ),
       },
     },
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -898,6 +898,7 @@
         "@adopt-dont-shop/lib.api": "*",
         "@adopt-dont-shop/lib.auth": "*",
         "@adopt-dont-shop/lib.components": "*",
+        "@adopt-dont-shop/lib.observability": "*",
         "@types/node": "^20.19.0",
         "@vanilla-extract/css": "^1.20.1",
         "react": "^19.0.0",

--- a/service.backend/src/__tests__/services/consent.service.test.ts
+++ b/service.backend/src/__tests__/services/consent.service.test.ts
@@ -27,7 +27,11 @@ vi.mock('../../models/EmailPreference', () => ({
 
 import { recordConsent } from '../../services/consent.service';
 import { captureRegistrationConsent } from '../../services/registration.service';
-import { PRIVACY_VERSION, TERMS_VERSION } from '../../services/legal-content.service';
+import {
+  COOKIES_VERSION,
+  PRIVACY_VERSION,
+  TERMS_VERSION,
+} from '../../services/legal-content.service';
 import { AuditLogService } from '../../services/auditLog.service';
 
 const ctx = { userId: 'user-abc', ip: '1.2.3.4', userAgent: 'test-agent/1.0' };
@@ -124,6 +128,61 @@ describe('consent.service — recordConsent', () => {
     );
 
     expect(result.tosVersion).toBeDefined();
+  });
+
+  it('records the active COOKIES_VERSION in the audit row by default', async () => {
+    const result = await recordConsent(
+      { tosAccepted: true, privacyAccepted: true, marketingConsent: false },
+      ctx
+    );
+
+    expect(result.cookiesVersion).toBe(COOKIES_VERSION);
+    const callArgs = (AuditLogService.log as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(callArgs.details.cookiesVersion).toBe(COOKIES_VERSION);
+  });
+
+  it('embeds analyticsConsent=false in the audit row when omitted (opt-in default)', async () => {
+    const result = await recordConsent(
+      { tosAccepted: true, privacyAccepted: true, marketingConsent: false },
+      ctx
+    );
+
+    expect(result.analyticsConsent).toBe(false);
+    const callArgs = (AuditLogService.log as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(callArgs.details.analyticsConsent).toBe(false);
+  });
+
+  it('embeds analyticsConsent=true in the audit row when explicitly granted', async () => {
+    const result = await recordConsent(
+      {
+        tosAccepted: true,
+        privacyAccepted: true,
+        marketingConsent: false,
+        analyticsConsent: true,
+      },
+      ctx
+    );
+
+    expect(result.analyticsConsent).toBe(true);
+    const callArgs = (AuditLogService.log as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(callArgs.details.analyticsConsent).toBe(true);
+  });
+
+  it('allows callers to override cookiesVersion (banner replays a prior choice)', async () => {
+    const result = await recordConsent(
+      {
+        tosAccepted: true,
+        privacyAccepted: true,
+        marketingConsent: false,
+        cookiesVersion: '2026-01-01-cookies-legacy',
+        analyticsConsent: true,
+      },
+      ctx
+    );
+
+    expect(result.cookiesVersion).toBe('2026-01-01-cookies-legacy');
+    const callArgs = (AuditLogService.log as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    expect(callArgs.details.cookiesVersion).toBe('2026-01-01-cookies-legacy');
   });
 });
 

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -2,11 +2,7 @@ import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import AuditLog from '../models/AuditLog';
 import User, { UserStatus, UserType } from '../models/User';
-import {
-  COOKIES_VERSION,
-  PRIVACY_VERSION,
-  TERMS_VERSION,
-} from '../services/legal-content.service';
+import { COOKIES_VERSION, PRIVACY_VERSION, TERMS_VERSION } from '../services/legal-content.service';
 
 /**
  * ADS-536: per-seed-run password.

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -2,7 +2,11 @@ import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import AuditLog from '../models/AuditLog';
 import User, { UserStatus, UserType } from '../models/User';
-import { PRIVACY_VERSION, TERMS_VERSION } from '../services/legal-content.service';
+import {
+  COOKIES_VERSION,
+  PRIVACY_VERSION,
+  TERMS_VERSION,
+} from '../services/legal-content.service';
 
 /**
  * ADS-536: per-seed-run password.
@@ -330,8 +334,11 @@ export async function seedUsers() {
 
   // Record consent acceptance for each seeded user so the
   // LegalReacceptanceModal in app.client (PR #420) doesn't fire for them
-  // in dev / E2E. Idempotent: skip if a CONSENT_RECORDED row already
-  // exists for this user. Audit logs are append-only, so we never update.
+  // in dev / E2E. Includes cookiesVersion since PR #419 widened the
+  // pending-reacceptance detection to cookies; without it, the modal
+  // would surface cookies for every seeded user and hard-block E2E.
+  // Idempotent: skip if a CONSENT_RECORDED row already exists for this
+  // user. Audit logs are append-only, so we never update.
   for (const userData of testUsers) {
     const existing = await AuditLog.findOne({
       where: { user: userData.userId, action: 'CONSENT_RECORDED' },
@@ -353,6 +360,8 @@ export async function seedUsers() {
         details: {
           tosVersion: TERMS_VERSION,
           privacyVersion: PRIVACY_VERSION,
+          cookiesVersion: COOKIES_VERSION,
+          analyticsConsent: false,
           acceptedAt: acceptedAt.toISOString(),
         },
       },

--- a/service.backend/src/services/consent.service.ts
+++ b/service.backend/src/services/consent.service.ts
@@ -1,13 +1,14 @@
 import { z } from 'zod';
 import EmailPreference, { EmailFrequency, NotificationType } from '../models/EmailPreference';
 import { AuditLogService } from './auditLog.service';
-import { PRIVACY_VERSION, TERMS_VERSION } from './legal-content.service';
+import { COOKIES_VERSION, PRIVACY_VERSION, TERMS_VERSION } from './legal-content.service';
 import { logger } from '../utils/logger';
 
 /**
  * ADS-496 / ADS-497: consent capture.
  *
- * Records two distinct consent decisions taken at registration:
+ * Records the consent decisions taken at registration and through the
+ * on-page cookie banner (slice 5):
  *
  *   1. ToS + Privacy Policy acceptance — required to create the account.
  *      Persisted as an immutable `CONSENT_RECORDED` AuditLog row capturing
@@ -21,8 +22,14 @@ import { logger } from '../utils/logger';
  *      preference rows are touched — the User.afterCreate hook leaves
  *      both types disabled by absence.
  *
- * The ToS/Privacy versions are pulled from `legal-content.service` so a
- * version bump in one place propagates to consent records, the public
+ *   3. Cookies / analytics — the on-page cookie banner posts the user's
+ *      `cookiesVersion` + `analyticsConsent` choice here. The cookies
+ *      version is recorded in the same audit row so `getPendingReacceptance`
+ *      can compare it to the currently published COOKIES_VERSION. Analytics
+ *      consent is opt-in only (default false).
+ *
+ * The ToS/Privacy/Cookies versions are pulled from `legal-content.service`
+ * so a version bump in one place propagates to consent records, the public
  * /legal endpoints, and the user-facing copy in lockstep.
  */
 
@@ -30,6 +37,12 @@ export const ConsentInputSchema = z.object({
   tosAccepted: z.boolean(),
   privacyAccepted: z.boolean(),
   marketingConsent: z.boolean().default(false),
+  // ADS-497 (slice 5): cookies + analytics consent captured by the
+  // on-page cookie banner. `cookiesVersion` defaults to the currently
+  // published COOKIES_VERSION when omitted (the normal path from the
+  // banner). `analyticsConsent` defaults to false — opt-in only.
+  cookiesVersion: z.string().optional(),
+  analyticsConsent: z.boolean().optional(),
   // Versions are normally inferred from the active legal-content
   // service; callers may override only when replaying historical
   // consent (e.g. data backfill scripts). Optional in the schema for
@@ -48,7 +61,9 @@ export type ConsentContext = {
 export type ConsentRecord = {
   tosVersion: string;
   privacyVersion: string;
+  cookiesVersion: string;
   marketingConsent: boolean;
+  analyticsConsent: boolean;
   acceptedAt: string;
 };
 
@@ -88,6 +103,8 @@ export const recordConsent = async (
 
   const tosVersion = input.tosVersion ?? TERMS_VERSION;
   const privacyVersion = input.privacyVersion ?? PRIVACY_VERSION;
+  const cookiesVersion = input.cookiesVersion ?? COOKIES_VERSION;
+  const analyticsConsent = input.analyticsConsent ?? false;
   const acceptedAt = new Date();
 
   await AuditLogService.log({
@@ -98,7 +115,9 @@ export const recordConsent = async (
     details: {
       tosVersion,
       privacyVersion,
+      cookiesVersion,
       marketingConsent: input.marketingConsent,
+      analyticsConsent,
       acceptedAt: acceptedAt.toISOString(),
     },
     ipAddress: context.ip ?? undefined,
@@ -110,7 +129,9 @@ export const recordConsent = async (
   return {
     tosVersion,
     privacyVersion,
+    cookiesVersion,
     marketingConsent: input.marketingConsent,
+    analyticsConsent,
     acceptedAt: acceptedAt.toISOString(),
   };
 };


### PR DESCRIPTION
## Summary

Slice 5 closes the loop opened by ADS-497 slices 1-4. After PRs #419/#426/#429 every authenticated user surfaced cookies as a pending re-acceptance because `consent.service` never persisted `cookiesVersion`. The on-page banner now captures the user's choice, persists it locally, and replays it against the user's account on first sign-in — which means cookies stops being pending naturally, without filtering it out at the modal level.

> **Live prod copy, no placeholders.** Every string in the banner is real, drafted from the cookies policy in `docs/legal/cookies.md` (sections 4-7). No TODO markers anywhere.

## Backend

- `consent.service.ts` — `ConsentInputSchema` widened with optional `cookiesVersion` + `analyticsConsent`. Audit row now records both. `cookiesVersion` defaults to current `COOKIES_VERSION`; `analyticsConsent` defaults to `false` (opt-in only). Route schema flows through automatically because `privacy.routes.ts` validates with `ConsentInputSchema` directly.
- No `getPendingReacceptance` change — the cookies-version comparison was already correct (PR #419). Existing `legal-content.test.ts` already pins the "older cookies version → cookies pending" behaviour, so no new test there.

## Frontend (`lib.legal`)

- **`CookieBanner.tsx` + `.css.ts`** — bottom-anchored bar (NOT a modal — page underneath stays usable). Three primary actions:
  - "Accept all" (analytics ON)
  - "Essentials only" (analytics OFF)
  - "Manage preferences" (disclosure with per-category toggles)
  - Categories: **Strictly necessary** (always on, no toggle) and **Analytics** (toggleable, default off). No Marketing / Functional categories — they're not in the policy.
- **`cookie-consent-storage.ts`** — Zod-validated localStorage under `legal-consent-v1`. Schema:
  ```ts
  { cookiesVersion: string; analyticsConsent: boolean; acceptedAt: string /* ISO */ }
  ```
  Reads return `null` on missing/malformed JSON/schema-fail/version-mismatch so a future `COOKIES_VERSION` bump auto-re-prompts.
- **`attach-stored-consent.ts`** — replays an anonymous choice against the user's account on `auth_session_authenticated`. Deduped per `(userId, cookiesVersion)` via a separate `legal-consent-v1:attached` key, so calling on every rehydrate is safe.
- **`useCookieConsent()` hook** — exposes `{ analyticsConsent, hasDecided, openPreferences }` for slice 5b's footer link. `openPreferences` clears the stored record and dispatches a synthetic event so the banner re-shows without a page reload.
- Banner flips `lib.observability/setAnalyticsConsent` so Sentry + Statsig respect the choice on the same tab without reload.
- Authenticated users: banner additionally POSTs `{ tosAccepted: true, privacyAccepted: true, cookiesVersion, analyticsConsent }` to `/api/v1/privacy/consent` so the audit log captures the choice. Anonymous users only persist locally.
- Knock-on: `LegalReacceptanceModal` now accepts `'cookies'` as a `documentType` (required because `PendingReacceptanceItemSchema` was widened) — added a `cookies` entry to the LABELS map. The modal will only ever show cookies in pending for users who never used the banner, which is the correct degenerate case (per the brief: don't filter, fix the capture path).

## Sign-in attach

Each app calls `attachStoredCookieConsent(userId)` from its own `onAuthEvent` handler — `lib.legal` is NOT added as a dep of `lib.auth` (would invert the boundary). Implementation lives in:
- `app.client/src/components/AppWithAuth.tsx`
- `app.admin/src/main.tsx` (admin wires `AuthProvider` directly in main.tsx)
- `app.rescue/src/components/AppWithAuth.tsx`

## Mount points

`<CookieBanner />` mounted before `<LegalReacceptanceModal />` in every app's JSX so the modal stacks on top in the rare case both surface. `app.admin` also mounts the banner on the public/login branch so first-visit anonymous admins decide too.

## Test counts (before → after)

| Package | Before | After | Notes |
|---|---|---|---|
| `lib.legal` | 4 | 28 | Banner + storage + attach helper, plus schema rejection cases |
| `service.backend` | 2114 | 2118 | 4 new cookies/analytics audit-row tests in `consent.service.test.ts` |
| `app.client` | 213 | 214 | One smoke test for banner mount |
| `app.admin` | 263 | 265 | Two smoke tests (auth + public branch banner mount) |
| `app.rescue` | 124 | 125 | One smoke test for banner mount |

`npx turbo lint test type-check --filter` passes cleanly for all five affected packages.

## Files added

```
lib.legal/src/components/CookieBanner.css.ts
lib.legal/src/components/CookieBanner.test.tsx
lib.legal/src/components/CookieBanner.tsx
lib.legal/src/services/attach-stored-consent.test.ts
lib.legal/src/services/attach-stored-consent.ts
lib.legal/src/services/cookie-consent-storage.test.ts
lib.legal/src/services/cookie-consent-storage.ts
```

## localStorage schema

```ts
// Key: legal-consent-v1
{
  cookiesVersion: string;     // matches backend COOKIES_VERSION; mismatch → re-prompt
  analyticsConsent: boolean;  // opt-in only
  acceptedAt: string;         // ISO timestamp
}

// Key: legal-consent-v1:attached
"<userId>::<cookiesVersion>"  // dedupe key for sign-in attach
```

## Open questions (deferred)

1. Should "Essentials only" (analytics off) record `analyticsConsent: false` to the backend immediately for authenticated users, or only when the user explicitly opens preferences and toggles? **Default in this PR: yes, record explicitly, so the user's choice is durable.**
2. After a `COOKIES_VERSION` bump, does the analytics gate immediately revert to "off" (forcing re-consent), or stay at the user's previous choice until they re-accept? **Default in this PR: revert to off — the bump implies the policy changed.**
3. Should anonymous users who accept analytics, then sign in, see their localStorage choice silently attached to the account? **Default in this PR: yes, that's the user's stated model.**
4. Does the backend's existing rate-limit on the consent endpoint allow the per-load attach call (e.g. on every page rehydrate)? Or do we need to dedupe on the frontend before posting? **Default in this PR: deduped on the frontend via the `(userId, cookiesVersion)` key — only ever one POST per browser per version.**

## Scope guards honoured

- No placeholder copy; real text drafted from `docs/legal/cookies.md`.
- Cookies policy doc is unchanged.
- No Marketing / Functional categories.
- No `/settings/cookies` page (slice 5b).
- `getPendingReacceptance` logic unchanged.
- No third-party cookie-consent libs introduced.
- Analytics toggle is OFF by default (opt-in).

## Test plan

- [ ] First-visit anonymous user on app.client: banner appears at the bottom, page underneath stays scrollable.
- [ ] "Accept all" → analytics gate flips to granted, banner disappears, refresh keeps it dismissed.
- [ ] "Essentials only" → analytics gate flips to denied, banner disappears.
- [ ] "Manage preferences" → analytics toggle defaults to OFF; check it then "Save preferences" → granted.
- [ ] Anonymous user accepts → signs up → audit log shows a `CONSENT_RECORDED` row with their cookiesVersion + analyticsConsent.
- [ ] Sign in twice in the same browser → only one audit row added (idempotent).
- [ ] Bump `COOKIES_VERSION` server-side → existing users' banners re-appear on next page load.
- [ ] Same flows in app.admin (login page + authenticated dashboard) and app.rescue.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_