### PR TITLE
docs(legal): refresh screen-reader runbook for post-#431 ARIA shape

### DIFF
--- a/docs/legal/screen-reader-runbook.md
+++ b/docs/legal/screen-reader-runbook.md
@@ -24,12 +24,12 @@ Setup:
 
 Checklist:
 
-- [ ] Screen reader announces a region landmark named "Cookie consent" (note: shipped `aria-label` is `Cookie consent`, not "Cookie preferences").
-- [ ] `Tab` into the banner. Each button announces with its visible label, in this order: "Essentials only, button", "Manage preferences, button, collapsed", "Accept all, button".
+- [ ] Screen reader announces a region landmark named "Cookie preferences".
+- [ ] `Tab` into the banner. Each button announces with its visible label, in this order: "Accept all, button", "Essentials only, button", "Manage preferences, button, collapsed".
 - [ ] Press `Enter` on "Manage preferences". Screen reader announces the expanded state ("expanded"). The analytics checkbox becomes reachable on next `Tab`.
-- [ ] `Tab` to the analytics checkbox. Press `Space`. Reader announces the checked-state change.
+- [ ] `Tab` to the analytics checkbox. Reader announces it as "Analytics, Optional, checkbox, not checked" — the visible label provides the accessible name (no separate `aria-label` overrides it). Press `Space`; reader announces the checked-state change.
 - [ ] Re-press `Enter` on the trigger button. The disclosure collapses; reader announces "collapsed".
-- [ ] Press `Esc` while focus is inside the disclosure. **Expected:** disclosure closes and focus returns to the "Manage preferences" trigger. **See Known Limitations §5 — this is currently NOT implemented in the live component, so this step is expected to FAIL today. File the failure rather than skip it.**
+- [ ] Press `Esc` while focus is inside the disclosure. **Expected:** disclosure closes and focus returns to the "Manage preferences" trigger (verified by the keyboard-handler test in `CookieBanner.test.tsx`). If focus does not move back to the trigger, file it.
 
 ## 3. Re-acceptance modal — pending docs smoke (signed-in, stale ToS)
 
@@ -54,7 +54,7 @@ Setup: complete §2 first so a stored consent record exists and the banner is hi
 
 Checklist:
 
-- [ ] `Tab` through the footer until you reach "Manage cookies". Reader announces it as a link/button.
+- [ ] `Tab` through the footer until you reach "Manage cookies". Reader announces it as "Manage cookies, button" (it is a `<button>` styled as an inline link, not an `<a>`, because it triggers in-page UI rather than navigating).
 - [ ] Press `Enter`. The cookie banner re-mounts.
 - [ ] Reader announces the banner region. (It should fire the same announcement as §2 first-visit because the trigger clears `legal-consent-v1` and dispatches `legal-consent-v1:cleared`.)
 - [ ] Focus does not get lost. If the banner appears off-screen of current focus, file it.
@@ -66,9 +66,6 @@ Checklist:
 - `prefers-reduced-motion`: the modal's open animation (from `lib.components/Modal`) should be reduced or skipped.
 - ChromeVox on Linux is a known weaker reader. Discrepancies between ChromeVox and VoiceOver/NVDA should be reported against the reader, not the app, unless reproducible on at least two readers.
 - Live announcements depend on the OS reader's verbosity setting. If a step "doesn't announce" on default verbosity, retry on "high" / "verbose" before filing.
-- **Banner Escape-to-close (§2 last step):** not implemented. The `Manage preferences` disclosure is a plain expanded `div`; pressing Escape does nothing. Tracked as a follow-up — file as a known issue on first run, don't re-file each pass.
-- **Banner accessible-name override (§2):** the analytics checkbox has both an `aria-label="Allow analytics cookies"` and a wrapping `<label>` whose visible text is "Analytics — Optional". The `aria-label` wins, so the announced name does not match the visible label. Track as a follow-up.
-- **Banner disclosure has no `aria-controls`:** the "Manage preferences" trigger sets `aria-expanded` but does not point at the disclosure region. Some readers will not associate the two. Track as a follow-up.
 
 ## 6. Reporting issues
 


### PR DESCRIPTION
## Summary

PR #436 merged `docs/legal/screen-reader-runbook.md` against pre-#431 `main`, so it documents the old `CookieBanner` ARIA shape and flags three "known limitations" that PR #431 has since fixed. This PR re-syncs the runbook against the actually-shipped post-#431 component (and verifies §4 against PR #435's `ManageCookiesLink.tsx`).

No component code changed; only `docs/legal/screen-reader-runbook.md`.

### §2 Cookie banner — scenario updates

- Region landmark accessible name: "Cookie consent" → "Cookie preferences" (drops the parenthetical caveat).
- Tab order announcement: reordered to "Accept all, button" → "Essentials only, button" → "Manage preferences, button, collapsed" to match the post-#431 action row.
- Analytics checkbox step: now asserts the announced name comes from the visible `<span>` label (post-#431 `aria-labelledby`), instead of warning that an `aria-label` overrides the visible text.
- Escape-to-close step: converted from a flagged-gap ("expected to FAIL today") to a positive assertion ("disclosure closes and focus returns to the trigger"), referencing the keyboard-handler test in `CookieBanner.test.tsx`.

### §4 Manage cookies footer link — verified against `ManageCookiesLink.tsx`

- Tightened the announcement expectation from "link/button" to "Manage cookies, button" — the shipped component renders a `<button>` styled as an inline link (because it triggers in-page UI rather than navigating).

### §5 Known limitations — items removed (fixed by PR #431)

- **Banner Escape-to-close not implemented** — fixed: `handleDisclosureKeyDown` closes the disclosure on Escape and returns focus to `manageButtonRef`.
- **Banner accessible-name override on the analytics checkbox** — fixed: the redundant `aria-label="Allow analytics cookies"` was replaced with `aria-labelledby` pointing at the visible `<span>` label.
- **Banner disclosure has no `aria-controls`** — fixed: the trigger now sets both `aria-expanded` and `aria-controls={detailsId}` and the disclosure `<div>` carries the matching `id`.

(The "Cookie consent" vs "Cookie preferences" naming inconsistency, called out inline in the §2 first checkbox rather than as a separate §5 bullet, is also resolved.)

### §5 Known limitations — items retained (genuinely still unresolved)

- High-contrast mode (Windows Contrast Themes / macOS Increase contrast) may strip banner background colours.
- Custom focus-ring visibility under the dark theme (`:focus-visible` ≥2 px, ≥3:1 contrast).
- `prefers-reduced-motion`: the re-acceptance modal's open animation should be reduced or skipped.
- ChromeVox-on-Linux fidelity caveat — discrepancies should be reproduced on a second reader before filing against the app.
- Reader verbosity caveat — retry on "high" / "verbose" before filing a "doesn't announce" finding.

### Word-count delta

961 → 875 words (-86), well within the ±200-word budget.

## Test plan

- [ ] Render the runbook in GitHub's markdown preview and confirm headings, code blocks, and links render unchanged.
- [ ] Spot-check the §2 checklist against `lib.legal/src/components/CookieBanner.tsx` (post-#431) — region `aria-label`, action-row order, `aria-controls` + `aria-expanded` on the trigger, `aria-labelledby` on the analytics input, Escape handler.
- [ ] Spot-check §4 against `lib.legal/src/components/ManageCookiesLink.tsx` (PR #435) — confirm it ships a `<button>` with visible text "Manage cookies" and calls `useCookieConsent().openPreferences()`.
- [ ] Confirm no source files outside `docs/legal/screen-reader-runbook.md` were modified (`git diff main...HEAD --stat`).

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_