### PR TITLE
docs(libraries): refresh lib index; add READMEs for lib.legal &amp; lib.observability

### DIFF
--- a/docs/libraries/README.md
+++ b/docs/libraries/README.md
@@ -1,12 +1,13 @@
 # Shared Libraries
 
-The monorepo ships **21 workspace libraries** under `@adopt-dont-shop/lib.*`. Each library's authoritative documentation is its own `README.md` next to the source — those READMEs are kept code-verified.
+The monorepo ships **23 workspace libraries** under `@adopt-dont-shop/lib.*`. Each library's authoritative documentation is its own `README.md` next to the source — those READMEs are kept code-verified.
 
 ## Standards
 
-- ESM-only, TypeScript strict mode
-- Built with `tsc`, orchestrated by Turborepo (`dependsOn: ["^build"]`)
-- Tested with Jest (Node libraries) or Vitest (libraries co-located with apps)
+- ESM by default; `lib.api`, `lib.permissions`, `lib.types`, and `lib.validation` additionally emit a CJS bundle via a second `tsc -p tsconfig.cjs.json` pass for backend consumers
+- TypeScript strict mode
+- Built with `tsc` (`lib.components` uses Vite to bundle styles/assets), orchestrated by Turborepo (`dependsOn: ["^build"]`)
+- Tested with Vitest — every library ships a `vitest.config.ts` and an `npm test` script that runs `vitest run`
 - Workspace-linked: depend on each other with `"*"` and rely on `npm install` at the repo root
 
 ## Index
@@ -37,6 +38,8 @@ The monorepo ships **21 workspace libraries** under `@adopt-dont-shop/lib.*`. Ea
 - [`lib.components`](../../lib.components/README.md) — shared React components
 - [`lib.analytics`](../../lib.analytics/README.md) — event tracking
 - [`lib.feature-flags`](../../lib.feature-flags/README.md) — Statsig type definitions
+- [`lib.observability`](../../lib.observability/README.md) — Sentry init, Web Vitals reporter, analytics-consent gate
+- [`lib.legal`](../../lib.legal/README.md) — legal re-acceptance modal, cookie banner, consent service
 
 ### Utilities
 - [`lib.utils`](../../lib.utils/README.md) — formatters, locale, env helpers

--- a/lib.legal/README.md
+++ b/lib.legal/README.md
@@ -1,0 +1,71 @@
+# @adopt-dont-shop/lib.legal
+
+Legal re-acceptance modal, cookie banner, and consent service shared by every frontend app. Centralises the user-facing flows around our Terms of Service, Privacy Policy, and Cookies Policy so the three apps don't drift out of sync.
+
+## What it ships
+
+### Components
+
+- **`LegalReacceptanceModal`** — hard-blocks the app after login when the current ToS / Privacy version is newer than what the user last accepted. Mount it once near the root of `app.client`, `app.admin`, and `app.rescue`. Non-dismissable; the user must tick each pending document and submit before continuing.
+- **`CookieBanner`** + `useCookieConsent` — bottom-anchored on-page banner that lets the user pick **Accept all** (analytics on) or **Essentials only** (analytics off, the default). Persists the choice in `localStorage` (`legal-consent-v1`) and, for signed-in users, POSTs it to `/api/v1/privacy/consent` so the audit log captures it.
+- **`ManageCookiesLink`** — small footer link that re-opens the banner so users can change their mind later.
+
+### Service
+
+`legal-service` is a thin Zod-validated wrapper around three backend endpoints:
+
+- `fetchPendingReacceptance()` → `GET /api/v1/legal/pending-reacceptance`
+- `fetchCookiesVersion()` → `GET /api/v1/legal/cookies` (just the version string)
+- `recordReacceptance(input)` → `POST /api/v1/privacy/consent`
+
+`PendingReacceptanceItemSchema`, `PendingReacceptanceResponseSchema`, and the corresponding `z.infer<>` types are exported so callers can compose on top.
+
+### Cookie-consent storage helpers
+
+- `readStoredConsent()` / `writeStoredConsent()` / `clearStoredConsent()` — typed access to the `legal-consent-v1` localStorage entry (`StoredCookieConsentSchema` validates it).
+- `attachStoredCookieConsent()` — call this on first sign-in to replay an anonymous user's locally-stored choice against their account.
+- `COOKIE_CONSENT_STORAGE_KEY` is exported in case a consumer needs to clear it directly.
+
+## Quick start
+
+```tsx
+import {
+  LegalReacceptanceModal,
+  CookieBanner,
+  ManageCookiesLink,
+} from '@adopt-dont-shop/lib.legal';
+
+export const AppShell = () => (
+  <>
+    <LegalReacceptanceModal />
+    <CookieBanner />
+    <Routes>{/* … */}</Routes>
+    <Footer>
+      <ManageCookiesLink />
+    </Footer>
+  </>
+);
+```
+
+On sign-in flows, call `attachStoredCookieConsent()` after authentication completes so anonymous consent is migrated to the new account.
+
+## Dependencies
+
+Workspace packages: `lib.api`, `lib.auth`, `lib.components`, `lib.observability`. The banner flips the analytics consent gate in `lib.observability` so Sentry replay / Statsig auto-capture respect the choice on the same tab without a reload.
+
+## Development
+
+```bash
+npx turbo build --filter=@adopt-dont-shop/lib.legal
+npx turbo test  --filter=@adopt-dont-shop/lib.legal
+npx turbo lint  --filter=@adopt-dont-shop/lib.legal
+```
+
+Or from `lib.legal/`: `npm run build`, `npm test`, `npm run lint`.
+
+## See also
+
+- [docs/legal/cookies.md](../docs/legal/cookies.md) — cookies-policy copy and category definitions
+- [docs/legal/privacy.md](../docs/legal/privacy.md) — privacy policy
+- [docs/legal/terms.md](../docs/legal/terms.md) — terms of service
+- [`lib.observability`](../lib.observability/README.md) — the analytics-consent gate the banner toggles

--- a/lib.observability/README.md
+++ b/lib.observability/README.md
@@ -1,0 +1,71 @@
+# @adopt-dont-shop/lib.observability
+
+Frontend observability helpers shared by `app.client`, `app.admin`, and `app.rescue`. Wraps Sentry init, a Web Vitals reporter, and the analytics-consent gate so the three apps don't reimplement them.
+
+## What it ships
+
+### Sentry
+
+- `initSentry(options: SentryInitOptions)` — initialise Sentry for one app. Safe to call when `dsn` is empty (logs a warning, skips). Sentry is classified as **strictly necessary** for service reliability and runs unconditionally — do **not** gate it on `hasAnalyticsConsent()`. Replay sample rates default to `0` so identifiable session content stays off until callers explicitly opt in.
+- `captureException(error, context?)` / `captureMessage(message, level?)` — thin re-exports of `@sentry/react`.
+- `SentryInitOptions` type covers DSN, app name (`'admin' | 'client' | 'rescue'`), environment, release, trace sample rate, and replay sample rates.
+
+### Web Vitals
+
+- `reportWebVitals(reporter)` — subscribes to CLS, INP, LCP, TTFB, and FCP via the `web-vitals` package and forwards each measurement to the supplied reporter. Designed to be called once during app bootstrap.
+- `WebVitalMetric` / `WebVitalsReporter` types describe the payload (name, value, rating, id, delta).
+
+### Analytics consent gate
+
+A minimal localStorage-backed switch for analytics SDKs (Statsig auto-capture, session replay). Sentry is **out of scope** for this gate — see above.
+
+- `hasAnalyticsConsent(): boolean` — read current state (defaults to denied / `false`).
+- `setAnalyticsConsent('granted' | 'denied' | 'unknown')` — write the choice. `'unknown'` clears storage. Dispatches an `ads:analytics-consent-change` custom event so same-tab listeners can react immediately (the native `storage` event only fires across tabs).
+- `subscribeToAnalyticsConsent(listener)` — subscribe to consent changes; returns an unsubscribe function. Listens to both the custom event and the cross-tab `storage` event.
+- `ANALYTICS_CONSENT_STORAGE_KEY` — the localStorage key (`ads:analytics-consent`), exported for tests and direct clearing.
+
+## Quick start
+
+```ts
+// In each app's entry point (e.g. app.client/src/main.tsx):
+import {
+  initSentry,
+  reportWebVitals,
+  hasAnalyticsConsent,
+} from '@adopt-dont-shop/lib.observability';
+
+initSentry({
+  dsn: import.meta.env.VITE_SENTRY_DSN,
+  appName: 'client',
+  environment: import.meta.env.MODE,
+  release: import.meta.env.VITE_BUILD_SHA,
+});
+
+reportWebVitals((metric) => {
+  // ship to wherever — Sentry metrics, /api/v1/web-vitals, console, …
+  console.log(metric.name, metric.value, metric.rating);
+});
+
+// Later, in an analytics SDK bootstrap:
+if (hasAnalyticsConsent()) {
+  initStatsigAutoCapture();
+}
+```
+
+The cookie banner in [`lib.legal`](../lib.legal/README.md) calls `setAnalyticsConsent` for you when the user picks **Accept all** / **Essentials only**.
+
+## Development
+
+```bash
+npx turbo build --filter=@adopt-dont-shop/lib.observability
+npx turbo test  --filter=@adopt-dont-shop/lib.observability
+npx turbo lint  --filter=@adopt-dont-shop/lib.observability
+```
+
+Or from `lib.observability/`: `npm run build`, `npm test`, `npm run lint`.
+
+## See also
+
+- [`lib.legal`](../lib.legal/README.md) — cookie banner that owns the consent UI and toggles this gate
+- [`docs/legal/cookies.md`](../docs/legal/cookies.md) — cookie category definitions; explains why Sentry is exempt
+- [`docs/observability-alerting.md`](../docs/observability-alerting.md) — how Sentry events feed alerting


### PR DESCRIPTION
## Summary

Batch 2 of the documentation-accuracy pass. Targets the shared-libraries index and the two libs that shipped without a README.

### What was wrong

- `docs/libraries/README.md` opened with "**21 workspace libraries**" — the root `package.json` workspaces array has 23 entries today (`lib.legal` and `lib.observability` were added after the doc was written).
- The same file said "Tested with Jest (Node libraries) or Vitest (libraries co-located with apps)". Every `lib.*` is on Vitest now — each ships a `vitest.config.ts` and an `npm test` that runs `vitest run`. Jest is not a dependency of any package and is not in root `devDependencies`.
- The index had no catalogue entry for `lib.legal` or `lib.observability`.
- Neither `lib.legal/` nor `lib.observability/` had a `README.md`, so consumers had to read the `src/index.ts` to figure out the public API.

### What this PR changes

- `docs/libraries/README.md`
  - Header count: 21 → 23.
  - "Standards" section now states that everything is Vitest, names the four libraries (`lib.api`, `lib.permissions`, `lib.types`, `lib.validation`) that additionally emit a CJS bundle via `tsc -p tsconfig.cjs.json`, and notes that `lib.components` uses Vite (not `tsc`) for bundling.
  - Adds index entries for `lib.legal` and `lib.observability` under "UI & analytics".
- `lib.legal/README.md` (new) — documents `LegalReacceptanceModal`, `CookieBanner` + `useCookieConsent`, `ManageCookiesLink`, the `legal-service` wrapper around `/api/v1/legal/*` and `/api/v1/privacy/consent`, and the cookie-consent storage helpers.
- `lib.observability/README.md` (new) — documents `initSentry` / `captureException` / `captureMessage`, `reportWebVitals` (CLS, INP, LCP, TTFB, FCP), and the analytics-consent gate (`hasAnalyticsConsent`, `setAnalyticsConsent`, `subscribeToAnalyticsConsent`), including the rule that Sentry is strictly necessary and runs unconditionally.

### How I verified

- Counted workspace entries in root `package.json` → 23 `lib.*` directories.
- Confirmed each new README's public-API surface by reading the corresponding `src/index.ts`.
- Confirmed the four CJS-emitting libs by `ls $lib/tsconfig.cjs.json` and `grep '"require"' $lib/package.json`.
- Confirmed every linked doc path (`docs/legal/cookies.md`, `docs/legal/privacy.md`, `docs/legal/terms.md`, `docs/observability-alerting.md`) exists.

## Test plan

- [ ] CI lint/format passes (docs-only change)
- [ ] Reviewer spot-checks the new READMEs against `lib.legal/src/index.ts` and `lib.observability/src/index.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvbQnwXpfj4Gno2HuphMDc)_