### PR TITLE
chore(deps): bump styled-components to ^6.1.13 for React 19 (ADS-531)

### DIFF
--- a/app.admin/package.json
+++ b/app.admin/package.json
@@ -60,7 +60,7 @@
     "react-spring": "^10.0.1",
     "recharts": "^2.12.6",
     "socket.io-client": "^4.8.3",
-    "styled-components": "^6.1.12",
+    "styled-components": "^6.1.13",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/app.client/package.json
+++ b/app.client/package.json
@@ -56,7 +56,7 @@
     "react-router-dom": "^6.22.3",
     "react-spring": "^10.0.1",
     "socket.io-client": "^4.8.3",
-    "styled-components": "^6.1.12",
+    "styled-components": "^6.1.13",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/lib.components/package.json
+++ b/lib.components/package.json
@@ -91,7 +91,7 @@
     "recast": "^0.23.11",
     "rimraf": "^5.0.5",
     "storybook": "^10.3.6",
-    "styled-components": "^6.1.12",
+    "styled-components": "^6.1.13",
     "ts-dedent": "^2.2.0",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "react-spring": "^10.0.1",
         "recharts": "^2.12.6",
         "socket.io-client": "^4.8.3",
-        "styled-components": "^6.1.12",
+        "styled-components": "^6.1.13",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -206,7 +206,7 @@
         "react-router-dom": "^6.22.3",
         "react-spring": "^10.0.1",
         "socket.io-client": "^4.8.3",
-        "styled-components": "^6.1.12",
+        "styled-components": "^6.1.13",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -724,7 +724,7 @@
         "recast": "^0.23.11",
         "rimraf": "^5.0.5",
         "storybook": "^10.3.6",
-        "styled-components": "^6.1.12",
+        "styled-components": "^6.1.13",
         "ts-dedent": "^2.2.0",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.0.0",


### PR DESCRIPTION
Superseded by **#XXX** (full removal of styled-components, which is the project's stated migration target — see the comment in `lib.components/src/styles/ThemeProvider.tsx`). Closing without merging.