### PR TITLE
fix(migrations): idempotency patches for migrations 04 / 12 / 14 to coexist with per-model baselines

### DIFF
--- a/service.backend/src/__tests__/migrations/idempotent-migrations.test.ts
+++ b/service.backend/src/__tests__/migrations/idempotent-migrations.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Idempotency tests for the rebaseline-coexistence patches on migrations
+ * 04, 12, and 14.
+ *
+ * Each of these legacy migrations overlaps with an object created by one
+ * of the per-model baseline files (`00-baseline-NNN-*.ts`). On a fresh DB
+ * the per-model baseline runs first, so the legacy migration's `up()`
+ * must be a no-op for the already-existing object while still creating it
+ * on existing DBs that were bootstrapped from the old monolithic
+ * `00-baseline.ts`.
+ *
+ * Tests are Postgres-only because the patches use Postgres-specific
+ * `IF NOT EXISTS` syntax and `pg_constraint` / `information_schema`
+ * lookups.
+ */
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import migration04 from '../../migrations/04-add-invitation-indexes-and-constraints';
+import migration12 from '../../migrations/12-create-user-consents';
+import migration14 from '../../migrations/14-add-revoked-tokens-updated-at';
+import * as models from '../../models';
+
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+const indexExists = async (table: string, name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM pg_indexes WHERE tablename = '${table}' AND indexname = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const constraintExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(`SELECT 1 FROM pg_constraint WHERE conname = '${name}'`);
+  return (rows as unknown[]).length > 0;
+};
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const columnExists = async (table: string, column: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.columns
+       WHERE table_name = '${table}' AND column_name = '${column}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const countColumns = async (table: string): Promise<number> => {
+  const [rows] = await sequelize.query(
+    `SELECT COUNT(*)::int AS n FROM information_schema.columns WHERE table_name = '${table}'`
+  );
+  return (rows as Array<{ n: number }>)[0].n;
+};
+
+describeIfPostgres('rebaseline-coexistence idempotency patches', () => {
+  beforeEach(async () => {
+    // Each test starts from a clean schema rebuilt from models.
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  describe('migration 04 — invitation indexes / constraint', () => {
+    const indexes = [
+      'invitations_rescue_id_idx',
+      'invitations_user_id_idx',
+      'invitations_email_idx',
+    ];
+
+    it('up() is a no-op when indexes and unique constraint already exist (fresh-DB-with-baseline path)', async () => {
+      // Pre-create everything as the per-model baseline would.
+      await sequelize.query(
+        `CREATE INDEX IF NOT EXISTS "invitations_rescue_id_idx" ON "invitations" ("rescue_id")`
+      );
+      await sequelize.query(
+        `CREATE INDEX IF NOT EXISTS "invitations_user_id_idx" ON "invitations" ("user_id")`
+      );
+      await sequelize.query(
+        `CREATE INDEX IF NOT EXISTS "invitations_email_idx" ON "invitations" ("email")`
+      );
+      if (!(await constraintExists('invitations_token_unique'))) {
+        await sequelize.query(
+          `ALTER TABLE "invitations" ADD CONSTRAINT "invitations_token_unique" UNIQUE ("token")`
+        );
+      }
+
+      await expect(migration04.up(queryInterface)).resolves.not.toThrow();
+
+      for (const name of indexes) {
+        expect(await indexExists('invitations', name)).toBe(true);
+      }
+      expect(await constraintExists('invitations_token_unique')).toBe(true);
+    });
+
+    it('up() creates the indexes and constraint when they do not exist (existing-DB-from-old-monolithic-baseline path)', async () => {
+      // Drop everything the migration is responsible for.
+      await sequelize.query(
+        `ALTER TABLE "invitations" DROP CONSTRAINT IF EXISTS "invitations_token_unique"`
+      );
+      for (const name of indexes) {
+        await sequelize.query(`DROP INDEX IF EXISTS "${name}"`);
+      }
+
+      await migration04.up(queryInterface);
+
+      for (const name of indexes) {
+        expect(await indexExists('invitations', name)).toBe(true);
+      }
+      expect(await constraintExists('invitations_token_unique')).toBe(true);
+    });
+  });
+
+  describe('migration 12 — user_consents table', () => {
+    it('up() is a no-op when user_consents already exists (fresh-DB-with-baseline path)', async () => {
+      // sync() already created user_consents from the model. Snapshot the
+      // pre-state so we can assert up() did not alter it.
+      expect(await tableExists('user_consents')).toBe(true);
+      const colsBefore = await countColumns('user_consents');
+      const indexBefore = await indexExists('user_consents', 'user_consents_user_purpose_idx');
+
+      await expect(migration12.up(queryInterface)).resolves.not.toThrow();
+
+      expect(await tableExists('user_consents')).toBe(true);
+      expect(await countColumns('user_consents')).toBe(colsBefore);
+      expect(await indexExists('user_consents', 'user_consents_user_purpose_idx')).toBe(
+        indexBefore
+      );
+    });
+
+    it('up() creates the table when it does not exist (existing-DB-from-old-monolithic-baseline path)', async () => {
+      // Drop the model-created table; the migration should re-create it
+      // using its own (older) shape.
+      await sequelize.query(`DROP TABLE IF EXISTS "user_consents"`);
+      // Drop the enum so up() can re-create it.
+      await sequelize.query(`DROP TYPE IF EXISTS "enum_user_consents_purpose"`);
+      expect(await tableExists('user_consents')).toBe(false);
+
+      await migration12.up(queryInterface);
+
+      expect(await tableExists('user_consents')).toBe(true);
+      expect(await indexExists('user_consents', 'user_consents_user_purpose_idx')).toBe(true);
+    });
+  });
+
+  describe('migration 14 — revoked_tokens.updated_at column', () => {
+    it('up() is a no-op when updated_at already exists (fresh-DB-with-baseline path)', async () => {
+      // Model already declares updated_at; ensure it is present before
+      // running the migration.
+      if (!(await columnExists('revoked_tokens', 'updated_at'))) {
+        await sequelize.query(
+          `ALTER TABLE "revoked_tokens"
+             ADD COLUMN "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()`
+        );
+      }
+      const colsBefore = await countColumns('revoked_tokens');
+
+      await expect(migration14.up(queryInterface)).resolves.not.toThrow();
+
+      expect(await columnExists('revoked_tokens', 'updated_at')).toBe(true);
+      expect(await countColumns('revoked_tokens')).toBe(colsBefore);
+    });
+
+    it('up() adds updated_at when it does not exist (existing-DB-from-old-monolithic-baseline path)', async () => {
+      await sequelize.query(`ALTER TABLE "revoked_tokens" DROP COLUMN IF EXISTS "updated_at"`);
+      expect(await columnExists('revoked_tokens', 'updated_at')).toBe(false);
+
+      await migration14.up(queryInterface);
+
+      expect(await columnExists('revoked_tokens', 'updated_at')).toBe(true);
+    });
+  });
+});

--- a/service.backend/src/migrations/04-add-invitation-indexes-and-constraints.ts
+++ b/service.backend/src/migrations/04-add-invitation-indexes-and-constraints.ts
@@ -1,28 +1,62 @@
 import { QueryInterface, DataTypes } from 'sequelize';
 
+/**
+ * Idempotency note (per-model rebaseline coexistence):
+ *
+ * The new `00-baseline-011-invitations.ts` baseline freezes today's
+ * `sync()` output, which already declares the same indexes and unique
+ * constraint that this migration adds (token unique, rescue_id, user_id,
+ * email). On fresh DBs the baseline runs first, so the bare `addIndex` /
+ * `addConstraint` calls below would fail with a duplicate-name error.
+ *
+ * The original index/constraint additions are therefore expressed as raw
+ * SQL with `IF NOT EXISTS` (and a `pg_constraint` precheck for the unique
+ * constraint, since Postgres has no `ADD CONSTRAINT IF NOT EXISTS`). On
+ * existing DBs created by the legacy monolithic `00-baseline.ts`, the
+ * objects don't exist yet and these statements still create them.
+ *
+ * The FK swap below (`removeConstraint` + `addConstraint`) is unchanged —
+ * it has always been idempotent via the `.catch(() => {})` on the
+ * removeConstraint, and the per-model baseline does not declare those FKs
+ * (they live in `00-baseline-zzz-foreign-keys.ts`).
+ *
+ * `down()` is intentionally unchanged. Per the design doc, rollback for
+ * the rebaseline-coexistent migrations is via DB backup, not
+ * `db:migrate:undo`.
+ */
 export default {
   up: async (queryInterface: QueryInterface) => {
-    // Add unique constraint on invitations.token
-    await queryInterface.addConstraint('invitations', {
-      fields: ['token'],
-      type: 'unique',
-      name: 'invitations_token_unique',
-    });
+    const sequelize = queryInterface.sequelize;
+
+    // Add unique constraint on invitations.token (skip if already present;
+    // the per-model baseline declares it on `token` via `unique: true`,
+    // which Postgres represents as a unique constraint with the matching
+    // name).
+    const [existing] = await sequelize.query(
+      `SELECT 1 FROM pg_constraint WHERE conname = 'invitations_token_unique'`
+    );
+    if ((existing as unknown[]).length === 0) {
+      await queryInterface.addConstraint('invitations', {
+        fields: ['token'],
+        type: 'unique',
+        name: 'invitations_token_unique',
+      });
+    }
 
     // Add index on rescue_id (FK performance)
-    await queryInterface.addIndex('invitations', ['rescue_id'], {
-      name: 'invitations_rescue_id_idx',
-    });
+    await sequelize.query(
+      `CREATE INDEX IF NOT EXISTS "invitations_rescue_id_idx" ON "invitations" ("rescue_id")`
+    );
 
     // Add index on user_id (FK performance)
-    await queryInterface.addIndex('invitations', ['user_id'], {
-      name: 'invitations_user_id_idx',
-    });
+    await sequelize.query(
+      `CREATE INDEX IF NOT EXISTS "invitations_user_id_idx" ON "invitations" ("user_id")`
+    );
 
     // Add index on email (lookup by invitee email)
-    await queryInterface.addIndex('invitations', ['email'], {
-      name: 'invitations_email_idx',
-    });
+    await sequelize.query(
+      `CREATE INDEX IF NOT EXISTS "invitations_email_idx" ON "invitations" ("email")`
+    );
 
     // Fix FK onDelete for rescue_id: CASCADE (invitation is meaningless without rescue)
     await queryInterface.removeConstraint('invitations', 'invitations_rescue_id_fkey').catch(() => {

--- a/service.backend/src/migrations/12-create-user-consents.ts
+++ b/service.backend/src/migrations/12-create-user-consents.ts
@@ -5,9 +5,35 @@ import { QueryInterface, DataTypes } from 'sequelize';
  *
  * Append-only event log: each grant / withdrawal is a new row. The
  * latest row per (user_id, purpose) is the user's current state.
+ *
+ * Idempotency note (per-model rebaseline coexistence): the new
+ * `00-baseline-055-user-consents.ts` baseline freezes today's `sync()`
+ * output for `user_consents`, which DOES include the `version` column and
+ * `*_created_by_idx` / `*_updated_by_idx` audit indexes that this older
+ * migration omits. The two definitions intentionally diverge — the
+ * baseline is source-of-truth (it mirrors what `withAuditHooks` emits
+ * today), and on fresh DBs the baseline runs first. To keep this
+ * migration safe to run against either schema, it now precheck-skips when
+ * `user_consents` already exists. On existing DBs created by the legacy
+ * monolithic `00-baseline.ts` (where neither file has run), the
+ * `createTable` + `addIndex` still execute as before.
+ *
+ * `down()` is intentionally unchanged. Per the design doc, rollback for
+ * the rebaseline-coexistent migrations is via DB backup, not
+ * `db:migrate:undo`.
  */
 export default {
   up: async (queryInterface: QueryInterface) => {
+    const [existing] = await queryInterface.sequelize.query(
+      `SELECT 1 FROM information_schema.tables WHERE table_name = 'user_consents'`
+    );
+    if ((existing as unknown[]).length > 0) {
+      // Table already exists (created by per-model baseline). The
+      // baseline produces a superset of the columns/indexes we would have
+      // added here, so there is nothing to do.
+      return;
+    }
+
     await queryInterface.createTable('user_consents', {
       consent_id: {
         type: DataTypes.UUID,

--- a/service.backend/src/migrations/14-add-revoked-tokens-updated-at.ts
+++ b/service.backend/src/migrations/14-add-revoked-tokens-updated-at.ts
@@ -1,4 +1,4 @@
-import { DataTypes, type QueryInterface } from 'sequelize';
+import { type QueryInterface } from 'sequelize';
 import { runInTransaction } from './_helpers';
 
 /**
@@ -14,18 +14,25 @@ import { runInTransaction } from './_helpers';
  * `revoked_at` continues to act as the "created at" — a token row is
  * inserted exactly once when revoked. `updated_at` exists for forward
  * compatibility and tracks any future status flips (e.g. unrevoke).
+ *
+ * Idempotency note (per-model rebaseline coexistence): the new
+ * `00-baseline-007-revoked-tokens.ts` baseline freezes today's `sync()`
+ * output, which already includes `updated_at`. On fresh DBs the baseline
+ * runs first, so a bare `addColumn` here would fail with "column already
+ * exists". The body therefore uses raw SQL `ADD COLUMN IF NOT EXISTS`,
+ * which is a no-op if the column is already there and still creates it on
+ * existing DBs that ran the legacy monolithic `00-baseline.ts`.
+ *
+ * `down()` is intentionally unchanged. Per the design doc, rollback for
+ * the rebaseline-coexistent migrations is via DB backup, not
+ * `db:migrate:undo`.
  */
 export default {
   up: async (queryInterface: QueryInterface) => {
     await runInTransaction(queryInterface, async t => {
-      await queryInterface.addColumn(
-        'revoked_tokens',
-        'updated_at',
-        {
-          type: DataTypes.DATE,
-          allowNull: false,
-          defaultValue: DataTypes.NOW,
-        },
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "revoked_tokens"
+           ADD COLUMN IF NOT EXISTS "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()`,
         { transaction: t }
       );
     });


### PR DESCRIPTION
## Summary

The 10 per-domain rebaseline PRs (#441-450) introduce explicit per-table baseline migrations (`00-baseline-NNN-<model>.ts`) that freeze today's `sync()` output. Three of those baselines overlap with objects that existing post-baseline migrations also create, producing duplicate-name errors on a fresh DB:

| Conflict | Symptom on fresh DB |
| --- | --- |
| `00-baseline-011-invitations` ⊕ `04-add-invitation-indexes-and-constraints` | Baseline `createTable` declares the same indexes (`token` unique, `rescue_id`, `user_id`, `email`); migration 04's `addIndex` / `addConstraint` then errors with duplicate name. |
| `00-baseline-055-user-consents` ⊕ `12-create-user-consents` | Baseline mirrors `sync()` output (which adds `version` + audit indexes via `withAuditHooks`); migration 12's `createTable` then errors with "relation already exists". |
| `00-baseline-007-revoked-tokens` ⊕ `14-add-revoked-tokens-updated-at` | Baseline freezes today's schema, which already has `updated_at`; migration 14's `addColumn` then errors with "column already exists". |

This PR makes the legacy migrations idempotent so they no-op when their target objects already exist (fresh-DB-with-baseline path) but still create them when missing (existing-DB-from-old-monolithic-baseline path).

## Patch patterns

- **Migration 04** — `addIndex(...)` -> raw `CREATE INDEX IF NOT EXISTS`. `addConstraint(... 'unique' ...)` guarded by a `pg_constraint` precheck (Postgres has no `ADD CONSTRAINT IF NOT EXISTS`). FK swap below is unchanged - it was already idempotent via `.catch(() => {})`.
- **Migration 12** — `information_schema.tables` precheck on `user_consents`; if the table exists (created by the per-model baseline) the entire body is skipped. Otherwise the original `createTable` + `addIndex` runs as before.
- **Migration 14** — `addColumn(...)` -> raw `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` inside the existing transaction wrapper.

`down()` is intentionally unchanged on all three. Per `docs/migrations/per-model-rebaseline.md`, rollback for rebaseline-coexistent migrations is via DB backup, not `db:migrate:undo`.

## Tests

Added `service.backend/src/__tests__/migrations/idempotent-migrations.test.ts` with 6 `describeIfPostgres` round-trip tests:

- mig 04 indexes/constraint pre-exist -> `up()` is a no-op
- mig 04 indexes/constraint missing -> `up()` creates them
- mig 12 `user_consents` table pre-exists -> `up()` is a no-op (column count unchanged)
- mig 12 `user_consents` table missing -> `up()` creates it
- mig 14 `updated_at` column pre-exists -> `up()` is a no-op (column count unchanged)
- mig 14 `updated_at` column missing -> `up()` adds it

Test count delta: +6.

## Merge ordering

This PR must land BEFORE any of the per-domain baseline PRs (#441-450) merge. Otherwise CI's fresh-DB test run breaks on the duplicate-name errors described above.

## Test plan

- [ ] Backend lint passes (`npx eslint .` shows no new errors on changed files)
- [ ] Backend typecheck passes (`npx tsc --noEmit`)
- [ ] Backend test suite passes (`npx vitest run`); new tests skip on SQLite per the `describeIfPostgres` convention
- [ ] CI's Postgres test run executes the 6 new idempotency tests and they pass
- [ ] Manually verified the SQL idempotency patterns (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, `pg_constraint` precheck, `information_schema.tables` precheck) on Postgres 16

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_