### PR TITLE
chore(deps): remove styled-components (ADS-531)

### DIFF
--- a/app.admin/package.json
+++ b/app.admin/package.json
@@ -60,7 +60,6 @@
     "react-spring": "^10.0.1",
     "recharts": "^2.12.6",
     "socket.io-client": "^4.8.3",
-    "styled-components": "^6.1.12",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/app.admin/vite.config.ts
+++ b/app.admin/vite.config.ts
@@ -51,10 +51,9 @@ export default defineConfig(({ mode }) => {
         '@/pages': resolve(__dirname, './src/pages'),
         ...libraryAliases,
       },
-      dedupe: ['styled-components', 'react', 'react-dom'],
+      dedupe: ['react', 'react-dom'],
     },
     optimizeDeps: {
-      include: ['styled-components'],
       exclude: [
         '@testing-library/dom',
         '@testing-library/react',
@@ -117,9 +116,6 @@ export default defineConfig(({ mode }) => {
             }
             if (id.includes('react-router')) {
               return 'router-vendor';
-            }
-            if (id.includes('styled-components')) {
-              return 'styled-components';
             }
             if (id.includes('react-dom') || /\/react\//.test(id)) {
               return 'react-vendor';

--- a/app.client/package.json
+++ b/app.client/package.json
@@ -56,7 +56,6 @@
     "react-router-dom": "^6.22.3",
     "react-spring": "^10.0.1",
     "socket.io-client": "^4.8.3",
-    "styled-components": "^6.1.12",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/app.client/src/pages/NotFoundPage.css.ts
+++ b/app.client/src/pages/NotFoundPage.css.ts
@@ -1,0 +1,44 @@
+import { style } from '@vanilla-extract/css';
+
+// ADS-480: catch-all 404 page. Brand colors hard-coded here (matching
+// the original styled-components version) — out of scope to refactor
+// to theme tokens; this file only exists to drop the styled-components
+// dependency.
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: '60vh',
+  padding: '2rem',
+  textAlign: 'center',
+});
+
+export const code = style({
+  fontSize: '4rem',
+  margin: 0,
+  color: '#2563eb',
+});
+
+export const title = style({
+  margin: '0.5rem 0 1rem',
+  fontSize: '1.5rem',
+  color: '#1f2937',
+});
+
+export const body = style({
+  color: '#4b5563',
+  maxWidth: '32rem',
+  margin: '0 0 1.5rem',
+});
+
+export const homeLink = style({
+  color: 'white',
+  backgroundColor: '#2563eb',
+  padding: '0.5rem 1rem',
+  borderRadius: '0.375rem',
+  textDecoration: 'none',
+  ':hover': {
+    backgroundColor: '#1d4ed8',
+  },
+});

--- a/app.client/src/pages/NotFoundPage.tsx
+++ b/app.client/src/pages/NotFoundPage.tsx
@@ -1,56 +1,19 @@
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+
+import * as styles from './NotFoundPage.css';
 
 // ADS-480: catch-all 404 page rendered when no other route matches.
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 60vh;
-  padding: 2rem;
-  text-align: center;
-`;
-
-const Code = styled.h1`
-  font-size: 4rem;
-  margin: 0;
-  color: #2563eb;
-`;
-
-const Title = styled.h2`
-  margin: 0.5rem 0 1rem;
-  font-size: 1.5rem;
-  color: #1f2937;
-`;
-
-const Body = styled.p`
-  color: #4b5563;
-  max-width: 32rem;
-  margin: 0 0 1.5rem;
-`;
-
-const HomeLink = styled(Link)`
-  color: white;
-  background-color: #2563eb;
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
-  text-decoration: none;
-
-  &:hover {
-    background-color: #1d4ed8;
-  }
-`;
-
 export const NotFoundPage = () => (
-  <Container>
-    <Code>404</Code>
-    <Title>Page not found</Title>
-    <Body>
+  <div className={styles.container}>
+    <h1 className={styles.code}>404</h1>
+    <h2 className={styles.title}>Page not found</h2>
+    <p className={styles.body}>
       We couldn&apos;t find the page you were looking for. It may have moved or no longer exists.
-    </Body>
-    <HomeLink to='/'>Go back home</HomeLink>
-  </Container>
+    </p>
+    <Link to='/' className={styles.homeLink}>
+      Go back home
+    </Link>
+  </div>
 );
 
 export default NotFoundPage;

--- a/app.client/vite.config.ts
+++ b/app.client/vite.config.ts
@@ -43,10 +43,9 @@ export default defineConfig(({ mode }) => {
         '@': resolve(__dirname, './src'),
         ...libraryAliases,
       },
-      dedupe: ['styled-components', 'react', 'react-dom'],
+      dedupe: ['react', 'react-dom'],
     },
     optimizeDeps: {
-      include: ['styled-components'],
       exclude: [
         '@testing-library/dom',
         '@testing-library/react',
@@ -109,9 +108,6 @@ export default defineConfig(({ mode }) => {
             }
             if (id.includes('react-router')) {
               return 'router-vendor';
-            }
-            if (id.includes('styled-components')) {
-              return 'styled-components';
             }
             if (id.includes('react-dom') || /\/react\//.test(id)) {
               return 'react-vendor';

--- a/app.rescue/package.json
+++ b/app.rescue/package.json
@@ -61,7 +61,6 @@
     "react-router-dom": "^6.22.3",
     "react-spring": "^10.0.1",
     "socket.io-client": "^4.8.3",
-    "styled-components": "^6.1.19",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -71,7 +70,6 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/styled-components": "^5.1.36",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "@vanilla-extract/vite-plugin": "^5.2.2",

--- a/app.rescue/src/pages/NotFoundPage.css.ts
+++ b/app.rescue/src/pages/NotFoundPage.css.ts
@@ -1,0 +1,43 @@
+import { style } from '@vanilla-extract/css';
+
+// ADS-480: catch-all 404 page for app.rescue. Brand colors hard-coded
+// (matching the original styled-components version); refactoring to
+// theme tokens is out of scope.
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: '60vh',
+  padding: '2rem',
+  textAlign: 'center',
+});
+
+export const code = style({
+  fontSize: '4rem',
+  margin: 0,
+  color: '#15803d',
+});
+
+export const title = style({
+  margin: '0.5rem 0 1rem',
+  fontSize: '1.5rem',
+  color: '#1f2937',
+});
+
+export const body = style({
+  color: '#4b5563',
+  maxWidth: '32rem',
+  margin: '0 0 1.5rem',
+});
+
+export const homeLink = style({
+  color: 'white',
+  backgroundColor: '#15803d',
+  padding: '0.5rem 1rem',
+  borderRadius: '0.375rem',
+  textDecoration: 'none',
+  ':hover': {
+    backgroundColor: '#166534',
+  },
+});

--- a/app.rescue/src/pages/NotFoundPage.tsx
+++ b/app.rescue/src/pages/NotFoundPage.tsx
@@ -1,56 +1,19 @@
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+
+import * as styles from './NotFoundPage.css';
 
 // ADS-480: catch-all 404 page rendered when no other route matches.
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 60vh;
-  padding: 2rem;
-  text-align: center;
-`;
-
-const Code = styled.h1`
-  font-size: 4rem;
-  margin: 0;
-  color: #15803d;
-`;
-
-const Title = styled.h2`
-  margin: 0.5rem 0 1rem;
-  font-size: 1.5rem;
-  color: #1f2937;
-`;
-
-const Body = styled.p`
-  color: #4b5563;
-  max-width: 32rem;
-  margin: 0 0 1.5rem;
-`;
-
-const HomeLink = styled(Link)`
-  color: white;
-  background-color: #15803d;
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
-  text-decoration: none;
-
-  &:hover {
-    background-color: #166534;
-  }
-`;
-
 const NotFoundPage = () => (
-  <Container>
-    <Code>404</Code>
-    <Title>Page not found</Title>
-    <Body>
+  <div className={styles.container}>
+    <h1 className={styles.code}>404</h1>
+    <h2 className={styles.title}>Page not found</h2>
+    <p className={styles.body}>
       We couldn&apos;t find the page you were looking for. It may have moved or no longer exists.
-    </Body>
-    <HomeLink to="/">Go back to dashboard</HomeLink>
-  </Container>
+    </p>
+    <Link to="/" className={styles.homeLink}>
+      Go back to dashboard
+    </Link>
+  </div>
 );
 
 export default NotFoundPage;

--- a/app.rescue/vite.config.ts
+++ b/app.rescue/vite.config.ts
@@ -51,10 +51,9 @@ export default defineConfig(({ mode }) => {
         '@/pages': resolve(__dirname, './src/pages'),
         ...libraryAliases,
       },
-      dedupe: ['styled-components', 'react', 'react-dom'],
+      dedupe: ['react', 'react-dom'],
     },
     optimizeDeps: {
-      include: ['styled-components'],
       exclude: [
         '@testing-library/dom',
         '@testing-library/react',
@@ -117,9 +116,6 @@ export default defineConfig(({ mode }) => {
             }
             if (id.includes('react-router')) {
               return 'router-vendor';
-            }
-            if (id.includes('styled-components')) {
-              return 'styled-components';
             }
             if (id.includes('react-dom') || /\/react\//.test(id)) {
               return 'react-vendor';

--- a/lib.components/package.json
+++ b/lib.components/package.json
@@ -91,7 +91,6 @@
     "recast": "^0.23.11",
     "rimraf": "^5.0.5",
     "storybook": "^10.3.6",
-    "styled-components": "^6.1.12",
     "ts-dedent": "^2.2.0",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.0.0",
@@ -104,7 +103,6 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "react-router-dom": ">=6.0.0",
-    "styled-components": ">=6.0.0"
+    "react-router-dom": ">=6.0.0"
   }
 }

--- a/lib.components/src/styles/ThemeProvider.tsx
+++ b/lib.components/src/styles/ThemeProvider.tsx
@@ -1,16 +1,8 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 
 import { darkTheme, highContrastTheme, lightTheme, Theme, ThemeMode } from './theme';
 import { darkThemeClass, highContrastThemeClass, lightThemeClass } from './theme.css';
 import './GlobalStyles.css';
-
-// Keep DefaultTheme augmented while consuming apps still use styled-components.
-// Remove once all app.* styled-components are migrated to Vanilla Extract.
-declare module 'styled-components' {
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  export interface DefaultTheme extends Theme {}
-}
 
 type ThemeContextType = {
   theme: Theme;
@@ -157,7 +149,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
         toggleHighContrast,
       }}
     >
-      <StyledThemeProvider theme={theme}>{children}</StyledThemeProvider>
+      {children}
     </ThemeContext.Provider>
   );
 };

--- a/lib.components/src/styles/theme.ts
+++ b/lib.components/src/styles/theme.ts
@@ -546,9 +546,10 @@ export const darkTheme: Theme = {
   },
 };
 
-// ADS-137: High-contrast theme for styled-components consumers. Mirrors the
-// vanilla-extract `highContrastThemeClass` so styled-components reading
-// theme.text.primary etc. resolve to the same tokens.
+// ADS-137: High-contrast theme. Mirrors the vanilla-extract
+// `highContrastThemeClass` so any consumer reading `useTheme().theme`
+// (the JS Theme object) sees the same tokens that the .css.ts files
+// render to CSS variables.
 export const highContrastTheme: Theme = {
   ...baseTheme,
   mode: 'high-contrast',

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,6 @@
         "react-spring": "^10.0.1",
         "recharts": "^2.12.6",
         "socket.io-client": "^4.8.3",
-        "styled-components": "^6.1.12",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -206,7 +205,6 @@
         "react-router-dom": "^6.22.3",
         "react-spring": "^10.0.1",
         "socket.io-client": "^4.8.3",
-        "styled-components": "^6.1.12",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -302,7 +300,6 @@
         "react-router-dom": "^6.22.3",
         "react-spring": "^10.0.1",
         "socket.io-client": "^4.8.3",
-        "styled-components": "^6.1.19",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -312,7 +309,6 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@types/styled-components": "^5.1.36",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "@vanilla-extract/vite-plugin": "^5.2.2",
@@ -724,7 +720,6 @@
         "recast": "^0.23.11",
         "rimraf": "^5.0.5",
         "storybook": "^10.3.6",
-        "styled-components": "^6.1.12",
         "ts-dedent": "^2.2.0",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.0.0",
@@ -737,8 +732,7 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
-        "react-router-dom": ">=6.0.0",
-        "styled-components": ">=6.0.0"
+        "react-router-dom": ">=6.0.0"
       }
     },
     "lib.components/node_modules/rimraf": {
@@ -2256,17 +2250,6 @@
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
       "license": "MIT"
     },
     "node_modules/@epic-web/invariant": {
@@ -5797,17 +5780,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "dev": true,
@@ -6072,16 +6044,6 @@
       "version": "0.0.30",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/styled-components": {
-      "version": "5.1.36",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.2.2"
-      }
     },
     "node_modules/@types/superagent": {
       "version": "8.1.9",
@@ -7420,13 +7382,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "license": "MIT",
@@ -8272,13 +8227,6 @@
         "http-errors": "^2.0.0"
       }
     },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/css-declaration-sorter": {
       "version": "7.4.0",
       "license": "ISC",
@@ -8309,15 +8257,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -10774,14 +10713,6 @@
       "peer": true,
       "dependencies": {
         "hermes-estree": "0.33.3"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -17969,40 +17900,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/styled-components": {
-      "version": "6.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/is-prop-valid": "1.4.0",
-        "css-to-react-native": "3.2.0",
-        "csstype": "3.2.3",
-        "stylis": "4.3.6"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "css-to-react-native": ">= 3.2.0",
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-native": ">= 0.68.0"
-      },
-      "peerDependenciesMeta": {
-        "css-to-react-native": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/stylehacks": {
       "version": "7.0.11",
       "license": "MIT",
@@ -18016,10 +17913,6 @@
       "peerDependencies": {
         "postcss": "^8.5.13"
       }
-    },
-    "node_modules/stylis": {
-      "version": "4.3.6",
-      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "8.1.2",


### PR DESCRIPTION
## Summary

**Supersedes #530.** That PR raised the styled-components floor to 6.1.13 for React 19 compatibility; this PR goes further and removes the dependency entirely, finishing the migration that ADS-137 + the lib-components epic started.

By the time the React 19 plan landed, only three source sites still imported styled-components:

- `app.client/src/pages/NotFoundPage.tsx`
- `app.rescue/src/pages/NotFoundPage.tsx`
- `lib.components/src/styles/ThemeProvider.tsx`

The comment in `ThemeProvider.tsx` already flagged this: _"Remove once all app.\* styled-components are migrated to Vanilla Extract."_ This PR is that removal.

## Changes

- **Both NotFoundPage files migrated to Vanilla Extract.** New `NotFoundPage.css.ts` neighbours each `.tsx` with `style({...})` exports; the `.tsx` applies them via `className`. Brand hex values preserved (not refactored to theme tokens — out of scope; the point of this PR is the dep drop, not a visual refactor).

- **`lib.components/styles/ThemeProvider.tsx`** loses the `StyledThemeProvider` wrapper and the `declare module 'styled-components'` augmentation. The context-based `useTheme()` hook keeps working — it still returns the same JS `Theme` object as before, just without the styled-components bridge wrapping it.

- **`styled-components` dropped** from the dependencies of `app.admin`, `app.client`, `app.rescue`, and `lib.components`, plus the peerDep in `lib.components` and the `@types/styled-components` devDep in `app.rescue`. `npm install` removes **10 transitive packages**.

- **Each app's `vite.config.ts`** loses its styled-components `dedupe`, `optimizeDeps.include` entry, and manual-chunk rule. The chunk splitter no longer needs a dedicated `'styled-components'` bundle.

## Test plan

- [x] `lib.components` build: clean
- [x] All three apps build: clean (`app.admin`, `app.client`, `app.rescue`)
- [x] `lib.components` tests: **433 passed**
- [x] `app.rescue` tests: **185 passed**
- [x] `app.admin` tests: **297 passed**
- [x] `app.client` tests: **258 passed**
- [x] No remaining `from 'styled-components'` in any src/ tree
- [x] `npm install` removes 10 packages
- [ ] CI green
- [ ] Eyeball the two NotFoundPage routes in dev mode (404 pages)
- [ ] Eyeball any major page that previously read `useTheme().theme` to verify the styled-components bridge removal didn't change rendering

## After this lands

React 19 plan is **done in full** from the dep-management perspective. Optional Stage 3 cleanups (drop `forwardRef` wrappers, adopt `<Context>` shorthand, React Compiler opt-in, server actions) remain deferrable indefinitely.

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_