### PR TITLE
fix(legal,email): fail-loud ESP, cookies-only consent, scalable reminder cron (ADS-549 / ADS-550 / ADS-551)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,21 @@ DB_POOL_MIN=2
 DB_POOL_ACQUIRE=30000
 DB_POOL_IDLE=10000
 
+# Database TLS (ADS-540)
+# DB_SSL_MODE controls the Sequelize/pg SSL handshake:
+#   disable     — plaintext (default for dev; refused in production)
+#   require     — TLS, no certificate verification
+#   verify-ca   — TLS, verify CA
+#   verify-full — TLS, verify CA + hostname (recommended for managed Postgres)
+# In production the default is `require`; setting `disable` is refused
+# unless ALLOW_INSECURE_DB=true is also set (only safe on a fully trusted
+# bridge such as in-cluster Docker networking).
+# For RDS/Neon/Supabase: mount the provider's CA bundle into the container
+# and point DB_SSL_ROOT_CERT at it, then set DB_SSL_MODE=verify-full.
+DB_SSL_MODE=disable
+# ALLOW_INSECURE_DB=true
+# DB_SSL_ROOT_CERT=/etc/ssl/certs/rds-combined-ca-bundle.pem
+
 # -----------------------------------------------------------------------------
 # Redis Configuration
 # -----------------------------------------------------------------------------

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -218,3 +218,55 @@ git push origin v1.0.0
 ---
 
 _This workflow structure follows GitHub's recommended practices and industry standards for CI/CD pipelines._
+
+---
+
+## Action pinning policy (ADS-539)
+
+Every `uses:` entry in this directory MUST reference a 40-character commit
+SHA, not a floating tag like `@v4`. A human-readable comment with the
+release version goes next to the SHA so the line is greppable:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+```
+
+### Why
+
+GitHub Actions tags are mutable. A malicious force-push to a third-party
+tag — or upstream account compromise (tj-actions/changed-files, 2025) —
+immediately exfiltrates every secret available to the job. SHA pinning
+makes the action contents tamper-evident and surfaces upstream changes
+through Dependabot rather than via silent re-resolution at run time.
+
+### Highest-risk actions
+
+These actions see production secrets and must be reviewed especially
+carefully on every bump:
+
+| Action                          | Where used        | Secrets exposed |
+| ------------------------------- | ----------------- | --------------- |
+| `appleboy/ssh-action`           | `deploy.yml`, `rollback.yml` | `HETZNER_SSH_KEY`, `HETZNER_HOST` |
+| `docker/login-action`           | `deploy.yml`, `docker.yml`    | `GHCR_TOKEN`     |
+| `github/codeql-action/*`        | `codeql.yml`, `docker.yml`    | `GITHUB_TOKEN` (security-events: write) |
+| `dorny/paths-filter`            | `ci.yml`                       | `GITHUB_TOKEN`   |
+
+### Updating an action
+
+1. Open the Dependabot PR for the action bump.
+2. Verify the proposed SHA matches the tag on
+   `https://github.com/<owner>/<repo>/releases/tag/v<version>`.
+3. If the action is on the highest-risk table above, also read the
+   release notes for any new entry-point/permission surface.
+4. Merge.
+
+### Adding a new action
+
+Look up the SHA from the release page, then write:
+
+```yaml
+- uses: owner/repo@<full-40-char-SHA>  # v<x.y.z>
+```
+
+Never copy a `@vN` reference from a Stack Overflow snippet without
+resolving to a SHA first.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Verify Workspace ↔ Filesystem Alignment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Verify workspace ↔ filesystem alignment
         run: |
           expected=$(node -p "require('./package.json').workspaces.filter(w => w.startsWith('lib.')).sort().join('\n')")
@@ -38,9 +38,9 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       libs: ${{ steps.filter.outputs.libs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.0
         id: filter
         with:
           filters: |
@@ -93,9 +93,9 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -108,7 +108,7 @@ jobs:
       # the root lockfile. A cache hit skips the build:libs step entirely.
       - name: Restore lib dist cache
         id: cache-lib-dist
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: lib.*/dist
           key: lib-dist-${{ runner.os }}-${{ hashFiles('lib.*/src/**', 'lib.*/package.json', 'lib.*/tsconfig*.json', 'package-lock.json') }}
@@ -122,7 +122,7 @@ jobs:
       # Bundle every lib.*/dist (and matching package.json) into a single artifact
       # that downstream jobs pick up via download-artifact. Wildcard expansion
       # is handled by upload-artifact's tar layer.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: lib-dist
           path: |
@@ -161,9 +161,9 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -199,7 +199,7 @@ jobs:
         run: npm run validate:env
 
       - name: Download pre-built libraries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: lib-dist
 
@@ -220,7 +220,7 @@ jobs:
         run: npm run build
         working-directory: service.backend
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-results-backend
@@ -246,9 +246,9 @@ jobs:
         app: [app.client, app.admin, app.rescue]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -257,7 +257,7 @@ jobs:
         run: npm ci
 
       - name: Download pre-built libraries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: lib-dist
 
@@ -278,7 +278,7 @@ jobs:
         env:
           CI: true
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-results-${{ matrix.app }}
@@ -302,9 +302,9 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -313,14 +313,14 @@ jobs:
         run: npm ci
 
       - name: Download pre-built libraries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: lib-dist
 
       - name: Lint, test and type-check all libraries
         run: npx turbo run lint test type-check --filter='@adopt-dont-shop/lib.*'
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-results-libs
@@ -358,18 +358,18 @@ jobs:
       E2E_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Free up disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY"
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
         with:
           driver-opts: |
             image=moby/buildkit:latest
@@ -385,7 +385,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -478,7 +478,7 @@ jobs:
         if: failure()
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml logs --no-color > docker-compose.log
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: e2e-playwright-report

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,10 +32,10 @@ jobs:
         language: [javascript-typescript]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
         with:
           languages: ${{ matrix.language }}
           # security-extended adds queries beyond the default set; this is
@@ -46,6 +46,6 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,10 @@ jobs:
     outputs:
       sha: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 22
           cache: 'npm'
@@ -39,7 +39,7 @@ jobs:
         run: npm run test
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -100,7 +100,7 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
     steps:
       - name: Deploy to server
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: deploy

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,9 +46,9 @@ jobs:
       packages: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
         with:
           driver-opts: |
             image=moby/buildkit:latest
@@ -56,14 +56,14 @@ jobs:
 
       - name: Log in to GHCR (for Trivy DB pulls)
         if: github.event_name == 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build development image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./service.backend/Dockerfile
@@ -76,7 +76,7 @@ jobs:
 
       - name: Build production image
         id: build-prod
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./service.backend/Dockerfile
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security tab
         if: github.event_name == 'pull_request' && always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -123,16 +123,16 @@ jobs:
         app: [app.client, app.admin, app.rescue]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
         with:
           driver-opts: |
             image=moby/buildkit:latest
             network=host
 
       - name: Build development image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./Dockerfile.app.optimized
@@ -146,7 +146,7 @@ jobs:
           cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Build production image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./Dockerfile.app.optimized
@@ -171,13 +171,13 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Free up disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY"
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
         with:
           driver-opts: |
             image=moby/buildkit:latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213  # v6.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/lib-test-guard.yml
+++ b/.github/workflows/lib-test-guard.yml
@@ -21,9 +21,9 @@ jobs:
     name: Verify every lib.* package has tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           # Cache npm downloads so matrix shards share artifacts instead

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
@@ -86,21 +86,21 @@ jobs:
     needs: guard
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # For workflow_run events, check out the commit CI actually validated
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: paragonjenko/adoptdontshop
           flavor: prefix=service-backend-
@@ -116,7 +116,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc') }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./service.backend/Dockerfile
@@ -142,20 +142,20 @@ jobs:
         app: [app.client, app.admin, app.rescue]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: paragonjenko/adoptdontshop
           flavor: prefix=${{ matrix.app }}-
@@ -168,7 +168,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc') }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./Dockerfile.app.optimized

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -21,7 +21,7 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
     steps:
       - name: Rollback on server
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: deploy

--- a/.github/workflows/schema-equivalence.yml
+++ b/.github/workflows/schema-equivalence.yml
@@ -71,9 +71,9 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -214,7 +214,7 @@ jobs:
         # `if: always()` so the artifact is uploaded on failure too — that's
         # the path operators care about most.
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: schema-equivalence-artifacts
           path: schema-equivalence-out/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           # Cache npm downloads so this workflow is fast and doesn't re-hit

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,15 +18,15 @@ jobs:
     name: Build Storybook
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
       - run: npm run build-storybook
         working-directory: lib.components
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         if: github.ref == 'refs/heads/main'
         with:
           path: lib.components/storybook-static
@@ -42,4 +42,4 @@ jobs:
     environment:
       name: github-pages
     steps:
-      - uses: actions/deploy-pages@v5
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,8 +15,15 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # ADS-539 follow-up: `EndBug/add-and-delete-github-labels` no longer
+      # exists on GitHub (returns 404). This step is broken regardless of
+      # SHA pinning. Replace with `EndBug/label-sync@v2` (same author,
+      # same `config-file` shape) in a separate change so behaviour can
+      # be verified end-to-end against a real label config. Until then,
+      # the workflow still fails fast on the missing action rather than
+      # exfiltrating any secret.
       - uses: EndBug/add-and-delete-github-labels@v1
         with:
           config-file: .github/labels.yml

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,6 +102,12 @@ services:
       DB_USERNAME: "${POSTGRES_USER:?Error: POSTGRES_USER required}"
       DB_PASSWORD: "${POSTGRES_PASSWORD:?Error: POSTGRES_PASSWORD required}"
       PROD_DB_NAME: "${POSTGRES_DB:?Error: POSTGRES_DB required}"
+      # ADS-540: enforce TLS on the DB link. In-cluster Postgres on the
+      # docker network can opt out via ALLOW_INSECURE_DB=true; managed
+      # Postgres should leave DB_SSL_MODE=require (or verify-full + CA).
+      DB_SSL_MODE: ${DB_SSL_MODE:-require}
+      ALLOW_INSECURE_DB: ${ALLOW_INSECURE_DB:-}
+      DB_SSL_ROOT_CERT: ${DB_SSL_ROOT_CERT:-}
     depends_on:
       database:
         condition: service_healthy
@@ -128,6 +134,10 @@ services:
       PROD_DB_NAME: "${POSTGRES_DB:?Error: POSTGRES_DB required}"
       DB_POOL_MAX: ${DB_POOL_MAX:-20}
       DB_POOL_MIN: ${DB_POOL_MIN:-5}
+      # ADS-540: enforce TLS on the DB link. See migrate service above.
+      DB_SSL_MODE: ${DB_SSL_MODE:-require}
+      ALLOW_INSECURE_DB: ${ALLOW_INSECURE_DB:-}
+      DB_SSL_ROOT_CERT: ${DB_SSL_ROOT_CERT:-}
       # Redis - NO DEFAULTS
       REDIS_HOST: redis
       REDIS_PORT: 6379

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -109,6 +109,37 @@ docker compose -f docker-compose.prod.yml run --rm service-backend-migrate \
   npx sequelize-cli db:migrate:undo
 ```
 
+## Database TLS (ADS-540)
+
+`docker-compose.prod.yml` defaults `DB_SSL_MODE=require`, which makes the
+Sequelize/`pg` driver open the link to Postgres over TLS. Three modes are
+supported:
+
+| `DB_SSL_MODE` | Behaviour |
+|---------------|-----------|
+| `require`     | TLS, no certificate verification (default) |
+| `verify-ca`   | TLS, verify CA chain |
+| `verify-full` | TLS, verify CA chain + hostname (recommended for managed providers) |
+
+The backend refuses to boot in production with `DB_SSL_MODE=disable` unless
+`ALLOW_INSECURE_DB=true` is also set — only safe on a fully trusted bridge
+such as the in-cluster docker network on the same host.
+
+### Managed Postgres (RDS / Neon / Supabase)
+
+1. Download the provider's CA bundle (e.g. `rds-combined-ca-bundle.pem`).
+2. Mount it into the backend container: add a `volumes:` entry to the
+   `service-backend` / `service-backend-migrate` services pointing to a
+   read-only path inside the container.
+3. Set the env vars in `.env`:
+   ```
+   DB_SSL_MODE=verify-full
+   DB_SSL_ROOT_CERT=/etc/ssl/certs/rds-combined-ca-bundle.pem
+   ```
+
+Boot logs print `sslMode=<mode>` so the effective setting is observable
+without exec'ing into the container.
+
 ## Backup / snapshot
 
 See [`snapshot-policy.md`](./snapshot-policy.md). [ADS-500]

--- a/lib.auth/src/__tests__/auth-service.test.ts
+++ b/lib.auth/src/__tests__/auth-service.test.ts
@@ -130,7 +130,7 @@ describe('AuthService', () => {
   });
 
   describe('register', () => {
-    it('should register successfully and store access token in sessionStorage', async () => {
+    it('returns user + message and stores no auth tokens (ADS-538)', async () => {
       const userData: RegisterRequest = {
         email: 'test@example.com',
         password: 'password123',
@@ -138,18 +138,19 @@ describe('AuthService', () => {
         lastName: 'Doe',
       };
 
-      (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue(mockAuthResponse);
+      const registerResponse = {
+        user: mockUser,
+        message: 'Registration successful. Please check your email to verify your account.',
+      };
+      (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue(registerResponse);
 
       const result = await authService.register(userData);
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/register', userData);
-      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.AUTH_TOKEN,
-        'mock-token'
-      );
-      // Refresh token NOT stored locally
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith('refreshToken', expect.any(String));
-      expect(result).toEqual({ ...mockAuthResponse, accessToken: 'mock-token' });
+      // No tokens — user must verify email + log in to get a session.
+      expect(mockSessionStorage.setItem).not.toHaveBeenCalled();
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
+      expect(result).toEqual(registerResponse);
     });
   });
 

--- a/lib.auth/src/contexts/AuthContext.tsx
+++ b/lib.auth/src/contexts/AuthContext.tsx
@@ -218,8 +218,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         userType: userData.userType || allowedUserTypes[0],
       };
 
+      // ADS-538: register no longer returns auth tokens — the user must
+      // verify their email and log in normally before the session
+      // becomes valid. Deliberately do NOT call setUser() here.
       const response = await authService.register(registerData);
-      setUser(response.user);
 
       onAuthEvent?.('auth_registration_successful', {
         user_id: response.user.userId,

--- a/lib.auth/src/services/auth-service.ts
+++ b/lib.auth/src/services/auth-service.ts
@@ -63,19 +63,17 @@ export class AuthService {
   }
 
   /**
-   * Register new user
+   * Register a new user.
+   *
+   * ADS-538: the backend no longer issues tokens on `/register`. The user
+   * must verify their email and log in normally before they have a
+   * session. This method therefore returns just the user record and a
+   * server-supplied message — clients should route to a
+   * "check your email" screen rather than treating the response as a
+   * successful login.
    */
-  async register(userData: RegisterRequest): Promise<AuthResponse> {
-    const response = await apiService.post<AuthResponse>(AUTH_ENDPOINTS.REGISTER, userData);
-
-    // Store access token in sessionStorage; refresh token is in httpOnly cookie
-    this.setToken(response.token);
-    this.setUser(response.user);
-
-    return {
-      ...response,
-      accessToken: response.token, // Map backend 'token' to frontend 'accessToken'
-    };
+  async register(userData: RegisterRequest): Promise<{ user: User; message: string }> {
+    return apiService.post<{ user: User; message: string }>(AUTH_ENDPOINTS.REGISTER, userData);
   }
 
   /**

--- a/lib.legal/src/components/CookieBanner.test.tsx
+++ b/lib.legal/src/components/CookieBanner.test.tsx
@@ -24,12 +24,12 @@ const baseUser: User = {
 };
 
 const fetchCookiesVersionMock = vi.fn();
-const recordReacceptanceMock = vi.fn();
+const recordCookiesConsentMock = vi.fn();
 const setAnalyticsConsentMock = vi.fn();
 
 vi.mock('../services/legal-service', () => ({
   fetchCookiesVersion: () => fetchCookiesVersionMock(),
-  recordReacceptance: (input: unknown) => recordReacceptanceMock(input),
+  recordCookiesConsent: (input: unknown) => recordCookiesConsentMock(input),
   // The banner imports these too — keep the mock surface complete to
   // avoid undefined-call traps during partial imports.
   fetchPendingReacceptance: vi.fn(),
@@ -76,7 +76,7 @@ describe('CookieBanner [ADS-497 slice 5]', () => {
     authState.isAuthenticated = false;
     window.localStorage.clear();
     fetchCookiesVersionMock.mockReset();
-    recordReacceptanceMock.mockReset();
+    recordCookiesConsentMock.mockReset();
     setAnalyticsConsentMock.mockReset();
     fetchCookiesVersionMock.mockResolvedValue(CURRENT_VERSION);
   });
@@ -187,13 +187,13 @@ describe('CookieBanner [ADS-497 slice 5]', () => {
     await waitFor(() => {
       expect(setAnalyticsConsentMock).toHaveBeenCalled();
     });
-    expect(recordReacceptanceMock).not.toHaveBeenCalled();
+    expect(recordCookiesConsentMock).not.toHaveBeenCalled();
   });
 
   it('calls the consent API for authenticated users with the captured cookies version + analytics flag', async () => {
     authState.user = baseUser;
     authState.isAuthenticated = true;
-    recordReacceptanceMock.mockResolvedValue(undefined);
+    recordCookiesConsentMock.mockResolvedValue(undefined);
 
     const user = userEvent.setup();
     render(<CookieBanner />);
@@ -201,11 +201,11 @@ describe('CookieBanner [ADS-497 slice 5]', () => {
     await user.click(await screen.findByTestId('cookie-banner-accept-all'));
 
     await waitFor(() => {
-      expect(recordReacceptanceMock).toHaveBeenCalledTimes(1);
+      expect(recordCookiesConsentMock).toHaveBeenCalledTimes(1);
     });
-    expect(recordReacceptanceMock).toHaveBeenCalledWith({
-      tosAccepted: true,
-      privacyAccepted: true,
+    // ADS-550: cookies-only path — the payload must NOT carry
+    // tosAccepted/privacyAccepted.
+    expect(recordCookiesConsentMock).toHaveBeenCalledWith({
       cookiesVersion: CURRENT_VERSION,
       analyticsConsent: true,
     });

--- a/lib.legal/src/components/CookieBanner.tsx
+++ b/lib.legal/src/components/CookieBanner.tsx
@@ -2,7 +2,7 @@ import { Button } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { setAnalyticsConsent } from '@adopt-dont-shop/lib.observability';
 import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react';
-import { fetchCookiesVersion, recordReacceptance } from '../services/legal-service';
+import { fetchCookiesVersion, recordCookiesConsent } from '../services/legal-service';
 import {
   readStoredConsent,
   writeStoredConsent,
@@ -112,9 +112,13 @@ export const CookieBanner = () => {
 
     if (isAuthenticated) {
       try {
-        await recordReacceptance({
-          tosAccepted: true,
-          privacyAccepted: true,
+        // ADS-550: cookies-only path. Previously this called
+        // `recordReacceptance` with hard-coded `tosAccepted: true,
+        // privacyAccepted: true`, which made the backend stamp the
+        // currently-published ToS/Privacy versions onto the audit row
+        // and silently consume pending re-acceptance for documents the
+        // user never saw.
+        await recordCookiesConsent({
           cookiesVersion: record.cookiesVersion,
           analyticsConsent: record.analyticsConsent,
         });

--- a/lib.legal/src/services/attach-stored-consent.test.ts
+++ b/lib.legal/src/services/attach-stored-consent.test.ts
@@ -4,11 +4,11 @@ import { COOKIE_CONSENT_STORAGE_KEY } from './cookie-consent-storage';
 const CURRENT_VERSION = '2026-05-09-v1';
 
 const fetchCookiesVersionMock = vi.fn();
-const recordReacceptanceMock = vi.fn();
+const recordCookiesConsentMock = vi.fn();
 
 vi.mock('./legal-service', () => ({
   fetchCookiesVersion: () => fetchCookiesVersionMock(),
-  recordReacceptance: (input: unknown) => recordReacceptanceMock(input),
+  recordCookiesConsent: (input: unknown) => recordCookiesConsentMock(input),
   // Round out the partial mock so other importers stay safe.
   fetchPendingReacceptance: vi.fn(),
 }));
@@ -21,9 +21,9 @@ describe('attachStoredCookieConsent', () => {
   beforeEach(() => {
     window.localStorage.clear();
     fetchCookiesVersionMock.mockReset();
-    recordReacceptanceMock.mockReset();
+    recordCookiesConsentMock.mockReset();
     fetchCookiesVersionMock.mockResolvedValue(CURRENT_VERSION);
-    recordReacceptanceMock.mockResolvedValue(undefined);
+    recordCookiesConsentMock.mockResolvedValue(undefined);
   });
 
   const storeConsent = (analyticsConsent: boolean): void => {
@@ -40,7 +40,7 @@ describe('attachStoredCookieConsent', () => {
   it('does nothing when no anonymous choice is stored', async () => {
     await attachStoredCookieConsent('user-1');
 
-    expect(recordReacceptanceMock).not.toHaveBeenCalled();
+    expect(recordCookiesConsentMock).not.toHaveBeenCalled();
   });
 
   it('does nothing when the stored choice is for an older cookies version', async () => {
@@ -55,7 +55,7 @@ describe('attachStoredCookieConsent', () => {
 
     await attachStoredCookieConsent('user-1');
 
-    expect(recordReacceptanceMock).not.toHaveBeenCalled();
+    expect(recordCookiesConsentMock).not.toHaveBeenCalled();
   });
 
   it('replays the stored choice to the consent endpoint on first attach', async () => {
@@ -63,10 +63,11 @@ describe('attachStoredCookieConsent', () => {
 
     await attachStoredCookieConsent('user-1');
 
-    expect(recordReacceptanceMock).toHaveBeenCalledTimes(1);
-    expect(recordReacceptanceMock).toHaveBeenCalledWith({
-      tosAccepted: true,
-      privacyAccepted: true,
+    expect(recordCookiesConsentMock).toHaveBeenCalledTimes(1);
+    // ADS-550: the payload must NOT carry tosAccepted/privacyAccepted —
+    // the dedicated cookies-consent endpoint is the only consent path
+    // that doesn't represent explicit ToS/Privacy action.
+    expect(recordCookiesConsentMock).toHaveBeenCalledWith({
       cookiesVersion: CURRENT_VERSION,
       analyticsConsent: true,
     });
@@ -79,7 +80,7 @@ describe('attachStoredCookieConsent', () => {
     await attachStoredCookieConsent('user-1');
     await attachStoredCookieConsent('user-1');
 
-    expect(recordReacceptanceMock).toHaveBeenCalledTimes(1);
+    expect(recordCookiesConsentMock).toHaveBeenCalledTimes(1);
     expect(window.localStorage.getItem(ATTACHED_KEY)).toBe(`user-1::${CURRENT_VERSION}`);
   });
 
@@ -89,21 +90,21 @@ describe('attachStoredCookieConsent', () => {
     await attachStoredCookieConsent('user-1');
     await attachStoredCookieConsent('user-2');
 
-    expect(recordReacceptanceMock).toHaveBeenCalledTimes(2);
+    expect(recordCookiesConsentMock).toHaveBeenCalledTimes(2);
     expect(window.localStorage.getItem(ATTACHED_KEY)).toBe(`user-2::${CURRENT_VERSION}`);
   });
 
   it('retries on the next call when the previous attach failed (no dedupe key written)', async () => {
     storeConsent(true);
-    recordReacceptanceMock.mockRejectedValueOnce(new Error('network'));
+    recordCookiesConsentMock.mockRejectedValueOnce(new Error('network'));
 
     await attachStoredCookieConsent('user-1');
     expect(window.localStorage.getItem(ATTACHED_KEY)).toBeNull();
 
-    recordReacceptanceMock.mockResolvedValueOnce(undefined);
+    recordCookiesConsentMock.mockResolvedValueOnce(undefined);
     await attachStoredCookieConsent('user-1');
 
-    expect(recordReacceptanceMock).toHaveBeenCalledTimes(2);
+    expect(recordCookiesConsentMock).toHaveBeenCalledTimes(2);
     expect(window.localStorage.getItem(ATTACHED_KEY)).toBe(`user-1::${CURRENT_VERSION}`);
   });
 
@@ -113,6 +114,6 @@ describe('attachStoredCookieConsent', () => {
 
     await attachStoredCookieConsent('user-1');
 
-    expect(recordReacceptanceMock).not.toHaveBeenCalled();
+    expect(recordCookiesConsentMock).not.toHaveBeenCalled();
   });
 });

--- a/lib.legal/src/services/attach-stored-consent.ts
+++ b/lib.legal/src/services/attach-stored-consent.ts
@@ -1,4 +1,4 @@
-import { fetchCookiesVersion, recordReacceptance } from './legal-service';
+import { fetchCookiesVersion, recordCookiesConsent } from './legal-service';
 import { readStoredConsent } from './cookie-consent-storage';
 
 /**
@@ -70,9 +70,11 @@ export const attachStoredCookieConsent = async (userId: string): Promise<void> =
     return;
   }
   try {
-    await recordReacceptance({
-      tosAccepted: true,
-      privacyAccepted: true,
+    // ADS-550: cookies-only path. The previous implementation called
+    // `recordReacceptance` with hard-coded `tosAccepted: true,
+    // privacyAccepted: true` on every first-sign-in replay, silently
+    // recording ToS / Privacy re-acceptance the user never gave.
+    await recordCookiesConsent({
       cookiesVersion: stored.cookiesVersion,
       analyticsConsent: stored.analyticsConsent,
     });

--- a/lib.legal/src/services/legal-service.ts
+++ b/lib.legal/src/services/legal-service.ts
@@ -60,6 +60,25 @@ export const recordReacceptance = async (input: RecordReacceptanceInput): Promis
 };
 
 /**
+ * ADS-550: cookies-only consent. The cookie banner and the
+ * attach-stored-consent replay must NOT call `recordReacceptance` with
+ * hard-coded `tosAccepted: true, privacyAccepted: true` — that path
+ * silently records a ToS / Privacy re-acceptance the user never gave.
+ * Use this dedicated endpoint instead; the backend writes a
+ * CONSENT_RECORDED audit row that omits `tosVersion`/`privacyVersion`.
+ */
+export type RecordCookiesConsentInput = {
+  cookiesVersion?: string;
+  analyticsConsent?: boolean;
+};
+
+export const recordCookiesConsent = async (
+  input: RecordCookiesConsentInput
+): Promise<void> => {
+  await api.post('/api/v1/privacy/cookies-consent', input);
+};
+
+/**
  * ADS-497 (slice 5): cookies-policy version snapshot for the on-page
  * banner. Returns just the version string so a banner mount can be
  * cheap; the full policy markdown is rendered on /cookies for users who

--- a/lib.legal/src/services/legal-service.ts
+++ b/lib.legal/src/services/legal-service.ts
@@ -72,9 +72,7 @@ export type RecordCookiesConsentInput = {
   analyticsConsent?: boolean;
 };
 
-export const recordCookiesConsent = async (
-  input: RecordCookiesConsentInput
-): Promise<void> => {
+export const recordCookiesConsent = async (input: RecordCookiesConsentInput): Promise<void> => {
   await api.post('/api/v1/privacy/cookies-consent', input);
 };
 

--- a/service.backend/src/__tests__/config/db-pool-config.test.ts
+++ b/service.backend/src/__tests__/config/db-pool-config.test.ts
@@ -7,7 +7,13 @@
  * functions rather than introspecting the live connection.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildPoolConfig, buildTimeoutConfig, logEffectiveDbConfig } from '../../sequelize';
+import {
+  buildPoolConfig,
+  buildSslConfig,
+  buildTimeoutConfig,
+  logEffectiveDbConfig,
+} from '../../sequelize';
+import { resolveDbSslMode } from '../../config/env';
 
 const POOL_VARS = ['DB_POOL_MAX', 'DB_POOL_MIN', 'DB_POOL_ACQUIRE_MS', 'DB_POOL_IDLE_MS'] as const;
 
@@ -90,6 +96,7 @@ describe('database pool + timeout config [ADS-401]', () => {
         lockTimeoutMs: 10000,
         idleInTransactionSessionTimeoutMs: 60000,
       },
+      'require',
       log
     );
 
@@ -99,5 +106,53 @@ describe('database pool + timeout config [ADS-401]', () => {
     expect(message).toContain('statementTimeoutMs=30000');
     expect(message).toContain('lockTimeoutMs=10000');
     expect(message).toContain('idleInTransactionSessionTimeoutMs=60000');
+    expect(message).toContain('sslMode=require');
+  });
+});
+
+describe('database TLS config [ADS-540]', () => {
+  afterEach(() => {
+    delete process.env.DB_SSL_ROOT_CERT;
+  });
+
+  it('defaults to disable in non-production', () => {
+    expect(resolveDbSslMode('development', undefined, undefined)).toBe('disable');
+    expect(resolveDbSslMode('test', undefined, undefined)).toBe('disable');
+  });
+
+  it('defaults to require in production', () => {
+    expect(resolveDbSslMode('production', undefined, undefined)).toBe('require');
+  });
+
+  it('refuses to boot in production with DB_SSL_MODE=disable unless explicitly allowed', () => {
+    expect(() => resolveDbSslMode('production', 'disable', undefined)).toThrow(
+      /DB_SSL_MODE=disable is not allowed in production/
+    );
+    expect(resolveDbSslMode('production', 'disable', 'true')).toBe('disable');
+  });
+
+  it('rejects unknown DB_SSL_MODE values', () => {
+    expect(() => resolveDbSslMode('production', 'totally-secure', undefined)).toThrow(
+      /Invalid DB_SSL_MODE/
+    );
+  });
+
+  it('builds a pg-shaped ssl config that maps onto libpq sslmode', () => {
+    expect(buildSslConfig('disable')).toBe(false);
+    expect(buildSslConfig('require')).toEqual({ rejectUnauthorized: false });
+    expect(buildSslConfig('verify-ca')).toEqual({ rejectUnauthorized: true });
+    expect(buildSslConfig('verify-full')).toEqual({ rejectUnauthorized: true });
+  });
+
+  it('attaches DB_SSL_ROOT_CERT when verify modes are used', () => {
+    process.env.DB_SSL_ROOT_CERT = '/etc/ssl/certs/rds-ca-bundle.pem';
+    expect(buildSslConfig('verify-full')).toEqual({
+      rejectUnauthorized: true,
+      ca: '/etc/ssl/certs/rds-ca-bundle.pem',
+    });
+    expect(buildSslConfig('verify-ca')).toEqual({
+      rejectUnauthorized: true,
+      ca: '/etc/ssl/certs/rds-ca-bundle.pem',
+    });
   });
 });

--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -1250,7 +1250,9 @@ describe('Authentication Flow Integration Tests', () => {
         const registerResult = await AuthService.register(registerData);
 
         expect(registerResult.user).toBeDefined();
-        expect(registerResult.token).toBeDefined();
+        // ADS-538: register no longer returns a token; the session is
+        // established by the subsequent login step below.
+        expect(registerResult).not.toHaveProperty('token');
 
         // Step 2: Verify Email
         const mockUserAfterVerification = createMockUser({

--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -162,8 +162,11 @@ describe('Authentication Flow Integration Tests', () => {
           })
         );
         expect(result.user).toBeDefined();
-        expect(result.token).toBeDefined();
-        expect(result.refreshToken).toBeDefined();
+        // ADS-538: register no longer returns auth tokens — user must
+        // verify email + log in before they have a session.
+        expect(result).not.toHaveProperty('token');
+        expect(result).not.toHaveProperty('refreshToken');
+        expect(result.message).toMatch(/verify your account/i);
       });
 
       it('should create user with verification token and expiration', async () => {
@@ -230,7 +233,7 @@ describe('Authentication Flow Integration Tests', () => {
         );
       });
 
-      it('should generate JWT tokens for new user', async () => {
+      it('should NOT generate JWT tokens at registration (ADS-538)', async () => {
         const mockUser = createMockUser({
           userId: 'user-new-123',
           email: registerData.email.toLowerCase(),
@@ -241,9 +244,9 @@ describe('Authentication Flow Integration Tests', () => {
 
         const result = await AuthService.register(registerData);
 
-        expect(result.token).toBeDefined();
-        expect(result.refreshToken).toBeDefined();
-        expect(result.expiresIn).toBeDefined();
+        expect(result).not.toHaveProperty('token');
+        expect(result).not.toHaveProperty('refreshToken');
+        expect(result).not.toHaveProperty('expiresIn');
       });
 
       it('should reject registration with existing email', async () => {

--- a/service.backend/src/__tests__/middleware/auth.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/auth.middleware.test.ts
@@ -329,6 +329,7 @@ describe('Authentication Middleware', () => {
           userId: 'user-123',
           email: 'test@example.com',
           status: 'active',
+          emailVerified: true,
           Roles: [],
         };
 
@@ -497,6 +498,7 @@ describe('Authentication Middleware', () => {
           userId: 'user-123',
           email: 'test@example.com',
           status: 'active',
+          emailVerified: true,
           Roles: [{ name: 'user' }],
         };
 
@@ -533,6 +535,7 @@ describe('Authentication Middleware', () => {
           userId: 'user-123',
           email: 'test@example.com',
           status: 'active',
+          emailVerified: true,
           Roles: [],
         };
 
@@ -560,6 +563,7 @@ describe('Authentication Middleware', () => {
           userId: 'user-123',
           email: 'test@example.com',
           status: 'active',
+          emailVerified: true,
           Roles: [],
         };
 
@@ -588,6 +592,7 @@ describe('Authentication Middleware', () => {
           userId: 'user-123',
           email: 'test@example.com',
           status: 'active',
+          emailVerified: true,
           Roles: [{ name: 'admin' }, { name: 'moderator' }],
         };
 
@@ -735,6 +740,7 @@ describe('Authentication Middleware', () => {
           userId: 'user-123',
           email: 'test@example.com',
           status: 'active',
+          emailVerified: true,
           Roles: [],
         };
 
@@ -882,6 +888,7 @@ describe('Authentication Middleware', () => {
           email: 'test@example.com',
           userType: 'adopter',
           status: 'active',
+          emailVerified: true,
           Roles: [],
         };
 

--- a/service.backend/src/__tests__/routes/auth.routes.test.ts
+++ b/service.backend/src/__tests__/routes/auth.routes.test.ts
@@ -128,17 +128,26 @@ describe('Auth routes', () => {
       userType: 'ADOPTER',
     };
 
-    it('returns 201 on successful registration', async () => {
+    it('returns 201 on successful registration with no tokens (ADS-538)', async () => {
       mockRegister.mockResolvedValue({
-        message: 'Registration successful. Please check your email for verification.',
-        userId: 'new-uuid',
-        token: 'access-token',
-        refreshToken: 'refresh-token',
+        user: { userId: 'new-uuid', email: validBody.email },
+        message: 'Registration successful. Please check your email to verify your account.',
       });
 
       const res = await request(buildApp()).post('/api/v1/auth/register').send(validBody);
 
       expect(res.status).toBe(201);
+      expect(res.body).not.toHaveProperty('token');
+      expect(res.body).not.toHaveProperty('refreshToken');
+      // No auth cookies set either.
+      const setCookieHeader = res.headers['set-cookie'];
+      const cookies = Array.isArray(setCookieHeader)
+        ? setCookieHeader
+        : setCookieHeader
+          ? [setCookieHeader]
+          : [];
+      expect(cookies.some((c: string) => c.startsWith('accessToken='))).toBe(false);
+      expect(cookies.some((c: string) => c.startsWith('refreshToken='))).toBe(false);
     });
 
     it('returns 422 when required fields are missing', async () => {

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -159,7 +159,11 @@ describe('AuthService', () => {
         })
       );
       expect(result.user).toBeDefined();
-      expect(result.token).toBe('mocked-access-token');
+      // ADS-538: register no longer returns tokens — the user must
+      // verify their email and log in normally first.
+      expect(result).not.toHaveProperty('token');
+      expect(result).not.toHaveProperty('refreshToken');
+      expect(result.message).toMatch(/verify your account/i);
     });
 
     it('should throw error if user already exists', async () => {
@@ -215,7 +219,7 @@ describe('AuthService', () => {
         })
       );
       expect(result.user).toBeDefined();
-      expect(result.token).toBe('mocked-access-token');
+      expect(result).not.toHaveProperty('token');
     });
 
     it('should register user successfully with empty phone number', async () => {
@@ -263,7 +267,7 @@ describe('AuthService', () => {
         })
       );
       expect(result.user).toBeDefined();
-      expect(result.token).toBe('mocked-access-token');
+      expect(result).not.toHaveProperty('token');
     });
 
     it('should throw error for invalid password', async () => {

--- a/service.backend/src/__tests__/services/email-provider-init.test.ts
+++ b/service.backend/src/__tests__/services/email-provider-init.test.ts
@@ -1,0 +1,137 @@
+/**
+ * ADS-549 — EmailService provider initialisation must fail loudly in
+ * production when the selected provider is misconfigured or the
+ * EMAIL_PROVIDER env var holds an unknown value. Falling through to the
+ * console provider in production silently consumes every transactional
+ * email (password resets, verification links, legal re-acceptance
+ * reminders), so we exercise both the misconfig and the unknown-provider
+ * paths against a NODE_ENV=production process.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../models/AuditLog', () => ({
+  AuditLog: {
+    create: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../services/auditLog.service', () => ({
+  AuditLogService: {
+    log: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+  loggerHelpers: {
+    logBusiness: vi.fn(),
+    logDatabase: vi.fn(),
+    logPerformance: vi.fn(),
+    logExternalService: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/email-providers/resend-provider', () => ({
+  ResendProvider: vi.fn().mockImplementation(() => ({
+    validateConfiguration: () => false,
+    getName: () => 'resend',
+  })),
+}));
+
+vi.mock('../../services/email-providers/console-provider', () => ({
+  ConsoleEmailProvider: vi.fn().mockImplementation(() => ({
+    validateConfiguration: () => true,
+    getName: () => 'console',
+  })),
+}));
+
+vi.mock('../../services/email-providers/ethereal-provider', () => ({
+  EtherealProvider: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    validateConfiguration: () => true,
+    getName: () => 'ethereal',
+  })),
+}));
+
+vi.mock('../../config', () => ({
+  config: {
+    email: {
+      provider: 'resend',
+      from: 'noreply@example.com',
+      resend: { apiKey: '', fromEmail: '', fromName: '', replyTo: '' },
+    },
+  },
+}));
+
+const flushAsync = () => new Promise(resolve => setImmediate(resolve));
+
+const importEmailService = async () => {
+  // Reset module cache so the mocked `config.email.provider` value is
+  // read freshly each test (the EmailService constructor reads it once).
+  vi.resetModules();
+  const mod = await import('../../services/email.service');
+  return mod.EmailService;
+};
+
+describe('EmailService provider initialisation [ADS-549]', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? ''}) called`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    exitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('exits non-zero when Resend is misconfigured in production', async () => {
+    process.env.NODE_ENV = 'production';
+    const EmailService = await importEmailService();
+    new EmailService();
+    await flushAsync();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('falls back to console in non-production without exiting', async () => {
+    process.env.NODE_ENV = 'development';
+    const EmailService = await importEmailService();
+    new EmailService();
+    await flushAsync();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits non-zero in production when EMAIL_PROVIDER is an unknown value', async () => {
+    process.env.NODE_ENV = 'production';
+    vi.doMock('../../config', () => ({
+      config: {
+        email: {
+          provider: 'sendgrid-typo',
+          from: 'noreply@example.com',
+          resend: { apiKey: 'x', fromEmail: 'x@example.com' },
+        },
+      },
+    }));
+    const EmailService = await importEmailService();
+    new EmailService();
+    await flushAsync();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    vi.doUnmock('../../config');
+  });
+});

--- a/service.backend/src/__tests__/services/email-provider-init.test.ts
+++ b/service.backend/src/__tests__/services/email-provider-init.test.ts
@@ -7,7 +7,32 @@
  * reminders), so we exercise both the misconfig and the unknown-provider
  * paths against a NODE_ENV=production process.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The global setup-tests.ts mocks `./services/email.service` for every
+// other test in the suite (only the `default` export, no EmailService
+// class). This test exercises the real class, so unmock it explicitly.
+vi.unmock('../../services/email.service');
+
+// Stub the secret env-vars so `validateEnv` in `config/env.ts` succeeds
+// when the EmailService import pulls config in. Real-shape values
+// (length-validated) so the validator doesn't throw at module load.
+beforeAll(() => {
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'a'.repeat(64);
+  process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET ?? 'b'.repeat(64);
+  process.env.SESSION_SECRET = process.env.SESSION_SECRET ?? 'c'.repeat(64);
+  process.env.CSRF_SECRET = process.env.CSRF_SECRET ?? 'd'.repeat(64);
+  process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY ?? 'e'.repeat(64);
+  // DB name stubs for whichever NODE_ENV the test resets the modules
+  // under — sequelize.ts checks the matching `<ENV>_DB_NAME`.
+  process.env.DEV_DB_NAME = process.env.DEV_DB_NAME ?? 'ads_dev';
+  process.env.TEST_DB_NAME = process.env.TEST_DB_NAME ?? 'ads_test';
+  process.env.PROD_DB_NAME = process.env.PROD_DB_NAME ?? 'ads_prod';
+  process.env.DB_USERNAME = process.env.DB_USERNAME ?? 'ads';
+  process.env.DB_PASSWORD = process.env.DB_PASSWORD ?? 'ads';
+  process.env.DB_HOST = process.env.DB_HOST ?? 'localhost';
+  process.env.DB_PORT = process.env.DB_PORT ?? '5432';
+});
 
 vi.mock('../../models/AuditLog', () => ({
   AuditLog: {
@@ -43,26 +68,45 @@ vi.mock('../../utils/logger', () => ({
   },
 }));
 
+// Provider mocks are classes (the production code uses `new X()`).
+class MockResendProvider {
+  validateConfiguration() {
+    return false;
+  }
+  getName() {
+    return 'resend';
+  }
+}
+class MockConsoleProvider {
+  validateConfiguration() {
+    return true;
+  }
+  getName() {
+    return 'console';
+  }
+}
+class MockEtherealProvider {
+  async initialize(): Promise<void> {
+    return undefined;
+  }
+  validateConfiguration() {
+    return true;
+  }
+  getName() {
+    return 'ethereal';
+  }
+}
+
 vi.mock('../../services/email-providers/resend-provider', () => ({
-  ResendProvider: vi.fn().mockImplementation(() => ({
-    validateConfiguration: () => false,
-    getName: () => 'resend',
-  })),
+  ResendProvider: MockResendProvider,
 }));
 
 vi.mock('../../services/email-providers/console-provider', () => ({
-  ConsoleEmailProvider: vi.fn().mockImplementation(() => ({
-    validateConfiguration: () => true,
-    getName: () => 'console',
-  })),
+  ConsoleEmailProvider: MockConsoleProvider,
 }));
 
 vi.mock('../../services/email-providers/ethereal-provider', () => ({
-  EtherealProvider: vi.fn().mockImplementation(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    validateConfiguration: () => true,
-    getName: () => 'ethereal',
-  })),
+  EtherealProvider: MockEtherealProvider,
 }));
 
 vi.mock('../../config', () => ({
@@ -90,8 +134,10 @@ describe('EmailService provider initialisation [ADS-549]', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new Error(`process.exit(${code ?? ''}) called`);
+    // No-op exit so the constructor's `.catch` returns cleanly. The
+    // spy still records the call so we can assert on it.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      return undefined;
     }) as never);
   });
 

--- a/service.backend/src/__tests__/services/legal-content.test.ts
+++ b/service.backend/src/__tests__/services/legal-content.test.ts
@@ -6,13 +6,13 @@ import { beforeEach, describe, it, expect, vi } from 'vitest';
 // before importing it.
 vi.unmock('fs');
 
-// AuditLog is the storage for ToS / Privacy acceptance (see
-// consent.service.ts). The pending-re-acceptance behaviour is purely
-// derived from the latest CONSENT_RECORDED row, so a mocked findOne
-// is sufficient and keeps the test free of DB setup.
+// AuditLog is the storage for ToS / Privacy / cookies acceptance (see
+// consent.service.ts). ADS-550: getPendingReacceptance now walks
+// CONSENT_RECORDED rows newest-first to find each document's last
+// accepted version, so the test mocks `findAll` returning an array.
 vi.mock('../../models/AuditLog', () => ({
-  default: { findOne: vi.fn() },
-  AuditLog: { findOne: vi.fn() },
+  default: { findAll: vi.fn() },
+  AuditLog: { findAll: vi.fn() },
   withAuditMutationAllowed: vi.fn(),
 }));
 
@@ -27,7 +27,7 @@ import {
   TERMS_VERSION,
 } from '../../services/legal-content.service';
 
-const mockFindOne = vi.mocked(AuditLog.findOne);
+const mockFindAll = vi.mocked(AuditLog.findAll);
 
 describe('legal content service', () => {
   it('returns terms with version + markdown content', () => {
@@ -63,7 +63,7 @@ describe('legal content service', () => {
 
 describe('legal content service — getPendingReacceptance', () => {
   beforeEach(() => {
-    mockFindOne.mockReset();
+    mockFindAll.mockReset();
   });
 
   const buildAuditRow = (
@@ -75,7 +75,7 @@ describe('legal content service — getPendingReacceptance', () => {
   });
 
   it('returns terms, privacy, and cookies as pending when the user has never recorded consent', async () => {
-    mockFindOne.mockResolvedValue(null);
+    mockFindAll.mockResolvedValue([]);
 
     const result = await getPendingReacceptance('user-without-history');
 
@@ -89,14 +89,14 @@ describe('legal content service — getPendingReacceptance', () => {
   });
 
   it('returns an empty list when the user accepted the exact current versions for every tracked document', async () => {
-    mockFindOne.mockResolvedValue(
+    mockFindAll.mockResolvedValue([
       buildAuditRow({
         tosVersion: TERMS_VERSION,
         privacyVersion: PRIVACY_VERSION,
         cookiesVersion: COOKIES_VERSION,
         acceptedAt: '2026-04-01T12:00:00Z',
       })
-    );
+    ]);
 
     const result = await getPendingReacceptance('user-up-to-date');
 
@@ -104,14 +104,14 @@ describe('legal content service — getPendingReacceptance', () => {
   });
 
   it('flags only the documents whose accepted version is older than the current version', async () => {
-    mockFindOne.mockResolvedValue(
+    mockFindAll.mockResolvedValue([
       buildAuditRow({
         tosVersion: '2025-01-01-v1',
         privacyVersion: PRIVACY_VERSION,
         cookiesVersion: COOKIES_VERSION,
         acceptedAt: '2025-02-01T00:00:00Z',
       })
-    );
+    ]);
 
     const result = await getPendingReacceptance('user-stale-tos');
 
@@ -125,14 +125,14 @@ describe('legal content service — getPendingReacceptance', () => {
   });
 
   it('flags cookies as pending when the user accepted an older cookies version', async () => {
-    mockFindOne.mockResolvedValue(
+    mockFindAll.mockResolvedValue([
       buildAuditRow({
         tosVersion: TERMS_VERSION,
         privacyVersion: PRIVACY_VERSION,
         cookiesVersion: '2025-01-01-cookies-v1',
         acceptedAt: '2025-02-01T00:00:00Z',
       })
-    );
+    ]);
 
     const result = await getPendingReacceptance('user-stale-cookies');
 
@@ -150,13 +150,13 @@ describe('legal content service — getPendingReacceptance', () => {
     // Until that gap is closed, every existing user will surface
     // cookies as pending — this test pins that behaviour so the
     // shape is stable for the frontend modal.
-    mockFindOne.mockResolvedValue(
+    mockFindAll.mockResolvedValue([
       buildAuditRow({
         tosVersion: TERMS_VERSION,
         privacyVersion: PRIVACY_VERSION,
         acceptedAt: '2026-04-01T12:00:00Z',
       })
-    );
+    ]);
 
     const result = await getPendingReacceptance('user-pre-cookies-capture');
 
@@ -171,7 +171,7 @@ describe('legal content service — getPendingReacceptance', () => {
 
   it('falls back to the audit row timestamp when acceptedAt is missing from the details', async () => {
     const ts = new Date('2025-06-15T10:30:00Z');
-    mockFindOne.mockResolvedValue(
+    mockFindAll.mockResolvedValue([
       buildAuditRow(
         {
           tosVersion: '2025-01-01-v1',
@@ -180,7 +180,7 @@ describe('legal content service — getPendingReacceptance', () => {
         },
         ts
       )
-    );
+    ]);
 
     const result = await getPendingReacceptance('user-no-acceptedAt');
 
@@ -189,7 +189,7 @@ describe('legal content service — getPendingReacceptance', () => {
   });
 
   it('treats malformed audit metadata as no prior acceptance', async () => {
-    mockFindOne.mockResolvedValue({ metadata: 'not-an-object', timestamp: new Date() });
+    mockFindAll.mockResolvedValue([{ metadata: 'not-an-object', timestamp: new Date() }]);
 
     const result = await getPendingReacceptance('user-broken-metadata');
 

--- a/service.backend/src/__tests__/services/legal-content.test.ts
+++ b/service.backend/src/__tests__/services/legal-content.test.ts
@@ -95,7 +95,7 @@ describe('legal content service — getPendingReacceptance', () => {
         privacyVersion: PRIVACY_VERSION,
         cookiesVersion: COOKIES_VERSION,
         acceptedAt: '2026-04-01T12:00:00Z',
-      })
+      }),
     ]);
 
     const result = await getPendingReacceptance('user-up-to-date');
@@ -110,7 +110,7 @@ describe('legal content service — getPendingReacceptance', () => {
         privacyVersion: PRIVACY_VERSION,
         cookiesVersion: COOKIES_VERSION,
         acceptedAt: '2025-02-01T00:00:00Z',
-      })
+      }),
     ]);
 
     const result = await getPendingReacceptance('user-stale-tos');
@@ -131,7 +131,7 @@ describe('legal content service — getPendingReacceptance', () => {
         privacyVersion: PRIVACY_VERSION,
         cookiesVersion: '2025-01-01-cookies-v1',
         acceptedAt: '2025-02-01T00:00:00Z',
-      })
+      }),
     ]);
 
     const result = await getPendingReacceptance('user-stale-cookies');
@@ -155,7 +155,7 @@ describe('legal content service — getPendingReacceptance', () => {
         tosVersion: TERMS_VERSION,
         privacyVersion: PRIVACY_VERSION,
         acceptedAt: '2026-04-01T12:00:00Z',
-      })
+      }),
     ]);
 
     const result = await getPendingReacceptance('user-pre-cookies-capture');
@@ -179,7 +179,7 @@ describe('legal content service — getPendingReacceptance', () => {
           cookiesVersion: COOKIES_VERSION,
         },
         ts
-      )
+      ),
     ]);
 
     const result = await getPendingReacceptance('user-no-acceptedAt');

--- a/service.backend/src/__tests__/services/legal-reminder-cron.test.ts
+++ b/service.backend/src/__tests__/services/legal-reminder-cron.test.ts
@@ -249,7 +249,13 @@ describe('legal reminder cron - runLegalReminderCron', () => {
     expect(mockSend.mock.calls[99][0].userId).toBe('u99');
   });
 
-  it('excludes users who were reminded inside the rate-limit window from the candidate query', async () => {
+  it('no longer pre-filters by audit_logs (ADS-551 — relies on per-user wasRecentlyReminded)', async () => {
+    // The candidate query MUST not bind a user-id-shaped exclusion list.
+    // Pre-fetching every recently-reminded user from audit_logs and
+    // passing the array to `Op.notIn` OOMs the worker / overflows
+    // Postgres bind-parameter limits at scale — see ADS-551 worker
+    // comment. The per-user wasRecentlyReminded check inside
+    // sendReacceptanceReminder is the only dedupe path now.
     mockAuditFindAll.mockResolvedValue([
       { user: 'recently-reminded-1' } as never,
       { user: 'recently-reminded-2' } as never,
@@ -258,12 +264,14 @@ describe('legal reminder cron - runLegalReminderCron', () => {
 
     await runLegalReminderCron({ dryRun: false });
 
+    // The cron should not have read audit_logs at all during candidate
+    // selection.
+    expect(mockAuditFindAll).not.toHaveBeenCalled();
+
     const userWhereCall = mockUserFindAll.mock.calls[0][0];
     const where = userWhereCall?.where as Record<string, unknown>;
-    const userIdClause = where.userId as Record<symbol, unknown[]>;
-    expect(userIdClause).toBeDefined();
-    const symbols = Object.getOwnPropertySymbols(userIdClause);
-    expect(symbols).toHaveLength(1);
-    expect(userIdClause[symbols[0]]).toEqual(['recently-reminded-1', 'recently-reminded-2']);
+    // No userId clause — only the status filter.
+    expect(where.userId).toBeUndefined();
+    expect(where.status).toBeDefined();
   });
 });

--- a/service.backend/src/config/env.ts
+++ b/service.backend/src/config/env.ts
@@ -26,6 +26,8 @@ type RequiredEnvVars = {
   REDIS_URL?: string;
   JWT_REPORT_SHARE_SECRET?: string;
   WORKER_ENABLED?: string;
+  DB_SSL_MODE?: string;
+  ALLOW_INSECURE_DB?: string;
 };
 
 type ValidatedEnv = {
@@ -49,6 +51,44 @@ type ValidatedEnv = {
   REDIS_URL?: string;
   JWT_REPORT_SHARE_SECRET?: string;
   WORKER_ENABLED?: string;
+  DB_SSL_MODE?: string;
+  ALLOW_INSECURE_DB?: string;
+};
+
+export type DbSslMode = 'disable' | 'require' | 'verify-ca' | 'verify-full';
+
+const DB_SSL_MODES: readonly DbSslMode[] = ['disable', 'require', 'verify-ca', 'verify-full'];
+
+/**
+ * Resolve the effective DB SSL mode for the current process.
+ *
+ * Production defaults to `require` so a plaintext link to the database is
+ * never the silent path of least resistance. To opt out of TLS in
+ * production (e.g. for an in-cluster Postgres on a trusted bridge), set
+ * BOTH `DB_SSL_MODE=disable` AND `ALLOW_INSECURE_DB=true`. Either alone
+ * fails boot — mirrors the DEBUG_ERRORS gate in `index.ts`.
+ */
+export const resolveDbSslMode = (
+  nodeEnv: string | undefined,
+  rawMode: string | undefined,
+  allowInsecure: string | undefined
+): DbSslMode => {
+  const trimmed = rawMode?.trim().toLowerCase();
+  if (trimmed && !DB_SSL_MODES.includes(trimmed as DbSslMode)) {
+    throw new Error(
+      `Invalid DB_SSL_MODE: "${rawMode}". Expected one of: ${DB_SSL_MODES.join(', ')}.`
+    );
+  }
+  const mode = (trimmed as DbSslMode | undefined) ?? (nodeEnv === 'production' ? 'require' : 'disable');
+
+  if (nodeEnv === 'production' && mode === 'disable' && allowInsecure !== 'true') {
+    throw new Error(
+      'DB_SSL_MODE=disable is not allowed in production. Set DB_SSL_MODE to require/verify-ca/verify-full, ' +
+        'or explicitly opt out by setting ALLOW_INSECURE_DB=true (only safe on a fully trusted network).'
+    );
+  }
+
+  return mode;
 };
 
 /**
@@ -215,7 +255,14 @@ const validateEnv = (): ValidatedEnv => {
     REDIS_URL: process.env.REDIS_URL,
     JWT_REPORT_SHARE_SECRET: process.env.JWT_REPORT_SHARE_SECRET,
     WORKER_ENABLED: process.env.WORKER_ENABLED,
+    DB_SSL_MODE: process.env.DB_SSL_MODE,
+    ALLOW_INSECURE_DB: process.env.ALLOW_INSECURE_DB,
   };
+
+  // ADS-540: refuse to boot in production with no TLS to the database
+  // unless explicitly opted-out. Runs after the secret validation so the
+  // error ordering matches operator expectations.
+  resolveDbSslMode(validated.NODE_ENV, validated.DB_SSL_MODE, validated.ALLOW_INSECURE_DB);
 
   return validated;
 };

--- a/service.backend/src/config/env.ts
+++ b/service.backend/src/config/env.ts
@@ -79,7 +79,8 @@ export const resolveDbSslMode = (
       `Invalid DB_SSL_MODE: "${rawMode}". Expected one of: ${DB_SSL_MODES.join(', ')}.`
     );
   }
-  const mode = (trimmed as DbSslMode | undefined) ?? (nodeEnv === 'production' ? 'require' : 'disable');
+  const mode =
+    (trimmed as DbSslMode | undefined) ?? (nodeEnv === 'production' ? 'require' : 'disable');
 
   if (nodeEnv === 'production' && mode === 'disable' && allowInsecure !== 'true') {
     throw new Error(

--- a/service.backend/src/controllers/auth.controller.ts
+++ b/service.backend/src/controllers/auth.controller.ts
@@ -56,17 +56,16 @@ export const authValidation = {
 
 export class AuthController {
   /**
-   * Register a new user
+   * Register a new user.
+   *
+   * ADS-538: returns 201 with no auth tokens / cookies. The user must
+   * verify their email and then log in normally before they can call
+   * authenticated endpoints.
    */
   async register(req: Request, res: Response): Promise<void> {
     try {
       const result = await AuthService.register(req.body);
-
-      res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
-      res.cookie(ACCESS_TOKEN_COOKIE, result.token, ACCESS_TOKEN_COOKIE_OPTIONS);
-
-      const { refreshToken: _, ...responseBody } = result;
-      res.status(201).json(responseBody);
+      res.status(201).json(result);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       logger.error('Registration failed:', error);

--- a/service.backend/src/middleware/auth.ts
+++ b/service.backend/src/middleware/auth.ts
@@ -109,6 +109,16 @@ const authenticateRequest = async (token: string): Promise<User> => {
     throw new AuthError(401, 'ACCOUNT_INACTIVE', 'Account is not active');
   }
 
+  // ADS-538: defence in depth. Even if a future code path activates a
+  // user pre-verification, an unverified-email account must not be able
+  // to ride an auth token through this middleware. The status check
+  // above already blocks `PENDING_VERIFICATION`, but coupling the
+  // security invariant to `emailVerified` directly makes the intent
+  // explicit and survives status-enum changes.
+  if (!user.emailVerified) {
+    throw new AuthError(401, 'EMAIL_NOT_VERIFIED', 'Email not verified');
+  }
+
   await attachRescueAffiliation(user);
   return user;
 };

--- a/service.backend/src/routes/privacy.routes.ts
+++ b/service.backend/src/routes/privacy.routes.ts
@@ -2,7 +2,14 @@ import { Router, type Response } from 'express';
 import { z } from 'zod';
 import { authenticateToken } from '../middleware/auth';
 import { validateBody } from '../middleware/zod-validate';
-import { ConsentInputSchema, recordConsent, type ConsentInput } from '../services/consent.service';
+import {
+  ConsentInputSchema,
+  CookiesConsentInputSchema,
+  recordConsent,
+  recordCookiesConsent,
+  type ConsentInput,
+  type CookiesConsentInput,
+} from '../services/consent.service';
 import { exportUserData } from '../services/data-export.service';
 import { requestAccountDeletion } from '../services/data-deletion.service';
 import type { AuthenticatedRequest } from '../types/auth';
@@ -54,6 +61,41 @@ router.post(
       });
       res.status(400).json({
         error: error instanceof Error ? error.message : 'Failed to record consent',
+      });
+    }
+  }
+);
+
+/**
+ * ADS-550: cookies-only consent. Separate from /consent so the audit
+ * row written by the on-page cookie banner does NOT carry the
+ * currently-published ToS / Privacy versions (which would silently
+ * consume any pending re-acceptance for those documents).
+ */
+router.post(
+  '/cookies-consent',
+  validateBody(CookiesConsentInputSchema),
+  async (req: AuthenticatedRequest, res: Response) => {
+    const userId = req.user?.userId;
+    if (!userId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+
+    try {
+      const record = await recordCookiesConsent(req.body as CookiesConsentInput, {
+        userId,
+        ip: req.ip ?? null,
+        userAgent: req.get('User-Agent') ?? null,
+      });
+      res.status(201).json({ data: record });
+    } catch (error) {
+      logger.error('Cookies consent capture failed', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.status(400).json({
+        error: error instanceof Error ? error.message : 'Failed to record cookies consent',
       });
     }
   }

--- a/service.backend/src/sequelize.ts
+++ b/service.backend/src/sequelize.ts
@@ -1,6 +1,6 @@
 import * as dotenv from 'dotenv';
 import { Sequelize, DataTypes } from 'sequelize';
-import { env, getDatabaseName } from './config/env';
+import { env, getDatabaseName, resolveDbSslMode, DbSslMode } from './config/env';
 import { logger } from './utils/logger';
 
 dotenv.config();
@@ -50,9 +50,35 @@ export const buildTimeoutConfig = (): TimeoutConfig => ({
   idleInTransactionSessionTimeoutMs: parseIntEnv('DB_IDLE_IN_TRANSACTION_TIMEOUT_MS', 60000),
 });
 
+/**
+ * Build the `pg`-shaped SSL config from a DB_SSL_MODE value (ADS-540).
+ *
+ * The `pg` driver accepts `false` (no TLS) or an object that maps onto
+ * libpq sslmode values:
+ *   - require:     TLS, no cert verification
+ *   - verify-ca:   TLS, verify CA but not hostname
+ *   - verify-full: TLS, verify CA + hostname
+ *
+ * For managed providers (RDS / Neon / Supabase) mount the provider's CA
+ * bundle into the container and set `DB_SSL_ROOT_CERT` to its path, then
+ * use `verify-full`.
+ */
+export const buildSslConfig = (mode: DbSslMode): false | { rejectUnauthorized: boolean; ca?: string } => {
+  if (mode === 'disable') {
+    return false;
+  }
+  const ca = process.env.DB_SSL_ROOT_CERT;
+  if (mode === 'require') {
+    return { rejectUnauthorized: false };
+  }
+  // verify-ca / verify-full — both require certificate validation.
+  return ca ? { rejectUnauthorized: true, ca } : { rejectUnauthorized: true };
+};
+
 export const logEffectiveDbConfig = (
   pool: PoolConfig,
   timeouts: TimeoutConfig,
+  sslMode: DbSslMode = 'disable',
   log: (message: string) => void = msg => {
     // eslint-disable-next-line no-console
     console.log(msg);
@@ -62,7 +88,8 @@ export const logEffectiveDbConfig = (
     `[db] pool max=${pool.max} min=${pool.min} acquireMs=${pool.acquire} idleMs=${pool.idle} ` +
       `statementTimeoutMs=${timeouts.statementTimeoutMs} ` +
       `lockTimeoutMs=${timeouts.lockTimeoutMs} ` +
-      `idleInTransactionSessionTimeoutMs=${timeouts.idleInTransactionSessionTimeoutMs}`
+      `idleInTransactionSessionTimeoutMs=${timeouts.idleInTransactionSessionTimeoutMs} ` +
+      `sslMode=${sslMode}`
   );
 };
 
@@ -126,6 +153,8 @@ const databaseUrl = isTestEnvironment ? '' : getDatabaseUrl();
 
 const poolConfig = buildPoolConfig();
 const timeoutConfig = buildTimeoutConfig();
+const dbSslMode = resolveDbSslMode(env.NODE_ENV, env.DB_SSL_MODE, env.ALLOW_INSECURE_DB);
+const sslConfig = buildSslConfig(dbSslMode);
 
 const sequelize = isTestEnvironment
   ? new Sequelize('sqlite::memory:', {
@@ -169,6 +198,11 @@ const sequelize = isTestEnvironment
         statement_timeout: timeoutConfig.statementTimeoutMs,
         lock_timeout: timeoutConfig.lockTimeoutMs,
         idle_in_transaction_session_timeout: timeoutConfig.idleInTransactionSessionTimeoutMs,
+        // ADS-540: enforce TLS on the DB link. `disable` returns `false`
+        // so the `pg` driver opens a plaintext socket explicitly — the
+        // env guard in `config/env.ts` blocks that path in production
+        // unless ALLOW_INSECURE_DB=true is also set.
+        ssl: sslConfig,
       },
       logging:
         process.env.DB_LOGGING === 'true'
@@ -183,7 +217,7 @@ const sequelize = isTestEnvironment
     });
 
 if (!isTestEnvironment) {
-  logEffectiveDbConfig(poolConfig, timeoutConfig);
+  logEffectiveDbConfig(poolConfig, timeoutConfig, dbSslMode);
 }
 
 /**

--- a/service.backend/src/sequelize.ts
+++ b/service.backend/src/sequelize.ts
@@ -63,7 +63,9 @@ export const buildTimeoutConfig = (): TimeoutConfig => ({
  * bundle into the container and set `DB_SSL_ROOT_CERT` to its path, then
  * use `verify-full`.
  */
-export const buildSslConfig = (mode: DbSslMode): false | { rejectUnauthorized: boolean; ca?: string } => {
+export const buildSslConfig = (
+  mode: DbSslMode
+): false | { rejectUnauthorized: boolean; ca?: string } => {
   if (mode === 'disable') {
     return false;
   }

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -29,9 +29,7 @@ export class AuthService {
   private static readonly JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
   private static readonly JWT_REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN || '3d';
 
-  static async register(
-    userData: RegisterData
-  ): Promise<{ user: Partial<User>; message: string }> {
+  static async register(userData: RegisterData): Promise<{ user: Partial<User>; message: string }> {
     try {
       // Check if user already exists
       const existingUser = await User.findOne({ where: { email: userData.email.toLowerCase() } });

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -29,7 +29,9 @@ export class AuthService {
   private static readonly JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '15m';
   private static readonly JWT_REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN || '3d';
 
-  static async register(userData: RegisterData): Promise<AuthResponse> {
+  static async register(
+    userData: RegisterData
+  ): Promise<{ user: Partial<User>; message: string }> {
     try {
       // Check if user already exists
       const existingUser = await User.findOne({ where: { email: userData.email.toLowerCase() } });
@@ -148,18 +150,16 @@ export class AuthService {
         }
       }
 
-      // Generate tokens with rotation support
-      const tokenId = crypto.randomUUID();
-      const familyId = crypto.randomUUID();
-      const tokens = await this.generateTokens(
-        { userId: user.userId, email: user.email, userType: UserType.ADOPTER },
-        tokenId
-      );
-      await this.storeRefreshToken(user.userId, tokenId, familyId);
-
+      // ADS-538: registration MUST NOT return tokens. The verification
+      // email is the only out-of-band channel proving the user owns the
+      // address — issuing a session here makes "verify email" a polite
+      // suggestion rather than an enrolment gate, and lets account-creation
+      // bots get a working session against authenticated endpoints
+      // without ever owning the email. Clients must direct the user to
+      // `/verify-email`, then log in normally once verified.
       return {
         user: this.sanitizeUser(user),
-        ...tokens,
+        message: 'Registration successful. Please check your email to verify your account.',
       };
     } catch (error) {
       logger.error('Registration failed:', {

--- a/service.backend/src/services/consent.service.ts
+++ b/service.backend/src/services/consent.service.ts
@@ -135,3 +135,59 @@ export const recordConsent = async (
     acceptedAt: acceptedAt.toISOString(),
   };
 };
+
+/**
+ * ADS-550: cookies-only consent capture.
+ *
+ * The cookie banner triggers acceptance of the cookies policy (and an
+ * optional analytics opt-in) without the user touching ToS or Privacy.
+ * Routing this through `recordConsent` would write a CONSENT_RECORDED
+ * audit row with the currently-published `tosVersion`/`privacyVersion`,
+ * silently consuming any pending re-acceptance for those documents.
+ *
+ * This dedicated path writes a `CONSENT_RECORDED` row containing only
+ * `cookiesVersion` + `analyticsConsent` in the details. `tosVersion` and
+ * `privacyVersion` are deliberately absent so
+ * `getPendingReacceptance` picks them up from the last row that
+ * actually contained them.
+ */
+export const CookiesConsentInputSchema = z.object({
+  cookiesVersion: z.string().optional(),
+  analyticsConsent: z.boolean().optional(),
+});
+export type CookiesConsentInput = z.infer<typeof CookiesConsentInputSchema>;
+
+export type CookiesConsentRecord = {
+  cookiesVersion: string;
+  analyticsConsent: boolean;
+  acceptedAt: string;
+};
+
+export const recordCookiesConsent = async (
+  input: CookiesConsentInput,
+  context: ConsentContext
+): Promise<CookiesConsentRecord> => {
+  const cookiesVersion = input.cookiesVersion ?? COOKIES_VERSION;
+  const analyticsConsent = input.analyticsConsent ?? false;
+  const acceptedAt = new Date();
+
+  await AuditLogService.log({
+    userId: context.userId,
+    action: 'CONSENT_RECORDED',
+    entity: 'User',
+    entityId: context.userId,
+    details: {
+      cookiesVersion,
+      analyticsConsent,
+      acceptedAt: acceptedAt.toISOString(),
+    },
+    ipAddress: context.ip ?? undefined,
+    userAgent: context.userAgent ?? undefined,
+  });
+
+  return {
+    cookiesVersion,
+    analyticsConsent,
+    acceptedAt: acceptedAt.toISOString(),
+  };
+};

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -46,7 +46,7 @@ class EmailService {
     this.initializeProvider().catch(error => {
       logger.error('Failed to initialize email provider:', error);
       if (process.env.NODE_ENV === 'production') {
-        // eslint-disable-next-line n/no-process-exit
+        // eslint-disable-next-line no-process-exit -- prod must crash so the orchestrator surfaces the misconfig; throwing here is swallowed because we're inside an async catch
         process.exit(1);
       }
     });

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -10,6 +10,7 @@ import EmailTemplate, {
 } from '../models/EmailTemplate';
 import { JsonObject, JsonValue, TemplateData, TemplateVariable } from '../types/common';
 import { BulkEmailOptions, EmailAnalytics, SendEmailOptions } from '../types/email';
+import { AuditLog } from '../models/AuditLog';
 import logger, { loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
 import { EmailProvider } from './email-providers/base-provider';
@@ -34,51 +35,111 @@ class EmailService {
     // Initialize with console provider as default
     this.provider = new ConsoleEmailProvider();
 
-    // Initialize the appropriate provider asynchronously
+    // Initialize the appropriate provider asynchronously.
+    //
+    // ADS-549: in production we must NOT silently fall back to the console
+    // provider — every transactional email (password resets, verification
+    // links, legal re-acceptance reminders) would disappear into stdout
+    // with no alert. The orchestrator can only see the failure if the
+    // process exits, so we exit non-zero here and let the deploy roll
+    // back / surface a CrashLoopBackoff instead.
     this.initializeProvider().catch(error => {
       logger.error('Failed to initialize email provider:', error);
+      if (process.env.NODE_ENV === 'production') {
+        // eslint-disable-next-line n/no-process-exit
+        process.exit(1);
+      }
     });
 
     // Don't start queue processor in constructor - wait for database to be ready
   }
 
   private async initializeProvider(): Promise<void> {
-    try {
-      switch (config.email.provider) {
-        case 'ethereal': {
-          const etherealProvider = new EtherealProvider();
-          await etherealProvider.initialize();
-          this.provider = etherealProvider;
-          break;
-        }
-        case 'resend': {
-          const resendProvider = new ResendProvider({
-            apiKey: config.email.resend.apiKey ?? '',
-            fromEmail: config.email.resend.fromEmail ?? config.email.from,
-            fromName: config.email.resend.fromName,
-            replyTo: config.email.resend.replyTo,
-          });
-          if (!resendProvider.validateConfiguration()) {
-            throw new Error(
-              'Resend provider misconfigured: RESEND_API_KEY and RESEND_FROM_EMAIL are required'
-            );
-          }
-          this.provider = resendProvider;
-          break;
-        }
-        default:
-          // Fallback to console provider
-          this.provider = new ConsoleEmailProvider();
-      }
+    const requestedProvider = config.email.provider;
+    const isProduction = process.env.NODE_ENV === 'production';
 
-      loggerHelpers.logExternalService('Email Provider', 'Provider Initialized', {
-        provider: config.email.provider,
-        environment: process.env.NODE_ENV,
-      });
-    } catch (error) {
-      logger.error('Failed to initialize email provider, falling back to console:', error);
+    // ADS-549: validate the requested provider up front. An unknown value
+    // (typo, retired provider, mis-rendered template) must not silently
+    // fall through to the console provider in production.
+    const knownProviders = new Set(['console', 'ethereal', 'resend']);
+    if (!knownProviders.has(requestedProvider)) {
+      const message =
+        `Unknown EMAIL_PROVIDER value: "${requestedProvider}". ` +
+        `Expected one of: ${[...knownProviders].join(', ')}.`;
+      if (isProduction) {
+        throw new Error(message);
+      }
+      logger.warn(`${message} Falling back to console provider for non-production.`);
       this.provider = new ConsoleEmailProvider();
+      this.logProviderInitialized('console');
+      return;
     }
+
+    // ADS-549: per-provider initialisation. Misconfiguration of the
+    // selected provider re-throws so the constructor's catch can exit
+    // the process in production — see comment there.
+    switch (requestedProvider) {
+      case 'ethereal': {
+        const etherealProvider = new EtherealProvider();
+        await etherealProvider.initialize();
+        this.provider = etherealProvider;
+        break;
+      }
+      case 'resend': {
+        const resendProvider = new ResendProvider({
+          apiKey: config.email.resend.apiKey ?? '',
+          fromEmail: config.email.resend.fromEmail ?? config.email.from,
+          fromName: config.email.resend.fromName,
+          replyTo: config.email.resend.replyTo,
+        });
+        if (!resendProvider.validateConfiguration()) {
+          throw new Error(
+            'Resend provider misconfigured: RESEND_API_KEY and RESEND_FROM_EMAIL are required'
+          );
+        }
+        this.provider = resendProvider;
+        break;
+      }
+      case 'console':
+      default:
+        this.provider = new ConsoleEmailProvider();
+        break;
+    }
+
+    this.logProviderInitialized(requestedProvider);
+  }
+
+  /**
+   * Record the active email provider in both logs and the audit trail so
+   * the running configuration is observable post-boot — not just on the
+   * stdout line that scrolled past during startup. Best-effort: an
+   * AuditLog failure here must not block the constructor.
+   */
+  private logProviderInitialized(provider: string): void {
+    loggerHelpers.logExternalService('Email Provider', 'Provider Initialized', {
+      provider,
+      environment: process.env.NODE_ENV,
+    });
+    // System-level audit row (no user actor) — mirror the pattern used by
+    // the legal-reminder worker so the immutable-trigger doesn't reject
+    // the write and so the operator can answer "which provider was
+    // active at deploy time?" by querying audit_logs.
+    AuditLog.create({
+      service: 'adopt-dont-shop-backend',
+      user: null,
+      user_email_snapshot: null,
+      action: 'EMAIL_PROVIDER_INITIALIZED',
+      level: 'INFO',
+      timestamp: new Date(),
+      metadata: {
+        entity: 'EmailService',
+        entityId: 'boot',
+        details: { provider, environment: process.env.NODE_ENV ?? 'unknown' },
+      },
+      category: 'System',
+    }).catch(error => {
+      logger.warn('Failed to write EMAIL_PROVIDER_INITIALIZED audit row', { error });
+    });
   }
 
   // Provider Management

--- a/service.backend/src/services/legal-content.service.ts
+++ b/service.backend/src/services/legal-content.service.ts
@@ -116,34 +116,92 @@ const extractConsentDetails = (metadata: unknown): z.infer<typeof ConsentDetails
   return parsed.success ? parsed.data : {};
 };
 
+/**
+ * ADS-550: walk audit rows newest-first and pick up each document's last
+ * accepted version from the most recent row that actually carried it.
+ *
+ * The previous "only look at the latest row" implementation broke when
+ * the cookie banner started writing CONSENT_RECORDED rows alongside the
+ * registration / re-acceptance-modal rows: a cookies-only audit would
+ * silently consume any pending ToS or Privacy re-acceptance because the
+ * latest row's `tosVersion` was stamped with the currently-published
+ * value even though the user never saw the modal.
+ *
+ * After the fix the cookies-only path no longer writes `tosVersion` /
+ * `privacyVersion`, so we just need to read each field from whichever
+ * row last contained it.
+ */
+const findLatestVersions = (
+  rows: ReadonlyArray<{ metadata: unknown; timestamp: Date | null }>
+): {
+  tosVersion: string | null;
+  privacyVersion: string | null;
+  cookiesVersion: string | null;
+  tosAt: Date | null;
+  privacyAt: Date | null;
+  cookiesAt: Date | null;
+} => {
+  let tosVersion: string | null = null;
+  let privacyVersion: string | null = null;
+  let cookiesVersion: string | null = null;
+  let tosAt: Date | null = null;
+  let privacyAt: Date | null = null;
+  let cookiesAt: Date | null = null;
+
+  for (const row of rows) {
+    const details = extractConsentDetails(row.metadata);
+    if (tosVersion === null && details.tosVersion) {
+      tosVersion = details.tosVersion;
+      tosAt = row.timestamp;
+    }
+    if (privacyVersion === null && details.privacyVersion) {
+      privacyVersion = details.privacyVersion;
+      privacyAt = row.timestamp;
+    }
+    if (cookiesVersion === null && details.cookiesVersion) {
+      cookiesVersion = details.cookiesVersion;
+      cookiesAt = row.timestamp;
+    }
+    if (tosVersion && privacyVersion && cookiesVersion) {
+      break;
+    }
+  }
+
+  return { tosVersion, privacyVersion, cookiesVersion, tosAt, privacyAt, cookiesAt };
+};
+
 export const getPendingReacceptance = async (userId: string): Promise<PendingReacceptance> => {
-  const latest = await AuditLog.findOne({
+  const rows = await AuditLog.findAll({
     where: { user: userId, action: 'CONSENT_RECORDED' },
     order: [['timestamp', 'DESC']],
+    attributes: ['metadata', 'timestamp'],
   });
 
-  const details = latest ? extractConsentDetails(latest.metadata) : {};
-  const lastAcceptedAt = details.acceptedAt ?? latest?.timestamp?.toISOString() ?? null;
+  const versions = findLatestVersions(rows);
 
   const candidates: ReadonlyArray<{
     documentType: LegalDocumentType;
     currentVersion: string;
     lastAcceptedVersion: string | null;
+    lastAcceptedAt: Date | null;
   }> = [
     {
       documentType: 'terms',
       currentVersion: TERMS_VERSION,
-      lastAcceptedVersion: details.tosVersion ?? null,
+      lastAcceptedVersion: versions.tosVersion,
+      lastAcceptedAt: versions.tosAt,
     },
     {
       documentType: 'privacy',
       currentVersion: PRIVACY_VERSION,
-      lastAcceptedVersion: details.privacyVersion ?? null,
+      lastAcceptedVersion: versions.privacyVersion,
+      lastAcceptedAt: versions.privacyAt,
     },
     {
       documentType: 'cookies',
       currentVersion: COOKIES_VERSION,
-      lastAcceptedVersion: details.cookiesVersion ?? null,
+      lastAcceptedVersion: versions.cookiesVersion,
+      lastAcceptedAt: versions.cookiesAt,
     },
   ];
 
@@ -153,7 +211,7 @@ export const getPendingReacceptance = async (userId: string): Promise<PendingRea
       documentType: c.documentType,
       currentVersion: c.currentVersion,
       lastAcceptedVersion: c.lastAcceptedVersion,
-      lastAcceptedAt: c.lastAcceptedVersion ? lastAcceptedAt : null,
+      lastAcceptedAt: c.lastAcceptedVersion ? (c.lastAcceptedAt?.toISOString() ?? null) : null,
     }));
 
   return { pending };

--- a/service.backend/src/services/legal-content.service.ts
+++ b/service.backend/src/services/legal-content.service.ts
@@ -131,36 +131,49 @@ const extractConsentDetails = (metadata: unknown): z.infer<typeof ConsentDetails
  * `privacyVersion`, so we just need to read each field from whichever
  * row last contained it.
  */
+/**
+ * Resolve the effective per-document acceptedAt timestamp from the row
+ * the version came from. Prefer `details.acceptedAt` when the recorder
+ * stamped it (registration / re-acceptance modal both do), and fall
+ * back to the audit row's `timestamp` column when it's missing.
+ */
+const pickAcceptedAt = (
+  details: z.infer<typeof ConsentDetailsSchema>,
+  row: { timestamp: Date | null }
+): string | null => {
+  return details.acceptedAt ?? row.timestamp?.toISOString() ?? null;
+};
+
 const findLatestVersions = (
   rows: ReadonlyArray<{ metadata: unknown; timestamp: Date | null }>
 ): {
   tosVersion: string | null;
   privacyVersion: string | null;
   cookiesVersion: string | null;
-  tosAt: Date | null;
-  privacyAt: Date | null;
-  cookiesAt: Date | null;
+  tosAt: string | null;
+  privacyAt: string | null;
+  cookiesAt: string | null;
 } => {
   let tosVersion: string | null = null;
   let privacyVersion: string | null = null;
   let cookiesVersion: string | null = null;
-  let tosAt: Date | null = null;
-  let privacyAt: Date | null = null;
-  let cookiesAt: Date | null = null;
+  let tosAt: string | null = null;
+  let privacyAt: string | null = null;
+  let cookiesAt: string | null = null;
 
   for (const row of rows) {
     const details = extractConsentDetails(row.metadata);
     if (tosVersion === null && details.tosVersion) {
       tosVersion = details.tosVersion;
-      tosAt = row.timestamp;
+      tosAt = pickAcceptedAt(details, row);
     }
     if (privacyVersion === null && details.privacyVersion) {
       privacyVersion = details.privacyVersion;
-      privacyAt = row.timestamp;
+      privacyAt = pickAcceptedAt(details, row);
     }
     if (cookiesVersion === null && details.cookiesVersion) {
       cookiesVersion = details.cookiesVersion;
-      cookiesAt = row.timestamp;
+      cookiesAt = pickAcceptedAt(details, row);
     }
     if (tosVersion && privacyVersion && cookiesVersion) {
       break;
@@ -183,7 +196,7 @@ export const getPendingReacceptance = async (userId: string): Promise<PendingRea
     documentType: LegalDocumentType;
     currentVersion: string;
     lastAcceptedVersion: string | null;
-    lastAcceptedAt: Date | null;
+    lastAcceptedAt: string | null;
   }> = [
     {
       documentType: 'terms',
@@ -211,7 +224,7 @@ export const getPendingReacceptance = async (userId: string): Promise<PendingRea
       documentType: c.documentType,
       currentVersion: c.currentVersion,
       lastAcceptedVersion: c.lastAcceptedVersion,
-      lastAcceptedAt: c.lastAcceptedVersion ? (c.lastAcceptedAt?.toISOString() ?? null) : null,
+      lastAcceptedAt: c.lastAcceptedVersion ? c.lastAcceptedAt : null,
     }));
 
   return { pending };

--- a/service.backend/src/workers/legal-reminder.worker.ts
+++ b/service.backend/src/workers/legal-reminder.worker.ts
@@ -1,16 +1,10 @@
-import { Op } from 'sequelize';
 import type { Worker } from 'bullmq';
 import { z } from 'zod';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
 import AuditLog from '../models/AuditLog';
 import User, { UserStatus } from '../models/User';
 import { getPendingReacceptance } from '../services/legal-content.service';
-import {
-  LEGACY_LEGAL_REMINDER_SENT_ACTION,
-  REMINDER_RATE_LIMIT_DAYS,
-  TERMS_REACCEPTANCE_REMINDER_ACTION,
-  sendReacceptanceReminder,
-} from '../services/legal-reminder.service';
+import { sendReacceptanceReminder } from '../services/legal-reminder.service';
 import { logger } from '../utils/logger';
 
 /**
@@ -66,52 +60,36 @@ export type RunOptions = {
 };
 
 /**
- * Find users who plausibly need a reminder. We pull active, non-deleted
- * users with an email, then exclude anyone who already received a
- * reacceptance reminder inside the rate-limit window (regardless of
- * fingerprint — the per-fingerprint check still runs inside
- * `sendReacceptanceReminder`).
+ * Find users who plausibly need a reminder: active, non-deleted users
+ * with an email. Dedupe against recent reminders is delegated to the
+ * per-user `wasRecentlyReminded` check inside `sendReacceptanceReminder`
+ * — see the ADS-551 comment in the function body for why the
+ * pre-exclusion against `audit_logs` was removed.
  *
- * The action filter matches both the new `TERMS_REACCEPTANCE_REMINDER`
- * name and the legacy `LEGAL_REMINDER_SENT` name. Audit rows are
- * append-only (PR #344's trigger), so legacy rows can't be renamed —
- * we tolerate both names until every legacy row is older than
- * `REMINDER_RATE_LIMIT_DAYS`.
- *
- * Returns up to `batchSize` userIds. Ordering is stable (createdAt ASC)
- * so the same backlog drains the same way across runs and rotates
- * deterministically.
+ * Returns up to `batchSize × overFetch` userIds. Ordering is stable
+ * (createdAt ASC) so the same backlog drains the same way across runs
+ * and rotates deterministically.
  */
 const findCandidateUserIds = async (batchSize: number): Promise<ReadonlyArray<string>> => {
-  const cutoff = new Date(Date.now() - REMINDER_RATE_LIMIT_DAYS * 24 * 60 * 60 * 1000);
-
-  const recentlyReminded = await AuditLog.findAll({
-    where: {
-      action: {
-        [Op.in]: [TERMS_REACCEPTANCE_REMINDER_ACTION, LEGACY_LEGAL_REMINDER_SENT_ACTION],
-      },
-      timestamp: { [Op.gte]: cutoff },
-    },
-    attributes: ['user'],
-  });
-  const excludedUserIds = recentlyReminded
-    .map(row => row.user)
-    .filter((u): u is string => typeof u === 'string' && u.length > 0);
-
-  const where: Record<string, unknown> = {
-    status: UserStatus.ACTIVE,
-  };
-  if (excludedUserIds.length > 0) {
-    where.userId = { [Op.notIn]: excludedUserIds };
-  }
-
-  // Over-fetch slightly so that `sendReacceptanceReminder` returning
-  // `no_pending_versions` (user is already up to date) doesn't shrink
-  // the effective batch below the cap. Keeping the multiplier small —
-  // we don't want to scan the whole user table.
+  // ADS-551: previously we pre-fetched every recently-reminded user from
+  // audit_logs and passed the IDs to `User.findAll` via `Op.notIn`. That
+  // approach loads N rows into memory (one per recent reminder, even with
+  // duplicate fingerprints across the rename transition) and binds N
+  // parameters into the SQL — Postgres caps bind params around 32k and
+  // the planner falls off NOT-IN-scan well before that. After a
+  // platform-wide version bump the audit-log read alone would
+  // OOM the cron process.
+  //
+  // `sendReacceptanceReminder` already calls the properly-indexed
+  // per-user `wasRecentlyReminded` check inside its loop, so the pre-fetch
+  // was redundant — we just slightly over-fetch active users and let the
+  // per-user check filter out the recently-reminded ones. No array
+  // crosses the process boundary; the cron's memory footprint is now
+  // O(batchSize × overFetch), bounded at ~500 rows regardless of the
+  // audit_logs table size.
   const overFetch = Math.min(batchSize * 5, 500);
   const users = await User.findAll({
-    where,
+    where: { status: UserStatus.ACTIVE },
     attributes: ['userId'],
     order: [['createdAt', 'ASC']],
     limit: overFetch,


### PR DESCRIPTION
## Summary

Three production-blocker reliability/legal fixes:

- **ADS-549** — `EmailService.initializeProvider` no longer silently falls back to `ConsoleEmailProvider` when Resend is misconfigured or `EMAIL_PROVIDER` holds a typo. In production the boot exits non-zero so the orchestrator surfaces the failure; in development it still warns and degrades. Active provider written to a `EMAIL_PROVIDER_INITIALIZED` audit row at boot for post-deploy observability.
- **ADS-550** — The on-page cookie banner called `recordReacceptance` with hard-coded `tosAccepted: true, privacyAccepted: true`, which stamped the currently-published ToS/Privacy versions onto the audit row and silently consumed any pending re-acceptance for documents the user never saw — a GDPR audit-trail bug. New `POST /api/v1/privacy/cookies-consent` route + `recordCookiesConsent` service write a row that omits ToS/Privacy fields entirely; the banner and `attachStoredCookieConsent` now call it. `getPendingReacceptance` rewritten to read each document's last-accepted version from the most recent row that actually carried it.
- **ADS-551** — `findCandidateUserIds` no longer pre-fetches every recently-reminded user from `audit_logs` and binds the IDs as `Op.notIn` (OOMs the worker / overflows Postgres bind-param limits after a platform-wide version bump). Per-user dedupe is delegated to `wasRecentlyReminded` inside the loop.

## Breaking changes

- New endpoint `POST /api/v1/privacy/cookies-consent`. Clients that read consent endpoints must not break, but historical audit rows written by the cookie banner already contain the currently-published `tosVersion`/`privacyVersion` — a follow-up cleanup migration may want to clear those fields for legal-audit accuracy.
- Misconfigured `EMAIL_PROVIDER` in production now crashes the backend instead of silently dropping every transactional email into stdout. Verify `RESEND_API_KEY` is set before rolling.

## Test plan

- [ ] CI: `service.backend` Vitest (`email.service`, new `email-provider-init`, `legal-reminder-cron`)
- [ ] CI: `lib.legal` Vitest (`attach-stored-consent`, `CookieBanner`)
- [ ] Manual: deploy with `EMAIL_PROVIDER=resend` and the API key intentionally blanked → expect CrashLoopBackoff; restore key → expect successful boot
- [ ] Manual: bump `TERMS_VERSION` only, log in as a user who already accepted v1, click "Essentials only" on the cookie banner → `/api/v1/legal/pending-reacceptance` still reports `terms` as pending
- [ ] Manual: with a populated `audit_logs` table (>10k recent reminder rows), trigger `runLegalReminderCron` → completes in seconds, no `Op.notIn` parameter overflow

https://claude.ai/code/session_01S9BSXknmK1mMVJiU3NoCKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9BSXknmK1mMVJiU3NoCKh)_