### PR TITLE
chore(legal): CookieBanner a11y improvements + dev DB re-seed note

### DIFF
--- a/lib.legal/src/components/CookieBanner.test.tsx
+++ b/lib.legal/src/components/CookieBanner.test.tsx
@@ -223,4 +223,119 @@ describe('CookieBanner [ADS-497 slice 5]', () => {
     expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
     expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
   });
+
+  describe('accessibility', () => {
+    it('exposes the banner as a landmark region with an accessible name', async () => {
+      render(<CookieBanner />);
+
+      const region = await screen.findByRole('region', { name: /cookie preferences/i });
+      expect(region).toBe(screen.getByTestId('cookie-banner'));
+    });
+
+    it('gives every action button a non-empty accessible name', async () => {
+      render(<CookieBanner />);
+
+      expect(await screen.findByRole('button', { name: /accept all/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /essentials only/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /manage preferences/i })).toBeInTheDocument();
+    });
+
+    it('does not auto-focus the banner on mount (page underneath stays usable)', async () => {
+      render(<CookieBanner />);
+
+      const banner = await screen.findByTestId('cookie-banner');
+      expect(banner).not.toContainElement(document.activeElement);
+      expect(document.activeElement).toBe(document.body);
+    });
+
+    it('tabs through Accept all → Essentials only → Manage preferences (collapsed state)', async () => {
+      const user = userEvent.setup();
+      render(<CookieBanner />);
+
+      // Seed focus on the first action so we can deterministically Tab forward
+      // past it (the description contains a focusable cookies-policy link that
+      // sits earlier in DOM order).
+      const acceptAll = await screen.findByRole('button', { name: /accept all/i });
+      acceptAll.focus();
+      expect(acceptAll).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: /essentials only/i })).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: /manage preferences/i })).toHaveFocus();
+    });
+
+    it('extends tab order into Analytics toggle → Save preferences when disclosure is expanded', async () => {
+      const user = userEvent.setup();
+      render(<CookieBanner />);
+
+      const manage = await screen.findByRole('button', { name: /manage preferences/i });
+      await user.click(manage);
+      // Seed focus at the disclosure trigger so we can step forward into the
+      // newly-visible disclosure controls deterministically.
+      const trigger = screen.getByRole('button', { name: /hide preferences/i });
+      trigger.focus();
+
+      await user.tab(); // → Analytics toggle
+      expect(screen.getByTestId('cookie-banner-analytics-toggle')).toHaveFocus();
+
+      await user.tab(); // → Save preferences
+      expect(screen.getByRole('button', { name: /save preferences/i })).toHaveFocus();
+    });
+
+    it('exposes aria-expanded + aria-controls on the disclosure trigger and toggles them', async () => {
+      const user = userEvent.setup();
+      render(<CookieBanner />);
+
+      const manage = await screen.findByRole('button', { name: /manage preferences/i });
+      expect(manage).toHaveAttribute('aria-expanded', 'false');
+      const controlsId = manage.getAttribute('aria-controls');
+      expect(controlsId).toBeTruthy();
+
+      await user.click(manage);
+      expect(manage).toHaveAttribute('aria-expanded', 'true');
+      expect(controlsId !== null && document.getElementById(controlsId)).toBeTruthy();
+    });
+
+    it('toggles the analytics checkbox via Space when keyboard-focused', async () => {
+      const user = userEvent.setup();
+      render(<CookieBanner />);
+
+      await user.click(await screen.findByRole('button', { name: /manage preferences/i }));
+      const toggle = await screen.findByTestId('cookie-banner-analytics-toggle');
+      toggle.focus();
+      expect(toggle).not.toBeChecked();
+
+      await user.keyboard(' ');
+      expect(toggle).toBeChecked();
+
+      await user.keyboard(' ');
+      expect(toggle).not.toBeChecked();
+    });
+
+    it('uses an associated label so the analytics toggle has an accessible name', async () => {
+      const user = userEvent.setup();
+      render(<CookieBanner />);
+
+      await user.click(await screen.findByRole('button', { name: /manage preferences/i }));
+      const toggle = await screen.findByRole('checkbox', { name: /analytics/i });
+      expect(toggle).toBe(screen.getByTestId('cookie-banner-analytics-toggle'));
+    });
+
+    it('closes the disclosure on Escape and returns focus to the trigger', async () => {
+      const user = userEvent.setup();
+      render(<CookieBanner />);
+
+      const manage = await screen.findByRole('button', { name: /manage preferences/i });
+      await user.click(manage);
+      const toggle = await screen.findByTestId('cookie-banner-analytics-toggle');
+      toggle.focus();
+
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByTestId('cookie-banner-analytics-toggle')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /manage preferences/i })).toHaveFocus();
+    });
+  });
 });

--- a/lib.legal/src/components/CookieBanner.tsx
+++ b/lib.legal/src/components/CookieBanner.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { setAnalyticsConsent } from '@adopt-dont-shop/lib.observability';
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react';
 import { fetchCookiesVersion, recordReacceptance } from '../services/legal-service';
 import {
   readStoredConsent,
@@ -55,6 +55,9 @@ export const CookieBanner = () => {
   const [hasDecided, setHasDecided] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
   const [analyticsToggle, setAnalyticsToggle] = useState(false);
+  const detailsId = useId();
+  const analyticsLabelId = useId();
+  const manageButtonRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -129,10 +132,22 @@ export const CookieBanner = () => {
     return null;
   }
 
+  // Escape inside the expanded "Manage preferences" disclosure closes it
+  // and returns focus to the trigger. Banner is otherwise non-blocking, so
+  // Escape outside the disclosure does nothing.
+  const handleDisclosureKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key !== 'Escape') {
+      return;
+    }
+    event.stopPropagation();
+    setShowDetails(false);
+    manageButtonRef.current?.focus();
+  };
+
   return (
     <div
       role='region'
-      aria-label='Cookie consent'
+      aria-label='Cookie preferences'
       className={styles.banner}
       data-testid='cookie-banner'
     >
@@ -149,8 +164,38 @@ export const CookieBanner = () => {
         </p>
       </div>
 
+      <div className={styles.actionRow}>
+        <Button
+          variant='primary'
+          onClick={() => void persistChoice(true)}
+          disabled={status === 'submitting'}
+          data-testid='cookie-banner-accept-all'
+        >
+          Accept all
+        </Button>
+        <Button
+          variant='secondary'
+          onClick={() => void persistChoice(false)}
+          disabled={status === 'submitting'}
+          data-testid='cookie-banner-essentials-only'
+        >
+          Essentials only
+        </Button>
+        <Button
+          ref={manageButtonRef}
+          variant='outline'
+          onClick={() => setShowDetails(prev => !prev)}
+          disabled={status === 'submitting'}
+          aria-expanded={showDetails}
+          aria-controls={detailsId}
+          data-testid='cookie-banner-manage-preferences'
+        >
+          {showDetails ? 'Hide preferences' : 'Manage preferences'}
+        </Button>
+      </div>
+
       {showDetails && (
-        <div className={styles.detailsBlock}>
+        <div id={detailsId} className={styles.detailsBlock} onKeyDown={handleDisclosureKeyDown}>
           <div className={styles.categoryRow}>
             <span className={styles.categoryLabel}>
               Strictly necessary
@@ -170,11 +215,13 @@ export const CookieBanner = () => {
                 checked={analyticsToggle}
                 onChange={e => setAnalyticsToggle(e.target.checked)}
                 disabled={status === 'submitting'}
-                aria-label='Allow analytics cookies'
+                aria-labelledby={analyticsLabelId}
                 data-testid='cookie-banner-analytics-toggle'
               />
-              Analytics
-              <span className={styles.categoryMeta}>Optional</span>
+              <span id={analyticsLabelId}>
+                Analytics
+                <span className={styles.categoryMeta}>Optional</span>
+              </span>
             </label>
             <p className={styles.categoryDescription}>
               Helps us understand how the site is used so we can fix problems and improve features.
@@ -194,34 +241,6 @@ export const CookieBanner = () => {
           </div>
         </div>
       )}
-
-      <div className={styles.actionRow}>
-        <Button
-          variant='secondary'
-          onClick={() => void persistChoice(false)}
-          disabled={status === 'submitting'}
-          data-testid='cookie-banner-essentials-only'
-        >
-          Essentials only
-        </Button>
-        <Button
-          variant='outline'
-          onClick={() => setShowDetails(prev => !prev)}
-          disabled={status === 'submitting'}
-          aria-expanded={showDetails}
-          data-testid='cookie-banner-manage-preferences'
-        >
-          {showDetails ? 'Hide preferences' : 'Manage preferences'}
-        </Button>
-        <Button
-          variant='primary'
-          onClick={() => void persistChoice(true)}
-          disabled={status === 'submitting'}
-          data-testid='cookie-banner-accept-all'
-        >
-          Accept all
-        </Button>
-      </div>
     </div>
   );
 };

--- a/service.backend/src/seeders/README.md
+++ b/service.backend/src/seeders/README.md
@@ -179,6 +179,10 @@ If you get foreign key constraint errors:
 
 The seeders use `findOrCreate` to avoid duplicates, so they're safe to run multiple times. Initial seeding typically takes 10-30 seconds depending on your database.
 
+### Stale `CONSENT_RECORDED` rows after pulling main
+
+The user seeder writes a `CONSENT_RECORDED` audit row per seeded account, and that row now carries `cookiesVersion` and `analyticsConsent` fields (added with the cookies banner work). Because the seeder is idempotent — it skips users whose audit row already exists — running the demo/fixture seeders again is **not** enough to backfill those fields on a dev DB seeded before that change. The visible symptom is the cookies banner / re-acceptance modal showing for every seeded login. Wipe and re-seed the dev DB (`npm run db:reset`) to pick up the current consent fields.
+
 ## Production Safety
 
 ⚠️ **Important**: These seeders are designed for development only. Do not run in production environments. The clear function truncates tables and should never be used with production data.


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #430.

**1. CookieBanner accessibility (`lib.legal/src/components/CookieBanner.tsx`)**

- Landmark accessible name renamed from "Cookie consent" to **"Cookie preferences"** so the role announcement matches the wider product copy.
- Action row reordered so the natural Tab order is **Accept all → Essentials only → Manage preferences**, and the disclosure block is now rendered after the action row so expanding it extends the same forward Tab path into **Analytics toggle → Save preferences**.
- Disclosure trigger gets `aria-controls` pointing at the (now `id`'d) details panel, alongside the existing `aria-expanded`.
- Analytics checkbox now uses `aria-labelledby` pointing at a span containing the visible "Analytics / Optional" text — the redundant `aria-label='Allow analytics cookies'` is gone, so screen readers announce what they see.
- **Escape inside the expanded disclosure** closes it and returns focus to the "Manage preferences" trigger. The banner is otherwise non-blocking — Escape outside the disclosure does nothing and we deliberately do **not** auto-focus the banner on mount (the page underneath stays usable).
- No focus trap, no axe-core dep, no visual restyle — only DOM / ARIA / keyboard.

**2. Dev DB drift note (`service.backend/src/seeders/README.md`)**

- Adds one paragraph under "Troubleshooting → Performance" explaining that `04-users.ts` writes a `CONSENT_RECORDED` audit row per user and is idempotent, so dev DBs seeded before the cookies-banner work have audit rows missing `cookiesVersion` / `analyticsConsent`. A plain `npm run db:seed` skips those rows — `npm run db:reset` is the fix.

## Test plan

- [x] `npx turbo test type-check lint --filter=@adopt-dont-shop/lib.legal` — 9/9 tasks green, 37/37 vitest cases pass (CookieBanner suite went from 10 → 19, +9 new a11y cases).
- [x] New cases verify: landmark `role='region'` + accessible name, button accessible names, no auto-focus on mount, collapsed Tab order, expanded Tab order, `aria-expanded` + `aria-controls` toggling, Space-toggling the analytics checkbox, label association on the toggle, Escape closes the disclosure and restores focus to the trigger.
- [ ] Manual smoke with NVDA / VoiceOver in a follow-up if reviewers want it — the keyboard + ARIA shape is what's asserted here.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_