### PR TITLE
fix(ADS-582): chat send retry / live region / reconnect queue

### DIFF
--- a/lib.chat/src/components/MessageBubbleComponent.tsx
+++ b/lib.chat/src/components/MessageBubbleComponent.tsx
@@ -56,7 +56,7 @@ export function MessageBubbleComponent({
   onToggleReaction,
   position = 'single',
 }: MessageBubbleProps) {
-  const { featureFlags, resolveFileUrl } = useChat();
+  const { featureFlags, resolveFileUrl, retryMessage } = useChat();
   const { logEvent } = featureFlags;
 
   const [lightboxOpen, setLightboxOpen] = useState(false);
@@ -111,13 +111,20 @@ export function MessageBubbleComponent({
   const bubbleClass = isOwn
     ? styles.messageBubbleOwn[position]
     : styles.messageBubbleOther[position];
+
+  // Incoming bubbles get a richer aria-label so AT users can navigate
+  // the message list (Tab / arrow) and hear who said what without
+  // first reading the preceding sender row.
+  const previewSource = message.content?.trim() || '';
+  const preview = previewSource.length > 80 ? `${previewSource.slice(0, 77)}…` : previewSource;
+  const bubbleAriaLabel = isOwn ? 'Your message' : `Message from ${message.senderName}: ${preview}`;
   const metaClass = isOwn ? styles.messageMetaOwn : styles.messageMetaOther;
   const metaVisibilityClass = showMeta ? styles.messageMetaVisible : styles.messageMetaHidden;
 
   return (
     <div className={wrapperClass}>
       <div className={bubbleRowClass}>
-        <article className={bubbleClass} aria-label={isOwn ? 'Your message' : 'Received message'}>
+        <article className={bubbleClass} aria-label={bubbleAriaLabel}>
           <div className={styles.messageContent}>{message.content}</div>
 
           {message.attachments && message.attachments.length > 0 && (
@@ -222,6 +229,28 @@ export function MessageBubbleComponent({
           isOwn={isOwn}
           readCount={message.readBy?.length}
         />
+        {isOwn && message.status === 'failed' && (
+          <button
+            type="button"
+            onClick={() => {
+              void retryMessage(message.id);
+            }}
+            aria-label="Retry sending message"
+            data-testid={`retry-message-${message.id}`}
+            style={{
+              marginLeft: '0.5rem',
+              background: 'transparent',
+              border: 'none',
+              color: 'inherit',
+              cursor: 'pointer',
+              textDecoration: 'underline',
+              font: 'inherit',
+              padding: 0,
+            }}
+          >
+            Retry
+          </button>
+        )}
       </div>
 
       {message.reactions && message.reactions.length > 0 && currentUserId && (

--- a/lib.chat/src/components/MessageList.tsx
+++ b/lib.chat/src/components/MessageList.tsx
@@ -189,6 +189,20 @@ export function MessageList({
     setVisibleCount((prev) => Math.min(safeMessages.length, prev + pageSize));
   };
 
+  // Latest *incoming* message drives the aria-live region. We deliberately
+  // exclude own messages — sending one is already a focused user action —
+  // and limit the region to a single preview so re-renders / scrolls
+  // don't re-announce the whole history.
+  const latestIncoming = useMemo(() => {
+    for (let i = safeMessages.length - 1; i >= 0; i -= 1) {
+      const msg = safeMessages[i];
+      if (!isMessageOwn(msg, currentUser?.userId, currentUser?.rescueId)) {
+        return msg;
+      }
+    }
+    return null;
+  }, [safeMessages, currentUser?.userId, currentUser?.rescueId]);
+
   if (safeMessages.length === 0) {
     return (
       <div className={styles.emptyMessages}>
@@ -231,6 +245,34 @@ export function MessageList({
           />
         </div>
       ))}
+      {/*
+        Single-message polite live region. Sits outside the visible message
+        flow (offscreen via aria attributes only) so screen readers
+        announce the latest incoming reply without re-announcing history
+        on every re-render. The content is just sender + preview; the full
+        message is still navigable through the rendered articles.
+      */}
+      <div
+        data-testid="messages-live-region"
+        aria-live="polite"
+        aria-relevant="additions"
+        aria-atomic="true"
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}
+      >
+        {latestIncoming
+          ? `New message from ${latestIncoming.senderName}: ${latestIncoming.content}`
+          : ''}
+      </div>
     </div>
   );
 }

--- a/lib.chat/src/components/__tests__/MessageList.test.tsx
+++ b/lib.chat/src/components/__tests__/MessageList.test.tsx
@@ -143,6 +143,56 @@ describe('MessageList', () => {
     expect(screen.queryByTestId('load-earlier-messages')).toBeNull();
   });
 
+  it('announces the latest incoming message via an aria-live polite region', () => {
+    // Screen readers should be notified when the other party replies.
+    // We wrap a focused live region around the most recent incoming
+    // bubble's preview so AT users hear the new content without
+    // re-announcing the whole conversation history.
+    const currentUser = { userId: 'me', firstName: 'Me' };
+    const messages = [
+      buildTestMessage({
+        id: 'm-other',
+        senderId: 'other-user',
+        senderName: 'Sarah Johnson',
+        content: 'hi there',
+      }),
+    ];
+
+    renderWithChatContext(<MessageList messages={messages} />, {
+      value: buildChatContextValue({ currentUser }),
+    });
+
+    const liveRegion = screen.getByTestId('messages-live-region');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(liveRegion).toHaveAttribute('aria-relevant', 'additions');
+    // The latest incoming preview should be announced.
+    expect(liveRegion).toHaveTextContent(/Sarah Johnson/);
+    expect(liveRegion).toHaveTextContent(/hi there/);
+  });
+
+  it('labels each new bubble with sender and preview for screen readers', () => {
+    const currentUser = { userId: 'me', firstName: 'Me' };
+    const messages = [
+      buildTestMessage({
+        id: 'm-other',
+        senderId: 'other-user',
+        senderName: 'Sarah Johnson',
+        content: 'hi there friend',
+      }),
+    ];
+
+    renderWithChatContext(<MessageList messages={messages} />, {
+      value: buildChatContextValue({ currentUser }),
+    });
+
+    // The incoming bubble carries an aria-label naming the sender and
+    // a content preview so an AT user landing on the article hears
+    // both pieces of context.
+    expect(
+      screen.getByLabelText(/Message from Sarah Johnson: hi there friend/)
+    ).toBeInTheDocument();
+  });
+
   it('groups consecutive messages from the same sender within the window', () => {
     const currentUser = { userId: 'me', firstName: 'Me' };
     const messages = [

--- a/lib.chat/src/context/ChatProvider.tsx
+++ b/lib.chat/src/context/ChatProvider.tsx
@@ -18,6 +18,27 @@ import type {
 const MESSAGES_PAGE_SIZE = 50;
 const TYPING_INDICATOR_CLEAR_MS = 3000;
 
+// Bounded exponential backoff for failed sends. After 3 total attempts
+// (initial + 2 retries) we surface a `failed` status and stop auto-retry
+// so the UI can show a manual Retry button. Delays grow 1s → 2s.
+const SEND_MAX_ATTEMPTS = 3;
+const SEND_RETRY_INITIAL_DELAY_MS = 1000;
+const SEND_RETRY_BACKOFF_MULTIPLIER = 2;
+
+type PendingSend = {
+  clientId: string;
+  conversationId: string;
+  content: string;
+  attachments?: File[];
+};
+
+const generateClientId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `client-${crypto.randomUUID()}`;
+  }
+  return `client-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
 type ConversationApiResponse = Conversation & { chat_id?: string };
 
 const mapConversationIds = (list: ReadonlyArray<ConversationApiResponse>): Conversation[] =>
@@ -98,7 +119,6 @@ export function ChatProvider({
       // ChatService has no offConnectionError helper; clearing is not
       // critical because the listener body is a stable setState.
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatService]);
 
   const isConnected = connectionStatus === 'connected';
@@ -230,7 +250,9 @@ export function ChatProvider({
       // inside loadConversations already ran — but the socket disconnect in the
       // cleanup will reset conversations on the next mount anyway.
     };
-    if (!cancelled) void doLoad();
+    if (!cancelled) {
+      void doLoad();
+    }
 
     return () => {
       cancelled = true;
@@ -298,6 +320,75 @@ export function ChatProvider({
     }
   }, [activeConversation, chatService, currentPage, hasMoreMessages, isLoadingMoreMessages]);
 
+  // Tracks the optimistic bubbles awaiting a server response. Lives in a
+  // ref because the retry timers + queue flush need to read the latest
+  // value without re-creating the callback identities on every send.
+  const reconnectQueueRef = useRef<PendingSend[]>([]);
+  const retryTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const buildOptimisticMessage = useCallback(
+    (clientId: string, conversationId: string, content: string): Message => ({
+      id: clientId,
+      conversationId,
+      senderId: user?.userId ?? '',
+      senderName: user?.firstName ?? '',
+      content,
+      timestamp: new Date().toISOString(),
+      type: 'text',
+      status: 'sending',
+    }),
+    [user]
+  );
+
+  const attemptSendWithRetry = useCallback(
+    async (pending: PendingSend, attempt: number): Promise<void> => {
+      try {
+        setError(null);
+        if (pending.attachments && pending.attachments.length > 0) {
+          for (const file of pending.attachments) {
+            await chatService.uploadAttachment(pending.conversationId, file);
+          }
+        }
+        const sent = await chatService.sendMessage(pending.conversationId, pending.content);
+        // Dedupe by clientId: replace the optimistic bubble. If a late
+        // success from an earlier attempt arrives after a manual retry
+        // already swapped the bubble, the filter below still leaves a
+        // single bubble with the server id.
+        setMessages((prev) => {
+          const withoutOptimistic = prev.filter((m) => m.id !== pending.clientId);
+          if (withoutOptimistic.some((m) => m.id === sent.id)) {
+            return withoutOptimistic;
+          }
+          return [...withoutOptimistic, sent];
+        });
+        setConversations((prev) =>
+          prev.map((conv) =>
+            conv.id === pending.conversationId
+              ? { ...conv, lastMessage: sent, updatedAt: sent.timestamp }
+              : conv
+          )
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Failed to send message';
+        if (attempt >= SEND_MAX_ATTEMPTS) {
+          setError(msg);
+          setMessages((prev) =>
+            prev.map((m) => (m.id === pending.clientId ? { ...m, status: 'failed' } : m))
+          );
+          return;
+        }
+        const delay =
+          SEND_RETRY_INITIAL_DELAY_MS * Math.pow(SEND_RETRY_BACKOFF_MULTIPLIER, attempt - 1);
+        const timer = setTimeout(() => {
+          retryTimersRef.current.delete(pending.clientId);
+          void attemptSendWithRetry(pending, attempt + 1);
+        }, delay);
+        retryTimersRef.current.set(pending.clientId, timer);
+      }
+    },
+    [chatService]
+  );
+
   const sendMessage = useCallback(
     async (content: string, attachments?: File[]) => {
       if (!activeConversation || !user) {
@@ -321,29 +412,91 @@ export function ChatProvider({
         return;
       }
 
-      try {
-        setError(null);
-        if (attachments && attachments.length > 0) {
-          for (const file of attachments) {
-            await chatService.uploadAttachment(activeConversation.id, file);
-          }
-        }
-        const sent = await chatService.sendMessage(activeConversation.id, content);
-        setMessages((prev) => (prev.some((m) => m.id === sent.id) ? prev : [...prev, sent]));
-        setConversations((prev) =>
-          prev.map((conv) =>
-            conv.id === activeConversation.id
-              ? { ...conv, lastMessage: sent, updatedAt: sent.timestamp }
-              : conv
-          )
-        );
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Failed to send message';
-        setError(msg);
+      const clientId = generateClientId();
+      const optimistic = buildOptimisticMessage(clientId, activeConversation.id, content);
+      setMessages((prev) => [...prev, optimistic]);
+
+      // Socket not yet connected (initial connect / mid-reconnect): hold
+      // the send locally and let the connection-status effect flush it
+      // when we reach `connected`. This guards the reconnect window —
+      // firing chatService.sendMessage here would hit the service's own
+      // disconnected-queue and return a placeholder we'd then have to
+      // reconcile out of band.
+      if (connectionStatus !== 'connected') {
+        reconnectQueueRef.current = [
+          ...reconnectQueueRef.current,
+          { clientId, conversationId: activeConversation.id, content, attachments },
+        ];
+        return;
       }
+
+      await attemptSendWithRetry(
+        { clientId, conversationId: activeConversation.id, content, attachments },
+        1
+      );
     },
-    [activeConversation, chatService, isOnline, offlineAdapter, user]
+    [
+      activeConversation,
+      attemptSendWithRetry,
+      buildOptimisticMessage,
+      connectionStatus,
+      isOnline,
+      offlineAdapter,
+      user,
+    ]
   );
+
+  const retryMessage = useCallback(
+    async (messageId: string) => {
+      const target = messages.find((m) => m.id === messageId);
+      if (!target || target.status !== 'failed') {
+        return;
+      }
+      // Clear any pending auto-retry timer for this id and re-arm the
+      // bubble's status to `sending` before kicking off attempt #1.
+      const timer = retryTimersRef.current.get(messageId);
+      if (timer) {
+        clearTimeout(timer);
+        retryTimersRef.current.delete(messageId);
+      }
+      setMessages((prev) =>
+        prev.map((m) => (m.id === messageId ? { ...m, status: 'sending' } : m))
+      );
+      await attemptSendWithRetry(
+        { clientId: messageId, conversationId: target.conversationId, content: target.content },
+        1
+      );
+    },
+    [attemptSendWithRetry, messages]
+  );
+
+  // Flush the reconnect queue when the socket transitions to connected.
+  // Each queued send re-enters the same retry/backoff path as a fresh
+  // send so transient failures during the flush still surface a Retry
+  // button on the bubble.
+  useEffect(() => {
+    if (connectionStatus !== 'connected') {
+      return;
+    }
+    const queued = reconnectQueueRef.current;
+    if (queued.length === 0) {
+      return;
+    }
+    reconnectQueueRef.current = [];
+    queued.forEach((pending) => {
+      void attemptSendWithRetry(pending, 1);
+    });
+  }, [attemptSendWithRetry, connectionStatus]);
+
+  // Clean up any in-flight retry timers on unmount to avoid setState
+  // on an unmounted provider.
+  useEffect(() => {
+    const timers = retryTimersRef.current;
+    return () => {
+      timers.forEach((t) => clearTimeout(t));
+      timers.clear();
+    };
+  }, []);
 
   const markAsRead = useCallback(
     async (conversationId: string) => {
@@ -546,6 +699,7 @@ export function ChatProvider({
     unreadMessageCount,
     setActiveConversation: handleSetActiveConversation,
     sendMessage,
+    retryMessage,
     markAsRead,
     loadConversations,
     loadMessages,

--- a/lib.chat/src/context/__tests__/ChatProvider.test.tsx
+++ b/lib.chat/src/context/__tests__/ChatProvider.test.tsx
@@ -60,7 +60,11 @@ type Harness2 = {
 const buildHarness = (initialConversations: Conversation[] = [buildConversation()]): Harness2 => {
   const chatService = new ChatService();
   const connectSpy = vi.spyOn(chatService, 'connect').mockImplementation(() => {
-    // Don't actually open a socket; the provider just needs the listeners to be registered.
+    // Don't actually open a socket — but synchronously fire the
+    // 'connected' status so the provider's reconnect-queue gate (which
+    // holds sends while the socket isn't connected, ADS-582) lets sends
+    // flow straight through in the default test setup.
+    chatService.simulateConnectEvent();
   });
   vi.spyOn(chatService, 'disconnect').mockImplementation(() => {});
 
@@ -468,6 +472,234 @@ describe('ChatProvider', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('marks a message as failed and shows a retry path when send fails repeatedly', async () => {
+    // User journey: I send a message on a flaky connection, the send
+    // fails. The bounded auto-retry exhausts its attempts and the bubble
+    // ends up in a `failed` state so the UI can show a manual Retry
+    // button. The optimistic bubble's id stays stable across retries so
+    // we never double-post.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const conv = buildConversation({ id: 'chat-1' });
+      const { chatService, tokenProvider } = buildHarness([conv]);
+
+      const sendSpy = vi
+        .spyOn(chatService, 'sendMessage')
+        .mockRejectedValue(new Error('network down'));
+      vi.spyOn(chatService, 'getMessages').mockResolvedValue({
+        data: [],
+        success: true,
+        timestamp: '2026-01-01T00:00:00Z',
+        pagination: { page: 1, limit: 50, total: 0, totalPages: 1, hasNext: false, hasPrev: false },
+      });
+      vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
+
+      let latest: Harness | null = null;
+      const Caller = () => {
+        const ctx = useChat();
+        const triggeredRef = useRef(false);
+        useEffect(() => {
+          if (ctx.conversations.length > 0 && ctx.activeConversation === null) {
+            ctx.setActiveConversation(ctx.conversations[0]);
+          }
+        }, [ctx]);
+        useEffect(() => {
+          if (ctx.activeConversation && !triggeredRef.current) {
+            triggeredRef.current = true;
+            void ctx.sendMessage('flaky hello');
+          }
+        }, [ctx]);
+        return null;
+      };
+
+      render(
+        <ChatProvider
+          chatService={chatService}
+          user={{ userId: 'user-1', firstName: 'Alice' }}
+          isAuthenticated
+          tokenProvider={tokenProvider}
+        >
+          <Caller />
+          <TestConsumer onRender={(h) => (latest = h)} />
+        </ChatProvider>
+      );
+
+      // Wait for the first send attempt to land.
+      await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1));
+
+      // Drive the backoff to completion: 3 attempts total (1s, 2s gaps).
+      // The provider keeps retrying until 3 failures, then gives up.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(3));
+
+      // The optimistic message should remain (single bubble) with status `failed`.
+      await waitFor(() => expect(latest?.messages).toHaveLength(1));
+      expect(latest?.messages[0].status).toBe('failed');
+
+      // No further auto retries fire beyond the bound.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+      expect(sendSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries the same client message id when retryMessage is called manually', async () => {
+    // User journey: my send failed and I tap the inline Retry button.
+    // The retry must reuse the original optimistic bubble's id so a
+    // late-arriving success from the original attempt cannot create a
+    // duplicate bubble.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const conv = buildConversation({ id: 'chat-1' });
+      const { chatService, tokenProvider } = buildHarness([conv]);
+
+      const sendSpy = vi
+        .spyOn(chatService, 'sendMessage')
+        .mockRejectedValue(new Error('network down'));
+      vi.spyOn(chatService, 'getMessages').mockResolvedValue({
+        data: [],
+        success: true,
+        timestamp: '2026-01-01T00:00:00Z',
+        pagination: { page: 1, limit: 50, total: 0, totalPages: 1, hasNext: false, hasPrev: false },
+      });
+      vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
+
+      let latest: Harness | null = null;
+      let retryFn: ((messageId: string) => Promise<void>) | null = null;
+      const Caller = () => {
+        const ctx = useChat();
+        const triggeredRef = useRef(false);
+        retryFn = ctx.retryMessage;
+        useEffect(() => {
+          if (ctx.conversations.length > 0 && ctx.activeConversation === null) {
+            ctx.setActiveConversation(ctx.conversations[0]);
+          }
+        }, [ctx]);
+        useEffect(() => {
+          if (ctx.activeConversation && !triggeredRef.current) {
+            triggeredRef.current = true;
+            void ctx.sendMessage('retryable');
+          }
+        }, [ctx]);
+        return null;
+      };
+
+      render(
+        <ChatProvider
+          chatService={chatService}
+          user={{ userId: 'user-1', firstName: 'Alice' }}
+          isAuthenticated
+          tokenProvider={tokenProvider}
+        >
+          <Caller />
+          <TestConsumer onRender={(h) => (latest = h)} />
+        </ChatProvider>
+      );
+
+      // Wait for the first send attempt, then drive backoff to completion.
+      await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(3));
+      await waitFor(() => expect(latest?.messages[0]?.status).toBe('failed'));
+
+      const failedId = latest?.messages[0].id;
+      expect(failedId).toBeTruthy();
+
+      // Manual retry — same optimistic bubble, no duplicate added.
+      await act(async () => {
+        await retryFn!(failedId!);
+      });
+      await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(4));
+      expect(latest?.messages).toHaveLength(1);
+      expect(latest?.messages[0].id).toBe(failedId);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('queues sends issued while disconnected and flushes them on reconnect', async () => {
+    // User journey: the socket is mid-reconnect when I hit send. The
+    // provider holds the message locally, surfaces it as `sending`, then
+    // flushes through to the server once the socket reaches `connected`.
+    const conv = buildConversation({ id: 'chat-1' });
+    const { chatService, connectSpy, tokenProvider } = buildHarness([conv]);
+
+    // Override the default harness behaviour: keep the socket
+    // disconnected on connect() so the send queues into the reconnect
+    // buffer. The test drives reconnect manually below.
+    connectSpy.mockImplementation(() => {
+      // no-op — leave status at 'disconnected'.
+    });
+
+    const sent = buildMessage({
+      id: 'srv-1',
+      senderId: 'user-1',
+      senderName: 'Alice',
+      content: 'queued',
+    });
+    const sendSpy = vi.spyOn(chatService, 'sendMessage').mockResolvedValue(sent);
+    vi.spyOn(chatService, 'getMessages').mockResolvedValue({
+      data: [],
+      success: true,
+      timestamp: '2026-01-01T00:00:00Z',
+      pagination: { page: 1, limit: 50, total: 0, totalPages: 1, hasNext: false, hasPrev: false },
+    });
+    vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
+
+    let latest: Harness | null = null;
+    const Caller = () => {
+      const ctx = useChat();
+      const triggeredRef = useRef(false);
+      useEffect(() => {
+        if (ctx.conversations.length > 0 && ctx.activeConversation === null) {
+          ctx.setActiveConversation(ctx.conversations[0]);
+        }
+      }, [ctx]);
+      useEffect(() => {
+        if (ctx.activeConversation && !triggeredRef.current && !ctx.isConnected) {
+          triggeredRef.current = true;
+          void ctx.sendMessage('queued');
+        }
+      }, [ctx]);
+      return null;
+    };
+
+    render(
+      <ChatProvider
+        chatService={chatService}
+        user={{ userId: 'user-1', firstName: 'Alice' }}
+        isAuthenticated
+        tokenProvider={tokenProvider}
+      >
+        <Caller />
+        <TestConsumer onRender={(h) => (latest = h)} />
+      </ChatProvider>
+    );
+
+    // The send fired while disconnected — provider must NOT have called
+    // through to chatService.sendMessage yet, and the optimistic bubble
+    // is visible as sending.
+    await waitFor(() => expect(latest?.messages).toHaveLength(1));
+    expect(latest?.messages[0].status).toBe('sending');
+    expect(sendSpy).not.toHaveBeenCalled();
+
+    // Reconnect — provider should flush the queue.
+    await act(async () => {
+      chatService.simulateConnectEvent();
+    });
+
+    await waitFor(() => expect(sendSpy).toHaveBeenCalledWith('chat-1', 'queued'));
+    await waitFor(() => expect(latest?.messages.find((m) => m.id === 'srv-1')).toBeDefined());
   });
 
   it('prepends older messages to the stream when loadMoreMessages is called', async () => {

--- a/lib.chat/src/context/chat-context-types.ts
+++ b/lib.chat/src/context/chat-context-types.ts
@@ -66,6 +66,12 @@ export type ChatContextValue = {
 
   setActiveConversation: (conversation: Conversation | null) => void;
   sendMessage: (content: string, attachments?: File[]) => Promise<void>;
+  /**
+   * Re-send a previously failed message by its client-side id. Reuses the
+   * original optimistic bubble (same id), so a late-arriving success from
+   * an earlier attempt cannot create a duplicate.
+   */
+  retryMessage: (messageId: string) => Promise<void>;
   markAsRead: (conversationId: string) => Promise<void>;
   loadConversations: () => Promise<void>;
   loadMessages: (conversationId: string) => Promise<void>;

--- a/lib.chat/src/test-utils.tsx
+++ b/lib.chat/src/test-utils.tsx
@@ -30,6 +30,7 @@ export const buildChatContextValue = (
   unreadMessageCount: 0,
   setActiveConversation: () => {},
   sendMessage: async () => {},
+  retryMessage: async () => {},
   markAsRead: async () => {},
   loadConversations: async () => {},
   loadMessages: async () => {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -675,8 +675,8 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-tooltip": "^1.0.7",
         "clsx": "^2.1.1",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-world-flags": "^1.6.0",
         "recharts": "^2.12.6",
         "sonner": "^2.0.7"


### PR DESCRIPTION
Closes ADS-582

## Summary

Three related fixes in the shared `lib.chat` library to address chat resilience and accessibility on real-world / flaky networks. Each sub-fix is small individually; together they make the chat feel reliable.

### 1. Send retry — `ChatProvider.tsx` + `MessageBubbleComponent.tsx`

- `sendMessage` failures now run through `attemptSendWithRetry` with bounded exponential backoff (3 total attempts, 1s → 2s gaps), tracked per client-side message UUID so late successes from earlier attempts can't double-post.
- After the backoff exhausts, the optimistic bubble flips to `failed` and an inline "Retry" button renders on the bubble's meta row. `retryMessage` re-arms the same `clientId`, so manual retries also dedupe.
- In-flight retry timers are cleared on unmount.

### 2. Live region for incoming messages — `MessageList.tsx` + `MessageBubbleComponent.tsx`

- Visually-hidden, polite `aria-live` region appended to the message list. Content is `New message from {sender}: {preview}`, derived from the latest *incoming* message only — own messages don't trigger announcements, and re-renders / scrolls don't re-announce history (`aria-relevant="additions"`, `aria-atomic="true"`).
- Per-bubble `aria-label` on incoming bubbles now reads `Message from {senderName}: {preview}` so AT users navigating bubble-by-bubble get sender + content context. Own bubbles read `Your message`.

### 3. Reconnect queue — `ChatProvider.tsx`

- Extended the offline queueing concept to cover the reconnect window: when `connectionStatus !== 'connected'`, sends create an optimistic bubble and enqueue into a local `reconnectQueueRef` instead of hitting `chatService.sendMessage`. A `useEffect` keyed on `connectionStatus` flushes the queue through `attemptSendWithRetry` once the socket reaches `connected`, so transient failures during the flush still surface a Retry button on the bubble.

## Files changed

- `lib.chat/src/components/MessageBubbleComponent.tsx`
- `lib.chat/src/components/MessageList.tsx`
- `lib.chat/src/components/__tests__/MessageList.test.tsx`
- `lib.chat/src/context/ChatProvider.tsx`
- `lib.chat/src/context/__tests__/ChatProvider.test.tsx`
- `lib.chat/src/context/chat-context-types.ts`
- `lib.chat/src/test-utils.tsx`

## Test plan

- [x] `npx turbo test type-check lint --filter=@adopt-dont-shop/lib.chat` — 81/81 tests pass, type-check clean, lint clean (warnings only, pre-existing pattern)
- [x] Type-check across all three consuming apps (`app.client`, `app.rescue`, `app.admin`) — clean
- [x] New behaviour tests cover all three sub-fixes:
  - `marks a message as failed and shows a retry path when send fails repeatedly`
  - `retries the same client message id when retryMessage is called manually`
  - `queues sends issued while disconnected and flushes them on reconnect`
  - `announces the latest incoming message via an aria-live polite region`
  - `labels each new bubble with sender and preview for screen readers`

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_