### PR TITLE
feat(legal): "Manage cookies" link on login pages

### DIFF
--- a/app.admin/src/__tests__/login.behavior.test.tsx
+++ b/app.admin/src/__tests__/login.behavior.test.tsx
@@ -13,6 +13,7 @@
 import { vi, describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { renderWithProviders, screen } from '../test-utils';
 import userEvent from '@testing-library/user-event';
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
 import { LoginPage } from '../pages/LoginPage';
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -142,6 +143,25 @@ describe('Login page', () => {
       await user.click(screen.getByRole('button', { name: /forgot password/i }));
 
       expect(mockNavigate).toHaveBeenCalledWith('/forgot-password');
+    });
+  });
+
+  describe('cookie preferences', () => {
+    it('clears the stored consent record when the "Manage cookies" link is clicked', async () => {
+      window.localStorage.setItem(
+        COOKIE_CONSENT_STORAGE_KEY,
+        JSON.stringify({
+          cookiesVersion: '2026-05-09-v1',
+          analyticsConsent: true,
+          acceptedAt: '2026-05-10T00:00:00.000Z',
+        })
+      );
+
+      renderWithProviders(<LoginPage />);
+
+      await userEvent.setup().click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+      expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
     });
   });
 });

--- a/app.admin/src/components/layout/AdminLayout.css.ts
+++ b/app.admin/src/components/layout/AdminLayout.css.ts
@@ -32,3 +32,15 @@ export const contentWrapper = style({
     },
   },
 });
+
+// ADS-497 (slice 5b): minimal footer strip carrying the "Manage cookies"
+// link. Admin has no public legal-link footer today; this is the
+// smallest surface that keeps the cookies-policy promise of an on-page
+// withdrawal control.
+export const layoutFooter = style({
+  borderTop: '1px solid #e5e7eb',
+  padding: '0.75rem 2rem',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  background: '#ffffff',
+});

--- a/app.admin/src/components/layout/AdminLayout.test.tsx
+++ b/app.admin/src/components/layout/AdminLayout.test.tsx
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
+import { AdminLayout } from './AdminLayout';
+
+// AdminSidebar / AdminHeader pull in heavy auth + nav deps that aren't
+// relevant to the footer behaviour under test. Stub them.
+vi.mock('./AdminSidebar', () => ({
+  AdminSidebar: () => <aside data-testid='admin-sidebar' />,
+}));
+vi.mock('./AdminHeader', () => ({
+  AdminHeader: () => <header data-testid='admin-header' />,
+}));
+
+const renderLayout = () =>
+  render(
+    <MemoryRouter>
+      <AdminLayout>
+        <div>page-content</div>
+      </AdminLayout>
+    </MemoryRouter>
+  );
+
+describe('AdminLayout [ADS-497 slice 5b]', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders a "Manage cookies" footer link that clears the stored consent record on click', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2026-05-09-v1',
+        analyticsConsent: true,
+        acceptedAt: '2026-05-10T00:00:00.000Z',
+      })
+    );
+
+    renderLayout();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/app.admin/src/components/layout/AdminLayout.tsx
+++ b/app.admin/src/components/layout/AdminLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import { AdminSidebar } from './AdminSidebar';
 import { AdminHeader } from './AdminHeader';
 import * as styles from './AdminLayout.css';
@@ -20,6 +21,9 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
       <main className={styles.mainContent({ sidebarCollapsed })}>
         <AdminHeader sidebarCollapsed={sidebarCollapsed} />
         <div className={styles.contentWrapper}>{children}</div>
+        <footer className={styles.layoutFooter}>
+          <ManageCookiesLink />
+        </footer>
       </main>
     </div>
   );

--- a/app.admin/src/pages/LoginPage.css.ts
+++ b/app.admin/src/pages/LoginPage.css.ts
@@ -22,6 +22,11 @@ globalStyle(`${registerPrompt} a:hover`, {
   textDecoration: 'underline',
 });
 
+export const manageCookies = style({
+  textAlign: 'center',
+  marginTop: '1rem',
+});
+
 export const helperText = style({
   fontSize: '0.875rem',
   color: '#6b7280',

--- a/app.admin/src/pages/LoginPage.tsx
+++ b/app.admin/src/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { AuthLayout, LoginForm } from '@adopt-dont-shop/lib.auth';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import * as styles from './LoginPage.css';
 
@@ -21,10 +22,15 @@ export const LoginPage = () => {
       title='Admin Portal'
       subtitle='System administration and management'
       footer={
-        <div className={styles.registerPrompt}>
-          <p>Need an admin account?</p>
-          <Link to='/register'>Request access</Link>
-        </div>
+        <>
+          <div className={styles.registerPrompt}>
+            <p>Need an admin account?</p>
+            <Link to='/register'>Request access</Link>
+          </div>
+          <div className={styles.manageCookies}>
+            <ManageCookiesLink />
+          </div>
+        </>
       }
     >
       <LoginForm

--- a/app.client/src/components/layout/AppShell.test.tsx
+++ b/app.client/src/components/layout/AppShell.test.tsx
@@ -1,8 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
 import { AppShell } from './AppShell';
 
 vi.mock('@adopt-dont-shop/lib.auth', async () => {
@@ -54,6 +56,10 @@ const renderShell = () =>
   );
 
 describe('AppShell', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('renders the app navbar logo', () => {
     renderShell();
     expect(screen.getByRole('link', { name: /adopt don't shop/i })).toBeInTheDocument();
@@ -67,5 +73,21 @@ describe('AppShell', () => {
   it('renders the floating swipe button', () => {
     renderShell();
     expect(screen.getByTestId('swipe-fab')).toBeInTheDocument();
+  });
+
+  it('clears the stored consent record when the footer "Manage cookies" link is clicked', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2026-05-09-v1',
+        analyticsConsent: true,
+        acceptedAt: '2026-05-10T00:00:00.000Z',
+      })
+    );
+    renderShell();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
   });
 });

--- a/app.client/src/components/layout/AppShell.tsx
+++ b/app.client/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Footer } from '@adopt-dont-shop/lib.components';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import { AppNavbar } from '@/components/navigation/AppNavbar';
 import { BottomTabBar } from '@/components/navigation/BottomTabBar';
 import { SwipeOnboarding } from '@/components/onboarding/SwipeOnboarding';
@@ -19,7 +20,7 @@ export const AppShell: React.FC = () => {
       <SwipeFloatingButton />
       <BottomTabBar />
       {showOnboarding && <SwipeOnboarding onClose={() => setShowOnboarding(false)} />}
-      <Footer />
+      <Footer extraLinks={<ManageCookiesLink />} />
     </div>
   );
 };

--- a/app.client/src/components/layout/PublicAuthLayout.css.ts
+++ b/app.client/src/components/layout/PublicAuthLayout.css.ts
@@ -59,3 +59,10 @@ export const main = style({
   justifyContent: 'center',
   padding: `${vars.spacing['8']} ${vars.spacing['4']}`,
 });
+
+export const footer = style({
+  display: 'flex',
+  justifyContent: 'center',
+  padding: `${vars.spacing['4']} ${vars.spacing['4']}`,
+  borderTop: `1px solid ${vars.border.color.primary}`,
+});

--- a/app.client/src/components/layout/PublicAuthLayout.test.tsx
+++ b/app.client/src/components/layout/PublicAuthLayout.test.tsx
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
 import { PublicAuthLayout } from './PublicAuthLayout';
 
 const renderAt = (path: string) =>
@@ -20,6 +22,10 @@ const renderAt = (path: string) =>
   );
 
 describe('PublicAuthLayout', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('renders the logo linking back to home', () => {
     renderAt('/login');
     expect(screen.getByRole('link', { name: /adopt don't shop/i })).toHaveAttribute('href', '/');
@@ -40,5 +46,22 @@ describe('PublicAuthLayout', () => {
   it('renders the nested route content', () => {
     renderAt('/login');
     expect(screen.getByText('Login page content')).toBeInTheDocument();
+  });
+
+  it('clears the stored consent record when the footer "Manage cookies" link is clicked', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2026-05-09-v1',
+        analyticsConsent: true,
+        acceptedAt: '2026-05-10T00:00:00.000Z',
+      })
+    );
+
+    renderAt('/login');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
   });
 });

--- a/app.client/src/components/layout/PublicAuthLayout.tsx
+++ b/app.client/src/components/layout/PublicAuthLayout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import * as styles from './PublicAuthLayout.css';
 
 export const PublicAuthLayout: React.FC = () => {
@@ -24,6 +25,9 @@ export const PublicAuthLayout: React.FC = () => {
       <main className={styles.main}>
         <Outlet />
       </main>
+      <footer className={styles.footer}>
+        <ManageCookiesLink />
+      </footer>
     </div>
   );
 };

--- a/app.client/src/setup-tests.ts
+++ b/app.client/src/setup-tests.ts
@@ -125,8 +125,12 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
         onFilesSelect?.(files);
       },
     }),
-  Footer: ({ children, ...props }: React.ComponentPropsWithoutRef<'footer'>) =>
-    React.createElement('footer', props, children),
+  Footer: ({
+    children,
+    extraLinks,
+    ...props
+  }: React.ComponentPropsWithoutRef<'footer'> & { extraLinks?: React.ReactNode }) =>
+    React.createElement('footer', props, children, extraLinks),
   TextInput: ({
     label,
     id,

--- a/app.rescue/src/components/shared/Layout.css.ts
+++ b/app.rescue/src/components/shared/Layout.css.ts
@@ -7,8 +7,27 @@ export const appLayout = style({
   background: vars.background.primary,
 });
 
+export const mainColumn = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '100vh',
+});
+
 export const mainContent = style({
   flex: 1,
   overflow: 'auto',
   padding: '2rem',
+});
+
+// ADS-497 (slice 5b): minimal footer strip carrying the "Manage cookies"
+// link. Rescue has no public legal-link footer today; this is the
+// smallest surface that keeps the cookies-policy promise of an on-page
+// withdrawal control.
+export const layoutFooter = style({
+  borderTop: `1px solid ${vars.border.color.primary}`,
+  padding: '0.75rem 2rem',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  background: vars.background.secondary,
 });

--- a/app.rescue/src/components/shared/Layout.test.tsx
+++ b/app.rescue/src/components/shared/Layout.test.tsx
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
+import Layout from './Layout';
+
+// Navigation pulls in auth/chat contexts that aren't relevant to the
+// footer behaviour under test. Stub it.
+vi.mock('./Navigation', () => ({
+  default: () => <nav data-testid="rescue-navigation" />,
+}));
+
+const renderLayout = () =>
+  render(
+    <MemoryRouter>
+      <Layout>
+        <div>page-content</div>
+      </Layout>
+    </MemoryRouter>
+  );
+
+describe('Layout [ADS-497 slice 5b]', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders a "Manage cookies" footer link that clears the stored consent record on click', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2026-05-09-v1',
+        analyticsConsent: true,
+        acceptedAt: '2026-05-10T00:00:00.000Z',
+      })
+    );
+
+    renderLayout();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/app.rescue/src/components/shared/Layout.tsx
+++ b/app.rescue/src/components/shared/Layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import Navigation from './Navigation';
 import * as styles from './Layout.css';
 
@@ -10,7 +11,12 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
     <div className={styles.appLayout}>
       <Navigation />
-      <main className={styles.mainContent}>{children}</main>
+      <div className={styles.mainColumn}>
+        <main className={styles.mainContent}>{children}</main>
+        <footer className={styles.layoutFooter}>
+          <ManageCookiesLink />
+        </footer>
+      </div>
     </div>
   );
 };

--- a/app.rescue/src/pages/LoginPage.css.ts
+++ b/app.rescue/src/pages/LoginPage.css.ts
@@ -10,3 +10,10 @@ export const helperText = style({
 globalStyle(`${helperText} strong`, {
   color: '#374151',
 });
+
+export const manageCookies = style({
+  textAlign: 'center',
+  marginTop: '1rem',
+  paddingTop: '1rem',
+  borderTop: '1px solid #e5e7eb',
+});

--- a/app.rescue/src/pages/LoginPage.test.tsx
+++ b/app.rescue/src/pages/LoginPage.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Behavioral tests for LoginPage (Rescue App).
+ *
+ * Covers the cookies-policy promise: an unauthenticated visitor on the
+ * login page can re-open the cookie banner from the page chrome.
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '../test-utils';
+import { COOKIE_CONSENT_STORAGE_KEY } from '@adopt-dont-shop/lib.legal';
+import LoginPage from './LoginPage';
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    AuthLayout: ({
+      title,
+      subtitle,
+      children,
+      footer,
+    }: {
+      title: string;
+      subtitle?: string;
+      children: React.ReactNode;
+      footer?: React.ReactNode;
+    }) => (
+      <div>
+        <h1>{title}</h1>
+        {subtitle && <p>{subtitle}</p>}
+        <div>{children}</div>
+        {footer && <div>{footer}</div>}
+      </div>
+    ),
+    LoginForm: () => <div data-testid="login-form" />,
+  };
+});
+
+describe('Rescue LoginPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('clears the stored consent record when the "Manage cookies" link is clicked', async () => {
+    window.localStorage.setItem(
+      COOKIE_CONSENT_STORAGE_KEY,
+      JSON.stringify({
+        cookiesVersion: '2026-05-09-v1',
+        analyticsConsent: true,
+        acceptedAt: '2026-05-10T00:00:00.000Z',
+      })
+    );
+
+    renderWithProviders(<LoginPage />);
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/app.rescue/src/pages/LoginPage.tsx
+++ b/app.rescue/src/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { AuthLayout, LoginForm } from '@adopt-dont-shop/lib.auth';
+import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import { useLocation, useNavigate } from 'react-router-dom';
 import * as styles from './LoginPage.css';
 
@@ -20,6 +21,11 @@ const LoginPage = () => {
     <AuthLayout
       title="Rescue Staff Sign In"
       subtitle="Welcome back to the Rescue Management System"
+      footer={
+        <div className={styles.manageCookies}>
+          <ManageCookiesLink />
+        </div>
+      }
     >
       <LoginForm
         onSuccess={handleSuccess}

--- a/lib.components/src/components/navigation/Footer/Footer.tsx
+++ b/lib.components/src/components/navigation/Footer/Footer.tsx
@@ -6,9 +6,15 @@ import { footer, footerContainer, footerText, footerLinks, footerLink } from './
 
 export interface FooterProps {
   className?: string;
+  /**
+   * Optional extra elements rendered inline at the end of the link row,
+   * after Contact. Use the exported `footerLink` class on any link-like
+   * element (e.g. a `<button>`) so it inherits the row's typography.
+   */
+  extraLinks?: React.ReactNode;
 }
 
-export const Footer: React.FC<FooterProps> = ({ className }) => {
+export const Footer: React.FC<FooterProps> = ({ className, extraLinks }) => {
   return (
     <footer className={clsx(footer, className)}>
       <div className={footerContainer}>
@@ -31,6 +37,7 @@ export const Footer: React.FC<FooterProps> = ({ className }) => {
           <Link to='/contact' className={footerLink}>
             Contact
           </Link>
+          {extraLinks}
         </div>
         <p className={footerText}>
           © {new Date().getFullYear()} Adopt Don&apos;t Shop. All rights reserved.

--- a/lib.legal/src/components/ManageCookiesLink.css.ts
+++ b/lib.legal/src/components/ManageCookiesLink.css.ts
@@ -1,0 +1,26 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+// Plain inline-link styling so the button sits naturally next to text
+// links like "Privacy" / "Terms" in a footer link row. No background,
+// no border, font matches surrounding link styles.
+export const link = style({
+  background: 'transparent',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+  color: vars.colors.neutral['700'],
+  fontSize: '0.875rem',
+  fontFamily: 'inherit',
+  textDecoration: 'none',
+  selectors: {
+    '&:hover': {
+      color: vars.colors.neutral['900'],
+      textDecoration: 'underline',
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${vars.colors.primary['600']}`,
+      outlineOffset: '2px',
+    },
+  },
+});

--- a/lib.legal/src/components/ManageCookiesLink.test.tsx
+++ b/lib.legal/src/components/ManageCookiesLink.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ManageCookiesLink } from './ManageCookiesLink';
+import {
+  COOKIE_CONSENT_STORAGE_KEY,
+  type StoredCookieConsent,
+} from '../services/cookie-consent-storage';
+
+const seedConsent = (record: StoredCookieConsent) => {
+  window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(record));
+};
+
+describe('ManageCookiesLink', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a button labelled "Manage cookies"', () => {
+    render(<ManageCookiesLink />);
+    expect(screen.getByRole('button', { name: 'Manage cookies' })).toBeInTheDocument();
+  });
+
+  it('clears the stored consent record when clicked', async () => {
+    seedConsent({
+      cookiesVersion: '2026-05-09-v1',
+      analyticsConsent: true,
+      acceptedAt: new Date().toISOString(),
+    });
+    render(<ManageCookiesLink />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toBeNull();
+  });
+
+  it('dispatches the legal-consent-v1:cleared event when clicked', async () => {
+    const handler = vi.fn();
+    window.addEventListener('legal-consent-v1:cleared', handler);
+
+    render(<ManageCookiesLink />);
+    await userEvent.click(screen.getByRole('button', { name: 'Manage cookies' }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener('legal-consent-v1:cleared', handler);
+  });
+
+  it('forwards an additional className to the rendered button', () => {
+    render(<ManageCookiesLink className='my-footer-link' />);
+    expect(screen.getByRole('button', { name: 'Manage cookies' })).toHaveClass('my-footer-link');
+  });
+});

--- a/lib.legal/src/components/ManageCookiesLink.tsx
+++ b/lib.legal/src/components/ManageCookiesLink.tsx
@@ -1,0 +1,36 @@
+import { useCookieConsent } from './CookieBanner';
+import * as styles from './ManageCookiesLink.css';
+
+/**
+ * ADS-497 (slice 5b): footer link that re-opens the cookie banner.
+ *
+ * The cookies policy (`docs/legal/cookies.md`) tells users to use the
+ * on-page banner to withdraw or change their analytics consent. This
+ * button is the entry point: clicking it clears the stored consent
+ * record and dispatches the synthetic event that `CookieBanner` listens
+ * for, so the banner re-appears without a page reload.
+ *
+ * Rendered as a `<button>` (not an `<a>`) because it triggers in-page
+ * UI rather than navigating. Styled to look like an inline link so it
+ * sits naturally next to existing "Privacy" / "Terms" footer links.
+ */
+
+type ManageCookiesLinkProps = {
+  className?: string;
+};
+
+export const ManageCookiesLink = ({ className }: ManageCookiesLinkProps) => {
+  const { openPreferences } = useCookieConsent();
+  const composedClassName = className ? `${styles.link} ${className}` : styles.link;
+
+  return (
+    <button
+      type='button'
+      className={composedClassName}
+      onClick={openPreferences}
+      data-testid='manage-cookies-link'
+    >
+      Manage cookies
+    </button>
+  );
+};

--- a/lib.legal/src/index.ts
+++ b/lib.legal/src/index.ts
@@ -3,6 +3,7 @@
 // Components
 export { LegalReacceptanceModal } from './components/LegalReacceptanceModal';
 export { CookieBanner, useCookieConsent } from './components/CookieBanner';
+export { ManageCookiesLink } from './components/ManageCookiesLink';
 
 // Service / schemas
 export {


### PR DESCRIPTION
## Summary

Follow-up to #435. That PR explicitly skipped login pages on the grounds they don't link Terms/Privacy either — but industry-standard practice on production sites is for cookie-consent withdrawal to be reachable pre-auth, since the banner itself is shown to anonymous visitors. This PR adds `<ManageCookiesLink />` to the unauthenticated chrome of all three apps.

**Stacks on #435.** This branch was rebased onto `worktree-agent-a7d5b89d009e0b9e8` (PR #435's head). Once #435 lands on main, this PR's diff against `main` will collapse to just the changes below.

## Per-app placement

| App | Where the link lives |
|---|---|
| `app.client` | `PublicAuthLayout` — the unauthenticated chrome wrapping `/login` + `/register` — gains a minimal centred footer strip carrying `<ManageCookiesLink />`. Covers both routes via the shared layout. |
| `app.admin` | `LoginPage` passes `<ManageCookiesLink />` alongside the existing "Request access" prompt in `AuthLayout`'s `footer` slot. |
| `app.rescue` | `LoginPage` passes `<ManageCookiesLink />` as a new `AuthLayout` `footer` slot (rescue's login had no footer content before). |

`app.admin` and `app.rescue` modify the LoginPage directly (no app-level chrome wrapping their login routes today). Only login pages were in scope per the brief — register pages are untouched for admin/rescue. For app.client, `PublicAuthLayout` covers both since they share chrome.

## What this PR does NOT do

- Does not add Terms / Privacy links to login pages (out of scope).
- Does not change authenticated chrome (#435 covers that).
- Does not restyle `<ManageCookiesLink />`.
- No internationalisation.

## Test counts (after PR #435 baseline → after this PR)

| Package | Before | After | Delta |
|---|---|---|---|
| `app.client` | 215 | 216 | +1 (`PublicAuthLayout` test) |
| `app.admin` | 266 | 267 | +1 (`login.behavior` cookie-prefs test) |
| `app.rescue` | 126 | 127 | +1 (new `LoginPage.test.tsx`) |

Each app's new test seeds `localStorage` with a consent record, renders the login page chrome, clicks the "Manage cookies" link, and asserts the record is cleared.

## Pre-existing baseline (unchanged)

`app.admin#type-check` reports the same `pages/Support.tsx` and `pages/Moderation.tsx` errors that PR #435's body documented. Untouched here. Lint + tests pass cleanly.

## Files changed

```
app.client/src/components/layout/PublicAuthLayout.tsx
app.client/src/components/layout/PublicAuthLayout.css.ts
app.client/src/components/layout/PublicAuthLayout.test.tsx
app.admin/src/pages/LoginPage.tsx
app.admin/src/pages/LoginPage.css.ts
app.admin/src/__tests__/login.behavior.test.tsx
app.rescue/src/pages/LoginPage.tsx
app.rescue/src/pages/LoginPage.css.ts
app.rescue/src/pages/LoginPage.test.tsx (new)
```

## Test plan

- [ ] On `app.client`, log out (or open in private mode), visit `/login`. Click "Manage cookies" in the page footer; banner re-appears.
- [ ] Same flow on `/register` (shares `PublicAuthLayout`).
- [ ] On `app.admin` `/login`, click "Manage cookies" below the "Request access" prompt; banner re-appears.
- [ ] On `app.rescue` `/login`, click "Manage cookies" in the AuthLayout footer; banner re-appears.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_