### PR TITLE
fix(ADS-584): application form a11y (3/3 sub-fixes)

### DIFF
--- a/app.client/src/components/application/ApplicationProgress.test.tsx
+++ b/app.client/src/components/application/ApplicationProgress.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@/test-utils/render';
+import { ApplicationProgress } from './ApplicationProgress';
+
+const steps = [
+  { id: 1, title: 'About you', description: 'Tell us a bit about yourself' },
+  { id: 2, title: 'Your home', description: 'Where the pet will live' },
+  { id: 3, title: 'Review', description: 'Final check' },
+];
+
+describe('ApplicationProgress accessibility', () => {
+  it('wraps the step list in a nav landmark labelled "Application steps"', () => {
+    render(<ApplicationProgress steps={steps} currentStep={2} onStepClick={vi.fn()} />);
+
+    const nav = screen.getByRole('navigation', { name: /application steps/i });
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('marks the active step with aria-current="step"', () => {
+    render(<ApplicationProgress steps={steps} currentStep={2} onStepClick={vi.fn()} />);
+
+    const active = screen.getByRole('button', { name: /2: your home/i });
+    expect(active).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('does not set aria-current on non-active steps', () => {
+    render(<ApplicationProgress steps={steps} currentStep={2} onStepClick={vi.fn()} />);
+
+    const completed = screen.getByRole('button', { name: /1: about you/i });
+    expect(completed).not.toHaveAttribute('aria-current');
+  });
+
+  it('gives each step an aria-label of "{number}: {title}"', () => {
+    render(<ApplicationProgress steps={steps} currentStep={1} onStepClick={vi.fn()} />);
+
+    const nav = screen.getByRole('navigation', { name: /application steps/i });
+    expect(within(nav).getByLabelText('1: About you')).toBeInTheDocument();
+  });
+});

--- a/app.client/src/components/application/ApplicationProgress.tsx
+++ b/app.client/src/components/application/ApplicationProgress.tsx
@@ -23,7 +23,7 @@ export const ApplicationProgress: React.FC<ApplicationProgressProps> = ({
 
   return (
     <div className={styles.progressContainer}>
-      <div className={styles.stepsContainer}>
+      <nav aria-label='Application steps' className={styles.stepsContainer}>
         {steps.map((step, index) => {
           const isActive = step.id === currentStep;
           const isCompleted = step.id < currentStep;
@@ -39,6 +39,8 @@ export const ApplicationProgress: React.FC<ApplicationProgressProps> = ({
                 )}
                 role={isClickable ? 'button' : undefined}
                 tabIndex={isClickable ? 0 : undefined}
+                aria-label={`${step.id}: ${step.title}`}
+                aria-current={isActive ? 'step' : undefined}
                 onClick={() => isClickable && onStepClick(step.id)}
                 onKeyDown={e =>
                   isClickable && (e.key === 'Enter' || e.key === ' ') && onStepClick(step.id)
@@ -92,7 +94,7 @@ export const ApplicationProgress: React.FC<ApplicationProgressProps> = ({
             </React.Fragment>
           );
         })}
-      </div>
+      </nav>
 
       <div className={styles.progressBar}>
         <div className={styles.progressFill} style={{ width: `${progressPercentage}%` }} />

--- a/app.client/src/components/application/QuestionCategoryStep.css.ts
+++ b/app.client/src/components/application/QuestionCategoryStep.css.ts
@@ -22,6 +22,15 @@ export const requiredNote = style({
   margin: '0 0 1.5rem 0',
 });
 
+export const errorSummary = style({
+  border: `1px solid ${vars.colors.semantic.error['500']}`,
+  background: vars.colors.semantic.error['50'],
+  padding: '0.75rem 1rem',
+  borderRadius: '0.375rem',
+  margin: '0 0 1.5rem 0',
+  color: vars.colors.semantic.error['700'],
+});
+
 export const visuallyHidden = style({
   position: 'absolute',
   width: '1px',

--- a/app.client/src/components/application/QuestionCategoryStep.css.ts
+++ b/app.client/src/components/application/QuestionCategoryStep.css.ts
@@ -21,3 +21,15 @@ export const requiredNote = style({
   color: vars.text.secondary,
   margin: '0 0 1.5rem 0',
 });
+
+export const visuallyHidden = style({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+});

--- a/app.client/src/components/application/QuestionCategoryStep.test.tsx
+++ b/app.client/src/components/application/QuestionCategoryStep.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { useState } from 'react';
+import { render, screen, fireEvent } from '@/test-utils/render';
+import { QuestionCategoryStep } from './QuestionCategoryStep';
+import type { Question } from './QuestionField';
+
+beforeAll(() => {
+  // jsdom doesn't implement scrollIntoView; stub it so the component's
+  // submit handler can run end-to-end in tests.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const homeOwnership: Question = {
+  questionId: 'q1',
+  questionKey: 'home_ownership',
+  scope: 'core',
+  category: 'housing',
+  questionType: 'select',
+  questionText: 'Do you rent or own?',
+  helpText: null,
+  placeholder: null,
+  options: ['Rent', 'Own'],
+  isRequired: true,
+  isEnabled: true,
+  displayOrder: 1,
+};
+
+const landlordPermission: Question = {
+  questionId: 'q2',
+  questionKey: 'landlord_permission',
+  scope: 'core',
+  category: 'housing',
+  questionType: 'boolean',
+  questionText: 'Do you have landlord permission?',
+  helpText: null,
+  placeholder: null,
+  options: null,
+  isRequired: true,
+  isEnabled: true,
+  displayOrder: 2,
+};
+
+type WrapperProps = {
+  questions: Question[];
+  initialAnswers?: Record<string, unknown>;
+  onComplete?: (answers: Record<string, unknown>) => void;
+};
+
+const Wrapper = ({ questions, initialAnswers = {}, onComplete = vi.fn() }: WrapperProps) => {
+  const [answers, setAnswers] = useState<Record<string, unknown>>(initialAnswers);
+  return (
+    <QuestionCategoryStep
+      stepId='test'
+      title='Test step'
+      questions={questions}
+      answers={answers}
+      onChange={setAnswers}
+      onComplete={onComplete}
+    />
+  );
+};
+
+describe('QuestionCategoryStep accessibility — conditional reveals', () => {
+  it('renders a polite live region for the conditional questions', () => {
+    const { container } = render(
+      <Wrapper questions={[homeOwnership, landlordPermission]} initialAnswers={{}} />
+    );
+
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).not.toBeNull();
+  });
+
+  it('announces a sentence when a conditional question becomes visible', () => {
+    render(<Wrapper questions={[homeOwnership, landlordPermission]} initialAnswers={{}} />);
+
+    // landlord_permission is hidden initially
+    expect(screen.queryByText(/Do you have landlord permission/i)).not.toBeInTheDocument();
+
+    // home_ownership renders as OptionTiles (radio inputs) for this key.
+    const rentRadio = screen.getByRole('radio', { name: /Rent/i });
+    fireEvent.click(rentRadio);
+
+    // After picking Rent, the conditional question shows AND an announcement is rendered
+    // (the matcher catches both the visible label and the live-region announcement).
+    expect(screen.getAllByText(/Do you have landlord permission/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/additional question/i)).toBeInTheDocument();
+  });
+});

--- a/app.client/src/components/application/QuestionCategoryStep.test.tsx
+++ b/app.client/src/components/application/QuestionCategoryStep.test.tsx
@@ -10,6 +10,36 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
 });
 
+const firstName: Question = {
+  questionId: 'q3',
+  questionKey: 'first_name',
+  scope: 'core',
+  category: 'about',
+  questionType: 'text',
+  questionText: 'What is your first name?',
+  helpText: null,
+  placeholder: null,
+  options: null,
+  isRequired: true,
+  isEnabled: true,
+  displayOrder: 1,
+};
+
+const lastName: Question = {
+  questionId: 'q4',
+  questionKey: 'last_name',
+  scope: 'core',
+  category: 'about',
+  questionType: 'text',
+  questionText: 'What is your last name?',
+  helpText: null,
+  placeholder: null,
+  options: null,
+  isRequired: true,
+  isEnabled: true,
+  displayOrder: 2,
+};
+
 const homeOwnership: Question = {
   questionId: 'q1',
   questionKey: 'home_ownership',
@@ -84,5 +114,47 @@ describe('QuestionCategoryStep accessibility — conditional reveals', () => {
     // (the matcher catches both the visible label and the live-region announcement).
     expect(screen.getAllByText(/Do you have landlord permission/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/additional question/i)).toBeInTheDocument();
+  });
+});
+
+describe('QuestionCategoryStep accessibility — validation errors', () => {
+  it('focuses the first error field on submit', () => {
+    render(<Wrapper questions={[firstName, lastName]} initialAnswers={{}} />);
+
+    const form = document.getElementById('step-test-form');
+    expect(form).not.toBeNull();
+    if (!form) {
+      return;
+    }
+    fireEvent.submit(form);
+
+    const firstInput = screen.getAllByRole('textbox')[0];
+    expect(document.activeElement).toBe(firstInput);
+  });
+
+  it('renders a role="alert" summary listing the count of missing fields', () => {
+    render(<Wrapper questions={[firstName, lastName]} initialAnswers={{}} />);
+
+    const form = document.getElementById('step-test-form');
+    if (!form) {
+      return;
+    }
+    fireEvent.submit(form);
+
+    // There are also per-field role="alert" messages; the summary is the
+    // alert that mentions the count of missing fields.
+    const summary = screen
+      .getAllByRole('alert')
+      .find(node => /required fields? (is|are) missing/i.test(node.textContent ?? ''));
+    expect(summary).toBeDefined();
+    expect(summary).toHaveTextContent(/2 required fields are missing/i);
+    expect(summary).toHaveTextContent(/first name/i);
+    expect(summary).toHaveTextContent(/last name/i);
+  });
+
+  it('does not render the alert summary when there are no errors', () => {
+    render(<Wrapper questions={[firstName]} initialAnswers={{ first_name: 'Ada' }} />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/app.client/src/components/application/QuestionCategoryStep.tsx
+++ b/app.client/src/components/application/QuestionCategoryStep.tsx
@@ -45,6 +45,7 @@ export const QuestionCategoryStep: React.FC<QuestionCategoryStepProps> = ({
   onChange,
 }) => {
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [missingFieldLabels, setMissingFieldLabels] = useState<readonly string[]>([]);
   const [touchedKeys, setTouchedKeys] = useState<Set<string>>(() => new Set());
   const [revealAnnouncement, setRevealAnnouncement] = useState<string>('');
   const previousVisibleKeys = useRef<Set<string> | null>(null);
@@ -84,24 +85,31 @@ export const QuestionCategoryStep: React.FC<QuestionCategoryStepProps> = ({
     e.preventDefault();
 
     const newErrors: Record<string, string> = {};
+    const missing: string[] = [];
     for (const q of questions) {
       if (!shouldShowQuestion(q, answers)) {
         continue;
       }
       if (q.isRequired && !hasAnswer(answers[q.questionKey])) {
         newErrors[q.questionKey] = "Don't forget this one 👀";
+        missing.push(q.questionText);
       }
     }
 
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
+      setMissingFieldLabels(missing);
       const firstKey = Object.keys(newErrors)[0];
-      document
-        .getElementById(`field-${firstKey}`)
-        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      const wrapper = document.getElementById(`field-${firstKey}`);
+      wrapper?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      const focusable = wrapper?.querySelector<HTMLElement>(
+        'input, select, textarea, [role="radio"], [role="button"], button'
+      );
+      focusable?.focus();
       return;
     }
 
+    setMissingFieldLabels([]);
     onComplete(answers);
   };
 
@@ -112,6 +120,20 @@ export const QuestionCategoryStep: React.FC<QuestionCategoryStepProps> = ({
       <h2 className={styles.stepTitle}>{title}</h2>
       {description && <p className={styles.stepDescription}>{description}</p>}
       {hasRequired && <p className={styles.requiredNote}>Fields marked with * are required.</p>}
+
+      {missingFieldLabels.length > 0 && (
+        <div role='alert' className={styles.errorSummary}>
+          <p>
+            {missingFieldLabels.length} required{' '}
+            {missingFieldLabels.length === 1 ? 'field is' : 'fields are'} missing:
+          </p>
+          <ul>
+            {missingFieldLabels.map(label => (
+              <li key={label}>{label}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <form id={`step-${stepId}-form`} onSubmit={handleSubmit} noValidate>
         <div aria-live='polite' aria-relevant='additions'>

--- a/app.client/src/components/application/QuestionCategoryStep.tsx
+++ b/app.client/src/components/application/QuestionCategoryStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Question, QuestionField } from './QuestionField';
 import { shouldShowQuestion } from './questionConditions';
 import * as styles from './QuestionCategoryStep.css';
@@ -24,6 +24,16 @@ const hasAnswer = (value: unknown): boolean => {
   return true;
 };
 
+const buildRevealAnnouncement = (revealedQuestions: Question[]): string => {
+  if (revealedQuestions.length === 0) {
+    return '';
+  }
+  if (revealedQuestions.length === 1) {
+    return `Additional question revealed: ${revealedQuestions[0].questionText}`;
+  }
+  return `${revealedQuestions.length} additional questions revealed.`;
+};
+
 export const QuestionCategoryStep: React.FC<QuestionCategoryStepProps> = ({
   stepId,
   title,
@@ -36,6 +46,23 @@ export const QuestionCategoryStep: React.FC<QuestionCategoryStepProps> = ({
 }) => {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [touchedKeys, setTouchedKeys] = useState<Set<string>>(() => new Set());
+  const [revealAnnouncement, setRevealAnnouncement] = useState<string>('');
+  const previousVisibleKeys = useRef<Set<string> | null>(null);
+
+  const visibleQuestions = questions.filter(q => shouldShowQuestion(q, answers));
+
+  useEffect(() => {
+    const currentKeys = new Set(visibleQuestions.map(q => q.questionKey));
+    const previous = previousVisibleKeys.current;
+    // Only announce on subsequent renders, not the initial mount.
+    if (previous) {
+      const newlyVisible = visibleQuestions.filter(q => !previous.has(q.questionKey));
+      if (newlyVisible.length > 0) {
+        setRevealAnnouncement(buildRevealAnnouncement(newlyVisible));
+      }
+    }
+    previousVisibleKeys.current = currentKeys;
+  }, [visibleQuestions]);
 
   const handleFieldChange = (questionKey: string, value: unknown) => {
     const updated = { ...answers, [questionKey]: value };
@@ -78,7 +105,6 @@ export const QuestionCategoryStep: React.FC<QuestionCategoryStepProps> = ({
     onComplete(answers);
   };
 
-  const visibleQuestions = questions.filter(q => shouldShowQuestion(q, answers));
   const hasRequired = visibleQuestions.some(q => q.isRequired);
 
   return (
@@ -88,22 +114,25 @@ export const QuestionCategoryStep: React.FC<QuestionCategoryStepProps> = ({
       {hasRequired && <p className={styles.requiredNote}>Fields marked with * are required.</p>}
 
       <form id={`step-${stepId}-form`} onSubmit={handleSubmit} noValidate>
-        {visibleQuestions.map(question => {
-          const isPrefilled =
-            !touchedKeys.has(question.questionKey) &&
-            (prefilledKeys?.has(question.questionKey) ?? false);
-          return (
-            <div id={`field-${question.questionKey}`} key={question.questionId}>
-              <QuestionField
-                question={question}
-                value={answers[question.questionKey]}
-                onChange={value => handleFieldChange(question.questionKey, value)}
-                error={errors[question.questionKey]}
-                isPrefilled={isPrefilled}
-              />
-            </div>
-          );
-        })}
+        <div aria-live='polite' aria-relevant='additions'>
+          <span className={styles.visuallyHidden}>{revealAnnouncement}</span>
+          {visibleQuestions.map(question => {
+            const isPrefilled =
+              !touchedKeys.has(question.questionKey) &&
+              (prefilledKeys?.has(question.questionKey) ?? false);
+            return (
+              <div id={`field-${question.questionKey}`} key={question.questionId}>
+                <QuestionField
+                  question={question}
+                  value={answers[question.questionKey]}
+                  onChange={value => handleFieldChange(question.questionKey, value)}
+                  error={errors[question.questionKey]}
+                  isPrefilled={isPrefilled}
+                />
+              </div>
+            );
+          })}
+        </div>
       </form>
     </div>
   );

--- a/app.client/src/pages/ApplicationPage.tsx
+++ b/app.client/src/pages/ApplicationPage.tsx
@@ -14,7 +14,10 @@ import {
   canQuickApply,
   splitAnswersForPersistence,
 } from '@/utils/applicationFieldMapping';
-import { applyConditionalDefaults } from '@/components/application/questionConditions';
+import {
+  applyConditionalDefaults,
+  shouldShowQuestion,
+} from '@/components/application/questionConditions';
 import type { ApplicationDefaults } from '@/types';
 
 type MacroStepDef = {
@@ -66,6 +69,26 @@ const CATEGORY_ORDER = [
   'references_verification',
   'final_acknowledgments',
 ];
+
+const hasAnswer = (value: unknown): boolean => {
+  if (value === null || value === undefined || value === '') {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return true;
+};
+
+const findMissingRequiredLabels = (
+  questions: Question[],
+  answers: Record<string, unknown>
+): string[] =>
+  questions
+    .filter(
+      q => q.isRequired && shouldShowQuestion(q, answers) && !hasAnswer(answers[q.questionKey])
+    )
+    .map(q => q.questionText);
 
 const groupQuestionsByMacroStep = (questions: Question[], petName?: string): CategoryGroup[] => {
   const byCategory = new Map<string, Question[]>();
@@ -314,11 +337,18 @@ export const ApplicationPage: React.FC = () => {
     } catch (err) {
       console.error('Failed to submit application:', err);
       const message = err instanceof Error ? err.message : null;
-      setError(
-        message?.includes('validation failed')
-          ? `A few required answers are still missing — pop back through and double-check each section.`
-          : (message ?? 'Something went wrong sending your application. Mind giving it another go?')
-      );
+      if (message?.includes('validation failed')) {
+        const missing = findMissingRequiredLabels(allQuestions, answers);
+        const intro =
+          missing.length > 0
+            ? `${missing.length} required ${missing.length === 1 ? 'answer is' : 'answers are'} still missing: ${missing.join(', ')}.`
+            : 'A few required answers are still missing.';
+        setError(`${intro} Pop back through and double-check each section.`);
+      } else {
+        setError(
+          message ?? 'Something went wrong sending your application. Mind giving it another go?'
+        );
+      }
       window.scrollTo({ top: 0, behavior: 'smooth' });
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
Closes ADS-584

## What's in this PR

Three sub-fixes for screen-reader and keyboard accessibility on the multi-step adopter application, all called out in ADS-584:

1. `fix(ADS-584): add ARIA semantics to ApplicationProgress` — wraps the step list in a `<nav aria-label="Application steps">`, adds `aria-current="step"` to the active step, and `aria-label="{n}: {title}"` to each step.
2. `fix(ADS-584): announce conditional question reveals` — wraps the dynamic question container in `<div aria-live="polite" aria-relevant="additions">` and emits a one-sentence announcement when conditional questions appear (e.g. landlord_permission after picking Rent).
3. `fix(ADS-584): focus and summarise first validation error` — on submit-with-errors, focuses (not just scrolls to) the first invalid field in `QuestionCategoryStep` and renders a top-of-form `role="alert"` summary listing which required questions are missing. Also updates `ApplicationPage`'s page-level fallback message so the backend "validation failed" path names the specific missing answers instead of telling the user to "double-check each section".

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/app.client` — `QuestionCategoryStep.test.tsx` and `ApplicationProgress.test.tsx` cover the new behaviour and pass locally
- [x] `npx turbo lint type-check --filter=@adopt-dont-shop/app.client` — clean (no new errors/warnings)
- [ ] Manual screen-reader test (VoiceOver/NVDA) on the full application -> submit -> error -> fix path

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_