### PR TITLE
feat(notifications): system-wide broadcast (ADS-107)

### DIFF
--- a/app.admin/src/App.tsx
+++ b/app.admin/src/App.tsx
@@ -32,6 +32,7 @@ const AccountSettings = lazy(() => import('./pages/AccountSettings'));
 const SecurityCenter = lazy(() => import('./pages/SecurityCenter'));
 const FieldPermissions = lazy(() => import('./pages/FieldPermissions'));
 const ContentManagement = lazy(() => import('./pages/ContentManagement'));
+const BroadcastNotifications = lazy(() => import('./pages/BroadcastNotifications'));
 
 const PageLoader = () => (
   <div className={styles.pageLoader}>
@@ -148,6 +149,14 @@ const AdminApp: React.FC = () => {
                 element={
                   <RouteBoundary name='messages'>
                     <Messages />
+                  </RouteBoundary>
+                }
+              />
+              <Route
+                path='/notifications/broadcast'
+                element={
+                  <RouteBoundary name='broadcast'>
+                    <BroadcastNotifications />
                   </RouteBoundary>
                 }
               />

--- a/app.admin/src/components/layout/AdminSidebar.tsx
+++ b/app.admin/src/components/layout/AdminSidebar.tsx
@@ -17,6 +17,7 @@ import {
   FiLock,
   FiSliders,
   FiLayout,
+  FiSend,
 } from 'react-icons/fi';
 
 interface SidebarProps {
@@ -134,6 +135,15 @@ export const AdminSidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) =>
           >
             <FiMessageSquare />
             <span className={styles.navLinkSpan({ collapsed })}>Messages</span>
+          </NavLink>
+          <NavLink
+            to='/notifications/broadcast'
+            className={({ isActive }) =>
+              styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
+            }
+          >
+            <FiSend />
+            <span className={styles.navLinkSpan({ collapsed })}>Broadcast</span>
           </NavLink>
         </div>
 

--- a/app.admin/src/pages/BroadcastNotifications.css.ts
+++ b/app.admin/src/pages/BroadcastNotifications.css.ts
@@ -1,0 +1,51 @@
+import { style } from '@vanilla-extract/css';
+
+export const form = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  maxWidth: '720px',
+});
+
+export const channelsRow = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '1rem',
+});
+
+export const channelLabel = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  fontSize: '0.875rem',
+});
+
+export const actions = style({
+  display: 'flex',
+  gap: '0.75rem',
+  alignItems: 'center',
+});
+
+export const previewLabel = style({
+  fontSize: '0.875rem',
+  color: '#6b7280',
+});
+
+export const result = style({
+  marginTop: '1rem',
+  padding: '0.875rem 1rem',
+  border: '1px solid #d1fae5',
+  background: '#ecfdf5',
+  borderRadius: '8px',
+  fontSize: '0.875rem',
+});
+
+export const error = style({
+  marginTop: '1rem',
+  padding: '0.875rem 1rem',
+  border: '1px solid #fecaca',
+  background: '#fef2f2',
+  color: '#991b1b',
+  borderRadius: '8px',
+  fontSize: '0.875rem',
+});

--- a/app.admin/src/pages/BroadcastNotifications.test.tsx
+++ b/app.admin/src/pages/BroadcastNotifications.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@adopt-dont-shop/lib.components', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@adopt-dont-shop/lib.components');
+  return {
+    ...actual,
+    SelectInput: ({
+      label,
+      value,
+      onChange,
+      options,
+    }: {
+      label: string;
+      value: string;
+      onChange: (v: string) => void;
+      options: { value: string; label: string }[];
+    }) =>
+      React.createElement(
+        'label',
+        null,
+        label,
+        React.createElement(
+          'select',
+          {
+            'aria-label': label,
+            value,
+            onChange: (e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value),
+          },
+          options.map(o => React.createElement('option', { key: o.value, value: o.value }, o.label))
+        )
+      ),
+    TextInput: ({
+      label,
+      value,
+      onChange,
+    }: {
+      label: string;
+      value: string;
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    }) =>
+      React.createElement(
+        'label',
+        null,
+        label,
+        React.createElement('input', { 'aria-label': label, value, onChange })
+      ),
+    TextArea: ({
+      label,
+      value,
+      onChange,
+    }: {
+      label: string;
+      value: string;
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    }) =>
+      React.createElement(
+        'label',
+        null,
+        label,
+        React.createElement('textarea', { 'aria-label': label, value, onChange })
+      ),
+  };
+});
+
+vi.mock('../components/ui', () => ({
+  PageContainer: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  PageHeader: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('header', null, children),
+  HeaderLeft: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  Card: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+  CardHeader: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  CardTitle: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('h2', null, children),
+  CardContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+
+const mockSendBroadcast = vi.fn();
+const mockPreviewBroadcast = vi.fn();
+vi.mock('../services/broadcastService', () => ({
+  sendBroadcast: (...args: unknown[]) => mockSendBroadcast(...args),
+  previewBroadcastAudience: (...args: unknown[]) => mockPreviewBroadcast(...args),
+}));
+
+import BroadcastNotifications from './BroadcastNotifications';
+
+describe('BroadcastNotifications page', () => {
+  beforeEach(() => {
+    mockSendBroadcast.mockReset();
+    mockPreviewBroadcast.mockReset();
+  });
+
+  it('disables the preview button until title and body are filled', () => {
+    render(<BroadcastNotifications />);
+    expect(screen.getByRole('button', { name: /preview & send/i })).toBeDisabled();
+  });
+
+  it('previews the audience count, then sends with an idempotency key', async () => {
+    mockPreviewBroadcast.mockResolvedValue(123);
+    mockSendBroadcast.mockResolvedValue({
+      audience: 'all',
+      targetCount: 123,
+      deliveredInApp: 123,
+      skippedByPrefs: 0,
+      skippedByDnd: 0,
+      channels: ['in_app'],
+    });
+
+    render(<BroadcastNotifications />);
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Hello' } });
+    fireEvent.change(screen.getByLabelText('Body'), { target: { value: 'Body text' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /preview & send/i }));
+
+    await waitFor(() => {
+      expect(mockPreviewBroadcast).toHaveBeenCalledWith('all');
+    });
+    expect(await screen.findByText(/123 users/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /send broadcast/i }));
+
+    await waitFor(() => {
+      expect(mockSendBroadcast).toHaveBeenCalledTimes(1);
+    });
+
+    const args = mockSendBroadcast.mock.calls[0][0];
+    expect(args.audience).toBe('all');
+    expect(args.title).toBe('Hello');
+    expect(args.body).toBe('Body text');
+    expect(args.channels).toEqual(['in_app']);
+    expect(typeof args.idempotencyKey).toBe('string');
+    expect(args.idempotencyKey.length).toBeGreaterThan(0);
+  });
+
+  it('surfaces an error message when the broadcast fails', async () => {
+    mockPreviewBroadcast.mockResolvedValue(5);
+    mockSendBroadcast.mockRejectedValue(new Error('Boom'));
+
+    render(<BroadcastNotifications />);
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'x' } });
+    fireEvent.change(screen.getByLabelText('Body'), { target: { value: 'y' } });
+    fireEvent.click(screen.getByRole('button', { name: /preview & send/i }));
+    await waitFor(() => expect(mockPreviewBroadcast).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: /send broadcast/i }));
+
+    expect(await screen.findByText('Boom')).toBeInTheDocument();
+  });
+});

--- a/app.admin/src/pages/BroadcastNotifications.tsx
+++ b/app.admin/src/pages/BroadcastNotifications.tsx
@@ -1,0 +1,221 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Heading,
+  SelectInput,
+  Text,
+  TextArea,
+  TextInput,
+} from '@adopt-dont-shop/lib.components';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  HeaderLeft,
+  PageContainer,
+  PageHeader,
+} from '../components/ui';
+import {
+  BroadcastAudience,
+  BroadcastChannel,
+  BroadcastResult,
+  previewBroadcastAudience,
+  sendBroadcast,
+} from '../services/broadcastService';
+import * as styles from './BroadcastNotifications.css';
+
+const AUDIENCE_OPTIONS = [
+  { value: 'all', label: 'Everyone (active users)' },
+  { value: 'all-rescues', label: 'All rescue staff & volunteers' },
+  { value: 'all-adopters', label: 'All adopters' },
+  { value: 'all-staff', label: 'All platform staff' },
+];
+
+const CHANNEL_OPTIONS: { value: BroadcastChannel; label: string }[] = [
+  { value: 'in_app', label: 'In-app' },
+  { value: 'email', label: 'Email' },
+  { value: 'push', label: 'Push' },
+  { value: 'sms', label: 'SMS' },
+];
+
+const generateIdempotencyKey = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID — used by tests
+  // and very old browsers. Random enough for an idempotency key; the
+  // server also hashes it before storing.
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
+const BroadcastNotifications: React.FC = () => {
+  const [audience, setAudience] = useState<BroadcastAudience>('all');
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [channels, setChannels] = useState<BroadcastChannel[]>(['in_app']);
+  const [previewCount, setPreviewCount] = useState<number | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [result, setResult] = useState<BroadcastResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleChannel = (channel: BroadcastChannel) => {
+    setChannels(prev =>
+      prev.includes(channel) ? prev.filter(c => c !== channel) : [...prev, channel]
+    );
+  };
+
+  const canSend = title.trim().length > 0 && body.trim().length > 0 && channels.length > 0;
+
+  const handlePreview = async () => {
+    setPreviewing(true);
+    setError(null);
+    try {
+      const count = await previewBroadcastAudience(audience);
+      setPreviewCount(count);
+      setConfirming(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to preview audience');
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const handleSend = async () => {
+    setSending(true);
+    setError(null);
+    try {
+      const broadcast = await sendBroadcast({
+        audience,
+        title,
+        body,
+        channels,
+        idempotencyKey: generateIdempotencyKey(),
+      });
+      setResult(broadcast);
+      setConfirming(false);
+      // Clear the composer on success so a stale title/body doesn't
+      // re-fire on the next click. Channels and audience are preserved
+      // because admins often send a series to the same cohort.
+      setTitle('');
+      setBody('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send broadcast');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <PageContainer>
+      <PageHeader>
+        <HeaderLeft>
+          <Heading level='h1'>Broadcast notifications</Heading>
+          <Text>
+            Send a system-wide notification to a coarse audience cohort. Per-user notification
+            preferences and Do Not Disturb are respected for email, push, and SMS — in-app is always
+            recorded.
+          </Text>
+        </HeaderLeft>
+      </PageHeader>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Compose broadcast</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className={styles.form}>
+            <SelectInput
+              label='Audience'
+              value={audience}
+              onChange={(value: string | string[]) => setAudience(value as BroadcastAudience)}
+              options={AUDIENCE_OPTIONS}
+            />
+
+            <TextInput
+              label='Title'
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              maxLength={200}
+              required
+              fullWidth
+            />
+
+            <TextArea
+              label='Body'
+              value={body}
+              onChange={e => setBody(e.target.value)}
+              maxLength={2000}
+              rows={6}
+              required
+            />
+
+            <div>
+              <Text>Channels</Text>
+              <div className={styles.channelsRow}>
+                {CHANNEL_OPTIONS.map(option => (
+                  <label key={option.value} className={styles.channelLabel}>
+                    <input
+                      type='checkbox'
+                      checked={channels.includes(option.value)}
+                      onChange={() => toggleChannel(option.value)}
+                    />
+                    {option.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className={styles.actions}>
+              <Button
+                variant='primary'
+                onClick={handlePreview}
+                disabled={!canSend || previewing || sending}
+              >
+                {previewing ? 'Checking audience…' : 'Preview & send'}
+              </Button>
+            </div>
+
+            {confirming && previewCount !== null && (
+              <div className={styles.result}>
+                <strong>Confirm broadcast</strong>
+                <div>
+                  This will notify {previewCount.toLocaleString()} user
+                  {previewCount === 1 ? '' : 's'} via {channels.join(', ')}.
+                </div>
+                <div className={styles.actions}>
+                  <Button variant='primary' onClick={handleSend} disabled={sending}>
+                    {sending ? 'Sending…' : 'Send broadcast'}
+                  </Button>
+                  <Button
+                    variant='secondary'
+                    onClick={() => setConfirming(false)}
+                    disabled={sending}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {result && (
+              <div className={styles.result}>
+                <strong>Broadcast sent.</strong>
+                <div>
+                  Target: {result.targetCount}, in-app delivered: {result.deliveredInApp}, skipped
+                  by prefs: {result.skippedByPrefs}, skipped by DND: {result.skippedByDnd}.
+                </div>
+              </div>
+            )}
+
+            {error && <div className={styles.error}>{error}</div>}
+          </div>
+        </CardContent>
+      </Card>
+    </PageContainer>
+  );
+};
+
+export default BroadcastNotifications;

--- a/app.admin/src/services/broadcastService.ts
+++ b/app.admin/src/services/broadcastService.ts
@@ -1,0 +1,66 @@
+import { apiService } from './libraryServices';
+
+export type BroadcastAudience = 'all' | 'all-rescues' | 'all-adopters' | 'all-staff';
+export type BroadcastChannel = 'in_app' | 'email' | 'push' | 'sms';
+
+export type BroadcastResult = {
+  audience: BroadcastAudience;
+  targetCount: number;
+  deliveredInApp: number;
+  skippedByPrefs: number;
+  skippedByDnd: number;
+  channels: BroadcastChannel[];
+};
+
+export type SendBroadcastInput = {
+  audience: BroadcastAudience;
+  title: string;
+  body: string;
+  channels: BroadcastChannel[];
+  idempotencyKey: string;
+};
+
+type SuccessEnvelope<T> = { success: true; data: T; message?: string };
+type ErrorEnvelope = { success: false; message?: string; error?: string };
+
+/**
+ * ADS-107: thin client over the backend broadcast endpoint. The
+ * idempotency key is sent via the `Idempotency-Key` header the
+ * server's shared idempotency middleware understands — a retry with
+ * the same key inside 24h replays the cached response, so the user
+ * isn't punished for an unreliable network.
+ */
+export const sendBroadcast = async (input: SendBroadcastInput): Promise<BroadcastResult> => {
+  const response = await apiService.fetchWithAuth<SuccessEnvelope<BroadcastResult> | ErrorEnvelope>(
+    '/api/v1/notifications/broadcast',
+    {
+      method: 'POST',
+      headers: { 'Idempotency-Key': input.idempotencyKey },
+      body: {
+        audience: input.audience,
+        title: input.title,
+        body: input.body,
+        channels: input.channels,
+      },
+    }
+  );
+
+  if (!response || response.success !== true) {
+    const message = response?.message ?? 'Failed to send broadcast';
+    throw new Error(message);
+  }
+
+  return response.data;
+};
+
+export const previewBroadcastAudience = async (audience: BroadcastAudience): Promise<number> => {
+  const response = await apiService.get<
+    SuccessEnvelope<{ audience: BroadcastAudience; count: number }> | ErrorEnvelope
+  >('/api/v1/notifications/broadcast/preview', { audience });
+
+  if (!response || response.success !== true) {
+    throw new Error('Failed to preview audience');
+  }
+
+  return response.data.count;
+};

--- a/service.backend/src/__tests__/middleware/rate-limiter.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/rate-limiter.middleware.test.ts
@@ -67,7 +67,8 @@ describe('Rate Limiter Middleware', () => {
       // API, Auth, Password Reset, Upload, 2FA, Login Email, Email Resend
       // + ADS-458 (account-deletion, invitation-send, sensitive-write)
       // + ADS-517 (search, report)
-      expect(rateLimitConfigs.length).toBe(12);
+      // + ADS-107 (broadcast)
+      expect(rateLimitConfigs.length).toBe(13);
     });
 
     it('should configure all limiters with standard headers', () => {

--- a/service.backend/src/__tests__/routes/broadcast.routes.test.ts
+++ b/service.backend/src/__tests__/routes/broadcast.routes.test.ts
@@ -1,0 +1,200 @@
+import express, { NextFunction, Response } from 'express';
+import request from 'supertest';
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { AuthenticatedRequest } from '../../types';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn(), logBusiness: vi.fn() },
+}));
+
+vi.mock('../../config/env', () => ({
+  env: {
+    JWT_SECRET: 'test-secret-min-32-characters-long-12345',
+    JWT_REFRESH_SECRET: 'test-refresh-secret-min-32-chars-12345',
+    SESSION_SECRET: 'test-session-secret',
+    CSRF_SECRET: 'test-csrf-secret',
+  },
+}));
+
+vi.mock('../../services/notification.service', () => ({
+  NotificationService: {
+    getUserNotifications: vi.fn(),
+    getUnreadCount: vi.fn(),
+    getNotificationPreferences: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/broadcast.service', async () => {
+  const actual = await vi.importActual<typeof import('../../services/broadcast.service')>(
+    '../../services/broadcast.service'
+  );
+  return {
+    ...actual,
+    BroadcastService: {
+      broadcast: vi.fn(),
+      previewAudienceCount: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../services/rich-text-processing.service', () => ({
+  RichTextProcessingService: { sanitize: vi.fn((c: string) => c) },
+}));
+
+// Bypass the shared Idempotency-Key middleware in this test layer; the
+// idempotency contract is already covered by its own dedicated tests.
+// Here we only assert the broadcast route validates input and calls the
+// service exactly once per request.
+vi.mock('../../middleware/idempotency', () => ({
+  idempotency: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+}));
+
+// Disable the rate-limit middleware so we can test the success-path
+// without the in-memory store leaking counts across tests.
+vi.mock('../../middleware/rate-limiter', () => ({
+  broadcastLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+}));
+
+const authenticateTokenMock = vi.fn();
+const requirePermissionMock = vi.fn();
+
+vi.mock('../../middleware/auth', () => ({
+  authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authenticateTokenMock(req, res, next),
+}));
+
+vi.mock('../../middleware/rbac', () => ({
+  requirePermission:
+    (perm: string) => (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+      requirePermissionMock(perm, req, res, next),
+}));
+
+import { BroadcastService } from '../../services/broadcast.service';
+import notificationRouter from '../../routes/notification.routes';
+
+const mockedBroadcast = vi.mocked(BroadcastService.broadcast);
+const mockedPreview = vi.mocked(BroadcastService.previewAudienceCount);
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/notifications', notificationRouter);
+  return app;
+};
+
+const mockUser = {
+  userId: 'admin-1',
+  email: 'admin@example.com',
+};
+
+describe('POST /api/v1/notifications/broadcast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateTokenMock.mockImplementation(
+      (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+        req.user = mockUser as AuthenticatedRequest['user'];
+        next();
+      }
+    );
+    requirePermissionMock.mockImplementation((_perm, _req, _res, next) => next());
+  });
+
+  it('returns 403 when caller lacks the broadcast permission', async () => {
+    requirePermissionMock.mockImplementationOnce((_perm, _req, res: Response) => {
+      res.status(403).json({ error: 'forbidden' });
+    });
+    const res = await request(buildApp())
+      .post('/api/v1/notifications/broadcast')
+      .send({
+        audience: 'all',
+        title: 'Hello',
+        body: 'Body',
+        channels: ['in_app'],
+      });
+    expect(res.status).toBe(403);
+    expect(mockedBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid audience with 400', async () => {
+    const res = await request(buildApp())
+      .post('/api/v1/notifications/broadcast')
+      .send({
+        audience: 'all-banned',
+        title: 'Hi',
+        body: 'Body',
+        channels: ['in_app'],
+      });
+    expect(res.status).toBe(400);
+    expect(mockedBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty channels array with 400', async () => {
+    const res = await request(buildApp()).post('/api/v1/notifications/broadcast').send({
+      audience: 'all',
+      title: 'Hi',
+      body: 'Body',
+      channels: [],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('sends a broadcast with the validated payload', async () => {
+    mockedBroadcast.mockResolvedValue({
+      audience: 'all',
+      targetCount: 5,
+      deliveredInApp: 5,
+      skippedByPrefs: 0,
+      skippedByDnd: 0,
+      channels: ['in_app'],
+    });
+
+    const res = await request(buildApp())
+      .post('/api/v1/notifications/broadcast')
+      .send({
+        audience: 'all',
+        title: 'Hello',
+        body: 'Body',
+        channels: ['in_app'],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.targetCount).toBe(5);
+    expect(mockedBroadcast).toHaveBeenCalledWith({
+      audience: 'all',
+      title: 'Hello',
+      body: 'Body',
+      channels: ['in_app'],
+      initiatedBy: mockUser.userId,
+    });
+  });
+});
+
+describe('GET /api/v1/notifications/broadcast/preview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateTokenMock.mockImplementation(
+      (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+        req.user = mockUser as AuthenticatedRequest['user'];
+        next();
+      }
+    );
+    requirePermissionMock.mockImplementation((_perm, _req, _res, next) => next());
+  });
+
+  it('returns the audience count', async () => {
+    mockedPreview.mockResolvedValue(42);
+    const res = await request(buildApp())
+      .get('/api/v1/notifications/broadcast/preview')
+      .query({ audience: 'all' });
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ audience: 'all', count: 42 });
+  });
+
+  it('rejects an invalid audience query', async () => {
+    const res = await request(buildApp())
+      .get('/api/v1/notifications/broadcast/preview')
+      .query({ audience: 'nonsense' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/service.backend/src/__tests__/services/broadcast.service.test.ts
+++ b/service.backend/src/__tests__/services/broadcast.service.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Notification, { NotificationChannel } from '../../models/Notification';
+import Role from '../../models/Role';
+import User, { UserStatus, UserType } from '../../models/User';
+import UserRole from '../../models/UserRole';
+import sequelize from '../../sequelize';
+import { BroadcastService } from '../../services/broadcast.service';
+
+// Sidestep the channel service's email/push/SMS side-effects — we
+// assert at the broadcast layer (counts + persisted in-app rows) and
+// trust the channel service's own tests for downstream delivery.
+vi.mock('../../services/notificationChannelService', () => ({
+  NotificationChannelService: {
+    getDeliveryChannels: vi.fn(async () => ['email']),
+    deliverToChannels: vi.fn(async () => []),
+    isInQuietHours: vi.fn(() => false),
+  },
+}));
+
+vi.mock('../../services/auditLog.service', () => ({
+  AuditLogService: { log: vi.fn(async () => undefined) },
+}));
+
+import { NotificationChannelService } from '../../services/notificationChannelService';
+
+const mockedChannelService = vi.mocked(NotificationChannelService);
+
+const createUser = async (
+  email: string,
+  status: UserStatus = UserStatus.ACTIVE,
+  userType: UserType = UserType.ADOPTER
+): Promise<string> => {
+  const user = await User.create({
+    email,
+    password: 'hashed-password-min-length',
+    firstName: 'Test',
+    lastName: 'User',
+    status,
+    userType,
+    loginAttempts: 0,
+    emailVerified: true,
+  });
+  return user.userId;
+};
+
+const seedRoles = async (): Promise<Record<string, number>> => {
+  const names = [
+    'super_admin',
+    'admin',
+    'moderator',
+    'rescue_admin',
+    'rescue_staff',
+    'rescue_volunteer',
+    'adopter',
+    'verified_adopter',
+  ];
+  const out: Record<string, number> = {};
+  for (const name of names) {
+    const [role] = await Role.findOrCreate({
+      where: { name },
+      defaults: { name, description: name },
+    });
+    out[name] = role.roleId;
+  }
+  return out;
+};
+
+const assignRole = async (userId: string, roleId: number): Promise<void> => {
+  await UserRole.create({ userId, roleId });
+};
+
+const seedCohorts = async (): Promise<{
+  roles: Record<string, number>;
+  staffId: string;
+  rescueStaffId: string;
+  rescueVolunteerId: string;
+  adopterId: string;
+  inactiveAdopterId: string;
+}> => {
+  const roles = await seedRoles();
+  const staffId = await createUser('admin@test.dev', UserStatus.ACTIVE, UserType.ADMIN);
+  await assignRole(staffId, roles.admin);
+
+  const rescueStaffId = await createUser(
+    'rescue@test.dev',
+    UserStatus.ACTIVE,
+    UserType.RESCUE_STAFF
+  );
+  await assignRole(rescueStaffId, roles.rescue_staff);
+
+  const rescueVolunteerId = await createUser('vol@test.dev');
+  await assignRole(rescueVolunteerId, roles.rescue_volunteer);
+
+  const adopterId = await createUser('adopter@test.dev');
+  await assignRole(adopterId, roles.adopter);
+
+  const inactiveAdopterId = await createUser(
+    'inactive@test.dev',
+    UserStatus.SUSPENDED,
+    UserType.ADOPTER
+  );
+  await assignRole(inactiveAdopterId, roles.adopter);
+
+  return { roles, staffId, rescueStaffId, rescueVolunteerId, adopterId, inactiveAdopterId };
+};
+
+describe('BroadcastService', () => {
+  beforeEach(async () => {
+    // Paranoid User model + SQLite truncate-as-delete in setup leaves
+    // soft-deleted rows that re-trigger the unique-email constraint on
+    // re-seed. Rebuilding the schema each test is the simplest reset.
+    await sequelize.sync({ force: true });
+    mockedChannelService.getDeliveryChannels.mockResolvedValue(['email']);
+    mockedChannelService.deliverToChannels.mockResolvedValue([]);
+    mockedChannelService.isInQuietHours.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('audience resolution', () => {
+    it('targets every active user for "all"', async () => {
+      const cohorts = await seedCohorts();
+
+      const result = await BroadcastService.broadcast({
+        audience: 'all',
+        title: 'Hello',
+        body: 'World',
+        channels: [NotificationChannel.IN_APP],
+        initiatedBy: cohorts.staffId,
+      });
+
+      // 4 active users: admin, rescue_staff, rescue_volunteer, adopter
+      // (the suspended adopter is excluded).
+      expect(result.targetCount).toBe(4);
+      expect(result.deliveredInApp).toBe(4);
+    });
+
+    it('targets only rescue role holders for "all-rescues"', async () => {
+      const cohorts = await seedCohorts();
+
+      const result = await BroadcastService.broadcast({
+        audience: 'all-rescues',
+        title: 'Rescue news',
+        body: 'Update',
+        channels: [NotificationChannel.IN_APP],
+        initiatedBy: cohorts.staffId,
+      });
+
+      // rescue_staff + rescue_volunteer
+      expect(result.targetCount).toBe(2);
+    });
+
+    it('targets only staff (admin/super_admin/moderator) for "all-staff"', async () => {
+      const cohorts = await seedCohorts();
+
+      const result = await BroadcastService.broadcast({
+        audience: 'all-staff',
+        title: 'Staff memo',
+        body: 'Update',
+        channels: [NotificationChannel.IN_APP],
+        initiatedBy: cohorts.staffId,
+      });
+
+      expect(result.targetCount).toBe(1);
+    });
+
+    it('excludes rescue + staff users for "all-adopters"', async () => {
+      const cohorts = await seedCohorts();
+
+      const result = await BroadcastService.broadcast({
+        audience: 'all-adopters',
+        title: 'Adopter news',
+        body: 'Update',
+        channels: [NotificationChannel.IN_APP],
+        initiatedBy: cohorts.staffId,
+      });
+
+      // Only the active adopter — the suspended one is excluded by status.
+      expect(result.targetCount).toBe(1);
+    });
+
+    it('skips suspended users from "all"', async () => {
+      const roles = await seedRoles();
+      const active = await createUser('a@test.dev');
+      await assignRole(active, roles.adopter);
+      const suspended = await createUser('s@test.dev', UserStatus.SUSPENDED);
+      await assignRole(suspended, roles.adopter);
+
+      const result = await BroadcastService.broadcast({
+        audience: 'all',
+        title: 'x',
+        body: 'y',
+        channels: [NotificationChannel.IN_APP],
+        initiatedBy: active,
+      });
+
+      expect(result.targetCount).toBe(1);
+    });
+  });
+
+  describe('preferences and DND', () => {
+    it('counts DND users as skipped without invoking channel delivery', async () => {
+      const cohorts = await seedCohorts();
+      mockedChannelService.isInQuietHours.mockReturnValue(true);
+
+      const result = await BroadcastService.broadcast({
+        audience: 'all-staff',
+        title: 'Memo',
+        body: 'Body',
+        channels: [NotificationChannel.IN_APP, NotificationChannel.EMAIL],
+        initiatedBy: cohorts.staffId,
+      });
+
+      expect(result.targetCount).toBe(1);
+      expect(result.skippedByDnd).toBe(1);
+      expect(mockedChannelService.deliverToChannels).not.toHaveBeenCalled();
+      // In-app row is still persisted — DND only gates external channels.
+      expect(result.deliveredInApp).toBe(1);
+    });
+
+    it('counts users with email disabled as skipped-by-prefs', async () => {
+      const cohorts = await seedCohorts();
+      mockedChannelService.getDeliveryChannels.mockResolvedValue([]);
+
+      const result = await BroadcastService.broadcast({
+        audience: 'all-staff',
+        title: 'Memo',
+        body: 'Body',
+        channels: [NotificationChannel.IN_APP, NotificationChannel.EMAIL],
+        initiatedBy: cohorts.staffId,
+      });
+
+      expect(result.skippedByPrefs).toBe(1);
+      expect(mockedChannelService.deliverToChannels).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('persistence', () => {
+    it('writes one in-app Notification per recipient', async () => {
+      const cohorts = await seedCohorts();
+
+      await BroadcastService.broadcast({
+        audience: 'all-rescues',
+        title: 'Hi',
+        body: 'Body',
+        channels: [NotificationChannel.IN_APP],
+        initiatedBy: cohorts.staffId,
+      });
+
+      const rows = await Notification.findAll();
+      expect(rows).toHaveLength(2);
+      for (const row of rows) {
+        expect(row.title).toBe('Hi');
+        expect(row.channel).toBe(NotificationChannel.IN_APP);
+      }
+    });
+  });
+
+  describe('previewAudienceCount', () => {
+    it('returns the active user count without writing anything', async () => {
+      const cohorts = await seedCohorts();
+
+      const count = await BroadcastService.previewAudienceCount('all');
+      expect(count).toBe(4);
+      const after = await Notification.count();
+      expect(after).toBe(0);
+      // and previewing doesn't change the seeded data
+      expect(cohorts.adopterId).toBeDefined();
+    });
+  });
+});

--- a/service.backend/src/controllers/broadcast.controller.ts
+++ b/service.backend/src/controllers/broadcast.controller.ts
@@ -1,0 +1,95 @@
+import { Response } from 'express';
+import { validationResult } from 'express-validator';
+import {
+  BROADCAST_AUDIENCES,
+  BroadcastAudience,
+  BroadcastService,
+} from '../services/broadcast.service';
+import { RichTextProcessingService } from '../services/rich-text-processing.service';
+import { AuthenticatedRequest } from '../types/auth';
+import { logger } from '../utils/logger';
+
+export class BroadcastController {
+  /**
+   * POST /api/v1/notifications/broadcast — fan a system-wide message
+   * out to a coarse audience cohort. Admin-gated upstream; the
+   * controller only validates input and translates service errors to
+   * HTTP. Idempotency is handled by the shared Idempotency-Key
+   * middleware on the route, so a retry with the same key returns the
+   * cached response inside 24h.
+   */
+  broadcast = async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({
+          success: false,
+          message: 'Validation failed',
+          errors: errors.array(),
+        });
+      }
+
+      const audience = req.body.audience as BroadcastAudience;
+      const title = req.body.title as string;
+      const body =
+        typeof req.body.body === 'string'
+          ? RichTextProcessingService.sanitize(req.body.body)
+          : req.body.body;
+      const channels = req.body.channels;
+
+      const result = await BroadcastService.broadcast({
+        audience,
+        title,
+        body,
+        channels,
+        initiatedBy: req.user!.userId,
+      });
+
+      res.status(201).json({
+        success: true,
+        message: `Broadcast queued for ${result.targetCount} user(s)`,
+        data: result,
+      });
+    } catch (error) {
+      logger.error('Broadcast failed:', error);
+      res.status(500).json({
+        success: false,
+        message: 'Failed to send broadcast',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+
+  /**
+   * GET /api/v1/notifications/broadcast/preview?audience=... — cheap
+   * count of recipients so the admin UI can render a confirm modal
+   * before sending.
+   */
+  previewAudience = async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const audience = req.query.audience;
+      if (
+        typeof audience !== 'string' ||
+        !BROADCAST_AUDIENCES.includes(audience as BroadcastAudience)
+      ) {
+        return res.status(400).json({
+          success: false,
+          message: 'Invalid audience',
+        });
+      }
+
+      const count = await BroadcastService.previewAudienceCount(audience as BroadcastAudience);
+      res.status(200).json({
+        success: true,
+        data: { audience, count },
+      });
+    } catch (error) {
+      logger.error('Broadcast preview failed:', error);
+      res.status(500).json({
+        success: false,
+        message: 'Failed to preview audience',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+}

--- a/service.backend/src/middleware/rate-limiter.ts
+++ b/service.backend/src/middleware/rate-limiter.ts
@@ -248,6 +248,32 @@ export const searchLimiter = buildRouteLimiter(15 * 60 * 1000, 30, 'SEARCH', 900
 // These run pre-aggregations and stream large response bodies.
 export const reportLimiter = buildRouteLimiter(15 * 60 * 1000, 10, 'REPORT', 900);
 
+// ADS-107: per-admin system-wide broadcast limiter. Coarse audiences
+// (all, all-rescues, all-adopters, all-staff) make this disproportionately
+// expensive — 10 / minute / admin keeps an over-eager admin from flooding
+// every user on the platform with notifications in a tight loop.
+export const broadcastLimiter =
+  config.nodeEnv === 'development'
+    ? createDevLimiter(60 * 1000, 10, 'BROADCAST')
+    : rateLimit({
+        windowMs: 60 * 1000,
+        max: 10,
+        keyGenerator: (req: RequestWithMaybeUser) => getUserIdOrIp(req),
+        message: {
+          error: 'Broadcast rate limit exceeded. Please wait before sending another broadcast.',
+          retryAfter: 60,
+        },
+        standardHeaders: true,
+        legacyHeaders: false,
+        handler: (req: RequestWithMaybeUser, res) => {
+          logger.warn(`Broadcast rate limit exceeded for user: ${req.user?.userId || req.ip}`);
+          res.status(429).json({
+            error: 'Broadcast rate limit exceeded. Please wait before sending another broadcast.',
+            retryAfter: 60,
+          });
+        },
+      });
+
 // Email verification resend limiter — stricter than auth limiter to prevent abuse
 // Keyed on both IP and target email to prevent using endpoint as email relay
 export const emailResendLimiter =

--- a/service.backend/src/routes/notification.routes.ts
+++ b/service.backend/src/routes/notification.routes.ts
@@ -1,12 +1,31 @@
 import { Router } from 'express';
 import { body, param, query } from 'express-validator';
+import { BroadcastController } from '../controllers/broadcast.controller';
 import { NotificationController } from '../controllers/notification.controller';
 import { authenticateToken } from '../middleware/auth';
+import { idempotency } from '../middleware/idempotency';
+import { broadcastLimiter } from '../middleware/rate-limiter';
 import { requirePermission } from '../middleware/rbac';
+import { BROADCAST_AUDIENCES } from '../services/broadcast.service';
 import { PERMISSIONS } from '../types/rbac';
 
 const router = Router();
 const notificationController = new NotificationController();
+const broadcastController = new BroadcastController();
+
+// ADS-107: system-wide broadcast validation.
+const validateBroadcast = [
+  body('audience')
+    .isString()
+    .isIn([...BROADCAST_AUDIENCES])
+    .withMessage('audience must be one of: all, all-rescues, all-adopters, all-staff'),
+  body('title').trim().isLength({ min: 1, max: 200 }).withMessage('Title must be 1-200 characters'),
+  body('body').trim().isLength({ min: 1, max: 2000 }).withMessage('Body must be 1-2000 characters'),
+  body('channels').isArray({ min: 1 }).withMessage('channels must be a non-empty array'),
+  body('channels.*')
+    .isIn(['in_app', 'email', 'push', 'sms'])
+    .withMessage('Invalid notification channel'),
+];
 
 // Validation middleware
 const validateNotificationId = param('notificationId')
@@ -734,6 +753,25 @@ router.post(
   '/cleanup',
   requirePermission(PERMISSIONS.NOTIFICATION_CLEANUP),
   notificationController.cleanupExpiredNotifications
+);
+
+// ADS-107: system-wide broadcast. The Idempotency-Key header replays
+// the cached response inside 24h (see middleware/idempotency.ts), so a
+// retried broadcast doesn't re-fan to every user. The dedicated
+// per-admin rate limiter (10/min) blunts accidental flood loops.
+router.get(
+  '/broadcast/preview',
+  requirePermission(PERMISSIONS.NOTIFICATION_BROADCAST),
+  broadcastController.previewAudience
+);
+
+router.post(
+  '/broadcast',
+  broadcastLimiter,
+  requirePermission(PERMISSIONS.NOTIFICATION_BROADCAST),
+  idempotency,
+  validateBroadcast,
+  broadcastController.broadcast
 );
 
 export default router;

--- a/service.backend/src/seeders/reference/permissions.ts
+++ b/service.backend/src/seeders/reference/permissions.ts
@@ -139,6 +139,8 @@ const permissions = [
   // Notifications (expanded)
   'notifications.bulk_create',
   'notifications.cleanup',
+  // ADS-107: system-wide broadcasts (admin only).
+  'notifications.broadcast',
 
   // Analytics Reports (ADS-105)
   'reports.create',
@@ -165,5 +167,6 @@ export async function seedPermissions() {
     });
   }
 
+  // eslint-disable-next-line no-console -- existing seeder log; surfaces to dev CLI only.
   console.log(`✅ Created ${permissions.length} permissions`);
 }

--- a/service.backend/src/seeders/reference/role-permissions.ts
+++ b/service.backend/src/seeders/reference/role-permissions.ts
@@ -108,6 +108,7 @@ const rolePermissionMappings = {
     'notifications.delete',
     'notifications.bulk_create',
     'notifications.cleanup',
+    'notifications.broadcast',
     'chat.analytics.read',
     // Analytics Reports (ADS-105)
     'reports.create',
@@ -215,6 +216,7 @@ const rolePermissionMappings = {
     'notifications.read',
     'notifications.update',
     'notifications.bulk_create',
+    'notifications.broadcast',
     'chat.analytics.read',
     // Analytics Reports (ADS-105) — admins get full platform read
     'reports.create',
@@ -440,5 +442,6 @@ export async function seedRolePermissions() {
     }
   }
 
+  // eslint-disable-next-line no-console -- existing seeder log; surfaces to dev CLI only.
   console.log(`✅ Created ${assignmentCount} role-permission assignments`);
 }

--- a/service.backend/src/services/broadcast.service.ts
+++ b/service.backend/src/services/broadcast.service.ts
@@ -1,0 +1,274 @@
+import { Op } from 'sequelize';
+import Notification, {
+  NotificationChannel,
+  NotificationPriority,
+  NotificationType,
+} from '../models/Notification';
+import Role from '../models/Role';
+import User, { UserStatus } from '../models/User';
+import UserNotificationPrefs from '../models/UserNotificationPrefs';
+import UserRole from '../models/UserRole';
+import logger, { loggerHelpers } from '../utils/logger';
+import { AuditLogService } from './auditLog.service';
+import { NotificationChannelService } from './notificationChannelService';
+import { NotificationPreferences } from './notification.service';
+
+/**
+ * Coarse audience cohorts for system-wide broadcasts (ADS-107). Finer
+ * targeting (per-rescue, per-cohort segment, etc.) is intentionally out
+ * of scope — those go through the targeted bulk_create path instead.
+ */
+export type BroadcastAudience = 'all' | 'all-rescues' | 'all-adopters' | 'all-staff';
+
+export const BROADCAST_AUDIENCES: readonly BroadcastAudience[] = [
+  'all',
+  'all-rescues',
+  'all-adopters',
+  'all-staff',
+] as const;
+
+const RESCUE_ROLE_NAMES = ['rescue_admin', 'rescue_staff', 'rescue_volunteer'] as const;
+const STAFF_ROLE_NAMES = ['super_admin', 'admin', 'moderator'] as const;
+
+export type BroadcastInput = {
+  audience: BroadcastAudience;
+  title: string;
+  body: string;
+  channels: NotificationChannel[];
+  initiatedBy: string;
+};
+
+export type BroadcastResult = {
+  audience: BroadcastAudience;
+  targetCount: number;
+  deliveredInApp: number;
+  skippedByPrefs: number;
+  skippedByDnd: number;
+  channels: NotificationChannel[];
+};
+
+/**
+ * Resolve a cohort to a set of user IDs. Only active users are
+ * considered — suspended/deactivated/pending-verification accounts are
+ * excluded so we don't leak broadcasts to users we've explicitly cut off.
+ */
+async function resolveAudience(audience: BroadcastAudience): Promise<string[]> {
+  if (audience === 'all') {
+    const users = await User.findAll({
+      where: { status: UserStatus.ACTIVE },
+      attributes: ['userId'],
+    });
+    return users.map(u => u.userId);
+  }
+
+  const roleNames =
+    audience === 'all-staff'
+      ? [...STAFF_ROLE_NAMES]
+      : audience === 'all-rescues'
+        ? [...RESCUE_ROLE_NAMES]
+        : null;
+
+  if (roleNames) {
+    const roles = await Role.findAll({ where: { name: { [Op.in]: roleNames } } });
+    const roleIds = roles.map(r => r.roleId);
+    if (roleIds.length === 0) {
+      return [];
+    }
+    const userRoles = await UserRole.findAll({
+      where: { roleId: { [Op.in]: roleIds } },
+      attributes: ['userId'],
+    });
+    const candidateUserIds = [...new Set(userRoles.map(ur => ur.userId))];
+    if (candidateUserIds.length === 0) {
+      return [];
+    }
+    const users = await User.findAll({
+      where: { userId: { [Op.in]: candidateUserIds }, status: UserStatus.ACTIVE },
+      attributes: ['userId'],
+    });
+    return users.map(u => u.userId);
+  }
+
+  // all-adopters: active users that do NOT hold any rescue_* or staff role.
+  const excludeRoleNames = [...RESCUE_ROLE_NAMES, ...STAFF_ROLE_NAMES];
+  const excludedRoles = await Role.findAll({ where: { name: { [Op.in]: excludeRoleNames } } });
+  const excludedRoleIds = excludedRoles.map(r => r.roleId);
+  const excludedUserRows = excludedRoleIds.length
+    ? await UserRole.findAll({
+        where: { roleId: { [Op.in]: excludedRoleIds } },
+        attributes: ['userId'],
+      })
+    : [];
+  const excludedUserIds = new Set(excludedUserRows.map(ur => ur.userId));
+
+  const activeUsers = await User.findAll({
+    where: { status: UserStatus.ACTIVE },
+    attributes: ['userId'],
+  });
+  return activeUsers.map(u => u.userId).filter(id => !excludedUserIds.has(id));
+}
+
+/**
+ * System-wide broadcast to a coarse audience cohort. Honours per-user
+ * preferences and DND for non-in-app channels — in-app delivery is the
+ * baseline because broadcasts are admin-initiated platform comms, not
+ * marketing.
+ *
+ * Idempotency: the route layer wraps this in the global Idempotency-Key
+ * middleware (see middleware/idempotency.ts), so a retry with the same
+ * key inside 24h replays the cached response instead of re-fanning.
+ */
+export class BroadcastService {
+  static async broadcast(input: BroadcastInput): Promise<BroadcastResult> {
+    const startTime = Date.now();
+
+    const userIds = await resolveAudience(input.audience);
+    const targetCount = userIds.length;
+
+    let deliveredInApp = 0;
+    let skippedByPrefs = 0;
+    let skippedByDnd = 0;
+
+    // Per-user fan-out. In-app delivery is unconditional (the broadcast
+    // is the platform telling the user something), but email/push/sms
+    // are gated by the user's preferences and DND just like every other
+    // notification path. This mirrors NotificationService.createNotification
+    // — we deliberately don't bypass user prefs from the broadcast layer.
+    const wantsExternalChannels = input.channels.some(c => c !== NotificationChannel.IN_APP);
+
+    for (const userId of userIds) {
+      try {
+        const notification = await Notification.create({
+          user_id: userId,
+          type: NotificationType.SYSTEM_ANNOUNCEMENT,
+          title: input.title,
+          message: input.body,
+          priority: NotificationPriority.NORMAL,
+          channel: NotificationChannel.IN_APP,
+          created_at: new Date(),
+        });
+
+        if (input.channels.includes(NotificationChannel.IN_APP)) {
+          deliveredInApp += 1;
+        }
+
+        if (!wantsExternalChannels) {
+          continue;
+        }
+
+        // External channel delivery respects per-user prefs and DND.
+        // The in-app row above is unconditional — it's a record of the
+        // platform announcement, distinct from push/email/SMS reach.
+        const userPrefs = await loadPrefsForBroadcast(userId);
+
+        if (NotificationChannelService.isInQuietHours(userPrefs)) {
+          skippedByDnd += 1;
+          continue;
+        }
+
+        const allowedChannels = await NotificationChannelService.getDeliveryChannels(
+          userId,
+          NotificationType.SYSTEM_ANNOUNCEMENT,
+          'normal'
+        );
+        const requestedExternal: ('email' | 'push' | 'sms')[] = [];
+        for (const c of input.channels) {
+          if (c === NotificationChannel.EMAIL) {
+            requestedExternal.push('email');
+          } else if (c === NotificationChannel.PUSH) {
+            requestedExternal.push('push');
+          } else if (c === NotificationChannel.SMS) {
+            requestedExternal.push('sms');
+          }
+        }
+        const toDeliver = requestedExternal.filter(c => allowedChannels.includes(c));
+
+        if (toDeliver.length === 0 && requestedExternal.length > 0) {
+          skippedByPrefs += 1;
+          continue;
+        }
+
+        await NotificationChannelService.deliverToChannels(
+          {
+            userId,
+            title: input.title,
+            message: input.body,
+            type: NotificationType.SYSTEM_ANNOUNCEMENT,
+            data: { notificationId: notification.notification_id },
+            priority: 'normal',
+          },
+          toDeliver
+        );
+      } catch (err) {
+        logger.error('[broadcast] per-user fan-out failed', {
+          userId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    await AuditLogService.log({
+      userId: input.initiatedBy,
+      action: 'BROADCAST_SENT',
+      entity: 'Notification',
+      entityId: 'broadcast',
+      details: {
+        audience: input.audience,
+        targetCount,
+        deliveredInApp,
+        skippedByPrefs,
+        skippedByDnd,
+        channels: input.channels,
+      },
+    });
+
+    loggerHelpers.logBusiness('Broadcast Sent', {
+      audience: input.audience,
+      targetCount,
+      deliveredInApp,
+      skippedByPrefs,
+      skippedByDnd,
+      duration: Date.now() - startTime,
+    });
+
+    return {
+      audience: input.audience,
+      targetCount,
+      deliveredInApp,
+      skippedByPrefs,
+      skippedByDnd,
+      channels: input.channels,
+    };
+  }
+
+  /**
+   * Helper exposed for the admin UI: how many users would receive a
+   * broadcast for a given cohort, without actually sending anything.
+   */
+  static async previewAudienceCount(audience: BroadcastAudience): Promise<number> {
+    const ids = await resolveAudience(audience);
+    return ids.length;
+  }
+}
+
+/**
+ * Project the typed prefs row into the API-shaped object the channel
+ * service's DND helper expects. Mirrors notificationChannelService.ts
+ * so we don't pull in additional helpers just for the broadcast path.
+ */
+async function loadPrefsForBroadcast(userId: string): Promise<NotificationPreferences> {
+  const row = await UserNotificationPrefs.findOne({ where: { user_id: userId } });
+  return {
+    email: row?.email_enabled ?? true,
+    push: row?.push_enabled ?? true,
+    sms: row?.sms_enabled ?? false,
+    applications: row?.application_updates ?? true,
+    messages: row?.chat_messages ?? true,
+    system: true,
+    marketing: false,
+    reminders: true,
+    quietHoursStart: row?.quiet_hours_start ?? undefined,
+    quietHoursEnd: row?.quiet_hours_end ?? undefined,
+    timezone: row?.timezone ?? 'UTC',
+  };
+}

--- a/service.backend/src/types/rbac.ts
+++ b/service.backend/src/types/rbac.ts
@@ -129,6 +129,12 @@ export const PERMISSIONS = {
   NOTIFICATION_CREATE: 'notifications.create',
   NOTIFICATION_BULK_CREATE: 'notifications.bulk_create',
   NOTIFICATION_CLEANUP: 'notifications.cleanup',
+  // ADS-107: system-wide broadcast to coarse audience cohorts (all,
+  // all-rescues, all-adopters, all-staff). Distinct from
+  // NOTIFICATION_BULK_CREATE so we can grant it only to platform admins
+  // without also enabling generic targeted bulk creation for any role
+  // that happens to need bulk_create.
+  NOTIFICATION_BROADCAST: 'notifications.broadcast',
 
   // System
   AUDIT_LOG_READ: 'audit.read',


### PR DESCRIPTION
## Summary

Adds a system-wide broadcast capability so platform admins can push a single notification to a coarse audience cohort (everyone, all rescues, all adopters, all platform staff). Per-user notification preferences and Do Not Disturb continue to gate email/push/SMS delivery — the broadcast layer never bypasses them. In-app rows are persisted unconditionally because a broadcast is by definition a platform-to-user record.

Parent: [ADS-572](https://linear.app/ideasquared/issue/ADS-572)

## Design

### Audience cohorts (coarse only)
- `all` — every active user.
- `all-rescues` — users holding any `rescue_*` role (rescue_admin / rescue_staff / rescue_volunteer).
- `all-adopters` — active users that hold no rescue or staff role.
- `all-staff` — users with `super_admin`, `admin`, or `moderator` role.

Suspended / deactivated / pending-verification users are excluded across all cohorts.

### Channels
The broadcast respects existing `UserNotificationPrefs` and DND. An in-app `Notification` row is always written (counted under `deliveredInApp`); email/push/SMS are filtered through the existing `NotificationChannelService.getDeliveryChannels` and skipped entirely when the user is in quiet hours.

### Idempotency
The endpoint plugs into the shared `Idempotency-Key` middleware (`middleware/idempotency.ts`). A retry with the same key within 24h replays the cached response — no migration needed because `idempotency_keys` already exists.

### Rate limit
New per-admin limiter (`broadcastLimiter`) caps broadcasts at 10/minute keyed on user ID.

### Permission
New `notifications.broadcast` permission, granted to `super_admin` and `admin`.

## ADS-83 verification verdict

The existing `lib.notifications` client + `service.backend` notification stack delivers the ADS-83 scope: send/bulk-send/schedule, get/list/mark-read/delete, per-user preferences with DND, templates, stats, unread count, and multi-channel delivery via `NotificationChannelService`. Considered **substantially complete** — no gaps small enough (<30 lines) to address in this PR. Minor observations for future work (not touched here):
- `sendEmailNotification` in `notification.service.ts` passes `notification.user_id` as `toEmail`, which is a user ID not an email; the actual email path in this PR goes through `NotificationChannelService.deliverToChannels`, which correctly resolves the user's email.
- `NotificationChannelService.deliverToChannels` does not itself check `isInQuietHours`; this PR applies the DND check at the broadcast layer before invoking it, so broadcasts honour DND even though other notification paths may not.

## Out of scope
- Finer audience targeting (per-rescue, per-segment) — those should continue to go through `POST /notifications/bulk` with an explicit `userIds` array.
- Scheduled broadcasts — synchronous send only.
- Migrations — none required; reuses `idempotency_keys` and existing `notifications` table.

## Notes on touched files

The two seeder files (`reference/permissions.ts`, `reference/role-permissions.ts`) had pre-existing `console.log` lines that triggered the repo's `no-console` lint rule once they were re-touched. Added a narrow `eslint-disable-next-line` comment on each line; did not modify the existing logging behaviour.

## Test plan
- [x] `npx turbo type-check --filter=@adopt-dont-shop/service-backend --filter=@adopt-dont-shop/app.admin` passes
- [x] `npx eslint` clean on all new files
- [x] `npx vitest run` — service.backend (2452 tests; the previously-failing rate-limiter-count test is updated to expect 13)
- [x] `npx turbo test --filter=@adopt-dont-shop/lib.notifications` (16 tests pass)
- [x] `npx vitest run src/pages/BroadcastNotifications.test.tsx` in app.admin (3 tests)
- [x] New broadcast service tests cover each audience cohort, suspended-user exclusion, DND skip, prefs skip, and in-app row persistence
- [x] New broadcast route tests cover input validation (audience, channels), 403 on missing permission, and end-to-end success path

https://claude.ai/code/session_01RqiAyiGqicd5SwuEprrL1k

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqiAyiGqicd5SwuEprrL1k)_