### PR TITLE
feat(migrations): per-model baseline for communications (rebaseline 5/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-communications.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-communications.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * communications domain (rebaseline 5/10):
+ *
+ *   00-baseline-029-chats
+ *   00-baseline-030-chat-participants
+ *   00-baseline-031-messages
+ *   00-baseline-032-message-reactions
+ *   00-baseline-033-message-reads
+ *   00-baseline-034-file-uploads
+ *   00-baseline-035-notifications
+ *   00-baseline-036-device-tokens
+ *
+ * Pattern: force-sync the schema to capture the canonical column / index
+ * set, drop the table, run `up()`, assert the table is rebuilt with the
+ * same columns and indexes. Then run `down()` (with the destructive-down
+ * env flag) and assert the table is gone.
+ *
+ * Postgres-only — Sequelize ENUM and partial-unique indexes have no
+ * SQLite equivalent.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import baseline029 from '../../migrations/00-baseline-029-chats';
+import baseline030 from '../../migrations/00-baseline-030-chat-participants';
+import baseline031 from '../../migrations/00-baseline-031-messages';
+import baseline032 from '../../migrations/00-baseline-032-message-reactions';
+import baseline033 from '../../migrations/00-baseline-033-message-reads';
+import baseline034 from '../../migrations/00-baseline-034-file-uploads';
+import baseline035 from '../../migrations/00-baseline-035-notifications';
+import baseline036 from '../../migrations/00-baseline-036-device-tokens';
+
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+type ColumnRow = { column_name: string };
+type IndexRow = { indexname: string };
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const listColumns = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT column_name FROM information_schema.columns
+       WHERE table_schema = current_schema() AND table_name = '${table}'
+       ORDER BY column_name`
+  );
+  return (rows as ColumnRow[]).map(r => r.column_name);
+};
+
+const listIndexes = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT indexname FROM pg_indexes
+       WHERE tablename = '${table}'
+       ORDER BY indexname`
+  );
+  return (rows as IndexRow[]).map(r => r.indexname);
+};
+
+type Migration = {
+  up: (qi: typeof queryInterface) => Promise<void>;
+  down: (qi: typeof queryInterface) => Promise<void>;
+};
+
+type Case = {
+  name: string;
+  table: string;
+  destructiveKey: string;
+  migration: Migration;
+};
+
+const CASES: ReadonlyArray<Case> = [
+  {
+    name: '029 — chats',
+    table: 'chats',
+    destructiveKey: '00-baseline-029-chats',
+    migration: baseline029,
+  },
+  {
+    name: '030 — chat_participants',
+    table: 'chat_participants',
+    destructiveKey: '00-baseline-030-chat-participants',
+    migration: baseline030,
+  },
+  {
+    name: '031 — messages',
+    table: 'messages',
+    destructiveKey: '00-baseline-031-messages',
+    migration: baseline031,
+  },
+  {
+    name: '032 — message_reactions',
+    table: 'message_reactions',
+    destructiveKey: '00-baseline-032-message-reactions',
+    migration: baseline032,
+  },
+  {
+    name: '033 — message_reads',
+    table: 'message_reads',
+    destructiveKey: '00-baseline-033-message-reads',
+    migration: baseline033,
+  },
+  {
+    name: '034 — file_uploads',
+    table: 'file_uploads',
+    destructiveKey: '00-baseline-034-file-uploads',
+    migration: baseline034,
+  },
+  {
+    name: '035 — notifications',
+    table: 'notifications',
+    destructiveKey: '00-baseline-035-notifications',
+    migration: baseline035,
+  },
+  {
+    name: '036 — device_tokens',
+    table: 'device_tokens',
+    destructiveKey: '00-baseline-036-device-tokens',
+    migration: baseline036,
+  },
+];
+
+describeIfPostgres('per-model baseline — communications (rebaseline 5/10)', () => {
+  // Snapshot the env vars we mutate so we restore them between tests and
+  // never leak into other test files.
+  const originalAllow = process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  const originalKey = process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+  beforeAll(async () => {
+    // Establish the canonical post-sync baseline once. Each test that
+    // needs to compare against the canonical shape captures it before
+    // dropping the table.
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    // Restore env so test ordering doesn't leak.
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+    await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    // Each test starts from a freshly-synced schema so dropTable in one
+    // test cannot stomp another's setup.
+    await sequelize.sync({ force: true });
+  });
+
+  afterEach(() => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+  });
+
+  describe.each(CASES)('$name', ({ table, destructiveKey, migration }) => {
+    it('up() recreates the table with the same columns sync() produces', async () => {
+      const expectedColumns = await listColumns(table);
+      expect(expectedColumns.length).toBeGreaterThan(0);
+
+      await queryInterface.dropTable(table);
+      expect(await tableExists(table)).toBe(false);
+
+      await migration.up(queryInterface);
+
+      expect(await tableExists(table)).toBe(true);
+      const actualColumns = await listColumns(table);
+      expect(actualColumns).toEqual(expectedColumns);
+    });
+
+    it('up() recreates the indexes sync() produces', async () => {
+      const expectedIndexes = await listIndexes(table);
+
+      await queryInterface.dropTable(table);
+      await migration.up(queryInterface);
+
+      const actualIndexes = await listIndexes(table);
+      // Compare as sets — sync()'s anonymous index naming order can drift
+      // from queryInterface.addIndex's, but the set of indexes must match.
+      expect(new Set(actualIndexes)).toEqual(new Set(expectedIndexes));
+    });
+
+    it('down() refuses to drop the table without the destructive-down env flags', async () => {
+      delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+      delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+      await expect(migration.down(queryInterface)).rejects.toThrow(/destructive down/);
+      expect(await tableExists(table)).toBe(true);
+    });
+
+    it('down() drops the table when the destructive-down env flags acknowledge it', async () => {
+      process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+      process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = destructiveKey;
+
+      await migration.down(queryInterface);
+
+      expect(await tableExists(table)).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-029-chats.ts
+++ b/service.backend/src/migrations/00-baseline-029-chats.ts
@@ -1,0 +1,107 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — chats (rebaseline 5/10).
+ *
+ * Frozen snapshot of `Chat`'s sync() output. Cross-table foreign keys
+ * (application_id, rescue_id, pet_id, created_by, updated_by) live in
+ * `00-baseline-zzz-foreign-keys.ts` so each per-model file is independently
+ * orderable. The columns themselves carry the right shape (UUID), but no
+ * REFERENCES clause until the FK file lands.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'chats',
+        {
+          chat_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          application_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          pet_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          status: {
+            type: DataTypes.ENUM('active', 'locked', 'archived'),
+            allowNull: false,
+            defaultValue: 'active',
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('chats', {
+        fields: ['application_id'],
+        name: 'chats_application_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('chats', {
+        fields: ['rescue_id'],
+        name: 'chats_rescue_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('chats', {
+        fields: ['pet_id'],
+        name: 'chats_pet_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('chats', { fields: ['status'], transaction: t });
+      await queryInterface.addIndex('chats', {
+        fields: ['created_by'],
+        name: 'chats_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('chats', {
+        fields: ['updated_by'],
+        name: 'chats_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-029-chats');
+    await queryInterface.dropTable('chats');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_chats_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-030-chat-participants.ts
+++ b/service.backend/src/migrations/00-baseline-030-chat-participants.ts
@@ -1,0 +1,104 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — chat_participants (rebaseline 5/10).
+ *
+ * Frozen snapshot of `ChatParticipant`'s sync() output. FKs (chat_id,
+ * participant_id, rescue_id, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'chat_participants',
+        {
+          chat_participant_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          chat_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          participant_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          role: {
+            type: DataTypes.ENUM('rescue', 'user', 'admin', 'member'),
+            allowNull: false,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          last_read_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('chat_participants', {
+        fields: ['chat_id', 'participant_id'],
+        unique: true,
+        name: 'chat_participants_chat_id_participant_id_unique',
+        transaction: t,
+      });
+      await queryInterface.addIndex('chat_participants', {
+        fields: ['participant_id'],
+        name: 'chat_participants_participant_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('chat_participants', { fields: ['role'], transaction: t });
+      await queryInterface.addIndex('chat_participants', {
+        fields: ['created_by'],
+        name: 'chat_participants_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('chat_participants', {
+        fields: ['updated_by'],
+        name: 'chat_participants_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-030-chat-participants');
+    await queryInterface.dropTable('chat_participants');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_chat_participants_role');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-031-messages.ts
+++ b/service.backend/src/migrations/00-baseline-031-messages.ts
@@ -1,0 +1,164 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — messages (rebaseline 5/10).
+ *
+ * Frozen snapshot of `Message`'s sync() output. FKs (chat_id, sender_id,
+ * created_by, updated_by) land in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Two model concerns NOT replicated as DDL here:
+ *
+ *   - The `search_vector` BEFORE INSERT/UPDATE trigger and its GIN
+ *     index (`messages_search_vector_gin_idx`) are installed by the model's
+ *     afterSync hook (`installGeneratedSearchVector` in
+ *     `models/generated-search-vector.ts`) — a model concern, not a baseline
+ *     concern. The column itself is declared here as a writable TSVECTOR.
+ *   - The `attachments` JSONB column declares its column type only. The
+ *     URL-shape correctness inside elements is enforced by callers (model
+ *     validators); migrations 17/18 fixed past write paths but the baseline
+ *     column type is just JSONB.
+ *
+ * Moderation columns (is_flagged / flag_reason / flag_severity /
+ * moderation_status / flagged_at) are part of the current `Message` model
+ * and therefore part of `sync()` output, but the moderation INDEXES added
+ * by migration 02 are not in the model's index list and are NOT part of
+ * the baseline — they continue to be created by migration 02.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'messages',
+        {
+          message_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          chat_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          sender_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          content: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          content_format: {
+            type: DataTypes.ENUM('plain', 'markdown', 'html'),
+            allowNull: false,
+            defaultValue: 'plain',
+          },
+          attachments: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: [],
+          },
+          search_vector: {
+            type: DataTypes.TSVECTOR,
+            allowNull: true,
+          },
+          is_flagged: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          flag_reason: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          flag_severity: {
+            type: DataTypes.ENUM('low', 'medium', 'high', 'critical'),
+            allowNull: true,
+          },
+          moderation_status: {
+            type: DataTypes.ENUM('pending_review', 'approved', 'rejected'),
+            allowNull: true,
+          },
+          flagged_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('messages', {
+        fields: ['chat_id'],
+        name: 'messages_chat_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('messages', {
+        fields: ['sender_id'],
+        name: 'messages_sender_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('messages', {
+        fields: ['created_at'],
+        name: 'messages_created_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('messages', {
+        fields: ['search_vector'],
+        using: 'gin',
+        name: 'messages_search_vector_gin_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('messages', {
+        fields: ['chat_id', { name: 'created_at', order: 'DESC' }],
+        name: 'messages_chat_created_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('messages', {
+        fields: ['created_by'],
+        name: 'messages_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('messages', {
+        fields: ['updated_by'],
+        name: 'messages_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-031-messages');
+    await queryInterface.dropTable('messages');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_messages_content_format');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_messages_flag_severity');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_messages_moderation_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-032-message-reactions.ts
+++ b/service.backend/src/migrations/00-baseline-032-message-reactions.ts
@@ -1,0 +1,89 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline — message_reactions (rebaseline 5/10).
+ *
+ * Frozen snapshot of `MessageReaction`'s sync() output. FKs (message_id,
+ * user_id, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `paranoid: false` on the model — no `deleted_at` column. Reactions are
+ * deleted hard.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'message_reactions',
+        {
+          reaction_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          message_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          emoji: {
+            type: DataTypes.STRING(32),
+            allowNull: false,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('message_reactions', {
+        fields: ['message_id', 'user_id', 'emoji'],
+        unique: true,
+        name: 'message_reactions_message_user_emoji_unique',
+        transaction: t,
+      });
+      await queryInterface.addIndex('message_reactions', {
+        fields: ['user_id'],
+        name: 'message_reactions_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('message_reactions', {
+        fields: ['created_by'],
+        name: 'message_reactions_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('message_reactions', {
+        fields: ['updated_by'],
+        name: 'message_reactions_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-032-message-reactions');
+    await queryInterface.dropTable('message_reactions');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-033-message-reads.ts
+++ b/service.backend/src/migrations/00-baseline-033-message-reads.ts
@@ -1,0 +1,90 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline — message_reads (rebaseline 5/10).
+ *
+ * Frozen snapshot of `MessageRead`'s sync() output. FKs (message_id,
+ * user_id, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'message_reads',
+        {
+          read_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          message_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          read_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('message_reads', {
+        fields: ['message_id', 'user_id'],
+        unique: true,
+        name: 'message_reads_message_user_unique',
+        transaction: t,
+      });
+      await queryInterface.addIndex('message_reads', {
+        fields: ['user_id'],
+        name: 'message_reads_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('message_reads', {
+        fields: ['created_by'],
+        name: 'message_reads_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('message_reads', {
+        fields: ['updated_by'],
+        name: 'message_reads_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-033-message-reads');
+    await queryInterface.dropTable('message_reads');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-034-file-uploads.ts
+++ b/service.backend/src/migrations/00-baseline-034-file-uploads.ts
@@ -1,0 +1,146 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — file_uploads (rebaseline 5/10).
+ *
+ * Frozen snapshot of `FileUpload`'s sync() output. FK (uploaded_by,
+ * created_by, updated_by) lands in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `url` and `thumbnail_url` are declared as STRING(1000) only — the
+ * `/uploads/<prefix>/<filename>` shape was fixed by migration 17 and is
+ * enforced by callers. The baseline column type captures the size limit;
+ * URL convention is not a DDL concern.
+ *
+ * `metadata` is JSONB. Per-key validation is on the model.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'file_uploads',
+        {
+          upload_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          original_filename: {
+            type: DataTypes.STRING(500),
+            allowNull: false,
+          },
+          stored_filename: {
+            type: DataTypes.STRING(500),
+            allowNull: false,
+            unique: true,
+          },
+          file_path: {
+            type: DataTypes.STRING(1000),
+            allowNull: false,
+          },
+          mime_type: {
+            type: DataTypes.STRING(100),
+            allowNull: false,
+          },
+          file_size: {
+            type: DataTypes.BIGINT,
+            allowNull: false,
+          },
+          url: {
+            type: DataTypes.STRING(1000),
+            allowNull: false,
+          },
+          thumbnail_url: {
+            type: DataTypes.STRING(1000),
+            allowNull: true,
+          },
+          uploaded_by: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          entity_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          entity_type: {
+            type: DataTypes.ENUM('chat', 'message', 'application', 'pet', 'user', 'rescue'),
+            allowNull: true,
+          },
+          purpose: {
+            type: DataTypes.STRING(100),
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('file_uploads', {
+        fields: ['uploaded_by'],
+        name: 'file_uploads_uploaded_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('file_uploads', {
+        fields: ['entity_id', 'entity_type'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('file_uploads', { fields: ['purpose'], transaction: t });
+      await queryInterface.addIndex('file_uploads', { fields: ['mime_type'], transaction: t });
+      await queryInterface.addIndex('file_uploads', { fields: ['created_at'], transaction: t });
+      await queryInterface.addIndex('file_uploads', {
+        fields: ['stored_filename'],
+        unique: true,
+        name: 'file_uploads_stored_filename_unique',
+        transaction: t,
+      });
+      await queryInterface.addIndex('file_uploads', {
+        fields: ['created_by'],
+        name: 'file_uploads_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('file_uploads', {
+        fields: ['updated_by'],
+        name: 'file_uploads_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-034-file-uploads');
+    await queryInterface.dropTable('file_uploads');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_file_uploads_entity_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-035-notifications.ts
+++ b/service.backend/src/migrations/00-baseline-035-notifications.ts
@@ -1,0 +1,274 @@
+import { DataTypes, Op, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — notifications (rebaseline 5/10).
+ *
+ * Frozen snapshot of `Notification`'s sync() output. FK (user_id,
+ * created_by, updated_by) lands in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Several columns use Postgres ENUMs (type / channel / priority / status /
+ * related_entity_type) — declared with the same value lists the model
+ * declares today.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'notifications',
+        {
+          notification_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          type: {
+            type: DataTypes.ENUM(
+              'application_status',
+              'message_received',
+              'pet_available',
+              'interview_scheduled',
+              'home_visit_scheduled',
+              'adoption_approved',
+              'adoption_rejected',
+              'reference_request',
+              'system_announcement',
+              'account_security',
+              'reminder',
+              'marketing',
+              'rescue_invitation',
+              'staff_assignment',
+              'pet_update',
+              'follow_up'
+            ),
+            allowNull: false,
+          },
+          channel: {
+            type: DataTypes.ENUM('in_app', 'email', 'push', 'sms'),
+            allowNull: false,
+          },
+          priority: {
+            type: DataTypes.ENUM('low', 'normal', 'high', 'urgent'),
+            allowNull: false,
+            defaultValue: 'normal',
+          },
+          status: {
+            type: DataTypes.ENUM('pending', 'sent', 'delivered', 'read', 'failed', 'cancelled'),
+            allowNull: false,
+            defaultValue: 'pending',
+          },
+          title: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          message: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          data: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          template_id: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          template_variables: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          related_entity_type: {
+            type: DataTypes.ENUM(
+              'application',
+              'pet',
+              'message',
+              'user',
+              'rescue',
+              'conversation',
+              'interview',
+              'home_visit',
+              'reminder',
+              'announcement',
+              'adoption',
+              'event',
+              'reference',
+              'security'
+            ),
+            allowNull: true,
+          },
+          related_entity_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          scheduled_for: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          sent_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          delivered_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          read_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          clicked_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          retry_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          max_retries: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 3,
+          },
+          error_message: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          external_id: {
+            type: DataTypes.STRING,
+            allowNull: true,
+            comment: 'External service ID for tracking delivery status',
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('notifications', {
+        fields: ['user_id'],
+        name: 'notifications_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['type'],
+        name: 'notifications_type_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['channel'],
+        name: 'notifications_channel_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['status'],
+        name: 'notifications_status_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['priority'],
+        name: 'notifications_priority_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['scheduled_for'],
+        name: 'notifications_scheduled_for_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['created_at'],
+        name: 'notifications_created_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['expires_at'],
+        name: 'notifications_expires_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['user_id', 'read_at'],
+        name: 'notifications_user_read_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['related_entity_type', 'related_entity_id'],
+        name: 'notifications_related_entity_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['external_id'],
+        name: 'notifications_external_id_idx',
+        where: { external_id: { [Op.ne]: null } },
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['user_id', 'status', { name: 'created_at', order: 'DESC' }],
+        name: 'notifications_user_status_created_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['deleted_at'],
+        name: 'notifications_deleted_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['created_by'],
+        name: 'notifications_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('notifications', {
+        fields: ['updated_by'],
+        name: 'notifications_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-035-notifications');
+    await queryInterface.dropTable('notifications');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_notifications_type');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_notifications_channel');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_notifications_priority');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_notifications_status');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_notifications_related_entity_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-036-device-tokens.ts
+++ b/service.backend/src/migrations/00-baseline-036-device-tokens.ts
@@ -1,0 +1,135 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — device_tokens (rebaseline 5/10).
+ *
+ * Frozen snapshot of `DeviceToken`'s sync() output. FK (user_id) lands in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `DeviceToken` does NOT use `withAuditHooks` — no `created_by`,
+ * `updated_by`, or `version` columns / indexes. Paranoid (deleted_at) is
+ * still on.
+ *
+ * The unique partial index `device_tokens_user_token_unique` enforces
+ * "one active token per user+device_token" while permitting historical
+ * soft-deleted rows.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'device_tokens',
+        {
+          token_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          device_token: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          platform: {
+            type: DataTypes.ENUM('ios', 'android', 'web'),
+            allowNull: false,
+          },
+          app_version: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+          },
+          device_info: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          status: {
+            type: DataTypes.ENUM('active', 'inactive', 'expired', 'invalid'),
+            allowNull: false,
+            defaultValue: 'active',
+          },
+          last_used_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('device_tokens', {
+        fields: ['user_id'],
+        name: 'device_tokens_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('device_tokens', {
+        fields: ['device_token'],
+        name: 'device_tokens_token_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('device_tokens', {
+        fields: ['platform'],
+        name: 'device_tokens_platform_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('device_tokens', {
+        fields: ['status'],
+        name: 'device_tokens_status_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('device_tokens', {
+        fields: ['last_used_at'],
+        name: 'device_tokens_last_used_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('device_tokens', {
+        fields: ['expires_at'],
+        name: 'device_tokens_expires_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('device_tokens', {
+        fields: ['user_id', 'device_token'],
+        unique: true,
+        name: 'device_tokens_user_token_unique',
+        where: { deleted_at: null },
+        transaction: t,
+      });
+      await queryInterface.addIndex('device_tokens', {
+        fields: ['deleted_at'],
+        name: 'device_tokens_deleted_at_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-036-device-tokens');
+    await queryInterface.dropTable('device_tokens');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_device_tokens_platform');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_device_tokens_status');
+  },
+};


### PR DESCRIPTION
## Summary

Per-model baseline rebaseline, domain 5 of 10 (communications). Per the design in `docs/migrations/per-model-rebaseline.md`, replaces the implicit `sequelize.sync()` baseline with explicit, frozen `createTable` calls — one file per table — so that fresh DBs produce a deterministic, reviewable schema.

Eight per-model files added (one table each):

- `00-baseline-029-chats.ts`
- `00-baseline-030-chat-participants.ts`
- `00-baseline-031-messages.ts`
- `00-baseline-032-message-reactions.ts`
- `00-baseline-033-message-reads.ts`
- `00-baseline-034-file-uploads.ts`
- `00-baseline-035-notifications.ts`
- `00-baseline-036-device-tokens.ts`

Each `up()` is wrapped in `runInTransaction` and creates the table + the model's non-FK indexes. Each `down()` calls `assertDestructiveDownAcknowledged` (per-file key) before `dropTable` and any orphan ENUM cleanup.

Cross-table FKs are intentionally NOT in this PR — they land in the forthcoming `00-baseline-zzz-foreign-keys.ts` so per-model files remain independently orderable.

JSONB columns whose URL shape was fixed by migrations 17/18 (`messages.attachments`, `file_uploads.url/thumbnail_url`) declare the column type only; URL-shape correctness is enforced by callers.

Round-trip tests in `service.backend/src/__tests__/migrations/baseline-communications.test.ts` (`describeIfPostgres`, 32 tests) verify per table:

1. `up()` rebuilds the same column set `sync()` produces.
2. `up()` rebuilds the same index set `sync()` produces.
3. `down()` refuses without `MIGRATION_ALLOW_DESTRUCTIVE_DOWN` + matching `MIGRATION_DESTRUCTIVE_DOWN_KEY`.
4. `down()` drops the table when the destructive-down env flags acknowledge it.

## Notes / Discrepancies

- `messages` declares `search_vector` as a writable TSVECTOR. The BEFORE INSERT/UPDATE trigger that fills it is installed via the model's `afterSync` hook (`installGeneratedSearchVector`) and is not part of the baseline DDL.
- `messages` includes the moderation columns (today's `Message` model emits them via `sync()`), but the moderation-specific indexes added by migration 02 are not in the model's index list and are not duplicated here.
- `device_tokens` is the only file in this set without `withAuditHooks` — no `created_by` / `updated_by` / `version` columns or audit indexes.
- All other communications tables get `created_by`, `updated_by`, `version`, and the matching `*_created_by_idx` / `*_updated_by_idx` indexes from `withAuditHooks`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes (no new warnings)
- [x] `npx vitest run` — 2118 passed, 93 skipped (4 migration test files require Postgres and skip via `describeIfPostgres`)
- [ ] CI runs `baseline-communications.test.ts` against the Postgres test DB to verify round-trip equivalence with `sync()` output

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_