### PR TITLE
chore(db): fold partial-index migrations into models (ADS-531)

### DIFF
--- a/service.backend/src/models/Application.ts
+++ b/service.backend/src/models/Application.ts
@@ -502,6 +502,17 @@ Application.init(
         fields: ['rescue_id', 'status', { name: 'created_at', order: 'DESC' }],
         name: 'applications_rescue_status_created_idx',
       },
+      // ADS-504: partial index on active rows for the rescue dashboard's
+      // primary query (`WHERE rescue_id = ? AND status IN (...) AND
+      // deleted_at IS NULL`). Paranoid mode always rewrites the
+      // `deleted_at IS NULL` clause, so a partial index lets Postgres
+      // skip the heap recheck once soft-deleted applications
+      // accumulate.
+      {
+        fields: ['rescue_id', 'status'],
+        name: 'applications_rescue_status_active_idx',
+        where: { deleted_at: null },
+      },
       { fields: ['deleted_at'], name: 'applications_deleted_at_idx' },
       ...auditIndexes('applications'),
     ],

--- a/service.backend/src/models/Pet.ts
+++ b/service.backend/src/models/Pet.ts
@@ -780,6 +780,17 @@ Pet.init(
         fields: ['status'],
         name: 'pets_status_idx',
       },
+      // ADS-504: partial index on active rows for the public listings
+      // query ("show me available pets"), which paranoid mode always
+      // rewrites to `... AND deleted_at IS NULL`. Without this the
+      // planner falls back to `pets_status_idx` and re-checks
+      // deleted_at on the heap, which doesn't scale once the
+      // soft-deleted population is non-trivial.
+      {
+        fields: ['status'],
+        name: 'pets_status_active_idx',
+        where: { deleted_at: null },
+      },
       {
         fields: ['type'],
         name: 'pets_type_idx',

--- a/service.backend/src/models/ReportShare.ts
+++ b/service.backend/src/models/ReportShare.ts
@@ -121,7 +121,19 @@ ReportShare.init(
     indexes: [
       { fields: ['saved_report_id'], name: 'report_shares_saved_report_idx' },
       { fields: ['shared_with_user_id'], name: 'report_shares_shared_with_user_idx' },
-      { fields: ['token_hash'], name: 'report_shares_token_hash_idx' },
+      // ADS-505: partial UNIQUE on token-typed shares. `token_hash`
+      // stores `sha256(share-jwt-jti)`; two rows with the same hash
+      // would resolve the same signed share to two different rows,
+      // leaking unauthorised access on a JTI collision or app bug.
+      // Partial because `token_hash` is NULL for `share_type = 'user'`
+      // rows; pairs with the existing `report_shares_unique_user_idx`
+      // partial unique on user-typed shares.
+      {
+        fields: ['token_hash'],
+        unique: true,
+        name: 'report_shares_token_hash_unique_idx',
+        where: { share_type: 'token' },
+      },
       ...auditIndexes('report_shares'),
     ],
   })

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -510,6 +510,19 @@ User.init(
         fields: ['deleted_at'],
         name: 'users_deleted_at_idx',
       },
+      // ADS-504: partial UNIQUE on active rows so the planner can satisfy
+      // the very hot `email = ? AND deleted_at IS NULL` lookup (login,
+      // "is this email taken") with an index-only scan instead of
+      // hitting the full `users_email_unique` and re-checking deleted_at
+      // in the heap. The full unique above stays — it's what stops a
+      // soft-deleted user re-registering with the same address — and the
+      // partial unique is the performance-only sibling.
+      {
+        fields: ['email'],
+        unique: true,
+        name: 'users_email_active_idx',
+        where: { deleted_at: null },
+      },
       ...auditIndexes('users'),
     ],
     hooks: {


### PR DESCRIPTION
## Summary

ADS-504 / ADS-505 added four partial indexes via migrations `15-add-report-shares-token-hash-unique-index` and `16-add-paranoid-partial-indexes` that weren't reflected in the model index arrays. Adding them to the models so `sequelize.sync()` produces an equivalent schema to running the migrations — closes the last schema-drift gap surfaced by the Phase 3 migration audit.

## The four indexes

| Model | Index | Purpose |
|---|---|---|
| `User` | `users_email_active_idx` (UNIQUE, `WHERE deleted_at IS NULL`) | Hot path: `email = ? AND deleted_at IS NULL` login lookup. The existing full `users_email_unique` stays — it's what stops a soft-deleted user re-registering with the same address. |
| `Pet` | `pets_status_active_idx` (`WHERE deleted_at IS NULL`) | Public listings ("show me available pets"). Paranoid mode always rewrites to include `deleted_at IS NULL`. |
| `Application` | `applications_rescue_status_active_idx` (`WHERE deleted_at IS NULL`) | Rescue dashboard's primary query. |
| `ReportShare` | `report_shares_token_hash_unique_idx` (UNIQUE, `WHERE share_type = 'token'`) | Promotes the plain `token_hash` index to a partial UNIQUE. `token_hash` stores `sha256(share-jwt-jti)`; two rows with the same hash would resolve a signed share to two different rows, so unique is a correctness requirement. Partial because `token_hash` is NULL for `share_type = 'user'` rows. |

All four use Sequelize's object form (`where: { field: null }` / `where: { field: 'value' }`) to match the pattern already established by `report_shares_unique_user_idx` in the analytics baseline — gives proper `IS NULL` SQL without resorting to raw `literal()`.

## Scope

Migrations 15 and 16 themselves **remain in the directory** for existing prod DBs that have already applied them. Deleting the historical migrations is the next (and final) Phase 3 chunk; doing so requires also moving the production migration sidecar off the historical migration set, which deserves its own PR.

## Test plan

- [x] `tsc --noEmit` clean for `service.backend`
- [x] Backend tests: **2,204 passed / 262 skipped / 0 failed**
- [ ] Tests pass in CI
- [ ] **Schema Equivalence (migrate vs sync)** check passes in CI — this is the test that directly verifies my premise that the model now matches what migrations produce
- [ ] Sanity check that the partial indexes appear in a fresh dev DB after `npm run docker:dev`

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_