### PR TITLE
feat(gdpr): rescue account deletion (ADS-87)

### DIFF
--- a/service.backend/src/__tests__/services/gdpr.service.test.ts
+++ b/service.backend/src/__tests__/services/gdpr.service.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import type { Response } from 'express';
+import sequelize from '../../sequelize';
+import Application, { ApplicationStatus } from '../../models/Application';
+import ApplicationStatusTransition from '../../models/ApplicationStatusTransition';
+import AuditLog from '../../models/AuditLog';
+import Notification from '../../models/Notification';
+import Pet from '../../models/Pet';
+import Rescue from '../../models/Rescue';
+import StaffMember from '../../models/StaffMember';
 import User, { UserStatus, UserType } from '../../models/User';
 import UserConsent, { ConsentPurpose } from '../../models/UserConsent';
 import GdprService from '../../services/gdpr.service';
@@ -21,6 +30,94 @@ const seedUser = async (overrides: Record<string, unknown> = {}) =>
     loginAttempts: 0,
     ...overrides,
   });
+
+const seedRescue = async (overrides: Record<string, unknown> = {}) => {
+  // Cast through unknown because the test schema's Rescue.create() typing
+  // requires every nullable column at the TS level even though the DB
+  // accepts the partial. Same pattern used in
+  // ApplicationStatusTransition.test.ts.
+  const payload: Record<string, unknown> = {
+    name: `Test Rescue ${Date.now()}-${Math.random()}`,
+    email: `rescue-${Date.now()}-${Math.random()}@example.com`,
+    address: '1 Lane',
+    city: 'London',
+    postcode: 'AB1 2CD',
+    country: 'GB',
+    contactPerson: 'Jane',
+    status: 'verified',
+    ...overrides,
+  };
+  return Rescue.create(payload as never);
+};
+
+// Raw inserts skip Pet's array-typed columns (SQLite ↔ Postgres mismatch),
+// same workaround as ApplicationStatusTransition.test.ts.
+const seedPet = async (rescueId: string, overrides: Record<string, unknown> = {}) => {
+  const petId = `${Date.now().toString(16)}-2222-4222-a222-${Math.random()
+    .toString(16)
+    .slice(2, 14)
+    .padEnd(12, '0')}`;
+  await sequelize.getQueryInterface().bulkInsert('pets', [
+    {
+      pet_id: petId,
+      name: `TestPet-${petId.slice(0, 8)}`,
+      rescue_id: rescueId,
+      type: 'dog',
+      status: 'available',
+      gender: 'male',
+      age_group: 'adult',
+      adoption_fee_minor: 0,
+      adoption_fee_currency: 'GBP',
+      archived: false,
+      featured: false,
+      priority_listing: false,
+      special_needs: false,
+      house_trained: false,
+      view_count: 0,
+      favorite_count: 0,
+      application_count: 0,
+      tags: '[]',
+      created_at: new Date(),
+      updated_at: new Date(),
+      version: 0,
+      ...overrides,
+    },
+  ]);
+  const pet = await Pet.findByPk(petId);
+  if (!pet) throw new Error('failed to seed pet');
+  return pet;
+};
+
+const seedApplication = async (
+  userId: string,
+  petId: string,
+  rescueId: string,
+  status: ApplicationStatus = ApplicationStatus.SUBMITTED
+) => {
+  const applicationId = `${Date.now().toString(16)}-3333-4333-a333-${Math.random()
+    .toString(16)
+    .slice(2, 14)
+    .padEnd(12, '0')}`;
+  await sequelize.getQueryInterface().bulkInsert('applications', [
+    {
+      application_id: applicationId,
+      user_id: userId,
+      pet_id: petId,
+      rescue_id: rescueId,
+      status,
+      priority: 'normal',
+      stage: 'pending',
+      documents: '[]',
+      tags: '[]',
+      created_at: new Date(),
+      updated_at: new Date(),
+      version: 0,
+    },
+  ]);
+  const app = await Application.findByPk(applicationId);
+  if (!app) throw new Error('failed to seed application');
+  return app;
+};
 
 describe('GdprService', () => {
   describe('anonymizeUser', () => {
@@ -124,6 +221,165 @@ describe('GdprService', () => {
       await expect(
         GdprService.exportUserData('00000000-0000-0000-0000-000000000000')
       ).rejects.toThrow('User not found');
+    });
+  });
+
+  describe('eraseRescue', () => {
+    it('archives pets, rejects pending applications, downgrades staff, and notifies applicants', async () => {
+      const rescue = await seedRescue();
+      const rescueId = rescue.rescueId;
+
+      // Sequential seeding — SQLite is single-writer and nested
+      // findOrCreate transactions in the Rescue afterCreate hook can
+      // collide when fired in parallel.
+      const pet1 = await seedPet(rescueId);
+      const pet2 = await seedPet(rescueId);
+      await seedPet(rescueId);
+
+      const applicant1 = await seedUser();
+      const applicant2 = await seedUser();
+      const staff1 = await seedUser({ userType: UserType.RESCUE_STAFF });
+      const staff2 = await seedUser({ userType: UserType.RESCUE_STAFF });
+      const actor = await seedUser({ userType: UserType.ADMIN });
+
+      await seedApplication(applicant1.userId, pet1.petId, rescueId);
+      await seedApplication(applicant2.userId, pet2.petId, rescueId);
+      await StaffMember.create({
+        rescueId,
+        userId: staff1.userId,
+        isVerified: true,
+        addedBy: actor.userId,
+        addedAt: new Date(),
+      });
+      await StaffMember.create({
+        rescueId,
+        userId: staff2.userId,
+        isVerified: true,
+        addedBy: actor.userId,
+        addedAt: new Date(),
+      });
+
+      const result = await GdprService.eraseRescue(rescueId, { actorUserId: actor.userId });
+
+      expect(result.petsArchived).toBe(3);
+      expect(result.applicationsRejected).toBe(2);
+      expect(result.staffDowngraded).toBe(2);
+      expect(result.alreadyArchived).toBe(false);
+
+      // Rescue row anonymised, soft-deleted, and flipped to inactive.
+      const reloadedRescue = await Rescue.findByPk(rescueId, { paranoid: false });
+      expect(reloadedRescue).not.toBeNull();
+      expect(reloadedRescue!.name).toContain('Deleted Rescue');
+      expect(reloadedRescue!.email).toMatch(/^deleted-rescue-.+@redacted\.local$/);
+      expect(reloadedRescue!.contactPerson).toBe('Deleted');
+      expect(reloadedRescue!.status).toBe('inactive');
+      expect(reloadedRescue!.deletedAt).not.toBeNull();
+
+      // All owned pets archived.
+      const pets = await Pet.findAll({ where: { rescueId } });
+      expect(pets).toHaveLength(3);
+      expect(pets.every(p => p.archived)).toBe(true);
+
+      // Pending applications rejected with the expected reason.
+      const apps = await Application.findAll({ where: { rescueId } });
+      expect(apps).toHaveLength(2);
+      expect(apps.every(a => a.status === ApplicationStatus.REJECTED)).toBe(true);
+      expect(apps.every(a => a.rejectionReason === 'Rescue account deleted')).toBe(true);
+
+      // A transition row was written for each rejected application.
+      const transitions = await ApplicationStatusTransition.findAll({
+        where: { toStatus: ApplicationStatus.REJECTED },
+      });
+      expect(transitions).toHaveLength(2);
+      expect(transitions.every(t => t.reason === 'Rescue account deleted')).toBe(true);
+
+      // Staff members soft-deleted (default scope hides them).
+      const remainingStaff = await StaffMember.findAll({ where: { rescueId } });
+      expect(remainingStaff).toHaveLength(0);
+      // User accounts untouched.
+      const staffUsers = await User.findAll({
+        where: { userId: [staff1.userId, staff2.userId] },
+      });
+      expect(staffUsers).toHaveLength(2);
+
+      // Applicants got an in-app notification.
+      const notifications = await Notification.findAll({
+        where: { user_id: [applicant1.userId, applicant2.userId] },
+      });
+      expect(notifications).toHaveLength(2);
+      expect(notifications.every(n => n.type === 'application_status')).toBe(true);
+
+      // Aggregate audit log row captures the operation. The audit_log
+      // table stores entity/entityId/details inside the metadata JSON
+      // column (see AuditLogService.log).
+      const auditRows = await AuditLog.findAll({ where: { action: 'GDPR_RESCUE_ERASE' } });
+      expect(auditRows).toHaveLength(1);
+      const metadata = auditRows[0].metadata as Record<string, unknown>;
+      expect(metadata.entityId).toBe(rescueId);
+      const details = metadata.details as Record<string, unknown>;
+      expect(details.petsArchived).toBe(3);
+      expect(details.applicationsRejected).toBe(2);
+      expect(details.staffDowngraded).toBe(2);
+    });
+
+    it('throws when the rescue does not exist', async () => {
+      await expect(GdprService.eraseRescue('00000000-0000-0000-0000-000000000000')).rejects.toThrow(
+        'Rescue not found'
+      );
+    });
+
+    it('rejects callers who are neither platform admin nor an admin of the target rescue', async () => {
+      const { default: GdprController } = await import('../../controllers/gdpr.controller');
+      const rescue = await seedRescue();
+      const outsider = await seedUser({
+        userType: UserType.RESCUE_STAFF,
+        rescueId: '00000000-0000-0000-0000-000000000000',
+      });
+
+      const statusFn = vi.fn().mockReturnThis();
+      const jsonFn = vi.fn();
+      // express-validator/req types — we only set the fields the controller reads.
+      const reqShape: Record<string, unknown> = {
+        params: { rescueId: rescue.rescueId },
+        body: {},
+        user: { ...outsider.toJSON(), rescueId: outsider.rescueId },
+      };
+      const resShape: Record<string, unknown> = { status: statusFn, json: jsonFn };
+      // The controller is shape-typed against AuthenticatedRequest /
+      // Response; this cast is the test-only equivalent of constructing
+      // a partial mock.
+      await GdprController.eraseRescue(
+        reqShape as unknown as Parameters<typeof GdprController.eraseRescue>[0],
+        resShape as unknown as Response
+      );
+
+      expect(statusFn).toHaveBeenCalledWith(403);
+      // Rescue is untouched.
+      const stillThere = await Rescue.findByPk(rescue.rescueId);
+      expect(stillThere?.name).toBe(rescue.name);
+    });
+
+    it('serializes overlapping erase attempts so the second observes already-archived state', async () => {
+      // SQLite is single-writer in tests; we exercise the serialization
+      // contract by issuing two back-to-back calls and asserting:
+      //   1. both succeed without throwing,
+      //   2. the second sees alreadyArchived = true (the lock-and-check
+      //      established by the row lock means the second cannot
+      //      re-run the destructive steps),
+      //   3. counts on the second run are zero (no double-rejection,
+      //      no double-archive).
+      const rescue = await seedRescue();
+      const rescueId = rescue.rescueId;
+      const actor = await seedUser({ userType: UserType.ADMIN });
+
+      const r1 = await GdprService.eraseRescue(rescueId, { actorUserId: actor.userId });
+      const r2 = await GdprService.eraseRescue(rescueId, { actorUserId: actor.userId });
+
+      expect(r1.alreadyArchived).toBe(false);
+      expect(r2.alreadyArchived).toBe(true);
+      expect(r2.petsArchived).toBe(0);
+      expect(r2.applicationsRejected).toBe(0);
+      expect(r2.staffDowngraded).toBe(0);
     });
   });
 });

--- a/service.backend/src/controllers/gdpr.controller.ts
+++ b/service.backend/src/controllers/gdpr.controller.ts
@@ -106,6 +106,49 @@ export class GdprController {
     }
   }
 
+  /**
+   * GDPR Art. 17 — rescue erasure (ADS-87). Gated: platform admin OR
+   * rescue admin / staff acting on their own rescue. Mirrors the same
+   * controller-side auth pattern as eraseByAdmin so failures funnel
+   * through one audited path.
+   */
+  async eraseRescue(req: AuthenticatedRequest, res: Response): Promise<void> {
+    try {
+      const { rescueId } = req.params;
+      const actor = req.user!;
+      const isPlatformAdmin = isAdmin(req);
+      const isOwnRescue = actor.userType === UserType.RESCUE_STAFF && actor.rescueId === rescueId;
+
+      if (!isPlatformAdmin && !isOwnRescue) {
+        res.status(403).json({ error: 'You do not have permission to erase this rescue' });
+        return;
+      }
+
+      const { reason } = req.body as { reason?: string };
+      const result = await GdprService.eraseRescue(rescueId, {
+        reason,
+        actorUserId: actor.userId,
+      });
+      res.json({
+        success: true,
+        message: 'Rescue anonymised',
+        summary: {
+          petsArchived: result.petsArchived,
+          applicationsRejected: result.applicationsRejected,
+          staffDowngraded: result.staffDowngraded,
+          alreadyArchived: result.alreadyArchived,
+        },
+      });
+    } catch (error) {
+      logger.error('GDPR rescue erase failed', { error });
+      if (error instanceof Error && error.message === 'Rescue not found') {
+        res.status(404).json({ error: 'Rescue not found' });
+        return;
+      }
+      res.status(500).json({ error: 'Failed to erase rescue' });
+    }
+  }
+
   async recordConsent(req: AuthenticatedRequest, res: Response): Promise<void> {
     try {
       const userId = req.user!.userId;

--- a/service.backend/src/routes/rescue.routes.ts
+++ b/service.backend/src/routes/rescue.routes.ts
@@ -14,6 +14,7 @@ import {
   StaffInvitationRequestSchema,
 } from '@adopt-dont-shop/lib.validation';
 import { RescueController } from '../controllers/rescue.controller';
+import GdprController, { gdprValidation } from '../controllers/gdpr.controller';
 import { QuestionController } from '../controllers/question.controller';
 import { authenticateToken } from '../middleware/auth';
 import { fieldMask, fieldWriteGuard } from '../middleware/field-permissions';
@@ -911,6 +912,18 @@ router.delete(
   validateDeletion,
   requirePermission('rescues.delete'),
   rescueController.deleteRescue
+);
+
+// GDPR Art. 17 — rescue account erasure (ADS-87). Anonymises the
+// rescue, archives owned pets, auto-rejects pending applications,
+// notifies applicants, and removes staff affiliations. The controller
+// gates: platform admin OR rescue admin acting on their own rescue.
+router.post(
+  '/:rescueId/erase',
+  sensitiveWriteLimiter,
+  validateRescueId,
+  gdprValidation.anonymize,
+  GdprController.eraseRescue.bind(GdprController)
 );
 
 // Send email to rescue organization (admin only)

--- a/service.backend/src/services/gdpr.service.ts
+++ b/service.backend/src/services/gdpr.service.ts
@@ -8,7 +8,7 @@ import ChatParticipant from '../models/ChatParticipant';
 import DeviceToken from '../models/DeviceToken';
 import Message from '../models/Message';
 import Notification, { NotificationType } from '../models/Notification';
-import Pet from '../models/Pet';
+import Pet, { PetStatus } from '../models/Pet';
 import Rating from '../models/Rating';
 import RefreshToken from '../models/RefreshToken';
 import Rescue from '../models/Rescue';
@@ -370,7 +370,7 @@ export const GdprService = {
       // pet out of discovery — existing pet scopes filter on
       // `archived: false`.
       const [petsArchived] = await Pet.update(
-        { archived: true, status: 'not_available' },
+        { archived: true, status: PetStatus.NOT_AVAILABLE },
         {
           where: { rescueId, archived: false },
           transaction: tx,

--- a/service.backend/src/services/gdpr.service.ts
+++ b/service.backend/src/services/gdpr.service.ts
@@ -1,14 +1,18 @@
 import { Transaction } from 'sequelize';
 import sequelize from '../sequelize';
-import Application from '../models/Application';
+import Application, { ApplicationStatus } from '../models/Application';
 import ApplicationAnswer from '../models/ApplicationAnswer';
 import ApplicationReference from '../models/ApplicationReference';
+import ApplicationStatusTransition from '../models/ApplicationStatusTransition';
 import ChatParticipant from '../models/ChatParticipant';
 import DeviceToken from '../models/DeviceToken';
 import Message from '../models/Message';
-import Notification from '../models/Notification';
+import Notification, { NotificationType } from '../models/Notification';
+import Pet from '../models/Pet';
 import Rating from '../models/Rating';
 import RefreshToken from '../models/RefreshToken';
+import Rescue from '../models/Rescue';
+import StaffMember from '../models/StaffMember';
 import SupportTicket from '../models/SupportTicket';
 import SupportTicketResponse from '../models/SupportTicketResponse';
 import User, { UserStatus } from '../models/User';
@@ -18,6 +22,7 @@ import UserFavorite from '../models/UserFavorite';
 import UserNotificationPrefs from '../models/UserNotificationPrefs';
 import UserPrivacyPrefs from '../models/UserPrivacyPrefs';
 import { AuditLogService } from './auditLog.service';
+import { NotificationService } from './notification.service';
 import { logger } from '../utils/logger';
 
 /**
@@ -35,12 +40,25 @@ type AnonymizeOptions = {
   actorUserId?: string;
 };
 
+type EraseRescueResult = {
+  rescueId: string;
+  alreadyArchived: boolean;
+  petsArchived: number;
+  applicationsRejected: number;
+  staffDowngraded: number;
+  applicantUserIdsToNotify: string[];
+};
+
 const ANON_EMAIL_DOMAIN = 'redacted.local';
 const ANON_FIRST_NAME = 'Deleted';
 const ANON_LAST_NAME = 'User';
 const ANON_MESSAGE_BODY = '[message removed at user request]';
+const ANON_RESCUE_NAME = 'Deleted Rescue';
+const ANON_CONTACT_PERSON = 'Deleted';
 
 const tombstoneEmail = (userId: string): string => `deleted-${userId}@${ANON_EMAIL_DOMAIN}`;
+const tombstoneRescueEmail = (rescueId: string): string =>
+  `deleted-rescue-${rescueId}@${ANON_EMAIL_DOMAIN}`;
 
 export const GdprService = {
   /**
@@ -276,6 +294,209 @@ export const GdprService = {
       supportTickets,
       ticketResponses,
     };
+  },
+
+  /**
+   * GDPR Art. 17 — rescue account erasure (ADS-87).
+   *
+   * Anonymises the Rescue row in place (PII stripped, status flipped to
+   * `inactive`, paranoid soft-delete applied) while preserving FK
+   * integrity for owned pets, adoption history, applications, chats and
+   * audit logs that reference the rescue.
+   *
+   * Side-effects per the design doc:
+   *   - Owned pets: archived (filtered out of discovery/search by
+   *     existing `archived: false` scopes).
+   *   - Pending applications on owned pets: transitioned to REJECTED
+   *     with reason "rescue account deleted"; applicants get an in-app
+   *     notification fired AFTER commit.
+   *   - StaffMember rows for the rescue: paranoid soft-deleted (the
+   *     rescue-affiliation join used by the auth middleware).
+   *   - User accounts and their UserRole rows are intentionally left
+   *     untouched — staff are downgraded, not deleted.
+   *   - Chat history retained; the rescue-side display name will now
+   *     read "Deleted Rescue" via the anonymised row.
+   *
+   * Idempotent: a second call on an already-archived rescue is a no-op
+   * apart from a fresh audit log row.
+   *
+   * Returns a summary of the action so the caller can surface counts
+   * (and the post-commit notification fan-out can target applicants).
+   */
+  async eraseRescue(rescueId: string, options: AnonymizeOptions = {}): Promise<EraseRescueResult> {
+    const { reason, actorUserId } = options;
+
+    const result = await sequelize.transaction(async (tx: Transaction) => {
+      // SELECT ... FOR UPDATE so concurrent erase attempts serialize
+      // rather than racing. Sequelize maps this to a row-level lock on
+      // dialects that support it; SQLite (test) is single-writer so the
+      // lock is effectively a no-op there.
+      const rescue = await Rescue.findByPk(rescueId, {
+        transaction: tx,
+        lock: tx.LOCK.UPDATE,
+        paranoid: false,
+      });
+      if (!rescue) {
+        throw new Error('Rescue not found');
+      }
+
+      const alreadyArchived =
+        rescue.email.endsWith(`@${ANON_EMAIL_DOMAIN}`) || rescue.deletedAt !== null;
+
+      // Anonymise the rescue row. Keep `name` collision-free by suffixing
+      // with the rescueId — the column has a unique index and a second
+      // erase would otherwise collide on "Deleted Rescue".
+      const rescueTombstone: Record<string, unknown> = {
+        name: `${ANON_RESCUE_NAME} ${rescueId}`,
+        email: tombstoneRescueEmail(rescueId),
+        phone: null,
+        address: 'redacted',
+        city: 'redacted',
+        county: null,
+        postcode: 'redacted',
+        description: null,
+        mission: null,
+        website: null,
+        contactPerson: ANON_CONTACT_PERSON,
+        contactTitle: null,
+        contactEmail: null,
+        contactPhone: null,
+        status: 'inactive',
+      };
+      await rescue.update(rescueTombstone, { transaction: tx });
+
+      // Archive every pet owned by the rescue. `archived: true` keeps
+      // the FK intact (adoption history, applications) but flips the
+      // pet out of discovery — existing pet scopes filter on
+      // `archived: false`.
+      const [petsArchived] = await Pet.update(
+        { archived: true, status: 'not_available' },
+        {
+          where: { rescueId, archived: false },
+          transaction: tx,
+        }
+      );
+
+      // Pending applications on this rescue's pets — auto-reject so the
+      // applicants don't sit waiting forever. SUBMITTED is the only
+      // pending status in this codebase; APPROVED / REJECTED /
+      // WITHDRAWN are final.
+      const pendingApps = await Application.findAll({
+        where: { rescueId, status: ApplicationStatus.SUBMITTED },
+        transaction: tx,
+      });
+
+      const applicantUserIdsToNotify: string[] = [];
+      const rejectionReason = 'Rescue account deleted';
+      for (const app of pendingApps) {
+        const fromStatus = app.status;
+        // The status-transition trigger denormalises to_status back onto
+        // the application row (Postgres trigger; SQLite test fallback
+        // is an afterCreate hook on ApplicationStatusTransition). We
+        // still set rejectionReason on the row directly because the
+        // trigger only propagates the status column.
+        await ApplicationStatusTransition.create(
+          {
+            applicationId: app.applicationId,
+            fromStatus,
+            toStatus: ApplicationStatus.REJECTED,
+            transitionedAt: new Date(),
+            transitionedBy: actorUserId ?? null,
+            reason: rejectionReason,
+            metadata: { cause: 'rescue_erasure', rescueId },
+          },
+          { transaction: tx }
+        );
+        await app.update(
+          { rejectionReason, status: ApplicationStatus.REJECTED },
+          { transaction: tx, hooks: false }
+        );
+        applicantUserIdsToNotify.push(app.userId);
+      }
+
+      // Downgrade staff: drop their StaffMember rows for this rescue.
+      // User accounts (and any UserRole grants) are untouched per the
+      // design doc — staff stay as users, they just lose this
+      // affiliation.
+      const staff = await StaffMember.findAll({
+        where: { rescueId },
+        transaction: tx,
+      });
+      let staffDowngraded = 0;
+      for (const member of staff) {
+        await member.destroy({ transaction: tx });
+        staffDowngraded += 1;
+      }
+
+      // Soft-delete the rescue row last so it stops resolving via the
+      // default scope. Anything that needs to reach it (audit logs,
+      // FK joins) can still do so with `paranoid: false`.
+      if (!rescue.deletedAt) {
+        await rescue.destroy({ transaction: tx });
+      }
+
+      await AuditLogService.log({
+        action: 'GDPR_RESCUE_ERASE',
+        entity: 'Rescue',
+        entityId: rescueId,
+        userId: actorUserId ?? rescueId,
+        details: {
+          reason: reason ?? 'GDPR Art. 17 rescue erasure request',
+          alreadyArchived,
+          petsArchived,
+          applicationsRejected: pendingApps.length,
+          staffDowngraded,
+          actorUserId: actorUserId ?? null,
+        },
+      });
+
+      logger.info('Rescue anonymised for GDPR erasure', {
+        rescueId,
+        actorUserId: actorUserId ?? null,
+        alreadyArchived,
+        petsArchived,
+        applicationsRejected: pendingApps.length,
+        staffDowngraded,
+      });
+
+      return {
+        rescueId,
+        alreadyArchived,
+        petsArchived,
+        applicationsRejected: pendingApps.length,
+        staffDowngraded,
+        applicantUserIdsToNotify,
+      };
+    });
+
+    // Post-commit side-effect: notify each applicant that the rescue
+    // they applied to has been deleted and their application was
+    // auto-rejected. Failure to deliver does NOT roll back the erase —
+    // the source-of-truth state is already committed.
+    const uniqueApplicants = [...new Set(result.applicantUserIdsToNotify)];
+    if (uniqueApplicants.length > 0) {
+      try {
+        await NotificationService.createBulkNotifications(
+          uniqueApplicants,
+          {
+            type: NotificationType.APPLICATION_STATUS,
+            title: 'Your application was closed',
+            message:
+              'The rescue you applied to has closed its account. Your application has been automatically rejected. Please browse other rescues for available pets.',
+            data: { rescueId, cause: 'rescue_erasure' },
+          },
+          actorUserId ?? rescueId
+        );
+      } catch (error) {
+        logger.error('Failed to notify applicants after rescue erasure', {
+          rescueId,
+          applicantCount: uniqueApplicants.length,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return result;
   },
 };
 


### PR DESCRIPTION
## Summary

Implements GDPR Art. 17 rescue-account erasure (ADS-87). A new `GdprService.eraseRescue` anonymises a rescue end-to-end inside a single transaction:

- **Rescue row**: PII columns (name, email, phone, address, description, contact*) blanked, status flipped to `inactive`, paranoid soft-deleted. The row is kept so FK references from preserved pets / applications / audit logs continue to resolve. The name is suffixed with `rescueId` to avoid collisions on the unique-name index when a second erase runs.
- **Owned pets**: archived (`archived: true`, `status: not_available`). Existing pet discovery / search scopes already filter on `archived: false`, so they drop out of public surfaces while staying available for adoption history and audit.
- **Pending applications** on the rescue's pets: auto-rejected via an `ApplicationStatusTransition` row (the append-only event log that the status trigger reads), with `reason: "Rescue account deleted"`. Applicants get an in-app notification fired AFTER commit — notification delivery failures cannot roll back the erase.
- **Staff**: `StaffMember` rows for the rescue are paranoid soft-deleted; `User` accounts and their `UserRole` grants are **untouched** per the design doc — staff are downgraded, not deleted.
- **Audit**: a single aggregate `GDPR_RESCUE_ERASE` log row captures counts (pets archived, applications rejected, staff downgraded).
- **Concurrency**: the rescue row is locked with `SELECT ... FOR UPDATE` inside the transaction. Overlapping calls serialise; the second observes `alreadyArchived = true` and is a no-op.

Route: `POST /api/v1/rescues/:rescueId/erase` (gated: platform admin OR rescue staff acting on their own rescue, mirroring the existing GDPR controller's admin pattern).

I did **not** add the optional `POST /api/v1/me/rescue/erase` self-service variant — the design doc allowed skipping it where there's no clean "current user's rescue" concept. `req.user.rescueId` is populated only for verified `RESCUE_STAFF` users, and the existing per-rescueId route already handles that case via the in-controller permission check, so a separate `/me/rescue/erase` route would be a duplicate alias rather than new capability.

## Verification of related tickets

- **ADS-86 (user erase)** — **Done.** `GdprService.anonymizeUser` tombstones the User row (email/firstName/lastName/phone/address/2FA/etc. blanked), invalidates refresh/device tokens, drops favourites and pending notifications, scrubs Message bodies, soft-deletes the user, writes a `GDPR_ANONYMIZE` audit log. Transactional and idempotent.
- **ADS-84 (DSAR export)** — **Done with one minor gap.** `GdprService.exportUserData` returns User + privacy/notification/application prefs + consents + applications + answers + references + favourites + messages + chat memberships + ratings (given/received) + support tickets + responses, stripped of password / 2FA secrets / verification & reset tokens. Self-service and admin routes are wired.
  - Gap: neither `exportSelf` nor `exportByAdmin` writes an audit log row for the export itself. Per ADS-84's privacy-of-the-data-subject expectation an explicit "export was performed by X for Y" audit entry would close the loop. **Out of scope here** — flagged for a follow-up; would be a 5-line change inside the controller.

## Test plan

- [x] Service test: rescue with 3 pets, 2 pending applications, 2 staff → erase → assert rescue anonymised + soft-deleted, all pets archived, both applications rejected with the expected reason + transition rows, staff rows gone, user accounts intact, notifications fanned out, audit log written with correct counts.
- [x] Idempotency / serialisation: back-to-back erases — first reports `alreadyArchived: false`, second reports `alreadyArchived: true` with zero counts. (SQLite is single-writer in tests, so true concurrent erasure is verified at the contract level only; Postgres exercises the real row lock in dev/prod.)
- [x] Missing rescue: explicit `Rescue not found`.
- [x] Permission: an unrelated rescue-staff user invoking the controller for a different rescue gets HTTP 403 and the target rescue is untouched.
- [x] Full `service.backend` suite (`vitest run`): **2179 passed, 262 skipped, 0 failed**.
- [x] `npm run type-check` clean across the monorepo.
- [x] ESLint clean on the changed files (the one residual warning on `rescue.routes.ts` for an unused `body` import is pre-existing on `main`).

## Open questions for review

1. **Notification copy**: the applicant notification reads *"The rescue you applied to has closed its account. Your application has been automatically rejected. Please browse other rescues for available pets."* Happy to swap if product wants a softer / branded version.
2. **Audit log shape for export**: per the gap noted under ADS-84 — should this PR include the 5-line audit-log addition for `exportSelf` / `exportByAdmin`, or leave it for a dedicated follow-up?
3. **Rescue email collision**: the rescue tombstone uses `deleted-rescue-{rescueId}@redacted.local`, which keeps the unique email index satisfied. The `name` column is also unique and gets suffixed with `rescueId` for the same reason. If product prefers a less identifying tombstone we'd need to drop the unique constraints — flagging in case.

Parent: [ADS-571](https://linear.app/ideasquared/issue/ADS-571)

https://claude.ai/code/session_01RqiAyiGqicd5SwuEprrL1k

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqiAyiGqicd5SwuEprrL1k)_