### PR TITLE
refactor(express): strip pass-through try/catch (ADS-531)

### DIFF
--- a/service.backend/src/__tests__/routes/applicationTimeline.routes.test.ts
+++ b/service.backend/src/__tests__/routes/applicationTimeline.routes.test.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import express, { NextFunction, Response } from 'express';
 import request from 'supertest';
 import { AuthenticatedRequest } from '../../types';
+import { errorHandler } from '../../middleware/error-handler';
 
 vi.mock('../../utils/logger', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
@@ -45,6 +46,7 @@ const buildApp = (
     app.use(authMiddleware);
   }
   app.use('/api/applications', applicationTimelineRouter);
+  app.use(errorHandler);
   return app;
 };
 
@@ -94,7 +96,7 @@ describe('Application timeline routes', () => {
       mockGetTimeline.mockRejectedValue(new Error('boom'));
       const res = await request(buildApp()).get('/api/applications/app-1/timeline');
       expect(res.status).toBe(500);
-      expect(res.body.success).toBe(false);
+      expect(res.body.status).toBe('error');
     });
   });
 

--- a/service.backend/src/__tests__/routes/invitation.routes.test.ts
+++ b/service.backend/src/__tests__/routes/invitation.routes.test.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import { errorHandler } from '../../middleware/error-handler';
 
 vi.mock('../../utils/logger', () => ({
   logger: {
@@ -32,6 +33,7 @@ const buildApp = () => {
   const app = express();
   app.use(express.json());
   app.use('/invitations', invitationRouter);
+  app.use(errorHandler);
   return app;
 };
 

--- a/service.backend/src/__tests__/routes/moderation.metrics.routes.test.ts
+++ b/service.backend/src/__tests__/routes/moderation.metrics.routes.test.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import express, { NextFunction, Response } from 'express';
 import request from 'supertest';
 import { AuthenticatedRequest } from '../../types';
+import { errorHandler } from '../../middleware/error-handler';
 
 vi.mock('../../utils/logger', () => ({
   logger: {
@@ -89,6 +90,7 @@ const buildApp = () => {
   const app = express();
   app.use(express.json());
   app.use('/api/v1/admin/moderation', moderationRouter);
+  app.use(errorHandler);
   return app;
 };
 
@@ -163,6 +165,6 @@ describe('GET /api/v1/admin/moderation/metrics', () => {
     const res = await request(app).get('/api/v1/admin/moderation/metrics');
 
     expect(res.status).toBe(500);
-    expect(res.body.success).toBe(false);
+    expect(res.body.status).toBe('error');
   });
 });

--- a/service.backend/src/controllers/admin.controller.ts
+++ b/service.backend/src/controllers/admin.controller.ts
@@ -13,32 +13,24 @@ export class AdminController {
    * Get platform metrics (dashboard data)
    */
   static async getPlatformMetrics(req: AuthenticatedRequest, res: Response) {
-    try {
-      const { startDate, endDate } = req.query;
+    const { startDate, endDate } = req.query;
 
-      let _start: Date | undefined;
-      let _end: Date | undefined;
+    let _start: Date | undefined;
+    let _end: Date | undefined;
 
-      if (startDate) {
-        _start = new Date(startDate as string);
-      }
-      if (endDate) {
-        _end = new Date(endDate as string);
-      }
-
-      const metrics = await AdminService.getPlatformMetrics();
-
-      res.json({
-        success: true,
-        data: metrics,
-      });
-    } catch (error) {
-      logger.error('Error getting platform metrics:', error);
-      res.status(500).json({
-        error: 'Failed to get platform metrics',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
+    if (startDate) {
+      _start = new Date(startDate as string);
     }
+    if (endDate) {
+      _end = new Date(endDate as string);
+    }
+
+    const metrics = await AdminService.getPlatformMetrics();
+
+    res.json({
+      success: true,
+      data: metrics,
+    });
   }
 
   /**
@@ -47,60 +39,46 @@ export class AdminController {
   static async searchUsers(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const {
-        search,
-        role,
-        status,
-        verificationStatus,
-        page = 1,
-        limit = DEFAULT_PAGE_SIZE,
-        sortBy = 'createdAt',
-        sortOrder = 'DESC',
-      } = req.query;
+    const {
+      search,
+      role,
+      status,
+      verificationStatus,
+      page = 1,
+      limit = DEFAULT_PAGE_SIZE,
+      sortBy = 'createdAt',
+      sortOrder = 'DESC',
+    } = req.query;
 
-      const allowedSortBy = ['email', 'firstName', 'lastName', 'createdAt', 'status'];
-      const safeSortBy = allowedSortBy.includes(sortBy as string)
-        ? (sortBy as string)
-        : 'createdAt';
-      const safeSortOrder =
-        (sortOrder as string)?.toUpperCase() === 'ASC' ? ('ASC' as const) : ('DESC' as const);
+    const allowedSortBy = ['email', 'firstName', 'lastName', 'createdAt', 'status'];
+    const safeSortBy = allowedSortBy.includes(sortBy as string) ? (sortBy as string) : 'createdAt';
+    const safeSortOrder =
+      (sortOrder as string)?.toUpperCase() === 'ASC' ? ('ASC' as const) : ('DESC' as const);
 
-      const parsedLimit = parseInt(limit as string);
+    const parsedLimit = parseInt(limit as string);
 
-      const result = await AdminService.getUsers({
-        search: search as string,
-        status: status as UserStatus,
-        userType: role as UserType,
-        page: parseInt(page as string),
+    const result = await AdminService.getUsers({
+      search: search as string,
+      status: status as UserStatus,
+      userType: role as UserType,
+      page: parseInt(page as string),
+      limit: parsedLimit,
+      sortBy: safeSortBy,
+      sortOrder: safeSortOrder,
+    });
+
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
+
+    res.json({
+      success: true,
+      data: result.users,
+      pagination: {
+        page: result.page,
         limit: parsedLimit,
-        sortBy: safeSortBy,
-        sortOrder: safeSortOrder,
-      });
-
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
-
-      res.json({
-        success: true,
-        data: result.users,
-        pagination: {
-          page: result.page,
-          limit: parsedLimit,
-          total: result.total,
-          pages: result.totalPages,
-        },
-      });
-    } catch (error) {
-      logger.error('Error searching users:', {
-        error: error instanceof Error ? error.message : String(error),
-        query: req.query,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to search users',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+        total: result.total,
+        pages: result.totalPages,
+      },
+    });
   }
 
   /**
@@ -180,20 +158,12 @@ export class AdminController {
    * Get system health metrics
    */
   static async getSystemHealth(req: AuthenticatedRequest, res: Response) {
-    try {
-      const health = await AdminService.getSystemHealth();
+    const health = await AdminService.getSystemHealth();
 
-      res.json({
-        success: true,
-        data: health,
-      });
-    } catch (error) {
-      logger.error('Error getting system health:', error);
-      res.status(500).json({
-        error: 'Failed to get system health',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: health,
+    });
   }
 
   /**
@@ -202,54 +172,42 @@ export class AdminController {
   static async getAuditLogs(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const {
-        page = 1,
-        limit = LARGE_PAGE_SIZE,
-        action,
-        userId,
-        entity,
-        level,
-        status,
-        startDate,
-        endDate,
-      } = req.query;
+    const {
+      page = 1,
+      limit = LARGE_PAGE_SIZE,
+      action,
+      userId,
+      entity,
+      level,
+      status,
+      startDate,
+      endDate,
+    } = req.query;
 
-      const result = await AdminService.getAuditLogs({
-        action: action as string,
-        userId: userId as string,
-        entity: entity as string,
-        level: level as 'INFO' | 'WARNING' | 'ERROR' | undefined,
-        status: status as 'success' | 'failure' | undefined,
-        startDate: startDate ? new Date(startDate as string) : undefined,
-        endDate: endDate ? new Date(endDate as string) : undefined,
-        page: parseInt(page as string),
-        limit: parseInt(limit as string),
-      });
+    const result = await AdminService.getAuditLogs({
+      action: action as string,
+      userId: userId as string,
+      entity: entity as string,
+      level: level as 'INFO' | 'WARNING' | 'ERROR' | undefined,
+      status: status as 'success' | 'failure' | undefined,
+      startDate: startDate ? new Date(startDate as string) : undefined,
+      endDate: endDate ? new Date(endDate as string) : undefined,
+      page: parseInt(page as string),
+      limit: parseInt(limit as string),
+    });
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: result.logs,
-        pagination: {
-          page: result.page,
-          limit: 20,
-          total: result.total,
-          pages: result.totalPages,
-        },
-      });
-    } catch (error) {
-      logger.error('Error getting audit logs:', {
-        error: error instanceof Error ? error.message : String(error),
-        query: req.query,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to get audit logs',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: result.logs,
+      pagination: {
+        page: result.page,
+        limit: 20,
+        total: result.total,
+        pages: result.totalPages,
+      },
+    });
   }
 
   /**
@@ -258,38 +216,26 @@ export class AdminController {
   static async getRescueManagement(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { page = 1, limit = DEFAULT_PAGE_SIZE, status } = req.query;
+    const { page = 1, limit = DEFAULT_PAGE_SIZE, status } = req.query;
 
-      const result = await AdminService.getRescues({
-        status: status as string,
-        page: parseInt(page as string),
-        limit: parseInt(limit as string),
-      });
+    const result = await AdminService.getRescues({
+      status: status as string,
+      page: parseInt(page as string),
+      limit: parseInt(limit as string),
+    });
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: result.rescues,
-        pagination: {
-          page: result.page,
-          limit: 20,
-          total: result.total,
-          pages: result.totalPages,
-        },
-      });
-    } catch (error) {
-      logger.error('Error getting rescue management:', {
-        error: error instanceof Error ? error.message : String(error),
-        query: req.query,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to get rescue management',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: result.rescues,
+      pagination: {
+        page: result.page,
+        limit: 20,
+        total: result.total,
+        pages: result.totalPages,
+      },
+    });
   }
 
   /**
@@ -298,44 +244,31 @@ export class AdminController {
   static async moderateRescue(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { rescueId } = req.params;
-      const { action, reason } = req.body;
-      const adminId = req.user!.userId;
+    const { rescueId } = req.params;
+    const { action, reason } = req.body;
+    const adminId = req.user!.userId;
 
-      let result;
-      switch (action) {
-        case 'verify':
-          result = await AdminService.verifyRescue(rescueId, adminId);
-          break;
-        case 'reject':
-          result = await AdminService.rejectRescueVerification(rescueId, adminId, reason);
-          break;
-        default:
-          return res.status(400).json({
-            error: 'Invalid action specified',
-          });
-      }
-
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
-
-      res.json({
-        success: true,
-        data: result,
-        message: `Rescue ${action} successful`,
-      });
-    } catch (error) {
-      logger.error('Error moderating rescue:', {
-        error: error instanceof Error ? error.message : String(error),
-        action: req.body.action,
-        rescueId: req.params.rescueId,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to moderate rescue',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
+    let result;
+    switch (action) {
+      case 'verify':
+        result = await AdminService.verifyRescue(rescueId, adminId);
+        break;
+      case 'reject':
+        result = await AdminService.rejectRescueVerification(rescueId, adminId, reason);
+        break;
+      default:
+        return res.status(400).json({
+          error: 'Invalid action specified',
+        });
     }
+
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
+
+    res.json({
+      success: true,
+      data: result,
+      message: `Rescue ${action} successful`,
+    });
   }
 
   /**
@@ -343,42 +276,34 @@ export class AdminController {
    */
   static async getDashboardAnalytics(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
-    try {
-      const { startDate, endDate } = req.query;
+    const { startDate, endDate } = req.query;
 
-      const { AnalyticsService } = await import('../services/analytics.service');
+    const { AnalyticsService } = await import('../services/analytics.service');
 
-      const options = {
-        startDate: startDate
-          ? new Date(startDate as string)
-          : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
-        endDate: endDate ? new Date(endDate as string) : new Date(),
-      };
+    const options = {
+      startDate: startDate
+        ? new Date(startDate as string)
+        : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      endDate: endDate ? new Date(endDate as string) : new Date(),
+    };
 
-      const [userMetrics, adoptionMetrics, applicationMetrics] = await Promise.all([
-        AnalyticsService.getUserBehaviorMetrics(options),
-        AnalyticsService.getAdoptionMetrics(options),
-        AnalyticsService.getApplicationMetrics(options),
-      ]);
+    const [userMetrics, adoptionMetrics, applicationMetrics] = await Promise.all([
+      AnalyticsService.getUserBehaviorMetrics(options),
+      AnalyticsService.getAdoptionMetrics(options),
+      AnalyticsService.getApplicationMetrics(options),
+    ]);
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: {
-          users: userMetrics,
-          adoptions: adoptionMetrics,
-          applications: applicationMetrics,
-          generatedAt: new Date(),
-        },
-      });
-    } catch (error) {
-      logger.error('Error getting dashboard analytics:', error);
-      res.status(500).json({
-        error: 'Failed to get dashboard analytics',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: {
+        users: userMetrics,
+        adoptions: adoptionMetrics,
+        applications: applicationMetrics,
+        generatedAt: new Date(),
+      },
+    });
   }
 
   /**
@@ -387,36 +312,24 @@ export class AdminController {
   static async getUsageAnalytics(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { startDate, endDate } = req.query;
+    const { startDate, endDate } = req.query;
 
-      let dateRange;
-      if (startDate && endDate) {
-        dateRange = {
-          start: new Date(startDate as string),
-          end: new Date(endDate as string),
-        };
-      }
-
-      const analytics = await AdminService.getSystemStatistics();
-
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
-
-      res.json({
-        success: true,
-        data: analytics,
-      });
-    } catch (error) {
-      logger.error('Error getting usage analytics:', {
-        error: error instanceof Error ? error.message : String(error),
-        query: req.query,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to get usage analytics',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
+    let dateRange;
+    if (startDate && endDate) {
+      dateRange = {
+        start: new Date(startDate as string),
+        end: new Date(endDate as string),
+      };
     }
+
+    const analytics = await AdminService.getSystemStatistics();
+
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
+
+    res.json({
+      success: true,
+      data: analytics,
+    });
   }
 
   /**
@@ -428,66 +341,58 @@ export class AdminController {
    * the response in JSON / JSONL / CSV.
    */
   static async exportData(req: AuthenticatedRequest, res: Response) {
-    try {
-      const { type, format = 'json' } = req.query;
+    const { type, format = 'json' } = req.query;
 
-      // Validation
-      if (!type) {
-        return res.status(400).json({
-          error: 'Export type is required',
-        });
-      }
-
-      const validTypes = ['users', 'rescues', 'pets', 'applications', 'audit_logs'];
-      if (!validTypes.includes(type as string)) {
-        return res.status(400).json({
-          error: 'Invalid export type',
-        });
-      }
-
-      const validFormats = ['json', 'jsonl', 'csv'];
-      if (!validFormats.includes(format as string)) {
-        return res.status(400).json({
-          error: 'Invalid export format',
-        });
-      }
-
-      const filename = `${type}_export_${new Date().toISOString().split('T')[0]}.${format}`;
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-
-      if (format === 'csv') {
-        res.setHeader('Content-Type', 'text/csv; charset=utf-8');
-      } else if (format === 'jsonl') {
-        res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
-      } else {
-        res.setHeader('Content-Type', 'application/json; charset=utf-8');
-      }
-
-      const stream = AdminService.streamExport(
-        type as 'users' | 'rescues' | 'pets' | 'applications' | 'audit_logs',
-        format as 'json' | 'jsonl' | 'csv'
-      );
-
-      stream.on('error', error => {
-        logger.error('Error streaming export:', error);
-        if (!res.headersSent) {
-          res.status(500).json({
-            error: 'Failed to export data',
-            message: error instanceof Error ? error.message : 'Unknown error',
-          });
-        } else {
-          res.end();
-        }
-      });
-
-      stream.pipe(res);
-    } catch (error) {
-      logger.error('Error exporting data:', error);
-      res.status(500).json({
-        error: 'Failed to export data',
-        message: error instanceof Error ? error.message : 'Unknown error',
+    // Validation
+    if (!type) {
+      return res.status(400).json({
+        error: 'Export type is required',
       });
     }
+
+    const validTypes = ['users', 'rescues', 'pets', 'applications', 'audit_logs'];
+    if (!validTypes.includes(type as string)) {
+      return res.status(400).json({
+        error: 'Invalid export type',
+      });
+    }
+
+    const validFormats = ['json', 'jsonl', 'csv'];
+    if (!validFormats.includes(format as string)) {
+      return res.status(400).json({
+        error: 'Invalid export format',
+      });
+    }
+
+    const filename = `${type}_export_${new Date().toISOString().split('T')[0]}.${format}`;
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+    if (format === 'csv') {
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    } else if (format === 'jsonl') {
+      res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+    } else {
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    }
+
+    const stream = AdminService.streamExport(
+      type as 'users' | 'rescues' | 'pets' | 'applications' | 'audit_logs',
+      format as 'json' | 'jsonl' | 'csv'
+    );
+
+    stream.on('error', error => {
+      logger.error('Error streaming export:', error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          error: 'Failed to export data',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        });
+      } else {
+        res.end();
+      }
+    });
+
+    stream.pipe(res);
   }
 
   /**
@@ -496,474 +401,314 @@ export class AdminController {
   static async getUserDetails(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { userId } = req.params;
+    const { userId } = req.params;
 
-      const user = await AdminService.getUserById(userId);
+    const user = await AdminService.getUserById(userId);
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: user,
-      });
-    } catch (error) {
-      logger.error('Error getting user details:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.params.userId,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to get user details',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: user,
+    });
   }
 
   /**
    * Get platform configuration
    */
   static async getConfiguration(req: AuthenticatedRequest, res: Response) {
-    try {
-      // This would typically return platform configuration settings
-      // For now, returning a placeholder
-      const config = {
-        platform: {
-          name: "Adopt Don't Shop",
-          version: '1.0.0',
-          environment: process.env.NODE_ENV || 'development',
-        },
-        features: {
-          realTimeMessaging: true,
-          fileUploads: true,
-          notifications: true,
-          analytics: true,
-        },
-        limits: {
-          maxFileSize: '10MB',
-          maxUsers: 'unlimited',
-          maxRescues: 'unlimited',
-          maxPets: 'unlimited',
-        },
-      };
+    // This would typically return platform configuration settings
+    // For now, returning a placeholder
+    const config = {
+      platform: {
+        name: "Adopt Don't Shop",
+        version: '1.0.0',
+        environment: process.env.NODE_ENV || 'development',
+      },
+      features: {
+        realTimeMessaging: true,
+        fileUploads: true,
+        notifications: true,
+        analytics: true,
+      },
+      limits: {
+        maxFileSize: '10MB',
+        maxUsers: 'unlimited',
+        maxRescues: 'unlimited',
+        maxPets: 'unlimited',
+      },
+    };
 
-      res.json({
-        success: true,
-        data: config,
-      });
-    } catch (error) {
-      logger.error('Error getting configuration:', error);
-      res.status(500).json({
-        error: 'Failed to get configuration',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: config,
+    });
   }
 
   /**
    * Update platform configuration (placeholder)
    */
   static async updateConfiguration(req: AuthenticatedRequest, res: Response) {
-    try {
-      const { key, value } = req.body;
+    const { key, value } = req.body;
 
-      // Validation
-      if (!key || value === undefined) {
-        return res.status(400).json({
-          error: 'Configuration key and value are required',
-        });
-      }
-
-      // This would implement actual configuration updates
-      // For now, just log the attempt
-      logger.info(`Admin ${req.user!.userId} attempted to update config: ${key} = ${value}`);
-
-      res.json({
-        success: true,
-        message: 'Configuration update not implemented yet',
-        data: { key, value },
-      });
-    } catch (error) {
-      logger.error('Error updating configuration:', error);
-      res.status(500).json({
-        error: 'Failed to update configuration',
-        message: error instanceof Error ? error.message : 'Unknown error',
+    // Validation
+    if (!key || value === undefined) {
+      return res.status(400).json({
+        error: 'Configuration key and value are required',
       });
     }
+
+    // This would implement actual configuration updates
+    // For now, just log the attempt
+    logger.info(`Admin ${req.user!.userId} attempted to update config: ${key} = ${value}`);
+
+    res.json({
+      success: true,
+      message: 'Configuration update not implemented yet',
+      data: { key, value },
+    });
   }
 
   static async getUsers(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { page = 1, limit = DEFAULT_PAGE_SIZE, status, userType, search } = req.query;
+    const { page = 1, limit = DEFAULT_PAGE_SIZE, status, userType, search } = req.query;
 
-      const result = await AdminService.getUsers({
-        status: status as UserStatus,
-        userType: userType as UserType,
-        search: search as string,
-        page: parseInt(page as string),
-        limit: parseInt(limit as string),
-      });
+    const result = await AdminService.getUsers({
+      status: status as UserStatus,
+      userType: userType as UserType,
+      search: search as string,
+      page: parseInt(page as string),
+      limit: parseInt(limit as string),
+    });
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Admin getUsers failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        query: req.query,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve users',
-      });
-    }
+    res.json({
+      success: true,
+      data: result,
+    });
   }
 
   static async getUserById(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { userId } = req.params;
+    const { userId } = req.params;
 
-      const user = await AdminService.getUserById(userId);
+    const user = await AdminService.getUserById(userId);
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: user,
-      });
-    } catch (error) {
-      logger.error('Admin getUserById failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.params.userId,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve user',
-      });
-    }
+    res.json({
+      success: true,
+      data: user,
+    });
   }
 
   static async updateUserStatus(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { userId } = req.params;
-      const { status } = req.body;
-      const adminId = req.user?.userId || 'system';
+    const { userId } = req.params;
+    const { status } = req.body;
+    const adminId = req.user?.userId || 'system';
 
-      const user = await AdminService.updateUserStatus(userId, status, adminId);
+    const user = await AdminService.updateUserStatus(userId, status, adminId);
 
-      // ADS-450 / ADS-464: capture request-level metadata (IP, user-agent)
-      // alongside the service-layer audit row so admin actions are
-      // forensically reconstructible.
-      await AuditLogService.log({
-        userId: adminId,
-        action: 'ADMIN_UPDATE_USER_STATUS',
-        entity: 'User',
-        entityId: userId,
-        details: { status },
-        ipAddress: req.ip,
-        userAgent: req.get('user-agent') || '',
-      });
+    // ADS-450 / ADS-464: capture request-level metadata (IP, user-agent)
+    // alongside the service-layer audit row so admin actions are
+    // forensically reconstructible.
+    await AuditLogService.log({
+      userId: adminId,
+      action: 'ADMIN_UPDATE_USER_STATUS',
+      entity: 'User',
+      entityId: userId,
+      details: { status },
+      ipAddress: req.ip,
+      userAgent: req.get('user-agent') || '',
+    });
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: user,
-      });
-    } catch (error) {
-      logger.error('Admin updateUserStatus failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.params.userId,
-        status: req.body.status,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to update user status',
-      });
-    }
+    res.json({
+      success: true,
+      data: user,
+    });
   }
 
   static async suspendUser(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { userId } = req.params;
-      const { reason } = req.body;
-      const adminId = req.user?.userId || 'system';
+    const { userId } = req.params;
+    const { reason } = req.body;
+    const adminId = req.user?.userId || 'system';
 
-      const user = await AdminService.suspendUser(userId, adminId, reason);
+    const user = await AdminService.suspendUser(userId, adminId, reason);
 
-      // ADS-450 / ADS-464: durable audit trail with request metadata.
-      await AuditLogService.log({
-        userId: adminId,
-        action: 'ADMIN_SUSPEND_USER',
-        entity: 'User',
-        entityId: userId,
-        details: { reason: reason ?? null },
-        ipAddress: req.ip,
-        userAgent: req.get('user-agent') || '',
-      });
+    // ADS-450 / ADS-464: durable audit trail with request metadata.
+    await AuditLogService.log({
+      userId: adminId,
+      action: 'ADMIN_SUSPEND_USER',
+      entity: 'User',
+      entityId: userId,
+      details: { reason: reason ?? null },
+      ipAddress: req.ip,
+      userAgent: req.get('user-agent') || '',
+    });
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: user,
-      });
-    } catch (error) {
-      logger.error('Admin suspendUser failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.params.userId,
-        reason: req.body.reason,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to suspend user',
-      });
-    }
+    res.json({
+      success: true,
+      data: user,
+    });
   }
 
   static async unsuspendUser(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { userId } = req.params;
-      const adminId = req.user?.userId || 'system';
+    const { userId } = req.params;
+    const adminId = req.user?.userId || 'system';
 
-      const user = await AdminService.unsuspendUser(userId, adminId);
+    const user = await AdminService.unsuspendUser(userId, adminId);
 
-      // ADS-450 / ADS-464: durable audit trail with request metadata.
-      await AuditLogService.log({
-        userId: adminId,
-        action: 'ADMIN_UNSUSPEND_USER',
-        entity: 'User',
-        entityId: userId,
-        ipAddress: req.ip,
-        userAgent: req.get('user-agent') || '',
-      });
+    // ADS-450 / ADS-464: durable audit trail with request metadata.
+    await AuditLogService.log({
+      userId: adminId,
+      action: 'ADMIN_UNSUSPEND_USER',
+      entity: 'User',
+      entityId: userId,
+      ipAddress: req.ip,
+      userAgent: req.get('user-agent') || '',
+    });
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: user,
-      });
-    } catch (error) {
-      logger.error('Admin unsuspendUser failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.params.userId,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to unsuspend user',
-      });
-    }
+    res.json({
+      success: true,
+      data: user,
+    });
   }
 
   static async deleteUser(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { userId } = req.params;
-      const { reason } = req.body;
-      const adminId = req.user?.userId || 'system';
+    const { userId } = req.params;
+    const { reason } = req.body;
+    const adminId = req.user?.userId || 'system';
 
-      await AdminService.deleteUser(userId, adminId, reason);
+    await AdminService.deleteUser(userId, adminId, reason);
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        message: 'User deleted successfully',
-      });
-    } catch (error) {
-      logger.error('Admin deleteUser failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.params.userId,
-        reason: req.body.reason,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to delete user',
-      });
-    }
+    res.json({
+      success: true,
+      message: 'User deleted successfully',
+    });
   }
 
   static async getRescues(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { page = 1, limit = DEFAULT_PAGE_SIZE, status, search } = req.query;
+    const { page = 1, limit = DEFAULT_PAGE_SIZE, status, search } = req.query;
 
-      const result = await AdminService.getRescues({
-        status: status as string,
-        search: search as string,
-        page: parseInt(page as string),
-        limit: parseInt(limit as string),
-      });
+    const result = await AdminService.getRescues({
+      status: status as string,
+      search: search as string,
+      page: parseInt(page as string),
+      limit: parseInt(limit as string),
+    });
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Admin getRescues failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        query: req.query,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve rescues',
-      });
-    }
+    res.json({
+      success: true,
+      data: result,
+    });
   }
 
   static async verifyRescue(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { rescueId } = req.params;
-      const adminId = req.user?.userId || 'system';
+    const { rescueId } = req.params;
+    const adminId = req.user?.userId || 'system';
 
-      const rescue = await AdminService.verifyRescue(rescueId, adminId);
+    const rescue = await AdminService.verifyRescue(rescueId, adminId);
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: rescue,
-      });
-    } catch (error) {
-      logger.error('Admin verifyRescue failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        rescueId: req.params.rescueId,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to verify rescue',
-      });
-    }
+    res.json({
+      success: true,
+      data: rescue,
+    });
   }
 
   static async getSystemStatistics(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const statistics = await AdminService.getSystemStatistics();
+    const statistics = await AdminService.getSystemStatistics();
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: statistics,
-      });
-    } catch (error) {
-      logger.error('Admin getSystemStatistics failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve system statistics',
-      });
-    }
+    res.json({
+      success: true,
+      data: statistics,
+    });
   }
 
   static async getDashboardStats(req: AuthenticatedRequest, res: Response): Promise<void> {
     const startTime = Date.now();
 
-    try {
-      const { startDate, endDate } = req.query;
+    const { startDate, endDate } = req.query;
 
-      const stats = await AdminService.getPlatformMetrics();
+    const stats = await AdminService.getPlatformMetrics();
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
-      res.json(stats);
-    } catch (error) {
-      logger.error('Failed to get dashboard stats:', {
-        error: error instanceof Error ? error.message : String(error),
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({ error: 'Failed to get dashboard stats' });
-    }
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    res.json(stats);
   }
 
   static async getUsersAdmin(req: AuthenticatedRequest, res: Response): Promise<void> {
     const startTime = Date.now();
 
-    try {
-      const {
-        search,
-        role,
-        status,
-        _verificationStatus, // Prefix with underscore to indicate intentionally unused
-        page = 1,
-        limit = DEFAULT_PAGE_SIZE,
-        sortBy = 'createdAt',
-        sortOrder = 'DESC',
-      } = req.query;
+    const {
+      search,
+      role,
+      status,
+      _verificationStatus, // Prefix with underscore to indicate intentionally unused
+      page = 1,
+      limit = DEFAULT_PAGE_SIZE,
+      sortBy = 'createdAt',
+      sortOrder = 'DESC',
+    } = req.query;
 
-      const allowedSortBy = ['email', 'firstName', 'lastName', 'createdAt', 'status'];
-      const safeSortBy = allowedSortBy.includes(sortBy as string)
-        ? (sortBy as string)
-        : 'createdAt';
-      const safeSortOrder =
-        (sortOrder as string)?.toUpperCase() === 'ASC' ? ('ASC' as const) : ('DESC' as const);
+    const allowedSortBy = ['email', 'firstName', 'lastName', 'createdAt', 'status'];
+    const safeSortBy = allowedSortBy.includes(sortBy as string) ? (sortBy as string) : 'createdAt';
+    const safeSortOrder =
+      (sortOrder as string)?.toUpperCase() === 'ASC' ? ('ASC' as const) : ('DESC' as const);
 
-      const parsedLimit = parseInt(limit as string);
+    const parsedLimit = parseInt(limit as string);
 
-      const result = await AdminService.getUsers({
-        search: search as string,
-        status: status as UserStatus,
-        userType: role as UserType,
-        page: parseInt(page as string),
+    const result = await AdminService.getUsers({
+      search: search as string,
+      status: status as UserStatus,
+      userType: role as UserType,
+      page: parseInt(page as string),
+      limit: parsedLimit,
+      sortBy: safeSortBy,
+      sortOrder: safeSortOrder,
+    });
+
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
+
+    res.json({
+      success: true,
+      data: result.users,
+      pagination: {
+        page: result.page,
         limit: parsedLimit,
-        sortBy: safeSortBy,
-        sortOrder: safeSortOrder,
-      });
-
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
-
-      res.json({
-        success: true,
-        data: result.users,
-        pagination: {
-          page: result.page,
-          limit: parsedLimit,
-          total: result.total,
-          pages: result.totalPages,
-        },
-      });
-    } catch (error) {
-      logger.error('Error searching users:', {
-        error: error instanceof Error ? error.message : String(error),
-        query: req.query,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to search users',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+        total: result.total,
+        pages: result.totalPages,
+      },
+    });
   }
 
   /**
@@ -972,116 +717,99 @@ export class AdminController {
   static async updateUserProfile(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { userId } = req.params;
-      const { firstName, lastName, email, phoneNumber, userType } = req.body;
-      const adminId = req.user!.userId;
+    const { userId } = req.params;
+    const { firstName, lastName, email, phoneNumber, userType } = req.body;
+    const adminId = req.user!.userId;
 
-      const user = await User.findByPk(userId);
-      if (!user) {
-        return res.status(404).json({
-          error: 'User not found',
-        });
-      }
-
-      const oldData = {
-        firstName: user.firstName,
-        lastName: user.lastName,
-        email: user.email,
-        phoneNumber: user.phoneNumber,
-        userType: user.userType,
-      };
-
-      // Update user fields
-      if (firstName !== undefined) {
-        user.firstName = firstName;
-      }
-      if (lastName !== undefined) {
-        user.lastName = lastName;
-      }
-      if (email !== undefined) {
-        user.email = email;
-      }
-      if (phoneNumber !== undefined) {
-        user.phoneNumber = phoneNumber;
-      }
-      if (userType !== undefined) {
-        user.userType = userType;
-      }
-
-      await user.save();
-
-      // Log the change
-      await AuditLogService.log({
-        userId: adminId,
-        action: 'UPDATE',
-        entity: 'User',
-        entityId: userId,
-        details: {
-          old: oldData,
-          new: { firstName, lastName, email, phoneNumber, userType },
-        },
-        ipAddress: req.ip,
-        userAgent: req.get('user-agent') || '',
-      });
-
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
-
-      res.json({
-        success: true,
-        data: user,
-        message: 'User profile updated successfully',
-      });
-    } catch (error) {
-      logger.error('Error updating user profile:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.params.userId,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to update user profile',
-        message: error instanceof Error ? error.message : 'Unknown error',
+    const user = await User.findByPk(userId);
+    if (!user) {
+      return res.status(404).json({
+        error: 'User not found',
       });
     }
+
+    const oldData = {
+      firstName: user.firstName,
+      lastName: user.lastName,
+      email: user.email,
+      phoneNumber: user.phoneNumber,
+      userType: user.userType,
+    };
+
+    // Update user fields
+    if (firstName !== undefined) {
+      user.firstName = firstName;
+    }
+    if (lastName !== undefined) {
+      user.lastName = lastName;
+    }
+    if (email !== undefined) {
+      user.email = email;
+    }
+    if (phoneNumber !== undefined) {
+      user.phoneNumber = phoneNumber;
+    }
+    if (userType !== undefined) {
+      user.userType = userType;
+    }
+
+    await user.save();
+
+    // Log the change
+    await AuditLogService.log({
+      userId: adminId,
+      action: 'UPDATE',
+      entity: 'User',
+      entityId: userId,
+      details: {
+        old: oldData,
+        new: { firstName, lastName, email, phoneNumber, userType },
+      },
+      ipAddress: req.ip,
+      userAgent: req.get('user-agent') || '',
+    });
+
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
+
+    res.json({
+      success: true,
+      data: user,
+      message: 'User profile updated successfully',
+    });
   }
 
   static async updateRescuePlan(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { rescueId } = req.params;
-      const { plan, planExpiresAt } = req.body as {
-        plan: RescuePlan;
-        planExpiresAt?: string | null;
-      };
+    const { rescueId } = req.params;
+    const { plan, planExpiresAt } = req.body as {
+      plan: RescuePlan;
+      planExpiresAt?: string | null;
+    };
 
-      const rescue = await Rescue.findByPk(rescueId);
-      if (!rescue) {
-        res.status(404).json({ error: 'Rescue not found' });
-        return;
-      }
-
-      const previousPlan = rescue.plan;
-      await rescue.update({
-        plan,
-        planExpiresAt: planExpiresAt ? new Date(planExpiresAt) : null,
-      });
-
-      await AuditLogService.log({
-        action: 'UPDATE_PLAN',
-        entity: 'Rescue',
-        entityId: rescueId,
-        details: { previousPlan, newPlan: plan, planExpiresAt: planExpiresAt ?? null },
-        userId: req.user?.userId ?? 'system',
-        ipAddress: req.ip ?? '',
-        userAgent: req.get('user-agent') ?? '',
-      });
-
-      res.json({
-        success: true,
-        data: { rescueId, plan, planExpiresAt: planExpiresAt ?? null },
-      });
-    } catch (error) {
-      logger.error('updateRescuePlan failed', { error });
-      res.status(500).json({ error: 'Failed to update rescue plan' });
+    const rescue = await Rescue.findByPk(rescueId);
+    if (!rescue) {
+      res.status(404).json({ error: 'Rescue not found' });
+      return;
     }
+
+    const previousPlan = rescue.plan;
+    await rescue.update({
+      plan,
+      planExpiresAt: planExpiresAt ? new Date(planExpiresAt) : null,
+    });
+
+    await AuditLogService.log({
+      action: 'UPDATE_PLAN',
+      entity: 'Rescue',
+      entityId: rescueId,
+      details: { previousPlan, newPlan: plan, planExpiresAt: planExpiresAt ?? null },
+      userId: req.user?.userId ?? 'system',
+      ipAddress: req.ip ?? '',
+      userAgent: req.get('user-agent') ?? '',
+    });
+
+    res.json({
+      success: true,
+      data: { rescueId, plan, planExpiresAt: planExpiresAt ?? null },
+    });
   }
 }

--- a/service.backend/src/controllers/analytics.controller.ts
+++ b/service.backend/src/controllers/analytics.controller.ts
@@ -8,154 +8,130 @@ export class AnalyticsController {
    * Record a pageview
    */
   async recordPageview(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-        return;
-      }
-
-      const { path, url, timestamp, sessionId, referrer, userAgent } = req.body;
-      const userId = req.user?.userId;
-
-      // Use either path or url, prefer path
-      const pagePath = path || url || req.url || 'unknown';
-
-      // For now, just log the pageview data
-      // In the future, this could be stored in a database or sent to an analytics service
-      logger.info('Pageview recorded', {
-        service: 'analytics',
-        type: 'pageview',
-        data: {
-          path: pagePath,
-          timestamp: timestamp || new Date().toISOString(),
-          userId,
-          sessionId,
-          referrer,
-          userAgent,
-          ip: req.ip,
-        },
-      });
-
-      res.status(201).json({
-        success: true,
-        message: 'Pageview recorded',
-      });
-    } catch (error) {
-      logger.error('Failed to record pageview', { error });
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
         success: false,
-        message: 'Failed to record pageview',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
+      return;
     }
+
+    const { path, url, timestamp, sessionId, referrer, userAgent } = req.body;
+    const userId = req.user?.userId;
+
+    // Use either path or url, prefer path
+    const pagePath = path || url || req.url || 'unknown';
+
+    // For now, just log the pageview data
+    // In the future, this could be stored in a database or sent to an analytics service
+    logger.info('Pageview recorded', {
+      service: 'analytics',
+      type: 'pageview',
+      data: {
+        path: pagePath,
+        timestamp: timestamp || new Date().toISOString(),
+        userId,
+        sessionId,
+        referrer,
+        userAgent,
+        ip: req.ip,
+      },
+    });
+
+    res.status(201).json({
+      success: true,
+      message: 'Pageview recorded',
+    });
   }
 
   /**
    * Record multiple analytics events in a batch
    */
   async recordEventsBatch(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-        return;
-      }
-
-      const { events } = req.body;
-      const userId = req.user?.userId;
-
-      if (!Array.isArray(events)) {
-        res.status(400).json({
-          success: false,
-          message: 'Events must be an array',
-        });
-        return;
-      }
-
-      // For now, just log the events
-      // In the future, this could be stored in a database or sent to an analytics service
-      logger.info('Batch events recorded', {
-        service: 'analytics',
-        type: 'batch_events',
-        count: events.length,
-        userId,
-        ip: req.ip,
-        events: events.map(event => ({
-          event: event.event || event.name || event.type || 'unknown',
-          timestamp: event.timestamp || new Date().toISOString(),
-          properties: event.properties || {},
-        })),
-      });
-
-      res.status(201).json({
-        success: true,
-        message: 'Events recorded',
-        processed: events.length,
-      });
-    } catch (error) {
-      logger.error('Failed to record batch events', { error });
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
         success: false,
-        message: 'Failed to record events',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
+      return;
     }
+
+    const { events } = req.body;
+    const userId = req.user?.userId;
+
+    if (!Array.isArray(events)) {
+      res.status(400).json({
+        success: false,
+        message: 'Events must be an array',
+      });
+      return;
+    }
+
+    // For now, just log the events
+    // In the future, this could be stored in a database or sent to an analytics service
+    logger.info('Batch events recorded', {
+      service: 'analytics',
+      type: 'batch_events',
+      count: events.length,
+      userId,
+      ip: req.ip,
+      events: events.map(event => ({
+        event: event.event || event.name || event.type || 'unknown',
+        timestamp: event.timestamp || new Date().toISOString(),
+        properties: event.properties || {},
+      })),
+    });
+
+    res.status(201).json({
+      success: true,
+      message: 'Events recorded',
+      processed: events.length,
+    });
   }
 
   /**
    * Record a single analytics event
    */
   async recordEvent(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-        return;
-      }
-
-      const { event, name, type, timestamp, properties, sessionId } = req.body;
-      const userId = req.user?.userId;
-
-      // Use event, name, or type - prefer event
-      const eventName = event || name || type || 'unknown';
-
-      // For now, just log the event data
-      // In the future, this could be stored in a database or sent to an analytics service
-      logger.info('Analytics event recorded', {
-        service: 'analytics',
-        type: 'single_event',
-        data: {
-          event: eventName,
-          timestamp: timestamp || new Date().toISOString(),
-          properties: properties || {},
-          userId,
-          sessionId,
-          ip: req.ip,
-        },
-      });
-
-      res.status(201).json({
-        success: true,
-        message: 'Event recorded',
-      });
-    } catch (error) {
-      logger.error('Failed to record event', { error });
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
         success: false,
-        message: 'Failed to record event',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
+      return;
     }
+
+    const { event, name, type, timestamp, properties, sessionId } = req.body;
+    const userId = req.user?.userId;
+
+    // Use event, name, or type - prefer event
+    const eventName = event || name || type || 'unknown';
+
+    // For now, just log the event data
+    // In the future, this could be stored in a database or sent to an analytics service
+    logger.info('Analytics event recorded', {
+      service: 'analytics',
+      type: 'single_event',
+      data: {
+        event: eventName,
+        timestamp: timestamp || new Date().toISOString(),
+        properties: properties || {},
+        userId,
+        sessionId,
+        ip: req.ip,
+      },
+    });
+
+    res.status(201).json({
+      success: true,
+      message: 'Event recorded',
+    });
   }
 
   /**

--- a/service.backend/src/controllers/application-profile.controller.ts
+++ b/service.backend/src/controllers/application-profile.controller.ts
@@ -2,7 +2,6 @@ import { Response } from 'express';
 import { validationResult } from 'express-validator';
 import { ApplicationProfileService } from '../services/application-profile.service';
 import { AuthenticatedRequest } from '../types/auth';
-import { logger } from '../utils/logger';
 
 /**
  * Phase 1 - Application Profile Controller
@@ -30,21 +29,13 @@ export class ApplicationProfileController {
    * ```
    */
   static async getApplicationDefaults(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const defaults = await ApplicationProfileService.getApplicationDefaults(userId);
+    const userId = req.user!.userId;
+    const defaults = await ApplicationProfileService.getApplicationDefaults(userId);
 
-      res.status(200).json({
-        success: true,
-        data: defaults,
-      });
-    } catch (error) {
-      logger.error('Error getting application defaults:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to get application defaults',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: defaults,
+    });
   }
 
   /**
@@ -65,35 +56,27 @@ export class ApplicationProfileController {
    * ```
    */
   static async updateApplicationDefaults(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-        return;
-      }
-
-      const userId = req.user!.userId;
-      const updatedDefaults = await ApplicationProfileService.updateApplicationDefaults(
-        userId,
-        req.body
-      );
-
-      res.status(200).json({
-        success: true,
-        message: 'Application defaults updated successfully',
-        data: updatedDefaults,
-      });
-    } catch (error) {
-      logger.error('Error updating application defaults:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
         success: false,
-        message: 'Failed to update application defaults',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
+      return;
     }
+
+    const userId = req.user!.userId;
+    const updatedDefaults = await ApplicationProfileService.updateApplicationDefaults(
+      userId,
+      req.body
+    );
+
+    res.status(200).json({
+      success: true,
+      message: 'Application defaults updated successfully',
+      data: updatedDefaults,
+    });
   }
 
   /**
@@ -116,21 +99,13 @@ export class ApplicationProfileController {
    * ```
    */
   static async getApplicationPreferences(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const preferences = await ApplicationProfileService.getApplicationPreferences(userId);
+    const userId = req.user!.userId;
+    const preferences = await ApplicationProfileService.getApplicationPreferences(userId);
 
-      res.status(200).json({
-        success: true,
-        data: preferences,
-      });
-    } catch (error) {
-      logger.error('Error getting application preferences:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to get application preferences',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: preferences,
+    });
   }
 
   /**
@@ -155,126 +130,94 @@ export class ApplicationProfileController {
     req: AuthenticatedRequest,
     res: Response
   ): Promise<void> {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-        return;
-      }
-
-      const userId = req.user!.userId;
-      const updatedPreferences = await ApplicationProfileService.updateApplicationPreferences(
-        userId,
-        req.body
-      );
-
-      res.status(200).json({
-        success: true,
-        message: 'Application preferences updated successfully',
-        data: updatedPreferences,
-      });
-    } catch (error) {
-      logger.error('Error updating application preferences:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
         success: false,
-        message: 'Failed to update application preferences',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
+      return;
     }
+
+    const userId = req.user!.userId;
+    const updatedPreferences = await ApplicationProfileService.updateApplicationPreferences(
+      userId,
+      req.body
+    );
+
+    res.status(200).json({
+      success: true,
+      message: 'Application preferences updated successfully',
+      data: updatedPreferences,
+    });
   }
 
   /**
    * Get profile completion status
    */
   static async getProfileCompletion(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const completion = await ApplicationProfileService.getProfileCompletion(userId);
+    const userId = req.user!.userId;
+    const completion = await ApplicationProfileService.getProfileCompletion(userId);
 
-      res.status(200).json({
-        success: true,
-        data: completion,
-      });
-    } catch (error) {
-      logger.error('Error getting profile completion:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to get profile completion status',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: completion,
+    });
   }
 
   /**
    * Get pre-population data for application forms
    */
   static async getPrePopulationData(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const { petId } = req.query;
+    const userId = req.user!.userId;
+    const { petId } = req.query;
 
-      const prePopulationData = await ApplicationProfileService.getPrePopulationData(
-        userId,
-        petId as string
-      );
+    const prePopulationData = await ApplicationProfileService.getPrePopulationData(
+      userId,
+      petId as string
+    );
 
-      res.status(200).json({
-        success: true,
-        data: prePopulationData,
-      });
-    } catch (error) {
-      logger.error('Error getting pre-population data:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to get pre-population data',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: prePopulationData,
+    });
   }
 
   /**
    * Process quick application request
    */
   static async processQuickApplication(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-        return;
-      }
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        message: 'Validation failed',
+        errors: errors.array(),
+      });
+      return;
+    }
 
-      const userId = req.user!.userId;
-      const result = await ApplicationProfileService.processQuickApplication(userId, req.body);
+    const userId = req.user!.userId;
+    const result = await ApplicationProfileService.processQuickApplication(userId, req.body);
 
-      if (!result.canProceed) {
-        res.status(400).json({
-          success: false,
-          message: 'Profile not complete enough for quick application',
-          data: {
-            missingFields: result.missingFields,
-          },
-        });
-        return;
-      }
-
-      res.status(200).json({
-        success: true,
-        message: 'Quick application can proceed',
+    if (!result.canProceed) {
+      res.status(400).json({
+        success: false,
+        message: 'Profile not complete enough for quick application',
         data: {
-          prePopulationData: result.prePopulationData,
+          missingFields: result.missingFields,
         },
       });
-    } catch (error) {
-      logger.error('Error processing quick application:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to process quick application request',
-      });
+      return;
     }
+
+    res.status(200).json({
+      success: true,
+      message: 'Quick application can proceed',
+      data: {
+        prePopulationData: result.prePopulationData,
+      },
+    });
   }
 }

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -222,69 +222,59 @@ export class ApplicationController extends BaseController {
 
   // Get applications with filtering and pagination
   getApplications = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return this.sendValidationError(res, errors.array());
-      }
-
-      const filters: ApplicationSearchFilters = {
-        search: req.query.search as string,
-        userId: req.query.userId as string,
-        petId: req.query.petId as string,
-        rescueId: req.query.rescueId as string,
-        status: req.query.status as ApplicationStatus,
-        priority: req.query.priority as ApplicationPriority,
-        score_min: req.query.score_min ? parseFloat(req.query.score_min as string) : undefined,
-        score_max: req.query.score_max ? parseFloat(req.query.score_max as string) : undefined,
-        createdFrom: req.query.createdFrom ? new Date(req.query.createdFrom as string) : undefined,
-        createdTo: req.query.createdTo ? new Date(req.query.createdTo as string) : undefined,
-        submittedFrom: req.query.submittedFrom
-          ? new Date(req.query.submittedFrom as string)
-          : undefined,
-        submittedTo: req.query.submittedTo ? new Date(req.query.submittedTo as string) : undefined,
-      };
-
-      const options: ApplicationSearchOptions = {
-        page: parsePage(req.query.page as string | undefined),
-        limit: parsePaginationLimit(req.query.limit as string | undefined, {
-          default: DEFAULT_PAGE_SIZE,
-          max: MAX_PAGE_SIZE,
-        }),
-        sortBy: (req.query.sortBy as string) || 'createdAt',
-        sortOrder: (req.query.sortOrder as 'ASC' | 'DESC') || 'DESC',
-        include_user: true,
-        include_pet: true,
-        include_rescue: false,
-      };
-
-      const result = await ApplicationService.searchApplications(
-        filters,
-        options,
-        req.user!.userId,
-        req.user!.userType as UserType
-      );
-
-      // Transform the applications to frontend format
-      const transformedApplications = result.applications.map(app =>
-        this.transformApplicationModel(app)
-      );
-
-      return this.sendPaginatedSuccess(res, transformedApplications, {
-        total: result.total_filtered || 0,
-        page: result.pagination.page,
-        limit: result.pagination.limit,
-        totalPages: result.pagination.totalPages,
-      });
-    } catch (error) {
-      logger.error('Error getting applications:', error);
-      return this.sendError(
-        res,
-        'Failed to retrieve applications',
-        500,
-        error instanceof Error ? error.message : 'Unknown error'
-      );
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return this.sendValidationError(res, errors.array());
     }
+
+    const filters: ApplicationSearchFilters = {
+      search: req.query.search as string,
+      userId: req.query.userId as string,
+      petId: req.query.petId as string,
+      rescueId: req.query.rescueId as string,
+      status: req.query.status as ApplicationStatus,
+      priority: req.query.priority as ApplicationPriority,
+      score_min: req.query.score_min ? parseFloat(req.query.score_min as string) : undefined,
+      score_max: req.query.score_max ? parseFloat(req.query.score_max as string) : undefined,
+      createdFrom: req.query.createdFrom ? new Date(req.query.createdFrom as string) : undefined,
+      createdTo: req.query.createdTo ? new Date(req.query.createdTo as string) : undefined,
+      submittedFrom: req.query.submittedFrom
+        ? new Date(req.query.submittedFrom as string)
+        : undefined,
+      submittedTo: req.query.submittedTo ? new Date(req.query.submittedTo as string) : undefined,
+    };
+
+    const options: ApplicationSearchOptions = {
+      page: parsePage(req.query.page as string | undefined),
+      limit: parsePaginationLimit(req.query.limit as string | undefined, {
+        default: DEFAULT_PAGE_SIZE,
+        max: MAX_PAGE_SIZE,
+      }),
+      sortBy: (req.query.sortBy as string) || 'createdAt',
+      sortOrder: (req.query.sortOrder as 'ASC' | 'DESC') || 'DESC',
+      include_user: true,
+      include_pet: true,
+      include_rescue: false,
+    };
+
+    const result = await ApplicationService.searchApplications(
+      filters,
+      options,
+      req.user!.userId,
+      req.user!.userType as UserType
+    );
+
+    // Transform the applications to frontend format
+    const transformedApplications = result.applications.map(app =>
+      this.transformApplicationModel(app)
+    );
+
+    return this.sendPaginatedSuccess(res, transformedApplications, {
+      total: result.total_filtered || 0,
+      page: result.pagination.page,
+      limit: result.pagination.limit,
+      totalPages: result.pagination.totalPages,
+    });
   };
 
   // Create new application
@@ -828,99 +818,57 @@ export class ApplicationController extends BaseController {
 
   // Get application form structure
   getApplicationFormStructure = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const { rescueId } = req.params;
-      const formStructure = await ApplicationService.getApplicationFormStructure(rescueId);
+    const { rescueId } = req.params;
+    const formStructure = await ApplicationService.getApplicationFormStructure(rescueId);
 
-      res.status(200).json({
-        success: true,
-        data: formStructure,
-      });
-    } catch (error) {
-      logger.error('Error getting application form structure:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to get application form structure',
-        error:
-          process.env.DEBUG_ERRORS === 'true'
-            ? error instanceof Error
-              ? error.message
-              : 'Unknown error'
-            : undefined,
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: formStructure,
+    });
   };
 
   // Get application statistics
   getApplicationStatistics = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const userType = req.user!.userType as UserType;
-      const userId = req.user!.userId;
+    const userType = req.user!.userType as UserType;
+    const userId = req.user!.userId;
 
-      let rescueId: string | undefined;
-      if (userType === UserType.ADMIN || userType === UserType.MODERATOR) {
-        rescueId = req.query.rescueId as string | undefined;
-      } else {
-        const staffRescueId = await ApplicationService.getStaffRescueIdForUser(userId);
-        if (!staffRescueId) {
-          return res.status(403).json({ success: false, message: 'Access denied' });
-        }
-        rescueId = staffRescueId;
+    let rescueId: string | undefined;
+    if (userType === UserType.ADMIN || userType === UserType.MODERATOR) {
+      rescueId = req.query.rescueId as string | undefined;
+    } else {
+      const staffRescueId = await ApplicationService.getStaffRescueIdForUser(userId);
+      if (!staffRescueId) {
+        return res.status(403).json({ success: false, message: 'Access denied' });
       }
-
-      const statistics = await ApplicationService.getApplicationStatistics(rescueId);
-
-      res.status(200).json({
-        success: true,
-        data: statistics,
-      });
-    } catch (error) {
-      logger.error('Error getting application statistics:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve application statistics',
-        error:
-          process.env.DEBUG_ERRORS === 'true'
-            ? error instanceof Error
-              ? error.message
-              : 'Unknown error'
-            : undefined,
-      });
+      rescueId = staffRescueId;
     }
+
+    const statistics = await ApplicationService.getApplicationStatistics(rescueId);
+
+    res.status(200).json({
+      success: true,
+      data: statistics,
+    });
   };
 
   // Bulk update applications
   bulkUpdateApplications = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const result = await ApplicationService.bulkUpdateApplications(req.body, req.user!.userId);
-
-      res.status(200).json({
-        success: true,
-        message: 'Bulk update completed',
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Error performing bulk update:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to perform bulk update',
-        error:
-          process.env.DEBUG_ERRORS === 'true'
-            ? error instanceof Error
-              ? error.message
-              : 'Unknown error'
-            : undefined,
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const result = await ApplicationService.bulkUpdateApplications(req.body, req.user!.userId);
+
+    res.status(200).json({
+      success: true,
+      message: 'Bulk update completed',
+      data: result,
+    });
   };
 
   // Delete application
@@ -970,159 +918,105 @@ export class ApplicationController extends BaseController {
 
   // Validate application answers
   validateApplicationAnswers = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const { rescueId } = req.params;
-      const { answers } = req.body;
+    const { rescueId } = req.params;
+    const { answers } = req.body;
 
-      if (!answers || typeof answers !== 'object') {
-        return res.status(400).json({
-          success: false,
-          message: 'Answers object is required',
-        });
-      }
-
-      const validation = await ApplicationService.validateApplicationAnswers(answers, rescueId);
-
-      res.status(200).json({
-        success: true,
-        data: validation,
-      });
-    } catch (error) {
-      logger.error('Error validating application answers:', error);
-      res.status(500).json({
+    if (!answers || typeof answers !== 'object') {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to validate application answers',
-        error:
-          process.env.DEBUG_ERRORS === 'true'
-            ? error instanceof Error
-              ? error.message
-              : 'Unknown error'
-            : undefined,
+        message: 'Answers object is required',
       });
     }
+
+    const validation = await ApplicationService.validateApplicationAnswers(answers, rescueId);
+
+    res.status(200).json({
+      success: true,
+      data: validation,
+    });
   };
 
   // Application history now provided by timeline events
   getApplicationHistory = async (req: Request, res: Response) => {
-    try {
-      // Application history is now handled by the timeline system
-      res.status(200).json({
-        success: true,
-        data: [],
-        message: 'Application history is now available through timeline events',
-      });
-    } catch (error) {
-      logger.error('Error getting application history:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve application history',
-      });
-    }
+    // Application history is now handled by the timeline system
+    res.status(200).json({
+      success: true,
+      data: [],
+      message: 'Application history is now available through timeline events',
+    });
   };
 
   scheduleVisit = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      // This would need to be implemented with visit scheduling functionality
-      res.status(501).json({
-        success: false,
-        message: 'Visit scheduling feature not yet implemented',
-      });
-    } catch (error) {
-      logger.error('Error scheduling visit:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to schedule visit',
-      });
-    }
+    // This would need to be implemented with visit scheduling functionality
+    res.status(501).json({
+      success: false,
+      message: 'Visit scheduling feature not yet implemented',
+    });
   };
 
   // Home Visits CRUD operations
   getHomeVisits = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const { applicationId } = req.params;
-      const formattedVisits = await ApplicationService.listHomeVisitsForApplication(applicationId);
+    const { applicationId } = req.params;
+    const formattedVisits = await ApplicationService.listHomeVisitsForApplication(applicationId);
 
-      res.json({
-        success: true,
-        visits: formattedVisits,
-      });
-    } catch (error) {
-      logger.error('Error getting home visits:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve home visits',
-      });
-    }
+    res.json({
+      success: true,
+      visits: formattedVisits,
+    });
   };
 
   scheduleHomeVisit = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const { applicationId } = req.params;
-      const { scheduled_date, scheduled_time, assigned_staff, notes } = req.body;
+    const { applicationId } = req.params;
+    const { scheduled_date, scheduled_time, assigned_staff, notes } = req.body;
 
-      if (!scheduled_date || !scheduled_time || !assigned_staff) {
-        return res.status(400).json({
-          success: false,
-          message: 'Missing required fields: scheduled_date, scheduled_time, assigned_staff',
-        });
-      }
-
-      const visit = await ApplicationService.scheduleHomeVisit(
-        applicationId,
-        {
-          scheduledDate: scheduled_date,
-          scheduledTime: scheduled_time,
-          assignedStaff: assigned_staff,
-          notes,
-        },
-        req.user?.userId ?? null
-      );
-
-      res.status(201).json({
-        success: true,
-        message: 'Home visit scheduled successfully',
-        visit,
-      });
-    } catch (error) {
-      logger.error('Error scheduling home visit:', error);
-      res.status(500).json({
+    if (!scheduled_date || !scheduled_time || !assigned_staff) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to schedule home visit',
+        message: 'Missing required fields: scheduled_date, scheduled_time, assigned_staff',
       });
     }
+
+    const visit = await ApplicationService.scheduleHomeVisit(
+      applicationId,
+      {
+        scheduledDate: scheduled_date,
+        scheduledTime: scheduled_time,
+        assignedStaff: assigned_staff,
+        notes,
+      },
+      req.user?.userId ?? null
+    );
+
+    res.status(201).json({
+      success: true,
+      message: 'Home visit scheduled successfully',
+      visit,
+    });
   };
 
   updateHomeVisit = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const { applicationId, visitId } = req.params;
-      const updateData = req.body;
+    const { applicationId, visitId } = req.params;
+    const updateData = req.body;
 
-      const visit = await ApplicationService.updateHomeVisit(
-        applicationId,
-        visitId,
-        updateData,
-        req.user?.userId ?? null
-      );
+    const visit = await ApplicationService.updateHomeVisit(
+      applicationId,
+      visitId,
+      updateData,
+      req.user?.userId ?? null
+    );
 
-      if (!visit) {
-        return res.status(404).json({
-          success: false,
-          message: 'Home visit not found',
-        });
-      }
-
-      res.json({
-        success: true,
-        message: 'Home visit updated successfully',
-        visit,
-      });
-    } catch (error) {
-      logger.error('Error updating home visit:', error);
-      res.status(500).json({
+    if (!visit) {
+      return res.status(404).json({
         success: false,
-        message: 'Failed to update home visit',
+        message: 'Home visit not found',
       });
     }
+
+    res.json({
+      success: true,
+      message: 'Home visit updated successfully',
+      visit,
+    });
   };
 }
 

--- a/service.backend/src/controllers/applicationTimeline.controller.ts
+++ b/service.backend/src/controllers/applicationTimeline.controller.ts
@@ -1,7 +1,6 @@
 import { Response } from 'express';
 import ApplicationTimelineService from '../services/applicationTimeline.service';
 import { TimelineEventType } from '../models/ApplicationTimeline';
-import { logger } from '../utils/logger';
 import { AuthenticatedRequest } from '../types/auth';
 
 export class ApplicationTimelineController {
@@ -9,175 +8,130 @@ export class ApplicationTimelineController {
    * Get timeline for an application
    */
   static async getApplicationTimeline(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { application_id } = req.params;
-      const { limit, offset, event_types } = req.query;
+    const { application_id } = req.params;
+    const { limit, offset, event_types } = req.query;
 
-      const options = {
-        limit: limit ? parseInt(limit as string, 10) : undefined,
-        offset: offset ? parseInt(offset as string, 10) : undefined,
-        event_types: event_types
-          ? ((event_types as string).split(',') as TimelineEventType[])
-          : undefined,
-      };
+    const options = {
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+      offset: offset ? parseInt(offset as string, 10) : undefined,
+      event_types: event_types
+        ? ((event_types as string).split(',') as TimelineEventType[])
+        : undefined,
+    };
 
-      const timeline = await ApplicationTimelineService.getApplicationTimeline(
-        application_id,
-        options
-      );
+    const timeline = await ApplicationTimelineService.getApplicationTimeline(
+      application_id,
+      options
+    );
 
-      res.json({
-        success: true,
-        data: timeline,
-        pagination: {
-          limit: options.limit || timeline.length,
-          offset: options.offset || 0,
-          total: timeline.length,
-        },
-      });
-    } catch (error) {
-      logger.error('Error fetching application timeline:', { error });
-      res.status(500).json({
-        success: false,
-        error: 'Failed to fetch application timeline',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: timeline,
+      pagination: {
+        limit: options.limit || timeline.length,
+        offset: options.offset || 0,
+        total: timeline.length,
+      },
+    });
   }
 
   /**
    * Get timeline statistics for an application
    */
   static async getTimelineStats(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { application_id } = req.params;
+    const { application_id } = req.params;
 
-      const stats = await ApplicationTimelineService.getTimelineStats(application_id);
+    const stats = await ApplicationTimelineService.getTimelineStats(application_id);
 
-      res.json({
-        success: true,
-        data: stats,
-      });
-    } catch (error) {
-      logger.error('Error fetching timeline stats:', { error });
-      res.status(500).json({
-        success: false,
-        error: 'Failed to fetch timeline statistics',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: stats,
+    });
   }
 
   /**
    * Create a manual timeline event (for notes, manual stage changes, etc.)
    */
   static async createManualEvent(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { application_id } = req.params;
-      const { event_type, title, description, metadata } = req.body;
+    const { application_id } = req.params;
+    const { event_type, title, description, metadata } = req.body;
 
-      // Get user ID from auth middleware (assuming it's available)
-      const created_by = req.user?.userId;
+    // Get user ID from auth middleware (assuming it's available)
+    const created_by = req.user?.userId;
 
-      if (!created_by) {
-        res.status(401).json({
-          success: false,
-          error: 'Authentication required',
-        });
-        return;
-      }
-
-      const event = await ApplicationTimelineService.createEvent({
-        application_id,
-        event_type,
-        title,
-        description,
-        metadata,
-        created_by,
-        created_by_system: false,
-      });
-
-      res.status(201).json({
-        success: true,
-        data: event,
-      });
-    } catch (error) {
-      logger.error('Error creating timeline event:', { error });
-      res.status(500).json({
+    if (!created_by) {
+      res.status(401).json({
         success: false,
-        error: 'Failed to create timeline event',
-        details: error instanceof Error ? error.message : 'Unknown error',
+        error: 'Authentication required',
       });
+      return;
     }
+
+    const event = await ApplicationTimelineService.createEvent({
+      application_id,
+      event_type,
+      title,
+      description,
+      metadata,
+      created_by,
+      created_by_system: false,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: event,
+    });
   }
 
   /**
    * Add a note to the application timeline
    */
   static async addNote(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { application_id } = req.params;
-      const { note_type, content } = req.body;
+    const { application_id } = req.params;
+    const { note_type, content } = req.body;
 
-      const created_by = req.user?.userId;
-      if (!created_by) {
-        res.status(401).json({
-          success: false,
-          error: 'Authentication required',
-        });
-        return;
-      }
-
-      const event = await ApplicationTimelineService.createNoteAddedEvent(
-        application_id,
-        note_type || 'general',
-        content,
-        created_by
-      );
-
-      res.status(201).json({
-        success: true,
-        data: event,
-      });
-    } catch (error) {
-      logger.error('Error adding note to timeline:', { error });
-      res.status(500).json({
+    const created_by = req.user?.userId;
+    if (!created_by) {
+      res.status(401).json({
         success: false,
-        error: 'Failed to add note to timeline',
-        details: error instanceof Error ? error.message : 'Unknown error',
+        error: 'Authentication required',
       });
+      return;
     }
+
+    const event = await ApplicationTimelineService.createNoteAddedEvent(
+      application_id,
+      note_type || 'general',
+      content,
+      created_by
+    );
+
+    res.status(201).json({
+      success: true,
+      data: event,
+    });
   }
 
   /**
    * Get bulk timeline statistics for multiple applications
    */
   static async getBulkTimelineStats(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { applicationIds } = req.body;
+    const { applicationIds } = req.body;
 
-      if (!applicationIds || !Array.isArray(applicationIds)) {
-        res.status(400).json({
-          success: false,
-          error: 'applicationIds array is required',
-        });
-        return;
-      }
-
-      const stats = await ApplicationTimelineService.getBulkTimelineStats(applicationIds);
-
-      res.json({
-        success: true,
-        summaries: stats,
-      });
-    } catch (error) {
-      logger.error('Error fetching bulk timeline stats:', { error });
-      res.status(500).json({
+    if (!applicationIds || !Array.isArray(applicationIds)) {
+      res.status(400).json({
         success: false,
-        error: 'Failed to fetch bulk timeline statistics',
-        details: error instanceof Error ? error.message : 'Unknown error',
+        error: 'applicationIds array is required',
       });
+      return;
     }
+
+    const stats = await ApplicationTimelineService.getBulkTimelineStats(applicationIds);
+
+    res.json({
+      success: true,
+      summaries: stats,
+    });
   }
 }
 

--- a/service.backend/src/controllers/auth.controller.ts
+++ b/service.backend/src/controllers/auth.controller.ts
@@ -63,14 +63,8 @@ export class AuthController {
    * authenticated endpoints.
    */
   async register(req: Request, res: Response): Promise<void> {
-    try {
-      const result = await AuthService.register(req.body);
-      res.status(201).json(result);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Registration failed:', error);
-      res.status(400).json({ error: errorMessage });
-    }
+    const result = await AuthService.register(req.body);
+    res.status(201).json(result);
   }
 
   /**
@@ -106,34 +100,34 @@ export class AuthController {
    * Logout user
    */
   async logout(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE] ?? req.body.refreshToken;
-      const accessToken = req.headers.authorization?.split(' ')[1];
+    const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE] ?? req.body.refreshToken;
+    const accessToken = req.headers.authorization?.split(' ')[1];
 
-      await AuthService.logout(refreshToken, accessToken, req.user?.userId);
+    await AuthService.logout(refreshToken, accessToken, req.user?.userId);
 
-      res.clearCookie(REFRESH_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE_OPTIONS);
-      res.clearCookie(ACCESS_TOKEN_COOKIE, ACCESS_TOKEN_COOKIE_OPTIONS);
+    res.clearCookie(REFRESH_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE_OPTIONS);
+    res.clearCookie(ACCESS_TOKEN_COOKIE, ACCESS_TOKEN_COOKIE_OPTIONS);
 
-      res.json({ message: 'Logged out successfully' });
-    } catch (error) {
-      logger.error('Logout failed:', error);
-      res.status(500).json({ error: 'Logout failed' });
-    }
+    res.json({ message: 'Logged out successfully' });
   }
 
   /**
    * Refresh access token
    */
   async refreshToken(req: Request, res: Response): Promise<void> {
+    const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE] ?? req.body.refreshToken;
+
+    if (!refreshToken) {
+      res.status(400).json({ error: 'Refresh token required' });
+      return;
+    }
+
+    // Catch retained on purpose: any failure of the refresh flow — bad
+    // token, expired token, revoked token, internal error — is collapsed
+    // to a 401 so the client cannot distinguish failure modes (avoids
+    // token-state oracle). Letting this propagate to the central error
+    // handler would surface 500s and leak server-side detail.
     try {
-      const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE] ?? req.body.refreshToken;
-
-      if (!refreshToken) {
-        res.status(400).json({ error: 'Refresh token required' });
-        return;
-      }
-
       const result = await AuthService.refreshToken(refreshToken);
 
       res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
@@ -151,15 +145,9 @@ export class AuthController {
    * Request password reset
    */
   async requestPasswordReset(req: Request, res: Response): Promise<void> {
-    try {
-      const authService = new AuthService();
-      const result = await authService.requestPasswordReset(req.body);
-      res.json(result);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Password reset request failed:', error);
-      res.status(500).json({ error: 'Failed to process password reset request' });
-    }
+    const authService = new AuthService();
+    const result = await authService.requestPasswordReset(req.body);
+    res.json(result);
   }
 
   /**
@@ -213,53 +201,35 @@ export class AuthController {
    * Resend verification email
    */
   async resendVerificationEmail(req: Request, res: Response): Promise<void> {
-    try {
-      const { email } = req.body;
-      const authService = new AuthService();
-      const result = await authService.resendVerificationEmail(email);
-      res.json(result);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Resend verification email failed:', error);
-      res.status(500).json({ error: 'Failed to resend verification email' });
-    }
+    const { email } = req.body;
+    const authService = new AuthService();
+    const result = await authService.resendVerificationEmail(email);
+    res.json(result);
   }
 
   /**
    * Get current user profile
    */
   async getCurrentUser(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      // Simply return the authenticated user from the request
-      res.json(req.user);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Get current user failed:', error);
-      res.status(500).json({ error: 'Failed to get user profile' });
-    }
+    // Simply return the authenticated user from the request
+    res.json(req.user);
   }
 
   /**
    * Generate 2FA secret and QR code for setup
    */
   async twoFactorSetup(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const user = req.user!;
+    const user = req.user!;
 
-      if (user.twoFactorEnabled) {
-        res.status(400).json({ error: 'Two-factor authentication is already enabled' });
-        return;
-      }
-
-      const { secret, otpauthUrl } = AuthService.generateTwoFactorSecret(user.email);
-      const qrCodeDataUrl = await AuthService.generateQrCodeDataUrl(otpauthUrl);
-
-      res.json({ secret, qrCodeDataUrl });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('2FA setup failed:', error);
-      res.status(500).json({ error: 'Failed to set up two-factor authentication' });
+    if (user.twoFactorEnabled) {
+      res.status(400).json({ error: 'Two-factor authentication is already enabled' });
+      return;
     }
+
+    const { secret, otpauthUrl } = AuthService.generateTwoFactorSecret(user.email);
+    const qrCodeDataUrl = await AuthService.generateQrCodeDataUrl(otpauthUrl);
+
+    res.json({ secret, qrCodeDataUrl });
   }
 
   /**
@@ -289,66 +259,56 @@ export class AuthController {
    * Disable 2FA after verifying current token
    */
   async twoFactorDisable(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const { token } = req.body;
+    const userId = req.user!.userId;
+    const { token } = req.body;
 
-      if (!req.user!.twoFactorEnabled) {
-        res.status(400).json({ error: 'Two-factor authentication is not enabled' });
-        return;
-      }
-
-      // Fetch user with secrets to access twoFactorSecret
-      const userWithSecret = await User.scope('withSecrets').findByPk(userId);
-      if (!userWithSecret || !userWithSecret.twoFactorSecret) {
-        res.status(400).json({ error: 'Two-factor authentication secret not found' });
-        return;
-      }
-
-      // Verify current TOTP before disabling
-      const isValid = AuthService.verifyTwoFactorSetupToken(userWithSecret.twoFactorSecret, token);
-      if (!isValid) {
-        res.status(400).json({ error: 'Invalid verification code' });
-        return;
-      }
-
-      await AuthService.disableTwoFactor(userId);
-      res.json({ success: true, message: 'Two-factor authentication has been disabled' });
-    } catch (error) {
-      logger.error('2FA disable failed:', error);
-      res.status(500).json({ error: 'Failed to disable two-factor authentication' });
+    if (!req.user!.twoFactorEnabled) {
+      res.status(400).json({ error: 'Two-factor authentication is not enabled' });
+      return;
     }
+
+    // Fetch user with secrets to access twoFactorSecret
+    const userWithSecret = await User.scope('withSecrets').findByPk(userId);
+    if (!userWithSecret || !userWithSecret.twoFactorSecret) {
+      res.status(400).json({ error: 'Two-factor authentication secret not found' });
+      return;
+    }
+
+    // Verify current TOTP before disabling
+    const isValid = AuthService.verifyTwoFactorSetupToken(userWithSecret.twoFactorSecret, token);
+    if (!isValid) {
+      res.status(400).json({ error: 'Invalid verification code' });
+      return;
+    }
+
+    await AuthService.disableTwoFactor(userId);
+    res.json({ success: true, message: 'Two-factor authentication has been disabled' });
   }
 
   /**
    * Regenerate backup codes
    */
   async twoFactorRegenerateBackupCodes(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const user = req.user!;
+    const user = req.user!;
 
-      if (!user.twoFactorEnabled) {
-        res.status(400).json({ error: 'Two-factor authentication is not enabled' });
-        return;
-      }
-
-      const backupCodes = AuthService.generateBackupCodes();
-
-      // Need to fetch the user with write access to update
-      const dbUser = await User.findByPk(user.userId);
-      if (!dbUser) {
-        res.status(404).json({ error: 'User not found' });
-        return;
-      }
-
-      dbUser.backupCodes = backupCodes;
-      await dbUser.save();
-
-      res.json({ success: true, backupCodes });
-    } catch (error) {
-      logger.error('Backup codes regeneration failed:', error);
-      res.status(500).json({ error: 'Failed to regenerate backup codes' });
+    if (!user.twoFactorEnabled) {
+      res.status(400).json({ error: 'Two-factor authentication is not enabled' });
+      return;
     }
+
+    const backupCodes = AuthService.generateBackupCodes();
+
+    // Need to fetch the user with write access to update
+    const dbUser = await User.findByPk(user.userId);
+    if (!dbUser) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    dbUser.backupCodes = backupCodes;
+    await dbUser.save();
+
+    res.json({ success: true, backupCodes });
   }
 
   /**

--- a/service.backend/src/controllers/broadcast.controller.ts
+++ b/service.backend/src/controllers/broadcast.controller.ts
@@ -7,7 +7,6 @@ import {
 } from '../services/broadcast.service';
 import { RichTextProcessingService } from '../services/rich-text-processing.service';
 import { AuthenticatedRequest } from '../types/auth';
-import { logger } from '../utils/logger';
 
 export class BroadcastController {
   /**
@@ -19,45 +18,36 @@ export class BroadcastController {
    * cached response inside 24h.
    */
   broadcast = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const audience = req.body.audience as BroadcastAudience;
-      const title = req.body.title as string;
-      const body =
-        typeof req.body.body === 'string'
-          ? RichTextProcessingService.sanitize(req.body.body)
-          : req.body.body;
-      const channels = req.body.channels;
-
-      const result = await BroadcastService.broadcast({
-        audience,
-        title,
-        body,
-        channels,
-        initiatedBy: req.user!.userId,
-      });
-
-      res.status(201).json({
-        success: true,
-        message: `Broadcast queued for ${result.targetCount} user(s)`,
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Broadcast failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to send broadcast',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const audience = req.body.audience as BroadcastAudience;
+    const title = req.body.title as string;
+    const body =
+      typeof req.body.body === 'string'
+        ? RichTextProcessingService.sanitize(req.body.body)
+        : req.body.body;
+    const channels = req.body.channels;
+
+    const result = await BroadcastService.broadcast({
+      audience,
+      title,
+      body,
+      channels,
+      initiatedBy: req.user!.userId,
+    });
+
+    res.status(201).json({
+      success: true,
+      message: `Broadcast queued for ${result.targetCount} user(s)`,
+      data: result,
+    });
   };
 
   /**
@@ -66,30 +56,21 @@ export class BroadcastController {
    * before sending.
    */
   previewAudience = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const audience = req.query.audience;
-      if (
-        typeof audience !== 'string' ||
-        !BROADCAST_AUDIENCES.includes(audience as BroadcastAudience)
-      ) {
-        return res.status(400).json({
-          success: false,
-          message: 'Invalid audience',
-        });
-      }
-
-      const count = await BroadcastService.previewAudienceCount(audience as BroadcastAudience);
-      res.status(200).json({
-        success: true,
-        data: { audience, count },
-      });
-    } catch (error) {
-      logger.error('Broadcast preview failed:', error);
-      res.status(500).json({
+    const audience = req.query.audience;
+    if (
+      typeof audience !== 'string' ||
+      !BROADCAST_AUDIENCES.includes(audience as BroadcastAudience)
+    ) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to preview audience',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Invalid audience',
       });
     }
+
+    const count = await BroadcastService.previewAudienceCount(audience as BroadcastAudience);
+    res.status(200).json({
+      success: true,
+      data: { audience, count },
+    });
   };
 }

--- a/service.backend/src/controllers/chat.controller.ts
+++ b/service.backend/src/controllers/chat.controller.ts
@@ -193,82 +193,70 @@ export class ChatController {
   static async createChat(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { rescueId, petId, applicationId, type, initialMessage } = req.body;
-      const createdBy = req.user!.userId;
+    const { rescueId, petId, applicationId, type, initialMessage } = req.body;
+    const createdBy = req.user!.userId;
 
-      // Create participant IDs array: start with the user who created the chat
-      const participantIds = [createdBy];
+    // Create participant IDs array: start with the user who created the chat
+    const participantIds = [createdBy];
 
-      // If there's a rescue involved, add the rescue staff users as participants
-      if (rescueId && rescueId !== createdBy) {
-        try {
-          // Find users who belong to this rescue (limit to 50 to avoid unbounded queries)
-          const rescueUserIds = await ChatService.getRescueParticipantUserIds(rescueId);
+    // If there's a rescue involved, add the rescue staff users as participants
+    if (rescueId && rescueId !== createdBy) {
+      try {
+        // Find users who belong to this rescue (limit to 50 to avoid unbounded queries)
+        const rescueUserIds = await ChatService.getRescueParticipantUserIds(rescueId);
 
-          // Add rescue staff user IDs to participants (use Set for O(1) dedup)
-          const participantSet = new Set(participantIds);
-          rescueUserIds.forEach(uid => participantSet.add(uid));
-          participantIds.length = 0;
-          participantIds.push(...Array.from(participantSet));
-        } catch (error) {
-          logger.error('Error finding rescue users:', error);
-          // Continue with chat creation even if we can't find rescue users
-        }
+        // Add rescue staff user IDs to participants (use Set for O(1) dedup)
+        const participantSet = new Set(participantIds);
+        rescueUserIds.forEach(uid => participantSet.add(uid));
+        participantIds.length = 0;
+        participantIds.push(...Array.from(participantSet));
+      } catch (error) {
+        logger.error('Error finding rescue users:', error);
+        // Continue with chat creation even if we can't find rescue users
       }
-
-      const chat = await ChatService.createChat(
-        {
-          participantIds,
-          rescueId,
-          applicationId,
-          petId,
-          type: type || 'application',
-          initialMessage,
-        },
-        createdBy
-      );
-
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
-
-      // Format the response to match frontend Conversation interface expectations
-      const response = {
-        id: chat.chat_id,
-        userId: createdBy, // The user who created the chat
-        rescueId: chat.rescue_id,
-        petId: chat.pet_id,
-        applicationId: chat.application_id,
-        type: type || 'application',
-        status: chat.status,
-        participants: [], // Will be populated by frontend when needed
-        unreadCount: 0, // New conversation starts with 0 unread
-        isTyping: [], // Empty initially
-        createdAt: readCreatedAt(chat),
-        updatedAt: readUpdatedAt(chat),
-        // Keep backward compatibility fields
-        chat_id: chat.chat_id,
-        rescue_id: chat.rescue_id,
-        pet_id: chat.pet_id,
-        application_id: chat.application_id,
-        created_at: readCreatedAt(chat),
-        updated_at: readUpdatedAt(chat),
-      };
-
-      res.json({
-        success: true,
-        data: response,
-      });
-    } catch (error) {
-      logger.error('Error creating chat:', {
-        error: error instanceof Error ? error.message : String(error),
-        body: req.body,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to create chat',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
     }
+
+    const chat = await ChatService.createChat(
+      {
+        participantIds,
+        rescueId,
+        applicationId,
+        petId,
+        type: type || 'application',
+        initialMessage,
+      },
+      createdBy
+    );
+
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
+
+    // Format the response to match frontend Conversation interface expectations
+    const response = {
+      id: chat.chat_id,
+      userId: createdBy, // The user who created the chat
+      rescueId: chat.rescue_id,
+      petId: chat.pet_id,
+      applicationId: chat.application_id,
+      type: type || 'application',
+      status: chat.status,
+      participants: [], // Will be populated by frontend when needed
+      unreadCount: 0, // New conversation starts with 0 unread
+      isTyping: [], // Empty initially
+      createdAt: readCreatedAt(chat),
+      updatedAt: readUpdatedAt(chat),
+      // Keep backward compatibility fields
+      chat_id: chat.chat_id,
+      rescue_id: chat.rescue_id,
+      pet_id: chat.pet_id,
+      application_id: chat.application_id,
+      created_at: readCreatedAt(chat),
+      updated_at: readUpdatedAt(chat),
+    };
+
+    res.json({
+      success: true,
+      data: response,
+    });
   }
 
   /**
@@ -371,153 +359,49 @@ export class ChatController {
    * Search and list chats for the authenticated user
    */
   static async getChats(req: AuthenticatedRequest, res: Response) {
-    try {
-      const userId = req.user!.userId;
-      const userType = req.user!.userType;
-      const rescueId = req.user!.rescueId;
-      const {
-        petId,
-        type,
-        page = 1,
-        limit = DEFAULT_PAGE_SIZE,
-        sortBy = 'updated_at',
-        sortOrder = 'DESC',
-      } = req.query;
+    const userId = req.user!.userId;
+    const userType = req.user!.userType;
+    const rescueId = req.user!.rescueId;
+    const {
+      petId,
+      type,
+      page = 1,
+      limit = DEFAULT_PAGE_SIZE,
+      sortBy = 'updated_at',
+      sortOrder = 'DESC',
+    } = req.query;
 
-      // Admin users can see all chats, regular users only see chats they're participants in
-      const isAdmin = userType === UserType.ADMIN;
-      const searchOptions = {
-        userId,
-        rescueId: rescueId || undefined,
-        petId: petId as string,
-        type: type as string,
-        page: parseInt(page as string),
-        limit: parseInt(limit as string),
-        sortBy: sortBy as string,
-        sortOrder: sortOrder as 'ASC' | 'DESC',
-        isAdmin,
-      };
+    // Admin users can see all chats, regular users only see chats they're participants in
+    const isAdmin = userType === UserType.ADMIN;
+    const searchOptions = {
+      userId,
+      rescueId: rescueId || undefined,
+      petId: petId as string,
+      type: type as string,
+      page: parseInt(page as string),
+      limit: parseInt(limit as string),
+      sortBy: sortBy as string,
+      sortOrder: sortOrder as 'ASC' | 'DESC',
+      isAdmin,
+    };
 
-      const result = await ChatService.searchChats(searchOptions);
+    const result = await ChatService.searchChats(searchOptions);
 
-      logger.info('Chat search results', {
-        isAdmin,
-        userId: isAdmin ? 'undefined (admin)' : userId,
-        rescueId: isAdmin ? 'undefined (admin)' : rescueId,
-        totalChats: result.chats.length,
-        totalCount: result.pagination.total,
-      });
+    logger.info('Chat search results', {
+      isAdmin,
+      userId: isAdmin ? 'undefined (admin)' : userId,
+      rescueId: isAdmin ? 'undefined (admin)' : rescueId,
+      totalChats: result.chats.length,
+      totalCount: result.pagination.total,
+    });
 
-      // Add rescueName, lastMessage, and real unread count to each chat.
-      // Unread is resolved per-chat in parallel; admin listings (no userId)
-      // skip the count since admins don't have an unread-mailbox view.
-      const chatsWithRescueName = await Promise.all(
-        result.chats.map(async chat => {
-          const chatObj = chat.toJSON();
-          // Get the latest message (should be first in Messages array due to DESC order)
-          let lastMessage = null;
-          if (Array.isArray(chatObj.Messages) && chatObj.Messages.length > 0) {
-            const msg = chatObj.Messages[0];
-            lastMessage = {
-              id: msg.message_id,
-              content:
-                typeof msg.content === 'string' && msg.content.length > 120
-                  ? msg.content.slice(0, 120) + '...'
-                  : msg.content,
-              senderId: msg.sender_id,
-              createdAt: readCreatedAt(msg),
-            };
-          }
-
-          // Transform participants to match frontend Participant interface
-          const participants =
-            (chatObj.Participants as ParticipantWithUser[] | undefined)?.map(p => ({
-              id: p.participant_id,
-              name: getUserFullName(p.User),
-              type: p.role === 'admin' ? 'admin' : 'user',
-              avatarUrl:
-                p.User && typeof p.User === 'object' && 'profileImageUrl' in p.User
-                  ? p.User.profileImageUrl
-                  : undefined,
-              isOnline: isUserOnline(p.participant_id),
-            })) || [];
-
-          const unreadCount = isAdmin
-            ? 0
-            : await ChatService.getUnreadMessageCount(
-                chatObj.chat_id,
-                userId,
-                rescueId || undefined
-              );
-
-          return {
-            id: chatObj.chat_id,
-            userId: undefined, // No user_id field in chat model
-            rescueId: chatObj.rescue_id,
-            petId: chatObj.pet_id,
-            applicationId: chatObj.application_id,
-            type: 'general', // Default type since not in model
-            status: chatObj.status,
-            participants,
-            unreadCount,
-            isTyping: [],
-            createdAt: readCreatedAt(chatObj),
-            updatedAt: readUpdatedAt(chatObj),
-            rescueName: chat.rescue?.name || null,
-            lastMessage,
-          };
-        })
-      );
-      res.json({
-        success: true,
-        data: chatsWithRescueName,
-        pagination: result.pagination,
-      });
-    } catch (error) {
-      logger.error('Error getting chats:', error);
-      res.status(500).json({
-        error: 'Failed to get chats',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
-  }
-
-  /**
-   * Search conversations with text search capability
-   */
-  static async searchConversations(req: AuthenticatedRequest, res: Response) {
-    try {
-      const userId = req.user!.userId;
-      const rescueId = req.user!.rescueId;
-      const {
-        query,
-        type,
-        page = 1,
-        limit = DEFAULT_PAGE_SIZE,
-        sortBy = 'updated_at',
-        sortOrder = 'DESC',
-      } = req.query;
-
-      if (!query || typeof query !== 'string' || query.trim().length === 0) {
-        return res.status(400).json({
-          error: 'Search query is required',
-        });
-      }
-
-      const result = await ChatService.searchConversations({
-        userId,
-        rescueId: rescueId || undefined,
-        query: query.trim(),
-        type: type as string,
-        page: parseInt(page as string),
-        limit: parseInt(limit as string),
-        sortBy: sortBy as string,
-        sortOrder: sortOrder as 'ASC' | 'DESC',
-      });
-
-      // Add rescueName and lastMessage to each chat in the response
-      const chatsWithRescueName = result.chats.map(chat => {
+    // Add rescueName, lastMessage, and real unread count to each chat.
+    // Unread is resolved per-chat in parallel; admin listings (no userId)
+    // skip the count since admins don't have an unread-mailbox view.
+    const chatsWithRescueName = await Promise.all(
+      result.chats.map(async chat => {
         const chatObj = chat.toJSON();
+        // Get the latest message (should be first in Messages array due to DESC order)
         let lastMessage = null;
         if (Array.isArray(chatObj.Messages) && chatObj.Messages.length > 0) {
           const msg = chatObj.Messages[0];
@@ -531,25 +415,109 @@ export class ChatController {
             createdAt: readCreatedAt(msg),
           };
         }
+
+        // Transform participants to match frontend Participant interface
+        const participants =
+          (chatObj.Participants as ParticipantWithUser[] | undefined)?.map(p => ({
+            id: p.participant_id,
+            name: getUserFullName(p.User),
+            type: p.role === 'admin' ? 'admin' : 'user',
+            avatarUrl:
+              p.User && typeof p.User === 'object' && 'profileImageUrl' in p.User
+                ? p.User.profileImageUrl
+                : undefined,
+            isOnline: isUserOnline(p.participant_id),
+          })) || [];
+
+        const unreadCount = isAdmin
+          ? 0
+          : await ChatService.getUnreadMessageCount(chatObj.chat_id, userId, rescueId || undefined);
+
         return {
-          ...chatObj,
+          id: chatObj.chat_id,
+          userId: undefined, // No user_id field in chat model
+          rescueId: chatObj.rescue_id,
+          petId: chatObj.pet_id,
+          applicationId: chatObj.application_id,
+          type: 'general', // Default type since not in model
+          status: chatObj.status,
+          participants,
+          unreadCount,
+          isTyping: [],
+          createdAt: readCreatedAt(chatObj),
+          updatedAt: readUpdatedAt(chatObj),
           rescueName: chat.rescue?.name || null,
           lastMessage,
         };
-      });
-      res.json({
-        success: true,
-        data: chatsWithRescueName,
-        pagination: result.pagination,
-        message: `Found ${result.pagination.total} conversations matching "${query}"`,
-      });
-    } catch (error) {
-      logger.error('Error searching conversations:', error);
-      res.status(500).json({
-        error: 'Failed to search conversations',
-        message: error instanceof Error ? error.message : 'Unknown error',
+      })
+    );
+    res.json({
+      success: true,
+      data: chatsWithRescueName,
+      pagination: result.pagination,
+    });
+  }
+
+  /**
+   * Search conversations with text search capability
+   */
+  static async searchConversations(req: AuthenticatedRequest, res: Response) {
+    const userId = req.user!.userId;
+    const rescueId = req.user!.rescueId;
+    const {
+      query,
+      type,
+      page = 1,
+      limit = DEFAULT_PAGE_SIZE,
+      sortBy = 'updated_at',
+      sortOrder = 'DESC',
+    } = req.query;
+
+    if (!query || typeof query !== 'string' || query.trim().length === 0) {
+      return res.status(400).json({
+        error: 'Search query is required',
       });
     }
+
+    const result = await ChatService.searchConversations({
+      userId,
+      rescueId: rescueId || undefined,
+      query: query.trim(),
+      type: type as string,
+      page: parseInt(page as string),
+      limit: parseInt(limit as string),
+      sortBy: sortBy as string,
+      sortOrder: sortOrder as 'ASC' | 'DESC',
+    });
+
+    // Add rescueName and lastMessage to each chat in the response
+    const chatsWithRescueName = result.chats.map(chat => {
+      const chatObj = chat.toJSON();
+      let lastMessage = null;
+      if (Array.isArray(chatObj.Messages) && chatObj.Messages.length > 0) {
+        const msg = chatObj.Messages[0];
+        lastMessage = {
+          id: msg.message_id,
+          content:
+            typeof msg.content === 'string' && msg.content.length > 120
+              ? msg.content.slice(0, 120) + '...'
+              : msg.content,
+          senderId: msg.sender_id,
+          createdAt: readCreatedAt(msg),
+        };
+      }
+      return {
+        ...chatObj,
+        rescueName: chat.rescue?.name || null,
+        lastMessage,
+      };
+    });
+    res.json({
+      success: true,
+      data: chatsWithRescueName,
+      pagination: result.pagination,
+      message: `Found ${result.pagination.total} conversations matching "${query}"`,
+    });
   }
 
   /**
@@ -709,24 +677,16 @@ export class ChatController {
    * Mark messages as read
    */
   static async markAsRead(req: AuthenticatedRequest, res: Response) {
-    try {
-      const { chatId } = req.params;
-      const userId = req.user!.userId;
-      const userRescueId = req.user!.rescueId || undefined;
+    const { chatId } = req.params;
+    const userId = req.user!.userId;
+    const userRescueId = req.user!.rescueId || undefined;
 
-      await ChatService.markMessagesAsRead(chatId, userId, userRescueId);
+    await ChatService.markMessagesAsRead(chatId, userId, userRescueId);
 
-      res.json({
-        success: true,
-        message: 'Messages marked as read',
-      });
-    } catch (error) {
-      logger.error('Error marking messages as read:', error);
-      res.status(500).json({
-        error: 'Failed to mark messages as read',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      message: 'Messages marked as read',
+    });
   }
 
   /**
@@ -840,31 +800,18 @@ export class ChatController {
   static async updateChat(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { chatId } = req.params;
-      const updateData = req.body;
-      const updatedBy = req.user!.userId;
+    const { chatId } = req.params;
+    const updateData = req.body;
+    const updatedBy = req.user!.userId;
 
-      const chat = await ChatService.updateChat(chatId, updateData, updatedBy);
+    const chat = await ChatService.updateChat(chatId, updateData, updatedBy);
 
-      loggerHelpers.logRequest(req, res, Date.now() - startTime);
+    loggerHelpers.logRequest(req, res, Date.now() - startTime);
 
-      res.json({
-        success: true,
-        data: chat,
-      });
-    } catch (error) {
-      logger.error('Error updating chat:', {
-        error: error instanceof Error ? error.message : String(error),
-        chatId: req.params.chatId,
-        body: req.body,
-        duration: Date.now() - startTime,
-      });
-      res.status(500).json({
-        error: 'Failed to update chat',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: chat,
+    });
   }
 
   /**
@@ -1009,34 +956,26 @@ export class ChatController {
    * Get chat analytics
    */
   static async getChatAnalytics(req: AuthenticatedRequest, res: Response) {
-    try {
-      const userType = req.user!.userType;
-      const rescueId = req.user!.rescueId;
-      const { startDate, endDate } = req.query;
+    const userType = req.user!.userType;
+    const rescueId = req.user!.rescueId;
+    const { startDate, endDate } = req.query;
 
-      // Admin users get analytics for all chats, regular users get rescue-specific analytics
-      const isAdmin = userType === UserType.ADMIN;
-      const analytics = await ChatService.getChatAnalytics(
-        startDate && endDate
-          ? {
-              start: new Date(startDate as string),
-              end: new Date(endDate as string),
-            }
-          : undefined,
-        isAdmin ? undefined : rescueId || undefined
-      );
+    // Admin users get analytics for all chats, regular users get rescue-specific analytics
+    const isAdmin = userType === UserType.ADMIN;
+    const analytics = await ChatService.getChatAnalytics(
+      startDate && endDate
+        ? {
+            start: new Date(startDate as string),
+            end: new Date(endDate as string),
+          }
+        : undefined,
+      isAdmin ? undefined : rescueId || undefined
+    );
 
-      res.json({
-        success: true,
-        data: analytics,
-      });
-    } catch (error) {
-      logger.error('Error getting chat analytics:', error);
-      res.status(500).json({
-        error: 'Failed to get chat analytics',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.json({
+      success: true,
+      data: analytics,
+    });
   }
 
   /**
@@ -1045,74 +984,66 @@ export class ChatController {
   static async uploadAttachment(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
 
-    try {
-      const { conversationId } = req.params;
-      const userId = req.user!.userId;
-      const userRescueId = req.user!.rescueId || undefined;
+    const { conversationId } = req.params;
+    const userId = req.user!.userId;
+    const userRescueId = req.user!.rescueId || undefined;
 
-      if (!req.file) {
-        return res.status(400).json({
-          error: 'No file uploaded',
-        });
-      }
-
-      // Verify user has access to this conversation. getChatById enforces
-      // participant-or-rescue-staff access; if the user is staff of the
-      // chat's rescue we don't also require a direct participant row.
-      const chat = await ChatService.getChatById(conversationId, userId, false, userRescueId);
-      if (!chat) {
-        return res.status(404).json({
-          error: 'Conversation not found',
-        });
-      }
-
-      const isParticipant = chat.Participants?.some(
-        (p: ChatParticipant) => p.participant_id === userId
-      );
-      const isRescueStaffOfChat = !!userRescueId && chat.rescue_id === userRescueId;
-      if (!isParticipant && !isRescueStaffOfChat) {
-        return res.status(403).json({
-          error: 'Access denied to this conversation',
-        });
-      }
-
-      // Process the uploaded file using FileUploadService
-      const fileUploadResult = await FileUploadService.uploadFile(req.file, 'chat', {
-        uploadedBy: userId,
-        entityId: conversationId,
-        entityType: 'chat',
-        purpose: 'attachment',
-      });
-
-      if (!fileUploadResult.success || !fileUploadResult.upload) {
-        throw new Error('File upload failed');
-      }
-
-      logger.info('Chat attachment uploaded successfully', {
-        conversationId,
-        userId,
-        fileId: fileUploadResult.upload.upload_id,
-        filename: fileUploadResult.upload.original_filename,
-        size: fileUploadResult.upload.file_size,
-        duration: Date.now() - startTime,
-      });
-
-      res.status(200).json({
-        success: true,
-        data: {
-          id: fileUploadResult.upload.upload_id,
-          filename: fileUploadResult.upload.original_filename,
-          url: fileUploadResult.upload.url,
-          mimeType: fileUploadResult.upload.mime_type,
-          size: fileUploadResult.upload.file_size,
-        },
-      });
-    } catch (error) {
-      logger.error('Error uploading chat attachment:', error);
-      res.status(500).json({
-        error: 'Failed to upload attachment',
-        message: error instanceof Error ? error.message : 'Unknown error',
+    if (!req.file) {
+      return res.status(400).json({
+        error: 'No file uploaded',
       });
     }
+
+    // Verify user has access to this conversation. getChatById enforces
+    // participant-or-rescue-staff access; if the user is staff of the
+    // chat's rescue we don't also require a direct participant row.
+    const chat = await ChatService.getChatById(conversationId, userId, false, userRescueId);
+    if (!chat) {
+      return res.status(404).json({
+        error: 'Conversation not found',
+      });
+    }
+
+    const isParticipant = chat.Participants?.some(
+      (p: ChatParticipant) => p.participant_id === userId
+    );
+    const isRescueStaffOfChat = !!userRescueId && chat.rescue_id === userRescueId;
+    if (!isParticipant && !isRescueStaffOfChat) {
+      return res.status(403).json({
+        error: 'Access denied to this conversation',
+      });
+    }
+
+    // Process the uploaded file using FileUploadService
+    const fileUploadResult = await FileUploadService.uploadFile(req.file, 'chat', {
+      uploadedBy: userId,
+      entityId: conversationId,
+      entityType: 'chat',
+      purpose: 'attachment',
+    });
+
+    if (!fileUploadResult.success || !fileUploadResult.upload) {
+      throw new Error('File upload failed');
+    }
+
+    logger.info('Chat attachment uploaded successfully', {
+      conversationId,
+      userId,
+      fileId: fileUploadResult.upload.upload_id,
+      filename: fileUploadResult.upload.original_filename,
+      size: fileUploadResult.upload.file_size,
+      duration: Date.now() - startTime,
+    });
+
+    res.status(200).json({
+      success: true,
+      data: {
+        id: fileUploadResult.upload.upload_id,
+        filename: fileUploadResult.upload.original_filename,
+        url: fileUploadResult.upload.url,
+        mimeType: fileUploadResult.upload.mime_type,
+        size: fileUploadResult.upload.file_size,
+      },
+    });
   }
 }

--- a/service.backend/src/controllers/discovery.controller.ts
+++ b/service.backend/src/controllers/discovery.controller.ts
@@ -92,68 +92,40 @@ export class DiscoveryController {
     });
     const userId = req.query.userId as string;
 
-    try {
-      const discoveryQueue = await this.discoveryService.getDiscoveryQueue(filters, limit, userId);
+    const discoveryQueue = await this.discoveryService.getDiscoveryQueue(filters, limit, userId);
 
-      res.status(200).json({
-        success: true,
-        message: 'Discovery queue retrieved successfully',
-        data: discoveryQueue,
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      logger.error('Error getting discovery queue:', {
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : '',
-        filtersProvided: filters,
-        userIdProvided: userId,
-        limitProvided: limit,
-      });
-
-      // Return a more user-friendly error response
-      res.status(500).json({
-        success: false,
-        message:
-          'Failed to get discovery queue. This might be due to database connectivity issues.',
-        error: error instanceof Error ? error.message : 'Unknown error',
-        timestamp: new Date().toISOString(),
-      });
-    }
+    res.status(200).json({
+      success: true,
+      message: 'Discovery queue retrieved successfully',
+      data: discoveryQueue,
+      timestamp: new Date().toISOString(),
+    });
   };
 
   /**
    * Load more pets for infinite scroll
    */
   loadMorePets = async (req: AuthenticatedRequest, res: Response): Promise<Response | void> => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-          timestamp: new Date().toISOString(),
-        });
-      }
-
-      const { sessionId, lastPetId, limit = 10 } = req.body;
-
-      const pets = await this.discoveryService.loadMorePets(sessionId, lastPetId, limit);
-
-      res.status(200).json({
-        success: true,
-        message: 'More pets loaded successfully',
-        data: { pets },
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      logger.error('Error loading more pets:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to load more pets',
+        message: 'Validation failed',
+        errors: errors.array(),
         timestamp: new Date().toISOString(),
       });
     }
+
+    const { sessionId, lastPetId, limit = 10 } = req.body;
+
+    const pets = await this.discoveryService.loadMorePets(sessionId, lastPetId, limit);
+
+    res.status(200).json({
+      success: true,
+      message: 'More pets loaded successfully',
+      data: { pets },
+      timestamp: new Date().toISOString(),
+    });
   };
 
   /**
@@ -163,160 +135,124 @@ export class DiscoveryController {
     req: AuthenticatedRequest,
     res: Response
   ): Promise<Response | void> => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-          timestamp: new Date().toISOString(),
-        });
-      }
-
-      const swipeAction = {
-        action: req.body.action,
-        petId: req.body.petId,
-        sessionId: req.body.sessionId,
-        timestamp: req.body.timestamp,
-        userId: req.body.userId, // Optional
-      };
-
-      await this.swipeService.recordSwipeAction(swipeAction);
-
-      res.status(200).json({
-        success: true,
-        message: 'Swipe action recorded successfully',
-        data: null,
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      logger.error('Error recording swipe action:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to record swipe action',
+        message: 'Validation failed',
+        errors: errors.array(),
         timestamp: new Date().toISOString(),
       });
     }
+
+    const swipeAction = {
+      action: req.body.action,
+      petId: req.body.petId,
+      sessionId: req.body.sessionId,
+      timestamp: req.body.timestamp,
+      userId: req.body.userId, // Optional
+    };
+
+    await this.swipeService.recordSwipeAction(swipeAction);
+
+    res.status(200).json({
+      success: true,
+      message: 'Swipe action recorded successfully',
+      data: null,
+      timestamp: new Date().toISOString(),
+    });
   };
 
   /**
    * Get user's swipe statistics
    */
   getSwipeStats = async (req: AuthenticatedRequest, res: Response): Promise<Response | void> => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-          timestamp: new Date().toISOString(),
-        });
-      }
-
-      const { userId } = req.params;
-
-      const stats = await this.swipeService.getUserSwipeStats(userId);
-
-      res.status(200).json({
-        success: true,
-        message: 'Swipe statistics retrieved successfully',
-        data: stats,
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      logger.error('Error getting swipe stats:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to get swipe statistics',
+        message: 'Validation failed',
+        errors: errors.array(),
         timestamp: new Date().toISOString(),
       });
     }
+
+    const { userId } = req.params;
+
+    const stats = await this.swipeService.getUserSwipeStats(userId);
+
+    res.status(200).json({
+      success: true,
+      message: 'Swipe statistics retrieved successfully',
+      data: stats,
+      timestamp: new Date().toISOString(),
+    });
   };
 
   /**
    * Get session statistics
    */
   getSessionStats = async (req: AuthenticatedRequest, res: Response): Promise<Response | void> => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-          timestamp: new Date().toISOString(),
-        });
-      }
-
-      const { sessionId } = req.params;
-
-      const stats = await this.swipeService.getSessionStats(sessionId);
-
-      res.status(200).json({
-        success: true,
-        message: 'Session statistics retrieved successfully',
-        data: stats,
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      logger.error('Error getting session stats:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to get session statistics',
+        message: 'Validation failed',
+        errors: errors.array(),
         timestamp: new Date().toISOString(),
       });
     }
+
+    const { sessionId } = req.params;
+
+    const stats = await this.swipeService.getSessionStats(sessionId);
+
+    res.status(200).json({
+      success: true,
+      message: 'Session statistics retrieved successfully',
+      data: stats,
+      timestamp: new Date().toISOString(),
+    });
   };
 
   /**
    * Get discovery queue via POST (filters passed in request body)
    */
   addToQueue = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-        return;
-      }
-
-      const {
-        filters = {},
-        userId,
-        limit = 20,
-      } = req.body as {
-        filters?: DiscoveryFilters;
-        userId?: string;
-        limit?: number;
-      };
-
-      logger.info('Discovery queue request received', {
-        service: 'discovery',
-        type: 'queue_request',
-        data: { filters, limit },
-        ip: req.ip,
-      });
-
-      const discoveryQueue = await this.discoveryService.getDiscoveryQueue(filters, limit, userId);
-
-      res.status(200).json({
-        pets: discoveryQueue.pets,
-        currentIndex: 0,
-        hasMore: discoveryQueue.hasMore,
-        nextBatchSize: limit,
-      });
-    } catch (error) {
-      logger.error('Error getting discovery queue:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
         success: false,
-        message: 'Failed to get discovery queue',
-        timestamp: new Date().toISOString(),
+        message: 'Validation failed',
+        errors: errors.array(),
       });
+      return;
     }
+
+    const {
+      filters = {},
+      userId,
+      limit = 20,
+    } = req.body as {
+      filters?: DiscoveryFilters;
+      userId?: string;
+      limit?: number;
+    };
+
+    logger.info('Discovery queue request received', {
+      service: 'discovery',
+      type: 'queue_request',
+      data: { filters, limit },
+      ip: req.ip,
+    });
+
+    const discoveryQueue = await this.discoveryService.getDiscoveryQueue(filters, limit, userId);
+
+    res.status(200).json({
+      pets: discoveryQueue.pets,
+      currentIndex: 0,
+      hasMore: discoveryQueue.hasMore,
+      nextBatchSize: limit,
+    });
   };
 }

--- a/service.backend/src/controllers/email.controller.ts
+++ b/service.backend/src/controllers/email.controller.ts
@@ -5,264 +5,175 @@ import { TemplateType, TemplateCategory, TemplateStatus } from '../models/EmailT
 import emailService from '../services/email.service';
 import { RichTextProcessingService } from '../services/rich-text-processing.service';
 import { AuthenticatedRequest } from '../types/auth';
-import { logger } from '../utils/logger';
 
 // Template Management
 export const getTemplates = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const { type, category, status, locale, limit, offset } = req.query;
+  const { type, category, status, locale, limit, offset } = req.query;
 
-    const result = await emailService.getTemplates({
-      type: typeof type === 'string' ? (type as TemplateType) : undefined,
-      category: typeof category === 'string' ? (category as TemplateCategory) : undefined,
-      status: typeof status === 'string' ? (status as TemplateStatus) : undefined,
-      locale: typeof locale === 'string' ? locale : undefined,
-      limit: typeof limit === 'string' ? parseInt(limit, 10) : undefined,
-      offset: typeof offset === 'string' ? parseInt(offset, 10) : undefined,
-    });
+  const result = await emailService.getTemplates({
+    type: typeof type === 'string' ? (type as TemplateType) : undefined,
+    category: typeof category === 'string' ? (category as TemplateCategory) : undefined,
+    status: typeof status === 'string' ? (status as TemplateStatus) : undefined,
+    locale: typeof locale === 'string' ? locale : undefined,
+    limit: typeof limit === 'string' ? parseInt(limit, 10) : undefined,
+    offset: typeof offset === 'string' ? parseInt(offset, 10) : undefined,
+  });
 
-    res.json({
-      message: 'Templates retrieved successfully',
-      data: result,
-    });
-  } catch (error) {
-    logger.error('Failed to get templates:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to get templates',
-    });
-  }
+  res.json({
+    message: 'Templates retrieved successfully',
+    data: result,
+  });
 };
 
 export const getTemplate = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const { templateId } = req.params;
-    const template = await emailService.getTemplate(templateId);
+  const { templateId } = req.params;
+  const template = await emailService.getTemplate(templateId);
 
-    if (!template) {
-      res.status(404).json({
-        error: 'Template not found',
-      });
-      return;
-    }
-
-    res.json({
-      message: 'Template retrieved successfully',
-      data: template,
+  if (!template) {
+    res.status(404).json({
+      error: 'Template not found',
     });
-  } catch (error) {
-    logger.error('Failed to get template:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to get template',
-    });
+    return;
   }
+
+  res.json({
+    message: 'Template retrieved successfully',
+    data: template,
+  });
 };
 
 export const createTemplate = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    if (typeof req.body.htmlContent === 'string') {
-      req.body.htmlContent = RichTextProcessingService.sanitize(req.body.htmlContent);
-    }
-    const template = await emailService.createTemplate({
-      ...req.body,
-      createdBy: req.user!.userId,
-    });
-
-    res.status(201).json({
-      message: 'Email template created successfully',
-      data: template,
-    });
-  } catch (error) {
-    logger.error('Failed to create email template:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to create email template',
-    });
+  if (typeof req.body.htmlContent === 'string') {
+    req.body.htmlContent = RichTextProcessingService.sanitize(req.body.htmlContent);
   }
+  const template = await emailService.createTemplate({
+    ...req.body,
+    createdBy: req.user!.userId,
+  });
+
+  res.status(201).json({
+    message: 'Email template created successfully',
+    data: template,
+  });
 };
 
 export const updateTemplate = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const { templateId } = req.params;
-    if (typeof req.body.htmlContent === 'string') {
-      req.body.htmlContent = RichTextProcessingService.sanitize(req.body.htmlContent);
-    }
-    const template = await emailService.updateTemplate(templateId, req.body, req.user!.userId);
-
-    res.json({
-      message: 'Email template updated successfully',
-      data: template,
-    });
-  } catch (error) {
-    logger.error('Failed to update email template:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to update email template',
-    });
+  const { templateId } = req.params;
+  if (typeof req.body.htmlContent === 'string') {
+    req.body.htmlContent = RichTextProcessingService.sanitize(req.body.htmlContent);
   }
+  const template = await emailService.updateTemplate(templateId, req.body, req.user!.userId);
+
+  res.json({
+    message: 'Email template updated successfully',
+    data: template,
+  });
 };
 
 export const deleteTemplate = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const { templateId } = req.params;
-    await emailService.deleteTemplate(templateId, req.user!.userId);
+  const { templateId } = req.params;
+  await emailService.deleteTemplate(templateId, req.user!.userId);
 
-    res.json({
-      message: 'Email template deleted successfully',
-    });
-  } catch (error) {
-    logger.error('Failed to delete email template:', {
-      error: error instanceof Error ? error.message : String(error),
-      templateId: req.params.templateId,
-      userId: req.user?.userId,
-    });
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to delete email template',
-    });
-  }
+  res.json({
+    message: 'Email template deleted successfully',
+  });
 };
 
 export const previewTemplate = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const { templateId } = req.params;
-    const { templateData } = req.body;
+  const { templateId } = req.params;
+  const { templateData } = req.body;
 
-    const template = await emailService.getTemplate(templateId);
-    if (!template) {
-      res.status(404).json({
-        error: 'Template not found',
-      });
-      return;
-    }
-
-    // Process template with provided data
-    const processedContent = await emailService.renderTemplatePreview(template, templateData || {});
-
-    res.json({
-      message: 'Template preview generated successfully',
-      data: processedContent,
+  const template = await emailService.getTemplate(templateId);
+  if (!template) {
+    res.status(404).json({
+      error: 'Template not found',
     });
-  } catch (error) {
-    logger.error('Failed to preview template:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to preview template',
-    });
+    return;
   }
+
+  // Process template with provided data
+  const processedContent = await emailService.renderTemplatePreview(template, templateData || {});
+
+  res.json({
+    message: 'Template preview generated successfully',
+    data: processedContent,
+  });
 };
 
 export const sendTestEmail = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const { templateId } = req.params;
-    const { toEmail, templateData } = req.body;
+  const { templateId } = req.params;
+  const { toEmail, templateData } = req.body;
 
-    const emailId = await emailService.sendEmail({
-      templateId,
-      toEmail,
-      templateData,
-      type: EmailType.SYSTEM,
-      priority: EmailPriority.HIGH,
-      userId: req.user!.userId,
-    });
+  const emailId = await emailService.sendEmail({
+    templateId,
+    toEmail,
+    templateData,
+    type: EmailType.SYSTEM,
+    priority: EmailPriority.HIGH,
+    userId: req.user!.userId,
+  });
 
-    res.json({
-      message: 'Test email sent successfully',
-      data: { emailId },
-    });
-  } catch (error) {
-    logger.error('Failed to send test email:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to send test email',
-    });
-  }
+  res.json({
+    message: 'Test email sent successfully',
+    data: { emailId },
+  });
 };
 
 // Email sending
 export const sendEmail = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const emailId = await emailService.sendEmail({
-      ...req.body,
-      userId: req.user!.userId,
-    });
+  const emailId = await emailService.sendEmail({
+    ...req.body,
+    userId: req.user!.userId,
+  });
 
-    res.json({
-      message: 'Email sent successfully',
-      data: { emailId },
-    });
-  } catch (error) {
-    logger.error('Failed to send email:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to send email',
-    });
-  }
+  res.json({
+    message: 'Email sent successfully',
+    data: { emailId },
+  });
 };
 
 export const sendBulkEmail = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const emailIds = await emailService.sendBulkEmail({
-      ...req.body,
-      createdBy: req.user!.userId,
-    });
+  const emailIds = await emailService.sendBulkEmail({
+    ...req.body,
+    createdBy: req.user!.userId,
+  });
 
-    res.json({
-      message: 'Bulk email sent successfully',
-      data: { emailIds, count: emailIds.length },
-    });
-  } catch (error) {
-    logger.error('Failed to send bulk email:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to send bulk email',
-    });
-  }
+  res.json({
+    message: 'Bulk email sent successfully',
+    data: { emailIds, count: emailIds.length },
+  });
 };
 
 // Queue management
 export const getQueueStatus = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    const status = await emailService.getQueueStatus();
+  const status = await emailService.getQueueStatus();
 
-    res.json({
-      message: 'Queue status retrieved successfully',
-      data: status,
-    });
-  } catch (error) {
-    logger.error('Failed to get queue status:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to get queue status',
-    });
-  }
+  res.json({
+    message: 'Queue status retrieved successfully',
+    data: status,
+  });
 };
 
 export const processQueue = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  try {
-    // Start queue processing
-    emailService.startQueueProcessor();
+  // Start queue processing
+  emailService.startQueueProcessor();
 
-    res.json({
-      message: 'Queue processing started successfully',
-    });
-  } catch (error) {
-    logger.error('Failed to process queue:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to process queue',
-    });
-  }
+  res.json({
+    message: 'Queue processing started successfully',
+  });
 };
 
 export const retryFailedEmails = async (
   req: AuthenticatedRequest,
   res: Response
 ): Promise<void> => {
-  try {
-    const { emailIds } = req.body;
-    const retryCount = await emailService.retryFailedEmails(emailIds);
+  const { emailIds } = req.body;
+  const retryCount = await emailService.retryFailedEmails(emailIds);
 
-    res.json({
-      message: 'Failed emails queued for retry',
-      data: { retryCount },
-    });
-  } catch (error) {
-    logger.error('Failed to retry emails:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to retry emails',
-    });
-  }
+  res.json({
+    message: 'Failed emails queued for retry',
+    data: { retryCount },
+  });
 };
 
 // Analytics
@@ -270,53 +181,39 @@ export const getEmailAnalytics = async (
   req: AuthenticatedRequest,
   res: Response
 ): Promise<void> => {
-  try {
-    const { templateId, campaignId, dateFrom, dateTo, type } = req.query;
+  const { templateId, campaignId, dateFrom, dateTo, type } = req.query;
 
-    const analytics = await emailService.getEmailAnalytics({
-      templateId: typeof templateId === 'string' ? templateId : undefined,
-      campaignId: typeof campaignId === 'string' ? campaignId : undefined,
-      dateFrom: typeof dateFrom === 'string' ? new Date(dateFrom) : undefined,
-      dateTo: typeof dateTo === 'string' ? new Date(dateTo) : undefined,
-      type: typeof type === 'string' ? (type as EmailType) : undefined,
-    });
+  const analytics = await emailService.getEmailAnalytics({
+    templateId: typeof templateId === 'string' ? templateId : undefined,
+    campaignId: typeof campaignId === 'string' ? campaignId : undefined,
+    dateFrom: typeof dateFrom === 'string' ? new Date(dateFrom) : undefined,
+    dateTo: typeof dateTo === 'string' ? new Date(dateTo) : undefined,
+    type: typeof type === 'string' ? (type as EmailType) : undefined,
+  });
 
-    res.json({
-      message: 'Email analytics retrieved successfully',
-      data: analytics,
-    });
-  } catch (error) {
-    logger.error('Failed to get email analytics:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to get email analytics',
-    });
-  }
+  res.json({
+    message: 'Email analytics retrieved successfully',
+    data: analytics,
+  });
 };
 
 export const getTemplateAnalytics = async (
   req: AuthenticatedRequest,
   res: Response
 ): Promise<void> => {
-  try {
-    const { templateId } = req.params;
-    const { dateFrom, dateTo } = req.query;
+  const { templateId } = req.params;
+  const { dateFrom, dateTo } = req.query;
 
-    const analytics = await emailService.getEmailAnalytics({
-      templateId,
-      dateFrom: dateFrom ? new Date(dateFrom as string) : undefined,
-      dateTo: dateTo ? new Date(dateTo as string) : undefined,
-    });
+  const analytics = await emailService.getEmailAnalytics({
+    templateId,
+    dateFrom: dateFrom ? new Date(dateFrom as string) : undefined,
+    dateTo: dateTo ? new Date(dateTo as string) : undefined,
+  });
 
-    res.json({
-      message: 'Template analytics retrieved successfully',
-      data: analytics,
-    });
-  } catch (error) {
-    logger.error('Failed to get template analytics:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to get template analytics',
-    });
-  }
+  res.json({
+    message: 'Template analytics retrieved successfully',
+    data: analytics,
+  });
 };
 
 // User preferences
@@ -324,47 +221,33 @@ export const getUserPreferences = async (
   req: AuthenticatedRequest,
   res: Response
 ): Promise<void> => {
-  try {
-    const { userId } = req.params;
-    const preferences = await emailService.getUserPreferences(userId);
+  const { userId } = req.params;
+  const preferences = await emailService.getUserPreferences(userId);
 
-    if (!preferences) {
-      res.status(404).json({
-        error: 'User preferences not found',
-      });
-      return;
-    }
-
-    res.json({
-      message: 'User preferences retrieved successfully',
-      data: preferences,
+  if (!preferences) {
+    res.status(404).json({
+      error: 'User preferences not found',
     });
-  } catch (error) {
-    logger.error('Failed to get user preferences:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to get user preferences',
-    });
+    return;
   }
+
+  res.json({
+    message: 'User preferences retrieved successfully',
+    data: preferences,
+  });
 };
 
 export const updateUserPreferences = async (
   req: AuthenticatedRequest,
   res: Response
 ): Promise<void> => {
-  try {
-    const { userId } = req.params;
-    const preferences = await emailService.updateUserPreferences(userId, req.body);
+  const { userId } = req.params;
+  const preferences = await emailService.updateUserPreferences(userId, req.body);
 
-    res.json({
-      message: 'Email preferences updated successfully',
-      data: preferences,
-    });
-  } catch (error) {
-    logger.error('Failed to update user preferences:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to update user preferences',
-    });
-  }
+  res.json({
+    message: 'Email preferences updated successfully',
+    data: preferences,
+  });
 };
 
 /**
@@ -382,58 +265,37 @@ export const rotateUnsubscribeToken = async (
   req: AuthenticatedRequest,
   res: Response
 ): Promise<void> => {
-  try {
-    const userId = req.user?.userId;
-    if (!userId) {
-      res.status(401).json({ error: 'Authentication required' });
-      return;
-    }
-    const newToken = await emailService.rotateUnsubscribeToken(userId);
-    res.json({
-      message: 'Unsubscribe token rotated',
-      data: { unsubscribeToken: newToken },
-    });
-  } catch (error) {
-    logger.error('Failed to rotate unsubscribe token:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to rotate unsubscribe token',
-    });
+  const userId = req.user?.userId;
+  if (!userId) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
   }
+  const newToken = await emailService.rotateUnsubscribeToken(userId);
+  res.json({
+    message: 'Unsubscribe token rotated',
+    data: { unsubscribeToken: newToken },
+  });
 };
 
 // Public endpoints
 export const unsubscribeUser = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const { token } = req.params;
-    const { type } = req.query;
+  const { token } = req.params;
+  const { type } = req.query;
 
-    await emailService.unsubscribeUser(token as string, type as NotificationType);
+  await emailService.unsubscribeUser(token as string, type as NotificationType);
 
-    res.json({
-      message: 'Successfully unsubscribed',
-    });
-  } catch (error) {
-    logger.error('Failed to unsubscribe user:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to unsubscribe user',
-    });
-  }
+  res.json({
+    message: 'Successfully unsubscribed',
+  });
 };
 
 export const handleDeliveryWebhook = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const webhookData = req.body;
+  const webhookData = req.body;
 
-    // Handle delivery webhook
-    await emailService.handleDeliveryWebhook(webhookData);
+  // Handle delivery webhook
+  await emailService.handleDeliveryWebhook(webhookData);
 
-    res.status(200).json({
-      message: 'Webhook processed successfully',
-    });
-  } catch (error) {
-    logger.error('Failed to handle delivery webhook:', error);
-    res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to handle delivery webhook',
-    });
-  }
+  res.status(200).json({
+    message: 'Webhook processed successfully',
+  });
 };

--- a/service.backend/src/controllers/gdpr.controller.ts
+++ b/service.backend/src/controllers/gdpr.controller.ts
@@ -29,30 +29,20 @@ export class GdprController {
    * /admin route.
    */
   async exportSelf(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const data = await GdprService.exportUserData(userId);
-      res.setHeader('Content-Disposition', `attachment; filename="user-${userId}.json"`);
-      res.json(data);
-    } catch (error) {
-      logger.error('GDPR self-export failed', { error });
-      res.status(500).json({ error: 'Failed to export user data' });
-    }
+    const userId = req.user!.userId;
+    const data = await GdprService.exportUserData(userId);
+    res.setHeader('Content-Disposition', `attachment; filename="user-${userId}.json"`);
+    res.json(data);
   }
 
   async exportByAdmin(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      if (!isAdmin(req)) {
-        res.status(403).json({ error: 'Admin access required' });
-        return;
-      }
-      const { userId } = req.params;
-      const data = await GdprService.exportUserData(userId);
-      res.json(data);
-    } catch (error) {
-      logger.error('GDPR admin export failed', { error });
-      res.status(500).json({ error: 'Failed to export user data' });
+    if (!isAdmin(req)) {
+      res.status(403).json({ error: 'Admin access required' });
+      return;
     }
+    const { userId } = req.params;
+    const data = await GdprService.exportUserData(userId);
+    res.json(data);
   }
 
   /**
@@ -96,14 +86,9 @@ export class GdprController {
   }
 
   async getConsents(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const consents = await GdprService.getCurrentConsents(userId);
-      res.json({ consents });
-    } catch (error) {
-      logger.error('Get consents failed', { error });
-      res.status(500).json({ error: 'Failed to get consents' });
-    }
+    const userId = req.user!.userId;
+    const consents = await GdprService.getCurrentConsents(userId);
+    res.json({ consents });
   }
 
   /**
@@ -150,27 +135,22 @@ export class GdprController {
   }
 
   async recordConsent(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const { purpose, granted, policyVersion, source } = req.body as {
-        purpose: ConsentPurpose;
-        granted: boolean;
-        policyVersion: string;
-        source?: string;
-      };
-      const consent = await GdprService.recordConsent({
-        userId,
-        purpose,
-        granted,
-        policyVersion,
-        source: source ?? null,
-        ipAddress: req.ip ?? null,
-      });
-      res.status(201).json({ consent });
-    } catch (error) {
-      logger.error('Record consent failed', { error });
-      res.status(500).json({ error: 'Failed to record consent' });
-    }
+    const userId = req.user!.userId;
+    const { purpose, granted, policyVersion, source } = req.body as {
+      purpose: ConsentPurpose;
+      granted: boolean;
+      policyVersion: string;
+      source?: string;
+    };
+    const consent = await GdprService.recordConsent({
+      userId,
+      purpose,
+      granted,
+      policyVersion,
+      source: source ?? null,
+      ipAddress: req.ip ?? null,
+    });
+    res.status(201).json({ consent });
   }
 }
 

--- a/service.backend/src/controllers/moderation.controller.ts
+++ b/service.backend/src/controllers/moderation.controller.ts
@@ -8,344 +8,247 @@ import ModerationService, {
 } from '../services/moderation.service';
 import { ReportStatus, ReportCategory, ReportSeverity } from '../models/Report';
 import { AuthenticatedRequest } from '../types/auth';
-import { logger } from '../utils/logger';
 import { parsePage, parsePaginationLimit } from '../utils/pagination';
 
 export class ModerationController {
   // Report Management
   async submitReport(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const reportData: ReportSubmission = req.body;
-      const reporterId = req.user!.userId;
-      const requestContext = {
-        ip: req.ip,
-        userAgent: req.get('User-Agent'),
-      };
+    const reportData: ReportSubmission = req.body;
+    const reporterId = req.user!.userId;
+    const requestContext = {
+      ip: req.ip,
+      userAgent: req.get('User-Agent'),
+    };
 
-      const report = await ModerationService.submitReport(reporterId, reportData, requestContext);
+    const report = await ModerationService.submitReport(reporterId, reportData, requestContext);
 
-      res.status(201).json({
-        success: true,
-        message: 'Report submitted successfully',
-        data: report,
-      });
-    } catch (error) {
-      logger.error('Error submitting report:', error);
-      res.status(400).json({
-        success: false,
-        message: error instanceof Error ? error.message : 'Failed to submit report',
-      });
-    }
+    res.status(201).json({
+      success: true,
+      message: 'Report submitted successfully',
+      data: report,
+    });
   }
 
   async getReports(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const filters: ReportFilters = {
-        status:
-          typeof req.query.status === 'string' ? (req.query.status as ReportStatus) : undefined,
-        category:
-          typeof req.query.category === 'string'
-            ? (req.query.category as ReportCategory)
-            : undefined,
-        severity:
-          typeof req.query.severity === 'string'
-            ? (req.query.severity as ReportSeverity)
-            : undefined,
-        reporterId: typeof req.query.reporterId === 'string' ? req.query.reporterId : undefined,
-        reportedUserId:
-          typeof req.query.reportedUserId === 'string' ? req.query.reportedUserId : undefined,
-        assignedModerator:
-          typeof req.query.assignedModerator === 'string' ? req.query.assignedModerator : undefined,
-        reportedEntityType:
-          typeof req.query.reportedEntityType === 'string'
-            ? req.query.reportedEntityType
-            : undefined,
-        search: typeof req.query.search === 'string' ? req.query.search : undefined,
-      };
+    const filters: ReportFilters = {
+      status: typeof req.query.status === 'string' ? (req.query.status as ReportStatus) : undefined,
+      category:
+        typeof req.query.category === 'string' ? (req.query.category as ReportCategory) : undefined,
+      severity:
+        typeof req.query.severity === 'string' ? (req.query.severity as ReportSeverity) : undefined,
+      reporterId: typeof req.query.reporterId === 'string' ? req.query.reporterId : undefined,
+      reportedUserId:
+        typeof req.query.reportedUserId === 'string' ? req.query.reportedUserId : undefined,
+      assignedModerator:
+        typeof req.query.assignedModerator === 'string' ? req.query.assignedModerator : undefined,
+      reportedEntityType:
+        typeof req.query.reportedEntityType === 'string' ? req.query.reportedEntityType : undefined,
+      search: typeof req.query.search === 'string' ? req.query.search : undefined,
+    };
 
-      // Date filters
-      if (req.query.dateFrom) {
-        filters.dateFrom = new Date(req.query.dateFrom as string);
-      }
-      if (req.query.dateTo) {
-        filters.dateTo = new Date(req.query.dateTo as string);
-      }
-
-      const options: ReportSearchOptions = {
-        page: parsePage(req.query.page as string | undefined),
-        limit: parsePaginationLimit(req.query.limit as string | undefined, {
-          default: DEFAULT_PAGE_SIZE,
-          max: MAX_PAGE_SIZE,
-        }),
-        sortBy: (req.query.sortBy as string) || 'createdAt',
-        sortOrder: (req.query.sortOrder as 'ASC' | 'DESC') || 'DESC',
-      };
-
-      const result = await ModerationService.getReportsWithContext(filters, options);
-
-      res.json({
-        success: true,
-        data: result.reports,
-        pagination: result.pagination,
-      });
-    } catch (error) {
-      logger.error('Error fetching reports:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to fetch reports',
-      });
+    // Date filters
+    if (req.query.dateFrom) {
+      filters.dateFrom = new Date(req.query.dateFrom as string);
     }
+    if (req.query.dateTo) {
+      filters.dateTo = new Date(req.query.dateTo as string);
+    }
+
+    const options: ReportSearchOptions = {
+      page: parsePage(req.query.page as string | undefined),
+      limit: parsePaginationLimit(req.query.limit as string | undefined, {
+        default: DEFAULT_PAGE_SIZE,
+        max: MAX_PAGE_SIZE,
+      }),
+      sortBy: (req.query.sortBy as string) || 'createdAt',
+      sortOrder: (req.query.sortOrder as 'ASC' | 'DESC') || 'DESC',
+    };
+
+    const result = await ModerationService.getReportsWithContext(filters, options);
+
+    res.json({
+      success: true,
+      data: result.reports,
+      pagination: result.pagination,
+    });
   }
 
   async getReportById(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { reportId } = req.params;
-      const includeActions = req.query.includeActions !== 'false';
+    const { reportId } = req.params;
+    const includeActions = req.query.includeActions !== 'false';
 
-      const report = await ModerationService.getReportById(reportId, includeActions);
+    const report = await ModerationService.getReportById(reportId, includeActions);
 
-      if (!report) {
-        res.status(404).json({
-          success: false,
-          message: 'Report not found',
-        });
-        return;
-      }
-
-      res.json({
-        success: true,
-        data: report,
-      });
-    } catch (error) {
-      logger.error('Error fetching report:', error);
-      res.status(500).json({
+    if (!report) {
+      res.status(404).json({
         success: false,
-        message: 'Failed to fetch report',
+        message: 'Report not found',
       });
+      return;
     }
+
+    res.json({
+      success: true,
+      data: report,
+    });
   }
 
   async updateReportStatus(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { reportId } = req.params;
-      const { status, assignedModerator, resolution, resolutionNotes } = req.body;
-      const updatedBy = req.user!.userId;
+    const { reportId } = req.params;
+    const { status, assignedModerator, resolution, resolutionNotes } = req.body;
+    const updatedBy = req.user!.userId;
 
-      // Get the report first
-      const report = await ModerationService.getReportById(reportId);
-      if (!report) {
-        res.status(404).json({
-          success: false,
-          message: 'Report not found',
-        });
-        return;
-      }
-
-      // Update the report with the new status
-      await report.update({
-        status,
-        assignedModerator,
-        resolution,
-        resolutionNotes,
-        resolvedBy: status === 'resolved' ? updatedBy : undefined,
-        resolvedAt: status === 'resolved' ? new Date() : undefined,
-      });
-
-      res.json({
-        success: true,
-        message: 'Report status updated successfully',
-        data: report,
-      });
-    } catch (error) {
-      logger.error('Error updating report status:', error);
-      res.status(400).json({
+    // Get the report first
+    const report = await ModerationService.getReportById(reportId);
+    if (!report) {
+      res.status(404).json({
         success: false,
-        message: error instanceof Error ? error.message : 'Failed to update report status',
+        message: 'Report not found',
       });
+      return;
     }
+
+    // Update the report with the new status
+    await report.update({
+      status,
+      assignedModerator,
+      resolution,
+      resolutionNotes,
+      resolvedBy: status === 'resolved' ? updatedBy : undefined,
+      resolvedAt: status === 'resolved' ? new Date() : undefined,
+    });
+
+    res.json({
+      success: true,
+      message: 'Report status updated successfully',
+      data: report,
+    });
   }
 
   // Moderation Actions
   async takeModerationAction(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const actionData: ModerationActionRequest = req.body;
-      const moderatorId = req.user!.userId;
+    const actionData: ModerationActionRequest = req.body;
+    const moderatorId = req.user!.userId;
 
-      const action = await ModerationService.takeModerationAction(moderatorId, actionData);
+    const action = await ModerationService.takeModerationAction(moderatorId, actionData);
 
-      res.status(201).json({
-        success: true,
-        message: 'Moderation action taken successfully',
-        data: action,
-      });
-    } catch (error) {
-      logger.error('Error taking moderation action:', error);
-      res.status(400).json({
-        success: false,
-        message: error instanceof Error ? error.message : 'Failed to take moderation action',
-      });
-    }
+    res.status(201).json({
+      success: true,
+      message: 'Moderation action taken successfully',
+      data: action,
+    });
   }
 
   async getActiveActions(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { userId } = req.params;
+    const { userId } = req.params;
 
-      const actions = await ModerationService.getActiveActionsForUser(userId);
+    const actions = await ModerationService.getActiveActionsForUser(userId);
 
-      res.json({
-        success: true,
-        data: actions,
-      });
-    } catch (error) {
-      logger.error('Error fetching active actions:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to fetch active actions',
-      });
-    }
+    res.json({
+      success: true,
+      data: actions,
+    });
   }
 
   // Analytics and Metrics
   async getModerationMetrics(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      let dateRange;
-      if (req.query.startDate && req.query.endDate) {
-        dateRange = {
-          from: new Date(req.query.startDate as string),
-          to: new Date(req.query.endDate as string),
-        };
-      }
-
-      const metrics = await ModerationService.getModerationMetrics(dateRange);
-
-      res.json({
-        success: true,
-        data: metrics,
-      });
-    } catch (error) {
-      logger.error('Error fetching moderation metrics:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to fetch moderation metrics',
-      });
+    let dateRange;
+    if (req.query.startDate && req.query.endDate) {
+      dateRange = {
+        from: new Date(req.query.startDate as string),
+        to: new Date(req.query.endDate as string),
+      };
     }
+
+    const metrics = await ModerationService.getModerationMetrics(dateRange);
+
+    res.json({
+      success: true,
+      data: metrics,
+    });
   }
 
   // Assign report to moderator
   async assignReport(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { reportId } = req.params;
-      const { moderatorId } = req.body;
-      const assignedBy = req.user!.userId;
+    const { reportId } = req.params;
+    const { moderatorId } = req.body;
+    const assignedBy = req.user!.userId;
 
-      const report = await ModerationService.assignReport(reportId, moderatorId, assignedBy);
+    const report = await ModerationService.assignReport(reportId, moderatorId, assignedBy);
 
-      res.json({
-        success: true,
-        message: 'Report assigned successfully',
-        data: report,
-      });
-    } catch (error) {
-      logger.error('Error assigning report:', error);
-      res.status(400).json({
-        success: false,
-        message: error instanceof Error ? error.message : 'Failed to assign report',
-      });
-    }
+    res.json({
+      success: true,
+      message: 'Report assigned successfully',
+      data: report,
+    });
   }
 
   // Escalate report
   async escalateReport(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { reportId } = req.params;
-      const { escalatedTo, reason } = req.body;
-      const escalatedBy = req.user!.userId;
+    const { reportId } = req.params;
+    const { escalatedTo, reason } = req.body;
+    const escalatedBy = req.user!.userId;
 
-      const report = await ModerationService.escalateReport(
-        reportId,
-        escalatedTo,
-        escalatedBy,
-        reason
-      );
+    const report = await ModerationService.escalateReport(
+      reportId,
+      escalatedTo,
+      escalatedBy,
+      reason
+    );
 
-      res.json({
-        success: true,
-        message: 'Report escalated successfully',
-        data: report,
-      });
-    } catch (error) {
-      logger.error('Error escalating report:', error);
-      res.status(400).json({
-        success: false,
-        message: error instanceof Error ? error.message : 'Failed to escalate report',
-      });
-    }
+    res.json({
+      success: true,
+      message: 'Report escalated successfully',
+      data: report,
+    });
   }
 
   // Bulk operations
   async bulkUpdateReports(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const { reportIds, action, resolutionNotes, assignTo, escalateTo, escalationReason } =
-        req.body;
-      const moderatorId = req.user!.userId;
+    const { reportIds, action, resolutionNotes, assignTo, escalateTo, escalationReason } = req.body;
+    const moderatorId = req.user!.userId;
 
-      // Validate input
-      if (!Array.isArray(reportIds) || reportIds.length === 0) {
-        res.status(400).json({
-          success: false,
-          message: 'Report IDs are required and must be an array',
-        });
-        return;
-      }
-
-      const result = await ModerationService.bulkUpdateReports({
-        reportIds,
-        action,
-        moderatorId,
-        resolutionNotes,
-        assignTo,
-        escalateTo,
-        escalationReason,
-      });
-
-      res.json(result);
-    } catch (error) {
-      logger.error('Error performing bulk update:', error);
+    // Validate input
+    if (!Array.isArray(reportIds) || reportIds.length === 0) {
       res.status(400).json({
         success: false,
-        message: error instanceof Error ? error.message : 'Failed to perform bulk update',
+        message: 'Report IDs are required and must be an array',
       });
+      return;
     }
+
+    const result = await ModerationService.bulkUpdateReports({
+      reportIds,
+      action,
+      moderatorId,
+      resolutionNotes,
+      assignTo,
+      escalateTo,
+      escalationReason,
+    });
+
+    res.json(result);
   }
 
   async getFlaggedMessages(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const page = parsePage(req.query.page as string | undefined);
-      const limit = parsePaginationLimit(req.query.limit as string | undefined, {
-        default: DEFAULT_PAGE_SIZE,
-        max: MAX_PAGE_SIZE,
-      });
-      const severity = req.query.severity ? String(req.query.severity) : undefined;
-      const moderationStatus = req.query.moderationStatus
-        ? String(req.query.moderationStatus)
-        : undefined;
+    const page = parsePage(req.query.page as string | undefined);
+    const limit = parsePaginationLimit(req.query.limit as string | undefined, {
+      default: DEFAULT_PAGE_SIZE,
+      max: MAX_PAGE_SIZE,
+    });
+    const severity = req.query.severity ? String(req.query.severity) : undefined;
+    const moderationStatus = req.query.moderationStatus
+      ? String(req.query.moderationStatus)
+      : undefined;
 
-      const result = await ModerationService.getFlaggedMessages({
-        page,
-        limit,
-        severity,
-        moderationStatus,
-      });
+    const result = await ModerationService.getFlaggedMessages({
+      page,
+      limit,
+      severity,
+      moderationStatus,
+    });
 
-      res.json({ success: true, data: result });
-    } catch (error) {
-      logger.error('Error fetching flagged messages:', error);
-      res.status(500).json({
-        success: false,
-        message: error instanceof Error ? error.message : 'Failed to fetch flagged messages',
-      });
-    }
+    res.json({ success: true, data: result });
   }
 }
 

--- a/service.backend/src/controllers/notification.controller.ts
+++ b/service.backend/src/controllers/notification.controller.ts
@@ -11,53 +11,42 @@ export class NotificationController {
    * Get user notifications with pagination and filtering
    */
   getUserNotifications = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const {
-        page = 1,
-        limit = DEFAULT_PAGE_SIZE,
-        status,
-        type,
-        sortBy = 'createdAt',
-        sortOrder = 'DESC',
-      } = req.query;
-
-      const options = {
-        page: parseInt(page as string) || 1,
-        limit: parseInt(limit as string) || DEFAULT_PAGE_SIZE,
-        status: status as 'unread' | 'read',
-        type: type as string,
-        sortBy: (sortBy === 'readAt'
-          ? 'read_at'
-          : sortBy === 'createdAt'
-            ? 'created_at'
-            : sortBy) as 'created_at' | 'read_at',
-        sortOrder: sortOrder as 'ASC' | 'DESC',
-      };
-
-      const result = await NotificationService.getUserNotifications(req.user!.userId, options);
-
-      res.status(200).json({
-        success: true,
-        data: result.notifications,
-        pagination: result.pagination,
-      });
-    } catch (error) {
-      logger.error('Get user notifications failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to retrieve notifications',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const {
+      page = 1,
+      limit = DEFAULT_PAGE_SIZE,
+      status,
+      type,
+      sortBy = 'createdAt',
+      sortOrder = 'DESC',
+    } = req.query;
+
+    const options = {
+      page: parseInt(page as string) || 1,
+      limit: parseInt(limit as string) || DEFAULT_PAGE_SIZE,
+      status: status as 'unread' | 'read',
+      type: type as string,
+      sortBy: (sortBy === 'readAt' ? 'read_at' : sortBy === 'createdAt' ? 'created_at' : sortBy) as
+        | 'created_at'
+        | 'read_at',
+      sortOrder: sortOrder as 'ASC' | 'DESC',
+    };
+
+    const result = await NotificationService.getUserNotifications(req.user!.userId, options);
+
+    res.status(200).json({
+      success: true,
+      data: result.notifications,
+      pagination: result.pagination,
+    });
   };
 
   /**
@@ -205,22 +194,13 @@ export class NotificationController {
    * Mark all notifications as read
    */
   markAllNotificationsAsRead = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const result = await NotificationService.markAllAsRead(req.user!.userId);
+    const result = await NotificationService.markAllAsRead(req.user!.userId);
 
-      res.status(200).json({
-        success: true,
-        message: `Marked ${result.affectedCount} notifications as read`,
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Mark all notifications as read failed:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to mark all notifications as read',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      message: `Marked ${result.affectedCount} notifications as read`,
+      data: result,
+    });
   };
 
   /**
@@ -268,21 +248,12 @@ export class NotificationController {
    * Get unread notification count
    */
   getUnreadCount = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const result = await NotificationService.getUnreadCount(req.user!.userId);
+    const result = await NotificationService.getUnreadCount(req.user!.userId);
 
-      res.status(200).json({
-        success: true,
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Get unread count failed:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to get unread notification count',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: result,
+    });
   };
 
   /**
@@ -364,69 +335,51 @@ export class NotificationController {
    * Create bulk notifications (admin only)
    */
   createBulkNotifications = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { userIds, ...notificationData } = req.body;
-
-      if (!Array.isArray(userIds) || userIds.length === 0) {
-        return res.status(400).json({
-          success: false,
-          message: 'userIds must be a non-empty array',
-        });
-      }
-
-      if (typeof notificationData.message === 'string') {
-        notificationData.message = RichTextProcessingService.sanitize(notificationData.message);
-      }
-
-      const result = await NotificationService.createBulkNotifications(
-        userIds,
-        notificationData,
-        req.user!.userId
-      );
-
-      res.status(201).json({
-        success: true,
-        message: `Created ${result.count} notifications successfully`,
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Create bulk notifications failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to create bulk notifications',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { userIds, ...notificationData } = req.body;
+
+    if (!Array.isArray(userIds) || userIds.length === 0) {
+      return res.status(400).json({
+        success: false,
+        message: 'userIds must be a non-empty array',
+      });
+    }
+
+    if (typeof notificationData.message === 'string') {
+      notificationData.message = RichTextProcessingService.sanitize(notificationData.message);
+    }
+
+    const result = await NotificationService.createBulkNotifications(
+      userIds,
+      notificationData,
+      req.user!.userId
+    );
+
+    res.status(201).json({
+      success: true,
+      message: `Created ${result.count} notifications successfully`,
+      data: result,
+    });
   };
 
   /**
    * Clean up expired notifications (admin only)
    */
   cleanupExpiredNotifications = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const result = await NotificationService.cleanupExpiredNotifications();
+    const result = await NotificationService.cleanupExpiredNotifications();
 
-      res.status(200).json({
-        success: true,
-        message: `Cleaned up ${result} expired notifications`,
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Cleanup expired notifications failed:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to cleanup expired notifications',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      message: `Cleaned up ${result} expired notifications`,
+      data: result,
+    });
   };
 }

--- a/service.backend/src/controllers/pet.controller.ts
+++ b/service.backend/src/controllers/pet.controller.ts
@@ -57,277 +57,244 @@ export class PetController {
 
   // Search pets with filters and pagination
   searchPets = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const filters: PetSearchFilters = {
-        search: req.query.search as string,
-        type: req.query.type as PetType | undefined,
-        breed: req.query.breed as string,
-        size: req.query.size as Size | undefined,
-        gender: req.query.gender as Gender | undefined,
-        goodWithChildren:
-          req.query.goodWithChildren === 'true'
-            ? true
-            : req.query.goodWithChildren === 'false'
-              ? false
-              : undefined,
-        goodWithCats:
-          req.query.goodWithCats === 'true'
-            ? true
-            : req.query.goodWithCats === 'false'
-              ? false
-              : undefined,
-        goodWithDogs:
-          req.query.goodWithDogs === 'true'
-            ? true
-            : req.query.goodWithDogs === 'false'
-              ? false
-              : undefined,
-        houseTrained:
-          req.query.houseTrained === 'true'
-            ? true
-            : req.query.houseTrained === 'false'
-              ? false
-              : undefined,
-        rescueId: req.query.rescueId as string,
-        status: req.query.status as PetStatus | undefined,
-        ageMin: req.query.ageMin ? parseInt(req.query.ageMin as string) : undefined,
-        ageMax: req.query.ageMax ? parseInt(req.query.ageMax as string) : undefined,
-        adoptionFeeMin: req.query.adoptionFeeMin
-          ? parseFloat(req.query.adoptionFeeMin as string)
-          : undefined,
-        adoptionFeeMax: req.query.adoptionFeeMax
-          ? parseFloat(req.query.adoptionFeeMax as string)
-          : undefined,
-        latitude: req.query.lat ? parseFloat(req.query.lat as string) : undefined,
-        longitude: req.query.lng ? parseFloat(req.query.lng as string) : undefined,
-        maxDistance: req.query.maxDistance
-          ? parseFloat(req.query.maxDistance as string)
-          : undefined,
-      };
-
-      // If user is authenticated and is rescue staff, and no specific rescueId is provided,
-      // automatically filter by their rescue
-      if (req.user && !filters.rescueId) {
-        try {
-          const rescueId = await PetService.getVerifiedRescueIdForUser(req.user.userId);
-
-          if (rescueId) {
-            filters.rescueId = rescueId;
-            logger.info('Auto-filtering pets by user rescue:', {
-              userId: req.user.userId,
-              rescueId,
-            });
-          }
-        } catch (error) {
-          // If there's an error getting staff member, just continue without filtering
-          logger.warn('Could not determine user rescue for auto-filtering:', error);
-        }
-      }
-
-      const options = {
-        page: parsePage(req.query.page as string | undefined),
-        limit: parsePaginationLimit(req.query.limit as string | undefined, {
-          default: DEFAULT_PAGE_SIZE,
-          max: MAX_PAGE_SIZE,
-        }),
-        sortBy: ((req.query.sortBy as string) || 'createdAt')
-          .replace('created_at', 'createdAt')
-          .replace('adoption_fee', 'adoptionFeeMinor'),
-        sortOrder: (req.query.sortOrder as 'ASC' | 'DESC') || 'DESC',
-      };
-
-      const result = await this.petService.searchPets(filters, options);
-
-      // Distance is computed by the service layer (Haversine). Preserve it through toJSON().
-      const readDistance = (value: unknown): number | undefined => {
-        if (!value || typeof value !== 'object') {
-          return undefined;
-        }
-        const candidate = (value as { distance?: unknown }).distance;
-        return typeof candidate === 'number' ? candidate : undefined;
-      };
-      const petsData = result.pets.map(pet => {
-        const distance = readDistance(pet);
-        // PetAttributes has typed fields, not an index signature; cast through
-        // `unknown` for the spread-into-record below.
-        const petJson = pet.toJSON() as unknown as Record<string, unknown>;
-        return distance !== undefined ? { ...petJson, distance } : petJson;
-      });
-
-      res.status(200).json({
-        success: true,
-        data: petsData,
-        meta: {
-          total: result.total,
-          page: result.page,
-          totalPages: result.totalPages,
-          hasNext: result.page < result.totalPages,
-          hasPrev: result.page > 1,
-        },
-      });
-    } catch (error) {
-      logger.error('Search pets failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to search pets',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const filters: PetSearchFilters = {
+      search: req.query.search as string,
+      type: req.query.type as PetType | undefined,
+      breed: req.query.breed as string,
+      size: req.query.size as Size | undefined,
+      gender: req.query.gender as Gender | undefined,
+      goodWithChildren:
+        req.query.goodWithChildren === 'true'
+          ? true
+          : req.query.goodWithChildren === 'false'
+            ? false
+            : undefined,
+      goodWithCats:
+        req.query.goodWithCats === 'true'
+          ? true
+          : req.query.goodWithCats === 'false'
+            ? false
+            : undefined,
+      goodWithDogs:
+        req.query.goodWithDogs === 'true'
+          ? true
+          : req.query.goodWithDogs === 'false'
+            ? false
+            : undefined,
+      houseTrained:
+        req.query.houseTrained === 'true'
+          ? true
+          : req.query.houseTrained === 'false'
+            ? false
+            : undefined,
+      rescueId: req.query.rescueId as string,
+      status: req.query.status as PetStatus | undefined,
+      ageMin: req.query.ageMin ? parseInt(req.query.ageMin as string) : undefined,
+      ageMax: req.query.ageMax ? parseInt(req.query.ageMax as string) : undefined,
+      adoptionFeeMin: req.query.adoptionFeeMin
+        ? parseFloat(req.query.adoptionFeeMin as string)
+        : undefined,
+      adoptionFeeMax: req.query.adoptionFeeMax
+        ? parseFloat(req.query.adoptionFeeMax as string)
+        : undefined,
+      latitude: req.query.lat ? parseFloat(req.query.lat as string) : undefined,
+      longitude: req.query.lng ? parseFloat(req.query.lng as string) : undefined,
+      maxDistance: req.query.maxDistance ? parseFloat(req.query.maxDistance as string) : undefined,
+    };
+
+    // If user is authenticated and is rescue staff, and no specific rescueId is provided,
+    // automatically filter by their rescue
+    if (req.user && !filters.rescueId) {
+      try {
+        const rescueId = await PetService.getVerifiedRescueIdForUser(req.user.userId);
+
+        if (rescueId) {
+          filters.rescueId = rescueId;
+          logger.info('Auto-filtering pets by user rescue:', {
+            userId: req.user.userId,
+            rescueId,
+          });
+        }
+      } catch (error) {
+        // If there's an error getting staff member, just continue without filtering
+        logger.warn('Could not determine user rescue for auto-filtering:', error);
+      }
+    }
+
+    const options = {
+      page: parsePage(req.query.page as string | undefined),
+      limit: parsePaginationLimit(req.query.limit as string | undefined, {
+        default: DEFAULT_PAGE_SIZE,
+        max: MAX_PAGE_SIZE,
+      }),
+      sortBy: ((req.query.sortBy as string) || 'createdAt')
+        .replace('created_at', 'createdAt')
+        .replace('adoption_fee', 'adoptionFeeMinor'),
+      sortOrder: (req.query.sortOrder as 'ASC' | 'DESC') || 'DESC',
+    };
+
+    const result = await this.petService.searchPets(filters, options);
+
+    // Distance is computed by the service layer (Haversine). Preserve it through toJSON().
+    const readDistance = (value: unknown): number | undefined => {
+      if (!value || typeof value !== 'object') {
+        return undefined;
+      }
+      const candidate = (value as { distance?: unknown }).distance;
+      return typeof candidate === 'number' ? candidate : undefined;
+    };
+    const petsData = result.pets.map(pet => {
+      const distance = readDistance(pet);
+      // PetAttributes has typed fields, not an index signature; cast through
+      // `unknown` for the spread-into-record below.
+      const petJson = pet.toJSON() as unknown as Record<string, unknown>;
+      return distance !== undefined ? { ...petJson, distance } : petJson;
+    });
+
+    res.status(200).json({
+      success: true,
+      data: petsData,
+      meta: {
+        total: result.total,
+        page: result.page,
+        totalPages: result.totalPages,
+        hasNext: result.page < result.totalPages,
+        hasPrev: result.page > 1,
+      },
+    });
   };
 
   // Create a new pet
   createPet = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      logger.info('Pet creation request received', {
+    logger.info('Pet creation request received', {
+      userId: req.user?.userId,
+      bodyKeys: Object.keys(req.body),
+    });
+
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      logger.warn('Pet creation validation failed', {
+        errors: errors.array(),
         userId: req.user?.userId,
-        bodyKeys: Object.keys(req.body),
       });
-
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        logger.warn('Pet creation validation failed', {
-          errors: errors.array(),
-          userId: req.user?.userId,
-        });
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const user = req.user;
-
-      if (!user) {
-        return res.status(401).json({
-          success: false,
-          message: 'Authentication required',
-        });
-      }
-
-      // ADS-376: a user can be verified staff at multiple rescues. Listing
-      // all verified rows lets us (a) keep the single-rescue UX implicit
-      // and (b) require an explicit selection when ambiguous. Explicit
-      // rescueId travels via the query string because `fieldWriteGuard`
-      // marks `pets.rescueId` as READ-only for rescue_staff and would
-      // reject it on the body.
-      const verifiedRescueIds = await PetService.getVerifiedRescueIdsForUser(user.userId);
-
-      if (verifiedRescueIds.length === 0) {
-        return res.status(403).json({
-          success: false,
-          message: 'User is not associated with a rescue organization',
-        });
-      }
-
-      const requestedRescueId =
-        typeof req.query.rescueId === 'string' && req.query.rescueId.trim() !== ''
-          ? req.query.rescueId
-          : null;
-
-      let resolvedRescueId: string;
-      if (requestedRescueId) {
-        const match = verifiedRescueIds.find(id => id === requestedRescueId);
-        if (!match) {
-          return res.status(403).json({
-            success: false,
-            message: 'You are not verified staff at the requested rescue',
-          });
-        }
-        resolvedRescueId = match;
-      } else if (verifiedRescueIds.length === 1) {
-        resolvedRescueId = verifiedRescueIds[0];
-      } else {
-        return res.status(400).json({
-          success: false,
-          message:
-            'You are verified staff at multiple rescues. Specify ?rescueId=<id> to indicate which rescue this pet belongs to.',
-          rescueIds: verifiedRescueIds,
-        });
-      }
-
-      logger.info('Creating pet for rescue', { rescueId: resolvedRescueId });
-
-      // Sanitize request body - convert empty strings to null for numeric fields
-      const sanitizedBody = { ...req.body };
-
-      // Handle numeric fields that might be empty strings
-      const numericFields = ['adoptionFeeMinor', 'weightKg'];
-      numericFields.forEach(field => {
-        if (
-          sanitizedBody[field] === '' ||
-          sanitizedBody[field] === null ||
-          sanitizedBody[field] === undefined
-        ) {
-          sanitizedBody[field] = null;
-        }
-      });
-
-      // Use the rescue ID resolved from the staff member association(s)
-      const pet = await this.petService.createPet(
-        sanitizedBody,
-        resolvedRescueId,
-        req.user!.userId
-      );
-
-      res.status(201).json({
-        success: true,
-        message: 'Pet created successfully',
-        data: pet,
-      });
-    } catch (error) {
-      logger.error('Create pet failed:', error);
-      res.status(500).json({
+      return res.status(400).json({
         success: false,
-        message: 'Failed to create pet',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const user = req.user;
+
+    if (!user) {
+      return res.status(401).json({
+        success: false,
+        message: 'Authentication required',
+      });
+    }
+
+    // ADS-376: a user can be verified staff at multiple rescues. Listing
+    // all verified rows lets us (a) keep the single-rescue UX implicit
+    // and (b) require an explicit selection when ambiguous. Explicit
+    // rescueId travels via the query string because `fieldWriteGuard`
+    // marks `pets.rescueId` as READ-only for rescue_staff and would
+    // reject it on the body.
+    const verifiedRescueIds = await PetService.getVerifiedRescueIdsForUser(user.userId);
+
+    if (verifiedRescueIds.length === 0) {
+      return res.status(403).json({
+        success: false,
+        message: 'User is not associated with a rescue organization',
+      });
+    }
+
+    const requestedRescueId =
+      typeof req.query.rescueId === 'string' && req.query.rescueId.trim() !== ''
+        ? req.query.rescueId
+        : null;
+
+    let resolvedRescueId: string;
+    if (requestedRescueId) {
+      const match = verifiedRescueIds.find(id => id === requestedRescueId);
+      if (!match) {
+        return res.status(403).json({
+          success: false,
+          message: 'You are not verified staff at the requested rescue',
+        });
+      }
+      resolvedRescueId = match;
+    } else if (verifiedRescueIds.length === 1) {
+      resolvedRescueId = verifiedRescueIds[0];
+    } else {
+      return res.status(400).json({
+        success: false,
+        message:
+          'You are verified staff at multiple rescues. Specify ?rescueId=<id> to indicate which rescue this pet belongs to.',
+        rescueIds: verifiedRescueIds,
+      });
+    }
+
+    logger.info('Creating pet for rescue', { rescueId: resolvedRescueId });
+
+    // Sanitize request body - convert empty strings to null for numeric fields
+    const sanitizedBody = { ...req.body };
+
+    // Handle numeric fields that might be empty strings
+    const numericFields = ['adoptionFeeMinor', 'weightKg'];
+    numericFields.forEach(field => {
+      if (
+        sanitizedBody[field] === '' ||
+        sanitizedBody[field] === null ||
+        sanitizedBody[field] === undefined
+      ) {
+        sanitizedBody[field] = null;
+      }
+    });
+
+    // Use the rescue ID resolved from the staff member association(s)
+    const pet = await this.petService.createPet(sanitizedBody, resolvedRescueId, req.user!.userId);
+
+    res.status(201).json({
+      success: true,
+      message: 'Pet created successfully',
+      data: pet,
+    });
   };
 
   // Get pet by ID
   getPetById = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const userId = req.user?.userId;
-      const pet = await this.petService.getPetById(req.params.petId, userId);
-
-      if (!pet) {
-        return res.status(404).json({
-          success: false,
-          message: 'Pet not found',
-        });
-      }
-
-      res.status(200).json({
-        success: true,
-        data: pet,
-      });
-    } catch (error) {
-      logger.error('Get pet by ID failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to retrieve pet',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const userId = req.user?.userId;
+    const pet = await this.petService.getPetById(req.params.petId, userId);
+
+    if (!pet) {
+      return res.status(404).json({
+        success: false,
+        message: 'Pet not found',
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      data: pet,
+    });
   };
 
   // Update pet
@@ -480,112 +447,94 @@ export class PetController {
 
   // Get pets by rescue
   getPetsByRescue = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const page = parsePage(req.query.page as string | undefined);
-      const limit = parsePaginationLimit(req.query.limit as string | undefined, {
-        default: DEFAULT_PAGE_SIZE,
-        max: MAX_PAGE_SIZE,
-      });
+    const page = parsePage(req.query.page as string | undefined);
+    const limit = parsePaginationLimit(req.query.limit as string | undefined, {
+      default: DEFAULT_PAGE_SIZE,
+      max: MAX_PAGE_SIZE,
+    });
 
-      const result = await this.petService.getPetsByRescue(req.params.rescueId, page, limit);
+    const result = await this.petService.getPetsByRescue(req.params.rescueId, page, limit);
 
-      res.status(200).json({
-        success: true,
-        data: result.pets,
-        meta: {
-          total: result.total,
-          page: result.page,
-          totalPages: result.totalPages,
-          hasNext: result.page < result.totalPages,
-          hasPrev: result.page > 1,
-        },
-      });
-    } catch (error) {
-      logger.error('Get pets by rescue failed:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve pets by rescue',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: result.pets,
+      meta: {
+        total: result.total,
+        page: result.page,
+        totalPages: result.totalPages,
+        hasNext: result.page < result.totalPages,
+        hasPrev: result.page > 1,
+      },
+    });
   };
 
   // Get pets for the authenticated user's rescue
   getMyRescuePets = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const user = req.user;
+    const user = req.user;
 
-      if (!user) {
-        return res.status(401).json({
-          success: false,
-          message: 'Authentication required',
-        });
-      }
-
-      // Find the user's rescue association
-      const staffRescueId = await PetService.getVerifiedRescueIdForUser(user.userId);
-
-      if (!staffRescueId) {
-        return res.status(403).json({
-          success: false,
-          message: 'User is not associated with a rescue organization',
-        });
-      }
-
-      const page = parsePage(req.query.page as string | undefined);
-      const limit = parsePaginationLimit(req.query.limit as string | undefined, {
-        default: DEFAULT_PAGE_SIZE,
-        max: MAX_PAGE_SIZE,
-      });
-      const status = req.query.status as string;
-      const search = req.query.search as string;
-      const type = req.query.type as string;
-      const size = req.query.size as string;
-      const breed = req.query.breed as string;
-      const ageGroup = req.query.ageGroup as string;
-      const gender = req.query.gender as string;
-      const sortBy = (req.query.sortBy as string) || 'createdAt';
-      const sortOrder = (req.query.sortOrder as string) || 'DESC';
-
-      // Use the searchPets method with rescue filter
-      const result = await this.petService.searchPets(
-        {
-          rescueId: staffRescueId,
-          status: status as PetStatus,
-          search,
-          type: type as PetType,
-          size: size as Size,
-          breed,
-          ageGroup: ageGroup as AgeGroup,
-          gender: gender as Gender,
-        },
-        {
-          page,
-          limit,
-          sortBy,
-          sortOrder: sortOrder as 'ASC' | 'DESC',
-        }
-      );
-
-      res.status(200).json({
-        success: true,
-        data: result.pets,
-        meta: {
-          total: result.total,
-          page: result.page,
-          totalPages: result.totalPages,
-          hasNext: result.page < result.totalPages,
-          hasPrev: result.page > 1,
-        },
-      });
-    } catch (error) {
-      logger.error('Get my rescue pets failed:', error);
-      res.status(500).json({
+    if (!user) {
+      return res.status(401).json({
         success: false,
-        message: 'Failed to retrieve your rescue pets',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Authentication required',
       });
     }
+
+    // Find the user's rescue association
+    const staffRescueId = await PetService.getVerifiedRescueIdForUser(user.userId);
+
+    if (!staffRescueId) {
+      return res.status(403).json({
+        success: false,
+        message: 'User is not associated with a rescue organization',
+      });
+    }
+
+    const page = parsePage(req.query.page as string | undefined);
+    const limit = parsePaginationLimit(req.query.limit as string | undefined, {
+      default: DEFAULT_PAGE_SIZE,
+      max: MAX_PAGE_SIZE,
+    });
+    const status = req.query.status as string;
+    const search = req.query.search as string;
+    const type = req.query.type as string;
+    const size = req.query.size as string;
+    const breed = req.query.breed as string;
+    const ageGroup = req.query.ageGroup as string;
+    const gender = req.query.gender as string;
+    const sortBy = (req.query.sortBy as string) || 'createdAt';
+    const sortOrder = (req.query.sortOrder as string) || 'DESC';
+
+    // Use the searchPets method with rescue filter
+    const result = await this.petService.searchPets(
+      {
+        rescueId: staffRescueId,
+        status: status as PetStatus,
+        search,
+        type: type as PetType,
+        size: size as Size,
+        breed,
+        ageGroup: ageGroup as AgeGroup,
+        gender: gender as Gender,
+      },
+      {
+        page,
+        limit,
+        sortBy,
+        sortOrder: sortOrder as 'ASC' | 'DESC',
+      }
+    );
+
+    res.status(200).json({
+      success: true,
+      data: result.pets,
+      meta: {
+        total: result.total,
+        page: result.page,
+        totalPages: result.totalPages,
+        hasNext: result.page < result.totalPages,
+        hasPrev: result.page > 1,
+      },
+    });
   };
 
   // Update pet status
@@ -631,209 +580,143 @@ export class PetController {
 
   // Get featured pets
   getFeaturedPets = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const limit = parsePaginationLimit(req.query.limit as string | undefined, {
-        default: 10,
-        max: 100,
-      });
-      const pets = await this.petService.getFeaturedPets(limit);
+    const limit = parsePaginationLimit(req.query.limit as string | undefined, {
+      default: 10,
+      max: 100,
+    });
+    const pets = await this.petService.getFeaturedPets(limit);
 
-      res.status(200).json({
-        success: true,
-        data: pets,
-      });
-    } catch (error) {
-      logger.error('Get featured pets failed:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve featured pets',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: pets,
+    });
   };
 
   // Get pet statistics
   getPetStatistics = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const rescueId = req.query.rescueId as string;
-      const stats = await this.petService.getPetStatistics(rescueId);
+    const rescueId = req.query.rescueId as string;
+    const stats = await this.petService.getPetStatistics(rescueId);
 
-      res.status(200).json({
-        success: true,
-        data: stats,
-      });
-    } catch (error) {
-      logger.error('Get pet statistics failed:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve pet statistics',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    res.status(200).json({
+      success: true,
+      data: stats,
+    });
   };
 
   // Get pet activity
   getPetActivity = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const petId = req.params.petId;
-      const activity = await this.petService.getPetActivity(petId);
-
-      res.json({
-        success: true,
-        data: activity,
-      });
-    } catch (error) {
-      logger.error('Error getting pet activity:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to get pet activity',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const petId = req.params.petId;
+    const activity = await this.petService.getPetActivity(petId);
+
+    res.json({
+      success: true,
+      data: activity,
+    });
   };
 
   // Favorite pets functionality
   addToFavorites = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const petId = req.params.petId;
-      const userId = req.user!.userId;
-
-      await this.petService.addToFavorites(userId, petId);
-
-      res.json({
-        success: true,
-        message: 'Pet added to favorites',
-      });
-    } catch (error) {
-      logger.error('Error adding pet to favorites:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to add pet to favorites',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const petId = req.params.petId;
+    const userId = req.user!.userId;
+
+    await this.petService.addToFavorites(userId, petId);
+
+    res.json({
+      success: true,
+      message: 'Pet added to favorites',
+    });
   };
 
   removeFromFavorites = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const petId = req.params.petId;
-      const userId = req.user!.userId;
-
-      await this.petService.removeFromFavorites(userId, petId);
-
-      res.json({
-        success: true,
-        message: 'Pet removed from favorites',
-      });
-    } catch (error) {
-      logger.error('Error removing pet from favorites:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to remove pet from favorites',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const petId = req.params.petId;
+    const userId = req.user!.userId;
+
+    await this.petService.removeFromFavorites(userId, petId);
+
+    res.json({
+      success: true,
+      message: 'Pet removed from favorites',
+    });
   };
 
   getUserFavorites = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const userId = req.user!.userId;
-      const page = parsePage(req.query.page as string | undefined);
-      const limit = parsePaginationLimit(req.query.limit as string | undefined, {
-        default: DEFAULT_PAGE_SIZE,
-        max: MAX_PAGE_SIZE,
-      });
+    const userId = req.user!.userId;
+    const page = parsePage(req.query.page as string | undefined);
+    const limit = parsePaginationLimit(req.query.limit as string | undefined, {
+      default: DEFAULT_PAGE_SIZE,
+      max: MAX_PAGE_SIZE,
+    });
 
-      const favorites = await this.petService.getUserFavorites(userId, { page, limit });
+    const favorites = await this.petService.getUserFavorites(userId, { page, limit });
 
-      res.json({
-        success: true,
-        data: favorites,
-      });
-    } catch (error) {
-      logger.error('Error getting user favorites:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to get user favorites',
-      });
-    }
+    res.json({
+      success: true,
+      data: favorites,
+    });
   };
 
   checkFavoriteStatus = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const userId = req.user!.userId;
-      const { petId } = req.params;
+    const userId = req.user!.userId;
+    const { petId } = req.params;
 
-      const isFavorite = await this.petService.checkFavoriteStatus(userId, petId);
+    const isFavorite = await this.petService.checkFavoriteStatus(userId, petId);
 
-      res.json({
-        success: true,
-        data: { isFavorite },
-      });
-    } catch (error) {
-      logger.error('Error checking favorite status:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to check favorite status',
-      });
-    }
+    res.json({
+      success: true,
+      data: { isFavorite },
+    });
   };
 
   /**
    * Get recent pets
    */
   getRecentPets = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const limit = parsePaginationLimit(req.query.limit as string | undefined, {
-        default: 12,
-        max: 100,
-      });
+    const limit = parsePaginationLimit(req.query.limit as string | undefined, {
+      default: 12,
+      max: 100,
+    });
 
-      if (limit < 1 || limit > 50) {
-        return res.status(400).json({
-          success: false,
-          message: 'Limit must be between 1 and 50',
-        });
-      }
-
-      const pets = await this.petService.getRecentPets(limit);
-
-      res.json({
-        success: true,
-        data: pets,
-        message: 'Recent pets retrieved successfully',
-      });
-    } catch (error) {
-      logger.error('Error getting recent pets:', error);
-      res.status(500).json({
+    if (limit < 1 || limit > 50) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to retrieve recent pets',
+        message: 'Limit must be between 1 and 50',
       });
     }
+
+    const pets = await this.petService.getRecentPets(limit);
+
+    res.json({
+      success: true,
+      data: pets,
+      message: 'Recent pets retrieved successfully',
+    });
   };
 
   /**
@@ -842,52 +725,36 @@ export class PetController {
   static validatePetType = [validateParams(PetTypeParamSchema)];
 
   getPetBreedsByType = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { type } = req.params;
-      const breeds = await this.petService.getPetBreedsByType(type);
-
-      res.json({
-        success: true,
-        data: breeds,
-        message: `Breeds for ${type} retrieved successfully`,
-      });
-    } catch (error) {
-      logger.error(`Error getting breeds for type ${req.params.type}:`, error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to retrieve pet breeds',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { type } = req.params;
+    const breeds = await this.petService.getPetBreedsByType(type);
+
+    res.json({
+      success: true,
+      data: breeds,
+      message: `Breeds for ${type} retrieved successfully`,
+    });
   };
 
   /**
    * Get all pet types
    */
   getPetTypes = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const types = await this.petService.getPetTypes();
+    const types = await this.petService.getPetTypes();
 
-      res.json({
-        success: true,
-        data: types,
-        message: 'Pet types retrieved successfully',
-      });
-    } catch (error) {
-      logger.error('Error getting pet types:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve pet types',
-      });
-    }
+    res.json({
+      success: true,
+      data: types,
+      message: 'Pet types retrieved successfully',
+    });
   };
 
   /**
@@ -980,33 +847,25 @@ export class PetController {
   static validateBulkUpdate = [validateBody(BulkPetOperationRequestSchema)];
 
   bulkUpdatePets = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const updatedBy = req.user!.userId;
-      const operation: BulkPetOperation = req.body;
-
-      const result = await this.petService.bulkUpdatePets(operation, updatedBy);
-
-      res.status(200).json({
-        success: true,
-        message: 'Bulk pet operation completed',
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Bulk pet update failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to perform bulk update',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const updatedBy = req.user!.userId;
+    const operation: BulkPetOperation = req.body;
+
+    const result = await this.petService.bulkUpdatePets(operation, updatedBy);
+
+    res.status(200).json({
+      success: true,
+      message: 'Bulk pet operation completed',
+      data: result,
+    });
   };
 }
 

--- a/service.backend/src/controllers/question.controller.ts
+++ b/service.backend/src/controllers/question.controller.ts
@@ -121,15 +121,8 @@ export class QuestionController {
 
     const { rescueId } = req.params;
 
-    try {
-      const questions = await QuestionService.getQuestionsForRescue(rescueId);
-      res.status(200).json({ success: true, questions });
-    } catch (error) {
-      res.status(500).json({
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to retrieve questions',
-      });
-    }
+    const questions = await QuestionService.getQuestionsForRescue(rescueId);
+    res.status(200).json({ success: true, questions });
   }
 
   async createQuestion(req: AuthenticatedRequest, res: Response): Promise<void> {

--- a/service.backend/src/controllers/rescue.controller.ts
+++ b/service.backend/src/controllers/rescue.controller.ts
@@ -18,51 +18,42 @@ export class RescueController {
    * Search rescues with filters and pagination
    */
   searchRescues = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const {
-        page = 1,
-        limit = DEFAULT_PAGE_SIZE,
-        search,
-        status,
-        location,
-        sortBy = 'createdAt',
-        sortOrder = 'DESC',
-      } = req.query;
-
-      const options = {
-        page: parseInt(page as string),
-        limit: Math.min(parseInt(limit as string), MAX_PAGE_SIZE),
-        search: search as string,
-        status: status as 'pending' | 'verified' | 'suspended' | 'inactive' | 'rejected',
-        location: location as string,
-        sortBy: sortBy as 'name' | 'createdAt' | 'verifiedAt',
-        sortOrder: sortOrder as 'ASC' | 'DESC',
-      };
-
-      const result = await RescueService.searchRescues(options);
-
-      res.status(200).json({
-        success: true,
-        data: result.rescues,
-        pagination: result.pagination,
-      });
-    } catch (error) {
-      logger.error('Search rescues failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to search rescues',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const {
+      page = 1,
+      limit = DEFAULT_PAGE_SIZE,
+      search,
+      status,
+      location,
+      sortBy = 'createdAt',
+      sortOrder = 'DESC',
+    } = req.query;
+
+    const options = {
+      page: parseInt(page as string),
+      limit: Math.min(parseInt(limit as string), MAX_PAGE_SIZE),
+      search: search as string,
+      status: status as 'pending' | 'verified' | 'suspended' | 'inactive' | 'rejected',
+      location: location as string,
+      sortBy: sortBy as 'name' | 'createdAt' | 'verifiedAt',
+      sortOrder: sortOrder as 'ASC' | 'DESC',
+    };
+
+    const result = await RescueService.searchRescues(options);
+
+    res.status(200).json({
+      success: true,
+      data: result.rescues,
+      pagination: result.pagination,
+    });
   };
 
   /**
@@ -328,47 +319,38 @@ export class RescueController {
    * Get rescue staff with pagination
    */
   getRescueStaff = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { rescueId } = req.params;
-      const { page = 1, limit = DEFAULT_PAGE_SIZE } = req.query;
-
-      // First verify rescue exists
-      const rescue = await RescueService.getRescueById(rescueId);
-      if (!rescue) {
-        return res.status(404).json({
-          success: false,
-          message: 'Rescue not found',
-        });
-      }
-
-      // Get staff members via RescueService
-      const result = await RescueService.getRescueStaff(rescueId, {
-        page: parseInt(page as string),
-        limit: parseInt(limit as string),
-      });
-
-      res.status(200).json({
-        success: true,
-        data: result.staff,
-        pagination: result.pagination,
-      });
-    } catch (error) {
-      logger.error('Get rescue staff failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to retrieve rescue staff',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { rescueId } = req.params;
+    const { page = 1, limit = DEFAULT_PAGE_SIZE } = req.query;
+
+    // First verify rescue exists
+    const rescue = await RescueService.getRescueById(rescueId);
+    if (!rescue) {
+      return res.status(404).json({
+        success: false,
+        message: 'Rescue not found',
+      });
+    }
+
+    // Get staff members via RescueService
+    const result = await RescueService.getRescueStaff(rescueId, {
+      page: parseInt(page as string),
+      limit: parseInt(limit as string),
+    });
+
+    res.status(200).json({
+      success: true,
+      data: result.staff,
+      pagination: result.pagination,
+    });
   };
 
   /**
@@ -546,89 +528,71 @@ export class RescueController {
    * Get rescue pets with pagination
    */
   getRescuePets = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { rescueId } = req.params;
-      const {
-        page = 1,
-        limit = DEFAULT_PAGE_SIZE,
-        status,
-        sortBy = 'createdAt',
-        sortOrder = 'DESC',
-      } = req.query;
-
-      const options = {
-        page: parseInt(page as string),
-        limit: Math.min(parseInt(limit as string), MAX_PAGE_SIZE),
-        status: status as string,
-        sortBy: sortBy as string,
-        sortOrder: sortOrder as 'ASC' | 'DESC',
-      };
-
-      const result = await RescueService.getRescuePets(rescueId, options);
-
-      res.status(200).json({
-        success: true,
-        data: result.pets,
-        pagination: result.pagination,
-      });
-    } catch (error) {
-      logger.error('Get rescue pets failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to retrieve rescue pets',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { rescueId } = req.params;
+    const {
+      page = 1,
+      limit = DEFAULT_PAGE_SIZE,
+      status,
+      sortBy = 'createdAt',
+      sortOrder = 'DESC',
+    } = req.query;
+
+    const options = {
+      page: parseInt(page as string),
+      limit: Math.min(parseInt(limit as string), MAX_PAGE_SIZE),
+      status: status as string,
+      sortBy: sortBy as string,
+      sortOrder: sortOrder as 'ASC' | 'DESC',
+    };
+
+    const result = await RescueService.getRescuePets(rescueId, options);
+
+    res.status(200).json({
+      success: true,
+      data: result.pets,
+      pagination: result.pagination,
+    });
   };
 
   /**
    * Get rescue analytics and statistics
    */
   getRescueAnalytics = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { rescueId } = req.params;
-      const userType = req.user!.userType as UserType;
-      const userId = req.user!.userId;
-
-      if (userType !== UserType.ADMIN && userType !== UserType.MODERATOR) {
-        const isStaff = await RescueService.isUserStaffOfRescue(userId, rescueId);
-        if (!isStaff) {
-          return res.status(403).json({ success: false, message: 'Access denied' });
-        }
-      }
-
-      const statistics = await RescueService.getRescueStatistics(rescueId);
-
-      res.status(200).json({
-        success: true,
-        data: statistics,
-      });
-    } catch (error) {
-      logger.error('Get rescue analytics failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to retrieve rescue analytics',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { rescueId } = req.params;
+    const userType = req.user!.userType as UserType;
+    const userId = req.user!.userId;
+
+    if (userType !== UserType.ADMIN && userType !== UserType.MODERATOR) {
+      const isStaff = await RescueService.isUserStaffOfRescue(userId, rescueId);
+      if (!isStaff) {
+        return res.status(403).json({ success: false, message: 'Access denied' });
+      }
+    }
+
+    const statistics = await RescueService.getRescueStatistics(rescueId);
+
+    res.status(200).json({
+      success: true,
+      data: statistics,
+    });
   };
 
   /**
@@ -677,105 +641,63 @@ export class RescueController {
    * Invite a new staff member to join the rescue
    */
   inviteStaffMember = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { rescueId } = req.params;
-      const { email, title } = req.body;
-      const invitedBy = req.user!.userId;
-
-      const result = await InvitationService.inviteStaffMember(rescueId, email, title, invitedBy);
-
-      res.status(201).json(result);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Error inviting staff member:', {
-        error: errorMessage,
-        rescueId: req.params.rescueId,
-      });
-
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to invite staff member',
-        error: errorMessage,
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { rescueId } = req.params;
+    const { email, title } = req.body;
+    const invitedBy = req.user!.userId;
+
+    const result = await InvitationService.inviteStaffMember(rescueId, email, title, invitedBy);
+
+    res.status(201).json(result);
   };
 
   /**
    * Get pending invitations for a rescue
    */
   getPendingInvitations = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { rescueId } = req.params;
-
-      const result = await InvitationService.getPendingInvitations(rescueId);
-
-      res.json(result);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Error getting pending invitations:', {
-        error: errorMessage,
-        rescueId: req.params.rescueId,
-      });
-
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to get pending invitations',
-        error: errorMessage,
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { rescueId } = req.params;
+
+    const result = await InvitationService.getPendingInvitations(rescueId);
+
+    res.json(result);
   };
 
   /**
    * Cancel a pending invitation
    */
   cancelInvitation = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { rescueId, invitationId } = req.params;
-      const cancelledBy = req.user!.userId;
-
-      const result = await InvitationService.cancelInvitation(invitationId, cancelledBy);
-
-      res.json(result);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      logger.error('Error cancelling invitation:', {
-        error: errorMessage,
-        invitationId: req.params.invitationId,
-      });
-
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to cancel invitation',
-        error: errorMessage,
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { rescueId, invitationId } = req.params;
+    const cancelledBy = req.user!.userId;
+
+    const result = await InvitationService.cancelInvitation(invitationId, cancelledBy);
+
+    res.json(result);
   };
 
   /**
@@ -970,36 +892,28 @@ export class RescueController {
   };
 
   bulkUpdateRescues = async (req: AuthenticatedRequest, res: Response) => {
-    try {
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(400).json({
-          success: false,
-          message: 'Validation failed',
-          errors: errors.array(),
-        });
-      }
-
-      const { rescueIds, action, reason } = req.body as {
-        rescueIds: string[];
-        action: BulkRescueAction;
-        reason?: string;
-      };
-      const performedBy = req.user!.userId;
-
-      const result = await RescueService.bulkUpdateRescues(rescueIds, action, performedBy, reason);
-
-      res.status(200).json({
-        success: true,
-        message: 'Bulk rescue update completed',
-        data: result,
-      });
-    } catch (error) {
-      logger.error('Bulk rescue update failed:', error);
-      res.status(500).json({
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
         success: false,
-        message: 'Failed to perform bulk update',
+        message: 'Validation failed',
+        errors: errors.array(),
       });
     }
+
+    const { rescueIds, action, reason } = req.body as {
+      rescueIds: string[];
+      action: BulkRescueAction;
+      reason?: string;
+    };
+    const performedBy = req.user!.userId;
+
+    const result = await RescueService.bulkUpdateRescues(rescueIds, action, performedBy, reason);
+
+    res.status(200).json({
+      success: true,
+      message: 'Bulk rescue update completed',
+      data: result,
+    });
   };
 }

--- a/service.backend/src/controllers/search.controller.ts
+++ b/service.backend/src/controllers/search.controller.ts
@@ -7,7 +7,6 @@
 import { Response } from 'express';
 import { LARGE_PAGE_SIZE, MAX_PAGE_SIZE } from '../constants/pagination';
 import { MessageSearchService } from '../services/messageSearch.service';
-import { logger } from '../utils/logger';
 import { AuthenticatedRequest } from '../types/auth';
 
 export class SearchController {
@@ -15,92 +14,66 @@ export class SearchController {
    * Search messages
    */
   static async searchMessages(req: AuthenticatedRequest, res: Response) {
-    try {
-      const userId = req.user?.userId;
-      const {
-        q: query,
-        conversationId,
-        senderId,
-        startDate,
-        endDate,
-        messageType,
-        page = 1,
-        limit = LARGE_PAGE_SIZE,
-        sortBy = 'relevance',
-        sortOrder = 'DESC',
-      } = req.query;
+    const userId = req.user?.userId;
+    const {
+      q: query,
+      conversationId,
+      senderId,
+      startDate,
+      endDate,
+      messageType,
+      page = 1,
+      limit = LARGE_PAGE_SIZE,
+      sortBy = 'relevance',
+      sortOrder = 'DESC',
+    } = req.query;
 
-      if (!query || typeof query !== 'string') {
-        return res.status(400).json({
-          error: 'Query parameter is required',
-        });
-      }
-
-      const searchOptions = {
-        query,
-        userId,
-        conversationId: conversationId as string,
-        senderId: senderId as string,
-        startDate: startDate ? new Date(startDate as string) : undefined,
-        endDate: endDate ? new Date(endDate as string) : undefined,
-        messageType: messageType as string,
-        page: parseInt(page as string, 10),
-        limit: Math.min(parseInt(limit as string, 10), MAX_PAGE_SIZE),
-        sortBy: sortBy as 'relevance' | 'date' | 'sender',
-        sortOrder: sortOrder as 'ASC' | 'DESC',
-      };
-
-      const results = await MessageSearchService.searchMessages(searchOptions);
-
-      res.json({
-        success: true,
-        ...results,
-      });
-    } catch (error) {
-      logger.error('Message search failed:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.user?.userId,
-        query: req.query.q,
-      });
-
-      res.status(500).json({
-        error: 'Search failed',
-        message: error instanceof Error ? error.message : 'Unknown error',
+    if (!query || typeof query !== 'string') {
+      return res.status(400).json({
+        error: 'Query parameter is required',
       });
     }
+
+    const searchOptions = {
+      query,
+      userId,
+      conversationId: conversationId as string,
+      senderId: senderId as string,
+      startDate: startDate ? new Date(startDate as string) : undefined,
+      endDate: endDate ? new Date(endDate as string) : undefined,
+      messageType: messageType as string,
+      page: parseInt(page as string, 10),
+      limit: Math.min(parseInt(limit as string, 10), MAX_PAGE_SIZE),
+      sortBy: sortBy as 'relevance' | 'date' | 'sender',
+      sortOrder: sortOrder as 'ASC' | 'DESC',
+    };
+
+    const results = await MessageSearchService.searchMessages(searchOptions);
+
+    res.json({
+      success: true,
+      ...results,
+    });
   }
 
   /**
    * Get search suggestions
    */
   static async getSearchSuggestions(req: AuthenticatedRequest, res: Response) {
-    try {
-      const userId = req.user?.userId;
-      const { q: query } = req.query;
+    const userId = req.user?.userId;
+    const { q: query } = req.query;
 
-      if (!query || typeof query !== 'string') {
-        return res.status(400).json({
-          error: 'Query parameter is required',
-        });
-      }
-
-      const suggestions = await MessageSearchService.getSearchSuggestions(query, userId);
-
-      res.json({
-        success: true,
-        suggestions,
-      });
-    } catch (error) {
-      logger.error('Failed to get search suggestions:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId: req.user?.userId,
-        query: req.query.q,
-      });
-
-      res.status(500).json({
-        error: 'Failed to get suggestions',
-        message: error instanceof Error ? error.message : 'Unknown error',
+    if (!query || typeof query !== 'string') {
+      return res.status(400).json({
+        error: 'Query parameter is required',
       });
     }
+
+    const suggestions = await MessageSearchService.getSearchSuggestions(query, userId);
+
+    res.json({
+      success: true,
+      suggestions,
+    });
   }
 }

--- a/service.backend/src/controllers/security.controller.ts
+++ b/service.backend/src/controllers/security.controller.ts
@@ -6,30 +6,22 @@ import { AuthenticatedRequest } from '../types/auth';
 
 export class SecurityController {
   static async listSessions(req: AuthenticatedRequest, res: Response) {
-    try {
-      const { userId, page, limit } = req.query;
-      const result = await SecurityService.listSessions({
-        userId: userId as string | undefined,
-        page: page ? parseInt(page as string, 10) : undefined,
-        limit: limit ? parseInt(limit as string, 10) : undefined,
-      });
-      return res.json({
-        success: true,
-        data: result.sessions,
-        pagination: {
-          page: result.page,
-          limit: parseInt((limit as string) || '50', 10),
-          total: result.total,
-          pages: result.totalPages,
-        },
-      });
-    } catch (error) {
-      logger.error('Error listing sessions:', error);
-      return res.status(500).json({
-        error: 'Failed to list sessions',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    const { userId, page, limit } = req.query;
+    const result = await SecurityService.listSessions({
+      userId: userId as string | undefined,
+      page: page ? parseInt(page as string, 10) : undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    });
+    return res.json({
+      success: true,
+      data: result.sessions,
+      pagination: {
+        page: result.page,
+        limit: parseInt((limit as string) || '50', 10),
+        total: result.total,
+        pages: result.totalPages,
+      },
+    });
   }
 
   static async revokeSession(req: AuthenticatedRequest, res: Response) {
@@ -50,30 +42,14 @@ export class SecurityController {
   }
 
   static async revokeAllUserSessions(req: AuthenticatedRequest, res: Response) {
-    try {
-      const { userId } = req.params;
-      const count = await SecurityService.revokeAllUserSessions(userId, req.user!.userId);
-      return res.json({ success: true, data: { revokedCount: count } });
-    } catch (error) {
-      logger.error('Error revoking user sessions:', error);
-      return res.status(500).json({
-        error: 'Failed to revoke sessions',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    const { userId } = req.params;
+    const count = await SecurityService.revokeAllUserSessions(userId, req.user!.userId);
+    return res.json({ success: true, data: { revokedCount: count } });
   }
 
   static async listIpRules(_req: AuthenticatedRequest, res: Response) {
-    try {
-      const rules = await SecurityService.listIpRules();
-      return res.json({ success: true, data: rules });
-    } catch (error) {
-      logger.error('Error listing IP rules:', error);
-      return res.status(500).json({
-        error: 'Failed to list IP rules',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    const rules = await SecurityService.listIpRules();
+    return res.json({ success: true, data: rules });
   }
 
   static async createIpRule(req: AuthenticatedRequest, res: Response) {
@@ -163,50 +139,34 @@ export class SecurityController {
   }
 
   static async getLoginHistory(req: AuthenticatedRequest, res: Response) {
-    try {
-      const { userId, status, startDate, endDate, page, limit } = req.query;
-      const result = await SecurityService.getLoginHistory({
-        userId: userId as string | undefined,
-        status: status as 'success' | 'failure' | undefined,
-        startDate: startDate ? new Date(startDate as string) : undefined,
-        endDate: endDate ? new Date(endDate as string) : undefined,
-        page: page ? parseInt(page as string, 10) : undefined,
-        limit: limit ? parseInt(limit as string, 10) : undefined,
-      });
-      return res.json({
-        success: true,
-        data: result.entries,
-        pagination: {
-          page: result.page,
-          limit: parseInt((limit as string) || '50', 10),
-          total: result.total,
-          pages: result.totalPages,
-        },
-      });
-    } catch (error) {
-      logger.error('Error fetching login history:', error);
-      return res.status(500).json({
-        error: 'Failed to fetch login history',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    const { userId, status, startDate, endDate, page, limit } = req.query;
+    const result = await SecurityService.getLoginHistory({
+      userId: userId as string | undefined,
+      status: status as 'success' | 'failure' | undefined,
+      startDate: startDate ? new Date(startDate as string) : undefined,
+      endDate: endDate ? new Date(endDate as string) : undefined,
+      page: page ? parseInt(page as string, 10) : undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    });
+    return res.json({
+      success: true,
+      data: result.entries,
+      pagination: {
+        page: result.page,
+        limit: parseInt((limit as string) || '50', 10),
+        total: result.total,
+        pages: result.totalPages,
+      },
+    });
   }
 
   static async getSuspiciousActivity(req: AuthenticatedRequest, res: Response) {
-    try {
-      const { failureThreshold, windowHours } = req.query;
-      const data = await SecurityService.getSuspiciousActivity({
-        failureThreshold: failureThreshold ? parseInt(failureThreshold as string, 10) : undefined,
-        windowHours: windowHours ? parseInt(windowHours as string, 10) : undefined,
-      });
-      return res.json({ success: true, data });
-    } catch (error) {
-      logger.error('Error fetching suspicious activity:', error);
-      return res.status(500).json({
-        error: 'Failed to fetch suspicious activity',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+    const { failureThreshold, windowHours } = req.query;
+    const data = await SecurityService.getSuspiciousActivity({
+      failureThreshold: failureThreshold ? parseInt(failureThreshold as string, 10) : undefined,
+      windowHours: windowHours ? parseInt(windowHours as string, 10) : undefined,
+    });
+    return res.json({ success: true, data });
   }
 }
 

--- a/service.backend/src/controllers/supportTicket.controller.ts
+++ b/service.backend/src/controllers/supportTicket.controller.ts
@@ -105,103 +105,95 @@ export class SupportTicketController {
    * Get all support tickets with filtering and pagination
    */
   static async getTickets(req: AuthenticatedRequest, res: Response) {
-    try {
-      const {
-        status,
-        priority,
-        category,
-        assignedTo,
-        userId,
-        search,
-        dateFrom,
-        dateTo,
-        page,
-        limit,
-        sortBy,
-        sortOrder,
-      } = req.query;
+    const {
+      status,
+      priority,
+      category,
+      assignedTo,
+      userId,
+      search,
+      dateFrom,
+      dateTo,
+      page,
+      limit,
+      sortBy,
+      sortOrder,
+    } = req.query;
 
-      // Build filters with proper type casting
-      const filters: {
-        status?: TicketStatus | TicketStatus[];
-        priority?: TicketPriority | TicketPriority[];
-        category?: TicketCategory | TicketCategory[];
-        assignedTo?: string;
-        userId?: string;
-        search?: string;
-        dateFrom?: Date;
-        dateTo?: Date;
-      } = {};
+    // Build filters with proper type casting
+    const filters: {
+      status?: TicketStatus | TicketStatus[];
+      priority?: TicketPriority | TicketPriority[];
+      category?: TicketCategory | TicketCategory[];
+      assignedTo?: string;
+      userId?: string;
+      search?: string;
+      dateFrom?: Date;
+      dateTo?: Date;
+    } = {};
 
-      if (status) {
-        const statusArray = typeof status === 'string' ? status.split(',') : (status as string[]);
-        filters.status =
-          statusArray.length === 1
-            ? (statusArray[0] as TicketStatus)
-            : (statusArray as TicketStatus[]);
-      }
-      if (priority) {
-        const priorityArray =
-          typeof priority === 'string' ? priority.split(',') : (priority as string[]);
-        filters.priority =
-          priorityArray.length === 1
-            ? (priorityArray[0] as TicketPriority)
-            : (priorityArray as TicketPriority[]);
-      }
-      if (category) {
-        const categoryArray =
-          typeof category === 'string' ? category.split(',') : (category as string[]);
-        filters.category =
-          categoryArray.length === 1
-            ? (categoryArray[0] as TicketCategory)
-            : (categoryArray as TicketCategory[]);
-      }
-      if (assignedTo) {
-        filters.assignedTo = assignedTo as string;
-      }
-      if (userId) {
-        filters.userId = userId as string;
-      }
-      if (search) {
-        filters.search = search as string;
-      }
-      if (dateFrom) {
-        filters.dateFrom = new Date(dateFrom as string);
-      }
-      if (dateTo) {
-        filters.dateTo = new Date(dateTo as string);
-      }
-
-      const pagination: PaginationOptions = {};
-      if (page) {
-        pagination.page = parseInt(page as string, 10);
-      }
-      if (limit) {
-        pagination.limit = parseInt(limit as string, 10);
-      }
-      if (sortBy) {
-        pagination.sortBy = sortBy as string;
-      }
-      // Validate and cast sortOrder to ensure it's "ASC" | "DESC"
-      if (sortOrder) {
-        const upperOrder = (sortOrder as string).toUpperCase();
-        pagination.sortOrder = upperOrder === 'ASC' || upperOrder === 'DESC' ? upperOrder : 'DESC';
-      }
-
-      const result = await SupportTicketService.getTickets(filters, pagination);
-
-      res.json({
-        success: true,
-        data: result.tickets.map(serializeTicket),
-        pagination: result.pagination,
-      });
-    } catch (error) {
-      logger.error('Error in getTickets:', error);
-      res.status(500).json({
-        success: false,
-        error: 'Failed to fetch support tickets',
-      });
+    if (status) {
+      const statusArray = typeof status === 'string' ? status.split(',') : (status as string[]);
+      filters.status =
+        statusArray.length === 1
+          ? (statusArray[0] as TicketStatus)
+          : (statusArray as TicketStatus[]);
     }
+    if (priority) {
+      const priorityArray =
+        typeof priority === 'string' ? priority.split(',') : (priority as string[]);
+      filters.priority =
+        priorityArray.length === 1
+          ? (priorityArray[0] as TicketPriority)
+          : (priorityArray as TicketPriority[]);
+    }
+    if (category) {
+      const categoryArray =
+        typeof category === 'string' ? category.split(',') : (category as string[]);
+      filters.category =
+        categoryArray.length === 1
+          ? (categoryArray[0] as TicketCategory)
+          : (categoryArray as TicketCategory[]);
+    }
+    if (assignedTo) {
+      filters.assignedTo = assignedTo as string;
+    }
+    if (userId) {
+      filters.userId = userId as string;
+    }
+    if (search) {
+      filters.search = search as string;
+    }
+    if (dateFrom) {
+      filters.dateFrom = new Date(dateFrom as string);
+    }
+    if (dateTo) {
+      filters.dateTo = new Date(dateTo as string);
+    }
+
+    const pagination: PaginationOptions = {};
+    if (page) {
+      pagination.page = parseInt(page as string, 10);
+    }
+    if (limit) {
+      pagination.limit = parseInt(limit as string, 10);
+    }
+    if (sortBy) {
+      pagination.sortBy = sortBy as string;
+    }
+    // Validate and cast sortOrder to ensure it's "ASC" | "DESC"
+    if (sortOrder) {
+      const upperOrder = (sortOrder as string).toUpperCase();
+      pagination.sortOrder = upperOrder === 'ASC' || upperOrder === 'DESC' ? upperOrder : 'DESC';
+    }
+
+    const result = await SupportTicketService.getTickets(filters, pagination);
+
+    res.json({
+      success: true,
+      data: result.tickets.map(serializeTicket),
+      pagination: result.pagination,
+    });
   }
 
   /**
@@ -239,50 +231,42 @@ export class SupportTicketController {
    * Create a new support ticket
    */
   static async createTicket(req: AuthenticatedRequest, res: Response) {
-    try {
-      const {
-        userId,
-        userEmail,
-        userName,
-        subject,
-        description,
-        category,
-        priority,
-        tags,
-        metadata,
-      } = req.body;
+    const {
+      userId,
+      userEmail,
+      userName,
+      subject,
+      description,
+      category,
+      priority,
+      tags,
+      metadata,
+    } = req.body;
 
-      // Validation
-      if (!userEmail || !subject || !description || !category) {
-        return res.status(400).json({
-          success: false,
-          error: 'Missing required fields: userEmail, subject, description, category',
-        });
-      }
-
-      const ticket = await SupportTicketService.createTicket({
-        userId,
-        userEmail,
-        userName,
-        subject,
-        description: RichTextProcessingService.sanitize(description),
-        category,
-        priority,
-        tags,
-        metadata,
-      });
-
-      res.status(201).json({
-        success: true,
-        data: serializeTicket(ticket),
-      });
-    } catch (error) {
-      logger.error('Error in createTicket:', error);
-      res.status(500).json({
+    // Validation
+    if (!userEmail || !subject || !description || !category) {
+      return res.status(400).json({
         success: false,
-        error: 'Failed to create support ticket',
+        error: 'Missing required fields: userEmail, subject, description, category',
       });
     }
+
+    const ticket = await SupportTicketService.createTicket({
+      userId,
+      userEmail,
+      userName,
+      subject,
+      description: RichTextProcessingService.sanitize(description),
+      category,
+      priority,
+      tags,
+      metadata,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: serializeTicket(ticket),
+    });
   }
 
   /**
@@ -478,20 +462,12 @@ export class SupportTicketController {
    * Get support ticket statistics
    */
   static async getTicketStats(req: AuthenticatedRequest, res: Response) {
-    try {
-      const stats = await SupportTicketService.getTicketStats();
+    const stats = await SupportTicketService.getTicketStats();
 
-      res.json({
-        success: true,
-        data: stats,
-      });
-    } catch (error) {
-      logger.error('Error in getTicketStats:', error);
-      res.status(500).json({
-        success: false,
-        error: 'Failed to fetch ticket statistics',
-      });
-    }
+    res.json({
+      success: true,
+      data: stats,
+    });
   }
 
   /**
@@ -499,32 +475,24 @@ export class SupportTicketController {
    * Get tickets assigned to the current agent
    */
   static async getMyTickets(req: AuthenticatedRequest, res: Response) {
-    try {
-      const agentId = req.user?.userId;
-      const { status } = req.query;
+    const agentId = req.user?.userId;
+    const { status } = req.query;
 
-      if (!agentId) {
-        return res.status(401).json({
-          success: false,
-          error: 'User not authenticated',
-        });
-      }
-
-      const tickets = await SupportTicketService.getAgentTickets(
-        agentId,
-        status as TicketStatus | undefined
-      );
-
-      res.json({
-        success: true,
-        data: tickets.map(serializeTicket),
-      });
-    } catch (error) {
-      logger.error('Error in getMyTickets:', error);
-      res.status(500).json({
+    if (!agentId) {
+      return res.status(401).json({
         success: false,
-        error: 'Failed to fetch assigned tickets',
+        error: 'User not authenticated',
       });
     }
+
+    const tickets = await SupportTicketService.getAgentTickets(
+      agentId,
+      status as TicketStatus | undefined
+    );
+
+    res.json({
+      success: true,
+      data: tickets.map(serializeTicket),
+    });
   }
 }

--- a/service.backend/src/controllers/user.controller.ts
+++ b/service.backend/src/controllers/user.controller.ts
@@ -78,14 +78,9 @@ export class UserController {
    * Get current user profile
    */
   async getCurrentUserProfile(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const user = await UserService.getUserById(userId);
-      res.json(user);
-    } catch (error) {
-      logger.error('Get current user profile failed:', error);
-      res.status(500).json({ error: 'Failed to get user profile' });
-    }
+    const userId = req.user!.userId;
+    const user = await UserService.getUserById(userId);
+    res.json(user);
   }
 
   /**
@@ -228,16 +223,11 @@ export class UserController {
    * Search users with filters
    */
   async searchUsers(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const filters = UserService.processSearchFilters(
-        req.query as Record<string, string | undefined>
-      );
-      const result = await UserService.searchUsers(filters);
-      res.json(result);
-    } catch (error) {
-      logger.error('Search users failed:', error);
-      res.status(500).json({ error: 'Failed to search users' });
-    }
+    const filters = UserService.processSearchFilters(
+      req.query as Record<string, string | undefined>
+    );
+    const result = await UserService.searchUsers(filters);
+    res.json(result);
   }
 
   /**
@@ -273,77 +263,48 @@ export class UserController {
    * Get user statistics
    */
   async getUserStats(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const stats = await UserService.getUserStatistics();
-      res.json(stats);
-    } catch (error) {
-      logger.error('Get user stats failed:', error);
-      res.status(500).json({ error: 'Failed to get user statistics' });
-    }
+    const stats = await UserService.getUserStatistics();
+    res.json(stats);
   }
 
   /**
    * Get user preferences
    */
   async getUserPreferences(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const preferences = await UserService.getUserPreferences(userId);
-      res.json({
-        success: true,
-        data: preferences,
-      });
-    } catch (error) {
-      logger.error('Get user preferences failed:', error);
-      res.status(500).json({
-        success: false,
-        error: 'Failed to get user preferences',
-      });
-    }
+    const userId = req.user!.userId;
+    const preferences = await UserService.getUserPreferences(userId);
+    res.json({
+      success: true,
+      data: preferences,
+    });
   }
 
   /**
    * Update user preferences
    */
   async updateUserPreferences(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const preferences = req.body;
+    const userId = req.user!.userId;
+    const preferences = req.body;
 
-      const updatedPreferences = await UserService.updateUserPreferences(userId, preferences);
-      res.json({
-        success: true,
-        data: updatedPreferences,
-        message: 'Preferences updated successfully',
-      });
-    } catch (error) {
-      logger.error('Update user preferences failed:', error);
-      res.status(500).json({
-        success: false,
-        error: 'Failed to update user preferences',
-      });
-    }
+    const updatedPreferences = await UserService.updateUserPreferences(userId, preferences);
+    res.json({
+      success: true,
+      data: updatedPreferences,
+      message: 'Preferences updated successfully',
+    });
   }
 
   /**
    * Reset user preferences to defaults
    */
   async resetUserPreferences(req: AuthenticatedRequest, res: Response): Promise<void> {
-    try {
-      const userId = req.user!.userId;
-      const resetPreferences = await UserService.resetUserPreferences(userId);
-      res.json({
-        success: true,
-        data: resetPreferences,
-        message: 'Preferences reset to defaults',
-      });
-    } catch (error) {
-      logger.error('Reset user preferences failed:', error);
-      res.status(500).json({
-        success: false,
-        error: 'Failed to reset user preferences',
-      });
-    }
+    const userId = req.user!.userId;
+    const resetPreferences = await UserService.resetUserPreferences(userId);
+    res.json({
+      success: true,
+      data: resetPreferences,
+      message: 'Preferences reset to defaults',
+    });
   }
 
   /**
@@ -539,32 +500,20 @@ export class UserController {
     const startTime = Date.now();
     const { userId } = req.params;
 
-    try {
-      const userWithPermissions = await UserService.getUserWithPermissions(userId);
+    const userWithPermissions = await UserService.getUserWithPermissions(userId);
 
-      if (!userWithPermissions) {
-        return res.status(404).json({
-          error: 'User not found',
-        });
-      }
-
-      logger.info('User with permissions retrieved', {
-        userId,
-        duration: Date.now() - startTime,
-      });
-
-      return res.json(userWithPermissions);
-    } catch (error) {
-      logger.error('Error getting user with permissions:', {
-        error: error instanceof Error ? error.message : String(error),
-        userId,
-        duration: Date.now() - startTime,
-      });
-
-      return res.status(500).json({
-        error: 'Failed to get user with permissions',
+    if (!userWithPermissions) {
+      return res.status(404).json({
+        error: 'User not found',
       });
     }
+
+    logger.info('User with permissions retrieved', {
+      userId,
+      duration: Date.now() - startTime,
+    });
+
+    return res.json(userWithPermissions);
   }
 }
 

--- a/service.backend/src/controllers/userSupport.controller.ts
+++ b/service.backend/src/controllers/userSupport.controller.ts
@@ -17,55 +17,47 @@ export class UserSupportController {
    * Create a support ticket for the authenticated user
    */
   static async createMyTicket(req: AuthenticatedRequest, res: Response) {
-    try {
-      const userId = req.user!.userId;
-      const { subject, description, category, priority } = req.body;
+    const userId = req.user!.userId;
+    const { subject, description, category, priority } = req.body;
 
-      // Validation
-      if (!subject || !description || !category) {
-        return res.status(400).json({
-          success: false,
-          error: 'Missing required fields: subject, description, category',
-        });
-      }
-
-      // Get user details
-      const user = await User.findByPk(userId);
-      if (!user) {
-        return res.status(404).json({
-          success: false,
-          error: 'User not found',
-        });
-      }
-
-      const ticket = await SupportTicketService.createTicket({
-        userId: user.userId,
-        userEmail: user.email,
-        userName: `${user.firstName} ${user.lastName}`,
-        subject,
-        description,
-        category,
-        priority: priority || TicketPriority.NORMAL,
-      });
-
-      logger.info('User created support ticket', {
-        userId,
-        ticketId: ticket.ticketId,
-        category,
-        priority: ticket.priority,
-      });
-
-      res.status(201).json({
-        success: true,
-        data: ticket,
-      });
-    } catch (error) {
-      logger.error('Error in createMyTicket:', error);
-      res.status(500).json({
+    // Validation
+    if (!subject || !description || !category) {
+      return res.status(400).json({
         success: false,
-        error: 'Failed to create support ticket',
+        error: 'Missing required fields: subject, description, category',
       });
     }
+
+    // Get user details
+    const user = await User.findByPk(userId);
+    if (!user) {
+      return res.status(404).json({
+        success: false,
+        error: 'User not found',
+      });
+    }
+
+    const ticket = await SupportTicketService.createTicket({
+      userId: user.userId,
+      userEmail: user.email,
+      userName: `${user.firstName} ${user.lastName}`,
+      subject,
+      description,
+      category,
+      priority: priority || TicketPriority.NORMAL,
+    });
+
+    logger.info('User created support ticket', {
+      userId,
+      ticketId: ticket.ticketId,
+      category,
+      priority: ticket.priority,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: ticket,
+    });
   }
 
   /**
@@ -73,47 +65,39 @@ export class UserSupportController {
    * Get all tickets for the authenticated user
    */
   static async getMyTickets(req: AuthenticatedRequest, res: Response) {
-    try {
-      const userId = req.user!.userId;
-      const { status, page, limit } = req.query;
+    const userId = req.user!.userId;
+    const { status, page, limit } = req.query;
 
-      // Build validated filters - convert string status to TicketStatus enum if needed
-      const ticketFilters: {
-        userId: string;
-        status?: TicketStatus | TicketStatus[];
-      } = { userId };
+    // Build validated filters - convert string status to TicketStatus enum if needed
+    const ticketFilters: {
+      userId: string;
+      status?: TicketStatus | TicketStatus[];
+    } = { userId };
 
-      if (status) {
-        const statusArray = typeof status === 'string' ? status.split(',') : (status as string[]);
-        // Type assertion safe: we're passing validated status strings to the service
-        ticketFilters.status =
-          statusArray.length === 1
-            ? (statusArray[0] as TicketStatus)
-            : (statusArray as TicketStatus[]);
-      }
-
-      const pagination: PaginationOptions = {};
-      if (page) {
-        pagination.page = parseInt(page as string, 10);
-      }
-      if (limit) {
-        pagination.limit = parseInt(limit as string, 10);
-      }
-
-      const result = await SupportTicketService.getUserTickets(userId, ticketFilters, pagination);
-
-      res.json({
-        success: true,
-        data: result.tickets,
-        pagination: result.pagination,
-      });
-    } catch (error) {
-      logger.error('Error in getMyTickets:', error);
-      res.status(500).json({
-        success: false,
-        error: 'Failed to fetch your support tickets',
-      });
+    if (status) {
+      const statusArray = typeof status === 'string' ? status.split(',') : (status as string[]);
+      // Type assertion safe: we're passing validated status strings to the service
+      ticketFilters.status =
+        statusArray.length === 1
+          ? (statusArray[0] as TicketStatus)
+          : (statusArray as TicketStatus[]);
     }
+
+    const pagination: PaginationOptions = {};
+    if (page) {
+      pagination.page = parseInt(page as string, 10);
+    }
+    if (limit) {
+      pagination.limit = parseInt(limit as string, 10);
+    }
+
+    const result = await SupportTicketService.getUserTickets(userId, ticketFilters, pagination);
+
+    res.json({
+      success: true,
+      data: result.tickets,
+      pagination: result.pagination,
+    });
   }
 
   /**

--- a/service.backend/src/routes/dashboard.routes.ts
+++ b/service.backend/src/routes/dashboard.routes.ts
@@ -15,143 +15,123 @@ router.use(authenticateToken);
  * Get rescue dashboard statistics
  */
 router.get('/rescue', async (req: AuthenticatedRequest, res) => {
-  try {
-    const user = req.user;
+  const user = req.user;
 
-    // Find the user's rescue association through StaffMember
-    const staffMember = await StaffMember.findOne({
-      where: {
-        userId: user?.userId,
-      },
-    });
+  // Find the user's rescue association through StaffMember
+  const staffMember = await StaffMember.findOne({
+    where: {
+      userId: user?.userId,
+    },
+  });
 
-    if (!staffMember) {
-      return res.status(400).json({
-        success: false,
-        message: 'User is not associated with a rescue organization',
-      });
-    }
-
-    const rescueId = staffMember.rescueId;
-
-    // Import the RescueService to get real statistics
-    const { RescueService } = await import('../services/rescue.service');
-
-    let dashboardData;
-    try {
-      // Get real rescue statistics from the database
-      const rescueStats = await RescueService.getRescueStatistics(rescueId);
-
-      dashboardData = {
-        totalAnimals: rescueStats.totalPets,
-        availableForAdoption: rescueStats.availablePets,
-        pendingApplications: rescueStats.pendingApplications,
-        recentAdoptions: rescueStats.monthlyAdoptions,
-        totalApplications: rescueStats.totalApplications,
-        adoptedPets: rescueStats.adoptedPets,
-        staffCount: rescueStats.staffCount,
-        averageTimeToAdoption: rescueStats.averageTimeToAdoption,
-        recentActivity: [
-          {
-            id: 'activity_1',
-            type: 'pet_added',
-            title: 'New Pet Added',
-            description: 'Check your latest pet listings',
-            timestamp: new Date().toISOString(),
-            metadata: {
-              petId: 'recent_pet',
-              petName: 'Recent Addition',
-            },
-          },
-          {
-            id: 'activity_2',
-            type: 'application_received',
-            title: 'Applications Pending',
-            description: `You have ${rescueStats.pendingApplications} pending applications to review`,
-            timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
-            metadata: {
-              applicationId: 'pending_apps',
-              count: rescueStats.pendingApplications,
-            },
-          },
-        ],
-      };
-    } catch (error) {
-      logger.error('Error fetching real rescue statistics:', { error });
-      // Fallback to basic mock data if database query fails
-      dashboardData = {
-        totalAnimals: 0,
-        availableForAdoption: 0,
-        pendingApplications: 0,
-        recentAdoptions: 0,
-        totalApplications: 0,
-        adoptedPets: 0,
-        staffCount: 0,
-        averageTimeToAdoption: 0,
-        recentActivity: [],
-      };
-    }
-
-    res.json({
-      success: true,
-      data: dashboardData,
-      message: 'Dashboard statistics retrieved successfully',
-    });
-  } catch (error) {
-    logger.error('Dashboard statistics error:', { error });
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    res.status(500).json({
+  if (!staffMember) {
+    return res.status(400).json({
       success: false,
-      message: 'Failed to retrieve dashboard statistics',
-      error: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+      message: 'User is not associated with a rescue organization',
     });
   }
+
+  const rescueId = staffMember.rescueId;
+
+  // Import the RescueService to get real statistics
+  const { RescueService } = await import('../services/rescue.service');
+
+  let dashboardData;
+  try {
+    // Get real rescue statistics from the database
+    const rescueStats = await RescueService.getRescueStatistics(rescueId);
+
+    dashboardData = {
+      totalAnimals: rescueStats.totalPets,
+      availableForAdoption: rescueStats.availablePets,
+      pendingApplications: rescueStats.pendingApplications,
+      recentAdoptions: rescueStats.monthlyAdoptions,
+      totalApplications: rescueStats.totalApplications,
+      adoptedPets: rescueStats.adoptedPets,
+      staffCount: rescueStats.staffCount,
+      averageTimeToAdoption: rescueStats.averageTimeToAdoption,
+      recentActivity: [
+        {
+          id: 'activity_1',
+          type: 'pet_added',
+          title: 'New Pet Added',
+          description: 'Check your latest pet listings',
+          timestamp: new Date().toISOString(),
+          metadata: {
+            petId: 'recent_pet',
+            petName: 'Recent Addition',
+          },
+        },
+        {
+          id: 'activity_2',
+          type: 'application_received',
+          title: 'Applications Pending',
+          description: `You have ${rescueStats.pendingApplications} pending applications to review`,
+          timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+          metadata: {
+            applicationId: 'pending_apps',
+            count: rescueStats.pendingApplications,
+          },
+        },
+      ],
+    };
+  } catch (error) {
+    logger.error('Error fetching real rescue statistics:', { error });
+    // Fallback to basic mock data if database query fails
+    dashboardData = {
+      totalAnimals: 0,
+      availableForAdoption: 0,
+      pendingApplications: 0,
+      recentAdoptions: 0,
+      totalApplications: 0,
+      adoptedPets: 0,
+      staffCount: 0,
+      averageTimeToAdoption: 0,
+      recentActivity: [],
+    };
+  }
+
+  res.json({
+    success: true,
+    data: dashboardData,
+    message: 'Dashboard statistics retrieved successfully',
+  });
 });
 
 /**
  * Get recent activity for dashboard
  */
 router.get('/activity', async (req: AuthenticatedRequest, res) => {
-  try {
-    const user = req.user;
+  const user = req.user;
 
-    // Find the user's rescue association through StaffMember
-    const staffMember = await StaffMember.findOne({
-      where: {
-        userId: user?.userId,
-      },
-    });
+  // Find the user's rescue association through StaffMember
+  const staffMember = await StaffMember.findOne({
+    where: {
+      userId: user?.userId,
+    },
+  });
 
-    if (!staffMember) {
-      return res.status(400).json({
-        success: false,
-        message: 'User is not associated with a rescue organization',
-      });
-    }
-
-    const rescueId = staffMember.rescueId;
-
-    const limit = parsePaginationLimit(req.query.limit as string | undefined, {
-      default: 10,
-      max: 100,
-    });
-
-    const activities = await DashboardService.getActivityForRescue(rescueId, limit);
-
-    res.json({
-      success: true,
-      data: activities,
-      message: 'Activity retrieved successfully',
-    });
-  } catch (error) {
-    logger.error('Dashboard activity error:', { error });
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    res.status(500).json({
+  if (!staffMember) {
+    return res.status(400).json({
       success: false,
-      message: 'Failed to retrieve dashboard activity',
-      error: process.env.NODE_ENV === 'development' ? errorMessage : undefined,
+      message: 'User is not associated with a rescue organization',
     });
   }
+
+  const rescueId = staffMember.rescueId;
+
+  const limit = parsePaginationLimit(req.query.limit as string | undefined, {
+    default: 10,
+    max: 100,
+  });
+
+  const activities = await DashboardService.getActivityForRescue(rescueId, limit);
+
+  res.json({
+    success: true,
+    data: activities,
+    message: 'Activity retrieved successfully',
+  });
 });
 
 export default router;

--- a/service.backend/src/routes/field-permissions.routes.ts
+++ b/service.backend/src/routes/field-permissions.routes.ts
@@ -5,7 +5,6 @@ import { requireRole } from '../middleware/rbac';
 import { UserType } from '../models/User';
 import { FieldPermissionService } from '../services/field-permission.service';
 import { AuthenticatedRequest } from '../types/auth';
-import { logger } from '../utils/logger';
 // Model enums are used for service-layer type compatibility within the backend.
 // These enums mirror the canonical types in @adopt-dont-shop/lib.types.
 import { FieldAccessLevel, FieldPermissionResource } from '../models/FieldPermission';
@@ -167,15 +166,10 @@ router.get(
       return;
     }
 
-    try {
-      const overrides = await FieldPermissionService.getByResource(
-        req.params.resource as FieldPermissionResource
-      );
-      res.json({ success: true, data: overrides });
-    } catch (error) {
-      logger.error('Failed to get field permissions', { error });
-      res.status(500).json({ success: false, message: 'Failed to get field permissions' });
-    }
+    const overrides = await FieldPermissionService.getByResource(
+      req.params.resource as FieldPermissionResource
+    );
+    res.json({ success: true, data: overrides });
   }
 );
 
@@ -203,16 +197,11 @@ router.get(
       return;
     }
 
-    try {
-      const overrides = await FieldPermissionService.getByResourceAndRole(
-        req.params.resource as FieldPermissionResource,
-        req.params.role
-      );
-      res.json({ success: true, data: overrides });
-    } catch (error) {
-      logger.error('Failed to get field permissions', { error });
-      res.status(500).json({ success: false, message: 'Failed to get field permissions' });
-    }
+    const overrides = await FieldPermissionService.getByResourceAndRole(
+      req.params.resource as FieldPermissionResource,
+      req.params.role
+    );
+    res.json({ success: true, data: overrides });
   }
 );
 
@@ -249,34 +238,29 @@ router.post(
       return;
     }
 
-    try {
-      const { resource, field_name, role, access_level } = req.body;
+    const { resource, field_name, role, access_level } = req.body;
 
-      const blocked = rejectSensitiveOverrides([{ resource, field_name }]);
-      if (blocked.length > 0) {
-        res.status(400).json({
-          success: false,
-          message: 'Cannot override sensitive fields',
-          blockedFields: blocked,
-        });
-        return;
-      }
-
-      const userId = req.user?.userId ?? 'unknown';
-
-      const record = await FieldPermissionService.upsert(
-        resource as FieldPermissionResource,
-        field_name,
-        role,
-        access_level as FieldAccessLevel,
-        userId
-      );
-
-      res.status(200).json({ success: true, data: record });
-    } catch (error) {
-      logger.error('Failed to upsert field permission', { error });
-      res.status(500).json({ success: false, message: 'Failed to update field permission' });
+    const blocked = rejectSensitiveOverrides([{ resource, field_name }]);
+    if (blocked.length > 0) {
+      res.status(400).json({
+        success: false,
+        message: 'Cannot override sensitive fields',
+        blockedFields: blocked,
+      });
+      return;
     }
+
+    const userId = req.user?.userId ?? 'unknown';
+
+    const record = await FieldPermissionService.upsert(
+      resource as FieldPermissionResource,
+      field_name,
+      role,
+      access_level as FieldAccessLevel,
+      userId
+    );
+
+    res.status(200).json({ success: true, data: record });
   }
 );
 
@@ -314,29 +298,24 @@ router.post(
       return;
     }
 
-    try {
-      const overrides = req.body.overrides as ReadonlyArray<{
-        resource: string;
-        field_name: string;
-      }>;
+    const overrides = req.body.overrides as ReadonlyArray<{
+      resource: string;
+      field_name: string;
+    }>;
 
-      const blocked = rejectSensitiveOverrides(overrides);
-      if (blocked.length > 0) {
-        res.status(400).json({
-          success: false,
-          message: 'Cannot override sensitive fields',
-          blockedFields: blocked,
-        });
-        return;
-      }
-
-      const userId = req.user?.userId ?? 'unknown';
-      const records = await FieldPermissionService.bulkUpsert(req.body.overrides, userId);
-      res.status(200).json({ success: true, data: records });
-    } catch (error) {
-      logger.error('Failed to bulk upsert field permissions', { error });
-      res.status(500).json({ success: false, message: 'Failed to bulk update field permissions' });
+    const blocked = rejectSensitiveOverrides(overrides);
+    if (blocked.length > 0) {
+      res.status(400).json({
+        success: false,
+        message: 'Cannot override sensitive fields',
+        blockedFields: blocked,
+      });
+      return;
     }
+
+    const userId = req.user?.userId ?? 'unknown';
+    const records = await FieldPermissionService.bulkUpsert(req.body.overrides, userId);
+    res.status(200).json({ success: true, data: records });
   }
 );
 
@@ -365,27 +344,22 @@ router.delete(
       return;
     }
 
-    try {
-      const { resource, role, field_name } = req.params;
-      const userId = req.user?.userId ?? 'unknown';
+    const { resource, role, field_name } = req.params;
+    const userId = req.user?.userId ?? 'unknown';
 
-      const deleted = await FieldPermissionService.deleteOverride(
-        resource as FieldPermissionResource,
-        role,
-        field_name,
-        userId
-      );
+    const deleted = await FieldPermissionService.deleteOverride(
+      resource as FieldPermissionResource,
+      role,
+      field_name,
+      userId
+    );
 
-      if (!deleted) {
-        res.status(404).json({ success: false, message: 'Field permission override not found' });
-        return;
-      }
-
-      res.json({ success: true, message: 'Field permission override deleted' });
-    } catch (error) {
-      logger.error('Failed to delete field permission', { error });
-      res.status(500).json({ success: false, message: 'Failed to delete field permission' });
+    if (!deleted) {
+      res.status(404).json({ success: false, message: 'Field permission override not found' });
+      return;
     }
+
+    res.json({ success: true, message: 'Field permission override deleted' });
   }
 );
 

--- a/service.backend/src/routes/invitation.routes.ts
+++ b/service.backend/src/routes/invitation.routes.ts
@@ -77,7 +77,12 @@ router.post(
   }
 );
 
-// Get invitation details (public route for form pre-population)
+// Get invitation details (public route for form pre-population).
+// The catch wrapper is intentional — `req.originalUrl` contains the
+// invitation token, so we must not let the error propagate to the
+// central error handler (which logs `req.originalUrl`) without
+// scrubbing. The catch logs only `err.message` and emits a generic
+// 500, keeping the raw token out of structured logs.
 router.get(
   '/details/:token',
   [param('token').notEmpty().withMessage('Invitation token is required')],

--- a/service.backend/src/routes/legal.routes.ts
+++ b/service.backend/src/routes/legal.routes.ts
@@ -7,7 +7,6 @@ import {
 } from '../services/legal-content.service';
 import { authenticateToken } from '../middleware/auth';
 import { AuthenticatedRequest } from '../types/api';
-import { logger } from '../utils/logger';
 
 /**
  * ADS-495: public legal endpoints for /terms and /privacy.
@@ -24,39 +23,18 @@ import { logger } from '../utils/logger';
 const router = Router();
 
 router.get('/terms', (_req, res) => {
-  try {
-    const doc = getTermsDocument();
-    res.json({ data: doc });
-  } catch (error) {
-    logger.error('Failed to read terms document', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    res.status(500).json({ error: 'Failed to load terms' });
-  }
+  const doc = getTermsDocument();
+  res.json({ data: doc });
 });
 
 router.get('/privacy', (_req, res) => {
-  try {
-    const doc = getPrivacyDocument();
-    res.json({ data: doc });
-  } catch (error) {
-    logger.error('Failed to read privacy document', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    res.status(500).json({ error: 'Failed to load privacy policy' });
-  }
+  const doc = getPrivacyDocument();
+  res.json({ data: doc });
 });
 
 router.get('/cookies', (_req, res) => {
-  try {
-    const doc = getCookiesDocument();
-    res.json({ data: doc });
-  } catch (error) {
-    logger.error('Failed to read cookies document', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    res.status(500).json({ error: 'Failed to load cookies policy' });
-  }
+  const doc = getCookiesDocument();
+  res.json({ data: doc });
 });
 
 /**
@@ -78,16 +56,8 @@ router.get(
       return;
     }
 
-    try {
-      const result = await getPendingReacceptance(userId);
-      res.json(result);
-    } catch (error) {
-      logger.error('Failed to compute pending re-acceptance', {
-        userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      res.status(500).json({ error: 'Failed to load pending re-acceptance' });
-    }
+    const result = await getPendingReacceptance(userId);
+    res.json(result);
   }
 );
 

--- a/service.backend/src/routes/metrics.routes.ts
+++ b/service.backend/src/routes/metrics.routes.ts
@@ -1,6 +1,5 @@
 import { Request, Response, Router } from 'express';
 import { registry } from '../middleware/metrics';
-import { logger } from '../utils/logger';
 
 /**
  * ADS-404: Prometheus scrape endpoint.
@@ -34,13 +33,8 @@ router.get('/', async (req: Request, res: Response) => {
     return;
   }
 
-  try {
-    res.set('Content-Type', registry.contentType);
-    res.send(await registry.metrics());
-  } catch (error) {
-    logger.error('Failed to render metrics', { error });
-    res.status(500).json({ error: 'metrics render failed' });
-  }
+  res.set('Content-Type', registry.contentType);
+  res.send(await registry.metrics());
 });
 
 export default router;

--- a/service.backend/src/routes/monitoring.routes.ts
+++ b/service.backend/src/routes/monitoring.routes.ts
@@ -577,12 +577,8 @@ if (process.env.NODE_ENV === 'development') {
    *         $ref: '#/components/responses/NotFoundError'
    */
   router.get('/api/health', async (req, res) => {
-    try {
-      const health = await HealthCheckService.getFullHealthCheck();
-      res.json(health);
-    } catch (error) {
-      res.status(500).json({ error: 'Failed to get health status' });
-    }
+    const health = await HealthCheckService.getFullHealthCheck();
+    res.json(health);
   });
 
   // Individual service health endpoints for frontend
@@ -695,12 +691,8 @@ if (process.env.NODE_ENV === 'development') {
    *         $ref: '#/components/responses/NotFoundError'
    */
   router.get('/api/health/database', async (req, res) => {
-    try {
-      const dbHealth = await HealthCheckService.checkDatabaseHealth();
-      res.json(dbHealth);
-    } catch (error) {
-      res.status(500).json({ error: 'Failed to check database health' });
-    }
+    const dbHealth = await HealthCheckService.checkDatabaseHealth();
+    res.json(dbHealth);
   });
 
   /**
@@ -811,12 +803,8 @@ if (process.env.NODE_ENV === 'development') {
    *         $ref: '#/components/responses/NotFoundError'
    */
   router.get('/api/health/email', async (req, res) => {
-    try {
-      const emailHealth = await HealthCheckService.checkEmailHealth();
-      res.json(emailHealth);
-    } catch (error) {
-      res.status(500).json({ error: 'Failed to check email health' });
-    }
+    const emailHealth = await HealthCheckService.checkEmailHealth();
+    res.json(emailHealth);
   });
 
   /**
@@ -927,12 +915,8 @@ if (process.env.NODE_ENV === 'development') {
    *         $ref: '#/components/responses/NotFoundError'
    */
   router.get('/api/health/storage', async (req, res) => {
-    try {
-      const storageHealth = await HealthCheckService.checkStorageHealth();
-      res.json(storageHealth);
-    } catch (error) {
-      res.status(500).json({ error: 'Failed to check storage health' });
-    }
+    const storageHealth = await HealthCheckService.checkStorageHealth();
+    res.json(storageHealth);
   });
 
   /**
@@ -1043,18 +1027,14 @@ if (process.env.NODE_ENV === 'development') {
    *         $ref: '#/components/responses/NotFoundError'
    */
   router.get('/api/health/system', async (req, res) => {
-    try {
-      const health = await HealthCheckService.getFullHealthCheck();
-      res.json({
-        uptime: health.uptime,
-        metrics: health.metrics,
-        timestamp: health.timestamp,
-        version: health.version,
-        environment: health.environment,
-      });
-    } catch (error) {
-      res.status(500).json({ error: 'Failed to get system metrics' });
-    }
+    const health = await HealthCheckService.getFullHealthCheck();
+    res.json({
+      uptime: health.uptime,
+      metrics: health.metrics,
+      timestamp: health.timestamp,
+      version: health.version,
+      environment: health.environment,
+    });
   });
 
   // Email provider info (development only)
@@ -1167,26 +1147,22 @@ if (process.env.NODE_ENV === 'development') {
    *         $ref: '#/components/responses/NotFoundError'
    */
   router.get('/api/email/provider-info', async (req, res) => {
-    try {
-      const EmailService = (await import('../services/email.service')).default;
-      const providerInfo = EmailService.getProviderInfo();
+    const EmailService = (await import('../services/email.service')).default;
+    const providerInfo = EmailService.getProviderInfo();
 
-      if (!providerInfo) {
-        return res.json({
-          provider: 'none',
-          message: 'No email provider info available',
-        });
-      }
-
-      res.json({
-        provider: 'ethereal',
-        ...providerInfo,
-        loginUrl: 'https://ethereal.email/login',
-        messagesUrl: 'https://ethereal.email/messages',
+    if (!providerInfo) {
+      return res.json({
+        provider: 'none',
+        message: 'No email provider info available',
       });
-    } catch (error) {
-      res.status(500).json({ error: 'Failed to get email provider info' });
     }
+
+    res.json({
+      provider: 'ethereal',
+      ...providerInfo,
+      loginUrl: 'https://ethereal.email/login',
+      messagesUrl: 'https://ethereal.email/messages',
+    });
   });
 
   // Dev seeded users endpoint — dynamic, queries the live DB so any
@@ -1196,84 +1172,76 @@ if (process.env.NODE_ENV === 'development') {
     // Production gate is enforced by `monitoringGuard` at the router level;
     // we keep an admin-auth requirement (router.use(requireAdmin)) since the
     // response includes user PII even outside production.
-    try {
-      const User = (await import('../models/User')).default;
+    const User = (await import('../models/User')).default;
 
-      const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
-      const userTypeRaw = typeof req.query.userType === 'string' ? req.query.userType : '';
-      const userTypes = userTypeRaw
-        .split(',')
-        .map(s => s.trim())
-        .filter(Boolean);
-      const limitRaw =
-        typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 100;
-      const limit = Number.isFinite(limitRaw) ? Math.min(500, Math.max(1, limitRaw)) : 100;
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    const userTypeRaw = typeof req.query.userType === 'string' ? req.query.userType : '';
+    const userTypes = userTypeRaw
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+    const limitRaw =
+      typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 100;
+    const limit = Number.isFinite(limitRaw) ? Math.min(500, Math.max(1, limitRaw)) : 100;
 
-      const where: Record<string | symbol, unknown> = {};
-      if (userTypes.length > 0) {
-        where.userType = { [Op.in]: userTypes };
-      }
-      if (q) {
-        const like = `%${q}%`;
-        where[Op.or] = [
-          { firstName: { [Op.iLike]: like } },
-          { lastName: { [Op.iLike]: like } },
-          // email is citext, so iLike here is redundant but harmless and
-          // matches the firstName/lastName pattern.
-          { email: { [Op.iLike]: like } },
-        ];
-      }
-
-      const seededUsers = await User.findAll({
-        where,
-        attributes: [
-          'userId',
-          'firstName',
-          'lastName',
-          'email',
-          'userType',
-          'status',
-          'emailVerified',
-          'country',
-          'city',
-          'addressLine1',
-          'postalCode',
-          'timezone',
-          'language',
-          'bio',
-          'dateOfBirth',
-          'phoneNumber',
-          'termsAcceptedAt',
-          'privacyPolicyAcceptedAt',
-          'createdAt',
-          'updatedAt',
-        ],
-        order: [['createdAt', 'DESC']],
-        limit,
-      });
-
-      const transformedUsers = seededUsers.map(user => ({
-        ...user.toJSON(),
-        description: getDevUserDescription(user.userType, user.email),
-      }));
-
-      // ADS-398: never return a shared dev password in the response. The
-      // dev password is documented in the seeder README; emitting it here
-      // turned a misconfigured NODE_ENV into a one-shot credential leak.
-      res.json({
-        users: transformedUsers,
-        source: 'database',
-        limit,
-        returned: transformedUsers.length,
-        timestamp: new Date(),
-      });
-    } catch (error) {
-      logger.error('Failed to fetch seeded users:', { error });
-      res.status(500).json({
-        error: 'Failed to fetch seeded users',
-        fallback: 'Use local data',
-      });
+    const where: Record<string | symbol, unknown> = {};
+    if (userTypes.length > 0) {
+      where.userType = { [Op.in]: userTypes };
     }
+    if (q) {
+      const like = `%${q}%`;
+      where[Op.or] = [
+        { firstName: { [Op.iLike]: like } },
+        { lastName: { [Op.iLike]: like } },
+        // email is citext, so iLike here is redundant but harmless and
+        // matches the firstName/lastName pattern.
+        { email: { [Op.iLike]: like } },
+      ];
+    }
+
+    const seededUsers = await User.findAll({
+      where,
+      attributes: [
+        'userId',
+        'firstName',
+        'lastName',
+        'email',
+        'userType',
+        'status',
+        'emailVerified',
+        'country',
+        'city',
+        'addressLine1',
+        'postalCode',
+        'timezone',
+        'language',
+        'bio',
+        'dateOfBirth',
+        'phoneNumber',
+        'termsAcceptedAt',
+        'privacyPolicyAcceptedAt',
+        'createdAt',
+        'updatedAt',
+      ],
+      order: [['createdAt', 'DESC']],
+      limit,
+    });
+
+    const transformedUsers = seededUsers.map(user => ({
+      ...user.toJSON(),
+      description: getDevUserDescription(user.userType, user.email),
+    }));
+
+    // ADS-398: never return a shared dev password in the response. The
+    // dev password is documented in the seeder README; emitting it here
+    // turned a misconfigured NODE_ENV into a one-shot credential leak.
+    res.json({
+      users: transformedUsers,
+      source: 'database',
+      limit,
+      returned: transformedUsers.length,
+      timestamp: new Date(),
+    });
   });
 
   // Rate limit testing endpoint (development only)

--- a/service.backend/src/routes/privacy.routes.ts
+++ b/service.backend/src/routes/privacy.routes.ts
@@ -13,7 +13,6 @@ import {
 import { exportUserData } from '../services/data-export.service';
 import { requestAccountDeletion } from '../services/data-deletion.service';
 import type { AuthenticatedRequest } from '../types/auth';
-import { logger } from '../utils/logger';
 
 /**
  * ADS-427 / ADS-496 / ADS-497: user-facing privacy endpoints.
@@ -47,22 +46,12 @@ router.post(
       return;
     }
 
-    try {
-      const record = await recordConsent(req.body as ConsentInput, {
-        userId,
-        ip: req.ip ?? null,
-        userAgent: req.get('User-Agent') ?? null,
-      });
-      res.status(201).json({ data: record });
-    } catch (error) {
-      logger.error('Consent capture failed', {
-        userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      res.status(400).json({
-        error: error instanceof Error ? error.message : 'Failed to record consent',
-      });
-    }
+    const record = await recordConsent(req.body as ConsentInput, {
+      userId,
+      ip: req.ip ?? null,
+      userAgent: req.get('User-Agent') ?? null,
+    });
+    res.status(201).json({ data: record });
   }
 );
 
@@ -82,22 +71,12 @@ router.post(
       return;
     }
 
-    try {
-      const record = await recordCookiesConsent(req.body as CookiesConsentInput, {
-        userId,
-        ip: req.ip ?? null,
-        userAgent: req.get('User-Agent') ?? null,
-      });
-      res.status(201).json({ data: record });
-    } catch (error) {
-      logger.error('Cookies consent capture failed', {
-        userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      res.status(400).json({
-        error: error instanceof Error ? error.message : 'Failed to record cookies consent',
-      });
-    }
+    const record = await recordCookiesConsent(req.body as CookiesConsentInput, {
+      userId,
+      ip: req.ip ?? null,
+      userAgent: req.get('User-Agent') ?? null,
+    });
+    res.status(201).json({ data: record });
   }
 );
 
@@ -108,20 +87,12 @@ router.get('/me/export', async (req: AuthenticatedRequest, res: Response) => {
     return;
   }
 
-  try {
-    const bundle = await exportUserData(userId);
-    res.setHeader(
-      'Content-Disposition',
-      `attachment; filename="adopt-dont-shop-export-${userId}.json"`
-    );
-    res.json(bundle);
-  } catch (error) {
-    logger.error('Data export failed', {
-      userId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    res.status(500).json({ error: 'Failed to export user data' });
-  }
+  const bundle = await exportUserData(userId);
+  res.setHeader(
+    'Content-Disposition',
+    `attachment; filename="adopt-dont-shop-export-${userId}.json"`
+  );
+  res.json(bundle);
 });
 
 const DeleteAccountSchema = z.object({
@@ -138,27 +109,19 @@ router.post(
       return;
     }
 
-    try {
-      const body = req.body as z.infer<typeof DeleteAccountSchema>;
-      const result = await requestAccountDeletion(userId, body.reason);
-      // Clear auth cookies so the now-deactivated session can't keep
-      // making requests until access-token expiry.
-      res.clearCookie('refreshToken');
-      res.clearCookie('accessToken');
-      res.status(202).json({
-        data: {
-          ...result,
-          message:
-            'Account scheduled for deletion. Your data will be permanently anonymised after a 30-day grace window.',
-        },
-      });
-    } catch (error) {
-      logger.error('Account deletion request failed', {
-        userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      res.status(500).json({ error: 'Failed to process deletion request' });
-    }
+    const body = req.body as z.infer<typeof DeleteAccountSchema>;
+    const result = await requestAccountDeletion(userId, body.reason);
+    // Clear auth cookies so the now-deactivated session can't keep
+    // making requests until access-token expiry.
+    res.clearCookie('refreshToken');
+    res.clearCookie('accessToken');
+    res.status(202).json({
+      data: {
+        ...result,
+        message:
+          'Account scheduled for deletion. Your data will be permanently anonymised after a 30-day grace window.',
+      },
+    });
   }
 );
 

--- a/service.backend/src/routes/staff.routes.ts
+++ b/service.backend/src/routes/staff.routes.ts
@@ -4,42 +4,32 @@ import { requirePermission } from '../middleware/rbac';
 import StaffMember from '../models/StaffMember';
 import User, { UserType } from '../models/User';
 import { AuthenticatedRequest } from '../types/auth';
-import { logger } from '../utils/logger';
 
 const router = express.Router();
 /** * @swagger * /api/v1/staff/me: *   get: *     tags: [Staff] *     summary: Get current user's staff information *     description: Get the current authenticated user's staff member record and rescue information *     security: *       - bearerAuth: [] *     responses: *       200: *         description: Staff information retrieved successfully *       401: *         description: Authentication required *       404: *         description: User is not associated with any rescue */ router.get(
   '/me',
   authenticateToken,
   async (req: AuthenticatedRequest, res) => {
-    try {
-      const userId = req.user!.userId;
-      const staffMember = await StaffMember.findOne({
-        where: { userId: userId },
-      });
-      if (!staffMember) {
-        return res
-          .status(404)
-          .json({ success: false, message: 'You are not associated with any rescue organization' });
-      }
-      res.status(200).json({
-        success: true,
-        data: {
-          staffMemberId: staffMember.staffMemberId,
-          userId: staffMember.userId,
-          rescueId: staffMember.rescueId,
-          title: staffMember.title,
-          isVerified: staffMember.isVerified,
-          addedAt: staffMember.addedAt,
-        },
-      });
-    } catch (error) {
-      logger.error('Get staff me failed:', error);
-      res.status(500).json({
-        success: false,
-        message: 'Failed to retrieve staff information',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+    const userId = req.user!.userId;
+    const staffMember = await StaffMember.findOne({
+      where: { userId: userId },
+    });
+    if (!staffMember) {
+      return res
+        .status(404)
+        .json({ success: false, message: 'You are not associated with any rescue organization' });
     }
+    res.status(200).json({
+      success: true,
+      data: {
+        staffMemberId: staffMember.staffMemberId,
+        userId: staffMember.userId,
+        rescueId: staffMember.rescueId,
+        title: staffMember.title,
+        isVerified: staffMember.isVerified,
+        addedAt: staffMember.addedAt,
+      },
+    });
   }
 );
 
@@ -99,67 +89,58 @@ router.get(
   authenticateToken,
   requirePermission('staff.read'),
   async (req: AuthenticatedRequest, res) => {
-    try {
-      const userId = req.user!.userId;
+    const userId = req.user!.userId;
 
-      // First find the current user's staff member record to get their rescue ID
-      const currentUserStaff = await StaffMember.findOne({
-        where: {
-          userId: userId,
-          isVerified: true,
-        },
-      });
+    // First find the current user's staff member record to get their rescue ID
+    const currentUserStaff = await StaffMember.findOne({
+      where: {
+        userId: userId,
+        isVerified: true,
+      },
+    });
 
-      if (!currentUserStaff) {
-        return res.status(404).json({
-          success: false,
-          message: 'You are not associated with any rescue organization',
-        });
-      }
-
-      // Get all staff members from the same rescue
-      const colleagues = await StaffMember.findAll({
-        where: {
-          rescueId: currentUserStaff.rescueId,
-        },
-        include: [
-          {
-            model: User,
-            as: 'user',
-            attributes: ['firstName', 'lastName', 'email'],
-          },
-        ],
-        order: [['addedAt', 'DESC']],
-      });
-
-      const transformedColleagues = colleagues.map(staff => ({
-        id: staff.staffMemberId,
-        userId: staff.userId,
-        rescueId: staff.rescueId,
-        title: staff.title,
-        isVerified: staff.isVerified,
-        addedAt: staff.addedAt,
-        user: staff.user
-          ? {
-              firstName: staff.user.firstName,
-              lastName: staff.user.lastName,
-              email: staff.user.email,
-            }
-          : null,
-      }));
-
-      res.status(200).json({
-        success: true,
-        data: transformedColleagues,
-      });
-    } catch (error) {
-      logger.error('Get staff colleagues failed:', error);
-      res.status(500).json({
+    if (!currentUserStaff) {
+      return res.status(404).json({
         success: false,
-        message: 'Failed to retrieve staff colleagues',
-        error: error instanceof Error ? error.message : 'Unknown error',
+        message: 'You are not associated with any rescue organization',
       });
     }
+
+    // Get all staff members from the same rescue
+    const colleagues = await StaffMember.findAll({
+      where: {
+        rescueId: currentUserStaff.rescueId,
+      },
+      include: [
+        {
+          model: User,
+          as: 'user',
+          attributes: ['firstName', 'lastName', 'email'],
+        },
+      ],
+      order: [['addedAt', 'DESC']],
+    });
+
+    const transformedColleagues = colleagues.map(staff => ({
+      id: staff.staffMemberId,
+      userId: staff.userId,
+      rescueId: staff.rescueId,
+      title: staff.title,
+      isVerified: staff.isVerified,
+      addedAt: staff.addedAt,
+      user: staff.user
+        ? {
+            firstName: staff.user.firstName,
+            lastName: staff.user.lastName,
+            email: staff.user.email,
+          }
+        : null,
+    }));
+
+    res.status(200).json({
+      success: true,
+      data: transformedColleagues,
+    });
   }
 );
 


### PR DESCRIPTION
## Summary

Express 5 introduced built-in async-catch — an unhandled rejection in an async route handler propagates to error-handling middleware automatically. Express 4 required `next(err)` or an explicit catch wrapper, so the codebase has ~140 `try { ... } catch { logger.error; res.status(500).json({error}) }` wrappers that paper every controller and route. With Express 5 they duplicate the central `errorHandler` middleware.

This PR strips those pass-through catches across **22 controllers + 7 routes** and routes uncaught errors through the central handler instead.

**User-visible response shape on 500 changes:**
- Before: `{ error: 'Failed to X', message: '...' }`
- After: `{ status: 'error', message: '...', code: 500 }`

The new shape is already the project's canonical error shape (emitted by validation / permission / db middleware). The shape change was an explicit acceptance criterion for this refactor.

### What was kept (NOT stripped)

- **Specific error → non-500 translation** (~70 sites): e.g. `Session not found` → 404, `already exists` → 409, `Invalid CIDR` → 400.
- **`auth.controller.refreshToken`**: collapses every failure to 401 so the client cannot distinguish bad / expired / revoked token from internal error (token-state oracle avoidance). Restored with an explanatory comment after the initial strip removed it.
- **`invitation.routes` GET `/details/:token`**: `req.originalUrl` contains the raw invitation token. Propagating to the central handler (which logs `req.originalUrl`) would leak the token into structured logs. Restored with a security comment.
- **Service-layer catches and middleware catches** — out of scope.

### Test changes

- `applicationTimeline.routes.test.ts`, `moderation.metrics.routes.test.ts`, `invitation.routes.test.ts`: mount the central `errorHandler` in `buildApp` so the "service throws → 500" tests exercise the same middleware chain as production. Assertions updated to the new central-handler response shape (`status: 'error'`).
- `auth.routes.test.ts`: the initial strip changed this test to expect 500; reverted to expect 401 once the auth catch was restored.

### Diff stats

- 32 files changed
- 3,233 insertions, 4,791 deletions
- Net: **−1,558 lines**

## Test plan

- [x] `tsc --noEmit` clean
- [x] Backend test suite: **2204 passed / 262 skipped / 0 failed**
- [ ] E2E tests pass in CI
- [ ] Spot-check error responses in dev to confirm the new shape doesn't break frontend error rendering

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_