### PR TITLE
feat(migrations): per-model baseline for pets (rebaseline 3/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-pets.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-pets.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Round-trip tests for the pets-domain per-model baseline migrations
+ * (rebaseline 3/10).
+ *
+ * Each test:
+ *   1. Drops the table the migration creates (sync() in beforeEach left
+ *      it behind), so up() has work to do.
+ *   2. Runs `up()` and asserts the canonical columns / indexes appear.
+ *   3. Runs `down()` (with the destructive-down ack) and asserts the
+ *      table is gone.
+ *
+ * Postgres-only — the four files use ENUM, ARRAY, TSVECTOR, GEOMETRY,
+ * and partial indexes; SQLite has no equivalent. Skipped on SQLite via
+ * `describeIfPostgres`, matching the existing migrations test pattern.
+ */
+import { afterAll, beforeAll, beforeEach, afterEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import baseline016Pets from '../../migrations/00-baseline-016-pets';
+import baseline017PetMedia from '../../migrations/00-baseline-017-pet-media';
+import baseline018PetStatusTransitions from '../../migrations/00-baseline-018-pet-status-transitions';
+import baseline019Breeds from '../../migrations/00-baseline-019-breeds';
+
+// Reference all models so they register with sequelize before sync().
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const indexExists = async (table: string, name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM pg_indexes WHERE tablename = '${table}' AND indexname = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+type ColumnInfo = { is_nullable: string; data_type: string; udt_name: string };
+
+const describeColumn = async (table: string, column: string): Promise<ColumnInfo | undefined> => {
+  const [rows] = await sequelize.query(
+    `SELECT is_nullable, data_type, udt_name FROM information_schema.columns
+       WHERE table_name = '${table}' AND column_name = '${column}'`
+  );
+  return (rows as ColumnInfo[])[0];
+};
+
+const enumExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(`SELECT 1 FROM pg_type WHERE typname = '${name}'`);
+  return (rows as unknown[]).length > 0;
+};
+
+const enableDestructiveDown = (key: string): void => {
+  process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+  process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = key;
+};
+
+const disableDestructiveDown = (): void => {
+  delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+};
+
+describeIfPostgres('per-model baseline migrations — pets domain (rebaseline 3/10)', () => {
+  beforeAll(async () => {
+    // Make sure the schema has all the expected tables before each test
+    // truncates them. sync() here leaves the existing PG schema in its
+    // post-migration state.
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  afterEach(() => {
+    disableDestructiveDown();
+  });
+
+  describe('00-baseline-016-pets', () => {
+    beforeEach(async () => {
+      // pets is referenced by pet_media, pet_status_transitions, ratings,
+      // chats, applications, swipe_actions, user_favorites, etc. Drop
+      // dependents before pets so the FK constraints don't block the
+      // dropTable. CASCADE on the raw query is the simplest path.
+      await sequelize.query('DROP TABLE IF EXISTS pets CASCADE');
+      // Drop the enum types so up() recreates them cleanly.
+      const enums = [
+        'enum_pets_age_group',
+        'enum_pets_gender',
+        'enum_pets_status',
+        'enum_pets_type',
+        'enum_pets_size',
+        'enum_pets_energy_level',
+        'enum_pets_vaccination_status',
+        'enum_pets_spay_neuter_status',
+      ];
+      for (const e of enums) {
+        await sequelize.query(`DROP TYPE IF EXISTS "${e}" CASCADE`);
+      }
+    });
+
+    it('up() creates the pets table with the expected columns and indexes', async () => {
+      expect(await tableExists('pets')).toBe(false);
+
+      await baseline016Pets.up(queryInterface);
+
+      expect(await tableExists('pets')).toBe(true);
+
+      // Spot-check a representative slice of columns rather than the
+      // whole 60-row sheet — the goal is to catch shape regressions, not
+      // re-state the schema.
+      const petId = await describeColumn('pets', 'pet_id');
+      expect(petId).toMatchObject({ is_nullable: 'NO', udt_name: 'uuid' });
+
+      // rescue_id is NULLABLE in sync() output despite the model saying
+      // allowNull: false — locking that in here.
+      const rescueId = await describeColumn('pets', 'rescue_id');
+      expect(rescueId).toMatchObject({ is_nullable: 'YES', udt_name: 'uuid' });
+
+      const status = await describeColumn('pets', 'status');
+      expect(status).toMatchObject({
+        is_nullable: 'NO',
+        udt_name: 'enum_pets_status',
+      });
+
+      const location = await describeColumn('pets', 'location');
+      expect(location).toMatchObject({ udt_name: 'geometry' });
+
+      const searchVector = await describeColumn('pets', 'search_vector');
+      expect(searchVector).toMatchObject({ udt_name: 'tsvector' });
+
+      const tags = await describeColumn('pets', 'tags');
+      expect(tags?.data_type).toBe('ARRAY');
+
+      const version = await describeColumn('pets', 'version');
+      expect(version).toMatchObject({ is_nullable: 'NO', udt_name: 'int4' });
+    });
+
+    it('up() creates all model-declared indexes including partial uniques and the GIN/GIST shapes', async () => {
+      await baseline016Pets.up(queryInterface);
+
+      const expectedIndexes = [
+        'pets_rescue_id_idx',
+        'pets_status_idx',
+        'pets_type_idx',
+        'pets_size_idx',
+        'pets_age_group_idx',
+        'pets_gender_idx',
+        'pets_breed_id_idx',
+        'pets_secondary_breed_id_idx',
+        'pets_featured_idx',
+        'pets_priority_idx',
+        'pets_created_at_idx',
+        'pets_available_since_idx',
+        'pets_microchip_unique',
+        'pets_microchip_id_key',
+        'pets_search_vector_gin_idx',
+        'pets_location_gist_idx',
+        'pets_status_rescue_idx',
+        'pets_status_type_size_idx',
+        'pets_deleted_at_idx',
+        'pets_created_by_idx',
+        'pets_updated_by_idx',
+      ];
+      for (const name of expectedIndexes) {
+        expect(await indexExists('pets', name)).toBe(true);
+      }
+
+      const [rows] = await sequelize.query(
+        `SELECT indexdef FROM pg_indexes
+           WHERE tablename = 'pets' AND indexname = 'pets_microchip_unique'`
+      );
+      const def = (rows as Array<{ indexdef: string }>)[0]?.indexdef ?? '';
+      expect(def).toContain('UNIQUE');
+      expect(def).toContain('microchip_id IS NOT NULL');
+    });
+
+    it('down() drops the pets table and its enum types', async () => {
+      await baseline016Pets.up(queryInterface);
+      enableDestructiveDown('00-baseline-016-pets');
+
+      await baseline016Pets.down(queryInterface);
+
+      expect(await tableExists('pets')).toBe(false);
+      expect(await enumExists('enum_pets_status')).toBe(false);
+      expect(await enumExists('enum_pets_type')).toBe(false);
+      expect(await enumExists('enum_pets_age_group')).toBe(false);
+    });
+
+    it('down() refuses to run without the destructive-down acknowledgement', async () => {
+      await baseline016Pets.up(queryInterface);
+      // No env vars set — the guard should reject.
+      await expect(baseline016Pets.down(queryInterface)).rejects.toThrow(
+        /Refusing to run destructive down/
+      );
+      // Table must still be there.
+      expect(await tableExists('pets')).toBe(true);
+    });
+  });
+
+  describe('00-baseline-017-pet-media', () => {
+    beforeEach(async () => {
+      await sequelize.query('DROP TABLE IF EXISTS pet_media CASCADE');
+      await sequelize.query('DROP TYPE IF EXISTS "enum_pet_media_type" CASCADE');
+    });
+
+    it('up() creates pet_media with the canonical column shape', async () => {
+      expect(await tableExists('pet_media')).toBe(false);
+
+      await baseline017PetMedia.up(queryInterface);
+
+      expect(await tableExists('pet_media')).toBe(true);
+      // pet_id retains NOT NULL on this table (the belongsTo association
+      // doesn't downgrade the model's allowNull: false).
+      const petId = await describeColumn('pet_media', 'pet_id');
+      expect(petId).toMatchObject({ is_nullable: 'NO', udt_name: 'uuid' });
+
+      const type = await describeColumn('pet_media', 'type');
+      expect(type).toMatchObject({ udt_name: 'enum_pet_media_type' });
+
+      const isPrimary = await describeColumn('pet_media', 'is_primary');
+      expect(isPrimary).toMatchObject({ is_nullable: 'NO', udt_name: 'bool' });
+    });
+
+    it('up() creates the partial-unique primary-image index and FK indexes', async () => {
+      await baseline017PetMedia.up(queryInterface);
+
+      expect(await indexExists('pet_media', 'pet_media_pet_order_idx')).toBe(true);
+      expect(await indexExists('pet_media', 'pet_media_pet_type_idx')).toBe(true);
+      expect(await indexExists('pet_media', 'pet_media_one_primary_per_pet')).toBe(true);
+      expect(await indexExists('pet_media', 'pet_media_created_by_idx')).toBe(true);
+      expect(await indexExists('pet_media', 'pet_media_updated_by_idx')).toBe(true);
+
+      const [rows] = await sequelize.query(
+        `SELECT indexdef FROM pg_indexes
+           WHERE tablename = 'pet_media' AND indexname = 'pet_media_one_primary_per_pet'`
+      );
+      const def = (rows as Array<{ indexdef: string }>)[0]?.indexdef ?? '';
+      expect(def).toContain('UNIQUE');
+      expect(def).toContain('is_primary = true');
+    });
+
+    it('down() drops pet_media and its enum type', async () => {
+      await baseline017PetMedia.up(queryInterface);
+      enableDestructiveDown('00-baseline-017-pet-media');
+
+      await baseline017PetMedia.down(queryInterface);
+
+      expect(await tableExists('pet_media')).toBe(false);
+      expect(await enumExists('enum_pet_media_type')).toBe(false);
+    });
+
+    it('down() refuses to run without the destructive-down acknowledgement', async () => {
+      await baseline017PetMedia.up(queryInterface);
+      await expect(baseline017PetMedia.down(queryInterface)).rejects.toThrow(
+        /Refusing to run destructive down/
+      );
+      expect(await tableExists('pet_media')).toBe(true);
+    });
+  });
+
+  describe('00-baseline-018-pet-status-transitions', () => {
+    beforeEach(async () => {
+      await sequelize.query('DROP TABLE IF EXISTS pet_status_transitions CASCADE');
+      await sequelize.query(
+        'DROP TYPE IF EXISTS "enum_pet_status_transitions_from_status" CASCADE'
+      );
+      await sequelize.query('DROP TYPE IF EXISTS "enum_pet_status_transitions_to_status" CASCADE');
+    });
+
+    it('up() creates the append-only event-log table', async () => {
+      expect(await tableExists('pet_status_transitions')).toBe(false);
+
+      await baseline018PetStatusTransitions.up(queryInterface);
+
+      expect(await tableExists('pet_status_transitions')).toBe(true);
+
+      const transitionId = await describeColumn('pet_status_transitions', 'transition_id');
+      expect(transitionId).toMatchObject({ is_nullable: 'NO', udt_name: 'uuid' });
+
+      // pet_id is NULLABLE in sync() output (belongsTo override).
+      const petId = await describeColumn('pet_status_transitions', 'pet_id');
+      expect(petId).toMatchObject({ is_nullable: 'YES', udt_name: 'uuid' });
+
+      const fromStatus = await describeColumn('pet_status_transitions', 'from_status');
+      expect(fromStatus).toMatchObject({
+        is_nullable: 'YES',
+        udt_name: 'enum_pet_status_transitions_from_status',
+      });
+
+      const toStatus = await describeColumn('pet_status_transitions', 'to_status');
+      expect(toStatus).toMatchObject({
+        is_nullable: 'NO',
+        udt_name: 'enum_pet_status_transitions_to_status',
+      });
+
+      // No timestamps (timestamps: false on the model), no audit columns.
+      const createdAt = await describeColumn('pet_status_transitions', 'created_at');
+      expect(createdAt).toBeUndefined();
+      const version = await describeColumn('pet_status_transitions', 'version');
+      expect(version).toBeUndefined();
+    });
+
+    it('up() creates the (pet_id, transitioned_at) and transitioned_by indexes', async () => {
+      await baseline018PetStatusTransitions.up(queryInterface);
+
+      expect(
+        await indexExists('pet_status_transitions', 'pet_status_transitions_pet_id_at_idx')
+      ).toBe(true);
+      expect(
+        await indexExists('pet_status_transitions', 'pet_status_transitions_transitioned_by_idx')
+      ).toBe(true);
+    });
+
+    it('down() drops the table and both per-column enum types', async () => {
+      await baseline018PetStatusTransitions.up(queryInterface);
+      enableDestructiveDown('00-baseline-018-pet-status-transitions');
+
+      await baseline018PetStatusTransitions.down(queryInterface);
+
+      expect(await tableExists('pet_status_transitions')).toBe(false);
+      expect(await enumExists('enum_pet_status_transitions_from_status')).toBe(false);
+      expect(await enumExists('enum_pet_status_transitions_to_status')).toBe(false);
+    });
+
+    it('down() refuses to run without the destructive-down acknowledgement', async () => {
+      await baseline018PetStatusTransitions.up(queryInterface);
+      await expect(baseline018PetStatusTransitions.down(queryInterface)).rejects.toThrow(
+        /Refusing to run destructive down/
+      );
+      expect(await tableExists('pet_status_transitions')).toBe(true);
+    });
+  });
+
+  describe('00-baseline-019-breeds', () => {
+    beforeEach(async () => {
+      await sequelize.query('DROP TABLE IF EXISTS breeds CASCADE');
+      await sequelize.query('DROP TYPE IF EXISTS "enum_breeds_species" CASCADE');
+    });
+
+    it('up() creates the breeds lookup table without a deleted_at column', async () => {
+      expect(await tableExists('breeds')).toBe(false);
+
+      await baseline019Breeds.up(queryInterface);
+
+      expect(await tableExists('breeds')).toBe(true);
+
+      const breedId = await describeColumn('breeds', 'breed_id');
+      expect(breedId).toMatchObject({ is_nullable: 'NO', udt_name: 'uuid' });
+
+      const species = await describeColumn('breeds', 'species');
+      expect(species).toMatchObject({ udt_name: 'enum_breeds_species' });
+
+      // paranoid: false on the model — no deleted_at column.
+      const deletedAt = await describeColumn('breeds', 'deleted_at');
+      expect(deletedAt).toBeUndefined();
+
+      // version + audit columns still present (auditColumns spread).
+      const version = await describeColumn('breeds', 'version');
+      expect(version).toMatchObject({ is_nullable: 'NO', udt_name: 'int4' });
+    });
+
+    it('up() creates the (species, name) composite unique index and the FK indexes', async () => {
+      await baseline019Breeds.up(queryInterface);
+
+      expect(await indexExists('breeds', 'breeds_species_name_unique')).toBe(true);
+      expect(await indexExists('breeds', 'breeds_name_idx')).toBe(true);
+      expect(await indexExists('breeds', 'breeds_created_by_idx')).toBe(true);
+      expect(await indexExists('breeds', 'breeds_updated_by_idx')).toBe(true);
+
+      const [rows] = await sequelize.query(
+        `SELECT indexdef FROM pg_indexes
+           WHERE tablename = 'breeds' AND indexname = 'breeds_species_name_unique'`
+      );
+      const def = (rows as Array<{ indexdef: string }>)[0]?.indexdef ?? '';
+      expect(def).toContain('UNIQUE');
+      expect(def).toContain('species');
+      expect(def).toContain('name');
+    });
+
+    it('down() drops the breeds table and its enum type', async () => {
+      await baseline019Breeds.up(queryInterface);
+      enableDestructiveDown('00-baseline-019-breeds');
+
+      await baseline019Breeds.down(queryInterface);
+
+      expect(await tableExists('breeds')).toBe(false);
+      expect(await enumExists('enum_breeds_species')).toBe(false);
+    });
+
+    it('down() refuses to run without the destructive-down acknowledgement', async () => {
+      await baseline019Breeds.up(queryInterface);
+      await expect(baseline019Breeds.down(queryInterface)).rejects.toThrow(
+        /Refusing to run destructive down/
+      );
+      expect(await tableExists('breeds')).toBe(true);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-016-pets.ts
+++ b/service.backend/src/migrations/00-baseline-016-pets.ts
@@ -1,0 +1,458 @@
+import { DataTypes, Op, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: pets) — see
+ * docs/migrations/per-model-rebaseline.md.
+ *
+ * Freezes the `pets` table shape produced by `sequelize.sync()` against
+ * the Pet model at the time of the rebaseline. Cross-table FKs
+ * (rescue_id → rescues, breed_id / secondary_breed_id → breeds,
+ * created_by / updated_by → users) are deferred to
+ * `00-baseline-zzz-foreign-keys.ts` so each per-model file is
+ * independently reorderable without dependency cycles.
+ *
+ * `search_vector` is created as a plain TSVECTOR column here — the
+ * trigger that maintains it (installGeneratedSearchVector) is installed
+ * via the model's afterSync hook and is not part of the baseline schema.
+ *
+ * NULLABILITY note: `rescue_id` is NULLABLE in the produced sync output
+ * (the belongsTo association overrides the model's `allowNull: false`
+ * with the default `onDelete: SET NULL`). The migration replicates that
+ * shape rather than the model declaration to stay sync-equivalent.
+ */
+
+const MIGRATION_KEY = '00-baseline-016-pets';
+
+const PET_STATUS_VALUES = [
+  'available',
+  'pending',
+  'adopted',
+  'foster',
+  'medical_hold',
+  'behavioral_hold',
+  'not_available',
+  'deceased',
+] as const;
+
+const PET_TYPE_VALUES = [
+  'dog',
+  'cat',
+  'rabbit',
+  'bird',
+  'reptile',
+  'small_mammal',
+  'fish',
+  'other',
+] as const;
+
+const GENDER_VALUES = ['male', 'female', 'unknown'] as const;
+const SIZE_VALUES = ['extra_small', 'small', 'medium', 'large', 'extra_large'] as const;
+const AGE_GROUP_VALUES = ['baby', 'young', 'adult', 'senior'] as const;
+const ENERGY_LEVEL_VALUES = ['low', 'medium', 'high', 'very_high'] as const;
+const VACCINATION_STATUS_VALUES = ['up_to_date', 'partial', 'not_vaccinated', 'unknown'] as const;
+const SPAY_NEUTER_STATUS_VALUES = ['spayed', 'neutered', 'not_altered', 'unknown'] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      // Column order matches the sync() output: explicit timestamps
+      // (createdAt/updatedAt/deletedAt) declared on the model land before
+      // the auditColumns spread, so created_by / updated_by / version come
+      // last.
+      await queryInterface.createTable(
+        'pets',
+        {
+          pet_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          name: {
+            type: DataTypes.STRING(100),
+            allowNull: false,
+          },
+          rescue_id: {
+            // NULLABLE in sync output despite model's allowNull: false.
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          short_description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          long_description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          age_years: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          age_months: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          birth_date: {
+            type: DataTypes.DATEONLY,
+            allowNull: true,
+          },
+          is_birth_date_estimate: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          age_group: {
+            type: DataTypes.ENUM(...AGE_GROUP_VALUES),
+            allowNull: false,
+            defaultValue: 'adult',
+          },
+          gender: {
+            type: DataTypes.ENUM(...GENDER_VALUES),
+            allowNull: false,
+            defaultValue: 'unknown',
+          },
+          status: {
+            type: DataTypes.ENUM(...PET_STATUS_VALUES),
+            allowNull: false,
+            defaultValue: 'available',
+          },
+          type: {
+            type: DataTypes.ENUM(...PET_TYPE_VALUES),
+            allowNull: false,
+          },
+          breed_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          secondary_breed_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          weight_kg: {
+            type: DataTypes.DECIMAL(5, 2),
+            allowNull: true,
+          },
+          size: {
+            type: DataTypes.ENUM(...SIZE_VALUES),
+            allowNull: false,
+            defaultValue: 'medium',
+          },
+          color: {
+            type: DataTypes.STRING(100),
+            allowNull: true,
+          },
+          markings: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+          },
+          microchip_id: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+            // Auto-creates the `pets_microchip_id_key` unique constraint
+            // alongside the partial unique index added below — both shapes
+            // appear in sync output.
+            unique: true,
+          },
+          archived: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          featured: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          priority_listing: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          adoption_fee_minor: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          adoption_fee_currency: {
+            type: DataTypes.CHAR(3),
+            allowNull: true,
+            defaultValue: 'GBP',
+          },
+          special_needs: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          special_needs_description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          house_trained: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          good_with_children: {
+            type: DataTypes.BOOLEAN,
+            allowNull: true,
+          },
+          good_with_dogs: {
+            type: DataTypes.BOOLEAN,
+            allowNull: true,
+          },
+          good_with_cats: {
+            type: DataTypes.BOOLEAN,
+            allowNull: true,
+          },
+          good_with_small_animals: {
+            type: DataTypes.BOOLEAN,
+            allowNull: true,
+          },
+          energy_level: {
+            type: DataTypes.ENUM(...ENERGY_LEVEL_VALUES),
+            allowNull: false,
+            defaultValue: 'medium',
+          },
+          exercise_needs: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          grooming_needs: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          training_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          temperament: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: true,
+          },
+          medical_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          behavioral_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          surrender_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          intake_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          vaccination_status: {
+            type: DataTypes.ENUM(...VACCINATION_STATUS_VALUES),
+            allowNull: false,
+            defaultValue: 'unknown',
+          },
+          vaccination_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          spay_neuter_status: {
+            type: DataTypes.ENUM(...SPAY_NEUTER_STATUS_VALUES),
+            allowNull: false,
+            defaultValue: 'unknown',
+          },
+          spay_neuter_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          last_vet_checkup: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          location: {
+            type: DataTypes.GEOMETRY('POINT'),
+            allowNull: true,
+          },
+          available_since: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          adopted_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          foster_start_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          foster_end_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          view_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          favorite_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          application_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          search_vector: {
+            type: DataTypes.TSVECTOR,
+            allowNull: true,
+          },
+          tags: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction: t }
+      );
+
+      // Single-column / direction-of-access indexes that the model declares.
+      // FK columns are indexed here to satisfy the standards check; the
+      // referenced FK constraints land in 00-baseline-zzz-foreign-keys.ts.
+      await queryInterface.addIndex('pets', ['rescue_id'], {
+        name: 'pets_rescue_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['status'], {
+        name: 'pets_status_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['type'], {
+        name: 'pets_type_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['size'], {
+        name: 'pets_size_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['age_group'], {
+        name: 'pets_age_group_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['gender'], {
+        name: 'pets_gender_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['breed_id'], {
+        name: 'pets_breed_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['secondary_breed_id'], {
+        name: 'pets_secondary_breed_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['featured'], {
+        name: 'pets_featured_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['priority_listing'], {
+        name: 'pets_priority_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['created_at'], {
+        name: 'pets_created_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['available_since'], {
+        name: 'pets_available_since_idx',
+        transaction: t,
+      });
+      // Partial unique index — only one non-null microchip_id per row.
+      // The full unique constraint (`pets_microchip_id_key`) added by the
+      // column-level `unique: true` above is the redundant looser shape;
+      // both appear in sync output.
+      await queryInterface.addIndex('pets', ['microchip_id'], {
+        name: 'pets_microchip_unique',
+        unique: true,
+        where: { microchip_id: { [Op.ne]: null } },
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['search_vector'], {
+        name: 'pets_search_vector_gin_idx',
+        using: 'gin',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['location'], {
+        name: 'pets_location_gist_idx',
+        using: 'gist',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['status', 'rescue_id'], {
+        name: 'pets_status_rescue_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['status', 'type', 'size'], {
+        name: 'pets_status_type_size_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['deleted_at'], {
+        name: 'pets_deleted_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['created_by'], {
+        name: 'pets_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pets', ['updated_by'], {
+        name: 'pets_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    // Pass an explicit options object — sequelize's PostgresQueryInterface
+    // mutates `options` to drop the per-column ENUM types when a model is
+    // registered, which throws if `options` is undefined.
+    await queryInterface.dropTable('pets', {});
+    // Each ENUM was the only consumer of its type; drop them so they don't
+    // leak into pg_type.
+    const sequelize = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sequelize, 'enum_pets_age_group');
+    await dropEnumTypeIfExists(sequelize, 'enum_pets_gender');
+    await dropEnumTypeIfExists(sequelize, 'enum_pets_status');
+    await dropEnumTypeIfExists(sequelize, 'enum_pets_type');
+    await dropEnumTypeIfExists(sequelize, 'enum_pets_size');
+    await dropEnumTypeIfExists(sequelize, 'enum_pets_energy_level');
+    await dropEnumTypeIfExists(sequelize, 'enum_pets_vaccination_status');
+    await dropEnumTypeIfExists(sequelize, 'enum_pets_spay_neuter_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-017-pet-media.ts
+++ b/service.backend/src/migrations/00-baseline-017-pet-media.ts
@@ -1,0 +1,134 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: pets) — see
+ * docs/migrations/per-model-rebaseline.md.
+ *
+ * Freezes the `pet_media` table shape produced by `sequelize.sync()`
+ * against the PetMedia model at the time of the rebaseline. Cross-table
+ * FKs (pet_id → pets, created_by / updated_by → users) are deferred to
+ * `00-baseline-zzz-foreign-keys.ts`.
+ */
+
+const MIGRATION_KEY = '00-baseline-017-pet-media';
+
+const PET_MEDIA_TYPE_VALUES = ['image', 'video'] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      // Column order matches sync(): the model spreads auditColumns BEFORE
+      // sequelize's auto-added timestamps, so created_by / updated_by come
+      // before created_at / updated_at / deleted_at, with `version` last.
+      await queryInterface.createTable(
+        'pet_media',
+        {
+          media_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          pet_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          type: {
+            type: DataTypes.ENUM(...PET_MEDIA_TYPE_VALUES),
+            allowNull: false,
+          },
+          url: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          thumbnail_url: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          caption: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          order_index: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          is_primary: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          duration_seconds: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          uploaded_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('pet_media', ['pet_id', 'order_index'], {
+        name: 'pet_media_pet_order_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pet_media', ['pet_id', 'type'], {
+        name: 'pet_media_pet_type_idx',
+        transaction: t,
+      });
+      // Partial unique: at most one is_primary=true media row per pet.
+      await queryInterface.addIndex('pet_media', ['pet_id'], {
+        name: 'pet_media_one_primary_per_pet',
+        unique: true,
+        where: { is_primary: true },
+        transaction: t,
+      });
+      await queryInterface.addIndex('pet_media', ['created_by'], {
+        name: 'pet_media_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pet_media', ['updated_by'], {
+        name: 'pet_media_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('pet_media', {});
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_pet_media_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-018-pet-status-transitions.ts
+++ b/service.backend/src/migrations/00-baseline-018-pet-status-transitions.ts
@@ -1,0 +1,107 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: pets) — see
+ * docs/migrations/per-model-rebaseline.md.
+ *
+ * Freezes the `pet_status_transitions` append-only event-log table shape
+ * produced by `sequelize.sync()`. Cross-table FK (pet_id → pets) is
+ * deferred to `00-baseline-zzz-foreign-keys.ts`. The trigger that
+ * denormalises to_status onto pets.status (installStatusTransitionTrigger)
+ * is installed via the model's afterSync hook and is not part of the
+ * baseline schema — it lives with the model definition, not here.
+ *
+ * NULLABILITY note: `pet_id` is NULLABLE in the produced sync output
+ * (the belongsTo association overrides the model's `allowNull: false`
+ * with the default `onDelete: SET NULL`). The migration replicates that
+ * shape rather than the model declaration to stay sync-equivalent.
+ *
+ * Each enum column gets its own Postgres ENUM type — `from_status` and
+ * `to_status` carry the same labels but different type names because
+ * Sequelize auto-derives the type name from (table, column).
+ */
+
+const MIGRATION_KEY = '00-baseline-018-pet-status-transitions';
+
+const PET_STATUS_VALUES = [
+  'available',
+  'pending',
+  'adopted',
+  'foster',
+  'medical_hold',
+  'behavioral_hold',
+  'not_available',
+  'deceased',
+] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'pet_status_transitions',
+        {
+          transition_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          pet_id: {
+            // NULLABLE in sync output despite model's allowNull: false.
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          from_status: {
+            type: DataTypes.ENUM(...PET_STATUS_VALUES),
+            allowNull: true,
+          },
+          to_status: {
+            type: DataTypes.ENUM(...PET_STATUS_VALUES),
+            allowNull: false,
+          },
+          transitioned_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          transitioned_by: {
+            // No FK enforcement on the actor — forensic metadata that should
+            // survive user deletion. The parent-side FK on pet_id is what
+            // enforces lifecycle integrity.
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('pet_status_transitions', ['pet_id', 'transitioned_at'], {
+        name: 'pet_status_transitions_pet_id_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('pet_status_transitions', ['transitioned_by'], {
+        name: 'pet_status_transitions_transitioned_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('pet_status_transitions', {});
+    const sequelize = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sequelize, 'enum_pet_status_transitions_from_status');
+    await dropEnumTypeIfExists(sequelize, 'enum_pet_status_transitions_to_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-019-breeds.ts
+++ b/service.backend/src/migrations/00-baseline-019-breeds.ts
@@ -1,0 +1,115 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  runInTransaction,
+  dropEnumTypeIfExists,
+  assertDestructiveDownAcknowledged,
+} from './_helpers';
+
+/**
+ * Per-model rebaseline (domain: pets) — see
+ * docs/migrations/per-model-rebaseline.md.
+ *
+ * Freezes the `breeds` lookup table shape produced by `sequelize.sync()`.
+ * Cross-table FKs (created_by / updated_by → users) are deferred to
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * The Breed model opts out of the global `paranoid: true` default (a
+ * soft-deleted breed leaves a deleted_at row that still collides on the
+ * (species, name) unique index), so this table has NO `deleted_at`
+ * column.
+ *
+ * The `enum_breeds_species` Postgres type is created with the same
+ * labels as `enum_pets_type` but is a distinct Postgres type — Sequelize
+ * derives the type name from (table, column).
+ */
+
+const MIGRATION_KEY = '00-baseline-019-breeds';
+
+const PET_TYPE_VALUES = [
+  'dog',
+  'cat',
+  'rabbit',
+  'bird',
+  'reptile',
+  'small_mammal',
+  'fish',
+  'other',
+] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      // Column order matches sync(): the model spreads auditColumns BEFORE
+      // sequelize's auto-added timestamps, so created_by / updated_by come
+      // before created_at / updated_at, with `version` last. No deleted_at
+      // because paranoid: false on this model.
+      await queryInterface.createTable(
+        'breeds',
+        {
+          breed_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          species: {
+            type: DataTypes.ENUM(...PET_TYPE_VALUES),
+            allowNull: false,
+          },
+          name: {
+            type: DataTypes.STRING(128),
+            allowNull: false,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction: t }
+      );
+
+      // Composite unique on (species, name): one canonical breed per name
+      // per species. Allows the same name across species (e.g. Persian cat
+      // vs Persian rabbit).
+      await queryInterface.addIndex('breeds', ['species', 'name'], {
+        name: 'breeds_species_name_unique',
+        unique: true,
+        transaction: t,
+      });
+      await queryInterface.addIndex('breeds', ['name'], {
+        name: 'breeds_name_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('breeds', ['created_by'], {
+        name: 'breeds_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('breeds', ['updated_by'], {
+        name: 'breeds_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('breeds', {});
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_breeds_species');
+  },
+};


### PR DESCRIPTION
## Summary

Domain 3 of 10 of the per-model rebaseline tracked in `docs/migrations/per-model-rebaseline.md`. Adds explicit `createTable` migrations for the four pets-domain tables so their schema no longer moves with model edits:

- `00-baseline-016-pets.ts`
- `00-baseline-017-pet-media.ts`
- `00-baseline-018-pet-status-transitions.ts`
- `00-baseline-019-breeds.ts`

Cross-table FKs are intentionally **not** added here — they land in a follow-up `00-baseline-zzz-foreign-keys.ts` so each per-model file is independently reorderable.

The migration shapes were derived by running `sequelize.sync()` against a clean Postgres + PostGIS database and replicating the produced DDL exactly. Two non-obvious sequelize quirks are now locked in:

- `pets.rescue_id` and `pet_status_transitions.pet_id` are **NULLABLE** despite the models declaring `allowNull: false` — the `belongsTo` association overrides with the default `onDelete: SET NULL`.
- `pets` keeps both the column-level UNIQUE constraint (`pets_microchip_id_key`) and the partial unique index (`pets_microchip_unique WHERE microchip_id IS NOT NULL`).

Round-trip tests in `baseline-pets.test.ts` (16 tests, `describeIfPostgres`-gated) drop the table, run `up()`, assert canonical columns / indexes / partial-index predicates, then run `down()` (with the destructive-ack env vars) and assert the table + enums are gone.

## Test plan

- [x] `npm run lint` — 0 errors (warnings unchanged from main)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 2118 passed, 77 skipped (postgres-only suites including this one); no regressions
- [x] Manual postgres round-trip: ran each migration's `up()` against a sync()'d schema and confirmed identical column types, nullability, defaults, and indexes
- [x] Manual postgres round-trip: ran each migration's `down()` with the destructive-down ack and confirmed table + ENUM types removed

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_