### PR TITLE
fix(matching): unblock CI on #554 — Dockerfile + lib.matching tests

### DIFF
--- a/Dockerfile.app.optimized
+++ b/Dockerfile.app.optimized
@@ -56,6 +56,7 @@ COPY --chown=viteuser:nodejs lib.discovery/package.json ./lib.discovery/
 COPY --chown=viteuser:nodejs lib.feature-flags/package.json ./lib.feature-flags/
 COPY --chown=viteuser:nodejs lib.invitations/package.json ./lib.invitations/
 COPY --chown=viteuser:nodejs lib.legal/package.json ./lib.legal/
+COPY --chown=viteuser:nodejs lib.matching/package.json ./lib.matching/
 COPY --chown=viteuser:nodejs lib.moderation/package.json ./lib.moderation/
 COPY --chown=viteuser:nodejs lib.notifications/package.json ./lib.notifications/
 COPY --chown=viteuser:nodejs lib.observability/package.json ./lib.observability/
@@ -88,6 +89,7 @@ COPY --chown=viteuser:nodejs lib.discovery/ ./lib.discovery/
 COPY --chown=viteuser:nodejs lib.feature-flags/ ./lib.feature-flags/
 COPY --chown=viteuser:nodejs lib.invitations/ ./lib.invitations/
 COPY --chown=viteuser:nodejs lib.legal/ ./lib.legal/
+COPY --chown=viteuser:nodejs lib.matching/ ./lib.matching/
 COPY --chown=viteuser:nodejs lib.moderation/ ./lib.moderation/
 COPY --chown=viteuser:nodejs lib.notifications/ ./lib.notifications/
 COPY --chown=viteuser:nodejs lib.observability/ ./lib.observability/
@@ -150,6 +152,7 @@ COPY lib.discovery/package.json ./lib.discovery/
 COPY lib.feature-flags/package.json ./lib.feature-flags/
 COPY lib.invitations/package.json ./lib.invitations/
 COPY lib.legal/package.json ./lib.legal/
+COPY lib.matching/package.json ./lib.matching/
 COPY lib.moderation/package.json ./lib.moderation/
 COPY lib.notifications/package.json ./lib.notifications/
 COPY lib.observability/package.json ./lib.observability/
@@ -187,6 +190,7 @@ COPY lib.discovery/ ./lib.discovery/
 COPY lib.feature-flags/ ./lib.feature-flags/
 COPY lib.invitations/ ./lib.invitations/
 COPY lib.legal/ ./lib.legal/
+COPY lib.matching/ ./lib.matching/
 COPY lib.moderation/ ./lib.moderation/
 COPY lib.notifications/ ./lib.notifications/
 COPY lib.observability/ ./lib.observability/

--- a/lib.matching/eslint.config.js
+++ b/lib.matching/eslint.config.js
@@ -1,0 +1,3 @@
+import baseConfig from '@adopt-dont-shop/eslint-config-base';
+
+export default baseConfig;

--- a/lib.matching/src/index.test.ts
+++ b/lib.matching/src/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { REASON_CHIP_KINDS, isReasonChipKind } from './index';
+
+describe('REASON_CHIP_KINDS', () => {
+  it('matches the backend ReasonChip surface (rule.scorer.ts + match-reason-chips component)', () => {
+    expect(REASON_CHIP_KINDS).toEqual([
+      'pref_match',
+      'lifestyle',
+      'distance',
+      'similar_to_liked',
+      'fresh',
+    ]);
+  });
+
+  it('has no duplicate kinds', () => {
+    expect(new Set(REASON_CHIP_KINDS).size).toBe(REASON_CHIP_KINDS.length);
+  });
+});
+
+describe('isReasonChipKind', () => {
+  it('accepts every declared kind', () => {
+    for (const kind of REASON_CHIP_KINDS) {
+      expect(isReasonChipKind(kind)).toBe(true);
+    }
+  });
+
+  it('rejects unknown strings and non-strings', () => {
+    expect(isReasonChipKind('unknown_kind')).toBe(false);
+    expect(isReasonChipKind('')).toBe(false);
+    expect(isReasonChipKind(undefined)).toBe(false);
+    expect(isReasonChipKind(null)).toBe(false);
+    expect(isReasonChipKind(42)).toBe(false);
+    expect(isReasonChipKind({})).toBe(false);
+  });
+});

--- a/lib.matching/src/index.ts
+++ b/lib.matching/src/index.ts
@@ -7,7 +7,18 @@
  * pet card, match profile read/write).
  */
 
-export type ReasonChipKind = 'pref_match' | 'lifestyle' | 'distance' | 'similar_to_liked' | 'fresh';
+export const REASON_CHIP_KINDS = [
+  'pref_match',
+  'lifestyle',
+  'distance',
+  'similar_to_liked',
+  'fresh',
+] as const;
+
+export type ReasonChipKind = (typeof REASON_CHIP_KINDS)[number];
+
+export const isReasonChipKind = (value: unknown): value is ReasonChipKind =>
+  typeof value === 'string' && (REASON_CHIP_KINDS as readonly string[]).includes(value);
 
 export type ReasonChip = {
   kind: ReasonChipKind;

--- a/lib.matching/vitest.config.ts
+++ b/lib.matching/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import sharedConfig from '../vitest.shared.config';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      name: 'lib.matching',
+    },
+  })
+);

--- a/service.backend/src/controllers/match.controller.ts
+++ b/service.backend/src/controllers/match.controller.ts
@@ -1,6 +1,5 @@
 import { Response } from 'express';
 import { body, query, validationResult } from 'express-validator';
-import { Op } from 'sequelize';
 import { matchService } from '../matching';
 import AdopterMatchProfile from '../models/AdopterMatchProfile';
 import Breed from '../models/Breed';
@@ -147,19 +146,5 @@ export class MatchController {
       });
       res.status(500).json({ success: false, message: 'Failed to load top picks' });
     }
-  }
-
-  /**
-   * Find candidate users for the new-match daily digest. Used by the
-   * BullMQ job — exposed here to keep DB access centralised in the
-   * controller layer.
-   */
-  static async listNotifiableProfiles(): Promise<AdopterMatchProfile[]> {
-    return AdopterMatchProfile.findAll({
-      where: {
-        notify_new_matches: true,
-        [Op.or]: [{ last_notified_at: null }, { last_notified_at: { [Op.lt]: new Date() } }],
-      },
-    });
   }
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -16,6 +16,7 @@ export default defineWorkspace([
   'lib.discovery/vitest.config.ts',
   'lib.feature-flags/vitest.config.ts',
   'lib.invitations/vitest.config.ts',
+  'lib.matching/vitest.config.ts',
   'lib.moderation/vitest.config.ts',
   'lib.notifications/vitest.config.ts',
   'lib.permissions/vitest.config.ts',


### PR DESCRIPTION
## Summary

Fixes the CI failures that #554 introduced. Targets the PR's head branch (`aj-explore-ai-ml-matching`) — merge here to update #554.

**Failures addressed**

- **Build app.client Image / Build app.admin Image** — `lib.matching` wasn't in `Dockerfile.app.optimized`'s three explicit COPY blocks, so the image build couldn't resolve the workspace. Added it.
- **Library Tests + Verify every lib.* package has tests** — `lib.matching` shipped without a test file (or a vitest/eslint config). Added a runtime `REASON_CHIP_KINDS` tuple as the single source of truth, a small `isReasonChipKind` guard, behaviour tests, and the missing `vitest.config.ts` / `eslint.config.js`. Registered the package in `vitest.workspace.ts`.

**Code-quality fix folded in**

- Removed `MatchController.listNotifiableProfiles`. It was dead (the digest job already queries `AdopterMatchProfile.findAll` directly) and the predicate `last_notified_at < new Date()` was a no-op filter — every persisted timestamp is in the past, so the OR collapsed to "all profiles where notify=true". Drops the unused `sequelize` Op import too.

**Not addressed here — see review comment on #554**

- `Frontend Tests (app.admin)`: pre-existing on `main` (commit 4a7abf8 introduced `useToast` / `useCreateUser` references that the test mock doesn't stub). Not from this PR.
- `CodeQL`: the default-setup status check failed in 3s while the "Analyze (javascript-typescript)" job ran the actual scan and passed. Likely a default-setup vs advanced-config mismatch in the repo — not a code finding.

## Test plan

- [x] `npm test -w @adopt-dont-shop/lib.matching` — 4 passing
- [x] `node scripts/check-lib-tests.mjs` — OK
- [x] `npx turbo run lint test type-check --filter='@adopt-dont-shop/lib.*'` — green
- [x] `npx turbo run test --filter='@adopt-dont-shop/service-backend'` — 2234 passing
- [ ] CI confirms app.client / app.admin image builds succeed

https://claude.ai/code/session_019CnifGaDjENxhAgrZDmnSn

---
_Generated by [Claude Code](https://claude.ai/code/session_019CnifGaDjENxhAgrZDmnSn)_