### PR TITLE
feat(migrations): per-model baseline for moderation & reports (rebaseline 7/10)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-moderation.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-moderation.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Round-trip tests for the per-model baseline migrations covering the
+ * moderation & reports domain (rebaseline 7/10):
+ *
+ *   00-baseline-041-reports
+ *   00-baseline-042-report-status-transitions
+ *   00-baseline-043-report-templates
+ *   00-baseline-044-report-shares
+ *   00-baseline-045-saved-reports
+ *   00-baseline-046-scheduled-reports
+ *   00-baseline-047-moderator-actions
+ *   00-baseline-048-moderation-evidence
+ *   00-baseline-049-user-sanctions
+ *   00-baseline-050-support-tickets
+ *   00-baseline-051-support-ticket-responses
+ *
+ * Pattern: force-sync the schema to capture the canonical column / index
+ * set, drop the table, run `up()`, assert the table is rebuilt with the
+ * same columns and indexes. Then run `down()` (with the destructive-down
+ * env flag) and assert the table is gone.
+ *
+ * Postgres-only — Sequelize ENUM, JSONB, ARRAY and GIN indexes have no
+ * SQLite equivalent.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import baseline041 from '../../migrations/00-baseline-041-reports';
+import baseline042 from '../../migrations/00-baseline-042-report-status-transitions';
+import baseline043 from '../../migrations/00-baseline-043-report-templates';
+import baseline044 from '../../migrations/00-baseline-044-report-shares';
+import baseline045 from '../../migrations/00-baseline-045-saved-reports';
+import baseline046 from '../../migrations/00-baseline-046-scheduled-reports';
+import baseline047 from '../../migrations/00-baseline-047-moderator-actions';
+import baseline048 from '../../migrations/00-baseline-048-moderation-evidence';
+import baseline049 from '../../migrations/00-baseline-049-user-sanctions';
+import baseline050 from '../../migrations/00-baseline-050-support-tickets';
+import baseline051 from '../../migrations/00-baseline-051-support-ticket-responses';
+
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+type ColumnRow = { column_name: string };
+type IndexRow = { indexname: string };
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const listColumns = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT column_name FROM information_schema.columns
+       WHERE table_schema = current_schema() AND table_name = '${table}'
+       ORDER BY column_name`
+  );
+  return (rows as ColumnRow[]).map(r => r.column_name);
+};
+
+const listIndexes = async (table: string): Promise<ReadonlyArray<string>> => {
+  const [rows] = await sequelize.query(
+    `SELECT indexname FROM pg_indexes
+       WHERE tablename = '${table}'
+       ORDER BY indexname`
+  );
+  return (rows as IndexRow[]).map(r => r.indexname);
+};
+
+type Migration = {
+  up: (qi: typeof queryInterface) => Promise<void>;
+  down: (qi: typeof queryInterface) => Promise<void>;
+};
+
+type Case = {
+  name: string;
+  table: string;
+  destructiveKey: string;
+  migration: Migration;
+};
+
+const CASES: ReadonlyArray<Case> = [
+  {
+    name: '041 — reports',
+    table: 'reports',
+    destructiveKey: '00-baseline-041-reports',
+    migration: baseline041,
+  },
+  {
+    name: '042 — report_status_transitions',
+    table: 'report_status_transitions',
+    destructiveKey: '00-baseline-042-report-status-transitions',
+    migration: baseline042,
+  },
+  {
+    name: '043 — report_templates',
+    table: 'report_templates',
+    destructiveKey: '00-baseline-043-report-templates',
+    migration: baseline043,
+  },
+  {
+    name: '044 — report_shares',
+    table: 'report_shares',
+    destructiveKey: '00-baseline-044-report-shares',
+    migration: baseline044,
+  },
+  {
+    name: '045 — saved_reports',
+    table: 'saved_reports',
+    destructiveKey: '00-baseline-045-saved-reports',
+    migration: baseline045,
+  },
+  {
+    name: '046 — scheduled_reports',
+    table: 'scheduled_reports',
+    destructiveKey: '00-baseline-046-scheduled-reports',
+    migration: baseline046,
+  },
+  {
+    name: '047 — moderator_actions',
+    table: 'moderator_actions',
+    destructiveKey: '00-baseline-047-moderator-actions',
+    migration: baseline047,
+  },
+  {
+    name: '048 — moderation_evidence',
+    table: 'moderation_evidence',
+    destructiveKey: '00-baseline-048-moderation-evidence',
+    migration: baseline048,
+  },
+  {
+    name: '049 — user_sanctions',
+    table: 'user_sanctions',
+    destructiveKey: '00-baseline-049-user-sanctions',
+    migration: baseline049,
+  },
+  {
+    name: '050 — support_tickets',
+    table: 'support_tickets',
+    destructiveKey: '00-baseline-050-support-tickets',
+    migration: baseline050,
+  },
+  {
+    name: '051 — support_ticket_responses',
+    table: 'support_ticket_responses',
+    destructiveKey: '00-baseline-051-support-ticket-responses',
+    migration: baseline051,
+  },
+];
+
+describeIfPostgres('per-model baseline — moderation & reports (rebaseline 7/10)', () => {
+  // Snapshot the env vars we mutate so we restore them between tests and
+  // never leak into other test files.
+  const originalAllow = process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  const originalKey = process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+  beforeAll(async () => {
+    // Establish the canonical post-sync baseline once. Each test that
+    // needs to compare against the canonical shape captures it before
+    // dropping the table.
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    // Restore env so test ordering doesn't leak.
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+    await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    // Each test starts from a freshly-synced schema so dropTable in one
+    // test cannot stomp another's setup.
+    await sequelize.sync({ force: true });
+  });
+
+  afterEach(() => {
+    process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = originalAllow;
+    process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = originalKey;
+  });
+
+  describe.each(CASES)('$name', ({ table, destructiveKey, migration }) => {
+    it('up() recreates the table with the same columns sync() produces', async () => {
+      const expectedColumns = await listColumns(table);
+      expect(expectedColumns.length).toBeGreaterThan(0);
+
+      await queryInterface.dropTable(table);
+      expect(await tableExists(table)).toBe(false);
+
+      await migration.up(queryInterface);
+
+      expect(await tableExists(table)).toBe(true);
+      const actualColumns = await listColumns(table);
+      expect(actualColumns).toEqual(expectedColumns);
+    });
+
+    it('up() recreates the indexes sync() produces', async () => {
+      const expectedIndexes = await listIndexes(table);
+
+      await queryInterface.dropTable(table);
+      await migration.up(queryInterface);
+
+      const actualIndexes = await listIndexes(table);
+      // Compare as sets — sync()'s anonymous index naming order can drift
+      // from queryInterface.addIndex's, but the set of indexes must match.
+      expect(new Set(actualIndexes)).toEqual(new Set(expectedIndexes));
+    });
+
+    it('down() refuses to drop the table without the destructive-down env flags', async () => {
+      delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+      delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+
+      await expect(migration.down(queryInterface)).rejects.toThrow(/destructive down/);
+      expect(await tableExists(table)).toBe(true);
+    });
+
+    it('down() drops the table when the destructive-down env flags acknowledge it', async () => {
+      process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+      process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = destructiveKey;
+
+      await migration.down(queryInterface);
+
+      expect(await tableExists(table)).toBe(false);
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-041-reports.ts
+++ b/service.backend/src/migrations/00-baseline-041-reports.ts
@@ -1,0 +1,204 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — reports (rebaseline 7/10).
+ *
+ * Frozen snapshot of `Report`'s sync() output. Cross-table foreign keys
+ * (reporter_id, reported_user_id, assigned_moderator, resolved_by,
+ * escalated_to, created_by, updated_by) live in
+ * `00-baseline-zzz-foreign-keys.ts`. Columns carry the right shape (UUID)
+ * but no REFERENCES clause until the FK file lands.
+ *
+ * `evidence` was moved to the `moderation_evidence` polymorphic table
+ * (see `00-baseline-048-moderation-evidence.ts`); no `evidence` column
+ * here.
+ */
+const MIGRATION_KEY = '00-baseline-041-reports';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'reports',
+        {
+          report_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          reporter_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          reported_entity_type: {
+            type: DataTypes.ENUM('user', 'rescue', 'pet', 'application', 'message', 'conversation'),
+            allowNull: false,
+          },
+          reported_entity_id: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          reported_user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          category: {
+            type: DataTypes.ENUM(
+              'inappropriate_content',
+              'spam',
+              'harassment',
+              'false_information',
+              'scam',
+              'animal_welfare',
+              'identity_theft',
+              'other'
+            ),
+            allowNull: false,
+          },
+          severity: {
+            type: DataTypes.ENUM('low', 'medium', 'high', 'critical'),
+            allowNull: false,
+            defaultValue: 'medium',
+          },
+          status: {
+            type: DataTypes.ENUM('pending', 'under_review', 'resolved', 'dismissed', 'escalated'),
+            allowNull: false,
+            defaultValue: 'pending',
+          },
+          title: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          assigned_moderator: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          assigned_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          resolved_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          resolved_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          resolution: {
+            type: DataTypes.STRING(100),
+            allowNull: true,
+          },
+          resolution_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          escalated_to: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          escalated_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          escalation_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('reports', {
+        fields: ['reporter_id'],
+        name: 'reports_reporter_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('reports', {
+        fields: ['reported_entity_type', 'reported_entity_id'],
+        transaction,
+      });
+      await queryInterface.addIndex('reports', {
+        fields: ['reported_user_id'],
+        name: 'reports_reported_user_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('reports', { fields: ['category'], transaction });
+      await queryInterface.addIndex('reports', { fields: ['status'], transaction });
+      await queryInterface.addIndex('reports', { fields: ['severity'], transaction });
+      await queryInterface.addIndex('reports', {
+        fields: ['assigned_moderator'],
+        name: 'reports_assigned_moderator_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('reports', {
+        fields: ['resolved_by'],
+        name: 'reports_resolved_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('reports', {
+        fields: ['escalated_to'],
+        name: 'reports_escalated_to_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('reports', { fields: ['created_at'], transaction });
+      await queryInterface.addIndex('reports', {
+        fields: ['created_by'],
+        name: 'reports_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('reports', {
+        fields: ['updated_by'],
+        name: 'reports_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('reports');
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_reports_reported_entity_type');
+    await dropEnumTypeIfExists(sql, 'enum_reports_category');
+    await dropEnumTypeIfExists(sql, 'enum_reports_severity');
+    await dropEnumTypeIfExists(sql, 'enum_reports_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-042-report-status-transitions.ts
+++ b/service.backend/src/migrations/00-baseline-042-report-status-transitions.ts
@@ -1,0 +1,88 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — report_status_transitions (rebaseline 7/10).
+ *
+ * Frozen snapshot of `ReportStatusTransition`'s sync() output. FKs
+ * (report_id with CASCADE; transitioned_by has no FK by design — see
+ * the model comment) are deferred to `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `timestamps: false` on the model — only `transitioned_at` tracks event
+ * time. No `created_at` / `updated_at` / `deleted_at` / audit columns.
+ *
+ * The AFTER INSERT trigger that propagates `to_status` to `reports.status`
+ * is installed by the model's `installStatusTransitionTrigger` afterSync
+ * hook and is not baseline DDL.
+ */
+const MIGRATION_KEY = '00-baseline-042-report-status-transitions';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'report_status_transitions',
+        {
+          transition_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          report_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          from_status: {
+            type: DataTypes.ENUM('pending', 'under_review', 'resolved', 'dismissed', 'escalated'),
+            allowNull: true,
+          },
+          to_status: {
+            type: DataTypes.ENUM('pending', 'under_review', 'resolved', 'dismissed', 'escalated'),
+            allowNull: false,
+          },
+          transitioned_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          transitioned_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('report_status_transitions', {
+        fields: ['report_id', 'transitioned_at'],
+        name: 'report_status_transitions_report_id_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_status_transitions', {
+        fields: ['transitioned_by'],
+        name: 'report_status_transitions_transitioned_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('report_status_transitions');
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_report_status_transitions_from_status');
+    await dropEnumTypeIfExists(sql, 'enum_report_status_transitions_to_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-043-report-templates.ts
+++ b/service.backend/src/migrations/00-baseline-043-report-templates.ts
@@ -1,0 +1,118 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — report_templates (rebaseline 7/10).
+ *
+ * Frozen snapshot of `ReportTemplate`'s sync() output. Cross-table FKs
+ * (rescue_id, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Paranoid: deleted_at column included. withAuditHooks contributes
+ * created_by / updated_by / version + matching FK indexes.
+ */
+const MIGRATION_KEY = '00-baseline-043-report-templates';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'report_templates',
+        {
+          template_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          name: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          category: {
+            type: DataTypes.ENUM('adoption', 'engagement', 'operations', 'fundraising', 'custom'),
+            allowNull: false,
+          },
+          config: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+          },
+          is_system: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('report_templates', {
+        fields: ['category'],
+        name: 'report_templates_category_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_templates', {
+        fields: ['is_system'],
+        name: 'report_templates_is_system_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_templates', {
+        fields: ['rescue_id'],
+        name: 'report_templates_rescue_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_templates', {
+        fields: ['created_by'],
+        name: 'report_templates_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_templates', {
+        fields: ['updated_by'],
+        name: 'report_templates_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('report_templates');
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_report_templates_category');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-044-report-shares.ts
+++ b/service.backend/src/migrations/00-baseline-044-report-shares.ts
@@ -1,0 +1,132 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — report_shares (rebaseline 7/10).
+ *
+ * Frozen snapshot of `ReportShare`'s sync() output. Cross-table FKs
+ * (saved_report_id, shared_with_user_id, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `report_shares_token_hash_idx` (plain B-tree on `token_hash`) IS in the
+ * model's index list and IS therefore part of `sync()` output, so it is
+ * recreated here. Post-baseline migration 15 (ADS-505) drops this plain
+ * index and replaces it with a partial UNIQUE index
+ * (`report_shares_token_hash_unique_idx`) — that unique index is NOT in
+ * the model and NOT in this baseline; it remains the responsibility of
+ * migration 15. Same pattern D1 followed for `ip_rules`.
+ *
+ * Paranoid: deleted_at column included. withAuditHooks contributes
+ * created_by / updated_by / version + FK-column indexes.
+ */
+const MIGRATION_KEY = '00-baseline-044-report-shares';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'report_shares',
+        {
+          share_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          saved_report_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          share_type: {
+            type: DataTypes.ENUM('user', 'token'),
+            allowNull: false,
+          },
+          shared_with_user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          token_hash: {
+            type: DataTypes.STRING(128),
+            allowNull: true,
+          },
+          permission: {
+            type: DataTypes.ENUM('view', 'edit'),
+            allowNull: false,
+            defaultValue: 'view',
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          revoked_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('report_shares', {
+        fields: ['saved_report_id'],
+        name: 'report_shares_saved_report_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_shares', {
+        fields: ['shared_with_user_id'],
+        name: 'report_shares_shared_with_user_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_shares', {
+        fields: ['token_hash'],
+        name: 'report_shares_token_hash_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_shares', {
+        fields: ['created_by'],
+        name: 'report_shares_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('report_shares', {
+        fields: ['updated_by'],
+        name: 'report_shares_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('report_shares');
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_report_shares_share_type');
+    await dropEnumTypeIfExists(sql, 'enum_report_shares_permission');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-045-saved-reports.ts
+++ b/service.backend/src/migrations/00-baseline-045-saved-reports.ts
@@ -1,0 +1,117 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model baseline — saved_reports (rebaseline 7/10).
+ *
+ * Frozen snapshot of `SavedReport`'s sync() output. Cross-table FKs
+ * (user_id, rescue_id, template_id, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Paranoid: deleted_at column included. withAuditHooks contributes
+ * created_by / updated_by / version + matching FK indexes.
+ */
+const MIGRATION_KEY = '00-baseline-045-saved-reports';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'saved_reports',
+        {
+          saved_report_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          template_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          name: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          config: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+          },
+          is_archived: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('saved_reports', {
+        fields: ['rescue_id', 'user_id'],
+        name: 'saved_reports_rescue_user_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('saved_reports', {
+        fields: ['template_id'],
+        name: 'saved_reports_template_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('saved_reports', {
+        fields: ['is_archived'],
+        name: 'saved_reports_archived_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('saved_reports', {
+        fields: ['created_by'],
+        name: 'saved_reports_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('saved_reports', {
+        fields: ['updated_by'],
+        name: 'saved_reports_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('saved_reports');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-046-scheduled-reports.ts
+++ b/service.backend/src/migrations/00-baseline-046-scheduled-reports.ts
@@ -1,0 +1,138 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — scheduled_reports (rebaseline 7/10).
+ *
+ * Frozen snapshot of `ScheduledReport`'s sync() output. Cross-table FKs
+ * (saved_report_id, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Paranoid: deleted_at column included. withAuditHooks contributes
+ * created_by / updated_by / version + matching FK indexes.
+ */
+const MIGRATION_KEY = '00-baseline-046-scheduled-reports';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'scheduled_reports',
+        {
+          schedule_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          saved_report_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          cron: {
+            type: DataTypes.STRING(120),
+            allowNull: false,
+          },
+          timezone: {
+            type: DataTypes.STRING(64),
+            allowNull: false,
+            defaultValue: 'UTC',
+          },
+          recipients: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: [],
+          },
+          format: {
+            type: DataTypes.ENUM('pdf', 'csv', 'inline-html'),
+            allowNull: false,
+            defaultValue: 'pdf',
+          },
+          is_enabled: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          last_run_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          next_run_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          last_status: {
+            type: DataTypes.ENUM('pending', 'success', 'failed'),
+            allowNull: true,
+          },
+          last_error: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          repeat_job_key: {
+            type: DataTypes.STRING(255),
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('scheduled_reports', {
+        fields: ['saved_report_id'],
+        name: 'scheduled_reports_saved_report_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('scheduled_reports', {
+        fields: ['is_enabled', 'next_run_at'],
+        name: 'scheduled_reports_enabled_next_run_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('scheduled_reports', {
+        fields: ['created_by'],
+        name: 'scheduled_reports_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('scheduled_reports', {
+        fields: ['updated_by'],
+        name: 'scheduled_reports_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('scheduled_reports');
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_scheduled_reports_format');
+    await dropEnumTypeIfExists(sql, 'enum_scheduled_reports_last_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-047-moderator-actions.ts
+++ b/service.backend/src/migrations/00-baseline-047-moderator-actions.ts
@@ -1,0 +1,201 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — moderator_actions (rebaseline 7/10).
+ *
+ * Frozen snapshot of `ModeratorAction`'s sync() output. Cross-table FKs
+ * (moderator_id, report_id, target_user_id, reversed_by, created_by,
+ * updated_by) land in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `paranoid: false` — append-only history of moderator decisions; no
+ * `deleted_at` column. `evidence` was moved to the `moderation_evidence`
+ * polymorphic table; no `evidence` column here.
+ *
+ * withAuditHooks contributes created_by / updated_by / version + matching
+ * FK indexes.
+ */
+const MIGRATION_KEY = '00-baseline-047-moderator-actions';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'moderator_actions',
+        {
+          action_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          moderator_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          report_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          target_entity_type: {
+            type: DataTypes.ENUM('user', 'rescue', 'pet', 'application', 'message', 'conversation'),
+            allowNull: false,
+          },
+          target_entity_id: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          target_user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          action_type: {
+            type: DataTypes.ENUM(
+              'warning_issued',
+              'content_removed',
+              'user_suspended',
+              'user_banned',
+              'account_restricted',
+              'content_flagged',
+              'report_dismissed',
+              'escalation',
+              'appeal_reviewed',
+              'no_action'
+            ),
+            allowNull: false,
+          },
+          severity: {
+            type: DataTypes.ENUM('low', 'medium', 'high', 'critical'),
+            allowNull: false,
+          },
+          reason: {
+            type: DataTypes.STRING(500),
+            allowNull: false,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          duration: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          is_active: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          reversed_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          reversed_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          reversal_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          notification_sent: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          internal_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('moderator_actions', {
+        fields: ['moderator_id'],
+        name: 'moderator_actions_moderator_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('moderator_actions', {
+        fields: ['report_id'],
+        name: 'moderator_actions_report_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('moderator_actions', {
+        fields: ['target_entity_type', 'target_entity_id'],
+        transaction,
+      });
+      await queryInterface.addIndex('moderator_actions', {
+        fields: ['target_user_id'],
+        name: 'moderator_actions_target_user_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('moderator_actions', {
+        fields: ['action_type'],
+        transaction,
+      });
+      await queryInterface.addIndex('moderator_actions', { fields: ['severity'], transaction });
+      await queryInterface.addIndex('moderator_actions', { fields: ['is_active'], transaction });
+      await queryInterface.addIndex('moderator_actions', { fields: ['expires_at'], transaction });
+      await queryInterface.addIndex('moderator_actions', {
+        fields: ['reversed_by'],
+        name: 'moderator_actions_reversed_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('moderator_actions', { fields: ['created_at'], transaction });
+      await queryInterface.addIndex('moderator_actions', {
+        fields: ['created_by'],
+        name: 'moderator_actions_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('moderator_actions', {
+        fields: ['updated_by'],
+        name: 'moderator_actions_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('moderator_actions');
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_moderator_actions_target_entity_type');
+    await dropEnumTypeIfExists(sql, 'enum_moderator_actions_action_type');
+    await dropEnumTypeIfExists(sql, 'enum_moderator_actions_severity');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-048-moderation-evidence.ts
+++ b/service.backend/src/migrations/00-baseline-048-moderation-evidence.ts
@@ -1,0 +1,110 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — moderation_evidence (rebaseline 7/10).
+ *
+ * Frozen snapshot of `ModerationEvidence`'s sync() output. The audit FK
+ * columns (created_by, updated_by) carry shape only — REFERENCES are
+ * deferred to `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Polymorphic via (parent_type, parent_id). The parent_type ENUM is the
+ * discriminator; there is no DB-level FK to a single parent table by
+ * design (see model comment).
+ *
+ * `paranoid: false` — no `deleted_at` column. withAuditHooks contributes
+ * created_by / updated_by / version + matching FK indexes.
+ */
+const MIGRATION_KEY = '00-baseline-048-moderation-evidence';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'moderation_evidence',
+        {
+          evidence_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          parent_type: {
+            type: DataTypes.ENUM('report', 'moderator_action'),
+            allowNull: false,
+          },
+          parent_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          type: {
+            type: DataTypes.ENUM('screenshot', 'url', 'text', 'file'),
+            allowNull: false,
+          },
+          content: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          uploaded_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('moderation_evidence', {
+        fields: ['parent_type', 'parent_id'],
+        name: 'moderation_evidence_parent_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('moderation_evidence', {
+        fields: ['created_by'],
+        name: 'moderation_evidence_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('moderation_evidence', {
+        fields: ['updated_by'],
+        name: 'moderation_evidence_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('moderation_evidence');
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_moderation_evidence_parent_type');
+    await dropEnumTypeIfExists(sql, 'enum_moderation_evidence_type');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-049-user-sanctions.ts
+++ b/service.backend/src/migrations/00-baseline-049-user-sanctions.ts
@@ -1,0 +1,248 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — user_sanctions (rebaseline 7/10).
+ *
+ * Frozen snapshot of `UserSanction`'s sync() output. Cross-table FKs
+ * (user_id, issued_by, report_id, moderator_action_id, appeal_resolved_by,
+ * revoked_by, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * `paranoid: false` — append-only sanction history. Lifting a sanction is
+ * a new row, not a soft-delete on the original. No `deleted_at` column.
+ *
+ * withAuditHooks contributes created_by / updated_by / version + matching
+ * FK indexes.
+ */
+const MIGRATION_KEY = '00-baseline-049-user-sanctions';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'user_sanctions',
+        {
+          sanction_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          sanction_type: {
+            type: DataTypes.ENUM(
+              'warning',
+              'restriction',
+              'temporary_ban',
+              'permanent_ban',
+              'messaging_restriction',
+              'posting_restriction',
+              'application_restriction'
+            ),
+            allowNull: false,
+          },
+          reason: {
+            type: DataTypes.ENUM(
+              'harassment',
+              'spam',
+              'inappropriate_content',
+              'terms_violation',
+              'scam_attempt',
+              'false_information',
+              'animal_welfare_concern',
+              'repeated_violations',
+              'other'
+            ),
+            allowNull: false,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          is_active: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: true,
+          },
+          start_date: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          end_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          duration: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          issued_by: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          issued_by_role: {
+            type: DataTypes.ENUM('ADMIN', 'MODERATOR', 'SUPER_ADMIN'),
+            allowNull: false,
+          },
+          report_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          moderator_action_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          appealed_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          appeal_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          appeal_status: {
+            type: DataTypes.ENUM('pending', 'approved', 'rejected'),
+            allowNull: true,
+          },
+          appeal_resolved_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          appeal_resolved_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          appeal_resolution: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          revoked_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          revoked_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          revocation_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          notification_sent: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          internal_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          warning_count: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            defaultValue: 0,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['user_id'],
+        name: 'user_sanctions_user_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('user_sanctions', { fields: ['sanction_type'], transaction });
+      await queryInterface.addIndex('user_sanctions', { fields: ['reason'], transaction });
+      await queryInterface.addIndex('user_sanctions', { fields: ['is_active'], transaction });
+      await queryInterface.addIndex('user_sanctions', { fields: ['start_date'], transaction });
+      await queryInterface.addIndex('user_sanctions', { fields: ['end_date'], transaction });
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['issued_by'],
+        name: 'user_sanctions_issued_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['report_id'],
+        name: 'user_sanctions_report_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['moderator_action_id'],
+        name: 'user_sanctions_moderator_action_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['appeal_resolved_by'],
+        name: 'user_sanctions_appeal_resolved_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['revoked_by'],
+        name: 'user_sanctions_revoked_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('user_sanctions', { fields: ['appeal_status'], transaction });
+      await queryInterface.addIndex('user_sanctions', { fields: ['created_at'], transaction });
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['user_id', 'is_active', 'end_date'],
+        transaction,
+      });
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['created_by'],
+        name: 'user_sanctions_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('user_sanctions', {
+        fields: ['updated_by'],
+        name: 'user_sanctions_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('user_sanctions');
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_user_sanctions_sanction_type');
+    await dropEnumTypeIfExists(sql, 'enum_user_sanctions_reason');
+    await dropEnumTypeIfExists(sql, 'enum_user_sanctions_issued_by_role');
+    await dropEnumTypeIfExists(sql, 'enum_user_sanctions_appeal_status');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-050-support-tickets.ts
+++ b/service.backend/src/migrations/00-baseline-050-support-tickets.ts
@@ -1,0 +1,232 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — support_tickets (rebaseline 7/10).
+ *
+ * Frozen snapshot of `SupportTicket`'s sync() output. Cross-table FKs
+ * (user_id, assigned_to, escalated_to, created_by, updated_by) land in
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * No `paranoid: true` on the model — no `deleted_at` column.
+ * `tags` is `ARRAY(STRING)` indexed with GIN. `attachments` and
+ * `metadata` are JSONB with the model's defaultValue (empty array /
+ * empty object).
+ *
+ * withAuditHooks contributes created_by / updated_by / version + matching
+ * FK indexes.
+ */
+const MIGRATION_KEY = '00-baseline-050-support-tickets';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'support_tickets',
+        {
+          ticket_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          user_email: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          user_name: {
+            type: DataTypes.STRING,
+            allowNull: true,
+          },
+          assigned_to: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          status: {
+            type: DataTypes.ENUM(
+              'open',
+              'in_progress',
+              'waiting_for_user',
+              'resolved',
+              'closed',
+              'escalated'
+            ),
+            allowNull: false,
+            defaultValue: 'open',
+          },
+          priority: {
+            type: DataTypes.ENUM('low', 'normal', 'high', 'urgent', 'critical'),
+            allowNull: false,
+            defaultValue: 'normal',
+          },
+          category: {
+            type: DataTypes.ENUM(
+              'technical_issue',
+              'account_problem',
+              'adoption_inquiry',
+              'payment_issue',
+              'feature_request',
+              'report_bug',
+              'general_question',
+              'compliance_concern',
+              'data_request',
+              'other'
+            ),
+            allowNull: false,
+          },
+          subject: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+          },
+          description: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          tags: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: false,
+          },
+          attachments: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: [],
+          },
+          metadata: {
+            type: DataTypes.JSONB,
+            allowNull: false,
+            defaultValue: {},
+          },
+          first_response_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          last_response_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          resolved_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          closed_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          escalated_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          escalated_to: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          escalation_reason: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          satisfaction_rating: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          satisfaction_feedback: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          internal_notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          due_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          estimated_resolution_time: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          actual_resolution_time: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('support_tickets', {
+        fields: ['user_id'],
+        name: 'support_tickets_user_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('support_tickets', { fields: ['user_email'], transaction });
+      await queryInterface.addIndex('support_tickets', {
+        fields: ['assigned_to'],
+        name: 'support_tickets_assigned_to_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('support_tickets', {
+        fields: ['escalated_to'],
+        name: 'support_tickets_escalated_to_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('support_tickets', { fields: ['status'], transaction });
+      await queryInterface.addIndex('support_tickets', { fields: ['priority'], transaction });
+      await queryInterface.addIndex('support_tickets', { fields: ['category'], transaction });
+      await queryInterface.addIndex('support_tickets', { fields: ['created_at'], transaction });
+      await queryInterface.addIndex('support_tickets', { fields: ['due_date'], transaction });
+      await queryInterface.addIndex('support_tickets', {
+        fields: ['tags'],
+        using: 'gin',
+        transaction,
+      });
+      await queryInterface.addIndex('support_tickets', {
+        fields: ['created_by'],
+        name: 'support_tickets_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('support_tickets', {
+        fields: ['updated_by'],
+        name: 'support_tickets_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('support_tickets');
+    const sql = queryInterface.sequelize;
+    await dropEnumTypeIfExists(sql, 'enum_support_tickets_status');
+    await dropEnumTypeIfExists(sql, 'enum_support_tickets_priority');
+    await dropEnumTypeIfExists(sql, 'enum_support_tickets_category');
+  },
+};

--- a/service.backend/src/migrations/00-baseline-051-support-ticket-responses.ts
+++ b/service.backend/src/migrations/00-baseline-051-support-ticket-responses.ts
@@ -1,0 +1,143 @@
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+/**
+ * Per-model baseline — support_ticket_responses (rebaseline 7/10).
+ *
+ * Frozen snapshot of `SupportTicketResponse`'s sync() output. Cross-table
+ * FKs (ticket_id with CASCADE, responder_id, created_by, updated_by)
+ * land in `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Paranoid: deleted_at column included; the model declares an explicit
+ * deleted_at field plus a `support_ticket_responses_deleted_at_idx`.
+ *
+ * `attachments` JSONB is the only nullable JSON in this domain — the
+ * model declares `allowNull: true` (no default).
+ *
+ * withAuditHooks contributes created_by / updated_by / version + matching
+ * FK indexes.
+ */
+const MIGRATION_KEY = '00-baseline-051-support-ticket-responses';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'support_ticket_responses',
+        {
+          response_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          ticket_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          responder_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+          },
+          responder_type: {
+            type: DataTypes.ENUM('staff', 'user'),
+            allowNull: false,
+          },
+          content: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+          },
+          attachments: {
+            type: DataTypes.JSONB,
+            allowNull: true,
+          },
+          is_internal: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+          },
+          version: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['ticket_id'],
+        transaction,
+      });
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['responder_id'],
+        transaction,
+      });
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['created_at'],
+        transaction,
+      });
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['responder_type'],
+        transaction,
+      });
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['is_internal'],
+        transaction,
+      });
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['ticket_id', 'created_at'],
+        transaction,
+      });
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['deleted_at'],
+        name: 'support_ticket_responses_deleted_at_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['created_by'],
+        name: 'support_ticket_responses_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('support_ticket_responses', {
+        fields: ['updated_by'],
+        name: 'support_ticket_responses_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await queryInterface.dropTable('support_ticket_responses');
+    await dropEnumTypeIfExists(
+      queryInterface.sequelize,
+      'enum_support_ticket_responses_responder_type'
+    );
+  },
+};


### PR DESCRIPTION
## Summary

Per-model baseline rebaseline, domain 7 of 10 (moderation & reports). Per the design in `docs/migrations/per-model-rebaseline.md` §2.2, replaces the implicit `sequelize.sync()` baseline with explicit, frozen `createTable` calls — one file per table — so that fresh DBs produce a deterministic, reviewable schema.

Eleven per-model files added (one table each):

- `00-baseline-041-reports.ts`
- `00-baseline-042-report-status-transitions.ts`
- `00-baseline-043-report-templates.ts`
- `00-baseline-044-report-shares.ts`
- `00-baseline-045-saved-reports.ts`
- `00-baseline-046-scheduled-reports.ts`
- `00-baseline-047-moderator-actions.ts`
- `00-baseline-048-moderation-evidence.ts`
- `00-baseline-049-user-sanctions.ts`
- `00-baseline-050-support-tickets.ts`
- `00-baseline-051-support-ticket-responses.ts`

Each `up()` is wrapped in `runInTransaction` and creates the table + the model's non-FK indexes. Each `down()` calls `assertDestructiveDownAcknowledged` (per-file key) before `dropTable` and any orphan ENUM cleanup.

Cross-table FKs are intentionally NOT in this PR — they land in the forthcoming `00-baseline-zzz-foreign-keys.ts` so per-model files remain independently orderable. FK-column B-tree indexes ARE included.

Round-trip tests in `service.backend/src/__tests__/migrations/baseline-moderation.test.ts` (`describeIfPostgres`, 44 tests = 11 tables × 4 cases) verify per table:

1. `up()` rebuilds the same column set `sync()` produces.
2. `up()` rebuilds the same index set `sync()` produces.
3. `down()` refuses without `MIGRATION_ALLOW_DESTRUCTIVE_DOWN` + matching `MIGRATION_DESTRUCTIVE_DOWN_KEY`.
4. `down()` drops the table when the destructive-down env flags acknowledge it.

## Notes / Discrepancies

- **`report_shares.token_hash` partial unique index (migration 15 collision).** The model's index list declares a plain B-tree `report_shares_token_hash_idx` on `token_hash` — `sync()` therefore emits it, so it's recreated in `00-baseline-044-report-shares.ts`. Post-baseline migration 15 (ADS-505) drops that plain index and creates the partial UNIQUE index `report_shares_token_hash_unique_idx` (`WHERE share_type = 'token' AND token_hash IS NOT NULL`). The unique index is NOT in the model and NOT in this baseline; it stays the responsibility of migration 15. Same pattern D1 followed for `ip_rules`.
- **`evidence` arrays moved to `moderation_evidence`.** Both `Report` and `ModeratorAction` historically had a JSONB `evidence[]` column; the current models do not. The polymorphic `moderation_evidence` table (created here as 048) is now the single source of truth, scoped via `parent_type` / `parent_id`. No `evidence` columns in 041 / 047.
- **Status-transition trigger stays in the model.** `00-baseline-042-report-status-transitions.ts` declares the table only. The AFTER INSERT trigger that propagates `to_status` to `reports.status` is installed by the model's `installStatusTransitionTrigger` afterSync hook (Postgres-only) and is not baseline DDL.
- **Paranoid coverage.** `report_templates` / `report_shares` / `saved_reports` / `scheduled_reports` / `support_ticket_responses` are paranoid (have `deleted_at`). `reports` / `report_status_transitions` / `moderator_actions` / `moderation_evidence` / `user_sanctions` / `support_tickets` are NOT paranoid (append-only or never-soft-deleted history).
- **`support_ticket_responses` declares an explicit `deleted_at` field on the model** (with `paranoid: true` *and* the column declared explicitly) plus its own `support_ticket_responses_deleted_at_idx`. Reproduced verbatim.
- **`support_tickets.tags`** is `ARRAY(STRING) NOT NULL` (no default) with a GIN index. Reproduced verbatim.
- **`report_status_transitions`** has `timestamps: false` and no `withAuditHooks` — only `transitioned_at` tracks event time. No `created_at` / `updated_at` / `deleted_at` / audit columns.
- **`moderation_evidence`** declares `timestamps: true` but `paranoid: false` — has `created_at` / `updated_at` but not `deleted_at`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes (no new warnings)
- [x] `npx vitest run` — 2118 passed, 105 skipped (the 44 new cases in `baseline-moderation.test.ts` skip on SQLite via `describeIfPostgres`)
- [ ] CI runs `baseline-moderation.test.ts` against the Postgres test DB to verify round-trip equivalence with `sync()` output

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi


---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_