### PR TITLE
Redesign swipe cards: overlay info, drag stamps, undo

### DIFF
--- a/app.client/src/components/discovery/DiscoveryPage.tsx
+++ b/app.client/src/components/discovery/DiscoveryPage.tsx
@@ -33,6 +33,7 @@ export const DiscoveryPage: React.FC = () => {
   });
   const [viewedPetIds, setViewedPetIds] = useState<string[]>(persistedState.viewedPetIds);
   const [currentPetIndex, setCurrentPetIndex] = useState(0);
+  const [undoStack, setUndoStack] = useState<SwipeAction[]>([]);
 
   // Load initial pets
   useEffect(() => {
@@ -83,6 +84,9 @@ export const DiscoveryPage: React.FC = () => {
       // Move to next pet
       setCurrentPetIndex(prev => prev + 1);
 
+      // Track for undo
+      setUndoStack(prev => [...prev, action].slice(-10));
+
       // Persist viewed pet so next session resumes correctly
       const next = recordViewedPet(action.petId);
       setViewedPetIds(next.viewedPetIds);
@@ -114,6 +118,22 @@ export const DiscoveryPage: React.FC = () => {
       console.error('Failed to load more pets:', error);
     }
   }, [pets, session.sessionId]);
+
+  const handleUndo = useCallback(() => {
+    setUndoStack(prev => {
+      if (prev.length === 0) return prev;
+      const last = prev[prev.length - 1];
+      setCurrentPetIndex(idx => Math.max(0, idx - 1));
+      setSession(s => ({
+        ...s,
+        totalSwipes: Math.max(0, s.totalSwipes - 1),
+        likes: s.likes - (last.action === 'like' ? 1 : 0),
+        passes: s.passes - (last.action === 'pass' ? 1 : 0),
+        superLikes: s.superLikes - (last.action === 'super_like' ? 1 : 0),
+      }));
+      return prev.slice(0, -1);
+    });
+  }, []);
 
   const handleControlAction = useCallback(
     (action: 'pass' | 'info' | 'like' | 'super_like') => {
@@ -256,7 +276,14 @@ export const DiscoveryPage: React.FC = () => {
               sessionId={session.sessionId}
             />
 
-            {!hasNoPets && <SwipeControls onAction={handleControlAction} disabled={hasNoPets} />}
+            {!hasNoPets && (
+              <SwipeControls
+                onAction={handleControlAction}
+                onUndo={handleUndo}
+                canUndo={undoStack.length > 0}
+                disabled={hasNoPets}
+              />
+            )}
           </>
         )}
 

--- a/app.client/src/components/swipe/SwipeCard.css.ts
+++ b/app.client/src/components/swipe/SwipeCard.css.ts
@@ -14,8 +14,7 @@ export const cardContainer = recipe({
     height: '620px',
     background: '#fff',
     borderRadius: '24px',
-    boxShadow:
-      '0 20px 40px -12px rgba(0, 0, 0, 0.25), 0 8px 16px -8px rgba(0, 0, 0, 0.1)',
+    boxShadow: '0 20px 40px -12px rgba(0, 0, 0, 0.25), 0 8px 16px -8px rgba(0, 0, 0, 0.1)',
     userSelect: 'none',
     overflow: 'hidden',
     willChange: 'transform',

--- a/app.client/src/components/swipe/SwipeCard.css.ts
+++ b/app.client/src/components/swipe/SwipeCard.css.ts
@@ -10,39 +10,31 @@ export const cardContainer = recipe({
   base: {
     position: 'absolute',
     width: '100%',
-    maxWidth: '350px',
-    height: '600px',
-    background: 'white',
-    borderRadius: '20px',
-    boxShadow: '0 10px 30px rgba(0, 0, 0, 0.2)',
+    maxWidth: '380px',
+    height: '620px',
+    background: '#fff',
+    borderRadius: '24px',
+    boxShadow:
+      '0 20px 40px -12px rgba(0, 0, 0, 0.25), 0 8px 16px -8px rgba(0, 0, 0, 0.1)',
     userSelect: 'none',
     overflow: 'hidden',
     willChange: 'transform',
-    selectors: {
-      '&:active': {
-        // cursor handled inline based on isTop prop
-      },
-    },
+    touchAction: 'none',
     '@media': {
       '(max-width: 768px)': {
-        maxWidth: '90vw',
-        height: '70vh',
+        maxWidth: 'min(92vw, 420px)',
+        height: 'min(70vh, 640px)',
+        borderRadius: '20px',
       },
     },
   },
   variants: {
     isTop: {
-      true: {
-        cursor: 'grab',
-      },
-      false: {
-        cursor: 'default',
-      },
+      true: { cursor: 'grab' },
+      false: { cursor: 'default', pointerEvents: 'none' },
     },
     disabled: {
-      true: {
-        cursor: 'default',
-      },
+      true: { cursor: 'default' },
       false: {},
     },
   },
@@ -51,14 +43,17 @@ export const cardContainer = recipe({
 
 export const imageContainer = style({
   position: 'relative',
-  height: '70%',
+  width: '100%',
+  height: '100%',
   overflow: 'hidden',
+  background: '#1a1a1a',
 });
 
 globalStyle(`${imageContainer} img`, {
   width: '100%',
   height: '100%',
   objectFit: 'cover',
+  display: 'block',
 });
 
 export const placeholderImage = style({
@@ -76,6 +71,7 @@ export const placeholderImage = style({
 globalStyle(`${placeholderImage} .placeholder-icon`, {
   fontSize: '80px',
   marginBottom: '20px',
+  opacity: 0.9,
 });
 
 export const placeholderIconSpin = style({
@@ -89,7 +85,7 @@ export const placeholderIconSpin = style({
 
 export const placeholderText = style({
   fontSize: '1.5rem',
-  fontWeight: 'bold',
+  fontWeight: 700,
   marginBottom: '8px',
   textShadow: '0 2px 4px rgba(0, 0, 0, 0.3)',
 });
@@ -100,141 +96,336 @@ export const placeholderSubtext = style({
   textShadow: '0 1px 2px rgba(0, 0, 0, 0.3)',
 });
 
-export const swipeOverlay = style({
-  position: 'absolute',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  width: '120px',
-  height: '120px',
-  borderRadius: '50%',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  fontSize: '48px',
-  color: 'white',
-  fontWeight: 'bold',
-  border: '4px solid white',
-  zIndex: 10,
-});
-
-export const cardContent = style({
-  padding: '20px',
-  height: '30%',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-});
-
-export const petName = style({
-  fontSize: '24px',
-  fontWeight: 700,
-  margin: '0 0 8px 0',
-  color: '#333',
-});
-
-export const petDetails = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '4px',
-});
-
-export const detailRow = style({
-  display: 'flex',
-  justifyContent: 'space-between',
-  fontSize: '16px',
-  color: '#666',
-});
-
-export const badge = recipe({
-  base: {
-    padding: '4px 8px',
-    borderRadius: '12px',
-    fontSize: '12px',
-    fontWeight: 600,
-  },
-  variants: {
-    variant: {
-      age: {
-        background: '#e3f2fd',
-        color: '#1976d2',
-      },
-      size: {
-        background: '#f3e5f5',
-        color: '#7b1fa2',
-      },
-      breed: {
-        background: '#e8f5e8',
-        color: '#388e3c',
-      },
-    },
-  },
-  defaultVariants: { variant: 'age' },
-});
-
-export const loginPromptOverlay = recipe({
+/* Tap-zones for cycling images (left/right halves of upper card) */
+export const tapZone = recipe({
   base: {
     position: 'absolute',
     top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    background: 'rgba(0, 0, 0, 0.7)',
+    bottom: '35%',
+    width: '40%',
+    zIndex: 4,
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    outline: 'none',
+  },
+  variants: {
+    side: {
+      left: { left: 0 },
+      right: { right: 0 },
+    },
+  },
+});
+
+/* Image dots indicator */
+export const imageDots = style({
+  position: 'absolute',
+  top: '12px',
+  left: '12px',
+  right: '12px',
+  display: 'flex',
+  gap: '4px',
+  zIndex: 5,
+  pointerEvents: 'none',
+});
+
+export const imageDot = recipe({
+  base: {
+    flex: 1,
+    height: '3px',
+    borderRadius: '2px',
+    background: 'rgba(255, 255, 255, 0.4)',
+    transition: 'background 0.2s ease',
+  },
+  variants: {
+    active: {
+      true: { background: 'rgba(255, 255, 255, 0.95)' },
+      false: {},
+    },
+  },
+});
+
+/* Gradient overlay that fades image to dark at the bottom so text is readable */
+export const gradientScrim = style({
+  position: 'absolute',
+  inset: 0,
+  background:
+    'linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 45%, rgba(0,0,0,0.35) 65%, rgba(0,0,0,0.85) 100%)',
+  pointerEvents: 'none',
+  zIndex: 1,
+});
+
+/* Corner stamps shown while dragging */
+export const stamp = recipe({
+  base: {
+    position: 'absolute',
+    top: '32px',
+    padding: '8px 18px',
+    border: '4px solid',
+    borderRadius: '10px',
+    fontSize: '2rem',
+    fontWeight: 800,
+    letterSpacing: '2px',
+    textTransform: 'uppercase',
+    pointerEvents: 'none',
+    zIndex: 6,
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+  },
+  variants: {
+    variant: {
+      like: {
+        right: '24px',
+        color: '#22c55e',
+        borderColor: '#22c55e',
+        transform: 'rotate(15deg)',
+      },
+      pass: {
+        left: '24px',
+        color: '#ef4444',
+        borderColor: '#ef4444',
+        transform: 'rotate(-15deg)',
+      },
+      super_like: {
+        top: '40%',
+        left: '50%',
+        marginLeft: '-90px',
+        color: '#0ea5e9',
+        borderColor: '#0ea5e9',
+        transform: 'rotate(-8deg)',
+      },
+      info: {
+        bottom: '40%',
+        left: '50%',
+        marginLeft: '-60px',
+        color: '#f59e0b',
+        borderColor: '#f59e0b',
+      },
+    },
+  },
+});
+
+/* Top badges (sponsored, compatibility) */
+export const topBadges = style({
+  position: 'absolute',
+  top: '24px',
+  right: '12px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+  alignItems: 'flex-end',
+  zIndex: 5,
+  pointerEvents: 'none',
+});
+
+export const topBadge = recipe({
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '4px',
+    padding: '4px 10px',
+    borderRadius: '999px',
+    fontSize: '0.75rem',
+    fontWeight: 700,
     backdropFilter: 'blur(8px)',
+    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+  },
+  variants: {
+    variant: {
+      sponsored: {
+        background: 'rgba(255, 255, 255, 0.92)',
+        color: '#7c3aed',
+      },
+      match: {
+        background: 'rgba(34, 197, 94, 0.92)',
+        color: 'white',
+      },
+    },
+  },
+});
+
+/* Bottom info layered over image */
+export const cardContent = style({
+  position: 'absolute',
+  left: 0,
+  right: 0,
+  bottom: 0,
+  padding: '20px 22px 24px',
+  color: 'white',
+  zIndex: 2,
+  pointerEvents: 'none',
+});
+
+export const nameRow = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: '10px',
+  flexWrap: 'wrap',
+  marginBottom: '6px',
+});
+
+export const petName = style({
+  fontSize: '2rem',
+  fontWeight: 800,
+  margin: 0,
+  color: 'white',
+  letterSpacing: '-0.02em',
+  textShadow: '0 2px 8px rgba(0, 0, 0, 0.4)',
+  lineHeight: 1.1,
+});
+
+export const petAge = style({
+  fontSize: '1.4rem',
+  fontWeight: 500,
+  color: 'rgba(255, 255, 255, 0.92)',
+  textShadow: '0 2px 8px rgba(0, 0, 0, 0.4)',
+});
+
+export const metaRow = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: '8px 12px',
+  fontSize: '0.95rem',
+  color: 'rgba(255, 255, 255, 0.95)',
+  textShadow: '0 1px 4px rgba(0, 0, 0, 0.4)',
+  marginBottom: '8px',
+});
+
+export const metaItem = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+});
+
+export const metaDot = style({
+  width: '3px',
+  height: '3px',
+  borderRadius: '50%',
+  background: 'rgba(255, 255, 255, 0.6)',
+});
+
+export const description = style({
+  fontSize: '0.9rem',
+  lineHeight: 1.4,
+  color: 'rgba(255, 255, 255, 0.92)',
+  textShadow: '0 1px 4px rgba(0, 0, 0, 0.4)',
+  marginTop: '6px',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+});
+
+export const chipsRow = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '6px',
+  marginTop: '10px',
+});
+
+export const chip = recipe({
+  base: {
+    padding: '4px 10px',
+    borderRadius: '999px',
+    fontSize: '0.75rem',
+    fontWeight: 600,
+    background: 'rgba(255, 255, 255, 0.18)',
+    color: 'white',
+    backdropFilter: 'blur(8px)',
+    border: '1px solid rgba(255, 255, 255, 0.25)',
+  },
+  variants: {
+    variant: {
+      default: {},
+      breed: { background: 'rgba(255, 255, 255, 0.22)' },
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});
+
+/* Info button (chevron) to expand details */
+export const infoButton = style({
+  position: 'absolute',
+  right: '16px',
+  bottom: '24px',
+  width: '40px',
+  height: '40px',
+  borderRadius: '50%',
+  background: 'rgba(255, 255, 255, 0.18)',
+  border: '1px solid rgba(255, 255, 255, 0.3)',
+  color: 'white',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  backdropFilter: 'blur(8px)',
+  fontSize: '1.4rem',
+  pointerEvents: 'auto',
+  zIndex: 5,
+  transition: 'all 0.2s ease',
+  ':hover': {
+    background: 'rgba(255, 255, 255, 0.28)',
+    transform: 'translateY(-2px)',
+  },
+});
+
+/* Login prompt overlay */
+export const loginPromptOverlay = recipe({
+  base: {
+    position: 'absolute',
+    inset: 0,
+    background: 'rgba(0, 0, 0, 0.75)',
+    backdropFilter: 'blur(10px)',
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
-    zIndex: 10,
-    borderRadius: '20px',
+    zIndex: 20,
+    borderRadius: '24px',
     textAlign: 'center',
     padding: '2rem',
   },
   variants: {
     show: {
-      true: {
-        display: 'flex',
-      },
-      false: {
-        display: 'none',
-      },
+      true: { display: 'flex' },
+      false: { display: 'none' },
     },
   },
   defaultVariants: { show: false },
 });
 
 export const promptIcon = style({
-  fontSize: '3rem',
+  fontSize: '3.5rem',
   marginBottom: '1rem',
-  color: '#4ecdc4',
 });
 
 export const promptTitle = style({
   color: 'white',
-  fontSize: '1.2rem',
+  fontSize: '1.4rem',
   marginBottom: '0.5rem',
-  fontWeight: 600,
+  fontWeight: 700,
 });
 
 export const promptText = style({
-  color: 'rgba(255, 255, 255, 0.8)',
-  fontSize: '0.9rem',
-  lineHeight: 1.4,
+  color: 'rgba(255, 255, 255, 0.85)',
+  fontSize: '0.95rem',
+  lineHeight: 1.5,
   marginBottom: '1.5rem',
+  maxWidth: '280px',
 });
 
 export const promptButton = style({
-  background: 'linear-gradient(45deg, #4ecdc4, #44a08d)',
+  background: 'linear-gradient(135deg, #4ecdc4, #44a08d)',
   color: 'white',
   border: 'none',
-  padding: '0.75rem 1.5rem',
-  borderRadius: '12px',
-  fontWeight: 600,
-  fontSize: '0.9rem',
+  padding: '0.85rem 1.75rem',
+  borderRadius: '999px',
+  fontWeight: 700,
+  fontSize: '0.95rem',
   cursor: 'pointer',
-  transition: 'all 0.3s ease',
-  boxShadow: '0 4px 15px rgba(78, 205, 196, 0.3)',
+  transition: 'all 0.2s ease',
+  boxShadow: '0 6px 20px rgba(78, 205, 196, 0.4)',
   ':hover': {
     transform: 'translateY(-2px)',
-    boxShadow: '0 6px 20px rgba(78, 205, 196, 0.4)',
+    boxShadow: '0 8px 24px rgba(78, 205, 196, 0.5)',
   },
 });

--- a/app.client/src/components/swipe/SwipeCard.tsx
+++ b/app.client/src/components/swipe/SwipeCard.tsx
@@ -65,7 +65,7 @@ const formatAge = (pet: DiscoveryPet): string => {
 };
 
 const formatDistance = (distance?: number): string | null => {
-  if (distance == null) {
+  if (distance === undefined || distance === null) {
     return null;
   }
   if (distance < 1) {
@@ -175,12 +175,8 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
   }));
 
   // Live drag stamp opacities (computed from x/y in a derived style)
-  const likeOpacity = to([x], (vx: number) =>
-    Math.min(1, Math.max(0, vx / STAMP_FADE_DISTANCE))
-  );
-  const passOpacity = to([x], (vx: number) =>
-    Math.min(1, Math.max(0, -vx / STAMP_FADE_DISTANCE))
-  );
+  const likeOpacity = to([x], (vx: number) => Math.min(1, Math.max(0, vx / STAMP_FADE_DISTANCE)));
+  const passOpacity = to([x], (vx: number) => Math.min(1, Math.max(0, -vx / STAMP_FADE_DISTANCE)));
   const superOpacity = to([x, y], (vx: number, vy: number) => {
     if (Math.abs(vx) > 60) return 0;
     return Math.min(1, Math.max(0, -vy / STAMP_FADE_DISTANCE));
@@ -377,9 +373,9 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
           </>
         )}
 
-        {(pet.isSponsored || pet.compatibilityScore != null) && (
+        {(pet.isSponsored || pet.compatibilityScore !== undefined && pet.compatibilityScore !== null) && (
           <div className={styles.topBadges}>
-            {pet.compatibilityScore != null && pet.compatibilityScore >= 0.7 && (
+            {pet.compatibilityScore !== undefined && pet.compatibilityScore !== null && pet.compatibilityScore >= 0.7 && (
               <span className={styles.topBadge({ variant: 'match' })}>
                 <MdVerified /> {Math.round(pet.compatibilityScore * 100)}% match
               </span>
@@ -454,9 +450,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
             </div>
           )}
 
-          {pet.shortDescription && (
-            <p className={styles.description}>{pet.shortDescription}</p>
-          )}
+          {pet.shortDescription && <p className={styles.description}>{pet.shortDescription}</p>}
         </div>
 
         {isTop && (

--- a/app.client/src/components/swipe/SwipeCard.tsx
+++ b/app.client/src/components/swipe/SwipeCard.tsx
@@ -284,6 +284,10 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
 
   const age = formatAge(pet);
   const distanceLabel = formatDistance(pet.distance);
+  const compatibilityScore =
+    pet.compatibilityScore !== undefined && pet.compatibilityScore !== null
+      ? pet.compatibilityScore
+      : null;
   const placeholderBackground =
     petTypeGradients[pet.type ?? ''] ?? 'linear-gradient(135deg, #fa709a 0%, #fee140 100%)';
 
@@ -373,11 +377,11 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
           </>
         )}
 
-        {(pet.isSponsored || pet.compatibilityScore !== undefined && pet.compatibilityScore !== null) && (
+        {(pet.isSponsored || compatibilityScore !== null) && (
           <div className={styles.topBadges}>
-            {pet.compatibilityScore !== undefined && pet.compatibilityScore !== null && pet.compatibilityScore >= 0.7 && (
+            {compatibilityScore !== null && compatibilityScore >= 0.7 && (
               <span className={styles.topBadge({ variant: 'match' })}>
-                <MdVerified /> {Math.round(pet.compatibilityScore * 100)}% match
+                <MdVerified /> {Math.round(compatibilityScore * 100)}% match
               </span>
             )}
             {pet.isSponsored && (

--- a/app.client/src/components/swipe/SwipeCard.tsx
+++ b/app.client/src/components/swipe/SwipeCard.tsx
@@ -1,12 +1,20 @@
 import { useStatsig } from '@/hooks/useStatsig';
 import { DiscoveryPet } from '@/services';
-import { animated, useSpring } from '@react-spring/web';
+import { ProgressiveImage } from '@adopt-dont-shop/lib.components';
+import { animated, to, useSpring } from '@react-spring/web';
 import { useDrag } from '@use-gesture/react';
 import React, { useCallback, useRef, useState } from 'react';
-import { MdCheckCircle, MdPets, MdRefresh, MdStar } from 'react-icons/md';
+import {
+  MdCheckCircle,
+  MdExpandLess,
+  MdLocationOn,
+  MdPets,
+  MdRefresh,
+  MdStar,
+  MdVerified,
+} from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { resolveFileUrl } from '../../utils/fileUtils';
-import { ProgressiveImage } from '@adopt-dont-shop/lib.components';
 import * as styles from './SwipeCard.css';
 
 interface SwipeCardProps {
@@ -25,13 +33,6 @@ const petTypeGradients: Record<string, string> = {
   bird: 'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)',
 };
 
-const overlayColors: Record<string, string> = {
-  like: 'rgba(76, 217, 100, 0.9)',
-  pass: 'rgba(255, 59, 92, 0.9)',
-  super_like: 'rgba(0, 149, 246, 0.9)',
-  info: 'rgba(255, 193, 7, 0.9)',
-};
-
 const PlaceholderIcon: React.FC<{ isLoading?: boolean; petType?: string }> = ({
   isLoading,
   petType,
@@ -39,7 +40,6 @@ const PlaceholderIcon: React.FC<{ isLoading?: boolean; petType?: string }> = ({
   if (isLoading) {
     return <MdRefresh className={styles.placeholderIconSpin} />;
   }
-
   switch (petType) {
     case 'dog':
       return <MdPets className='placeholder-icon' />;
@@ -51,7 +51,36 @@ const PlaceholderIcon: React.FC<{ isLoading?: boolean; petType?: string }> = ({
 };
 
 const SWIPE_THRESHOLD = 100;
-const ROTATION_MULTIPLIER = 0.1;
+const ROTATION_MULTIPLIER = 0.08;
+const STAMP_FADE_DISTANCE = 120;
+
+const formatAge = (pet: DiscoveryPet): string => {
+  if (pet.ageYears && pet.ageYears > 0) {
+    return `${pet.ageYears} yr${pet.ageYears > 1 ? 's' : ''}`;
+  }
+  if (pet.ageMonths && pet.ageMonths > 0) {
+    return `${pet.ageMonths} mo`;
+  }
+  return pet.ageGroup ?? '';
+};
+
+const formatDistance = (distance?: number): string | null => {
+  if (distance == null) {
+    return null;
+  }
+  if (distance < 1) {
+    return '< 1 mi';
+  }
+  return `${Math.round(distance)} mi away`;
+};
+
+const sizeLabels: Record<string, string> = {
+  extra_small: 'XS',
+  small: 'Small',
+  medium: 'Medium',
+  large: 'Large',
+  extra_large: 'XL',
+};
 
 export const SwipeCard: React.FC<SwipeCardProps> = ({
   pet,
@@ -61,12 +90,11 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
   style,
   disabled = false,
 }) => {
-  const [overlayAction, setOverlayAction] = useState<string>('');
   const cardRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
   const { logEvent } = useStatsig();
+  const [imageIndex, setImageIndex] = useState(0);
 
-  // Log when card is displayed
   React.useEffect(() => {
     if (isTop) {
       logEvent('swipe_card_displayed', 1, {
@@ -80,36 +108,28 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
     }
   }, [isTop, pet, logEvent]);
 
-  // Keyboard navigation handler
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (!isTop) {
         return;
       }
-
-      let action: string = '';
+      let action = '';
       switch (event.key) {
         case 'ArrowLeft':
           event.preventDefault();
-          if (disabled) {
-            return;
-          }
+          if (disabled) return;
           action = 'pass';
           onSwipe('pass', pet.petId);
           break;
         case 'ArrowRight':
           event.preventDefault();
-          if (disabled) {
-            return;
-          }
+          if (disabled) return;
           action = 'like';
           onSwipe('like', pet.petId);
           break;
         case 'ArrowUp':
           event.preventDefault();
-          if (disabled) {
-            return;
-          }
+          if (disabled) return;
           action = 'super_like';
           onSwipe('super_like', pet.petId);
           break;
@@ -129,15 +149,11 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
           break;
         case 'Escape':
           event.preventDefault();
-          if (disabled) {
-            return;
-          }
+          if (disabled) return;
           action = 'pass';
           onSwipe('pass', pet.petId);
           break;
       }
-
-      // Log keyboard interaction
       if (action) {
         logEvent('swipe_keyboard_action', 1, {
           pet_id: pet.petId,
@@ -150,20 +166,25 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
     [isTop, onSwipe, pet, navigate, logEvent, disabled]
   );
 
-  const [{ x, y, rotate, scale, opacity }, api] = useSpring(() => ({
+  const [{ x, y, rotate, opacity }, api] = useSpring(() => ({
     x: 0,
     y: 0,
     rotate: 0,
-    scale: 1,
     opacity: 1,
     config: { tension: 300, friction: 30 },
   }));
 
-  const [overlaySpring, overlayApi] = useSpring(() => ({
-    opacity: 0,
-    scale: 0.8,
-    config: { tension: 400, friction: 25 },
-  }));
+  // Live drag stamp opacities (computed from x/y in a derived style)
+  const likeOpacity = to([x], (vx: number) =>
+    Math.min(1, Math.max(0, vx / STAMP_FADE_DISTANCE))
+  );
+  const passOpacity = to([x], (vx: number) =>
+    Math.min(1, Math.max(0, -vx / STAMP_FADE_DISTANCE))
+  );
+  const superOpacity = to([x, y], (vx: number, vy: number) => {
+    if (Math.abs(vx) > 60) return 0;
+    return Math.min(1, Math.max(0, -vy / STAMP_FADE_DISTANCE));
+  });
 
   const bind = useDrag(
     ({
@@ -172,86 +193,39 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
       velocity: [vx],
       direction: [dx],
       cancel,
+      tap,
     }: {
       active: boolean;
       movement: [number, number];
       velocity: [number, number];
       direction: [number, number];
       cancel?: () => void;
+      tap?: boolean;
     }) => {
-      if (!isTop || disabled) {
+      if (!isTop || disabled || tap) {
         return;
       }
 
       const trigger = Math.abs(mx) > SWIPE_THRESHOLD;
+      const isSuperGesture = my < -SWIPE_THRESHOLD && Math.abs(mx) < 60;
       const isFlick = Math.abs(vx) > 0.5;
 
-      let action = '';
-      if (Math.abs(mx) > 50) {
-        if (mx > 0) {
-          action = 'like';
-        } else {
-          action = 'pass';
-        }
-      } else if (my < -50) {
-        action = 'super_like';
-      } else if (my > 50) {
-        action = 'info';
-      }
-
-      // Update overlay
-      if (active && action !== overlayAction) {
-        setOverlayAction(action);
-        overlayApi.start({
-          opacity: action ? 1 : 0,
-          scale: action ? 1 : 0.8,
-        });
-      }
-
       if (active) {
-        // Card follows the drag
         api.start({
           x: mx,
           y: my,
           rotate: mx * ROTATION_MULTIPLIER,
-          scale: 1.05,
           immediate: true,
         });
       } else {
-        // Released
-        overlayApi.start({ opacity: 0, scale: 0.8 });
-        setOverlayAction('');
-
-        if (trigger || isFlick) {
-          // Handle special actions based on movement patterns
-          let finalAction: 'like' | 'pass' | 'super_like' | 'info';
-          if (overlayAction === 'info' && my > 50) {
-            // Navigate to pet details instead of swiping away
-            logEvent('swipe_pet_details_viewed', 1, {
-              pet_id: pet.petId,
-              pet_name: pet.name || 'unknown',
-              pet_type: pet.type || 'unknown',
-              interaction_method: 'swipe_down',
-              movement_y: my.toString(),
-            });
-            navigate(`/pets/${pet.petId}`);
-            // Reset card position
-            api.start({
-              x: 0,
-              y: 0,
-              rotate: 0,
-              scale: 1,
-              opacity: 1,
-            });
-            return;
-          } else if (overlayAction === 'super_like' && my < -50) {
+        if (trigger || isFlick || isSuperGesture) {
+          let finalAction: 'like' | 'pass' | 'super_like';
+          if (isSuperGesture) {
             finalAction = 'super_like';
           } else {
-            // Regular horizontal swipe
             finalAction = mx > 0 ? 'like' : 'pass';
           }
 
-          // Log swipe action
           logEvent('swipe_action_performed', 1, {
             pet_id: pet.petId,
             pet_name: pet.name || 'unknown',
@@ -265,76 +239,73 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
             is_flick: isFlick.toString(),
           });
 
-          // Animate card off screen
+          const exitX = finalAction === 'pass' ? -800 : finalAction === 'like' ? 800 : 0;
+          const exitY = finalAction === 'super_like' ? -900 : my * 0.5;
+
           api.start({
-            x: dx * 1000,
-            y: my + dx * 1000 * 0.1,
-            rotate: dx * 30,
-            scale: 0.8,
+            x: exitX,
+            y: exitY,
+            rotate: finalAction === 'super_like' ? 0 : dx * 25,
             opacity: 0,
-            config: { tension: 200, friction: 20 },
+            config: { tension: 220, friction: 24 },
           });
 
-          // Trigger callback after a short delay
-          setTimeout(() => {
-            onSwipe(finalAction, pet.petId);
-          }, 100);
-
-          if (cancel) {
-            cancel();
-          }
+          setTimeout(() => onSwipe(finalAction, pet.petId), 120);
+          if (cancel) cancel();
         } else {
-          // Return to center
-          api.start({
-            x: 0,
-            y: 0,
-            rotate: 0,
-            scale: 1,
-            opacity: 1,
-          });
+          api.start({ x: 0, y: 0, rotate: 0, opacity: 1 });
         }
       }
     },
     {
-      axis: undefined,
-      bounds: { left: -300, right: 300, top: -200, bottom: 200 },
-      rubberband: true,
+      filterTaps: true,
+      bounds: { left: -400, right: 400, top: -300, bottom: 200 },
+      rubberband: 0.15,
     }
   );
 
-  const primaryImage = pet.images?.[0];
+  const images = pet.images && pet.images.length > 0 ? pet.images : [];
+  const currentImage = images[imageIndex];
+  const imageUrl = resolveFileUrl(currentImage);
+  const hasMultipleImages = images.length > 1;
 
-  const imageUrl = resolveFileUrl(primaryImage);
+  const cycleImage = (delta: number) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!hasMultipleImages) return;
+    setImageIndex(prev => (prev + delta + images.length) % images.length);
+  };
 
-  // Calculate age display - handle undefined values properly
-  let age = '';
-  if (pet.ageYears && pet.ageYears > 0) {
-    age = `${pet.ageYears}y`;
-  } else if (pet.ageMonths && pet.ageMonths > 0) {
-    age = `${pet.ageMonths}m`;
-  } else {
-    // Fallback to age group if specific age not available
-    age = pet.ageGroup || 'Unknown age';
-  }
+  const openDetails = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    logEvent('swipe_pet_details_viewed', 1, {
+      pet_id: pet.petId,
+      pet_name: pet.name || 'unknown',
+      pet_type: pet.type || 'unknown',
+      interaction_method: 'info_button',
+    });
+    navigate(`/pets/${pet.petId}`);
+  };
 
+  const age = formatAge(pet);
+  const distanceLabel = formatDistance(pet.distance);
   const placeholderBackground =
     petTypeGradients[pet.type ?? ''] ?? 'linear-gradient(135deg, #fa709a 0%, #fee140 100%)';
 
   return (
     <animated.div
       ref={cardRef}
-      {...(disabled ? {} : bind())}
+      {...(disabled || !isTop ? {} : bind())}
       className={styles.cardContainer({ isTop, disabled })}
       tabIndex={isTop ? 0 : -1}
       onKeyDown={handleKeyDown}
       role='button'
-      aria-label={`${pet.name}, ${pet.breed}, ${age} old. Use arrow keys to swipe or Enter to view details.`}
+      aria-label={`${pet.name}, ${pet.breed ?? pet.type}, ${age}. Swipe right to like, left to pass, up to super like, or press Enter for details.`}
       style={{
         ...style,
         zIndex,
-        transform: x.to(
-          (x: number) =>
-            `translateX(${x}px) translateY(${y.get()}px) rotate(${rotate.get()}deg) scale(${scale.get()})`
+        transform: to(
+          [x, y, rotate],
+          (vx, vy, vr) => `translate3d(${vx}px, ${vy}px, 0) rotate(${vr}deg)`
         ),
         opacity,
       }}
@@ -376,35 +347,128 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
           </div>
         )}
 
-        <animated.div
-          className={styles.swipeOverlay}
-          style={{
-            opacity: overlaySpring.opacity,
-            transform: overlaySpring.scale.to(s => `translate(-50%, -50%) scale(${s})`),
-            background: overlayColors[overlayAction] ?? 'transparent',
-          }}
-        >
-          {overlayAction === 'like' && '❤️'}
-          {overlayAction === 'pass' && '❌'}
-          {overlayAction === 'super_like' && '⭐'}
-          {overlayAction === 'info' && 'ℹ️'}
-        </animated.div>
-      </div>
+        <div className={styles.gradientScrim} />
 
-      <div className={styles.cardContent}>
-        <div>
-          <h3 className={styles.petName}>{pet.name}</h3>
-          <div className={styles.petDetails}>
-            <div className={styles.detailRow}>
-              <span className={styles.badge({ variant: 'age' })}>{age} old</span>
-              <span className={styles.badge({ variant: 'size' })}>{pet.size}</span>
+        {hasMultipleImages && (
+          <>
+            <div className={styles.imageDots} aria-hidden='true'>
+              {images.map((src, i) => (
+                <div key={src + i} className={styles.imageDot({ active: i === imageIndex })} />
+              ))}
             </div>
-            <div className={styles.detailRow}>
-              <span className={styles.badge({ variant: 'breed' })}>{pet.breed}</span>
-              <span>{pet.gender}</span>
-            </div>
+            {isTop && (
+              <>
+                <button
+                  type='button'
+                  className={styles.tapZone({ side: 'left' })}
+                  onClick={cycleImage(-1)}
+                  aria-label='Previous photo'
+                  tabIndex={-1}
+                />
+                <button
+                  type='button'
+                  className={styles.tapZone({ side: 'right' })}
+                  onClick={cycleImage(1)}
+                  aria-label='Next photo'
+                  tabIndex={-1}
+                />
+              </>
+            )}
+          </>
+        )}
+
+        {(pet.isSponsored || pet.compatibilityScore != null) && (
+          <div className={styles.topBadges}>
+            {pet.compatibilityScore != null && pet.compatibilityScore >= 0.7 && (
+              <span className={styles.topBadge({ variant: 'match' })}>
+                <MdVerified /> {Math.round(pet.compatibilityScore * 100)}% match
+              </span>
+            )}
+            {pet.isSponsored && (
+              <span className={styles.topBadge({ variant: 'sponsored' })}>
+                <MdStar /> Featured
+              </span>
+            )}
           </div>
+        )}
+
+        {isTop && (
+          <>
+            <animated.div
+              className={styles.stamp({ variant: 'like' })}
+              style={{ opacity: likeOpacity }}
+              aria-hidden='true'
+            >
+              Like
+            </animated.div>
+            <animated.div
+              className={styles.stamp({ variant: 'pass' })}
+              style={{ opacity: passOpacity }}
+              aria-hidden='true'
+            >
+              Nope
+            </animated.div>
+            <animated.div
+              className={styles.stamp({ variant: 'super_like' })}
+              style={{ opacity: superOpacity }}
+              aria-hidden='true'
+            >
+              Super Like
+            </animated.div>
+          </>
+        )}
+
+        <div className={styles.cardContent}>
+          <div className={styles.nameRow}>
+            <h3 className={styles.petName}>{pet.name}</h3>
+            {age && <span className={styles.petAge}>{age}</span>}
+          </div>
+
+          <div className={styles.metaRow}>
+            {pet.breed && <span className={styles.metaItem}>{pet.breed}</span>}
+            {pet.gender && pet.gender !== 'unknown' && (
+              <>
+                <span className={styles.metaDot} />
+                <span className={styles.metaItem} style={{ textTransform: 'capitalize' }}>
+                  {pet.gender}
+                </span>
+              </>
+            )}
+            {pet.size && (
+              <>
+                <span className={styles.metaDot} />
+                <span className={styles.metaItem}>{sizeLabels[pet.size] ?? pet.size}</span>
+              </>
+            )}
+          </div>
+
+          {(pet.rescueName || distanceLabel) && (
+            <div className={styles.metaRow}>
+              {distanceLabel && (
+                <span className={styles.metaItem}>
+                  <MdLocationOn /> {distanceLabel}
+                </span>
+              )}
+              {pet.rescueName && distanceLabel && <span className={styles.metaDot} />}
+              {pet.rescueName && <span className={styles.metaItem}>{pet.rescueName}</span>}
+            </div>
+          )}
+
+          {pet.shortDescription && (
+            <p className={styles.description}>{pet.shortDescription}</p>
+          )}
         </div>
+
+        {isTop && (
+          <button
+            type='button'
+            className={styles.infoButton}
+            onClick={openDetails}
+            aria-label={`View full details for ${pet.name}`}
+          >
+            <MdExpandLess />
+          </button>
+        )}
       </div>
 
       <div className={styles.loginPromptOverlay({ show: disabled && isTop })}>

--- a/app.client/src/components/swipe/SwipeControls.css.ts
+++ b/app.client/src/components/swipe/SwipeControls.css.ts
@@ -6,11 +6,11 @@ export const controlsContainer = style({
   justifyContent: 'center',
   alignItems: 'center',
   gap: '1rem',
-  padding: '1rem',
+  padding: '1.25rem 1rem',
   '@media': {
-    '(max-width: 768px)': {
+    '(max-width: 480px)': {
       gap: '0.75rem',
-      padding: '0.75rem',
+      padding: '1rem 0.5rem',
     },
   },
 });
@@ -23,73 +23,91 @@ export const actionButton = recipe({
     alignItems: 'center',
     justifyContent: 'center',
     cursor: 'pointer',
-    transition: 'all 0.2s ease',
+    transition: 'transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease',
+    background: 'white',
     fontSize: '1.5rem',
+    flexShrink: 0,
     ':disabled': {
-      opacity: 0.5,
+      opacity: 0.4,
       cursor: 'not-allowed',
+    },
+    ':focus-visible': {
+      outline: '3px solid rgba(78, 205, 196, 0.6)',
+      outlineOffset: '2px',
     },
     selectors: {
       '&:not(:disabled):hover': {
-        transform: 'scale(1.1)',
-        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+        transform: 'translateY(-3px)',
       },
       '&:not(:disabled):active': {
-        transform: 'scale(0.95)',
+        transform: 'translateY(0) scale(0.95)',
       },
     },
   },
   variants: {
     variant: {
-      pass: {
-        width: '50px',
-        height: '50px',
-        background: '#ff6b6b',
-        color: 'white',
-        boxShadow: '0 2px 8px rgba(255, 107, 107, 0.3)',
+      undo: {
+        width: '48px',
+        height: '48px',
+        color: '#f59e0b',
+        boxShadow: '0 4px 14px rgba(245, 158, 11, 0.25)',
+        fontSize: '1.3rem',
         selectors: {
           '&:not(:disabled):hover': {
-            background: '#ee5a5a',
-            boxShadow: '0 4px 12px rgba(255, 107, 107, 0.4)',
+            boxShadow: '0 8px 22px rgba(245, 158, 11, 0.35)',
+            background: '#fffbeb',
+          },
+        },
+      },
+      pass: {
+        width: '64px',
+        height: '64px',
+        color: '#ef4444',
+        boxShadow: '0 6px 18px rgba(239, 68, 68, 0.3)',
+        fontSize: '1.9rem',
+        selectors: {
+          '&:not(:disabled):hover': {
+            boxShadow: '0 10px 28px rgba(239, 68, 68, 0.4)',
+            background: '#fef2f2',
           },
         },
       },
       info: {
-        width: '45px',
-        height: '45px',
-        background: '#ffd93d',
-        color: 'white',
-        boxShadow: '0 2px 8px rgba(255, 217, 61, 0.3)',
+        width: '48px',
+        height: '48px',
+        color: '#8b5cf6',
+        boxShadow: '0 4px 14px rgba(139, 92, 246, 0.25)',
+        fontSize: '1.3rem',
         selectors: {
           '&:not(:disabled):hover': {
-            background: '#ffcd02',
-            boxShadow: '0 4px 12px rgba(255, 217, 61, 0.4)',
-          },
-        },
-      },
-      like: {
-        width: '60px',
-        height: '60px',
-        background: '#4ecdc4',
-        color: 'white',
-        boxShadow: '0 2px 8px rgba(78, 205, 196, 0.3)',
-        selectors: {
-          '&:not(:disabled):hover': {
-            background: '#45b7b8',
-            boxShadow: '0 4px 12px rgba(78, 205, 196, 0.4)',
+            boxShadow: '0 8px 22px rgba(139, 92, 246, 0.35)',
+            background: '#f5f3ff',
           },
         },
       },
       super: {
-        width: '45px',
-        height: '45px',
-        background: '#74b9ff',
-        color: 'white',
-        boxShadow: '0 2px 8px rgba(116, 185, 255, 0.3)',
+        width: '48px',
+        height: '48px',
+        color: '#0ea5e9',
+        boxShadow: '0 4px 14px rgba(14, 165, 233, 0.25)',
+        fontSize: '1.3rem',
         selectors: {
           '&:not(:disabled):hover': {
-            background: '#0984e3',
-            boxShadow: '0 4px 12px rgba(116, 185, 255, 0.4)',
+            boxShadow: '0 8px 22px rgba(14, 165, 233, 0.35)',
+            background: '#f0f9ff',
+          },
+        },
+      },
+      like: {
+        width: '64px',
+        height: '64px',
+        color: '#22c55e',
+        boxShadow: '0 6px 18px rgba(34, 197, 94, 0.3)',
+        fontSize: '1.9rem',
+        selectors: {
+          '&:not(:disabled):hover': {
+            boxShadow: '0 10px 28px rgba(34, 197, 94, 0.4)',
+            background: '#f0fdf4',
           },
         },
       },
@@ -101,4 +119,5 @@ export const actionButton = recipe({
 export const buttonIcon = style({
   fontSize: 'inherit',
   lineHeight: 1,
+  display: 'flex',
 });

--- a/app.client/src/components/swipe/SwipeControls.tsx
+++ b/app.client/src/components/swipe/SwipeControls.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import { MdClose, MdFavorite, MdInfo, MdStar } from 'react-icons/md';
+import { MdClose, MdFavorite, MdInfoOutline, MdReplay, MdStar } from 'react-icons/md';
 import * as styles from './SwipeControls.css';
 
 interface SwipeControlsProps {
   onAction: (action: 'pass' | 'info' | 'like' | 'super_like') => void;
+  onUndo?: () => void;
+  canUndo?: boolean;
   disabled?: boolean;
   className?: string;
 }
 
 export const SwipeControls: React.FC<SwipeControlsProps> = ({
   onAction,
+  onUndo,
+  canUndo = false,
   disabled = false,
   className,
 }) => {
@@ -20,12 +24,32 @@ export const SwipeControls: React.FC<SwipeControlsProps> = ({
   };
 
   return (
-    <div className={`${styles.controlsContainer}${className ? ` ${className}` : ''}`}>
+    <div
+      className={`${styles.controlsContainer}${className ? ` ${className}` : ''}`}
+      role='group'
+      aria-label='Swipe actions'
+    >
+      {onUndo && (
+        <button
+          className={styles.actionButton({ variant: 'undo' })}
+          onClick={onUndo}
+          disabled={disabled || !canUndo}
+          aria-label='Undo last swipe'
+          title='Undo last swipe'
+          type='button'
+        >
+          <span className={styles.buttonIcon}>
+            <MdReplay />
+          </span>
+        </button>
+      )}
+
       <button
         className={styles.actionButton({ variant: 'pass' })}
         onClick={() => handleAction('pass')}
         disabled={disabled}
-        title='Pass - Not interested'
+        aria-label='Pass on this pet'
+        title='Pass — not interested'
         type='button'
       >
         <span className={styles.buttonIcon}>
@@ -34,14 +58,15 @@ export const SwipeControls: React.FC<SwipeControlsProps> = ({
       </button>
 
       <button
-        className={styles.actionButton({ variant: 'info' })}
-        onClick={() => handleAction('info')}
+        className={styles.actionButton({ variant: 'super' })}
+        onClick={() => handleAction('super_like')}
         disabled={disabled}
-        title='Info - View details'
+        aria-label='Super like this pet'
+        title='Super Like — priority interest'
         type='button'
       >
         <span className={styles.buttonIcon}>
-          <MdInfo />
+          <MdStar />
         </span>
       </button>
 
@@ -49,7 +74,8 @@ export const SwipeControls: React.FC<SwipeControlsProps> = ({
         className={styles.actionButton({ variant: 'like' })}
         onClick={() => handleAction('like')}
         disabled={disabled}
-        title='Like - Add to favorites'
+        aria-label='Like this pet'
+        title='Like — add to favorites'
         type='button'
       >
         <span className={styles.buttonIcon}>
@@ -58,14 +84,15 @@ export const SwipeControls: React.FC<SwipeControlsProps> = ({
       </button>
 
       <button
-        className={styles.actionButton({ variant: 'super' })}
-        onClick={() => handleAction('super_like')}
+        className={styles.actionButton({ variant: 'info' })}
+        onClick={() => handleAction('info')}
         disabled={disabled}
-        title='Super Like - Priority interest'
+        aria-label='View pet details'
+        title='View full details'
         type='button'
       >
         <span className={styles.buttonIcon}>
-          <MdStar />
+          <MdInfoOutline />
         </span>
       </button>
     </div>

--- a/app.client/src/components/swipe/SwipeStack.css.ts
+++ b/app.client/src/components/swipe/SwipeStack.css.ts
@@ -63,8 +63,7 @@ export const skeletonCard = style({
   maxWidth: '380px',
   height: '620px',
   borderRadius: '24px',
-  background:
-    'linear-gradient(90deg, #f1f5f9 0%, #e2e8f0 40%, #f1f5f9 80%)',
+  background: 'linear-gradient(90deg, #f1f5f9 0%, #e2e8f0 40%, #f1f5f9 80%)',
   backgroundSize: '800px 100%',
   animationName: shimmer,
   animationDuration: '1.4s',

--- a/app.client/src/components/swipe/SwipeStack.css.ts
+++ b/app.client/src/components/swipe/SwipeStack.css.ts
@@ -1,18 +1,23 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
+
+const shimmer = keyframes({
+  '0%': { backgroundPosition: '-400px 0' },
+  '100%': { backgroundPosition: '400px 0' },
+});
 
 export const stackContainer = style({
   position: 'relative',
   width: '100%',
-  maxWidth: '400px',
-  height: '600px',
+  maxWidth: '420px',
+  height: '640px',
   margin: '0 auto',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   '@media': {
     '(max-width: 768px)': {
-      height: '70vh',
-      maxWidth: '90vw',
+      height: 'min(70vh, 660px)',
+      maxWidth: 'min(92vw, 420px)',
     },
   },
 });
@@ -23,25 +28,53 @@ export const emptyState = style({
   alignItems: 'center',
   justifyContent: 'center',
   height: '100%',
+  width: '100%',
   textAlign: 'center',
-  color: '#666',
+  color: '#475569',
   padding: '2rem',
+  background: 'linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%)',
+  borderRadius: '24px',
+  border: '2px dashed #cbd5e1',
 });
 
 export const emptyIcon = style({
   fontSize: '4rem',
   marginBottom: '1rem',
-  opacity: 0.5,
+  opacity: 0.7,
 });
 
 export const emptyTitle = style({
-  fontSize: '1.5rem',
+  fontSize: '1.4rem',
+  fontWeight: 700,
   marginBottom: '0.5rem',
-  color: '#333',
+  color: '#1e293b',
 });
 
 export const emptyText = style({
-  fontSize: '1rem',
+  fontSize: '0.95rem',
   lineHeight: 1.5,
-  maxWidth: '300px',
+  maxWidth: '320px',
+  color: '#64748b',
+});
+
+export const skeletonCard = style({
+  position: 'absolute',
+  width: '100%',
+  maxWidth: '380px',
+  height: '620px',
+  borderRadius: '24px',
+  background:
+    'linear-gradient(90deg, #f1f5f9 0%, #e2e8f0 40%, #f1f5f9 80%)',
+  backgroundSize: '800px 100%',
+  animationName: shimmer,
+  animationDuration: '1.4s',
+  animationIterationCount: 'infinite',
+  animationTimingFunction: 'linear',
+  boxShadow: '0 20px 40px -12px rgba(0, 0, 0, 0.18)',
+  '@media': {
+    '(max-width: 768px)': {
+      maxWidth: 'min(92vw, 420px)',
+      height: 'min(70vh, 640px)',
+    },
+  },
 });

--- a/app.client/src/components/swipe/SwipeStack.tsx
+++ b/app.client/src/components/swipe/SwipeStack.tsx
@@ -16,8 +16,8 @@ interface SwipeStackProps {
 
 const VISIBLE_CARDS = 3;
 const PRELOAD_AHEAD = 5;
-const CARD_SCALE_STEP = 0.05;
-const CARD_Y_OFFSET = 8;
+const CARD_SCALE_STEP = 0.04;
+const CARD_Y_OFFSET = 12;
 
 export const SwipeStack: React.FC<SwipeStackProps> = ({
   pets,


### PR DESCRIPTION
## Summary

The old swipe cards wasted ~30% of the card on a plain text strip, ignored most of the `DiscoveryPet` payload (`shortDescription`, `distance`, `rescueName`, `isSponsored`, `compatibilityScore` were all unused), and used a centered emoji bubble for swipe feedback. This PR redesigns the deck to feel like a modern card-stack UI.

### Card (`SwipeCard`)
- Full-bleed image with a bottom gradient scrim. Name, age, breed, gender, size, rescue name, distance, and short description are layered on the image — surfacing all available pet fields.
- Tilted **LIKE / NOPE / SUPER LIKE** corner stamps whose opacity tracks drag distance in real time, replacing the centered emoji.
- Photo carousel: dots indicator across the top and tap-left / tap-right zones to cycle through `pet.images`.
- Sponsored + compatibility-score badges in the top-right when present.
- Info chevron button to jump to the full pet details page.
- Larger card (380×620), 24px rounded corners, layered shadow, `touch-action: none` for cleaner mobile gestures, and `pointer-events: none` on non-top cards so the drag never fights the stack underneath.

### Controls (`SwipeControls`)
- Added an **Undo** button (restores the previous pet and rolls back session stats).
- Consistent circular icon buttons on a white background, larger touch targets, `:focus-visible` outline, tactile hover/active.
- Reordered to Pass / Super / Like / Info with Like + Pass as the prominent primaries.

### Stack & page
- `SwipeStack`: subtler stack scaling, shimmering skeleton style, and a friendlier empty state.
- `DiscoveryPage`: bounded (10-deep) undo stack wired through `SwipeControls`.

## Test plan
- [ ] Discovery page loads and the top card shows name/age/breed/rescue/distance/description over the photo.
- [ ] Drag right → "Like" stamp fades in, card flies off, next pet shows.
- [ ] Drag left → "Nope" stamp; drag up → "Super Like" stamp.
- [ ] Keyboard: ←/→/↑ trigger pass/like/super_like; Enter/Space opens details.
- [ ] Tap left/right halves of a card with multiple images cycles photos (dots update).
- [ ] Tap the info chevron → navigates to `/pets/:petId`.
- [ ] Click Undo after a swipe → previous pet returns; stats decrement; Undo disables when stack is empty.
- [ ] Mobile (≤768px): card sizes to viewport, controls stay reachable, no horizontal overflow.
- [ ] Login-prompt overlay still appears for disabled state.

---
_Generated by [Claude Code](https://claude.ai/code/session_012eeXov4NZHVFjELQsaUWCi)_