### PR TITLE
docs: monorepo-wide documentation accuracy sweep

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -10,7 +10,7 @@
 
 ## Lib Build Artifact Caching (ADS-390)
 
-`ci.yml` uses a dedicated `build-libs` job that compiles all `lib.*/dist` outputs once, then uploads them as a single `lib-dist` artifact via `actions/upload-artifact@v7`. Downstream jobs (`test-backend`, `test-frontend`, `test-libs`) use `actions/download-artifact@v7` to retrieve the pre-built artifacts instead of rebuilding.
+`ci.yml` uses a dedicated `build-libs` job that compiles all `lib.*/dist` outputs once, then uploads them as a single `lib-dist` artifact via `actions/upload-artifact@v7`. Downstream jobs (`test-backend`, `test-frontend`, `test-libs`) use `actions/download-artifact@v8` to retrieve the pre-built artifacts instead of rebuilding.
 
 This eliminates the ~4x redundant `npm run build:libs` calls that previously occurred across parallel jobs (~10 minutes of duplicated work per run).
 
@@ -26,10 +26,10 @@ Cold-cache behaviour: if the `build-libs` job fails or is skipped, downstream jo
 npm audit --workspaces --include-workspace-root --audit-level=high
 ```
 
-This covers all 28 packages via the deduplicated `package-lock.json`.
+This covers all workspace packages via the deduplicated `package-lock.json`.
 
-## E2E Gate (ADS-386)
+## E2E Gate (ADS-386 / ADS-419)
 
-The `test-e2e` job in `ci.yml` currently runs with `continue-on-error: true`. This will be flipped to `false` (and added as a required branch-protection check) once the suite has 10 consecutive green runs on `main`. See the comment block in `ci.yml` for the exact criteria.
+The `test-e2e` job in `ci.yml` is a blocking signal — a failure fails the PR check. The previous `continue-on-error: true` escape hatch was removed by ADS-419; see the comment block at `ci.yml:339`.
 
 Playwright is configured with `retries: 2` in CI (see `e2e/playwright.config.ts`). Flaky-retry counts are surfaced in the "Report E2E retry counts" step after each run.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci --no-audit --no-fund
 
-      # ADS-387: Single workspace-level outdated check covers all 28 packages,
+      # ADS-387: Single workspace-level outdated check covers every workspace package,
       # replacing the previous 5-package hardcoded matrix.
       # continue-on-error because outdated deps are advisory, not blocking.
       - name: Check for outdated dependencies across all workspaces

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci --no-audit --no-fund
 
-      # ADS-387: Single workspace-level audit covers all 28 packages via the
-      # root package-lock.json, replacing the previous 5-package hardcoded matrix.
+      # ADS-387: Single workspace-level audit covers every workspace package via
+      # the root package-lock.json, replacing the previous 5-package hardcoded matrix.
       - name: Audit all workspaces for high+ vulnerabilities
         run: npm audit --workspaces --include-workspace-root --audit-level=high

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ npm run test:e2e:report
 
 - Playwright runs with `retries: 2` in CI. A test must fail 3 times in a row before it counts as a failure.
 - Flaky retry counts are printed in the "Report E2E retry counts" CI step.
-- The `test-e2e` job currently has `continue-on-error: true` — failures are surfaced but do not block merge. This will be removed once the suite has 10 consecutive green runs on `main` (see ADS-386).
+- The `test-e2e` job is a blocking signal — a failure fails the PR check (see ADS-419 and the comment block at `.github/workflows/ci.yml:339`).
 
 ### Selector guidelines
 

--- a/app.client/src/contexts/README.md
+++ b/app.client/src/contexts/README.md
@@ -9,7 +9,7 @@ The notification system provides real-time notifications with context-based stat
 ### Using the Context Hook (Recommended)
 
 ```tsx
-import { useNotifications } from '@/contexts/NotificationContext';
+import { useNotifications } from '@/contexts/NotificationsContext';
 
 function MyComponent() {
   const { unreadCount, recentNotifications, markAsRead, markAllAsRead, isLoading } =
@@ -34,16 +34,18 @@ function MyComponent() {
 
 ### Provider Setup
 
-The `NotificationProvider` is already set up in `App.tsx` and wraps the entire application:
+The `NotificationsProvider` is already set up in `App.tsx`. `AuthProvider` wraps the app in `main.tsx`, then `App` composes the rest:
 
 ```tsx
-<AuthProvider>
-  <NotificationProvider>
-    <ChatProvider>
-      <FavoritesProvider>{/* Your app content */}</FavoritesProvider>
-    </ChatProvider>
-  </NotificationProvider>
-</AuthProvider>
+<PermissionsProvider>
+  <AnalyticsProvider>
+    <NotificationsProvider userId={user?.userId}>
+      <ChatProvider>
+        <FavoritesProvider>{/* Your app content */}</FavoritesProvider>
+      </ChatProvider>
+    </NotificationsProvider>
+  </AnalyticsProvider>
+</PermissionsProvider>
 ```
 
 ## Features

--- a/app.client/src/docs/STATSIG_FEATURE_FLAGS.md
+++ b/app.client/src/docs/STATSIG_FEATURE_FLAGS.md
@@ -36,9 +36,10 @@ function MyComponent() {
 
 ### Currently Used Gates:
 
-- `pdf_viewer_enabled` - Controls PDF preview functionality in chat
-- `image_lightbox_enabled` - Controls image lightbox/modal functionality
-- `chat_attachments_enabled` - Controls chat attachment features
+- `advanced_search_filters` — toggles the advanced filter UI in `SearchPage`
+- `new_hero_design` — toggles the new hero variant in `HomePage`
+
+Gate identifiers ship as constants in `@adopt-dont-shop/lib.feature-flags` under `KNOWN_GATES` — see that package's README for the full list and prefer the constants over string literals.
 
 ### Setting up new gates in Statsig Console:
 
@@ -100,31 +101,10 @@ logEvent('feature_used', 1, {
 
 ## Examples in the Codebase
 
-- **MessageBubbleComponent**: Shows PDF viewer and image lightbox feature gates
-- **StatsigFeatureExample**: Demonstrates all Statsig features in one component
+- **`SearchPage.tsx`** — `useFeatureGate('advanced_search_filters')` toggles the advanced filter UI.
+- **`HomePage.tsx`** — `useFeatureGate('new_hero_design')` swaps the hero variant.
 
-## Migration from Static Features
-
-Old way (features.ts):
-
-```tsx
-import { FEATURES } from '@/config/features';
-
-{
-  FEATURES.PDF_VIEWER_ENABLED && <PDFViewer />;
-}
-```
-
-New way (Statsig):
-
-```tsx
-import { useStatsig } from '@/hooks/useStatsig';
-
-const { checkGate } = useStatsig();
-{
-  checkGate('pdf_viewer_enabled') && <PDFViewer />;
-}
-```
+Prefer the `useFeatureGate` / `useDynamicConfig` hooks from `@adopt-dont-shop/lib.feature-flags` for new code; the `useStatsig` hook is the imperative escape hatch for places that need to log events or fetch experiments alongside a gate check.
 
 ## Troubleshooting
 

--- a/app.rescue/README.md
+++ b/app.rescue/README.md
@@ -6,8 +6,9 @@ See the full product spec: [docs/frontend/app-rescue-prd.md](../docs/frontend/ap
 
 ## Stack
 
-- React 18 + TypeScript (strict)
+- React 19 + TypeScript (strict)
 - Vite
+- vanilla-extract for styling (`*.css.ts` files)
 - Vitest + React Testing Library
 - ESLint + Prettier
 - Docker (multi-stage build for dev and prod)
@@ -45,6 +46,7 @@ Or from this directory: `npm run dev` — Vite serves on http://localhost:3000 (
 ```
 src/
 ├── components/     Reusable UI components
+├── contexts/       React contexts (Analytics, Chat, Notifications, Permissions, Statsig)
 ├── pages/          Route-level components
 ├── hooks/          Custom React hooks
 ├── services/       API clients and external services

--- a/docs/ANALYTICS-REPORTS.md
+++ b/docs/ANALYTICS-REPORTS.md
@@ -23,7 +23,7 @@ Browser  ──WS────►  Socket.IO  ──►  analytics:invalidate / m
 
 | Path | Purpose |
 | --- | --- |
-| `service.backend/src/migrations/08-create-analytics-reports.ts` | Tables: `report_templates`, `saved_reports`, `scheduled_reports`, `report_shares` |
+| `service.backend/src/migrations/00-baseline-041..046-*.ts` | Tables: `reports`, `report_status_transitions`, `report_templates`, `report_shares`, `saved_reports`, `scheduled_reports` |
 | `service.backend/src/models/{ReportTemplate,SavedReport,ScheduledReport,ReportShare}.ts` | Sequelize models (audit-columns + paranoid soft-delete) |
 | `service.backend/src/schemas/reports.schema.ts` | Canonical Zod schemas for the report config |
 | `service.backend/src/services/reports.service.ts` | CRUD + execute + share + schedule orchestration |
@@ -42,7 +42,7 @@ Browser  ──WS────►  Socket.IO  ──►  analytics:invalidate / m
 | --- | --- |
 | `lib.analytics/src/schemas/reports.ts` | Zod schemas mirroring the backend (single source of truth for types) |
 | `lib.analytics/src/services/report-service.ts` | Typed API client over `lib.api`'s `ApiService` |
-| `lib.analytics/src/hooks/useReports.ts` | React Query v3 hooks: `useReports`, `useReport`, `useExecuteSavedReport`, `useExecuteReportPreview`, `useSaveReport`, `useUpdateReport`, `useDeleteReport`, `useUpsertSchedule`, `useCreateUserShare`, `useCreateTokenShare`, `useRevokeShare` |
+| `lib.analytics/src/hooks/useReports.ts` | React Query v5 hooks: `useReports`, `useReport`, `useExecuteSavedReport`, `useExecuteReportPreview`, `useSaveReport`, `useUpdateReport`, `useDeleteReport`, `useUpsertSchedule`, `useCreateUserShare`, `useCreateTokenShare`, `useRevokeShare` |
 | `lib.analytics/src/hooks/useRealtimeAnalytics.ts` | Socket.IO subscription + `useAnalyticsInvalidator` (mount once at app root) |
 | `lib.components/src/components/charts/*` | Recharts-backed primitives: `LineChart`, `BarChart`, `PieChart`, `AreaChart`, `MetricCard`, `DataTable`, `ChartFrame` |
 | `lib.components/src/components/reports/*` | `ReportBuilder`, `ReportRenderer`, `WidgetPicker`, `FilterPanel`, `DrillDownModal` |

--- a/docs/SECURITY-CENTER.md
+++ b/docs/SECURITY-CENTER.md
@@ -21,9 +21,10 @@ Two new RBAC permissions gate the Security Center:
 - `admin.security.manage` — mutating operations (revoke sessions,
   add/remove IP rules, lock/unlock accounts).
 
-Both are granted to `super_admin` and `admin` roles by the
-`03-role-permissions` seeder. Re-run the permissions + role-permissions
-seeders on existing environments to pick them up.
+Both are granted to `super_admin` and `admin` roles by the role-permissions
+reference seeder (`service.backend/src/seeders/reference/role-permissions.ts`,
+exported as `seedRolePermissions`). Re-run `npm run db:seed:reference`
+on existing environments to pick them up.
 
 ## Best practices
 

--- a/docs/backend/api-endpoints.md
+++ b/docs/backend/api-endpoints.md
@@ -28,10 +28,10 @@ The Adopt Don't Shop Backend API provides RESTful endpoints for managing users, 
 | POST   | `/api/v1/auth/register`               | Create new user account                | No                  |
 | POST   | `/api/v1/auth/login`                  | Authenticate and get tokens            | No                  |
 | POST   | `/api/v1/auth/logout`                 | Invalidate current session             | Yes                 |
-| POST   | `/api/v1/auth/refresh-token`          | Refresh access token                   | Yes (refresh token) |
+| POST   | `/api/v1/auth/refresh-token`          | Refresh access token (refresh token in body) | No (rate-limited)  |
 | POST   | `/api/v1/auth/forgot-password`        | Request password reset                 | No                  |
 | POST   | `/api/v1/auth/reset-password`         | Reset password with token              | No                  |
-| GET    | `/api/v1/auth/verify-email/:token`    | Verify email address                   | No                  |
+| POST   | `/api/v1/auth/verify-email`           | Verify email address (token in body)   | No                  |
 | POST   | `/api/v1/auth/resend-verification`    | Resend verification email              | No                  |
 | GET    | `/api/v1/auth/me`                     | Get current user profile               | Yes                 |
 | PUT    | `/api/v1/auth/me`                     | Update current user profile            | Yes                 |
@@ -44,14 +44,17 @@ The Adopt Don't Shop Backend API provides RESTful endpoints for managing users, 
 
 ### Users
 
-| Method | Endpoint                            | Description                              |
-| ------ | ----------------------------------- | ---------------------------------------- |
-| GET    | `/api/v1/users`                     | List users (admin only, with pagination) |
-| GET    | `/api/v1/users/:userId`             | Get user details                         |
-| PUT    | `/api/v1/users/:userId`             | Update user profile                      |
-| DELETE | `/api/v1/users/:userId`             | Delete user account (soft delete)        |
-| GET    | `/api/v1/users/:userId/preferences` | Get user preferences                     |
-| PUT    | `/api/v1/users/:userId/preferences` | Update preferences                       |
+User listing lives under [Admin Endpoints](#admin-endpoints) (`GET /api/v1/admin/users`); the `/api/v1/users` mount is for the current user's own resources.
+
+| Method | Endpoint                       | Description                                          |
+| ------ | ------------------------------ | ---------------------------------------------------- |
+| GET    | `/api/v1/users/profile`        | Get current user profile                             |
+| PUT    | `/api/v1/users/profile`        | Update current user profile                          |
+| GET    | `/api/v1/users/preferences`    | Get current user's preferences                       |
+| PUT    | `/api/v1/users/preferences`    | Update current user's preferences                    |
+| POST   | `/api/v1/users/preferences/reset` | Reset preferences to defaults                     |
+| DELETE | `/api/v1/users/account`        | Delete own account (soft delete; rate-limited)       |
+| GET    | `/api/v1/users/:userId`        | Get another user's public profile                    |
 
 ### Pets
 
@@ -62,8 +65,9 @@ The Adopt Don't Shop Backend API provides RESTful endpoints for managing users, 
 | GET    | `/api/v1/pets/:petId`                 | Get pet details                                     |
 | PUT    | `/api/v1/pets/:petId`                 | Update pet information                              |
 | DELETE | `/api/v1/pets/:petId`                 | Delete pet (soft delete)                            |
-| POST   | `/api/v1/pets/:petId/images`          | Upload pet images                                   |
-| DELETE | `/api/v1/pets/:petId/images/:imageId` | Delete specific image                               |
+| POST   | `/api/v1/pets/:petId/images`          | Upload / replace pet images                         |
+| DELETE | `/api/v1/pets/:petId/images`          | Delete pet image (identifier in body)               |
+| PATCH  | `/api/v1/pets/:petId/status`          | Update pet availability status                      |
 | POST   | `/api/v1/pets/:petId/favorite`        | Add to favorites                                    |
 | DELETE | `/api/v1/pets/:petId/favorite`        | Remove from favorites                               |
 
@@ -84,7 +88,7 @@ The Adopt Don't Shop Backend API provides RESTful endpoints for managing users, 
 | POST   | `/api/v1/applications`                        | Submit new application               |
 | GET    | `/api/v1/applications/:applicationId`         | Get application details              |
 | PATCH  | `/api/v1/applications/:applicationId/status`  | Update application status            |
-| DELETE | `/api/v1/applications/:applicationId`         | Withdraw application                 |
+| POST   | `/api/v1/applications/:applicationId/withdraw`| Withdraw application                 |
 | GET    | `/api/v1/applications/:applicationId/history` | Get status history                   |
 
 ### Rescues
@@ -140,17 +144,20 @@ Chat routes are mounted at `/api/v1/chats` (canonical). `/api/v1/conversations` 
 
 ## Admin Endpoints
 
-| Method | Endpoint                                             | Description                     |
-| ------ | ---------------------------------------------------- | ------------------------------- |
-| GET    | `/api/v1/admin/users`                                | List all users (with filtering) |
-| PATCH  | `/api/v1/admin/users/:userId/status`                 | Update user status              |
-| POST   | `/api/v1/admin/users/:userId/suspend`                | Suspend user                    |
-| GET    | `/api/v1/admin/rescues`                              | List all rescues                |
-| POST   | `/api/v1/admin/rescues/:rescueId/verify`             | Verify rescue organization      |
-| GET    | `/api/v1/admin/moderation/reports`                   | Get content reports             |
-| POST   | `/api/v1/admin/moderation/reports/:reportId/actions` | Take moderation action          |
-| GET    | `/api/v1/admin/system/health`                        | System health status            |
-| GET    | `/api/v1/admin/analytics/dashboard`                  | Admin dashboard analytics       |
+Mounted at `/api/v1/admin`. Moderation routes live under the separate `/api/v1/admin/moderation` mount.
+
+| Method | Endpoint                                             | Description                                                            |
+| ------ | ---------------------------------------------------- | ---------------------------------------------------------------------- |
+| GET    | `/api/v1/admin/users`                                | List all users (with filtering)                                        |
+| PATCH  | `/api/v1/admin/users/:userId`                        | Update a user record                                                   |
+| PATCH  | `/api/v1/admin/users/:userId/action`                 | Perform an admin action (suspend, restore, force-logout, etc.)         |
+| GET    | `/api/v1/admin/rescues`                              | List all rescues                                                       |
+| PATCH  | `/api/v1/admin/rescues/:rescueId/moderate`           | Verify / reject a rescue (sets `verification_status`)                  |
+| PATCH  | `/api/v1/admin/rescues/:rescueId/plan`               | Change rescue subscription plan                                        |
+| GET    | `/api/v1/admin/moderation/reports`                   | Get content reports                                                    |
+| POST   | `/api/v1/admin/moderation/reports/:reportId/actions` | Take moderation action                                                 |
+| GET    | `/api/v1/admin/system/health`                        | System health status                                                   |
+| GET    | `/api/v1/admin/analytics/dashboard`                  | Admin dashboard analytics                                              |
 
 ## Common Patterns
 

--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-PostgreSQL database with Sequelize ORM supporting a comprehensive pet adoption platform. Includes user management, pet profiles, adoption workflows, messaging, and administrative features.
+PostgreSQL 16 with the PostGIS extension and Sequelize 7. Models live in `service.backend/src/models/` and are mirrored 1:1 by baseline migrations under `service.backend/src/migrations/`. This document is a high-level reference — the source of truth is always the model file.
 
 ## Entity Relationships
 
@@ -21,7 +21,7 @@ erDiagram
     Pet ||--o{ Application : receives
     Pet ||--o{ UserFavorite : favorited_by
 
-    Application ||--o{ Timeline : tracks
+    Application ||--o{ ApplicationTimeline : tracks
     Application ||--o{ Message : generates
 
     Chat ||--o{ Message : contains
@@ -32,109 +32,125 @@ erDiagram
 
 ### Users
 
-**Purpose**: Central user management for all platform participants
+**Purpose**: Central user management for all platform participants. Defined in `User.ts`.
 
-| Field          | Type         | Description                  |
-| -------------- | ------------ | ---------------------------- |
-| user_id        | UUID (PK)    | Primary identifier           |
-| email          | VARCHAR (UK) | Email address (unique)       |
-| password_hash  | VARCHAR      | Hashed password              |
-| first_name     | VARCHAR      | First name                   |
-| last_name      | VARCHAR      | Last name                    |
-| phone_number   | VARCHAR      | Contact number               |
-| user_type      | ENUM         | ADOPTER, RESCUE_STAFF, ADMIN |
-| status         | ENUM         | ACTIVE, SUSPENDED, DELETED   |
-| email_verified | BOOLEAN      | Email verification status    |
-| created_at     | TIMESTAMP    | Registration date            |
-| updated_at     | TIMESTAMP    | Last update                  |
+| Field          | Type         | Description                                                                          |
+| -------------- | ------------ | ------------------------------------------------------------------------------------ |
+| user_id        | UUID (PK)    | Primary identifier                                                                   |
+| email          | VARCHAR (UK) | Email address (unique)                                                               |
+| password       | VARCHAR      | bcrypt-hashed password (bcrypt 12 rounds; column is `password`, not `password_hash`) |
+| first_name     | VARCHAR      | First name                                                                           |
+| last_name      | VARCHAR      | Last name                                                                            |
+| phone_number   | VARCHAR      | Contact number                                                                       |
+| user_type      | ENUM         | `adopter`, `rescue_staff`, `admin`, `moderator`, `super_admin`, `support_agent`      |
+| status         | ENUM         | `active`, `inactive`, `suspended`, `pending_verification`, `deactivated`             |
+| email_verified | BOOLEAN      | Email verification status                                                            |
+| created_at     | TIMESTAMP    | Registration date                                                                    |
+| updated_at     | TIMESTAMP    | Last update                                                                          |
+| deleted_at     | TIMESTAMP    | Soft-delete timestamp (paranoid)                                                     |
 
 **Indexes**: email, user_type, status
 
+> The model also defines optional columns for two-factor (`two_factor_secret`, `backup_codes`), reset/verification tokens, address fields, and a PostGIS `location` point. See `User.ts` for the full attribute list.
+
 ### Rescues
 
-**Purpose**: Rescue organization profiles and settings
+**Purpose**: Rescue organization profiles and settings. Defined in `Rescue.ts`.
 
-| Field            | Type         | Description         |
-| ---------------- | ------------ | ------------------- |
-| rescue_id        | UUID (PK)    | Primary identifier  |
-| rescue_name      | VARCHAR      | Organization name   |
-| rescue_type      | VARCHAR      | Type of rescue org  |
-| reference_number | VARCHAR (UK) | Unique reference    |
-| verified         | BOOLEAN      | Verification status |
-| email            | VARCHAR      | Contact email       |
-| phone            | VARCHAR      | Contact phone       |
-| address          | JSONB        | Physical address    |
-| location         | GEOGRAPHY    | GIS coordinates     |
-| created_at       | TIMESTAMP    | Registration date   |
+| Field                        | Type         | Description                                              |
+| ---------------------------- | ------------ | -------------------------------------------------------- |
+| rescue_id                    | UUID (PK)    | Primary identifier                                       |
+| name                         | VARCHAR      | Organization name                                        |
+| email                        | VARCHAR      | Contact email                                            |
+| phone                        | VARCHAR      | Contact phone                                            |
+| address_line_1               | VARCHAR      | Street address                                           |
+| city / state / zip_code      | VARCHAR      | UK locality fields (mapped to existing columns)          |
+| country                      | CHAR(2)      | ISO-3166 country code (default `GB`)                     |
+| companies_house_number       | VARCHAR      | Companies House registration (UK verification source)    |
+| charity_registration_number  | VARCHAR      | Charity Commission registration                          |
+| verification_status          | ENUM         | `pending`, `verified`, `rejected`                        |
+| verified_at / verified_by    | TIMESTAMP / UUID | Verification audit                                   |
+| settings                     | JSONB        | Per-rescue feature settings                              |
+| plan                         | VARCHAR      | Subscription plan (default `free`)                       |
+| created_at / updated_at      | TIMESTAMP    | Auditing                                                 |
 
-**Indexes**: verified, location (GIS index)
+**Indexes**: verified_by, deleted_at (soft delete)
 
 ### Pets
 
-**Purpose**: Pet profiles and availability
+**Purpose**: Pet profiles and availability. Defined in `Pet.ts`.
 
-| Field           | Type      | Description                                    |
-| --------------- | --------- | ---------------------------------------------- |
-| pet_id          | UUID (PK) | Primary identifier                             |
-| rescue_id       | UUID (FK) | Owning rescue                                  |
-| name            | VARCHAR   | Pet name                                       |
-| type            | ENUM      | DOG, CAT, OTHER                                |
-| breed           | VARCHAR   | Breed information                              |
-| age             | INTEGER   | Age in months                                  |
-| gender          | ENUM      | MALE, FEMALE                                   |
-| size            | ENUM      | SMALL, MEDIUM, LARGE                           |
-| status          | ENUM      | AVAILABLE, PENDING, ADOPTED, MEDICAL, DECEASED |
-| description     | TEXT      | Pet description                                |
-| special_needs   | TEXT      | Special care requirements                      |
-| images          | JSONB     | Array of image URLs                            |
-| medical_history | JSONB     | Medical records                                |
-| adoption_fee    | DECIMAL   | Adoption fee amount                            |
-| created_at      | TIMESTAMP | Listed date                                    |
+| Field                   | Type      | Description                                                                                              |
+| ----------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| pet_id                  | UUID (PK) | Primary identifier                                                                                       |
+| rescue_id               | UUID (FK) | Owning rescue                                                                                            |
+| name                    | VARCHAR   | Pet name                                                                                                 |
+| type                    | ENUM      | `dog`, `cat`, `rabbit`, `bird`, `reptile`, `small_mammal`, `fish`, `other`                               |
+| breed                   | VARCHAR   | Breed information                                                                                        |
+| age_years / age_months  | INTEGER   | Age components (also `birth_date` + `age_group`)                                                         |
+| gender                  | ENUM      | `male`, `female`, `unknown`                                                                              |
+| size                    | ENUM      | `extra_small`, `small`, `medium`, `large`, `extra_large`                                                 |
+| status                  | ENUM      | `available`, `pending`, `adopted`, `foster`, `medical_hold`, `behavioral_hold`, `not_available`, `deceased` |
+| short_description       | TEXT      | Card / list copy                                                                                         |
+| long_description        | TEXT      | Full profile body                                                                                        |
+| medical_notes           | TEXT      | Free-text vet notes (no separate `medical_history` JSON column)                                          |
+| adoption_fee_minor      | INTEGER   | Fee in minor currency units (e.g. pence). Pair with `adoption_fee_currency`.                             |
+| adoption_fee_currency   | CHAR(3)   | ISO-4217 currency code                                                                                   |
+| created_at / updated_at | TIMESTAMP | Auditing                                                                                                 |
 
 **Indexes**: rescue_id, type, status, breed
 
+> Pet images and videos live in the separate **`pet_media`** table (`PetMedia.ts`) — there is no `images` JSONB column on `pets`. Status transitions are append-only in `pet_status_transitions`.
+
 ### Applications
 
-**Purpose**: Adoption application tracking
+**Purpose**: Adoption application tracking. Defined in `Application.ts`.
 
-| Field              | Type      | Description                                      |
-| ------------------ | --------- | ------------------------------------------------ |
-| application_id     | UUID (PK) | Primary identifier                               |
-| user_id            | UUID (FK) | Applicant                                        |
-| pet_id             | UUID (FK) | Applied pet                                      |
-| rescue_id          | UUID (FK) | Rescue org                                       |
-| stage              | ENUM      | PENDING, REVIEWING, VISITING, DECIDING, RESOLVED |
-| final_outcome      | ENUM      | APPROVED, CONDITIONAL, REJECTED, WITHDRAWN       |
-| answers            | JSONB     | Application answers                              |
-| review_started_at  | TIMESTAMP | Review start time                                |
-| visit_scheduled_at | TIMESTAMP | Visit scheduled                                  |
-| visit_completed_at | TIMESTAMP | Visit completion                                 |
-| resolved_at        | TIMESTAMP | Resolution time                                  |
-| created_at         | TIMESTAMP | Submission date                                  |
+| Field              | Type      | Description                                                                       |
+| ------------------ | --------- | --------------------------------------------------------------------------------- |
+| application_id     | UUID (PK) | Primary identifier                                                                |
+| user_id            | UUID (FK) | Applicant                                                                         |
+| pet_id             | UUID (FK) | Applied pet                                                                       |
+| rescue_id          | UUID (FK) | Rescue org                                                                        |
+| status             | ENUM      | `submitted`, `approved`, `rejected`, `withdrawn` (simplified outcome)             |
+| priority           | ENUM      | `low`, `normal`, `high`, `urgent`                                                 |
+| stage              | ENUM      | `pending`, `reviewing`, `visiting`, `deciding`, `resolved`, `withdrawn`           |
+| final_outcome      | ENUM      | `approved`, `rejected`, `withdrawn` (set when `stage = resolved`)                 |
+| review_started_at  | TIMESTAMP | Review start time                                                                 |
+| visit_scheduled_at | TIMESTAMP | Visit scheduled                                                                   |
+| visit_completed_at | TIMESTAMP | Visit completion                                                                  |
+| resolved_at        | TIMESTAMP | Resolution time                                                                   |
+| documents          | JSONB     | Uploaded supporting documents                                                     |
+| created_at         | TIMESTAMP | Submission date                                                                   |
 
-**Indexes**: user_id, pet_id, rescue_id, stage, final_outcome
+**Indexes**: user_id, pet_id, rescue_id, stage, status
+
+> Application **answers** live in the separate `application_answers` table (`ApplicationAnswer.ts`), and **references** in `application_references` (`ApplicationReference.ts`). Stage/status changes are mirrored in `application_status_transitions` and `application_timeline` for audit.
 
 ### Staff Members
 
-**Purpose**: Rescue staff and volunteer management
+**Purpose**: Junction table linking users to the rescues they staff. Defined in `StaffMember.ts`. RBAC roles live on the `user_roles` table — staff_members does **not** store roles or permissions itself.
 
-| Field              | Type      | Description                      |
-| ------------------ | --------- | -------------------------------- |
-| staff_member_id    | UUID (PK) | Primary identifier               |
-| user_id            | UUID (FK) | User account                     |
-| rescue_id          | UUID (FK) | Rescue org                       |
-| role               | ENUM      | ADMIN, MANAGER, STAFF, VOLUNTEER |
-| verified_by_rescue | BOOLEAN   | Verification status              |
-| permissions        | JSONB     | Role permissions                 |
-| created_at         | TIMESTAMP | Join date                        |
+| Field           | Type      | Description                                          |
+| --------------- | --------- | ---------------------------------------------------- |
+| staff_member_id | UUID (PK) | Primary identifier                                   |
+| rescue_id       | UUID (FK) | Rescue org (FK → rescues)                            |
+| user_id         | UUID (FK) | User account (FK → users)                            |
+| title           | VARCHAR   | Free-text role/title (e.g. "Adoptions Coordinator")  |
+| is_verified     | BOOLEAN   | Verified-by-rescue flag                              |
+| verified_by     | UUID (FK) | User who verified (nullable)                         |
+| verified_at     | TIMESTAMP | When verified                                        |
+| added_by        | UUID (FK) | Who added the staffer                                |
+| added_at        | TIMESTAMP | When added                                           |
+| deleted_at      | TIMESTAMP | Soft-delete timestamp (paranoid)                     |
 
-**Indexes**: user_id, rescue_id, role
+**Indexes**: user_id, rescue_id
 
 ## Communication Tables
 
 ### Chats
 
-**Purpose**: Chat thread management between adopters and rescues. Defined in `service.backend/src/models/Chat.ts`.
+**Purpose**: Chat thread management between adopters and rescues. Defined in `Chat.ts`.
 
 | Field          | Type      | Description                                |
 | -------------- | --------- | ------------------------------------------ |
@@ -142,7 +158,7 @@ erDiagram
 | rescue_id      | UUID (FK) | Owning rescue                              |
 | pet_id         | UUID (FK) | Pet that initiated the chat (optional)     |
 | application_id | UUID (FK) | Related application (optional)             |
-| status         | ENUM      | active, locked, archived                   |
+| status         | ENUM      | `active`, `locked`, `archived`             |
 | created_at     | TIMESTAMP | Creation date                              |
 | updated_at     | TIMESTAMP | Last update                                |
 
@@ -160,37 +176,54 @@ erDiagram
 
 ### Messages
 
-**Purpose**: Individual messages within a chat.
+**Purpose**: Individual messages within a chat. Defined in `Message.ts`.
 
-| Field       | Type      | Description        |
-| ----------- | --------- | ------------------ |
-| message_id  | UUID (PK) | Primary identifier |
-| chat_id     | UUID (FK) | Parent chat        |
-| sender_id   | UUID (FK) | Message sender     |
-| content     | TEXT      | Message content    |
-| attachments | JSONB     | File attachments   |
-| created_at  | TIMESTAMP | Send time          |
+| Field             | Type      | Description                                                          |
+| ----------------- | --------- | -------------------------------------------------------------------- |
+| message_id        | UUID (PK) | Primary identifier                                                   |
+| chat_id           | UUID (FK) | Parent chat                                                          |
+| sender_id         | UUID (FK) | Message sender                                                       |
+| content           | TEXT      | Message content                                                      |
+| content_format    | ENUM      | Content type (e.g. plain / markdown)                                 |
+| attachments       | JSONB     | File attachments                                                     |
+| search_vector     | TSVECTOR  | Stored generated column for full-text search (`messages_search_vector_gin_idx`) |
+| is_flagged        | BOOLEAN   | Content-moderation flag                                              |
+| flag_reason       | VARCHAR   | Reason set when flagged                                              |
+| flag_severity     | ENUM      | Severity from moderation pipeline                                    |
+| moderation_status | ENUM      | Outcome of moderation scan                                           |
+| flagged_at        | TIMESTAMP | When the flag was applied                                            |
+| created_at        | TIMESTAMP | Send time                                                            |
 
 Read receipts are tracked in a separate `MessageRead` table; reactions in `MessageReaction`.
 
-**Indexes**: chat_id, sender_id, created_at
+**Indexes**: chat_id, sender_id, created_at, search_vector (GIN)
 
 ### Notifications
 
-**Purpose**: User notifications
+**Purpose**: Multi-channel user notifications. Defined in `Notification.ts`.
 
-| Field           | Type      | Description        |
-| --------------- | --------- | ------------------ |
-| notification_id | UUID (PK) | Primary identifier |
-| user_id         | UUID (FK) | Recipient          |
-| type            | VARCHAR   | Notification type  |
-| title           | VARCHAR   | Notification title |
-| message         | TEXT      | Content            |
-| data            | JSONB     | Additional data    |
-| read            | BOOLEAN   | Read status        |
-| created_at      | TIMESTAMP | Creation time      |
+| Field                   | Type      | Description                                                                       |
+| ----------------------- | --------- | --------------------------------------------------------------------------------- |
+| notification_id         | UUID (PK) | Primary identifier                                                                |
+| user_id                 | UUID (FK) | Recipient                                                                         |
+| type                    | ENUM      | Notification category (see `NotificationType`)                                    |
+| channel                 | ENUM      | Delivery channel (email / push / in-app / SMS)                                    |
+| priority                | ENUM      | `low`, `normal`, `high`, `urgent`                                                 |
+| status                  | ENUM      | `pending`, `sent`, `delivered`, `read`, `failed`, `cancelled`                     |
+| title                   | VARCHAR   | Notification title                                                                |
+| message                 | TEXT      | Content                                                                           |
+| data                    | JSONB     | Additional data                                                                   |
+| template_id             | VARCHAR   | Optional template reference                                                       |
+| template_variables      | JSONB     | Template substitution values                                                      |
+| scheduled_for           | TIMESTAMP | Send-after timestamp                                                              |
+| sent_at / delivered_at  | TIMESTAMP | Lifecycle timestamps                                                              |
+| read_at / clicked_at    | TIMESTAMP | Engagement timestamps (there is **no** boolean `read` column — use `read_at` / `status = read`) |
+| retry_count / max_retries | INTEGER | Delivery retry bookkeeping                                                        |
+| error_message           | VARCHAR   | Last failure reason                                                               |
+| external_id             | VARCHAR   | Provider message ID                                                               |
+| created_at              | TIMESTAMP | Creation time                                                                     |
 
-**Indexes**: user_id, read, created_at
+**Indexes**: user_id, status, created_at
 
 ## Discovery Tables
 
@@ -241,9 +274,9 @@ Read receipts are tracked in a separate `MessageRead` table; reactions in `Messa
 
 **Indexes**: token, email, rescue_id, status
 
-### Timeline Events
+### Application Timeline
 
-**Purpose**: Application history tracking
+**Purpose**: Application history tracking (`ApplicationTimeline.ts`).
 
 | Field          | Type      | Description            |
 | -------------- | --------- | ---------------------- |
@@ -260,17 +293,27 @@ Read receipts are tracked in a separate `MessageRead` table; reactions in `Messa
 
 ### Email Queue
 
-**Purpose**: Outbound email management
+**Purpose**: Outbound email management. Defined in `EmailQueue.ts`.
 
-| Field           | Type      | Description           |
-| --------------- | --------- | --------------------- |
-| email_id        | UUID (PK) | Primary identifier    |
-| recipient_email | VARCHAR   | Recipient             |
-| template_id     | VARCHAR   | Email template        |
-| variables       | JSONB     | Template variables    |
-| status          | ENUM      | PENDING, SENT, FAILED |
-| sent_at         | TIMESTAMP | Send time             |
-| created_at      | TIMESTAMP | Queue time            |
+| Field             | Type      | Description                                          |
+| ----------------- | --------- | ---------------------------------------------------- |
+| email_id          | UUID (PK) | Primary identifier                                   |
+| template_id       | VARCHAR   | Email template                                       |
+| from_email / from_name | VARCHAR | Sender envelope                                    |
+| to_email          | VARCHAR   | Recipient (column is `to_email`, not `recipient_email`) |
+| to_name           | VARCHAR   | Recipient display name                               |
+| cc_emails         | JSONB     | CC list                                              |
+| bcc_emails        | JSONB     | BCC list                                             |
+| reply_to_email    | VARCHAR   | Reply-to address                                     |
+| html_content / text_content | TEXT | Rendered bodies                                  |
+| template_data     | JSONB     | Template substitution values                         |
+| status            | ENUM      | Delivery status                                      |
+| scheduled_for     | TIMESTAMP | Send-after timestamp                                 |
+| max_retries / current_retries | INTEGER | Retry bookkeeping                            |
+| last_attempt_at / sent_at | TIMESTAMP | Lifecycle timestamps                             |
+| failure_reason    | TEXT      | Last error                                           |
+| provider_id / provider_message_id | VARCHAR | Provider correlation                         |
+| created_at        | TIMESTAMP | Queue time                                           |
 
 **Indexes**: status, created_at
 
@@ -312,17 +355,19 @@ Most tables use soft delete (deleted_at timestamp) instead of hard delete for:
 
 ### Migration Management
 
-Migrations live in `service.backend/src/migrations/` as numbered TypeScript files (e.g. `30-create-file-uploads.ts`). Create a new one by adding the next sequential file following the existing pattern — the repo doesn't ship a `migration:create` npm script.
+Migrations live in `service.backend/src/migrations/` as numbered TypeScript files (e.g. `00-baseline-001-users.ts`, `01-add-user-type-support-agent-super-admin.ts`). The project uses [Umzug](https://github.com/sequelize/umzug) via a custom runner at `service.backend/src/migrations/runner.ts` — **`sequelize-cli` is not installed**. Create a new migration by adding the next sequential file following the existing pattern.
 
 ```bash
-# Run migrations (from repo root, while the dev stack is running)
+# From the repo root, while the dev stack is running:
 npm run db:migrate
 
-# Rollback / status — shell into the backend container and use sequelize-cli directly
+# Rollback / status (run inside the backend container):
 npm run docker:shell:backend
-npx sequelize-cli db:migrate:undo
-npx sequelize-cli db:migrate:status
+npm run db:migrate:undo      # ts-node src/migrations/runner.ts down
+npm run db:migrate:status    # ts-node src/migrations/runner.ts status
 ```
+
+The backend exposes three migration scripts in `service.backend/package.json`: `db:migrate`, `db:migrate:undo`, `db:migrate:status`.
 
 ### Best Practices
 

--- a/docs/backend/implementation-guide.md
+++ b/docs/backend/implementation-guide.md
@@ -4,8 +4,8 @@
 
 ### Prerequisites
 
-- Node.js 20+ and npm
-- PostgreSQL 16+ with PostGIS (provided by the Docker stack)
+- Node.js 22 (pinned in `.nvmrc`; `package.json` `engines` requires `>=22 <23`)
+- PostgreSQL 16 with PostGIS (provided by the Docker stack)
 - Docker and Docker Compose (recommended)
 
 ### Development Setup
@@ -35,10 +35,14 @@ From the repository root the typical workflow uses Docker — the container boot
 
 4. **Initialize the database (first run, or after `docker:reset`)**
 
+   The migration runner is a custom Umzug script at `service.backend/src/migrations/runner.ts` (the project does not use `sequelize-cli`). Seeds are split into reference / demo / fixtures with no "do everything" alias — pick the right one for what you're doing.
+
    ```bash
-   npm run db:migrate          # runs sequelize-cli db:migrate inside the backend container
-   npm run db:seed             # optional sample data
-   # or: npm run db:reset      # migrate + seed
+   # From the repo root — wrappers shell into the service-backend container
+   npm run db:migrate                                       # runs `ts-node src/migrations/runner.ts up`
+   docker compose exec service-backend npm run db:seed:reference  # idempotent reference data
+   docker compose exec service-backend npm run db:seed:demo       # Faker-generated demo data (dev/staging only)
+   docker compose exec service-backend npm run db:seed:fixtures   # deterministic e2e fixtures
    ```
 
 5. **Backend is reachable at**
@@ -182,39 +186,36 @@ uploads/
 
 ## Database Management
 
-Migrations and seeders use `sequelize-cli`. From the repo root, `npm run db:migrate` and `npm run db:seed` are thin wrappers that shell into the backend container and call `sequelize-cli db:migrate` / `db:seed:all`. For commands that don't have an npm wrapper, shell into the container first:
-
-```bash
-npm run docker:shell:backend
-# then inside the container:
-npx sequelize-cli <command>
-```
+The project uses a custom [Umzug](https://github.com/sequelize/umzug) runner (`service.backend/src/migrations/runner.ts`) and a custom seed CLI (`service.backend/src/seeders/cli.ts`) — `sequelize-cli` is **not** installed. Migrations live in `service.backend/src/migrations/`; seeders in `service.backend/src/seeders/`.
 
 ### Migrations
 
 ```bash
-# Run migrations (from repo root)
+# Run pending migrations (from repo root)
 npm run db:migrate
 
-# Inside the backend container (npm run docker:shell:backend):
-npx sequelize-cli migration:generate --name add-user-fields
-npx sequelize-cli db:migrate:undo
-npx sequelize-cli db:migrate:undo:all
+# Status / rollback — exec inside the backend container
+docker compose exec service-backend npm run db:migrate:status
+docker compose exec service-backend npm run db:migrate:undo
+
+# Authoring a new migration: copy an existing file in
+# service.backend/src/migrations/ and follow the numbered naming pattern
+# (e.g. 01-add-something.ts). The runner picks them up automatically.
 ```
 
 ### Seeders
 
-```bash
-# Run all seeders (from repo root)
-npm run db:seed
+Seeds are deliberately not fungible — each type has a different safety profile:
 
-# Inside the backend container:
-npx sequelize-cli seed:generate --name demo-users
-npx sequelize-cli db:seed:undo
-npx sequelize-cli db:seed:undo:all
+```bash
+docker compose exec service-backend npm run db:seed:reference   # idempotent, safe anywhere
+docker compose exec service-backend npm run db:seed:demo        # Faker (dev/staging) — ALLOW_DEMO_SEED required
+docker compose exec service-backend npm run db:seed:fixtures    # deterministic e2e fixtures
+docker compose exec service-backend npm run db:seed:reset       # truncate demo+fixture tables
+docker compose exec service-backend npm run db:bootstrap        # first-run admin in production
 ```
 
-Migrations live in `service.backend/src/migrations/` and seeders in `service.backend/src/seeders/`.
+See `service.backend/src/seeders/README.md` for the full split.
 
 ## Testing
 
@@ -320,18 +321,12 @@ The root `docker-compose.prod.yml` overlay exercises this path end-to-end — se
 
 ### Add Database Model
 
-1. **Create migration** (inside the backend container):
-
-   ```bash
-   npm run docker:shell:backend
-   npx sequelize-cli migration:generate --name create-my-table
-   ```
-
+1. **Create migration** by copying the latest file in `service.backend/src/migrations/` and renaming it (the runner is a custom Umzug script — no generator). Follow the existing numbered naming pattern (`NN-create-my-table.ts`).
 2. **Define schema** in the migration file under `src/migrations/`
 3. **Create model** `src/models/MyModel.ts`
 4. **Run migration** `npm run db:migrate` (from the repo root)
 5. **Add associations** in the model file
-6. **Create seeder** (optional) under `src/seeders/`
+6. **Create seeder** (optional) under `src/seeders/{reference,demo,fixtures}/` depending on whether it's idempotent reference data, Faker-generated demo data, or a deterministic e2e fixture.
 
 ### Update Email Template
 
@@ -353,7 +348,9 @@ docker compose ps database
 # Nuclear reset (wipes the volume, then re-initializes)
 npm run docker:reset
 npm run docker:dev:detach
-npm run db:reset          # migrate + seed
+npm run db:migrate
+docker compose exec service-backend npm run db:seed:reference
+docker compose exec service-backend npm run db:seed:fixtures
 ```
 
 ### Email Not Sending
@@ -381,15 +378,14 @@ npm run dev  # Will recreate automatically
 ### Performance Issues
 
 ```bash
-# Check database query performance
-npm run db:log
-
-# Profile application
-npm run profile
+# Toggle Sequelize query logging by setting DB_LOGGING=true in .env and restarting the backend
+# (`service.backend/src/sequelize.ts` reads DB_LOGGING).
 
 # Monitor in development dashboard
 open http://localhost:5000/monitoring/dashboard
 ```
+
+Load-testing and performance-profiling scripts are not yet set up.
 
 ## Best Practices
 

--- a/docs/backend/service-backend-prd.md
+++ b/docs/backend/service-backend-prd.md
@@ -137,14 +137,12 @@ Frontend `ApplicationStage` (PENDING / REVIEWING / VISITING / DECIDING / RESOLVE
 
 ### 11. Foster Coordination
 
-- `FosterPlacement` model (PK: `placementId`; FKs: `petId`, `fosterUserId`, `rescueId`; columns: `startDate`, `endDate`, `status` (`active | completed | cancelled`), `notes`)
-- `FosterPlacementTransition` append-only event log (mirrors `PetStatusTransition`)
-- Routes mounted at `/api/v1/foster/placements`:
+- `FosterPlacement` model (`FosterPlacement.ts`; PK: `placementId`; FKs: `petId`, `fosterUserId`, `rescueId`; columns: `startDate`, `endDate`, `status` (`active | completed | cancelled`), `notes`)
+- Routes mounted at `/api/v1/foster` (see `foster.routes.ts`):
   - `POST /placements` — create (triggers Pet status transition to `FOSTER`)
   - `GET /placements` — list (filtered by current user's rescue/user scope)
   - `GET /placements/:id` — detail
-  - `PATCH /placements/:id` — update notes/dates
-  - `POST /placements/:id/end` — end placement; outcome param selects new Pet status (`AVAILABLE` or `ADOPTED`)
+  - `POST /placements/:id/end` — end placement; `outcome` is one of `return_to_rescue` | `adopted_by_foster` | `cancelled`, which drives the corresponding Pet status transition
 - RBAC: `rescue_staff` for their own rescue; `admin` / `super_admin` global; `support_agent` read-only
 
 ## Performance Requirements

--- a/docs/backend/testing.md
+++ b/docs/backend/testing.md
@@ -182,16 +182,16 @@ describe('Application Workflow Integration', () => {
       .send({ petId: pet.petId })
       .expect(201);
 
-    // Progress through stages
+    // Progress through stages — the status route drives both `status` and `stage`
     await request(server)
-      .patch(`/api/v1/applications/${app.body.applicationId}/stage`)
+      .patch(`/api/v1/applications/${app.body.applicationId}/status`)
       .set('Authorization', `Bearer ${rescueToken}`)
-      .send({ stage: 'REVIEWING' })
+      .send({ stage: 'reviewing' })
       .expect(200);
 
     // Verify stage transition
     const updated = await Application.findByPk(app.body.applicationId);
-    expect(updated.stage).toBe('REVIEWING');
+    expect(updated.stage).toBe('reviewing');
     expect(updated.reviewStartedAt).toBeTruthy();
   });
 });

--- a/docs/frontend/app-admin-prd.md
+++ b/docs/frontend/app-admin-prd.md
@@ -272,8 +272,7 @@ For support/moderation models see backend PRD §5–§8.
 
 ### Near Term
 
-- Admin GDPR/Privacy Tools page (this PRD section §9)
-- Foster Coordination tab in `RescueDetailModal`
+- Foster Coordination tab in `RescueDetailModal` (the full Foster page already lives in `app.rescue`)
 - Email campaign workflow
 - Maintenance-mode toggle
 - MFA enforcement for admin login

--- a/docs/frontend/implementation-plan.md
+++ b/docs/frontend/implementation-plan.md
@@ -150,12 +150,12 @@ Implementation roadmap for the Rescue App (app.rescue) - a comprehensive managem
 
 ### Core Technologies
 
-- **Framework**: React 18+ with TypeScript
+- **Framework**: React 19 with TypeScript
 - **Build Tool**: Vite
-- **Styling**: Styled-components with theme support
+- **Styling**: vanilla-extract (`*.css.ts` files)
 - **State Management**: React Context + Custom Hooks
 - **Routing**: React Router v6
-- **HTTP Client**: Axios
+- **HTTP Client**: native `fetch` (via `@adopt-dont-shop/lib.api`)
 - **WebSocket**: Socket.IO client
 - **Forms**: React Hook Form + Zod validation
 - **Testing**: Vitest + React Testing Library + Playwright

--- a/docs/frontend/technical-architecture.md
+++ b/docs/frontend/technical-architecture.md
@@ -51,7 +51,7 @@ Technical architecture for the Rescue App (app.rescue) - a comprehensive managem
 
 ### Communication Layer
 
-- **HTTP**: Axios + React Query for REST APIs
+- **HTTP**: native `fetch` (wrapped by `@adopt-dont-shop/lib.api`'s `apiService`) + React Query
 - **WebSocket**: Socket.IO for real-time updates
 - **Interceptors**: Auth management, error handling, caching
 
@@ -66,30 +66,29 @@ Technical architecture for the Rescue App (app.rescue) - a comprehensive managem
 
 ### Global State (React Context)
 
-**AuthContext**
+Authentication is owned by `@adopt-dont-shop/lib.auth` (`AuthProvider` / `useAuth`) and shared across all three apps. The rescue app additionally composes a small set of app-owned contexts under `app.rescue/src/contexts/`:
 
-- User authentication state
-- Login/logout functionality
-- Token management
-- User profile data
+**AnalyticsContext**
 
-**RescueContext**
+- Forwards UI events into `lib.analytics`
 
-- Current rescue organization data
-- Rescue settings and configuration
-- Staff and permission information
+**ChatContext**
 
-**NotificationContext**
+- Per-app chat connection state from `lib.chat`
 
-- Real-time notifications
-- Notification preferences
-- Unread counts and alerts
+**NotificationsContext**
 
-**PermissionContext**
+- Real-time notifications, unread counts, browser-notification opt-in
 
-- User roles and permissions
-- Access control logic
-- Permission checking utilities
+**PermissionsContext**
+
+- Role / permission data from `lib.permissions`, used by route guards and field-level checks
+
+**StatsigContext**
+
+- Wraps `@statsig/react-bindings` for the rescue app
+
+Rescue-organization data (settings, staff, etc.) is fetched on demand via React Query — there is no dedicated `RescueContext`.
 
 ### Server State (React Query)
 

--- a/docs/infrastructure/INFRASTRUCTURE.md
+++ b/docs/infrastructure/INFRASTRUCTURE.md
@@ -92,7 +92,7 @@ The Adopt Don't Shop platform uses a modern microservices architecture with shar
 - Development: Local uploads directory
 - Production: AWS S3 with CloudFront CDN
 
-## Shared Libraries (21 libraries)
+## Shared Libraries (23 libraries)
 
 All libraries follow ESM-only architecture with TypeScript strict mode. Package names are scoped as `@adopt-dont-shop/lib.<name>` (dots, matching the directory names).
 
@@ -125,7 +125,9 @@ All libraries follow ESM-only architecture with TypeScript strict mode. Package 
 
 - `@adopt-dont-shop/lib.components` - Shared React components
 - `@adopt-dont-shop/lib.analytics` - Event tracking
-- `@adopt-dont-shop/lib.feature-flags` - Feature flags
+- `@adopt-dont-shop/lib.feature-flags` - Statsig hooks + typed gate/config constants
+- `@adopt-dont-shop/lib.observability` - Sentry init, Web Vitals reporter, analytics-consent gate
+- `@adopt-dont-shop/lib.legal` - Legal re-acceptance modal, cookie banner, consent service
 
 **Utilities:**
 
@@ -143,7 +145,7 @@ See [Libraries Documentation](../libraries/README.md) for details.
 docker compose up
 
 # Start specific service
-docker compose up service.backend
+docker compose up service-backend
 
 # View logs
 docker compose logs -f
@@ -220,19 +222,22 @@ cd lib.api && npm run dev
 
 ### Database Migrations
 
+The backend uses a custom Umzug runner (`service.backend/src/migrations/runner.ts`) and a custom seed CLI (`service.backend/src/seeders/cli.ts`). `sequelize-cli` is not installed.
+
 ```bash
 # From the repo root (containers must be running):
-npm run db:migrate                     # run migrations
-npm run db:seed                        # run seeders
-npm run db:reset                       # migrate + seed
+npm run db:migrate                                              # ts-node src/migrations/runner.ts up
+docker compose exec service-backend npm run db:migrate:undo     # rollback
+docker compose exec service-backend npm run db:migrate:status   # show applied / pending
 
-# From inside service.backend directly:
-npm run migrate                        # sequelize-cli db:migrate
-npm run seed                           # sequelize-cli db:seed:all
+# Seeders are split by safety profile — no "do everything" alias:
+docker compose exec service-backend npm run db:seed:reference   # idempotent reference data
+docker compose exec service-backend npm run db:seed:demo        # Faker (dev/staging; ALLOW_DEMO_SEED=true)
+docker compose exec service-backend npm run db:seed:fixtures    # deterministic e2e fixtures
+docker compose exec service-backend npm run db:seed:reset       # truncate demo+fixture tables
 
-# Create / rollback migrations via sequelize-cli directly:
-npx sequelize-cli migration:generate --name add-new-field
-npx sequelize-cli db:migrate:undo
+# Authoring a new migration: copy the latest file in
+# service.backend/src/migrations/ and follow the numbered naming pattern.
 ```
 
 ## CI/CD Pipeline
@@ -249,22 +254,17 @@ npx sequelize-cli db:migrate:undo
 
 ### Environments
 
-**Development:**
-
-- Branch: develop
-- Deployment: Automatic on commit
-- URL: dev.adoptdontshop.com
+All deploys are driven from `main` via the `Makefile` targets at the repo root, which dispatch the `deploy.yml` workflow with the appropriate `environment` input. See [DEPLOYMENT-PLAN.md](./DEPLOYMENT-PLAN.md) for the full procedure.
 
 **Staging:**
 
-- Branch: staging
-- Deployment: Manual approval
+- `make staging` — deploys `main` to staging (runs immediately)
 - URL: staging.adoptdontshop.com
 
 **Production:**
 
-- Branch: main
-- Deployment: Manual approval with rollback
+- `make prod` — deploys `main` to production (requires GitHub UI approval)
+- Rollback: `make rollback env=production sha=<commit>`
 - URL: adoptdontshop.com
 
 ## Monitoring & Logging

--- a/docs/infrastructure/MICROSERVICES-STANDARDS.md
+++ b/docs/infrastructure/MICROSERVICES-STANDARDS.md
@@ -14,7 +14,7 @@ The Adopt Don't Shop platform uses a hybrid microservices architecture combining
 │  @adopt-dont-shop/lib.api, lib-auth, lib-chat...   │
 └─────────────────────────────────────────────────────┘
                            │
-                    workspace:* dependency
+                    "*" dependency
                            │
 ┌─────────────────────────────────────────────────────┐
 │                  Applications                        │
@@ -36,7 +36,7 @@ The Adopt Don't Shop platform uses a hybrid microservices architecture combining
 
 **✅ Shared Libraries**
 
-- 21 libraries with consistent ESM architecture
+- 23 libraries with consistent ESM architecture
 - TypeScript-first with full type safety
 - Linked as npm workspace dependencies (`"*"` version)
 - Tested independently
@@ -105,11 +105,13 @@ The canonical index with links is in [`docs/libraries/README.md`](../libraries/R
 
 - `lib.applications`, `lib.chat`, `lib.discovery`, `lib.notifications`, `lib.pets`, `lib.rescue`, `lib.search`, `lib.moderation`, `lib.support-tickets`, `lib.audit-logs`
 
-**UI & analytics (3)**
+**UI & analytics (5)**
 
 - `lib.components` — shared React components
 - `lib.analytics` — event tracking
-- `lib.feature-flags` — Statsig types
+- `lib.feature-flags` — Statsig hooks + typed gate/config constants
+- `lib.observability` — Sentry init, Web Vitals reporter, analytics-consent gate
+- `lib.legal` — legal re-acceptance modal, cookie banner, consent service
 
 **Utilities (2)**
 
@@ -192,8 +194,8 @@ npm install -D typescript @types/node
 // package.json
 {
   "dependencies": {
-    "@adopt-dont-shop/lib.api": "workspace:*",
-    "@adopt-dont-shop/lib.auth": "workspace:*"
+    "@adopt-dont-shop/lib.api": "*",
+    "@adopt-dont-shop/lib.auth": "*"
   }
 }
 
@@ -237,7 +239,7 @@ const user = authService.getCurrentUser();
 
 ```dockerfile
 # Base stage - install workspace
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci

--- a/docs/infrastructure/new-app-generator.md
+++ b/docs/infrastructure/new-app-generator.md
@@ -7,46 +7,39 @@ The `npm run new-app` command scaffolds new applications in the workspace with a
 ## Usage
 
 ```bash
-npm run new-app <app-name> <app-type>
+npm run new-app <app-name> [template] [--overwrite]
+# or:
+npm run new-app <app-name> --template <template>
 ```
 
 ### Parameters
 
 - **app-name**: Application name (e.g., `app.mobile`, `app.veterinary`)
-- **app-type**: Type of application (`client`, `rescue`, `admin`, `service`)
+- **template**: One of `minimal`, `standard`, `enterprise` (defaults to `standard` if omitted)
+- **--overwrite**: Replace an existing app directory of the same name
 
-### App Types
+The generator only scaffolds React apps under `app.*`. Backend services are not produced by this script — `service.backend` is the single backend; add new domain code there.
 
-| Type      | Description                 | Use Case                |
-| --------- | --------------------------- | ----------------------- |
-| `client`  | Client-facing React app     | Public adoption portals |
-| `rescue`  | Rescue management React app | Rescue staff tools      |
-| `admin`   | Admin dashboard React app   | Platform administration |
-| `service` | Backend Node.js service     | API services            |
+### Templates
+
+| Template     | Description                                                  | Pre-installed libraries                                                                                                                                                  |
+| ------------ | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `minimal`    | Basic React app with auth and routing                        | `lib.components`, `lib.auth`                                                                                                                                             |
+| `standard`   | Full-featured app with data fetching and analytics           | `lib.components`, `lib.auth`, `lib.analytics`, `lib.api`, `@tanstack/react-query`                                                                                        |
+| `enterprise` | Complete enterprise app with all features                    | `lib.components`, `lib.auth`, `lib.analytics`, `lib.api`, `lib.feature-flags`, `lib.notifications`, `lib.permissions`, `lib.discovery`, `lib.search`, `@statsig/react-bindings`, `@tanstack/react-query` |
 
 ## Examples
 
-### Frontend Apps
-
 ```bash
-# Mobile adoption app
-npm run new-app app.mobile client
+# Mobile adoption app (standard template)
+npm run new-app app.mobile
 
-# Veterinary rescue portal
-npm run new-app app.veterinary rescue
+# Pick a template explicitly
+npm run new-app app.veterinary minimal
+npm run new-app app.superadmin enterprise
 
-# Super admin dashboard
-npm run new-app app.superadmin admin
-```
-
-### Backend Services
-
-```bash
-# Notification service
-npm run new-app service.notifications service
-
-# Payment processing service
-npm run new-app service.payments service
+# Replace an existing scaffold
+npm run new-app app.mobile standard --overwrite
 ```
 
 ## What Gets Created

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -4,8 +4,10 @@
 **Last updated:** 10 May 2026
 
 > Placeholder copy — must be reviewed and approved by legal counsel before
-> production launch. The version string above is the canonical
-> identifier persisted in `consent_events.privacy_version` when a user accepts.
+> production launch. The version string above is the canonical identifier
+> recorded against the user via `users.privacy_policy_accepted_at`
+> (`service.backend/src/models/User.ts`) and surfaced through the
+> `ConsentRecord` type in `service.backend/src/services/consent.service.ts`.
 
 ## 1. Who we are
 

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -4,8 +4,10 @@
 **Last updated:** 10 May 2026
 
 > Placeholder copy — must be reviewed and approved by legal counsel before
-> production launch. The version string above is the canonical
-> identifier persisted in `consent_events.tos_version` when a user accepts.
+> production launch. The version string above is the canonical identifier
+> recorded against the user via `users.terms_accepted_at`
+> (`service.backend/src/models/User.ts`) and surfaced through the
+> `ConsentRecord` type in `service.backend/src/services/consent.service.ts`.
 
 ## 1. Acceptance of terms
 

--- a/docs/libraries/README.md
+++ b/docs/libraries/README.md
@@ -37,7 +37,7 @@ The monorepo ships **23 workspace libraries** under `@adopt-dont-shop/lib.*`. Ea
 ### UI & analytics
 - [`lib.components`](../../lib.components/README.md) — shared React components
 - [`lib.analytics`](../../lib.analytics/README.md) — event tracking
-- [`lib.feature-flags`](../../lib.feature-flags/README.md) — Statsig type definitions
+- [`lib.feature-flags`](../../lib.feature-flags/README.md) — Statsig hooks (`useFeatureGate`, `useDynamicConfig`, `useConfigValue`) + typed gate/config constants
 - [`lib.observability`](../../lib.observability/README.md) — Sentry init, Web Vitals reporter, analytics-consent gate
 - [`lib.legal`](../../lib.legal/README.md) — legal re-acceptance modal, cookie banner, consent service
 

--- a/docs/migrations/per-model-rebaseline.md
+++ b/docs/migrations/per-model-rebaseline.md
@@ -1,8 +1,7 @@
 # Per-Model Baseline Rebaseline — Design Proposal
 
-Status: **DRAFT — design only**, no migration code is being written or run as part of this PR.
-Owner: TBD (see "Decision needed").
-Tracks the follow-up hinted at in `service.backend/src/migrations/00-baseline.ts` line 19.
+Status: ✅ **Implemented** — the per-domain baseline files now exist as `service.backend/src/migrations/00-baseline-001-users.ts` through `00-baseline-061-cms-navigation-menus.ts` plus `00-baseline-999-foreign-keys.ts`. The `SequelizeMeta` reseeder lives at `service.backend/scripts/rebaseline-seed-meta.ts`. The design notes below are retained for context.
+Tracks the follow-up hinted at in the original `service.backend/src/migrations/00-baseline.ts`.
 
 ---
 

--- a/docs/migrations/schema-equivalence-runbook.md
+++ b/docs/migrations/schema-equivalence-runbook.md
@@ -24,7 +24,7 @@ Triggers on **`pull_request`** events that touch any of:
 
 The job:
 
-1. Spins up Postgres 15 as a service container.
+1. Spins up Postgres 16 with PostGIS (`postgis/postgis:16-3.4`) as a service container.
 2. Creates two empty databases: `schema_equiv_a`, `schema_equiv_b`.
 3. Bootstraps **DB-A** via `npm run db:migrate` — runs every migration in `service.backend/src/migrations/` in order.
 4. Bootstraps **DB-B** via a one-shot inline `sequelize.sync()` invocation that loads `src/models/index.ts` and calls `sync()` once.

--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -14,7 +14,7 @@ The backend exposes a Prometheus scrape endpoint at `/metrics`, gated by
 - HTTP counter: `http_requests_total{method,route,status_code}`
 
 Health-check probes also publish status data via `/api/v1/health` and
-`/api/v1/ready` (the readiness probe asserts DB + Redis + BullMQ).
+`/health/ready` (the readiness probe asserts DB + Redis + BullMQ).
 
 ## Severity / routing convention
 
@@ -88,7 +88,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "Backend /api/v1/ready failing (DB/Redis/BullMQ)"
+          summary: "Backend /health/ready failing (DB/Redis/BullMQ)"
 ```
 
 ## Dashboards
@@ -117,6 +117,5 @@ Recommended Grafana panels:
 | ------------------- | ------------------------------- | -------------------- |
 | `/health/simple`    | server is up                    | Load balancer        |
 | `/api/v1/health`    | DB, email, storage, fs, Redis, queue | Operator dashboards |
-| `/api/v1/ready`     | DB + Redis + BullMQ             | Kubernetes readiness |
-| `/health/ready`     | (alias of `/api/v1/ready`)      | Legacy probes        |
+| `/health/ready`     | DB + Redis + BullMQ             | Kubernetes readiness |
 | `/metrics`          | Prometheus scrape               | Prometheus           |

--- a/docs/operations/snapshot-policy.md
+++ b/docs/operations/snapshot-policy.md
@@ -11,7 +11,7 @@ has its own RPO / RTO and backup mechanism.
 | `postgres_data`       | `database` service (Postgres 16+PostGIS) | Tier-1 (full)  | 30 days   |
 | `uploads`             | `service-backend` user uploads         | Tier-1 (full)  | 90 days   |
 | `letsencrypt`         | nginx TLS state                        | Regenerable — no backup |  N/A     |
-| Application images    | Docker registry (Docker Hub)           | Immutable tags | indefinite (per-tag) |
+| Application images    | GitHub Container Registry (GHCR)       | Immutable tags | indefinite (per-tag) |
 
 ## Postgres — `pg_dump` to S3
 

--- a/docs/upgrades/README.md
+++ b/docs/upgrades/README.md
@@ -1,18 +1,20 @@
 # Major-version Upgrade Plans
 
-This directory holds **planning documents** for the next round of major-framework
+This directory holds **planning documents** for the round of major-framework
 upgrades flagged by the Production Readiness Audit (Linear: ADS-531, ADS-532).
-None of the upgrades have been executed yet — these documents exist to scope the
-work, identify risk, and let us file follow-up tickets with confidence.
+Node 22, Express 5 and React 19 have all shipped; Sequelize is on 7-alpha. The
+individual planning docs below retain the original scoping, risk inventory and
+migration notes for posterity — re-read the **Status** banner at the top of
+each one before treating it as live guidance.
 
 ## Index
 
-| Doc | Linear | Driver |
-| --- | --- | --- |
-| [Node 20 → 22 LTS](./node-22-migration.md) | ADS-532 | Node 20 enters EOL April 2026 |
-| [Express 4 → 5](./express-5-migration.md) | ADS-531 | Express 5 stable since Oct 2024; v4 long-term security supply will dry up |
-| [Sequelize 6 → 7](./sequelize-7-migration.md) | ADS-531 | Sequelize 7 has the active maintenance line |
-| [React 18 → 19](./react-19-migration.md) | ADS-531 | React 19 stable since Dec 2024; ecosystem libs starting to deprecate v18 |
+| Doc | Linear | Status | Driver |
+| --- | --- | --- | --- |
+| [Node 20 → 22 LTS](./node-22-migration.md) | ADS-532 | ✅ Shipped | Node 20 EOL April 2026 |
+| [Express 4 → 5](./express-5-migration.md) | ADS-531 | ✅ Shipped | Express 5 stable Oct 2024 |
+| [Sequelize 6 → 7](./sequelize-7-migration.md) | ADS-531 | ⚠️ On 7.0.0-alpha — stable bump pending | Active maintenance line |
+| [React 18 → 19](./react-19-migration.md) | ADS-531 | ✅ Shipped | React 19 stable Dec 2024 |
 
 ## Sequencing recommendation
 

--- a/docs/upgrades/express-5-migration.md
+++ b/docs/upgrades/express-5-migration.md
@@ -1,8 +1,7 @@
 # Express 4 → Express 5 Migration Plan
 
 **Linear**: ADS-531 (this document covers the Express portion)
-**Status**: Not started — planning only
-**Recommended quarter**: After Node 22 migration lands.
+**Status**: ✅ Shipped — `service.backend/package.json` pins `"express": "^5.0.0"` and root `overrides` pin the express type packages to v5. The historical plan below is retained for context only; do not treat it as live work.
 
 > Express 5 went stable on **2024-10-15** after a long beta. The biggest
 > structural change is the move from `path-to-regexp` v0 → v8 (route syntax)

--- a/docs/upgrades/node-22-migration.md
+++ b/docs/upgrades/node-22-migration.md
@@ -1,8 +1,7 @@
 # Node 20 → Node 22 LTS Migration Plan
 
 **Linear**: ADS-532
-**Status**: Not started — planning only
-**Recommended quarter**: Q3 2026 (well before Node 20 EOL in April 2026)
+**Status**: ✅ Shipped — Node 22 is the current target (`.nvmrc` 22.15.1, `engines.node` `>=22 <23`, Dockerfiles pin `ARG NODE_VERSION=22.15.1`). The historical plan below is retained for context only; do not treat it as live work.
 
 > Node 20 enters end-of-life on **2026-04-30**. Node 22 ("Jod") became Active LTS
 > on **2024-10-29** and is supported through **2027-04-30**. We have plenty of

--- a/docs/upgrades/react-19-migration.md
+++ b/docs/upgrades/react-19-migration.md
@@ -1,9 +1,7 @@
 # React 18 → React 19 Migration Plan
 
 **Linear**: ADS-531 (this document covers the React portion)
-**Status**: Not started — planning only
-**Recommended quarter**: After Express 5 lands; before mid-2026 to stay on
-ecosystem-supported majors.
+**Status**: ✅ Shipped — every app pins `"react": "^19.0.0"` / `"react-dom": "^19.0.0"`; root `overrides` enforces React 19 for `@types/react` and `@types/react-dom`. The historical plan below is retained for context only; do not treat it as live work.
 
 > React 19 stable shipped on **2024-12-05**. The big-ticket items are
 > stable `use()`, the React Compiler (opt-in), removal of legacy APIs, and

--- a/docs/upgrades/sequelize-7-migration.md
+++ b/docs/upgrades/sequelize-7-migration.md
@@ -1,10 +1,8 @@
 # Sequelize 6 → Sequelize 7 Migration Plan
 
 **Linear**: ADS-531 (this document covers the Sequelize portion)
-**Status**: Not started — planning only
-**Recommended quarter**: After Sequelize 7 ships a stable (non-alpha) tag and
-`sequelize-typescript` (or our chosen replacement) catches up. **Do not start
-until that's true.**
+**Status**: ⚠️ Partially shipped — `service.backend/package.json` already pins `"sequelize": "7.0.0-alpha.9"` and `sequelize-typescript` / `sequelize-cli` / `@types/sequelize` were removed. The remaining work is the bump to a stable 7.x release once one lands.
+**Recommended quarter**: After Sequelize 7 ships a stable (non-alpha) tag.
 
 > Sequelize 7 has been in alpha for an extended period. It rewrites a large
 > part of the internals (TypeScript-first decorators, new model-definition

--- a/lib.api/README.md
+++ b/lib.api/README.md
@@ -124,7 +124,7 @@ type ApiServiceConfig = {
 
 ## Data Transformation
 
-Responses that contain pet objects are automatically normalised from API snake_case to camelCase, and PostGIS geometry is converted to a readable `"lat, lng"` string. See `src/transformers` for the precise mapping.
+Responses that contain pet objects are automatically normalised from API snake_case to camelCase, and PostGIS geometry is converted to a readable `"lat, lng"` string. The mapping is inlined in `src/services/api-service.ts` (search for `normalizePet`).
 
 ```typescript
 // API Response (snake_case)

--- a/lib.auth/README.md
+++ b/lib.auth/README.md
@@ -33,7 +33,7 @@ From `@adopt-dont-shop/lib.auth`:
 
 - `User`, `LoginRequest`, `RegisterRequest`, `AuthResponse`, `ChangePasswordRequest`, `RefreshTokenRequest`, `RefreshTokenResponse`
 - `TwoFactorSetupResponse`, `TwoFactorEnableResponse`, `TwoFactorDisableResponse`, `TwoFactorBackupCodesResponse`
-- `Rescue`, `RescueRole`, `Permission`, `rolePermissions`
+- `RescueRole`, `Permission`, `rolePermissions`
 - And everything re-exported from `./types`
 
 ## Quick Start
@@ -109,8 +109,7 @@ Two-factor:
 Token storage (local):
 
 - `getToken(): string | null`
-- `getRefreshToken(): string | null`
-- `setToken(token: string): void`
+- `setToken(token: string | null | undefined): void`
 - `clearTokens(): void`
 
 ## useAuth hook

--- a/lib.components/src/components/form/DateInput/README.md
+++ b/lib.components/src/components/form/DateInput/README.md
@@ -1,44 +1,28 @@
-# DateInput Component
+# DateInput
 
-A date input component with date picker functionality and consistent styling.
-
-## Usage
+Thin wrapper around `<input type="date">` for ISO date strings. Source: `DateInput.tsx`. Not re-exported from `lib.components/src/index.ts`.
 
 ```tsx
-import { DateInput } from '@/components/form/DateInput'
+import { DateInput } from '@adopt-dont-shop/lib.components/src/components/form/DateInput/DateInput';
 
-// Basic usage
-<DateInput
-  value={selectedDate}
-  onChange={handleDateChange}
-/>
+const [value, setValue] = useState('');
 
-// With custom configuration
 <DateInput
-  value={selectedDate}
-  onChange={handleDateChange}
-  placeholder="Select a date..."
-  minDate={minDate}
-  maxDate={maxDate}
-  className="custom-date-input"
+  id="dob"
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+  min="1900-01-01"
+  max={new Date().toISOString().slice(0, 10)}
 />
 ```
 
 ## Props
 
-- `value`: Currently selected date
-- `onChange`: Function called when date changes
-- `placeholder`: Optional placeholder text
-- `minDate`: Minimum selectable date
-- `maxDate`: Maximum selectable date
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying input element
-
-## Features
-
-- Date picker integration
-- Date validation
-- Keyboard navigation
-- Accessible markup
-- TypeScript support
-- Consistent with other form inputs
+| Prop       | Type                                            | Required | Description                                  |
+| ---------- | ----------------------------------------------- | -------- | -------------------------------------------- |
+| `value`    | `string`                                        | Yes      | ISO date string (YYYY-MM-DD).                |
+| `onChange` | `(e: ChangeEvent<HTMLInputElement>) => void`    | Yes      | Native change handler.                       |
+| `disabled` | `boolean`                                       | No       | Disable the input.                           |
+| `min`      | `string`                                        | No       | Earliest selectable ISO date.                |
+| `max`      | `string`                                        | No       | Latest selectable ISO date.                  |
+| `id`       | `string`                                        | No       | Used by external `<label htmlFor>`.          |

--- a/lib.components/src/components/form/FilterPanel/README.md
+++ b/lib.components/src/components/form/FilterPanel/README.md
@@ -1,39 +1,28 @@
-# FilterPanel Component
+# GenericFilters (`form/FilterPanel`)
 
-A flexible filter panel component for creating advanced filtering interfaces with various filter types.
-
-## Usage
+Generic filter bar for table / list views. Default export from `FilterPanel.tsx`; the component is named `GenericFilters`. Not re-exported from `lib.components/src/index.ts` — the `FilterPanel` re-export at the top level refers to a different (reports) component.
 
 ```tsx
-import { FilterPanel } from '@/components/form/FilterPanel'
+import GenericFilters from '@adopt-dont-shop/lib.components/src/components/form/FilterPanel/FilterPanel';
 
-// Basic usage
-<FilterPanel
-  filters={filters}
-  onApplyFilters={handleApplyFilters}
-/>
+const filterConfig = [
+  { name: 'status', label: 'Status', type: 'select', options: [/* … */] },
+  { name: 'search', label: 'Search', type: 'text' },
+];
 
-// With custom configuration
-<FilterPanel
+<GenericFilters
   filters={filters}
-  onApplyFilters={handleApplyFilters}
-  onClearFilters={handleClearFilters}
-  className="custom-filter-panel"
+  onFilterChange={(name, value) => setFilters((prev) => ({ ...prev, [name]: value }))}
+  filterConfig={filterConfig}
 />
 ```
 
 ## Props
 
-- `filters`: Array of filter configurations
-- `onApplyFilters`: Function called when filters are applied
-- `onClearFilters`: Optional function called when filters are cleared
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying element
+| Prop             | Type                                                                | Required | Description                                            |
+| ---------------- | ------------------------------------------------------------------- | -------- | ------------------------------------------------------ |
+| `filters`        | `T extends Record<string, string \| boolean \| number \| undefined>` | Yes     | Current filter values.                                 |
+| `onFilterChange` | `(name: string, value: string \| boolean \| number) => void`        | Yes      | Called when an individual field changes.               |
+| `filterConfig`   | `FilterConfig[]`                                                    | Yes      | Field schema (label, type, options for selects, etc.). |
 
-## Features
-
-- Multiple filter types support
-- Collapsible sections
-- Clear all functionality
-- Accessible markup
-- TypeScript support
+> The top-level `FilterPanel` named export from `@adopt-dont-shop/lib.components` is the reports-domain component (`components/reports/FilterPanel`), which has a different API. Pick the one that matches your use case.

--- a/lib.components/src/components/layout/BaseSidebar/README.md
+++ b/lib.components/src/components/layout/BaseSidebar/README.md
@@ -1,41 +1,26 @@
-# BaseSidebar Component
+# BaseSidebar
 
-A base sidebar component providing the foundation for navigation sidebars with collapsible functionality.
-
-## Usage
+Controlled drawer/sidebar primitive. Source: `BaseSidebar.tsx`. Not re-exported from `lib.components/src/index.ts`.
 
 ```tsx
-import { BaseSidebar } from '@/components/layout/BaseSidebar'
+import BaseSidebar from '@adopt-dont-shop/lib.components/src/components/layout/BaseSidebar/BaseSidebar';
 
-// Basic usage
-<BaseSidebar>
-  <nav>
-    {/* Navigation items */}
-  </nav>
-</BaseSidebar>
-
-// With custom props
 <BaseSidebar
-  isOpen={isOpen}
-  onToggle={handleToggle}
-  className="custom-sidebar"
+  show={isOpen}
+  handleClose={() => setIsOpen(false)}
+  title="Filters"
+  size="md"
 >
-  {children}
+  <FilterForm />
 </BaseSidebar>
 ```
 
 ## Props
 
-- `children`: Content to display in the sidebar
-- `isOpen`: Whether the sidebar is expanded
-- `onToggle`: Function to handle sidebar toggle
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying element
-
-## Features
-
-- Collapsible functionality
-- Responsive design
-- Accessible markup
-- TypeScript support
-- Flexible content area
+| Prop          | Type           | Required | Description                            |
+| ------------- | -------------- | -------- | -------------------------------------- |
+| `show`        | `boolean`      | Yes      | Whether the sidebar is open.           |
+| `handleClose` | `() => void`   | Yes      | Called when the user dismisses it.     |
+| `title`       | `string`       | Yes      | Header text.                           |
+| `size`        | `string`       | No       | Width preset (component-defined).      |
+| `children`    | `ReactNode`    | Yes      | Body content.                          |

--- a/lib.components/src/components/layout/Container/README.md
+++ b/lib.components/src/components/layout/Container/README.md
@@ -1,41 +1,23 @@
-# Container Component
+# Container
 
-A layout container component that provides consistent spacing, max-width constraints, and responsive behavior.
-
-## Usage
+Layout wrapper that constrains width, optionally goes fluid, and can center its children. Source: `Container.tsx`.
 
 ```tsx
-import { Container } from '@/components/layout/Container'
+import { Container } from '@adopt-dont-shop/lib.components';
 
-// Basic usage
-<Container>
-  <div>Content goes here</div>
-</Container>
-
-// With custom configuration
-<Container
-  maxWidth="lg"
-  padding="md"
-  centered={true}
-  className="custom-container"
->
-  {children}
+<Container size="lg" centerContent>
+  <h1>Page title</h1>
 </Container>
 ```
 
 ## Props
 
-- `children`: Content to display within the container
-- `maxWidth`: Maximum width constraint (xs, sm, md, lg, xl, full)
-- `padding`: Padding size (none, sm, md, lg)
-- `centered`: Whether to center the container
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying div element
+| Prop            | Type                                        | Required | Default | Description                                  |
+| --------------- | ------------------------------------------- | -------- | ------- | -------------------------------------------- |
+| `children`      | `ReactNode`                                 | Yes      | —       | Content.                                     |
+| `size`          | `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'`    | No       | `'lg'`  | Max-width preset.                            |
+| `fluid`         | `boolean`                                   | No       | `false` | Drop the max-width and span the parent.      |
+| `centerContent` | `boolean`                                   | No       | `false` | Center children with flex.                   |
+| `className`     | `string`                                    | No       | —       | Override the root element's class.           |
 
-## Features
-
-- Responsive max-width constraints
-- Flexible padding options
-- Centering functionality
-- Accessible markup
-- TypeScript support
+Standard `HTMLDivElement` attributes are also accepted via the spread on the root.

--- a/lib.components/src/components/ui/DateTime/README.md
+++ b/lib.components/src/components/ui/DateTime/README.md
@@ -1,36 +1,17 @@
-# DateTime Component
+# DateTime
 
-A component for displaying formatted date and time values with consistent styling.
-
-## Usage
+Formats an ISO timestamp (or `Date`) for display with optional tooltip showing the absolute value. Source: `DateTime.tsx`.
 
 ```tsx
-import { DateTime } from '@/components/ui/DateTime'
+import { DateTime } from '@adopt-dont-shop/lib.components';
 
-// Display current date/time
-<DateTime />
-
-// Display specific date
-<DateTime date={new Date('2024-01-01')} />
-
-// Custom format
-<DateTime
-  date={date}
-  format="short"
-  className="custom-class"
-/>
+<DateTime timestamp={pet.createdAt} localeOption="en-GB" showTooltip />
 ```
 
 ## Props
 
-- `date`: Date object or string to display (defaults to current date)
-- `format`: Format style for the date/time display
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying element
-
-## Features
-
-- Multiple date formats
-- Timezone handling
-- Accessible markup
-- TypeScript support
+| Prop           | Type                       | Required | Default   | Description                                  |
+| -------------- | -------------------------- | -------- | --------- | -------------------------------------------- |
+| `timestamp`    | `string \| Date`           | Yes      | —         | ISO string or `Date` to render.              |
+| `localeOption` | `'en-GB' \| 'en-US'`       | No       | `'en-GB'` | Locale used by `Intl.DateTimeFormat`.        |
+| `showTooltip`  | `boolean`                  | No       | `false`   | Show absolute timestamp on hover.            |

--- a/lib.components/src/components/ui/DropdownButton/README.md
+++ b/lib.components/src/components/ui/DropdownButton/README.md
@@ -1,41 +1,23 @@
-# DropdownButton Component
+# DropdownButton
 
-A button component that triggers dropdown menus with flexible content and positioning.
-
-## Usage
+Button-styled dropdown that renders a list of label/route/onClick items. Source: `DropdownButton.tsx`. Not re-exported from `lib.components/src/index.ts`.
 
 ```tsx
-import { DropdownButton } from '@/components/ui/DropdownButton'
+import DropdownButton from '@adopt-dont-shop/lib.components/src/components/ui/DropdownButton/DropdownButton';
 
-// Basic usage
-<DropdownButton label="Actions">
-  <div>Dropdown content</div>
-</DropdownButton>
-
-// With custom configuration
 <DropdownButton
-  label="More Options"
-  variant="secondary"
-  position="bottom-end"
-  className="custom-dropdown"
->
-  {dropdownContent}
-</DropdownButton>
+  triggerLabel="Actions"
+  items={[
+    { label: 'Edit', onClick: handleEdit },
+    { label: 'Delete', onClick: handleDelete },
+  ]}
+/>
 ```
 
 ## Props
 
-- `label`: Button text or content
-- `children`: Dropdown content
-- `variant`: Button styling variant
-- `position`: Dropdown position relative to button
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying button element
-
-## Features
-
-- Flexible positioning
-- Keyboard navigation
-- Click outside to close
-- Accessible markup
-- TypeScript support
+| Prop           | Type             | Required | Description                                                       |
+| -------------- | ---------------- | -------- | ----------------------------------------------------------------- |
+| `triggerLabel` | `string`         | Yes      | Text rendered on the trigger button.                              |
+| `items`        | `DropdownItem[]` | Yes      | Each item has `label`, and either `to` (route) or `onClick`.      |
+| `className`    | `string`         | No       | Override the root element's class.                                |

--- a/lib.components/src/components/ui/DropdownMenu/README.md
+++ b/lib.components/src/components/ui/DropdownMenu/README.md
@@ -1,41 +1,22 @@
-# DropdownMenu Component
+# Dropdown (DropdownMenu)
 
-A dropdown menu component with support for menu items, separators, and nested menus.
-
-## Usage
+Click-trigger dropdown that renders a list of label/route/onClick items. Default export from `DropdownMenu.tsx` (component is named `Dropdown`, file is `DropdownMenu.tsx`). Not re-exported from `lib.components/src/index.ts`.
 
 ```tsx
-import { DropdownMenu } from '@/components/ui/DropdownMenu'
+import Dropdown from '@adopt-dont-shop/lib.components/src/components/ui/DropdownMenu/DropdownMenu';
 
-// Basic usage
-<DropdownMenu
-  trigger={<button>Menu</button>}
-  items={menuItems}
-/>
-
-// With custom configuration
-<DropdownMenu
-  trigger={triggerElement}
-  items={menuItems}
-  position="bottom-start"
-  onItemClick={handleItemClick}
-  className="custom-menu"
+<Dropdown
+  triggerLabel="Account"
+  items={[
+    { label: 'Profile', to: '/profile' },
+    { label: 'Sign out', onClick: handleSignOut },
+  ]}
 />
 ```
 
 ## Props
 
-- `trigger`: Element that triggers the menu
-- `items`: Array of menu items
-- `position`: Menu position relative to trigger
-- `onItemClick`: Function called when item is clicked
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying element
-
-## Features
-
-- Keyboard navigation
-- Menu item icons and shortcuts
-- Separators and groups
-- Accessible markup
-- TypeScript support
+| Prop           | Type             | Required | Description                                                       |
+| -------------- | ---------------- | -------- | ----------------------------------------------------------------- |
+| `triggerLabel` | `string`         | Yes      | Text rendered on the trigger button.                              |
+| `items`        | `DropdownItem[]` | Yes      | Each item has `label`, and either `to` (route) or `onClick`.      |

--- a/lib.components/src/components/ui/ImageGallery/README.md
+++ b/lib.components/src/components/ui/ImageGallery/README.md
@@ -1,38 +1,23 @@
-# ImageGallery Component
+# ImageGallery
 
-An image gallery component with lightbox functionality, thumbnails, and navigation controls.
-
-## Usage
+Displays a list of image URLs either as a swipable carousel or a grid gallery, with optional upload/delete handlers. Default export from `ImageGallery.tsx`. Not re-exported from `lib.components/src/index.ts`.
 
 ```tsx
-import { ImageGallery } from '@/components/ui/ImageGallery'
+import ImageGallery from '@adopt-dont-shop/lib.components/src/components/ui/ImageGallery/ImageGallery';
 
-// Basic usage
-<ImageGallery images={imageArray} />
-
-// With custom configuration
 <ImageGallery
-  images={imageArray}
-  showThumbnails={true}
-  autoPlay={false}
-  className="custom-gallery"
+  images={pet.images.map((i) => i.url)}
+  viewMode="gallery"
+  onUpload={(file) => uploadPetImage(pet.petId, file)}
+  onDelete={(fileName) => deletePetImage(pet.petId, fileName)}
 />
 ```
 
 ## Props
 
-- `images`: Array of image objects with src and alt
-- `showThumbnails`: Whether to display thumbnail navigation
-- `autoPlay`: Whether to auto-advance images
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying element
-
-## Features
-
-- Lightbox modal view
-- Thumbnail navigation
-- Keyboard controls
-- Touch/swipe support
-- Lazy loading
-- Accessible markup
-- TypeScript support
+| Prop       | Type                              | Required | Description                                            |
+| ---------- | --------------------------------- | -------- | ------------------------------------------------------ |
+| `images`   | `string[]`                        | Yes      | Image URLs (strings, not objects).                     |
+| `viewMode` | `'carousel' \| 'gallery'`         | Yes      | Render mode.                                           |
+| `onUpload` | `(file: File) => void`            | No       | Show upload affordance and call this with the file.    |
+| `onDelete` | `(fileName: string) => void`      | No       | Show delete affordance and call this with the name.    |

--- a/lib.components/src/components/ui/ThemeToggle/README.md
+++ b/lib.components/src/components/ui/ThemeToggle/README.md
@@ -1,37 +1,13 @@
-# ThemeToggle Component
+# ThemeToggle
 
-A theme toggle component for switching between light and dark themes with smooth transitions.
+Reads the current theme from `useTheme()` and toggles it. Takes no props. Source: `ThemeToggle.tsx`.
 
-## Usage
+Not re-exported from `lib.components/src/index.ts` — import from the component path:
 
 ```tsx
-import { ThemeToggle } from '@/components/ui/ThemeToggle'
+import { ThemeToggle } from '@adopt-dont-shop/lib.components/src/components/ui/ThemeToggle/ThemeToggle';
 
-// Basic usage
 <ThemeToggle />
-
-// With custom configuration
-<ThemeToggle
-  currentTheme={theme}
-  onThemeChange={handleThemeChange}
-  showLabel={true}
-  className="custom-toggle"
-/>
 ```
 
-## Props
-
-- `currentTheme`: Current theme value
-- `onThemeChange`: Function called when theme changes
-- `showLabel`: Whether to show theme labels
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying element
-
-## Features
-
-- Smooth theme transitions
-- Icon indicators
-- Keyboard accessible
-- Persistent theme storage
-- Accessible markup
-- TypeScript support
+Wrap the consumer tree with the theme provider that exposes `useTheme()` (see the app it's mounted in for the exact provider).

--- a/lib.components/src/components/ui/Tooltip/README.md
+++ b/lib.components/src/components/ui/Tooltip/README.md
@@ -1,42 +1,21 @@
-# Tooltip Component
+# Tooltip
 
-A tooltip component for displaying contextual information on hover or focus with flexible positioning.
-
-## Usage
+Wraps a child element with a hover/focus tooltip. Default export from `Tooltip.tsx`. Not re-exported from `lib.components/src/index.ts`.
 
 ```tsx
-import { Tooltip } from '@/components/ui/Tooltip'
+import Tooltip from '@adopt-dont-shop/lib.components/src/components/ui/Tooltip/Tooltip';
 
-// Basic usage
-<Tooltip content="This is a tooltip">
-  <button>Hover me</button>
-</Tooltip>
-
-// With custom configuration
-<Tooltip
-  content={tooltipContent}
-  position="top"
-  delay={500}
-  className="custom-tooltip"
->
-  {triggerElement}
+<Tooltip content="Save changes" side="bottom">
+  <button>Save</button>
 </Tooltip>
 ```
 
 ## Props
 
-- `content`: Tooltip content (string or JSX)
-- `children`: Element that triggers the tooltip
-- `position`: Tooltip position relative to trigger
-- `delay`: Delay before showing tooltip
-- `className`: Optional CSS class names
-- Additional props are forwarded to the underlying element
-
-## Features
-
-- Smart positioning
-- Hover and focus triggers
-- Customizable delay
-- Keyboard accessible
-- Screen reader support
-- TypeScript support
+| Prop        | Type                                            | Required | Default   | Description                          |
+| ----------- | ----------------------------------------------- | -------- | --------- | ------------------------------------ |
+| `content`   | `ReactNode`                                     | Yes      | —         | Tooltip body.                        |
+| `children`  | `ReactNode`                                     | Yes      | —         | Trigger element.                     |
+| `side`      | `'top' \| 'right' \| 'bottom' \| 'left'`        | No       | `'top'`   | Side of the trigger.                 |
+| `align`     | `'start' \| 'center' \| 'end'`                  | No       | `'center'`| Alignment along that side.           |
+| `className` | `string`                                        | No       | —         | Override the tooltip's class.        |

--- a/lib.dev-tools/README.md
+++ b/lib.dev-tools/README.md
@@ -18,7 +18,7 @@ See [src/index.ts](./src/index.ts) for the authoritative list.
 
 ### Components
 
-- **`DevPanelComponent`** — dev-user quick-switcher panel. Takes a `DevPanelAuthContext` (your auth's `login`/`logout`/`currentUser`) and a list of `DevUser`s.
+- **`DevPanelComponent`** — dev-user quick-switcher panel. Required props: `title: string` and `authContext: DevPanelAuthContext` (your auth's `user`, `login`, `logout`, `isAuthenticated`). Optional `seededUsers?: DevUser[]` to override the built-in list.
 - **`EtherealCredentialsPanel`** — shows the per-session Ethereal SMTP credentials backend issues when `EMAIL_PROVIDER=ethereal`.
 - **`DevOnly`** — wraps children and only renders them when `isDevelopmentMode()` is true. Accepts an optional `fallback`.
 
@@ -44,14 +44,15 @@ import { DevOnly, DevPanelComponent, useSeededUsers } from '@adopt-dont-shop/lib
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 
 export function DevHeader() {
-  const { login, logout, currentUser } = useAuth();
+  const { user, login, logout, isAuthenticated } = useAuth();
   const { data: users } = useSeededUsers();
 
   return (
     <DevOnly>
       <DevPanelComponent
-        auth={{ login, logout, currentUser }}
-        users={users ?? []}
+        title="Dev panel"
+        authContext={{ user, login, logout, isAuthenticated }}
+        seededUsers={users}
       />
     </DevOnly>
   );

--- a/lib.feature-flags/README.md
+++ b/lib.feature-flags/README.md
@@ -1,13 +1,14 @@
 # @adopt-dont-shop/lib.feature-flags
 
-Simplified feature flag library providing type definitions and constants for Statsig integration.
+Feature-flag library providing typed hooks and constants for Statsig integration across the apps.
 
 ## Overview
 
 This library has been refactored to support Statsig-only feature flag management. It provides:
 
+- React hooks (`useFeatureGate`, `useDynamicConfig`, `useConfigValue`) layered on top of `@statsig/react-bindings`
 - TypeScript type definitions for gates and dynamic configs
-- Constants for known feature gates
+- Constants for known feature gates (`KNOWN_GATES`, `KNOWN_CONFIGS`)
 - Type-safe config shapes for admin settings
 
 ## Migration

--- a/lib.moderation/README.md
+++ b/lib.moderation/README.md
@@ -38,9 +38,12 @@ const reports = await moderationService.getReports({
   limit: 20,
 });
 
-// Take moderation action
+// Take moderation action — payload must satisfy CreateModeratorActionRequestSchema
 await moderationService.takeAction(reportId, {
+  targetEntityType: 'message',
+  targetEntityId: messageId,
   actionType: 'warning_issued',
+  severity: 'medium',
   reason: 'Violation of community guidelines',
 });
 ```

--- a/lib.support-tickets/README.md
+++ b/lib.support-tickets/README.md
@@ -18,7 +18,7 @@ See [src/index.ts](./src/index.ts) for the authoritative list.
 
 ### Service
 
-- **`SupportTicketService`** — class client over the `/api/v1/support-tickets` endpoints
+- **`SupportTicketService`** — class client over the `/api/v1/admin/support` endpoints
 - **`supportTicketService`** — ready-to-use singleton
 
 Core methods: `getTickets`, `getTicketById`, `getTicketStats`, `getMyTickets`, `createTicket`, `updateTicket`, `assignTicket`, `addResponse`, `escalateTicket`, `getTicketMessages`, `closeTicket`, `resolveTicket`, `reopenTicket`, `setPriority`, `rateTicket`.

--- a/lib.validation/README.md
+++ b/lib.validation/README.md
@@ -28,7 +28,6 @@ See [src/index.ts](./src/index.ts) for the authoritative list. Highlights:
 - **Pet schemas** — `PetCreateRequestSchema`, `PetUpdateRequestSchema`, `PetStatusUpdateRequestSchema`, `PetSearchFiltersSchema`, `BulkPetOperationRequestSchema`, plus enums (`PetStatusSchema`, `PetTypeSchema`, `GenderSchema`, `SizeSchema`, `AgeGroupSchema`, `EnergyLevelSchema`, `VaccinationStatusSchema`, `SpayNeuterStatusSchema`, `GoodWithSchema`).
 - **Rescue schemas** — request and search shapes for the rescue domain.
 - **Application schemas** — adoption application request/update shapes.
-- **`ValidationService`** — placeholder class with `exampleMethod(data, options)` and `healthCheck()`. Not currently consumed; safe to ignore.
 
 Each schema also exports its inferred TypeScript type via `z.infer<>` (e.g. `PetCreateRequest`, `PetSearchFilters`).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,11 +6,15 @@ Utility scripts referenced from the root `package.json` or mounted into containe
 
 | Script | Invoked via | Purpose |
 | --- | --- | --- |
+| `bootstrap.mjs` | `npm run setup` | One-shot project bootstrap: verifies Node v22, creates `.env`, generates secrets, installs deps, builds libraries, and runs `validate:env`. |
 | `generate-secrets.mjs` | `npm run secrets:generate` | Print fresh JWT/session/CSRF/encryption secrets to append to `.env`. Pure Node — works on Windows/macOS/Linux without OpenSSL. |
 | `validate-env.mjs` | `npm run validate:env` | Check `.env` against the required-variable list and warn on missing/insecure values. |
+| `check-lib-tests.mjs` | `npm run check:lib-tests` | CI guard: fails when a `lib.*` package ships with zero test files. Allowlist lives inside the script. |
 | `create-new-app.js` | `npm run new-app` | Scaffold a new `app.<name>` package with Vite + React + workspace wiring. |
-| `create-new-lib.js` | `npm run new-lib` | Scaffold a new `lib.<name>` package with TypeScript + Jest + workspace wiring. |
+| `create-new-lib.js` | `npm run new-lib` | Scaffold a new `lib.<name>` package with TypeScript + Vitest + workspace wiring. |
 | `generate-test-attachments.js` | `npm run generate:attachments` | Generate sample chat attachments (images + PDFs) into `uploads/chat/` for the `20-emily-attachment-test` seeder. |
+| `snapshot-postgres.sh` | cron on production host | Daily `pg_dump` of the prod database to S3. See `docs/operations/snapshot-policy.md`. Bash — Linux/macOS only. |
+| `snapshot-uploads.sh` | cron on production host | Daily rsync of the `uploads` Docker volume to S3. See `docs/operations/snapshot-policy.md`. Bash — Linux/macOS only. |
 | `init-postgis.sql` | mounted into `database` container at `/docker-entrypoint-initdb.d/` | Enables the PostGIS extension on first DB init. Runs automatically — do not invoke manually. |
 
 ## Adding a new script

--- a/service.backend/README.md
+++ b/service.backend/README.md
@@ -37,11 +37,13 @@ npm install
 ### 3. Database Setup
 
 ```bash
-# Run migrations
+# Run pending migrations (umzug runner — no sequelize-cli)
 npm run migrate
 
-# Seed initial data (optional)
-npm run seed
+# Seed initial data — pick the right safety profile (no "do everything" alias)
+npm run db:seed:reference   # idempotent reference data (RBAC, breeds, templates)
+npm run db:seed:demo        # Faker-generated demo data (dev/staging; ALLOW_DEMO_SEED=true)
+npm run db:seed:fixtures    # deterministic e2e fixtures
 ```
 
 ### 4. Development Server
@@ -106,23 +108,28 @@ All endpoints are prefixed with `/api/v1` and follow RESTful conventions.
 
 ### Users
 
-- GET `/api/v1/users` - List users (admin)
-- GET `/api/v1/users/:id` - Get user
-- PATCH `/api/v1/users/:id` - Update user
+User listing is admin-only and lives at `GET /api/v1/admin/users`. The `/api/v1/users` mount exposes the current user's own resources.
+
+- GET `/api/v1/users/profile` - Get own profile
+- PUT `/api/v1/users/profile` - Update own profile
+- GET `/api/v1/users/preferences` - Get own preferences
+- GET `/api/v1/users/:userId` - Get another user's public profile
 
 ### Pets
 
 - GET `/api/v1/pets` - List pets with filtering
-- POST `/api/v1/pets` - Create pet (rescue)
-- GET `/api/v1/pets/:id` - Get pet
-- PATCH `/api/v1/pets/:id` - Update pet (rescue)
+- POST `/api/v1/pets` - Create pet (rescue staff)
+- GET `/api/v1/pets/:petId` - Get pet
+- PUT `/api/v1/pets/:petId` - Update pet (rescue staff)
+- PATCH `/api/v1/pets/:petId/status` - Update pet availability status
 
 ### Applications
 
 - GET `/api/v1/applications` - List applications (filtered by role)
 - POST `/api/v1/applications` - Submit application
-- GET `/api/v1/applications/:id` - Get application
-- PATCH `/api/v1/applications/:id` - Update application
+- GET `/api/v1/applications/:applicationId` - Get application
+- PATCH `/api/v1/applications/:applicationId/status` - Update application status
+- POST `/api/v1/applications/:applicationId/withdraw` - Withdraw application
 
 ### Health Check
 
@@ -323,11 +330,16 @@ This service uses PostgreSQL with Sequelize ORM.
 ### Migrations
 
 ```bash
-# Run pending migrations
+# Run pending migrations (umzug runner — sequelize-cli is not installed)
 npm run migrate
 
-# Create new migration
-npx sequelize-cli migration:generate --name your-migration-name
+# Rollback / status
+npm run db:migrate:undo
+npm run db:migrate:status
+
+# Create new migration: copy the latest file in src/migrations/ and
+# follow the existing numbered naming pattern (NN-create-my-table.ts).
+# The runner picks up new files automatically.
 ```
 
 ## Monitoring

--- a/service.backend/SECURITY.md
+++ b/service.backend/SECURITY.md
@@ -178,6 +178,5 @@ For security issues:
 
 ---
 
-**Last Updated**: June 2024  
 **Security Version**: 1.0  
 **Compliance**: OWASP Top 10, GDPR, CCPA Ready

--- a/service.backend/src/seeders/README.md
+++ b/service.backend/src/seeders/README.md
@@ -43,24 +43,16 @@ npm run db:seed:fixtures
 npm run db:seed:reset
 ```
 
-## Seeder Order
+## Layout
 
-The seeders run in this specific order to maintain referential integrity:
+Seeders are split across three subdirectories by safety profile, plus a `bootstrap/` directory for the first-run admin:
 
-1. **Permissions** (`01-permissions.ts`) - Base permission system
-2. **Roles** (`02-roles.ts`) - User roles (admin, rescue_staff, adopter, etc.)
-3. **Role-Permissions** (`03-role-permissions.ts`) - Maps permissions to roles
-4. **Users** (`04-users.ts`) - Test users with various types
-5. **User-Roles** (`05-user-roles.ts`) - Assigns roles to users
-6. **Rescues** (`06-rescues.ts`) - Rescue organization profiles
-7. **Feature Flags** (`07-feature-flags.ts`) - System feature toggles
-8. **Pets** (`08-pets.ts`) - Pet profiles with detailed information
-9. **Applications** (`09-applications.ts`) - Adoption applications
-10. **Chats** (`10-chats.ts`) - Chat conversations
-11. **Messages** (`11-messages.ts`) - Chat messages
-12. **Notifications** (`12-notifications.ts`) - User notifications
-13. **Ratings** (`13-ratings.ts`) - Reviews and ratings
-14. **Email Templates** (`14-email-templates.ts`) - System email templates
+- `reference/` — idempotent reference data (RBAC permissions/roles/role-permissions, breeds, email templates). Composed by `db:seed:reference` and safe in every environment.
+- `demo/` — Faker-generated demo data (additional users, rescues, pets, applications, chats, messages, ratings). Composed by `db:seed:demo` and gated on `ALLOW_DEMO_SEED=true` — never run in production.
+- `fixtures/` — deterministic test fixtures (Emily conversations, the seeded API-probe accounts the e2e suite relies on). Composed by `db:seed:fixtures`.
+- `bootstrap/` — first-run admin creation for fresh production environments. Invoked via `db:bootstrap` and gated on `ALLOW_BOOTSTRAP=true`.
+
+The numbered top-level files (`04-users.ts`, `06-rescues.ts`, `08-pets.ts`, etc.) are the underlying building blocks that the demo/fixture pipelines call into; you normally run the composed `npm run db:seed:*` scripts rather than invoking them directly.
 
 ## Test Data Created
 

--- a/service.backend/src/types/README.md
+++ b/service.backend/src/types/README.md
@@ -6,13 +6,24 @@ This directory contains all TypeScript type definitions for the adopt-dont-shop 
 
 ```
 types/
-├── index.ts          # Main export file - exports all types
-├── api.ts           # API request/response types
-├── auth.ts          # Authentication & authorization types
-├── user.ts          # User management types
-├── rbac.ts          # Role-based access control types
-├── database.ts      # Database & service layer types
-└── README.md        # This documentation
+├── index.ts             # Main export file
+├── admin.ts             # Admin tooling DTOs
+├── analytics.ts         # Analytics events / report DTOs
+├── api.ts               # Generic API request/response types
+├── application.ts       # Adoption-application DTOs
+├── auth.ts              # Authentication & authorization types
+├── chat.ts              # Chat / messaging DTOs
+├── common.ts            # Cross-domain primitives
+├── configuration.ts     # Runtime configuration shapes
+├── database.ts          # Database & service-layer types
+├── email.ts             # Email template / send DTOs
+├── enhanced-profile.ts  # Enhanced user-profile types
+├── mjml.d.ts            # Ambient declarations for mjml
+├── pet.ts               # Pet DTOs
+├── rbac.ts              # Role-based access control types
+├── rescue.ts            # Rescue-org DTOs
+├── user.ts              # User management types
+└── README.md            # This documentation
 ```
 
 ## Usage
@@ -38,7 +49,7 @@ interface ApiResponse<T> {
   message: string;
   data?: T;
   error?: string;
-  details?: any;
+  details?: unknown;
 }
 
 // Authenticated request with user context


### PR DESCRIPTION
## Summary

Documentation accuracy sweep across the whole monorepo (122 markdown files). Each commit is a self-contained batch; every claim was cross-checked against the underlying source (`service.backend/src/**`, `lib.*/src/index.ts`, `app.*/src/**`, `package.json` files, `docker-compose*.yml`, `.github/workflows/`, `Makefile`, `scripts/`). No code behaviour changes — only docs and a couple of stale CI workflow comments.

## Batches

1. **Top-level / CI / scripts** (`7187ff1`) — `download-artifact@v7` → `@v8`, stale `28 packages` claim, E2E gate now blocking per ADS-419, `scripts/README.md` Jest → Vitest, missing script rows.
2. **Backend docs** (`1fa997c`) — `docs/backend/database-schema.md` now reflects the real models (users uses `password`, full enum sets, pet images in `pet_media`, `adoption_fee_minor/_currency`, full notification/email_queue/message columns), `implementation-guide.md` + `README` + `seeders/README` swap sequelize-cli for the umzug runner & split `db:seed:*` scripts, `api-endpoints.md` fixes user/admin/foster routes, PRD drops nonexistent `FosterPlacementTransition` model and `PATCH /placements/:id`.
3. **Library READMEs** (`7a7d9ac`) — `lib.api` (no `src/transformers/`), `lib.auth` (drop `Rescue` + `getRefreshToken`), `lib.dev-tools` (DevPanelComponent prop names), `lib.feature-flags` + libraries index (also exports hooks), `lib.moderation` (full `takeAction` payload), `lib.support-tickets` (`/api/v1/admin/support` baseUrl), `lib.validation` (drop nonexistent `ValidationService`).
4. **Frontend / app docs** (`8a6b6e5`) — React 18 → 19 across all apps, `NotificationsContext` (plural), Statsig gate list reflects what the code actually consumes (`advanced_search_filters`, `new_hero_design`), admin PRD drops the contradictory PrivacyTools roadmap bullet, `technical-architecture.md` + `implementation-plan.md` switch Axios → fetch and styled-components → vanilla-extract, real context names.
5. **Infrastructure / operations / upgrades** (`026461b`) — library count 21 → 23, `service.backend` → `service-backend`, drop sequelize-cli / `npm run seed` instructions, `make staging`/`make prod` flow off main (no `develop` branch), Node 22 / Express 5 / React 19 migration plans marked ✅ Shipped, Sequelize 7 marked partially shipped (already on 7.0.0-alpha.9), per-model rebaseline marked Implemented, snapshot policy points at GHCR (not Docker Hub), observability uses `/health/ready` (no `/api/v1/ready` route exists), schema-equivalence Postgres 15 → 16, `new-app-generator.md` rewritten for the real `minimal/standard/enterprise` templates.
6. **Component READMEs + remaining docs** (`da9f50e`) — replace fabricated prop tables in 10 component READMEs (`DateTime`, `ThemeToggle`, `DropdownMenu`, `DropdownButton`, `Container`, `BaseSidebar`, `DateInput`, `Tooltip`, `ImageGallery`, `FilterPanel`) with the actual prop shapes; SECURITY-CENTER points at the real role-permissions seeder; ANALYTICS-REPORTS uses the per-domain baseline filenames and React Query v5; legal/privacy + legal/terms point at the real `users.{terms,privacy_policy}_accepted_at` columns and `ConsentRecord` type (no `consent_events` table exists).

## Test plan

- [x] Each numbered batch is its own commit with the file:line references it cross-checked
- [x] No source code modified; the only non-doc edits are `.github/workflows/security.yml` and `quality.yml` comment lines that became stale
- [ ] CI passes (note: pre-existing `Frontend Tests (app.admin)` failure on main, not introduced here — see review thread)

https://claude.ai/code/session_017pHCRdEdBKR6VPhyquZVct