### PR TITLE
feat(legal): "Manage cookies" footer link in app shells (ADS-497, slice 5b)

### DIFF
--- a/app.admin/src/components/layout/AdminLayout.css.ts
+++ b/app.admin/src/components/layout/AdminLayout.css.ts
@@ -32,3 +32,15 @@ export const contentWrapper = style({
     },
   },
 });
+
+// ADS-497 (slice 5b): minimal footer strip carrying the "Manage cookies"
+// link. Admin has no public legal-link footer today; this is the
+// smallest surface that keeps the cookies-policy promise of an on-page
+// withdrawal control.
+export const layoutFooter = style({
+  borderTop: '1px solid #e5e7eb',
+  padding: '0.75rem 2rem',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  background: '#ffffff',
+});

--- a/app.admin/src/components/layout/AdminLayout.test.tsx
+++ b/app.admin/src/components/layout/AdminLayout.test.tsx
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
+import { AdminLayout } from './AdminLayout';
+
+// AdminSidebar / AdminHeader pull in heavy auth + nav deps that aren't
+// relevant to the footer behaviour under test. Stub them.
+vi.mock('./AdminSidebar', () => ({
+  AdminSidebar: () => <aside data-testid='admin-sidebar' />,
+}));
+vi.mock('./AdminHeader', () => ({
+  AdminHeader: () => <header data-testid='admin-header' />,
+}));
+
+const renderLayout = () =>
+  render(
+    <MemoryRouter>
+      <AdminLayout>
+        <div>page-content</div>
+      </AdminLayout>
+    </MemoryRouter>
+  );
+
+describe('AdminLayout [ADS-497 slice 5b]', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders a "Manage cookies" footer link that clears the stored consent record on click', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2026-05-09-v1',
+        analyticsConsent: true,
+        acceptedAt: '2026-05-10T00:00:00.000Z',
+      })
+    );
+
+    renderLayout();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/app.admin/src/components/layout/AdminLayout.tsx
+++ b/app.admin/src/components/layout/AdminLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import { AdminSidebar } from './AdminSidebar';
 import { AdminHeader } from './AdminHeader';
 import * as styles from './AdminLayout.css';
@@ -20,6 +21,9 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
       <main className={styles.mainContent({ sidebarCollapsed })}>
         <AdminHeader sidebarCollapsed={sidebarCollapsed} />
         <div className={styles.contentWrapper}>{children}</div>
+        <footer className={styles.layoutFooter}>
+          <ManageCookiesLink />
+        </footer>
       </main>
     </div>
   );

--- a/app.client/src/components/layout/AppShell.test.tsx
+++ b/app.client/src/components/layout/AppShell.test.tsx
@@ -1,8 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
 import { AppShell } from './AppShell';
 
 vi.mock('@adopt-dont-shop/lib.auth', async () => {
@@ -54,6 +56,10 @@ const renderShell = () =>
   );
 
 describe('AppShell', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('renders the app navbar logo', () => {
     renderShell();
     expect(screen.getByRole('link', { name: /adopt don't shop/i })).toBeInTheDocument();
@@ -67,5 +73,21 @@ describe('AppShell', () => {
   it('renders the floating swipe button', () => {
     renderShell();
     expect(screen.getByTestId('swipe-fab')).toBeInTheDocument();
+  });
+
+  it('clears the stored consent record when the footer "Manage cookies" link is clicked', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2026-05-09-v1',
+        analyticsConsent: true,
+        acceptedAt: '2026-05-10T00:00:00.000Z',
+      })
+    );
+    renderShell();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
   });
 });

--- a/app.client/src/components/layout/AppShell.tsx
+++ b/app.client/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Footer } from '@adopt-dont-shop/lib.components';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import { AppNavbar } from '@/components/navigation/AppNavbar';
 import { BottomTabBar } from '@/components/navigation/BottomTabBar';
 import { SwipeOnboarding } from '@/components/onboarding/SwipeOnboarding';
@@ -19,7 +20,7 @@ export const AppShell: React.FC = () => {
       <SwipeFloatingButton />
       <BottomTabBar />
       {showOnboarding && <SwipeOnboarding onClose={() => setShowOnboarding(false)} />}
-      <Footer />
+      <Footer extraLinks={<ManageCookiesLink />} />
     </div>
   );
 };

--- a/app.client/src/setup-tests.ts
+++ b/app.client/src/setup-tests.ts
@@ -125,8 +125,12 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
         onFilesSelect?.(files);
       },
     }),
-  Footer: ({ children, ...props }: React.ComponentPropsWithoutRef<'footer'>) =>
-    React.createElement('footer', props, children),
+  Footer: ({
+    children,
+    extraLinks,
+    ...props
+  }: React.ComponentPropsWithoutRef<'footer'> & { extraLinks?: React.ReactNode }) =>
+    React.createElement('footer', props, children, extraLinks),
   TextInput: ({
     label,
     id,

--- a/app.rescue/src/components/shared/Layout.css.ts
+++ b/app.rescue/src/components/shared/Layout.css.ts
@@ -7,8 +7,27 @@ export const appLayout = style({
   background: vars.background.primary,
 });
 
+export const mainColumn = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '100vh',
+});
+
 export const mainContent = style({
   flex: 1,
   overflow: 'auto',
   padding: '2rem',
+});
+
+// ADS-497 (slice 5b): minimal footer strip carrying the "Manage cookies"
+// link. Rescue has no public legal-link footer today; this is the
+// smallest surface that keeps the cookies-policy promise of an on-page
+// withdrawal control.
+export const layoutFooter = style({
+  borderTop: `1px solid ${vars.border.color.primary}`,
+  padding: '0.75rem 2rem',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  background: vars.background.secondary,
 });

--- a/app.rescue/src/components/shared/Layout.test.tsx
+++ b/app.rescue/src/components/shared/Layout.test.tsx
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
+import Layout from './Layout';
+
+// Navigation pulls in auth/chat contexts that aren't relevant to the
+// footer behaviour under test. Stub it.
+vi.mock('./Navigation', () => ({
+  default: () => <nav data-testid="rescue-navigation" />,
+}));
+
+const renderLayout = () =>
+  render(
+    <MemoryRouter>
+      <Layout>
+        <div>page-content</div>
+      </Layout>
+    </MemoryRouter>
+  );
+
+describe('Layout [ADS-497 slice 5b]', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders a "Manage cookies" footer link that clears the stored consent record on click', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2026-05-09-v1',
+        analyticsConsent: true,
+        acceptedAt: '2026-05-10T00:00:00.000Z',
+      })
+    );
+
+    renderLayout();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/app.rescue/src/components/shared/Layout.tsx
+++ b/app.rescue/src/components/shared/Layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import Navigation from './Navigation';
 import * as styles from './Layout.css';
 
@@ -10,7 +11,12 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
     <div className={styles.appLayout}>
       <Navigation />
-      <main className={styles.mainContent}>{children}</main>
+      <div className={styles.mainColumn}>
+        <main className={styles.mainContent}>{children}</main>
+        <footer className={styles.layoutFooter}>
+          <ManageCookiesLink />
+        </footer>
+      </div>
     </div>
   );
 };

--- a/lib.components/src/components/navigation/Footer/Footer.tsx
+++ b/lib.components/src/components/navigation/Footer/Footer.tsx
@@ -6,9 +6,15 @@ import { footer, footerContainer, footerText, footerLinks, footerLink } from './
 
 export interface FooterProps {
   className?: string;
+  /**
+   * Optional extra elements rendered inline at the end of the link row,
+   * after Contact. Use the exported `footerLink` class on any link-like
+   * element (e.g. a `<button>`) so it inherits the row's typography.
+   */
+  extraLinks?: React.ReactNode;
 }
 
-export const Footer: React.FC<FooterProps> = ({ className }) => {
+export const Footer: React.FC<FooterProps> = ({ className, extraLinks }) => {
   return (
     <footer className={clsx(footer, className)}>
       <div className={footerContainer}>
@@ -31,6 +37,7 @@ export const Footer: React.FC<FooterProps> = ({ className }) => {
           <Link to='/contact' className={footerLink}>
             Contact
           </Link>
+          {extraLinks}
         </div>
         <p className={footerText}>
           © {new Date().getFullYear()} Adopt Don&apos;t Shop. All rights reserved.

--- a/lib.legal/src/components/ManageCookiesLink.css.ts
+++ b/lib.legal/src/components/ManageCookiesLink.css.ts
@@ -1,0 +1,26 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+// Plain inline-link styling so the button sits naturally next to text
+// links like "Privacy" / "Terms" in a footer link row. No background,
+// no border, font matches surrounding link styles.
+export const link = style({
+  background: 'transparent',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+  color: vars.colors.neutral['700'],
+  fontSize: '0.875rem',
+  fontFamily: 'inherit',
+  textDecoration: 'none',
+  selectors: {
+    '&:hover': {
+      color: vars.colors.neutral['900'],
+      textDecoration: 'underline',
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${vars.colors.primary['600']}`,
+      outlineOffset: '2px',
+    },
+  },
+});

--- a/lib.legal/src/components/ManageCookiesLink.test.tsx
+++ b/lib.legal/src/components/ManageCookiesLink.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ManageCookiesLink } from './ManageCookiesLink';
+import {
+  COOKIE_CONSENT_STORAGE_KEY,
+  type StoredCookieConsent,
+} from '../services/cookie-consent-storage';
+
+const seedConsent = (record: StoredCookieConsent) => {
+  window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(record));
+};
+
+describe('ManageCookiesLink', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a button labelled "Manage cookies"', () => {
+    render(<ManageCookiesLink />);
+    expect(screen.getByRole('button', { name: 'Manage cookies' })).toBeInTheDocument();
+  });
+
+  it('clears the stored consent record when clicked', async () => {
+    seedConsent({
+      cookiesVersion: '2026-05-09-v1',
+      analyticsConsent: true,
+      acceptedAt: new Date().toISOString(),
+    });
+    render(<ManageCookiesLink />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
+  });
+
+  it('dispatches the legal-consent-v1:cleared event when clicked', async () => {
+    const handler = vi.fn();
+    window.addEventListener('legal-consent-v1:cleared', handler);
+
+    render(<ManageCookiesLink />);
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener('legal-consent-v1:cleared', handler);
+  });
+
+  it('forwards an additional className to the rendered button', () => {
+    render(<ManageCookiesLink className='my-footer-link' />);
+    expect(screen.getByRole('button', { name: 'Manage cookies' })).toHaveClass('my-footer-link');
+  });
+});

--- a/lib.legal/src/components/ManageCookiesLink.tsx
+++ b/lib.legal/src/components/ManageCookiesLink.tsx
@@ -1,0 +1,36 @@
+import { useCookieConsent } from './CookieBanner';
+import * as styles from './ManageCookiesLink.css';
+
+/**
+ * ADS-497 (slice 5b): footer link that re-opens the cookie banner.
+ *
+ * The cookies policy (`docs/legal/cookies.md`) tells users to use the
+ * on-page banner to withdraw or change their analytics consent. This
+ * button is the entry point: clicking it clears the stored consent
+ * record and dispatches the synthetic event that `CookieBanner` listens
+ * for, so the banner re-appears without a page reload.
+ *
+ * Rendered as a `<button>` (not an `<a>`) because it triggers in-page
+ * UI rather than navigating. Styled to look like an inline link so it
+ * sits naturally next to existing "Privacy" / "Terms" footer links.
+ */
+
+type ManageCookiesLinkProps = {
+  className?: string;
+};
+
+export const ManageCookiesLink = ({ className }: ManageCookiesLinkProps) => {
+  const { openPreferences } = useCookieConsent();
+  const composedClassName = className ? `${styles.link} ${className}` : styles.link;
+
+  return (
+    <button
+      type='button'
+      className={composedClassName}
+      onClick={openPreferences}
+      data-testid='manage-cookies-link'
+    >
+      Manage cookies
+    </button>
+  );
+};

--- a/lib.legal/src/index.ts
+++ b/lib.legal/src/index.ts
@@ -3,6 +3,7 @@
 // Components
 export { LegalReacceptanceModal } from './components/LegalReacceptanceModal';
 export { CookieBanner, useCookieConsent } from './components/CookieBanner';
+export { ManageCookiesLink } from './components/ManageCookiesLink';
 
 // Service / schemas
 export {


### PR DESCRIPTION
## Summary

Slice 5b, the follow-up to PR #430. The cookies policy (`docs/legal/cookies.md`) tells users to use the on-page banner to change or withdraw their analytics consent — but slice 5 only exposed `useCookieConsent().openPreferences()` as a hook, with no UI surface to call it. Until now the only way for a user to re-open the banner has been to clear localStorage manually.

This PR adds a "Manage cookies" link in the chrome of every app, wired straight to `openPreferences()`. Clicking it clears the stored consent record and dispatches the synthetic event the existing `CookieBanner` already listens for, so the banner re-appears without a page reload.

## Footer locations per app

| App | Where the link lives |
|---|---|
| `app.client` | Inside the existing shared `Footer` (`lib.components`) link row, after Contact. The Footer gained an optional `extraLinks` slot for this. |
| `app.admin` | New minimal `<footer>` strip at the bottom of `AdminLayout` (admin had no legal-link footer today). |
| `app.rescue` | New minimal `<footer>` strip at the bottom of `Layout` (rescue had no legal-link footer today). |

## Implementation

- **`lib.legal/components/ManageCookiesLink`** — small `<button>` that calls `useCookieConsent().openPreferences()`. Inline-link styling so it sits naturally next to text links. Accepts an optional `className` for callers that want to compose with their own footer-link class.
- **`lib.components/Footer`** — added optional `extraLinks?: React.ReactNode` slot, rendered at the end of the link row. Backwards-compatible: the only existing consumer is `app.client/AppShell`.
- **`app.client/AppShell`** — passes `<ManageCookiesLink />` as `Footer.extraLinks`.
- **`app.admin/AdminLayout`** + **`app.rescue/Layout`** — render a minimal `<footer>` strip below the main content carrying the link.

The banner re-render path is unchanged: `openPreferences()` writes to localStorage / dispatches `legal-consent-v1:cleared` (already implemented in slice 5), and the mounted `CookieBanner` already handles that event.

## Chosen label: "Manage cookies"

Existing footer link wording is single-word ("Privacy", "Terms"). Picking "Cookies" alone would be ambiguous — users would expect navigation to the `/cookies` policy page, not in-page banner re-open. "Manage cookies" is action-oriented and distinct from the policy link in the banner itself.

## Open questions

1. **Label wording** — chose "Manage cookies" over "Cookies" / "Cookie preferences" because the existing Privacy/Terms links are nouns that *navigate*, and we needed something action-oriented for an in-page button. Flag if a different choice is preferred.
2. **Login page footer** — the `PublicAuthLayout` (app.client) and admin/rescue login pages don't currently render Terms/Privacy links, so the link was **not** added there in this PR. The cookies banner already shows on those pages for first-visit users, so withdrawal is still reachable, just via the banner the user already saw. Happy to add it on the login page chrome too if preferred.

## Test counts (before → after)

| Package | Before | After | Notes |
|---|---|---|---|
| `lib.legal` | 28 | 32 | 4 new tests for `ManageCookiesLink` (label, clear-on-click, event dispatch, className forwarding) |
| `app.client` | 214 | 215 | New AppShell test: clicking the footer link clears the stored consent record |
| `app.admin` | 265 | 266 | New AdminLayout test: same behaviour |
| `app.rescue` | 125 | 126 | New Layout test: same behaviour |

`npx turbo lint test type-check --filter=@adopt-dont-shop/lib.legal --filter=@adopt-dont-shop/app.client --filter=@adopt-dont-shop/app.admin --filter=@adopt-dont-shop/app.rescue` passes cleanly. Pre-existing type errors in `app.admin/pages/Moderation.tsx` and `app.admin/pages/Support.tsx` are present on `main` and untouched.

## Scope guards honoured

- No `/settings/cookies` page — footer link only.
- Banner behaviour is unchanged.
- No confirmation modal — clicking the link surfaces the banner immediately.
- No internationalisation.

## Files changed

```
lib.legal/src/components/ManageCookiesLink.tsx
lib.legal/src/components/ManageCookiesLink.css.ts
lib.legal/src/components/ManageCookiesLink.test.tsx
lib.legal/src/index.ts
lib.components/src/components/navigation/Footer/Footer.tsx
app.client/src/components/layout/AppShell.tsx
app.client/src/components/layout/AppShell.test.tsx
app.client/src/setup-tests.ts (Footer mock now passes extraLinks through)
app.admin/src/components/layout/AdminLayout.tsx
app.admin/src/components/layout/AdminLayout.css.ts
app.admin/src/components/layout/AdminLayout.test.tsx
app.rescue/src/components/shared/Layout.tsx
app.rescue/src/components/shared/Layout.css.ts
app.rescue/src/components/shared/Layout.test.tsx
```

## Test plan

- [ ] On `app.client` (signed in or anonymous), accept cookies via the banner; the banner disappears.
- [ ] Click "Manage cookies" in the footer; the banner re-appears (preferences disclosure expanded).
- [ ] Toggle analytics off, save, reload — choice persists.
- [ ] Click "Manage cookies" again; banner re-appears.
- [ ] Same flow on `app.admin` (footer strip below the dashboard content) and `app.rescue` (footer strip below the rescue portal content).

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi


---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_