### PR TITLE
fix(ADS-573): wire ApplicationList stage action buttons

### DIFF
--- a/app.rescue/src/components/applications/ApplicationList.test.tsx
+++ b/app.rescue/src/components/applications/ApplicationList.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ApplicationListItem } from '../../types/applications';
+
+// Stub child components so we can render ApplicationList in isolation
+vi.mock('./ApplicationStats', () => ({
+  default: () => null,
+}));
+
+vi.mock('./ApplicationFilters', () => ({
+  default: () => null,
+}));
+
+import ApplicationList from './ApplicationList';
+
+// ApplicationListItem extends a wide backend type with many fields the list
+// view never touches. Justified type assertion: keep the test fixture focused
+// on the fields the render path actually reads.
+const buildApplication = (overrides: Partial<ApplicationListItem> = {}): ApplicationListItem => {
+  const base = {
+    id: 'app-1',
+    applicantName: 'Jane Doe',
+    petName: 'Buddy',
+    petType: 'dog',
+    petBreed: 'Labrador',
+    status: 'pending',
+    priority: 'medium',
+    submittedDaysAgo: 1,
+    stage: 'PENDING',
+    referencesStatus: 'pending',
+    homeVisitStatus: 'not_scheduled',
+    stageProgressPercentage: 0,
+    data: { personalInfo: { email: 'jane@example.com' } },
+    ...overrides,
+  } as unknown as ApplicationListItem;
+  return base;
+};
+
+const renderList = (application: ApplicationListItem, onApplicationSelect = vi.fn()) => {
+  render(
+    <ApplicationList
+      applications={[application]}
+      loading={false}
+      error={null}
+      filter={{}}
+      sort={{ field: 'submittedAt', direction: 'desc' }}
+      pagination={{ page: 1, limit: 10, total: 1, totalPages: 1 }}
+      onFilterChange={vi.fn()}
+      onSortChange={vi.fn()}
+      onApplicationSelect={onApplicationSelect}
+      selectedApplications={[]}
+      onSelectionChange={vi.fn()}
+    />
+  );
+  return { onApplicationSelect };
+};
+
+describe('ApplicationList stage action buttons', () => {
+  it('invokes onApplicationSelect when Start Review is clicked on a pending application', () => {
+    const application = buildApplication({ stage: 'PENDING' });
+    const { onApplicationSelect } = renderList(application);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start Review' }));
+
+    expect(onApplicationSelect).toHaveBeenCalledWith(application);
+  });
+
+  it('invokes onApplicationSelect when Schedule Visit is clicked on a reviewing application', () => {
+    const application = buildApplication({ stage: 'REVIEWING' });
+    const { onApplicationSelect } = renderList(application);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Schedule Visit' }));
+
+    expect(onApplicationSelect).toHaveBeenCalledWith(application);
+  });
+
+  it('invokes onApplicationSelect when View Details is clicked on a visiting application', () => {
+    const application = buildApplication({ stage: 'VISITING' });
+    const { onApplicationSelect } = renderList(application);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Details' }));
+
+    expect(onApplicationSelect).toHaveBeenCalledWith(application);
+  });
+
+  it('invokes onApplicationSelect when View Details is clicked on a deciding application', () => {
+    const application = buildApplication({ stage: 'DECIDING' });
+    const { onApplicationSelect } = renderList(application);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Details' }));
+
+    expect(onApplicationSelect).toHaveBeenCalledWith(application);
+  });
+
+  it('invokes onApplicationSelect when View Details is clicked on a resolved application', () => {
+    const application = buildApplication({ stage: 'RESOLVED' });
+    const { onApplicationSelect } = renderList(application);
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Details' }));
+
+    expect(onApplicationSelect).toHaveBeenCalledWith(application);
+  });
+});

--- a/app.rescue/src/components/applications/ApplicationList.tsx
+++ b/app.rescue/src/components/applications/ApplicationList.tsx
@@ -85,27 +85,31 @@ const getStepLabel = (stepIndex: number, stage: string, finalOutcome?: string): 
   return labels[stepIndex] || '';
 };
 
-const getActionButtons = (application: ApplicationListItem) => {
+const getActionButtons = (
+  application: ApplicationListItem,
+  onSelect: (application: ApplicationListItem) => void
+) => {
   const actions = [];
   const stage = application.stage || 'PENDING';
+  const select = () => onSelect(application);
 
   // Stage-based actions
   switch (stage) {
     case 'PENDING':
-      actions.push({ label: 'Start Review', action: () => {}, variant: 'primary' as const });
+      actions.push({ label: 'Start Review', action: select, variant: 'primary' as const });
       break;
     case 'REVIEWING':
-      actions.push({ label: 'Schedule Visit', action: () => {}, variant: 'primary' as const });
+      actions.push({ label: 'Schedule Visit', action: select, variant: 'primary' as const });
       break;
     case 'VISITING':
     case 'DECIDING':
-      actions.push({ label: 'View Details', action: () => {}, variant: 'secondary' as const });
+      actions.push({ label: 'View Details', action: select, variant: 'secondary' as const });
       break;
     case 'RESOLVED':
-      actions.push({ label: 'View Details', action: () => {}, variant: 'secondary' as const });
+      actions.push({ label: 'View Details', action: select, variant: 'secondary' as const });
       break;
     default:
-      actions.push({ label: 'View', action: () => {}, variant: 'secondary' as const });
+      actions.push({ label: 'View', action: select, variant: 'secondary' as const });
   }
 
   return actions.slice(0, 2);
@@ -432,7 +436,7 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
                     </td>
                     <td className={styles.tableCell} onClick={e => e.stopPropagation()}>
                       <div className={styles.actionsContainer}>
-                        {getActionButtons(application).map(action => (
+                        {getActionButtons(application, onApplicationSelect).map(action => (
                           <button
                             key={action.label}
                             className={styles.actionButton({ variant: action.variant })}


### PR DESCRIPTION
Closes ADS-573

## Summary

Every stage-based action button in `app.rescue/src/components/applications/ApplicationList.tsx` (`getActionButtons`, lines 88-112) was wired to an empty `() => {}` handler. The visible primary CTA on every row of the rescue application queue (Start Review, Schedule Visit, View Details, View) did nothing when clicked. Staff were working around it by clicking the row body, which already calls `onApplicationSelect` to open the `ApplicationReview` modal.

Routed each action through the existing `onApplicationSelect` prop so the buttons match the row-click behaviour and open the review modal. No new props on the parent (`Applications.tsx`) were needed — `onApplicationSelect` is already plumbed through.

## Verification

- Added behaviour tests in `app.rescue/src/components/applications/ApplicationList.test.tsx` asserting each stage's button (PENDING, REVIEWING, VISITING, DECIDING, RESOLVED) triggers `onApplicationSelect` with the application.
- `npx turbo lint test type-check --filter=@adopt-dont-shop/app.rescue` — all 23 tasks pass, 151 tests pass including the 5 new ones, lint and type-check clean.

## Test plan

- [x] Lint passes for `app.rescue`
- [x] Type-check passes for `app.rescue`
- [x] Tests pass for `app.rescue` (151 tests, 16 files)
- [ ] Manual smoke: click each stage's button in the application queue and confirm the review modal opens for the correct application

https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_