### PR TITLE
fix(ADS-578): make adoption fee a validated numeric input [WIP - org limit]

### DIFF
--- a/app.rescue/src/components/pets/PetFormModal.css.ts
+++ b/app.rescue/src/components/pets/PetFormModal.css.ts
@@ -120,3 +120,21 @@ export const submitError = style({
   color: '#ef4444',
   marginBottom: '1rem',
 });
+
+export const currencyInputWrapper = style({
+  position: 'relative',
+});
+
+export const currencyAdornment = style({
+  position: 'absolute',
+  left: '0.75rem',
+  top: '50%',
+  transform: 'translateY(-50%)',
+  color: '#6b7280',
+  fontSize: '0.875rem',
+  pointerEvents: 'none',
+});
+
+globalStyle(`${currencyInputWrapper} input`, {
+  paddingLeft: '1.75rem',
+});

--- a/app.rescue/src/components/pets/PetFormModal.test.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Behavioural tests for the rescue PetFormModal adoption fee field.
+ *
+ * Documents ADS-578: the field accepts only non-negative numeric values
+ * (up to 2 decimal places) and rejects free-text values such as "free",
+ * "£150", or "tbd".
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import type { PetCreateData, PetUpdateData } from '@adopt-dont-shop/lib.pets';
+import { fireEvent, renderWithProviders, screen, waitFor } from '../../test-utils/render';
+import PetFormModal from './PetFormModal';
+
+type SubmitArg = PetCreateData | PetUpdateData;
+
+const fillRequiredFields = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByLabelText(/pet name/i), 'Rex');
+  await user.type(screen.getByLabelText(/primary breed/i), 'Labrador');
+  await user.type(screen.getByLabelText(/^color/i), 'Brown');
+  await user.type(screen.getByLabelText(/short description/i), 'A friendly dog.');
+};
+
+describe('PetFormModal — adoption fee field (ADS-578)', () => {
+  it('renders the adoption fee as a numeric input with a £ currency adornment', () => {
+    renderWithProviders(
+      <PetFormModal isOpen={true} onClose={() => {}} onSubmit={() => Promise.resolve()} />
+    );
+
+    const feeInput = screen.getByLabelText(/adoption fee/i);
+    expect(feeInput).toHaveAttribute('type', 'number');
+    expect(feeInput).toHaveAttribute('min', '0');
+    expect(feeInput).toHaveAttribute('step', '0.01');
+    expect(screen.getByText('£')).toBeInTheDocument();
+  });
+
+  it('drops non-numeric characters typed into the field (browser-enforced numeric input)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <PetFormModal isOpen={true} onClose={() => {}} onSubmit={() => Promise.resolve()} />
+    );
+
+    const feeInput = screen.getByLabelText(/adoption fee/i);
+    await user.type(feeInput, 'free');
+    // The browser's number input filters letters; the visible value stays empty.
+    expect((feeInput as HTMLInputElement).value).toBe('');
+  });
+
+  it('rejects values with more than 2 decimal places and blocks submission', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+    const { container } = renderWithProviders(
+      <PetFormModal isOpen={true} onClose={() => {}} onSubmit={onSubmit} />
+    );
+
+    await fillRequiredFields(user);
+    // step="0.01" doesn't actually block typed values in jsdom — exercise
+    // the form-level guard that rejects sub-pence precision.
+    fireEvent.change(screen.getByLabelText(/adoption fee/i), { target: { value: '150.123' } });
+
+    const form = container.querySelector('form');
+    if (!form) {
+      throw new Error('form not found');
+    }
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/adoption fee must be a non-negative number/i)
+      ).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid two-decimal amount and submits', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+    renderWithProviders(
+      <PetFormModal isOpen={true} onClose={() => {}} onSubmit={onSubmit} />
+    );
+
+    await fillRequiredFields(user);
+    await user.type(screen.getByLabelText(/adoption fee/i), '150.5');
+    await user.click(screen.getByRole('button', { name: /add pet/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.adoptionFee).toBe('150.5');
+  });
+
+  it('accepts an empty fee (optional field)', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+    renderWithProviders(
+      <PetFormModal isOpen={true} onClose={() => {}} onSubmit={onSubmit} />
+    );
+
+    await fillRequiredFields(user);
+    // Leave the adoption fee blank.
+    await user.click(screen.getByRole('button', { name: /add pet/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app.rescue/src/components/pets/PetFormModal.test.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.test.tsx
@@ -65,9 +65,7 @@ describe('PetFormModal — adoption fee field (ADS-578)', () => {
     fireEvent.submit(form);
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/adoption fee must be a non-negative number/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/adoption fee must be a non-negative number/i)).toBeInTheDocument();
     });
     expect(onSubmit).not.toHaveBeenCalled();
   });
@@ -75,9 +73,7 @@ describe('PetFormModal — adoption fee field (ADS-578)', () => {
   it('accepts a valid two-decimal amount and submits', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
-    renderWithProviders(
-      <PetFormModal isOpen={true} onClose={() => {}} onSubmit={onSubmit} />
-    );
+    renderWithProviders(<PetFormModal isOpen={true} onClose={() => {}} onSubmit={onSubmit} />);
 
     await fillRequiredFields(user);
     await user.type(screen.getByLabelText(/adoption fee/i), '150.5');
@@ -93,9 +89,7 @@ describe('PetFormModal — adoption fee field (ADS-578)', () => {
   it('accepts an empty fee (optional field)', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
-    renderWithProviders(
-      <PetFormModal isOpen={true} onClose={() => {}} onSubmit={onSubmit} />
-    );
+    renderWithProviders(<PetFormModal isOpen={true} onClose={() => {}} onSubmit={onSubmit} />);
 
     await fillRequiredFields(user);
     // Leave the adoption fee blank.

--- a/app.rescue/src/components/pets/PetFormModal.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.tsx
@@ -134,6 +134,15 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
       newErrors.age = 'Please enter a valid age';
     }
 
+    // Adoption fee: optional, but if provided must be a non-negative number
+    // with up to 2 decimal places. Mirrors AdoptionFeeStringSchema in
+    // lib.pets so the form rejects "free", "£150", "tbd", etc. (ADS-578).
+    const adoptionFeeRaw = (formData.adoptionFee ?? '').trim();
+    if (adoptionFeeRaw !== '' && !/^\d+(\.\d{1,2})?$/.test(adoptionFeeRaw)) {
+      newErrors.adoptionFee =
+        'Adoption fee must be a non-negative number with up to 2 decimal places';
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -288,13 +297,22 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
 
             <div className={styles.formGroup()}>
               <label htmlFor="adoptionFee">Adoption Fee</label>
-              <input
-                id="adoptionFee"
-                type="text"
-                value={formData.adoptionFee || ''}
-                onChange={e => handleInputChange('adoptionFee', e.target.value)}
-                placeholder="Enter adoption fee (e.g., 150.00)"
-              />
+              <div className={styles.currencyInputWrapper}>
+                <span className={styles.currencyAdornment} aria-hidden="true">
+                  £
+                </span>
+                <input
+                  id="adoptionFee"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  inputMode="decimal"
+                  value={formData.adoptionFee || ''}
+                  onChange={e => handleInputChange('adoptionFee', e.target.value)}
+                  placeholder="150.00"
+                />
+              </div>
+              {errors.adoptionFee && <div className="error">{errors.adoptionFee}</div>}
             </div>
 
             <div className={styles.formGroup({ fullWidth: true })}>

--- a/lib.pets/src/schemas.test.ts
+++ b/lib.pets/src/schemas.test.ts
@@ -35,14 +35,14 @@ describe('PetCreateDataSchema adoptionFee field', () => {
   });
 
   it('accepts a valid numeric adoption fee string', () => {
-    expect(
-      PetCreateDataSchema.safeParse({ ...validBase, adoptionFee: '150.00' }).success
-    ).toBe(true);
+    expect(PetCreateDataSchema.safeParse({ ...validBase, adoptionFee: '150.00' }).success).toBe(
+      true
+    );
   });
 
   it('rejects a non-numeric adoption fee string', () => {
-    expect(
-      PetCreateDataSchema.safeParse({ ...validBase, adoptionFee: '£150' }).success
-    ).toBe(false);
+    expect(PetCreateDataSchema.safeParse({ ...validBase, adoptionFee: '£150' }).success).toBe(
+      false
+    );
   });
 });

--- a/lib.pets/src/schemas.test.ts
+++ b/lib.pets/src/schemas.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Schema-level tests for adoption fee validation (ADS-578).
+ *
+ * The form layer mirrors this regex, but the schema is the source of
+ * truth: any value that survives PetCreateDataSchema.parse must be a
+ * non-negative decimal with at most two fractional digits.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AdoptionFeeStringSchema, PetCreateDataSchema } from './schemas';
+
+describe('AdoptionFeeStringSchema', () => {
+  it.each(['0', '150', '150.0', '150.5', '150.00', '0.99'])('accepts %s', (value) => {
+    expect(AdoptionFeeStringSchema.safeParse(value).success).toBe(true);
+  });
+
+  it.each(['free', '£150', 'tbd', '-100', '1.234', '1e5', ''])('rejects %s', (value) => {
+    expect(AdoptionFeeStringSchema.safeParse(value).success).toBe(false);
+  });
+});
+
+describe('PetCreateDataSchema adoptionFee field', () => {
+  const validBase = {
+    name: 'Rex',
+    type: 'dog' as const,
+    breed: 'Labrador',
+    gender: 'male' as const,
+    size: 'medium' as const,
+    color: 'Brown',
+    rescueId: 'rescue-1',
+  };
+
+  it('accepts an omitted adoption fee', () => {
+    expect(PetCreateDataSchema.safeParse(validBase).success).toBe(true);
+  });
+
+  it('accepts a valid numeric adoption fee string', () => {
+    expect(
+      PetCreateDataSchema.safeParse({ ...validBase, adoptionFee: '150.00' }).success
+    ).toBe(true);
+  });
+
+  it('rejects a non-numeric adoption fee string', () => {
+    expect(
+      PetCreateDataSchema.safeParse({ ...validBase, adoptionFee: '£150' }).success
+    ).toBe(false);
+  });
+});

--- a/lib.pets/src/schemas.ts
+++ b/lib.pets/src/schemas.ts
@@ -56,6 +56,17 @@ export const PetSpayNeuterStatusSchema = z.enum([
   'unknown',
 ]);
 
+// ── Adoption fee ──────────────────────────────────────────────────────────────
+//
+// The fee is captured as a string in the create/update payload (the backend
+// further normalises it into `adoption_fee_minor`/`adoption_fee_currency`),
+// but the value must encode a non-negative monetary amount with at most two
+// decimal places. Anything else (`"free"`, `"£150"`, `"tbd"`) should be
+// rejected at the form boundary — see ADS-578.
+export const AdoptionFeeStringSchema = z
+  .string()
+  .regex(/^\d+(\.\d{1,2})?$/, 'Adoption fee must be a non-negative number with up to 2 decimal places');
+
 // ── Sub-schemas ───────────────────────────────────────────────────────────────
 
 export const PetImageSchema = z.object({
@@ -241,7 +252,7 @@ export const PetCreateDataSchema = z.object({
   microchipId: z.string().optional(),
   shortDescription: z.string().optional(),
   longDescription: z.string().optional(),
-  adoptionFee: z.string().optional(),
+  adoptionFee: AdoptionFeeStringSchema.optional(),
   energyLevel: PetEnergyLevelSchema.optional(),
   exerciseNeeds: z.string().optional(),
   groomingNeeds: z.string().optional(),
@@ -290,7 +301,7 @@ export const PetUpdateDataSchema = z.object({
   microchipId: z.string().optional(),
   shortDescription: z.string().optional(),
   longDescription: z.string().optional(),
-  adoptionFee: z.string().optional(),
+  adoptionFee: AdoptionFeeStringSchema.optional(),
   energyLevel: PetEnergyLevelSchema.optional(),
   exerciseNeeds: z.string().optional(),
   groomingNeeds: z.string().optional(),

--- a/lib.pets/src/schemas.ts
+++ b/lib.pets/src/schemas.ts
@@ -65,7 +65,10 @@ export const PetSpayNeuterStatusSchema = z.enum([
 // rejected at the form boundary — see ADS-578.
 export const AdoptionFeeStringSchema = z
   .string()
-  .regex(/^\d+(\.\d{1,2})?$/, 'Adoption fee must be a non-negative number with up to 2 decimal places');
+  .regex(
+    /^\d+(\.\d{1,2})?$/,
+    'Adoption fee must be a non-negative number with up to 2 decimal places'
+  );
 
 // ── Sub-schemas ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes ADS-578

> [!WARNING]
> **Incomplete — agent halted at org's monthly Claude usage limit.** This PR captures the partial work so it isn't lost. A follow-up is needed to verify everything compiles + tests pass.

## What the agent got to

Switched the `PetFormModal` adoption fee field from `<input type="text">` to a validated numeric input, updated the Zod schema, and added tests.

Files modified:
- `app.rescue/src/components/pets/PetFormModal.tsx`
- `app.rescue/src/components/pets/PetFormModal.css.ts`
- `app.rescue/src/components/pets/PetFormModal.test.tsx` (new)
- `lib.pets/src/schemas.ts`
- `lib.pets/src/schemas.test.ts` (new)

## What's left

- Run `npx turbo lint test type-check --filter=@adopt-dont-shop/app.rescue --filter=@adopt-dont-shop/lib.pets`.
- Confirm the backend model column type is numeric and matches.
- Confirm the `£` adornment renders correctly (visual).

## Test plan

- [ ] Field rejects non-numeric input
- [ ] Field rejects negative values
- [ ] Valid `150.00` saves and round-trips

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_