### PR TITLE
feat(migrations): per-model baseline for discovery (rebaseline 8/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-discovery.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-discovery.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * discovery domain (rebaseline 8/10):
+ *
+ *   00-baseline-052-swipe-actions
+ *   00-baseline-053-swipe-sessions
+ *   00-baseline-054-user-favorites
+ *
+ * Pattern: force-sync the schema to capture the canonical column / index
+ * set, drop the table, run `up()`, assert the table is rebuilt with the
+ * same columns and indexes. Then run `down()` (with the destructive-down
+ * env flag) and assert the table is gone.
+ *
+ * Postgres-only — Sequelize ENUM, JSONB, INET, and partial-unique indexes
+ * have no SQLite equivalent.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import baseline052 from '../../migrations/00-baseline-052-swipe-actions';
+import baseline053 from '../../migrations/00-baseline-053-swipe-sessions';
+import baseline054 from '../../migrations/00-baseline-054-user-favorites';
+
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+type ColumnRow = { column_name: string };
+type IndexRow = { indexname: string };
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const listColumns = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT column_name FROM information_schema.columns
+       WHERE table_schema = current_schema() AND table_name = '${table}'
+       ORDER BY column_name`
+  );
+  return (rows as ColumnRow[]).map(r => r.column_name);
+};
+
+const listIndexes = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT indexname FROM pg_indexes
+       WHERE tablename = '${table}'
+       ORDER BY indexname`
+  );
+  return (rows as IndexRow[]).map(r => r.indexname);
+};
+
+type Migration = {
+  up: (qi: typeof queryInterface) => Promise<void>;
+  down: (qi: typeof queryInterface) => Promise<void>;
+};
+
+type Case = {
+  name: string;
+  table: string;
+  destructiveKey: string;
+  migration: Migration;
+};
+
+const CASES: ReadonlyArray<Case> = [
+  {
+    name: '052 — swipe_actions',
+    table: 'swipe_actions',
+    destructiveKey: '00-baseline-052-swipe-actions',
+    migration: baseline052,
+  },
+  {
+    name: '053 — swipe_sessions',
+    table: 'swipe_sessions',
+    destructiveKey: '00-baseline-053-swipe-sessions',
+    migration: baseline053,
+  },
+  {
+    name: '054 — user_favorites',
+    table: 'user_favorites',
+    destructiveKey: '00-baseline-054-user-favorites',
+    migration: baseline054,
+  },
+];
+
+describeIfPostgres('per-model baseline — discovery (rebaseline 8/10)', () => {
+  // Snapshot the env vars we mutate so we restore them between tests and
+  // never leak into other test files.
+  const originalAllow = process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  const originalKey = process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+  beforeAll(async () => {
+    // Establish the canonical post-sync baseline once. Each test that
+    // needs to compare against the canonical shape captures it before
+    // dropping the table.
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+    await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    // Each test starts from a freshly-synced schema so dropTable in one
+    // test cannot stomp another's setup.
+    await sequelize.sync({ force: true });
+  });
+
+  afterEach(() => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+  });
+
+  describe.each(CASES)('$name', ({ table, destructiveKey, migration }) => {
+    it('up() recreates the table with the same columns sync() produces', async () => {
+      const expectedColumns = await listColumns(table);
+      expect(expectedColumns.length).toBeGreaterThan(0);
+
+      await queryInterface.dropTable(table);
+      expect(await tableExists(table)).toBe(false);
+
+      await migration.up(queryInterface);
+
+      expect(await tableExists(table)).toBe(true);
+      const actualColumns = await listColumns(table);
+      expect(actualColumns).toEqual(expectedColumns);
+    });
+
+    it('up() recreates the indexes sync() produces', async () => {
+      const expectedIndexes = await listIndexes(table);
+
+      await queryInterface.dropTable(table);
+      await migration.up(queryInterface);
+
+      const actualIndexes = await listIndexes(table);
+      // Compare as sets — sync()'s anonymous index naming order can drift
+      // from queryInterface.addIndex's, but the set of indexes must match.
+      expect(new Set(actualIndexes)).toEqual(new Set(expectedIndexes));
+    });
+
+    it('down() refuses to drop the table without the destructive-down env flags', async () => {
+      delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+      delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+      await expect(migration.down(queryInterface)).rejects.toThrow(/destructive down/);
+      expect(await tableExists(table)).toBe(true);
+    });
+
+    it('down() drops the table when the destructive-down env flags acknowledge it', async () => {
+      process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+      process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = destructiveKey;
+
+      await migration.down(queryInterface);
+
+      expect(await tableExists(table)).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-052-swipe-actions.ts
+++ b/service.backend/src/migrations/00-baseline-052-swipe-actions.ts
@@ -1,0 +1,116 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — swipe_actions (rebaseline 8/10).
+ *
+ * Frozen snapshot of `SwipeAction`'s sync() output. Cross-table foreign keys
+ * (session_id, pet_id, user_id) live in `00-baseline-zzz-foreign-keys.ts` so
+ * each per-model file is independently orderable. The columns themselves
+ * carry the right shape (UUID), but no REFERENCES clause until the FK file
+ * lands.
+ *
+ * `SwipeAction` is non-paranoid (no `deleted_at`) and does NOT use
+ * `withAuditHooks` — no `created_by` / `updated_by` / `version` columns or
+ * audit indexes. High-volume behavioural log per the model comment.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'swipe_actions',
+        {
+          swipe_action_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          session_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          pet_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          action: {
+            type: DataTypes.ENUM('like', 'pass', 'super_like', 'info'),
+            allowNull: false,
+          },
+          timestamp: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          response_time: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          device_type: {
+            type: DataTypes.STRING(50),
+            allowNull: true,
+          },
+          coordinates: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          gesture_data: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('swipe_actions', {
+        fields: ['session_id'],
+        name: 'idx_swipe_actions_session',
+        transaction: t,
+      });
+      await queryInterface.addIndex('swipe_actions', {
+        fields: ['pet_id'],
+        name: 'idx_swipe_actions_pet',
+        transaction: t,
+      });
+      await queryInterface.addIndex('swipe_actions', {
+        fields: ['user_id', 'action'],
+        name: 'idx_swipe_actions_user_action',
+        transaction: t,
+      });
+      await queryInterface.addIndex('swipe_actions', {
+        fields: ['timestamp'],
+        name: 'idx_swipe_actions_timestamp',
+        transaction: t,
+      });
+      await queryInterface.addIndex('swipe_actions', {
+        fields: ['action', 'timestamp'],
+        name: 'idx_swipe_actions_action_time',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-052-swipe-actions');
+    await queryInterface.dropTable('swipe_actions');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_swipe_actions_action');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-053-swipe-sessions.ts
+++ b/service.backend/src/migrations/00-baseline-053-swipe-sessions.ts
@@ -1,0 +1,125 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — swipe_sessions (rebaseline 8/10).
+ *
+ * Frozen snapshot of `SwipeSession`'s sync() output. Cross-table foreign key
+ * (user_id) lives in `00-baseline-zzz-foreign-keys.ts` so each per-model
+ * file is independently orderable. The column itself carries the right
+ * shape (UUID), but no REFERENCES clause until the FK file lands.
+ *
+ * `SwipeSession` is non-paranoid (no `deleted_at`) and does NOT use
+ * `withAuditHooks` — no `created_by` / `updated_by` / `version` columns or
+ * audit indexes. Behavioural session log per the model comment.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'swipe_sessions',
+        {
+          session_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          start_time: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          end_time: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          total_swipes: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          likes: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          passes: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          super_likes: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          filters: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          ip_address: {
+            type: DataTypes.INET,
+            allowNull: true,
+          },
+          user_agent: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          device_type: {
+            type: DataTypes.ENUM('desktop', 'mobile', 'tablet', 'unknown'),
+            allowNull: true,
+            defaultValue: 'unknown',
+          },
+          is_active: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('swipe_sessions', {
+        fields: ['user_id', 'is_active'],
+        name: 'idx_swipe_sessions_user_active',
+        transaction: t,
+      });
+      await queryInterface.addIndex('swipe_sessions', {
+        fields: ['start_time'],
+        name: 'idx_swipe_sessions_start_time',
+        transaction: t,
+      });
+      await queryInterface.addIndex('swipe_sessions', {
+        fields: ['session_id'],
+        unique: true,
+        name: 'idx_swipe_sessions_session_id',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-053-swipe-sessions');
+    await queryInterface.dropTable('swipe_sessions');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_swipe_sessions_device_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-054-user-favorites.ts
+++ b/service.backend/src/migrations/00-baseline-054-user-favorites.ts
@@ -1,0 +1,113 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline — user_favorites (rebaseline 8/10).
+ *
+ * Frozen snapshot of `UserFavorite`'s sync() output. Cross-table foreign keys
+ * (user_id, pet_id, created_by, updated_by) live in
+ * `00-baseline-zzz-foreign-keys.ts` so each per-model file is independently
+ * orderable. The columns themselves carry the right shape (UUID), but no
+ * REFERENCES clause until the FK file lands.
+ *
+ * `UserFavorite` is paranoid (`deleted_at`) and uses `withAuditHooks`, so
+ * `created_by`, `updated_by`, and `version` are part of the column set and
+ * the matching audit indexes are part of the index set. The unique partial
+ * index `unique_user_pet_favorite` enforces "one active favorite per
+ * user+pet" while permitting historical soft-deleted rows.
+ *
+ * No ENUM types are declared on this table, so `down()` only drops the
+ * table itself.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'user_favorites',
+        {
+          id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          pet_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('user_favorites', {
+        fields: ['user_id', 'pet_id'],
+        unique: true,
+        name: 'unique_user_pet_favorite',
+        where: { deleted_at: null },
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_favorites', {
+        fields: ['user_id'],
+        name: 'idx_user_favorites_user_id',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_favorites', {
+        fields: ['pet_id'],
+        name: 'idx_user_favorites_pet_id',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_favorites', {
+        fields: ['created_at'],
+        name: 'idx_user_favorites_created_at',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_favorites', {
+        fields: ['deleted_at'],
+        name: 'user_favorites_deleted_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_favorites', {
+        fields: ['created_by'],
+        name: 'user_favorites_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('user_favorites', {
+        fields: ['updated_by'],
+        name: 'user_favorites_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-054-user-favorites');
+    await queryInterface.dropTable('user_favorites');
+  },
+};


### PR DESCRIPTION
## Summary

Per-model baseline rebaseline, domain 8 of 10 (discovery). Per the design in `docs/migrations/per-model-rebaseline.md` §2.2, replaces the implicit `sequelize.sync()` baseline with explicit, frozen `createTable` calls — one file per table — so that fresh DBs produce a deterministic, reviewable schema.

Three per-model files added (one table each):

- `00-baseline-052-swipe-actions.ts`
- `00-baseline-053-swipe-sessions.ts`
- `00-baseline-054-user-favorites.ts`

Each `up()` is wrapped in `runInTransaction` and creates the table + the model's non-FK indexes (including FK-column B-tree indexes). Each `down()` calls `assertDestructiveDownAcknowledged` (per-file key) before `dropTable` and any orphan ENUM cleanup.

Cross-table FKs are intentionally NOT in this PR — they land in the forthcoming `00-baseline-zzz-foreign-keys.ts` so per-model files remain independently orderable.

Round-trip tests in `service.backend/src/__tests__/migrations/baseline-discovery.test.ts` (`describeIfPostgres`, 12 tests = 3 cases × 4 assertions) verify per table:

1. `up()` rebuilds the same column set `sync()` produces.
2. `up()` rebuilds the same index set `sync()` produces.
3. `down()` refuses without `MIGRATION_ALLOW_DESTRUCTIVE_DOWN` + matching `MIGRATION_DESTRUCTIVE_DOWN_KEY`.
4. `down()` drops the table when the destructive-down env flags acknowledge it.

## Notes / Discrepancies

- `swipe_actions` is non-paranoid (no `deleted_at`) and does NOT use `withAuditHooks` — no `created_by` / `updated_by` / `version` columns or audit indexes. High-volume behavioural log per the model comment.
- `swipe_sessions` is non-paranoid and does NOT use `withAuditHooks` either. Same retention story as `swipe_actions`.
- `user_favorites` IS paranoid AND uses `withAuditHooks`, so `created_by`, `updated_by`, `version`, and the matching `user_favorites_created_by_idx` / `user_favorites_updated_by_idx` are part of the baseline. The unique partial index `unique_user_pet_favorite` (with `WHERE deleted_at IS NULL`) is preserved.
- `swipe_sessions.ip_address` is `INET`. `swipe_actions.coordinates` and `gesture_data` are `JSONB`. `swipe_sessions.filters` is `JSONB` with default `{}`.
- The model declares `swipe_sessions.session_id` as both the primary key AND a model-level unique index `idx_swipe_sessions_session_id`. The migration mirrors that — sync() emits both the implicit PK index and the explicit unique index, and the test compares index sets to confirm.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint src` — 0 errors (only pre-existing warnings)
- [x] `npx prettier --check` — all files use Prettier code style
- [x] `npx vitest run` — 2118 passed, 73 skipped (4 baseline-* test files Postgres-only via `describeIfPostgres`, including the new 12 tests)
- [ ] CI runs `baseline-discovery.test.ts` against the Postgres test DB to verify round-trip equivalence with `sync()` output

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_