### PR TITLE
feat(ADS-588): add POST /api/v1/uploads/images endpoint [WIP - org limit]

### DIFF
--- a/lib.api/package.json
+++ b/lib.api/package.json
@@ -39,7 +39,8 @@
   "license": "MIT",
   "dependencies": {
     "@adopt-dont-shop/lib.types": "*",
-    "@types/node": "^20.19.0"
+    "@types/node": "^20.19.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "*",

--- a/lib.api/src/index.ts
+++ b/lib.api/src/index.ts
@@ -6,6 +6,9 @@ export { ApiService, apiService, api } from './services/api-service';
 // Path constants for URL construction
 export { API_PATHS, buildApiPath } from './constants/api-paths';
 
+// Schemas (Zod) and inferred types
+export { ImageUploadResponseSchema, type ImageUploadResponse } from './schemas/upload-schemas';
+
 // Infrastructure
 export * from './interceptors';
 export * from './errors';

--- a/lib.api/src/schemas/upload-schemas.test.ts
+++ b/lib.api/src/schemas/upload-schemas.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { ImageUploadResponseSchema } from './upload-schemas';
+
+describe('ImageUploadResponseSchema', () => {
+  it('accepts a well-formed staged image upload response', () => {
+    const parsed = ImageUploadResponseSchema.parse({
+      url: '/uploads/pets/pets_1_abc.jpg',
+      thumbnail_url: '/uploads/pets/pets_1_abc.thumb.jpg',
+      original_filename: 'photo.jpg',
+      size_bytes: 12345,
+      content_type: 'image/jpeg',
+    });
+
+    expect(parsed.url).toBe('/uploads/pets/pets_1_abc.jpg');
+    expect(parsed.thumbnail_url).toBe('/uploads/pets/pets_1_abc.thumb.jpg');
+  });
+
+  it('rejects a response missing the thumbnail_url field', () => {
+    const result = ImageUploadResponseSchema.safeParse({
+      url: '/uploads/pets/x.jpg',
+      original_filename: 'photo.jpg',
+      size_bytes: 1,
+      content_type: 'image/jpeg',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a negative size_bytes value', () => {
+    const result = ImageUploadResponseSchema.safeParse({
+      url: '/uploads/pets/x.jpg',
+      thumbnail_url: '/uploads/pets/x.thumb.jpg',
+      original_filename: 'photo.jpg',
+      size_bytes: -1,
+      content_type: 'image/jpeg',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/lib.api/src/schemas/upload-schemas.ts
+++ b/lib.api/src/schemas/upload-schemas.ts
@@ -1,0 +1,17 @@
+/**
+ * ADS-588: schemas for the staged image upload endpoint
+ * (`POST /api/v1/uploads/images`). The endpoint returns a public URL +
+ * thumbnail URL pair that clients embed in subsequent create/update
+ * requests (e.g. the pet-create payload's `images: string[]`).
+ */
+import { z } from 'zod';
+
+export const ImageUploadResponseSchema = z.object({
+  url: z.string().min(1),
+  thumbnail_url: z.string().min(1),
+  original_filename: z.string().min(1),
+  size_bytes: z.number().int().nonnegative(),
+  content_type: z.string().min(1),
+});
+
+export type ImageUploadResponse = z.infer<typeof ImageUploadResponseSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -476,7 +476,8 @@
       "license": "MIT",
       "dependencies": {
         "@adopt-dont-shop/lib.types": "*",
-        "@types/node": "^20.19.0"
+        "@types/node": "^20.19.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-base": "*",
@@ -675,8 +676,8 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-tooltip": "^1.0.7",
         "clsx": "^2.1.1",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-world-flags": "^1.6.0",
         "recharts": "^2.12.6",
         "sonner": "^2.0.7"

--- a/service.backend/src/__tests__/routes/upload.routes.test.ts
+++ b/service.backend/src/__tests__/routes/upload.routes.test.ts
@@ -1,0 +1,248 @@
+/**
+ * ADS-588: POST /api/v1/uploads/images — staged image upload endpoint.
+ *
+ * The endpoint accepts a single image file (multipart/form-data, field
+ * name `image`) and returns the public URL + thumbnail URL pair that
+ * clients embed in a subsequent create-pet payload's `images: string[]`.
+ *
+ * These tests cover the contract the ticket spells out:
+ *   - 200 happy path with the documented response shape
+ *   - 401 when unauthenticated
+ *   - 400 when the multer fileFilter rejects a disallowed MIME
+ *   - 413 when multer reports LIMIT_FILE_SIZE
+ *   - 400 when the magic-byte guard reports a mismatch
+ */
+
+import { vi } from 'vitest';
+import express, { NextFunction, Response } from 'express';
+import multer from 'multer';
+import request from 'supertest';
+import type { AuthenticatedRequest } from '../../types';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn() },
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../config/env', () => ({
+  env: {
+    JWT_SECRET: 'test-secret-min-32-characters-long-12345',
+    JWT_REFRESH_SECRET: 'test-refresh-secret-min-32-chars-12345',
+    SESSION_SECRET: 'test-session-secret',
+    CSRF_SECRET: 'test-csrf-secret',
+  },
+}));
+
+vi.mock('../../middleware/rate-limiter', () => ({
+  uploadLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+}));
+
+// Stub petImageUpload with a deterministic in-memory multer. The default
+// limit is 10 MB and the fileFilter mirrors the production allowlist (image
+// MIME types only). Individual tests override behaviour by re-mocking
+// before importing the router (see helper buildAppWithMulter).
+const petImageUploadMock = {
+  single: vi.fn(),
+};
+const fileUploadServiceMock = {
+  uploadFile: vi.fn(),
+};
+vi.mock('../../services/file-upload.service', () => ({
+  petImageUpload: petImageUploadMock,
+  FileUploadService: fileUploadServiceMock,
+}));
+
+const enforceUploadMimeMock = vi.fn();
+vi.mock('../../middleware/upload-mime-guard', () => ({
+  enforceUploadMime: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    enforceUploadMimeMock(req, res, next),
+}));
+
+const authenticateTokenMock = vi.fn();
+vi.mock('../../middleware/auth', () => ({
+  authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authenticateTokenMock(req, res, next),
+}));
+
+const mockUser = {
+  userId: 'user-abc',
+  email: 'user@example.com',
+  userType: 'adopter',
+};
+
+const buildApp = async () => {
+  const app = express();
+  const { default: uploadRouter } = await import('../../routes/upload.routes');
+  app.use('/api/v1/uploads', uploadRouter);
+  return app;
+};
+
+const installMulter = (
+  options: Parameters<typeof multer>[0] = { storage: multer.memoryStorage() }
+) => {
+  const realMulter = multer(options);
+  petImageUploadMock.single.mockImplementation(realMulter.single.bind(realMulter));
+};
+
+const installAuthenticated = () => {
+  authenticateTokenMock.mockImplementation(
+    (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+      req.user = mockUser as AuthenticatedRequest['user'];
+      next();
+    }
+  );
+};
+
+const installPassthroughMimeGuard = () => {
+  enforceUploadMimeMock.mockImplementation(
+    (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+  );
+};
+
+describe('POST /api/v1/uploads/images — staged image upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installAuthenticated();
+    installPassthroughMimeGuard();
+    installMulter({
+      storage: multer.memoryStorage(),
+      limits: { fileSize: 10 * 1024 * 1024 },
+      fileFilter: (_req, file, cb) => {
+        const allowed = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+        if (!allowed.includes(file.mimetype)) {
+          cb(new Error(`File type ${file.mimetype} is not allowed`));
+          return;
+        }
+        cb(null, true);
+      },
+    });
+  });
+
+  it('returns 200 with the documented response shape on a successful upload', async () => {
+    fileUploadServiceMock.uploadFile.mockResolvedValue({
+      success: true,
+      upload: {
+        upload_id: 'upload-123',
+        original_filename: 'photo.jpg',
+        stored_filename: 'pets_1700000000_abc.jpg',
+        file_path: 'pets/pets_1700000000_abc.jpg',
+        mime_type: 'image/jpeg',
+        file_size: 1234,
+        url: '/uploads/pets/pets_1700000000_abc.jpg',
+        thumbnail_url: '/uploads/pets/pets_1700000000_abc.thumb.jpg',
+        uploaded_by: 'user-abc',
+        metadata: {
+          uploadedAt: '2026-05-16T00:00:00.000Z',
+          lastModified: '2026-05-16T00:00:00.000Z',
+          checksum: 'abc',
+        },
+        created_at: new Date('2026-05-16'),
+        updated_at: new Date('2026-05-16'),
+      },
+    });
+
+    const app = await buildApp();
+    const response = await request(app)
+      .post('/api/v1/uploads/images')
+      .attach('image', Buffer.from('fake jpg bytes'), {
+        filename: 'photo.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      url: '/uploads/pets/pets_1700000000_abc.jpg',
+      thumbnail_url: '/uploads/pets/pets_1700000000_abc.thumb.jpg',
+      original_filename: 'photo.jpg',
+      size_bytes: 1234,
+      content_type: 'image/jpeg',
+    });
+    expect(fileUploadServiceMock.uploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({ originalname: 'photo.jpg', mimetype: 'image/jpeg' }),
+      'pets',
+      expect.objectContaining({ uploadedBy: 'user-abc' })
+    );
+  });
+
+  it('returns 401 when the requester is not authenticated', async () => {
+    authenticateTokenMock.mockImplementation(
+      (_req: AuthenticatedRequest, res: Response, _next: NextFunction) => {
+        res.status(401).json({ error: 'Unauthorised' });
+      }
+    );
+
+    const app = await buildApp();
+    const response = await request(app)
+      .post('/api/v1/uploads/images')
+      .attach('image', Buffer.from('fake jpg bytes'), {
+        filename: 'photo.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(response.status).toBe(401);
+    expect(fileUploadServiceMock.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the file MIME type is not on the image allowlist', async () => {
+    const app = await buildApp();
+    const response = await request(app)
+      .post('/api/v1/uploads/images')
+      .attach('image', Buffer.from('plain text payload'), {
+        filename: 'evil.txt',
+        contentType: 'text/plain',
+      });
+
+    expect(response.status).toBe(400);
+    expect(fileUploadServiceMock.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 when the file exceeds the multer size limit', async () => {
+    installMulter({
+      storage: multer.memoryStorage(),
+      // 32-byte ceiling so a tiny test payload trips LIMIT_FILE_SIZE
+      // without consuming real memory.
+      limits: { fileSize: 32 },
+      fileFilter: (_req, _file, cb) => cb(null, true),
+    });
+
+    const app = await buildApp();
+    const oversized = Buffer.alloc(64, 'A');
+    const response = await request(app)
+      .post('/api/v1/uploads/images')
+      .attach('image', oversized, { filename: 'big.jpg', contentType: 'image/jpeg' });
+
+    expect(response.status).toBe(413);
+    expect(fileUploadServiceMock.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the magic-byte guard reports a content/MIME mismatch', async () => {
+    enforceUploadMimeMock.mockImplementation(
+      (_req: AuthenticatedRequest, res: Response, _next: NextFunction) => {
+        res.status(400).json({
+          error: 'Uploaded file content does not match declared type',
+          details: ['File evil.jpg declares image/jpeg but content is text/html'],
+        });
+      }
+    );
+
+    const app = await buildApp();
+    const response = await request(app)
+      .post('/api/v1/uploads/images')
+      .attach('image', Buffer.from('<html>not a jpeg</html>'), {
+        filename: 'evil.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(response.status).toBe(400);
+    expect(fileUploadServiceMock.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the request omits the file field', async () => {
+    const app = await buildApp();
+    const response = await request(app).post('/api/v1/uploads/images');
+
+    expect(response.status).toBe(400);
+    expect(fileUploadServiceMock.uploadFile).not.toHaveBeenCalled();
+  });
+});

--- a/service.backend/src/controllers/upload.controller.ts
+++ b/service.backend/src/controllers/upload.controller.ts
@@ -1,0 +1,54 @@
+import { Response } from 'express';
+import { FileUploadService } from '../services/file-upload.service';
+import { AuthenticatedRequest } from '../types/api';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-588: staged image upload controller.
+ *
+ * Sits behind `petImageUpload.single('image')` + `enforceUploadMime`, so by the
+ * time the handler runs multer has written the file to disk and the magic-byte
+ * guard has confirmed the content matches the declared MIME. The controller's
+ * remaining job is to:
+ *   1. confirm a file is present,
+ *   2. hand it to FileUploadService.uploadFile (which resizes + thumbnails
+ *      per ADS-518 and records a FileUpload row),
+ *   3. return the public URL pair the client embeds in a follow-up
+ *      create-pet payload.
+ */
+export class UploadController {
+  static async uploadImage(req: AuthenticatedRequest, res: Response): Promise<Response> {
+    if (!req.file) {
+      return res.status(400).json({ error: 'No file uploaded' });
+    }
+
+    const userId = req.user!.userId;
+
+    try {
+      const result = await FileUploadService.uploadFile(req.file, 'pets', {
+        uploadedBy: userId,
+        purpose: 'staged-image',
+      });
+
+      if (!result.success || !result.upload) {
+        logger.error('Staged image upload failed: service returned no upload record');
+        return res.status(500).json({ error: 'Failed to store uploaded file' });
+      }
+
+      const { upload } = result;
+      return res.status(200).json({
+        url: upload.url,
+        thumbnail_url: upload.thumbnail_url ?? upload.url,
+        original_filename: upload.original_filename,
+        size_bytes: upload.file_size,
+        content_type: upload.mime_type,
+      });
+    } catch (error) {
+      logger.error('Staged image upload failed', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return res.status(500).json({ error: 'Failed to store uploaded file' });
+    }
+  }
+}

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -57,6 +57,7 @@ import metricsRoutes from './routes/metrics.routes';
 import reportsRoutes from './routes/reports.routes';
 import legalRoutes from './routes/legal.routes';
 import privacyRoutes from './routes/privacy.routes';
+import uploadRoutes from './routes/upload.routes';
 import uploadServeRoutes from './routes/upload-serve.routes';
 import { authenticateToken } from './middleware/auth';
 import { requireRole } from './middleware/rbac';
@@ -309,6 +310,7 @@ app.use('/api/v1/cms', cmsRoutes);
 app.use('/api/v1/reports', reportsRoutes); // ADS-105: custom analytics reports
 app.use('/api/v1/legal', legalRoutes); // ADS-495: public terms / privacy
 app.use('/api/v1/privacy', privacyRoutes); // ADS-427/496/497: GDPR delete + export + consent
+app.use('/api/v1/uploads', uploadRoutes); // ADS-588: staged image upload (POST /images)
 
 // ADS-446 / ADS-460: readiness endpoint that probes DB + Redis + BullMQ.
 app.use('/api/v1', healthRoutes);

--- a/service.backend/src/routes/upload.routes.ts
+++ b/service.backend/src/routes/upload.routes.ts
@@ -1,0 +1,62 @@
+/**
+ * ADS-588: staged image upload route.
+ *
+ * `POST /api/v1/uploads/images` accepts a single image file
+ * (multipart/form-data, field `image`) and returns the public URL +
+ * thumbnail URL the client embeds in a follow-up create-pet payload.
+ *
+ * Mounted under `/api/v1/uploads`. The sibling `/api/v1/uploads/authorize`
+ * route in upload-serve.routes.ts handles nginx auth_request subrequests
+ * and is not affected by this router because they use different HTTP
+ * methods.
+ */
+import { NextFunction, Request, Response, Router } from 'express';
+import multer from 'multer';
+import { UploadController } from '../controllers/upload.controller';
+import { authenticateToken } from '../middleware/auth';
+import { uploadLimiter } from '../middleware/rate-limiter';
+import { enforceUploadMime } from '../middleware/upload-mime-guard';
+import { petImageUpload } from '../services/file-upload.service';
+import type { AuthenticatedRequest } from '../types/api';
+
+const router = Router();
+
+/**
+ * Translate multer's `LIMIT_FILE_SIZE` to 413 and any other multer /
+ * fileFilter rejection to 400. Without this wrapper, multer errors fall
+ * through to the generic Express error handler, which returns 500 with
+ * the raw error message.
+ */
+const handleMulterErrors = (
+  err: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  if (err instanceof multer.MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      res.status(413).json({ error: 'File too large' });
+      return;
+    }
+    res.status(400).json({ error: err.message });
+    return;
+  }
+  if (err instanceof Error) {
+    // fileFilter rejections surface here as plain Errors.
+    res.status(400).json({ error: err.message });
+    return;
+  }
+  next(err);
+};
+
+router.post(
+  '/images',
+  uploadLimiter,
+  authenticateToken,
+  (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    petImageUpload.single('image')(req, res, err => handleMulterErrors(err, req, res, next)),
+  enforceUploadMime,
+  UploadController.uploadImage
+);
+
+export default router;


### PR DESCRIPTION
Closes ADS-588

> [!WARNING]
> **Incomplete — agent halted at org's monthly Claude usage limit.** This PR captures the partial work so it isn't lost. Likely only `lib.api` plumbing was started; the actual `service.backend` route and controller still need to be written.

## What the agent got to

Started on `lib.api` plumbing for the new endpoint (no backend route registered yet).

Files modified:
- `lib.api/package.json`
- `lib.api/src/index.ts`
- `lib.api/src/schemas/` (new directory; check what's inside)
- `package-lock.json`

## What's left (most of the ticket)

- `service.backend/src/routes/upload.routes.ts` — register `POST /api/v1/uploads/images` with the existing `petImageUpload` multer middleware.
- `service.backend/src/controllers/upload.controller.ts` — handle the upload, run through `FileUploadService.processFile`, return `{ url, thumbnail_url, ... }`.
- `service.backend/src/index.ts` — mount the new route.
- `service.backend/src/__tests__/routes/upload.routes.test.ts` — auth / mime / size / magic-byte cases.
- Run `npx turbo lint test type-check --filter=@adopt-dont-shop/service-backend --filter=@adopt-dont-shop/lib.api`.

## Test plan

- [ ] Authenticated upload returns 200 with `url` and `thumbnail_url`
- [ ] Unauthenticated returns 401
- [ ] Disallowed MIME returns 400
- [ ] Oversize returns 413
- [ ] Magic-byte mismatch returns 400
- [ ] Unblocks ADS-574 (PetFormModal image upload UI)

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_