### PR TITLE
fix(ADS-576): remove dead bulk-select UI from ApplicationList

### DIFF
--- a/app.rescue/src/components/applications/ApplicationList.css.ts
+++ b/app.rescue/src/components/applications/ApplicationList.css.ts
@@ -51,11 +51,6 @@ export const title = style({
   margin: 0,
 });
 
-export const selectionCount = style({
-  fontSize: '0.875rem',
-  color: '#6b7280',
-});
-
 export const sortSelect = style({
   fontSize: '0.875rem',
   border: '1px solid #d1d5db',
@@ -147,17 +142,6 @@ export const tableCell = style({
       textAlign: 'right',
     },
   },
-});
-
-export const checkboxCell = style({
-  padding: '1rem 1.5rem',
-  whiteSpace: 'nowrap',
-  borderBottom: '1px solid #e5e7eb',
-});
-
-export const checkbox = style({
-  borderRadius: '0.25rem',
-  border: '1px solid #d1d5db',
 });
 
 export const applicantInfo = style({

--- a/app.rescue/src/components/applications/ApplicationList.test.tsx
+++ b/app.rescue/src/components/applications/ApplicationList.test.tsx
@@ -1,17 +1,72 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { ApplicationListItem } from '../../types/applications';
 
-// Stub child components so we can render ApplicationList in isolation
-vi.mock('./ApplicationStats', () => ({
-  default: () => null,
+/**
+ * Behaviour tests for the rescue ApplicationList component.
+ *
+ * - ADS-573: every stage's action button (Start Review / Schedule Visit /
+ *   View Details / View) routes through `onApplicationSelect` so the row's
+ *   primary CTA actually opens the review modal instead of being a no-op.
+ * - ADS-576: the cosmetic bulk-select UI (per-row checkboxes + header chip)
+ *   is gone since no bulk-actions toolbar exists in the product.
+ */
+
+// Stub the vanilla-extract CSS module so styles are plain class names.
+vi.mock('./ApplicationList.css', () => ({
+  container: 'container',
+  statsSection: 'statsSection',
+  filtersSection: 'filtersSection',
+  header: 'header',
+  headerLeft: 'headerLeft',
+  headerRight: 'headerRight',
+  title: 'title',
+  sortSelect: 'sortSelect',
+  tableContainer: 'tableContainer',
+  loadingContainer: 'loadingContainer',
+  spinner: 'spinner',
+  loadingText: 'loadingText',
+  emptyContainer: 'emptyContainer',
+  emptyText: 'emptyText',
+  tableWrapper: 'tableWrapper',
+  table: 'table',
+  tableHead: 'tableHead',
+  tableRow: 'tableRow',
+  tableHeader: 'tableHeader',
+  tableBody: 'tableBody',
+  tableCell: 'tableCell',
+  applicantInfo: 'applicantInfo',
+  applicantName: 'applicantName',
+  applicantEmail: 'applicantEmail',
+  petInfo: 'petInfo',
+  petName: 'petName',
+  petDetails: 'petDetails',
+  priorityBadge: () => 'priorityBadge',
+  progressIndicators: 'progressIndicators',
+  progressBar: 'progressBar',
+  progressStep: () => 'progressStep',
+  progressLabel: 'progressLabel',
+  actionsContainer: 'actionsContainer',
+  actionButton: () => 'actionButton',
+  errorContainer: 'errorContainer',
+  errorContent: 'errorContent',
+  errorText: 'errorText',
+  errorTitle: 'errorTitle',
+  errorMessage: 'errorMessage',
 }));
 
+// Stub child components so we exercise ApplicationList in isolation.
+vi.mock('./ApplicationStats', () => ({
+  default: () => <div data-testid="application-stats" />,
+}));
 vi.mock('./ApplicationFilters', () => ({
-  default: () => null,
+  default: () => <div data-testid="application-filters" />,
+}));
+vi.mock('../common/StatusBadge', () => ({
+  default: ({ status }: { status: string }) => <span>{status}</span>,
 }));
 
 import ApplicationList from './ApplicationList';
+import type { ApplicationListItem } from '../../types/applications';
 
 // ApplicationListItem extends a wide backend type with many fields the list
 // view never touches. Justified type assertion: keep the test fixture focused
@@ -27,29 +82,31 @@ const buildApplication = (overrides: Partial<ApplicationListItem> = {}): Applica
     priority: 'medium',
     submittedDaysAgo: 1,
     stage: 'PENDING',
+    finalOutcome: undefined,
+    stageProgressPercentage: 0,
     referencesStatus: 'pending',
     homeVisitStatus: 'not_scheduled',
-    stageProgressPercentage: 0,
     data: { personalInfo: { email: 'jane@example.com' } },
-    ...overrides,
   } as unknown as ApplicationListItem;
-  return base;
+  return { ...base, ...overrides };
+};
+
+const baseProps = {
+  loading: false,
+  error: null,
+  filter: {},
+  sort: { field: 'submittedAt' as const, direction: 'desc' as const },
+  pagination: { page: 1, limit: 10, total: 1, totalPages: 1 },
+  onFilterChange: vi.fn(),
+  onSortChange: vi.fn(),
 };
 
 const renderList = (application: ApplicationListItem, onApplicationSelect = vi.fn()) => {
   render(
     <ApplicationList
+      {...baseProps}
       applications={[application]}
-      loading={false}
-      error={null}
-      filter={{}}
-      sort={{ field: 'submittedAt', direction: 'desc' }}
-      pagination={{ page: 1, limit: 10, total: 1, totalPages: 1 }}
-      onFilterChange={vi.fn()}
-      onSortChange={vi.fn()}
       onApplicationSelect={onApplicationSelect}
-      selectedApplications={[]}
-      onSelectionChange={vi.fn()}
     />
   );
   return { onApplicationSelect };
@@ -99,5 +156,31 @@ describe('ApplicationList stage action buttons', () => {
     fireEvent.click(screen.getByRole('button', { name: 'View Details' }));
 
     expect(onApplicationSelect).toHaveBeenCalledWith(application);
+  });
+});
+
+describe('ApplicationList [ADS-576] selection UI removed', () => {
+  it('renders no checkbox inputs in the table', () => {
+    render(
+      <ApplicationList
+        {...baseProps}
+        applications={[buildApplication()]}
+        onApplicationSelect={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('does not show a "selected" count chip in the header', () => {
+    render(
+      <ApplicationList
+        {...baseProps}
+        applications={[buildApplication(), buildApplication({ id: 'app-2' })]}
+        onApplicationSelect={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/selected$/i)).toBeNull();
   });
 });

--- a/app.rescue/src/components/applications/ApplicationList.tsx
+++ b/app.rescue/src/components/applications/ApplicationList.tsx
@@ -130,8 +130,6 @@ interface ApplicationListProps {
   onFilterChange: (filter: ApplicationFilter) => void;
   onSortChange: (sort: ApplicationSort) => void;
   onApplicationSelect: (application: ApplicationListItem) => void;
-  selectedApplications: string[];
-  onSelectionChange: (selected: string[]) => void;
 }
 
 const ApplicationList: React.FC<ApplicationListProps> = ({
@@ -144,8 +142,6 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
   onFilterChange,
   onSortChange,
   onApplicationSelect,
-  selectedApplications,
-  onSelectionChange,
 }) => {
   // Convert complex ApplicationFilter to simple string-based filters for UI
   const getDateRangeValue = () => {
@@ -243,22 +239,6 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
     onFilterChange(newFilter);
   };
 
-  const handleSelectAll = (checked: boolean) => {
-    if (checked) {
-      onSelectionChange(applications.map(app => app.id));
-    } else {
-      onSelectionChange([]);
-    }
-  };
-
-  const handleSelectApplication = (id: string, checked: boolean) => {
-    if (checked) {
-      onSelectionChange([...selectedApplications, id]);
-    } else {
-      onSelectionChange(selectedApplications.filter(appId => appId !== id));
-    }
-  };
-
   if (error) {
     return (
       <div className={styles.errorContainer}>
@@ -295,10 +275,6 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
         </div>
 
         <div className={styles.headerRight}>
-          {selectedApplications.length > 0 && (
-            <span className={styles.selectionCount}>{selectedApplications.length} selected</span>
-          )}
-
           <select
             className={styles.sortSelect}
             value={`${sort.field}-${sort.direction}`}
@@ -335,17 +311,6 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
             <table className={styles.table}>
               <thead className={styles.tableHead}>
                 <tr>
-                  <th className={styles.tableHeader}>
-                    <input
-                      className={styles.checkbox}
-                      type="checkbox"
-                      checked={
-                        applications.length > 0 &&
-                        applications.every(app => selectedApplications.includes(app.id))
-                      }
-                      onChange={e => handleSelectAll(e.target.checked)}
-                    />
-                  </th>
                   <th className={styles.tableHeader}>Applicant</th>
                   <th className={styles.tableHeader}>Pet</th>
                   <th className={styles.tableHeader}>Status</th>
@@ -362,14 +327,6 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
                     className={styles.tableRow}
                     onClick={() => onApplicationSelect(application)}
                   >
-                    <td className={styles.checkboxCell} onClick={e => e.stopPropagation()}>
-                      <input
-                        className={styles.checkbox}
-                        type="checkbox"
-                        checked={selectedApplications.includes(application.id)}
-                        onChange={e => handleSelectApplication(application.id, e.target.checked)}
-                      />
-                    </td>
                     <td className={styles.tableCell}>
                       <div className={styles.applicantInfo}>
                         <div className={styles.applicantName}>{application.applicantName}</div>

--- a/app.rescue/src/pages/Applications.tsx
+++ b/app.rescue/src/pages/Applications.tsx
@@ -6,7 +6,6 @@ import type { ApplicationListItem } from '../types/applications';
 
 const Applications: React.FC = () => {
   const [selectedApplication, setSelectedApplication] = useState<ApplicationListItem | null>(null);
-  const [selectedApplications, setSelectedApplications] = useState<string[]>([]);
 
   // Main applications data
   const {
@@ -82,8 +81,6 @@ const Applications: React.FC = () => {
         onFilterChange={updateFilter}
         onSortChange={updateSort}
         onApplicationSelect={handleApplicationSelect}
-        selectedApplications={selectedApplications}
-        onSelectionChange={setSelectedApplications}
       />
 
       {/* Application Review Modal */}


### PR DESCRIPTION
Closes ADS-576

## Summary

The rescue `ApplicationList` rendered per-row and "select all" checkboxes plus a `{n} selected` header chip, but no consumer existed — there is no bulk-actions toolbar. The selection UI was purely cosmetic and misled rescue staff into expecting batch actions that aren't wired up.

Per the ticket's recommended option (2), this removes the selection UI cleanly so the UI tells the truth until proper bulk actions are built (which would be a follow-up feature ticket).

### Changes

- `app.rescue/src/components/applications/ApplicationList.tsx` — drop `selectedApplications` / `onSelectionChange` props, `handleSelectAll` / `handleSelectApplication`, the header chip, the table-header checkbox cell, and the per-row checkbox cell.
- `app.rescue/src/pages/Applications.tsx` — remove the now-unused `selectedApplications` state and props passed to `ApplicationList`.
- `app.rescue/src/components/applications/ApplicationList.css.ts` — remove orphaned `selectionCount`, `checkboxCell`, `checkbox` styles (only used by the deleted UI; verified no other consumers).
- `app.rescue/src/components/applications/ApplicationList.test.tsx` — new behaviour test asserting no `checkbox` role is rendered and no "selected" chip appears.

No other file referenced `selectedApplications` / `onSelectionChange`, so no partial bulk-actions toolbar exists elsewhere.

## Test plan

- [x] `npx turbo lint test type-check --filter=@adopt-dont-shop/app.rescue` — all 23 tasks pass (148 tests, including 2 new ADS-576 tests).
- [ ] Manual: open the rescue Applications page, confirm no checkbox column, no "select all" header, no `{n} selected` chip, and row click still opens the review modal.


---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_