### PR TITLE
feat(migrations): per-model baseline for platform (rebaseline 10/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-platform.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-platform.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * platform domain (rebaseline 10/10):
+ *
+ *   00-baseline-058-audit-logs
+ *   00-baseline-059-idempotency-keys
+ *   00-baseline-060-cms-content
+ *   00-baseline-061-cms-navigation-menus
+ *
+ * Pattern: capture the canonical column / index set from `sync()`, drop
+ * the table, run `up()`, assert the table is rebuilt with the same
+ * columns and indexes. Then run `down()` (with the destructive-down env
+ * flag) and assert the table is gone.
+ *
+ * Postgres-only — Sequelize ENUMs and JSONB columns have no SQLite
+ * equivalent.
+ *
+ * Bonus: a dedicated test verifies the audit_logs baseline DOES NOT
+ * install the immutability trigger from migration 11. The trigger lives
+ * in its post-baseline migration and the boundary should be visible to
+ * reviewers.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import baseline058 from '../../migrations/00-baseline-058-audit-logs';
+import baseline059 from '../../migrations/00-baseline-059-idempotency-keys';
+import baseline060 from '../../migrations/00-baseline-060-cms-content';
+import baseline061 from '../../migrations/00-baseline-061-cms-navigation-menus';
+
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+type ColumnRow = { column_name: string };
+type IndexRow = { indexname: string };
+type TriggerRow = { trigger_name: string };
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const listColumns = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT column_name FROM information_schema.columns
+       WHERE table_schema = current_schema() AND table_name = '${table}'
+       ORDER BY column_name`
+  );
+  return (rows as ColumnRow[]).map(r => r.column_name);
+};
+
+const listIndexes = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT indexname FROM pg_indexes
+       WHERE tablename = '${table}'
+       ORDER BY indexname`
+  );
+  return (rows as IndexRow[]).map(r => r.indexname);
+};
+
+const listTriggers = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT trigger_name FROM information_schema.triggers
+       WHERE event_object_table = '${table}'
+       ORDER BY trigger_name`
+  );
+  return (rows as TriggerRow[]).map(r => r.trigger_name);
+};
+
+type Migration = {
+  up: (qi: typeof queryInterface) => Promise<void>;
+  down: (qi: typeof queryInterface) => Promise<void>;
+};
+
+type Case = {
+  name: string;
+  table: string;
+  destructiveKey: string;
+  migration: Migration;
+};
+
+const CASES: ReadonlyArray<Case> = [
+  {
+    name: '058 — audit_logs',
+    table: 'audit_logs',
+    destructiveKey: '00-baseline-058-audit-logs',
+    migration: baseline058,
+  },
+  {
+    name: '059 — idempotency_keys',
+    table: 'idempotency_keys',
+    destructiveKey: '00-baseline-059-idempotency-keys',
+    migration: baseline059,
+  },
+  {
+    name: '060 — cms_content',
+    table: 'cms_content',
+    destructiveKey: '00-baseline-060-cms-content',
+    migration: baseline060,
+  },
+  {
+    name: '061 — cms_navigation_menus',
+    table: 'cms_navigation_menus',
+    destructiveKey: '00-baseline-061-cms-navigation-menus',
+    migration: baseline061,
+  },
+];
+
+describeIfPostgres('per-model baseline — platform (rebaseline 10/10)', () => {
+  // Snapshot the env vars we mutate so we restore them between tests and
+  // never leak into other test files.
+  const originalAllow = process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  const originalKey = process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+  beforeAll(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+    await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    // Each test starts from a freshly-synced schema so dropTable in one
+    // test cannot stomp another's setup.
+    await sequelize.sync({ force: true });
+  });
+
+  afterEach(() => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+  });
+
+  describe.each(CASES)('$name', ({ table, destructiveKey, migration }) => {
+    it('up() recreates the table with the same columns sync() produces', async () => {
+      const expectedColumns = await listColumns(table);
+      expect(expectedColumns.length).toBeGreaterThan(0);
+
+      await queryInterface.dropTable(table);
+      expect(await tableExists(table)).toBe(false);
+
+      await migration.up(queryInterface);
+
+      expect(await tableExists(table)).toBe(true);
+      const actualColumns = await listColumns(table);
+      expect(actualColumns).toEqual(expectedColumns);
+    });
+
+    it('up() recreates the indexes sync() produces', async () => {
+      const expectedIndexes = await listIndexes(table);
+
+      await queryInterface.dropTable(table);
+      await migration.up(queryInterface);
+
+      const actualIndexes = await listIndexes(table);
+      // Compare as sets — sync()'s anonymous index naming order can drift
+      // from queryInterface.addIndex's, but the set of indexes must match.
+      expect(new Set(actualIndexes)).toEqual(new Set(expectedIndexes));
+    });
+
+    it('down() refuses to drop the table without the destructive-down env flags', async () => {
+      delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+      delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+      await expect(migration.down(queryInterface)).rejects.toThrow(/destructive down/);
+      expect(await tableExists(table)).toBe(true);
+    });
+
+    it('down() drops the table when the destructive-down env flags acknowledge it', async () => {
+      process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+      process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = destructiveKey;
+
+      await migration.down(queryInterface);
+
+      expect(await tableExists(table)).toBe(false);
+    });
+  });
+
+  describe('audit_logs immutability trigger boundary', () => {
+    // Documents the design boundary: triggers cannot be expressed in
+    // Sequelize's createTable, so they live in their post-baseline
+    // migration. A reviewer skimming this test should be able to see
+    // immediately that the baseline does NOT install
+    // `audit_logs_immutable` — that's migration 11's job.
+    it('up() does not install the audit_logs_immutable trigger from migration 11', async () => {
+      await queryInterface.dropTable('audit_logs');
+      await baseline058.up(queryInterface);
+
+      const triggers = await listTriggers('audit_logs');
+      expect(triggers).not.toContain('audit_logs_immutable');
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-058-audit-logs.ts
+++ b/service.backend/src/migrations/00-baseline-058-audit-logs.ts
@@ -1,0 +1,109 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — audit_logs (rebaseline 10/10, platform domain).
+ *
+ * Frozen snapshot of `AuditLog`'s sync() output. Notable shape:
+ *   - INTEGER autoincrement PK (`id`) — not a UUID. AuditLog predates the
+ *     UUIDv7 standardisation and stays on bigserial-style numeric ids.
+ *   - `timestamps: false` — the model writes its own `timestamp` column
+ *     (event time) instead of created_at/updated_at.
+ *   - No audit columns, no `version`, no soft-delete. Append-only by design.
+ *
+ * Trigger installed by migration 11 (`11-add-audit-log-immutable-trigger.ts`)
+ * is NOT included here. Sequelize cannot represent triggers natively; they
+ * live in their post-baseline migration. See design doc Q6.
+ *
+ * Cross-table foreign keys — none for audit_logs. The `user` column is a
+ * deliberate soft reference (the user may be deleted long after the log
+ * row is written; the `user_email_snapshot` keeps the trail readable).
+ */
+const MIGRATION_KEY = '00-baseline-058-audit-logs';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'audit_logs',
+        {
+          id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+            allowNull: false,
+          },
+          service: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          user: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          user_email_snapshot: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          action: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          level: {
+            type: DataTypes.ENUM('INFO', 'WARNING', 'ERROR'),
+            allowNull: false,
+          },
+          status: {
+            type: DataTypes.ENUM('success', 'failure'),
+            allowNull: true,
+          },
+          timestamp: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          category: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            defaultValue: 'GENERAL',
+          },
+          ip_address: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          user_agent: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('audit_logs', { fields: ['timestamp'], transaction: t });
+      await queryInterface.addIndex('audit_logs', { fields: ['service'], transaction: t });
+      await queryInterface.addIndex('audit_logs', { fields: ['level'], transaction: t });
+      await queryInterface.addIndex('audit_logs', { fields: ['status'], transaction: t });
+      await queryInterface.addIndex('audit_logs', { fields: ['category'], transaction: t });
+      await queryInterface.addIndex('audit_logs', {
+        fields: ['user'],
+        name: 'audit_logs_user_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('audit_logs');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_audit_logs_level');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_audit_logs_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-059-idempotency-keys.ts
+++ b/service.backend/src/migrations/00-baseline-059-idempotency-keys.ts
@@ -1,0 +1,81 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline — idempotency_keys (rebaseline 10/10, platform domain).
+ *
+ * Frozen snapshot of `IdempotencyKey`'s sync() output. Per-request scratch
+ * keyed by SHA-256 hash of the client `Idempotency-Key` header. 24h TTL
+ * with hard cleanup; no soft-delete, no audit columns, no `version`.
+ *
+ * The `user_id` foreign key declared on the model lands in
+ * `00-baseline-zzz-foreign-keys.ts`; the column itself is created here so
+ * the table is functionally usable before the FK file runs.
+ *
+ * No ENUMs to drop on `down`.
+ */
+const MIGRATION_KEY = '00-baseline-059-idempotency-keys';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'idempotency_keys',
+        {
+          key_hash: {
+            type: DataTypes.CHAR(64),
+            primaryKey: true,
+            allowNull: false,
+          },
+          endpoint: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          response_status: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+          },
+          response_body: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('idempotency_keys', {
+        fields: ['user_id'],
+        name: 'idempotency_keys_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('idempotency_keys', {
+        fields: ['expires_at'],
+        name: 'idempotency_keys_expires_at_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('idempotency_keys');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-060-cms-content.ts
+++ b/service.backend/src/migrations/00-baseline-060-cms-content.ts
@@ -1,0 +1,181 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — cms_content (rebaseline 10/10, platform domain).
+ *
+ * Frozen snapshot of `Content`'s sync() output. Carries the audit columns
+ * (`created_by`, `updated_by`), `version` (optimistic concurrency), and
+ * paranoid `deleted_at`.
+ *
+ * Cross-table foreign keys (`author_id`, `last_modified_by`, `created_by`,
+ * `updated_by` → users) are intentionally omitted — they land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `metaKeywords` is a Postgres TEXT[] (array of strings); `versions` is
+ * JSONB with the version-history shape documented on the model.
+ */
+const MIGRATION_KEY = '00-baseline-060-cms-content';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'cms_content',
+        {
+          content_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          title: {
+            type: DataTypes.STRING(500),
+            allowNull: false,
+          },
+          slug: {
+            type: DataTypes.STRING(500),
+            allowNull: false,
+            unique: true,
+          },
+          content_type: {
+            type: DataTypes.ENUM('page', 'blog_post', 'help_article'),
+            allowNull: false,
+          },
+          status: {
+            type: DataTypes.ENUM('draft', 'published', 'archived', 'scheduled'),
+            allowNull: false,
+            defaultValue: 'draft',
+          },
+          content: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+            defaultValue: '',
+          },
+          excerpt: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          meta_title: {
+            type: DataTypes.STRING(500),
+            allowNull: true,
+          },
+          meta_description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          meta_keywords: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: false,
+            defaultValue: [],
+          },
+          featured_image_url: {
+            type: DataTypes.STRING(2000),
+            allowNull: true,
+          },
+          published_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          scheduled_publish_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          scheduled_unpublish_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          versions: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: [],
+          },
+          current_version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 1,
+          },
+          author_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          last_modified_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('cms_content', {
+        fields: ['slug'],
+        unique: true,
+        transaction: t,
+      });
+      await queryInterface.addIndex('cms_content', { fields: ['content_type'], transaction: t });
+      await queryInterface.addIndex('cms_content', { fields: ['status'], transaction: t });
+      await queryInterface.addIndex('cms_content', { fields: ['author_id'], transaction: t });
+      await queryInterface.addIndex('cms_content', {
+        fields: ['last_modified_by'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('cms_content', { fields: ['published_at'], transaction: t });
+      await queryInterface.addIndex('cms_content', {
+        fields: ['scheduled_publish_at'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('cms_content', {
+        fields: ['deleted_at'],
+        name: 'cms_content_deleted_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('cms_content', {
+        fields: ['created_by'],
+        name: 'cms_content_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('cms_content', {
+        fields: ['updated_by'],
+        name: 'cms_content_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('cms_content');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_cms_content_content_type');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_cms_content_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-061-cms-navigation-menus.ts
+++ b/service.backend/src/migrations/00-baseline-061-cms-navigation-menus.ts
@@ -1,0 +1,105 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — cms_navigation_menus (rebaseline 10/10, platform domain).
+ *
+ * Frozen snapshot of `NavigationMenu`'s sync() output. Carries the audit
+ * columns (`created_by`, `updated_by`) and `version` (optimistic
+ * concurrency). No paranoid soft-delete.
+ *
+ * Cross-table FKs (`created_by`, `updated_by` → users) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `items` is JSONB carrying the `NavigationItem[]` tree (label / url /
+ * order / children) defined on the model.
+ */
+const MIGRATION_KEY = '00-baseline-061-cms-navigation-menus';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'cms_navigation_menus',
+        {
+          menu_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          name: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          location: {
+            type: DataTypes.ENUM('header', 'footer', 'sidebar'),
+            allowNull: false,
+          },
+          items: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: [],
+          },
+          is_active: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('cms_navigation_menus', {
+        fields: ['location'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('cms_navigation_menus', {
+        fields: ['is_active'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('cms_navigation_menus', {
+        fields: ['created_by'],
+        name: 'cms_navigation_menus_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('cms_navigation_menus', {
+        fields: ['updated_by'],
+        name: 'cms_navigation_menus_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('cms_navigation_menus');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_cms_navigation_menus_location');
+  },
+};


### PR DESCRIPTION
## Summary

Final domain (10/10) of the per-model baseline rebaseline (design doc `docs/migrations/per-model-rebaseline.md` §2.2). Sibling PRs already up: D1 #443 / D2 #444 / D3 #445 / D4 #442 / D5 #441.

Adds four hand-written `00-baseline-NNN-*.ts` files freezing the platform-domain schema:

- `00-baseline-058-audit-logs.ts` — `audit_logs`. INTEGER autoincrement PK, `timestamps: false`, no audit columns, no `version`. Six non-FK indexes (timestamp, service, level, status, category, user).
- `00-baseline-059-idempotency-keys.ts` — `idempotency_keys`. CHAR(64) PK, no audit columns, no `version`, no soft-delete. FK column `user_id` present without REFERENCES (FK lives in the cross-table file). Two indexes (user_id, expires_at).
- `00-baseline-060-cms-content.ts` — `cms_content`. Audit columns + `version` + paranoid `deleted_at`. Two ENUMs (content_type, status), TEXT[] meta_keywords, JSONB versions. Ten indexes including unique slug.
- `00-baseline-061-cms-navigation-menus.ts` — `cms_navigation_menus`. Audit columns + `version`, no paranoid. One ENUM (location), JSONB items. Four indexes.

### audit_logs immutability trigger boundary

The Postgres trigger installed by migration 11 (`11-add-audit-log-immutable-trigger.ts`) is **NOT** included in this baseline. Sequelize cannot represent triggers natively, so they live in their post-baseline migration. The file header documents this and a dedicated test asserts the baseline does not install `audit_logs_immutable` — so reviewers can see the boundary explicitly.

### Out of scope (deliberate)

- Cross-table foreign keys (`cms_content.author_id`, `cms_content.last_modified_by`, `cms_content.created_by`, `cms_content.updated_by`, `cms_navigation_menus.created_by`, `cms_navigation_menus.updated_by`, `idempotency_keys.user_id` → users) — they land in `00-baseline-zzz-foreign-keys.ts` (separate PR) so per-model files stay independently orderable. `audit_logs` has no FK columns by design — `user` is a soft reference paired with `user_email_snapshot`.
- Triggers and functions — stay in their post-baseline migrations.
- The monolithic `00-baseline.ts` and migrations 01..18 — untouched.

## Test plan

- [x] `npx tsc --noEmit` passes (service.backend)
- [x] `npx eslint` clean on the new files
- [x] `npx vitest run src/__tests__/migrations/baseline-platform.test.ts` runs — 17 tests defined (all skipped under sqlite, run under postgres CI)
- [x] All 4 migration test files (existing + new) coexist without collision
- [ ] Postgres CI: `up()` recreates each table with the same column / index set `sync()` produces (per-table parameterised tests)
- [ ] Postgres CI: `down()` refuses without destructive-down env flags; succeeds with them
- [ ] Postgres CI: `audit_logs` baseline `up()` does NOT install the `audit_logs_immutable` trigger

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_