### PR TITLE
feat(pets): CSV import with column mapping + preview (ADS-133)

### DIFF
--- a/app.rescue/src/components/pets/PetCsvImportModal.css.ts
+++ b/app.rescue/src/components/pets/PetCsvImportModal.css.ts
@@ -1,0 +1,125 @@
+import { style } from '@vanilla-extract/css';
+
+export const stepContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  minHeight: '300px',
+});
+
+export const stepHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '1rem',
+  paddingBottom: '0.75rem',
+  borderBottom: '1px solid #e5e7eb',
+});
+
+export const steps = style({
+  display: 'flex',
+  gap: '0.5rem',
+  fontSize: '0.85rem',
+  color: '#6b7280',
+});
+
+export const stepActive = style({
+  color: '#2563eb',
+  fontWeight: 600,
+});
+
+export const dropZone = style({
+  border: '2px dashed #d1d5db',
+  borderRadius: '0.5rem',
+  padding: '2.5rem',
+  textAlign: 'center',
+  cursor: 'pointer',
+  background: '#f9fafb',
+});
+
+export const mappingGrid = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '0.5rem 1rem',
+  alignItems: 'center',
+});
+
+export const fieldLabel = style({
+  fontWeight: 500,
+  fontSize: '0.875rem',
+});
+
+export const requiredMark = style({
+  color: '#dc2626',
+  marginLeft: '0.25rem',
+});
+
+export const select = style({
+  padding: '0.4rem 0.5rem',
+  borderRadius: '0.375rem',
+  border: '1px solid #d1d5db',
+  width: '100%',
+});
+
+export const previewTable = style({
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: '0.85rem',
+});
+
+export const previewCell = style({
+  border: '1px solid #e5e7eb',
+  padding: '0.4rem 0.5rem',
+  verticalAlign: 'top',
+});
+
+export const rowOk = style({
+  background: '#f0fdf4',
+});
+
+export const rowError = style({
+  background: '#fef2f2',
+});
+
+export const errorList = style({
+  margin: 0,
+  paddingLeft: '1.25rem',
+  color: '#b91c1c',
+  fontSize: '0.8rem',
+});
+
+export const summary = style({
+  display: 'flex',
+  gap: '1.5rem',
+  padding: '0.75rem',
+  background: '#f3f4f6',
+  borderRadius: '0.375rem',
+});
+
+export const summaryItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.15rem',
+});
+
+export const summaryNumber = style({
+  fontSize: '1.25rem',
+  fontWeight: 700,
+});
+
+export const actionsRow = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: '0.75rem',
+  paddingTop: '0.75rem',
+  borderTop: '1px solid #e5e7eb',
+});
+
+export const warning = style({
+  padding: '0.6rem 0.75rem',
+  background: '#fffbeb',
+  border: '1px solid #fcd34d',
+  borderRadius: '0.375rem',
+  fontSize: '0.85rem',
+  color: '#92400e',
+});

--- a/app.rescue/src/components/pets/PetCsvImportModal.tsx
+++ b/app.rescue/src/components/pets/PetCsvImportModal.tsx
@@ -1,0 +1,422 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { Button, Modal, toast } from '@adopt-dont-shop/lib.components';
+import {
+  IMPORTABLE_FIELDS,
+  type ColumnMapping,
+  type ImportableField,
+  type ParsedCsv,
+  type ValidatedRow,
+  autoMapColumns,
+  parseCsv,
+  petManagementService,
+  validateMappedRow,
+} from '@adopt-dont-shop/lib.pets';
+import * as styles from './PetCsvImportModal.css';
+
+// localStorage key for cross-import idempotency tracking. Keyed by
+// rescueId so multiple staff members at the same browser don't
+// cross-contaminate each other's imported IDs.
+const importedIdsKey = (rescueId: string) => `ads.pets.csvImport.externalIds.${rescueId}`;
+
+const loadImportedIds = (rescueId: string): Set<string> => {
+  try {
+    const raw = localStorage.getItem(importedIdsKey(rescueId));
+    if (!raw) {
+      return new Set();
+    }
+    return new Set(JSON.parse(raw) as string[]);
+  } catch {
+    return new Set();
+  }
+};
+
+const persistImportedIds = (rescueId: string, ids: Set<string>): void => {
+  try {
+    localStorage.setItem(importedIdsKey(rescueId), JSON.stringify(Array.from(ids)));
+  } catch {
+    // Best-effort. If localStorage is unavailable, the user just loses
+    // cross-session idempotency — they'll still get a duplicate warning
+    // within a single session via the in-memory set.
+  }
+};
+
+type Step = 'upload' | 'map' | 'preview' | 'importing' | 'done';
+
+type ImportSummary = {
+  imported: number;
+  skippedDuplicates: number;
+  failed: { rowIndex: number; reason: string }[];
+};
+
+type Props = {
+  isOpen: boolean;
+  rescueId: string;
+  onClose: () => void;
+  onImported: () => void;
+};
+
+const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImported }) => {
+  const [step, setStep] = useState<Step>('upload');
+  const [parsed, setParsed] = useState<ParsedCsv | null>(null);
+  const [mapping, setMapping] = useState<ColumnMapping>({});
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const reset = () => {
+    setStep('upload');
+    setParsed(null);
+    setMapping({});
+    setSummary(null);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleFile = async (file: File) => {
+    const text = await file.text();
+    const result = parseCsv(text);
+    if (result.headers.length === 0 || result.rows.length === 0) {
+      toast.error('CSV is empty or could not be parsed');
+      return;
+    }
+    setParsed(result);
+    setMapping(autoMapColumns(result.headers));
+    setStep('map');
+  };
+
+  const validatedRows = useMemo<ValidatedRow[]>(() => {
+    if (!parsed) {
+      return [];
+    }
+    return parsed.rows.map((row, idx) =>
+      // rowIndex is 1-based "data row" for human-friendly error messages.
+      validateMappedRow(row, mapping, idx + 1, rescueId)
+    );
+  }, [parsed, mapping, rescueId]);
+
+  const validCount = validatedRows.filter(r => r.ok).length;
+  const invalidCount = validatedRows.length - validCount;
+
+  const previouslyImportedIds = useMemo(
+    () => (step === 'preview' ? loadImportedIds(rescueId) : new Set<string>()),
+    [step, rescueId]
+  );
+
+  const duplicateRowIndexes = useMemo(() => {
+    const ids = new Set<string>();
+    const dupes = new Set<number>();
+    for (const r of validatedRows) {
+      if (!r.ok || !r.externalId) {
+        continue;
+      }
+      if (previouslyImportedIds.has(r.externalId) || ids.has(r.externalId)) {
+        dupes.add(r.rowIndex);
+      } else {
+        ids.add(r.externalId);
+      }
+    }
+    return dupes;
+  }, [validatedRows, previouslyImportedIds]);
+
+  const requiredFieldsMapped = IMPORTABLE_FIELDS.filter(f => f.required).every(f => mapping[f.key]);
+
+  const handleImport = async () => {
+    if (!parsed) {
+      return;
+    }
+    setStep('importing');
+
+    const importedIds = loadImportedIds(rescueId);
+    const result: ImportSummary = { imported: 0, skippedDuplicates: 0, failed: [] };
+
+    for (const validated of validatedRows) {
+      if (!validated.ok) {
+        result.failed.push({
+          rowIndex: validated.rowIndex,
+          reason: validated.errors.join('; '),
+        });
+        continue;
+      }
+      if (validated.externalId && importedIds.has(validated.externalId)) {
+        result.skippedDuplicates += 1;
+        continue;
+      }
+      try {
+        await petManagementService.createPet(validated.data);
+        result.imported += 1;
+        if (validated.externalId) {
+          importedIds.add(validated.externalId);
+        }
+      } catch (err) {
+        result.failed.push({
+          rowIndex: validated.rowIndex,
+          reason: err instanceof Error ? err.message : 'API error',
+        });
+      }
+    }
+
+    persistImportedIds(rescueId, importedIds);
+    setSummary(result);
+    setStep('done');
+    if (result.imported > 0) {
+      toast.success(`Imported ${result.imported} pet${result.imported === 1 ? '' : 's'}`);
+      onImported();
+    }
+  };
+
+  const stepLabel = (s: Step) => (
+    <span className={step === s ? styles.stepActive : undefined}>
+      {
+        {
+          upload: '1. Upload',
+          map: '2. Map columns',
+          preview: '3. Preview',
+          importing: '4. Import',
+          done: '4. Import',
+        }[s]
+      }
+    </span>
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Import pets from CSV"
+      size="xl"
+      closeOnOverlayClick={false}
+    >
+      <div className={styles.stepContainer}>
+        <div className={styles.stepHeader}>
+          <div className={styles.steps}>
+            {stepLabel('upload')} → {stepLabel('map')} → {stepLabel('preview')} →{' '}
+            {stepLabel('done')}
+          </div>
+        </div>
+
+        {step === 'upload' && (
+          <>
+            <div
+              className={styles.dropZone}
+              role="button"
+              tabIndex={0}
+              onClick={() => fileRef.current?.click()}
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  fileRef.current?.click();
+                }
+              }}
+            >
+              <p>
+                <strong>Click to upload a CSV</strong>
+              </p>
+              <p style={{ fontSize: '0.85rem', color: '#6b7280' }}>
+                First row must be column headers. Required columns:{' '}
+                {IMPORTABLE_FIELDS.filter(f => f.required)
+                  .map(f => f.label)
+                  .join(', ')}
+                .
+              </p>
+              <input
+                ref={fileRef}
+                type="file"
+                accept=".csv,text/csv"
+                style={{ display: 'none' }}
+                onChange={e => {
+                  const file = e.target.files?.[0];
+                  if (file) {
+                    void handleFile(file);
+                  }
+                }}
+              />
+            </div>
+            <div className={styles.actionsRow}>
+              <Button variant="outline" onClick={handleClose}>
+                Cancel
+              </Button>
+            </div>
+          </>
+        )}
+
+        {step === 'map' && parsed && (
+          <>
+            <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
+              We auto-matched columns by header name. Adjust any that look wrong, then continue to
+              the preview step.
+            </p>
+            <div className={styles.mappingGrid}>
+              {IMPORTABLE_FIELDS.map(field => (
+                <React.Fragment key={field.key}>
+                  <label className={styles.fieldLabel} htmlFor={`map-${field.key}`}>
+                    {field.label}
+                    {field.required && <span className={styles.requiredMark}>*</span>}
+                  </label>
+                  <select
+                    id={`map-${field.key}`}
+                    className={styles.select}
+                    value={mapping[field.key] ?? ''}
+                    onChange={e => {
+                      const newMapping = { ...mapping };
+                      if (e.target.value === '') {
+                        delete newMapping[field.key as ImportableField];
+                      } else {
+                        newMapping[field.key as ImportableField] = e.target.value;
+                      }
+                      setMapping(newMapping);
+                    }}
+                  >
+                    <option value="">— skip —</option>
+                    {parsed.headers.map(h => (
+                      <option key={h} value={h}>
+                        {h}
+                      </option>
+                    ))}
+                  </select>
+                </React.Fragment>
+              ))}
+            </div>
+            <div className={styles.actionsRow}>
+              <Button variant="outline" onClick={() => setStep('upload')}>
+                Back
+              </Button>
+              <Button
+                variant="primary"
+                disabled={!requiredFieldsMapped}
+                onClick={() => setStep('preview')}
+              >
+                Preview rows
+              </Button>
+            </div>
+          </>
+        )}
+
+        {step === 'preview' && parsed && (
+          <>
+            <div className={styles.summary}>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryNumber}>{validCount}</span>
+                <span>Valid</span>
+              </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryNumber}>{invalidCount}</span>
+                <span>Invalid</span>
+              </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryNumber}>{duplicateRowIndexes.size}</span>
+                <span>Will skip as duplicates</span>
+              </div>
+            </div>
+            {!mapping.externalId && (
+              <div className={styles.warning}>
+                No <strong>External ID</strong> column is mapped. Re-importing the same CSV later
+                may create duplicate pets. Map an external ID column on the previous step to enable
+                de-duplication across imports.
+              </div>
+            )}
+            <div style={{ maxHeight: '320px', overflow: 'auto' }}>
+              <table className={styles.previewTable}>
+                <thead>
+                  <tr>
+                    <th className={styles.previewCell}>Row</th>
+                    <th className={styles.previewCell}>Name</th>
+                    <th className={styles.previewCell}>Type</th>
+                    <th className={styles.previewCell}>Breed</th>
+                    <th className={styles.previewCell}>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {validatedRows.map(r => {
+                    const isDup = duplicateRowIndexes.has(r.rowIndex);
+                    const className = r.ok && !isDup ? styles.rowOk : styles.rowError;
+                    const rawRow = parsed.rows[r.rowIndex - 1];
+                    const cell = (field: ImportableField) =>
+                      mapping[field] ? rawRow[mapping[field]!] : '';
+                    return (
+                      <tr key={r.rowIndex} className={className}>
+                        <td className={styles.previewCell}>{r.rowIndex}</td>
+                        <td className={styles.previewCell}>{cell('name')}</td>
+                        <td className={styles.previewCell}>{cell('type')}</td>
+                        <td className={styles.previewCell}>{cell('breed')}</td>
+                        <td className={styles.previewCell}>
+                          {r.ok && !isDup && <span>OK</span>}
+                          {r.ok && isDup && <span>Duplicate — will skip</span>}
+                          {!r.ok && (
+                            <ul className={styles.errorList}>
+                              {r.errors.map((e, i) => (
+                                <li key={i}>{e}</li>
+                              ))}
+                            </ul>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+            <div className={styles.actionsRow}>
+              <Button variant="outline" onClick={() => setStep('map')}>
+                Back
+              </Button>
+              <Button variant="primary" disabled={validCount === 0} onClick={handleImport}>
+                Import {validCount} valid row{validCount === 1 ? '' : 's'}
+              </Button>
+            </div>
+          </>
+        )}
+
+        {step === 'importing' && (
+          <p style={{ padding: '2rem', textAlign: 'center' }}>Importing pets…</p>
+        )}
+
+        {step === 'done' && summary && (
+          <>
+            <div className={styles.summary}>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryNumber}>{summary.imported}</span>
+                <span>Imported</span>
+              </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryNumber}>{summary.skippedDuplicates}</span>
+                <span>Skipped (duplicate)</span>
+              </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryNumber}>{summary.failed.length}</span>
+                <span>Failed</span>
+              </div>
+            </div>
+            {summary.failed.length > 0 && (
+              <div style={{ maxHeight: '240px', overflow: 'auto' }}>
+                <table className={styles.previewTable}>
+                  <thead>
+                    <tr>
+                      <th className={styles.previewCell}>Row</th>
+                      <th className={styles.previewCell}>Reason</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {summary.failed.map(f => (
+                      <tr key={f.rowIndex} className={styles.rowError}>
+                        <td className={styles.previewCell}>{f.rowIndex}</td>
+                        <td className={styles.previewCell}>{f.reason}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <div className={styles.actionsRow}>
+              <Button variant="primary" onClick={handleClose}>
+                Done
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default PetCsvImportModal;

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -7,6 +7,7 @@ import PetGrid from '../components/pets/PetGrid';
 import PetFilters from '../components/pets/PetFilters.tsx';
 import PetFormModal from '../components/pets/PetFormModal.tsx';
 import PetStatusFilter from '../components/pets/PetStatusFilter.tsx';
+import PetCsvImportModal from '../components/pets/PetCsvImportModal.tsx';
 import * as styles from './PetManagement.css';
 
 interface PetStats {
@@ -66,6 +67,7 @@ const PetManagement: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showAddModal, setShowAddModal] = useState(false);
+  const [showCsvImport, setShowCsvImport] = useState(false);
   const [editingPet, setEditingPet] = useState<Pet | null>(null);
 
   // Filter states
@@ -328,6 +330,13 @@ const PetManagement: React.FC = () => {
             <p>Manage your rescue's pet inventory, medical records, and adoption status.</p>
           </div>
           <div className={styles.headerActions}>
+            <Button
+              variant="outline"
+              onClick={() => setShowCsvImport(true)}
+              disabled={!user?.rescueId}
+            >
+              Import CSV
+            </Button>
             <Button variant="primary" onClick={() => setShowAddModal(true)}>
               Add New Pet
             </Button>
@@ -466,6 +475,19 @@ const PetManagement: React.FC = () => {
           />
         </div>
       </div>
+
+      {/* CSV Import Modal (ADS-133) */}
+      {showCsvImport && user?.rescueId && (
+        <PetCsvImportModal
+          isOpen={showCsvImport}
+          rescueId={user.rescueId}
+          onClose={() => setShowCsvImport(false)}
+          onImported={() => {
+            fetchPets();
+            fetchStats();
+          }}
+        />
+      )}
 
       {/* Add/Edit Pet Modal */}
       {(showAddModal || editingPet) && (

--- a/lib.pets/src/csv-import.test.ts
+++ b/lib.pets/src/csv-import.test.ts
@@ -1,0 +1,149 @@
+// Behaviour tests for CSV import (ADS-133).
+//
+// Covers: happy-path round-trip, header auto-mapping, and the three
+// failure modes called out in the acceptance criteria — missing
+// required field, bad enum value, invalid date.
+
+import { describe, it, expect } from 'vitest';
+import { autoMapColumns, parseCsv, validateMappedRow, type ColumnMapping } from './csv-import';
+
+const RESCUE_ID = 'rescue_abc';
+
+describe('parseCsv', () => {
+  it('parses a simple comma-separated file with headers', () => {
+    const csv = 'name,type\nFido,dog\nWhiskers,cat\n';
+    const result = parseCsv(csv);
+    expect(result.headers).toEqual(['name', 'type']);
+    expect(result.rows).toEqual([
+      { name: 'Fido', type: 'dog' },
+      { name: 'Whiskers', type: 'cat' },
+    ]);
+  });
+
+  it('handles quoted fields containing commas and escaped quotes', () => {
+    const csv = 'name,description\n' + '"Comma, Cat","She said ""hi"""\n';
+    const result = parseCsv(csv);
+    expect(result.rows[0]).toEqual({
+      name: 'Comma, Cat',
+      description: 'She said "hi"',
+    });
+  });
+
+  it('skips fully blank lines', () => {
+    const csv = 'name\nFido\n\nWhiskers\n';
+    const result = parseCsv(csv);
+    expect(result.rows.map((r) => r.name)).toEqual(['Fido', 'Whiskers']);
+  });
+});
+
+describe('autoMapColumns', () => {
+  it('matches headers by exact key, label, and alias regardless of case/punctuation', () => {
+    const mapping = autoMapColumns([
+      'Name',
+      'animal_type',
+      'Primary Breed',
+      'Sex',
+      'Size',
+      'Colour',
+      'External ID',
+    ]);
+    expect(mapping).toMatchObject({
+      name: 'Name',
+      type: 'animal_type',
+      breed: 'Primary Breed',
+      gender: 'Sex',
+      size: 'Size',
+      color: 'Colour',
+      externalId: 'External ID',
+    });
+  });
+
+  it('leaves unmatched fields out of the mapping', () => {
+    const mapping = autoMapColumns(['name', 'favourite_food']);
+    expect(mapping.name).toBe('name');
+    expect(Object.keys(mapping)).toEqual(['name']);
+  });
+});
+
+describe('validateMappedRow', () => {
+  const fullRow = {
+    name: 'Fido',
+    type: 'dog',
+    breed: 'Labrador',
+    gender: 'male',
+    size: 'large',
+    color: 'black',
+    intake_date: '2026-01-15',
+    good_with_children: 'yes',
+    age_years: '3',
+  };
+  const fullMapping: ColumnMapping = {
+    name: 'name',
+    type: 'type',
+    breed: 'breed',
+    gender: 'gender',
+    size: 'size',
+    color: 'color',
+    intakeDate: 'intake_date',
+    goodWithChildren: 'good_with_children',
+    ageYears: 'age_years',
+  };
+
+  it('happy path: returns a valid PetCreateData for a complete row', () => {
+    const result = validateMappedRow(fullRow, fullMapping, 0, RESCUE_ID);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.name).toBe('Fido');
+      expect(result.data.type).toBe('dog');
+      expect(result.data.goodWithChildren).toBe(true);
+      expect(result.data.ageYears).toBe(3);
+      expect(result.data.rescueId).toBe(RESCUE_ID);
+      expect(result.data.intakeDate).toMatch(/^2026-01-15T/);
+    }
+  });
+
+  it('failure: missing required field is reported by name', () => {
+    const result = validateMappedRow({ ...fullRow, breed: '' }, fullMapping, 4, RESCUE_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.rowIndex).toBe(4);
+      expect(result.errors.some((e) => e.includes('breed') && e.includes('required'))).toBe(true);
+    }
+  });
+
+  it('failure: bad enum value lists the allowed options', () => {
+    const result = validateMappedRow({ ...fullRow, type: 'dragon' }, fullMapping, 7, RESCUE_ID);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const enumErr = result.errors.find((e) => e.startsWith('type:'));
+      expect(enumErr).toBeDefined();
+      expect(enumErr).toContain('dragon');
+      expect(enumErr).toContain('dog');
+    }
+  });
+
+  it('failure: invalid date is reported clearly', () => {
+    const result = validateMappedRow(
+      { ...fullRow, intake_date: 'not-a-date' },
+      fullMapping,
+      2,
+      RESCUE_ID
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.includes('intakeDate') && e.includes('valid date'))).toBe(
+        true
+      );
+    }
+  });
+
+  it('captures external_id when mapped, for idempotency keying', () => {
+    const result = validateMappedRow(
+      { ...fullRow, ext: 'PET-001' },
+      { ...fullMapping, externalId: 'ext' },
+      0,
+      RESCUE_ID
+    );
+    expect(result.externalId).toBe('PET-001');
+  });
+});

--- a/lib.pets/src/csv-import.ts
+++ b/lib.pets/src/csv-import.ts
@@ -1,0 +1,463 @@
+// CSV import helpers for bulk pet onboarding (ADS-133).
+//
+// Three pure functions form the core of the import flow so they can be
+// tested independently of the React UI in app.rescue:
+//   parseCsv          → splits raw CSV text into headers + row records
+//   autoMapColumns    → best-effort guess of csvHeader → Pet field
+//   validateMappedRow → validates one mapped row against PetCreateData
+//
+// The UI is responsible for: file upload, letting the user adjust the
+// mapping, previewing validation results, and POSTing valid rows.
+
+import { z } from 'zod';
+import {
+  PetAgeGroupSchema,
+  PetCreateDataSchema,
+  PetEnergyLevelSchema,
+  PetGenderSchema,
+  PetSizeSchema,
+  PetSpayNeuterStatusSchema,
+  PetTypeSchema,
+  PetVaccinationStatusSchema,
+  type PetCreateData,
+} from './schemas';
+
+// ── Field catalogue ──────────────────────────────────────────────────────────
+
+export type ImportableField =
+  | 'externalId'
+  | 'name'
+  | 'type'
+  | 'breed'
+  | 'secondaryBreed'
+  | 'gender'
+  | 'size'
+  | 'color'
+  | 'markings'
+  | 'ageYears'
+  | 'ageMonths'
+  | 'ageGroup'
+  | 'weightKg'
+  | 'microchipId'
+  | 'shortDescription'
+  | 'longDescription'
+  | 'adoptionFee'
+  | 'energyLevel'
+  | 'specialNeeds'
+  | 'houseTrained'
+  | 'goodWithChildren'
+  | 'goodWithDogs'
+  | 'goodWithCats'
+  | 'goodWithSmallAnimals'
+  | 'vaccinationStatus'
+  | 'vaccinationDate'
+  | 'spayNeuterStatus'
+  | 'spayNeuterDate'
+  | 'intakeDate';
+
+type FieldDef = {
+  key: ImportableField;
+  label: string;
+  required: boolean;
+  aliases: string[];
+};
+
+// Required matches `PetCreateData` minus `rescueId` (set server-side from auth).
+// `externalId` is only used for idempotency — it is stripped before POST.
+export const IMPORTABLE_FIELDS: readonly FieldDef[] = [
+  {
+    key: 'externalId',
+    label: 'External ID',
+    required: false,
+    aliases: ['external_id', 'id', 'source_id', 'sourceid'],
+  },
+  { key: 'name', label: 'Name', required: true, aliases: ['pet_name', 'animal_name'] },
+  { key: 'type', label: 'Type', required: true, aliases: ['species', 'animal_type'] },
+  { key: 'breed', label: 'Breed', required: true, aliases: ['primary_breed'] },
+  {
+    key: 'secondaryBreed',
+    label: 'Secondary Breed',
+    required: false,
+    aliases: ['secondary_breed', 'mix'],
+  },
+  { key: 'gender', label: 'Gender', required: true, aliases: ['sex'] },
+  { key: 'size', label: 'Size', required: true, aliases: [] },
+  { key: 'color', label: 'Color', required: true, aliases: ['colour'] },
+  { key: 'markings', label: 'Markings', required: false, aliases: [] },
+  { key: 'ageYears', label: 'Age (years)', required: false, aliases: ['age_years', 'years'] },
+  { key: 'ageMonths', label: 'Age (months)', required: false, aliases: ['age_months', 'months'] },
+  { key: 'ageGroup', label: 'Age Group', required: false, aliases: ['age_group'] },
+  { key: 'weightKg', label: 'Weight (kg)', required: false, aliases: ['weight_kg', 'weight'] },
+  {
+    key: 'microchipId',
+    label: 'Microchip ID',
+    required: false,
+    aliases: ['microchip', 'microchip_id', 'chip'],
+  },
+  {
+    key: 'shortDescription',
+    label: 'Short Description',
+    required: false,
+    aliases: ['short_description', 'summary'],
+  },
+  {
+    key: 'longDescription',
+    label: 'Long Description',
+    required: false,
+    aliases: ['long_description', 'description', 'bio'],
+  },
+  { key: 'adoptionFee', label: 'Adoption Fee', required: false, aliases: ['adoption_fee', 'fee'] },
+  {
+    key: 'energyLevel',
+    label: 'Energy Level',
+    required: false,
+    aliases: ['energy_level', 'energy'],
+  },
+  { key: 'specialNeeds', label: 'Special Needs', required: false, aliases: ['special_needs'] },
+  {
+    key: 'houseTrained',
+    label: 'House Trained',
+    required: false,
+    aliases: ['house_trained', 'housetrained'],
+  },
+  {
+    key: 'goodWithChildren',
+    label: 'Good With Children',
+    required: false,
+    aliases: ['good_with_children', 'good_with_kids'],
+  },
+  { key: 'goodWithDogs', label: 'Good With Dogs', required: false, aliases: ['good_with_dogs'] },
+  { key: 'goodWithCats', label: 'Good With Cats', required: false, aliases: ['good_with_cats'] },
+  {
+    key: 'goodWithSmallAnimals',
+    label: 'Good With Small Animals',
+    required: false,
+    aliases: ['good_with_small_animals'],
+  },
+  {
+    key: 'vaccinationStatus',
+    label: 'Vaccination Status',
+    required: false,
+    aliases: ['vaccination_status', 'vaccinated'],
+  },
+  {
+    key: 'vaccinationDate',
+    label: 'Vaccination Date',
+    required: false,
+    aliases: ['vaccination_date'],
+  },
+  {
+    key: 'spayNeuterStatus',
+    label: 'Spay/Neuter Status',
+    required: false,
+    aliases: ['spay_neuter_status', 'fixed'],
+  },
+  {
+    key: 'spayNeuterDate',
+    label: 'Spay/Neuter Date',
+    required: false,
+    aliases: ['spay_neuter_date'],
+  },
+  { key: 'intakeDate', label: 'Intake Date', required: false, aliases: ['intake_date', 'date_in'] },
+];
+
+export const REQUIRED_FIELDS: readonly ImportableField[] = IMPORTABLE_FIELDS.filter(
+  (f) => f.required
+).map((f) => f.key);
+
+// ── CSV parser ───────────────────────────────────────────────────────────────
+
+export type CsvRow = Record<string, string>;
+export type ParsedCsv = { headers: string[]; rows: CsvRow[] };
+
+// RFC 4180-ish: handles quoted fields, embedded commas/newlines, and ""
+// to escape a quote. Sufficient for spreadsheets exported by Google
+// Sheets / Excel / common adoption platforms.
+export function parseCsv(text: string): ParsedCsv {
+  const rows: string[][] = [];
+  let field = '';
+  let row: string[] = [];
+  let inQuotes = false;
+  let i = 0;
+  const src = text.replace(/^﻿/, '');
+
+  while (i < src.length) {
+    const c = src[i];
+
+    if (inQuotes) {
+      if (c === '"' && src[i + 1] === '"') {
+        field += '"';
+        i += 2;
+        continue;
+      }
+      if (c === '"') {
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      field += c;
+      i += 1;
+      continue;
+    }
+
+    if (c === '"') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+    if (c === ',') {
+      row.push(field);
+      field = '';
+      i += 1;
+      continue;
+    }
+    if (c === '\r') {
+      i += 1;
+      continue;
+    }
+    if (c === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      i += 1;
+      continue;
+    }
+    field += c;
+    i += 1;
+  }
+  // Final field (no trailing newline)
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  if (rows.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = rows[0].map((h) => h.trim());
+  const dataRows: CsvRow[] = rows
+    .slice(1)
+    .filter((r) => r.some((cell) => cell.trim() !== ''))
+    .map((r) => {
+      const record: CsvRow = {};
+      headers.forEach((h, idx) => {
+        record[h] = (r[idx] ?? '').trim();
+      });
+      return record;
+    });
+
+  return { headers, rows: dataRows };
+}
+
+// ── Auto column mapping ──────────────────────────────────────────────────────
+
+export type ColumnMapping = Partial<Record<ImportableField, string>>;
+
+const normalise = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+export function autoMapColumns(csvHeaders: string[]): ColumnMapping {
+  const mapping: ColumnMapping = {};
+  const used = new Set<string>();
+
+  for (const field of IMPORTABLE_FIELDS) {
+    const candidates = [field.key, field.label, ...field.aliases].map(normalise);
+    const match = csvHeaders.find((h) => !used.has(h) && candidates.includes(normalise(h)));
+    if (match) {
+      mapping[field.key] = match;
+      used.add(match);
+    }
+  }
+  return mapping;
+}
+
+// ── Row validation ───────────────────────────────────────────────────────────
+
+export type ValidRow = {
+  ok: true;
+  rowIndex: number;
+  data: PetCreateData;
+  externalId: string | null;
+};
+export type InvalidRow = {
+  ok: false;
+  rowIndex: number;
+  errors: string[];
+  externalId: string | null;
+};
+export type ValidatedRow = ValidRow | InvalidRow;
+
+const parseBool = (raw: string): boolean | null => {
+  const v = raw.trim().toLowerCase();
+  if (['true', 'yes', 'y', '1'].includes(v)) {
+    return true;
+  }
+  if (['false', 'no', 'n', '0'].includes(v)) {
+    return false;
+  }
+  return null;
+};
+
+const parseDate = (raw: string): string | null => {
+  const v = raw.trim();
+  if (!v) {
+    return null;
+  }
+  const t = Date.parse(v);
+  if (Number.isNaN(t)) {
+    return null;
+  }
+  return new Date(t).toISOString();
+};
+
+const parseInteger = (raw: string): number | null => {
+  const v = raw.trim();
+  if (!/^-?\d+$/.test(v)) {
+    return null;
+  }
+  return Number.parseInt(v, 10);
+};
+
+type FieldHandler = (
+  raw: string,
+  errors: string[],
+  data: Record<string, unknown>,
+  field: ImportableField
+) => void;
+
+const enumHandler =
+  (schema: z.ZodEnum<Record<string, string>>): FieldHandler =>
+  (raw, errors, data, field) => {
+    const parsed = schema.safeParse(raw.trim().toLowerCase());
+    if (!parsed.success) {
+      errors.push(
+        `${field}: "${raw}" is not a valid value (expected one of ${schema.options.join(', ')})`
+      );
+      return;
+    }
+    data[field] = parsed.data;
+  };
+
+const stringHandler: FieldHandler = (raw, _errors, data, field) => {
+  if (raw.trim()) {
+    data[field] = raw.trim();
+  }
+};
+
+const intHandler: FieldHandler = (raw, errors, data, field) => {
+  if (!raw.trim()) {
+    return;
+  }
+  const n = parseInteger(raw);
+  if (n === null) {
+    errors.push(`${field}: "${raw}" is not a valid integer`);
+    return;
+  }
+  data[field] = n;
+};
+
+const boolHandler: FieldHandler = (raw, errors, data, field) => {
+  if (!raw.trim()) {
+    return;
+  }
+  const b = parseBool(raw);
+  if (b === null) {
+    errors.push(`${field}: "${raw}" is not a valid boolean (use true/false, yes/no, 1/0)`);
+    return;
+  }
+  data[field] = b;
+};
+
+const dateHandler: FieldHandler = (raw, errors, data, field) => {
+  if (!raw.trim()) {
+    return;
+  }
+  const iso = parseDate(raw);
+  if (iso === null) {
+    errors.push(`${field}: "${raw}" is not a valid date`);
+    return;
+  }
+  data[field] = iso;
+};
+
+const FIELD_HANDLERS: Record<ImportableField, FieldHandler> = {
+  externalId: () => {},
+  name: stringHandler,
+  type: enumHandler(PetTypeSchema),
+  breed: stringHandler,
+  secondaryBreed: stringHandler,
+  gender: enumHandler(PetGenderSchema),
+  size: enumHandler(PetSizeSchema),
+  color: stringHandler,
+  markings: stringHandler,
+  ageYears: intHandler,
+  ageMonths: intHandler,
+  ageGroup: enumHandler(PetAgeGroupSchema),
+  weightKg: stringHandler,
+  microchipId: stringHandler,
+  shortDescription: stringHandler,
+  longDescription: stringHandler,
+  adoptionFee: stringHandler,
+  energyLevel: enumHandler(PetEnergyLevelSchema),
+  specialNeeds: boolHandler,
+  houseTrained: boolHandler,
+  goodWithChildren: boolHandler,
+  goodWithDogs: boolHandler,
+  goodWithCats: boolHandler,
+  goodWithSmallAnimals: boolHandler,
+  vaccinationStatus: enumHandler(PetVaccinationStatusSchema),
+  vaccinationDate: dateHandler,
+  spayNeuterStatus: enumHandler(PetSpayNeuterStatusSchema),
+  spayNeuterDate: dateHandler,
+  intakeDate: dateHandler,
+};
+
+export function validateMappedRow(
+  row: CsvRow,
+  mapping: ColumnMapping,
+  rowIndex: number,
+  rescueId: string
+): ValidatedRow {
+  const errors: string[] = [];
+  const data: Record<string, unknown> = { rescueId };
+
+  const externalIdHeader = mapping.externalId;
+  const externalId = externalIdHeader ? (row[externalIdHeader] || '').trim() || null : null;
+
+  // Required-field presence check first.
+  for (const field of IMPORTABLE_FIELDS) {
+    const header = mapping[field.key];
+    if (field.required) {
+      const value = header ? (row[header] || '').trim() : '';
+      if (!value) {
+        errors.push(`${field.key}: required field is missing`);
+        continue;
+      }
+    }
+    if (!header) {
+      continue;
+    }
+    const raw = row[header] ?? '';
+    if (!raw.trim() && !field.required) {
+      continue;
+    }
+    FIELD_HANDLERS[field.key](raw, errors, data, field.key);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, rowIndex, errors, externalId };
+  }
+
+  const parsed = PetCreateDataSchema.safeParse(data);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      rowIndex,
+      errors: parsed.error.issues.map((i) => `${i.path.join('.') || 'row'}: ${i.message}`),
+      externalId,
+    };
+  }
+
+  return { ok: true, rowIndex, data: parsed.data, externalId };
+}

--- a/lib.pets/src/index.ts
+++ b/lib.pets/src/index.ts
@@ -8,4 +8,7 @@ export * from './schemas';
 // Re-export non-schema types from types module
 export type { PaginatedResponse, PetsServiceConfig } from './types';
 
+// CSV import helpers (ADS-133)
+export * from './csv-import';
+
 export * from './constants';


### PR DESCRIPTION
Closes [ADS-133](https://linear.app/ideasquared/issue/ADS-133/csv-import-for-pets-with-column-mapping-preview).

## Summary

Lets a rescue bulk-onboard their pet list from a CSV instead of re-keying every animal — the wedge feature for migrating rescues off spreadsheets / other adoption platforms.

The full flow is a 4-step wizard in `app.rescue` Pet Management:

1. **Upload** — pick a CSV file.
2. **Map columns** — CSV headers are auto-matched against Pet fields by name/alias; staff can adjust the mapping manually. Required fields (name, type, breed, gender, size, color) must be mapped before continuing.
3. **Preview** — every row is validated client-side against the existing `PetCreateDataSchema`. Valid rows are highlighted green; invalid rows show the row number and a per-field reason (e.g. `type: "dragon" is not a valid value (expected one of dog, cat, …)`).
4. **Import** — only valid rows are POSTed. Failures from the API are reported back row-by-row. Invalid rows never block valid rows.

### Idempotency

If the user maps an **External ID** column, those IDs are persisted in `localStorage` scoped to the rescueId. Re-uploading the same CSV later skips the already-imported rows (and reports them under "Skipped — duplicate"). If no external ID column is mapped, a yellow warning surfaces on the preview step.

## Implementation

- **`lib.pets/src/csv-import.ts`** — pure functions: `parseCsv` (RFC 4180-ish, handles quoted fields + embedded commas/newlines), `autoMapColumns`, `validateMappedRow`. All testable independently of React.
- **`lib.pets/src/csv-import.test.ts`** — behaviour tests covering the AC's required modes (happy path, missing required field, bad enum value, invalid date) plus parser edge cases and auto-mapping.
- **`app.rescue/.../PetCsvImportModal.tsx`** — the 4-step wizard, reusing the existing `petManagementService.createPet` per valid row.
- **`PetManagement.tsx`** — adds the "Import CSV" button next to "Add New Pet" (disabled until the user is associated with a rescue) and wires the modal to refresh the pet list on completion.

## Out of scope (deferred from the original L scope)

- Application / contact import
- Image URL import (rescues can attach photos after import)
- Rollback of completed imports (standard delete-pet flow covers this)
- Pre-built per-source-platform import templates

## Test plan

- [x] `npx vitest run` in `lib.pets` — 28/28 pass, including the 4 behaviour tests for CSV import.
- [x] `turbo build --filter=@adopt-dont-shop/lib.pets` succeeds.
- [ ] Manual: upload a sample CSV in the rescue app, confirm auto-mapping is sensible, edit a mapping, observe live preview validation, run the import, then re-upload the same file and confirm rows are skipped as duplicates.
- [ ] Manual: upload a CSV with one row missing `breed`, one with `type=dragon`, and one with `intake_date=not-a-date` — all three should be flagged inline; valid rows in the same file should still import.

https://claude.ai/code/session_01VWnJLK4rAqCtiiSBAWZV99

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWnJLK4rAqCtiiSBAWZV99)_