### PR TITLE
feat(lib.applications): Zod schema-first validation (ADS-187)

### DIFF
--- a/lib.applications/package.json
+++ b/lib.applications/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@adopt-dont-shop/lib.api": "*",
     "@adopt-dont-shop/lib.types": "*",
-    "@types/node": "^20.19.0"
+    "@types/node": "^20.19.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "*",

--- a/lib.applications/src/index.ts
+++ b/lib.applications/src/index.ts
@@ -1,13 +1,8 @@
 // Main exports for @adopt-dont-shop/lib.applications
 export { ApplicationsService, applicationsService } from './services/applications-service';
-export type {
-  Application,
-  ApplicationData,
-  ApplicationStatus,
-  ApplicationPriority,
-  ApplicationWithPetInfo,
-  Document,
-  DocumentUpload,
-  ApplicationsServiceConfig,
-} from './types';
-export * from './types';
+
+// Export schemas for consumers that need runtime validation
+export * from './schemas';
+
+// Re-export config/options types from types module
+export type { ApplicationsServiceConfig, ApplicationsServiceOptions } from './types';

--- a/lib.applications/src/schemas.ts
+++ b/lib.applications/src/schemas.ts
@@ -1,0 +1,254 @@
+import { z } from 'zod';
+
+// ── Enums ─────────────────────────────────────────────────────────────────────
+
+export const ApplicationStatusSchema = z.enum(['submitted', 'approved', 'rejected', 'withdrawn']);
+
+export const ApplicationPrioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);
+
+// ── ApplicationData sub-schemas ───────────────────────────────────────────────
+
+export const PersonalInfoSchema = z.object({
+  firstName: z.string(),
+  lastName: z.string(),
+  email: z.string(),
+  phone: z.string(),
+  address: z.string(),
+  city: z.string(),
+  state: z.string(),
+  zipCode: z.string(),
+  county: z.string().optional(),
+  postcode: z.string().optional(),
+  country: z.string().optional(),
+  dateOfBirth: z.string().optional(),
+  occupation: z.string().optional(),
+});
+
+export const HouseholdMemberSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+  relationship: z.string(),
+});
+
+export const LivingSituationSchema = z.object({
+  housingType: z.enum(['house', 'apartment', 'condo', 'other']),
+  isOwned: z.boolean(),
+  hasYard: z.boolean(),
+  yardSize: z.enum(['small', 'medium', 'large']).optional(),
+  yardFenced: z.boolean().optional(),
+  allowsPets: z.boolean(),
+  landlordContact: z.string().optional(),
+  householdSize: z.number(),
+  householdMembers: z.array(HouseholdMemberSchema).optional(),
+  hasAllergies: z.boolean(),
+  allergyDetails: z.string().optional(),
+});
+
+export const CurrentPetSchema = z.object({
+  type: z.string(),
+  breed: z.string().optional(),
+  age: z.number(),
+  spayedNeutered: z.boolean(),
+  vaccinated: z.boolean(),
+});
+
+export const PreviousPetSchema = z.object({
+  type: z.string(),
+  breed: z.string().optional(),
+  yearsOwned: z.number(),
+  whatHappened: z.string(),
+});
+
+export const PetExperienceSchema = z.object({
+  hasPetsCurrently: z.boolean(),
+  currentPets: z.array(CurrentPetSchema).optional(),
+  previousPets: z.array(PreviousPetSchema).optional(),
+  experienceLevel: z.enum(['beginner', 'some', 'experienced', 'expert']),
+  willingToTrain: z.boolean(),
+  hoursAloneDaily: z.number(),
+  exercisePlans: z.string(),
+});
+
+export const VeterinarianSchema = z.object({
+  name: z.string(),
+  clinicName: z.string(),
+  phone: z.string(),
+  email: z.string().optional(),
+  yearsUsed: z.number(),
+});
+
+export const PersonalReferenceSchema = z.object({
+  name: z.string(),
+  relationship: z.string(),
+  phone: z.string(),
+  email: z.string().optional(),
+  yearsKnown: z.number(),
+});
+
+export const ReferencesSchema = z.object({
+  veterinarian: VeterinarianSchema.optional(),
+  personal: z.array(PersonalReferenceSchema),
+});
+
+export const AdditionalInfoSchema = z.object({
+  whyAdopt: z.string(),
+  expectations: z.string(),
+  petName: z.string().optional(),
+  emergencyPlan: z.string(),
+  agreement: z.boolean(),
+});
+
+export const ApplicationDataSchema = z.object({
+  petId: z.string(),
+  userId: z.string(),
+  rescueId: z.string(),
+  personalInfo: PersonalInfoSchema,
+  livingsituation: LivingSituationSchema,
+  petExperience: PetExperienceSchema,
+  references: ReferencesSchema,
+  additionalInfo: AdditionalInfoSchema.optional(),
+});
+
+// ── Document schemas ───────────────────────────────────────────────────────────
+
+export const ApplicationDocumentSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  filename: z.string(),
+  url: z.string(),
+  uploadedAt: z.string(),
+});
+
+export const DocumentUploadSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  filename: z.string(),
+  type: z.string(),
+  uploadedAt: z.string(),
+});
+
+export const DocumentSchema = z.object({
+  id: z.string(),
+  applicationId: z.string(),
+  type: z.string(),
+  filename: z.string(),
+  url: z.string(),
+  uploadedAt: z.string(),
+  size: z.number().optional(),
+  mimeType: z.string().optional(),
+});
+
+// ── Application schemas ────────────────────────────────────────────────────────
+
+export const ApplicationSchema = z.object({
+  id: z.string(),
+  petId: z.string(),
+  userId: z.string(),
+  rescueId: z.string(),
+  status: ApplicationStatusSchema,
+  priority: ApplicationPrioritySchema.optional(),
+  submittedAt: z.string().optional(),
+  reviewedAt: z.string().optional(),
+  reviewedBy: z.string().optional(),
+  reviewNotes: z.string().optional(),
+  data: ApplicationDataSchema,
+  documents: z.array(ApplicationDocumentSchema).optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const ApplicationWithPetInfoSchema = ApplicationSchema.extend({
+  petName: z.string().optional(),
+  petType: z.string().optional(),
+  petBreed: z.string().optional(),
+});
+
+// Backend getApplicationById returns a flat structure: personalInfo, livingsituation,
+// petExperience at root level rather than nested under `data`.
+export const ApplicationFlatResponseSchema = z.object({
+  id: z.string(),
+  petId: z.string(),
+  userId: z.string(),
+  rescueId: z.string(),
+  status: ApplicationStatusSchema,
+  submittedAt: z.string().optional(),
+  reviewedAt: z.string().optional(),
+  reviewedBy: z.string().optional(),
+  reviewNotes: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  personalInfo: PersonalInfoSchema.optional(),
+  livingsituation: LivingSituationSchema.optional(),
+  petExperience: PetExperienceSchema.optional(),
+  references: ReferencesSchema.optional(),
+  additionalInfo: AdditionalInfoSchema.optional(),
+  documents: z.array(ApplicationDocumentSchema).optional().default([]),
+  petName: z.string().optional(),
+  petType: z.string().optional(),
+  petBreed: z.string().optional(),
+});
+
+// ── Response schemas ───────────────────────────────────────────────────────────
+
+export const ApplicationListResponseSchema = z.object({
+  data: z
+    .union([z.object({ applications: z.array(ApplicationSchema) }), z.array(ApplicationSchema)])
+    .optional(),
+});
+
+export const ApplicationByPetResponseSchema = z.object({
+  data: z
+    .object({
+      data: z
+        .object({
+          applications: z.array(ApplicationSchema),
+          total: z.number(),
+          page: z.number(),
+          totalPages: z.number(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+export const RescueApplicationsResponseSchema = z.object({
+  success: z.boolean(),
+  data: z.array(ApplicationSchema),
+  meta: z.object({
+    total: z.number(),
+    page: z.number(),
+    totalPages: z.number(),
+    hasNext: z.boolean(),
+    hasPrev: z.boolean(),
+  }),
+});
+
+export const ApplicationStatsSchema = z.object({
+  total: z.number().default(0),
+  submitted: z.number().default(0),
+  underReview: z.number().default(0),
+  approved: z.number().default(0),
+  rejected: z.number().default(0),
+  pendingReferences: z.number().default(0),
+});
+
+export const DocumentsResponseSchema = z.object({
+  data: z.array(DocumentSchema).optional(),
+});
+
+// ── Inferred types ─────────────────────────────────────────────────────────────
+
+export type ApplicationStatus = z.infer<typeof ApplicationStatusSchema>;
+export type ApplicationPriority = z.infer<typeof ApplicationPrioritySchema>;
+export type PersonalInfo = z.infer<typeof PersonalInfoSchema>;
+export type LivingSituation = z.infer<typeof LivingSituationSchema>;
+export type PetExperience = z.infer<typeof PetExperienceSchema>;
+export type References = z.infer<typeof ReferencesSchema>;
+export type AdditionalInfo = z.infer<typeof AdditionalInfoSchema>;
+export type ApplicationData = z.infer<typeof ApplicationDataSchema>;
+export type ApplicationDocument = z.infer<typeof ApplicationDocumentSchema>;
+export type DocumentUpload = z.infer<typeof DocumentUploadSchema>;
+export type Document = z.infer<typeof DocumentSchema>;
+export type Application = z.infer<typeof ApplicationSchema>;
+export type ApplicationWithPetInfo = z.infer<typeof ApplicationWithPetInfoSchema>;
+export type ApplicationStats = z.infer<typeof ApplicationStatsSchema>;

--- a/lib.applications/src/services/__tests__/applications-service.test.ts
+++ b/lib.applications/src/services/__tests__/applications-service.test.ts
@@ -1,8 +1,7 @@
 import { ApplicationsService } from '../applications-service';
 import { ApiService } from '@adopt-dont-shop/lib.api';
-import {
+import type {
   ApplicationData,
-  ApplicationStatus,
   Application,
   ApplicationWithPetInfo,
   DocumentUpload,
@@ -107,7 +106,7 @@ describe('ApplicationsService', () => {
     petId: 'pet-123',
     userId: 'user-123',
     rescueId: 'rescue-123',
-    status: 'pending' as ApplicationStatus,
+    status: 'submitted',
     submittedAt: '2024-01-01T00:00:00Z',
     reviewedAt: '',
     reviewedBy: '',
@@ -208,7 +207,7 @@ describe('ApplicationsService', () => {
           petId: 'pet-123',
           userId: 'user-123',
           rescueId: 'rescue-123',
-          status: 'pending',
+          status: 'submitted',
           submittedAt: '2024-01-01T00:00:00Z',
           reviewedAt: '',
           reviewedBy: '',
@@ -228,9 +227,9 @@ describe('ApplicationsService', () => {
 
       expect(mockApiService.get).toHaveBeenCalledWith('/api/v1/applications/app-123');
       expect(result.id).toBe('app-123');
-      expect((result as ApplicationWithPetInfo).petName).toBe('Buddy');
-      expect((result as ApplicationWithPetInfo).petType).toBe('dog');
-      expect((result as ApplicationWithPetInfo).petBreed).toBe('Golden Retriever');
+      expect(result.petName).toBe('Buddy');
+      expect(result.petType).toBe('dog');
+      expect(result.petBreed).toBe('Golden Retriever');
     });
   });
 
@@ -301,12 +300,12 @@ describe('ApplicationsService', () => {
 
   describe('updateApplicationStatus', () => {
     it('should update application status successfully', async () => {
-      const updatedApplication = { ...mockApplication, status: 'approved' as ApplicationStatus };
+      const updatedApplication = { ...mockApplication, status: 'approved' as const };
       mockApiService.patch.mockResolvedValue({ data: updatedApplication });
 
       const result = await applicationsService.updateApplicationStatus(
         'app-123',
-        'approved' as ApplicationStatus,
+        'approved',
         'Application looks good'
       );
 

--- a/lib.applications/src/services/applications-service.ts
+++ b/lib.applications/src/services/applications-service.ts
@@ -1,31 +1,25 @@
-/**
- * ApplicationsService - Handles applications operations
- */
 import { ApiService } from '@adopt-dont-shop/lib.api';
 import {
-  Application,
-  ApplicationData,
-  ApplicationStatus,
-  ApplicationWithPetInfo,
-  DocumentUpload,
-  Document,
-  ApplicationsServiceConfig,
-} from '../types';
+  ApplicationSchema,
+  ApplicationWithPetInfoSchema,
+  ApplicationFlatResponseSchema,
+  ApplicationListResponseSchema,
+  ApplicationByPetResponseSchema,
+  RescueApplicationsResponseSchema,
+  ApplicationStatsSchema,
+  DocumentUploadSchema,
+  DocumentSchema,
+  DocumentsResponseSchema,
+  type Application,
+  type ApplicationData,
+  type ApplicationStatus,
+  type ApplicationWithPetInfo,
+  type DocumentUpload,
+  type Document,
+  type ApplicationStats,
+} from '../schemas';
+import { type ApplicationsServiceConfig } from '../types';
 
-/**
- * Applications Service
- *
- * Provides complete adoption application workflow and document management
- * capabilities. Handles multi-step form processing, document uploads,
- * and application status tracking.
- *
- * Features:
- * - Multi-step application form handling
- * - Document upload with file validation
- * - Application status tracking
- * - Pet-specific application logic
- * - Data transformation for API compatibility
- */
 export class ApplicationsService {
   private apiService: ApiService;
   private config: ApplicationsServiceConfig;
@@ -39,9 +33,6 @@ export class ApplicationsService {
     };
   }
 
-  /**
-   * Update service configuration
-   */
   updateConfig(config: Partial<ApplicationsServiceConfig>): void {
     this.config = { ...this.config, ...config };
     if (config.apiUrl) {
@@ -49,15 +40,13 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Submit a new adoption application
-   */
   async submitApplication(applicationData: ApplicationData): Promise<Application> {
     try {
-      const response = (await this.apiService.post(this.baseUrl, applicationData)) as {
-        data: Application;
-      };
-      return response.data;
+      const response = await this.apiService.post<{ data: unknown }>(
+        this.baseUrl,
+        applicationData
+      );
+      return ApplicationSchema.parse(response.data);
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to submit application:', error);
@@ -66,19 +55,16 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Update an existing application
-   */
   async updateApplication(
     applicationId: string,
     applicationData: Partial<ApplicationData>
   ): Promise<Application> {
     try {
-      const response = (await this.apiService.put(
+      const response = await this.apiService.put<{ data: unknown }>(
         `${this.baseUrl}/${applicationId}`,
         applicationData
-      )) as { data: Application };
-      return response.data;
+      );
+      return ApplicationSchema.parse(response.data);
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to update application:', error);
@@ -87,72 +73,64 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Get application by ID
-   */
-  async getApplicationById(applicationId: string): Promise<Application> {
+  async getApplicationById(applicationId: string): Promise<ApplicationWithPetInfo> {
     try {
-      const response = (await this.apiService.get(`${this.baseUrl}/${applicationId}`)) as unknown;
+      const response = await this.apiService.get<{ data: unknown }>(
+        `${this.baseUrl}/${applicationId}`
+      );
+      // Backend returns a flat structure: personalInfo, livingsituation, petExperience
+      // are at the root of the data object rather than nested under a `data` sub-key.
+      const flat = ApplicationFlatResponseSchema.parse(response.data);
 
-      // Handle different response formats
-      let applicationData: Record<string, unknown>;
-      if (response && typeof response === 'object' && 'data' in response) {
-        applicationData = (response as { data: Record<string, unknown> }).data;
-      } else {
-        applicationData = response as Record<string, unknown>;
-      }
-
-      // Transform the response to match the frontend Application interface
-      // The backend returns personalInfo, livingsituation, and petExperience at the root level
-      // but the frontend expects them nested under a 'data' property
-      const application: ApplicationWithPetInfo = {
-        id: applicationData.id as string,
-        petId: applicationData.petId as string,
-        userId: applicationData.userId as string,
-        rescueId: applicationData.rescueId as string,
-        status: applicationData.status as ApplicationStatus,
-        submittedAt: applicationData.submittedAt as string,
-        reviewedAt: applicationData.reviewedAt as string,
-        reviewedBy: applicationData.reviewedBy as string,
-        reviewNotes: applicationData.reviewNotes as string,
-        createdAt: applicationData.createdAt as string,
-        updatedAt: applicationData.updatedAt as string,
+      const application: ApplicationWithPetInfo = ApplicationWithPetInfoSchema.parse({
+        id: flat.id,
+        petId: flat.petId,
+        userId: flat.userId,
+        rescueId: flat.rescueId,
+        status: flat.status,
+        submittedAt: flat.submittedAt,
+        reviewedAt: flat.reviewedAt,
+        reviewedBy: flat.reviewedBy,
+        reviewNotes: flat.reviewNotes,
+        createdAt: flat.createdAt,
+        updatedAt: flat.updatedAt,
+        documents: flat.documents,
+        petName: flat.petName,
+        petType: flat.petType,
+        petBreed: flat.petBreed,
         data: {
-          petId: applicationData.petId as string,
-          userId: applicationData.userId as string,
-          rescueId: applicationData.rescueId as string,
-          personalInfo:
-            (applicationData.personalInfo as ApplicationData['personalInfo']) ??
-            ({} as ApplicationData['personalInfo']),
-          livingsituation:
-            (applicationData.livingsituation as ApplicationData['livingsituation']) ??
-            ({} as ApplicationData['livingsituation']),
-          petExperience:
-            (applicationData.petExperience as ApplicationData['petExperience']) ??
-            ({} as ApplicationData['petExperience']),
-          references: (applicationData.references as ApplicationData['references']) ?? {
-            personal: [],
+          petId: flat.petId,
+          userId: flat.userId,
+          rescueId: flat.rescueId,
+          personalInfo: flat.personalInfo ?? {
+            firstName: '',
+            lastName: '',
+            email: '',
+            phone: '',
+            address: '',
+            city: '',
+            state: '',
+            zipCode: '',
           },
-          additionalInfo:
-            (applicationData.additionalInfo as ApplicationData['additionalInfo']) ??
-            ({} as ApplicationData['additionalInfo']),
+          livingsituation: flat.livingsituation ?? {
+            housingType: 'house',
+            isOwned: false,
+            hasYard: false,
+            allowsPets: false,
+            householdSize: 0,
+            hasAllergies: false,
+          },
+          petExperience: flat.petExperience ?? {
+            hasPetsCurrently: false,
+            experienceLevel: 'beginner',
+            willingToTrain: false,
+            hoursAloneDaily: 0,
+            exercisePlans: '',
+          },
+          references: flat.references ?? { personal: [] },
+          additionalInfo: flat.additionalInfo,
         },
-        documents:
-          (applicationData.documents as Array<{
-            id: string;
-            type: string;
-            filename: string;
-            url: string;
-            uploadedAt: string;
-          }>) || [],
-      };
-
-      // Add pet information if available (backend already provides these)
-      if (applicationData.petName) {
-        application.petName = applicationData.petName as string;
-        application.petType = applicationData.petType as string;
-        application.petBreed = applicationData.petBreed as string;
-      }
+      });
 
       return application;
     } catch (error) {
@@ -163,22 +141,13 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Get user's applications
-   */
   async getUserApplications(userId?: string): Promise<Application[]> {
     try {
       const queryParams = userId ? { user_id: userId } : {};
-      const response = (await this.apiService.get(this.baseUrl, queryParams)) as {
-        data?: { applications?: Application[] } | Application[];
-      };
-
-      // Handle nested response structure
-      const applications =
-        (response.data as { applications?: Application[] })?.applications ||
-        (response.data as Application[]) ||
-        [];
-      return applications;
+      const response = await this.apiService.get<unknown>(this.baseUrl, queryParams);
+      const parsed = ApplicationListResponseSchema.parse(response);
+      if (!parsed.data) return [];
+      return Array.isArray(parsed.data) ? parsed.data : (parsed.data.applications ?? []);
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to get user applications:', error);
@@ -187,32 +156,12 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Get application by pet ID
-   */
   async getApplicationByPetId(petId: string): Promise<Application | null> {
     try {
-      const response = (await this.apiService.get(this.baseUrl, { pet_id: petId })) as {
-        data: {
-          success: boolean;
-          data: {
-            applications: Application[];
-            total: number;
-            page: number;
-            totalPages: number;
-          };
-        };
-      };
-
-      // Extract applications from nested structure
-      const applications = response?.data?.data?.applications || [];
-
-      if (applications.length === 0) {
-        return null;
-      }
-
-      // Return the first (most recent) application for this pet
-      return applications[0];
+      const response = await this.apiService.get<unknown>(this.baseUrl, { pet_id: petId });
+      const parsed = ApplicationByPetResponseSchema.parse(response);
+      const applications = parsed.data?.data?.applications ?? [];
+      return applications.length > 0 ? applications[0] : null;
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to get application by pet ID:', error);
@@ -221,20 +170,17 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Update application status
-   */
   async updateApplicationStatus(
     id: string,
     status: ApplicationStatus,
     notes?: string
   ): Promise<Application> {
     try {
-      const response = (await this.apiService.patch(`${this.baseUrl}/${id}/status`, {
-        status,
-        notes,
-      })) as { data: Application };
-      return response.data;
+      const response = await this.apiService.patch<{ data: unknown }>(
+        `${this.baseUrl}/${id}/status`,
+        { status, notes }
+      );
+      return ApplicationSchema.parse(response.data);
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to update application status:', error);
@@ -243,14 +189,9 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Withdraw application
-   */
   async withdrawApplication(id: string, reason?: string): Promise<void> {
     try {
-      await this.apiService.put(`${this.baseUrl}/${id}/withdraw`, {
-        reason,
-      });
+      await this.apiService.put(`${this.baseUrl}/${id}/withdraw`, { reason });
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to withdraw application:', error);
@@ -259,20 +200,16 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Upload document for application
-   */
   async uploadDocument(applicationId: string, file: File, type: string): Promise<DocumentUpload> {
     try {
       const formData = new FormData();
       formData.append('file', file);
       formData.append('type', type);
-
-      const response = (await this.apiService.post(
+      const response = await this.apiService.post<{ data: unknown }>(
         `${this.baseUrl}/${applicationId}/documents`,
         formData
-      )) as { data: DocumentUpload };
-      return response.data;
+      );
+      return DocumentUploadSchema.parse(response.data);
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to upload document:', error);
@@ -281,9 +218,6 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Remove document from application
-   */
   async removeDocument(applicationId: string, documentId: string): Promise<void> {
     try {
       await this.apiService.delete(`${this.baseUrl}/${applicationId}/documents/${documentId}`);
@@ -295,16 +229,13 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Get documents for application
-   */
   async getDocuments(applicationId: string): Promise<Document[]> {
     try {
-      const response = (await this.apiService.get(`${this.baseUrl}/${applicationId}/documents`)) as
-        | { data?: Document[] }
-        | Document[];
-
-      return (response as { data?: Document[] }).data || [];
+      const response = await this.apiService.get<unknown>(
+        `${this.baseUrl}/${applicationId}/documents`
+      );
+      const parsed = DocumentsResponseSchema.parse(response);
+      return parsed.data ?? [];
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to get documents:', error);
@@ -313,10 +244,6 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Get all applications for a rescue organization
-   * For use in rescue management dashboard
-   */
   async getRescueApplications(
     rescueId?: string,
     options?: {
@@ -328,40 +255,18 @@ export class ApplicationsService {
   ): Promise<Application[]> {
     try {
       const params = new URLSearchParams();
-
-      if (rescueId) {
-        params.append('rescueId', rescueId);
-      }
-      if (options?.status) {
-        params.append('status', options.status);
-      }
-      if (options?.search) {
-        params.append('search', options.search);
-      }
-      if (options?.limit) {
-        params.append('limit', options.limit.toString());
-      }
-      if (options?.offset) {
-        params.append('offset', options.offset.toString());
-      }
+      if (rescueId) params.append('rescueId', rescueId);
+      if (options?.status) params.append('status', options.status);
+      if (options?.search) params.append('search', options.search);
+      if (options?.limit) params.append('limit', options.limit.toString());
+      if (options?.offset) params.append('offset', options.offset.toString());
 
       const queryString = params.toString();
       const url = `${this.baseUrl}${queryString ? `?${queryString}` : ''}`;
 
-      const response = await this.apiService.get<{
-        success: boolean;
-        data: Application[];
-        meta: {
-          total: number;
-          page: number;
-          totalPages: number;
-          hasNext: boolean;
-          hasPrev: boolean;
-        };
-      }>(url);
-
-      // Return the applications array from the standardized response
-      return response.data || [];
+      const response = await this.apiService.get<unknown>(url);
+      const parsed = RescueApplicationsResponseSchema.parse(response);
+      return parsed.data;
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to get rescue applications:', error);
@@ -370,31 +275,13 @@ export class ApplicationsService {
     }
   }
 
-  /**
-   * Get application statistics for rescue dashboard
-   */
-  async getApplicationStats(rescueId?: string): Promise<{
-    total: number;
-    submitted: number;
-    underReview: number;
-    approved: number;
-    rejected: number;
-    pendingReferences: number;
-  }> {
+  async getApplicationStats(rescueId?: string): Promise<ApplicationStats> {
     try {
       const params = rescueId ? `?rescueId=${rescueId}` : '';
-      const response = await this.apiService.get<any>(`${this.baseUrl}/stats${params}`);
-
-      return (
-        response.data || {
-          total: 0,
-          submitted: 0,
-          underReview: 0,
-          approved: 0,
-          rejected: 0,
-          pendingReferences: 0,
-        }
+      const response = await this.apiService.get<{ data: unknown }>(
+        `${this.baseUrl}/stats${params}`
       );
+      return ApplicationStatsSchema.parse(response.data ?? {});
     } catch (error) {
       if (this.config.debug) {
         console.error('Failed to get application stats:', error);

--- a/lib.applications/src/services/applications-service.ts
+++ b/lib.applications/src/services/applications-service.ts
@@ -8,7 +8,6 @@ import {
   RescueApplicationsResponseSchema,
   ApplicationStatsSchema,
   DocumentUploadSchema,
-  DocumentSchema,
   DocumentsResponseSchema,
   type Application,
   type ApplicationData,

--- a/lib.applications/src/types/index.ts
+++ b/lib.applications/src/types/index.ts
@@ -1,177 +1,38 @@
-// Application types for lib.applications
-
-export interface ApplicationData {
-  petId: string;
-  userId: string;
-  rescueId: string;
-  personalInfo: {
-    firstName: string;
-    lastName: string;
-    email: string;
-    phone: string;
-    address: string;
-    city: string;
-    state: string;
-    zipCode: string;
-    county?: string;
-    postcode?: string;
-    country?: string;
-    dateOfBirth?: string;
-    occupation?: string;
-  };
-  livingsituation: {
-    housingType: 'house' | 'apartment' | 'condo' | 'other';
-    isOwned: boolean;
-    hasYard: boolean;
-    yardSize?: 'small' | 'medium' | 'large';
-    yardFenced?: boolean;
-    allowsPets: boolean;
-    landlordContact?: string;
-    householdSize: number;
-    householdMembers?: Array<{
-      name: string;
-      age: number;
-      relationship: string;
-    }>;
-    hasAllergies: boolean;
-    allergyDetails?: string;
-  };
-  petExperience: {
-    hasPetsCurrently: boolean;
-    currentPets?: Array<{
-      type: string;
-      breed?: string;
-      age: number;
-      spayedNeutered: boolean;
-      vaccinated: boolean;
-    }>;
-    previousPets?: Array<{
-      type: string;
-      breed?: string;
-      yearsOwned: number;
-      whatHappened: string;
-    }>;
-    experienceLevel: 'beginner' | 'some' | 'experienced' | 'expert';
-    willingToTrain: boolean;
-    hoursAloneDaily: number;
-    exercisePlans: string;
-  };
-  references: {
-    veterinarian?: {
-      name: string;
-      clinicName: string;
-      phone: string;
-      email?: string;
-      yearsUsed: number;
-    };
-    personal: Array<{
-      name: string;
-      relationship: string;
-      phone: string;
-      email?: string;
-      yearsKnown: number;
-    }>;
-  };
-  additionalInfo?: {
-    whyAdopt: string;
-    expectations: string;
-    petName?: string;
-    emergencyPlan: string;
-    agreement: boolean;
-  };
-}
-
-export type ApplicationStatus = 'submitted' | 'approved' | 'rejected' | 'withdrawn';
-
-export type ApplicationPriority = 'low' | 'normal' | 'high' | 'urgent';
-
-export interface Application {
-  id: string;
-  petId: string;
-  userId: string;
-  rescueId: string;
-  status: ApplicationStatus;
-  priority?: ApplicationPriority;
-  submittedAt?: string;
-  reviewedAt?: string;
-  reviewedBy?: string;
-  reviewNotes?: string;
-  data: ApplicationData;
-  documents?: Array<{
-    id: string;
-    type: string;
-    filename: string;
-    url: string;
-    uploadedAt: string;
-  }>;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface ApplicationWithPetInfo extends Application {
-  petName?: string;
-  petType?: string;
-  petBreed?: string;
-}
-
-export interface DocumentUpload {
-  id: string;
-  url: string;
-  filename: string;
-  type: string;
-  uploadedAt: string;
-}
-
-export interface Document {
-  id: string;
-  applicationId: string;
-  type: string;
-  filename: string;
-  url: string;
-  uploadedAt: string;
-  size?: number;
-  mimeType?: string;
-}
+// Re-export all domain types from schemas (source of truth)
+export type {
+  ApplicationStatus,
+  ApplicationPriority,
+  PersonalInfo,
+  LivingSituation,
+  PetExperience,
+  References,
+  AdditionalInfo,
+  ApplicationData,
+  ApplicationDocument,
+  DocumentUpload,
+  Document,
+  Application,
+  ApplicationWithPetInfo,
+  ApplicationStats,
+} from '../schemas';
 
 /**
  * Configuration options for ApplicationsService
  */
-export interface ApplicationsServiceConfig {
-  /**
-   * API base URL
-   */
+export type ApplicationsServiceConfig = {
   apiUrl?: string;
-
-  /**
-   * Enable debug logging
-   */
   debug?: boolean;
-
-  /**
-   * Custom headers to include with requests
-   */
   headers?: Record<string, string>;
-}
+};
 
 /**
  * Options for ApplicationsService operations
  */
-export interface ApplicationsServiceOptions {
-  /**
-   * Timeout in milliseconds
-   */
+export type ApplicationsServiceOptions = {
   timeout?: number;
-
-  /**
-   * Whether to use caching
-   */
   useCache?: boolean;
-
-  /**
-   * Custom metadata
-   */
   metadata?: Record<string, unknown>;
-}
+};
 
 // ADS-262: response envelopes are owned by @adopt-dont-shop/lib.types.
 export type { BaseResponse, ErrorResponse, PaginatedResponse } from '@adopt-dont-shop/lib.types';

--- a/package-lock.json
+++ b/package-lock.json
@@ -509,7 +509,8 @@
       "dependencies": {
         "@adopt-dont-shop/lib.api": "*",
         "@adopt-dont-shop/lib.types": "*",
-        "@types/node": "^20.19.0"
+        "@types/node": "^20.19.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-base": "*",


### PR DESCRIPTION
## Summary

- Introduces `schemas.ts` to `lib.applications` with Zod schemas for every domain type (ApplicationData sub-objects, Application, ApplicationWithPetInfo, DocumentUpload, Document, response envelopes)
- Replaces all `as any`, `as unknown`, and bare `as {data: T}` casts in `applications-service.ts` with `Schema.parse()` calls — the same pattern used by `lib.moderation` and `lib.support-tickets`
- Types in `src/types/index.ts` are now inferred from schemas via `z.infer<>` rather than hand-written interfaces
- Adds `zod ^4.4.3` as a runtime dependency (consistent with other converted libraries)
- Fixes a latent type bug: `ApplicationStatus` did not include `'pending'` (the backend enum has no such value), but test mocks used `'pending' as ApplicationStatus` to bypass TypeScript — corrected to `'submitted'`

## Affected files

| File | Change |
|---|---|
| `lib.applications/package.json` | Add `zod ^4.4.3` dependency |
| `lib.applications/src/schemas.ts` | **New** — all Zod schemas and inferred types |
| `lib.applications/src/types/index.ts` | Re-exports types from schemas; keeps config/options types |
| `lib.applications/src/services/applications-service.ts` | Uses `Schema.parse()` throughout, no `as` casts |
| `lib.applications/src/index.ts` | Also exports schemas for consumers |
| `lib.applications/src/services/__tests__/applications-service.test.ts` | Fix invalid `'pending'` status mock; remove `as ApplicationStatus` casts |

## Test plan

- [x] All 17 existing tests in `lib.applications` pass (`vitest run`)
- [ ] Remaining libraries (`lib.pets`, `lib.rescue`, `lib.chat`) to be converted in follow-up commits on this branch

## Linear

Closes ADS-187

https://claude.ai/code/session_01NSWvY8Nd4YycGh9HV1dgp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSWvY8Nd4YycGh9HV1dgp7)_