### PR TITLE
chore(react19): annotate hot list components for React Compiler (ADS-531)

### DIFF
--- a/app.client/src/components/PetCard.tsx
+++ b/app.client/src/components/PetCard.tsx
@@ -23,6 +23,7 @@ export const PetCard: React.FC<PetCardProps> = ({
   onFavoriteToggle,
   isFavorite: propIsFavorite,
 }) => {
+  'use memo';
   const [isLoadingFavorite, setIsLoadingFavorite] = useState(false);
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
   const { isAuthenticated } = useAuth();

--- a/app.client/src/pages/SearchPage.tsx
+++ b/app.client/src/pages/SearchPage.tsx
@@ -13,6 +13,7 @@ import { SORT_OPTIONS } from './searchOptions';
 import { SearchFilters } from './SearchFilters';
 
 export const SearchPage: React.FC = () => {
+  'use memo';
   const [searchParams, setSearchParams] = useSearchParams();
   const [pets, setPets] = useState<Pet[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/app.rescue/src/components/ApplicationTimeline.tsx
+++ b/app.rescue/src/components/ApplicationTimeline.tsx
@@ -3,7 +3,6 @@ import { formatDateTime } from '@adopt-dont-shop/lib.utils';
 import * as styles from './ApplicationTimeline.css';
 
 // Timeline Event Types (matching backend)
-// eslint-disable-next-line react-refresh/only-export-components
 export enum TimelineEventType {
   STAGE_CHANGE = 'stage_change',
   STATUS_UPDATE = 'status_update',
@@ -116,6 +115,7 @@ export const ApplicationTimeline: React.FC<ApplicationTimelineProps> = ({
   loading = false,
   onAddNote,
 }) => {
+  'use memo';
   const [noteText, setNoteText] = React.useState('');
   const [noteType, setNoteType] = React.useState('general');
   const [submitting, setSubmitting] = React.useState(false);

--- a/app.rescue/src/components/TimelineWidget.tsx
+++ b/app.rescue/src/components/TimelineWidget.tsx
@@ -74,6 +74,7 @@ export const TimelineWidget: React.FC<TimelineWidgetProps> = ({
   showViewAll = true,
   onViewAll,
 }) => {
+  'use memo';
   const displayEvents = events.slice(0, maxEvents);
   const hasMoreEvents = events.length > maxEvents;
 

--- a/app.rescue/src/components/pets/PetCard.tsx
+++ b/app.rescue/src/components/pets/PetCard.tsx
@@ -66,6 +66,7 @@ interface PetCardProps {
 }
 
 const PetCard: React.FC<PetCardProps> = ({ pet, onStatusChange, onEdit, onDelete }) => {
+  'use memo';
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [newStatus, setNewStatus] = useState<PetStatus>(pet.status as PetStatus);

--- a/app.rescue/src/components/pets/PetGrid.tsx
+++ b/app.rescue/src/components/pets/PetGrid.tsx
@@ -27,6 +27,7 @@ const PetGrid: React.FC<PetGridProps> = ({
   onDeletePet,
   pagination,
 }) => {
+  'use memo';
   if (loading && pets.length === 0) {
     return (
       <div className={styles.loadingGrid}>


### PR DESCRIPTION
## Summary

Follow-up to PR #536 (React Compiler infra in annotation mode). Adds a `'use memo'` directive to six render-heavy list components so the compiler auto-memoizes them. The compiler runs over each marked function and inserts the equivalent of a hand-written `useMemo` / `useCallback` / `memo` tree where it would be correct — fewer re-renders on prop reference churn, no source-level boilerplate.

## Annotated components

Chosen because they re-render frequently with large prop trees (pet feeds, paginated lists, real-time timelines) and per the candidate list documented in #536:

| File | Why it's hot |
|---|---|
| `app.client/src/components/PetCard.tsx` | rendered across search / home / favorites / rescue-details pages |
| `app.client/src/pages/SearchPage.tsx` | search results grid; filter-driven refetch on every keystroke |
| `app.rescue/src/components/pets/PetCard.tsx` | rescue's pet list cards |
| `app.rescue/src/components/pets/PetGrid.tsx` | rescue's pet grid container |
| `app.rescue/src/components/ApplicationTimeline.tsx` | real-time timeline view per application |
| `app.rescue/src/components/TimelineWidget.tsx` | per-row timeline widget on the applications list |

The directive goes inside the function body as the first statement (per the React Compiler docs for annotation mode); the rest of the file is untouched.

## Also fixed

Dead `eslint-disable-next-line react-refresh/only-export-components` comment in `ApplicationTimeline.tsx`. The `react-refresh` plugin isn't installed in any of the project's eslint configs, so the directive was a no-op and pre-commit lint flagged it as a "rule definition not found" error blocking the commit.

## Not annotated (deliberately)

- **`lib.chat/src/components/MessageList.tsx`** and **`MessageBubbleComponent.tsx`** would also benefit, but `lib.chat` doesn't have the compiler wired into its own Vite build yet. Annotating now would have no effect in prod builds (the source is consumed pre-compiled). Wiring the compiler into `lib.chat` is a separate PR.
- **Anything inside `lib.components`** — those are leaf components consumed through stable refs; the compiler payoff lives in the calling list.

## Rollback safety

If a specific annotation causes a regression it can be reverted in isolation; the file-level safety valve is the inverse directive `'use no memo'` placed in the same position.

## Test plan

- [x] `app.client` build: clean
- [x] `app.rescue` build: clean
- [x] `app.client`: **284 tests passed** (38 files)
- [x] `app.rescue`: **185 tests passed** (21 files)
- [x] No compiler bailouts or warnings on the annotated files (a Rules-of-React violation would have surfaced as a build-time warning under the compiler — the silent build is the all-clear signal)
- [ ] CI green
- [ ] Eyeball the search results page and rescue pet list in dev — render count via React DevTools should drop on the annotated paths

https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjmeWo74XFA11WwhbUqtCS)_