### PR TITLE
chore: allow Linear save_comment MCP tool in local settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(timeout /t 30 npm test -- email.service.test.ts --maxWorkers=1)",
       "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__list_issues",
       "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__get_issue",
-      "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__save_issue"
+      "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__save_issue",
+      "mcp__1bf85348-1043-4e09-a7af-8d10413739a7__save_comment"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary

- Adds `mcp__1bf85348-1043-4e09-a7af-8d10413739a7__save_comment` to the local Claude Code permissions allowlist. Captured during a backlog-grooming session that used the Linear MCP to create parent epics, re-parent ~27 children, close 6 stale 2024 tickets, and annotate 4 still-valid ones.
- No code changes — `.claude/settings.local.json` only.

The grooming work itself was Linear-side and is summarized below for record:

- **Parent epics created:** ADS-568 (Security Review), ADS-569 (Daily Code Review), ADS-570 (DevEx/CI), ADS-571 (GDPR), ADS-572 (Notifications)
- **Closed as Done:** ADS-3, ADS-5, ADS-8, ADS-10, ADS-11, ADS-12
- **Left open with May 2026 verdict embedded in description:** ADS-7, ADS-9, ADS-13, ADS-14

## Test plan

- [ ] No code paths exercised — settings-only change.

https://claude.ai/code/session_01RqiAyiGqicd5SwuEprrL1k

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqiAyiGqicd5SwuEprrL1k)_