### PR TITLE
feat(migrations): per-model baseline for identity & auth (rebaseline 1/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-identity.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-identity.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * Identity & auth domain (rebaseline 1/10).
+ *
+ *   00-baseline-001-users
+ *   00-baseline-002-roles
+ *   00-baseline-003-permissions
+ *   00-baseline-004-role-permissions
+ *   00-baseline-005-user-roles
+ *   00-baseline-006-refresh-tokens
+ *   00-baseline-007-revoked-tokens
+ *   00-baseline-008-ip-rules
+ *   00-baseline-009-field-permissions
+ *   00-baseline-010-staff-members
+ *   00-baseline-011-invitations
+ *
+ * Each test runs `up` against an empty schema (no model state — we drop
+ * any table the model would have created via sync() so up() actually has
+ * work to do), asserts the table + expected indexes exist, then runs
+ * `down` and asserts the table is gone. Postgres-only — the migration
+ * bodies use dialect-specific features (CITEXT, ENUM types, GEOMETRY)
+ * that have no SQLite equivalent.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import baseline001 from '../../migrations/00-baseline-001-users';
+import baseline002 from '../../migrations/00-baseline-002-roles';
+import baseline003 from '../../migrations/00-baseline-003-permissions';
+import baseline004 from '../../migrations/00-baseline-004-role-permissions';
+import baseline005 from '../../migrations/00-baseline-005-user-roles';
+import baseline006 from '../../migrations/00-baseline-006-refresh-tokens';
+import baseline007 from '../../migrations/00-baseline-007-revoked-tokens';
+import baseline008 from '../../migrations/00-baseline-008-ip-rules';
+import baseline009 from '../../migrations/00-baseline-009-field-permissions';
+import baseline010 from '../../migrations/00-baseline-010-staff-members';
+import baseline011 from '../../migrations/00-baseline-011-invitations';
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const columnExists = async (table: string, column: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.columns
+       WHERE table_name = '${table}' AND column_name = '${column}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const indexExists = async (table: string, name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM pg_indexes WHERE tablename = '${table}' AND indexname = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+type ColumnInfo = { data_type: string; udt_name: string; is_nullable: string };
+
+const describeColumn = async (table: string, column: string): Promise<ColumnInfo | undefined> => {
+  const [rows] = await sequelize.query(
+    `SELECT data_type, udt_name, is_nullable FROM information_schema.columns
+       WHERE table_name = '${table}' AND column_name = '${column}'`
+  );
+  return (rows as ColumnInfo[])[0];
+};
+
+/**
+ * Drop tables (and their dependent ENUMs) in reverse-creation order before
+ * each test so `up()` always operates on an empty schema. We can't use
+ * sequelize.sync({ force: true }) here because that would *create* the
+ * tables, defeating the test.
+ *
+ * The list intentionally enumerates every table the suite touches; CASCADE
+ * handles the unlikely-but-possible case of a stray dependent object.
+ */
+const TABLES = [
+  'invitations',
+  'staff_members',
+  'field_permissions',
+  'ip_rules',
+  'revoked_tokens',
+  'refresh_tokens',
+  'user_roles',
+  'role_permissions',
+  'permissions',
+  'roles',
+  'users',
+] as const;
+
+const ENUMS = [
+  'enum_users_status',
+  'enum_users_user_type',
+  'enum_ip_rules_type',
+  'enum_field_permissions_resource',
+  'enum_field_permissions_access_level',
+] as const;
+
+const dropAll = async (): Promise<void> => {
+  for (const table of TABLES) {
+    await sequelize.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+  }
+  for (const enumName of ENUMS) {
+    await sequelize.query(`DROP TYPE IF EXISTS "${enumName}"`);
+  }
+};
+
+// Destructive `down()` is gated by env vars (assertDestructiveDownAcknowledged);
+// set them once for the whole suite. The key changes per-migration so each
+// test sets it before invoking down().
+const setDownKey = (key: string): void => {
+  process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+  process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = key;
+};
+
+const clearDownKey = (): void => {
+  delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+};
+
+describeIfPostgres('per-model baseline — Identity & auth (rebaseline 1/10)', () => {
+  beforeAll(async () => {
+    // Required for User.email (CITEXT). The other migrations don't need it
+    // but creating it once is idempotent.
+    await sequelize.query('CREATE EXTENSION IF NOT EXISTS citext');
+  });
+
+  beforeEach(async () => {
+    await dropAll();
+    clearDownKey();
+  });
+
+  afterAll(async () => {
+    clearDownKey();
+    await sequelize.close();
+  });
+
+  describe('00-baseline-001-users', () => {
+    it('up creates users with expected columns + indexes; down drops it', async () => {
+      await baseline001.up(queryInterface);
+      expect(await tableExists('users')).toBe(true);
+      // Spot-check columns that exercise dialect-specific types and
+      // paranoid/audit additions.
+      expect((await describeColumn('users', 'email'))?.udt_name).toBe('citext');
+      expect((await describeColumn('users', 'location'))?.udt_name).toBe('geometry');
+      expect((await describeColumn('users', 'application_defaults'))?.udt_name).toBe('jsonb');
+      expect(await columnExists('users', 'deleted_at')).toBe(true);
+      expect(await columnExists('users', 'version')).toBe(true);
+      expect(await columnExists('users', 'created_by')).toBe(true);
+      expect(await indexExists('users', 'users_email_unique')).toBe(true);
+      expect(await indexExists('users', 'users_deleted_at_idx')).toBe(true);
+      expect(await indexExists('users', 'users_created_by_idx')).toBe(true);
+
+      setDownKey('00-baseline-001-users');
+      await baseline001.down(queryInterface);
+      expect(await tableExists('users')).toBe(false);
+    });
+
+    it('down without env-var acknowledgement refuses to run', async () => {
+      await baseline001.up(queryInterface);
+      await expect(baseline001.down(queryInterface)).rejects.toThrow(/destructive/i);
+    });
+  });
+
+  describe('00-baseline-002-roles', () => {
+    it('up creates roles with the role_name column; down drops it', async () => {
+      await baseline002.up(queryInterface);
+      expect(await tableExists('roles')).toBe(true);
+      // The model maps `name` → `role_name`; ensure the migration mirrors that.
+      expect(await columnExists('roles', 'role_name')).toBe(true);
+      expect(await columnExists('roles', 'name')).toBe(false);
+
+      setDownKey('00-baseline-002-roles');
+      await baseline002.down(queryInterface);
+      expect(await tableExists('roles')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-003-permissions', () => {
+    it('up creates permissions; down drops it', async () => {
+      await baseline003.up(queryInterface);
+      expect(await tableExists('permissions')).toBe(true);
+      expect(await columnExists('permissions', 'permission_name')).toBe(true);
+
+      setDownKey('00-baseline-003-permissions');
+      await baseline003.down(queryInterface);
+      expect(await tableExists('permissions')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-004-role-permissions', () => {
+    it('up creates the junction table with composite PK; down drops it', async () => {
+      await baseline004.up(queryInterface);
+      expect(await tableExists('role_permissions')).toBe(true);
+      // Composite primary key — both columns NOT NULL.
+      expect((await describeColumn('role_permissions', 'role_id'))?.is_nullable).toBe('NO');
+      expect((await describeColumn('role_permissions', 'permission_id'))?.is_nullable).toBe('NO');
+
+      setDownKey('00-baseline-004-role-permissions');
+      await baseline004.down(queryInterface);
+      expect(await tableExists('role_permissions')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-005-user-roles', () => {
+    it('up creates the junction table with composite PK; down drops it', async () => {
+      await baseline005.up(queryInterface);
+      expect(await tableExists('user_roles')).toBe(true);
+      expect((await describeColumn('user_roles', 'user_id'))?.udt_name).toBe('uuid');
+      expect((await describeColumn('user_roles', 'role_id'))?.udt_name).toBe('int4');
+
+      setDownKey('00-baseline-005-user-roles');
+      await baseline005.down(queryInterface);
+      expect(await tableExists('user_roles')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-006-refresh-tokens', () => {
+    it('up creates refresh_tokens with all five model-declared indexes; down drops it', async () => {
+      await baseline006.up(queryInterface);
+      expect(await tableExists('refresh_tokens')).toBe(true);
+      expect(await indexExists('refresh_tokens', 'refresh_tokens_user_id_idx')).toBe(true);
+      expect(await indexExists('refresh_tokens', 'refresh_tokens_family_id_idx')).toBe(true);
+      expect(await indexExists('refresh_tokens', 'refresh_tokens_is_revoked_idx')).toBe(true);
+      expect(await indexExists('refresh_tokens', 'refresh_tokens_expires_at_idx')).toBe(true);
+      expect(await indexExists('refresh_tokens', 'refresh_tokens_user_family_idx')).toBe(true);
+
+      setDownKey('00-baseline-006-refresh-tokens');
+      await baseline006.down(queryInterface);
+      expect(await tableExists('refresh_tokens')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-007-revoked-tokens', () => {
+    it('up creates revoked_tokens including updated_at; down drops it', async () => {
+      await baseline007.up(queryInterface);
+      expect(await tableExists('revoked_tokens')).toBe(true);
+      // updated_at was introduced in migration 14 — the baseline now reflects it.
+      expect(await columnExists('revoked_tokens', 'updated_at')).toBe(true);
+      expect(await indexExists('revoked_tokens', 'revoked_tokens_expires_at_idx')).toBe(true);
+      expect(await indexExists('revoked_tokens', 'revoked_tokens_user_id_idx')).toBe(true);
+
+      setDownKey('00-baseline-007-revoked-tokens');
+      await baseline007.down(queryInterface);
+      expect(await tableExists('revoked_tokens')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-008-ip-rules', () => {
+    it('up creates ip_rules with native CIDR; down drops it and its enum', async () => {
+      await baseline008.up(queryInterface);
+      expect(await tableExists('ip_rules')).toBe(true);
+      // The model declares cidr as DataTypes.CIDR — migration 13's promotion
+      // is folded into the baseline.
+      expect((await describeColumn('ip_rules', 'cidr'))?.udt_name).toBe('cidr');
+
+      setDownKey('00-baseline-008-ip-rules');
+      await baseline008.down(queryInterface);
+      expect(await tableExists('ip_rules')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-009-field-permissions', () => {
+    it('up creates field_permissions with composite unique + lookup indexes; down drops it', async () => {
+      await baseline009.up(queryInterface);
+      expect(await tableExists('field_permissions')).toBe(true);
+      expect(await columnExists('field_permissions', 'deleted_at')).toBe(true);
+      expect(await indexExists('field_permissions', 'unique_field_permission')).toBe(true);
+
+      setDownKey('00-baseline-009-field-permissions');
+      await baseline009.down(queryInterface);
+      expect(await tableExists('field_permissions')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-010-staff-members', () => {
+    it('up creates staff_members with audit + paranoid columns; down drops it', async () => {
+      await baseline010.up(queryInterface);
+      expect(await tableExists('staff_members')).toBe(true);
+      expect(await columnExists('staff_members', 'version')).toBe(true);
+      expect(await columnExists('staff_members', 'deleted_at')).toBe(true);
+      expect(await indexExists('staff_members', 'staff_members_rescue_id_idx')).toBe(true);
+      expect(await indexExists('staff_members', 'staff_members_user_id_idx')).toBe(true);
+      expect(await indexExists('staff_members', 'staff_members_deleted_at_idx')).toBe(true);
+
+      setDownKey('00-baseline-010-staff-members');
+      await baseline010.down(queryInterface);
+      expect(await tableExists('staff_members')).toBe(false);
+    });
+  });
+
+  describe('00-baseline-011-invitations', () => {
+    it('up creates invitations with token unique + lookup indexes; down drops it', async () => {
+      await baseline011.up(queryInterface);
+      expect(await tableExists('invitations')).toBe(true);
+      expect(await columnExists('invitations', 'version')).toBe(true);
+      expect(await columnExists('invitations', 'deleted_at')).toBe(false);
+      expect(await indexExists('invitations', 'invitations_token_unique')).toBe(true);
+      expect(await indexExists('invitations', 'invitations_email_idx')).toBe(true);
+      expect(await indexExists('invitations', 'invitations_invited_by_idx')).toBe(true);
+
+      setDownKey('00-baseline-011-invitations');
+      await baseline011.down(queryInterface);
+      expect(await tableExists('invitations')).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-001-users.ts
+++ b/service.backend/src/migrations/00-baseline-001-users.ts
@@ -1,0 +1,259 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `users`.
+ *
+ * Mirrors what `sequelize.sync()` produces from `service.backend/src/models/User.ts`
+ * today — column types, nullability, defaults, single-table indexes. Cross-table
+ * foreign keys (`created_by`, `updated_by`) are intentionally omitted; they live
+ * in `00-baseline-zzz-foreign-keys.ts` so each per-model file is independently
+ * reorderable.
+ *
+ * `down` drops the table and the ENUM types created inline (`enum_users_status`,
+ * `enum_users_user_type`) so we don't leak orphaned types into pg_type.
+ */
+const MIGRATION_KEY = '00-baseline-001-users';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'users',
+        {
+          user_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          first_name: {
+            type: DataTypes.STRING(100),
+            allowNull: true,
+          },
+          last_name: {
+            type: DataTypes.STRING(100),
+            allowNull: true,
+          },
+          email: {
+            type: DataTypes.CITEXT,
+            allowNull: false,
+            unique: true,
+          },
+          password: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          email_verified: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          verification_token: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          verification_token_expires_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          reset_token: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          reset_token_expiration: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          reset_token_force_flag: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          phone_number: {
+            type: DataTypes.STRING(20),
+            allowNull: true,
+          },
+          phone_verified: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          date_of_birth: {
+            type: DataTypes.DATEONLY,
+            allowNull: true,
+          },
+          profile_image_url: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          bio: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          status: {
+            type: DataTypes.ENUM(
+              'active',
+              'inactive',
+              'suspended',
+              'pending_verification',
+              'deactivated'
+            ),
+            allowNull: false,
+            defaultValue: 'pending_verification',
+          },
+          user_type: {
+            type: DataTypes.ENUM('adopter', 'rescue_staff', 'admin', 'moderator'),
+            allowNull: false,
+            defaultValue: 'adopter',
+          },
+          last_login_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          login_attempts: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          locked_until: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          two_factor_enabled: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          two_factor_secret: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          backup_codes: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: true,
+          },
+          timezone: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+            defaultValue: 'UTC',
+          },
+          language: {
+            type: DataTypes.STRING(10),
+            allowNull: true,
+            defaultValue: 'en',
+          },
+          country: {
+            type: DataTypes.STRING(100),
+            allowNull: true,
+          },
+          city: {
+            type: DataTypes.STRING(100),
+            allowNull: true,
+          },
+          address_line_1: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+          },
+          address_line_2: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+          },
+          postal_code: {
+            type: DataTypes.STRING(20),
+            allowNull: true,
+          },
+          location: {
+            type: DataTypes.GEOMETRY('POINT'),
+            allowNull: true,
+          },
+          terms_accepted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          privacy_policy_accepted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          application_defaults: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+            defaultValue: null,
+          },
+          profile_completion_status: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+            defaultValue: {
+              basic_info: false,
+              living_situation: false,
+              pet_experience: false,
+              references: false,
+              overall_percentage: 0,
+              last_updated: null,
+            },
+          },
+          // Audit columns (FK constraints added in 00-baseline-zzz-foreign-keys.ts).
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('users', ['email'], {
+        unique: true,
+        name: 'users_email_unique',
+        transaction: t,
+      });
+      await queryInterface.addIndex('users', ['status'], { transaction: t });
+      await queryInterface.addIndex('users', ['user_type'], { transaction: t });
+      await queryInterface.addIndex('users', ['created_at'], { transaction: t });
+      await queryInterface.addIndex('users', ['deleted_at'], {
+        name: 'users_deleted_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('users', ['created_by'], {
+        name: 'users_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('users', ['updated_by'], {
+        name: 'users_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('users', { transaction: t });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_users_status');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_users_user_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-002-roles.ts
+++ b/service.backend/src/migrations/00-baseline-002-roles.ts
@@ -1,0 +1,57 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `roles`.
+ *
+ * Reference data (`paranoid: false`). Note the model maps `name` to the
+ * column `role_name`, so the DDL column is `role_name`, not `name`. The
+ * unique constraint on `role_name` is applied at the column level — no
+ * separate index entry in the model's `init()` block.
+ */
+const MIGRATION_KEY = '00-baseline-002-roles';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'roles',
+        {
+          role_id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
+            allowNull: false,
+          },
+          role_name: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+            unique: true,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('roles', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-003-permissions.ts
+++ b/service.backend/src/migrations/00-baseline-003-permissions.ts
@@ -1,0 +1,51 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `permissions`.
+ *
+ * Reference data (`paranoid: false`). The unique constraint on
+ * `permission_name` is declared at the column level.
+ */
+const MIGRATION_KEY = '00-baseline-003-permissions';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'permissions',
+        {
+          permission_id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
+            allowNull: false,
+          },
+          permission_name: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+            unique: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('permissions', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-004-role-permissions.ts
+++ b/service.backend/src/migrations/00-baseline-004-role-permissions.ts
@@ -1,0 +1,51 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `role_permissions`.
+ *
+ * Junction table for the role/permission many-to-many. Composite primary key
+ * (role_id, permission_id). The cross-table FKs to `roles.role_id` and
+ * `permissions.permission_id` are added in `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-004-role-permissions';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'role_permissions',
+        {
+          role_id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            allowNull: false,
+          },
+          permission_id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            allowNull: false,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('role_permissions', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-005-user-roles.ts
+++ b/service.backend/src/migrations/00-baseline-005-user-roles.ts
@@ -1,0 +1,51 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `user_roles`.
+ *
+ * Junction table for the user/role many-to-many. Composite primary key
+ * (user_id, role_id). The cross-table FKs to `users.user_id` and
+ * `roles.role_id` are added in `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-005-user-roles';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'user_roles',
+        {
+          user_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          role_id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            allowNull: false,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('user_roles', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-006-refresh-tokens.ts
+++ b/service.backend/src/migrations/00-baseline-006-refresh-tokens.ts
@@ -1,0 +1,89 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `refresh_tokens`.
+ *
+ * The model declares a single-column `replaced_by_token_id` with no
+ * `references:` block — it's a soft pointer to another row in this same
+ * table, but Sequelize doesn't emit a DB-level FK for it. The cross-table FK
+ * to `users.user_id` is added in `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-006-refresh-tokens';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'refresh_tokens',
+        {
+          token_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          family_id: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          is_revoked: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          replaced_by_token_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('refresh_tokens', ['user_id'], {
+        name: 'refresh_tokens_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('refresh_tokens', ['family_id'], {
+        name: 'refresh_tokens_family_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('refresh_tokens', ['is_revoked'], {
+        name: 'refresh_tokens_is_revoked_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('refresh_tokens', ['expires_at'], {
+        name: 'refresh_tokens_expires_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('refresh_tokens', ['user_id', 'family_id'], {
+        name: 'refresh_tokens_user_family_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('refresh_tokens', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-007-revoked-tokens.ts
+++ b/service.backend/src/migrations/00-baseline-007-revoked-tokens.ts
@@ -1,0 +1,69 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `revoked_tokens`.
+ *
+ * Note: the original `01-create-revoked-tokens.ts` migration created this
+ * table without `updated_at`; migration 14 added the column afterwards.
+ * Today's `RevokedToken` model declares both `revoked_at` (acting as
+ * createdAt) and `updated_at`, so the baseline includes both. This file
+ * runs FIRST (before migration 14), so when migration 14 runs against a
+ * fresh DB, its `addColumn` will be skipped — but on existing DBs that ran
+ * the legacy `00-baseline.ts`, migration 14 still does its job because
+ * SequelizeMeta will have skipped this per-model file via the rebaseline
+ * pre-seed (see `docs/migrations/per-model-rebaseline.md` §3).
+ */
+const MIGRATION_KEY = '00-baseline-007-revoked-tokens';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'revoked_tokens',
+        {
+          jti: {
+            type: DataTypes.STRING,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          revoked_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('revoked_tokens', ['expires_at'], {
+        name: 'revoked_tokens_expires_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('revoked_tokens', ['user_id'], {
+        name: 'revoked_tokens_user_id_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('revoked_tokens', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-008-ip-rules.ts
+++ b/service.backend/src/migrations/00-baseline-008-ip-rules.ts
@@ -1,0 +1,85 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `ip_rules`.
+ *
+ * The model declares `cidr` as native Postgres CIDR (the legacy
+ * `07-create-ip-rules.ts` initially used VARCHAR(64); migration 13
+ * promoted it). The model has no `indexes:` block — the legacy
+ * `07-create-ip-rules.ts` migration adds `ip_rules_type_active_idx` and
+ * `ip_rules_expires_at_idx`. Those indexes are NOT declared on the model,
+ * so a faithful `sync()` reproduction does not include them here. The
+ * legacy migration 07 (kept unchanged) creates those indexes when it runs
+ * against a fresh DB after this baseline.
+ *
+ * Cross-table FK to `users.user_id` (`created_by`) lives in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-008-ip-rules';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'ip_rules',
+        {
+          ip_rule_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+            defaultValue: DataTypes.UUIDV4,
+          },
+          type: {
+            type: DataTypes.ENUM('allow', 'block'),
+            allowNull: false,
+          },
+          cidr: {
+            type: DataTypes.CIDR,
+            allowNull: false,
+          },
+          label: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+          },
+          is_active: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('ip_rules', { transaction: t });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_ip_rules_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-009-field-permissions.ts
+++ b/service.backend/src/migrations/00-baseline-009-field-permissions.ts
@@ -1,0 +1,83 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `field_permissions`.
+ *
+ * Model has `paranoid: true` so the table includes `deleted_at`. The
+ * model's `indexes:` block declares both a unique composite (the only
+ * cross-column index) and three single-column lookup indexes — all stay
+ * here in the baseline because none cross tables.
+ */
+const MIGRATION_KEY = '00-baseline-009-field-permissions';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'field_permissions',
+        {
+          field_permission_id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
+            allowNull: false,
+          },
+          resource: {
+            type: DataTypes.ENUM('users', 'pets', 'applications', 'rescues'),
+            allowNull: false,
+          },
+          field_name: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          role: {
+            type: DataTypes.STRING(50),
+            allowNull: false,
+          },
+          access_level: {
+            type: DataTypes.ENUM('none', 'read', 'write'),
+            allowNull: false,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('field_permissions', ['resource', 'field_name', 'role'], {
+        unique: true,
+        name: 'unique_field_permission',
+        transaction: t,
+      });
+      await queryInterface.addIndex('field_permissions', ['resource'], { transaction: t });
+      await queryInterface.addIndex('field_permissions', ['role'], { transaction: t });
+      await queryInterface.addIndex('field_permissions', ['resource', 'role'], { transaction: t });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('field_permissions', { transaction: t });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_field_permissions_resource');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_field_permissions_access_level');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-010-staff-members.ts
+++ b/service.backend/src/migrations/00-baseline-010-staff-members.ts
@@ -1,0 +1,128 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `staff_members`.
+ *
+ * Uses `withAuditHooks` so the table picks up the `version` column and
+ * standard `created_by`/`updated_by` audit columns. `paranoid: true` adds
+ * `deleted_at`. Cross-table FKs (`rescue_id`, `user_id`, `verified_by`,
+ * `added_by`, `created_by`, `updated_by`) live in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-010-staff-members';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'staff_members',
+        {
+          staff_member_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          title: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          is_verified: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          verified_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          verified_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          added_by: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          added_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('staff_members', ['rescue_id'], {
+        name: 'staff_members_rescue_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('staff_members', ['user_id'], {
+        name: 'staff_members_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('staff_members', ['verified_by'], {
+        name: 'staff_members_verified_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('staff_members', ['added_by'], {
+        name: 'staff_members_added_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('staff_members', ['deleted_at'], {
+        name: 'staff_members_deleted_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('staff_members', ['created_by'], {
+        name: 'staff_members_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('staff_members', ['updated_by'], {
+        name: 'staff_members_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('staff_members', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-011-invitations.ts
+++ b/service.backend/src/migrations/00-baseline-011-invitations.ts
@@ -1,0 +1,135 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 1/10): `invitations`.
+ *
+ * Uses `withAuditHooks` (adds `version`, `created_by`, `updated_by`). The
+ * model is NOT paranoid (no `deleted_at`). Cross-table FKs (`rescue_id`,
+ * `user_id`, `invited_by`, `created_by`, `updated_by`) live in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Note: the legacy `04-add-invitation-indexes-and-constraints.ts`
+ * migration adds the same `invitations_token_unique`,
+ * `invitations_rescue_id_idx`, `invitations_user_id_idx`, and
+ * `invitations_email_idx` constraints/indexes that today's model already
+ * declares. Because the legacy migration runs AFTER this baseline (lex
+ * order: `00-...` < `04-...`), and because it uses `addConstraint`/
+ * `addIndex` without IF NOT EXISTS guards, fresh DBs would hit a duplicate
+ * error today. This is a known artifact of the rebaseline; resolution is
+ * tracked in §3 of the rebaseline design doc (the FK PR will adjust the
+ * legacy migration's index order or add IF NOT EXISTS guards).
+ */
+const MIGRATION_KEY = '00-baseline-011-invitations';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'invitations',
+        {
+          invitation_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          email: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          token: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            unique: true,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          title: {
+            type: DataTypes.STRING(100),
+            allowNull: true,
+          },
+          invited_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          expiration: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          used: {
+            type: DataTypes.BOOLEAN,
+            allowNull: true,
+            defaultValue: false,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('invitations', ['token'], {
+        unique: true,
+        name: 'invitations_token_unique',
+        transaction: t,
+      });
+      await queryInterface.addIndex('invitations', ['rescue_id'], {
+        name: 'invitations_rescue_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('invitations', ['user_id'], {
+        name: 'invitations_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('invitations', ['email'], {
+        name: 'invitations_email_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('invitations', ['invited_by'], {
+        name: 'invitations_invited_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('invitations', ['created_by'], {
+        name: 'invitations_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('invitations', ['updated_by'], {
+        name: 'invitations_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('invitations', { transaction: t });
+    });
+  },
+};


### PR DESCRIPTION
## Summary

Hand-written `createTable` migrations for the **11 Identity & auth tables** (domain 1 of 10), per `docs/migrations/per-model-rebaseline.md` §2.2. Freezes the schema `sequelize.sync()` emits today so future model edits stop silently moving the baseline. Cross-table FKs are intentionally deferred to a separate `00-baseline-zzz-foreign-keys.ts` file (out-of-scope for this PR) so per-model files stay independently reorderable.

## Files added (12)

Migrations (11):

| File | Table |
| ---- | ----- |
| `00-baseline-001-users.ts` | `users` |
| `00-baseline-002-roles.ts` | `roles` |
| `00-baseline-003-permissions.ts` | `permissions` |
| `00-baseline-004-role-permissions.ts` | `role_permissions` |
| `00-baseline-005-user-roles.ts` | `user_roles` |
| `00-baseline-006-refresh-tokens.ts` | `refresh_tokens` |
| `00-baseline-007-revoked-tokens.ts` | `revoked_tokens` |
| `00-baseline-008-ip-rules.ts` | `ip_rules` |
| `00-baseline-009-field-permissions.ts` | `field_permissions` |
| `00-baseline-010-staff-members.ts` | `staff_members` |
| `00-baseline-011-invitations.ts` | `invitations` |

Tests (1):

- `service.backend/src/__tests__/migrations/baseline-identity.test.ts` — 12 `describeIfPostgres` tests (one per file plus the destructive-down guard check on `users`).

## Conventions followed

- `up()` uses `runInTransaction` + `queryInterface.createTable` + `addIndex` to mirror what `sync()` produces today (column types, nullability, defaults).
- Single-column indexes declared in each model's `indexes:` block are recreated in the same migration (audit indexes on `created_by`/`updated_by` included — they are indexes, not the FK constraints, which still live in the FK PR).
- Cross-table `references:` blocks are omitted from every column definition.
- ENUM types are inline `DataTypes.ENUM(...)` and the matching `enum_<table>_<column>` types are dropped by `down()` via `dropEnumTypeIfExists` so we don't leak orphan types.
- `down()` is gated by `assertDestructiveDownAcknowledged` with a per-file key — operators must take a backup before rolling back.

## Model-vs-DDL discrepancies surfaced

A few things didn't quite match my prior assumptions — flagging them so the FK-PR / future domains can decide if they need follow-up:

1. **`Role` model maps `name` → column `role_name`.** The DDL column name diverges from the attribute key. The migration uses `role_name`; tests assert no `name` column exists.
2. **`ip_rules` indexes are declared in legacy migration 07, not on the model.** `IpRule.init` has no `indexes:` block today, so `sync()` does not emit `ip_rules_type_active_idx` / `ip_rules_expires_at_idx`. Migration 07 (kept unchanged) still creates them; the baseline file does not. If we want the baseline to be a true superset of model state we should leave it as-is — but if the goal is "baseline = whatever the live schema looks like after all migrations applied", these need to move into the baseline. Calling out for the FK PR or a follow-up.
3. **`invitations` model already declares the indexes that legacy migration 04 also creates** (`invitations_token_unique`, `invitations_rescue_id_idx`, `invitations_user_id_idx`, `invitations_email_idx`). On a fresh DB the new baseline creates them first, then migration 04's `addIndex` calls (no `IF NOT EXISTS` guard) will fail with duplicate-name errors. Documented inline in `00-baseline-011-invitations.ts`. The FK PR should either patch migration 04 to no-op-on-exists or reorder. Not fixed here per the "don't modify migrations 01..17" rule.
4. **`revoked_tokens.updated_at` is in the baseline** even though legacy migration 14 adds the column. Same fresh-DB-vs-existing-DB story as above; resolved by the SequelizeMeta pre-seed (§3 of the design doc) for existing DBs.
5. **`auditIndexes` adds `<table>_created_by_idx` / `<table>_updated_by_idx`** on the audit FK columns. Included these in the baseline because `sync()` emits them; the FK *constraint* still lives in the FK PR.
6. **`StaffMember.title` is declared in `interface StaffMemberAttributes` but the migration emits `STRING` (no length cap)** — that's what `DataTypes.STRING` produces (`VARCHAR(255)`). Faithful to today's `sync()`.

## Local validation

- `npx tsc --noEmit` — clean
- `npm run lint` — no new errors (167 pre-existing warnings unrelated to this PR)
- Round-tripped all 11 migrations against a local Postgres 17 instance: every `up()` succeeded, every reverse-order `down()` succeeded, all tables and ENUM types cleaned up.
- `vitest run src/__tests__/migrations/ src/__tests__/models` → 165 passed / 69 skipped (the 12 new tests are part of the 69 — `describeIfPostgres` skips them under SQLite, matching the existing `forward-fix-migrations.test.ts` pattern).

## Test plan

- [ ] CI runs the suite against Postgres and the 12 new tests execute (look for `per-model baseline — Identity & auth (rebaseline 1/10)` in the test output).
- [ ] Run `db:migrate` against a fresh dev DB and confirm tables come up clean.
- [ ] Verify `pg_dump --schema-only` of a sync()-bootstrapped DB matches a migrate-bootstrapped DB after this PR + future per-domain PRs land (§3.4 of the design doc).

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_