### PR TITLE
fix(csp): remove unsafe-inline and unsafe-eval from script-src (ADS-594)

### DIFF
--- a/app.admin/index.html
+++ b/app.admin/index.html
@@ -34,7 +34,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fredoka:wght@300..700&family=Playfair+Display:wght@400..900&family=JetBrains+Mono:wght@400;500;600&display=swap"
       media="print"
-      onload="this.media='all'"
+      data-deferred-stylesheet
     />
     <noscript>
       <link

--- a/app.admin/src/main.tsx
+++ b/app.admin/src/main.tsx
@@ -12,11 +12,9 @@ import { StatsigWrapper } from './contexts/StatsigContext';
 
 // ADS-594: promote deferred font stylesheet via CSSOM so the non-blocking
 // load works under a strict CSP (no inline `onload=` handler).
-document
-  .querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]')
-  .forEach(link => {
-    link.media = 'all';
-  });
+document.querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]').forEach(link => {
+  link.media = 'all';
+});
 
 // ADS-406: initialise Sentry as early as possible so any synchronous module-load
 // error is captured. No-ops when VITE_SENTRY_DSN is unset.

--- a/app.admin/src/main.tsx
+++ b/app.admin/src/main.tsx
@@ -10,6 +10,14 @@ import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 import { StatsigWrapper } from './contexts/StatsigContext';
 
+// ADS-594: promote deferred font stylesheet via CSSOM so the non-blocking
+// load works under a strict CSP (no inline `onload=` handler).
+document
+  .querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]')
+  .forEach(link => {
+    link.media = 'all';
+  });
+
 // ADS-406: initialise Sentry as early as possible so any synchronous module-load
 // error is captured. No-ops when VITE_SENTRY_DSN is unset.
 initSentry({

--- a/app.client/index.html
+++ b/app.client/index.html
@@ -61,7 +61,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fredoka:wght@300..700&family=Playfair+Display:wght@400..900&family=JetBrains+Mono:wght@400;500;600&display=swap"
       media="print"
-      onload="this.media='all'"
+      data-deferred-stylesheet
     />
     <noscript>
       <link

--- a/app.client/src/main.tsx
+++ b/app.client/src/main.tsx
@@ -11,11 +11,9 @@ import { ErrorBoundary } from './components/common/ErrorBoundary';
 
 // ADS-594: promote deferred font stylesheet via CSSOM so the non-blocking
 // load works under a strict CSP (no inline `onload=` handler).
-document
-  .querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]')
-  .forEach(link => {
-    link.media = 'all';
-  });
+document.querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]').forEach(link => {
+  link.media = 'all';
+});
 
 // ADS-406: initialise Sentry as early as possible so any synchronous module-load
 // error is captured. No-ops when VITE_SENTRY_DSN is unset.

--- a/app.client/src/main.tsx
+++ b/app.client/src/main.tsx
@@ -9,6 +9,14 @@ import App from './App';
 import { StatsigWrapper } from './contexts/StatsigContext';
 import { ErrorBoundary } from './components/common/ErrorBoundary';
 
+// ADS-594: promote deferred font stylesheet via CSSOM so the non-blocking
+// load works under a strict CSP (no inline `onload=` handler).
+document
+  .querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]')
+  .forEach(link => {
+    link.media = 'all';
+  });
+
 // ADS-406: initialise Sentry as early as possible so any synchronous module-load
 // error is captured. No-ops when VITE_SENTRY_DSN is unset.
 initSentry({

--- a/app.client/src/pages/PetDetailsPage.tsx
+++ b/app.client/src/pages/PetDetailsPage.tsx
@@ -397,7 +397,10 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
                 alt={pet.name}
                 onError={e => {
                   e.currentTarget.style.display = 'none';
-                  e.currentTarget.nextElementSibling?.setAttribute('style', 'display: flex');
+                  const fallback = e.currentTarget.nextElementSibling;
+                  if (fallback instanceof HTMLElement) {
+                    fallback.style.display = 'flex';
+                  }
                 }}
               />
             ) : null}

--- a/app.rescue/index.html
+++ b/app.rescue/index.html
@@ -34,7 +34,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Fredoka:wght@300..700&family=Playfair+Display:wght@400..900&family=JetBrains+Mono:wght@400;500;600&display=swap"
       media="print"
-      onload="this.media='all'"
+      data-deferred-stylesheet
     />
     <noscript>
       <link

--- a/app.rescue/src/main.tsx
+++ b/app.rescue/src/main.tsx
@@ -13,11 +13,9 @@ import ErrorBoundary from './components/ErrorBoundary';
 
 // ADS-594: promote deferred font stylesheet via CSSOM so the non-blocking
 // load works under a strict CSP (no inline `onload=` handler).
-document
-  .querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]')
-  .forEach(link => {
-    link.media = 'all';
-  });
+document.querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]').forEach(link => {
+  link.media = 'all';
+});
 
 // ADS-406: initialise Sentry as early as possible so any synchronous module-load
 // error is captured. No-ops when VITE_SENTRY_DSN is unset.

--- a/app.rescue/src/main.tsx
+++ b/app.rescue/src/main.tsx
@@ -11,6 +11,14 @@ import { PermissionsProvider } from '@/contexts/PermissionsContext';
 import { StatsigWrapper } from '@/contexts/StatsigContext';
 import ErrorBoundary from './components/ErrorBoundary';
 
+// ADS-594: promote deferred font stylesheet via CSSOM so the non-blocking
+// load works under a strict CSP (no inline `onload=` handler).
+document
+  .querySelectorAll<HTMLLinkElement>('link[data-deferred-stylesheet]')
+  .forEach(link => {
+    link.media = 'all';
+  });
+
 // ADS-406: initialise Sentry as early as possible so any synchronous module-load
 // error is captured. No-ops when VITE_SENTRY_DSN is unset.
 initSentry({

--- a/docs/backend/deployment.md
+++ b/docs/backend/deployment.md
@@ -1052,9 +1052,10 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", 'https://fonts.googleapis.com'],
         scriptSrc: ["'self'"],
         imgSrc: ["'self'", 'data:', 'https:'],
+        fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com'],
       },
     },
   })

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -83,7 +83,13 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+        # ADS-594: strict CSP — no 'unsafe-inline' / 'unsafe-eval' anywhere.
+        # Inline `onload=` handler in index.html was removed (deferred stylesheet
+        # promotion is now done via CSSOM from main.tsx). React's `style={{}}`
+        # prop applies styles via CSSOM property assignment, which is not
+        # constrained by `style-src-attr`, so no inline-attribute carve-out is
+        # required. Google Fonts hosts are whitelisted explicitly.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
 
         # Static asset caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
@@ -121,7 +127,13 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+        # ADS-594: strict CSP — no 'unsafe-inline' / 'unsafe-eval' anywhere.
+        # Inline `onload=` handler in index.html was removed (deferred stylesheet
+        # promotion is now done via CSSOM from main.tsx). React's `style={{}}`
+        # prop applies styles via CSSOM property assignment, which is not
+        # constrained by `style-src-attr`, so no inline-attribute carve-out is
+        # required. Google Fonts hosts are whitelisted explicitly.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
 
         # Static asset caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
@@ -159,7 +171,13 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+        # ADS-594: strict CSP — no 'unsafe-inline' / 'unsafe-eval' anywhere.
+        # Inline `onload=` handler in index.html was removed (deferred stylesheet
+        # promotion is now done via CSSOM from main.tsx). React's `style={{}}`
+        # prop applies styles via CSSOM property assignment, which is not
+        # constrained by `style-src-attr`, so no inline-attribute carve-out is
+        # required. Google Fonts hosts are whitelisted explicitly.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
 
         # API routes
         location / {
@@ -213,7 +231,13 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+        # ADS-594: strict CSP — no 'unsafe-inline' / 'unsafe-eval' anywhere.
+        # Inline `onload=` handler in index.html was removed (deferred stylesheet
+        # promotion is now done via CSSOM from main.tsx). React's `style={{}}`
+        # prop applies styles via CSSOM property assignment, which is not
+        # constrained by `style-src-attr`, so no inline-attribute carve-out is
+        # required. Google Fonts hosts are whitelisted explicitly.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
 
         # Health check endpoint
         location /health {

--- a/service.backend/src/__tests__/security/security-headers.test.ts
+++ b/service.backend/src/__tests__/security/security-headers.test.ts
@@ -35,11 +35,11 @@ describe('Security Headers', () => {
         contentSecurityPolicy: {
           directives: {
             defaultSrc: ["'self'"],
-            styleSrc: ["'self'", "'unsafe-inline'"],
+            styleSrc: ["'self'", 'https://fonts.googleapis.com'],
             scriptSrc: ["'self'"],
             imgSrc: ["'self'", 'data:', 'https:'],
             connectSrc: ["'self'", 'ws:', 'wss:'],
-            fontSrc: ["'self'", 'https:', 'data:'],
+            fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com'],
             objectSrc: ["'none'"],
             mediaSrc: ["'self'"],
             frameSrc: ["'none'"],
@@ -201,6 +201,43 @@ describe('Security Headers', () => {
 
       expect(csp).toContain('data:');
       expect(csp).toContain('https:');
+    });
+
+    // ADS-594: lock in the script-src tightening so the unsafes can't silently
+    // come back.
+    it("should not allow 'unsafe-eval' in script-src", async () => {
+      const response = await request(app).get('/test');
+      const csp = response.headers['content-security-policy'];
+
+      const scriptSrc = csp?.split(';').find((d: string) => d.trim().startsWith('script-src'));
+      expect(scriptSrc).toBeDefined();
+      expect(scriptSrc).not.toContain("'unsafe-eval'");
+    });
+
+    it("should not allow 'unsafe-inline' in script-src", async () => {
+      const response = await request(app).get('/test');
+      const csp = response.headers['content-security-policy'];
+
+      const scriptSrc = csp?.split(';').find((d: string) => d.trim().startsWith('script-src'));
+      expect(scriptSrc).toBeDefined();
+      expect(scriptSrc).not.toContain("'unsafe-inline'");
+    });
+
+    it("should not allow 'unsafe-inline' in style-src", async () => {
+      const response = await request(app).get('/test');
+      const csp = response.headers['content-security-policy'];
+
+      const styleSrc = csp?.split(';').find((d: string) => d.trim().startsWith('style-src'));
+      expect(styleSrc).toBeDefined();
+      expect(styleSrc).not.toContain("'unsafe-inline'");
+    });
+
+    it('should whitelist Google Fonts hosts explicitly', async () => {
+      const response = await request(app).get('/test');
+      const csp = response.headers['content-security-policy'];
+
+      expect(csp).toContain('https://fonts.googleapis.com');
+      expect(csp).toContain('https://fonts.gstatic.com');
     });
   });
 

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -136,7 +136,11 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'"], // Required for styled-components runtime style injection; remove when migrating to CSS modules
+        // ADS-594: styled-components is no longer used and React's `style={{}}`
+        // prop applies styles via CSSOM (not the parsed `style=""` attribute),
+        // so no `'unsafe-inline'` is required for style-src. Google Fonts is
+        // whitelisted explicitly because the frontend pulls it via <link>.
+        styleSrc: ["'self'", 'https://fonts.googleapis.com'],
         scriptSrc: ["'self'"],
         imgSrc: ["'self'", 'data:', 'https:'],
         connectSrc: [
@@ -147,7 +151,7 @@ app.use(
           (process.env.API_URL ?? 'ws://localhost:5000').replace(/^https?/, 'ws'),
           (process.env.API_URL ?? 'wss://localhost:5000').replace(/^https?/, 'wss'),
         ],
-        fontSrc: ["'self'", 'https:', 'data:'],
+        fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com'],
         objectSrc: ["'none'"], // Disallow plugins
         mediaSrc: ["'self'"],
         frameSrc: ["'none'"], // Prevent clickjacking via iframes


### PR DESCRIPTION
Closes [ADS-594](https://linear.app/ideasquared/issue/ADS-594/nginx-csp-allows-unsafe-inline-and-unsafe-eval-for-scripts).

## Summary

The production CSP (set by nginx, which terminates user-facing requests) previously carried both `'unsafe-inline'` and `'unsafe-eval'` on `script-src`, effectively disabling CSP as an XSS defence. This PR tightens both the nginx and helmet policies so the browser-visible CSP is the strict one.

## Why the 424-inline-style refactor didn't happen

We considered migrating every `style={{}}` site off inline attributes to fully eliminate `'unsafe-inline'` from `style-src`. After investigating:

- All three apps are **CSR-only** (no `renderToString` / SSR anywhere in the tree).
- React's reconciler applies `style={{}}` via CSSOM property assignment (`element.style.color = 'red'`), not via the parsed `style="..."` attribute or `setAttribute('style', ...)`.
- CSP's `style-src-attr` only governs the parsed attribute path, so React inline styles do **not** trip it under strict CSP.
- Only one literal `setAttribute('style', ...)` call existed in the codebase (`PetDetailsPage.tsx:400`) — refactored in this PR.

So the 424-file churn was unnecessary; the tighter `style-src 'self' https://fonts.googleapis.com` (no `'unsafe-inline'`) works as-is.

## Changes

### CSP policy
- `nginx/nginx.conf`: drop `'unsafe-eval'` and `'unsafe-inline'` from `script-src` and `style-src` across all four server blocks (admin, rescue, api, default-client). Whitelist `https://fonts.googleapis.com` for `style-src` and `https://fonts.gstatic.com` for `font-src`. Add `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'` at the edge for parity with helmet.
- `service.backend/src/index.ts`: drop `'unsafe-inline'` from `styleSrc`. Whitelist Google Fonts hosts explicitly (replacing the wildcard `'https:'` on `fontSrc`). Replace the stale styled-components comment.

### Removing the one inline event handler
- `app.{admin,client,rescue}/index.html`: replace `onload="this.media='all'"` on the deferred Google Fonts stylesheet with a `data-deferred-stylesheet` marker attribute.
- `app.{admin,client,rescue}/src/main.tsx`: promote the deferred stylesheet's `media` via CSSOM at module load, preserving the ADS-481 non-blocking-font behaviour with no inline handler.

### Removing the one `setAttribute('style')` call
- `app.client/src/pages/PetDetailsPage.tsx:400`: replace `setAttribute('style', 'display: flex')` with direct CSSOM property assignment.

### Tests + docs
- `service.backend/src/__tests__/security/security-headers.test.ts`: align the duplicated helmet config with production, and add assertions that lock in the absence of `'unsafe-eval'` / `'unsafe-inline'` on `script-src` and `'unsafe-inline'` on `style-src` (so they can't silently regress).
- `docs/backend/deployment.md`: update the example helmet snippet to match the new policy.

## Out of scope

- The Sentry-backed `report-uri` rollout mentioned in the ticket (no CSP report endpoint exists yet — separate ticket).
- Migrating React inline `style={{}}` to vanilla-extract — unnecessary under strict CSP as explained above; can be done later for code-style reasons but offers no further security win.

## Test plan

- [ ] CI green (lint, type-check, vitest suite).
- [ ] After deploy: `curl -I https://admin.adoptdontshop.app/` shows `script-src 'self'` (no unsafes) and Google Fonts hosts on `style-src` / `font-src`.
- [ ] In a browser: the apps load, fonts render (verify Inter/Fredoka/Playfair/JetBrains Mono apply after first paint), the pet detail page placeholder still swaps in on broken image URLs, and no CSP violations appear in the console for normal flows.
- [ ] Pen-test smoke: a stored `<script>alert(1)</script>` rendered via `SafeHtml` does not execute and the browser logs a CSP violation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxWDXLnG8YQowMJVovFici)_