### PR TITLE
docs: update README Node.js version from v20 to v22 (ADS-557)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A monorepo containing three React frontends, a Node.js/Express backend, and shar
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) v20+
+- [Node.js](https://nodejs.org/) v22+ (the exact version is pinned in [`.nvmrc`](./.nvmrc); install via `nvm use`)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (includes Docker Compose v2)
 - [Git](https://git-scm.com/)
 
@@ -19,7 +19,7 @@ npm run setup
 ```
 
 That's it. `npm run setup` is the one-shot bootstrap and it will:
-1. Verify Node.js v20+
+1. Verify Node.js v22+
 2. Create `.env` from `.env.example` (if missing)
 3. **Generate fresh JWT / session / CSRF / encryption secrets straight into `.env`** (won't overwrite existing values)
 4. Install all dependencies (`npm ci`)
@@ -119,7 +119,7 @@ The Docker dev stack is configured for HMR on Windows/macOS/Linux:
 ## Tech Stack
 
 **Frontend:** React 18, TypeScript, Vite, styled-components, React Router, React Query, Socket.io
-**Backend:** Node.js 20, Express, TypeScript, Sequelize, PostgreSQL 16 + PostGIS, Redis 7, Socket.io, JWT
+**Backend:** Node.js 22, Express, TypeScript, Sequelize, PostgreSQL 16 + PostGIS, Redis 7, Socket.io, JWT
 **Tooling:** Turborepo, Docker (BuildKit), Nginx, GitHub Actions
 
 ## Environment Configuration


### PR DESCRIPTION
## Summary

ADS-374 pinned the toolchain to Node 22 (`.nvmrc` → 22.15.1, `engines.node` → `>=22.0.0 <23.0.0`), but the top-level README still told new contributors to install Node 20. Three call-outs replaced: the Prerequisites bullet (now links to `.nvmrc` as the source of truth), the `npm run setup` description, and the Tech Stack block.

A contributor on Node 20 following the README will now hit a clear `EBADENGINE` rather than wasting time on Node 22-only runtime errors.

## Test plan

- [ ] `grep -nE "Node\\.js (v?20|20\\+)" README.md` returns no matches
- [ ] Optional: fresh-clone the repo on a Node 20 machine, follow the README, confirm `npm ci` errors out with `EBADENGINE`

https://claude.ai/code/session_01S9BSXknmK1mMVJiU3NoCKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9BSXknmK1mMVJiU3NoCKh)_