### PR TITLE
feat(migrations): per-model baseline for email pipeline (rebaseline 6/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-email.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-email.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * email pipeline (rebaseline 6/10):
+ *
+ *   00-baseline-037-email-templates
+ *   00-baseline-038-email-template-versions
+ *   00-baseline-039-email-queue
+ *   00-baseline-040-email-preferences
+ *
+ * Pattern: force-sync the schema to capture the canonical column / index
+ * set, drop the table, run `up()`, assert the table is rebuilt with the
+ * same columns and indexes. Then run `down()` (with the destructive-down
+ * env flag) and assert the table is gone.
+ *
+ * Postgres-only — Sequelize ENUM, JSONB, GIN-on-array, and the partial /
+ * named-unique indexes used here have no SQLite equivalent.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import baseline037 from '../../migrations/00-baseline-037-email-templates';
+import baseline038 from '../../migrations/00-baseline-038-email-template-versions';
+import baseline039 from '../../migrations/00-baseline-039-email-queue';
+import baseline040 from '../../migrations/00-baseline-040-email-preferences';
+
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+type ColumnRow = { column_name: string };
+type IndexRow = { indexname: string };
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const listColumns = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT column_name FROM information_schema.columns
+       WHERE table_schema = current_schema() AND table_name = '${table}'
+       ORDER BY column_name`
+  );
+  return (rows as ColumnRow[]).map(r => r.column_name);
+};
+
+const listIndexes = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT indexname FROM pg_indexes
+       WHERE tablename = '${table}'
+       ORDER BY indexname`
+  );
+  return (rows as IndexRow[]).map(r => r.indexname);
+};
+
+type Migration = {
+  up: (qi: typeof queryInterface) => Promise<void>;
+  down: (qi: typeof queryInterface) => Promise<void>;
+};
+
+type Case = {
+  name: string;
+  table: string;
+  destructiveKey: string;
+  migration: Migration;
+};
+
+const CASES: ReadonlyArray<Case> = [
+  {
+    name: '037 — email_templates',
+    table: 'email_templates',
+    destructiveKey: '00-baseline-037-email-templates',
+    migration: baseline037,
+  },
+  {
+    name: '038 — email_template_versions',
+    table: 'email_template_versions',
+    destructiveKey: '00-baseline-038-email-template-versions',
+    migration: baseline038,
+  },
+  {
+    name: '039 — email_queue',
+    table: 'email_queue',
+    destructiveKey: '00-baseline-039-email-queue',
+    migration: baseline039,
+  },
+  {
+    name: '040 — email_preferences',
+    table: 'email_preferences',
+    destructiveKey: '00-baseline-040-email-preferences',
+    migration: baseline040,
+  },
+];
+
+describeIfPostgres('per-model baseline — email pipeline (rebaseline 6/10)', () => {
+  const originalAllow = process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  const originalKey = process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+  beforeAll(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+    await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  afterEach(() => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+  });
+
+  describe.each(CASES)('$name', ({ table, destructiveKey, migration }) => {
+    it('up() recreates the table with the same columns sync() produces', async () => {
+      const expectedColumns = await listColumns(table);
+      expect(expectedColumns.length).toBeGreaterThan(0);
+
+      await queryInterface.dropTable(table);
+      expect(await tableExists(table)).toBe(false);
+
+      await migration.up(queryInterface);
+
+      expect(await tableExists(table)).toBe(true);
+      const actualColumns = await listColumns(table);
+      expect(actualColumns).toEqual(expectedColumns);
+    });
+
+    it('up() recreates the indexes sync() produces', async () => {
+      const expectedIndexes = await listIndexes(table);
+
+      await queryInterface.dropTable(table);
+      await migration.up(queryInterface);
+
+      const actualIndexes = await listIndexes(table);
+      // Compare as sets — sync()'s anonymous index naming order can drift
+      // from queryInterface.addIndex's, but the set of indexes must match.
+      expect(new Set(actualIndexes)).toEqual(new Set(expectedIndexes));
+    });
+
+    it('down() refuses to drop the table without the destructive-down env flags', async () => {
+      delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+      delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+      await expect(migration.down(queryInterface)).rejects.toThrow(/destructive down/);
+      expect(await tableExists(table)).toBe(true);
+    });
+
+    it('down() drops the table when the destructive-down env flags acknowledge it', async () => {
+      process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+      process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = destructiveKey;
+
+      await migration.down(queryInterface);
+
+      expect(await tableExists(table)).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-037-email-templates.ts
+++ b/service.backend/src/migrations/00-baseline-037-email-templates.ts
@@ -1,0 +1,231 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — email_templates (rebaseline 6/10).
+ *
+ * Frozen snapshot of `EmailTemplate`'s sync() output. Cross-table foreign
+ * keys (parent_template_id self-reference, last_modified_by → users,
+ * created_by/updated_by → users) live in `00-baseline-zzz-foreign-keys.ts`.
+ * Column types still carry the right shape (UUID), but no REFERENCES
+ * clause until the FK file lands.
+ *
+ * Three Postgres ENUMs are declared inline (type / category / status) —
+ * `sync()` materialises them as `enum_email_templates_<col>` and the
+ * matching `dropEnumTypeIfExists` calls in `down()` clean them up so they
+ * don't leak into pg_type.
+ *
+ * `tags` is a Postgres TEXT[] (the model's `getArrayType` resolves to
+ * `ARRAY(STRING)` outside test env).
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'email_templates',
+        {
+          template_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          name: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+            unique: true,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          type: {
+            type: DataTypes.ENUM(
+              'transactional',
+              'notification',
+              'marketing',
+              'system',
+              'administrative'
+            ),
+            allowNull: false,
+          },
+          category: {
+            type: DataTypes.ENUM(
+              'welcome',
+              'password_reset',
+              'email_verification',
+              'application_update',
+              'adoption_confirmation',
+              'rescue_verification',
+              'staff_invitation',
+              'notification_digest',
+              'reminder',
+              'announcement',
+              'newsletter',
+              'system_alert'
+            ),
+            allowNull: false,
+          },
+          status: {
+            type: DataTypes.ENUM('draft', 'active', 'inactive', 'archived'),
+            allowNull: false,
+            defaultValue: 'draft',
+          },
+          subject: {
+            type: DataTypes.STRING(500),
+            allowNull: false,
+          },
+          html_content: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          text_content: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          variables: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          locale: {
+            type: DataTypes.STRING(10),
+            allowNull: false,
+            defaultValue: 'en',
+          },
+          parent_template_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          current_version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 1,
+          },
+          is_default: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          priority: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          tags: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: false,
+            defaultValue: [],
+          },
+          last_modified_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          last_used_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          usage_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          test_emails_sent: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          // Audit columns (FKs in 00-baseline-zzz-foreign-keys.ts).
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('email_templates', {
+        fields: ['name'],
+        unique: true,
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_templates', { fields: ['type'], transaction: t });
+      await queryInterface.addIndex('email_templates', { fields: ['category'], transaction: t });
+      await queryInterface.addIndex('email_templates', { fields: ['status'], transaction: t });
+      await queryInterface.addIndex('email_templates', { fields: ['locale'], transaction: t });
+      await queryInterface.addIndex('email_templates', { fields: ['is_default'], transaction: t });
+      await queryInterface.addIndex('email_templates', {
+        fields: ['last_modified_by'],
+        name: 'email_templates_last_modified_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_templates', {
+        fields: ['parent_template_id'],
+        name: 'email_templates_parent_template_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_templates', {
+        fields: ['last_used_at'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_templates', {
+        fields: ['tags'],
+        using: 'gin',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_templates', {
+        fields: ['deleted_at'],
+        name: 'email_templates_deleted_at_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_templates', {
+        fields: ['created_by'],
+        name: 'email_templates_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_templates', {
+        fields: ['updated_by'],
+        name: 'email_templates_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-037-email-templates');
+    await queryInterface.dropTable('email_templates');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_email_templates_type');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_email_templates_category');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_email_templates_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-038-email-template-versions.ts
+++ b/service.backend/src/migrations/00-baseline-038-email-template-versions.ts
@@ -1,0 +1,103 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline — email_template_versions (rebaseline 6/10).
+ *
+ * Frozen snapshot of `EmailTemplateVersion`'s sync() output. FKs (template_id
+ * → email_templates with CASCADE, created_by/updated_by → users) live in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Append-only history of template revisions (plan 5.4) — no soft-delete
+ * (paranoid not set), so no `deleted_at` column. No ENUMs on this table.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'email_template_versions',
+        {
+          template_version_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          template_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+          },
+          subject: {
+            type: DataTypes.STRING(500),
+            allowNull: false,
+          },
+          html_content: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          text_content: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          change_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          // Audit columns (FKs in 00-baseline-zzz-foreign-keys.ts).
+          // NOTE: the model declares a `version` column (template revision
+          // number) AND opts into optimistic locking via `withAuditHooks`,
+          // which also wants a `version` column. Sequelize collapses the
+          // two onto the existing `version` column above — there is no
+          // separate optimistic-lock counter on this table.
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('email_template_versions', {
+        fields: ['template_id', { name: 'version', order: 'DESC' }],
+        name: 'email_template_versions_template_version_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_template_versions', {
+        fields: ['template_id', 'version'],
+        name: 'email_template_versions_template_version_unique',
+        unique: true,
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_template_versions', {
+        fields: ['created_by'],
+        name: 'email_template_versions_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_template_versions', {
+        fields: ['updated_by'],
+        name: 'email_template_versions_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-038-email-template-versions');
+    await queryInterface.dropTable('email_template_versions');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-039-email-queue.ts
+++ b/service.backend/src/migrations/00-baseline-039-email-queue.ts
@@ -1,0 +1,251 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — email_queue (rebaseline 6/10).
+ *
+ * Frozen snapshot of `EmailQueue`'s sync() output. FKs (template_id →
+ * email_templates, user_id → users, created_by/updated_by → users) live in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Append-only delivery queue with its own `status` ENUM column —
+ * `paranoid: false` on the model, so no `deleted_at`. The retention job
+ * hard-archives sent rows.
+ *
+ * Three Postgres ENUMs declared inline (type / priority / status). The
+ * 9-value `status` enum captures the full delivery lifecycle (queued →
+ * sending → sent → delivered → opened → clicked, plus failed / bounced /
+ * unsubscribed terminal states).
+ *
+ * `attachments` is JSONB allowNull: false WITHOUT a default — the model
+ * declares no defaultValue, so callers must supply the column on insert.
+ * `cc_emails`, `bcc_emails`, `tags` are TEXT[] (Postgres native arrays
+ * via `getArrayType` outside the test env).
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'email_queue',
+        {
+          email_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          template_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          from_email: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          from_name: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          to_email: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          to_name: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          cc_emails: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: false,
+            defaultValue: [],
+          },
+          bcc_emails: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: false,
+            defaultValue: [],
+          },
+          reply_to_email: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          subject: {
+            type: DataTypes.STRING(500),
+            allowNull: false,
+          },
+          html_content: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          text_content: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          template_data: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          attachments: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+          },
+          type: {
+            type: DataTypes.ENUM('transactional', 'notification', 'marketing', 'system'),
+            allowNull: false,
+          },
+          priority: {
+            type: DataTypes.ENUM('low', 'normal', 'high', 'urgent'),
+            allowNull: false,
+            defaultValue: 'normal',
+          },
+          status: {
+            type: DataTypes.ENUM(
+              'queued',
+              'sending',
+              'sent',
+              'delivered',
+              'opened',
+              'clicked',
+              'failed',
+              'bounced',
+              'unsubscribed'
+            ),
+            allowNull: false,
+            defaultValue: 'queued',
+          },
+          scheduled_for: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          max_retries: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 3,
+          },
+          current_retries: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          last_attempt_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          sent_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          failure_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          provider_id: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          provider_message_id: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          tracking: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          campaign_id: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          tags: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: false,
+            defaultValue: [],
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          // Audit columns (FKs in 00-baseline-zzz-foreign-keys.ts).
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('email_queue', { fields: ['status'], transaction: t });
+      await queryInterface.addIndex('email_queue', { fields: ['priority'], transaction: t });
+      await queryInterface.addIndex('email_queue', { fields: ['type'], transaction: t });
+      await queryInterface.addIndex('email_queue', { fields: ['to_email'], transaction: t });
+      await queryInterface.addIndex('email_queue', {
+        fields: ['user_id'],
+        name: 'email_queue_user_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_queue', {
+        fields: ['template_id'],
+        name: 'email_queue_template_id_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_queue', { fields: ['campaign_id'], transaction: t });
+      await queryInterface.addIndex('email_queue', { fields: ['scheduled_for'], transaction: t });
+      await queryInterface.addIndex('email_queue', { fields: ['sent_at'], transaction: t });
+      await queryInterface.addIndex('email_queue', { fields: ['created_at'], transaction: t });
+      await queryInterface.addIndex('email_queue', {
+        fields: ['tags'],
+        using: 'gin',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_queue', {
+        fields: ['status', 'priority', 'scheduled_for'],
+        name: 'email_queue_processing_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_queue', {
+        fields: ['created_by'],
+        name: 'email_queue_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_queue', {
+        fields: ['updated_by'],
+        name: 'email_queue_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-039-email-queue');
+    await queryInterface.dropTable('email_queue');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_email_queue_type');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_email_queue_priority');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_email_queue_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-040-email-preferences.ts
+++ b/service.backend/src/migrations/00-baseline-040-email-preferences.ts
@@ -1,0 +1,192 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — email_preferences (rebaseline 6/10).
+ *
+ * Frozen snapshot of `EmailPreference`'s sync() output. FKs (user_id →
+ * users with CASCADE, created_by/updated_by → users) live in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Two Postgres ENUMs declared inline (email_format / digest_frequency).
+ * The `preferences` JSONB column stores an array of NotificationPreference
+ * objects — per-key validation lives on the model.
+ *
+ * Both `user_id` and `unsubscribe_token` carry the column-level UNIQUE
+ * constraint AND a separate named unique index, mirroring `sync()`.
+ */
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.createTable(
+        'email_preferences',
+        {
+          preference_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            unique: true,
+          },
+          is_email_enabled: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          global_unsubscribe: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          preferences: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+          },
+          language: {
+            type: DataTypes.STRING(10),
+            allowNull: false,
+            defaultValue: 'en',
+          },
+          timezone: {
+            type: DataTypes.STRING(50),
+            allowNull: false,
+            defaultValue: 'UTC',
+          },
+          email_format: {
+            type: DataTypes.ENUM('html', 'text', 'both'),
+            allowNull: false,
+            defaultValue: 'html',
+          },
+          digest_frequency: {
+            type: DataTypes.ENUM('immediate', 'daily', 'weekly', 'monthly', 'never'),
+            allowNull: false,
+            defaultValue: 'weekly',
+          },
+          digest_time: {
+            type: DataTypes.STRING(5),
+            allowNull: false,
+            defaultValue: '09:00',
+          },
+          unsubscribe_token: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            unique: true,
+          },
+          last_digest_sent: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          bounce_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          last_bounce_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          is_blacklisted: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          blacklist_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          blacklisted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          // Audit columns (FKs in 00-baseline-zzz-foreign-keys.ts).
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction: t }
+      );
+
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['user_id'],
+        unique: true,
+        name: 'email_preferences_user_id_unique',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['unsubscribe_token'],
+        unique: true,
+        name: 'email_preferences_unsubscribe_token_unique',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['is_email_enabled'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['global_unsubscribe'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['is_blacklisted'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['digest_frequency'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['last_digest_sent'],
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['created_by'],
+        name: 'email_preferences_created_by_idx',
+        transaction: t,
+      });
+      await queryInterface.addIndex('email_preferences', {
+        fields: ['updated_by'],
+        name: 'email_preferences_updated_by_idx',
+        transaction: t,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged('00-baseline-040-email-preferences');
+    await queryInterface.dropTable('email_preferences');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_email_preferences_email_format');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_email_preferences_digest_frequency');
+  },
+};


### PR DESCRIPTION
## Summary

Domain 6 of 10 of the per-model rebaseline tracked in `docs/migrations/per-model-rebaseline.md` §2.2. Replaces the implicit `sequelize.sync()` baseline for the email pipeline with explicit, reviewable `createTable` migrations — one per model — so fresh databases produce a deterministic schema and future model edits show up as a real migration diff.

Tables covered (4):

- `email_templates`
- `email_template_versions`
- `email_queue`
- `email_preferences`

Each migration mirrors what `sync()` produces today against the matching model file. Cross-table FK constraints are intentionally NOT declared here — they batch into the planned `00-baseline-zzz-foreign-keys.ts` so per-model files stay independently reorderable. FK-column B-tree indexes (plain) are included because they accelerate joins regardless of whether the FK constraint is enforced at the DB layer.

ENUMs declared inline in `DataTypes.ENUM(...)` and torn down in `down()` via `dropEnumTypeIfExists` so they don't leak into `pg_type`. Every `down()` is gated by `assertDestructiveDownAcknowledged` because rebuilding the table from scratch would erase data.

## Files

New migrations under `service.backend/src/migrations/`:

- `00-baseline-037-email-templates.ts`
- `00-baseline-038-email-template-versions.ts`
- `00-baseline-039-email-queue.ts`
- `00-baseline-040-email-preferences.ts`

New round-trip test:

- `service.backend/src/__tests__/migrations/baseline-email.test.ts` — 16 cases (4 tables × 4 assertions: column-set match, index-set match, destructive-down refusal, destructive-down acknowledgement). Gated by `describeIfPostgres`.

## ENUM-heavy email status fields

Eight Postgres ENUMs are materialised across this domain. Each one is dropped in the matching `down()`:

| Table | Column | Values | Enum type name |
| --- | --- | --- | --- |
| `email_templates` | `type` | transactional, notification, marketing, system, administrative | `enum_email_templates_type` |
| `email_templates` | `category` | welcome, password_reset, email_verification, application_update, adoption_confirmation, rescue_verification, staff_invitation, notification_digest, reminder, announcement, newsletter, system_alert | `enum_email_templates_category` |
| `email_templates` | `status` | draft, active, inactive, archived | `enum_email_templates_status` |
| `email_queue` | `type` | transactional, notification, marketing, system | `enum_email_queue_type` |
| `email_queue` | `priority` | low, normal, high, urgent | `enum_email_queue_priority` |
| `email_queue` | `status` | queued, sending, sent, delivered, opened, clicked, failed, bounced, unsubscribed | `enum_email_queue_status` |
| `email_preferences` | `email_format` | html, text, both | `enum_email_preferences_email_format` |
| `email_preferences` | `digest_frequency` | immediate, daily, weekly, monthly, never | `enum_email_preferences_digest_frequency` |

## Notes / discrepancies surfaced during transcription

- `email_template_versions` contains a single `version` INTEGER column that serves a dual purpose: the model declares it as the template revision number AND opts into optimistic locking via `withAuditHooks` (which also wants a column called `version`). Sequelize collapses both onto the existing column — there is no separate optimistic-lock counter on this table. Documented inline.
- `email_queue` is `paranoid: false` (append-only delivery queue with its own `status` field for lifecycle tracking, hard-archived by the retention job). No `deleted_at` column. The other three tables in this domain follow the standard paranoid pattern except `email_template_versions`, which simply sets no `paranoid` flag — its history is also append-only.
- `email_queue.attachments` is JSONB `allowNull: false` WITHOUT a `defaultValue` on the model. Callers must supply the column on insert; the baseline reproduces the sync() output verbatim.
- `email_templates.tags`, `email_queue.tags`, `email_queue.cc_emails`, `email_queue.bcc_emails` are TEXT[] (Postgres native arrays via `getArrayType` outside the test env). Each defaults to `[]`.
- `email_preferences.user_id` and `email_preferences.unsubscribe_token` carry both a column-level UNIQUE constraint AND a separate named unique index in the model — the baseline reproduces both, which is what `sync()` emits.
- `email_templates.parent_template_id` is a self-FK in the model (with `onDelete: SET NULL`). The column shape is here (UUID, NULL); the REFERENCES clause lands in the FK file.
- `email_preferences.user_id` has `onDelete: CASCADE` in the model. Same treatment — column shape here, REFERENCES in the FK file.
- `email_template_versions.template_id` has `onDelete: CASCADE` in the model. Same treatment.
- All four tables opt into `withAuditHooks`, so all four get `created_by`, `updated_by`, `version`, and the matching `*_created_by_idx` / `*_updated_by_idx` indexes.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes (0 errors, no new warnings)
- [x] `npx vitest run` — 2118 passed, 77 skipped (4 migration test files require Postgres and skip via `describeIfPostgres`); no regressions
- [ ] CI runs `baseline-email.test.ts` against the Postgres test DB to verify round-trip equivalence with `sync()` output

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_