### PR TITLE
chore(react19): drop forwardRef wrappers (ADS-531)

### DIFF
--- a/lib.components/src/components/form/CheckboxInput/CheckboxInput.tsx
+++ b/lib.components/src/components/form/CheckboxInput/CheckboxInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
 import {
@@ -32,112 +32,107 @@ export type CheckboxInputProps = {
   description?: string;
   className?: string;
   'data-testid'?: string;
+  ref?: React.Ref<HTMLInputElement>;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
-const CheckboxInputComponent = forwardRef<HTMLInputElement, CheckboxInputProps>(
-  (
-    {
-      label: labelText,
-      checked,
-      defaultChecked,
-      indeterminate = false,
-      size = 'md',
-      state = 'default',
-      disabled = false,
-      required = false,
-      error,
-      helperText: helperTextProp,
-      description: descriptionText,
-      className,
-      'data-testid': dataTestId,
-      id,
-      onChange,
-      ...props
-    },
-    ref
-  ) => {
-    const inputId = id || `checkbox-${Math.random().toString(36).substring(2, 9)}`;
-    const effectiveState = error ? 'error' : state;
-    const effectiveHelperText = error || helperTextProp;
-    const isChecked = checked || defaultChecked || false;
+export const CheckboxInput = ({
+  label: labelText,
+  checked,
+  defaultChecked,
+  indeterminate = false,
+  size = 'md',
+  state = 'default',
+  disabled = false,
+  required = false,
+  error,
+  helperText: helperTextProp,
+  description: descriptionText,
+  className,
+  'data-testid': dataTestId,
+  id,
+  onChange,
+  ref,
+  ...props
+}: CheckboxInputProps) => {
+  const inputId = id || `checkbox-${Math.random().toString(36).substring(2, 9)}`;
+  const effectiveState = error ? 'error' : state;
+  const effectiveHelperText = error || helperTextProp;
+  const isChecked = checked || defaultChecked || false;
 
-    const handleContainerClick = () => {
-      if (!disabled && ref && 'current' in ref && ref.current) {
-        ref.current.click();
-      }
-    };
+  const handleContainerClick = () => {
+    if (!disabled && ref && typeof ref === 'object' && 'current' in ref && ref.current) {
+      ref.current.click();
+    }
+  };
 
-    const handleContainerKeyDown = (event: React.KeyboardEvent) => {
-      if (
-        (event.key === 'Enter' || event.key === ' ') &&
-        !disabled &&
-        ref &&
-        'current' in ref &&
-        ref.current
-      ) {
-        event.preventDefault();
-        ref.current.click();
-      }
-    };
+  const handleContainerKeyDown = (event: React.KeyboardEvent) => {
+    if (
+      (event.key === 'Enter' || event.key === ' ') &&
+      !disabled &&
+      ref &&
+      typeof ref === 'object' &&
+      'current' in ref &&
+      ref.current
+    ) {
+      event.preventDefault();
+      ref.current.click();
+    }
+  };
 
-    return (
-      <div className={clsx(container, className)}>
+  return (
+    <div className={clsx(container, className)}>
+      <div
+        className={checkboxContainer}
+        onClick={handleContainerClick}
+        onKeyDown={handleContainerKeyDown}
+        role='button'
+        tabIndex={disabled ? -1 : 0}
+      >
+        <input
+          type='checkbox'
+          ref={ref}
+          id={inputId}
+          checked={checked}
+          defaultChecked={defaultChecked}
+          disabled={disabled}
+          required={required}
+          data-testid={dataTestId}
+          onChange={onChange}
+          className={hiddenCheckbox}
+          {...props}
+        />
+
         <div
-          className={checkboxContainer}
-          onClick={handleContainerClick}
-          onKeyDown={handleContainerKeyDown}
-          role='button'
-          tabIndex={disabled ? -1 : 0}
+          className={clsx(
+            styledCheckbox({ state: effectiveState, checked: isChecked, disabled }),
+            styledCheckboxSizes[size]
+          )}
         >
-          <input
-            type='checkbox'
-            ref={ref}
-            id={inputId}
-            checked={checked}
-            defaultChecked={defaultChecked}
-            disabled={disabled}
-            required={required}
-            data-testid={dataTestId}
-            onChange={onChange}
-            className={hiddenCheckbox}
-            {...props}
-          />
-
-          <div
+          <span
             className={clsx(
-              styledCheckbox({ state: effectiveState, checked: isChecked, disabled }),
-              styledCheckboxSizes[size]
+              checkIcon({ visible: isChecked || indeterminate }),
+              checkIconSizes[size]
             )}
           >
-            <span
-              className={clsx(
-                checkIcon({ visible: isChecked || indeterminate }),
-                checkIconSizes[size]
-              )}
-            >
-              {indeterminate ? '−' : '✓'}
-            </span>
-          </div>
-
-          {(labelText || descriptionText) && (
-            <div className={labelContainer}>
-              {labelText && (
-                <label htmlFor={inputId} className={label({ disabled, required })}>
-                  {labelText}
-                </label>
-              )}
-              {descriptionText && <p className={description({ disabled })}>{descriptionText}</p>}
-            </div>
-          )}
+            {indeterminate ? '−' : '✓'}
+          </span>
         </div>
 
-        {effectiveHelperText && (
-          <div className={helperText[effectiveState]}>{effectiveHelperText}</div>
+        {(labelText || descriptionText) && (
+          <div className={labelContainer}>
+            {labelText && (
+              <label htmlFor={inputId} className={label({ disabled, required })}>
+                {labelText}
+              </label>
+            )}
+            {descriptionText && <p className={description({ disabled })}>{descriptionText}</p>}
+          </div>
         )}
       </div>
-    );
-  }
-);
 
-CheckboxInputComponent.displayName = 'CheckboxInput';
-export const CheckboxInput = CheckboxInputComponent;
+      {effectiveHelperText && (
+        <div className={helperText[effectiveState]}>{effectiveHelperText}</div>
+      )}
+    </div>
+  );
+};

--- a/lib.components/src/components/form/RadioInput/RadioInput.tsx
+++ b/lib.components/src/components/form/RadioInput/RadioInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import clsx from 'clsx';
 
 import {
@@ -39,88 +39,83 @@ export type RadioInputProps = {
   className?: string;
   'data-testid'?: string;
   onChange?: (value: string) => void;
+  ref?: Ref<HTMLInputElement>;
 };
 
-export const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
-  (
-    {
-      name,
-      options,
-      value,
-      defaultValue,
-      size = 'md',
-      state = 'default',
-      disabled = false,
-      required = false,
-      label,
-      error,
-      helperText: helperTextProp,
-      direction = 'vertical',
-      fullWidth = false,
-      className,
-      'data-testid': testId,
-      onChange,
-      ...props
-    },
-    ref
-  ) => {
-    const handleChange = (optionValue: string) => {
-      if (onChange) {
-        onChange(optionValue);
-      }
-    };
+export const RadioInput = ({
+  name,
+  options,
+  value,
+  defaultValue,
+  size = 'md',
+  state = 'default',
+  disabled = false,
+  required = false,
+  label,
+  error,
+  helperText: helperTextProp,
+  direction = 'vertical',
+  fullWidth = false,
+  className,
+  'data-testid': testId,
+  onChange,
+  ref,
+  ...props
+}: RadioInputProps) => {
+  const handleChange = (optionValue: string) => {
+    if (onChange) {
+      onChange(optionValue);
+    }
+  };
 
-    const finalState = error ? 'error' : state;
-    const finalHelperText = error || helperTextProp;
+  const finalState = error ? 'error' : state;
+  const finalHelperText = error || helperTextProp;
 
-    return (
-      <div className={clsx(radioContainer({ fullWidth }), className)} data-testid={testId}>
-        {label && <label className={groupLabel({ required })}>{label}</label>}
+  return (
+    <div className={clsx(radioContainer({ fullWidth }), className)} data-testid={testId}>
+      {label && <label className={groupLabel({ required })}>{label}</label>}
 
-        <div className={radioGroup[direction]}>
-          {options.map((option, index) => {
-            const isOptionDisabled = disabled || option.disabled || false;
-            const isChecked = value === option.value;
+      <div className={radioGroup[direction]}>
+        {options.map((option, index) => {
+          const isOptionDisabled = disabled || option.disabled || false;
+          const isChecked = value === option.value;
 
-            return (
-              <label
-                key={option.value}
-                className={radioOptionContainer({ disabled: isOptionDisabled })}
-              >
-                <input
-                  type='radio'
-                  ref={index === 0 ? ref : undefined}
-                  name={name}
-                  value={option.value}
-                  {...(value !== undefined
-                    ? { checked: isChecked }
-                    : { defaultChecked: defaultValue === option.value })}
-                  disabled={isOptionDisabled}
-                  required={required}
-                  onChange={() => handleChange(option.value)}
-                  className={hiddenRadio}
-                  {...props}
-                />
-                <div
-                  className={clsx(
-                    styledRadio({
-                      state: finalState,
-                      checked: isChecked,
-                      disabled: isOptionDisabled,
-                    }),
-                    styledRadioSizes[size]
-                  )}
-                />
-                <span className={optionLabel}>{option.label}</span>
-              </label>
-            );
-          })}
-        </div>
-
-        {finalHelperText && <div className={helperText[finalState]}>{finalHelperText}</div>}
+          return (
+            <label
+              key={option.value}
+              className={radioOptionContainer({ disabled: isOptionDisabled })}
+            >
+              <input
+                type='radio'
+                ref={index === 0 ? ref : undefined}
+                name={name}
+                value={option.value}
+                {...(value !== undefined
+                  ? { checked: isChecked }
+                  : { defaultChecked: defaultValue === option.value })}
+                disabled={isOptionDisabled}
+                required={required}
+                onChange={() => handleChange(option.value)}
+                className={hiddenRadio}
+                {...props}
+              />
+              <div
+                className={clsx(
+                  styledRadio({
+                    state: finalState,
+                    checked: isChecked,
+                    disabled: isOptionDisabled,
+                  }),
+                  styledRadioSizes[size]
+                )}
+              />
+              <span className={optionLabel}>{option.label}</span>
+            </label>
+          );
+        })}
       </div>
-    );
-  }
-);
 
-RadioInput.displayName = 'RadioInput';
+      {finalHelperText && <div className={helperText[finalState]}>{finalHelperText}</div>}
+    </div>
+  );
+};

--- a/lib.components/src/components/form/SelectInput/SelectInput.tsx
+++ b/lib.components/src/components/form/SelectInput/SelectInput.tsx
@@ -1,5 +1,5 @@
 import * as Select from '@radix-ui/react-select';
-import React, { forwardRef, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import clsx from 'clsx';
 import countries from '../CountrySelectInput/CountryList.json';
 import {
@@ -55,6 +55,7 @@ export type SelectInputProps = {
   isCountrySelect?: boolean;
   onChange?: (value: string | string[]) => void;
   onSearch?: (query: string) => void;
+  ref?: React.Ref<HTMLButtonElement>;
 };
 
 const ChevronDownIcon = () => (
@@ -78,216 +79,210 @@ const XIcon = () => (
   </svg>
 );
 
-export const SelectInput = forwardRef<HTMLButtonElement, SelectInputProps>(
-  (
-    {
-      options: propOptions,
-      value,
-      defaultValue,
-      label,
-      placeholder: placeholderText = 'Select an option...',
-      size = 'md',
-      state = 'default',
-      disabled = false,
-      required = false,
-      multiple = false,
-      searchable = false,
-      clearable = false,
-      error,
-      helperText: helperTextProp,
-      fullWidth = false,
-      className,
-      'data-testid': dataTestId,
-      isCountrySelect = false,
-      onChange,
-      onSearch,
-    },
-    ref
-  ) => {
-    const [searchQuery, setSearchQuery] = useState('');
+export const SelectInput = ({
+  options: propOptions,
+  value,
+  defaultValue,
+  label,
+  placeholder: placeholderText = 'Select an option...',
+  size = 'md',
+  state = 'default',
+  disabled = false,
+  required = false,
+  multiple = false,
+  searchable = false,
+  clearable = false,
+  error,
+  helperText: helperTextProp,
+  fullWidth = false,
+  className,
+  'data-testid': dataTestId,
+  isCountrySelect = false,
+  onChange,
+  onSearch,
+  ref,
+}: SelectInputProps) => {
+  const [searchQuery, setSearchQuery] = useState('');
 
-    // Use country options if isCountrySelect is true
-    const countryOptions: SelectOption[] = useMemo(() => {
-      return countries.map(country => ({
-        value: country.name,
-        label: country.name,
-      }));
-    }, []);
+  // Use country options if isCountrySelect is true
+  const countryOptions: SelectOption[] = useMemo(() => {
+    return countries.map(country => ({
+      value: country.name,
+      label: country.name,
+    }));
+  }, []);
 
-    const options = isCountrySelect ? countryOptions : propOptions;
+  const options = isCountrySelect ? countryOptions : propOptions;
 
-    // Filter options based on search query and convert empty values for Radix compatibility
-    const filteredOptions = useMemo(() => {
-      const processedOptions = options.map(option => ({
-        ...option,
-        // Convert empty string values to a special value for Radix compatibility
-        value: option.value === '' ? '__all__' : option.value,
-        originalValue: option.value,
-      }));
+  // Filter options based on search query and convert empty values for Radix compatibility
+  const filteredOptions = useMemo(() => {
+    const processedOptions = options.map(option => ({
+      ...option,
+      // Convert empty string values to a special value for Radix compatibility
+      value: option.value === '' ? '__all__' : option.value,
+      originalValue: option.value,
+    }));
 
-      if (!searchable || !searchQuery) {
-        return processedOptions;
-      }
-      return processedOptions.filter(option =>
-        option.label.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-    }, [options, searchQuery, searchable]);
-
-    // Handle single/multiple values
-    const currentValue = multiple ? (Array.isArray(value) ? value : []) : value;
-    const selectedOptions = multiple
-      ? options.filter(option => (currentValue as string[]).includes(option.value))
-      : options.find(option => option.value === currentValue);
-
-    const handleValueChange = (newValue: string) => {
-      // Convert special "all" value back to empty string
-      const actualValue = newValue === '__all__' ? '' : newValue;
-
-      if (multiple) {
-        const currentArray = Array.isArray(value) ? value : [];
-        const updatedArray = currentArray.includes(actualValue)
-          ? currentArray.filter(v => v !== actualValue)
-          : [...currentArray, actualValue];
-        onChange?.(updatedArray);
-      } else {
-        onChange?.(actualValue);
-      }
-    };
-
-    const handleRemoveValue = (valueToRemove: string) => {
-      if (multiple && Array.isArray(value)) {
-        const updatedArray = value.filter(v => v !== valueToRemove);
-        onChange?.(updatedArray);
-      }
-    };
-
-    const handleClear = () => {
-      onChange?.(multiple ? [] : '');
-    };
-
-    const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const query = e.target.value;
-      setSearchQuery(query);
-      onSearch?.(query);
-    };
-
-    const renderValue = () => {
-      if (multiple && Array.isArray(currentValue) && currentValue.length > 0) {
-        const multipleSelectedOptions = selectedOptions as SelectOption[];
-        return (
-          <div className={valueContainer}>
-            {multipleSelectedOptions.map((option: SelectOption) => (
-              <div className={multiValue} key={option.value}>
-                {option.label}
-                <button
-                  className={multiValueRemove}
-                  onClick={e => {
-                    e.stopPropagation();
-                    handleRemoveValue(option.value);
-                  }}
-                  aria-label={`Remove ${option.label}`}
-                >
-                  <XIcon />
-                </button>
-              </div>
-            ))}
-          </div>
-        );
-      }
-
-      if (!multiple && selectedOptions) {
-        const singleSelectedOption = selectedOptions as SelectOption;
-        return <div className={singleValue}>{singleSelectedOption.label}</div>;
-      }
-
-      return <span className={placeholder}>{placeholderText}</span>;
-    };
-
-    const actualState = error ? 'error' : state;
-    const displayText = error || helperTextProp;
-
-    return (
-      <div className={clsx(container({ fullWidth }), className)} data-testid={dataTestId}>
-        {label && (
-          <label className={labelStyle({ required })} htmlFor={dataTestId}>
-            {label}
-          </label>
-        )}
-        <div className={selectContainer({ fullWidth })}>
-          <Select.Root
-            value={
-              multiple
-                ? undefined
-                : (currentValue === '' ? '__all__' : (currentValue as string)) || ''
-            }
-            defaultValue={
-              multiple ? undefined : defaultValue === '' ? '__all__' : (defaultValue as string)
-            }
-            onValueChange={handleValueChange}
-            disabled={disabled}
-          >
-            <Select.Trigger
-              ref={ref}
-              className={trigger({ size, state: actualState, disabled, fullWidth })}
-              aria-label={label}
-            >
-              {renderValue()}
-              <div className={iconRow}>
-                {clearable &&
-                  (currentValue || (Array.isArray(currentValue) && currentValue.length > 0)) && (
-                    <button
-                      className={clearButton}
-                      onClick={e => {
-                        e.stopPropagation();
-                        handleClear();
-                      }}
-                      aria-label='Clear selection'
-                    >
-                      <XIcon />
-                    </button>
-                  )}
-                <Select.Icon>
-                  <ChevronDownIcon />
-                </Select.Icon>
-              </div>
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Content className={content} position='popper' sideOffset={4}>
-                {searchable && (
-                  <div className={searchContainer}>
-                    <input
-                      className={searchInput}
-                      placeholder='Search options...'
-                      value={searchQuery}
-                      onChange={handleSearchChange}
-                      onClick={e => e.stopPropagation()}
-                    />
-                  </div>
-                )}
-                <Select.Viewport className={viewport}>
-                  {filteredOptions.length === 0 ? (
-                    <div className={emptyMessage}>No options found</div>
-                  ) : (
-                    filteredOptions.map(option => (
-                      <Select.Item
-                        key={option.value}
-                        value={option.value}
-                        disabled={option.disabled}
-                        className={selectItem({ disabled: option.disabled })}
-                      >
-                        <Select.ItemText>{option.label}</Select.ItemText>
-                      </Select.Item>
-                    ))
-                  )}
-                </Select.Viewport>
-              </Select.Content>
-            </Select.Portal>
-          </Select.Root>
-        </div>
-        {displayText && <div className={helperText({ state: actualState })}>{displayText}</div>}
-      </div>
+    if (!searchable || !searchQuery) {
+      return processedOptions;
+    }
+    return processedOptions.filter(option =>
+      option.label.toLowerCase().includes(searchQuery.toLowerCase())
     );
-  }
-);
+  }, [options, searchQuery, searchable]);
 
-SelectInput.displayName = 'SelectInput';
+  // Handle single/multiple values
+  const currentValue = multiple ? (Array.isArray(value) ? value : []) : value;
+  const selectedOptions = multiple
+    ? options.filter(option => (currentValue as string[]).includes(option.value))
+    : options.find(option => option.value === currentValue);
+
+  const handleValueChange = (newValue: string) => {
+    // Convert special "all" value back to empty string
+    const actualValue = newValue === '__all__' ? '' : newValue;
+
+    if (multiple) {
+      const currentArray = Array.isArray(value) ? value : [];
+      const updatedArray = currentArray.includes(actualValue)
+        ? currentArray.filter(v => v !== actualValue)
+        : [...currentArray, actualValue];
+      onChange?.(updatedArray);
+    } else {
+      onChange?.(actualValue);
+    }
+  };
+
+  const handleRemoveValue = (valueToRemove: string) => {
+    if (multiple && Array.isArray(value)) {
+      const updatedArray = value.filter(v => v !== valueToRemove);
+      onChange?.(updatedArray);
+    }
+  };
+
+  const handleClear = () => {
+    onChange?.(multiple ? [] : '');
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const query = e.target.value;
+    setSearchQuery(query);
+    onSearch?.(query);
+  };
+
+  const renderValue = () => {
+    if (multiple && Array.isArray(currentValue) && currentValue.length > 0) {
+      const multipleSelectedOptions = selectedOptions as SelectOption[];
+      return (
+        <div className={valueContainer}>
+          {multipleSelectedOptions.map((option: SelectOption) => (
+            <div className={multiValue} key={option.value}>
+              {option.label}
+              <button
+                className={multiValueRemove}
+                onClick={e => {
+                  e.stopPropagation();
+                  handleRemoveValue(option.value);
+                }}
+                aria-label={`Remove ${option.label}`}
+              >
+                <XIcon />
+              </button>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (!multiple && selectedOptions) {
+      const singleSelectedOption = selectedOptions as SelectOption;
+      return <div className={singleValue}>{singleSelectedOption.label}</div>;
+    }
+
+    return <span className={placeholder}>{placeholderText}</span>;
+  };
+
+  const actualState = error ? 'error' : state;
+  const displayText = error || helperTextProp;
+
+  return (
+    <div className={clsx(container({ fullWidth }), className)} data-testid={dataTestId}>
+      {label && (
+        <label className={labelStyle({ required })} htmlFor={dataTestId}>
+          {label}
+        </label>
+      )}
+      <div className={selectContainer({ fullWidth })}>
+        <Select.Root
+          value={
+            multiple
+              ? undefined
+              : (currentValue === '' ? '__all__' : (currentValue as string)) || ''
+          }
+          defaultValue={
+            multiple ? undefined : defaultValue === '' ? '__all__' : (defaultValue as string)
+          }
+          onValueChange={handleValueChange}
+          disabled={disabled}
+        >
+          <Select.Trigger
+            ref={ref}
+            className={trigger({ size, state: actualState, disabled, fullWidth })}
+            aria-label={label}
+          >
+            {renderValue()}
+            <div className={iconRow}>
+              {clearable &&
+                (currentValue || (Array.isArray(currentValue) && currentValue.length > 0)) && (
+                  <button
+                    className={clearButton}
+                    onClick={e => {
+                      e.stopPropagation();
+                      handleClear();
+                    }}
+                    aria-label='Clear selection'
+                  >
+                    <XIcon />
+                  </button>
+                )}
+              <Select.Icon>
+                <ChevronDownIcon />
+              </Select.Icon>
+            </div>
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Content className={content} position='popper' sideOffset={4}>
+              {searchable && (
+                <div className={searchContainer}>
+                  <input
+                    className={searchInput}
+                    placeholder='Search options...'
+                    value={searchQuery}
+                    onChange={handleSearchChange}
+                    onClick={e => e.stopPropagation()}
+                  />
+                </div>
+              )}
+              <Select.Viewport className={viewport}>
+                {filteredOptions.length === 0 ? (
+                  <div className={emptyMessage}>No options found</div>
+                ) : (
+                  filteredOptions.map(option => (
+                    <Select.Item
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      className={selectItem({ disabled: option.disabled })}
+                    >
+                      <Select.ItemText>{option.label}</Select.ItemText>
+                    </Select.Item>
+                  ))
+                )}
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </div>
+      {displayText && <div className={helperText({ state: actualState })}>{displayText}</div>}
+    </div>
+  );
+};

--- a/lib.components/src/components/form/TextArea/TextArea.tsx
+++ b/lib.components/src/components/form/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import * as styles from './TextArea.css';
@@ -29,168 +29,161 @@ export type TextAreaProps = {
   fullWidth?: boolean;
   className?: string;
   'data-testid'?: string;
+  ref?: React.Ref<HTMLTextAreaElement>;
 } & Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'>;
 
-const TextAreaComponent = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  (
-    {
-      label,
-      placeholder,
-      size = 'md',
-      variant = 'default',
-      state = 'default',
-      disabled = false,
-      required = false,
-      readOnly = false,
-      error,
-      helperText,
-      rows = 4,
-      minRows = 2,
-      maxRows = 10,
-      autoResize = false,
-      showCharacterCount = false,
-      maxLength,
-      fullWidth = false,
-      className,
-      'data-testid': dataTestId,
-      id,
-      value,
-      defaultValue,
-      onChange,
-      ...props
-    },
-    ref
-  ) => {
-    const textAreaRef = useRef<HTMLTextAreaElement>(null);
-    const [characterCount, setCharacterCount] = useState(0);
+export const TextArea = ({
+  label,
+  placeholder,
+  size = 'md',
+  variant = 'default',
+  state = 'default',
+  disabled = false,
+  required = false,
+  readOnly = false,
+  error,
+  helperText,
+  rows = 4,
+  minRows = 2,
+  maxRows = 10,
+  autoResize = false,
+  showCharacterCount = false,
+  maxLength,
+  fullWidth = false,
+  className,
+  'data-testid': dataTestId,
+  id,
+  value,
+  defaultValue,
+  onChange,
+  ref,
+  ...props
+}: TextAreaProps) => {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const [characterCount, setCharacterCount] = useState(0);
 
-    // Combine refs
-    const combinedRef = (node: HTMLTextAreaElement) => {
-      if (textAreaRef.current !== node) {
-        (textAreaRef as React.MutableRefObject<HTMLTextAreaElement | null>).current = node;
-      }
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref) {
-        ref.current = node;
-      }
-    };
+  // Combine refs
+  const combinedRef = (node: HTMLTextAreaElement) => {
+    if (textAreaRef.current !== node) {
+      (textAreaRef as React.MutableRefObject<HTMLTextAreaElement | null>).current = node;
+    }
+    if (typeof ref === 'function') {
+      ref(node);
+    } else if (ref) {
+      (ref as React.MutableRefObject<HTMLTextAreaElement | null>).current = node;
+    }
+  };
 
-    const inputId = id || `textarea-${Math.random().toString(36).substring(2, 9)}`;
-    const effectiveState = error ? 'error' : state;
-    const effectiveHelperText = error || helperText;
+  const inputId = id || `textarea-${Math.random().toString(36).substring(2, 9)}`;
+  const effectiveState = error ? 'error' : state;
+  const effectiveHelperText = error || helperText;
 
-    // Auto-resize functionality
-    const adjustHeight = React.useCallback(() => {
-      const textArea = textAreaRef.current;
-      if (!textArea || !autoResize) {
-        return;
-      }
+  // Auto-resize functionality
+  const adjustHeight = React.useCallback(() => {
+    const textArea = textAreaRef.current;
+    if (!textArea || !autoResize) {
+      return;
+    }
 
-      // Reset height to calculate scrollHeight
-      textArea.style.height = 'auto';
+    // Reset height to calculate scrollHeight
+    textArea.style.height = 'auto';
 
-      const scrollHeight = textArea.scrollHeight;
-      const lineHeight = parseInt(getComputedStyle(textArea).lineHeight);
-      const paddingTop = parseInt(getComputedStyle(textArea).paddingTop);
-      const paddingBottom = parseInt(getComputedStyle(textArea).paddingBottom);
+    const scrollHeight = textArea.scrollHeight;
+    const lineHeight = parseInt(getComputedStyle(textArea).lineHeight);
+    const paddingTop = parseInt(getComputedStyle(textArea).paddingTop);
+    const paddingBottom = parseInt(getComputedStyle(textArea).paddingBottom);
 
-      const minHeight = minRows * lineHeight + paddingTop + paddingBottom;
-      const maxHeight = maxRows * lineHeight + paddingTop + paddingBottom;
+    const minHeight = minRows * lineHeight + paddingTop + paddingBottom;
+    const maxHeight = maxRows * lineHeight + paddingTop + paddingBottom;
 
-      const newHeight = Math.min(Math.max(scrollHeight, minHeight), maxHeight);
-      textArea.style.height = `${newHeight}px`;
-    }, [autoResize, minRows, maxRows]);
+    const newHeight = Math.min(Math.max(scrollHeight, minHeight), maxHeight);
+    textArea.style.height = `${newHeight}px`;
+  }, [autoResize, minRows, maxRows]);
 
-    // Handle value changes
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const newValue = e.target.value;
-      setCharacterCount(newValue.length);
+  // Handle value changes
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    setCharacterCount(newValue.length);
+
+    if (autoResize) {
+      adjustHeight();
+    }
+
+    if (onChange) {
+      onChange(e);
+    }
+  };
+
+  // Initialize character count and height
+  useEffect(() => {
+    const textArea = textAreaRef.current;
+    if (textArea) {
+      const initialValue = value || defaultValue || textArea.value || '';
+      setCharacterCount(initialValue.length);
 
       if (autoResize) {
         adjustHeight();
       }
+    }
+  }, [value, defaultValue, autoResize, adjustHeight]);
 
-      if (onChange) {
-        onChange(e);
-      }
-    };
+  // Adjust height when value changes externally
+  useEffect(() => {
+    if (autoResize) {
+      adjustHeight();
+    }
+  }, [value, autoResize, adjustHeight]);
 
-    // Initialize character count and height
-    useEffect(() => {
-      const textArea = textAreaRef.current;
-      if (textArea) {
-        const initialValue = value || defaultValue || textArea.value || '';
-        setCharacterCount(initialValue.length);
+  const isOverLimit = maxLength !== undefined && characterCount > maxLength;
+  const showFooter = effectiveHelperText || showCharacterCount;
 
-        if (autoResize) {
-          adjustHeight();
-        }
-      }
-    }, [value, defaultValue, autoResize, adjustHeight]);
+  return (
+    <div className={clsx(styles.container({ fullWidth }), className)}>
+      {label && (
+        <label htmlFor={inputId} className={clsx(styles.label, required && styles.labelRequired)}>
+          {label}
+        </label>
+      )}
 
-    // Adjust height when value changes externally
-    useEffect(() => {
-      if (autoResize) {
-        adjustHeight();
-      }
-    }, [value, autoResize, adjustHeight]);
-
-    const isOverLimit = maxLength !== undefined && characterCount > maxLength;
-    const showFooter = effectiveHelperText || showCharacterCount;
-
-    return (
-      <div className={clsx(styles.container({ fullWidth }), className)}>
-        {label && (
-          <label htmlFor={inputId} className={clsx(styles.label, required && styles.labelRequired)}>
-            {label}
-          </label>
-        )}
-
-        <div className={styles.textAreaWrapper}>
-          <textarea
-            ref={combinedRef}
-            id={inputId}
-            placeholder={placeholder}
-            disabled={disabled}
-            required={required}
-            readOnly={readOnly}
-            rows={autoResize ? minRows : rows}
-            maxLength={maxLength}
-            value={value}
-            defaultValue={defaultValue}
-            data-testid={dataTestId}
-            onChange={handleChange}
-            className={styles.textArea({
-              size,
-              variant,
-              state: effectiveState,
-              autoResize,
-            })}
-            {...props}
-          />
-        </div>
-
-        {showFooter && (
-          <div className={styles.footerContainer}>
-            {effectiveHelperText && (
-              <div className={styles.helperText({ state: effectiveState })}>
-                {effectiveHelperText}
-              </div>
-            )}
-
-            {showCharacterCount && (
-              <div className={styles.characterCount({ isOverLimit })}>
-                {maxLength ? `${characterCount}/${maxLength}` : characterCount}
-              </div>
-            )}
-          </div>
-        )}
+      <div className={styles.textAreaWrapper}>
+        <textarea
+          ref={combinedRef}
+          id={inputId}
+          placeholder={placeholder}
+          disabled={disabled}
+          required={required}
+          readOnly={readOnly}
+          rows={autoResize ? minRows : rows}
+          maxLength={maxLength}
+          value={value}
+          defaultValue={defaultValue}
+          data-testid={dataTestId}
+          onChange={handleChange}
+          className={styles.textArea({
+            size,
+            variant,
+            state: effectiveState,
+            autoResize,
+          })}
+          {...props}
+        />
       </div>
-    );
-  }
-);
 
-TextAreaComponent.displayName = 'TextArea';
+      {showFooter && (
+        <div className={styles.footerContainer}>
+          {effectiveHelperText && (
+            <div className={styles.helperText({ state: effectiveState })}>
+              {effectiveHelperText}
+            </div>
+          )}
 
-export const TextArea = TextAreaComponent;
+          {showCharacterCount && (
+            <div className={styles.characterCount({ isOverLimit })}>
+              {maxLength ? `${characterCount}/${maxLength}` : characterCount}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/lib.components/src/components/form/TextInput/TextInput.tsx
+++ b/lib.components/src/components/form/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
 import * as styles from './TextInput.css';
@@ -27,120 +27,115 @@ export type TextInputProps = {
   fullWidth?: boolean;
   className?: string;
   'data-testid'?: string;
+  ref?: React.Ref<HTMLInputElement>;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
-export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
-  (
-    {
-      label,
-      placeholder,
-      value,
-      defaultValue,
-      size = 'md',
-      variant = 'default',
-      state = 'default',
-      disabled = false,
-      required = false,
-      readOnly = false,
-      error,
-      helperText,
-      leftIcon,
-      rightIcon,
-      leftAddon,
-      rightAddon,
-      fullWidth = false,
-      className,
-      'data-testid': dataTestId,
-      id,
-      ...props
-    },
-    ref
-  ) => {
-    const inputId = id || `text-input-${Math.random().toString(36).substring(2, 9)}`;
-    const effectiveState = error ? 'error' : state;
-    const effectiveHelperText = error || helperText;
+export const TextInput = ({
+  label,
+  placeholder,
+  value,
+  defaultValue,
+  size = 'md',
+  variant = 'default',
+  state = 'default',
+  disabled = false,
+  required = false,
+  readOnly = false,
+  error,
+  helperText,
+  leftIcon,
+  rightIcon,
+  leftAddon,
+  rightAddon,
+  fullWidth = false,
+  className,
+  'data-testid': dataTestId,
+  id,
+  ref,
+  ...props
+}: TextInputProps) => {
+  const inputId = id || `text-input-${Math.random().toString(36).substring(2, 9)}`;
+  const effectiveState = error ? 'error' : state;
+  const effectiveHelperText = error || helperText;
 
-    const inputEl = (
-      <input
-        ref={ref}
-        id={inputId}
-        placeholder={placeholder}
-        value={value}
-        defaultValue={defaultValue}
-        disabled={disabled}
-        required={required}
-        readOnly={readOnly}
-        data-testid={dataTestId}
-        aria-invalid={effectiveState === 'error'}
-        aria-describedby={effectiveHelperText ? `${inputId}-helper` : undefined}
-        className={styles.input({
-          size,
-          hasLeftIcon: !!leftIcon,
-          hasRightIcon: !!rightIcon,
-        })}
-        {...props}
-      />
-    );
+  const inputEl = (
+    <input
+      ref={ref}
+      id={inputId}
+      placeholder={placeholder}
+      value={value}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      required={required}
+      readOnly={readOnly}
+      data-testid={dataTestId}
+      aria-invalid={effectiveState === 'error'}
+      aria-describedby={effectiveHelperText ? `${inputId}-helper` : undefined}
+      className={styles.input({
+        size,
+        hasLeftIcon: !!leftIcon,
+        hasRightIcon: !!rightIcon,
+      })}
+      {...props}
+    />
+  );
 
-    const inputWithIcons = (
-      <div
-        className={styles.inputWrapper({
-          size,
-          variant,
-          state: effectiveState,
-          disabled,
-          hasLeftAddon: !!leftAddon,
-          hasRightAddon: !!rightAddon,
-        })}
-      >
-        {leftIcon && (
-          <div className={styles.iconContainer({ position: 'left', size })}>{leftIcon}</div>
+  const inputWithIcons = (
+    <div
+      className={styles.inputWrapper({
+        size,
+        variant,
+        state: effectiveState,
+        disabled,
+        hasLeftAddon: !!leftAddon,
+        hasRightAddon: !!rightAddon,
+      })}
+    >
+      {leftIcon && (
+        <div className={styles.iconContainer({ position: 'left', size })}>{leftIcon}</div>
+      )}
+      {inputEl}
+      {rightIcon && (
+        <div className={styles.iconContainer({ position: 'right', size })}>{rightIcon}</div>
+      )}
+    </div>
+  );
+
+  const inputWithAddons =
+    leftAddon || rightAddon ? (
+      <div className={styles.addonGroup}>
+        {leftAddon && (
+          <div className={styles.addon({ position: 'left', size, variant })}>{leftAddon}</div>
         )}
-        {inputEl}
-        {rightIcon && (
-          <div className={styles.iconContainer({ position: 'right', size })}>{rightIcon}</div>
+        {inputWithIcons}
+        {rightAddon && (
+          <div className={styles.addon({ position: 'right', size, variant })}>{rightAddon}</div>
         )}
       </div>
+    ) : (
+      inputWithIcons
     );
 
-    const inputWithAddons =
-      leftAddon || rightAddon ? (
-        <div className={styles.addonGroup}>
-          {leftAddon && (
-            <div className={styles.addon({ position: 'left', size, variant })}>{leftAddon}</div>
+  return (
+    <div className={clsx(styles.container({ fullWidth }), className)}>
+      {label && (
+        <label
+          htmlFor={inputId}
+          className={clsx(
+            styles.label,
+            required && styles.labelRequired,
+            disabled && styles.labelDisabled
           )}
-          {inputWithIcons}
-          {rightAddon && (
-            <div className={styles.addon({ position: 'right', size, variant })}>{rightAddon}</div>
-          )}
+        >
+          {label}
+        </label>
+      )}
+      {inputWithAddons}
+      {effectiveHelperText && (
+        <div className={styles.helperText({ state: effectiveState })} id={`${inputId}-helper`}>
+          {effectiveHelperText}
         </div>
-      ) : (
-        inputWithIcons
-      );
-
-    return (
-      <div className={clsx(styles.container({ fullWidth }), className)}>
-        {label && (
-          <label
-            htmlFor={inputId}
-            className={clsx(
-              styles.label,
-              required && styles.labelRequired,
-              disabled && styles.labelDisabled
-            )}
-          >
-            {label}
-          </label>
-        )}
-        {inputWithAddons}
-        {effectiveHelperText && (
-          <div className={styles.helperText({ state: effectiveState })} id={`${inputId}-helper`}>
-            {effectiveHelperText}
-          </div>
-        )}
-      </div>
-    );
-  }
-);
-
-TextInput.displayName = 'TextInput';
+      )}
+    </div>
+  );
+};

--- a/lib.components/src/components/ui/Button.tsx
+++ b/lib.components/src/components/ui/Button.tsx
@@ -4,71 +4,65 @@ import React from 'react';
 import { ButtonProps } from '../../types';
 import * as styles from './Button.css';
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      variant = 'primary',
-      size = 'md',
-      isLoading = false,
-      isFullWidth = false,
-      isRounded = false,
-      disabled = false,
-      children,
-      startIcon,
-      endIcon,
-      leftIcon,
-      rightIcon,
-      className,
-      onClick,
-      ...props
-    },
-    ref
-  ) => {
-    const effectiveStartIcon = startIcon ?? leftIcon;
-    const effectiveEndIcon = endIcon ?? rightIcon;
+export const Button = ({
+  variant = 'primary',
+  size = 'md',
+  isLoading = false,
+  isFullWidth = false,
+  isRounded = false,
+  disabled = false,
+  children,
+  startIcon,
+  endIcon,
+  leftIcon,
+  rightIcon,
+  className,
+  onClick,
+  ref,
+  ...props
+}: ButtonProps) => {
+  const effectiveStartIcon = startIcon ?? leftIcon;
+  const effectiveEndIcon = endIcon ?? rightIcon;
 
-    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-      if (isLoading || disabled) {
-        event.preventDefault();
-        return;
-      }
-      onClick?.(event);
-    };
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (isLoading || disabled) {
+      event.preventDefault();
+      return;
+    }
+    onClick?.(event);
+  };
 
-    return (
-      <button
-        ref={ref}
-        className={clsx(
-          styles.button({
-            variant,
-            size,
-            isLoading,
-            isFullWidth,
-            isRounded,
-            hasStartIcon: !!effectiveStartIcon,
-            hasEndIcon: !!effectiveEndIcon,
-          }),
-          className
-        )}
-        disabled={disabled || isLoading}
-        onClick={handleClick}
-        aria-disabled={disabled || isLoading}
-        aria-busy={isLoading}
-        type='button'
-        {...props}
-      >
-        {effectiveStartIcon && !isLoading && (
-          <span className={styles.iconContainer}>{effectiveStartIcon}</span>
-        )}
-        {children}
-        {effectiveEndIcon && !isLoading && (
-          <span className={styles.iconContainer}>{effectiveEndIcon}</span>
-        )}
-      </button>
-    );
-  }
-);
-
-Button.displayName = 'Button';
+  return (
+    <button
+      ref={ref}
+      className={clsx(
+        styles.button({
+          variant,
+          size,
+          isLoading,
+          isFullWidth,
+          isRounded,
+          hasStartIcon: !!effectiveStartIcon,
+          hasEndIcon: !!effectiveEndIcon,
+        }),
+        className
+      )}
+      disabled={disabled || isLoading}
+      onClick={handleClick}
+      aria-disabled={disabled || isLoading}
+      aria-busy={isLoading}
+      type='button'
+      {...props}
+    >
+      {effectiveStartIcon && !isLoading && (
+        <span className={styles.iconContainer}>{effectiveStartIcon}</span>
+      )}
+      {children}
+      {effectiveEndIcon && !isLoading && (
+        <span className={styles.iconContainer}>{effectiveEndIcon}</span>
+      )}
+    </button>
+  );
+};
 
 export default Button;

--- a/lib.components/src/components/ui/Heading.tsx
+++ b/lib.components/src/components/ui/Heading.tsx
@@ -33,6 +33,7 @@ export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   noMargin?: boolean;
   className?: string;
   children: React.ReactNode;
+  ref?: React.Ref<HTMLHeadingElement>;
 }
 
 const defaultSizeForLevel: Record<HeadingLevel, HeadingSize> = {
@@ -44,44 +45,38 @@ const defaultSizeForLevel: Record<HeadingLevel, HeadingSize> = {
   h6: 'md',
 };
 
-export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
-  (
-    {
-      level = 'h2',
-      size,
-      weight = 'semibold',
-      align = 'left',
-      color = 'body',
-      truncate = false,
-      noMargin = false,
-      className = '',
-      children,
-      ...rest
-    },
-    ref
-  ) => {
-    const Tag = level;
-    const headingSize = size ?? defaultSizeForLevel[level];
+export const Heading = ({
+  level = 'h2',
+  size,
+  weight = 'semibold',
+  align = 'left',
+  color = 'body',
+  truncate = false,
+  noMargin = false,
+  className = '',
+  children,
+  ref,
+  ...rest
+}: HeadingProps) => {
+  const Tag = level;
+  const headingSize = size ?? defaultSizeForLevel[level];
 
-    return (
-      <Tag
-        ref={ref}
-        className={clsx(
-          styles.base,
-          styles.sizes[headingSize],
-          styles.weights[weight],
-          styles.colors[color],
-          styles.aligns[align],
-          noMargin ? styles.margins.none : styles.margins[level],
-          truncate && styles.truncate,
-          className
-        )}
-        {...rest}
-      >
-        {children}
-      </Tag>
-    );
-  }
-);
-
-Heading.displayName = 'Heading';
+  return (
+    <Tag
+      ref={ref}
+      className={clsx(
+        styles.base,
+        styles.sizes[headingSize],
+        styles.weights[weight],
+        styles.colors[color],
+        styles.aligns[align],
+        noMargin ? styles.margins.none : styles.margins[level],
+        truncate && styles.truncate,
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  );
+};

--- a/lib.components/src/components/ui/Input.tsx
+++ b/lib.components/src/components/ui/Input.tsx
@@ -1,75 +1,69 @@
 import clsx from 'clsx';
-import React, { useId } from 'react';
+import { useId } from 'react';
 
 import { InputProps } from '../../types';
 import * as styles from './Input.css';
 
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  (
-    {
-      className = '',
-      label,
-      error,
-      helperText,
-      id,
-      required = false,
-      isFullWidth = true,
-      size = 'md',
-      variant = 'default',
-      startIcon,
-      endIcon,
-      ...props
-    },
-    ref
-  ) => {
-    const generatedId = useId();
-    const inputId = id || generatedId;
-    const hasError = !!error;
-    const helpText = error || helperText;
-    const helperId = helpText ? `${inputId}-helper` : undefined;
-    const actualVariant = hasError ? 'error' : variant;
+export const Input = ({
+  className = '',
+  label,
+  error,
+  helperText,
+  id,
+  required = false,
+  isFullWidth = true,
+  size = 'md',
+  variant = 'default',
+  startIcon,
+  endIcon,
+  ref,
+  ...props
+}: InputProps) => {
+  const generatedId = useId();
+  const inputId = id || generatedId;
+  const hasError = !!error;
+  const helpText = error || helperText;
+  const helperId = helpText ? `${inputId}-helper` : undefined;
+  const actualVariant = hasError ? 'error' : variant;
 
-    return (
-      <div className={styles.inputWrapper({ isFullWidth })}>
-        {label && (
-          <label className={styles.inputLabel} htmlFor={inputId}>
-            {label}
-            {required && <span className={styles.requiredIndicator}>*</span>}
-          </label>
-        )}
+  return (
+    <div className={styles.inputWrapper({ isFullWidth })}>
+      {label && (
+        <label className={styles.inputLabel} htmlFor={inputId}>
+          {label}
+          {required && <span className={styles.requiredIndicator}>*</span>}
+        </label>
+      )}
 
-        <div className={styles.inputContainer}>
-          {startIcon && <div className={styles.startIconWrapper}>{startIcon}</div>}
+      <div className={styles.inputContainer}>
+        {startIcon && <div className={styles.startIconWrapper}>{startIcon}</div>}
 
-          <input
-            id={inputId}
-            ref={ref}
-            className={clsx(
-              styles.styledInput({
-                variant: actualVariant,
-                size,
-                hasStartIcon: !!startIcon,
-                hasEndIcon: !!endIcon,
-              }),
-              className
-            )}
-            aria-invalid={hasError}
-            aria-describedby={helperId}
-            required={required}
-            {...props}
-          />
+        <input
+          id={inputId}
+          ref={ref}
+          className={clsx(
+            styles.styledInput({
+              variant: actualVariant,
+              size,
+              hasStartIcon: !!startIcon,
+              hasEndIcon: !!endIcon,
+            }),
+            className
+          )}
+          aria-invalid={hasError}
+          aria-describedby={helperId}
+          required={required}
+          {...props}
+        />
 
-          {endIcon && <div className={styles.endIconWrapper}>{endIcon}</div>}
-        </div>
-
-        {helpText && (
-          <p id={helperId} className={styles.helperText({ hasError })}>
-            {helpText}
-          </p>
-        )}
+        {endIcon && <div className={styles.endIconWrapper}>{endIcon}</div>}
       </div>
-    );
-  }
-);
 
-Input.displayName = 'Input';
+      {helpText && (
+        <p id={helperId} className={styles.helperText({ hasError })}>
+          {helpText}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/lib.components/src/components/ui/Spinner.tsx
+++ b/lib.components/src/components/ui/Spinner.tsx
@@ -14,60 +14,49 @@ export interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
   showLabel?: boolean;
   text?: string;
   className?: string;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
-  (
-    {
-      size = 'md',
-      variant = 'default',
-      label = 'Loading...',
-      showLabel = false,
-      text,
-      className = '',
-      ...rest
-    },
-    ref
-  ) => {
-    return (
-      <div ref={ref} className={clsx(styles.container, className)} {...rest}>
-        <div className={styles.spinner({ size, variant })} role='status' aria-label={label} />
-        {showLabel && <span className={styles.label}>{text || label}</span>}
+export const Spinner = ({
+  size = 'md',
+  variant = 'default',
+  label = 'Loading...',
+  showLabel = false,
+  text,
+  className = '',
+  ref,
+  ...rest
+}: SpinnerProps) => {
+  return (
+    <div ref={ref} className={clsx(styles.container, className)} {...rest}>
+      <div className={styles.spinner({ size, variant })} role='status' aria-label={label} />
+      {showLabel && <span className={styles.label}>{text || label}</span>}
+    </div>
+  );
+};
+
+export const DotSpinner = ({
+  size = 'md',
+  variant = 'default',
+  label = 'Loading...',
+  showLabel = false,
+  text,
+  className = '',
+  ref,
+  ...rest
+}: SpinnerProps) => {
+  return (
+    <div ref={ref} className={clsx(styles.container, className)} {...rest}>
+      <div className={styles.dotContainer[size]} role='status' aria-label={label}>
+        {([-0.32, -0.16, 0] as const).map(delay => (
+          <div
+            key={delay}
+            className={styles.dot({ size, variant })}
+            style={{ '--dot-delay': `${delay}s` } as React.CSSProperties}
+          />
+        ))}
       </div>
-    );
-  }
-);
-
-Spinner.displayName = 'Spinner';
-
-export const DotSpinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
-  (
-    {
-      size = 'md',
-      variant = 'default',
-      label = 'Loading...',
-      showLabel = false,
-      text,
-      className = '',
-      ...rest
-    },
-    ref
-  ) => {
-    return (
-      <div ref={ref} className={clsx(styles.container, className)} {...rest}>
-        <div className={styles.dotContainer[size]} role='status' aria-label={label}>
-          {([-0.32, -0.16, 0] as const).map(delay => (
-            <div
-              key={delay}
-              className={styles.dot({ size, variant })}
-              style={{ '--dot-delay': `${delay}s` } as React.CSSProperties}
-            />
-          ))}
-        </div>
-        {showLabel && <span className={styles.label}>{text || label}</span>}
-      </div>
-    );
-  }
-);
-
-DotSpinner.displayName = 'DotSpinner';
+      {showLabel && <span className={styles.label}>{text || label}</span>}
+    </div>
+  );
+};

--- a/lib.components/src/components/ui/Text.tsx
+++ b/lib.components/src/components/ui/Text.tsx
@@ -35,48 +35,43 @@ export interface TextProps extends React.HTMLAttributes<HTMLElement> {
   underline?: boolean;
   className?: string;
   children: React.ReactNode;
+  ref?: React.Ref<HTMLElement>;
 }
 
-export const Text = React.forwardRef<HTMLElement, TextProps>(
-  (
-    {
-      variant = 'body',
-      size = 'base',
-      weight = 'normal',
-      align = 'left',
-      color = 'body',
-      as = 'span' as keyof React.JSX.IntrinsicElements,
-      truncate = false,
-      italic = false,
-      underline = false,
-      className = '',
-      children,
-      ...rest
-    },
-    ref
-  ) => {
-    const Component = as as React.ElementType;
-    return (
-      <Component
-        ref={ref}
-        className={clsx(
-          styles.base,
-          styles.variants[variant],
-          styles.sizes[size],
-          styles.weights[weight],
-          styles.colors[color],
-          styles.aligns[align],
-          truncate && styles.truncate,
-          italic && styles.italic,
-          underline && styles.underline,
-          className
-        )}
-        {...rest}
-      >
-        {children}
-      </Component>
-    );
-  }
-);
-
-Text.displayName = 'Text';
+export const Text = ({
+  variant = 'body',
+  size = 'base',
+  weight = 'normal',
+  align = 'left',
+  color = 'body',
+  as = 'span' as keyof React.JSX.IntrinsicElements,
+  truncate = false,
+  italic = false,
+  underline = false,
+  className = '',
+  children,
+  ref,
+  ...rest
+}: TextProps) => {
+  const Component = as as React.ElementType;
+  return (
+    <Component
+      ref={ref}
+      className={clsx(
+        styles.base,
+        styles.variants[variant],
+        styles.sizes[size],
+        styles.weights[weight],
+        styles.colors[color],
+        styles.aligns[align],
+        truncate && styles.truncate,
+        italic && styles.italic,
+        underline && styles.underline,
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+};

--- a/lib.components/src/types.ts
+++ b/lib.components/src/types.ts
@@ -25,6 +25,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   startIcon?: React.ReactNode;
   endIcon?: React.ReactNode;
   children: React.ReactNode;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
 export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
@@ -38,6 +39,7 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
   rightIcon?: React.ReactNode;
   startIcon?: React.ReactNode;
   endIcon?: React.ReactNode;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 // Re-export additional component types from their respective files


### PR DESCRIPTION
## Summary

React 19 plan Stage 3 cleanup. React 19 lets function components accept `ref` as a regular prop — no more `React.forwardRef` wrapper required.

```tsx
// Before
export const Input = React.forwardRef<HTMLInputElement, InputProps>(
  ({ ... }, ref) => <input ref={ref} ... />
);
Input.displayName = 'Input';

// After
type InputProps = { ref?: React.Ref<HTMLInputElement>; /* ... */ };
export const Input = ({ ref, ... }: InputProps) => <input ref={ref} ... />;
```

## Files touched (11)

- `ui/`: `Button.tsx`, `Input.tsx`, `Heading.tsx`, `Spinner.tsx`, `Text.tsx`
- `form/`: `CheckboxInput.tsx`, `RadioInput.tsx`, `SelectInput.tsx`, `TextArea.tsx`, `TextInput.tsx`
- `types.ts` — added `ref?: React.Ref<…>` to the shared `ButtonProps` and `InputProps` interfaces (`Button.tsx` and `Input.tsx` import their props type from here)

Stats: **840 insertions, 898 deletions** (net −58 lines).

## Notable nuances

- **`CheckboxInput`** had a manual `ref.current.click()` keyboard handler. `React.Ref<T>` is a union of callback ref / ref object / `null`; the old `'current' in ref` narrowing produced a `never` for callback refs after the type change. Added a `typeof ref === 'object'` guard. Preserves prior behaviour.
- **`TextArea`** has combined-ref logic that needed an explicit `as React.MutableRefObject<…>` cast on assignment to `ref.current`, same root cause.

## Out of scope (deliberately left alone)

- `ui/DateTime/DateTime.test.tsx` and `ui/DropdownButton/DropdownButton.test.tsx` use `forwardRef` in test fixtures (not in the components under test). No tests broke.
- `types.ts` and `types/index.ts` have overlapping `ButtonProps` / `InputProps` definitions — pre-existing tech debt outside this PR's scope. Flagging here so it's not forgotten.

## Test plan

- [x] `lib.components` build: clean
- [x] `lib.components`: **441 tests passed** (41 files)
- [x] `app.admin`: **321 tests passed** (28 files)
- [x] `app.client`: **284 tests passed** (38 files)
- [x] `app.rescue`: **185 tests passed** (21 files)
- [ ] CI green
- [ ] Spot-check Storybook stories for the 10 components — visual sanity that nothing renders differently

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_