### PR TITLE
fix(migrations): idempotency patch for migration 03 (follow-up to #451)

### DIFF
--- a/service.backend/src/migrations/03-add-composite-indexes-for-performance.ts
+++ b/service.backend/src/migrations/03-add-composite-indexes-for-performance.ts
@@ -10,47 +10,62 @@ import { QueryInterface } from 'sequelize';
  *
  * These indexes reduce query planning overhead and enable single-pass scans.
  * Resolves ADS-226, ADS-227, ADS-259.
+ *
+ * Idempotency note: each addIndex was replaced with raw `CREATE INDEX IF NOT
+ * EXISTS` so this migration coexists with the per-model rebaseline baselines
+ * (#441-450). `messages_chat_created_idx` is declared on the `Message` model's
+ * `indexes:` block and is therefore emitted by `00-baseline-031-messages.ts`.
+ * The other four indexes do not currently collide with any baseline file, but
+ * are wrapped in the same IF NOT EXISTS pattern as a guard against future
+ * model-side index declarations adding the same names. Same approach as #451.
  */
 export async function up(queryInterface: QueryInterface): Promise<void> {
+  const sequelize = queryInterface.sequelize;
+
   // ADS-226: Rescue dashboard's primary query filters by (rescue_id, status)
   // and orders by created_at. The composite index allows Postgres to skip
   // the heap entirely and perform a single index range scan.
-  await queryInterface.addIndex('applications', {
-    fields: ['rescue_id', 'status', { name: 'created_at', order: 'DESC' }],
-    name: 'applications_rescue_status_created_idx',
-  });
+  await sequelize.query(
+    'CREATE INDEX IF NOT EXISTS "applications_rescue_status_created_idx" ' +
+      'ON "applications" ("rescue_id", "status", "created_at" DESC)'
+  );
 
   // ADS-227: Every chat timeline query paginates with
   // WHERE chat_id = ? ORDER BY created_at DESC. The composite index
   // enables a single index range scan instead of heap lookups + sort.
-  await queryInterface.addIndex('messages', {
-    fields: ['chat_id', { name: 'created_at', order: 'DESC' }],
-    name: 'messages_chat_created_idx',
-  });
+  await sequelize.query(
+    'CREATE INDEX IF NOT EXISTS "messages_chat_created_idx" ' +
+      'ON "messages" ("chat_id", "created_at" DESC)'
+  );
 
   // ADS-259: CMS audit queries filter by last_modified_by to show
   // "everything this admin edited". Postgres needs an index to avoid
   // sequential scans. This mirrors the existing index on author_id.
-  await queryInterface.addIndex('cms_content', ['last_modified_by'], {
-    name: 'cms_content_last_modified_by_idx',
-  });
+  await sequelize.query(
+    'CREATE INDEX IF NOT EXISTS "cms_content_last_modified_by_idx" ' +
+      'ON "cms_content" ("last_modified_by")'
+  );
 
   // ADS-259: Navigation menu audit queries filter by created_by and
   // updated_by (the audit columns). These prevent sequential scans during
   // user deletion cascades or audit lookups. Note: auditIndexes helper
   // provides these automatically, but we add them explicitly here for
   // clarity and schema versioning.
-  await queryInterface.addIndex('cms_navigation_menus', ['created_by'], {
-    name: 'cms_nav_created_by_idx',
-  });
+  await sequelize.query(
+    'CREATE INDEX IF NOT EXISTS "cms_nav_created_by_idx" ' +
+      'ON "cms_navigation_menus" ("created_by")'
+  );
 
-  await queryInterface.addIndex('cms_navigation_menus', ['updated_by'], {
-    name: 'cms_nav_updated_by_idx',
-  });
+  await sequelize.query(
+    'CREATE INDEX IF NOT EXISTS "cms_nav_updated_by_idx" ' +
+      'ON "cms_navigation_menus" ("updated_by")'
+  );
 }
 
 export async function down(queryInterface: QueryInterface): Promise<void> {
-  // Drop in reverse order
+  // Drop in reverse order. Down is intentionally unchanged — per the
+  // per-model rebaseline design doc, rollback for rebaseline-coexistent
+  // migrations is via DB backup, not `db:migrate:undo`.
   await queryInterface.removeIndex('cms_navigation_menus', 'cms_nav_updated_by_idx');
   await queryInterface.removeIndex('cms_navigation_menus', 'cms_nav_created_by_idx');
   await queryInterface.removeIndex('cms_content', 'cms_content_last_modified_by_idx');


### PR DESCRIPTION
## Summary

Follow-up to #451. The cleanup PR patched migrations 04 / 12 / 14 but missed migration 03, which has the same fresh-DB conflict pattern.

D5's PR body (#441) flagged it during the rebaseline:

> `messages_chat_created_idx` is present in both the model's `indexes:` and migration 03. Baseline includes it (sync produces it); migration 03 effectively becomes idempotent for fresh DBs.

The "effectively idempotent" assumption was wrong — `queryInterface.addIndex` is NOT idempotent and fails with `duplicate-name` when the index already exists. This is why #452's schema-equivalence gate fails at "Bootstrap DB-A via db:migrate" even after #451 merged.

## Patch pattern

All 5 `addIndex` calls in `03-add-composite-indexes-for-performance.ts` → raw `CREATE INDEX IF NOT EXISTS ...`. Same pattern as #451's mig 04 fix.

Only `messages_chat_created_idx` is known to collide today. The other 4 (`applications_rescue_status_created_idx`, `cms_content_last_modified_by_idx`, `cms_nav_created_by_idx`, `cms_nav_updated_by_idx`) don't currently collide with any baseline file but get the same `IF NOT EXISTS` wrap as a guard against future model-side index declarations.

`down()` intentionally unchanged — per design doc, rollback is via DB backup, not `db:migrate:undo`.

## Test plan

- [ ] Backend Tests pass (SQLite path — should be unchanged; this PR only modifies SQL strings used on Postgres).
- [ ] After this merges, refresh #452 (schema-equivalence CI gate) and verify "Bootstrap DB-A via db:migrate" succeeds. If the gate then surfaces actual schema drift, that's a separate (and expected) discussion.
- [ ] Add round-trip test to the existing `idempotent-migrations.test.ts` from #451 — pre-create `messages_chat_created_idx` manually, run mig 03 `up()`, assert no error. (Optional follow-up; #451's pattern is already proven.)

## Notes

- This was missed in #451 because that PR's brief listed only mig 04 / 12 / 14 as known collision points. I should have done a broader scan of every post-baseline migration for `addIndex` / `addColumn` / `createTable` calls that might overlap with the per-model baselines. Mig 03 is the only additional one I've identified so far. Mig 15 (report_shares.token_hash) was analysed in D7's PR (#450) and confirmed safe because it uses `removeIndex` + `addIndex` on a different name. Will keep an eye on the gate for any further surprises.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_