### PR TITLE
feat(migrations): per-model baseline for consent & prefs (rebaseline 9/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-consent.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-consent.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * consent & prefs domain (rebaseline 9/10):
+ *
+ *   00-baseline-055-user-consents
+ *   00-baseline-056-user-notification-prefs
+ *   00-baseline-057-user-privacy-prefs
+ *
+ * Pattern: force-sync the schema to capture the canonical column / index
+ * set, drop the table, run `up()`, assert the table is rebuilt with the
+ * same columns and indexes. Then run `down()` (with the destructive-down
+ * env flag) and assert the table is gone.
+ *
+ * Postgres-only — Sequelize ENUM types have no SQLite equivalent.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import baseline055 from '../../migrations/00-baseline-055-user-consents';
+import baseline056 from '../../migrations/00-baseline-056-user-notification-prefs';
+import baseline057 from '../../migrations/00-baseline-057-user-privacy-prefs';
+
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+type ColumnRow = { column_name: string };
+type IndexRow = { indexname: string };
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const listColumns = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT column_name FROM information_schema.columns
+       WHERE table_schema = current_schema() AND table_name = '${table}'
+       ORDER BY column_name`
+  );
+  return (rows as ColumnRow[]).map(r => r.column_name);
+};
+
+const listIndexes = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT indexname FROM pg_indexes
+       WHERE tablename = '${table}'
+       ORDER BY indexname`
+  );
+  return (rows as IndexRow[]).map(r => r.indexname);
+};
+
+type Migration = {
+  up: (qi: typeof queryInterface) => Promise<void>;
+  down: (qi: typeof queryInterface) => Promise<void>;
+};
+
+type Case = {
+  name: string;
+  table: string;
+  destructiveKey: string;
+  migration: Migration;
+};
+
+const CASES: ReadonlyArray<Case> = [
+  {
+    name: '055 — user_consents',
+    table: 'user_consents',
+    destructiveKey: '00-baseline-055-user-consents',
+    migration: baseline055,
+  },
+  {
+    name: '056 — user_notification_prefs',
+    table: 'user_notification_prefs',
+    destructiveKey: '00-baseline-056-user-notification-prefs',
+    migration: baseline056,
+  },
+  {
+    name: '057 — user_privacy_prefs',
+    table: 'user_privacy_prefs',
+    destructiveKey: '00-baseline-057-user-privacy-prefs',
+    migration: baseline057,
+  },
+];
+
+describeIfPostgres('per-model baseline — consent & prefs (rebaseline 9/10)', () => {
+  // Snapshot the env vars we mutate so we restore them between tests and
+  // never leak into other test files.
+  const originalAllow = process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  const originalKey = process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+  beforeAll(async () => {
+    // Establish the canonical post-sync baseline once. Each test that
+    // needs to compare against the canonical shape captures it before
+    // dropping the table.
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    // Restore env so test ordering doesn't leak.
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+    await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    // Each test starts from a freshly-synced schema so dropTable in one
+    // test cannot stomp another's setup.
+    await sequelize.sync({ force: true });
+  });
+
+  afterEach(() => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+  });
+
+  describe.each(CASES)('$name', ({ table, destructiveKey, migration }) => {
+    it('up() recreates the table with the same columns sync() produces', async () => {
+      const expectedColumns = await listColumns(table);
+      expect(expectedColumns.length).toBeGreaterThan(0);
+
+      await queryInterface.dropTable(table);
+      expect(await tableExists(table)).toBe(false);
+
+      await migration.up(queryInterface);
+
+      expect(await tableExists(table)).toBe(true);
+      const actualColumns = await listColumns(table);
+      expect(actualColumns).toEqual(expectedColumns);
+    });
+
+    it('up() recreates the indexes sync() produces', async () => {
+      const expectedIndexes = await listIndexes(table);
+
+      await queryInterface.dropTable(table);
+      await migration.up(queryInterface);
+
+      const actualIndexes = await listIndexes(table);
+      // Compare as sets — sync()'s anonymous index naming order can drift
+      // from queryInterface.addIndex's, but the set of indexes must match.
+      expect(new Set(actualIndexes)).toEqual(new Set(expectedIndexes));
+    });
+
+    it('down() refuses to drop the table without the destructive-down env flags', async () => {
+      delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+      delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+      await expect(migration.down(queryInterface)).rejects.toThrow(/destructive down/);
+      expect(await tableExists(table)).toBe(true);
+    });
+
+    it('down() drops the table when the destructive-down env flags acknowledge it', async () => {
+      process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+      process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = destructiveKey;
+
+      await migration.down(queryInterface);
+
+      expect(await tableExists(table)).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-055-user-consents.ts
+++ b/service.backend/src/migrations/00-baseline-055-user-consents.ts
@@ -1,0 +1,116 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — user_consents (rebaseline 9/10).
+ *
+ * Frozen snapshot of `UserConsent`'s sync() output. FKs (user_id,
+ * created_by, updated_by) land in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * GDPR Art. 7 — append-only consent event log. Each grant / withdrawal
+ * is a new row; latest row per (user_id, purpose) is the user's current
+ * state. No `paranoid` — events are never soft-deleted.
+ *
+ * Source-of-truth note: legacy migration `12-create-user-consents.ts`
+ * also creates this table via an explicit `createTable`, but predates
+ * the `withAuditHooks` adoption — it does not declare a `version` column
+ * and has no audit indexes. Today's `sync()` output (driven by
+ * `withAuditHooks`) DOES emit `version` and the `*_created_by_idx` /
+ * `*_updated_by_idx` indexes. The baseline mirrors `sync()`, not migration
+ * 12. On fresh DBs the per-model file creates the table first; migration
+ * 12 would then collide. Existing DBs are unaffected via the SequelizeMeta
+ * pre-seed (see `docs/migrations/per-model-rebaseline.md` §3).
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'user_consents',
+        {
+          consent_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          purpose: {
+            type: DataTypes.ENUM(
+              'marketing_email',
+              'analytics',
+              'third_party_sharing',
+              'profiling'
+            ),
+            allowNull: false,
+          },
+          granted: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+          },
+          policy_version: {
+            type: DataTypes.STRING(32),
+            allowNull: false,
+          },
+          source: {
+            type: DataTypes.STRING(64),
+            allowNull: true,
+          },
+          ip_address: {
+            type: DataTypes.STRING(45),
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('user_consents', {
+        fields: ['user_id', 'purpose', 'created_at'],
+        name: 'user_consents_user_purpose_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_consents', {
+        fields: ['created_by'],
+        name: 'user_consents_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_consents', {
+        fields: ['updated_by'],
+        name: 'user_consents_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-055-user-consents');
+    await queryInterface.dropTable('user_consents');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_user_consents_purpose');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-056-user-notification-prefs.ts
+++ b/service.backend/src/migrations/00-baseline-056-user-notification-prefs.ts
@@ -1,0 +1,128 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — user_notification_prefs (rebaseline 9/10).
+ *
+ * Frozen snapshot of `UserNotificationPrefs`'s sync() output. FKs (user_id,
+ * created_by, updated_by) land in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * 1:1 with users — `user_id` is both the primary key and the FK to
+ * `users.user_id`. A row is auto-created by `User.afterCreate` so consumers
+ * can always assume the row exists. `paranoid: false` — no `deleted_at`.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'user_notification_prefs',
+        {
+          user_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          email_enabled: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          push_enabled: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          sms_enabled: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          digest_frequency: {
+            type: DataTypes.ENUM('immediate', 'daily', 'weekly', 'never'),
+            allowNull: false,
+            defaultValue: 'weekly',
+          },
+          application_updates: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          pet_matches: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          rescue_updates: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          chat_messages: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          quiet_hours_start: {
+            type: DataTypes.TIME,
+            allowNull: true,
+          },
+          quiet_hours_end: {
+            type: DataTypes.TIME,
+            allowNull: true,
+          },
+          timezone: {
+            type: DataTypes.STRING(64),
+            allowNull: false,
+            defaultValue: 'UTC',
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('user_notification_prefs', {
+        fields: ['created_by'],
+        name: 'user_notification_prefs_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_notification_prefs', {
+        fields: ['updated_by'],
+        name: 'user_notification_prefs_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-056-user-notification-prefs');
+    await queryInterface.dropTable('user_notification_prefs');
+    await dropEnumTypeIfExists(
+      queryInterface.sequelize,
+      'enum_user_notification_prefs_digest_frequency'
+    );
+  },
+};

--- a/service.backend/src/migrations/00-baseline-057-user-privacy-prefs.ts
+++ b/service.backend/src/migrations/00-baseline-057-user-privacy-prefs.ts
@@ -1,0 +1,100 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — user_privacy_prefs (rebaseline 9/10).
+ *
+ * Frozen snapshot of `UserPrivacyPrefs`'s sync() output. FKs (user_id,
+ * created_by, updated_by) land in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * 1:1 with users — `user_id` is both the primary key and the FK to
+ * `users.user_id`. A row is auto-created by `User.afterCreate` so consumers
+ * can always assume the row exists. `paranoid: false` — no `deleted_at`.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'user_privacy_prefs',
+        {
+          user_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          profile_visibility: {
+            type: DataTypes.ENUM('public', 'rescues_only', 'private'),
+            allowNull: false,
+            defaultValue: 'rescues_only',
+          },
+          show_last_seen: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          show_location: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          allow_search_indexing: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          allow_data_export: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('user_privacy_prefs', {
+        fields: ['created_by'],
+        name: 'user_privacy_prefs_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_privacy_prefs', {
+        fields: ['updated_by'],
+        name: 'user_privacy_prefs_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-057-user-privacy-prefs');
+    await queryInterface.dropTable('user_privacy_prefs');
+    await dropEnumTypeIfExists(
+      queryInterface.sequelize,
+      'enum_user_privacy_prefs_profile_visibility'
+    );
+  },
+};


### PR DESCRIPTION
## Summary

Per-model baseline rebaseline, domain 9 of 10 (consent & prefs). Per the design in `docs/migrations/per-model-rebaseline.md`, freezes the schema `sequelize.sync()` emits today for these three tables into explicit `createTable` calls so that fresh DBs produce a deterministic, reviewable schema.

Three per-model files added (one table each):

- `00-baseline-055-user-consents.ts`
- `00-baseline-056-user-notification-prefs.ts`
- `00-baseline-057-user-privacy-prefs.ts`

Each `up()` is wrapped in `runInTransaction` and creates the table + the model's non-FK indexes (including the FK-column B-tree indexes on `created_by` / `updated_by` and the composite `user_consents_user_purpose_idx`). Each `down()` calls `assertDestructiveDownAcknowledged` (per-file key) before `dropTable` and orphan-ENUM cleanup via `dropEnumTypeIfExists`.

Cross-table foreign keys (`user_id`, `created_by`, `updated_by`) are intentionally NOT in this PR — they land in the forthcoming `00-baseline-zzz-foreign-keys.ts` so per-model files remain independently orderable.

Round-trip tests in `service.backend/src/__tests__/migrations/baseline-consent.test.ts` (`describeIfPostgres`, **12 tests**) verify per table:

1. `up()` rebuilds the same column set `sync()` produces.
2. `up()` rebuilds the same index set `sync()` produces.
3. `down()` refuses without `MIGRATION_ALLOW_DESTRUCTIVE_DOWN` + matching `MIGRATION_DESTRUCTIVE_DOWN_KEY`.
4. `down()` drops the table when the destructive-down env flags acknowledge it.

## `user_consents` source-of-truth decision

Two candidate sources exist for `user_consents` and they disagree:

- The `UserConsent` model (registered in `models/index.ts`, so part of `sync()` output via `00-baseline.ts`).
- The legacy explicit migration `12-create-user-consents.ts` (predates `withAuditHooks` adoption).

**Decision: use `sync()` output as the source of truth.**

The model uses `withAuditHooks`, which adds:

- a `version` INTEGER column (optimistic concurrency) — migration 12 does **not** declare this.
- audit indexes on `created_by` / `updated_by` (`user_consents_created_by_idx`, `user_consents_updated_by_idx`) — migration 12 does **not** declare these.

Today's running schema for `user_consents` was created by `sync()` (it ran first in `00-baseline.ts`, before migration 12 was reached). Migration 12's `createTable` call would then have failed with "relation already exists", but the round-trip test suite never replays migrations sequentially — it `sync({force:true})`s and exercises individual migrations in isolation — so the conflict has been masked.

The baseline mirrors `sync()`. On a fresh DB created via this rebaseline PR (and the eventual SequelizeMeta pre-seed for existing DBs):

- `00-baseline-055-user-consents.ts` creates the table with `version` + audit indexes.
- Migration 12 is then a duplicate-`createTable` that will collide. Same fresh-DB-vs-existing-DB pattern flagged by the sibling identity PR (#443) for `revoked_tokens.updated_at` / migration 14, and resolved the same way: the SequelizeMeta pre-seed (design doc §3) makes existing DBs skip both the per-model file and migration 12 doesn't run twice. For fresh DBs we'll need the FK-PR (or a follow-up) to either no-op-on-exists in migration 12 or reorder; not fixed here per the "don't modify migrations 01..18" rule.

## Other model-vs-DDL discrepancies

1. **`UserConsent` `paranoid: false`** — no `deleted_at` column. Same for `UserNotificationPrefs` and `UserPrivacyPrefs`.
2. **`UserNotificationPrefs` and `UserPrivacyPrefs` use `user_id` as the PRIMARY KEY** (1:1 with `users`). The implicit PK index covers user-id lookups; no separate `user_id` index is added.
3. **`UserNotificationPrefs.timezone` defaults to `'UTC'`** and is `STRING(64)` per the model. Captured.
4. **All three tables get `version`, `created_by`, `updated_by`, and the matching `*_created_by_idx` / `*_updated_by_idx` indexes** from `withAuditHooks` — captured.
5. **No legacy migration touches `user_notification_prefs` or `user_privacy_prefs`** — they exist solely as `sync()` artefacts. The baseline file is the new source of truth on fresh DBs.

## Test plan

- [x] `npx tsc --noEmit -p service.backend/tsconfig.json` — clean
- [x] `npx eslint` on the four new files — no warnings
- [x] `npx vitest run src/__tests__/migrations/` — 4 files / 62 tests skipped under SQLite (12 of those are the new tests, matching the `describeIfPostgres` pattern of every other migration test file)
- [ ] CI runs `baseline-consent.test.ts` against the Postgres test DB to verify round-trip equivalence with `sync()` output.
- [ ] When all rebaseline domain PRs land, run `pg_dump --schema-only` on a fresh `db:migrate` DB and `diff` it against a `sync()`-bootstrapped DB at the same SHA (design doc §3.4).

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi


---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_