### PR TITLE
feat(legal): update DPO contact domain to adoptdontshop.app and reclassify Sentry as strictly necessary

### DIFF
--- a/docs/legal/cookies.md
+++ b/docs/legal/cookies.md
@@ -1,7 +1,7 @@
 # Cookies Policy
 
-**Version:** 2026-05-09-v1
-**Last updated:** 9 May 2026
+**Version:** 2026-05-10-v1
+**Last updated:** 10 May 2026
 
 This policy explains how Adopt Don't Shop uses cookies and similar
 technologies on our websites and apps. It sits alongside the
@@ -11,7 +11,7 @@ technologies on our websites and apps. It sits alongside the
 
 Adopt Don't Shop is the data controller for the cookies described in
 this notice. Contact our Data Protection Officer at
-privacy@adoptdontshop.example.
+privacy@adoptdontshop.app.
 
 ## 2. What cookies are
 
@@ -54,20 +54,30 @@ JavaScript and are never sent on cross-site requests.
 
 ## 5. Analytics, performance, and error monitoring
 
-We use **Statsig** for product analytics, feature experimentation, and
-optional session replay, and **Sentry** for error and performance
-monitoring. Both are loaded only after you grant analytics consent
-through the on-site banner.
+We use **Sentry** for error and performance monitoring, and **Statsig**
+for product analytics, feature experimentation, and optional session
+replay.
 
-Statsig stores its identifiers in your browser's `localStorage` rather
-than in a cookie; Sentry transmits events over HTTPS without setting
-cookies. Neither tool runs before consent is granted, and no
-identifiable data is sent to either tool while consent is denied or
-unknown.
+**Sentry is strictly necessary for service reliability** and runs
+unconditionally — it captures unhandled errors and performance traces
+so we can detect and fix outages, regressions, and security issues
+that affect every user of the platform. We rely on this under PECR
+reg. 6(4) (information society service requested by the user) and on
+our legitimate interest in keeping the platform secure and available
+under UK GDPR Art. 6(1)(f). Sentry transmits events over HTTPS without
+setting cookies and we do not send identifiable profile data to it.
 
-If consent is later withdrawn, the third-party SDKs stop on your next
-page load and the local identifiers can be cleared from your browser's
-site-data settings.
+**Statsig is loaded only after you grant analytics consent** through
+the on-site banner. Until consent is granted, Statsig is not
+initialised with auto-capture or session replay and no behavioural
+data leaves your device. Statsig stores its identifiers in your
+browser's `localStorage` rather than in a cookie.
+
+If analytics consent is later withdrawn, Statsig auto-capture and
+session replay stop on your next page load and the local identifiers
+can be cleared from your browser's site-data settings. Sentry
+continues to run because it is not part of the analytics consent
+scope.
 
 ## 6. Marketing and advertising
 
@@ -89,7 +99,7 @@ You can manage cookies in two ways:
 
 The on-site cookie banner is being rolled out; until it is live in
 your app, withdraw analytics consent by clearing site data for
-`adoptdontshop.example` in your browser's settings. The strictly
+`adoptdontshop.app` in your browser's settings. The strictly
 necessary cookies are unaffected by analytics consent.
 
 ## 8. Your rights
@@ -108,4 +118,4 @@ notified through the in-app re-acceptance flow on next sign-in.
 
 ## 10. Contact
 
-Questions about cookies or this policy: privacy@adoptdontshop.example.
+Questions about cookies or this policy: privacy@adoptdontshop.app.

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,7 +1,7 @@
 # Privacy Policy
 
-**Version:** 2026-05-08-v1
-**Last updated:** 8 May 2026
+**Version:** 2026-05-10-v1
+**Last updated:** 10 May 2026
 
 > Placeholder copy — must be reviewed and approved by legal counsel before
 > production launch. The version string above is the canonical
@@ -11,7 +11,7 @@
 
 Adopt Don't Shop is the data controller for the personal data described
 in this notice. Contact our Data Protection Officer at
-privacy@adoptdontshop.example.
+privacy@adoptdontshop.app.
 
 ## 2. What we collect
 
@@ -36,7 +36,7 @@ You may at any time:
   `POST /api/v1/privacy/me/delete`. Hard deletion follows after a
   30-day grace window in line with our retention policy.
 - **Object** to processing or **restrict** processing by emailing
-  privacy@adoptdontshop.example.
+  privacy@adoptdontshop.app.
 
 ## 5. Retention
 

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,7 +1,7 @@
 # Terms of Service
 
-**Version:** 2026-05-08-v1
-**Last updated:** 8 May 2026
+**Version:** 2026-05-10-v1
+**Last updated:** 10 May 2026
 
 > Placeholder copy — must be reviewed and approved by legal counsel before
 > production launch. The version string above is the canonical
@@ -50,4 +50,4 @@ re-acceptance on next sign-in.
 
 ## 8. Contact
 
-Questions about these terms: legal@adoptdontshop.example.
+Questions about these terms: legal@adoptdontshop.app.

--- a/lib.observability/src/consent.test.ts
+++ b/lib.observability/src/consent.test.ts
@@ -5,6 +5,18 @@ import {
   setAnalyticsConsent,
   subscribeToAnalyticsConsent,
 } from './consent';
+import { initSentry } from './sentry';
+
+// Mock @sentry/react so we can observe whether `Sentry.init` was called.
+// vi.spyOn cannot rebind ESM module namespaces; vi.mock must be used and
+// any spy referenced inside the factory has to come from vi.hoisted so
+// it's available at the (hoisted) mock-evaluation time.
+const { sentryInitSpy } = vi.hoisted(() => ({ sentryInitSpy: vi.fn() }));
+vi.mock('@sentry/react', () => ({
+  init: sentryInitSpy,
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
 
 const memoryStore = (): Storage => {
   const map = new Map<string, string>();
@@ -68,5 +80,44 @@ describe('analytics consent', () => {
     unsubscribe();
     setAnalyticsConsent('granted');
     expect(listener).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Sentry init bypasses the analytics consent gate', () => {
+  // Sentry is classified as strictly necessary for service reliability
+  // (cookies policy §5). It must initialise regardless of the analytics
+  // consent state — these tests pin that contract so a future refactor
+  // can't silently re-introduce a consent gate.
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: memoryStore(),
+      configurable: true,
+    });
+    sentryInitSpy.mockReset();
+  });
+
+  it('initialises Sentry when analytics consent has never been granted', () => {
+    expect(hasAnalyticsConsent()).toBe(false);
+
+    initSentry({
+      dsn: 'https://public@sentry.example/1',
+      appName: 'admin',
+      environment: 'production',
+    });
+
+    expect(sentryInitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('initialises Sentry even when analytics consent is explicitly denied', () => {
+    setAnalyticsConsent('denied');
+    expect(hasAnalyticsConsent()).toBe(false);
+
+    initSentry({
+      dsn: 'https://public@sentry.example/1',
+      appName: 'client',
+      environment: 'production',
+    });
+
+    expect(sentryInitSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib.observability/src/consent.ts
+++ b/lib.observability/src/consent.ts
@@ -1,12 +1,18 @@
 /**
  * Minimal analytics consent gate. Persists a boolean in localStorage so
- * Statsig session-replay / auto-capture / web-vitals reporting can be
- * gated behind explicit opt-in (PECR / GDPR).
+ * Statsig session-replay / auto-capture can be gated behind explicit
+ * opt-in (PECR / GDPR).
+ *
+ * Scope: this gate is for analytics SDKs only. Sentry is classified as
+ * strictly necessary for service reliability (see docs/legal/cookies.md
+ * §5) and runs unconditionally — callers must NOT consult this gate
+ * before calling `initSentry`.
  *
  * The full consent banner UI is intentionally out of scope here — this
  * module just provides the storage primitive. Callers (apps) own the
  * banner. Until consent is granted, hasAnalyticsConsent() returns false
- * and analytics SDKs should not initialise.
+ * and analytics SDKs (Statsig auto-capture, session replay) should not
+ * initialise.
  */
 export const ANALYTICS_CONSENT_STORAGE_KEY = 'ads:analytics-consent';
 

--- a/lib.observability/src/sentry.ts
+++ b/lib.observability/src/sentry.ts
@@ -21,6 +21,12 @@ export type SentryInitOptions = {
  * Initialise Sentry for a frontend app. Safe to call when DSN is empty —
  * it just logs a warning and skips, so dev/local builds without a DSN
  * don't crash.
+ *
+ * Sentry is strictly necessary for service reliability and is NOT gated
+ * on analytics consent. Do not consult `hasAnalyticsConsent()` before
+ * calling this — see docs/legal/cookies.md §5 and consent.ts for the
+ * scope rules. Replay sample rates default to 0 here so identifiable
+ * session content stays off until callers explicitly opt in.
  */
 export const initSentry = (options: SentryInitOptions): void => {
   const {

--- a/service.backend/src/services/legal-content.service.ts
+++ b/service.backend/src/services/legal-content.service.ts
@@ -17,9 +17,9 @@ import AuditLog from '../models/AuditLog';
  *      email notification are tracked in follow-up ADS-497 slices.
  */
 
-export const TERMS_VERSION = '2026-05-08-v1';
-export const PRIVACY_VERSION = '2026-05-08-v1';
-export const COOKIES_VERSION = '2026-05-09-v1';
+export const TERMS_VERSION = '2026-05-10-v1';
+export const PRIVACY_VERSION = '2026-05-10-v1';
+export const COOKIES_VERSION = '2026-05-10-v1';
 
 const DOCS_DIR = path.resolve(__dirname, '..', '..', '..', 'docs', 'legal');
 


### PR DESCRIPTION
## Summary

Follow-up to merged #426 / #430. Two confirmed live-content changes:

- **DPO contact domain.** Replace the `adoptdontshop.example` placeholder used in the published legal contact addresses with the production domain `adoptdontshop.app` across `cookies.md`, `privacy.md`, `terms.md`. The deploy-guide example domain in `docs/operations/deploy.md` (an nginx config placeholder, not legal contact text) is intentionally left untouched.
- **Sentry reclassified as strictly necessary.** Cookies policy §5 used to describe Sentry as "loaded only after you grant analytics consent through the on-site banner." That was wrong — Sentry has always initialised unconditionally in `lib.observability` and the apps (no consent gate exists in code today). The prose now matches reality: Sentry is strictly necessary for service reliability under PECR reg. 6(4) + UK GDPR Art. 6(1)(f) and runs regardless of analytics consent. Statsig stays analytics-consent-gated via the existing `StatsigContext` (untouched).

> [!IMPORTANT]
> **This bumps `COOKIES_VERSION` to `2026-05-10-v1` so every existing user will re-banner / re-accept on next load.** That is the intended effect of a material content change to the cookies policy. The cookies banner from #430 already handles this via the `cookiesVersion` mismatch check in `readStoredConsent`; the re-acceptance modal handles it via `getPendingReacceptance`.

`TERMS_VERSION` and `PRIVACY_VERSION` are also bumped to `2026-05-10-v1` because the DPO email is published in the user-facing markdown of those documents — bumping is consistent with the policy's "version string above identifies the version each user accepted" guarantee.

### Files changed

- `docs/legal/cookies.md` — DPO email (3x), version line, last-updated, §5 prose rewrite (Sentry strictly necessary; Statsig still consent-gated). Cookie inventory table left untouched.
- `docs/legal/privacy.md` — DPO email (2x), version line, last-updated.
- `docs/legal/terms.md` — `legal@` email, version line, last-updated.
- `service.backend/src/services/legal-content.service.ts` — `TERMS_VERSION`, `PRIVACY_VERSION`, `COOKIES_VERSION` all bumped to `2026-05-10-v1`.
- `lib.observability/src/consent.ts` — docstring clarifies the gate is for analytics SDKs only; Sentry must NOT consult it.
- `lib.observability/src/sentry.ts` — docstring states `initSentry` is not consent-gated and points readers at the cookies policy + `consent.ts`.
- `lib.observability/src/consent.test.ts` — adds two behaviour tests pinning the contract: Sentry initialises (a) when consent has never been granted and (b) when consent is explicitly denied.

### What stayed gated

- **Statsig auto-capture + session replay** continue to gate on `hasAnalyticsConsent()` via `app.client/src/contexts/StatsigContext.tsx`. Not modified here.

### Open questions

- Confirm `adoptdontshop.app` is the right domain for `privacy@`, `support@`, `legal@`, and `dpo@` aliases (mailbox provisioning + MX setup is out of scope for this PR).

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/lib.observability` — 7/7 pass (5 existing analytics-consent + 2 new Sentry-bypass tests).
- [x] `vitest run` for backend legal suites: `legal-content.test.ts`, `legal-reminder.test.ts`, `legal-reminder-cron.test.ts`, `legal.routes.test.ts`, `admin-legal-reminder.routes.test.ts`, `consent.service.test.ts` — 58/58 pass.
- [x] `npx turbo lint --filter=@adopt-dont-shop/lib.observability --filter=@adopt-dont-shop/service-backend` — 0 errors (pre-existing warnings only).
- [x] `tsc --noEmit` clean for both packages.
- [ ] Manual smoke once merged: existing logged-in user sees the cookies banner (or re-acceptance modal in admin/rescue) on next load due to the `COOKIES_VERSION` bump.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_