### PR TITLE
chore(react19): adopt &lt;Context&gt; shorthand for Context Providers (ADS-531)

### DIFF
--- a/app.client/src/contexts/AnalyticsContext.tsx
+++ b/app.client/src/contexts/AnalyticsContext.tsx
@@ -56,5 +56,5 @@ export const AnalyticsProvider = ({ children }: AnalyticsProviderProps) => {
     [analyticsService]
   );
 
-  return <AnalyticsContext.Provider value={value}>{children}</AnalyticsContext.Provider>;
+  return <AnalyticsContext value={value}>{children}</AnalyticsContext>;
 };

--- a/app.client/src/contexts/FavoritesContext.tsx
+++ b/app.client/src/contexts/FavoritesContext.tsx
@@ -149,7 +149,7 @@ export const FavoritesProvider: React.FC<FavoritesProviderProps> = ({ children }
     clearError,
   };
 
-  return <FavoritesContext.Provider value={value}>{children}</FavoritesContext.Provider>;
+  return <FavoritesContext value={value}>{children}</FavoritesContext>;
 };
 
 export { useFavorites };

--- a/app.client/src/contexts/NotificationContext.tsx
+++ b/app.client/src/contexts/NotificationContext.tsx
@@ -262,7 +262,7 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
     refreshCount,
   };
 
-  return <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>;
+  return <NotificationContext value={value}>{children}</NotificationContext>;
 };
 
 export { useNotifications };

--- a/app.client/src/contexts/NotificationsContext.tsx
+++ b/app.client/src/contexts/NotificationsContext.tsx
@@ -115,5 +115,5 @@ export const NotificationsProvider = ({ children, userId }: NotificationsProvide
     [notificationsService, notifications, unreadCount, isLoading]
   );
 
-  return <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>;
+  return <NotificationsContext value={value}>{children}</NotificationsContext>;
 };

--- a/app.client/src/contexts/PermissionsContext.tsx
+++ b/app.client/src/contexts/PermissionsContext.tsx
@@ -106,5 +106,5 @@ export const PermissionsProvider = ({ children, userId }: PermissionsProviderPro
     [permissionsService, userPermissions, userWithPermissions, isLoading]
   );
 
-  return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>;
+  return <PermissionsContext value={value}>{children}</PermissionsContext>;
 };

--- a/app.rescue/src/contexts/AnalyticsContext.tsx
+++ b/app.rescue/src/contexts/AnalyticsContext.tsx
@@ -56,5 +56,5 @@ export const AnalyticsProvider = ({ children }: AnalyticsProviderProps) => {
     [analyticsService]
   );
 
-  return <AnalyticsContext.Provider value={value}>{children}</AnalyticsContext.Provider>;
+  return <AnalyticsContext value={value}>{children}</AnalyticsContext>;
 };

--- a/app.rescue/src/contexts/NotificationsContext.tsx
+++ b/app.rescue/src/contexts/NotificationsContext.tsx
@@ -120,5 +120,5 @@ export const NotificationsProvider = ({ children, userId }: NotificationsProvide
     ]
   );
 
-  return <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>;
+  return <NotificationsContext value={value}>{children}</NotificationsContext>;
 };

--- a/app.rescue/src/contexts/PermissionsContext.tsx
+++ b/app.rescue/src/contexts/PermissionsContext.tsx
@@ -117,5 +117,5 @@ export const PermissionsProvider = ({ children }: PermissionsProviderProps) => {
     [permissionsService, userPermissions, isLoading, user?.role]
   );
 
-  return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>;
+  return <PermissionsContext value={value}>{children}</PermissionsContext>;
 };

--- a/lib.components/src/styles/ThemeProvider.tsx
+++ b/lib.components/src/styles/ThemeProvider.tsx
@@ -139,7 +139,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   }, [toggleHighContrast]);
 
   return (
-    <ThemeContext.Provider
+    <ThemeContext
       value={{
         theme,
         themeMode,
@@ -150,6 +150,6 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
       }}
     >
       {children}
-    </ThemeContext.Provider>
+    </ThemeContext>
   );
 };


### PR DESCRIPTION
## Summary

React 19 plan Stage 3 cleanup. React 19 lets you use a Context object directly as a JSX element instead of accessing its `.Provider`:

```tsx
// Before
<ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>

// After
<ThemeContext value={value}>{children}</ThemeContext>
```

The Context object is exactly the same — only the JSX surface changes. Same render behavior, just less noise.

## Sites transformed (9 across 4 packages)

| Package | Files |
|---|---|
| `lib.components/src` | `styles/ThemeProvider.tsx` |
| `app.client/src` | `contexts/{NotificationsContext, NotificationContext, AnalyticsContext, PermissionsContext, FavoritesContext}.tsx` |
| `app.rescue/src` | `contexts/{AnalyticsContext, PermissionsContext, NotificationsContext}.tsx` |
| `app.admin/src` | 0 sites (grep confirmed) |

## Left alone (correctly)

- `lib.components/src/components/ui/DateTime/DateTime.tsx` — `<Tooltip.Provider>` is `@radix-ui/react-tooltip`'s Provider component, not a React Context.
- `lib.components/src/components/ui/Tooltip/Tooltip.tsx` — `<TooltipPrimitive.Provider>` is also radix-ui.

The React 19 shorthand only applies to React Contexts.

## Test plan

- [x] `lib.components`: **441 tests passed** (41 files)
- [x] `app.admin`: **321 tests passed** (28 files)
- [x] `app.client`: **284 tests passed** (38 files)
- [x] `app.rescue`: **185 tests passed** (21 files)
- [x] All four packages build clean
- [ ] CI green

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_