### PR TITLE
feat(client): image preloading and progressive loading for swipe stack (ADS-138)

### DIFF
--- a/app.client/src/__tests__/image-preloading.behavior.test.tsx
+++ b/app.client/src/__tests__/image-preloading.behavior.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Behavioural tests for image preloading and progressive loading in the
+ * swipe-to-adopt flow.
+ *
+ * Acceptance criteria covered:
+ *   - Upcoming swipe cards have their primary image preloaded
+ *   - The currently visible card renders its image (no blank flash)
+ *   - Failed image loads show a graceful fallback
+ *   - Off-screen / not-yet-visible images are not eagerly fetched
+ */
+
+import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../test-utils';
+
+vi.mock('@/hooks/useStatsig', () => ({
+  useStatsig: () => ({
+    logEvent: vi.fn(),
+    checkGate: () => false,
+    client: null,
+    getExperiment: () => null,
+    getDynamicConfig: () => null,
+  }),
+}));
+
+import { SwipeStack } from '../components/swipe/SwipeStack';
+import type { DiscoveryPet } from '../services';
+
+const buildPet = (overrides: Partial<DiscoveryPet> & { petId: string }): DiscoveryPet => ({
+  petId: overrides.petId,
+  name: `Pet ${overrides.petId}`,
+  type: 'dog',
+  breed: 'Mixed',
+  ageGroup: 'adult',
+  size: 'medium',
+  gender: 'male',
+  images: [`https://cdn.example/${overrides.petId}.jpg`],
+  rescueName: 'Test Rescue',
+  ...overrides,
+});
+
+describe('Swipe image preloading behaviour', () => {
+  let constructedImageSrcs: string[];
+  let originalImage: typeof Image;
+
+  beforeEach(() => {
+    constructedImageSrcs = [];
+    originalImage = global.Image;
+    // Track every Image() instance created so we can assert preload requests.
+    class TrackingImage {
+      onload: ((ev: Event) => void) | null = null;
+      onerror: ((ev: Event) => void) | null = null;
+      decoding = 'auto';
+      private _src = '';
+      get src(): string {
+        return this._src;
+      }
+      set src(value: string) {
+        this._src = value;
+        constructedImageSrcs.push(value);
+      }
+    }
+    global.Image = TrackingImage as unknown as typeof Image;
+  });
+
+  afterEach(() => {
+    global.Image = originalImage;
+  });
+
+  it('preloads images for the cards just past the visible window', () => {
+    const pets = [
+      buildPet({ petId: 'a' }),
+      buildPet({ petId: 'b' }),
+      buildPet({ petId: 'c' }),
+      buildPet({ petId: 'd' }), // first preload candidate (n+1)
+      buildPet({ petId: 'e' }),
+      buildPet({ petId: 'f' }),
+      buildPet({ petId: 'g' }),
+      buildPet({ petId: 'h' }), // last preload candidate (n+5)
+      buildPet({ petId: 'i' }), // should not preload yet
+    ];
+
+    renderWithProviders(
+      <SwipeStack pets={pets} onSwipe={vi.fn()} onEndReached={vi.fn()} sessionId='session-1' />
+    );
+
+    expect(constructedImageSrcs).toContain('https://cdn.example/d.jpg');
+    expect(constructedImageSrcs).toContain('https://cdn.example/h.jpg');
+    expect(constructedImageSrcs).not.toContain('https://cdn.example/i.jpg');
+  });
+
+  it('does not preload when there are no upcoming cards beyond the visible window', () => {
+    const pets = [buildPet({ petId: 'a' }), buildPet({ petId: 'b' })];
+
+    renderWithProviders(
+      <SwipeStack pets={pets} onSwipe={vi.fn()} onEndReached={vi.fn()} sessionId='session-1' />
+    );
+
+    expect(constructedImageSrcs).toEqual([]);
+  });
+
+  it('skips preload for pets without an image', () => {
+    const pets = [
+      buildPet({ petId: 'a' }),
+      buildPet({ petId: 'b' }),
+      buildPet({ petId: 'c' }),
+      buildPet({ petId: 'no-image', images: [] }),
+      buildPet({ petId: 'e' }),
+    ];
+
+    renderWithProviders(
+      <SwipeStack pets={pets} onSwipe={vi.fn()} onEndReached={vi.fn()} sessionId='session-1' />
+    );
+
+    expect(constructedImageSrcs).not.toContain('');
+    expect(constructedImageSrcs).toContain('https://cdn.example/e.jpg');
+  });
+});
+
+describe('Swipe card progressive loading behaviour', () => {
+  it('renders a placeholder for the visible card while the image is loading', () => {
+    const pets = [buildPet({ petId: 'a', name: 'Buddy' })];
+
+    renderWithProviders(
+      <SwipeStack pets={pets} onSwipe={vi.fn()} onEndReached={vi.fn()} sessionId='session-1' />
+    );
+
+    // Placeholder text should be present until the image loads.
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows an error fallback when the visible card image fails to load', () => {
+    const pets = [buildPet({ petId: 'a', name: 'Buddy', breed: 'Labrador' })];
+
+    renderWithProviders(
+      <SwipeStack pets={pets} onSwipe={vi.fn()} onEndReached={vi.fn()} sessionId='session-1' />
+    );
+
+    const img = screen.getByAltText('Buddy - Labrador');
+    fireEvent.error(img);
+
+    expect(screen.getByLabelText('Buddy image unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
+
+  it('marks the top card image as eager and stacked cards as lazy', () => {
+    const pets = [
+      buildPet({ petId: 'a', name: 'Buddy', breed: 'Labrador' }),
+      buildPet({ petId: 'b', name: 'Max', breed: 'Husky' }),
+    ];
+
+    renderWithProviders(
+      <SwipeStack pets={pets} onSwipe={vi.fn()} onEndReached={vi.fn()} sessionId='session-1' />
+    );
+
+    const topImg = screen.getByAltText('Buddy - Labrador') as HTMLImageElement;
+    const stackedImg = screen.getByAltText('Max - Husky') as HTMLImageElement;
+
+    expect(topImg.getAttribute('loading')).toBe('eager');
+    expect(stackedImg.getAttribute('loading')).toBe('lazy');
+  });
+});

--- a/app.client/src/components/swipe/SwipeCard.tsx
+++ b/app.client/src/components/swipe/SwipeCard.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { MdCheckCircle, MdPets, MdRefresh, MdStar } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { resolveFileUrl } from '../../utils/fileUtils';
+import { ProgressiveImage } from '../ui/ProgressiveImage';
 import * as styles from './SwipeCard.css';
 
 interface SwipeCardProps {
@@ -61,8 +62,6 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
   disabled = false,
 }) => {
   const [overlayAction, setOverlayAction] = useState<string>('');
-  const [imageLoaded, setImageLoaded] = useState(false);
-  const [imageError, setImageError] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
   const { logEvent } = useStatsig();
@@ -80,23 +79,6 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       });
     }
   }, [isTop, pet, logEvent]);
-
-  // Image loading handlers
-  const handleImageLoad = useCallback(() => {
-    setImageLoaded(true);
-    setImageError(false);
-  }, []);
-
-  const handleImageError = useCallback(() => {
-    setImageLoaded(false);
-    setImageError(true);
-  }, []);
-
-  // Reset image state when pet changes
-  React.useEffect(() => {
-    setImageLoaded(false);
-    setImageError(false);
-  }, [pet.petId]);
 
   // Keyboard navigation handler
   const handleKeyDown = useCallback(
@@ -359,38 +341,33 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
     >
       <div className={styles.imageContainer}>
         {imageUrl ? (
-          <>
-            <img
-              src={imageUrl}
-              alt={`${pet.name} - ${pet.breed || 'pet'}`}
-              draggable={false}
-              onLoad={handleImageLoad}
-              onError={handleImageError}
-              style={{
-                opacity: imageLoaded && !imageError ? 1 : 0,
-                transition: 'opacity 0.3s ease-in-out',
-              }}
-            />
-            {(!imageLoaded || imageError) && (
+          <ProgressiveImage
+            src={imageUrl}
+            alt={`${pet.name} - ${pet.breed || 'pet'}`}
+            eager={isTop}
+            placeholder={
               <div
                 className={styles.placeholderImage}
                 style={{ background: placeholderBackground }}
               >
-                <PlaceholderIcon isLoading={!imageError && !imageLoaded} petType={pet.type} />
-                {!imageLoaded && !imageError ? (
-                  <>
-                    <div className={styles.placeholderText}>Loading...</div>
-                    <div className={styles.placeholderSubtext}>{pet.name}</div>
-                  </>
-                ) : (
-                  <>
-                    <div className={styles.placeholderText}>{pet.name}</div>
-                    <div className={styles.placeholderSubtext}>{pet.breed || pet.type}</div>
-                  </>
-                )}
+                <PlaceholderIcon isLoading petType={pet.type} />
+                <div className={styles.placeholderText}>Loading...</div>
+                <div className={styles.placeholderSubtext}>{pet.name}</div>
               </div>
-            )}
-          </>
+            }
+            errorFallback={
+              <div
+                className={styles.placeholderImage}
+                style={{ background: placeholderBackground }}
+                role='img'
+                aria-label={`${pet.name} image unavailable`}
+              >
+                <PlaceholderIcon petType={pet.type} />
+                <div className={styles.placeholderText}>{pet.name}</div>
+                <div className={styles.placeholderSubtext}>{pet.breed || pet.type}</div>
+              </div>
+            }
+          />
         ) : (
           <div className={styles.placeholderImage} style={{ background: placeholderBackground }}>
             <PlaceholderIcon petType={pet.type} />

--- a/app.client/src/components/swipe/SwipeStack.tsx
+++ b/app.client/src/components/swipe/SwipeStack.tsx
@@ -1,5 +1,7 @@
+import { useImagePreloader } from '@/hooks/useImagePreloader';
 import { DiscoveryPet, SwipeAction } from '@/services';
-import React, { useCallback, useEffect, useState } from 'react';
+import { resolveFileUrl } from '@/utils/fileUtils';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { SwipeCard } from './SwipeCard';
 import * as styles from './SwipeStack.css';
 
@@ -13,6 +15,7 @@ interface SwipeStackProps {
 }
 
 const VISIBLE_CARDS = 3;
+const PRELOAD_AHEAD = 5;
 const CARD_SCALE_STEP = 0.05;
 const CARD_Y_OFFSET = 8;
 
@@ -59,6 +62,18 @@ export const SwipeStack: React.FC<SwipeStackProps> = ({
   }, [pets]);
 
   const visiblePets = pets.slice(currentIndex, currentIndex + VISIBLE_CARDS);
+
+  // Preload primary images for cards just past the visible window so the next
+  // swipe shows the image instantly instead of fetching on-demand.
+  const preloadUrls = useMemo(
+    () =>
+      pets
+        .slice(currentIndex + VISIBLE_CARDS, currentIndex + VISIBLE_CARDS + PRELOAD_AHEAD)
+        .map(pet => resolveFileUrl(pet.images?.[0]))
+        .filter((url): url is string => Boolean(url)),
+    [pets, currentIndex]
+  );
+  useImagePreloader(preloadUrls);
 
   if (pets.length === 0) {
     return (

--- a/app.client/src/components/ui/ProgressiveImage.css.ts
+++ b/app.client/src/components/ui/ProgressiveImage.css.ts
@@ -1,0 +1,48 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const wrapper = style({
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+  overflow: 'hidden',
+});
+
+globalStyle(`${wrapper} picture`, {
+  display: 'block',
+  width: '100%',
+  height: '100%',
+});
+
+export const image = recipe({
+  base: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    transition: 'opacity 0.3s ease-in-out, filter 0.3s ease-in-out',
+  },
+  variants: {
+    visible: {
+      true: {
+        opacity: 1,
+        filter: 'blur(0)',
+      },
+      false: {
+        // Blur-up: render the image (when present) at low-res blurred until decoded.
+        opacity: 0,
+        filter: 'blur(20px)',
+      },
+    },
+  },
+  defaultVariants: { visible: false },
+});
+
+export const placeholderLayer = style({
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});

--- a/app.client/src/components/ui/ProgressiveImage.test.tsx
+++ b/app.client/src/components/ui/ProgressiveImage.test.tsx
@@ -1,0 +1,176 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { ProgressiveImage } from './ProgressiveImage';
+
+describe('ProgressiveImage', () => {
+  describe('eager loading', () => {
+    it('renders the image immediately when eager is true', () => {
+      render(<ProgressiveImage src='https://cdn.example/cat.jpg' alt='A cat' eager />);
+
+      const img = screen.getByAltText('A cat') as HTMLImageElement;
+      expect(img.src).toContain('cat.jpg');
+      expect(img.getAttribute('loading')).toBe('eager');
+    });
+  });
+
+  describe('lazy loading', () => {
+    let originalIO: typeof IntersectionObserver;
+
+    beforeEach(() => {
+      originalIO = global.IntersectionObserver;
+    });
+
+    afterEach(() => {
+      global.IntersectionObserver = originalIO;
+    });
+
+    it('does not render the image until intersection occurs', () => {
+      const observers: IntersectionObserverCallback[] = [];
+      class DeferredObserver {
+        constructor(cb: IntersectionObserverCallback) {
+          observers.push(cb);
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords(): IntersectionObserverEntry[] {
+          return [];
+        }
+      }
+      global.IntersectionObserver = DeferredObserver as unknown as typeof IntersectionObserver;
+
+      render(<ProgressiveImage src='https://cdn.example/dog.jpg' alt='A dog' />);
+
+      // Image should not be in the DOM yet — waiting for intersection
+      expect(screen.queryByAltText('A dog')).not.toBeInTheDocument();
+      expect(observers.length).toBe(1);
+    });
+
+    it('loads the image once it scrolls into view', () => {
+      const observers: { cb: IntersectionObserverCallback; target?: Element }[] = [];
+      class DeferredObserver {
+        cb: IntersectionObserverCallback;
+        constructor(cb: IntersectionObserverCallback) {
+          this.cb = cb;
+          observers.push({ cb });
+        }
+        observe(target: Element) {
+          observers[observers.length - 1].target = target;
+        }
+        unobserve() {}
+        disconnect() {}
+        takeRecords(): IntersectionObserverEntry[] {
+          return [];
+        }
+      }
+      global.IntersectionObserver = DeferredObserver as unknown as typeof IntersectionObserver;
+
+      render(<ProgressiveImage src='https://cdn.example/dog.jpg' alt='A dog' />);
+      expect(screen.queryByAltText('A dog')).not.toBeInTheDocument();
+
+      // Simulate viewport intersection
+      const { cb, target } = observers[0];
+      act(() => {
+        cb(
+          [{ isIntersecting: true, target } as IntersectionObserverEntry],
+          {} as IntersectionObserver
+        );
+      });
+
+      expect(screen.getByAltText('A dog')).toBeInTheDocument();
+    });
+  });
+
+  describe('placeholder and error fallback', () => {
+    it('shows placeholder until the image loads', () => {
+      render(
+        <ProgressiveImage
+          src='https://cdn.example/cat.jpg'
+          alt='A cat'
+          eager
+          placeholder={<div>Loading cat...</div>}
+        />
+      );
+
+      expect(screen.getByText('Loading cat...')).toBeInTheDocument();
+
+      fireEvent.load(screen.getByAltText('A cat'));
+
+      expect(screen.queryByText('Loading cat...')).not.toBeInTheDocument();
+    });
+
+    it('shows error fallback when image fails to load', () => {
+      render(
+        <ProgressiveImage
+          src='https://cdn.example/broken.jpg'
+          alt='A cat'
+          eager
+          placeholder={<div>Loading...</div>}
+          errorFallback={<div>Image unavailable</div>}
+        />
+      );
+
+      fireEvent.error(screen.getByAltText('A cat'));
+
+      expect(screen.getByText('Image unavailable')).toBeInTheDocument();
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('webp support', () => {
+    it('emits a <picture> with a webp source when webpSrc is provided', () => {
+      const { container } = render(
+        <ProgressiveImage
+          src='https://cdn.example/cat.jpg'
+          webpSrc='https://cdn.example/cat.webp'
+          alt='A cat'
+          eager
+        />
+      );
+
+      const source = container.querySelector('source[type="image/webp"]');
+      expect(source).not.toBeNull();
+      expect(source?.getAttribute('srcset')).toBe('https://cdn.example/cat.webp');
+    });
+
+    it('omits the picture element when no webpSrc is provided', () => {
+      const { container } = render(
+        <ProgressiveImage src='https://cdn.example/cat.jpg' alt='A cat' eager />
+      );
+
+      expect(container.querySelector('picture')).toBeNull();
+    });
+  });
+
+  describe('callbacks', () => {
+    it('invokes onLoad and onError when the image fires the corresponding event', () => {
+      const onLoad = vi.fn();
+      const onError = vi.fn();
+
+      const { rerender } = render(
+        <ProgressiveImage
+          src='https://cdn.example/cat.jpg'
+          alt='A cat'
+          eager
+          onLoad={onLoad}
+          onError={onError}
+        />
+      );
+
+      fireEvent.load(screen.getByAltText('A cat'));
+      expect(onLoad).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <ProgressiveImage
+          src='https://cdn.example/broken.jpg'
+          alt='A cat'
+          eager
+          onLoad={onLoad}
+          onError={onError}
+        />
+      );
+      fireEvent.error(screen.getByAltText('A cat'));
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app.client/src/components/ui/ProgressiveImage.tsx
+++ b/app.client/src/components/ui/ProgressiveImage.tsx
@@ -1,0 +1,129 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import * as styles from './ProgressiveImage.css';
+
+type ProgressiveImageProps = {
+  src: string;
+  alt: string;
+  /** Optional WebP variant URL. When provided, served via <picture> to browsers that support it. */
+  webpSrc?: string;
+  /** When true, image fetch starts immediately. When false, it waits until the element scrolls into view. */
+  eager?: boolean;
+  /** Margin around the viewport used by IntersectionObserver. Defaults to '200px' so images start loading slightly before they appear. */
+  rootMargin?: string;
+  className?: string;
+  draggable?: boolean;
+  /** Renders behind the image. Visible while the image is loading or has failed. */
+  placeholder?: React.ReactNode;
+  /** Renders in place of the placeholder when the image fails to load. */
+  errorFallback?: React.ReactNode;
+  onLoad?: () => void;
+  onError?: () => void;
+};
+
+const isIntersectionObserverSupported = () =>
+  typeof window !== 'undefined' && typeof window.IntersectionObserver !== 'undefined';
+
+export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
+  src,
+  alt,
+  webpSrc,
+  eager = false,
+  rootMargin = '200px',
+  className,
+  draggable = false,
+  placeholder,
+  errorFallback,
+  onLoad,
+  onError,
+}) => {
+  const [shouldLoad, setShouldLoad] = useState<boolean>(
+    eager || !isIntersectionObserverSupported()
+  );
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Reset state when src changes so the placeholder reappears for the new image.
+  useEffect(() => {
+    setLoaded(false);
+    setErrored(false);
+    setShouldLoad(eager || !isIntersectionObserverSupported());
+  }, [src, eager]);
+
+  useEffect(() => {
+    if (shouldLoad || !wrapperRef.current) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0];
+        if (entry?.isIntersecting) {
+          setShouldLoad(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin }
+    );
+
+    observer.observe(wrapperRef.current);
+    return () => observer.disconnect();
+  }, [shouldLoad, rootMargin]);
+
+  const handleLoad = useCallback(() => {
+    setLoaded(true);
+    setErrored(false);
+    onLoad?.();
+  }, [onLoad]);
+
+  const handleError = useCallback(() => {
+    setLoaded(false);
+    setErrored(true);
+    onError?.();
+  }, [onError]);
+
+  const showPlaceholder = !loaded && !errored;
+  const showErrorFallback = errored;
+
+  return (
+    <div ref={wrapperRef} className={`${styles.wrapper}${className ? ` ${className}` : ''}`}>
+      {shouldLoad &&
+        (webpSrc ? (
+          <picture>
+            <source type='image/webp' srcSet={webpSrc} />
+            <img
+              src={src}
+              alt={alt}
+              draggable={draggable}
+              loading={eager ? 'eager' : 'lazy'}
+              decoding='async'
+              onLoad={handleLoad}
+              onError={handleError}
+              className={styles.image({ visible: loaded && !errored })}
+            />
+          </picture>
+        ) : (
+          <img
+            src={src}
+            alt={alt}
+            draggable={draggable}
+            loading={eager ? 'eager' : 'lazy'}
+            decoding='async'
+            onLoad={handleLoad}
+            onError={handleError}
+            className={styles.image({ visible: loaded && !errored })}
+          />
+        ))}
+
+      {showPlaceholder && placeholder !== undefined && (
+        <div className={styles.placeholderLayer} aria-hidden='true'>
+          {placeholder}
+        </div>
+      )}
+
+      {showErrorFallback && errorFallback !== undefined && (
+        <div className={styles.placeholderLayer}>{errorFallback}</div>
+      )}
+    </div>
+  );
+};

--- a/app.client/src/hooks/useImagePreloader.ts
+++ b/app.client/src/hooks/useImagePreloader.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Preloads a list of image URLs by constructing in-memory `Image` instances,
+ * causing the browser to fetch them into the HTTP cache. URLs already
+ * preloaded in this hook's lifetime are skipped.
+ */
+export const useImagePreloader = (urls: ReadonlyArray<string | undefined>): void => {
+  const preloadedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (typeof Image === 'undefined') {
+      return;
+    }
+
+    urls.forEach(url => {
+      if (!url || preloadedRef.current.has(url)) {
+        return;
+      }
+      preloadedRef.current.add(url);
+      const img = new Image();
+      img.decoding = 'async';
+      img.src = url;
+    });
+  }, [urls]);
+};

--- a/app.client/src/setup-tests.ts
+++ b/app.client/src/setup-tests.ts
@@ -36,7 +36,32 @@ global.Image = class MockImage {
   onload: ((ev: Event) => void) | null = null;
   onerror: ((ev: Event) => void) | null = null;
   src: string = '';
+  decoding: string = 'auto';
 } as any;
+
+// Mock IntersectionObserver. The default behaviour is to fire intersection
+// immediately so lazy-loaded components reveal their content in tests.
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    this.callback(
+      [{ isIntersecting: true, target } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  root = null;
+  rootMargin = '';
+  thresholds: ReadonlyArray<number> = [];
+}
+global.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
 
 vi.mock('@adopt-dont-shop/lib.components', () => ({
   lightTheme: {},


### PR DESCRIPTION
## Summary

Closes [ADS-138](https://linear.app/ideasquared/issue/ADS-138/implement-image-preloading-and-progressive-loading).

The swipe-to-adopt flow loaded each card's image on-demand, causing a visible blank flash when swiping — especially on slow connections. This PR makes the next swipe feel instantaneous.

- **`ProgressiveImage` component** (`app.client/src/components/ui/`): wraps `<img>` / `<picture>` with IntersectionObserver-driven lazy loading, blur-up fade-in placeholder, optional WebP source via `webpSrc` prop, and an explicit `errorFallback` slot.
- **`useImagePreloader` hook** (`app.client/src/hooks/`): preloads a list of URLs by constructing in-memory `Image` instances (deduped per render lifetime).
- **`SwipeStack`**: preloads the primary image of the next 5 cards beyond the visible 3-card window, so swipe→next is instant.
- **`SwipeCard`**: now renders its image through `ProgressiveImage`. The top card loads `eager`; stacked/below cards load `lazy` and only fetch once they intersect the viewport. The existing colourful gradient placeholder is reused via the `placeholder` slot, and the error state goes through `errorFallback` (with an `aria-label` for screen readers).

### Acceptance criteria mapping

- ✅ Preload next 3–5 cards (`PRELOAD_AHEAD = 5`)
- ✅ Progressive blur-up: placeholder is rendered behind the `<img>` until decoded; the image fades in from `opacity:0 / blur(20px)` to `opacity:1 / blur(0)`
- ✅ Off-screen images use IntersectionObserver — fetch is deferred until `isIntersecting`
- ✅ Failed loads render the error fallback (silhouette-style placeholder with the pet's name)
- ✅ `<picture>` element with `<source type="image/webp">` is wired up via the `webpSrc` prop. Not yet supplied by `SwipeCard` because the backend doesn't currently expose WebP variant URLs (the server-side resize pipeline is explicitly out of scope per the issue); ready to be wired the moment a variant URL is available.
- ✅ Behaviour tests covering preload, lazy/eager, placeholder, and error fallback

### Out of scope (per the issue)

- Service worker / offline caching (deferred — ADS-131 cancelled)
- Server-side image resizing pipeline (tracked separately)

## Test plan

- [x] `vitest run` in `app.client` — 231 tests pass (8 new in `ProgressiveImage.test.tsx`, 6 new in `image-preloading.behavior.test.tsx`)
- [x] ESLint clean on all changed files (no new warnings)
- [ ] Manual smoke on a throttled 3G profile: open the discovery flow, observe first card paints with placeholder→image fade, swipe rapidly and confirm no blank cards
- [ ] Manual: disconnect network on the second card to verify the silhouette fallback renders
- [ ] Manual: scroll the favorites list (or any future surface using `ProgressiveImage`) and confirm off-viewport images don't appear in the network tab until they intersect

https://claude.ai/code/session_01CxqKdsbDwXkZjMwgE56inG

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxqKdsbDwXkZjMwgE56inG)_