### PR TITLE
fix(ADS-577): make UK-only phone constraint explicit

### DIFF
--- a/app.client/src/components/application/steps/BasicInfoStep.test.tsx
+++ b/app.client/src/components/application/steps/BasicInfoStep.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Override the global lib.components mock from setup-tests with a realistic
+// Input that mirrors the real component's accessibility contract: a label
+// associated by htmlFor, helper text in a <p> with an id, and aria-describedby
+// pointing at that id when helperText is supplied. This is the behaviour the
+// real lib.components Input gives us, and what we want to assert here.
+vi.mock('@adopt-dont-shop/lib.components', () => {
+  type InputLikeProps = React.ComponentPropsWithoutRef<'input'> & {
+    label?: string;
+    helperText?: string;
+    error?: string;
+  };
+  const Input = React.forwardRef<HTMLInputElement, InputLikeProps>(
+    ({ label, helperText, error, id, ...rest }, ref) => {
+      const reactId = React.useId();
+      const inputId = id ?? reactId;
+      const helpText = error ?? helperText;
+      const helperId = helpText ? `${inputId}-helper` : undefined;
+      return React.createElement(
+        'div',
+        null,
+        label && React.createElement('label', { htmlFor: inputId }, label),
+        React.createElement('input', {
+          id: inputId,
+          ref,
+          'aria-describedby': helperId,
+          ...rest,
+        }),
+        helpText && React.createElement('p', { id: helperId }, helpText)
+      );
+    }
+  );
+  Input.displayName = 'Input';
+  return { Input };
+});
+
+import { BasicInfoStep } from './BasicInfoStep';
+
+describe('BasicInfoStep — UK mobile phone field guidance', () => {
+  const noop = () => undefined;
+
+  it('labels the phone field as a UK mobile number so the constraint is visible before typing', () => {
+    render(<BasicInfoStep data={{}} onComplete={noop} />);
+
+    const phoneInput = screen.getByLabelText(/UK Mobile Phone Number/i);
+    expect(phoneInput).toBeInTheDocument();
+    expect(phoneInput).toHaveAttribute('type', 'tel');
+  });
+
+  it('shows helper text explaining that only UK mobile numbers are accepted, with examples', () => {
+    render(<BasicInfoStep data={{}} onComplete={noop} />);
+
+    const helper = screen.getByText(
+      /We can only accept UK mobile numbers \(e\.g\. 07123 456789 or \+44 7123 456789\)/i
+    );
+    expect(helper).toBeInTheDocument();
+  });
+
+  it('wires aria-describedby on the phone input to the helper text element so assistive tech announces the constraint', () => {
+    render(<BasicInfoStep data={{}} onComplete={noop} />);
+
+    const phoneInput = screen.getByLabelText(/UK Mobile Phone Number/i);
+    const describedBy = phoneInput.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    const helper = describedBy ? document.getElementById(describedBy) : null;
+    expect(helper).not.toBeNull();
+    expect(helper?.textContent).toMatch(
+      /We can only accept UK mobile numbers \(e\.g\. 07123 456789 or \+44 7123 456789\)/i
+    );
+  });
+});

--- a/app.client/src/components/application/steps/BasicInfoStep.tsx
+++ b/app.client/src/components/application/steps/BasicInfoStep.tsx
@@ -75,9 +75,10 @@ export const BasicInfoStep: React.FC<BasicInfoStepProps> = ({ data, onComplete, 
           />
 
           <Input
-            label='Phone Number'
+            label='UK Mobile Phone Number'
             type='tel'
             placeholder='07123 456789'
+            helperText='We can only accept UK mobile numbers (e.g. 07123 456789 or +44 7123 456789)'
             {...register('phone', {
               required: 'Phone number is required',
               pattern: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -675,8 +675,8 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-tooltip": "^1.0.7",
         "clsx": "^2.1.1",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-world-flags": "^1.6.0",
         "recharts": "^2.12.6",
         "sonner": "^2.0.7"


### PR DESCRIPTION
Closes ADS-577

## Summary

Adopter application phone field now declares its UK-only constraint up-front instead of only on validation error (ticket option 1).

Changes in `app.client/src/components/application/steps/BasicInfoStep.tsx`:
- Field label: `Phone Number` -> `UK Mobile Phone Number`
- Added `helperText="We can only accept UK mobile numbers (e.g. 07123 456789 or +44 7123 456789)"`. The shared `lib.components` `Input` wires `helperText` to the underlying input via `aria-describedby`, so assistive tech announces the constraint before the user types.
- Existing UK mobile regex left as the source of truth for actual validation.

`lib.applications` Zod schemas were inspected: `PersonalInfoSchema.phone` is intentionally `z.string().optional()` at the read boundary (per the file's own comment, "strict typing belongs at the form validator, not at the read boundary"). No schema change is needed or appropriate.

## Test plan

- [x] New `BasicInfoStep.test.tsx` covers: label reads "UK Mobile Phone Number"; helper text mentions UK-only with examples; `aria-describedby` resolves to the helper text element
- [x] `npx turbo test type-check lint --filter=@adopt-dont-shop/app.client` passes locally (191 tests pass; type-check + lint clean)
- [x] All GitHub CI checks green

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_