### PR TITLE
feat(migrations): per-model baseline for rescue org (rebaseline 2/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-rescue.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-rescue.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * Rescue org domain (rebaseline 2/10).
+ *
+ *   00-baseline-012-rescues
+ *   00-baseline-013-rescue-settings
+ *   00-baseline-014-addresses
+ *   00-baseline-015-ratings
+ *
+ * Each test runs `up` against an empty schema (we drop any table the
+ * model would have created via sync() so up() actually has work to do),
+ * asserts the table + expected indexes exist, then runs `down` (with
+ * the destructive-down env-var acknowledgement set) and asserts the
+ * table is gone. Postgres-only — the migration bodies use
+ * dialect-specific features (CITEXT, ENUM types, JSONB, partial unique
+ * indexes) that have no SQLite equivalent.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import baseline012 from '../../migrations/00-baseline-012-rescues';
+import baseline013 from '../../migrations/00-baseline-013-rescue-settings';
+import baseline014 from '../../migrations/00-baseline-014-addresses';
+import baseline015 from '../../migrations/00-baseline-015-ratings';
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const columnExists = async (table: string, column: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.columns
+       WHERE table_name = '${table}' AND column_name = '${column}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const indexExists = async (table: string, name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM pg_indexes WHERE tablename = '${table}' AND indexname = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+type ColumnInfo = { data_type: string; udt_name: string; is_nullable: string };
+
+const describeColumn = async (table: string, column: string): Promise<ColumnInfo | undefined> => {
+  const [rows] = await sequelize.query(
+    `SELECT data_type, udt_name, is_nullable FROM information_schema.columns
+       WHERE table_name = '${table}' AND column_name = '${column}'`
+  );
+  return (rows as ColumnInfo[])[0];
+};
+
+const enumExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(`SELECT 1 FROM pg_type WHERE typname = '${name}'`);
+  return (rows as unknown[]).length > 0;
+};
+
+/**
+ * Drop tables (and their dependent ENUMs) in reverse-creation order
+ * before each test so `up()` always operates on an empty schema.
+ */
+const TABLES = ['ratings', 'addresses', 'rescue_settings', 'rescues'] as const;
+
+const ENUMS = [
+  'enum_rescues_status',
+  'enum_rescues_verification_source',
+  'enum_addresses_owner_type',
+  'enum_ratings_rating_type',
+  'enum_ratings_category',
+] as const;
+
+const dropAll = async (): Promise<void> => {
+  for (const table of TABLES) {
+    await sequelize.query(`DROP TABLE IF EXISTS "${table}" CASCADE`);
+  }
+  for (const enumName of ENUMS) {
+    await sequelize.query(`DROP TYPE IF EXISTS "${enumName}"`);
+  }
+};
+
+const setDownKey = (key: string): void => {
+  process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+  process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = key;
+};
+
+const clearDownKey = (): void => {
+  delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+};
+
+describeIfPostgres('per-model baseline — Rescue org (rebaseline 2/10)', () => {
+  beforeAll(async () => {
+    // Required for rescues.email (CITEXT). Idempotent.
+    await sequelize.query('CREATE EXTENSION IF NOT EXISTS citext');
+  });
+
+  beforeEach(async () => {
+    await dropAll();
+    clearDownKey();
+  });
+
+  afterAll(async () => {
+    clearDownKey();
+    await sequelize.close();
+  });
+
+  describe('00-baseline-012-rescues', () => {
+    it('up creates rescues with model-mapped columns + indexes; down drops it', async () => {
+      await baseline012.up(queryInterface);
+      expect(await tableExists('rescues')).toBe(true);
+      // CITEXT email and the legacy column names that the model maps to.
+      expect((await describeColumn('rescues', 'email'))?.udt_name).toBe('citext');
+      expect(await columnExists('rescues', 'state')).toBe(true);
+      expect(await columnExists('rescues', 'zip_code')).toBe(true);
+      expect((await describeColumn('rescues', 'settings'))?.udt_name).toBe('jsonb');
+      expect(await columnExists('rescues', 'companies_house_number')).toBe(true);
+      expect(await columnExists('rescues', 'verification_source')).toBe(true);
+      expect(await columnExists('rescues', 'manual_verification_requested_at')).toBe(true);
+      expect(await columnExists('rescues', 'version')).toBe(true);
+      expect(await columnExists('rescues', 'created_by')).toBe(true);
+      expect(await columnExists('rescues', 'deleted_at')).toBe(true);
+      expect(await indexExists('rescues', 'rescues_verified_by_idx')).toBe(true);
+      expect(await indexExists('rescues', 'rescues_deleted_at_idx')).toBe(true);
+      expect(await indexExists('rescues', 'rescues_created_by_idx')).toBe(true);
+      expect(await enumExists('enum_rescues_status')).toBe(true);
+      expect(await enumExists('enum_rescues_verification_source')).toBe(true);
+
+      setDownKey('00-baseline-012-rescues');
+      await baseline012.down(queryInterface);
+      expect(await tableExists('rescues')).toBe(false);
+      expect(await enumExists('enum_rescues_status')).toBe(false);
+      expect(await enumExists('enum_rescues_verification_source')).toBe(false);
+    });
+
+    it('down without env-var acknowledgement refuses to run', async () => {
+      await baseline012.up(queryInterface);
+      await expect(baseline012.down(queryInterface)).rejects.toThrow(/destructive/i);
+    });
+  });
+
+  describe('00-baseline-013-rescue-settings', () => {
+    it('up creates rescue_settings with PK on rescue_id; down drops it', async () => {
+      await baseline013.up(queryInterface);
+      expect(await tableExists('rescue_settings')).toBe(true);
+      // 1:1 with rescues — PK is rescue_id, not a synthetic id.
+      expect((await describeColumn('rescue_settings', 'rescue_id'))?.is_nullable).toBe('NO');
+      expect(await columnExists('rescue_settings', 'auto_approve_applications')).toBe(true);
+      expect(await columnExists('rescue_settings', 'min_adopter_age')).toBe(true);
+      expect(await columnExists('rescue_settings', 'application_expiry_days')).toBe(true);
+      expect(await columnExists('rescue_settings', 'version')).toBe(true);
+      // Not paranoid — model overrides global default.
+      expect(await columnExists('rescue_settings', 'deleted_at')).toBe(false);
+      expect(await indexExists('rescue_settings', 'rescue_settings_created_by_idx')).toBe(true);
+      expect(await indexExists('rescue_settings', 'rescue_settings_updated_by_idx')).toBe(true);
+
+      setDownKey('00-baseline-013-rescue-settings');
+      await baseline013.down(queryInterface);
+      expect(await tableExists('rescue_settings')).toBe(false);
+    });
+
+    it('down without env-var acknowledgement refuses to run', async () => {
+      await baseline013.up(queryInterface);
+      await expect(baseline013.down(queryInterface)).rejects.toThrow(/destructive/i);
+    });
+  });
+
+  describe('00-baseline-014-addresses', () => {
+    it('up creates addresses with polymorphic owner + partial unique index; down drops it', async () => {
+      await baseline014.up(queryInterface);
+      expect(await tableExists('addresses')).toBe(true);
+      expect(await columnExists('addresses', 'owner_type')).toBe(true);
+      expect(await columnExists('addresses', 'owner_id')).toBe(true);
+      expect(await columnExists('addresses', 'is_primary')).toBe(true);
+      expect(await indexExists('addresses', 'addresses_owner_idx')).toBe(true);
+      expect(await indexExists('addresses', 'addresses_one_primary_per_owner')).toBe(true);
+      expect(await indexExists('addresses', 'addresses_country_postal_idx')).toBe(true);
+      expect(await indexExists('addresses', 'addresses_created_by_idx')).toBe(true);
+      expect(await enumExists('enum_addresses_owner_type')).toBe(true);
+
+      setDownKey('00-baseline-014-addresses');
+      await baseline014.down(queryInterface);
+      expect(await tableExists('addresses')).toBe(false);
+      expect(await enumExists('enum_addresses_owner_type')).toBe(false);
+    });
+
+    it('partial unique index permits multiple non-primary rows per owner but rejects a second primary', async () => {
+      await baseline014.up(queryInterface);
+
+      const ownerId = '00000000-0000-0000-0000-000000000001';
+      const buildRow = (label: string, isPrimary: boolean): string =>
+        `('${crypto.randomUUID()}', 'user', '${ownerId}', '${label}', 'L1', 'C', 'PC', 'GB', ${isPrimary}, 0, NOW(), NOW())`;
+
+      // Three non-primary + one primary all coexist.
+      await sequelize.query(
+        `INSERT INTO addresses (address_id, owner_type, owner_id, label, line_1, city, postal_code, country, is_primary, version, created_at, updated_at)
+           VALUES ${buildRow('home', false)}, ${buildRow('work', false)}, ${buildRow('mailing', true)}`
+      );
+
+      // A second primary for the same owner must violate the partial unique index.
+      await expect(
+        sequelize.query(
+          `INSERT INTO addresses (address_id, owner_type, owner_id, label, line_1, city, postal_code, country, is_primary, version, created_at, updated_at)
+             VALUES ${buildRow('second-primary', true)}`
+        )
+      ).rejects.toThrow();
+    });
+
+    it('down without env-var acknowledgement refuses to run', async () => {
+      await baseline014.up(queryInterface);
+      await expect(baseline014.down(queryInterface)).rejects.toThrow(/destructive/i);
+    });
+  });
+
+  describe('00-baseline-015-ratings', () => {
+    it('up creates ratings with all model-declared FK indexes + audit indexes; down drops it', async () => {
+      await baseline015.up(queryInterface);
+      expect(await tableExists('ratings')).toBe(true);
+      expect(await columnExists('ratings', 'rating_type')).toBe(true);
+      expect(await columnExists('ratings', 'category')).toBe(true);
+      expect(await columnExists('ratings', 'helpful_count')).toBe(true);
+      expect(await columnExists('ratings', 'is_moderated')).toBe(true);
+      expect(await columnExists('ratings', 'response_text')).toBe(true);
+      expect(await columnExists('ratings', 'version')).toBe(true);
+      // Model does not override the global paranoid default.
+      expect(await columnExists('ratings', 'deleted_at')).toBe(true);
+      expect((await describeColumn('ratings', 'pros'))?.udt_name).toBe('jsonb');
+      expect((await describeColumn('ratings', 'cons'))?.udt_name).toBe('jsonb');
+      expect(await indexExists('ratings', 'ratings_pet_id_idx')).toBe(true);
+      expect(await indexExists('ratings', 'ratings_rescue_id_idx')).toBe(true);
+      expect(await indexExists('ratings', 'ratings_reviewer_id_idx')).toBe(true);
+      expect(await indexExists('ratings', 'ratings_reviewee_id_idx')).toBe(true);
+      expect(await indexExists('ratings', 'ratings_application_id_idx')).toBe(true);
+      expect(await indexExists('ratings', 'ratings_created_by_idx')).toBe(true);
+      expect(await indexExists('ratings', 'ratings_updated_by_idx')).toBe(true);
+      expect(await enumExists('enum_ratings_rating_type')).toBe(true);
+      expect(await enumExists('enum_ratings_category')).toBe(true);
+
+      setDownKey('00-baseline-015-ratings');
+      await baseline015.down(queryInterface);
+      expect(await tableExists('ratings')).toBe(false);
+      expect(await enumExists('enum_ratings_rating_type')).toBe(false);
+      expect(await enumExists('enum_ratings_category')).toBe(false);
+    });
+
+    it('down without env-var acknowledgement refuses to run', async () => {
+      await baseline015.up(queryInterface);
+      await expect(baseline015.down(queryInterface)).rejects.toThrow(/destructive/i);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-012-rescues.ts
+++ b/service.backend/src/migrations/00-baseline-012-rescues.ts
@@ -1,0 +1,196 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 2/10): `rescues`.
+ *
+ * Mirrors what `sequelize.sync()` produces from `service.backend/src/models/Rescue.ts`
+ * today — column types, nullability, defaults, single-table indexes. Cross-table
+ * foreign keys (`verified_by`, `created_by`, `updated_by`) are intentionally
+ * omitted; they live in `00-baseline-zzz-foreign-keys.ts` so each per-model file
+ * is independently reorderable.
+ *
+ * `down` drops the table and the ENUM types created inline (`enum_rescues_status`,
+ * `enum_rescues_verification_source`) so we don't leak orphaned types into pg_type.
+ */
+const MIGRATION_KEY = '00-baseline-012-rescues';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'rescues',
+        {
+          rescue_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          name: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            unique: true,
+          },
+          email: {
+            type: DataTypes.CITEXT,
+            allowNull: false,
+            unique: true,
+          },
+          phone: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          address: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          city: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          // Model attribute `county` maps to legacy column `state` (see Rescue.ts).
+          state: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          // Model attribute `postcode` maps to legacy column `zip_code`.
+          zip_code: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          country: {
+            type: DataTypes.CHAR(2),
+            allowNull: false,
+            defaultValue: 'GB',
+          },
+          website: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          mission: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          companies_house_number: {
+            type: DataTypes.STRING(8),
+            allowNull: true,
+            unique: true,
+          },
+          charity_registration_number: {
+            type: DataTypes.STRING(12),
+            allowNull: true,
+            unique: true,
+          },
+          contact_person: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          contact_title: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          contact_email: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          contact_phone: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          status: {
+            type: DataTypes.ENUM('pending', 'verified', 'suspended', 'inactive', 'rejected'),
+            allowNull: false,
+            defaultValue: 'pending',
+          },
+          verified_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          // FK to users.user_id deferred to 00-baseline-zzz-foreign-keys.ts.
+          verified_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          verification_source: {
+            type: DataTypes.ENUM('companies_house', 'charity_commission', 'manual'),
+            allowNull: true,
+          },
+          verification_failure_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          manual_verification_requested_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          settings: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+            defaultValue: {},
+          },
+          // Audit columns (FK constraints added in 00-baseline-zzz-foreign-keys.ts).
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('rescues', ['verified_by'], {
+        name: 'rescues_verified_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('rescues', ['deleted_at'], {
+        name: 'rescues_deleted_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('rescues', ['created_by'], {
+        name: 'rescues_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('rescues', ['updated_by'], {
+        name: 'rescues_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('rescues', { transaction: t });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_rescues_status');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_rescues_verification_source');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-013-rescue-settings.ts
+++ b/service.backend/src/migrations/00-baseline-013-rescue-settings.ts
@@ -1,0 +1,101 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 2/10): `rescue_settings`.
+ *
+ * 1:1 typed preference table for `rescues` (plan 5.6 — see model docstring).
+ * Auto-created via `Rescue.afterCreate` so consumers can always assume the
+ * row exists.
+ *
+ * Cross-table FKs (`rescue_id` → rescues, `created_by`/`updated_by` → users)
+ * are intentionally omitted; they live in `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-013-rescue-settings';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'rescue_settings',
+        {
+          // FK to rescues.rescue_id deferred to 00-baseline-zzz-foreign-keys.ts.
+          rescue_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          auto_approve_applications: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          require_home_visit: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          require_references: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          min_adopter_age: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 18,
+          },
+          allow_out_of_area_adoptions: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          application_expiry_days: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 30,
+          },
+          // Audit columns (FK constraints added in 00-baseline-zzz-foreign-keys.ts).
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('rescue_settings', ['created_by'], {
+        name: 'rescue_settings_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('rescue_settings', ['updated_by'], {
+        name: 'rescue_settings_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('rescue_settings', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/00-baseline-014-addresses.ts
+++ b/service.backend/src/migrations/00-baseline-014-addresses.ts
@@ -1,0 +1,134 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 2/10): `addresses`.
+ *
+ * Polymorphic address book — `owner_type` ('user' | 'rescue') + `owner_id`
+ * points at either users.user_id or rescues.rescue_id. Parent existence
+ * is enforced at the application layer (see Address.ts header), so the
+ * polymorphic FK has no DB-level constraint to defer.
+ *
+ * Audit FK constraints (`created_by`/`updated_by` → users) are deferred
+ * to `00-baseline-zzz-foreign-keys.ts`.
+ */
+const MIGRATION_KEY = '00-baseline-014-addresses';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'addresses',
+        {
+          address_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          owner_type: {
+            type: DataTypes.ENUM('user', 'rescue'),
+            allowNull: false,
+          },
+          owner_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          label: {
+            type: DataTypes.STRING(64),
+            allowNull: true,
+          },
+          line_1: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          line_2: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+          },
+          city: {
+            type: DataTypes.STRING(128),
+            allowNull: false,
+          },
+          region: {
+            type: DataTypes.STRING(128),
+            allowNull: true,
+          },
+          postal_code: {
+            type: DataTypes.STRING(32),
+            allowNull: false,
+          },
+          country: {
+            type: DataTypes.CHAR(2),
+            allowNull: false,
+          },
+          is_primary: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          // Audit columns (FK constraints added in 00-baseline-zzz-foreign-keys.ts).
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+        },
+        { transaction: t }
+      );
+
+      // Composite index for polymorphic-resolution + per-owner listings.
+      await queryInterface.addIndex('addresses', ['owner_type', 'owner_id'], {
+        name: 'addresses_owner_idx',
+        transaction: t,
+      });
+      // Partial unique index — exactly one primary per owner.
+      await queryInterface.addIndex('addresses', ['owner_type', 'owner_id'], {
+        name: 'addresses_one_primary_per_owner',
+        unique: true,
+        where: { is_primary: true },
+        transaction: t,
+      });
+      // Country + postal_code lookups for postcode-based search paths.
+      await queryInterface.addIndex('addresses', ['country', 'postal_code'], {
+        name: 'addresses_country_postal_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('addresses', ['created_by'], {
+        name: 'addresses_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('addresses', ['updated_by'], {
+        name: 'addresses_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('addresses', { transaction: t });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_addresses_owner_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-015-ratings.ts
+++ b/service.backend/src/migrations/00-baseline-015-ratings.ts
@@ -1,0 +1,209 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline (rebaseline 2/10): `ratings`.
+ *
+ * Cross-table FKs (`reviewer_id`/`reviewee_id` → users, `pet_id` → pets,
+ * `rescue_id` → rescues, `application_id` → applications,
+ * `created_by`/`updated_by` → users) are intentionally omitted; they live
+ * in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `down` drops the table and the ENUM types created inline
+ * (`enum_ratings_rating_type`, `enum_ratings_category`).
+ */
+const MIGRATION_KEY = '00-baseline-015-ratings';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'ratings',
+        {
+          rating_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          // FK columns; constraints deferred to 00-baseline-zzz-foreign-keys.ts.
+          reviewer_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          reviewee_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          pet_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          application_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          rating_type: {
+            type: DataTypes.ENUM('pet', 'rescue', 'user', 'application', 'experience'),
+            allowNull: false,
+          },
+          category: {
+            type: DataTypes.ENUM(
+              'overall',
+              'communication',
+              'process',
+              'care',
+              'follow_up',
+              'value',
+              'recommendation'
+            ),
+            allowNull: false,
+          },
+          score: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+          },
+          title: {
+            type: DataTypes.STRING(200),
+            allowNull: true,
+          },
+          review_text: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          pros: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          cons: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          helpful_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          reported_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          is_verified: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          is_anonymous: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          is_featured: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          is_moderated: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          moderation_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          response_text: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          response_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          // Audit columns (FK constraints added in 00-baseline-zzz-foreign-keys.ts).
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          // The model does not override the global `paranoid: true` default,
+          // so sync() emits deleted_at for ratings too.
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      // Indexes from the model. The first one omits an explicit name, so
+      // Sequelize generates `ratings_rating_type_category`.
+      await queryInterface.addIndex('ratings', ['rating_type', 'category'], { transaction: t });
+      await queryInterface.addIndex('ratings', ['pet_id'], {
+        name: 'ratings_pet_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('ratings', ['rescue_id'], {
+        name: 'ratings_rescue_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('ratings', ['reviewer_id'], {
+        name: 'ratings_reviewer_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('ratings', ['reviewee_id'], {
+        name: 'ratings_reviewee_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('ratings', ['application_id'], {
+        name: 'ratings_application_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('ratings', ['score'], { transaction: t });
+      await queryInterface.addIndex('ratings', ['is_featured'], { transaction: t });
+      await queryInterface.addIndex('ratings', ['is_moderated'], { transaction: t });
+      await queryInterface.addIndex('ratings', ['created_at'], { transaction: t });
+      await queryInterface.addIndex('ratings', ['created_by'], {
+        name: 'ratings_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('ratings', ['updated_by'], {
+        name: 'ratings_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.dropTable('ratings', { transaction: t });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_ratings_rating_type');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_ratings_category');
+  },
+};


### PR DESCRIPTION
## Summary

Per-model baseline rebaseline, domain 2/10 — rescue org. See `docs/migrations/per-model-rebaseline.md` §2.2.

Splits four tables out of the monolithic `00-baseline.ts` `sync()` call into reviewable per-model migration files:

- `00-baseline-012-rescues.ts` — `rescues`
- `00-baseline-013-rescue-settings.ts` — `rescue_settings`
- `00-baseline-014-addresses.ts` — `addresses`
- `00-baseline-015-ratings.ts` — `ratings`

Each migration mirrors what `sequelize.sync()` produces from the current model definition (columns, defaults, ENUMs, FK-free indexes including audit + paranoid + partial-unique). Cross-table foreign keys (`rescue_id`, `verified_by`, `pet_id`, `application_id`, `created_by`, `updated_by`, etc.) are intentionally NOT declared here — they land in the final `00-baseline-zzz-foreign-keys.ts` PR so per-model files stay independently reorderable.

Operational details:

- Up runs `createTable` + non-FK index ops inside `runInTransaction`.
- Down is gated behind `assertDestructiveDownAcknowledged(MIGRATION_KEY)` and additionally drops any inline-created ENUM types (`enum_rescues_status`, `enum_rescues_verification_source`, `enum_addresses_owner_type`, `enum_ratings_rating_type`, `enum_ratings_category`).
- `00-baseline.ts`, migrations 01..18, and the model files are untouched.

Round-trip tests in `service.backend/src/__tests__/migrations/baseline-rescue.test.ts` (9 tests, Postgres-gated via `describeIfPostgres`) cover: up creates the table + columns + indexes + ENUM types; down without acknowledgement is refused; down with acknowledgement removes the table and owned ENUM types; the `addresses` partial unique index permits multiple non-primary rows per owner but rejects a second primary.

Model-vs-DDL findings (model attribute → DB column mapping is preserved as-is in the migration):

- `Rescue.county` is mapped to legacy column `state`
- `Rescue.postcode` is mapped to legacy column `zip_code`
- `Rating` does not override the global `paranoid: true` default, so the migration emits `deleted_at` for it (`RescueSettings` does set `paranoid: false` and so omits it)

## Test plan

- [x] `npx tsc -p service.backend --noEmit` — clean
- [x] `npx eslint .` in `service.backend` — 0 errors (167 pre-existing warnings unchanged)
- [x] `npx vitest run` in `service.backend` — 2118 passed, 70 skipped (the 9 new tests skip under the SQLite test dialect; they exercise their assertions when run against Postgres)
- [ ] Reviewer: run `baseline-rescue.test.ts` against a Postgres DB to validate the up/down round trip end-to-end
- [ ] Reviewer: cross-check column set against `service.backend/src/models/Rescue.ts`, `RescueSettings.ts`, `Address.ts`, `Rating.ts` once more before merge

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_