### PR TITLE
feat(migrations): per-model baseline for applications (rebaseline 4/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-applications.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-applications.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * applications domain (rebaseline 4/10).
+ *
+ * Each migration is exercised by:
+ *   1. Bootstrapping the schema via `sync({ force: true })` so the
+ *      starting state matches what fresh databases will see today.
+ *   2. Dropping the migration's table (CASCADE so any sync()-installed
+ *      cross-table FKs to/from it come along) and any owned ENUM types.
+ *   3. Running `up()` and asserting the table, key columns, and
+ *      enumerated indexes exist.
+ *   4. Running `down()` (with the destructive-down env-flags set so
+ *      `assertDestructiveDownAcknowledged` permits it) and asserting
+ *      the table and ENUM types are gone.
+ *
+ * Postgres-only — the migrations declare native ENUM types and use
+ * `DataTypes.JSONB`, neither of which has a SQLite equivalent we
+ * exercise here.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import baseline020 from '../../migrations/00-baseline-020-applications';
+import baseline021 from '../../migrations/00-baseline-021-application-answers';
+import baseline022 from '../../migrations/00-baseline-022-application-questions';
+import baseline023 from '../../migrations/00-baseline-023-application-references';
+import baseline024 from '../../migrations/00-baseline-024-application-status-transitions';
+import baseline025 from '../../migrations/00-baseline-025-application-timeline';
+import baseline026 from '../../migrations/00-baseline-026-user-application-prefs';
+import baseline027 from '../../migrations/00-baseline-027-home-visits';
+import baseline028 from '../../migrations/00-baseline-028-home-visit-status-transitions';
+
+// Force all model side-effects to run so `sync()` has every table.
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const columnExists = async (table: string, column: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.columns
+       WHERE table_name = '${table}' AND column_name = '${column}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const indexExists = async (table: string, name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM pg_indexes WHERE tablename = '${table}' AND indexname = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const enumExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM pg_type WHERE typname = '${name}' AND typtype = 'e'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const dropTableCascade = async (name: string): Promise<void> => {
+  await sequelize.query(`DROP TABLE IF EXISTS "${name}" CASCADE`);
+};
+
+const dropEnum = async (name: string): Promise<void> => {
+  await sequelize.query(`DROP TYPE IF EXISTS "${name}"`);
+};
+
+const ackKey = (key: string): void => {
+  process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+  process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = key;
+};
+
+const clearAck = (): void => {
+  delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+};
+
+describeIfPostgres('per-model baseline — applications domain (round trip)', () => {
+  beforeAll(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  afterEach(() => {
+    clearAck();
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  describe('00-baseline-020-applications', () => {
+    beforeEach(async () => {
+      await dropTableCascade('applications');
+      await dropEnum('enum_applications_status');
+      await dropEnum('enum_applications_priority');
+      await dropEnum('enum_applications_stage');
+      await dropEnum('enum_applications_final_outcome');
+    });
+
+    it('up() creates the applications table with its enumerated indexes', async () => {
+      await baseline020.up(queryInterface);
+
+      expect(await tableExists('applications')).toBe(true);
+      expect(await columnExists('applications', 'application_id')).toBe(true);
+      expect(await columnExists('applications', 'requires_coppa_consent')).toBe(true);
+      expect(await columnExists('applications', 'references_consented')).toBe(true);
+      expect(await columnExists('applications', 'version')).toBe(true);
+
+      expect(await indexExists('applications', 'applications_user_id_idx')).toBe(true);
+      expect(await indexExists('applications', 'applications_pet_id_idx')).toBe(true);
+      expect(await indexExists('applications', 'applications_user_pet_unique')).toBe(true);
+      expect(await indexExists('applications', 'applications_rescue_status_created_idx')).toBe(
+        true
+      );
+
+      expect(await enumExists('enum_applications_status')).toBe(true);
+      expect(await enumExists('enum_applications_stage')).toBe(true);
+    });
+
+    it('down() refuses without the destructive-down acknowledgement', async () => {
+      await baseline020.up(queryInterface);
+      await expect(baseline020.down(queryInterface)).rejects.toThrow(/destructive down/i);
+    });
+
+    it('down() drops the table and its enum types when acknowledged', async () => {
+      await baseline020.up(queryInterface);
+      ackKey('00-baseline-020-applications');
+
+      await baseline020.down(queryInterface);
+
+      expect(await tableExists('applications')).toBe(false);
+      expect(await enumExists('enum_applications_status')).toBe(false);
+      expect(await enumExists('enum_applications_priority')).toBe(false);
+      expect(await enumExists('enum_applications_stage')).toBe(false);
+      expect(await enumExists('enum_applications_final_outcome')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-021-application-answers', () => {
+    beforeEach(async () => {
+      await dropTableCascade('application_answers');
+    });
+
+    it('up() creates the application_answers table with its unique key index', async () => {
+      await baseline021.up(queryInterface);
+
+      expect(await tableExists('application_answers')).toBe(true);
+      expect(await columnExists('application_answers', 'question_key')).toBe(true);
+      expect(await columnExists('application_answers', 'answer_value')).toBe(true);
+      expect(
+        await indexExists('application_answers', 'application_answers_app_question_unique')
+      ).toBe(true);
+      expect(await indexExists('application_answers', 'application_answers_question_key_idx')).toBe(
+        true
+      );
+    });
+
+    it('down() drops the table when acknowledged', async () => {
+      await baseline021.up(queryInterface);
+      ackKey('00-baseline-021-application-answers');
+
+      await baseline021.down(queryInterface);
+      expect(await tableExists('application_answers')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-022-application-questions', () => {
+    beforeEach(async () => {
+      await dropTableCascade('application_questions');
+      await dropEnum('enum_application_questions_scope');
+      await dropEnum('enum_application_questions_category');
+      await dropEnum('enum_application_questions_question_type');
+    });
+
+    it('up() creates the application_questions table with its three ENUM types', async () => {
+      await baseline022.up(queryInterface);
+
+      expect(await tableExists('application_questions')).toBe(true);
+      expect(await columnExists('application_questions', 'scope')).toBe(true);
+      expect(await columnExists('application_questions', 'category')).toBe(true);
+      expect(await columnExists('application_questions', 'question_type')).toBe(true);
+
+      expect(await enumExists('enum_application_questions_scope')).toBe(true);
+      expect(await enumExists('enum_application_questions_category')).toBe(true);
+      expect(await enumExists('enum_application_questions_question_type')).toBe(true);
+
+      expect(
+        await indexExists('application_questions', 'application_questions_key_rescue_unique')
+      ).toBe(true);
+      expect(
+        await indexExists('application_questions', 'application_questions_core_key_unique')
+      ).toBe(true);
+    });
+
+    it('down() drops the table and all three enum types when acknowledged', async () => {
+      await baseline022.up(queryInterface);
+      ackKey('00-baseline-022-application-questions');
+
+      await baseline022.down(queryInterface);
+
+      expect(await tableExists('application_questions')).toBe(false);
+      expect(await enumExists('enum_application_questions_scope')).toBe(false);
+      expect(await enumExists('enum_application_questions_category')).toBe(false);
+      expect(await enumExists('enum_application_questions_question_type')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-023-application-references', () => {
+    beforeEach(async () => {
+      await dropTableCascade('application_references');
+      await dropEnum('enum_application_references_status');
+    });
+
+    it('up() creates the application_references table with its status ENUM', async () => {
+      await baseline023.up(queryInterface);
+
+      expect(await tableExists('application_references')).toBe(true);
+      expect(await columnExists('application_references', 'legacy_id')).toBe(true);
+      expect(await columnExists('application_references', 'order_index')).toBe(true);
+      expect(await enumExists('enum_application_references_status')).toBe(true);
+      expect(
+        await indexExists('application_references', 'application_references_app_legacy_unique')
+      ).toBe(true);
+    });
+
+    it('down() drops the table and status ENUM when acknowledged', async () => {
+      await baseline023.up(queryInterface);
+      ackKey('00-baseline-023-application-references');
+
+      await baseline023.down(queryInterface);
+      expect(await tableExists('application_references')).toBe(false);
+      expect(await enumExists('enum_application_references_status')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-024-application-status-transitions', () => {
+    beforeEach(async () => {
+      await dropTableCascade('application_status_transitions');
+      await dropEnum('enum_application_status_transitions_from_status');
+      await dropEnum('enum_application_status_transitions_to_status');
+    });
+
+    it('up() creates the transitions table with both from/to ENUM types', async () => {
+      await baseline024.up(queryInterface);
+
+      expect(await tableExists('application_status_transitions')).toBe(true);
+      // Append-only event log — no updated_at column.
+      expect(await columnExists('application_status_transitions', 'updated_at')).toBe(false);
+      expect(await columnExists('application_status_transitions', 'transitioned_at')).toBe(true);
+      expect(await enumExists('enum_application_status_transitions_from_status')).toBe(true);
+      expect(await enumExists('enum_application_status_transitions_to_status')).toBe(true);
+      expect(
+        await indexExists(
+          'application_status_transitions',
+          'application_status_transitions_app_id_at_idx'
+        )
+      ).toBe(true);
+    });
+
+    it('down() drops the table and both ENUM types when acknowledged', async () => {
+      await baseline024.up(queryInterface);
+      ackKey('00-baseline-024-application-status-transitions');
+
+      await baseline024.down(queryInterface);
+      expect(await tableExists('application_status_transitions')).toBe(false);
+      expect(await enumExists('enum_application_status_transitions_from_status')).toBe(false);
+      expect(await enumExists('enum_application_status_transitions_to_status')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-025-application-timeline', () => {
+    beforeEach(async () => {
+      await dropTableCascade('application_timeline');
+      await dropEnum('enum_application_timeline_event_type');
+    });
+
+    it('up() creates the timeline table with its event_type ENUM', async () => {
+      await baseline025.up(queryInterface);
+
+      expect(await tableExists('application_timeline')).toBe(true);
+      // Append-only — paranoid: false on the model, no deleted_at column.
+      expect(await columnExists('application_timeline', 'deleted_at')).toBe(false);
+      expect(await enumExists('enum_application_timeline_event_type')).toBe(true);
+      expect(
+        await indexExists('application_timeline', 'application_timeline_application_id_idx')
+      ).toBe(true);
+      expect(await indexExists('application_timeline', 'application_timeline_created_by_idx')).toBe(
+        true
+      );
+    });
+
+    it('down() drops the table and event_type ENUM when acknowledged', async () => {
+      await baseline025.up(queryInterface);
+      ackKey('00-baseline-025-application-timeline');
+
+      await baseline025.down(queryInterface);
+      expect(await tableExists('application_timeline')).toBe(false);
+      expect(await enumExists('enum_application_timeline_event_type')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-026-user-application-prefs', () => {
+    beforeEach(async () => {
+      await dropTableCascade('user_application_prefs');
+    });
+
+    it('up() creates the user_application_prefs table keyed by user_id', async () => {
+      await baseline026.up(queryInterface);
+
+      expect(await tableExists('user_application_prefs')).toBe(true);
+      expect(await columnExists('user_application_prefs', 'user_id')).toBe(true);
+      expect(await columnExists('user_application_prefs', 'auto_fill_profile')).toBe(true);
+      expect(await columnExists('user_application_prefs', 'default_household_size')).toBe(true);
+      expect(await columnExists('user_application_prefs', 'version')).toBe(true);
+    });
+
+    it('down() drops the table when acknowledged', async () => {
+      await baseline026.up(queryInterface);
+      ackKey('00-baseline-026-user-application-prefs');
+
+      await baseline026.down(queryInterface);
+      expect(await tableExists('user_application_prefs')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-027-home-visits', () => {
+    beforeEach(async () => {
+      await dropTableCascade('home_visits');
+      await dropEnum('enum_home_visits_status');
+      await dropEnum('enum_home_visits_outcome');
+    });
+
+    it('up() creates the home_visits table with its status and outcome ENUMs', async () => {
+      await baseline027.up(queryInterface);
+
+      expect(await tableExists('home_visits')).toBe(true);
+      expect(await columnExists('home_visits', 'scheduled_date')).toBe(true);
+      expect(await columnExists('home_visits', 'scheduled_time')).toBe(true);
+      expect(await enumExists('enum_home_visits_status')).toBe(true);
+      expect(await enumExists('enum_home_visits_outcome')).toBe(true);
+      expect(await indexExists('home_visits', 'home_visits_application_id_idx')).toBe(true);
+    });
+
+    it('down() drops the table and both ENUM types when acknowledged', async () => {
+      await baseline027.up(queryInterface);
+      ackKey('00-baseline-027-home-visits');
+
+      await baseline027.down(queryInterface);
+      expect(await tableExists('home_visits')).toBe(false);
+      expect(await enumExists('enum_home_visits_status')).toBe(false);
+      expect(await enumExists('enum_home_visits_outcome')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-028-home-visit-status-transitions', () => {
+    beforeEach(async () => {
+      await dropTableCascade('home_visit_status_transitions');
+      await dropEnum('enum_home_visit_status_transitions_from_status');
+      await dropEnum('enum_home_visit_status_transitions_to_status');
+    });
+
+    it('up() creates the transitions table with both from/to ENUM types', async () => {
+      await baseline028.up(queryInterface);
+
+      expect(await tableExists('home_visit_status_transitions')).toBe(true);
+      expect(await columnExists('home_visit_status_transitions', 'visit_id')).toBe(true);
+      expect(await columnExists('home_visit_status_transitions', 'updated_at')).toBe(false);
+      expect(await enumExists('enum_home_visit_status_transitions_from_status')).toBe(true);
+      expect(await enumExists('enum_home_visit_status_transitions_to_status')).toBe(true);
+      expect(
+        await indexExists(
+          'home_visit_status_transitions',
+          'home_visit_status_transitions_visit_id_at_idx'
+        )
+      ).toBe(true);
+    });
+
+    it('down() drops the table and both ENUM types when acknowledged', async () => {
+      await baseline028.up(queryInterface);
+      ackKey('00-baseline-028-home-visit-status-transitions');
+
+      await baseline028.down(queryInterface);
+      expect(await tableExists('home_visit_status_transitions')).toBe(false);
+      expect(await enumExists('enum_home_visit_status_transitions_from_status')).toBe(false);
+      expect(await enumExists('enum_home_visit_status_transitions_to_status')).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-020-applications.ts
+++ b/service.backend/src/migrations/00-baseline-020-applications.ts
@@ -1,0 +1,234 @@
+import { DataTypes, Op, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) — `applications` table.
+ *
+ * Frozen `createTable` body extracted from `models/Application.ts` as it
+ * stood at the rebaseline cut. Mirrors what `sequelize.sync()` produces
+ * today; landing this file plus its sibling `00-baseline-NNN-*.ts` files
+ * gives fresh databases an explicit, reviewable schema diff in place of
+ * the implicit `sync()` call in `00-baseline.ts`.
+ *
+ * Cross-table foreign-key constraints are NOT declared here — they are
+ * batched into `00-baseline-zzz-foreign-keys.ts` so per-model files are
+ * independently reorderable. Indexes covering FK columns ARE created
+ * here (they are plain B-tree indexes, not constraints).
+ *
+ * `down()` drops the table and its dialect-private ENUM types. It is
+ * gated by `assertDestructiveDownAcknowledged` because rebuilding the
+ * table from scratch would erase data.
+ */
+const MIGRATION_KEY = '00-baseline-020-applications';
+
+const APPLICATION_STATUSES = ['submitted', 'approved', 'rejected', 'withdrawn'] as const;
+const APPLICATION_PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
+const APPLICATION_STAGES = [
+  'pending',
+  'reviewing',
+  'visiting',
+  'deciding',
+  'resolved',
+  'withdrawn',
+] as const;
+const APPLICATION_OUTCOMES = ['approved', 'rejected', 'withdrawn'] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'applications',
+        {
+          application_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          pet_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          status: {
+            type: DataTypes.ENUM(...APPLICATION_STATUSES),
+            allowNull: false,
+            defaultValue: 'submitted',
+          },
+          priority: {
+            type: DataTypes.ENUM(...APPLICATION_PRIORITIES),
+            allowNull: false,
+            defaultValue: 'normal',
+          },
+          stage: {
+            type: DataTypes.ENUM(...APPLICATION_STAGES),
+            allowNull: false,
+            defaultValue: 'pending',
+          },
+          final_outcome: {
+            type: DataTypes.ENUM(...APPLICATION_OUTCOMES),
+            allowNull: true,
+          },
+          review_started_at: { type: DataTypes.DATE, allowNull: true },
+          visit_scheduled_at: { type: DataTypes.DATE, allowNull: true },
+          visit_completed_at: { type: DataTypes.DATE, allowNull: true },
+          resolved_at: { type: DataTypes.DATE, allowNull: true },
+          withdrawal_reason: { type: DataTypes.TEXT, allowNull: true },
+          rejection_reason: { type: DataTypes.TEXT, allowNull: true },
+          actioned_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          actioned_at: { type: DataTypes.DATE, allowNull: true },
+          documents: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+          },
+          requires_coppa_consent: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          parental_consent_given_at: { type: DataTypes.DATE, allowNull: true },
+          references_consented: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          interview_notes: { type: DataTypes.TEXT, allowNull: true },
+          home_visit_notes: { type: DataTypes.TEXT, allowNull: true },
+          score: { type: DataTypes.INTEGER, allowNull: true },
+          tags: { type: DataTypes.ARRAY(DataTypes.STRING), allowNull: true },
+          notes: { type: DataTypes.TEXT, allowNull: true },
+          submitted_at: { type: DataTypes.DATE, allowNull: true },
+          reviewed_at: { type: DataTypes.DATE, allowNull: true },
+          decision_at: { type: DataTypes.DATE, allowNull: true },
+          expires_at: { type: DataTypes.DATE, allowNull: true },
+          follow_up_date: { type: DataTypes.DATE, allowNull: true },
+          created_by: { type: DataTypes.UUID, allowNull: true },
+          updated_by: { type: DataTypes.UUID, allowNull: true },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: { type: DataTypes.DATE, allowNull: true },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('applications', {
+        fields: ['user_id'],
+        name: 'applications_user_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['pet_id'],
+        name: 'applications_pet_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['rescue_id'],
+        name: 'applications_rescue_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['actioned_by'],
+        name: 'applications_actioned_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['status'],
+        name: 'applications_status_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['priority'],
+        name: 'applications_priority_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['created_at'],
+        name: 'applications_created_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['submitted_at'],
+        name: 'applications_submitted_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['expires_at'],
+        name: 'applications_expires_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['follow_up_date'],
+        name: 'applications_follow_up_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['user_id', 'pet_id'],
+        unique: true,
+        name: 'applications_user_pet_unique',
+        where: {
+          deleted_at: null,
+          status: { [Op.not]: ['rejected', 'withdrawn'] },
+        },
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['rescue_id', 'status', { name: 'created_at', order: 'DESC' }],
+        name: 'applications_rescue_status_created_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['deleted_at'],
+        name: 'applications_deleted_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['created_by'],
+        name: 'applications_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('applications', {
+        fields: ['updated_by'],
+        name: 'applications_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('applications', { transaction });
+    });
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_applications_status');
+    await dropEnumTypeIfExists(sql, 'enum_applications_priority');
+    await dropEnumTypeIfExists(sql, 'enum_applications_stage');
+    await dropEnumTypeIfExists(sql, 'enum_applications_final_outcome');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-021-application-answers.ts
+++ b/service.backend/src/migrations/00-baseline-021-application-answers.ts
@@ -1,0 +1,99 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { runInTransaction, assertDestructiveDownAcknowledged } from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) — `application_answers` table.
+ *
+ * Frozen `createTable` body extracted from `models/ApplicationAnswer.ts`.
+ * No ENUM columns. Cross-table FK constraints are batched into the
+ * separate `00-baseline-zzz-foreign-keys.ts` file; FK-column indexes
+ * (plain B-tree) are created here because they accelerate joins
+ * regardless of whether the FK is enforced at the DB layer.
+ */
+const MIGRATION_KEY = '00-baseline-021-application-answers';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'application_answers',
+        {
+          answer_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          application_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          question_key: {
+            type: DataTypes.STRING(128),
+            allowNull: false,
+          },
+          answer_value: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          answered_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          created_by: { type: DataTypes.UUID, allowNull: true },
+          updated_by: { type: DataTypes.UUID, allowNull: true },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('application_answers', {
+        fields: ['application_id', 'question_key'],
+        unique: true,
+        name: 'application_answers_app_question_unique',
+        transaction,
+      });
+      await queryInterface.addIndex('application_answers', {
+        fields: ['application_id'],
+        name: 'application_answers_app_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_answers', {
+        fields: ['question_key'],
+        name: 'application_answers_question_key_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_answers', {
+        fields: ['created_by'],
+        name: 'application_answers_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_answers', {
+        fields: ['updated_by'],
+        name: 'application_answers_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('application_answers', { transaction });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-022-application-questions.ts
+++ b/service.backend/src/migrations/00-baseline-022-application-questions.ts
@@ -1,0 +1,208 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) — `application_questions` table.
+ *
+ * Frozen `createTable` body extracted from `models/ApplicationQuestion.ts`.
+ * Three ENUM columns (scope, category, question_type); their dialect-private
+ * types are dropped in `down()` to avoid leaking into pg_type.
+ *
+ * Cross-table FK constraints are added in `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-022-application-questions';
+
+const QUESTION_SCOPES = ['core', 'rescue_specific'] as const;
+const QUESTION_CATEGORIES = [
+  'personal_information',
+  'household_information',
+  'pet_ownership_experience',
+  'lifestyle_compatibility',
+  'pet_care_commitment',
+  'references_verification',
+  'final_acknowledgments',
+] as const;
+const QUESTION_TYPES = [
+  'text',
+  'email',
+  'phone',
+  'number',
+  'boolean',
+  'select',
+  'multi_select',
+  'address',
+  'date',
+  'file',
+] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'application_questions',
+        {
+          question_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          question_key: {
+            type: DataTypes.STRING(100),
+            allowNull: false,
+          },
+          scope: {
+            type: DataTypes.ENUM(...QUESTION_SCOPES),
+            allowNull: false,
+          },
+          category: {
+            type: DataTypes.ENUM(...QUESTION_CATEGORIES),
+            allowNull: false,
+          },
+          question_type: {
+            type: DataTypes.ENUM(...QUESTION_TYPES),
+            allowNull: false,
+          },
+          question_text: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          help_text: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          placeholder: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+          },
+          options: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: true,
+          },
+          validation_rules: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+            defaultValue: null,
+          },
+          display_order: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          is_enabled: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          is_required: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          conditional_logic: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+            defaultValue: null,
+          },
+          created_by: { type: DataTypes.UUID, allowNull: true },
+          updated_by: { type: DataTypes.UUID, allowNull: true },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: { type: DataTypes.DATE, allowNull: true },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('application_questions', {
+        fields: ['rescue_id'],
+        name: 'application_questions_rescue_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['scope'],
+        name: 'application_questions_scope_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['category'],
+        name: 'application_questions_category_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['question_type'],
+        name: 'application_questions_type_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['is_enabled'],
+        name: 'application_questions_enabled_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['display_order'],
+        name: 'application_questions_order_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['question_key', 'rescue_id'],
+        unique: true,
+        name: 'application_questions_key_rescue_unique',
+        where: { deleted_at: null },
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['question_key'],
+        unique: true,
+        name: 'application_questions_core_key_unique',
+        where: { scope: 'core', deleted_at: null },
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['deleted_at'],
+        name: 'application_questions_deleted_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['created_by'],
+        name: 'application_questions_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_questions', {
+        fields: ['updated_by'],
+        name: 'application_questions_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('application_questions', { transaction });
+    });
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_application_questions_scope');
+    await dropEnumTypeIfExists(sql, 'enum_application_questions_category');
+    await dropEnumTypeIfExists(sql, 'enum_application_questions_question_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-023-application-references.ts
+++ b/service.backend/src/migrations/00-baseline-023-application-references.ts
@@ -1,0 +1,138 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) — `application_references` table.
+ *
+ * Frozen `createTable` body extracted from `models/ApplicationReference.ts`.
+ * One ENUM column (status). Cross-table FK constraints land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-023-application-references';
+
+const REFERENCE_STATUSES = ['pending', 'contacted', 'verified', 'failed'] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'application_references',
+        {
+          reference_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          application_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          legacy_id: {
+            type: DataTypes.STRING(64),
+            allowNull: false,
+          },
+          name: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          relationship: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          phone: {
+            type: DataTypes.STRING(64),
+            allowNull: false,
+          },
+          email: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+          },
+          status: {
+            type: DataTypes.ENUM(...REFERENCE_STATUSES),
+            allowNull: false,
+            defaultValue: 'pending',
+          },
+          contacted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          contacted_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          order_index: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_by: { type: DataTypes.UUID, allowNull: true },
+          updated_by: { type: DataTypes.UUID, allowNull: true },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('application_references', {
+        fields: ['application_id', 'order_index'],
+        name: 'application_references_app_order_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_references', {
+        fields: ['application_id', 'legacy_id'],
+        unique: true,
+        name: 'application_references_app_legacy_unique',
+        transaction,
+      });
+      await queryInterface.addIndex('application_references', {
+        fields: ['status'],
+        name: 'application_references_status_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_references', {
+        fields: ['contacted_by'],
+        name: 'application_references_contacted_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_references', {
+        fields: ['created_by'],
+        name: 'application_references_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_references', {
+        fields: ['updated_by'],
+        name: 'application_references_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('application_references', { transaction });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_application_references_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-024-application-status-transitions.ts
+++ b/service.backend/src/migrations/00-baseline-024-application-status-transitions.ts
@@ -1,0 +1,98 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) —
+ * `application_status_transitions` table.
+ *
+ * Frozen `createTable` body extracted from
+ * `models/ApplicationStatusTransition.ts`. Append-only event log:
+ * `timestamps: false` in the model — only `transitioned_at` (set on
+ * insert via `defaultValue: NOW`) tracks event time. Two ENUM columns
+ * (from_status, to_status) sharing the same set of values but Postgres
+ * gives each its own type.
+ *
+ * The AFTER INSERT trigger that denormalises `to_status` onto
+ * `applications.status` is installed by the model's `afterSync` hook;
+ * it lives outside the per-model baseline because the trigger depends
+ * on `applications` already existing. Equivalent rebaselining of the
+ * trigger DDL would belong with the FK-batch file or a follow-up
+ * migration.
+ *
+ * Cross-table FK constraints land in `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-024-application-status-transitions';
+
+const APPLICATION_STATUSES = ['submitted', 'approved', 'rejected', 'withdrawn'] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'application_status_transitions',
+        {
+          transition_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          application_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          from_status: {
+            type: DataTypes.ENUM(...APPLICATION_STATUSES),
+            allowNull: true,
+          },
+          to_status: {
+            type: DataTypes.ENUM(...APPLICATION_STATUSES),
+            allowNull: false,
+          },
+          transitioned_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          transitioned_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('application_status_transitions', {
+        fields: ['application_id', 'transitioned_at'],
+        name: 'application_status_transitions_app_id_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('application_status_transitions', {
+        fields: ['transitioned_by'],
+        name: 'application_status_transitions_transitioned_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('application_status_transitions', { transaction });
+    });
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_application_status_transitions_from_status');
+    await dropEnumTypeIfExists(sql, 'enum_application_status_transitions_to_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-025-application-timeline.ts
+++ b/service.backend/src/migrations/00-baseline-025-application-timeline.ts
@@ -1,0 +1,141 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) — `application_timeline` table.
+ *
+ * Frozen `createTable` body extracted from `models/ApplicationTimeline.ts`.
+ * Append-only event log; the model opts out of paranoid soft-delete so
+ * there is no `deleted_at` column. One ENUM column (event_type).
+ *
+ * Cross-table FK constraints land in `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-025-application-timeline';
+
+const TIMELINE_EVENT_TYPES = [
+  'stage_change',
+  'status_update',
+  'note_added',
+  'reference_contacted',
+  'reference_verified',
+  'interview_scheduled',
+  'interview_completed',
+  'home_visit_scheduled',
+  'home_visit_completed',
+  'home_visit_rescheduled',
+  'home_visit_cancelled',
+  'score_updated',
+  'document_uploaded',
+  'decision_made',
+  'application_approved',
+  'application_rejected',
+  'application_withdrawn',
+  'application_reopened',
+  'communication_sent',
+  'communication_received',
+  'system_auto_progression',
+  'manual_override',
+] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'application_timeline',
+        {
+          timeline_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          application_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          event_type: {
+            type: DataTypes.ENUM(...TIMELINE_EVENT_TYPES),
+            allowNull: false,
+          },
+          title: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          created_by_email_snapshot: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          created_by_system: {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false,
+          },
+          previous_stage: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+          },
+          new_stage: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+          },
+          previous_status: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+          },
+          new_status: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('application_timeline', {
+        fields: ['application_id', 'created_at'],
+        name: 'application_timeline_application_id_idx',
+        transaction,
+      });
+      // Index on event_type — name auto-generated to match what
+      // `sync()` produces (no explicit name set on the model index).
+      await queryInterface.addIndex('application_timeline', {
+        fields: ['event_type'],
+        transaction,
+      });
+      await queryInterface.addIndex('application_timeline', {
+        fields: ['created_by'],
+        name: 'application_timeline_created_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('application_timeline', { transaction });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_application_timeline_event_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-026-user-application-prefs.ts
+++ b/service.backend/src/migrations/00-baseline-026-user-application-prefs.ts
@@ -1,0 +1,90 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { runInTransaction, assertDestructiveDownAcknowledged } from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) —
+ * `user_application_prefs` table.
+ *
+ * Frozen `createTable` body extracted from `models/UserApplicationPrefs.ts`.
+ * 1:1 with `users` (user_id is the PK, no separate row id). No ENUM
+ * columns. Cross-table FK constraints land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-026-user-application-prefs';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'user_application_prefs',
+        {
+          user_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          auto_fill_profile: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          remember_answers: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          share_with_rescues: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          completion_reminders: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          default_household_size: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          created_by: { type: DataTypes.UUID, allowNull: true },
+          updated_by: { type: DataTypes.UUID, allowNull: true },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('user_application_prefs', {
+        fields: ['created_by'],
+        name: 'user_application_prefs_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('user_application_prefs', {
+        fields: ['updated_by'],
+        name: 'user_application_prefs_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('user_application_prefs', { transaction });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-027-home-visits.ts
+++ b/service.backend/src/migrations/00-baseline-027-home-visits.ts
@@ -1,0 +1,137 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) — `home_visits` table.
+ *
+ * Frozen `createTable` body extracted from `models/HomeVisit.ts`. Two
+ * ENUM columns (status, outcome). Cross-table FK constraints land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-027-home-visits';
+
+const HOME_VISIT_STATUSES = ['scheduled', 'in_progress', 'completed', 'cancelled'] as const;
+const HOME_VISIT_OUTCOMES = ['approved', 'rejected', 'conditional'] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'home_visits',
+        {
+          visit_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          application_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          scheduled_date: {
+            type: DataTypes.DATEONLY,
+            allowNull: false,
+          },
+          scheduled_time: {
+            type: DataTypes.TIME,
+            allowNull: false,
+          },
+          assigned_staff: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          status: {
+            type: DataTypes.ENUM(...HOME_VISIT_STATUSES),
+            allowNull: false,
+            defaultValue: 'scheduled',
+          },
+          notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          outcome: {
+            type: DataTypes.ENUM(...HOME_VISIT_OUTCOMES),
+            allowNull: true,
+          },
+          outcome_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          reschedule_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          cancelled_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          completed_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          created_by: { type: DataTypes.UUID, allowNull: true },
+          updated_by: { type: DataTypes.UUID, allowNull: true },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('home_visits', {
+        fields: ['application_id'],
+        name: 'home_visits_application_id_idx',
+        transaction,
+      });
+      // Indexes without explicit names — match what `sync()` auto-generates.
+      await queryInterface.addIndex('home_visits', {
+        fields: ['status'],
+        transaction,
+      });
+      await queryInterface.addIndex('home_visits', {
+        fields: ['assigned_staff'],
+        transaction,
+      });
+      await queryInterface.addIndex('home_visits', {
+        fields: ['scheduled_date'],
+        transaction,
+      });
+      await queryInterface.addIndex('home_visits', {
+        fields: ['created_by'],
+        name: 'home_visits_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('home_visits', {
+        fields: ['updated_by'],
+        name: 'home_visits_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('home_visits', { transaction });
+    });
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_home_visits_status');
+    await dropEnumTypeIfExists(sql, 'enum_home_visits_outcome');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-028-home-visit-status-transitions.ts
+++ b/service.backend/src/migrations/00-baseline-028-home-visit-status-transitions.ts
@@ -1,0 +1,96 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: applications) —
+ * `home_visit_status_transitions` table.
+ *
+ * Frozen `createTable` body extracted from
+ * `models/HomeVisitStatusTransition.ts`. Append-only event log
+ * (`timestamps: false`); two ENUM columns sharing the same value set
+ * but Postgres gives each its own type. The model intentionally has no
+ * Sequelize-level FK constraint on `transitioned_by` — the association
+ * uses `constraints: false` so the actor reference is preserved when
+ * the user is deleted (forensic). Cross-table FK to `home_visits` lives
+ * in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * The AFTER INSERT trigger that propagates `to_status` onto
+ * `home_visits.status` is installed by the model's `afterSync` hook
+ * and is out of scope here — same arrangement as the application
+ * status-transitions baseline.
+ */
+const MIGRATION_KEY = '00-baseline-028-home-visit-status-transitions';
+
+const HOME_VISIT_STATUSES = ['scheduled', 'in_progress', 'completed', 'cancelled'] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'home_visit_status_transitions',
+        {
+          transition_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          visit_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          from_status: {
+            type: DataTypes.ENUM(...HOME_VISIT_STATUSES),
+            allowNull: true,
+          },
+          to_status: {
+            type: DataTypes.ENUM(...HOME_VISIT_STATUSES),
+            allowNull: false,
+          },
+          transitioned_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          transitioned_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('home_visit_status_transitions', {
+        fields: ['visit_id', 'transitioned_at'],
+        name: 'home_visit_status_transitions_visit_id_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('home_visit_status_transitions', {
+        fields: ['transitioned_by'],
+        name: 'home_visit_status_transitions_transitioned_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('home_visit_status_transitions', { transaction });
+    });
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_home_visit_status_transitions_from_status');
+    await dropEnumTypeIfExists(sql, 'enum_home_visit_status_transitions_to_status');
+  },
+};


### PR DESCRIPTION
## Summary

Domain 4 of 10 in the per-model rebaseline tracked in `docs/migrations/per-model-rebaseline.md` §2.2. Replaces the implicit `sequelize.sync()` baseline for the applications domain with explicit, reviewable `createTable` migrations — one per model — so fresh databases produce a deterministic schema and future model edits show up as a real migration diff.

Tables covered (9):

- `applications`
- `application_answers`
- `application_questions`
- `application_references`
- `application_status_transitions`
- `application_timeline`
- `user_application_prefs`
- `home_visits`
- `home_visit_status_transitions`

Each migration mirrors what `sync()` produces today against the matching model file. Cross-table FK constraints are intentionally NOT declared here — they batch into the planned `00-baseline-zzz-foreign-keys.ts` so per-model files stay independently reorderable. FK-column indexes (plain B-tree) are included because they accelerate joins regardless of whether the FK constraint is enforced at the DB layer.

ENUMs declared inline in `DataTypes.ENUM(...)` and torn down in `down()` via `dropEnumTypeIfExists` so they don't leak into `pg_type`. Every `down()` is gated by `assertDestructiveDownAcknowledged` because rebuilding the table from scratch would erase data.

The model-level AFTER INSERT triggers that propagate `to_status` from the transition tables to the parent rows are NOT recreated here — they are installed by the model's `afterSync` hook (Postgres-only) and depend on both tables already existing. Recreating them belongs alongside the FK-batch file or a follow-up.

## Files

New migrations under `service.backend/src/migrations/`:

- `00-baseline-020-applications.ts`
- `00-baseline-021-application-answers.ts`
- `00-baseline-022-application-questions.ts`
- `00-baseline-023-application-references.ts`
- `00-baseline-024-application-status-transitions.ts`
- `00-baseline-025-application-timeline.ts`
- `00-baseline-026-user-application-prefs.ts`
- `00-baseline-027-home-visits.ts`
- `00-baseline-028-home-visit-status-transitions.ts`

New round-trip test:

- `service.backend/src/__tests__/migrations/baseline-applications.test.ts` — 19 cases, gated by `describeIfPostgres`. Each migration is exercised by dropping the (sync-built) table + ENUMs, running `up()`, asserting structure, then running `down()` with the destructive-down env-flags set.

## Test plan

- [ ] `npm run lint` clean for the new files (verified locally — pre-existing warnings unrelated, 0 errors)
- [ ] `npm run build` (tsc) passes (verified locally)
- [ ] `npm run test` skips the 19 new cases on SQLite locally; CI runs them on Postgres
- [ ] Manual: confirm enum types are gone after `down()` runs in CI Postgres

## Notes / discrepancies surfaced during transcription

- The `audit_columns` mixin contributes `created_by`, `updated_by`, `version` (via `version: true`) plus matching FK-column indexes; these are reproduced verbatim in every model that opts in (`applications`, `application_answers`, `application_questions`, `application_references`, `user_application_prefs`, `home_visits`). The two transitions tables and `application_timeline` opt out of `withAuditHooks`, so they have no `version` column.
- `application_timeline` declares `paranoid: false`, so it has no `deleted_at` column despite living in a domain where most tables have one. The test asserts the absence.
- `application_status_transitions` and `home_visit_status_transitions` set `timestamps: false` — only `transitioned_at` tracks event time. The test asserts no `updated_at`.
- The `home_visits` model declares two unnamed indexes (`status`, `assigned_staff`, `scheduled_date`) and one named (`application_id`) — Sequelize auto-generates the unnamed index names. Reproduced verbatim. Same applies to `application_timeline`'s `event_type` index.
- `applications` carries the COPPA / references-consent fields (`requires_coppa_consent`, `parental_consent_given_at`, `references_consented`) added by migration 10; including them here is consistent with the rebaseline's "freeze what `sync()` produces today" rule.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_