### PR TITLE
docs(libraries): replace stale &quot;npm test  # jest&quot; comments with vitest

### DIFF
--- a/docs/upgrades/node-22-migration.md
+++ b/docs/upgrades/node-22-migration.md
@@ -46,7 +46,7 @@ Highlights that may bite us:
 | **`fetch`/`Headers`/`Request` stable** | Low | Current code uses axios; future code may switch but nothing forces it. |
 | **`--watch` mode default behaviour tweaks** | None | Not used in production, only in scripts. |
 | **OpenSSL 3.x stricter defaults** (already in 20) | None | Already vetted on Node 20. |
-| **`node:test` runner improvements** | None | We use Vitest/Jest. |
+| **`node:test` runner improvements** | None | We use Vitest. |
 | **GLIBC bump** (alpine: needs 3.18+) | Medium | `node:22-alpine` ships on Alpine 3.20; our base image moves with the upstream tag. Verify glibc-linked native deps (`bcrypt`, `pg-native` if added) still link. |
 
 ## 3. Risk inventory
@@ -188,8 +188,9 @@ release-blockers, but we should track them):
 - **DEP0166** `Invalid URL escape characters in import specifiers` — fires
   only if a dep ships malformed URLs in package.json `exports`. Should be
   zero hits for us.
-- Generic `ExperimentalWarning` for `--experimental-vm-modules` if Jest tests
-  in any lib opt into it (Vitest does not require it).
+- (Was previously a risk only for Jest-based suites opting into
+  `--experimental-vm-modules`; every package is on Vitest now, which does
+  not require that flag, so this is no longer a concern.)
 
 ## 11. Linear follow-up sub-issues to file (titles only)
 

--- a/lib.analytics/README.md
+++ b/lib.analytics/README.md
@@ -72,7 +72,7 @@ const metrics = await analytics.getEngagementMetrics({ start: from, end: to });
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.applications/README.md
+++ b/lib.applications/README.md
@@ -57,7 +57,7 @@ await applicationsService.uploadDocument(application.applicationId, file, 'proof
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.chat/README.md
+++ b/lib.chat/README.md
@@ -54,7 +54,7 @@ const { isConnected, isReconnecting, reconnectionAttempts } = useConnectionStatu
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.components/README.md
+++ b/lib.components/README.md
@@ -60,7 +60,7 @@ lib.components/src/
 ```bash
 npm run dev               # vite build --watch
 npm run build             # vite build (lib + theme bundle)
-npm run test              # jest
+npm run test              # vitest run
 npm run storybook         # storybook dev server on :6006
 npm run build-storybook   # static storybook build
 ```

--- a/lib.dev-tools/README.md
+++ b/lib.dev-tools/README.md
@@ -63,7 +63,7 @@ export function DevHeader() {
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest --passWithNoTests
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.discovery/README.md
+++ b/lib.discovery/README.md
@@ -48,7 +48,7 @@ await discovery.recordSwipeAction({
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.invitations/README.md
+++ b/lib.invitations/README.md
@@ -47,7 +47,7 @@ await invitations.sendInvitation({
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.notifications/README.md
+++ b/lib.notifications/README.md
@@ -67,7 +67,7 @@ await notifications.sendNotification({
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.permissions/README.md
+++ b/lib.permissions/README.md
@@ -367,8 +367,9 @@ lib.permissions/
     config/
       __tests__/
         field-permission-defaults.test.ts
-  jest.config.cjs
+  vitest.config.ts
   tsconfig.json
+  tsconfig.cjs.json
   package.json
 ```
 
@@ -376,13 +377,13 @@ lib.permissions/
 
 ```bash
 # From lib.permissions directory
-npx jest --config jest.config.cjs
+npm test                                                            # vitest run
 
 # Run a specific test file
-npx jest --config jest.config.cjs src/config/__tests__/field-permission-defaults.test.ts
+npx vitest run src/config/__tests__/field-permission-defaults.test.ts
 
 # With coverage
-npx jest --config jest.config.cjs --coverage
+npm run test:coverage                                               # vitest run --coverage
 ```
 
 ## Development

--- a/lib.pets/README.md
+++ b/lib.pets/README.md
@@ -50,7 +50,7 @@ const pet = await petManagementService.createPet({ /* … */ });
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.rescue/README.md
+++ b/lib.rescue/README.md
@@ -42,7 +42,7 @@ const { data } = await rescueService.searchRescues({ type: 'CHARITY', location: 
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.search/README.md
+++ b/lib.search/README.md
@@ -42,7 +42,7 @@ const suggestions = await search.getSearchSuggestions('gold');
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.support-tickets/README.md
+++ b/lib.support-tickets/README.md
@@ -72,7 +72,7 @@ export function MyTickets() {
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint

--- a/lib.validation/README.md
+++ b/lib.validation/README.md
@@ -49,7 +49,7 @@ if (!parsed.success) {
 ```bash
 npm run build           # tsc
 npm run dev             # tsc --watch
-npm test                # jest
+npm test                # vitest run
 npm run test:watch
 npm run test:coverage
 npm run lint


### PR DESCRIPTION
## Summary

Batch 3 of the documentation-accuracy pass. Cleans up the per-library README cheat-sheets so the `# jest` comment in their test invocations matches reality (every lib runs `vitest run`).

### What was wrong

`grep '# jest' lib.*/README.md` returned 13 files, plus `lib.permissions/README.md` referenced a non-existent `jest.config.cjs` file three times in its Testing section and once in the file tree. The `npm test` script in every one of those packages actually invokes `vitest run`.

### What this PR changes

- 13 lib READMEs (analytics, applications, chat, components, dev-tools, discovery, invitations, notifications, pets, rescue, search, support-tickets, validation): trailing comment on `npm test` changes from `# jest` / `# jest --passWithNoTests` to `# vitest run`.
- `lib.permissions/README.md`: file tree shows `vitest.config.ts` (and `tsconfig.cjs.json`, which actually exists for the CJS build) instead of the non-existent `jest.config.cjs`; the three `npx jest --config jest.config.cjs ...` examples in the Testing section become `npm test`, `npx vitest run …`, and `npm run test:coverage`.
- `docs/upgrades/node-22-migration.md`: two stale notes that mentioned Jest as one of our test runners are reworded — Vitest is the only test runner in the repo, so the Node 22 risk vectors that were Jest-specific (`--experimental-vm-modules`) no longer apply.

### How I verified

- `grep '"test"' lib.*/package.json` → every match is `"test": "vitest run"`.
- `ls lib.permissions/` confirms `vitest.config.ts` exists, `jest.config.cjs` does not, and `tsconfig.cjs.json` is real (used by the CJS build step).
- `grep -rn jest lib.*/README.md docs/` after the patch returns only the deliberately-explanatory line in `docs/backend/testing.md` ("The service does not use Jest…").

## Test plan

- [ ] CI passes (docs-only change)
- [ ] Reviewer spot-checks one or two of the touched READMEs to confirm the comment is the only change

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvbQnwXpfj4Gno2HuphMDc)_