### PR TITLE
chore(test): re-ratchet backend coverage thresholds after ADS-497 slices 3-5

### DIFF
--- a/service.backend/vitest.config.ts
+++ b/service.backend/vitest.config.ts
@@ -48,11 +48,12 @@ export default defineConfig({
       // Run via `npm run test:coverage`; the default `npm test` skips
       // coverage to keep watch-mode fast.
       // Re-baselined post-ADS-417/490 to L=41/S=41/F=49/B=34
+      // Re-ratcheted post-ADS-497 slices 3-5 to L=43/S=43/F=52/B=35
       thresholds: {
-        lines: 41,
-        statements: 41,
-        functions: 49,
-        branches: 34,
+        lines: 43,
+        statements: 43,
+        functions: 52,
+        branches: 35,
       },
     },
 


### PR DESCRIPTION
## Summary

Re-ratcheting `service.backend/vitest.config.ts` coverage thresholds upward to reflect the new test surface added since the previous ratchet (PR #416, post-ADS-417/490). Per the in-file ratchet rule (each PR adding tests should ratchet up, never down), set each threshold to `floor(actual - 1)`.

### Measured actual coverage

Run: `npx vitest run --coverage` from `service.backend/` (2114 passed, 44 skipped):

| Metric     | Actual  |
|------------|---------|
| Lines      | 44.93%  |
| Statements | 44.88%  |
| Functions  | 53.56%  |
| Branches   | 36.49%  |

### Threshold changes (old -> new)

| Metric     | Old | New |
|------------|-----|-----|
| Lines      | 41  | 43  |
| Statements | 41  | 43  |
| Functions  | 49  | 52  |
| Branches   | 34  | 35  |

All new thresholds confirmed passing on a second `npx vitest run --coverage` invocation against the updated config.

### Driving PRs (since last ratchet)

- ADS-497 slice 3 (#424): legal-reminder.service + admin route tests
- ADS-497 slice 4 (#427): legal-reminder cron worker + CLI tests
- ADS-497 slice 5 (#430): lib.legal + service.backend consent.service tests
- #421: FileUpload.url migration #17 round-trip tests
- #426: cookies policy code surface
- Plus minor test adds across other PRs

## Test plan

- [x] `npx vitest run --coverage` in `service.backend/` -> all 2114 tests pass, no threshold violation
- [x] New thresholds are strictly higher than the previous values (41/41/49/34)
- [x] New thresholds are strictly below current actuals (44.93/44.88/53.56/36.49) so the gate isn't immediately broken

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_