### PR TITLE
chore(ads-531): wire installers in prod + eager-load tripwires

### DIFF
--- a/service.backend/src/__tests__/integration/eager-load-regression.test.ts
+++ b/service.backend/src/__tests__/integration/eager-load-regression.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Eager-load regression tripwires (ADS-531 Sequelize 7 plan §1.4).
+ *
+ * Sequelize 7 tightened the typing on `Includeable` and changed
+ * through-table behaviour. The plan called for "a regression test for
+ * one representative findAll({ include }) path per model area to give
+ * us a tripwire". This file is that tripwire: a small, fast, no-mock
+ * suite that exercises the include patterns the project actually
+ * relies on, and asserts the loaded shape directly.
+ *
+ * Coverage by association type:
+ *   - belongsTo with alias (Pet.belongsTo(Rescue, as: 'Rescue'))
+ *   - hasMany inverse (Rescue.hasMany(Pet, as: 'Pets'))
+ *   - belongsToMany through join table (User <-> Role via UserRole)
+ *   - nested two-level include (Application -> Pet -> Breed)
+ *
+ * Tests run against the in-memory SQLite from the shared test
+ * sequelize. They sync({force:true}) per test so each starts clean.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  loggerHelpers: {
+    logBusiness: vi.fn(),
+    logDatabase: vi.fn(),
+    logPerformance: vi.fn(),
+    logExternalService: vi.fn(),
+  },
+}));
+
+import sequelize from '../../sequelize';
+import { Application, Breed, Pet, Rescue, Role, User, UserRole } from '../../models';
+import { UserStatus, UserType } from '../../models/User';
+import { PetStatus, PetType, Gender, Size, EnergyLevel } from '../../models/Pet';
+import { ApplicationStatus } from '../../models/Application';
+
+const seedRescue = async (rescueId = 'rescue-eager-1') =>
+  Rescue.create({
+    rescueId,
+    name: 'Eager Rescue',
+    email: `${rescueId}@example.com`,
+    country: 'GB',
+    address: '1 Test St',
+    city: 'Testville',
+    postcode: 'TT1 1TT',
+    contactPerson: 'Test Person',
+  } as Partial<Rescue>);
+
+const seedUser = async (userId = 'user-eager-1') =>
+  User.create({
+    userId,
+    email: `${userId}@example.com`,
+    password: 'hashed-password-meets-min-length',
+    firstName: 'Eager',
+    lastName: 'User',
+    userType: UserType.ADOPTER,
+    status: UserStatus.ACTIVE,
+    emailVerified: true,
+  } as Partial<User>);
+
+describe('Eager-load regression tripwires (ADS-531 §1.4)', () => {
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  it('belongsTo with alias: Pet.findByPk includes its Rescue under the alias key', async () => {
+    const rescue = await seedRescue();
+    const pet = await Pet.create({
+      petId: 'pet-eager-1',
+      name: 'Mochi',
+      rescueId: rescue.rescueId,
+      type: PetType.DOG,
+      status: PetStatus.AVAILABLE,
+      gender: Gender.FEMALE,
+      size: Size.SMALL,
+      energyLevel: EnergyLevel.LOW,
+    } as Partial<Pet>);
+
+    const fetched = await Pet.findByPk(pet.petId, {
+      include: [{ model: Rescue, as: 'Rescue', attributes: ['rescueId', 'name'] }],
+    });
+
+    expect(fetched).not.toBeNull();
+    // Alias key must be present and populated — regressions in v7 around
+    // mixin generation tend to surface as the association loading under
+    // the model name ('Rescue') vs the alias.
+    const loadedRescue = (fetched as Pet & { Rescue?: Rescue }).Rescue;
+    expect(loadedRescue).toBeDefined();
+    expect(loadedRescue?.rescueId).toBe(rescue.rescueId);
+    expect(loadedRescue?.name).toBe('Eager Rescue');
+  });
+
+  it('hasMany inverse: Rescue.findByPk includes its Pets as an array under the alias', async () => {
+    const rescue = await seedRescue();
+    await Pet.bulkCreate([
+      {
+        petId: 'pet-eager-2',
+        name: 'Bean',
+        rescueId: rescue.rescueId,
+        type: PetType.CAT,
+        status: PetStatus.AVAILABLE,
+        gender: Gender.MALE,
+        size: Size.SMALL,
+        energyLevel: EnergyLevel.MEDIUM,
+      },
+      {
+        petId: 'pet-eager-3',
+        name: 'Toast',
+        rescueId: rescue.rescueId,
+        type: PetType.CAT,
+        status: PetStatus.AVAILABLE,
+        gender: Gender.FEMALE,
+        size: Size.SMALL,
+        energyLevel: EnergyLevel.LOW,
+      },
+    ] as Partial<Pet>[]);
+
+    const fetched = await Rescue.findByPk(rescue.rescueId, {
+      include: [{ model: Pet, as: 'Pets', attributes: ['petId', 'name'] }],
+    });
+
+    const loadedPets = (fetched as Rescue & { Pets?: Pet[] }).Pets;
+    expect(Array.isArray(loadedPets)).toBe(true);
+    expect(loadedPets).toHaveLength(2);
+    expect(loadedPets?.map(p => p.name).sort()).toEqual(['Bean', 'Toast']);
+  });
+
+  it('belongsToMany through join table: User.findByPk includes Roles via UserRole', async () => {
+    const user = await seedUser();
+    const adminRole = await Role.create({
+      name: 'admin',
+      description: 'Administrator',
+    } as Partial<Role>);
+    await UserRole.create({
+      userId: user.userId,
+      roleId: adminRole.roleId,
+    } as Partial<UserRole>);
+
+    const fetched = await User.findByPk(user.userId, {
+      include: [{ model: Role, as: 'Roles', through: { attributes: [] } }],
+    });
+
+    const loadedRoles = (fetched as User & { Roles?: Role[] }).Roles;
+    expect(loadedRoles).toHaveLength(1);
+    expect(loadedRoles?.[0]?.name).toBe('admin');
+    // Through: { attributes: [] } strips the join row off the result.
+    // Regression check: the UserRole join object must NOT appear under
+    // the default `UserRole` key in v7.
+    expect((loadedRoles?.[0] as Role & { UserRole?: unknown })?.UserRole).toBeUndefined();
+  });
+
+  it('nested two-level include: Application -> Pet -> Breed shape matches application.service', async () => {
+    const rescue = await seedRescue();
+    const user = await seedUser();
+    const breed = await Breed.create({
+      breed_id: 'breed-eager-1',
+      name: 'Tabby',
+      species: PetType.CAT,
+    } as unknown as Partial<Breed>);
+    const pet = await Pet.create({
+      petId: 'pet-eager-4',
+      name: 'Stripey',
+      rescueId: rescue.rescueId,
+      breedId: breed.breed_id,
+      type: PetType.CAT,
+      status: PetStatus.AVAILABLE,
+      gender: Gender.MALE,
+      size: Size.SMALL,
+      energyLevel: EnergyLevel.MEDIUM,
+    } as Partial<Pet>);
+    const application = await Application.create({
+      applicationId: 'app-eager-1',
+      userId: user.userId,
+      petId: pet.petId,
+      rescueId: rescue.rescueId,
+      // Use APPROVED to bypass the SUBMITTED-status consent gate; the
+      // eager-load assertion only cares about include shape, not the
+      // application's lifecycle state.
+      status: ApplicationStatus.APPROVED,
+      answers: {},
+      documents: [],
+    } as Partial<Application>);
+
+    const fetched = await Application.findByPk(application.applicationId, {
+      include: [
+        {
+          model: Pet,
+          as: 'Pet',
+          attributes: ['petId', 'name', 'breedId'],
+          include: [{ model: Breed, as: 'Breed', attributes: ['breed_id', 'name'] }],
+        },
+      ],
+    });
+
+    const loadedPet = (fetched as Application & { Pet?: Pet & { Breed?: Breed } }).Pet;
+    expect(loadedPet?.petId).toBe(pet.petId);
+    expect(loadedPet?.Breed?.name).toBe('Tabby');
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -672,14 +672,10 @@ const startServer = async () => {
         }
 
         // DB-level invariants that aren't expressible in Sequelize models.
-        // Idempotent and Postgres-gated; safe to run on every boot path
-        // (force-seed, fresh DB, warm reload). Independent — run in parallel.
-        // installAuditLogsImmutableTrigger is called unconditionally
-        // outside this dev block — see comment below.
-        await Promise.all([
-          installImmutableCreatedAtTriggers(Object.values(models)),
-          installIsoCheckConstraints(),
-        ]);
+        // The actual installer calls run in the unconditional Postgres
+        // block below — see the long comment there. Keep this comment
+        // for grep-ability when future hands look for installer wiring
+        // inside the dev sync path.
       } catch (error) {
         logger.error('Failed to sync database models:', error);
         throw error;
@@ -688,29 +684,30 @@ const startServer = async () => {
 
     // DB-level invariants that aren't expressible in Sequelize models
     // and aren't created by the schema bootstrap (sync in dev, baseline
-    // migrations in prod). Postgres-only, idempotent (CREATE OR REPLACE
-    // FUNCTION / DROP TRIGGER IF EXISTS), so safe regardless of
-    // environment or whether the DB is fresh.
+    // migrations in prod). Postgres-only, idempotent (skip-if-exists
+    // checks inside each installer), so safe regardless of environment
+    // or whether the DB is fresh.
     //
-    // History: migration 11-add-audit-log-immutable-trigger originally
-    // installed the audit_logs trigger as part of the prod migration
-    // sidecar; PR #521 dropped that migration when the forward
-    // migrations were folded into models/installers. This boot-time
-    // call replaces it so fresh prod DBs continue to get the trigger.
-    //
-    // installImmutableCreatedAtTriggers and installIsoCheckConstraints
-    // run only in dev (their schema-creation pair, sequelize.sync(),
-    // only runs in dev) — prod's broader trigger coverage is a separate
-    // concern beyond this fix.
+    // Why outside the dev block: the broader trigger / check-constraint
+    // coverage was never installed in prod (latent gap pre-dating
+    // ADS-531). When PR #521 dropped migration 11, prod also lost the
+    // audit_logs trigger on fresh deploys — fixed in #522. Lifting the
+    // remaining two installers out of the dev gate closes that latent
+    // gap. Each installer logs failures but does not re-throw — they're
+    // defence in depth, not a hard correctness requirement, so a
+    // failure shouldn't wedge the HTTP server before it comes up.
     if (sequelize.getDialect() === 'postgres') {
-      try {
-        await installAuditLogsImmutableTrigger();
-      } catch (error) {
-        logger.error('Failed to install audit_logs immutable trigger:', error);
-        // Non-fatal — the trigger is defence in depth (ADS-508). Boot
-        // continues so the HTTP server still comes up; the install
-        // failure is loud in logs for operators to investigate.
-      }
+      await Promise.all([
+        installImmutableCreatedAtTriggers(Object.values(models)).catch(error => {
+          logger.error('Failed to install immutable-created-at triggers:', error);
+        }),
+        installIsoCheckConstraints().catch(error => {
+          logger.error('Failed to install ISO check constraints:', error);
+        }),
+        installAuditLogsImmutableTrigger().catch(error => {
+          logger.error('Failed to install audit_logs immutable trigger:', error);
+        }),
+      ]);
     }
 
     // Start listening


### PR DESCRIPTION
## Summary

Two follow-ups closing the last items from the ADS-531 plan audit (post-#527).

### 1. Wire the remaining two installers into prod boot

`installImmutableCreatedAtTriggers` and `installIsoCheckConstraints` were both dev-gated by an `if (config.nodeEnv === 'development')` block (alongside `sequelize.sync`), which left prod without the broader trigger / check-constraint coverage from plan 5.5.10 and 5.5.7. PR #522 closed the same gap for `installAuditLogsImmutableTrigger`. This PR lifts the other two out of the dev block, so the full set runs unconditionally after schema bootstrap (sync in dev, baseline migrations in prod).

Each installer call is wrapped in `.catch` that logs but does **not** re-throw — they're defence in depth, not a hard correctness requirement; a hook failure shouldn't wedge the HTTP server before it comes up. Both installers are idempotent (skip-if-exists checks inside) so running on every boot is safe.

**Behaviour change for existing prod DBs:** the installers will attempt to add triggers / check-constraints that have never been installed before. The trigger installer is safe — it only fires on future updates that try to mutate `created_at`. The check-constraint installer's `ALTER TABLE … ADD CONSTRAINT CHECK` validates against existing rows; if any prod row has e.g. `rescues.country = 'United Kingdom'` instead of `'GB'`, the constraint add will fail (caught and logged, boot continues).

### 2. Add eager-load regression tripwires

Per Sequelize 7 plan §1.4. New file `service.backend/src/__tests__/integration/eager-load-regression.test.ts`. Covers the four association patterns most at risk under v7's `Includeable` tightening:

| Pattern | Test |
|---|---|
| `belongsTo` with alias | Pet → Rescue, asserts alias key on result |
| `hasMany` inverse | Rescue → Pets, asserts array under alias |
| `belongsToMany` through join | User ↔ Role via UserRole, asserts `through: { attributes: [] }` strips the join row |
| Nested two-level include | Application → Pet → Breed |

Each test creates rows in-line via `Model.create` and asserts the loaded shape directly. These are tripwires, not exhaustive coverage; existing service tests already exercise the queries in context, but a targeted assertion on the include shape catches v7 regressions that service tests would miss (e.g. associations loading under the model name instead of the alias).

## Test plan

- [x] `tsc --noEmit` clean
- [x] Backend tests: **2,223 passed / 206 skipped / 0 failed** (4 new tests vs prior 2,219)
- [ ] CI green
- [ ] Sanity check on dev boot — installer logs should appear exactly once per restart

## After this lands

The only remaining ADS-531 work is React 19 (`docs/upgrades/react-19-migration.md`) — biggest unstarted piece, separate epic from the backend dep work this PR closes out.

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_