### PR TITLE
chore(devex): batch implementation of ADS-570 children

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -281,3 +281,16 @@ SMS_DEFAULT_COUNTRY_CODE=GB
 # ✅ Reviewed and limited rate limiting settings
 # ✅ Disabled debug logging (VITE_ENABLE_DEBUG_LOGGING=false)
 # =============================================================================
+
+# -----------------------------------------------------------------------------
+# Seeding (dev/test only)
+# -----------------------------------------------------------------------------
+# When true, the backend wipes and re-seeds the database on startup in
+# non-production environments. Leave false unless you explicitly want a
+# fresh dev dataset on every boot. Has no effect when NODE_ENV=production.
+FORCE_SEED=false
+
+# Password assigned to every seeded user. If unset, the seeder generates a
+# random password once and prints it to stdout. Set this to keep a stable,
+# memorable password across resets for local development.
+SEED_PASSWORD=DevPassword123!

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
-          node-version: 22
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ test: add edge cases for registration
 docs: update API reference
 ```
 
+A Husky `commit-msg` hook runs [commitlint](https://commitlint.js.org/) with `@commitlint/config-conventional` to enforce this locally — non-conforming messages will be rejected before the commit is created. In an emergency you can bypass the hook with `git commit --no-verify`, but the CI commit-message check will still fail the PR.
+
 ### TDD loop
 
 This project follows strict Test-Driven Development — **no new behaviour without a test first**:

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ npm run docker:down         # stop
 
 ### Run (native — no Docker)
 
-You'll need Postgres + Redis running locally yourself.
+You'll need Postgres + Redis running locally. The quickest option is to let Docker run just those two services while the rest of the stack runs natively:
 
 ```bash
+npm run dev:services        # start Postgres + Redis in Docker (detached)
 npm run dev                 # all packages via Turbo
 npm run dev:apps            # frontend apps only
 npm run dev:backend         # backend only

--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ CORS origins are defined once in the root `.env` (`CORS_ORIGIN`), covering both 
 
 All API endpoints live under `/api/v1/` (e.g. `/api/v1/auth/login`). Swagger UI: http://localhost:5000/api/docs (or http://api.localhost/api/docs via the nginx proxy).
 
+## Deployment
+
+Deploys are driven by the `Makefile` at the repo root, which dispatches the GitHub Actions workflows.
+
+```bash
+make staging               # deploy main to staging (runs immediately)
+make prod                  # deploy main to production (requires approval in the GitHub UI)
+make rollback env=production sha=abc1234   # roll the named environment back to a specific commit
+make history               # list recent commits to pick a rollback target
+```
+
+> `make prod` triggers a real production deployment via the `deploy.yml` workflow. Do not confuse it with `npm run prod:up`, which only spins up the production Docker stack locally for a smoke test and does not deploy anywhere.
+
 ## Documentation
 
 - [docs/DOCKER.md](./docs/DOCKER.md) — Docker infrastructure deep dive

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+export default { extends: ['@commitlint/config-conventional'] };

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,9 @@
 # CI override - removes dev volume mounts that shadow built artifacts
 # Usage: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d
+#
+# Why this overlay exists, what it changes, and how to reproduce a CI E2E run
+# locally are documented in docs/DOCKER.md:
+#   https://github.com/ideaSquared/adopt-dont-shop/blob/main/docs/DOCKER.md#ci-overlay-docker-composeciyml
 
 services:
   service-backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
   # ============================================================================
 
   lib-types-watcher:
-    image: node:20-alpine
+    image: node:22-alpine
     working_dir: /app/lib.types
     volumes:
       - ./lib.types:/app/lib.types

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -9,6 +9,7 @@ Comprehensive guide to the Docker setup for this monorepo. Pairs with [the root 
 - [Best Practices](#best-practices)
 - [Development Workflow](#development-workflow)
 - [Production Deployment](#production-deployment)
+- [CI overlay (docker-compose.ci.yml)](#ci-overlay-docker-composeciyml)
 - [Troubleshooting](#troubleshooting)
 
 ## Quick Start
@@ -224,6 +225,42 @@ CI uses BuildKit cache for 40-60% faster builds:
     path: /tmp/.buildx-cache
     key: ${{ runner.os }}-buildx-${{ github.sha }}
 ```
+
+## CI overlay (docker-compose.ci.yml)
+
+### Why it exists
+
+The dev stack in `docker-compose.yml` is optimised for inner-loop development: it bind-mounts source code, overrides the backend `entrypoint`/`command` to wire up a runtime `lib.types` symlink, and mounts a writable `./uploads` directory from the host. None of that is appropriate for CI:
+
+- Bind-mounted source shadows the built artifacts baked into the image, so we'd be testing the host's working tree instead of the image we just built.
+- The host `./uploads` mount masks the image's `appuser`-owned uploads directory and causes `EACCES` when the backend tries to `mkdirSync` inside it.
+- The dev `entrypoint`/`command` reference paths that only resolve when bind mounts are active — in CI they don't exist.
+
+`docker-compose.ci.yml` is a minimal overlay applied on top of `docker-compose.yml` to undo exactly those dev-only behaviours.
+
+### What it changes
+
+For the `service-backend` service:
+
+- `volumes: !reset []` — the `!reset` tag *replaces* the base volume list rather than appending to it (the default Compose merge for sequences). This is what removes the dev bind mounts, including the `./uploads` mount that breaks permissions.
+- `entrypoint: ["/usr/bin/dumb-init", "--"]` — restores the Dockerfile ENTRYPOINT. The compose override entrypoint uses relative paths (`./service.backend/…`) that only resolve under bind mounts.
+- `command: ["npm", "run", "dev"]` — restores the Dockerfile CMD. The compose command override creates a runtime symlink for bind-mounted `lib.types`, which is irrelevant when the image already contains a copy of the built library in `node_modules`.
+
+### Reproducing a CI E2E run locally
+
+```bash
+# Build images the same way CI does, then bring the stack up with the overlay
+docker compose -f docker-compose.yml -f docker-compose.ci.yml build
+docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d
+
+# Tail logs / run the same smoke checks CI runs
+docker compose -f docker-compose.yml -f docker-compose.ci.yml logs -f service-backend
+
+# Tear down (always include both files so the project name matches)
+docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
+```
+
+If you skip the overlay, you'll either hit the `uploads` `EACCES` error or end up testing your local working tree rather than the built image.
 
 ## Troubleshooting
 

--- a/lib.analytics/package.json
+++ b/lib.analytics/package.json
@@ -70,11 +70,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.analytics"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.analytics#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.analytics#readme"
 }

--- a/lib.api/package.json
+++ b/lib.api/package.json
@@ -59,11 +59,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.api"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.api#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.api#readme"
 }

--- a/lib.applications/package.json
+++ b/lib.applications/package.json
@@ -59,11 +59,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.applications"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.applications#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.applications#readme"
 }

--- a/lib.auth/package.json
+++ b/lib.auth/package.json
@@ -70,11 +70,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.auth"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.auth#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.auth#readme"
 }

--- a/lib.chat/package.json
+++ b/lib.chat/package.json
@@ -77,11 +77,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.chat"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.chat#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.chat#readme"
 }

--- a/lib.dev-tools/package.json
+++ b/lib.dev-tools/package.json
@@ -69,11 +69,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.dev-tools"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.dev-tools#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.dev-tools#readme"
 }

--- a/lib.discovery/package.json
+++ b/lib.discovery/package.json
@@ -58,11 +58,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.discovery"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.discovery#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.discovery#readme"
 }

--- a/lib.feature-flags/package.json
+++ b/lib.feature-flags/package.json
@@ -58,11 +58,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.feature-flags"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.feature-flags#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.feature-flags#readme"
 }

--- a/lib.invitations/package.json
+++ b/lib.invitations/package.json
@@ -57,11 +57,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.invitations"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.invitations#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.invitations#readme"
 }

--- a/lib.moderation/package.json
+++ b/lib.moderation/package.json
@@ -64,11 +64,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.moderation"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.moderation#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.moderation#readme"
 }

--- a/lib.moderation/package.json
+++ b/lib.moderation/package.json
@@ -20,7 +20,7 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",
-    "test:watch": "jest --watch --passWithNoTests",
+    "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/lib.notifications/package.json
+++ b/lib.notifications/package.json
@@ -58,11 +58,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.notifications"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.notifications#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.notifications#readme"
 }

--- a/lib.permissions/package.json
+++ b/lib.permissions/package.json
@@ -60,11 +60,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.permissions"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.permissions#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.permissions#readme"
 }

--- a/lib.pets/package.json
+++ b/lib.pets/package.json
@@ -58,11 +58,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.pets"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.pets#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.pets#readme"
 }

--- a/lib.rescue/package.json
+++ b/lib.rescue/package.json
@@ -58,11 +58,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.rescue"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.rescue#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.rescue#readme"
 }

--- a/lib.search/package.json
+++ b/lib.search/package.json
@@ -58,11 +58,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.search"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.search#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.search#readme"
 }

--- a/lib.support-tickets/package.json
+++ b/lib.support-tickets/package.json
@@ -20,7 +20,7 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",
-    "test:watch": "jest --watch --passWithNoTests",
+    "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/lib.support-tickets/package.json
+++ b/lib.support-tickets/package.json
@@ -64,11 +64,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.support-tickets"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.support-tickets#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.support-tickets#readme"
 }

--- a/lib.types/package.json
+++ b/lib.types/package.json
@@ -58,11 +58,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.types"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.types#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.types#readme"
 }

--- a/lib.utils/package.json
+++ b/lib.utils/package.json
@@ -58,11 +58,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.utils"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.utils#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.utils#readme"
 }

--- a/lib.validation/package.json
+++ b/lib.validation/package.json
@@ -60,11 +60,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParagonJenko/pet-adoption-react.git",
+    "url": "git+https://github.com/ideaSquared/adopt-dont-shop.git",
     "directory": "lib.validation"
   },
   "bugs": {
-    "url": "https://github.com/ParagonJenko/pet-adoption-react/issues"
+    "url": "https://github.com/ideaSquared/adopt-dont-shop/issues"
   },
-  "homepage": "https://github.com/ParagonJenko/pet-adoption-react/tree/main/lib.validation#readme"
+  "homepage": "https://github.com/ideaSquared/adopt-dont-shop/tree/main/lib.validation#readme"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,8 @@
         "e2e"
       ],
       "devDependencies": {
+        "@commitlint/cli": "^21.0.1",
+        "@commitlint/config-conventional": "^21.0.1",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "@vitest/coverage-v8": "^4.0.8",
@@ -1904,6 +1906,416 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.1.tgz",
+      "integrity": "sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^21.0.1",
+        "@commitlint/lint": "^21.0.1",
+        "@commitlint/load": "^21.0.1",
+        "@commitlint/read": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
+        "tinyexec": "^1.0.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/cli/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.1.tgz",
+      "integrity": "sha512-gRorrkfWOh/+V5X8GYWWbQvrzPczopGMS4CCNrQdHkK4xWElv82BDvIsDhJZWTlI7TazOlYea6VATufCsFs+sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "conventional-changelog-conventionalcommits": "^9.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.1.tgz",
+      "integrity": "sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-validator/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.1.tgz",
+      "integrity": "sha512-jJ1037967wU7YN/xkv+iRlOBlmaOXPhPO5KQSqya6GyXzBlwuLzELBFao16DVg9dZyqmNrhewzwZ3SAibetHBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "es-toolkit": "^1.46.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+      "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.0.1.tgz",
+      "integrity": "sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.1.tgz",
+      "integrity": "sha512-iNDP8SFdw8JEkM0CHZ2XFnhTN4Zg5jKUY2d8kBOSFrI2aA+3YJI7fcqVpfgbpJ9xtxFVYpi+DBATU5AvhoTq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.1.tgz",
+      "integrity": "sha512-gF+iYtUw1gBG3HUH9z3VxwUjGg2R2G5j+nmvPs8aIeYkiB7TtneBu3wO85I0bUl93bYNsvsCNI9Nte2fmDUMww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^21.0.1",
+        "@commitlint/parse": "^21.0.1",
+        "@commitlint/rules": "^21.0.1",
+        "@commitlint/types": "^21.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.1.tgz",
+      "integrity": "sha512-Btg1q1mKmiihN4W3x0EsPDrJMOQfMa9NIqlzlJyXAfxvsOGdGXOW5p3R3RcSxDCaY7JabY9flIl+Om1af3PSrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/execute-rule": "^21.0.1",
+        "@commitlint/resolve-extends": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
+        "cosmiconfig": "^9.0.1",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "es-toolkit": "^1.46.0",
+        "is-plain-obj": "^4.1.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.1.tgz",
+      "integrity": "sha512-R3dVQeJQ0B6yqrZEjkUHD4r7UJYLV9Lvk2xs3PTOmtWk2G3mI6Xgc+YdRxL1PwcDfBiUjv2SkIkW4AUc976w1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.1.tgz",
+      "integrity": "sha512-oh/nCSOqdoeQNA1tO8aAmxkq5EBo8/NzcFQRvv66AWc9HpED28sL2iSicCKU6hPintWuscL6BJEWi77Wq1LPMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^21.0.1",
+        "conventional-changelog-angular": "^8.2.0",
+        "conventional-commits-parser": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.1.tgz",
+      "integrity": "sha512-pMEu4lbpC8W0ZgKJj2U6WaobXIZWdFlULpIEewYhkPXx+WZcnoO53YrVPc7QErQuNolq2Me8dP58Wu7YAVXVOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
+        "git-raw-commits": "^5.0.0",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.1.tgz",
+      "integrity": "sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
+        "es-toolkit": "^1.46.0",
+        "global-directory": "^5.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.1.tgz",
+      "integrity": "sha512-VMooYpz4nJg7xlaUso6CCOWEz8D/ChkvsvZUMARcoJ1ZpfKPyFCGrHNha2tbsETNAb6ErgiRuCr2DvghrvPDYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^21.0.1",
+        "@commitlint/message": "^21.0.1",
+        "@commitlint/to-lines": "^21.0.1",
+        "@commitlint/types": "^21.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+      "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.1.tgz",
+      "integrity": "sha512-4esUYqzY7K0FCgcJ/1xWEZekV7Ch4yZT1+xjEb7KzqbJ05XEkxHVsTfC8ADKNNtlCE2pj98KEbPGZWw9WwEnVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-parser": "^6.3.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -6113,6 +6525,35 @@
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -8339,6 +8780,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/array-includes": {
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
@@ -9562,6 +10010,17 @@
         "node": ">=20"
       }
     },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
     "node_modules/compare-versions": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
@@ -9748,6 +10207,49 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9842,6 +10344,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
       }
     },
     "node_modules/create-require": {
@@ -10742,6 +11262,19 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -11235,6 +11768,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -12008,6 +12552,23 @@
         "fast-string-truncated-width": "^3.0.2"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
@@ -12394,6 +12955,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -12455,6 +13029,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/git-raw-commits": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+      "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/github-from-package": {
@@ -12525,6 +13116,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/globals": {
@@ -13469,6 +14086,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -13876,6 +14516,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-beautify": {
@@ -14948,6 +15598,19 @@
       "resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
       "integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==",
       "license": "MIT"
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dev": "turbo run dev --parallel",
     "dev:apps": "turbo run dev --filter='@adopt-dont-shop/app.*' --parallel",
     "dev:backend": "turbo run dev --filter=@adopt-dont-shop/service-backend",
+    "dev:services": "docker compose up -d database redis",
     "docker:dev": "docker compose up",
     "docker:dev:build": "docker compose up --build",
     "docker:dev:detach": "docker compose up -d",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "generate:attachments": "node scripts/generate-test-attachments.js"
   },
   "devDependencies": {
+    "@commitlint/cli": "^21.0.1",
+    "@commitlint/config-conventional": "^21.0.1",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "@vitest/coverage-v8": "^4.0.8",


### PR DESCRIPTION
Batch implementation of the 10 DevEx / CI tickets clustered under parent epic [ADS-570](https://linear.app/ideasquared/issue/ADS-570).

## Tickets

| Ticket | Description | How implemented |
|---|---|---|
| ADS-558 | Pin `lib-types-watcher` to Node 22 | Bumped `image: node:20-alpine` → `node:22-alpine` in `docker-compose.yml`. |
| ADS-559 | Use `.nvmrc` in `deploy.yml` | Replaced the hardcoded `node-version: 22` in the deploy workflow's `setup-node` step with `node-version-file: '.nvmrc'`, matching `ci.yml`. |
| ADS-560 | `vitest test:watch` for stale-jest libs | Changed `"test:watch": "jest --watch --passWithNoTests"` → `"vitest"` in `lib.moderation/package.json` and `lib.support-tickets/package.json` (both already use `vitest` for `test`). |
| ADS-561 | Husky `commit-msg` hook | Added root devDeps `@commitlint/cli` + `@commitlint/config-conventional`, created `commitlint.config.js` (ESM to match the workspace `"type": "module"`), added `.husky/commit-msg` running `npx --no -- commitlint --edit "$1"`, and documented the hook + `--no-verify` bypass in `CONTRIBUTING.md`. |
| ADS-562 | `.env.example` seed vars | Appended a "Seeding (dev/test only)" section with `FORCE_SEED=false` and `SEED_PASSWORD=DevPassword123!`, each with an explanatory comment. Both vars are already consumed by `service.backend/src/index.ts` and the seeders — this just makes them discoverable. |
| ADS-563 | Fix `repository.url` in `package.json`s | Replaced `git+https://github.com/ParagonJenko/pet-adoption-react.git` with `git+https://github.com/ideaSquared/adopt-dont-shop.git` across 19 `lib.*` packages (and updated the matching `bugs.url` / `homepage` fields so `grep -rn "pet-adoption-react" --include=package.json .` returns no matches). The `"directory"` field was already present in every file, so no additions needed there. |
| ADS-564 | `storybook.yml` paths filter on PR | **No-op — already implemented on `main`.** `.github/workflows/storybook.yml` already has `paths: ['lib.components/**']` on both `push` and `pull_request`. Leaving the ticket open for housekeeping; no diff in this PR. |
| ADS-565 | `dev:services` script | Added `"dev:services": "docker compose up -d database redis"` to the root `package.json` and updated the README "native — no Docker" section to reference it. |
| ADS-566 | Surface Makefile deploy commands in README | Added a new "Deployment" section to `README.md` documenting `make staging`, `make prod`, `make rollback env=… sha=…`, and `make history`, with a callout disambiguating `make prod` (real deploy) from `npm run prod:up` (local Docker smoke test). |
| ADS-567 | Document `docker-compose.ci.yml` | Added a "CI overlay (docker-compose.ci.yml)" section to `docs/DOCKER.md` covering why the overlay exists, what it changes (`volumes: !reset []`, restored `entrypoint`/`command`), and how to reproduce a CI E2E run locally. Added a pointer comment block at the top of `docker-compose.ci.yml` linking back to that section. |

## Skipped

- **ADS-564** — already implemented on `main` (see table above). No code change needed.

## Quality gates

Run locally before pushing:

- `npm run lint` — passed (26/26 tasks; warnings only, all pre-existing).
- `npm run type-check` — passed (48/48 tasks).
- `npm run format:check` — one pre-existing warning in `e2e/tests/client/adoption-application.spec.ts` (introduced by commit `3637e85`, unrelated to this PR).
- Tests not run — all changes are config / docs, no code paths touched.

## Test plan

- [ ] CI workflows green on this branch (commit-msg hook, ci.yml, deploy.yml lint, storybook.yml).
- [ ] Verify `npm run dev:services` brings up `database` + `redis` only.
- [ ] Verify a non-conventional commit message is rejected locally by the new `commit-msg` hook.
- [ ] Spot-check the new "Deployment" and "CI overlay" sections render correctly on GitHub.

https://claude.ai/code/session_01RqiAyiGqicd5SwuEprrL1k

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqiAyiGqicd5SwuEprrL1k)_