### PR TITLE
feat(ADS-583): let rescue staff mark conversations resolved

### DIFF
--- a/app.rescue/src/pages/Communication.css.ts
+++ b/app.rescue/src/pages/Communication.css.ts
@@ -90,3 +90,45 @@ globalStyle(`${mobileViewHideChat} > :last-child`, {
     },
   },
 });
+
+export const toolbar = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  marginTop: '1rem',
+  flexWrap: 'wrap',
+});
+
+export const filterTab = style({
+  padding: '0.375rem 0.875rem',
+  borderRadius: '9999px',
+  border: '1px solid #d1d5db',
+  background: '#ffffff',
+  color: '#374151',
+  fontWeight: 500,
+  fontSize: '0.875rem',
+  cursor: 'pointer',
+  selectors: {
+    '&:hover': {
+      background: '#f3f4f6',
+    },
+  },
+});
+
+export const filterTabActive = style({
+  background: '#2563eb',
+  borderColor: '#2563eb',
+  color: '#ffffff',
+  selectors: {
+    '&:hover': {
+      background: '#1d4ed8',
+    },
+  },
+});
+
+export const actionGroup = style({
+  marginLeft: 'auto',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+});

--- a/app.rescue/src/pages/Communication.test.tsx
+++ b/app.rescue/src/pages/Communication.test.tsx
@@ -1,0 +1,327 @@
+/**
+ * ADS-583: rescue staff need a way to mark conversations as resolved.
+ *
+ * Behaviour under test:
+ * - The Active tab is the default view.
+ * - When the active conversation is loaded and the viewer has chat-management
+ *   permission, a "Mark resolved" action appears.
+ * - Clicking "Mark resolved" opens a useConfirm modal; confirming calls
+ *   updateConversationStatus with 'archived'.
+ * - Switching to Resolved shows the resolved conversation; switching back
+ *   to Active hides it.
+ * - Filter selection persists in localStorage across mounts.
+ */
+import React, { useState } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { Conversation } from '@adopt-dont-shop/lib.chat';
+
+type ConfirmOptions = {
+  title?: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: 'danger' | 'warning' | 'info';
+};
+
+vi.mock('@adopt-dont-shop/lib.components', async () => {
+  type Resolver = (v: boolean) => void;
+  const useConfirm = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [opts, setOpts] = useState<ConfirmOptions>({ message: '' });
+    const [resolver, setResolver] = useState<{ resolve: Resolver } | null>(null);
+
+    const confirm = (o: ConfirmOptions) => {
+      setOpts(o);
+      setIsOpen(true);
+      return new Promise<boolean>(resolve => {
+        setResolver({ resolve });
+      });
+    };
+    const onClose = () => {
+      setIsOpen(false);
+      resolver?.resolve(false);
+      setResolver(null);
+    };
+    const onConfirm = () => {
+      setIsOpen(false);
+      resolver?.resolve(true);
+      setResolver(null);
+    };
+    return {
+      confirm,
+      confirmProps: { isOpen, onClose, onConfirm, ...opts },
+    };
+  };
+
+  const ConfirmDialog = (props: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    title?: string;
+    message: string;
+    confirmText?: string;
+    cancelText?: string;
+    'data-testid'?: string;
+  }) => {
+    if (!props.isOpen) {
+      return null;
+    }
+    return (
+      <div role="dialog" data-testid={props['data-testid']}>
+        <h2>{props.title}</h2>
+        <p>{props.message}</p>
+        <button onClick={props.onClose}>{props.cancelText ?? 'Cancel'}</button>
+        <button onClick={props.onConfirm}>{props.confirmText ?? 'Confirm'}</button>
+      </div>
+    );
+  };
+
+  const Button = (props: {
+    children?: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    variant?: string;
+    size?: string;
+    type?: 'button' | 'submit' | 'reset';
+  }) => (
+    <button type={props.type ?? 'button'} onClick={props.onClick} disabled={props.disabled}>
+      {props.children}
+    </button>
+  );
+
+  const toast = { success: vi.fn(), error: vi.fn() };
+
+  return { useConfirm, ConfirmDialog, Button, toast };
+});
+
+// lib.chat renders the conversation rows and the chat window from the
+// useChat context. For these tests we replace those with light test doubles
+// so we can drive the page from the conversations + active conversation
+// state, without spinning up a real socket or provider.
+const mockedUseChat = vi.fn();
+vi.mock('@adopt-dont-shop/lib.chat', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.chat')>(
+    '@adopt-dont-shop/lib.chat'
+  );
+
+  const ConversationList = ({ filter }: { filter?: 'active' | 'resolved' | 'all' }) => {
+    const ctx = mockedUseChat();
+    const visible = (ctx.conversations as Conversation[]).filter(c => {
+      if (filter === 'resolved') {
+        return c.status === 'archived' || c.status === 'closed';
+      }
+      if (filter === 'active') {
+        return !c.status || c.status === 'active';
+      }
+      return true;
+    });
+    return (
+      <ul data-testid="conversation-list">
+        {visible.map(c => (
+          <li key={c.id} data-testid={`conv-${c.id}`}>
+            {c.title ?? c.id}
+          </li>
+        ))}
+      </ul>
+    );
+  };
+  const ChatWindow = () => {
+    const ctx = mockedUseChat();
+    return <div data-testid="chat-window">{ctx.activeConversation?.id ?? 'none'}</div>;
+  };
+  return { ...actual, ConversationList, ChatWindow };
+});
+
+// PermissionsContext is the gate. We replace it inline so we can grant or
+// revoke CHAT_UPDATE per test.
+const mockedHasPermission = vi.fn();
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({ hasPermission: mockedHasPermission }),
+}));
+
+vi.mock('@/contexts/ChatContext', () => ({
+  useChat: () => mockedUseChat(),
+}));
+
+import Communication from './Communication';
+
+type BuildOptions = {
+  conversations?: Conversation[];
+  activeConversation?: Conversation | null;
+  hasPermission?: boolean;
+  updateConversationStatus?: ReturnType<typeof vi.fn>;
+};
+
+const baseConversation = (overrides: Partial<Conversation>): Conversation => ({
+  id: 'conv-1',
+  participants: [],
+  unreadCount: 0,
+  updatedAt: '2026-05-01T10:00:00Z',
+  createdAt: '2026-05-01T10:00:00Z',
+  isActive: true,
+  status: 'active',
+  ...overrides,
+});
+
+const setupHooks = (opts: BuildOptions = {}) => {
+  const updateConversationStatus =
+    opts.updateConversationStatus ?? vi.fn().mockResolvedValue(undefined);
+  mockedHasPermission.mockReset();
+  mockedHasPermission.mockImplementation(() => opts.hasPermission ?? true);
+  mockedUseChat.mockReset();
+  mockedUseChat.mockReturnValue({
+    conversations: opts.conversations ?? [],
+    activeConversation: opts.activeConversation ?? null,
+    updateConversationStatus,
+  });
+  return { updateConversationStatus };
+};
+
+const renderPage = () => render(<Communication />);
+
+describe('Communication page - ADS-583 mark resolved', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to the Active filter on first mount', () => {
+    setupHooks({
+      conversations: [
+        baseConversation({ id: 'a', title: 'Active thread', status: 'active' }),
+        baseConversation({ id: 'b', title: 'Resolved thread', status: 'archived' }),
+      ],
+    });
+
+    renderPage();
+
+    const activeTab = screen.getByRole('tab', { name: /^active$/i });
+    expect(activeTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('conv-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('conv-b')).not.toBeInTheDocument();
+  });
+
+  it('moves a conversation to Resolved after the user confirms "Mark resolved"', async () => {
+    const active = baseConversation({ id: 'a', title: 'Open thread', status: 'active' });
+    const { updateConversationStatus } = setupHooks({
+      conversations: [active],
+      activeConversation: active,
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+    const dialog = await screen.findByTestId('mark-resolved-confirm');
+    expect(dialog).toHaveTextContent(/resolved/i);
+
+    // Confirm by clicking the dialog's confirm button.
+    const dialogButtons = Array.from(dialog.querySelectorAll('button'));
+    const confirmBtn = dialogButtons.find(b => b.textContent === 'Mark resolved');
+    expect(confirmBtn).toBeDefined();
+    fireEvent.click(confirmBtn!);
+
+    await waitFor(() => {
+      expect(updateConversationStatus).toHaveBeenCalledWith('a', 'archived');
+    });
+  });
+
+  it('does not call updateConversationStatus when the confirmation is cancelled', async () => {
+    const active = baseConversation({ id: 'a', title: 'Open thread', status: 'active' });
+    const { updateConversationStatus } = setupHooks({
+      conversations: [active],
+      activeConversation: active,
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /mark resolved/i }));
+    const dialog = await screen.findByTestId('mark-resolved-confirm');
+    const cancelBtn = Array.from(dialog.querySelectorAll('button')).find(
+      b => b.textContent === 'Cancel'
+    );
+    fireEvent.click(cancelBtn!);
+
+    await new Promise(r => setTimeout(r, 0));
+    expect(updateConversationStatus).not.toHaveBeenCalled();
+  });
+
+  it('shows Reopen instead of Mark resolved when the active conversation is resolved', () => {
+    const resolved = baseConversation({ id: 'a', title: 'Done thread', status: 'archived' });
+    setupHooks({
+      conversations: [resolved],
+      activeConversation: resolved,
+    });
+
+    renderPage();
+
+    expect(screen.queryByRole('button', { name: /mark resolved/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reopen/i })).toBeInTheDocument();
+  });
+
+  it('reopens a resolved conversation when Reopen is clicked', async () => {
+    const resolved = baseConversation({ id: 'a', title: 'Done thread', status: 'archived' });
+    const { updateConversationStatus } = setupHooks({
+      conversations: [resolved],
+      activeConversation: resolved,
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /reopen/i }));
+
+    await waitFor(() => {
+      expect(updateConversationStatus).toHaveBeenCalledWith('a', 'active');
+    });
+  });
+
+  it('hides the resolve/reopen actions when the user lacks chat-management permission', () => {
+    const active = baseConversation({ id: 'a', status: 'active' });
+    setupHooks({
+      conversations: [active],
+      activeConversation: active,
+      hasPermission: false,
+    });
+
+    renderPage();
+
+    expect(screen.queryByRole('button', { name: /mark resolved/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reopen/i })).not.toBeInTheDocument();
+  });
+
+  it('switches the visible list when the user toggles the Resolved filter', () => {
+    setupHooks({
+      conversations: [
+        baseConversation({ id: 'a', title: 'Open thread', status: 'active' }),
+        baseConversation({ id: 'b', title: 'Done thread', status: 'archived' }),
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('tab', { name: /^resolved$/i }));
+
+    expect(screen.queryByTestId('conv-a')).not.toBeInTheDocument();
+    expect(screen.getByTestId('conv-b')).toBeInTheDocument();
+  });
+
+  it('persists the selected filter across re-mounts via localStorage', () => {
+    setupHooks({
+      conversations: [
+        baseConversation({ id: 'a', title: 'Open thread', status: 'active' }),
+        baseConversation({ id: 'b', title: 'Done thread', status: 'archived' }),
+      ],
+    });
+
+    const { unmount } = renderPage();
+    fireEvent.click(screen.getByRole('tab', { name: /^resolved$/i }));
+    unmount();
+
+    renderPage();
+    expect(screen.getByRole('tab', { name: /^resolved$/i })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.queryByTestId('conv-a')).not.toBeInTheDocument();
+    expect(screen.getByTestId('conv-b')).toBeInTheDocument();
+  });
+});

--- a/app.rescue/src/pages/Communication.tsx
+++ b/app.rescue/src/pages/Communication.tsx
@@ -1,12 +1,62 @@
 import { useChat } from '@/contexts/ChatContext';
-import { ChatWindow, ConversationList } from '@adopt-dont-shop/lib.chat';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import {
+  ChatWindow,
+  ConversationList,
+  type ConversationListFilter,
+  type ConversationStatus,
+} from '@adopt-dont-shop/lib.chat';
+import { Button, ConfirmDialog, toast, useConfirm } from '@adopt-dont-shop/lib.components';
+import { CHAT_UPDATE } from '@adopt-dont-shop/lib.permissions';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import * as styles from './Communication.css';
 
+// ADS-583: "resolved" maps to the backend's `archived` status. The backend's
+// ChatStatus enum only accepts active|locked|archived; lib.chat's broader
+// zod schema lists 'closed' too but the API rejects it. Mirror the admin
+// archive flow to stay consistent.
+const RESOLVED_STATUS: ConversationStatus = 'archived';
+const ACTIVE_STATUS: ConversationStatus = 'active';
+
+const FILTER_STORAGE_KEY = 'rescue.communication.filter';
+
+const isFilterValue = (value: string | null): value is 'active' | 'resolved' =>
+  value === 'active' || value === 'resolved';
+
+const loadInitialFilter = (): 'active' | 'resolved' => {
+  if (typeof window === 'undefined') {
+    return 'active';
+  }
+  try {
+    const stored = window.localStorage.getItem(FILTER_STORAGE_KEY);
+    if (isFilterValue(stored)) {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable (e.g. private mode); fall through to default
+  }
+  return 'active';
+};
+
+const persistFilter = (filter: 'active' | 'resolved'): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(FILTER_STORAGE_KEY, filter);
+  } catch {
+    // ignore — filter still works in memory
+  }
+};
+
 function Communication() {
-  const { activeConversation } = useChat();
+  const { activeConversation, updateConversationStatus } = useChat();
+  const { hasPermission } = usePermissions();
+  const { confirm, confirmProps } = useConfirm();
   const [isMobile, setIsMobile] = useState(false);
+  const [filter, setFilter] = useState<'active' | 'resolved'>(loadInitialFilter);
+  const [isUpdating, setIsUpdating] = useState(false);
 
   useEffect(() => {
     const checkMobile = () => {
@@ -22,12 +72,102 @@ function Communication() {
   }, []);
 
   const showChat = isMobile && activeConversation !== null;
+  const canManageChat = hasPermission(CHAT_UPDATE);
+
+  const handleFilterChange = (next: 'active' | 'resolved') => {
+    setFilter(next);
+    persistFilter(next);
+  };
+
+  const isResolved =
+    activeConversation?.status === RESOLVED_STATUS || activeConversation?.status === 'closed';
+
+  const handleMarkResolved = async () => {
+    if (!activeConversation) {
+      return;
+    }
+    const confirmed = await confirm({
+      title: 'Mark conversation as resolved',
+      message:
+        'This will move the conversation out of your Active inbox. A new message from the adopter will reopen it.',
+      confirmText: 'Mark resolved',
+      cancelText: 'Cancel',
+      variant: 'warning',
+    });
+    if (!confirmed) {
+      return;
+    }
+    setIsUpdating(true);
+    try {
+      await updateConversationStatus(activeConversation.id, RESOLVED_STATUS);
+      toast.success('Conversation marked as resolved');
+    } catch {
+      toast.error('Failed to mark conversation as resolved. Please try again.');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleReopen = async () => {
+    if (!activeConversation) {
+      return;
+    }
+    setIsUpdating(true);
+    try {
+      await updateConversationStatus(activeConversation.id, ACTIVE_STATUS);
+      toast.success('Conversation reopened');
+    } catch {
+      toast.error('Failed to reopen conversation. Please try again.');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const conversationListFilter: ConversationListFilter = filter;
 
   return (
     <div className={styles.pageContainer}>
       <div className={styles.pageHeader}>
         <h1>Communication</h1>
         <p>Manage conversations with potential adopters</p>
+        <div className={styles.toolbar} role="tablist" aria-label="Conversation filter">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={filter === 'active'}
+            className={clsx(styles.filterTab, filter === 'active' && styles.filterTabActive)}
+            onClick={() => handleFilterChange('active')}
+          >
+            Active
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={filter === 'resolved'}
+            className={clsx(styles.filterTab, filter === 'resolved' && styles.filterTabActive)}
+            onClick={() => handleFilterChange('resolved')}
+          >
+            Resolved
+          </button>
+          {activeConversation && canManageChat && (
+            <div className={styles.actionGroup}>
+              {isResolved ? (
+                <Button variant="secondary" size="sm" onClick={handleReopen} disabled={isUpdating}>
+                  Reopen
+                </Button>
+              ) : (
+                <Button
+                  variant="warning"
+                  size="sm"
+                  onClick={handleMarkResolved}
+                  disabled={isUpdating}
+                >
+                  Mark resolved
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
       <div className={styles.chatContainer}>
@@ -38,16 +178,18 @@ function Communication() {
               showChat ? styles.mobileViewShowChat : styles.mobileViewHideChat
             )}
           >
-            <ConversationList />
+            <ConversationList filter={conversationListFilter} />
             <ChatWindow />
           </div>
         ) : (
           <>
-            <ConversationList />
+            <ConversationList filter={conversationListFilter} />
             <ChatWindow />
           </>
         )}
       </div>
+
+      <ConfirmDialog {...confirmProps} data-testid="mark-resolved-confirm" />
     </div>
   );
 }

--- a/lib.chat/src/components/ConversationList.tsx
+++ b/lib.chat/src/components/ConversationList.tsx
@@ -17,6 +17,15 @@ const computeInitials = (name: string): string => {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 };
 
+/**
+ * Status filter for the list:
+ * - `'active'`: show conversations whose status is `active` or undefined
+ *   (legacy/default backend rows).
+ * - `'resolved'`: show conversations whose status is `archived` or `closed`.
+ * - `'all'` (default): no filtering, show everything from context.
+ */
+export type ConversationListFilter = 'active' | 'resolved' | 'all';
+
 type ConversationListProps = {
   /**
    * Called after a conversation is selected and the active conversation has
@@ -34,6 +43,20 @@ type ConversationListProps = {
     label: string;
     onClick: () => void;
   };
+  /** Show only active or only resolved conversations. Defaults to `'all'`. */
+  filter?: ConversationListFilter;
+};
+
+const matchesFilter = (conversation: Conversation, filter: ConversationListFilter): boolean => {
+  if (filter === 'all') {
+    return true;
+  }
+  const status = conversation.status;
+  if (filter === 'resolved') {
+    return status === 'archived' || status === 'closed';
+  }
+  // 'active' — treat undefined/null status as active (legacy rows).
+  return !status || status === 'active';
 };
 
 export function ConversationList({
@@ -41,6 +64,7 @@ export function ConversationList({
   title = 'Conversations',
   emptyStateDescription = 'Start a conversation when you have a matching pet or application to discuss.',
   emptyAction,
+  filter = 'all',
 }: ConversationListProps) {
   const { conversations, activeConversation, setActiveConversation, isLoading } = useChat();
 
@@ -51,7 +75,9 @@ export function ConversationList({
 
   const getUnreadCount = (conversation: Conversation) => conversation.unreadCount || 0;
 
-  const totalUnread = (conversations || []).reduce((sum, c) => sum + (c.unreadCount ?? 0), 0);
+  const visibleConversations = (conversations || []).filter((c) => matchesFilter(c, filter));
+
+  const totalUnread = visibleConversations.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0);
 
   if (isLoading && (!conversations || conversations.length === 0)) {
     return (
@@ -70,7 +96,7 @@ export function ConversationList({
         {totalUnread > 0 && <span className={styles.headerCount}>{totalUnread} unread</span>}
       </div>
 
-      {!conversations || conversations.length === 0 ? (
+      {visibleConversations.length === 0 ? (
         <div className={styles.emptyState}>
           <div className="illustration" aria-hidden>
             {'\u{1F4AC}'}
@@ -85,7 +111,7 @@ export function ConversationList({
         </div>
       ) : (
         <div className={styles.conversationsList}>
-          {(conversations || []).map((conversationRaw) => {
+          {visibleConversations.map((conversationRaw) => {
             const conversation = conversationRaw as ConversationWithRescueName;
             const unreadCount = getUnreadCount(conversation);
             const isActive = activeConversation?.id === conversation.id;

--- a/lib.chat/src/components/__tests__/ConversationList.test.tsx
+++ b/lib.chat/src/components/__tests__/ConversationList.test.tsx
@@ -82,4 +82,41 @@ describe('ConversationList', () => {
 
     expect(screen.getByText('99+')).toBeInTheDocument();
   });
+
+  // ADS-583: support an Active/Resolved filter so rescue staff can hide
+  // archived adoption threads from their working inbox.
+  describe('filter prop', () => {
+    const buildPair = () => [
+      buildTestConversation({ id: 'c1', rescueName: 'Active Rescue', status: 'active' }),
+      buildTestConversation({ id: 'c2', rescueName: 'Resolved Rescue', status: 'archived' }),
+    ];
+
+    it('shows only active conversations when filter="active"', () => {
+      renderWithChatContext(<ConversationList filter="active" />, {
+        value: buildChatContextValue({ conversations: buildPair() }),
+      });
+
+      expect(screen.getByText('Active Rescue')).toBeInTheDocument();
+      expect(screen.queryByText('Resolved Rescue')).not.toBeInTheDocument();
+    });
+
+    it('shows only resolved conversations when filter="resolved"', () => {
+      renderWithChatContext(<ConversationList filter="resolved" />, {
+        value: buildChatContextValue({ conversations: buildPair() }),
+      });
+
+      expect(screen.queryByText('Active Rescue')).not.toBeInTheDocument();
+      expect(screen.getByText('Resolved Rescue')).toBeInTheDocument();
+    });
+
+    it('treats conversations without an explicit status as active', () => {
+      renderWithChatContext(<ConversationList filter="active" />, {
+        value: buildChatContextValue({
+          conversations: [buildTestConversation({ id: 'c1', rescueName: 'Legacy Rescue' })],
+        }),
+      });
+
+      expect(screen.getByText('Legacy Rescue')).toBeInTheDocument();
+    });
+  });
 });

--- a/lib.chat/src/context/ChatProvider.tsx
+++ b/lib.chat/src/context/ChatProvider.tsx
@@ -5,6 +5,7 @@ import { ChatContext } from './chat-context';
 import type {
   ChatContextValue,
   ChatProviderProps,
+  ConversationStatus,
   FeatureFlagsAdapter,
   ResolveFileUrl,
 } from './chat-context-types';
@@ -185,11 +186,20 @@ export function ChatProvider({
             return conv;
           }
           const isActive = activeConversationIdRef.current === conv.id;
+          // ADS-583: auto-reopen a resolved/archived conversation when
+          // another participant sends a new message so the rescue sees it
+          // back under "Active". Self-sent messages don't flip the status,
+          // otherwise replying inside a resolved thread would silently
+          // reopen it for the resolver.
+          const shouldReopen =
+            (conv.status === 'archived' || conv.status === 'closed') &&
+            message.senderId !== user.userId;
           return {
             ...conv,
             lastMessage: message,
             updatedAt: message.timestamp,
             unreadCount: isActive ? conv.unreadCount : (conv.unreadCount ?? 0) + 1,
+            status: shouldReopen ? 'active' : conv.status,
           };
         })
       );
@@ -521,6 +531,29 @@ export function ChatProvider({
     [chatService]
   );
 
+  const updateConversationStatus = useCallback(
+    async (conversationId: string, status: ConversationStatus) => {
+      // Optimistic update so the conversation immediately moves between
+      // Active/Resolved filters without waiting on the PATCH round-trip.
+      const previousConversations = conversations;
+      setConversations((prev) =>
+        prev.map((conv) => (conv.id === conversationId ? { ...conv, status } : conv))
+      );
+      setActiveConversation((prev) =>
+        prev && prev.id === conversationId ? { ...prev, status } : prev
+      );
+      try {
+        await chatService.updateConversationStatus(conversationId, status);
+      } catch (err) {
+        setConversations(previousConversations);
+        const msg = err instanceof Error ? err.message : 'Failed to update conversation';
+        setError(msg);
+        throw err;
+      }
+    },
+    [chatService, conversations]
+  );
+
   const startConversation = useCallback(
     async (rescueId: string, petId?: string): Promise<Conversation> => {
       setError(null);
@@ -698,6 +731,7 @@ export function ChatProvider({
     pendingMessageCount,
     unreadMessageCount,
     setActiveConversation: handleSetActiveConversation,
+    updateConversationStatus,
     sendMessage,
     retryMessage,
     markAsRead,

--- a/lib.chat/src/context/__tests__/ChatProvider.test.tsx
+++ b/lib.chat/src/context/__tests__/ChatProvider.test.tsx
@@ -771,4 +771,150 @@ describe('ChatProvider', () => {
     expect(latest?.messages[latest?.messages.length - 1].id).toBe('m-recent-49');
     expect(getMessagesSpy).toHaveBeenCalledTimes(2);
   });
+
+  // ADS-583: rescue staff need to mark conversations resolved/archived
+  // and have them automatically reopen when a participant replies.
+  describe('updateConversationStatus + auto-reopen', () => {
+    it('optimistically updates the local conversation status and calls the service', async () => {
+      const conv = buildConversation({ id: 'chat-1', status: 'active' });
+      const { chatService, tokenProvider } = buildHarness([conv]);
+      const updateSpy = vi
+        .spyOn(chatService, 'updateConversationStatus')
+        .mockResolvedValue({ ...conv, status: 'archived' });
+
+      let ctxRef: ReturnType<typeof useChat> | null = null;
+      const Capture = () => {
+        ctxRef = useChat();
+        return null;
+      };
+
+      render(
+        <ChatProvider
+          chatService={chatService}
+          user={{ userId: 'user-1' }}
+          isAuthenticated
+          tokenProvider={tokenProvider}
+        >
+          <Capture />
+        </ChatProvider>
+      );
+
+      await waitFor(() => expect(ctxRef?.conversations).toHaveLength(1));
+
+      await act(async () => {
+        await ctxRef!.updateConversationStatus('chat-1', 'archived');
+      });
+
+      expect(updateSpy).toHaveBeenCalledWith('chat-1', 'archived');
+      expect(ctxRef?.conversations[0].status).toBe('archived');
+    });
+
+    it('reverts the optimistic status change when the service call fails', async () => {
+      const conv = buildConversation({ id: 'chat-1', status: 'active' });
+      const { chatService, tokenProvider } = buildHarness([conv]);
+      vi.spyOn(chatService, 'updateConversationStatus').mockRejectedValue(new Error('nope'));
+
+      let ctxRef: ReturnType<typeof useChat> | null = null;
+      const Capture = () => {
+        ctxRef = useChat();
+        return null;
+      };
+
+      render(
+        <ChatProvider
+          chatService={chatService}
+          user={{ userId: 'user-1' }}
+          isAuthenticated
+          tokenProvider={tokenProvider}
+        >
+          <Capture />
+        </ChatProvider>
+      );
+
+      await waitFor(() => expect(ctxRef?.conversations).toHaveLength(1));
+
+      await act(async () => {
+        await expect(ctxRef!.updateConversationStatus('chat-1', 'archived')).rejects.toThrow(
+          'nope'
+        );
+      });
+
+      expect(ctxRef?.conversations[0].status).toBe('active');
+    });
+
+    it('reopens an archived conversation when another participant sends a message', async () => {
+      const conv = buildConversation({ id: 'chat-1', status: 'archived' });
+      const { chatService, tokenProvider } = buildHarness([conv]);
+
+      let ctxRef: ReturnType<typeof useChat> | null = null;
+      const Capture = () => {
+        ctxRef = useChat();
+        return null;
+      };
+
+      render(
+        <ChatProvider
+          chatService={chatService}
+          user={{ userId: 'user-1' }}
+          isAuthenticated
+          tokenProvider={tokenProvider}
+        >
+          <Capture />
+        </ChatProvider>
+      );
+
+      await waitFor(() => expect(ctxRef?.conversations).toHaveLength(1));
+      expect(ctxRef?.conversations[0].status).toBe('archived');
+
+      const incoming = buildMessage({
+        id: 'msg-from-adopter',
+        senderId: 'user-other',
+        content: 'one more question',
+      });
+      await act(async () => {
+        chatService.simulateIncomingMessage(incoming);
+      });
+
+      await waitFor(() => expect(ctxRef?.conversations[0].status).toBe('active'));
+    });
+
+    it('does not reopen when the resolver themselves replies to a resolved conversation', async () => {
+      const conv = buildConversation({ id: 'chat-1', status: 'archived' });
+      const { chatService, tokenProvider } = buildHarness([conv]);
+
+      let ctxRef: ReturnType<typeof useChat> | null = null;
+      const Capture = () => {
+        ctxRef = useChat();
+        return null;
+      };
+
+      render(
+        <ChatProvider
+          chatService={chatService}
+          user={{ userId: 'user-1' }}
+          isAuthenticated
+          tokenProvider={tokenProvider}
+        >
+          <Capture />
+        </ChatProvider>
+      );
+
+      await waitFor(() => expect(ctxRef?.conversations).toHaveLength(1));
+
+      const selfEcho = buildMessage({
+        id: 'msg-self',
+        senderId: 'user-1',
+        content: 'a note for the record',
+      });
+      await act(async () => {
+        chatService.simulateIncomingMessage(selfEcho);
+      });
+
+      // Status must remain archived — replying inside a resolved thread
+      // should not silently reopen it for the rescue staff member who
+      // closed it.
+      await waitFor(() => expect(ctxRef?.messages).toHaveLength(1));
+      expect(ctxRef?.conversations[0].status).toBe('archived');
+    });
+  });
 });

--- a/lib.chat/src/context/chat-context-types.ts
+++ b/lib.chat/src/context/chat-context-types.ts
@@ -2,6 +2,8 @@ import type { ChatService } from '../services/chat-service';
 import type { Conversation, Message, ConnectionStatus } from '../types';
 import type { ConnectionQuality, OfflineAdapter } from './offline-adapter';
 
+export type ConversationStatus = NonNullable<Conversation['status']>;
+
 /**
  * Minimal authenticated-user shape the provider needs. Apps pass whatever
  * their auth layer exposes so long as it matches this.
@@ -65,6 +67,12 @@ export type ChatContextValue = {
   unreadMessageCount: number;
 
   setActiveConversation: (conversation: Conversation | null) => void;
+  /**
+   * Update a conversation's status (e.g. `archived` to mark resolved,
+   * `active` to reopen). Optimistically updates local state and
+   * persists via the backend.
+   */
+  updateConversationStatus: (conversationId: string, status: ConversationStatus) => Promise<void>;
   sendMessage: (content: string, attachments?: File[]) => Promise<void>;
   /**
    * Re-send a previously failed message by its client-side id. Reuses the

--- a/lib.chat/src/index.ts
+++ b/lib.chat/src/index.ts
@@ -31,7 +31,12 @@ export {
 // Context + provider for React apps
 export { ChatProvider } from './context/ChatProvider';
 export { useChat } from './context/use-chat';
-export type { ChatContextValue, ChatProviderProps, ChatUser } from './context/chat-context-types';
+export type {
+  ChatContextValue,
+  ChatProviderProps,
+  ChatUser,
+  ConversationStatus,
+} from './context/chat-context-types';
 export type {
   ConnectionQuality,
   OfflineAdapter,
@@ -50,6 +55,7 @@ export { AvatarComponent } from './components/AvatarComponent';
 export { ChatWindow } from './components/ChatWindow';
 export { ConnectionStatusBanner } from './components/ConnectionStatusBanner';
 export { ConversationList } from './components/ConversationList';
+export type { ConversationListFilter } from './components/ConversationList';
 export { ImageLightbox } from './components/ImageLightbox';
 export { MessageBubbleComponent } from './components/MessageBubbleComponent';
 export { MessageInput } from './components/MessageInput';

--- a/lib.chat/src/services/__tests__/chat-service.test.ts
+++ b/lib.chat/src/services/__tests__/chat-service.test.ts
@@ -835,4 +835,46 @@ describe('ChatService', () => {
       expect(init.credentials).toBe('include');
     });
   });
+
+  // ADS-583: rescue staff need to mark a conversation as resolved (archived
+  // on the backend) and optionally reopen it. The service is a thin PATCH
+  // wrapper; the provider does the optimistic state plumbing.
+  describe('updateConversationStatus', () => {
+    it('issues a PATCH to /api/v1/chats/:id with the new status and credentials', async () => {
+      const service = new ChatService({ apiUrl: 'https://api.test' });
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({ data: { id: 'chat-1', status: 'archived' } }),
+        } as Response)
+      );
+
+      const result = await service.updateConversationStatus('chat-1', 'archived');
+
+      const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const url = call[0] as string;
+      const init = call[1] as RequestInit & { headers: Record<string, string> };
+      expect(url).toBe('https://api.test/api/v1/chats/chat-1');
+      expect(init.method).toBe('PATCH');
+      expect(init.credentials).toBe('include');
+      expect(JSON.parse(init.body as string)).toEqual({ status: 'archived' });
+      expect(result).toEqual({ id: 'chat-1', status: 'archived' });
+    });
+
+    it('throws when the backend rejects the status update', async () => {
+      const service = new ChatService({ apiUrl: 'https://api.test' });
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(() =>
+        Promise.resolve({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          json: () => Promise.resolve({}),
+        } as Response)
+      );
+
+      await expect(service.updateConversationStatus('chat-1', 'bogus')).rejects.toThrow(/HTTP 400/);
+    });
+  });
 });

--- a/lib.chat/src/services/chat-service.ts
+++ b/lib.chat/src/services/chat-service.ts
@@ -664,6 +664,34 @@ export class ChatService {
   }
 
   /**
+   * Update a conversation's status (e.g. mark as resolved/archived,
+   * or reopen by setting it back to active). The backend's
+   * `ChatStatus` enum currently accepts `active | locked | archived`.
+   */
+  async updateConversationStatus(conversationId: string, status: string): Promise<Conversation> {
+    try {
+      const response = await fetch(`${this.config.apiUrl}/api/v1/chats/${conversationId}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: await this.getMutatingHeaders(),
+        body: JSON.stringify({ status }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const result = await response.json();
+      return result.data;
+    } catch (error) {
+      if (this.config.debug) {
+        console.error(`${ChatService.name} updateConversationStatus error:`, error);
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Create a new conversation
    */
   async createConversation(data: {

--- a/lib.chat/src/test-utils.tsx
+++ b/lib.chat/src/test-utils.tsx
@@ -29,6 +29,7 @@ export const buildChatContextValue = (
   pendingMessageCount: 0,
   unreadMessageCount: 0,
   setActiveConversation: () => {},
+  updateConversationStatus: async () => {},
   sendMessage: async () => {},
   retryMessage: async () => {},
   markAsRead: async () => {},


### PR DESCRIPTION
Closes ADS-583

## Summary

Adds a "Mark resolved" action and an Active/Resolved filter toggle to the rescue Communication page so staff with chat-management permission can clear adoption threads out of their working inbox.

- `lib.chat`: new `ChatService.updateConversationStatus` method, exposed via `ChatContext` with optimistic local state. Auto-reopens an archived conversation when another participant sends a new message (self-sent replies do not flip the status).
- `lib.chat`: `ConversationList` grows an optional `filter` prop (`'active' | 'resolved' | 'all'`) so consumers can drive the visible list without forking the component.
- `app.rescue`: Communication page adds the Mark resolved / Reopen action gated by `CHAT_UPDATE`, plus an Active/Resolved tablist persisted to `localStorage`.

## Implementation notes

- "Resolved" maps to the backend's `archived` status. The backend's `ChatStatus` enum only accepts `active | locked | archived`; the lib.chat zod schema lists `closed` for forward-compat but the API rejects it. Mirrors the admin archive flow at `app.admin/src/components/modals/ChatDetailModal.tsx`.
- Permission gate: `CHAT_UPDATE` ('chats.update'). In the default seed only `RESCUE_ADMIN` is granted this permission; `RESCUE_STAFF` ships without it. Staff who should manage conversations need to have the permission assigned.
- The auto-reopen logic lives client-side in the provider's incoming-message handler. The backend's `ChatStatus` stays `archived` until someone explicitly PATCHes it; if the rescue navigates away and back, the conversation appears under Resolved again until they reopen it manually. Out-of-scope for this ticket: a backend hook that reopens on incoming messages.

## Test plan

- [x] `npx turbo lint test type-check --filter=@adopt-dont-shop/app.rescue --filter=@adopt-dont-shop/lib.chat` (0 lint errors, all tests pass, type-check passes)
- New behaviour tests:
  - `lib.chat/src/services/__tests__/chat-service.test.ts` — PATCH wire format + error propagation
  - `lib.chat/src/context/__tests__/ChatProvider.test.tsx` — optimistic update, rollback on failure, auto-reopen on participant message, no self-reopen
  - `lib.chat/src/components/__tests__/ConversationList.test.tsx` — `filter` prop for active / resolved / undefined-status
  - `app.rescue/src/pages/Communication.test.tsx` — Active default, confirm dialog flow, reopen path, permission gating, filter persistence
- Manual verification (per ticket):
  - [ ] As rescue staff: open a conversation → Mark resolved → confirm it leaves the default Active view and appears under Resolved
  - [ ] As an adopter on the same conversation: send a new message → confirm it reappears in the rescue's Active view
  - [ ] Filter toggle persists per-user (localStorage key `rescue.communication.filter`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013depUhY5BoNTjYTCnjPquS)_