### PR TITLE
fix(auth): require step-up auth on account deletion and clear correct cookies (ADS-592)

### DIFF
--- a/app.client/src/pages/ProfilePage.tsx
+++ b/app.client/src/pages/ProfilePage.tsx
@@ -5,6 +5,8 @@ import {
   Alert,
   Button,
   ConfirmDialog,
+  Input,
+  Modal,
   Spinner,
   toast,
   useConfirm,
@@ -52,7 +54,12 @@ export const ProfilePage: React.FC = () => {
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [isSavingSettings, setIsSavingSettings] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const { confirm, confirmProps } = useConfirm();
+  const { confirmProps } = useConfirm();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deleteTwoFactorToken, setDeleteTwoFactorToken] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const loadApplications = useCallback(async () => {
     try {
@@ -215,29 +222,49 @@ export const ProfilePage: React.FC = () => {
     }
   };
 
-  const handleDeleteAccount = async () => {
-    const confirmed = await confirm({
-      title: 'Delete account?',
-      message: 'Are you sure you want to delete your account? This action cannot be undone.',
-      confirmText: 'Delete account',
-      cancelText: 'Cancel',
-      variant: 'danger',
-    });
-    if (!confirmed) {
+  const handleDeleteAccount = () => {
+    setDeletePassword('');
+    setDeleteTwoFactorToken('');
+    setDeleteError(null);
+    setIsDeleteModalOpen(true);
+  };
+
+  const closeDeleteModal = () => {
+    if (isDeleting) {
+      return;
+    }
+    setIsDeleteModalOpen(false);
+    setDeletePassword('');
+    setDeleteTwoFactorToken('');
+    setDeleteError(null);
+  };
+
+  const submitDeleteAccount = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!deletePassword) {
+      setDeleteError('Please enter your password to confirm.');
       return;
     }
 
     try {
-      setError(null);
+      setIsDeleting(true);
+      setDeleteError(null);
 
-      // Call the API to delete account
-      await authService.deleteAccount('User requested account deletion');
+      await authService.deleteAccount(deletePassword, {
+        twoFactorToken: deleteTwoFactorToken || undefined,
+        reason: 'User requested account deletion',
+      });
 
-      // Navigate to home page
+      setIsDeleteModalOpen(false);
       navigate('/');
     } catch (error) {
       console.error('Failed to delete account:', error);
-      setError('Failed to delete account. Please try again.');
+      const message =
+        error instanceof Error && error.message ? error.message : 'Failed to delete account.';
+      setDeleteError(message);
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -454,6 +481,71 @@ export const ProfilePage: React.FC = () => {
       {activeTab === 'settings' && renderSettingsTab()}
 
       <ConfirmDialog {...confirmProps} />
+
+      <Modal
+        isOpen={isDeleteModalOpen}
+        onClose={closeDeleteModal}
+        title='Delete account?'
+        size='sm'
+      >
+        <form onSubmit={submitDeleteAccount}>
+          <p>
+            This will permanently delete your profile, applications, and all associated data.
+            Re-enter your password to confirm.
+          </p>
+          <div style={{ marginTop: '1rem' }}>
+            <Input
+              type='password'
+              label='Current password'
+              value={deletePassword}
+              onChange={e => setDeletePassword(e.target.value)}
+              autoComplete='current-password'
+              autoFocus
+              required
+              disabled={isDeleting}
+            />
+          </div>
+          {user?.twoFactorEnabled && (
+            <div style={{ marginTop: '0.75rem' }}>
+              <Input
+                type='text'
+                label='Two-factor code'
+                value={deleteTwoFactorToken}
+                onChange={e => setDeleteTwoFactorToken(e.target.value)}
+                autoComplete='one-time-code'
+                inputMode='numeric'
+                pattern='[0-9]*'
+                disabled={isDeleting}
+              />
+            </div>
+          )}
+          {deleteError && (
+            <div style={{ marginTop: '0.75rem' }} role='alert'>
+              <Alert variant='error'>{deleteError}</Alert>
+            </div>
+          )}
+          <div
+            style={{
+              marginTop: '1.25rem',
+              display: 'flex',
+              gap: '0.5rem',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <Button
+              type='button'
+              variant='secondary'
+              onClick={closeDeleteModal}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button type='submit' variant='danger' isLoading={isDeleting} disabled={isDeleting}>
+              Delete account
+            </Button>
+          </div>
+        </form>
+      </Modal>
     </div>
   );
 };

--- a/lib.auth/README.md
+++ b/lib.auth/README.md
@@ -89,7 +89,7 @@ Profile:
 
 - `getProfile(): Promise<User>`
 - `updateProfile(partial: Partial<User>): Promise<User>`
-- `deleteAccount(reason?: string): Promise<void>`
+- `deleteAccount(password: string, options?: { twoFactorToken?: string; reason?: string }): Promise<void>` — backend requires step-up auth (ADS-592)
 
 Password / email:
 

--- a/lib.auth/__tests__/auth-service.test.ts
+++ b/lib.auth/__tests__/auth-service.test.ts
@@ -358,14 +358,14 @@ describe('AuthService', () => {
   });
 
   describe('deleteAccount', () => {
-    it('should delete account and clear storage', async () => {
+    it('should send password and reason and clear storage on success', async () => {
       (apiService.fetchWithAuth as jest.Mock).mockResolvedValue({});
 
-      await authService.deleteAccount('reason');
+      await authService.deleteAccount('my-password', { reason: 'reason' });
 
       expect(apiService.fetchWithAuth).toHaveBeenCalledWith('/api/v1/users/account', {
         method: 'DELETE',
-        body: { reason: 'reason' },
+        body: { password: 'my-password', reason: 'reason' },
       });
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
@@ -374,14 +374,25 @@ describe('AuthService', () => {
       expect(apiService.setToken).toHaveBeenCalledWith('');
     });
 
-    it('should delete account without reason', async () => {
+    it('should include twoFactorToken when provided', async () => {
       (apiService.fetchWithAuth as jest.Mock).mockResolvedValue({});
 
-      await authService.deleteAccount();
+      await authService.deleteAccount('my-password', { twoFactorToken: '123456' });
 
       expect(apiService.fetchWithAuth).toHaveBeenCalledWith('/api/v1/users/account', {
         method: 'DELETE',
-        body: undefined,
+        body: { password: 'my-password', twoFactorToken: '123456' },
+      });
+    });
+
+    it('should omit reason and twoFactorToken when not provided', async () => {
+      (apiService.fetchWithAuth as jest.Mock).mockResolvedValue({});
+
+      await authService.deleteAccount('my-password');
+
+      expect(apiService.fetchWithAuth).toHaveBeenCalledWith('/api/v1/users/account', {
+        method: 'DELETE',
+        body: { password: 'my-password' },
       });
     });
   });

--- a/lib.auth/src/services/auth-service.ts
+++ b/lib.auth/src/services/auth-service.ts
@@ -235,13 +235,22 @@ export class AuthService {
   }
 
   /**
-   * Delete user account
+   * Delete user account.
+   *
+   * ADS-592: backend requires step-up auth — caller must supply current
+   * password (and TOTP code if 2FA is enabled).
    */
-  async deleteAccount(reason?: string): Promise<void> {
-    const body = reason ? { reason } : undefined;
+  async deleteAccount(
+    password: string,
+    options?: { twoFactorToken?: string; reason?: string }
+  ): Promise<void> {
     await apiService.fetchWithAuth('/api/v1/users/account', {
       method: 'DELETE',
-      body,
+      body: {
+        password,
+        ...(options?.twoFactorToken ? { twoFactorToken: options.twoFactorToken } : {}),
+        ...(options?.reason ? { reason: options.reason } : {}),
+      },
     });
 
     this.clearStorage();

--- a/service.backend/src/__tests__/routes/user.routes.test.ts
+++ b/service.backend/src/__tests__/routes/user.routes.test.ts
@@ -28,6 +28,26 @@ vi.mock('../../config/env', () => ({
   },
 }));
 
+vi.mock('../../models/User', () => {
+  const findByPk = vi.fn();
+  return {
+    default: { findByPk },
+    UserType: { ADOPTER: 'ADOPTER', RESCUE_STAFF: 'RESCUE_STAFF', ADMIN: 'ADMIN' },
+    UserStatus: { ACTIVE: 'ACTIVE' },
+  };
+});
+
+vi.mock('../../services/auth.service', () => ({
+  default: {
+    verifyStepUpCredentials: vi.fn(),
+    logout: vi.fn(),
+  },
+  AuthService: {
+    verifyStepUpCredentials: vi.fn(),
+    logout: vi.fn(),
+  },
+}));
+
 vi.mock('../../services/user.service', () => ({
   default: {
     getUserById: vi.fn(),
@@ -188,12 +208,80 @@ describe('User routes', () => {
       expect(res.status).toBe(401);
     });
 
-    it('reaches the controller when authenticated', async () => {
-      // Controller may return 200 or 500 depending on service availability;
-      // either way the auth guard allowed it through.
-      const res = await request(buildApp()).delete('/api/v1/users/account');
-      expect(res.status).not.toBe(401);
-      expect(res.status).not.toBe(403);
+    it('returns 401 when no password is supplied', async () => {
+      const res = await request(buildApp()).delete('/api/v1/users/account').send({});
+      expect(res.status).toBe(401);
+      expect(res.body.error).toMatch(/password/i);
+    });
+
+    it('returns 401 when the supplied password does not match', async () => {
+      const userModel = (await import('../../models/User')).default as unknown as {
+        findByPk: ReturnType<typeof vi.fn>;
+      };
+      const authService = (await import('../../services/auth.service')).default as unknown as {
+        verifyStepUpCredentials: ReturnType<typeof vi.fn>;
+      };
+      userModel.findByPk.mockResolvedValue({ userId: mockUser.userId, twoFactorEnabled: false });
+      authService.verifyStepUpCredentials.mockRejectedValue(new Error('Invalid credentials'));
+
+      const res = await request(buildApp())
+        .delete('/api/v1/users/account')
+        .send({ password: 'wrong-password' });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Invalid credentials');
+    });
+
+    it('returns 401 when 2FA is enabled and no token is supplied', async () => {
+      const userModel = (await import('../../models/User')).default as unknown as {
+        findByPk: ReturnType<typeof vi.fn>;
+      };
+      const authService = (await import('../../services/auth.service')).default as unknown as {
+        verifyStepUpCredentials: ReturnType<typeof vi.fn>;
+      };
+      userModel.findByPk.mockResolvedValue({ userId: mockUser.userId, twoFactorEnabled: true });
+      authService.verifyStepUpCredentials.mockRejectedValue(
+        new Error('Two-factor authentication code required')
+      );
+
+      const res = await request(buildApp())
+        .delete('/api/v1/users/account')
+        .send({ password: 'correct-password' });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toMatch(/two-factor/i);
+    });
+
+    it('clears accessToken and refreshToken cookies, revokes tokens, and deletes the account on success', async () => {
+      const userModel = (await import('../../models/User')).default as unknown as {
+        findByPk: ReturnType<typeof vi.fn>;
+      };
+      const authService = (await import('../../services/auth.service')).default as unknown as {
+        verifyStepUpCredentials: ReturnType<typeof vi.fn>;
+        logout: ReturnType<typeof vi.fn>;
+      };
+      const userService = (await import('../../services/user.service')).default as unknown as {
+        deleteAccount: ReturnType<typeof vi.fn>;
+      };
+
+      userModel.findByPk.mockResolvedValue({ userId: mockUser.userId, twoFactorEnabled: false });
+      authService.verifyStepUpCredentials.mockResolvedValue(undefined);
+      authService.logout.mockResolvedValue(undefined);
+      userService.deleteAccount.mockResolvedValue(undefined);
+
+      const res = await request(buildApp())
+        .delete('/api/v1/users/account')
+        .send({ password: 'correct-password', reason: 'no longer needed' });
+
+      expect(res.status).toBe(200);
+      expect(authService.logout).toHaveBeenCalled();
+      expect(userService.deleteAccount).toHaveBeenCalledWith(mockUser.userId, 'no longer needed');
+
+      const setCookie = res.headers['set-cookie'];
+      const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+      const cookieHeader = cookies.join('\n');
+      expect(cookieHeader).toMatch(/accessToken=;/);
+      expect(cookieHeader).toMatch(/refreshToken=;/);
     });
   });
 

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -947,4 +947,58 @@ describe('AuthService', () => {
       expect(MockedRevokedToken.create).not.toHaveBeenCalled();
     });
   });
+
+  describe('verifyStepUpCredentials (ADS-592)', () => {
+    it('resolves when password matches and 2FA is disabled', async () => {
+      mockedBcrypt.compare = vi.fn().mockResolvedValue(true as never);
+      const user = { password: 'hashed', twoFactorEnabled: false } as unknown as User;
+
+      await expect(
+        AuthService.verifyStepUpCredentials(user, 'plain-password')
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects with "Invalid credentials" when password does not match', async () => {
+      mockedBcrypt.compare = vi.fn().mockResolvedValue(false as never);
+      const user = { password: 'hashed', twoFactorEnabled: false } as unknown as User;
+
+      await expect(AuthService.verifyStepUpCredentials(user, 'wrong')).rejects.toThrow(
+        'Invalid credentials'
+      );
+    });
+
+    it('rejects when 2FA is enabled and no TOTP is supplied', async () => {
+      mockedBcrypt.compare = vi.fn().mockResolvedValue(true as never);
+      const user = {
+        password: 'hashed',
+        twoFactorEnabled: true,
+        twoFactorSecret: 'secret',
+      } as unknown as User;
+
+      await expect(AuthService.verifyStepUpCredentials(user, 'plain-password')).rejects.toThrow(
+        /two-factor/i
+      );
+    });
+
+    it('rejects when 2FA token is invalid', async () => {
+      mockedBcrypt.compare = vi.fn().mockResolvedValue(true as never);
+      const user = {
+        password: 'hashed',
+        twoFactorEnabled: true,
+        twoFactorSecret: 'secret',
+      } as unknown as User;
+      const verifySpy = vi
+        .spyOn(
+          AuthService as unknown as { verifyTwoFactorToken: () => Promise<boolean> },
+          'verifyTwoFactorToken'
+        )
+        .mockResolvedValue(false);
+
+      await expect(
+        AuthService.verifyStepUpCredentials(user, 'plain-password', '000000')
+      ).rejects.toThrow(/invalid two-factor/i);
+
+      verifySpy.mockRestore();
+    });
+  });
 });

--- a/service.backend/src/controllers/auth.controller.ts
+++ b/service.backend/src/controllers/auth.controller.ts
@@ -15,16 +15,16 @@ import { AuthenticatedRequest } from '../types';
 import { validateBody } from '../middleware/zod-validate';
 import { logger } from '../utils/logger';
 
-const REFRESH_TOKEN_COOKIE = 'refreshToken';
-const REFRESH_TOKEN_COOKIE_OPTIONS = {
+export const REFRESH_TOKEN_COOKIE = 'refreshToken';
+export const REFRESH_TOKEN_COOKIE_OPTIONS = {
   httpOnly: true,
   secure: process.env.NODE_ENV === 'production',
   sameSite: 'strict' as const,
   maxAge: 3 * 24 * 60 * 60 * 1000, // 3 days
 };
 
-const ACCESS_TOKEN_COOKIE = 'accessToken';
-const ACCESS_TOKEN_COOKIE_OPTIONS = {
+export const ACCESS_TOKEN_COOKIE = 'accessToken';
+export const ACCESS_TOKEN_COOKIE_OPTIONS = {
   httpOnly: true,
   secure: process.env.NODE_ENV === 'production',
   sameSite: 'strict' as const,

--- a/service.backend/src/controllers/user.controller.ts
+++ b/service.backend/src/controllers/user.controller.ts
@@ -1,10 +1,17 @@
 import { Response } from 'express';
 import { body, query } from 'express-validator';
 import { BulkUserUpdateRequestSchema } from '@adopt-dont-shop/lib.validation';
-import { UserType } from '../models/User';
+import User, { UserType } from '../models/User';
 import UserService from '../services/user.service';
+import AuthService from '../services/auth.service';
+import {
+  ACCESS_TOKEN_COOKIE,
+  ACCESS_TOKEN_COOKIE_OPTIONS,
+  REFRESH_TOKEN_COOKIE,
+  REFRESH_TOKEN_COOKIE_OPTIONS,
+} from './auth.controller';
 import { AuthenticatedRequest } from '../types';
-import { logger } from '../utils/logger';
+import { logger, loggerHelpers } from '../utils/logger';
 import { validateBody } from '../middleware/zod-validate';
 
 // Validation rules
@@ -413,42 +420,73 @@ export class UserController {
   }
 
   /**
-   * Delete current user account
+   * Delete current user account.
+   *
+   * ADS-592: requires step-up auth — the caller must re-supply their current
+   * password (and a TOTP code if 2FA is enabled). On success, both
+   * `accessToken` and `refreshToken` cookies are cleared and the underlying
+   * tokens are revoked so a stolen session cannot continue to act as the
+   * deleted user.
    */
   async deleteAccount(req: AuthenticatedRequest, res: Response) {
     const startTime = Date.now();
+    const userId = req.user!.userId;
 
     try {
-      const userId = req.user!.userId;
-      const { reason } = req.body;
+      const { password, twoFactorToken, reason } = req.body ?? {};
+
+      if (typeof password !== 'string' || password.length === 0) {
+        return res.status(401).json({ error: 'Password is required' });
+      }
+
+      const user = await User.findByPk(userId);
+      if (!user) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      try {
+        await AuthService.verifyStepUpCredentials(user, password, twoFactorToken);
+      } catch (verifyError) {
+        const message = verifyError instanceof Error ? verifyError.message : 'Invalid credentials';
+        loggerHelpers.logSecurity('Account deletion step-up auth failed', {
+          userId,
+          reason: message,
+        });
+        return res.status(401).json({ error: message });
+      }
+
+      const accessToken =
+        req.cookies?.[ACCESS_TOKEN_COOKIE] || req.headers.authorization?.replace(/^Bearer\s+/i, '');
+      const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE];
+
+      // Revoke tokens before destroying the user so any race with a parallel
+      // request sees the revocation. AuthService.logout is best-effort and
+      // does not throw on missing/invalid tokens.
+      await AuthService.logout(refreshToken, accessToken, userId);
 
       await UserService.deleteAccount(userId, reason);
 
-      // Clear the user's session by logging them out
-      res.clearCookie('authToken');
+      res.clearCookie(ACCESS_TOKEN_COOKIE, ACCESS_TOKEN_COOKIE_OPTIONS);
+      res.clearCookie(REFRESH_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE_OPTIONS);
 
-      res.json({
+      logger.info('User account deleted', { userId, duration: Date.now() - startTime });
+
+      return res.json({
         success: true,
         message: 'Account deleted successfully',
       });
-
-      logger.info('User account deleted', { userId, duration: Date.now() - startTime });
     } catch (error) {
       logger.error('Error deleting account:', {
         error: error instanceof Error ? error.message : String(error),
-        userId: req.user?.userId,
+        userId,
         duration: Date.now() - startTime,
       });
 
       if (error instanceof Error && error.message === 'User not found') {
-        return res.status(404).json({
-          error: 'User not found',
-        });
+        return res.status(404).json({ error: 'User not found' });
       }
 
-      res.status(500).json({
-        error: 'Failed to delete account',
-      });
+      return res.status(500).json({ error: 'Failed to delete account' });
     }
   }
 

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -903,6 +903,32 @@ Need help? Contact us at support@adoptdontshop.com
     }
   }
 
+  /**
+   * Verify a user's password and, if 2FA is enabled, a TOTP code.
+   * Used for "step-up" authentication on destructive actions
+   * (account deletion, etc.). Throws on failure to match the login flow.
+   */
+  static async verifyStepUpCredentials(
+    user: User,
+    password: string,
+    twoFactorToken?: string
+  ): Promise<void> {
+    const isPasswordValid = await bcrypt.compare(password, user.password);
+    if (!isPasswordValid) {
+      throw new Error('Invalid credentials');
+    }
+
+    if (user.twoFactorEnabled) {
+      if (!twoFactorToken) {
+        throw new Error('Two-factor authentication code required');
+      }
+      const isValid = await this.verifyTwoFactorToken(user, twoFactorToken);
+      if (!isValid) {
+        throw new Error('Invalid two-factor authentication code');
+      }
+    }
+  }
+
   private static async verifyTwoFactorToken(
     user: User,
     token: string,


### PR DESCRIPTION
## Summary

Fixes [ADS-592](https://linear.app/ideasquared/issue/ADS-592/account-deletion-requires-no-re-authentication-and-clears-wrong-cookie). `DELETE /api/v1/users/account` previously deleted the authenticated user solely on the basis of the active session and cleared a cookie name (`authToken`) that the app does not use, leaving real `accessToken`/`refreshToken` cookies and the corresponding tokens live.

- **Step-up auth**: account deletion now requires the caller's current password (and a TOTP code if 2FA is enabled). A new public `AuthService.verifyStepUpCredentials` helper reuses the same `bcrypt`/`speakeasy` paths as login.
- **Token revocation**: the controller now calls `AuthService.logout(refreshToken, accessToken, userId)` so any matching `RefreshToken` row is marked `is_revoked` and the access token's `jti` lands in `RevokedToken` (the canonical revocation flow from ADS-589). Subsequent use of the previously issued access token returns 401.
- **Correct cookies cleared**: `accessToken` and `refreshToken` cookies are cleared with their original options (`httpOnly`, `secure`, `sameSite`, `path`).
- **Frontend**: the Delete account flow on `ProfilePage` now opens a modal that collects the current password and, when 2FA is enabled, a one-time code, before calling the API.

## Test plan

- [x] `service.backend` route tests: 401 with no password, 401 on wrong password, 401 when 2FA required but missing, success path clears both cookies and invokes `AuthService.logout` + `UserService.deleteAccount`.
- [x] `service.backend` service tests: new `verifyStepUpCredentials` behaviour (password mismatch, 2FA missing, 2FA invalid, happy path).
- [x] `lib.auth` tests updated for the new `deleteAccount(password, options?)` signature.
- [x] `app.client` ProfilePage tests still pass.
- [ ] Manual: log in, open Settings → Delete account, confirm modal collects password + optional 2FA, verify cookies cleared and old JWT rejected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sg6u6riL5NRmvYjJ7F6JAs)_