### PR TITLE
feat(migrations): cross-table foreign-key constraints (rebaseline FK file)

### DIFF
--- a/service.backend/src/__tests__/migrations/baseline-foreign-keys.test.ts
+++ b/service.backend/src/__tests__/migrations/baseline-foreign-keys.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Round-trip + behaviour tests for the FK baseline file
+ * `00-baseline-zzz-foreign-keys.ts`.
+ *
+ * Strategy:
+ *   1. `sequelize.sync({ force: true })` to bootstrap all tables (sync
+ *      installs FKs itself; we drop them so the migration's `up()` has
+ *      work to do).
+ *   2. Drop every cross-table FK constraint produced by sync().
+ *   3. Run the FK baseline's `up()` — re-installs them.
+ *   4. Spot-check pg_constraint to confirm the constraints exist with
+ *      the expected `confdeltype` / `confupdtype` for representative
+ *      FKs (CASCADE, SET NULL, NO ACTION combinations).
+ *   5. Idempotency: `up()` twice doesn't throw — the precheck skips
+ *      already-installed constraints.
+ *   6. `down()` refuses without the destructive-down ack; with the ack,
+ *      it drops every constraint we added.
+ *
+ * Postgres-only — `pg_constraint` and `pg_dump`-equivalent behaviour
+ * have no SQLite analogue; sync()-bootstrapped SQLite wouldn't emit FK
+ * constraints in the same shape.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import fkBaseline from '../../migrations/00-baseline-zzz-foreign-keys';
+
+// Force every model file to register with sequelize so sync() has the
+// full table set.
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+type ConstraintRow = { confdeltype: string; confupdtype: string };
+
+/**
+ * Map Postgres' single-char codes from `pg_constraint` to human strings.
+ * https://www.postgresql.org/docs/current/catalog-pg-constraint.html
+ *   a = NO ACTION, r = RESTRICT, c = CASCADE, n = SET NULL, d = SET DEFAULT
+ */
+const PG_ACTION: Record<string, string> = {
+  a: 'NO ACTION',
+  r: 'RESTRICT',
+  c: 'CASCADE',
+  n: 'SET NULL',
+  d: 'SET DEFAULT',
+};
+
+const fetchConstraintActions = async (
+  name: string
+): Promise<{ onDelete: string; onUpdate: string } | null> => {
+  const [rows] = await sequelize.query(
+    `SELECT confdeltype, confupdtype FROM pg_constraint WHERE conname = '${name}'`
+  );
+  const row = (rows as ConstraintRow[])[0];
+  if (!row) return null;
+  return {
+    onDelete: PG_ACTION[row.confdeltype] ?? row.confdeltype,
+    onUpdate: PG_ACTION[row.confupdtype] ?? row.confupdtype,
+  };
+};
+
+const dropAllForeignKeys = async (): Promise<void> => {
+  // Drop every FK in current_schema so up() has work to do.
+  const [rows] = await sequelize.query(
+    `SELECT conname, conrelid::regclass AS tbl FROM pg_constraint
+       WHERE contype = 'f' AND connamespace = current_schema()::regnamespace`
+  );
+  for (const r of rows as Array<{ conname: string; tbl: string }>) {
+    await sequelize.query(`ALTER TABLE ${r.tbl} DROP CONSTRAINT "${r.conname}"`);
+  }
+};
+
+const ackKey = (key: string): void => {
+  process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+  process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = key;
+};
+
+const clearAck = (): void => {
+  delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+};
+
+describeIfPostgres('per-model baseline — cross-table foreign keys', () => {
+  beforeAll(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    await dropAllForeignKeys();
+  });
+
+  afterEach(() => {
+    clearAck();
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  describe('up()', () => {
+    it('installs FK constraints with the expected ON DELETE / ON UPDATE actions', async () => {
+      await fkBaseline.up(queryInterface);
+
+      // Representative samples covering every ON DELETE / ON UPDATE
+      // combination the FK file emits. Names follow Postgres' default
+      // `<table>_<column>_fkey`.
+
+      // CASCADE / CASCADE — model declares both, also belongsTo adds CASCADE.
+      expect(await fetchConstraintActions('applications_user_id_fkey')).toEqual({
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      });
+      // CASCADE / CASCADE — junction table FK (belongsToMany default).
+      expect(await fetchConstraintActions('user_roles_user_id_fkey')).toEqual({
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      });
+      expect(await fetchConstraintActions('role_permissions_role_id_fkey')).toEqual({
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      });
+
+      // SET NULL / CASCADE — nullable FK with belongsTo association.
+      expect(await fetchConstraintActions('moderator_actions_moderator_id_fkey')).toEqual({
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+      });
+
+      // SET NULL / NO ACTION — audit FK (no belongsTo).
+      expect(await fetchConstraintActions('users_created_by_fkey')).toEqual({
+        onDelete: 'SET NULL',
+        onUpdate: 'NO ACTION',
+      });
+      expect(await fetchConstraintActions('rescues_updated_by_fkey')).toEqual({
+        onDelete: 'SET NULL',
+        onUpdate: 'NO ACTION',
+      });
+
+      // CASCADE / CASCADE — single-column FK on a status-transition log.
+      expect(
+        await fetchConstraintActions('application_status_transitions_application_id_fkey')
+      ).toEqual({ onDelete: 'CASCADE', onUpdate: 'CASCADE' });
+
+      // SET NULL / CASCADE — invitations.user_id (mig 04 also creates
+      // this; the precheck means we don't double-install).
+      expect(await fetchConstraintActions('invitations_user_id_fkey')).toEqual({
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE',
+      });
+    });
+
+    it('does NOT install a FK on audit_logs.user (soft reference per D10)', async () => {
+      await fkBaseline.up(queryInterface);
+      expect(await fetchConstraintActions('audit_logs_user_fkey')).toBeNull();
+    });
+
+    it('is idempotent — running up() a second time does not throw', async () => {
+      await fkBaseline.up(queryInterface);
+      await expect(fkBaseline.up(queryInterface)).resolves.toBeUndefined();
+    });
+
+    it('coexists with migration 04 — pre-existing invitation FKs are not duplicated', async () => {
+      // Simulate the migration-04 ordering: install the invitation FKs
+      // first (under the same names), then run the FK baseline. The
+      // precheck must skip the existing constraints rather than throwing
+      // a duplicate-name error.
+      await queryInterface.addConstraint('invitations', {
+        fields: ['rescue_id'],
+        type: 'foreign key',
+        name: 'invitations_rescue_id_fkey',
+        references: { table: 'rescues', field: 'rescue_id' },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      });
+
+      await expect(fkBaseline.up(queryInterface)).resolves.toBeUndefined();
+
+      // The FK still exists with the original definition (migration 04's,
+      // which happens to match what this file would emit).
+      expect(await fetchConstraintActions('invitations_rescue_id_fkey')).toEqual({
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      });
+    });
+  });
+
+  describe('down()', () => {
+    it('refuses without the destructive-down acknowledgement', async () => {
+      await fkBaseline.up(queryInterface);
+      await expect(fkBaseline.down(queryInterface)).rejects.toThrow(/destructive down/i);
+    });
+
+    it('drops every constraint when acknowledged', async () => {
+      await fkBaseline.up(queryInterface);
+      ackKey('00-baseline-zzz-foreign-keys');
+
+      await fkBaseline.down(queryInterface);
+
+      expect(await fetchConstraintActions('applications_user_id_fkey')).toBeNull();
+      expect(await fetchConstraintActions('users_created_by_fkey')).toBeNull();
+      expect(await fetchConstraintActions('user_roles_user_id_fkey')).toBeNull();
+      expect(await fetchConstraintActions('invitations_rescue_id_fkey')).toBeNull();
+    });
+  });
+});

--- a/service.backend/src/migrations/00-baseline-zzz-foreign-keys.ts
+++ b/service.backend/src/migrations/00-baseline-zzz-foreign-keys.ts
@@ -1,0 +1,1668 @@
+import type { QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+/**
+ * Per-model rebaseline (FK file): cross-table FOREIGN KEY constraints.
+ *
+ * Why this file exists separately from the 61 per-model baselines (PRs
+ * #441–450): each per-model file declares its own table's columns,
+ * including FK *column* shapes (UUID, NOT NULL where appropriate), but
+ * intentionally omits cross-table FK CONSTRAINTS. Splitting the
+ * constraints out means each per-model baseline can be reordered or
+ * replaced independently — the FK file runs last (lex order `...zzz...`
+ * sorts after every numbered baseline), by which point every referenced
+ * table exists.
+ *
+ * Source of truth for each entry below is `sequelize.sync()` against the
+ * model code shipped in `service.backend/src/models/*.ts`. Two Sequelize
+ * mechanisms determine the final ON DELETE / ON UPDATE seen at sync()
+ * time (see lib/dialects/postgres/query-generator.js and
+ * lib/associations/belongs-to.js):
+ *
+ *   1. The column-level `references: { ... }, onDelete: '...',
+ *      onUpdate: '...'` declaration on the model. This is the model
+ *      author's intent.
+ *   2. `Model.belongsTo()` (and `hasMany`/`hasOne`/`belongsToMany`) call
+ *      `_injectAttributes` which fills in missing `onDelete` / `onUpdate`
+ *      via `mergeDefaults`. The fill defaults are:
+ *        - `onDelete`: `'SET NULL'` if the column is nullable, else
+ *          `'NO ACTION'` (belongsTo) or `'CASCADE'` (hasMany/hasOne).
+ *        - `onUpdate`: `'CASCADE'`.
+ *      Associations declared with `constraints: false` skip injection
+ *      AND skip emitting any DB-level FK (so those columns don't appear
+ *      below at all).
+ *
+ * Naming convention: the per-table default `<table>_<column>_fkey`,
+ * matching Postgres' implicit name for `ADD CONSTRAINT ... FOREIGN KEY`
+ * with no explicit name. This is also what `sequelize.sync()` produces.
+ * The CI schema-equivalence gate (PR #452) byte-compares DB-A
+ * (db:migrate, includes this file) against DB-B (sync()) so any naming
+ * drift would surface as a diff.
+ *
+ * Idempotency: Postgres has no `ADD CONSTRAINT IF NOT EXISTS`, so each
+ * constraint is gated on a `pg_constraint` precheck (same pattern as
+ * PR #451 for migration 04's unique constraint). This matters because:
+ *   - `04-add-invitation-indexes-and-constraints.ts` already creates
+ *     `invitations_rescue_id_fkey` and `invitations_user_id_fkey` via
+ *     `removeConstraint + addConstraint`. On a fresh DB that runs the
+ *     baselines first, this file installs those FKs; migration 04 then
+ *     idempotently drops-and-readds them with the same definitions.
+ *   - Re-running `up()` after a partial failure must not throw.
+ *
+ * Explicit non-FK references (no DB constraint emitted by sync(), so
+ * none added here):
+ *   - `audit_logs.user`: soft reference to `users.user_id`. The
+ *     association in `models/index.ts` is `constraints: false` so audit
+ *     rows survive their user being deleted (per AuditLog.ts header
+ *     comment). Confirmed by D10.
+ *   - `application_timeline.{application_id, created_by}`,
+ *     `pet_status_transitions.transitioned_by`,
+ *     `home_visit_status_transitions.transitioned_by`,
+ *     `report_status_transitions.transitioned_by`,
+ *     `application_references.contacted_by` (association only —
+ *     constraints:false), `message_reads.user_id` (association only),
+ *     `email_template_versions.created_by` (association only),
+ *     `moderation_evidence.parent_id`: same pattern — forensic /
+ *     polymorphic references with `constraints: false`. The column
+ *     itself has no `references:` clause OR it does but the only
+ *     association uses `constraints: false`, so sync() emits no FK.
+ *   - `addresses.{owner_type, owner_id}`: polymorphic pointer. No FK.
+ *
+ * Down: drops every constraint, gated by
+ * `assertDestructiveDownAcknowledged` — dropping every cross-table FK
+ * in production is destructive enough that rollback should be a backup
+ * restore, not a `db:migrate:undo`.
+ */
+const MIGRATION_KEY = '00-baseline-zzz-foreign-keys';
+
+type ForeignKeySpec = {
+  table: string;
+  column: string;
+  refTable: string;
+  refKey: string;
+  onDelete: 'CASCADE' | 'SET NULL' | 'NO ACTION' | 'SET DEFAULT' | 'RESTRICT';
+  onUpdate: 'CASCADE' | 'SET NULL' | 'NO ACTION' | 'SET DEFAULT' | 'RESTRICT' | null;
+};
+
+const constraintName = (table: string, column: string): string => `${table}_${column}_fkey`;
+
+const FOREIGN_KEYS: ReadonlyArray<ForeignKeySpec> = [
+  // -- addresses --
+  {
+    table: 'addresses',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'addresses',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- application_answers --
+  {
+    table: 'application_answers',
+    column: 'application_id',
+    refTable: 'applications',
+    refKey: 'application_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'application_answers',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'application_answers',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- application_questions --
+  {
+    table: 'application_questions',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'application_questions',
+    column: 'rescue_id',
+    refTable: 'rescues',
+    refKey: 'rescue_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'application_questions',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- application_references --
+  {
+    table: 'application_references',
+    column: 'application_id',
+    refTable: 'applications',
+    refKey: 'application_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'application_references',
+    column: 'contacted_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'application_references',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'application_references',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- application_status_transitions --
+  {
+    table: 'application_status_transitions',
+    column: 'application_id',
+    refTable: 'applications',
+    refKey: 'application_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'application_status_transitions',
+    column: 'transitioned_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- applications --
+  {
+    table: 'applications',
+    column: 'actioned_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'applications',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'applications',
+    column: 'pet_id',
+    refTable: 'pets',
+    refKey: 'pet_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'applications',
+    column: 'rescue_id',
+    refTable: 'rescues',
+    refKey: 'rescue_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'applications',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'applications',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- breeds --
+  {
+    table: 'breeds',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'breeds',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- chat_participants --
+  {
+    table: 'chat_participants',
+    column: 'chat_id',
+    refTable: 'chats',
+    refKey: 'chat_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'chat_participants',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'chat_participants',
+    column: 'participant_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'chat_participants',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- chats --
+  {
+    table: 'chats',
+    column: 'application_id',
+    refTable: 'applications',
+    refKey: 'application_id',
+    onDelete: 'CASCADE',
+    onUpdate: null,
+  },
+  {
+    table: 'chats',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'chats',
+    column: 'pet_id',
+    refTable: 'pets',
+    refKey: 'pet_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'chats',
+    column: 'rescue_id',
+    refTable: 'rescues',
+    refKey: 'rescue_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'chats',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- cms_content --
+  {
+    table: 'cms_content',
+    column: 'author_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'cms_content',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'cms_content',
+    column: 'last_modified_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'cms_content',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- cms_navigation_menus --
+  {
+    table: 'cms_navigation_menus',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'cms_navigation_menus',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- device_tokens --
+  {
+    table: 'device_tokens',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- email_preferences --
+  {
+    table: 'email_preferences',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'email_preferences',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'email_preferences',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- email_queue --
+  {
+    table: 'email_queue',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'email_queue',
+    column: 'template_id',
+    refTable: 'email_templates',
+    refKey: 'template_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'email_queue',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'email_queue',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- email_template_versions --
+  {
+    table: 'email_template_versions',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'email_template_versions',
+    column: 'template_id',
+    refTable: 'email_templates',
+    refKey: 'template_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'email_template_versions',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- email_templates --
+  {
+    table: 'email_templates',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'email_templates',
+    column: 'last_modified_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'email_templates',
+    column: 'parent_template_id',
+    refTable: 'email_templates',
+    refKey: 'template_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'email_templates',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- file_uploads --
+  {
+    table: 'file_uploads',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'file_uploads',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'file_uploads',
+    column: 'uploaded_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- home_visit_status_transitions --
+  {
+    table: 'home_visit_status_transitions',
+    column: 'visit_id',
+    refTable: 'home_visits',
+    refKey: 'visit_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- home_visits --
+  {
+    table: 'home_visits',
+    column: 'application_id',
+    refTable: 'applications',
+    refKey: 'application_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'home_visits',
+    column: 'assigned_staff',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'home_visits',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'home_visits',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- idempotency_keys --
+  {
+    table: 'idempotency_keys',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- invitations --
+  {
+    table: 'invitations',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'invitations',
+    column: 'invited_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'invitations',
+    column: 'rescue_id',
+    refTable: 'rescues',
+    refKey: 'rescue_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'invitations',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'invitations',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- message_reactions --
+  {
+    table: 'message_reactions',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'message_reactions',
+    column: 'message_id',
+    refTable: 'messages',
+    refKey: 'message_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'message_reactions',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'message_reactions',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- message_reads --
+  {
+    table: 'message_reads',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'message_reads',
+    column: 'message_id',
+    refTable: 'messages',
+    refKey: 'message_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'message_reads',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'message_reads',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- messages --
+  {
+    table: 'messages',
+    column: 'chat_id',
+    refTable: 'chats',
+    refKey: 'chat_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'messages',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'messages',
+    column: 'sender_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'messages',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- moderation_evidence --
+  {
+    table: 'moderation_evidence',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'moderation_evidence',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- moderator_actions --
+  {
+    table: 'moderator_actions',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'moderator_actions',
+    column: 'moderator_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'moderator_actions',
+    column: 'report_id',
+    refTable: 'reports',
+    refKey: 'report_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'moderator_actions',
+    column: 'reversed_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'moderator_actions',
+    column: 'target_user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'moderator_actions',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- notifications --
+  {
+    table: 'notifications',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'notifications',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'notifications',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- pet_media --
+  {
+    table: 'pet_media',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'pet_media',
+    column: 'pet_id',
+    refTable: 'pets',
+    refKey: 'pet_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'pet_media',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- pet_status_transitions --
+  {
+    table: 'pet_status_transitions',
+    column: 'pet_id',
+    refTable: 'pets',
+    refKey: 'pet_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- pets --
+  {
+    table: 'pets',
+    column: 'breed_id',
+    refTable: 'breeds',
+    refKey: 'breed_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'pets',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'pets',
+    column: 'rescue_id',
+    refTable: 'rescues',
+    refKey: 'rescue_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'pets',
+    column: 'secondary_breed_id',
+    refTable: 'breeds',
+    refKey: 'breed_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'pets',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- ratings --
+  {
+    table: 'ratings',
+    column: 'application_id',
+    refTable: 'applications',
+    refKey: 'application_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'ratings',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'ratings',
+    column: 'pet_id',
+    refTable: 'pets',
+    refKey: 'pet_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'ratings',
+    column: 'rescue_id',
+    refTable: 'rescues',
+    refKey: 'rescue_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'ratings',
+    column: 'reviewee_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'ratings',
+    column: 'reviewer_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'ratings',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- refresh_tokens --
+  {
+    table: 'refresh_tokens',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- report_shares --
+  {
+    table: 'report_shares',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'report_shares',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- report_status_transitions --
+  {
+    table: 'report_status_transitions',
+    column: 'report_id',
+    refTable: 'reports',
+    refKey: 'report_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- report_templates --
+  {
+    table: 'report_templates',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'report_templates',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- reports --
+  {
+    table: 'reports',
+    column: 'assigned_moderator',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'reports',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'reports',
+    column: 'escalated_to',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'reports',
+    column: 'reported_user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'reports',
+    column: 'reporter_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'reports',
+    column: 'resolved_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'reports',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- rescue_settings --
+  {
+    table: 'rescue_settings',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'rescue_settings',
+    column: 'rescue_id',
+    refTable: 'rescues',
+    refKey: 'rescue_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'rescue_settings',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- rescues --
+  {
+    table: 'rescues',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'rescues',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'rescues',
+    column: 'verified_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- role_permissions --
+  {
+    table: 'role_permissions',
+    column: 'permission_id',
+    refTable: 'permissions',
+    refKey: 'permission_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'role_permissions',
+    column: 'role_id',
+    refTable: 'roles',
+    refKey: 'role_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- saved_reports --
+  {
+    table: 'saved_reports',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'saved_reports',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- scheduled_reports --
+  {
+    table: 'scheduled_reports',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'scheduled_reports',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- staff_members --
+  {
+    table: 'staff_members',
+    column: 'added_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'staff_members',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'staff_members',
+    column: 'rescue_id',
+    refTable: 'rescues',
+    refKey: 'rescue_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'staff_members',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'staff_members',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'staff_members',
+    column: 'verified_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- support_ticket_responses --
+  {
+    table: 'support_ticket_responses',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'support_ticket_responses',
+    column: 'responder_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'support_ticket_responses',
+    column: 'ticket_id',
+    refTable: 'support_tickets',
+    refKey: 'ticket_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'support_ticket_responses',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+
+  // -- support_tickets --
+  {
+    table: 'support_tickets',
+    column: 'assigned_to',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'support_tickets',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'support_tickets',
+    column: 'escalated_to',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'support_tickets',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'support_tickets',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- swipe_actions --
+  {
+    table: 'swipe_actions',
+    column: 'pet_id',
+    refTable: 'pets',
+    refKey: 'pet_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'swipe_actions',
+    column: 'session_id',
+    refTable: 'swipe_sessions',
+    refKey: 'session_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'swipe_actions',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- swipe_sessions --
+  {
+    table: 'swipe_sessions',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- user_application_prefs --
+  {
+    table: 'user_application_prefs',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_application_prefs',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_application_prefs',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- user_consents --
+  {
+    table: 'user_consents',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_consents',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_consents',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- user_favorites --
+  {
+    table: 'user_favorites',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_favorites',
+    column: 'pet_id',
+    refTable: 'pets',
+    refKey: 'pet_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'user_favorites',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_favorites',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- user_notification_prefs --
+  {
+    table: 'user_notification_prefs',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_notification_prefs',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_notification_prefs',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- user_privacy_prefs --
+  {
+    table: 'user_privacy_prefs',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_privacy_prefs',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_privacy_prefs',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- user_roles --
+  {
+    table: 'user_roles',
+    column: 'role_id',
+    refTable: 'roles',
+    refKey: 'role_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'user_roles',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- user_sanctions --
+  {
+    table: 'user_sanctions',
+    column: 'appeal_resolved_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_sanctions',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_sanctions',
+    column: 'issued_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'user_sanctions',
+    column: 'moderator_action_id',
+    refTable: 'moderator_actions',
+    refKey: 'action_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'user_sanctions',
+    column: 'report_id',
+    refTable: 'reports',
+    refKey: 'report_id',
+    onDelete: 'SET NULL',
+    onUpdate: 'CASCADE',
+  },
+  {
+    table: 'user_sanctions',
+    column: 'revoked_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_sanctions',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'user_sanctions',
+    column: 'user_id',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  },
+
+  // -- users --
+  {
+    table: 'users',
+    column: 'created_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+  {
+    table: 'users',
+    column: 'updated_by',
+    refTable: 'users',
+    refKey: 'user_id',
+    onDelete: 'SET NULL',
+    onUpdate: null,
+  },
+];
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    const sequelize = queryInterface.sequelize;
+    await runInTransaction(queryInterface, async t => {
+      for (const fk of FOREIGN_KEYS) {
+        const name = constraintName(fk.table, fk.column);
+        // Postgres has no ADD CONSTRAINT IF NOT EXISTS. Precheck
+        // pg_constraint by name — same pattern as PR #451 for
+        // migration 04's invitations_token_unique. Catches the case
+        // where migration 04 already installed the constraint (it
+        // names them identically).
+        const [existing] = await sequelize.query(
+          `SELECT 1 FROM pg_constraint WHERE conname = '${name}'`,
+          { transaction: t }
+        );
+        if ((existing as unknown[]).length > 0) {
+          continue;
+        }
+        // Sequelize's `AddForeignKeyConstraintOptions` types `onUpdate`
+        // as non-optional `string`. For FKs where the model declares
+        // no `onUpdate` AND no `belongsTo` association injects a
+        // default, sync() likewise emits no `ON UPDATE` clause —
+        // Postgres records this as `NO ACTION` in pg_constraint
+        // (confupdtype = 'a'). Passing the explicit string here
+        // produces the same `pg_constraint` row, so the normalised
+        // pg_dump in DB-A and DB-B match.
+        const onUpdate = fk.onUpdate ?? 'NO ACTION';
+        await queryInterface.addConstraint(fk.table, {
+          fields: [fk.column],
+          type: 'foreign key',
+          name,
+          references: { table: fk.refTable, field: fk.refKey },
+          onDelete: fk.onDelete,
+          onUpdate,
+          transaction: t,
+        });
+      }
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async t => {
+      for (const fk of FOREIGN_KEYS) {
+        await queryInterface
+          .removeConstraint(fk.table, constraintName(fk.table, fk.column), { transaction: t })
+          .catch(() => {
+            // Tolerate missing constraints — partial up() failures or
+            // operator-initiated drops shouldn't block rollback.
+          });
+      }
+    });
+  },
+};


### PR DESCRIPTION
## Summary

Closes the last gap in the per-model rebaseline plan: a dedicated FK file that installs every cross-table foreign-key constraint `sequelize.sync()` emits today. Lex order `...zzz...` runs it after all 61 per-model baselines, so every referenced table exists when the `ADD CONSTRAINT` statements execute.

- **177 FK constraints total**:
  - 91 model-declared FKs (column-level `references:` blocks across 39 tables).
  - 86 audit FKs (43 tables using `withAuditHooks` × `created_by`/`updated_by` → `users`).
- Each `ON DELETE` / `ON UPDATE` is computed from the column-level declaration plus the defaults Sequelize injects in `belongsTo._injectAttributes` (`onUpdate: CASCADE` and `onDelete: SET NULL` for nullable / `NO ACTION` for non-nullable), so the resulting `pg_constraint` rows match what `sync()` writes to DB-B in the schema-equivalence gate.
- Idempotent via `pg_constraint` precheck per constraint (same pattern as PR #451). Coexists cleanly with migration 04 — that migration installs `invitations_{rescue_id,user_id}_fkey` under matching names; the precheck skips them on the second pass.
- Naming follows Postgres' default `<table>_<column>_fkey` to match `sync()`'s implicit naming.
- `down()` is gated by `assertDestructiveDownAcknowledged` (requires both `MIGRATION_ALLOW_DESTRUCTIVE_DOWN=1` and `MIGRATION_DESTRUCTIVE_DOWN_KEY=00-baseline-zzz-foreign-keys`).

### Constraint groups by source table

```
addresses                       2  (audit only)
application_answers             3
application_questions           3
application_references          4
application_status_transitions  2
applications                    6
breeds                          2  (audit only)
chat_participants               4
chats                           5
cms_content                     4
cms_navigation_menus            2  (audit only; created_by gets ON UPDATE CASCADE via belongsTo)
device_tokens                   1
email_preferences               3
email_queue                     4
email_template_versions         3
email_templates                 4  (incl. self-FK parent_template_id)
file_uploads                    3
home_visit_status_transitions   1
home_visits                     4
idempotency_keys                1
invitations                     5  (rescue_id/user_id overlap with mig 04 — precheck handles it)
message_reactions               4
message_reads                   4
messages                        4
moderation_evidence             2  (audit only — polymorphic parent_id has constraints:false)
moderator_actions               6
notifications                   3
pet_media                       3
pet_status_transitions          1
pets                            5
ratings                         7
refresh_tokens                  1
report_shares                   2  (audit only)
report_status_transitions       1
report_templates                2  (audit only)
reports                         7
rescue_settings                 3
rescues                         3
role_permissions                2  (junction)
saved_reports                   2  (audit only)
scheduled_reports               2  (audit only)
staff_members                   6
support_ticket_responses        4
support_tickets                 5
swipe_actions                   3
swipe_sessions                  1
user_application_prefs          3
user_consents                   3
user_favorites                  4
user_notification_prefs         3
user_privacy_prefs              3
user_roles                      2  (junction)
user_sanctions                  8
users                           2  (self-FK audit only)
                              ----
TOTAL                          177
```

### Migration 04 interaction

`04-add-invitation-indexes-and-constraints.ts` already creates `invitations_rescue_id_fkey` and `invitations_user_id_fkey` via `removeConstraint + addConstraint` (using `.catch(() => {})` on the remove). On fresh DBs the baselines including this FK file run first, so migration 04 ends up dropping-and-readding the same FK with the same definitions — idempotent for both ordering directions. Inline comment in the file documents this.

### Sequelize quirks worth documenting

Per the source in `node_modules/sequelize/lib/associations/belongs-to.js` lines 77-82 (mirrored in `has-many.js` and `has-one.js`):

- Every `belongsTo`/`hasMany`/`hasOne` association with `constraints !== false` injects defaults into the column via `mergeDefaults`:
  - `onDelete` ← `'SET NULL'` if `allowNull`, else `'NO ACTION'` (belongsTo) / `'CASCADE'` (hasMany/hasOne).
  - `onUpdate` ← `'CASCADE'`.
- Several columns therefore end up with effective FKs whose ON UPDATE is **not** what the model column declared — e.g. `applications.user_id` has no explicit `onUpdate` on the column, but `Application.belongsTo(User, …)` injects `CASCADE`, so the FK is `ON UPDATE CASCADE` in the live DB. This file matches sync()'s output, not the bare column declaration.
- Audit FKs (`created_by`/`updated_by`) don't have a corresponding `belongsTo` for most tables, so no `onUpdate` default gets injected — those FKs land with `ON DELETE SET NULL` and no `ON UPDATE` clause (`NO ACTION` in `pg_constraint`). `cms_navigation_menus.created_by` is the one exception — the `User.hasMany(NavigationMenu, { foreignKey: 'created_by' })` / `belongsTo` pair in `models/index.ts` injects `ON UPDATE CASCADE` for it.

### Model-vs-DDL discrepancies (no action taken — these are intentional)

- `staff_members.{user_id, rescue_id}` declare `allowNull: false` AND `onDelete: 'SET NULL'`. Postgres accepts the constraint (it's structurally valid), but a parent delete would fail at execution time because the column is NOT NULL — effectively `NO ACTION` semantics. Left as-is to match sync().
- `audit_logs.user`: soft reference, no FK (D10).

### Schema-equivalence verification status

**Not run locally** — no Docker / Postgres available in this sandbox to execute `service.backend/scripts/schema-equivalence.sh`. The static analysis (reading every model, every `belongsTo`/`belongsToMany` in `models/index.ts`, and the Sequelize source for FK injection) is the authority for the 177-row constraint list and their ON DELETE / ON UPDATE values. The CI gate added in PR #452 will run against this PR and surface any divergence as a `diff` between the normalised DB-A and DB-B dumps. If anything mismatches I'll iterate on the FK definitions until the diff is empty.

## Test plan

- [ ] CI's schema-equivalence gate is the load-bearing test — confirm it's green before un-drafting.
- [x] `npx vitest run` — full suite passes locally (2133 passed / 262 skipped on SQLite).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors (167 pre-existing warnings, none in the new files).
- [x] `npx prettier --check` — formatted.
- [ ] In a Postgres-enabled env (`describeIfPostgres`), `baseline-foreign-keys.test.ts` spot-checks every ON DELETE / ON UPDATE combination, idempotency, mig 04 coexistence, and destructive-down gating.

https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016ny3dQofHdvz7C2pCCefbi)_