### PR TITLE
refactor(ADS-586): replace window.confirm()/alert() in app.rescue

### DIFF
--- a/app.rescue/eslint.config.js
+++ b/app.rescue/eslint.config.js
@@ -1,3 +1,23 @@
 import reactConfig from '@adopt-dont-shop/eslint-config-react';
 
-export default reactConfig;
+export default [
+  ...reactConfig,
+  {
+    // ADS-586: native dialogs (window.confirm / alert) are banned in app.rescue.
+    // Use useConfirm + ConfirmDialog or toast from @adopt-dont-shop/lib.components.
+    rules: {
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'alert',
+          message: 'Use toast from @adopt-dont-shop/lib.components instead of alert().',
+        },
+        {
+          name: 'confirm',
+          message:
+            'Use useConfirm + ConfirmDialog from @adopt-dont-shop/lib.components instead of confirm().',
+        },
+      ],
+    },
+  },
+];

--- a/app.rescue/src/__tests__/no-restricted-globals.lint.test.ts
+++ b/app.rescue/src/__tests__/no-restricted-globals.lint.test.ts
@@ -1,0 +1,40 @@
+/**
+ * ADS-586: Fixture test verifying the rescue ESLint config forbids
+ * native `alert(...)` and `confirm(...)` calls — they must be migrated to
+ * `useConfirm` and `toast.*` from @adopt-dont-shop/lib.components.
+ */
+import { Linter } from 'eslint';
+import { describe, it, expect } from 'vitest';
+
+const lint = (source: string) => {
+  const linter = new Linter();
+  return linter.verify(source, {
+    languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+    rules: {
+      'no-restricted-globals': ['error', 'alert', 'confirm'],
+    },
+  });
+};
+
+describe('no-restricted-globals fixture (ADS-586)', () => {
+  it('flags alert(...) as an error', () => {
+    const messages = lint('alert("oops");');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.ruleId).toBe('no-restricted-globals');
+    expect(messages[0]?.severity).toBe(2);
+  });
+
+  it('flags confirm(...) as an error', () => {
+    const messages = lint('if (confirm("really?")) {}');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.ruleId).toBe('no-restricted-globals');
+    expect(messages[0]?.severity).toBe(2);
+  });
+
+  it('allows toast.error(...) and useConfirm() replacements', () => {
+    const messages = lint(
+      'const toast = { error: (_m) => {} }; toast.error("nope"); const useConfirm = () => ({ confirm: async () => true }); useConfirm();'
+    );
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/app.rescue/src/__tests__/questions-builder.behavior.test.tsx
+++ b/app.rescue/src/__tests__/questions-builder.behavior.test.tsx
@@ -32,6 +32,37 @@ vi.mock('../utils/env', () => ({
   isDevelopment: () => false,
 }));
 
+// ADS-586: Override the global lib.components mock with a controllable
+// `useConfirm` so tests can simulate accept/reject of the destructive delete
+// confirmation. The other exports kept here match the global mock so existing
+// rendering still works.
+const confirmFn = vi.fn().mockResolvedValue(true);
+vi.mock('@adopt-dont-shop/lib.components', async () => {
+  const React = await import('react');
+  return {
+    lightTheme: {},
+    darkTheme: {},
+    ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+    Card: ({ children, ...props }: Record<string, unknown>) =>
+      React.createElement('div', props, children as React.ReactNode),
+    Button: ({ children, ...props }: Record<string, unknown>) =>
+      React.createElement('button', props, children as React.ReactNode),
+    Alert: ({ children, ...props }: Record<string, unknown>) =>
+      React.createElement('div', { role: 'alert', ...props }, children as React.ReactNode),
+    useConfirm: () => ({
+      isOpen: false,
+      confirm: confirmFn,
+      confirmProps: {
+        isOpen: false,
+        onClose: () => {},
+        onConfirm: () => {},
+        message: '',
+      },
+    }),
+    ConfirmDialog: () => null,
+  };
+});
+
 import { apiService } from '../services/libraryServices';
 
 const RESCUE_ID = 'rescue-uuid-123';
@@ -373,7 +404,7 @@ describe('Questions Builder - Behavioral Tests', () => {
   describe('Deleting questions', () => {
     it('deletes a question after confirmation', async () => {
       const user = userEvent.setup();
-      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      confirmFn.mockResolvedValueOnce(true);
 
       renderWithProviders(<QuestionsBuilder rescueId={RESCUE_ID} />);
 
@@ -394,7 +425,7 @@ describe('Questions Builder - Behavioral Tests', () => {
 
     it('does not delete when confirmation is cancelled', async () => {
       const user = userEvent.setup();
-      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      confirmFn.mockResolvedValueOnce(false);
 
       renderWithProviders(<QuestionsBuilder rescueId={RESCUE_ID} />);
 
@@ -404,6 +435,8 @@ describe('Questions Builder - Behavioral Tests', () => {
 
       await user.click(screen.getByTestId(`delete-${mockCustomQuestion.questionId}`));
 
+      // Give the async confirm() promise a tick to resolve before asserting.
+      await new Promise(resolve => setTimeout(resolve, 0));
       expect(vi.mocked(apiService.delete)).not.toHaveBeenCalled();
     });
   });

--- a/app.rescue/src/components/applications/ApplicationReview.test.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.test.tsx
@@ -195,7 +195,18 @@ vi.mock('@adopt-dont-shop/lib.components', async () => {
     );
   };
 
-  return { useConfirm, ConfirmDialog };
+  // ADS-586: `toast` is consumed by ApplicationReview for error feedback.
+  const toast = Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  });
+
+  return { useConfirm, ConfirmDialog, toast };
 });
 
 import ApplicationReview from './ApplicationReview';

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { ConfirmDialog, useConfirm } from '@adopt-dont-shop/lib.components';
+import { ConfirmDialog, toast, useConfirm } from '@adopt-dont-shop/lib.components';
 import { formatStatusName } from '../../utils/statusUtils';
 import {
   TimelineEventType,
@@ -199,7 +199,9 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
       setShowAddEvent(false);
     } catch (error) {
       console.error('Failed to add timeline event:', error);
-      alert('Failed to add timeline event. Please try again.');
+      toast.error('Failed to add timeline event. Please try again.', {
+        action: { label: 'Retry', onClick: handleAddEvent },
+      });
     } finally {
       setIsAddingEvent(false);
     }
@@ -373,8 +375,14 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
     } catch (error) {
       console.error('Failed to update reference:', error);
       // Show user-friendly error message
-      alert(
-        `Failed to update reference: ${error instanceof Error ? error.message : 'Unknown error'}`
+      toast.error(
+        `Failed to update reference: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        {
+          action: {
+            label: 'Retry',
+            onClick: () => handleReferenceUpdate(referenceId, status, notes),
+          },
+        }
       );
     }
   };
@@ -426,8 +434,9 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
       }
     } catch (error) {
       console.error('Failed to schedule visit:', error);
-      alert(
-        `Failed to schedule visit: ${error instanceof Error ? error.message : 'Unknown error'}`
+      toast.error(
+        `Failed to schedule visit: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { action: { label: 'Retry', onClick: handleScheduleVisit } }
       );
     } finally {
       setIsSchedulingVisit(false);
@@ -446,7 +455,10 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
       }
     } catch (error) {
       console.error('Failed to mark visit as in progress:', error);
-      alert(`Failed to update visit: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      toast.error(
+        `Failed to mark visit as in progress: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { action: { label: 'Retry', onClick: () => handleMarkVisitInProgress(visitId) } }
+      );
     }
   };
 
@@ -472,8 +484,9 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
       }
     } catch (error) {
       console.error('Failed to reschedule visit:', error);
-      alert(
-        `Failed to reschedule visit: ${error instanceof Error ? error.message : 'Unknown error'}`
+      toast.error(
+        `Failed to reschedule visit: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { action: { label: 'Retry', onClick: () => handleRescheduleVisit(visitId) } }
       );
     }
   };
@@ -506,8 +519,9 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
       }
     } catch (error) {
       console.error('Failed to complete visit:', error);
-      alert(
-        `Failed to complete visit: ${error instanceof Error ? error.message : 'Unknown error'}`
+      toast.error(
+        `Failed to complete visit: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { action: { label: 'Retry', onClick: () => handleCompleteVisit(visitId) } }
       );
     }
   };
@@ -530,7 +544,10 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
       }
     } catch (error) {
       console.error('Failed to cancel visit:', error);
-      alert(`Failed to cancel visit: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      toast.error(
+        `Failed to cancel visit: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { action: { label: 'Retry', onClick: () => handleCancelVisit(visitId) } }
+      );
     }
   };
 
@@ -613,8 +630,9 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
     } catch (error) {
       console.error('Failed to update application status:', error);
       // Show user-friendly error message
-      alert(
-        `Failed to update application status: ${error instanceof Error ? error.message : 'Unknown error'}`
+      toast.error(
+        `Failed to update application status: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { action: { label: 'Retry', onClick: handleStatusUpdate } }
       );
     } finally {
       setIsUpdatingStatus(false);

--- a/app.rescue/src/components/applications/StageTransitionModal.tsx
+++ b/app.rescue/src/components/applications/StageTransitionModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { toast } from '@adopt-dont-shop/lib.components';
 import {
   ApplicationStage,
   STAGE_CONFIG,
@@ -35,8 +36,9 @@ const StageTransitionModal: React.FC<StageTransitionModalProps> = ({
       onClose();
     } catch (error) {
       console.error('Failed to transition stage:', error);
-      alert(
-        `Failed to transition stage: ${error instanceof Error ? error.message : 'Unknown error'}`
+      toast.error(
+        `Failed to transition stage: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { action: { label: 'Retry', onClick: handleSubmit } }
       );
     } finally {
       setIsSubmitting(false);

--- a/app.rescue/src/components/rescue/QuestionsBuilder.tsx
+++ b/app.rescue/src/components/rescue/QuestionsBuilder.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Button, Card, Alert } from '@adopt-dont-shop/lib.components';
+import { Alert, Button, Card, ConfirmDialog, useConfirm } from '@adopt-dont-shop/lib.components';
 import { apiService } from '../../services/libraryServices';
 import { getApiBaseUrl } from '../../utils/env';
 import * as styles from './QuestionsBuilder.css';
@@ -230,6 +230,9 @@ const QuestionsBuilder: React.FC<QuestionsBuilderProps> = ({ rescueId }) => {
   const [formErrors, setFormErrors] = useState<Partial<Record<keyof QuestionFormData, string>>>({});
   const [submitting, setSubmitting] = useState(false);
 
+  // ADS-586: confirm dialog for destructive question deletion.
+  const { confirm, confirmProps } = useConfirm();
+
   const apiBase = getApiBaseUrl();
 
   const loadQuestions = useCallback(async () => {
@@ -379,11 +382,14 @@ const QuestionsBuilder: React.FC<QuestionsBuilderProps> = ({ rescueId }) => {
   };
 
   const handleDelete = async (question: Question) => {
-    if (
-      !window.confirm(
-        `Are you sure you want to delete the question "${question.questionText}"? This cannot be undone.`
-      )
-    ) {
+    const confirmed = await confirm({
+      title: 'Delete question?',
+      message: `Are you sure you want to delete the question "${question.questionText}"? This cannot be undone.`,
+      confirmText: 'Delete question',
+      cancelText: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) {
       return;
     }
 
@@ -810,6 +816,8 @@ const QuestionsBuilder: React.FC<QuestionsBuilderProps> = ({ rescueId }) => {
           </div>
         );
       })}
+
+      <ConfirmDialog {...confirmProps} />
     </div>
   );
 };

--- a/app.rescue/src/pages/Analytics.tsx
+++ b/app.rescue/src/pages/Analytics.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Card, Heading } from '@adopt-dont-shop/lib.components';
+import { Card, Heading, toast } from '@adopt-dont-shop/lib.components';
 import {
   FiTrendingUp,
   FiUsers,
@@ -106,7 +106,9 @@ const Analytics: React.FC = () => {
       document.body.removeChild(a);
     } catch (err) {
       console.error('Export CSV failed:', err);
-      alert('Failed to export CSV. Please try again.');
+      toast.error('Failed to export CSV. Please try again.', {
+        action: { label: 'Retry', onClick: handleExportCSV },
+      });
     }
   };
 
@@ -128,7 +130,9 @@ const Analytics: React.FC = () => {
       document.body.removeChild(a);
     } catch (err) {
       console.error('Export PDF failed:', err);
-      alert('Failed to export PDF. Please try again.');
+      toast.error('Failed to export PDF. Please try again.', {
+        action: { label: 'Retry', onClick: handleExportPDF },
+      });
     }
   };
 
@@ -149,10 +153,12 @@ const Analytics: React.FC = () => {
         [email]
       );
 
-      alert('Report sent successfully!');
+      toast.success('Report sent successfully!');
     } catch (err) {
       console.error('Email report failed:', err);
-      alert('Failed to send report. Please try again.');
+      toast.error('Failed to send report. Please try again.', {
+        action: { label: 'Retry', onClick: handleEmailReport },
+      });
     }
   };
 

--- a/app.rescue/src/pages/Events.tsx
+++ b/app.rescue/src/pages/Events.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import clsx from 'clsx';
-import { Card } from '@adopt-dont-shop/lib.components';
+import { Card, ConfirmDialog, toast, useConfirm } from '@adopt-dont-shop/lib.components';
 import { FiCalendar, FiPlus } from 'react-icons/fi';
 import * as styles from './Events.css';
 
@@ -50,6 +50,9 @@ const Events: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   // In-flight flag to prevent duplicate create/update/delete submissions.
   const [submitting, setSubmitting] = useState(false);
+
+  // ADS-586: confirm dialog for destructive event deletion.
+  const { confirm, confirmProps } = useConfirm();
 
   // Fetch events on mount and when filters change
   useEffect(() => {
@@ -140,7 +143,9 @@ const Events: React.FC = () => {
       setShowCreateModal(false);
     } catch (err) {
       console.error('Failed to create event:', err);
-      alert('Failed to create event. Please try again.');
+      toast.error('Failed to create event. Please try again.', {
+        action: { label: 'Retry', onClick: () => handleCreateEvent(eventData) },
+      });
     } finally {
       setSubmitting(false);
     }
@@ -170,7 +175,9 @@ const Events: React.FC = () => {
       }
     } catch (err) {
       console.error('Failed to update event:', err);
-      alert('Failed to update event. Please try again.');
+      toast.error('Failed to update event. Please try again.', {
+        action: { label: 'Retry', onClick: () => handleUpdateEvent(eventData) },
+      });
     } finally {
       setSubmitting(false);
     }
@@ -183,7 +190,14 @@ const Events: React.FC = () => {
     if (submitting) {
       return;
     }
-    if (!confirm('Are you sure you want to delete this event? This action cannot be undone.')) {
+    const confirmed = await confirm({
+      title: 'Delete event?',
+      message: 'Are you sure you want to delete this event? This action cannot be undone.',
+      confirmText: 'Delete event',
+      cancelText: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) {
       return;
     }
 
@@ -195,7 +209,9 @@ const Events: React.FC = () => {
       setSelectedEvent(null);
     } catch (err) {
       console.error('Failed to delete event:', err);
-      alert('Failed to delete event. Please try again.');
+      toast.error('Failed to delete event. Please try again.', {
+        action: { label: 'Retry', onClick: () => handleDeleteEvent(eventId) },
+      });
     } finally {
       setSubmitting(false);
     }
@@ -215,7 +231,9 @@ const Events: React.FC = () => {
       }
     } catch (err) {
       console.error('Failed to update event status:', err);
-      alert('Failed to update event status. Please try again.');
+      toast.error('Failed to update event status. Please try again.', {
+        action: { label: 'Retry', onClick: () => handleUpdateEventStatus(eventId, status) },
+      });
     }
   };
 
@@ -264,7 +282,9 @@ const Events: React.FC = () => {
       setEventAttendees(updatedAttendees);
     } catch (err) {
       console.error('Failed to check in attendee:', err);
-      alert('Failed to check in attendee. Please try again.');
+      toast.error('Failed to check in attendee. Please try again.', {
+        action: { label: 'Retry', onClick: () => handleCheckInAttendee(userId) },
+      });
     }
   };
 
@@ -458,6 +478,8 @@ const Events: React.FC = () => {
           </div>
         </div>
       </div>
+
+      <ConfirmDialog {...confirmProps} />
     </div>
   );
 };

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -52,10 +52,12 @@ const PetManagement: React.FC = () => {
       // Refresh the user data
       await refreshUser();
       setShowRescueSetup(false);
-      alert('Demo rescue created successfully! You can now manage pets.');
+      toast.success('Demo rescue created successfully! You can now manage pets.');
     } catch (error) {
       console.error('Error creating demo rescue:', error);
-      alert('Failed to create demo rescue. Please check the console for details.');
+      toast.error('Failed to create demo rescue. Please check the console for details.', {
+        action: { label: 'Retry', onClick: handleCreateDemoRescue },
+      });
     } finally {
       setLoading(false);
     }
@@ -291,7 +293,9 @@ const PetManagement: React.FC = () => {
               variant="outline"
               onClick={() => {
                 // Navigate to rescue creation form
-                alert('Full rescue registration coming soon. For now, please use the backend API.');
+                toast.info(
+                  'Full rescue registration coming soon. For now, please use the backend API.'
+                );
               }}
             >
               Register New Rescue

--- a/app.rescue/src/pages/ReportViewPage.tsx
+++ b/app.rescue/src/pages/ReportViewPage.tsx
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { Heading, ReportRenderer, Text } from '@adopt-dont-shop/lib.components';
+import {
+  ConfirmDialog,
+  Heading,
+  ReportRenderer,
+  Text,
+  useConfirm,
+} from '@adopt-dont-shop/lib.components';
 import {
   useDeleteReport,
   useExecuteSavedReport,
@@ -33,6 +39,8 @@ const ReportViewPage: React.FC = () => {
   const [cron, setCron] = useState('0 9 * * 1');
   const [recipientEmail, setRecipientEmail] = useState('');
   const [shareUrl, setShareUrl] = useState<string | null>(null);
+  // ADS-586: confirm dialog for destructive report deletion.
+  const { confirm, confirmProps } = useConfirm();
 
   if (!id) {
     return (
@@ -57,7 +65,14 @@ const ReportViewPage: React.FC = () => {
   }
 
   const handleDelete = async (): Promise<void> => {
-    if (!confirm('Delete this report?')) {
+    const confirmed = await confirm({
+      title: 'Delete report?',
+      message: 'Delete this report? This action cannot be undone.',
+      confirmText: 'Delete report',
+      cancelText: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) {
       return;
     }
     await deleteMutation.mutateAsync(id);
@@ -166,6 +181,8 @@ const ReportViewPage: React.FC = () => {
           error={(executeQuery.error as Error | null) ?? null}
         />
       )}
+
+      <ConfirmDialog {...confirmProps} />
     </div>
   );
 };

--- a/app.rescue/src/pages/StaffManagement.tsx
+++ b/app.rescue/src/pages/StaffManagement.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { ConfirmDialog, useConfirm } from '@adopt-dont-shop/lib.components';
 import {
   StaffList,
   StaffForm,
@@ -34,6 +35,9 @@ const StaffManagement: React.FC = () => {
   const [actionLoading, setActionLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+
+  // ADS-586: confirm dialog for destructive staff/invitation actions.
+  const { confirm, confirmProps } = useConfirm();
 
   // Check permissions using the permissions service
   const canDeleteStaff = hasPermission(STAFF_DELETE);
@@ -100,7 +104,14 @@ const StaffManagement: React.FC = () => {
   };
 
   const handleCancelInvitation = async (invitationId: number) => {
-    if (!confirm('Are you sure you want to cancel this invitation?')) {
+    const confirmed = await confirm({
+      title: 'Cancel invitation?',
+      message: 'Are you sure you want to cancel this invitation?',
+      confirmText: 'Cancel invitation',
+      cancelText: 'Keep invitation',
+      variant: 'danger',
+    });
+    if (!confirmed) {
       return;
     }
 
@@ -183,11 +194,14 @@ const StaffManagement: React.FC = () => {
       return;
     }
 
-    if (
-      !confirm(
-        `Are you sure you want to remove ${staffMember.firstName} ${staffMember.lastName} from your staff?`
-      )
-    ) {
+    const confirmed = await confirm({
+      title: 'Remove staff member?',
+      message: `Are you sure you want to remove ${staffMember.firstName} ${staffMember.lastName} from your staff?`,
+      confirmText: 'Remove',
+      cancelText: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) {
       return;
     }
 
@@ -338,6 +352,8 @@ const StaffManagement: React.FC = () => {
           loading={actionLoading}
         />
       )}
+
+      <ConfirmDialog {...confirmProps} />
     </div>
   );
 };

--- a/app.rescue/src/setup-tests.ts
+++ b/app.rescue/src/setup-tests.ts
@@ -135,4 +135,28 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   TextInput: ({ children, ...props }: any) =>
     React.createElement('input', { type: 'text', ...props }),
   TextArea: ({ children, ...props }: any) => React.createElement('textarea', props, children),
+  // ADS-586: useConfirm / ConfirmDialog mocks so tests can intercept the
+  // promise-based confirm flow without rendering the real modal. Default
+  // returns `true` so existing flows don't break.
+  useConfirm: () => ({
+    isOpen: false,
+    confirm: vi.fn().mockResolvedValue(true),
+    confirmProps: {
+      isOpen: false,
+      onClose: () => {},
+      onConfirm: () => {},
+      message: '',
+    },
+  }),
+  ConfirmDialog: () => null,
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+  Toaster: () => null,
 }));


### PR DESCRIPTION
Closes ADS-586

## Summary

Rescue slice of the ADS-580 native-dialog cleanup. Replaces every `window.confirm()` and `alert()` in `app.rescue` with `useConfirm` + `ConfirmDialog` or `toast.*` from `@adopt-dont-shop/lib.components`, and locks the rule in via ESLint.

## Verification

```
$ grep -rn "window.confirm\|alert(" app.rescue/src --include='*.tsx' --include='*.ts' | grep -v '\.test\.' | grep -v '\.spec\.'
# before: 22 hits across 6 files
# after:  0 hits
```

## Migrated sites (26 total)

The ticket listed 22 sites covered by the `window.confirm\|alert(` grep. Adding `confirm` to `no-restricted-globals` also requires migrating four bare `confirm()` calls that the original grep didn't catch — included here so lint stays green:

- `app.rescue/src/components/rescue/QuestionsBuilder.tsx` — `window.confirm` -> `useConfirm` (variant: danger)
- `app.rescue/src/pages/Events.tsx` — 5 alerts -> `toast.error` with Retry actions, 1 bare `confirm` -> `useConfirm` (variant: danger)
- `app.rescue/src/pages/Analytics.tsx` — 3 export-error alerts -> `toast.error` with Retry, 1 success alert -> `toast.success`
- `app.rescue/src/pages/PetManagement.tsx` — 1 success alert -> `toast.success`, 1 error alert -> `toast.error` with Retry, 1 info alert -> `toast.info`
- `app.rescue/src/components/applications/ApplicationReview.tsx` — 8 alerts -> `toast.error` (each with action-specific message + Retry): timeline event added, reference contacted, visit scheduled/in-progress/rescheduled/completed/cancelled, status update
- `app.rescue/src/components/applications/StageTransitionModal.tsx` — 1 alert -> `toast.error` with Retry
- `app.rescue/src/pages/ReportViewPage.tsx` — 1 bare `confirm` -> `useConfirm` (variant: danger) [needed for ESLint to pass]
- `app.rescue/src/pages/StaffManagement.tsx` — 2 bare `confirm` -> `useConfirm` (variant: danger) [needed for ESLint to pass]

## ESLint enforcement

- Added `no-restricted-globals: ['error', 'alert', 'confirm']` to `app.rescue/eslint.config.js` with messages pointing engineers at `toast` and `useConfirm`.
- Fixture test at `app.rescue/src/__tests__/no-restricted-globals.lint.test.ts` verifies the rule fires on `alert(...)` / `confirm(...)` and allows the replacements.

## Test plan

- [x] `npx turbo lint test type-check --filter=@adopt-dont-shop/app.rescue` -> 23 tasks successful, 169 tests pass (incl. 3 new fixture tests)
- [x] `grep -rn "window.confirm\|alert(" app.rescue/src --include='*.tsx' --include='*.ts' | grep -v '\.test\.' | grep -v '\.spec\.'` returns zero hits
- [x] Updated `questions-builder.behavior.test.tsx` to drive the new promise-based confirm flow (replaces `vi.spyOn(window, 'confirm')`)
- [x] `setup-tests.ts` mocks `useConfirm`, `ConfirmDialog`, `toast`, `Toaster` so existing tests keep working

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_