### PR TITLE
fix(ci): mock optionalAuth in rescue route tests and unignore docs/legal

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -65,6 +65,8 @@ test-results
 *.md
 !README.md
 docs
+!docs/legal
+!docs/legal/**
 .claude
 
 # ============================================================================

--- a/service.backend/src/__tests__/routes/rescue.routes.test.ts
+++ b/service.backend/src/__tests__/routes/rescue.routes.test.ts
@@ -104,6 +104,9 @@ const requirePermissionMock = vi.fn();
 vi.mock('../../middleware/auth', () => ({
   authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
     authenticateTokenMock(req, res, next),
+  optionalAuth: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  authenticateOptionalToken: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>
+    next(),
 }));
 
 vi.mock('../../middleware/rbac', () => ({

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -219,7 +219,7 @@ export class ApplicationController extends BaseController {
     }
 
     if (Rescue) {
-      (transformed as Record<string, unknown>).rescueName = Rescue.name as string;
+      (transformed as unknown as Record<string, unknown>).rescueName = Rescue.name as string;
     }
 
     return transformed;


### PR DESCRIPTION
## Summary

Two unrelated CI failures, fixed together:

- **Vitest** `src/__tests__/routes/rescue.routes.test.ts` was failing with `No "optionalAuth" export is defined on the "../../middleware/auth" mock`. A recent change (`4aa552d`) wired `optionalAuth` into `GET /rescues` in `service.backend/src/routes/rescue.routes.ts:282`, but the test's `vi.mock('../../middleware/auth', ...)` only stubbed `authenticateToken`. Added `optionalAuth` (and `authenticateOptionalToken` for parity with the real module) as pass-through middleware.
- **Docker build** for the backend image was failing on `COPY docs/legal/ docs/legal/` (`service.backend/Dockerfile:89,207`) because `.dockerignore` excluded `docs` wholesale. Added a `!docs/legal` / `!docs/legal/**` exception so the legal markdown (read by `legal-content.service.ts` at runtime) is included in the build context.

## Test plan

- [ ] `npx turbo test --filter=@adopt-dont-shop/service-backend` — rescue.routes suite green.
- [ ] `docker build -f service.backend/Dockerfile --target development .` — gets past the `COPY docs/legal/` step.
- [ ] Full CI run on this branch goes green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MYofzwhr3XzofHzAp3gLns)_