### PR TITLE
chore(ads-531): close residual gaps from the upgrade plans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5641,11 +5641,6 @@
         "bcryptjs": "*"
       }
     },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.42",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "dev": true,
@@ -5666,14 +5661,6 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/continuation-local-storage": {
-      "version": "3.2.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5879,11 +5866,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/marked": {
       "version": "6.0.0",
       "deprecated": "This is a stub types definition. marked provides its own type definitions, so you do not need this installed.",
@@ -6049,17 +6031,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/sequelize": {
-      "version": "4.28.20",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/bluebird": "*",
-        "@types/continuation-local-storage": "*",
-        "@types/lodash": "*",
-        "@types/validator": "*"
       }
     },
     "node_modules/@types/serve-static": {
@@ -20171,7 +20142,6 @@
         "@types/papaparse": "^5.3.14",
         "@types/pdfkit": "^0.13.4",
         "@types/qrcode": "^1.5.6",
-        "@types/sequelize": "^4.28.20",
         "@types/speakeasy": "^2.0.10",
         "@types/supertest": "^2.0.12",
         "@types/swagger-jsdoc": "^6.0.4",

--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -105,7 +105,6 @@
     "@types/papaparse": "^5.3.14",
     "@types/pdfkit": "^0.13.4",
     "@types/qrcode": "^1.5.6",
-    "@types/sequelize": "^4.28.20",
     "@types/speakeasy": "^2.0.10",
     "@types/supertest": "^2.0.12",
     "@types/swagger-jsdoc": "^6.0.4",

--- a/service.backend/src/__tests__/middleware/csrf.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/csrf.middleware.test.ts
@@ -99,16 +99,18 @@ describe('CSRF Middleware', () => {
     });
 
     describe('when token generation fails', () => {
-      it('should log error and pass to next middleware', () => {
+      it('should log error and re-throw so Express 5 routes it to the central handler', () => {
         const error = new Error('Token generation failed');
         mockGenerateToken.mockImplementation(() => {
           throw error;
         });
 
-        csrfTokenGenerator(mockRequest as Request, mockResponse as Response, mockNext);
+        expect(() =>
+          csrfTokenGenerator(mockRequest as Request, mockResponse as Response, mockNext)
+        ).toThrow(error);
 
         expect(logger.error).toHaveBeenCalledWith('Failed to generate CSRF token', { error });
-        expect(mockNext).toHaveBeenCalledWith(error);
+        expect(mockNext).not.toHaveBeenCalled();
       });
 
       it('should not set response locals on error', () => {
@@ -116,7 +118,9 @@ describe('CSRF Middleware', () => {
           throw new Error('Generation error');
         });
 
-        csrfTokenGenerator(mockRequest as Request, mockResponse as Response, mockNext);
+        expect(() =>
+          csrfTokenGenerator(mockRequest as Request, mockResponse as Response, mockNext)
+        ).toThrow('Generation error');
 
         expect(mockResponse.locals?.csrfToken).toBeUndefined();
       });
@@ -126,7 +130,9 @@ describe('CSRF Middleware', () => {
           throw new Error('Generation error');
         });
 
-        csrfTokenGenerator(mockRequest as Request, mockResponse as Response, mockNext);
+        expect(() =>
+          csrfTokenGenerator(mockRequest as Request, mockResponse as Response, mockNext)
+        ).toThrow('Generation error');
 
         expect(mockResponse.setHeader).not.toHaveBeenCalled();
       });
@@ -139,7 +145,7 @@ describe('CSRF Middleware', () => {
         const generatedToken = 'csrf-token-789';
         mockGenerateToken.mockReturnValue(generatedToken);
 
-        getCsrfToken(mockRequest as Request, mockResponse as Response, mockNext);
+        getCsrfToken(mockRequest as Request, mockResponse as Response);
 
         expect(mockGenerateToken).toHaveBeenCalledWith(mockRequest, mockResponse, {
           overwrite: true,
@@ -155,7 +161,7 @@ describe('CSRF Middleware', () => {
         const secondToken = 'token-2';
 
         mockGenerateToken.mockReturnValueOnce(firstToken);
-        getCsrfToken(mockRequest as Request, mockResponse as Response, mockNext);
+        getCsrfToken(mockRequest as Request, mockResponse as Response);
 
         expect(mockResponse.json).toHaveBeenCalledWith({
           csrfToken: firstToken,
@@ -164,7 +170,7 @@ describe('CSRF Middleware', () => {
         vi.clearAllMocks();
 
         mockGenerateToken.mockReturnValueOnce(secondToken);
-        getCsrfToken(mockRequest as Request, mockResponse as Response, mockNext);
+        getCsrfToken(mockRequest as Request, mockResponse as Response);
 
         expect(mockResponse.json).toHaveBeenCalledWith({
           csrfToken: secondToken,
@@ -173,16 +179,15 @@ describe('CSRF Middleware', () => {
     });
 
     describe('when token generation fails', () => {
-      it('should log error and pass to error handler', () => {
+      it('should log error and re-throw so Express 5 routes it to the central handler', () => {
         const error = new Error('Token endpoint error');
         mockGenerateToken.mockImplementation(() => {
           throw error;
         });
 
-        getCsrfToken(mockRequest as Request, mockResponse as Response, mockNext);
+        expect(() => getCsrfToken(mockRequest as Request, mockResponse as Response)).toThrow(error);
 
         expect(logger.error).toHaveBeenCalledWith('Failed to generate CSRF token', { error });
-        expect(mockNext).toHaveBeenCalledWith(error);
       });
 
       it('should not send JSON response on error', () => {
@@ -190,7 +195,9 @@ describe('CSRF Middleware', () => {
           throw new Error('Generation failed');
         });
 
-        getCsrfToken(mockRequest as Request, mockResponse as Response, mockNext);
+        expect(() => getCsrfToken(mockRequest as Request, mockResponse as Response)).toThrow(
+          'Generation failed'
+        );
 
         expect(mockResponse.json).not.toHaveBeenCalled();
       });

--- a/service.backend/src/__tests__/middleware/json-body-parser.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/json-body-parser.middleware.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression test for ADS-531 Express 5 upgrade (per
+ * docs/upgrades/express-5-migration.md §3.2). Express 5 changed how
+ * body-parser surfaces JSON-parse errors — they now propagate through
+ * the standard async-catch path instead of being collapsed at the
+ * parser. We assert the public contract: a malformed JSON body returns
+ * 400 with a structured error envelope, never 500 or a leaked stack.
+ */
+import { vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn() },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../../middleware/error-handler';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.post('/echo', (req, res) => {
+    res.json(req.body);
+  });
+  app.use(errorHandler);
+  return app;
+};
+
+describe('Express JSON body parser — malformed body', () => {
+  it('returns 400, not 500, when the request body is unparseable JSON', async () => {
+    const res = await request(buildApp())
+      .post('/echo')
+      .set('Content-Type', 'application/json')
+      .send('{ this is not valid json');
+
+    expect(res.status).toBe(400);
+  });
+
+  it('emits the central error-handler envelope shape, not a leaked stack', async () => {
+    const res = await request(buildApp())
+      .post('/echo')
+      .set('Content-Type', 'application/json')
+      .send('{');
+
+    expect(res.body).toMatchObject({ status: 'error' });
+    expect(res.body).not.toHaveProperty('stack');
+  });
+
+  it('still parses well-formed JSON bodies (sanity check)', async () => {
+    const res = await request(buildApp())
+      .post('/echo')
+      .set('Content-Type', 'application/json')
+      .send({ hello: 'world' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ hello: 'world' });
+  });
+});

--- a/service.backend/src/middleware/csrf.ts
+++ b/service.backend/src/middleware/csrf.ts
@@ -118,8 +118,12 @@ export const csrfTokenGenerator = (req: Request, res: Response, next: NextFuncti
 
     next();
   } catch (error) {
+    // Express 5 auto-catches throws from async handlers; for sync
+    // middleware we still need to log + throw so the central error
+    // handler picks it up. Plan: drop `next(error)` in favour of
+    // throws once on Express 5 (ADS-531).
     logger.error('Failed to generate CSRF token', { error });
-    next(error);
+    throw error;
   }
 };
 
@@ -133,7 +137,7 @@ export const csrfProtection = doubleCsrfProtection;
  * Route handler to provide CSRF token to clients
  * Clients should call this endpoint to get a token before making state-changing requests
  */
-export const getCsrfToken = (req: Request, res: Response, next: NextFunction): void => {
+export const getCsrfToken = (req: Request, res: Response): void => {
   try {
     // overwrite: true ensures a fresh token+cookie pair is always issued when
     // this endpoint is called explicitly, preventing stale tokens from being
@@ -144,7 +148,7 @@ export const getCsrfToken = (req: Request, res: Response, next: NextFunction): v
     });
   } catch (error) {
     logger.error('Failed to generate CSRF token', { error });
-    next(error);
+    throw error;
   }
 };
 

--- a/service.backend/src/middleware/error-handler.ts
+++ b/service.backend/src/middleware/error-handler.ts
@@ -39,6 +39,24 @@ export const errorHandler = (
     });
   }
 
+  // Handle body-parser JSON parse failures. Express 5 propagates the
+  // body-parser SyntaxError through the standard async-catch path
+  // (Express 4 collapsed it inside the parser). Without an explicit
+  // branch the error falls through to the generic 500, but the user
+  // contract is "malformed JSON → 400" per ADS-531 §3.2.
+  if (
+    err instanceof SyntaxError &&
+    'status' in err &&
+    (err as SyntaxError & { status: number }).status === 400 &&
+    'body' in err
+  ) {
+    return res.status(400).json({
+      status: 'error',
+      message: 'Malformed JSON in request body',
+      code: 400,
+    });
+  }
+
   // Handle Sequelize validation errors
   if (err.name === 'SequelizeValidationError' || err.name === 'SequelizeUniqueConstraintError') {
     type SequelizeError = { path?: string; message: string };


### PR DESCRIPTION
Three small fixups from the ADS-531 plan checklists that were deferred during the main upgrade work:

1. Add the malformed-JSON 400 prep test (Express 5 plan §3.2). The test surfaced a real regression: the central errorHandler had no branch for body-parser's SyntaxError, so unparseable bodies were returning 500 instead of 400 since the Express 5 upgrade. Added the branch to error-handler.ts — checks `err instanceof SyntaxError && err.status === 400 && 'body' in err` which is body-parser's canonical error shape. Three test cases: malformed JSON → 400, response uses central envelope shape with no stack leak, well-formed JSON still parses (sanity).

2. Drop `@types/sequelize` from service.backend/package.json. Zero `import …/types/sequelize` in src; the bundled Sequelize 7 types are authoritative now. Per Sequelize 7 plan §1.2.

3. Drop the two remaining `next(error)` calls in middleware/csrf.ts (lines 122 and 147) in favour of throws so Express 5's async-catch picks them up. Per Express 5 plan §3.7. The `getCsrfToken` route handler also lost its now-unused `next` parameter. Updated the 5 csrf middleware tests that previously asserted `mockNext.toHaveBeenCalledWith(error)` to instead `expect(() => handler(...)).toThrow(error)`.

Verification:
- tsc --noEmit clean
- 2219 passed / 206 skipped / 0 failed (3 new tests vs prior 2216)
- npm install regenerates lockfile (removes 4 transitive deps from @types/sequelize)