### PR TITLE
feat(ADS-13): implement S3-compatible object storage provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,6 +1665,503 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1048.0.tgz",
+      "integrity": "sha512-SrJn5FteqqtcDBgQIvqLKk3Qn/2vSsi5XR03I53EDDR4CbCdLysVSNgUnjVncEECMua9Pz+nxO0/lEx3TP+6mA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.13",
+        "@aws-sdk/middleware-expect-continue": "^3.972.12",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.19",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.40",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.8.tgz",
+      "integrity": "sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.13.tgz",
+      "integrity": "sha512-JDaukix+kt5KwF7FzNSkfZHpqiPJajVkKJLJexF6z5B44+CN70BXGiQaCEAiCtKtRZNvC16eF3SY9L0bDJPlbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.12.tgz",
+      "integrity": "sha512-dA5pKTom/Ls9mgeyeaRBNQrRIVOLVjv4AmKOB0/e4yaiXEUy0gSz2d3liP8JHtYoCAEWySU1jWnyzwLOREN+4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.19.tgz",
+      "integrity": "sha512-GLciZVIvWM3C+ffuqnUqlAZwRjQdLt+KXiqr9+aRwZyKVyF2J5lrJAzzSqwweNl9hUWBN00BhilWXdMI5DjNcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/crc64-nvme": "^3.972.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.40.tgz",
+      "integrity": "sha512-vyFY4EsAGySqqd87Z7n4qcCYXJO3QArB8VIJzuupY5XuLHIp579HTZldIUGGABvAOzLptfPb9+lJBJcB+3/cvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -5600,6 +6097,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
@@ -9195,6 +9704,126 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -11835,6 +12464,12 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -15306,6 +15941,43 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fb-dotslash": {
@@ -20869,6 +21541,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -25143,6 +25830,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -27715,6 +28414,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -27978,6 +28692,7 @@
       "dependencies": {
         "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/lib.validation": "*",
+        "@aws-sdk/client-s3": "^3.1048.0",
         "@faker-js/faker": "^10.4.0",
         "@sentry/node": "^10.52.0",
         "@sentry/profiling-node": "^10.52.0",

--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/lib.validation": "*",
+    "@aws-sdk/client-s3": "^3.1048.0",
     "@faker-js/faker": "^10.4.0",
     "@sentry/node": "^10.52.0",
     "@sentry/profiling-node": "^10.52.0",

--- a/service.backend/src/__tests__/services/file-upload.service.test.ts
+++ b/service.backend/src/__tests__/services/file-upload.service.test.ts
@@ -48,6 +48,13 @@ vi.mock('../../config', () => ({
   },
 }));
 
+// Default to local storage so existing tests are unaffected.
+// Individual tests that exercise S3 wiring override this with vi.mocked().
+vi.mock('../../services/storage', () => ({
+  getStorageProvider: vi.fn(() => ({ getName: () => 'local' })),
+  StorageCategory: {},
+}));
+
 // ──── Imports ─────────────────────────────────────────────────────────────────
 
 import fs from 'fs';
@@ -56,6 +63,7 @@ import DOMPurify from 'isomorphic-dompurify';
 import FileUpload from '../../models/FileUpload';
 import { AuditLogService } from '../../services/auditLog.service';
 import { FileUploadService } from '../../services/file-upload.service';
+import { getStorageProvider } from '../../services/storage';
 
 // ──── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -567,6 +575,115 @@ describe('FileUploadService', () => {
           userId: 'user-456',
         })
       );
+    });
+  });
+
+  describe('S3 storage provider wiring', () => {
+    const s3ProviderUploadFile = vi.fn();
+    const s3ProviderDeleteFile = vi.fn();
+    const mockS3Provider = {
+      getName: () => 's3',
+      uploadFile: s3ProviderUploadFile,
+      deleteFile: s3ProviderDeleteFile,
+    };
+
+    beforeEach(() => {
+      s3ProviderUploadFile.mockResolvedValue({
+        url: 'https://bucket.s3.us-east-1.amazonaws.com/pets/uuid.jpg',
+        filename: 'uuid.jpg',
+        size: 1024,
+      });
+      s3ProviderDeleteFile.mockResolvedValue(undefined);
+      vi.mocked(getStorageProvider).mockReturnValue(
+        mockS3Provider as ReturnType<typeof getStorageProvider>
+      );
+    });
+
+    afterEach(() => {
+      vi.mocked(getStorageProvider).mockReturnValue({ getName: () => 'local' } as ReturnType<typeof getStorageProvider>);
+    });
+
+    describe('upload', () => {
+      it('uploads the processed file to the S3 provider when STORAGE_PROVIDER=s3', async () => {
+        const file = makeFile({ originalname: 'cat.jpg', mimetype: 'image/jpeg' });
+        setupSuccessfulUpload();
+        vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('processed-content'));
+        vi.mocked(FileUpload.create).mockResolvedValue(
+          makeMockRecord({ url: 'https://bucket.s3.us-east-1.amazonaws.com/pets/uuid.jpg' })
+        );
+
+        const result = await FileUploadService.uploadFile(file, 'pets', {
+          uploadedBy: 'user-456',
+        });
+
+        expect(result.success).toBe(true);
+        expect(s3ProviderUploadFile).toHaveBeenCalledWith(
+          expect.any(Buffer),
+          'cat.jpg',
+          'image/jpeg',
+          'pets'
+        );
+      });
+
+      it('stores the S3 URL in the database record', async () => {
+        const file = makeFile({ originalname: 'dog.jpg', mimetype: 'image/jpeg' });
+        setupSuccessfulUpload();
+        vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('data'));
+        vi.mocked(FileUpload.create).mockResolvedValue(
+          makeMockRecord({ url: 'https://bucket.s3.us-east-1.amazonaws.com/pets/uuid.jpg' })
+        );
+
+        await FileUploadService.uploadFile(file, 'pets', { uploadedBy: 'user-456' });
+
+        expect(vi.mocked(FileUpload.create)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: 'https://bucket.s3.us-east-1.amazonaws.com/pets/uuid.jpg',
+          })
+        );
+      });
+
+      it('maps profiles upload type to the "users" S3 category', async () => {
+        const file = makeFile({
+          originalname: 'avatar.jpg',
+          mimetype: 'image/jpeg',
+          path: '/test-uploads/avatar.jpg',
+          filename: 'avatar_123.jpg',
+          destination: '/test-uploads',
+        });
+        setupSuccessfulUpload();
+        vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('data'));
+        vi.mocked(FileUpload.create).mockResolvedValue(makeMockRecord());
+
+        await FileUploadService.uploadFile(file, 'profiles', { uploadedBy: 'user-456' });
+
+        expect(s3ProviderUploadFile).toHaveBeenCalledWith(
+          expect.any(Buffer),
+          'avatar.jpg',
+          'image/jpeg',
+          'users'
+        );
+      });
+    });
+
+    describe('delete', () => {
+      it('delegates deletion to the S3 provider using the stored file path as key', async () => {
+        const mockRecord = makeMockRecord({ file_path: 'pets/photo_123.jpg', uploaded_by: 'user-456' });
+        vi.mocked(FileUpload.findByPk).mockResolvedValue(mockRecord);
+
+        await FileUploadService.deleteFile('upload-abc-123', { id: 'user-456', type: UserType.ADOPTER });
+
+        expect(s3ProviderDeleteFile).toHaveBeenCalledWith('photo_123.jpg', 'pets');
+        expect(vi.mocked(fs.promises.unlink)).not.toHaveBeenCalled();
+      });
+
+      it('handles a file_path without a directory segment gracefully', async () => {
+        const mockRecord = makeMockRecord({ file_path: 'orphan.jpg', uploaded_by: 'user-456' });
+        vi.mocked(FileUpload.findByPk).mockResolvedValue(mockRecord);
+
+        await FileUploadService.deleteFile('upload-abc-123', { id: 'user-456', type: UserType.ADOPTER });
+
+        expect(s3ProviderDeleteFile).toHaveBeenCalledWith('orphan.jpg', 'documents');
+      });
     });
   });
 });

--- a/service.backend/src/__tests__/services/file-upload.service.test.ts
+++ b/service.backend/src/__tests__/services/file-upload.service.test.ts
@@ -600,7 +600,9 @@ describe('FileUploadService', () => {
     });
 
     afterEach(() => {
-      vi.mocked(getStorageProvider).mockReturnValue({ getName: () => 'local' } as ReturnType<typeof getStorageProvider>);
+      vi.mocked(getStorageProvider).mockReturnValue({ getName: () => 'local' } as ReturnType<
+        typeof getStorageProvider
+      >);
     });
 
     describe('upload', () => {
@@ -667,10 +669,16 @@ describe('FileUploadService', () => {
 
     describe('delete', () => {
       it('delegates deletion to the S3 provider using the stored file path as key', async () => {
-        const mockRecord = makeMockRecord({ file_path: 'pets/photo_123.jpg', uploaded_by: 'user-456' });
+        const mockRecord = makeMockRecord({
+          file_path: 'pets/photo_123.jpg',
+          uploaded_by: 'user-456',
+        });
         vi.mocked(FileUpload.findByPk).mockResolvedValue(mockRecord);
 
-        await FileUploadService.deleteFile('upload-abc-123', { id: 'user-456', type: UserType.ADOPTER });
+        await FileUploadService.deleteFile('upload-abc-123', {
+          id: 'user-456',
+          type: UserType.ADOPTER,
+        });
 
         expect(s3ProviderDeleteFile).toHaveBeenCalledWith('photo_123.jpg', 'pets');
         expect(vi.mocked(fs.promises.unlink)).not.toHaveBeenCalled();
@@ -680,7 +688,10 @@ describe('FileUploadService', () => {
         const mockRecord = makeMockRecord({ file_path: 'orphan.jpg', uploaded_by: 'user-456' });
         vi.mocked(FileUpload.findByPk).mockResolvedValue(mockRecord);
 
-        await FileUploadService.deleteFile('upload-abc-123', { id: 'user-456', type: UserType.ADOPTER });
+        await FileUploadService.deleteFile('upload-abc-123', {
+          id: 'user-456',
+          type: UserType.ADOPTER,
+        });
 
         expect(s3ProviderDeleteFile).toHaveBeenCalledWith('orphan.jpg', 'documents');
       });

--- a/service.backend/src/__tests__/services/storage/s3-storage-provider.test.ts
+++ b/service.backend/src/__tests__/services/storage/s3-storage-provider.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ──── Mocks (hoisted before imports) ──────────────────────────────────────────
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: vi.fn(),
+  PutObjectCommand: class PutObjectCommand {
+    constructor(public readonly params: unknown) {}
+  },
+  DeleteObjectCommand: class DeleteObjectCommand {
+    constructor(public readonly params: unknown) {}
+  },
+  HeadObjectCommand: class HeadObjectCommand {
+    constructor(public readonly params: unknown) {}
+  },
+}));
+
+vi.mock('../../../utils/uuid-helpers', () => ({
+  generateCryptoUuid: vi.fn(() => 'test-uuid-1234'),
+}));
+
+// ──── Imports ─────────────────────────────────────────────────────────────────
+
+import { S3Client } from '@aws-sdk/client-s3';
+import { S3StorageProvider } from '../../../services/storage/s3-storage-provider';
+
+// ──── Fixtures ────────────────────────────────────────────────────────────────
+
+const validConfig = {
+  bucket: 'test-bucket',
+  region: 'us-east-1',
+  accessKeyId: 'test-access-key',
+  secretAccessKey: 'test-secret-key',
+};
+
+const withCloudFront = { ...validConfig, cloudFrontDomain: 'cdn.example.com' };
+
+const mockSend = vi.fn();
+const mockClient = { send: mockSend } as unknown as S3Client;
+
+const makeProvider = (config = validConfig) => new S3StorageProvider(config, mockClient);
+
+// ──── Tests ───────────────────────────────────────────────────────────────────
+
+describe('S3StorageProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockResolvedValue({});
+  });
+
+  describe('validateConfiguration', () => {
+    it('returns true when all required credentials are present', () => {
+      expect(new S3StorageProvider(validConfig).validateConfiguration()).toBe(true);
+    });
+
+    it('returns false when bucket is missing', () => {
+      expect(
+        new S3StorageProvider({ ...validConfig, bucket: undefined }).validateConfiguration()
+      ).toBe(false);
+    });
+
+    it('returns false when region is missing', () => {
+      expect(
+        new S3StorageProvider({ ...validConfig, region: undefined }).validateConfiguration()
+      ).toBe(false);
+    });
+
+    it('returns false when accessKeyId is missing', () => {
+      expect(
+        new S3StorageProvider({ ...validConfig, accessKeyId: undefined }).validateConfiguration()
+      ).toBe(false);
+    });
+
+    it('returns false when secretAccessKey is missing', () => {
+      expect(
+        new S3StorageProvider({ ...validConfig, secretAccessKey: undefined }).validateConfiguration()
+      ).toBe(false);
+    });
+  });
+
+  describe('getName', () => {
+    it('returns "s3"', () => {
+      expect(makeProvider().getName()).toBe('s3');
+    });
+  });
+
+  describe('uploadFile', () => {
+    it('sends PutObjectCommand with the correct bucket, key, body, and content type', async () => {
+      const buffer = Buffer.from('image-data');
+
+      await makeProvider().uploadFile(buffer, 'photo.jpg', 'image/jpeg', 'pets');
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      expect(sentCommand.params).toEqual(
+        expect.objectContaining({
+          Bucket: 'test-bucket',
+          Key: 'pets/test-uuid-1234.jpg',
+          Body: buffer,
+          ContentType: 'image/jpeg',
+        })
+      );
+    });
+
+    it('returns the S3 URL, filename, and size', async () => {
+      const buffer = Buffer.from('image-data');
+
+      const result = await makeProvider().uploadFile(buffer, 'photo.jpg', 'image/jpeg', 'pets');
+
+      expect(result).toEqual({
+        url: 'https://test-bucket.s3.us-east-1.amazonaws.com/pets/test-uuid-1234.jpg',
+        filename: 'test-uuid-1234.jpg',
+        size: buffer.length,
+      });
+    });
+
+    it('uses CloudFront domain in URL when configured', async () => {
+      const result = await makeProvider(withCloudFront).uploadFile(
+        Buffer.from('pdf-data'),
+        'document.pdf',
+        'application/pdf',
+        'documents'
+      );
+
+      expect(result.url).toBe('https://cdn.example.com/documents/test-uuid-1234.pdf');
+    });
+
+    it('defaults category to "documents" when not specified', async () => {
+      await makeProvider().uploadFile(Buffer.from('data'), 'file.pdf', 'application/pdf');
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      expect(sentCommand.params).toMatchObject({ Key: 'documents/test-uuid-1234.pdf' });
+    });
+
+    it('preserves the original file extension in the stored filename', async () => {
+      const result = await makeProvider().uploadFile(
+        Buffer.from('data'),
+        'report.xlsx',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'documents'
+      );
+
+      expect(result.filename).toBe('test-uuid-1234.xlsx');
+    });
+
+    it('throws when the S3 send fails', async () => {
+      mockSend.mockRejectedValueOnce(new Error('S3 connection refused'));
+
+      await expect(
+        makeProvider().uploadFile(Buffer.from('data'), 'photo.jpg', 'image/jpeg', 'pets')
+      ).rejects.toThrow('S3 connection refused');
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('sends DeleteObjectCommand with the correct bucket and key', async () => {
+      await makeProvider().deleteFile('photo.jpg', 'pets');
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      expect(sentCommand.params).toEqual({ Bucket: 'test-bucket', Key: 'pets/photo.jpg' });
+    });
+
+    it('defaults category to "documents" when not specified', async () => {
+      await makeProvider().deleteFile('report.pdf');
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      expect(sentCommand.params).toMatchObject({ Key: 'documents/report.pdf' });
+    });
+
+    it('throws when the S3 send fails', async () => {
+      mockSend.mockRejectedValueOnce(new Error('Access denied'));
+
+      await expect(makeProvider().deleteFile('photo.jpg', 'pets')).rejects.toThrow('Access denied');
+    });
+  });
+
+  describe('getFileInfo', () => {
+    it('returns file info when the object exists', async () => {
+      const lastModified = new Date('2024-06-01T12:00:00Z');
+      mockSend.mockResolvedValueOnce({ ContentLength: 2048, LastModified: lastModified });
+
+      const info = await makeProvider().getFileInfo('photo.jpg', 'pets');
+
+      const sentCommand = mockSend.mock.calls[0][0];
+      expect(sentCommand.params).toEqual({ Bucket: 'test-bucket', Key: 'pets/photo.jpg' });
+      expect(info).toEqual({ exists: true, size: 2048, modified: lastModified });
+    });
+
+    it('returns { exists: false } when the object does not exist', async () => {
+      mockSend.mockRejectedValueOnce(Object.assign(new Error('NotFound'), { name: 'NotFound' }));
+
+      const info = await makeProvider().getFileInfo('missing.jpg', 'pets');
+
+      expect(info).toEqual({ exists: false });
+    });
+
+    it('defaults size to 0 when ContentLength is absent in the HeadObject response', async () => {
+      mockSend.mockResolvedValueOnce({ LastModified: new Date() });
+
+      const info = await makeProvider().getFileInfo('photo.jpg', 'pets');
+
+      expect(info).toMatchObject({ exists: true, size: 0 });
+    });
+  });
+});

--- a/service.backend/src/__tests__/services/storage/s3-storage-provider.test.ts
+++ b/service.backend/src/__tests__/services/storage/s3-storage-provider.test.ts
@@ -73,7 +73,10 @@ describe('S3StorageProvider', () => {
 
     it('returns false when secretAccessKey is missing', () => {
       expect(
-        new S3StorageProvider({ ...validConfig, secretAccessKey: undefined }).validateConfiguration()
+        new S3StorageProvider({
+          ...validConfig,
+          secretAccessKey: undefined,
+        }).validateConfiguration()
       ).toBe(false);
     });
   });

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -316,8 +316,10 @@ export class FileUploadService {
       const provider = getStorageProvider();
       if (provider.getName() !== 'local') {
         const lastSlash = uploadRecord.file_path.lastIndexOf('/');
-        const category = lastSlash !== -1 ? uploadRecord.file_path.slice(0, lastSlash) : 'documents';
-        const filename = lastSlash !== -1 ? uploadRecord.file_path.slice(lastSlash + 1) : uploadRecord.file_path;
+        const category =
+          lastSlash !== -1 ? uploadRecord.file_path.slice(0, lastSlash) : 'documents';
+        const filename =
+          lastSlash !== -1 ? uploadRecord.file_path.slice(lastSlash + 1) : uploadRecord.file_path;
         await provider.deleteFile(filename, category);
       } else {
         const filePath = path.join(config.storage.local.directory, uploadRecord.file_path);
@@ -614,6 +616,21 @@ export class FileUploadService {
     return categoryMap[uploadType];
   }
 
+  /**
+   * Resolve a path and assert it lives inside the configured local upload
+   * directory. CodeQL flags `file.path` as user-controllable; constraining
+   * to the upload root closes the path-traversal sink.
+   */
+  private static assertWithinUploadRoot(candidate: string): string {
+    const uploadRoot = path.resolve(config.storage.local.directory);
+    const resolved = path.resolve(candidate);
+    const rel = path.relative(uploadRoot, resolved);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error('Upload path escapes configured upload directory');
+    }
+    return resolved;
+  }
+
   private static async transferToRemoteStorage(
     file: Express.Multer.File,
     processedFile: ProcessedFileInfo,
@@ -626,7 +643,8 @@ export class FileUploadService {
 
     const category = this.mapUploadTypeToCategory(uploadType);
 
-    const processedBuffer = await fs.promises.readFile(processedFile.processedPath);
+    const safeProcessedPath = this.assertWithinUploadRoot(processedFile.processedPath);
+    const processedBuffer = await fs.promises.readFile(safeProcessedPath);
     const uploadResult = await provider.uploadFile(
       processedBuffer,
       file.originalname,
@@ -636,7 +654,8 @@ export class FileUploadService {
 
     let thumbnailUrl: string | undefined;
     if (processedFile.thumbnailPath) {
-      const thumbBuffer = await fs.promises.readFile(processedFile.thumbnailPath);
+      const safeThumbPath = this.assertWithinUploadRoot(processedFile.thumbnailPath);
+      const thumbBuffer = await fs.promises.readFile(safeThumbPath);
       const thumbResult = await provider.uploadFile(
         thumbBuffer,
         `thumb_${file.originalname}`,
@@ -655,7 +674,15 @@ export class FileUploadService {
         : undefined,
     ].filter((p): p is string => p !== undefined);
 
-    await Promise.all(localPaths.map(p => fs.promises.unlink(p).catch(() => undefined)));
+    await Promise.all(
+      localPaths.map(async p => {
+        try {
+          await fs.promises.unlink(this.assertWithinUploadRoot(p));
+        } catch {
+          // best-effort cleanup
+        }
+      })
+    );
 
     return {
       url: uploadResult.url,

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -616,21 +616,6 @@ export class FileUploadService {
     return categoryMap[uploadType];
   }
 
-  /**
-   * Resolve a path and assert it lives inside the configured local upload
-   * directory. CodeQL flags `file.path` as user-controllable; constraining
-   * to the upload root closes the path-traversal sink.
-   */
-  private static assertWithinUploadRoot(candidate: string): string {
-    const uploadRoot = path.resolve(config.storage.local.directory);
-    const resolved = path.resolve(candidate);
-    const rel = path.relative(uploadRoot, resolved);
-    if (rel.startsWith('..') || path.isAbsolute(rel)) {
-      throw new Error('Upload path escapes configured upload directory');
-    }
-    return resolved;
-  }
-
   private static async transferToRemoteStorage(
     file: Express.Multer.File,
     processedFile: ProcessedFileInfo,
@@ -643,7 +628,7 @@ export class FileUploadService {
 
     const category = this.mapUploadTypeToCategory(uploadType);
 
-    const safeProcessedPath = this.assertWithinUploadRoot(processedFile.processedPath);
+    const safeProcessedPath = this.safeResolveUploadPath(processedFile.processedPath);
     const processedBuffer = await fs.promises.readFile(safeProcessedPath);
     const uploadResult = await provider.uploadFile(
       processedBuffer,
@@ -654,7 +639,7 @@ export class FileUploadService {
 
     let thumbnailUrl: string | undefined;
     if (processedFile.thumbnailPath) {
-      const safeThumbPath = this.assertWithinUploadRoot(processedFile.thumbnailPath);
+      const safeThumbPath = this.safeResolveUploadPath(processedFile.thumbnailPath);
       const thumbBuffer = await fs.promises.readFile(safeThumbPath);
       const thumbResult = await provider.uploadFile(
         thumbBuffer,
@@ -677,7 +662,7 @@ export class FileUploadService {
     await Promise.all(
       localPaths.map(async p => {
         try {
-          await fs.promises.unlink(this.assertWithinUploadRoot(p));
+          await fs.promises.unlink(this.safeResolveUploadPath(p));
         } catch {
           // best-effort cleanup
         }

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -12,6 +12,8 @@ import { UserType } from '../models/User';
 import { fileTypeFromFile } from '../utils/file-type-wrapper';
 import DOMPurify from 'isomorphic-dompurify';
 import { getAvProvider } from './av-providers';
+import { getStorageProvider } from './storage';
+import { StorageCategory } from './storage/base-provider';
 
 // File upload configuration
 const UPLOAD_CONFIG = {
@@ -207,8 +209,18 @@ export class FileUploadService {
       // Process file (resize images, generate thumbnails, etc.)
       const processedFile = await this.processFile(file, uploadType);
 
-      // Generate file metadata
+      // Generate file metadata (must happen before remote transfer to access local file stats)
       const fileMetadata = await this.generateFileMetadata(file, processedFile, uploadType);
+
+      // Transfer to remote storage if configured; updates URL and path in metadata
+      const remoteUrls = await this.transferToRemoteStorage(file, processedFile, uploadType);
+      if (remoteUrls) {
+        fileMetadata.url = remoteUrls.url;
+        fileMetadata.path = remoteUrls.path;
+        if (remoteUrls.thumbnailUrl !== undefined) {
+          fileMetadata.thumbnailUrl = remoteUrls.thumbnailUrl;
+        }
+      }
 
       // Create database record
       const uploadRecord = await this.createUploadRecord(fileMetadata, metadata);
@@ -300,10 +312,18 @@ export class FileUploadService {
         throw Object.assign(new Error('Not allowed to delete this file'), { statusCode: 403 });
       }
 
-      // Delete physical file
-      const filePath = path.join(config.storage.local.directory, uploadRecord.file_path);
-      if (fs.existsSync(filePath)) {
-        await fs.promises.unlink(filePath);
+      // Delete physical file via the configured storage provider
+      const provider = getStorageProvider();
+      if (provider.getName() !== 'local') {
+        const lastSlash = uploadRecord.file_path.lastIndexOf('/');
+        const category = lastSlash !== -1 ? uploadRecord.file_path.slice(0, lastSlash) : 'documents';
+        const filename = lastSlash !== -1 ? uploadRecord.file_path.slice(lastSlash + 1) : uploadRecord.file_path;
+        await provider.deleteFile(filename, category);
+      } else {
+        const filePath = path.join(config.storage.local.directory, uploadRecord.file_path);
+        if (fs.existsSync(filePath)) {
+          await fs.promises.unlink(filePath);
+        }
       }
 
       // Delete database record
@@ -578,6 +598,70 @@ export class FileUploadService {
     }
 
     return processedInfo;
+  }
+
+  private static mapUploadTypeToCategory(
+    uploadType: keyof typeof UPLOAD_CONFIG.directories
+  ): StorageCategory {
+    const categoryMap: Record<keyof typeof UPLOAD_CONFIG.directories, StorageCategory> = {
+      pets: 'pets',
+      profiles: 'users',
+      applications: 'documents',
+      chat: 'documents',
+      documents: 'documents',
+      temp: 'documents',
+    };
+    return categoryMap[uploadType];
+  }
+
+  private static async transferToRemoteStorage(
+    file: Express.Multer.File,
+    processedFile: ProcessedFileInfo,
+    uploadType: keyof typeof UPLOAD_CONFIG.directories
+  ): Promise<{ url: string; thumbnailUrl?: string; path: string } | undefined> {
+    const provider = getStorageProvider();
+    if (provider.getName() === 'local') {
+      return undefined;
+    }
+
+    const category = this.mapUploadTypeToCategory(uploadType);
+
+    const processedBuffer = await fs.promises.readFile(processedFile.processedPath);
+    const uploadResult = await provider.uploadFile(
+      processedBuffer,
+      file.originalname,
+      file.mimetype,
+      category
+    );
+
+    let thumbnailUrl: string | undefined;
+    if (processedFile.thumbnailPath) {
+      const thumbBuffer = await fs.promises.readFile(processedFile.thumbnailPath);
+      const thumbResult = await provider.uploadFile(
+        thumbBuffer,
+        `thumb_${file.originalname}`,
+        'image/jpeg',
+        category
+      );
+      thumbnailUrl = thumbResult.url;
+    }
+
+    // Best-effort cleanup of local temp files after successful remote upload
+    const localPaths = [
+      processedFile.processedPath,
+      processedFile.thumbnailPath,
+      processedFile.originalPath !== processedFile.processedPath
+        ? processedFile.originalPath
+        : undefined,
+    ].filter((p): p is string => p !== undefined);
+
+    await Promise.all(localPaths.map(p => fs.promises.unlink(p).catch(() => undefined)));
+
+    return {
+      url: uploadResult.url,
+      thumbnailUrl,
+      path: `${category}/${uploadResult.filename}`,
+    };
   }
 
   /**

--- a/service.backend/src/services/storage/s3-storage-provider.ts
+++ b/service.backend/src/services/storage/s3-storage-provider.ts
@@ -110,9 +110,9 @@ export class S3StorageProvider implements StorageProvider {
   validateConfiguration(): boolean {
     return Boolean(
       this.config.bucket &&
-        this.config.region &&
-        this.config.accessKeyId &&
-        this.config.secretAccessKey
+      this.config.region &&
+      this.config.accessKeyId &&
+      this.config.secretAccessKey
     );
   }
 

--- a/service.backend/src/services/storage/s3-storage-provider.ts
+++ b/service.backend/src/services/storage/s3-storage-provider.ts
@@ -1,3 +1,11 @@
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import path from 'path';
+import { generateCryptoUuid as uuidv4 } from '../../utils/uuid-helpers';
 import { logger } from '../../utils/logger';
 import { FileInfo, StorageCategory, StorageProvider, UploadResult } from './base-provider';
 
@@ -9,39 +17,90 @@ export type S3Config = {
   cloudFrontDomain?: string;
 };
 
-/**
- * S3 storage provider scaffold. Vendor wiring deferred — install
- * `@aws-sdk/client-s3` and implement upload/delete/getFileInfo when the
- * production deploy is ready.
- *
- * `validateConfiguration` returns true only when all required creds are
- * present so startup can fail fast in production.
- */
 export class S3StorageProvider implements StorageProvider {
   private readonly config: S3Config;
+  private readonly client: S3Client;
 
-  constructor(s3Config: S3Config) {
+  constructor(s3Config: S3Config, client?: S3Client) {
     this.config = s3Config;
+    this.client =
+      client ??
+      new S3Client({
+        region: s3Config.region ?? 'us-east-1',
+        credentials:
+          s3Config.accessKeyId && s3Config.secretAccessKey
+            ? {
+                accessKeyId: s3Config.accessKeyId,
+                secretAccessKey: s3Config.secretAccessKey,
+              }
+            : undefined,
+      });
   }
 
   async uploadFile(
-    _file: Buffer,
-    _originalName: string,
-    _contentType: string,
-    _category: StorageCategory = 'documents'
+    file: Buffer,
+    originalName: string,
+    contentType: string,
+    category: StorageCategory = 'documents'
   ): Promise<UploadResult> {
-    logger.error('S3StorageProvider.uploadFile invoked but not implemented');
-    throw new Error('S3 storage provider not implemented — vendor wiring required');
+    const ext = path.extname(originalName);
+    const filename = `${uuidv4()}${ext}`;
+    const key = `${category}/${filename}`;
+
+    try {
+      await this.client.send(
+        new PutObjectCommand({
+          Bucket: this.config.bucket!,
+          Key: key,
+          Body: file,
+          ContentType: contentType,
+        })
+      );
+
+      const url = this.buildUrl(key);
+
+      logger.info('File uploaded to S3', { key, size: file.length, category, url });
+
+      return { url, filename, size: file.length };
+    } catch (error) {
+      logger.error('Failed to upload file to S3:', error);
+      throw error;
+    }
   }
 
-  async deleteFile(_filename: string, _category: string = 'documents'): Promise<void> {
-    logger.error('S3StorageProvider.deleteFile invoked but not implemented');
-    throw new Error('S3 storage provider not implemented — vendor wiring required');
+  async deleteFile(filename: string, category: string = 'documents'): Promise<void> {
+    const key = `${category}/${filename}`;
+    try {
+      await this.client.send(
+        new DeleteObjectCommand({
+          Bucket: this.config.bucket!,
+          Key: key,
+        })
+      );
+      logger.info(`File deleted from S3: ${key}`);
+    } catch (error) {
+      logger.error('Failed to delete file from S3:', error);
+      throw error;
+    }
   }
 
-  async getFileInfo(_filename: string, _category: string = 'documents'): Promise<FileInfo> {
-    logger.error('S3StorageProvider.getFileInfo invoked but not implemented');
-    throw new Error('S3 storage provider not implemented — vendor wiring required');
+  async getFileInfo(filename: string, category: string = 'documents'): Promise<FileInfo> {
+    const key = `${category}/${filename}`;
+    try {
+      const response = await this.client.send(
+        new HeadObjectCommand({
+          Bucket: this.config.bucket!,
+          Key: key,
+        })
+      );
+      return {
+        exists: true,
+        size: response.ContentLength ?? 0,
+        modified: response.LastModified ?? new Date(),
+      };
+    } catch {
+      return { exists: false };
+    }
   }
 
   getName(): string {
@@ -51,9 +110,16 @@ export class S3StorageProvider implements StorageProvider {
   validateConfiguration(): boolean {
     return Boolean(
       this.config.bucket &&
-      this.config.region &&
-      this.config.accessKeyId &&
-      this.config.secretAccessKey
+        this.config.region &&
+        this.config.accessKeyId &&
+        this.config.secretAccessKey
     );
+  }
+
+  private buildUrl(key: string): string {
+    if (this.config.cloudFrontDomain) {
+      return `https://${this.config.cloudFrontDomain}/${key}`;
+    }
+    return `https://${this.config.bucket}.s3.${this.config.region}.amazonaws.com/${key}`;
   }
 }


### PR DESCRIPTION
## Summary

Closes ADS-13. Implements S3-compatible image storage to replace local-filesystem-only storage, unblocking production deployment.

- **S3StorageProvider** fully implemented (`uploadFile`, `deleteFile`, `getFileInfo`) using `@aws-sdk/client-s3`. URL format uses CloudFront domain when `CLOUDFRONT_DOMAIN` is set, otherwise the standard S3 virtual-hosted URL. S3Client is injectable for testability.
- **FileUploadService wired**: after sharp processing writes files to disk, `transferToRemoteStorage` reads the processed buffer and uploads via the configured provider, updates the file URL/path in metadata, then best-effort cleans up local temp files. `deleteFile` delegates to `provider.deleteFile` for non-local providers.
- **Upload type → S3 category mapping**: `pets→pets`, `profiles→users`, all others→`documents`.
- **Local default unchanged**: `STORAGE_PROVIDER=local` (the default) takes the existing code path without calling the new S3 logic.

## Test plan

- [ ] All 147 test files pass (2452 tests), including 18 new tests for `S3StorageProvider` and 5 new tests for the `FileUploadService` S3 wiring
- [ ] `npx tsc --noEmit` clean
- [ ] Set `STORAGE_PROVIDER=s3` with valid `S3_BUCKET_NAME`, `S3_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` in `.env` and verify a pet image upload round-trips through a real S3-compatible bucket
- [ ] Verify `STORAGE_PROVIDER=local` (default) continues to work as before with no behaviour change

https://claude.ai/code/session_0155XTdUEg6ht3Ej4Z8K54H4

---
_Generated by [Claude Code](https://claude.ai/code/session_0155XTdUEg6ht3Ej4Z8K54H4)_