### PR TITLE
fix(security): require verified rescue staff (ADS-591) and remove unsafe requireOwnership (ADS-595)

### DIFF
--- a/service.backend/src/__tests__/middleware/rbac.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/rbac.middleware.test.ts
@@ -4,7 +4,6 @@ import { UserType } from '../../models/User';
 import {
   requireRole,
   requirePermission,
-  requireOwnership,
   requirePermissionOrOwnership,
   requireAdmin,
   requireRescue,
@@ -294,131 +293,6 @@ describe('RBAC Middleware', () => {
 
         expect(mockResponse.status).toHaveBeenCalledWith(403);
         expect(mockNext).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('requireOwnership - Resource ownership check', () => {
-    describe('when user is not authenticated', () => {
-      it('should reject request with 401', () => {
-        mockRequest.user = undefined;
-
-        const middleware = requireOwnership('userId');
-        middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
-
-        expect(mockResponse.status).toHaveBeenCalledWith(401);
-        expect(mockResponse.json).toHaveBeenCalledWith({
-          error: 'Authentication required',
-          message: 'User must be authenticated',
-        });
-      });
-    });
-
-    describe('when checking userId ownership', () => {
-      it('should reject if user does not own the resource', () => {
-        const requestWithPath = {
-          ...mockRequest,
-          path: '/api/users/user-456/profile',
-          params: { userId: 'user-456' },
-        };
-        requestWithPath.user = {
-          userId: 'user-123',
-          userType: UserType.ADOPTER,
-        } as AuthenticatedRequest['user'];
-
-        const middleware = requireOwnership('userId');
-        middleware(requestWithPath as AuthenticatedRequest, mockResponse as Response, mockNext);
-
-        expect(mockResponse.status).toHaveBeenCalledWith(403);
-        expect(mockResponse.json).toHaveBeenCalledWith({
-          error: 'Access denied',
-          message: 'You can only access your own resources',
-        });
-      });
-
-      it('should log ownership check failure', () => {
-        const requestWithPath = {
-          ...mockRequest,
-          path: '/api/users/user-456/profile',
-          params: { userId: 'user-456' },
-        };
-        requestWithPath.user = {
-          userId: 'user-123',
-          userType: UserType.ADOPTER,
-        } as unknown as AuthenticatedRequest['user'];
-
-        const middleware = requireOwnership('userId');
-        middleware(requestWithPath as AuthenticatedRequest, mockResponse as Response, mockNext);
-
-        expect(logger.warn).toHaveBeenCalledWith(
-          'Access denied - resource ownership check failed',
-          {
-            userId: 'user-123',
-            resourceId: 'user-456',
-            resourceParam: 'userId',
-            endpoint: '/api/users/user-456/profile',
-          }
-        );
-      });
-
-      it('should allow access if user owns the resource', () => {
-        mockRequest.user = {
-          userId: 'user-123',
-          userType: UserType.ADOPTER,
-        } as AuthenticatedRequest['user'];
-        mockRequest.params = { userId: 'user-123' };
-
-        const middleware = requireOwnership('userId');
-        middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
-
-        expect(mockNext).toHaveBeenCalled();
-        expect(mockResponse.status).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('when checking non-userId resources', () => {
-      it('should pass through for other resource types', () => {
-        mockRequest.user = {
-          userId: 'user-123',
-          userType: UserType.ADOPTER,
-        } as AuthenticatedRequest['user'];
-        mockRequest.params = { id: 'resource-456' };
-
-        const middleware = requireOwnership('id');
-        middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
-
-        expect(mockNext).toHaveBeenCalled();
-      });
-
-      it('should attach resourceId to request', () => {
-        mockRequest.user = {
-          userId: 'user-123',
-          userType: UserType.ADOPTER,
-        } as AuthenticatedRequest['user'];
-        mockRequest.params = { petId: 'pet-789' };
-
-        const middleware = requireOwnership('petId');
-        middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
-
-        expect((mockRequest as AuthenticatedRequest & { resourceId: string }).resourceId).toBe(
-          'pet-789'
-        );
-        expect(mockNext).toHaveBeenCalled();
-      });
-    });
-
-    describe('when using default parameter', () => {
-      it('should default to "id" parameter', () => {
-        mockRequest.user = {
-          userId: 'user-123',
-          userType: UserType.ADOPTER,
-        } as AuthenticatedRequest['user'];
-        mockRequest.params = { id: 'resource-123' };
-
-        const middleware = requireOwnership();
-        middleware(mockRequest as AuthenticatedRequest, mockResponse as Response, mockNext);
-
-        expect(mockNext).toHaveBeenCalled();
       });
     });
   });

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -626,6 +626,31 @@ describe('ApplicationService - Business Logic', () => {
       expect(result).toBeDefined();
     });
 
+    it('denies unverified rescue staff (ADS-591)', async () => {
+      // Given: Application owned by rescue, but the staff lookup with
+      // isVerified: true returns no match.
+      const mockApplication = createMockApplication();
+      mockApplication.rescueId = mockRescueId;
+
+      MockedApplication.findOne = vi.fn().mockResolvedValue(mockApplication);
+      MockedStaffMember.findOne = vi.fn().mockResolvedValue(null);
+
+      // When & Then: Access denied
+      await expect(
+        ApplicationService.getApplicationById(
+          mockApplicationId,
+          'unverified-staff-123',
+          UserType.RESCUE_STAFF
+        )
+      ).rejects.toThrow('Access denied');
+
+      expect(MockedStaffMember.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ isVerified: true }),
+        })
+      );
+    });
+
     it('allows admin to view any application', async () => {
       // Given: Any application
       const mockApplication = createMockApplication();

--- a/service.backend/src/middleware/rbac.ts
+++ b/service.backend/src/middleware/rbac.ts
@@ -72,42 +72,6 @@ export const requirePermission = (requiredPermission: string) => {
   };
 };
 
-// Resource ownership check
-export const requireOwnership = (resourceIdParam: string = 'id') => {
-  return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
-    if (!req.user) {
-      res.status(401).json({
-        error: 'Authentication required',
-        message: 'User must be authenticated',
-      });
-      return;
-    }
-
-    const resourceId = req.params[resourceIdParam];
-    const userId = req.user.userId;
-
-    // For user resources, check if user owns the resource
-    if (resourceIdParam === 'userId' && resourceId !== userId) {
-      logger.warn(`Access denied - resource ownership check failed`, {
-        userId,
-        resourceId,
-        resourceParam: resourceIdParam,
-        endpoint: req.path,
-      });
-
-      res.status(403).json({
-        error: 'Access denied',
-        message: 'You can only access your own resources',
-      });
-      return;
-    }
-
-    // Store resource ID for use in controller - using proper typing
-    (req as AuthenticatedRequest & { resourceId: string }).resourceId = resourceId;
-    next();
-  };
-};
-
 // Combined permission and ownership check
 export const requirePermissionOrOwnership = (
   permission: string,
@@ -209,7 +173,6 @@ export const requireOwnershipOrAdmin = (
 export default {
   requireRole,
   requirePermission,
-  requireOwnership,
   requirePermissionOrOwnership,
   requireAdmin,
   requireRescue,

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -114,14 +114,12 @@ const formatHomeVisit = (visit: HomeVisit): HomeVisitDto => ({
 
 export class ApplicationService {
   /**
-   * Look up the rescueId for any StaffMember row owned by the user.
-   * Mirrors the previous controller-side `StaffMember.findOne({ where:
-   * { userId } })` lookup (no `isVerified` filter), centralised in the
-   * service layer so the controller stays thin (ADS-489).
+   * Look up the rescueId for a verified StaffMember row owned by the user.
+   * Unverified rows must not grant rescue-scoped access (ADS-591).
    */
   static async getStaffRescueIdForUser(userId: string): Promise<string | null> {
     const membership = await StaffMember.findOne({
-      where: { userId },
+      where: { userId, isVerified: true },
       attributes: ['rescueId'],
     });
     return membership?.rescueId ?? null;
@@ -549,7 +547,10 @@ export class ApplicationService {
         }
         if (userType === UserType.RESCUE_STAFF) {
           const StaffMember = (await import('../models/StaffMember')).default;
-          const membership = await StaffMember.findOne({ where: { userId } });
+          const membership = await StaffMember.findOne({
+            where: { userId, isVerified: true },
+            attributes: ['rescueId'],
+          });
           if (!membership || membership.rescueId !== application.rescueId) {
             throw new Error('Access denied');
           }


### PR DESCRIPTION
## Summary

Two related security fixes in `service.backend`.

### ADS-591 — Unverified rescue staff can read applications
- `ApplicationService.getApplicationById` previously looked up the staff membership with `StaffMember.findOne({ where: { userId } })` — no `isVerified` filter. Anyone with an unverified `staff_members` row (e.g. invited but pending approval, or whose verification was revoked) could authenticate as `RESCUE_STAFF` and read full applicant PII via `GET /api/v1/applications/:id`.
- Tightened the lookup to require `isVerified: true`, matching `searchApplications`, `updateApplicationStatus`, and `attachRescueAffiliation`.
- Also tightened `getStaffRescueIdForUser` (used by application statistics) to require verification — its prior carve-out had no caller that needed unverified rows.

### ADS-595 — `requireOwnership` middleware fails open
- The exported `requireOwnership(resourceIdParam)` only enforced an ownership check when `resourceIdParam === 'userId'`. For any other param (`petId`, `applicationId`, ...) it silently called `next()`. No production route used the broken path, but the helper was a latent IDOR trap.
- Removed the helper entirely. `requireOwnershipOrAdmin` already covers the supported case with an explicit owner-resolver function.
- Removed the corresponding test block that codified the silent-allow behaviour.

## Test plan
- [x] `vitest run src/__tests__/middleware/rbac.middleware.test.ts src/__tests__/services/application.service.test.ts` → 76 passed, including new "denies unverified rescue staff" case.
- [ ] Manual: hit `GET /api/v1/applications/:id` as an unverified `RESCUE_STAFF` user → expect `Access denied`.
- [ ] Manual: same endpoint as verified staff at the owning rescue → expect 200 with full payload.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SHvLCk54PGBYvpg4RwpF2w)_