### PR TITLE
chore(legal): rate-limit reminder to 7 days + rename action to TERMS_REACCEPTANCE_REMINDER

### DIFF
--- a/service.backend/src/__tests__/services/legal-reminder-cron.test.ts
+++ b/service.backend/src/__tests__/services/legal-reminder-cron.test.ts
@@ -46,8 +46,9 @@ vi.mock('../../models/User', () => ({
 
 vi.mock('../../services/legal-reminder.service', () => ({
   sendReacceptanceReminder: vi.fn(),
-  REMINDER_RATE_LIMIT_HOURS: 24,
-  LEGAL_REMINDER_SENT_ACTION: 'LEGAL_REMINDER_SENT',
+  REMINDER_RATE_LIMIT_DAYS: 7,
+  TERMS_REACCEPTANCE_REMINDER_ACTION: 'TERMS_REACCEPTANCE_REMINDER',
+  LEGACY_LEGAL_REMINDER_SENT_ACTION: 'LEGAL_REMINDER_SENT',
 }));
 
 vi.mock('../../services/legal-content.service', () => ({

--- a/service.backend/src/__tests__/services/legal-reminder.test.ts
+++ b/service.backend/src/__tests__/services/legal-reminder.test.ts
@@ -40,8 +40,9 @@ import User from '../../models/User';
 import { AuditLogService } from '../../services/auditLog.service';
 import emailService from '../../services/email.service';
 import {
-  LEGAL_REMINDER_SENT_ACTION,
-  REMINDER_RATE_LIMIT_HOURS,
+  LEGACY_LEGAL_REMINDER_SENT_ACTION,
+  REMINDER_RATE_LIMIT_DAYS,
+  TERMS_REACCEPTANCE_REMINDER_ACTION,
   sendReacceptanceReminder,
 } from '../../services/legal-reminder.service';
 import { getPendingReacceptance } from '../../services/legal-content.service';
@@ -107,7 +108,7 @@ describe('legal-reminder service - sendReacceptanceReminder', () => {
 
     expect(mockAuditLog).toHaveBeenCalledTimes(1);
     const auditArgs = mockAuditLog.mock.calls[0][0];
-    expect(auditArgs.action).toBe(LEGAL_REMINDER_SENT_ACTION);
+    expect(auditArgs.action).toBe(TERMS_REACCEPTANCE_REMINDER_ACTION);
     expect(auditArgs.entity).toBe('User');
     expect(auditArgs.entityId).toBe('user-1');
     expect(auditArgs.userId).toBe('user-1');
@@ -143,6 +144,41 @@ describe('legal-reminder service - sendReacceptanceReminder', () => {
             { documentType: 'terms', currentVersion: '2026-05-08-v1' },
             { documentType: 'privacy', currentVersion: '2026-05-08-v1' },
           ],
+          triggeredBy: 'admin-7',
+        },
+      },
+      timestamp: new Date(),
+    } as never);
+
+    const result = await sendReacceptanceReminder({ userId: 'user-1' });
+
+    expect(result).toEqual({ sent: false, reason: 'rate_limited' });
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits on a legacy LEGAL_REMINDER_SENT audit row with a matching fingerprint (transition window)', async () => {
+    // Audit rows are append-only, so legacy `LEGAL_REMINDER_SENT` rows
+    // written before the rename can't be relabelled. The dedupe query
+    // must still recognise them so we don't double-send a user whose
+    // most recent reminder happened to be written under the old name.
+    mockGetPending.mockResolvedValue({
+      pending: [
+        {
+          documentType: 'terms',
+          currentVersion: '2026-05-08-v1',
+          lastAcceptedVersion: null,
+          lastAcceptedAt: null,
+        },
+      ],
+    });
+    // Simulate a row a real legacy writer would have produced.
+    mockAuditFindOne.mockResolvedValue({
+      action: LEGACY_LEGAL_REMINDER_SENT_ACTION,
+      metadata: {
+        details: {
+          versionFingerprint: 'terms:2026-05-08-v1',
+          versions: [{ documentType: 'terms', currentVersion: '2026-05-08-v1' }],
           triggeredBy: 'admin-7',
         },
       },
@@ -203,14 +239,22 @@ describe('legal-reminder service - sendReacceptanceReminder', () => {
     expect(mockAuditFindOne).toHaveBeenCalledTimes(1);
     const where = mockAuditFindOne.mock.calls[0][0]?.where as Record<string, unknown>;
     expect(where.user).toBe('user-1');
-    expect(where.action).toBe(LEGAL_REMINDER_SENT_ACTION);
+    // Dedupe must recognise both the new action name and the legacy
+    // name (audit rows are immutable, so legacy rows can't be renamed).
+    const actionClause = where.action as Record<symbol, ReadonlyArray<string>>;
+    const actionSymbols = Object.getOwnPropertySymbols(actionClause);
+    expect(actionSymbols).toHaveLength(1);
+    expect(actionClause[actionSymbols[0]]).toEqual([
+      TERMS_REACCEPTANCE_REMINDER_ACTION,
+      LEGACY_LEGAL_REMINDER_SENT_ACTION,
+    ]);
 
     const tsClause = where.timestamp as Record<symbol, Date>;
     const symbols = Object.getOwnPropertySymbols(tsClause);
     expect(symbols).toHaveLength(1);
     const cutoff = tsClause[symbols[0]] as Date;
-    const expectedMin = before - REMINDER_RATE_LIMIT_HOURS * 60 * 60 * 1000;
-    const expectedMax = after - REMINDER_RATE_LIMIT_HOURS * 60 * 60 * 1000;
+    const expectedMin = before - REMINDER_RATE_LIMIT_DAYS * 24 * 60 * 60 * 1000;
+    const expectedMax = after - REMINDER_RATE_LIMIT_DAYS * 24 * 60 * 60 * 1000;
     expect(cutoff.getTime()).toBeGreaterThanOrEqual(expectedMin);
     expect(cutoff.getTime()).toBeLessThanOrEqual(expectedMax);
   });

--- a/service.backend/src/services/legal-reminder.service.ts
+++ b/service.backend/src/services/legal-reminder.service.ts
@@ -22,22 +22,39 @@ import { logger } from '../utils/logger';
  *      without emailing — version bumps shouldn't surprise users who
  *      already accepted the latest copy.
  *   2. Per-user-per-version dedupe via the audit log: if a
- *      `LEGAL_REMINDER_SENT` row exists for this user with the same
- *      pending-version fingerprint inside the rate-limit window, return
- *      `{ sent: false, reason: 'rate_limited' }`. No new email, no new
- *      audit row.
+ *      `TERMS_REACCEPTANCE_REMINDER` row (or a legacy
+ *      `LEGAL_REMINDER_SENT` row, see below) exists for this user with
+ *      the same pending-version fingerprint inside the rate-limit
+ *      window, return `{ sent: false, reason: 'rate_limited' }`. No new
+ *      email, no new audit row.
  *   3. Otherwise, send a transactional email with subject + body that
  *      lists the docs to review and links back to the app. Append a
- *      `LEGAL_REMINDER_SENT` audit row capturing the version
+ *      `TERMS_REACCEPTANCE_REMINDER` audit row capturing the version
  *      fingerprint so subsequent calls can dedupe.
  *
  * Dedupe storage: reusing `audit_logs` (matches consent capture in
  * `consent.service.ts`). Avoids a new table for what is effectively an
  * append-only audit trail.
+ *
+ * Action-name transition: this service originally wrote
+ * `LEGAL_REMINDER_SENT`. It now writes `TERMS_REACCEPTANCE_REMINDER`.
+ * Existing audit rows are immutable (PR #344's trigger), so the dedupe
+ * query has to recognise both names until every legacy row is older
+ * than the rate-limit window.
  */
 
-export const REMINDER_RATE_LIMIT_HOURS = 24;
-export const LEGAL_REMINDER_SENT_ACTION = 'LEGAL_REMINDER_SENT';
+export const REMINDER_RATE_LIMIT_DAYS = 7;
+export const TERMS_REACCEPTANCE_REMINDER_ACTION = 'TERMS_REACCEPTANCE_REMINDER';
+/**
+ * Legacy action name used by writes prior to the rename. NEW writes
+ * MUST use `TERMS_REACCEPTANCE_REMINDER_ACTION`; this constant exists
+ * only so the dedupe read-path can `Op.in` across both names. Audit
+ * rows are immutable, so we cannot backfill — instead we tolerate the
+ * legacy name until every `LEGAL_REMINDER_SENT` row predates the
+ * rate-limit window. After that point this constant and its use in
+ * `wasRecentlyReminded` / the cron candidate query can be removed.
+ */
+export const LEGACY_LEGAL_REMINDER_SENT_ACTION = 'LEGAL_REMINDER_SENT';
 
 export const ReminderResultSchema = z.discriminatedUnion('sent', [
   z.object({
@@ -92,11 +109,18 @@ const buildVersionFingerprint = (pending: ReadonlyArray<ReminderableDocument>): 
 };
 
 const wasRecentlyReminded = async (userId: string, fingerprint: string): Promise<boolean> => {
-  const cutoff = new Date(Date.now() - REMINDER_RATE_LIMIT_HOURS * 60 * 60 * 1000);
+  const cutoff = new Date(Date.now() - REMINDER_RATE_LIMIT_DAYS * 24 * 60 * 60 * 1000);
+  // Audit rows are append-only (PR #344's trigger), so we can't rename
+  // legacy `LEGAL_REMINDER_SENT` rows in place. Match on either name
+  // until every legacy row is older than `REMINDER_RATE_LIMIT_DAYS`,
+  // at which point `LEGACY_LEGAL_REMINDER_SENT_ACTION` can be dropped
+  // from this query.
   const recent = await AuditLog.findOne({
     where: {
       user: userId,
-      action: LEGAL_REMINDER_SENT_ACTION,
+      action: {
+        [Op.in]: [TERMS_REACCEPTANCE_REMINDER_ACTION, LEGACY_LEGAL_REMINDER_SENT_ACTION],
+      },
       timestamp: { [Op.gte]: cutoff },
     },
     order: [['timestamp', 'DESC']],
@@ -109,7 +133,7 @@ const wasRecentlyReminded = async (userId: string, fingerprint: string): Promise
   );
   if (!parsed.success) {
     // Malformed metadata — treat as no record, but log so we notice.
-    logger.warn('LEGAL_REMINDER_SENT audit row had unparseable details', {
+    logger.warn('Reacceptance reminder audit row had unparseable details', {
       userId,
     });
     return false;
@@ -265,7 +289,7 @@ export const sendReacceptanceReminder = async (
 
   await AuditLogService.log({
     userId,
-    action: LEGAL_REMINDER_SENT_ACTION,
+    action: TERMS_REACCEPTANCE_REMINDER_ACTION,
     entity: 'User',
     entityId: userId,
     details: auditDetails,

--- a/service.backend/src/workers/legal-reminder.worker.ts
+++ b/service.backend/src/workers/legal-reminder.worker.ts
@@ -6,8 +6,9 @@ import AuditLog from '../models/AuditLog';
 import User, { UserStatus } from '../models/User';
 import { getPendingReacceptance } from '../services/legal-content.service';
 import {
-  LEGAL_REMINDER_SENT_ACTION,
-  REMINDER_RATE_LIMIT_HOURS,
+  LEGACY_LEGAL_REMINDER_SENT_ACTION,
+  REMINDER_RATE_LIMIT_DAYS,
+  TERMS_REACCEPTANCE_REMINDER_ACTION,
   sendReacceptanceReminder,
 } from '../services/legal-reminder.service';
 import { logger } from '../utils/logger';
@@ -17,8 +18,10 @@ import { logger } from '../utils/logger';
  *
  * Sequential loop over up to `batchSize` users-with-pending and a single
  * summary audit row at the end. Per-user dedupe is delegated to
- * `legal-reminder.service` (LEGAL_REMINDER_SENT fingerprint window) so
- * this worker only does coarse pre-filtering and aggregation.
+ * `legal-reminder.service` (TERMS_REACCEPTANCE_REMINDER fingerprint
+ * window — also recognising legacy `LEGAL_REMINDER_SENT` rows during
+ * the transition) so this worker only does coarse pre-filtering and
+ * aggregation.
  *
  * Guardrails (also captured in the PR body):
  *   - Hard batch cap (default 100). Bigger backlogs drain over multiple
@@ -65,20 +68,28 @@ export type RunOptions = {
 /**
  * Find users who plausibly need a reminder. We pull active, non-deleted
  * users with an email, then exclude anyone who already received a
- * LEGAL_REMINDER_SENT inside the rate-limit window (regardless of
+ * reacceptance reminder inside the rate-limit window (regardless of
  * fingerprint — the per-fingerprint check still runs inside
  * `sendReacceptanceReminder`).
+ *
+ * The action filter matches both the new `TERMS_REACCEPTANCE_REMINDER`
+ * name and the legacy `LEGAL_REMINDER_SENT` name. Audit rows are
+ * append-only (PR #344's trigger), so legacy rows can't be renamed —
+ * we tolerate both names until every legacy row is older than
+ * `REMINDER_RATE_LIMIT_DAYS`.
  *
  * Returns up to `batchSize` userIds. Ordering is stable (createdAt ASC)
  * so the same backlog drains the same way across runs and rotates
  * deterministically.
  */
 const findCandidateUserIds = async (batchSize: number): Promise<ReadonlyArray<string>> => {
-  const cutoff = new Date(Date.now() - REMINDER_RATE_LIMIT_HOURS * 60 * 60 * 1000);
+  const cutoff = new Date(Date.now() - REMINDER_RATE_LIMIT_DAYS * 24 * 60 * 60 * 1000);
 
   const recentlyReminded = await AuditLog.findAll({
     where: {
-      action: LEGAL_REMINDER_SENT_ACTION,
+      action: {
+        [Op.in]: [TERMS_REACCEPTANCE_REMINDER_ACTION, LEGACY_LEGAL_REMINDER_SENT_ACTION],
+      },
       timestamp: { [Op.gte]: cutoff },
     },
     attributes: ['user'],


### PR DESCRIPTION
## Summary

Two related default changes the team confirmed after slice 4 of ADS-497:

1. **Rate-limit window**: was 24 hours, is now 7 days. `REMINDER_RATE_LIMIT_HOURS = 24` -> `REMINDER_RATE_LIMIT_DAYS = 7` in `legal-reminder.service.ts`. The cutoff calculation in both the service and the cron worker is updated accordingly. The previous 24h window was too noisy in operational use.
2. **Audit action rename**: was `LEGAL_REMINDER_SENT` (too broad — could be confused with any legal-doc email), is now `TERMS_REACCEPTANCE_REMINDER`. The constant is renamed `LEGAL_REMINDER_SENT_ACTION` -> `TERMS_REACCEPTANCE_REMINDER_ACTION`.

The cron summary action `LEGAL_REMINDER_CRON_RAN` is intentionally unchanged — that one describes the cron-run summary row, not the per-user reminder.

## Audit-log immutability constraint

`audit_logs` rows are append-only at the database layer (PR #344's `audit_logs.allow_mutation` GUC + trigger from migration #11). We **cannot** rename existing rows in place, and we don't want to. Two transition mechanics:

- **Writes**: every new write (service + cron) uses `TERMS_REACCEPTANCE_REMINDER`. There is no shim that writes the legacy name.
- **Reads (dedupe)**: both `wasRecentlyReminded` (per-user fingerprint check in the service) and `findCandidateUserIds` (coarse pre-filter in the cron worker) now query `action IN ('TERMS_REACCEPTANCE_REMINDER', 'LEGAL_REMINDER_SENT')`. Without this, a user whose most recent reminder happens to be a legacy row would be re-reminded immediately after this PR ships.

A new exported constant `LEGACY_LEGAL_REMINDER_SENT_ACTION = 'LEGAL_REMINDER_SENT'` exists solely to feed those `Op.in` arrays. Its docblock spells out that it is read-only legacy compat.

## Deprecation timeline for the legacy name

The legacy `LEGAL_REMINDER_SENT_ACTION` allowance can be removed from the dedupe queries once every `LEGAL_REMINDER_SENT` audit row is older than `REMINDER_RATE_LIMIT_DAYS` (7 days). Concretely: **7 days after this PR is deployed to production**, no legacy row can still be inside the rate-limit window, and the constant + its uses in `wasRecentlyReminded` and `findCandidateUserIds` can be deleted in a follow-up. (The legacy rows themselves stay forever — they're audit history.)

## Test plan

- [x] `npx vitest run src/__tests__/services/legal-reminder.test.ts` — 9 tests pass (was 8; +1 for legacy-action-recognized dedupe)
- [x] `npx vitest run src/__tests__/services/legal-reminder-cron.test.ts` — 9 tests pass (no count change; mock updated to expose the new constants)
- [x] `npx vitest run src/__tests__/routes/admin-legal-reminder.routes.test.ts` — 10 tests pass (no changes; route doesn't reference the action constants directly)
- [x] Full `service.backend` suite: 2119 passed / 44 skipped, no regressions
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (167 pre-existing warnings, none introduced)

## What is NOT in this PR

- No data migration / backfill of legacy audit rows (immutable).
- `LEGAL_REMINDER_CRON_RAN` is unchanged.
- No feature flag — the rename is straightforward.
- No email subject/body changes.
- No cron schedule change.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_