### PR TITLE
fix(db): call installAuditLogsImmutableTrigger in every env (ADS-531)

### DIFF
--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -674,14 +674,42 @@ const startServer = async () => {
         // DB-level invariants that aren't expressible in Sequelize models.
         // Idempotent and Postgres-gated; safe to run on every boot path
         // (force-seed, fresh DB, warm reload). Independent — run in parallel.
+        // installAuditLogsImmutableTrigger is called unconditionally
+        // outside this dev block — see comment below.
         await Promise.all([
           installImmutableCreatedAtTriggers(Object.values(models)),
           installIsoCheckConstraints(),
-          installAuditLogsImmutableTrigger(),
         ]);
       } catch (error) {
         logger.error('Failed to sync database models:', error);
         throw error;
+      }
+    }
+
+    // DB-level invariants that aren't expressible in Sequelize models
+    // and aren't created by the schema bootstrap (sync in dev, baseline
+    // migrations in prod). Postgres-only, idempotent (CREATE OR REPLACE
+    // FUNCTION / DROP TRIGGER IF EXISTS), so safe regardless of
+    // environment or whether the DB is fresh.
+    //
+    // History: migration 11-add-audit-log-immutable-trigger originally
+    // installed the audit_logs trigger as part of the prod migration
+    // sidecar; PR #521 dropped that migration when the forward
+    // migrations were folded into models/installers. This boot-time
+    // call replaces it so fresh prod DBs continue to get the trigger.
+    //
+    // installImmutableCreatedAtTriggers and installIsoCheckConstraints
+    // run only in dev (their schema-creation pair, sequelize.sync(),
+    // only runs in dev) — prod's broader trigger coverage is a separate
+    // concern beyond this fix.
+    if (sequelize.getDialect() === 'postgres') {
+      try {
+        await installAuditLogsImmutableTrigger();
+      } catch (error) {
+        logger.error('Failed to install audit_logs immutable trigger:', error);
+        // Non-fatal — the trigger is defence in depth (ADS-508). Boot
+        // continues so the HTTP server still comes up; the install
+        // failure is loud in logs for operators to investigate.
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up fix for a regression introduced by PR #521 (drop forward migrations 01..19). The audit_logs immutable trigger (ADS-508 — tamper-resistance for the forensic record-of-record) lost its production install path:

- **dev:** `installAuditLogsImmutableTrigger()` runs inside the `if (config.nodeEnv === 'development')` boot block (wired in PR #518). Still works.
- **prod:** the dev block is skipped, and migration `11-add-audit-log-immutable-trigger` no longer exists. **Fresh prod DBs come up without the trigger** — a silent security-control regression for any deploy that starts from an empty database after #521.

Existing prod DBs already have the trigger from the old migration run, so the regression only affects fresh deploys. Still important to close now while the rest of ADS-531 is fresh in everyone's heads.

## Fix

Move the `installAuditLogsImmutableTrigger()` call out of the dev-only `Promise.all` and into an unconditional block guarded only by `sequelize.getDialect() === 'postgres'`. The installer remains idempotent (`CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS`), so running on every boot in every environment is safe.

Failures are logged but not re-thrown — the trigger is defence in depth, not a hard correctness requirement; we'd rather boot without it and surface the error than wedge the HTTP server.

## Out of scope

`installImmutableCreatedAtTriggers` and `installIsoCheckConstraints` stay dev-only because their schema-creation pair (`sequelize.sync()`) is dev-only too. Prod's broader trigger / check-constraint coverage is a **pre-existing** gap from before ADS-531 and deserves a separate PR (it would install previously-absent invariants on existing prod tables, which is a behaviour change worth its own review).

## Test plan

- [x] `tsc --noEmit` clean
- [x] Backend tests: **2,216 passed / 206 skipped / 0 failed**
- [ ] CI green
- [ ] Sanity check that a fresh dev DB (`FORCE_SEED=true`) still installs the trigger exactly once (idempotent)

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_