### PR TITLE
chore(boot): wire installAuditLogsImmutableTrigger (ADS-531 Phase 3)

### DIFF
--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -27,6 +27,7 @@ import { printEnvironmentInfo, validateEnvironment } from './utils/validate-env'
 import models from './models';
 import { installImmutableCreatedAtTriggers } from './models/immutable-created-at';
 import { installIsoCheckConstraints } from './models/iso-check-constraints';
+import { installAuditLogsImmutableTrigger } from './models/audit-logs-immutable';
 
 // Import routes
 import adminRoutes from './routes/admin.routes';
@@ -674,6 +675,7 @@ const startServer = async () => {
         await Promise.all([
           installImmutableCreatedAtTriggers(Object.values(models)),
           installIsoCheckConstraints(),
+          installAuditLogsImmutableTrigger(),
         ]);
       } catch (error) {
         logger.error('Failed to sync database models:', error);


### PR DESCRIPTION
## Summary

PR #508 introduced the post-sync installer at `service.backend/src/models/audit-logs-immutable.ts` but left it unwired so the scaffold commit stayed minimal. This PR finishes the connection: the installer now runs after `sequelize.sync()` in the dev/test boot path, alongside the existing `installImmutableCreatedAtTriggers` and `installIsoCheckConstraints`.

- Postgres-only — the installer no-ops on SQLite (tests)
- Idempotent (`CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS`), so safe to run on every dev reboot including `FORCE_SEED` resets

## Scope

**NOT** yet wired into the production boot path. Prod still relies on migration `11-add-audit-log-immutable-trigger` to install the trigger via the sidecar. Wiring the installer into prod boot lands later, together with the full migration audit-and-delete that the rest of Phase 3 covers.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Backend tests pass in CI
- [ ] Dev boot completes without error (manual verification once merged)

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_