### PR TITLE
feat(ADS-574): add image upload UI to PetFormModal

### DIFF
--- a/app.rescue/src/components/pets/PetFormModal.css.ts
+++ b/app.rescue/src/components/pets/PetFormModal.css.ts
@@ -138,3 +138,112 @@ export const currencyAdornment = style({
 globalStyle(`${currencyInputWrapper} input`, {
   paddingLeft: '1.75rem',
 });
+
+// ── Image uploader (ADS-574) ─────────────────────────────────────────────────
+
+export const imageHelper = style({
+  fontSize: '0.75rem',
+  color: '#6b7280',
+  marginTop: '0.5rem',
+});
+
+export const imageList = style({
+  listStyle: 'none',
+  margin: '1rem 0 0 0',
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+});
+
+export const imageItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  padding: '0.5rem',
+  border: '1px solid #e5e7eb',
+  borderRadius: '4px',
+  background: '#fff',
+});
+
+export const imageThumbWrapper = style({
+  position: 'relative',
+  width: '56px',
+  height: '56px',
+  flexShrink: 0,
+});
+
+export const imageThumb = style({
+  width: '56px',
+  height: '56px',
+  objectFit: 'cover',
+  borderRadius: '4px',
+  border: '1px solid #d1d5db',
+});
+
+export const imageThumbPlaceholder = style({
+  width: '56px',
+  height: '56px',
+  borderRadius: '4px',
+  background: '#f3f4f6',
+  border: '1px dashed #d1d5db',
+});
+
+export const primaryBadge = style({
+  position: 'absolute',
+  bottom: '-6px',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  background: '#2563eb',
+  color: '#fff',
+  fontSize: '0.625rem',
+  fontWeight: 600,
+  padding: '0.125rem 0.375rem',
+  borderRadius: '999px',
+  whiteSpace: 'nowrap',
+});
+
+export const imageMeta = style({
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.125rem',
+});
+
+export const imageFilename = style({
+  fontSize: '0.875rem',
+  color: '#111827',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+export const imageStatus = style({
+  fontSize: '0.75rem',
+  color: '#6b7280',
+});
+
+export const imageStatusError = style({
+  fontSize: '0.75rem',
+  color: '#ef4444',
+});
+
+export const imageActions = style({
+  display: 'flex',
+  gap: '0.25rem',
+});
+
+globalStyle(`${imageActions} button`, {
+  fontSize: '0.75rem',
+  padding: '0.25rem 0.5rem',
+  border: '1px solid #d1d5db',
+  background: '#fff',
+  borderRadius: '4px',
+  cursor: 'pointer',
+});
+
+globalStyle(`${imageActions} button:disabled`, {
+  color: '#9ca3af',
+  cursor: 'not-allowed',
+});

--- a/app.rescue/src/components/pets/PetFormModal.test.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.test.tsx
@@ -1,15 +1,20 @@
 /**
- * Behavioural tests for the rescue PetFormModal adoption fee field.
+ * Behavioural tests for the rescue PetFormModal.
  *
- * Documents ADS-578: the field accepts only non-negative numeric values
- * (up to 2 decimal places) and rejects free-text values such as "free",
- * "£150", or "tbd".
+ * Documents:
+ *   - ADS-578: the adoption fee field accepts only non-negative numeric
+ *     values (up to 2 decimal places) and rejects free-text values such as
+ *     "free", "£150", or "tbd".
+ *   - ADS-574: the image upload field — multi-file picker, per-file states
+ *     (pending/uploading/uploaded/error), drag-to-reorder, inline mime/size
+ *     validation, and the `images` URL array in the submit payload.
  */
 
-import { describe, expect, it, vi } from 'vitest';
-import userEvent from '@testing-library/user-event';
+import type { ImageUploadResponse } from '@adopt-dont-shop/lib.api';
 import type { PetCreateData, PetUpdateData } from '@adopt-dont-shop/lib.pets';
-import { fireEvent, renderWithProviders, screen, waitFor } from '../../test-utils/render';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, renderWithProviders, screen, waitFor } from '../../test-utils/render';
 import PetFormModal from './PetFormModal';
 
 type SubmitArg = PetCreateData | PetUpdateData;
@@ -97,6 +102,270 @@ describe('PetFormModal — adoption fee field (ADS-578)', () => {
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('PetFormModal — image upload field (ADS-574)', () => {
+  const makeImageFile = (name = 'photo.png', size = 1024, mime = 'image/png'): File => {
+    const blob = new Blob([new Uint8Array(size)], { type: mime });
+    return new File([blob], name, { type: mime });
+  };
+
+  const makeUploadResponse = (suffix: string): ImageUploadResponse => ({
+    url: `/uploads/pets/pets_${suffix}.png`,
+    thumbnail_url: `/uploads/pets/pets_${suffix}.thumb.png`,
+    original_filename: `photo-${suffix}.png`,
+    size_bytes: 1024,
+    content_type: 'image/png',
+  });
+
+  it('renders a multi-file image picker', () => {
+    renderWithProviders(
+      <PetFormModal isOpen={true} onClose={() => {}} onSubmit={() => Promise.resolve()} />
+    );
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    expect(fileInput).toHaveAttribute('type', 'file');
+    expect(fileInput).toHaveAttribute('multiple');
+    expect(fileInput).toHaveAttribute('accept', expect.stringContaining('image/'));
+  });
+
+  it('rejects non-image files with an inline error and never calls the upload service', async () => {
+    const uploadImage = vi.fn(() => Promise.resolve(makeUploadResponse('x')));
+    renderWithProviders(
+      <PetFormModal
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => Promise.resolve()}
+        uploadImage={uploadImage}
+      />
+    );
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    const badFile = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [badFile] } });
+    });
+
+    expect(await screen.findByText(/not a supported image type/i)).toBeInTheDocument();
+    expect(uploadImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects files above the size limit with an inline error', async () => {
+    const uploadImage = vi.fn(() => Promise.resolve(makeUploadResponse('x')));
+    renderWithProviders(
+      <PetFormModal
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => Promise.resolve()}
+        uploadImage={uploadImage}
+      />
+    );
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    const oversize = makeImageFile('huge.png', 11 * 1024 * 1024);
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [oversize] } });
+    });
+
+    expect(await screen.findByText(/too large/i)).toBeInTheDocument();
+    expect(uploadImage).not.toHaveBeenCalled();
+  });
+
+  it('progresses an image through uploading -> uploaded and stores its url in the create payload', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+
+    // Hold the upload promise so the test can observe the uploading state.
+    let resolveUpload: (response: ImageUploadResponse) => void = () => {};
+    const uploadImage = vi.fn(
+      () =>
+        new Promise<ImageUploadResponse>(resolve => {
+          resolveUpload = resolve;
+        })
+    );
+
+    renderWithProviders(
+      <PetFormModal
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+        uploadImage={uploadImage}
+      />
+    );
+
+    await fillRequiredFields(user);
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [makeImageFile('rex.png')] } });
+    });
+
+    expect(await screen.findByText(/uploading/i)).toBeInTheDocument();
+    expect(uploadImage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveUpload(makeUploadResponse('rex'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/uploading/i)).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /add pet/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.images).toEqual(['/uploads/pets/pets_rex.png']);
+  });
+
+  it('surfaces an inline error when the upload service rejects and excludes the file from the payload', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+
+    const uploadImage = vi.fn(() => Promise.reject(new Error('Server is down')));
+
+    renderWithProviders(
+      <PetFormModal
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+        uploadImage={uploadImage}
+      />
+    );
+
+    await fillRequiredFields(user);
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [makeImageFile('rex.png')] } });
+    });
+
+    expect(await screen.findByText(/upload failed/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /add pet/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.images ?? []).toEqual([]);
+  });
+
+  it('lets the user remove an uploaded image before submission', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+    const uploadImage = vi
+      .fn<(file: File) => Promise<ImageUploadResponse>>()
+      .mockResolvedValueOnce(makeUploadResponse('a'))
+      .mockResolvedValueOnce(makeUploadResponse('b'));
+
+    renderWithProviders(
+      <PetFormModal
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+        uploadImage={uploadImage}
+      />
+    );
+
+    await fillRequiredFields(user);
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    await act(async () => {
+      fireEvent.change(fileInput, {
+        target: { files: [makeImageFile('a.png'), makeImageFile('b.png')] },
+      });
+    });
+
+    await waitFor(() => {
+      expect(uploadImage).toHaveBeenCalledTimes(2);
+    });
+
+    const removeButtons = await screen.findAllByRole('button', { name: /remove image/i });
+    await user.click(removeButtons[0]);
+
+    await user.click(screen.getByRole('button', { name: /add pet/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.images).toEqual(['/uploads/pets/pets_b.png']);
+  });
+
+  it('moves an image to the primary slot when the "make primary" control is clicked', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+    const uploadImage = vi
+      .fn<(file: File) => Promise<ImageUploadResponse>>()
+      .mockResolvedValueOnce(makeUploadResponse('a'))
+      .mockResolvedValueOnce(makeUploadResponse('b'));
+
+    renderWithProviders(
+      <PetFormModal
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+        uploadImage={uploadImage}
+      />
+    );
+
+    await fillRequiredFields(user);
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    await act(async () => {
+      fireEvent.change(fileInput, {
+        target: { files: [makeImageFile('a.png'), makeImageFile('b.png')] },
+      });
+    });
+
+    await waitFor(() => {
+      expect(uploadImage).toHaveBeenCalledTimes(2);
+    });
+
+    const makePrimaryButtons = await screen.findAllByRole('button', { name: /make primary/i });
+    // The first image is already primary so its button is disabled; click the
+    // second one to promote it.
+    await user.click(makePrimaryButtons[1]);
+
+    await user.click(screen.getByRole('button', { name: /add pet/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.images).toEqual(['/uploads/pets/pets_b.png', '/uploads/pets/pets_a.png']);
+  });
+
+  it('refuses to add more files once the max count is reached', async () => {
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+    const uploadImage = vi
+      .fn<(file: File) => Promise<ImageUploadResponse>>()
+      .mockResolvedValue(makeUploadResponse('x'));
+
+    renderWithProviders(
+      <PetFormModal
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+        uploadImage={uploadImage}
+      />
+    );
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    // 11 files in a single drop — only the first 10 should be accepted.
+    const files = Array.from({ length: 11 }, (_, i) => makeImageFile(`p${i}.png`));
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files } });
+    });
+
+    expect(await screen.findByText(/maximum of 10 images/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(uploadImage).toHaveBeenCalledTimes(10);
     });
   });
 });

--- a/app.rescue/src/components/pets/PetFormModal.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.tsx
@@ -1,16 +1,56 @@
-import React, { useState, useEffect } from 'react';
-import { Card, Button } from '@adopt-dont-shop/lib.components';
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, Card } from '@adopt-dont-shop/lib.components';
+import { apiService, type ImageUploadResponse } from '@adopt-dont-shop/lib.api';
 import { Pet, PetCreateData, PetUpdateData } from '@adopt-dont-shop/lib.pets';
 import * as styles from './PetFormModal.css';
+
+// ADS-574: image uploader configuration.
+//
+// `MAX_IMAGES` matches the rescue-side product cap (a handful of photos per
+// pet — not a hard backend limit, just a sensible UX ceiling).
+// `MAX_IMAGE_BYTES` mirrors the backend multer `petImageUpload` size limit
+// so we reject locally before the network round trip rather than after a
+// 413. The backend also magic-byte-checks the MIME so we still validate
+// `image/*` here to spare the user a server rejection.
+const MAX_IMAGES = 10;
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const ACCEPTED_IMAGE_TYPES = 'image/png,image/jpeg,image/jpg,image/webp,image/gif';
+
+type UploadedImage = {
+  // Local id keyed off the file slot so React can track items across reorders
+  // without using array index as the key.
+  localId: string;
+  filename: string;
+  status: 'uploading' | 'uploaded' | 'error';
+  // Populated once the upload succeeds. Stays undefined while uploading /
+  // after a failure so the submit payload only contains finalised URLs.
+  url?: string;
+  thumbnailUrl?: string;
+  errorMessage?: string;
+};
+
+type UploadImageFn = (file: File) => Promise<ImageUploadResponse>;
 
 interface PetFormModalProps {
   isOpen: boolean;
   pet?: Pet;
   onClose: () => void;
   onSubmit: (data: PetCreateData | PetUpdateData) => Promise<void>;
+  /**
+   * Test seam — defaults to the real `apiService.uploadImage`. The rescue
+   * page renders the modal without overriding this; tests inject a mock so
+   * they don't depend on `fetch`.
+   */
+  uploadImage?: UploadImageFn;
 }
 
-const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSubmit }) => {
+const PetFormModal: React.FC<PetFormModalProps> = ({
+  isOpen,
+  pet,
+  onClose,
+  onSubmit,
+  uploadImage = (file: File) => apiService.uploadImage(file),
+}) => {
   const [formData, setFormData] = useState<PetCreateData>({
     name: '',
     type: 'dog',
@@ -35,6 +75,18 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
 
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [images, setImages] = useState<UploadedImage[]>([]);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Monotonically increasing id so each upload slot has a stable React key
+  // across reorders / removals.
+  const nextLocalIdRef = useRef(0);
+  const allocateLocalId = (): string => {
+    const id = `img-${nextLocalIdRef.current}`;
+    nextLocalIdRef.current += 1;
+    return id;
+  };
 
   useEffect(() => {
     if (pet) {
@@ -74,6 +126,20 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
         medicalNotes: pet.medical_notes,
         behavioralNotes: pet.behavioral_notes,
       });
+      // Seed the uploader from the existing pet record so the editor can
+      // reorder / remove existing photos. Pet.images carries an
+      // order_index; we honour it via the array sort.
+      const seeded: UploadedImage[] = (pet.images ?? [])
+        .slice()
+        .sort((a, b) => a.order_index - b.order_index)
+        .map(img => ({
+          localId: allocateLocalId(),
+          filename: img.url.split('/').pop() ?? img.url,
+          status: 'uploaded' as const,
+          url: img.url,
+          thumbnailUrl: img.thumbnail_url,
+        }));
+      setImages(seeded);
     } else {
       setFormData({
         name: '',
@@ -96,8 +162,10 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
         energyLevel: 'medium',
         temperament: [],
       });
+      setImages([]);
     }
     setErrors({});
+    setImageError(null);
   }, [pet, isOpen]);
 
   const handleInputChange = (field: string, value: unknown) => {
@@ -147,6 +215,127 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
     return Object.keys(newErrors).length === 0;
   };
 
+  // ADS-574: image upload helpers.
+  //
+  // Each selected file gets a placeholder UploadedImage in `uploading` state
+  // appended synchronously. The upload runs asynchronously per-file (so a
+  // failure on one doesn't block the others) and patches the matching row
+  // by `localId` when it resolves. Submission only includes URLs from rows
+  // in the `uploaded` state so in-flight or failed uploads never leak into
+  // the create payload.
+  const validateImageFile = (file: File): string | null => {
+    if (!file.type.startsWith('image/')) {
+      return `${file.name} is not a supported image type.`;
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+      const mb = (MAX_IMAGE_BYTES / 1024 / 1024).toFixed(0);
+      return `${file.name} is too large. Maximum size is ${mb}MB.`;
+    }
+    return null;
+  };
+
+  const startUpload = (localId: string, file: File) => {
+    uploadImage(file)
+      .then(response => {
+        setImages(prev =>
+          prev.map(img =>
+            img.localId === localId
+              ? {
+                  ...img,
+                  status: 'uploaded',
+                  url: response.url,
+                  thumbnailUrl: response.thumbnail_url,
+                }
+              : img
+          )
+        );
+      })
+      .catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : 'Upload failed.';
+        setImages(prev =>
+          prev.map(img =>
+            img.localId === localId
+              ? { ...img, status: 'error', errorMessage: `Upload failed: ${message}` }
+              : img
+          )
+        );
+      });
+  };
+
+  const handleFilesSelected = (fileList: FileList | null) => {
+    setImageError(null);
+    if (!fileList || fileList.length === 0) {
+      return;
+    }
+    const selected = Array.from(fileList);
+    const remainingSlots = Math.max(0, MAX_IMAGES - images.length);
+    const overflow = selected.length > remainingSlots;
+    const toProcess = overflow ? selected.slice(0, remainingSlots) : selected;
+
+    const newRows: UploadedImage[] = [];
+    for (const file of toProcess) {
+      const validation = validateImageFile(file);
+      if (validation) {
+        setImageError(validation);
+        continue;
+      }
+      const localId = allocateLocalId();
+      newRows.push({
+        localId,
+        filename: file.name,
+        status: 'uploading',
+      });
+      startUpload(localId, file);
+    }
+
+    if (newRows.length > 0) {
+      setImages(prev => [...prev, ...newRows]);
+    }
+
+    if (overflow) {
+      setImageError(`You can attach a maximum of ${MAX_IMAGES} images per pet.`);
+    }
+
+    // Allow re-selecting the same file later (browsers won't refire change
+    // for an identical FileList).
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const removeImage = (localId: string) => {
+    setImages(prev => prev.filter(img => img.localId !== localId));
+    setImageError(null);
+  };
+
+  const moveToPrimary = (localId: string) => {
+    setImages(prev => {
+      const idx = prev.findIndex(img => img.localId === localId);
+      if (idx <= 0) {
+        return prev;
+      }
+      const next = prev.slice();
+      const [moved] = next.splice(idx, 1);
+      next.unshift(moved);
+      return next;
+    });
+  };
+
+  const reorderImages = (from: number, to: number) => {
+    if (from === to || from < 0 || to < 0) {
+      return;
+    }
+    setImages(prev => {
+      if (from >= prev.length || to >= prev.length) {
+        return prev;
+      }
+      const next = prev.slice();
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      return next;
+    });
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -154,9 +343,24 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
       return;
     }
 
+    // Only finalised uploads contribute to the submit payload — uploading /
+    // errored slots are dropped silently (the user sees them as not-yet-
+    // attached in the preview).
+    const imageUrls = images
+      .filter(
+        (img): img is UploadedImage & { url: string } =>
+          img.status === 'uploaded' && typeof img.url === 'string'
+      )
+      .map(img => img.url);
+
+    const payload: PetCreateData = {
+      ...formData,
+      images: imageUrls,
+    };
+
     setIsSubmitting(true);
     try {
-      await onSubmit(formData);
+      await onSubmit(payload);
       onClose();
     } catch (error) {
       console.error('Error submitting pet form:', error);
@@ -169,6 +373,8 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
   if (!isOpen) {
     return null;
   }
+
+  const remainingSlots = Math.max(0, MAX_IMAGES - images.length);
 
   return (
     <div
@@ -336,6 +542,99 @@ const PetFormModal: React.FC<PetFormModalProps> = ({ isOpen, pet, onClose, onSub
                 placeholder="Detailed description of the pet's personality, history, and needs"
                 rows={4}
               />
+            </div>
+
+            <div className={styles.formGroup({ fullWidth: true })}>
+              <label htmlFor="petImages">Add Pet Photos</label>
+              <input
+                id="petImages"
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept={ACCEPTED_IMAGE_TYPES}
+                onChange={e => handleFilesSelected(e.target.files)}
+                disabled={remainingSlots === 0}
+              />
+              <div className={styles.imageHelper}>
+                {remainingSlots} of {MAX_IMAGES} slots remaining. First photo is the primary listing
+                image — drag a photo to reorder or use &ldquo;Make primary&rdquo; to promote one.
+              </div>
+              {imageError && <div className="error">{imageError}</div>}
+
+              {images.length > 0 && (
+                <ul className={styles.imageList} aria-label="Attached pet photos">
+                  {images.map((img, index) => {
+                    const isPrimary = index === 0;
+                    const previewSrc = img.thumbnailUrl ?? img.url;
+                    return (
+                      <li
+                        key={img.localId}
+                        className={styles.imageItem}
+                        draggable={img.status === 'uploaded'}
+                        onDragStart={() => setDragIndex(index)}
+                        onDragOver={e => {
+                          if (dragIndex === null) {
+                            return;
+                          }
+                          e.preventDefault();
+                        }}
+                        onDrop={e => {
+                          if (dragIndex === null) {
+                            return;
+                          }
+                          e.preventDefault();
+                          reorderImages(dragIndex, index);
+                          setDragIndex(null);
+                        }}
+                        onDragEnd={() => setDragIndex(null)}
+                      >
+                        <div className={styles.imageThumbWrapper}>
+                          {previewSrc ? (
+                            <img
+                              className={styles.imageThumb}
+                              src={previewSrc}
+                              alt={img.filename}
+                            />
+                          ) : (
+                            <div className={styles.imageThumbPlaceholder} aria-hidden="true" />
+                          )}
+                          {isPrimary && <span className={styles.primaryBadge}>Primary</span>}
+                        </div>
+                        <div className={styles.imageMeta}>
+                          <span className={styles.imageFilename} title={img.filename}>
+                            {img.filename}
+                          </span>
+                          {img.status === 'uploading' && (
+                            <span className={styles.imageStatus}>Uploading...</span>
+                          )}
+                          {img.status === 'error' && (
+                            <span className={styles.imageStatusError}>
+                              {img.errorMessage ?? 'Upload failed'}
+                            </span>
+                          )}
+                        </div>
+                        <div className={styles.imageActions}>
+                          <button
+                            type="button"
+                            onClick={() => moveToPrimary(img.localId)}
+                            disabled={isPrimary || img.status !== 'uploaded'}
+                            aria-label={`Make primary: ${img.filename}`}
+                          >
+                            Make primary
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => removeImage(img.localId)}
+                            aria-label={`Remove image: ${img.filename}`}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
             </div>
 
             <div className={styles.formGroup()}>

--- a/lib.api/src/services/api-service.ts
+++ b/lib.api/src/services/api-service.ts
@@ -1,6 +1,8 @@
 import { ApiServiceConfig, FetchOptions } from '../types';
 import { InterceptorManager } from '../interceptors';
 import { createHttpError, TimeoutError, NetworkError } from '../errors';
+import { UPLOAD_PATHS } from '../constants/api-paths';
+import { ImageUploadResponseSchema, type ImageUploadResponse } from '../schemas/upload-schemas';
 
 /**
  * ApiService - Pure HTTP transport layer with interceptors and error handling
@@ -461,6 +463,29 @@ export class ApiService {
       method: 'POST',
       body: formData,
     });
+  }
+
+  /**
+   * ADS-574: typed client for the staged image upload endpoint
+   * (`POST /api/v1/uploads/images`).
+   *
+   * The backend route expects `multipart/form-data` with field name `image`
+   * (singular) — different from {@link uploadFile}'s generic `file` field —
+   * and returns the public URL + thumbnail URL pair that the rescue UI
+   * embeds in the `images: string[]` payload of a subsequent create/update
+   * pet request. We validate the response shape with the Zod schema to
+   * catch backend drift early.
+   */
+  async uploadImage(file: File): Promise<ImageUploadResponse> {
+    const formData = new FormData();
+    formData.append('image', file);
+
+    const raw = await this.fetchWithAuth<unknown>(UPLOAD_PATHS.IMAGES, {
+      method: 'POST',
+      body: formData,
+    });
+
+    return ImageUploadResponseSchema.parse(raw);
   }
 
   /**

--- a/lib.pets/src/schemas.ts
+++ b/lib.pets/src/schemas.ts
@@ -332,6 +332,7 @@ export const PetUpdateDataSchema = z.object({
   featured: z.boolean().optional(),
   priorityListing: z.boolean().optional(),
   tags: z.array(z.string()).optional(),
+  images: z.array(z.string()).optional(),
   status: PetStatusSchema.optional(),
 });
 


### PR DESCRIPTION
Closes ADS-574.

## Summary

Wires the staged image upload endpoint shipped in ADS-588 into the rescue `PetFormModal` so rescues can attach pet photos without leaving the standard create/edit flow. Photos are uploaded one-at-a-time to `POST /api/v1/uploads/images`, and the returned URLs are submitted as the pet payload's `images: string[]` field.

The form now supports:

- multi-file picker with `image/*` accept filter
- per-file thumbnail + filename + status (uploading / error)
- per-file upload progress reporting via row status transitions
- inline validation: image-only MIME, 10 MB per file, max 10 photos
- failed uploads remain visible with an inline error and are excluded from the submit payload
- drag-to-reorder via native HTML5 drag & drop
- a "Make primary" button that promotes a photo to index 0 (the primary listing image)
- when editing an existing pet, seeds the uploader from `pet.images` and honours their `order_index`

## Plumbing

- new typed `apiService.uploadImage(file)` in `lib.api` that POSTs `multipart/form-data` with field `image` and validates the response with `ImageUploadResponseSchema`
- `images: z.array(z.string()).optional()` added to `PetUpdateDataSchema` (already present on `PetCreateDataSchema`) so the form can roundtrip the URL array on edit

## Test plan

Behavioural tests (Vitest + React Testing Library, no implementation coupling):

- [x] rejects non-image files with an inline error and never calls the upload service
- [x] rejects files above 10 MB with an inline error and never calls the upload service
- [x] file progresses through `uploading` → `uploaded` and its URL ends up in the create payload
- [x] upload service errors surface as an inline `"Upload failed: ..."` message; that file is excluded from the payload
- [x] the user can remove an uploaded image and it is dropped from the submit payload
- [x] "Make primary" reorders the URLs so the chosen file becomes index 0
- [x] dropping 11 files at once only uploads the first 10 and surfaces a maximum-reached error
- [x] existing PetFormModal adoption-fee tests (ADS-578) still pass
- [x] `npx turbo lint test type-check` clean for `@adopt-dont-shop/app.rescue`, `@adopt-dont-shop/lib.pets`, `@adopt-dont-shop/lib.api`
- [x] all 13 CI checks green

## Verification (manual)

1. Open the rescue PetManagement page → "Add Pet"
2. Upload 2–3 images via the new picker → save
3. Confirm the pet detail page on `app.client` shows the uploaded images
4. Edit the pet → reorder via drag, or click "Make primary" → save
5. Confirm the new order persists

## Scope notes

In scope (matches the ticket):

- file picker, preview, progress, error states, drag-to-reorder, inline validation, `images` URL array in payload

Deliberately out of scope (would need a separate ticket):

- extracting the uploader to `lib.components` for reuse with `RescueSettings.tsx`
- replacing native HTML5 drag with a richer DnD library

https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS