### PR TITLE
fix(ADS-575): wire ApplicationList filters end-to-end [WIP - org limit]

### DIFF
--- a/app.rescue/src/components/applications/ApplicationList.tsx
+++ b/app.rescue/src/components/applications/ApplicationList.tsx
@@ -190,9 +190,10 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
   // Convert simple string-based filters back to complex ApplicationFilter.
   // ADS-575: search, status, priority, petType, petBreed, dateRange are
   // all honoured server-side. referencesStatus / homeVisitStatus are
-  // currently accepted but not applied (the rescue list derives those
-  // values from application.status; real filtering requires a join on
-  // application_references / home_visits and is tracked separately).
+  // still synthetic — the list derives them from application.status (see
+  // RescueApplicationService.calculateReferencesStatus /
+  // calculateHomeVisitStatus), so filtering on them server-side would
+  // require persisting the real reference-check / home-visit records.
   const handleFilterChange = (key: string, value: string) => {
     const newFilter = { ...filter };
 

--- a/app.rescue/src/components/applications/ApplicationList.tsx
+++ b/app.rescue/src/components/applications/ApplicationList.tsx
@@ -187,8 +187,12 @@ const ApplicationList: React.FC<ApplicationListProps> = ({
     petBreed: filter.petBreed || '',
   };
 
-  // Convert simple string-based filters back to complex ApplicationFilter
-  // Only search and status filters actually work for filtering data
+  // Convert simple string-based filters back to complex ApplicationFilter.
+  // ADS-575: search, status, priority, petType, petBreed, dateRange are
+  // all honoured server-side. referencesStatus / homeVisitStatus are
+  // currently accepted but not applied (the rescue list derives those
+  // values from application.status; real filtering requires a join on
+  // application_references / home_visits and is tracked separately).
   const handleFilterChange = (key: string, value: string) => {
     const newFilter = { ...filter };
 

--- a/app.rescue/src/services/applicationService.test.ts
+++ b/app.rescue/src/services/applicationService.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ApplicationFilter } from '../types/applications';
+
+const apiServiceMock = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock('./libraryServices', () => ({
+  apiService: apiServiceMock,
+}));
+
+import { RescueApplicationService } from './applicationService';
+
+/**
+ * ADS-575: behaviour tests that pin down which filter fields the
+ * rescue application service forwards to the backend `/applications`
+ * endpoint. Each filter that the UI exposes must surface as a query
+ * parameter or the dropdowns silently lie to staff.
+ */
+describe('RescueApplicationService.getApplications query parameters (ADS-575)', () => {
+  const service = new RescueApplicationService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiServiceMock.get.mockResolvedValue({ applications: [], total: 0 });
+  });
+
+  const getRequestedUrl = (): string => {
+    expect(apiServiceMock.get).toHaveBeenCalledTimes(1);
+    const [url] = apiServiceMock.get.mock.calls[0];
+    return url as string;
+  };
+
+  const getRequestedParams = (): URLSearchParams => {
+    const url = getRequestedUrl();
+    const queryStart = url.indexOf('?');
+    return new URLSearchParams(url.slice(queryStart + 1));
+  };
+
+  it('forwards a pet-type filter as a petType query parameter', async () => {
+    const filter: ApplicationFilter = { petType: 'Dog' };
+
+    await service.getApplications(filter);
+
+    expect(getRequestedParams().get('petType')).toBe('Dog');
+  });
+
+  it('forwards a pet-breed filter as a petBreed query parameter', async () => {
+    const filter: ApplicationFilter = { petBreed: 'golden retriever' };
+
+    await service.getApplications(filter);
+
+    expect(getRequestedParams().get('petBreed')).toBe('golden retriever');
+  });
+
+  it('forwards a date range as submittedFrom / submittedTo ISO timestamps', async () => {
+    const start = new Date('2026-05-01T00:00:00.000Z');
+    const end = new Date('2026-05-08T00:00:00.000Z');
+    const filter: ApplicationFilter = { dateRange: { start, end } };
+
+    await service.getApplications(filter);
+
+    const params = getRequestedParams();
+    expect(params.get('submittedFrom')).toBe(start.toISOString());
+    expect(params.get('submittedTo')).toBe(end.toISOString());
+    // The legacy startDate / endDate names were never read server-side.
+    expect(params.get('startDate')).toBeNull();
+    expect(params.get('endDate')).toBeNull();
+  });
+
+  it('still forwards the search and status filters that already worked', async () => {
+    const filter: ApplicationFilter = {
+      searchQuery: 'jane',
+      status: ['submitted'],
+    };
+
+    await service.getApplications(filter);
+
+    const params = getRequestedParams();
+    expect(params.get('search')).toBe('jane');
+    expect(params.get('status')).toBe('submitted');
+  });
+
+  it('omits filter parameters when the filter value is empty', async () => {
+    await service.getApplications({});
+
+    const params = getRequestedParams();
+    expect(params.get('petType')).toBeNull();
+    expect(params.get('petBreed')).toBeNull();
+    expect(params.get('submittedFrom')).toBeNull();
+    expect(params.get('submittedTo')).toBeNull();
+  });
+});

--- a/app.rescue/src/services/applicationService.test.ts
+++ b/app.rescue/src/services/applicationService.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ApplicationFilter } from '../types/applications';
 
 const apiServiceMock = vi.hoisted(() => ({
-  get: vi.fn(),
+  get: vi.fn<(url: string) => Promise<unknown>>(),
 }));
 
 vi.mock('./libraryServices', () => ({
@@ -28,7 +28,7 @@ describe('RescueApplicationService.getApplications query parameters (ADS-575)', 
   const getRequestedUrl = (): string => {
     expect(apiServiceMock.get).toHaveBeenCalledTimes(1);
     const [url] = apiServiceMock.get.mock.calls[0];
-    return url as string;
+    return url;
   };
 
   const getRequestedParams = (): URLSearchParams => {

--- a/app.rescue/src/services/applicationService.ts
+++ b/app.rescue/src/services/applicationService.ts
@@ -46,8 +46,16 @@ export class RescueApplicationService {
       if (filter?.petId) {
         params.append('pet_id', filter.petId);
       }
-      // Note: pet_type, pet_breed, references_status, home_visit_status are not validated by backend
-      // These will need to be filtered client-side or backend validation needs to be updated
+      // ADS-575: petType / petBreed are now backend-supported filters
+      // (case-insensitive match against the eager-loaded Pet record).
+      // referencesStatus / homeVisitStatus remain client-side stubs —
+      // see ApplicationFilter and applyClientSideFilters below.
+      if (filter?.petType) {
+        params.append('petType', filter.petType);
+      }
+      if (filter?.petBreed) {
+        params.append('petBreed', filter.petBreed);
+      }
       if (filter?.priority?.length) {
         params.append('priority', filter.priority.join(','));
       }
@@ -55,8 +63,10 @@ export class RescueApplicationService {
         params.append('search', filter.searchQuery);
       }
       if (filter?.dateRange) {
-        params.append('startDate', filter.dateRange.start.toISOString());
-        params.append('endDate', filter.dateRange.end.toISOString());
+        // ADS-575: backend search service filters by submittedAt window.
+        // The legacy startDate/endDate params were never read server-side.
+        params.append('submittedFrom', filter.dateRange.start.toISOString());
+        params.append('submittedTo', filter.dateRange.end.toISOString());
       }
       if (sort) {
         // Backend validates sortBy as camelCase (see application.controller.ts
@@ -86,10 +96,7 @@ export class RescueApplicationService {
       }
 
       return {
-        applications: this.applyClientSideFilters(
-          applicationsArray.map(this.transformApplicationForList) || [],
-          filter || {}
-        ),
+        applications: applicationsArray.map(this.transformApplicationForList) || [],
         total: response.total || response.count || applicationsArray.length,
         page: response.page || response.currentPage || 1,
         totalPages:
@@ -659,42 +666,6 @@ export class RescueApplicationService {
       console.error('Failed to perform bulk action:', error);
       throw new Error('Failed to perform bulk action on server');
     }
-  }
-
-  /**
-   * Apply client-side filtering for parameters not supported by backend
-   */
-  private applyClientSideFilters(
-    applications: ApplicationListItem[],
-    filter: ApplicationFilter
-  ): ApplicationListItem[] {
-    return applications.filter(app => {
-      // Filter by pet type (not validated by backend, need to be filtered client-side)
-      if (filter.petType && filter.petType !== 'all' && app.petType !== filter.petType) {
-        return false;
-      }
-
-      // Filter by pet breed (not validated by backend, need to be filtered client-side)
-      if (filter.petBreed && filter.petBreed !== 'all' && app.petBreed !== filter.petBreed) {
-        return false;
-      }
-
-      // Filter by references status (not validated by backend, need to be filtered client-side)
-      if (filter.referencesStatus && filter.referencesStatus !== 'all') {
-        // Note: This would need reference data to properly filter,
-        // for now we'll allow all applications through
-        // In a complete implementation, we'd need to fetch reference data or include it in the application response
-      }
-
-      // Filter by home visit status (not validated by backend, need to be filtered client-side)
-      if (filter.homeVisitStatus && filter.homeVisitStatus !== 'all') {
-        // Note: This would need visit data to properly filter,
-        // for now we'll allow all applications through
-        // In a complete implementation, we'd need to fetch visit data or include it in the application response
-      }
-
-      return true;
-    });
   }
 
   /**

--- a/app.rescue/src/services/applicationService.ts
+++ b/app.rescue/src/services/applicationService.ts
@@ -48,8 +48,9 @@ export class RescueApplicationService {
       }
       // ADS-575: petType / petBreed are now backend-supported filters
       // (case-insensitive match against the eager-loaded Pet record).
-      // referencesStatus / homeVisitStatus remain client-side stubs —
-      // see ApplicationFilter and applyClientSideFilters below.
+      // referencesStatus / homeVisitStatus are still unwired — the
+      // ApplicationList comment block documents why and tracks the
+      // follow-up.
       if (filter?.petType) {
         params.append('petType', filter.petType);
       }

--- a/lib.validation/src/schemas/__tests__/application.test.ts
+++ b/lib.validation/src/schemas/__tests__/application.test.ts
@@ -210,6 +210,32 @@ describe('Application schemas', () => {
       expect(() => ApplicationSearchQuerySchema.parse({ score_min: -1 })).toThrow();
       expect(() => ApplicationSearchQuerySchema.parse({ score_max: 101 })).toThrow();
     });
+
+    // ADS-575: the rescue dashboard filters (pet type, pet breed, date
+    // window) must round-trip through the canonical query schema or the
+    // backend rejects them as unknown.
+    it('accepts the new pet-type / pet-breed filters', () => {
+      const parsed = ApplicationSearchQuerySchema.parse({
+        petType: 'Dog',
+        petBreed: 'Golden Retriever',
+      });
+      expect(parsed.petType).toBe('Dog');
+      expect(parsed.petBreed).toBe('Golden Retriever');
+    });
+
+    it('coerces submittedFrom / submittedTo strings to Date', () => {
+      const parsed = ApplicationSearchQuerySchema.parse({
+        submittedFrom: '2026-05-01T00:00:00.000Z',
+        submittedTo: '2026-05-08T00:00:00.000Z',
+      });
+      expect(parsed.submittedFrom).toBeInstanceOf(Date);
+      expect(parsed.submittedTo).toBeInstanceOf(Date);
+    });
+
+    it('rejects an empty petType / petBreed string', () => {
+      expect(() => ApplicationSearchQuerySchema.parse({ petType: '' })).toThrow();
+      expect(() => ApplicationSearchQuerySchema.parse({ petBreed: '   ' })).toThrow();
+    });
   });
 
   describe('ApplicationBulkUpdateRequestSchema', () => {

--- a/lib.validation/src/schemas/application.ts
+++ b/lib.validation/src/schemas/application.ts
@@ -246,6 +246,16 @@ export const ApplicationSearchQuerySchema = z.object({
   sortOrder: z.enum(['ASC', 'DESC']).optional(),
   score_min: ScoreSchema.optional(),
   score_max: ScoreSchema.optional(),
+  // ADS-575: narrow results by the associated pet's type / breed. Both
+  // are matched case-insensitively in the backend so callers can pass
+  // either "Dog" or "dog" without a coordinated normalisation pass.
+  petType: z.string().trim().min(1).max(50).optional(),
+  petBreed: z.string().trim().min(1).max(100).optional(),
+  // ADS-575: submitted-date window. The backend search service already
+  // honours submittedFrom/submittedTo; surfacing them here lets the
+  // rescue dashboard "Date Range" preset reach the API.
+  submittedFrom: z.coerce.date().optional(),
+  submittedTo: z.coerce.date().optional(),
 });
 export type ApplicationSearchQuery = z.infer<typeof ApplicationSearchQuerySchema>;
 

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -877,30 +877,42 @@ describe('ApplicationService - Business Logic', () => {
     it('narrows the search by pet type using a case-insensitive match', async () => {
       await ApplicationService.searchApplications({ petType: 'Dog' }, { page: 1, limit: 10 });
 
-      const callArgs = MockedApplication.findAndCountAll.mock.calls[0][0];
-      const whereWithPetType = callArgs.where as Record<string, { [key: symbol]: string }>;
       // The Pet.type filter is keyed by Sequelize's $association$ syntax
       // so it reaches the eager-loaded Pet record rather than the
-      // Application table directly.
-      expect(whereWithPetType['$Pet.type$']).toBeDefined();
+      // Application table directly. Comparing against the canonical
+      // `[Op.iLike]: 'Dog'` shape would tie the test to the Sequelize
+      // symbol implementation, so we just assert the path is present.
+      expect(MockedApplication.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ '$Pet.type$': expect.anything() }),
+        })
+      );
     });
 
     it('narrows the search by pet breed using a case-insensitive substring match', async () => {
       await ApplicationService.searchApplications({ petBreed: 'golden' }, { page: 1, limit: 10 });
 
-      const callArgs = MockedApplication.findAndCountAll.mock.calls[0][0];
-      const whereWithBreed = callArgs.where as Record<string, { [key: symbol]: string }>;
       // Breed lives on the lookup table eager-loaded via Pet->Breed.
-      expect(whereWithBreed['$Pet->Breed.name$']).toBeDefined();
+      expect(MockedApplication.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ '$Pet->Breed.name$': expect.anything() }),
+        })
+      );
     });
 
     it('omits pet filters from the query when no value is provided', async () => {
       await ApplicationService.searchApplications({}, { page: 1, limit: 10 });
 
-      const callArgs = MockedApplication.findAndCountAll.mock.calls[0][0];
-      const where = callArgs.where as Record<string, unknown>;
-      expect(where['$Pet.type$']).toBeUndefined();
-      expect(where['$Pet->Breed.name$']).toBeUndefined();
+      expect(MockedApplication.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.not.objectContaining({ '$Pet.type$': expect.anything() }),
+        })
+      );
+      expect(MockedApplication.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.not.objectContaining({ '$Pet->Breed.name$': expect.anything() }),
+        })
+      );
     });
   });
 

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -853,6 +853,57 @@ describe('ApplicationService - Business Logic', () => {
     });
   });
 
+  describe('Business Rule: Pet-shape filters (ADS-575)', () => {
+    // ADS-575: rescue staff need to narrow the application list by the
+    // applied-for pet's type / breed. Both must reach the SQL query so
+    // the rendered list actually changes — previously these filters
+    // round-tripped through state without affecting the database read.
+    const mockApplicationRow = () => {
+      const app = createMockApplication();
+      return {
+        ...app,
+        toJSON: vi.fn().mockReturnValue(app),
+        Answers: [],
+      };
+    };
+
+    beforeEach(() => {
+      MockedApplication.findAndCountAll = vi.fn().mockResolvedValue({
+        rows: [mockApplicationRow()],
+        count: 1,
+      });
+    });
+
+    it('narrows the search by pet type using a case-insensitive match', async () => {
+      await ApplicationService.searchApplications({ petType: 'Dog' }, { page: 1, limit: 10 });
+
+      const callArgs = MockedApplication.findAndCountAll.mock.calls[0][0];
+      const whereWithPetType = callArgs.where as Record<string, { [key: symbol]: string }>;
+      // The Pet.type filter is keyed by Sequelize's $association$ syntax
+      // so it reaches the eager-loaded Pet record rather than the
+      // Application table directly.
+      expect(whereWithPetType['$Pet.type$']).toBeDefined();
+    });
+
+    it('narrows the search by pet breed using a case-insensitive substring match', async () => {
+      await ApplicationService.searchApplications({ petBreed: 'golden' }, { page: 1, limit: 10 });
+
+      const callArgs = MockedApplication.findAndCountAll.mock.calls[0][0];
+      const whereWithBreed = callArgs.where as Record<string, { [key: symbol]: string }>;
+      // Breed lives on the lookup table eager-loaded via Pet->Breed.
+      expect(whereWithBreed['$Pet->Breed.name$']).toBeDefined();
+    });
+
+    it('omits pet filters from the query when no value is provided', async () => {
+      await ApplicationService.searchApplications({}, { page: 1, limit: 10 });
+
+      const callArgs = MockedApplication.findAndCountAll.mock.calls[0][0];
+      const where = callArgs.where as Record<string, unknown>;
+      expect(where['$Pet.type$']).toBeUndefined();
+      expect(where['$Pet->Breed.name$']).toBeUndefined();
+    });
+  });
+
   describe('Error Handling', () => {
     it('throws error when application not found', async () => {
       // Given: Application does not exist

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -222,59 +222,72 @@ export class ApplicationController extends BaseController {
 
   // Get applications with filtering and pagination
   getApplications = async (req: AuthenticatedRequest, res: Response) => {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return this.sendValidationError(res, errors.array());
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return this.sendValidationError(res, errors.array());
+      }
+
+      const filters: ApplicationSearchFilters = {
+        search: req.query.search as string,
+        userId: req.query.userId as string,
+        petId: req.query.petId as string,
+        rescueId: req.query.rescueId as string,
+        status: req.query.status as ApplicationStatus,
+        priority: req.query.priority as ApplicationPriority,
+        score_min: req.query.score_min ? parseFloat(req.query.score_min as string) : undefined,
+        score_max: req.query.score_max ? parseFloat(req.query.score_max as string) : undefined,
+        // ADS-575: pet-type / pet-breed filters from the rescue dashboard.
+        petType: req.query.petType as string,
+        petBreed: req.query.petBreed as string,
+        createdFrom: req.query.createdFrom ? new Date(req.query.createdFrom as string) : undefined,
+        createdTo: req.query.createdTo ? new Date(req.query.createdTo as string) : undefined,
+        submittedFrom: req.query.submittedFrom
+          ? new Date(req.query.submittedFrom as string)
+          : undefined,
+        submittedTo: req.query.submittedTo ? new Date(req.query.submittedTo as string) : undefined,
+      };
+
+      const options: ApplicationSearchOptions = {
+        page: parsePage(req.query.page as string | undefined),
+        limit: parsePaginationLimit(req.query.limit as string | undefined, {
+          default: DEFAULT_PAGE_SIZE,
+          max: MAX_PAGE_SIZE,
+        }),
+        sortBy: (req.query.sortBy as string) || 'createdAt',
+        sortOrder: (req.query.sortOrder as 'ASC' | 'DESC') || 'DESC',
+        include_user: true,
+        include_pet: true,
+        include_rescue: false,
+      };
+
+      const result = await ApplicationService.searchApplications(
+        filters,
+        options,
+        req.user!.userId,
+        req.user!.userType as UserType
+      );
+
+      // Transform the applications to frontend format
+      const transformedApplications = result.applications.map(app =>
+        this.transformApplicationModel(app)
+      );
+
+      return this.sendPaginatedSuccess(res, transformedApplications, {
+        total: result.total_filtered || 0,
+        page: result.pagination.page,
+        limit: result.pagination.limit,
+        totalPages: result.pagination.totalPages,
+      });
+    } catch (error) {
+      logger.error('Error getting applications:', error);
+      return this.sendError(
+        res,
+        'Failed to retrieve applications',
+        500,
+        error instanceof Error ? error.message : 'Unknown error'
+      );
     }
-
-    const filters: ApplicationSearchFilters = {
-      search: req.query.search as string,
-      userId: req.query.userId as string,
-      petId: req.query.petId as string,
-      rescueId: req.query.rescueId as string,
-      status: req.query.status as ApplicationStatus,
-      priority: req.query.priority as ApplicationPriority,
-      score_min: req.query.score_min ? parseFloat(req.query.score_min as string) : undefined,
-      score_max: req.query.score_max ? parseFloat(req.query.score_max as string) : undefined,
-      createdFrom: req.query.createdFrom ? new Date(req.query.createdFrom as string) : undefined,
-      createdTo: req.query.createdTo ? new Date(req.query.createdTo as string) : undefined,
-      submittedFrom: req.query.submittedFrom
-        ? new Date(req.query.submittedFrom as string)
-        : undefined,
-      submittedTo: req.query.submittedTo ? new Date(req.query.submittedTo as string) : undefined,
-    };
-
-    const options: ApplicationSearchOptions = {
-      page: parsePage(req.query.page as string | undefined),
-      limit: parsePaginationLimit(req.query.limit as string | undefined, {
-        default: DEFAULT_PAGE_SIZE,
-        max: MAX_PAGE_SIZE,
-      }),
-      sortBy: (req.query.sortBy as string) || 'createdAt',
-      sortOrder: (req.query.sortOrder as 'ASC' | 'DESC') || 'DESC',
-      include_user: true,
-      include_pet: true,
-      include_rescue: false,
-    };
-
-    const result = await ApplicationService.searchApplications(
-      filters,
-      options,
-      req.user!.userId,
-      req.user!.userType as UserType
-    );
-
-    // Transform the applications to frontend format
-    const transformedApplications = result.applications.map(app =>
-      this.transformApplicationModel(app)
-    );
-
-    return this.sendPaginatedSuccess(res, transformedApplications, {
-      total: result.total_filtered || 0,
-      page: result.pagination.page,
-      limit: result.pagination.limit,
-      totalPages: result.pagination.totalPages,
-    });
   };
 
   // Create new application

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -705,6 +705,21 @@ export class ApplicationService {
           : { [Op.is]: null };
       }
 
+      // ADS-575: pet-type / pet-breed filters. Both are matched
+      // case-insensitively against the eager-loaded Pet association so
+      // the rescue dashboard's "Dog" dropdown matches the lowercase
+      // enum value stored on Pet.type.
+      if (filters.petType) {
+        (whereConditions as Record<string, unknown>)['$Pet.type$'] = {
+          [Op.iLike]: filters.petType,
+        };
+      }
+      if (filters.petBreed) {
+        (whereConditions as Record<string, unknown>)['$Pet->Breed.name$'] = {
+          [Op.iLike]: `%${filters.petBreed}%`,
+        };
+      }
+
       // Text search
       if (filters.search) {
         const searchConditions = [

--- a/service.backend/src/types/application.ts
+++ b/service.backend/src/types/application.ts
@@ -183,6 +183,10 @@ export interface ApplicationSearchFilters {
   tags?: string[];
   hasInterviewNotes?: boolean;
   hasHomeVisitNotes?: boolean;
+  // ADS-575: narrow results by the associated pet's type / breed. Both
+  // are matched case-insensitively against the eager-loaded Pet record.
+  petType?: string;
+  petBreed?: string;
   submittedFrom?: Date;
   submittedTo?: Date;
   reviewedFrom?: Date;


### PR DESCRIPTION
Closes ADS-575

> [!WARNING]
> **Incomplete — agent halted at org's monthly Claude usage limit.** This PR captures the partial work so it isn't lost. A follow-up is needed to finish per the ticket and confirm everything compiles + tests pass.

## What the agent got to

The agent began wiring `ApplicationFilter` end-to-end so that `petType`, `referencesStatus`, `homeVisitStatus`, `dateRange`, and `petBreed` (currently no-op per the `ApplicationList.tsx:186-187` comment) actually narrow results.

Files modified:
- `app.rescue/src/components/applications/ApplicationList.tsx`
- `app.rescue/src/services/applicationService.ts`
- `lib.validation/src/schemas/application.ts`
- `service.backend/src/__tests__/services/application.service.test.ts`
- `package-lock.json`

## What's left

- Verify the lib.validation schema change matches the consumed type on both client and backend.
- Confirm the backend service honours the new filter fields (the test stub was added but the service implementation may not be complete).
- Run `npx turbo lint test type-check --filter=@adopt-dont-shop/app.rescue --filter=@adopt-dont-shop/service-backend --filter=@adopt-dont-shop/lib.validation`.
- Add the frontend behaviour test referenced in the ticket.

## Test plan

- [ ] Backend route test asserts each filter narrows results
- [ ] Frontend behaviour test asserts each filter call hits service with correct payload
- [ ] Apply each filter in browser and confirm the table narrows

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_