### PR TITLE
fix(security): enforce per-resource ACL on Express /uploads/* route (ADS-537)

### DIFF
--- a/service.backend/src/__tests__/routes/upload-serve.routes.test.ts
+++ b/service.backend/src/__tests__/routes/upload-serve.routes.test.ts
@@ -331,6 +331,8 @@ describe('GET /uploads/:path — Express fallback streaming route', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // Default: authenticated user allowed by ACL.
+    decideUploadAccessMock.mockResolvedValue(200);
     fs.mkdirSync(TEST_UPLOAD_DIR, { recursive: true });
     app = await buildApp();
   });
@@ -392,6 +394,81 @@ describe('GET /uploads/:path — Express fallback streaming route', () => {
 
     const response = await request(app).get('/uploads/../etc/passwd');
     expect(response.status).toBe(400);
+  });
+
+  // ── per-resource ACL wiring ────────────────────────────────────────────────
+  //
+  // The streaming route must invoke decideUploadAccess and honour its verdict,
+  // closing the IDOR that existed when the route only required authenticateToken.
+
+  describe('per-resource ACL', () => {
+    beforeEach(() => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+    });
+
+    it('returns 403 and does not stream when a non-owner requests an application document', async () => {
+      fs.mkdirSync(path.join(TEST_UPLOAD_DIR, 'applications'), { recursive: true });
+      fs.writeFileSync(path.join(TEST_UPLOAD_DIR, 'applications', 'other-user.pdf'), 'data');
+      decideUploadAccessMock.mockResolvedValue(403);
+
+      const response = await request(app).get('/uploads/applications/other-user.pdf');
+
+      expect(response.status).toBe(403);
+      expect(decideUploadAccessMock).toHaveBeenCalledWith({
+        filePath: 'applications/other-user.pdf',
+        user: expect.objectContaining({ userId: mockUser.userId }),
+      });
+    });
+
+    it('returns 403 and does not stream when a non-participant requests a chat attachment', async () => {
+      fs.mkdirSync(path.join(TEST_UPLOAD_DIR, 'chat'), { recursive: true });
+      fs.writeFileSync(path.join(TEST_UPLOAD_DIR, 'chat', 'attachment.png'), 'data');
+      decideUploadAccessMock.mockResolvedValue(403);
+
+      const response = await request(app).get('/uploads/chat/attachment.png');
+
+      expect(response.status).toBe(403);
+    });
+
+    it('streams the file when the ACL helper permits access', async () => {
+      fs.mkdirSync(path.join(TEST_UPLOAD_DIR, 'applications'), { recursive: true });
+      fs.writeFileSync(path.join(TEST_UPLOAD_DIR, 'applications', 'my-doc.pdf'), 'pdf data');
+      decideUploadAccessMock.mockResolvedValue(200);
+
+      const response = await request(app).get('/uploads/applications/my-doc.pdf');
+
+      expect(response.status).toBe(200);
+    });
+
+    it('fails closed with 403 when the ACL helper throws unexpectedly', async () => {
+      fs.mkdirSync(path.join(TEST_UPLOAD_DIR, 'applications'), { recursive: true });
+      fs.writeFileSync(path.join(TEST_UPLOAD_DIR, 'applications', 'explode.pdf'), 'data');
+      decideUploadAccessMock.mockRejectedValue(new Error('db down'));
+
+      const response = await request(app).get('/uploads/applications/explode.pdf');
+
+      expect(response.status).toBe(403);
+    });
+
+    it('returns 401 when authenticateToken sets no user (defensive guard)', async () => {
+      // authenticateToken calls next() without setting req.user — should not
+      // happen in production but the route must not crash or stream blindly.
+      authenticateTokenMock.mockImplementation(
+        (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+      );
+
+      fs.mkdirSync(path.join(TEST_UPLOAD_DIR, 'applications'), { recursive: true });
+      fs.writeFileSync(path.join(TEST_UPLOAD_DIR, 'applications', 'doc.pdf'), 'data');
+
+      const response = await request(app).get('/uploads/applications/doc.pdf');
+
+      expect(response.status).toBe(401);
+    });
   });
 });
 

--- a/service.backend/src/routes/upload-serve.routes.ts
+++ b/service.backend/src/routes/upload-serve.routes.ts
@@ -239,6 +239,11 @@ router.get(
   apiLimiter,
   authenticateToken,
   (req: AuthenticatedRequest, res: Response) => {
+    if (!config.storage.local.serveLocalUploads) {
+      res.status(404).end();
+      return;
+    }
+
     const filePath = (req.params as Record<string, string>)['0'] ?? '';
     const resolved = safeResolve(filePath);
     if (!resolved) {
@@ -249,7 +254,34 @@ router.get(
       res.status(400).json({ error: 'Invalid file path' });
       return;
     }
-    streamFile(resolved, res);
+
+    const user = req.user;
+    if (!user) {
+      res.status(401).json({ error: 'Unauthorised' });
+      return;
+    }
+
+    decideUploadAccess({ filePath, user })
+      .then(verdict => {
+        if (verdict !== 200) {
+          logger.warn('Upload serve: ACL denied', {
+            userId: user.userId,
+            requested: filePath,
+            verdict,
+          });
+          res.status(verdict).end();
+          return;
+        }
+        streamFile(resolved, res);
+      })
+      .catch(err => {
+        logger.error('Upload serve: ACL check failed', {
+          userId: user.userId,
+          requested: filePath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        res.status(403).end();
+      });
   }
 );
 


### PR DESCRIPTION
## Summary

Closes **ADS-537** — Urgent IDOR: any authenticated user could stream any private upload by hitting the Express `/uploads/*` fallback route, which only checked `authenticateToken` and never called the per-resource ACL helper (`decideUploadAccess`).

- Wires `decideUploadAccess({filePath, user})` into the `/uploads/*` handler before any file is streamed, returning the ACL verdict (403/404) directly — mirroring the pattern already used by `/api/v1/uploads/authorize`
- Adds a `user` null-guard (returns 401) to match the defensive pattern in the authorize endpoint
- Gates the route on `config.storage.local.serveLocalUploads`: returns 404 immediately when the flag is false, so the streaming path is inert in production where nginx serves `/uploads/*` directly

## Test plan

- [x] New: non-owner `GET /uploads/applications/<file>` → 403
- [x] New: non-participant `GET /uploads/chat/<file>` → 403
- [x] New: ACL mock called with correct `{filePath, user}` args
- [x] New: fails closed with 403 when ACL helper throws
- [x] New: returns 401 when `req.user` is not set after auth middleware
- [x] Existing: all 30 prior tests still pass (authorize endpoint, decideUploadAccess helper)
- [x] `serveLocalUploads: true` set in test config mock — streaming tests unaffected

All 35 tests pass locally.

https://claude.ai/code/session_019eWN12e5apmd6V8XGB9bQd

---
_Generated by [Claude Code](https://claude.ai/code/session_019eWN12e5apmd6V8XGB9bQd)_