### PR TITLE
fix(auth): invalidate auth cache on User row mutations (ADS-596)

### DIFF
--- a/service.backend/src/__tests__/lib/auth-cache-invalidation.test.ts
+++ b/service.backend/src/__tests__/lib/auth-cache-invalidation.test.ts
@@ -1,0 +1,134 @@
+/**
+ * ADS-596: any persisted change to a cached User field must drop the
+ * in-process auth cache entry so the next authenticated request can't
+ * ride a stale entry through the status / role / emailVerified checks
+ * in `authenticateRequest`.
+ */
+
+import User, { UserStatus, UserType } from '../../models/User';
+import { getCachedUser, setCachedUser, resetAuthCacheForTests } from '../../lib/auth-cache';
+import { UserService } from '../../services/user.service';
+import AdminService from '../../services/admin.service';
+import { AuthService } from '../../services/auth.service';
+
+describe('auth-cache invalidation [ADS-596]', () => {
+  beforeEach(() => {
+    resetAuthCacheForTests();
+  });
+
+  const createCachedUser = async (
+    overrides: Partial<{
+      email: string;
+      status: UserStatus;
+      emailVerified: boolean;
+    }> = {}
+  ) => {
+    const user = await User.create({
+      email: overrides.email ?? `cache-${Date.now()}-${Math.random()}@example.com`,
+      password: 'hashedpassword',
+      firstName: 'Cache',
+      lastName: 'User',
+      userType: UserType.ADOPTER,
+      status: overrides.status ?? UserStatus.ACTIVE,
+      emailVerified: overrides.emailVerified ?? true,
+    });
+    setCachedUser(user.userId, user);
+    return user;
+  };
+
+  it('busts the cache when the User row is saved', async () => {
+    const user = await createCachedUser();
+    expect(getCachedUser(user.userId)).not.toBeNull();
+
+    const fresh = await User.findByPk(user.userId);
+    fresh!.status = UserStatus.INACTIVE;
+    await fresh!.save();
+
+    expect(getCachedUser(user.userId)).toBeNull();
+  });
+
+  it('busts the cache when the User row is destroyed', async () => {
+    const user = await createCachedUser();
+    expect(getCachedUser(user.userId)).not.toBeNull();
+
+    const fresh = await User.findByPk(user.userId);
+    await fresh!.destroy();
+
+    expect(getCachedUser(user.userId)).toBeNull();
+  });
+
+  it('busts the cache on UserService.deactivateUser', async () => {
+    const user = await createCachedUser();
+    expect(getCachedUser(user.userId)).not.toBeNull();
+
+    await UserService.deactivateUser(user.userId, 'admin-id');
+
+    expect(getCachedUser(user.userId)).toBeNull();
+  });
+
+  it('busts the cache on UserService.reactivateUser', async () => {
+    const user = await createCachedUser({ status: UserStatus.INACTIVE });
+    expect(getCachedUser(user.userId)).not.toBeNull();
+
+    await UserService.reactivateUser(user.userId, 'admin-id');
+
+    expect(getCachedUser(user.userId)).toBeNull();
+  });
+
+  it('busts the cache on AdminService.suspendUser / unsuspendUser', async () => {
+    const user = await createCachedUser();
+    expect(getCachedUser(user.userId)).not.toBeNull();
+
+    await AdminService.suspendUser(user.userId, 'admin-id');
+    expect(getCachedUser(user.userId)).toBeNull();
+
+    setCachedUser(user.userId, (await User.findByPk(user.userId)) as User);
+    await AdminService.unsuspendUser(user.userId, 'admin-id');
+    expect(getCachedUser(user.userId)).toBeNull();
+  });
+
+  it('busts the cache for every userId touched by bulkUpdateUsers', async () => {
+    const a = await createCachedUser({ email: 'bulk-a@example.com' });
+    const b = await createCachedUser({ email: 'bulk-b@example.com' });
+    expect(getCachedUser(a.userId)).not.toBeNull();
+    expect(getCachedUser(b.userId)).not.toBeNull();
+
+    await UserService.bulkUpdateUsers(
+      [{ userIds: [a.userId, b.userId], updates: { status: UserStatus.INACTIVE } }],
+      'admin-id'
+    );
+
+    expect(getCachedUser(a.userId)).toBeNull();
+    expect(getCachedUser(b.userId)).toBeNull();
+  });
+
+  it('busts the cache on email verification', async () => {
+    const user = await User.create({
+      email: 'verify@example.com',
+      password: 'hashedpassword',
+      firstName: 'Verify',
+      lastName: 'User',
+      userType: UserType.ADOPTER,
+      status: UserStatus.PENDING_VERIFICATION,
+      emailVerified: false,
+      verificationToken: 'plain-token',
+      verificationTokenExpiresAt: new Date(Date.now() + 60_000),
+    });
+    setCachedUser(user.userId, user);
+    expect(getCachedUser(user.userId)).not.toBeNull();
+
+    const authService = new AuthService();
+    await authService.verifyEmail('plain-token');
+
+    expect(getCachedUser(user.userId)).toBeNull();
+  });
+
+  it('busts the cache on logout when the caller userId is known', async () => {
+    const user = await createCachedUser();
+    expect(getCachedUser(user.userId)).not.toBeNull();
+
+    await AuthService.logout(undefined, undefined, user.userId);
+
+    expect(getCachedUser(user.userId)).toBeNull();
+  });
+});

--- a/service.backend/src/lib/auth-cache.ts
+++ b/service.backend/src/lib/auth-cache.ts
@@ -15,9 +15,12 @@ import type User from '../models/User';
  * - Cached for 60 seconds. Long enough to absorb typical request bursts
  *   from a single page load, short enough that a role change propagates
  *   without an explicit bust.
- * - Role-mutating call sites (`UserRole.create` / `setRoles` /
- *   `removeRole`) explicitly call `invalidateAuthCache(userId)` so the
- *   change takes effect on the next request without waiting for TTL.
+ * - The User model's `afterSave` / `afterDestroy` hooks call
+ *   `invalidateAuthCache(userId)` so any persisted change to the user
+ *   row (status, emailVerified, role, password, 2FA, …) takes effect on
+ *   the next request without waiting for TTL (ADS-596). Call sites that
+ *   bypass instance hooks (`Model.update`, role-only mutations,
+ *   `logout`) invalidate explicitly.
  * - Revoked tokens are checked *before* the cache lookup in
  *   `authenticateRequest`, so a revoked session can't ride a stale
  *   cache entry.

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -8,6 +8,7 @@ import sequelize, {
 } from '../sequelize';
 import { hashPassword, verifyPassword } from '../utils/password';
 import { encryptSecret, hashBackupCode, hashToken } from '../utils/secrets';
+import { invalidateAuthCache } from '../lib/auth-cache';
 import { JsonObject } from '../types/common';
 import { generateUuidV7 } from '../utils/uuid';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
@@ -553,6 +554,19 @@ User.init(
           user.password = await hashPassword(user.password);
         }
         await protectSecretsIfChanged(user);
+      },
+      // ADS-596: blanket auth-cache invalidation. The in-process auth cache
+      // holds the full User instance (status, emailVerified, roles, etc.)
+      // for 60s; any persisted change to those fields must propagate to the
+      // next authenticated request. Doing it here removes the burden from
+      // every individual writer (deactivate, suspend, password reset, 2FA
+      // toggle, email verify, …) and is safe to over-fire — the worst case
+      // is one extra DB round-trip on the next request for that user.
+      afterSave: (user: User) => {
+        invalidateAuthCache(user.userId);
+      },
+      afterDestroy: (user: User) => {
+        invalidateAuthCache(user.userId);
       },
       // Plan 5.6 — every user gets typed pref rows at creation time so
       // consumers can always assume they exist. Defaults are declared on

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -14,6 +14,7 @@ import { getValidatedFrontendOrigin } from '../utils/url-allowlist';
 import { AuditLogService } from './auditLog.service';
 import { redactEmail } from './redact';
 import { env } from '../config/env';
+import { invalidateAuthCache } from '../lib/auth-cache';
 
 import {
   AuthResponse,
@@ -725,6 +726,12 @@ Need help? Contact us at support@adoptdontshop.com
     }
 
     if (!refreshToken) {
+      // ADS-596: bust the auth cache so the next request can't ride a
+      // stale entry past the freshly-revoked access token. Logout doesn't
+      // mutate the User row, so the User-model hook doesn't fire here.
+      if (callerUserId) {
+        invalidateAuthCache(callerUserId);
+      }
       return;
     }
 
@@ -739,6 +746,11 @@ Need help? Contact us at support@adoptdontshop.com
     } catch {
       // Expired or malformed token — nothing to revoke
       logger.info('Logout with invalid or expired token, skipping revocation');
+    }
+
+    // ADS-596: see comment in the early-return branch above.
+    if (callerUserId) {
+      invalidateAuthCache(callerUserId);
     }
   }
 

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -23,6 +23,7 @@ import { UserActivity } from '../types/user';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
 import { redactSensitiveFields } from '../utils/redact';
+import { invalidateAuthCache } from '../lib/auth-cache';
 
 const USER_SORT_FIELDS = [
   'createdAt',
@@ -1308,6 +1309,12 @@ export class UserService {
           },
         },
       });
+
+      // ADS-596: Model.update bypasses the per-instance afterSave hook that
+      // normally busts the auth cache, so we have to do it explicitly here.
+      for (const userId of updates[0].userIds) {
+        invalidateAuthCache(userId);
+      }
 
       // Log bulk update
       await AuditLogService.log({


### PR DESCRIPTION
## Summary

Closes [ADS-596](https://linear.app/ideasquared/issue/ADS-596/auth-cache-not-invalidated-on-status-password-logout-changes-60s).

The 60s in-process auth cache (`service.backend/src/lib/auth-cache.ts`) held the full `User` instance, including `status`, `emailVerified`, role list, etc. Only two call sites busted it, so for up to 60s after suspension / deactivation / role downgrade / password reset / email verification / 2FA changes, `authenticateRequest` returned the stale cached user — letting a suspended account keep issuing authed calls and a downgraded admin keep admin privileges.

## Approach

Per the ticket's proposed fix:

1. **Sequelize `afterSave` / `afterDestroy` hook on the `User` model** — blanket safety. Any persisted change to the user row drops its cache entry, so every writer (`deactivateUser`, `reactivateUser`, `suspendUser`, `unsuspendUser`, `updateUserStatus`, `updateUserRole`, `confirmPasswordReset`, `verifyEmail`, `enableTwoFactor`, `disableTwoFactor`, `deleteAccount`, …) is covered without per-site changes.
2. **Explicit `invalidateAuthCache` calls** in the two paths that bypass instance hooks:
   - `UserService.bulkUpdateUsers` — uses `Model.update(..., { where })` which skips instance hooks; we loop over the affected `userIds`.
   - `AuthService.logout` — doesn't mutate the user row, so the hook never fires; invalidate explicitly when the caller's `userId` is known.

The hook approach was chosen over option 2 in the ticket (cache contract redesign) because it's surgical, future-proof, and keeps the cache's existing fast-path. Option 2 would be a bigger refactor that's not strictly needed to close the gap.

## Test plan

- [x] `auth-cache-invalidation.test.ts` — 8 new behaviour tests covering hook-driven invalidation, explicit invalidation, deactivate/reactivate/suspend/unsuspend/bulkUpdate/verifyEmail/logout.
- [x] Existing `user.service`, `admin.service`, `auth.service`, `auth-cache`, `auth.middleware`, `auth-security` tests all still pass (76 + 88 = 164 pre-existing tests green).
- [ ] Manual smoke: suspend a user via admin endpoint, immediately re-issue the same JWT — expect 401 `Account is not active` on the next request.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEym2eHQrZyUxC4DmKyXv4)_