### PR TITLE
Design system: token sweep, form/layout primitives, EmptyState rollout

### DIFF
--- a/DESIGN_TOKENS.md
+++ b/DESIGN_TOKENS.md
@@ -1,0 +1,155 @@
+# Design Tokens
+
+All visual styling in this monorepo flows from a single source of truth: the
+theme contract defined in
+[`lib.components/src/styles/theme.css.ts`](./lib.components/src/styles/theme.css.ts).
+Three themes derive from the same contract: `lightThemeClass`,
+`darkThemeClass`, and `highContrastThemeClass`.
+
+## Importing tokens
+
+In any `*.css.ts` file inside a `lib.*` package:
+
+```ts
+import { vars } from '../../../styles/theme.css';
+```
+
+In any `*.css.ts` file inside an `app.*` package:
+
+```ts
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+```
+
+In React/TS files (rare — usually only for dynamic style props):
+
+```ts
+import { vars } from '@adopt-dont-shop/lib.components';
+```
+
+## Token reference
+
+### Colors
+
+Use semantic tokens whenever possible — they switch with the active theme.
+
+| Token group | Use for |
+|---|---|
+| `vars.text.primary / secondary / tertiary / quaternary` | Body text, in descending emphasis |
+| `vars.text.inverse / disabled / link / linkHover` | Inverted, muted, and link text |
+| `vars.text.success / error / warning / info` | Status text on default surfaces |
+| `vars.background.primary / secondary / tertiary` | Page, surface, raised-surface fills |
+| `vars.background.inverse / overlay / disabled` | Inverted, modal scrims, disabled fills |
+| `vars.background.success / error / warning / info` | Status surface fills (e.g. alert banner) |
+| `vars.border.color.primary / secondary / tertiary` | Borders/dividers, in descending emphasis |
+| `vars.border.color.focus / success / error / warning / info` | Status borders, focus rings |
+
+If you need a specific shade, use the 11-step scale (`50` → `950`):
+
+```ts
+vars.colors.primary['500']           // brand primary
+vars.colors.neutral['100']           // light surface
+vars.colors.semantic.success['600']  // strong success
+```
+
+**Never** hardcode hex codes (`#ffffff`, `#6b7280`, …) in app or library styles.
+The theme cannot follow them across light/dark/high-contrast modes.
+
+### Spacing (4 px base)
+
+Two equivalent scales. Prefer the named one in component-level code.
+
+| Named | Numeric | px |
+|---|---|---|
+| `vars.spacing.xs` | `vars.spacing['1']` | 4 |
+| `vars.spacing.sm` | `vars.spacing['2']` | 8 |
+| `vars.spacing.md` | `vars.spacing['4']` | 16 |
+| `vars.spacing.lg` | `vars.spacing['6']` | 24 |
+| `vars.spacing.xl` | `vars.spacing['8']` | 32 |
+| `vars.spacing['2xl']` | `vars.spacing['12']` | 48 |
+| `vars.spacing['3xl']` | `vars.spacing['16']` | 64 |
+| `vars.spacing['4xl']` | `vars.spacing['20']` | 80 |
+
+The numeric scale also covers half-steps (`0.5`, `1.5`, `2.5`, `3.5`) for fine
+adjustments. Anything not on the scale (`13px`, `0.625rem`) is a smell.
+
+### Border radius
+
+| Token | px |
+|---|---|
+| `vars.border.radius.none` | 0 |
+| `vars.border.radius.xs` | 2 |
+| `vars.border.radius.sm` | 4 |
+| `vars.border.radius.md` | 6 |
+| `vars.border.radius.lg` | 8 |
+| `vars.border.radius.xl` | 12 |
+| `vars.border.radius['2xl']` | 16 |
+| `vars.border.radius['3xl']` | 24 |
+| `vars.border.radius.full` | 9999 (pill/circle) |
+
+### Typography
+
+```ts
+vars.typography.family.sans     // body
+vars.typography.family.mono     // code, IPs, IDs
+vars.typography.family.display  // marketing headings
+
+vars.typography.size.xs   // 12px-ish (captions)
+vars.typography.size.sm   // 14px (helper text)
+vars.typography.size.base // 16px (body)
+vars.typography.size.lg   // 18px (section titles)
+vars.typography.size.xl   // 20px
+vars.typography.size['2xl'] // 24px (page titles)
+// …up to 9xl
+
+vars.typography.weight.normal | medium | semibold | bold
+vars.typography.lineHeight.tight | snug | normal | relaxed | loose
+```
+
+### Shadows, transitions, z-index
+
+```ts
+vars.shadows.sm | md | lg | xl | 2xl
+vars.shadows.focus | focusPrimary | focusError | focusWarning | focusSuccess
+vars.transitions.fast | normal | slow      // includes timing + easing
+vars.zIndex.dropdown | sticky | overlay | modal | popover | toast | tooltip
+```
+
+### Breakpoints
+
+```ts
+'@media': {
+  [`(min-width: ${vars.breakpoints.sm})`]: { … },  // 640px
+  [`(min-width: ${vars.breakpoints.md})`]: { … },  // 768px
+  [`(min-width: ${vars.breakpoints.lg})`]: { … },  // 1024px
+}
+```
+
+## Reusable components first
+
+Before writing your own CSS, check whether
+[`lib.components`](./lib.components/src/index.ts) already exports what you
+need. Frequently overlooked:
+
+- **`Stack`** / **`Container`** — layout primitives instead of manual flex/grid
+- **`Card`** / **`CardHeader`** / **`CardContent`** / **`CardFooter`**
+- **`EmptyState`** — empty/error/loading/search states with consistent styling
+- **`FormSection`** / **`FormRow`** / **`FormField`** — form layout primitives
+- **`Badge`** / **`Alert`** / **`Heading`** / **`Text`**
+
+## Checklist when reviewing styles
+
+- [ ] No hardcoded hex codes (`#…`) — use `vars.*`
+- [ ] No off-scale spacing (`13px`, `0.625rem`, `padding: 11px 19px`) — use `vars.spacing.*`
+- [ ] No raw `borderRadius: '12px'` — use `vars.border.radius.xl`
+- [ ] Uses `vars.text.*` / `vars.background.*` for theme-aware foregrounds/backgrounds
+- [ ] Status colors use `vars.colors.semantic.*` rather than ad-hoc greens/reds
+- [ ] Page layout uses `Stack` / `Container` / `FormRow` rather than hand-rolled grids
+- [ ] Empty/error/loading states use `EmptyState`, not raw divs
+
+## Why this matters
+
+The library already supports light, dark, and high-contrast (WCAG-AAA) themes
+via the same token contract. Every hardcoded color is a value that **cannot**
+follow theme changes — it locks light-mode colors into dark-mode UI and breaks
+high-contrast accessibility. Centralising on tokens is what makes
+theme-switching, brand updates, and a11y compliance one-line changes.

--- a/app.admin/src/pages/AccountSettings.css.ts
+++ b/app.admin/src/pages/AccountSettings.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   padding: '2rem',
   maxWidth: '800px',
@@ -13,19 +15,19 @@ export const pageHeader = style({
 globalStyle(`${pageHeader} h1`, {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#1f2937',
+  color: vars.colors.neutral['800'],
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${pageHeader} p`, {
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
 export const section = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '0.75rem',
   padding: '2rem',
   marginBottom: '1.5rem',
@@ -33,12 +35,12 @@ export const section = style({
 
 globalStyle(`${section} h2`, {
   fontSize: '1.25rem',
-  color: '#374151',
+  color: vars.text.secondary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${section} > p`, {
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: '0 0 1.5rem 0',
 });

--- a/app.admin/src/pages/Analytics.css.ts
+++ b/app.admin/src/pages/Analytics.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style, keyframes } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const headerActions = style({
   display: 'flex',
   gap: '0.75rem',
@@ -50,7 +52,7 @@ export const barLabel = style({
   position: 'absolute',
   bottom: '-30px',
   fontSize: '0.75rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontWeight: '500',
   whiteSpace: 'nowrap',
 });
@@ -60,7 +62,7 @@ export const barValue = style({
   top: '-30px',
   fontSize: '0.875rem',
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const lineChart = style({
@@ -103,14 +105,14 @@ export const legendColor = style({
 
 export const legendLabel = style({
   fontSize: '0.875rem',
-  color: '#374151',
+  color: vars.text.secondary,
   flex: 1,
 });
 
 export const legendValue = style({
   fontSize: '0.875rem',
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const metricChangePositive = style({
@@ -131,7 +133,7 @@ export const metricChangeNegative = style({
   alignItems: 'center',
   gap: '0.25rem',
   fontSize: '0.875rem',
-  color: '#dc2626',
+  color: vars.colors.semantic.error['600'],
   fontWeight: '600',
 });
 
@@ -151,12 +153,12 @@ export const topItem = style({
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: '0.875rem',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
   transition: 'all 0.2s ease',
   ':hover': {
-    background: '#f9fafb',
-    borderColor: '#d1d5db',
+    background: vars.background.primary,
+    borderColor: vars.border.color.secondary,
   },
 });
 
@@ -164,8 +166,8 @@ export const topItemRank = style({
   width: '32px',
   height: '32px',
   borderRadius: '8px',
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-  color: '#ffffff',
+  background: vars.colors.gradients.primary,
+  color: vars.background.secondary,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -181,20 +183,20 @@ export const topItemInfo = style({
 
 export const topItemName = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
   fontSize: '0.875rem',
 });
 
 export const topItemMeta = style({
   fontSize: '0.75rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginTop: '0.125rem',
 });
 
 export const topItemValue = style({
   fontSize: '1.125rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 const shimmerAnim = keyframes({
@@ -213,10 +215,10 @@ export const skeletonBlock = style({
 });
 
 export const errorBanner = style({
-  background: '#fee2e2',
-  border: '1px solid #fecaca',
+  background: vars.colors.semantic.error['100'],
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
   borderRadius: '8px',
   padding: '1rem',
-  color: '#991b1b',
+  color: vars.colors.semantic.error['800'],
   fontSize: '0.875rem',
 });

--- a/app.admin/src/pages/Applications.css.ts
+++ b/app.admin/src/pages/Applications.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   display: 'flex',
   flexDirection: 'column',
@@ -19,13 +21,13 @@ export const headerLeft = style({});
 globalStyle(`${headerLeft} h1`, {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 export const filterBar = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.5rem',
   display: 'flex',
@@ -45,7 +47,7 @@ export const filterGroup = style({
 export const filterLabel = style({
   fontSize: '0.875rem',
   fontWeight: '500',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const searchInputWrapper = style({
@@ -59,7 +61,7 @@ globalStyle(`${searchInputWrapper} svg`, {
   left: '0.75rem',
   top: '50%',
   transform: 'translateY(-50%)',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   fontSize: '1.125rem',
 });
 
@@ -69,19 +71,19 @@ globalStyle(`${searchInputWrapper} input`, {
 
 export const select = style({
   padding: '0.625rem 0.875rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#111827',
-  background: '#ffffff',
+  color: vars.text.primary,
+  background: vars.background.secondary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    borderColor: '#9ca3af',
+    borderColor: vars.text.quaternary,
   },
   ':focus': {
     outline: 'none',
-    borderColor: '#667eea',
+    borderColor: vars.colors.primary['500'],
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
   },
 });
@@ -93,8 +95,8 @@ export const badgeSuccess = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#d1fae5',
-  color: '#065f46',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 export const badgeWarning = style({
@@ -104,8 +106,8 @@ export const badgeWarning = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 export const badgeDanger = style({
@@ -115,8 +117,8 @@ export const badgeDanger = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fee2e2',
-  color: '#991b1b',
+  background: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['800'],
 });
 
 export const badgeNeutral = style({
@@ -126,8 +128,8 @@ export const badgeNeutral = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#f3f4f6',
-  color: '#374151',
+  background: vars.background.tertiary,
+  color: vars.text.secondary,
 });
 
 export const applicantInfo = style({
@@ -138,19 +140,19 @@ export const applicantInfo = style({
 
 export const applicantName = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const applicantEmail = style({
   fontSize: '0.8125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const errorMessage = style({
-  background: '#fee2e2',
-  border: '1px solid #fecaca',
+  background: vars.colors.semantic.error['100'],
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
   borderRadius: '8px',
   padding: '1rem',
-  color: '#991b1b',
+  color: vars.colors.semantic.error['800'],
   fontSize: '0.875rem',
 });

--- a/app.admin/src/pages/Audit.css.ts
+++ b/app.admin/src/pages/Audit.css.ts
@@ -1,178 +1,154 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const headerActions = style({
   display: 'flex',
-  gap: '0.75rem',
+  gap: vars.spacing['3'],
 });
 
 export const logDetails = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: '0.25rem',
+  gap: vars.spacing['1'],
 });
 
 export const logAction = style({
-  fontWeight: '600',
-  color: '#111827',
+  fontWeight: vars.typography.weight.semibold,
+  color: vars.text.primary,
   display: 'flex',
   alignItems: 'center',
-  gap: '0.5rem',
+  gap: vars.spacing['2'],
 });
 
 globalStyle(`${logAction} svg`, {
-  fontSize: '0.875rem',
-  color: '#6b7280',
+  fontSize: vars.typography.size.sm,
+  color: vars.text.tertiary,
 });
 
 export const logResource = style({
-  fontSize: '0.8125rem',
-  color: '#6b7280',
+  fontSize: vars.typography.size.sm,
+  color: vars.text.tertiary,
 });
 
 export const userInfo = style({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.5rem',
+  gap: vars.spacing['2'],
 });
 
 export const userAvatar = style({
   width: '24px',
   height: '24px',
-  borderRadius: '50%',
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  borderRadius: vars.border.radius.full,
+  background: vars.colors.gradients.primary,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  color: '#ffffff',
-  fontWeight: '600',
-  fontSize: '0.625rem',
+  color: vars.text.inverse,
+  fontWeight: vars.typography.weight.semibold,
+  fontSize: vars.typography.size.xs,
   flexShrink: 0,
 });
 
 export const userName = style({
-  fontSize: '0.875rem',
-  color: '#111827',
-  fontWeight: '500',
+  fontSize: vars.typography.size.sm,
+  color: vars.text.primary,
+  fontWeight: vars.typography.weight.medium,
 });
 
-export const actionIconCreate = style({
+const actionIconBase = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   width: '24px',
   height: '24px',
-  borderRadius: '6px',
-  background: '#d1fae5',
-  color: '#065f46',
+  borderRadius: vars.border.radius.md,
   flexShrink: 0,
+} as const;
+
+export const actionIconCreate = style({
+  ...actionIconBase,
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 globalStyle(`${actionIconCreate} svg`, {
-  fontSize: '0.875rem',
+  fontSize: vars.typography.size.sm,
 });
 
 export const actionIconUpdate = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '24px',
-  height: '24px',
-  borderRadius: '6px',
-  background: '#dbeafe',
-  color: '#1e40af',
-  flexShrink: 0,
+  ...actionIconBase,
+  background: vars.colors.semantic.info['100'],
+  color: vars.colors.semantic.info['800'],
 });
 
 globalStyle(`${actionIconUpdate} svg`, {
-  fontSize: '0.875rem',
+  fontSize: vars.typography.size.sm,
 });
 
 export const actionIconDelete = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '24px',
-  height: '24px',
-  borderRadius: '6px',
-  background: '#fee2e2',
-  color: '#991b1b',
-  flexShrink: 0,
+  ...actionIconBase,
+  background: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['800'],
 });
 
 globalStyle(`${actionIconDelete} svg`, {
-  fontSize: '0.875rem',
+  fontSize: vars.typography.size.sm,
 });
 
 export const actionIconLogin = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '24px',
-  height: '24px',
-  borderRadius: '6px',
-  background: '#fef3c7',
-  color: '#92400e',
-  flexShrink: 0,
+  ...actionIconBase,
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 globalStyle(`${actionIconLogin} svg`, {
-  fontSize: '0.875rem',
+  fontSize: vars.typography.size.sm,
 });
 
 export const actionIconLogout = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '24px',
-  height: '24px',
-  borderRadius: '6px',
-  background: '#f3f4f6',
-  color: '#374151',
-  flexShrink: 0,
+  ...actionIconBase,
+  background: vars.colors.neutral['100'],
+  color: vars.colors.neutral['700'],
 });
 
 globalStyle(`${actionIconLogout} svg`, {
-  fontSize: '0.875rem',
+  fontSize: vars.typography.size.sm,
 });
 
 export const actionIconDefault = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '24px',
-  height: '24px',
-  borderRadius: '6px',
-  background: '#e0e7ff',
-  color: '#3730a3',
-  flexShrink: 0,
+  ...actionIconBase,
+  background: vars.colors.primary['100'],
+  color: vars.colors.primary['800'],
 });
 
 globalStyle(`${actionIconDefault} svg`, {
-  fontSize: '0.875rem',
+  fontSize: vars.typography.size.sm,
 });
 
 export const changesButton = style({
-  padding: '0.25rem 0.625rem',
-  border: '1px solid #d1d5db',
-  borderRadius: '6px',
-  background: '#ffffff',
-  color: '#6b7280',
-  fontSize: '0.75rem',
+  padding: `${vars.spacing['1']} ${vars.spacing['2.5']}`,
+  border: `1px solid ${vars.border.color.secondary}`,
+  borderRadius: vars.border.radius.md,
+  background: vars.background.secondary,
+  color: vars.text.tertiary,
+  fontSize: vars.typography.size.xs,
   cursor: 'pointer',
-  transition: 'all 0.2s ease',
+  transition: `all ${vars.transitions.fast}`,
   ':hover': {
-    background: '#f9fafb',
-    borderColor: '#9ca3af',
+    background: vars.background.tertiary,
+    borderColor: vars.border.color.tertiary,
   },
 });
 
 export const ipAddress = style({
-  fontFamily: "'Monaco', 'Courier New', monospace",
-  fontSize: '0.75rem',
-  color: '#6b7280',
-  background: '#f3f4f6',
-  padding: '0.125rem 0.5rem',
-  borderRadius: '4px',
+  fontFamily: vars.typography.family.mono,
+  fontSize: vars.typography.size.xs,
+  color: vars.text.tertiary,
+  background: vars.background.tertiary,
+  padding: `${vars.spacing['0.5']} ${vars.spacing['2']}`,
+  borderRadius: vars.border.radius.sm,
 });
 
 export const modal = style({
@@ -181,44 +157,44 @@ export const modal = style({
   left: 0,
   right: 0,
   bottom: 0,
-  background: 'rgba(0, 0, 0, 0.5)',
+  background: vars.background.overlay,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  zIndex: 1000,
+  zIndex: vars.zIndex.modal,
 });
 
 export const modalContent = style({
-  background: 'white',
-  borderRadius: '12px',
-  padding: '1.5rem',
+  background: vars.background.secondary,
+  borderRadius: vars.border.radius.xl,
+  padding: vars.spacing.lg,
   maxWidth: '600px',
   maxHeight: '80vh',
   overflow: 'auto',
-  boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
+  boxShadow: vars.shadows.xl,
 });
 
 export const modalHeader = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  marginBottom: '1rem',
-  paddingBottom: '1rem',
-  borderBottom: '1px solid #e5e7eb',
+  marginBottom: vars.spacing.md,
+  paddingBottom: vars.spacing.md,
+  borderBottom: `1px solid ${vars.border.color.primary}`,
 });
 
 export const modalTitle = style({
-  fontSize: '1.125rem',
-  fontWeight: '600',
-  color: '#111827',
+  fontSize: vars.typography.size.lg,
+  fontWeight: vars.typography.weight.semibold,
+  color: vars.text.primary,
   margin: 0,
 });
 
 export const closeButton = style({
   background: 'none',
   border: 'none',
-  fontSize: '1.5rem',
-  color: '#6b7280',
+  fontSize: vars.typography.size.xl,
+  color: vars.text.tertiary,
   cursor: 'pointer',
   padding: 0,
   width: '32px',
@@ -226,39 +202,39 @@ export const closeButton = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  borderRadius: '6px',
-  transition: 'all 0.2s ease',
+  borderRadius: vars.border.radius.md,
+  transition: `all ${vars.transitions.fast}`,
   ':hover': {
-    background: '#f3f4f6',
-    color: '#111827',
+    background: vars.background.tertiary,
+    color: vars.text.primary,
   },
 });
 
 export const jsonBlock = style({
-  background: '#1f2937',
-  color: '#f9fafb',
-  padding: '1rem',
-  borderRadius: '8px',
+  background: vars.colors.neutral['900'],
+  color: vars.colors.neutral['50'],
+  padding: vars.spacing.md,
+  borderRadius: vars.border.radius.lg,
   overflow: 'auto',
-  fontFamily: "'Monaco', 'Courier New', monospace",
-  fontSize: '0.875rem',
-  lineHeight: 1.5,
+  fontFamily: vars.typography.family.mono,
+  fontSize: vars.typography.size.sm,
+  lineHeight: vars.typography.lineHeight.relaxed,
   margin: 0,
 });
 
 export const subUserType = style({
-  fontSize: '0.75rem',
-  color: '#9ca3af',
+  fontSize: vars.typography.size.xs,
+  color: vars.text.quaternary,
 });
 
 export const buttonIcon = style({
-  marginRight: '0.5rem',
+  marginRight: vars.spacing['2'],
 });
 
 export const errorBanner = style({
-  padding: '1rem',
-  color: '#dc2626',
-  background: '#fee2e2',
-  borderRadius: '8px',
-  margin: '1rem 0',
+  padding: vars.spacing.md,
+  color: vars.text.error,
+  background: vars.background.error,
+  borderRadius: vars.border.radius.lg,
+  margin: `${vars.spacing.md} 0`,
 });

--- a/app.admin/src/pages/BroadcastNotifications.css.ts
+++ b/app.admin/src/pages/BroadcastNotifications.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const form = style({
   display: 'flex',
   flexDirection: 'column',
@@ -28,13 +30,13 @@ export const actions = style({
 
 export const previewLabel = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const result = style({
   marginTop: '1rem',
   padding: '0.875rem 1rem',
-  border: '1px solid #d1fae5',
+  border: `1px solid ${vars.colors.semantic.success['100']}`,
   background: '#ecfdf5',
   borderRadius: '8px',
   fontSize: '0.875rem',
@@ -43,9 +45,9 @@ export const result = style({
 export const error = style({
   marginTop: '1rem',
   padding: '0.875rem 1rem',
-  border: '1px solid #fecaca',
-  background: '#fef2f2',
-  color: '#991b1b',
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
+  background: vars.colors.semantic.error['50'],
+  color: vars.colors.semantic.error['800'],
   borderRadius: '8px',
   fontSize: '0.875rem',
 });

--- a/app.admin/src/pages/Configuration.css.ts
+++ b/app.admin/src/pages/Configuration.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const headerActions = style({
   display: 'flex',
   gap: '0.75rem',
@@ -22,11 +24,11 @@ export const infoBanner = style({
   alignItems: 'flex-start',
   gap: '0.75rem',
   padding: '1rem',
-  background: '#eff6ff',
-  border: '1px solid #bfdbfe',
+  background: vars.colors.semantic.info['50'],
+  border: `1px solid ${vars.colors.semantic.info['200']}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#1e40af',
+  color: vars.colors.semantic.info['800'],
   marginBottom: '1rem',
 });
 
@@ -36,7 +38,7 @@ globalStyle(`${infoBanner} svg`, {
 });
 
 globalStyle(`${infoBanner} a`, {
-  color: '#2563eb',
+  color: vars.colors.semantic.info['600'],
   fontWeight: '600',
   textDecoration: 'none',
 });
@@ -50,12 +52,12 @@ export const gateItem = style({
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '1rem',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
   transition: 'all 0.2s ease',
   ':hover': {
-    borderColor: '#d1d5db',
-    background: '#f9fafb',
+    borderColor: vars.border.color.secondary,
+    background: vars.background.primary,
   },
 });
 
@@ -68,20 +70,20 @@ export const gateInfo = style({
 
 export const gateName = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
   fontSize: '0.9375rem',
 });
 
 export const gateDescription = style({
   fontSize: '0.8125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: 1.4,
 });
 
 export const gateKey = style({
   fontFamily: 'monospace',
   fontSize: '0.75rem',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   marginTop: '0.25rem',
 });
 
@@ -92,8 +94,8 @@ export const statusBadgeEnabled = style({
   borderRadius: '6px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#d1fae5',
-  color: '#065f46',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 export const statusBadgeDisabled = style({
@@ -103,8 +105,8 @@ export const statusBadgeDisabled = style({
   borderRadius: '6px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#f3f4f6',
-  color: '#6b7280',
+  background: vars.background.tertiary,
+  color: vars.text.tertiary,
 });
 
 export const settingItem = style({
@@ -112,22 +114,22 @@ export const settingItem = style({
   flexDirection: 'column',
   gap: '0.5rem',
   padding: '1rem',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
 });
 
 export const settingLabel = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
   fontSize: '0.875rem',
 });
 
 export const settingValue = style({
   fontFamily: 'monospace',
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   padding: '0.5rem',
-  background: '#f9fafb',
+  background: vars.background.primary,
   borderRadius: '6px',
 });
 
@@ -135,7 +137,7 @@ export const statsigLink = style({
   display: 'inline-flex',
   alignItems: 'center',
   gap: '0.375rem',
-  color: '#2563eb',
+  color: vars.colors.semantic.info['600'],
   textDecoration: 'none',
   fontSize: '0.875rem',
   fontWeight: '600',

--- a/app.admin/src/pages/ContentManagement.css.ts
+++ b/app.admin/src/pages/ContentManagement.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   display: 'flex',
   flexDirection: 'column',
@@ -19,13 +21,13 @@ export const headerLeft = style({});
 globalStyle(`${headerLeft} h1`, {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${headerLeft} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -37,7 +39,7 @@ export const headerActions = style({
 export const tabBar = style({
   display: 'flex',
   gap: 0,
-  borderBottom: '2px solid #e5e7eb',
+  borderBottom: `2px solid ${vars.border.color.primary}`,
 });
 
 export const tab = style({
@@ -46,7 +48,7 @@ export const tab = style({
   border: 'none',
   borderBottom: '2px solid transparent',
   marginBottom: '-2px',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontWeight: '400',
   fontSize: '0.875rem',
   cursor: 'pointer',
@@ -56,14 +58,14 @@ export const tab = style({
 });
 
 export const tabActive = style({
-  borderBottomColor: '#2563eb',
-  color: '#2563eb',
+  borderBottomColor: vars.colors.semantic.info['600'],
+  color: vars.colors.semantic.info['600'],
   fontWeight: '600',
 });
 
 export const card = style({
-  background: '#fff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.5rem',
 });
@@ -85,16 +87,16 @@ export const filterGroup = style({
 export const filterLabel = style({
   fontSize: '0.8rem',
   fontWeight: '500',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const select = style({
   padding: '0.5rem 0.75rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  background: '#fff',
-  color: '#111827',
+  background: vars.background.secondary,
+  color: vars.text.primary,
   cursor: 'pointer',
 });
 
@@ -109,13 +111,13 @@ globalStyle(`${searchWrapper} svg`, {
   left: '0.75rem',
   top: '50%',
   transform: 'translateY(-50%)',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
 });
 
 export const searchInput = style({
   width: '100%',
   padding: '0.5rem 0.75rem 0.5rem 2.25rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
   boxSizing: 'border-box',
@@ -134,16 +136,16 @@ export const th = style({
   fontWeight: '600',
   textTransform: 'uppercase',
   letterSpacing: '0.05em',
-  color: '#6b7280',
-  borderBottom: '1px solid #e5e7eb',
-  background: '#f9fafb',
+  color: vars.text.tertiary,
+  borderBottom: `1px solid ${vars.border.color.primary}`,
+  background: vars.background.primary,
 });
 
 export const td = style({
   padding: '0.875rem 1rem',
-  borderBottom: '1px solid #f3f4f6',
+  borderBottom: `1px solid ${vars.background.tertiary}`,
   fontSize: '0.875rem',
-  color: '#374151',
+  color: vars.text.secondary,
   verticalAlign: 'middle',
 });
 
@@ -154,8 +156,8 @@ export const statusBadgePublished = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '500',
-  background: '#d1fae5',
-  color: '#065f46',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 export const statusBadgeDraft = style({
@@ -165,8 +167,8 @@ export const statusBadgeDraft = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '500',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 export const statusBadgeScheduled = style({
@@ -176,8 +178,8 @@ export const statusBadgeScheduled = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '500',
-  background: '#dbeafe',
-  color: '#1e40af',
+  background: vars.colors.semantic.info['100'],
+  color: vars.colors.semantic.info['800'],
 });
 
 export const statusBadgeDefault = style({
@@ -187,8 +189,8 @@ export const statusBadgeDefault = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '500',
-  background: '#f3f4f6',
-  color: '#374151',
+  background: vars.background.tertiary,
+  color: vars.text.secondary,
 });
 
 export const actionGroup = style({
@@ -203,9 +205,9 @@ export const iconButton = style({
   justifyContent: 'center',
   padding: '0.375rem',
   borderRadius: '6px',
-  border: '1px solid #e5e7eb',
-  background: '#fff',
-  color: '#6b7280',
+  border: `1px solid ${vars.border.color.primary}`,
+  background: vars.background.secondary,
+  color: vars.text.tertiary,
   cursor: 'pointer',
   ':hover': {
     opacity: 0.8,
@@ -219,8 +221,8 @@ export const iconButtonPrimary = style({
   padding: '0.375rem',
   borderRadius: '6px',
   border: '1px solid #93c5fd',
-  background: '#eff6ff',
-  color: '#2563eb',
+  background: vars.colors.semantic.info['50'],
+  color: vars.colors.semantic.info['600'],
   cursor: 'pointer',
   ':hover': {
     opacity: 0.8,
@@ -234,8 +236,8 @@ export const iconButtonDanger = style({
   padding: '0.375rem',
   borderRadius: '6px',
   border: '1px solid #fca5a5',
-  background: '#fef2f2',
-  color: '#dc2626',
+  background: vars.colors.semantic.error['50'],
+  color: vars.colors.semantic.error['600'],
   cursor: 'pointer',
   ':hover': {
     opacity: 0.8,
@@ -247,15 +249,15 @@ export const primaryButton = style({
   alignItems: 'center',
   gap: '0.5rem',
   padding: '0.625rem 1.25rem',
-  background: '#2563eb',
-  color: '#fff',
+  background: vars.colors.semantic.info['600'],
+  color: vars.background.secondary,
   border: 'none',
   borderRadius: '8px',
   fontSize: '0.875rem',
   fontWeight: '500',
   cursor: 'pointer',
   ':hover': {
-    background: '#1d4ed8',
+    background: vars.colors.semantic.info['700'],
   },
   ':disabled': {
     opacity: 0.6,
@@ -275,7 +277,7 @@ export const overlay = style({
 });
 
 export const modal = style({
-  background: '#fff',
+  background: vars.background.secondary,
   borderRadius: '16px',
   width: '100%',
   maxWidth: '760px',
@@ -296,7 +298,7 @@ export const modalHeader = style({
 globalStyle(`${modalHeader} h2`, {
   margin: 0,
   fontSize: '1.25rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const closeButton = style({
@@ -304,7 +306,7 @@ export const closeButton = style({
   border: 'none',
   fontSize: '1.5rem',
   cursor: 'pointer',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: 1,
 });
 
@@ -335,27 +337,27 @@ export const formGroupFull = style({
 export const formLabel = style({
   fontSize: '0.8rem',
   fontWeight: '600',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const formInput = style({
   padding: '0.5rem 0.75rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
   ':focus': {
     outline: 'none',
-    borderColor: '#2563eb',
+    borderColor: vars.colors.semantic.info['600'],
   },
   ':disabled': {
-    background: '#f9fafb',
-    color: '#9ca3af',
+    background: vars.background.primary,
+    color: vars.text.quaternary,
   },
 });
 
 export const formTextarea = style({
   padding: '0.5rem 0.75rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
   resize: 'vertical',
@@ -363,16 +365,16 @@ export const formTextarea = style({
   fontFamily: 'monospace',
   ':focus': {
     outline: 'none',
-    borderColor: '#2563eb',
+    borderColor: vars.colors.semantic.info['600'],
   },
 });
 
 export const formSelect = style({
   padding: '0.5rem 0.75rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  background: '#fff',
+  background: vars.background.secondary,
 });
 
 export const modalActions = style({
@@ -380,14 +382,14 @@ export const modalActions = style({
   justifyContent: 'flex-end',
   gap: '0.75rem',
   paddingTop: '0.5rem',
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.primary}`,
 });
 
 export const secondaryButton = style({
   padding: '0.625rem 1.25rem',
-  border: '1px solid #d1d5db',
-  background: '#fff',
-  color: '#374151',
+  border: `1px solid ${vars.border.color.secondary}`,
+  background: vars.background.secondary,
+  color: vars.text.secondary,
   borderRadius: '8px',
   fontSize: '0.875rem',
   cursor: 'pointer',
@@ -396,21 +398,21 @@ export const secondaryButton = style({
 export const emptyState = style({
   padding: '3rem',
   textAlign: 'center',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   fontSize: '0.95rem',
 });
 
 export const errorMessage = style({
-  color: '#dc2626',
+  color: vars.colors.semantic.error['600'],
   fontSize: '0.875rem',
   margin: 0,
 });
 
 export const seoSection = style({
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
   padding: '1rem',
-  background: '#f9fafb',
+  background: vars.background.primary,
   gridColumn: '1 / -1',
   display: 'flex',
   flexDirection: 'column',
@@ -420,6 +422,6 @@ export const seoSection = style({
 export const seoTitle = style({
   fontSize: '0.875rem',
   fontWeight: '600',
-  color: '#374151',
+  color: vars.text.secondary,
   margin: 0,
 });

--- a/app.admin/src/pages/Dashboard.css.ts
+++ b/app.admin/src/pages/Dashboard.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style, keyframes } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const dashboardContainer = style({
   display: 'flex',
   flexDirection: 'column',
@@ -18,8 +20,8 @@ export const metricsGrid = style({
 });
 
 export const metricCard = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.5rem',
   transition: 'all 0.2s ease',
@@ -43,7 +45,7 @@ globalStyle(`${metricHeader} span`, {
 export const metricLabel = style({
   fontSize: '0.875rem',
   fontWeight: '600',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   textTransform: 'uppercase',
   letterSpacing: '0.025em',
 });
@@ -51,19 +53,19 @@ export const metricLabel = style({
 export const metricValue = style({
   fontSize: '2.25rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   marginBottom: '0.5rem',
 });
 
 export const metricChangePositive = style({
   fontSize: '0.875rem',
-  color: '#10b981',
+  color: vars.colors.semantic.success['500'],
   fontWeight: '500',
 });
 
 export const metricChangeNegative = style({
   fontSize: '0.875rem',
-  color: '#ef4444',
+  color: vars.colors.semantic.error['500'],
   fontWeight: '500',
 });
 
@@ -83,10 +85,10 @@ export const skeletonBlock = style({
 });
 
 export const errorBanner = style({
-  background: '#fee2e2',
-  border: '1px solid #fecaca',
+  background: vars.colors.semantic.error['100'],
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
   borderRadius: '12px',
   padding: '1.5rem',
-  color: '#991b1b',
+  color: vars.colors.semantic.error['800'],
   fontSize: '0.875rem',
 });

--- a/app.admin/src/pages/Dashboard.css.ts
+++ b/app.admin/src/pages/Dashboard.css.ts
@@ -2,14 +2,11 @@ import { globalStyle, style, keyframes } from '@vanilla-extract/css';
 
 import { vars } from '@adopt-dont-shop/lib.components/theme';
 
-export const dashboardContainer = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '2rem',
-});
+// Stack handles direction/gap; the className only adds page-level overrides.
+export const dashboardContainer = style({});
 
 export const pageHeader = style({
-  marginBottom: '1rem',
+  marginBottom: vars.spacing.md,
 });
 
 export const metricsGrid = style({
@@ -22,7 +19,7 @@ export const metricsGrid = style({
 export const metricCard = style({
   background: vars.background.secondary,
   border: `1px solid ${vars.border.color.primary}`,
-  borderRadius: '12px',
+  borderRadius: vars.border.radius.xl,
   padding: '1.5rem',
   transition: 'all 0.2s ease',
   ':hover': {
@@ -75,8 +72,8 @@ const shimmerAnim = keyframes({
 });
 
 export const skeletonBlock = style({
-  borderRadius: '6px',
-  background: 'linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%)',
+  borderRadius: vars.border.radius.md,
+  background: `linear-gradient(90deg, ${vars.background.tertiary} 25%, ${vars.background.primary} 50%, ${vars.background.tertiary} 75%)`,
   backgroundSize: '200px 100%',
   animationName: shimmerAnim,
   animationDuration: '1.4s',
@@ -87,7 +84,7 @@ export const skeletonBlock = style({
 export const errorBanner = style({
   background: vars.colors.semantic.error['100'],
   border: `1px solid ${vars.colors.semantic.error['200']}`,
-  borderRadius: '12px',
+  borderRadius: vars.border.radius.xl,
   padding: '1.5rem',
   color: vars.colors.semantic.error['800'],
   fontSize: '0.875rem',

--- a/app.admin/src/pages/Dashboard.tsx
+++ b/app.admin/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Heading, Text } from '@adopt-dont-shop/lib.components';
+import { EmptyState, Heading, Stack, Text } from '@adopt-dont-shop/lib.components';
 import { usePlatformMetrics } from '../hooks';
 import * as styles from './Dashboard.css';
 
@@ -77,7 +77,7 @@ const Dashboard: React.FC = () => {
     : [];
 
   return (
-    <div className={styles.dashboardContainer}>
+    <Stack spacing='xl' className={styles.dashboardContainer}>
       <div className={styles.pageHeader}>
         <Heading level='h1'>Admin Dashboard</Heading>
         <Text>Welcome back! Here's what's happening across the platform today.</Text>
@@ -129,21 +129,12 @@ const Dashboard: React.FC = () => {
             ))}
       </div>
 
-      <div
-        style={{
-          background: '#ffffff',
-          border: '1px solid #e5e7eb',
-          borderRadius: '12px',
-          padding: '2rem',
-          textAlign: 'center',
-          color: '#6b7280',
-        }}
-      >
-        <p style={{ margin: 0, fontSize: '0.875rem' }}>
-          📊 Additional dashboard widgets will be added here: recent activity, charts, alerts, etc.
-        </p>
-      </div>
-    </div>
+      <EmptyState
+        title='More widgets coming soon'
+        description='Recent activity, charts, and alerts will appear here.'
+        variant='loading'
+      />
+    </Stack>
   );
 };
 

--- a/app.admin/src/pages/FieldPermissions.css.ts
+++ b/app.admin/src/pages/FieldPermissions.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const headerActions = style({
   display: 'flex',
   gap: '0.75rem',
@@ -10,11 +12,11 @@ export const infoBanner = style({
   alignItems: 'flex-start',
   gap: '0.75rem',
   padding: '1rem',
-  background: '#eff6ff',
-  border: '1px solid #bfdbfe',
+  background: vars.colors.semantic.info['50'],
+  border: `1px solid ${vars.colors.semantic.info['200']}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#1e40af',
+  color: vars.colors.semantic.info['800'],
   marginBottom: '1.5rem',
 });
 
@@ -26,7 +28,7 @@ globalStyle(`${infoBanner} svg`, {
 export const tabRow = style({
   display: 'flex',
   gap: 0,
-  borderBottom: '2px solid #e5e7eb',
+  borderBottom: `2px solid ${vars.border.color.primary}`,
   marginBottom: '1.5rem',
 });
 
@@ -36,20 +38,20 @@ export const tab = style({
   background: 'none',
   cursor: 'pointer',
   fontWeight: '400',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   borderBottom: '2px solid transparent',
   marginBottom: '-2px',
   textTransform: 'capitalize',
   transition: 'all 0.2s',
   ':hover': {
-    color: '#2563eb',
+    color: vars.colors.semantic.info['600'],
   },
 });
 
 export const tabActive = style({
   fontWeight: '600',
-  color: '#2563eb',
-  borderBottomColor: '#2563eb',
+  color: vars.colors.semantic.info['600'],
+  borderBottomColor: vars.colors.semantic.info['600'],
 });
 
 export const roleSelector = style({
@@ -61,22 +63,22 @@ export const roleSelector = style({
 export const roleChip = style({
   padding: '0.5rem 1rem',
   borderRadius: '20px',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   background: 'white',
-  color: '#374151',
+  color: vars.text.secondary,
   cursor: 'pointer',
   fontSize: '0.875rem',
   fontWeight: '500',
   textTransform: 'capitalize',
   transition: 'all 0.2s',
   ':hover': {
-    borderColor: '#2563eb',
+    borderColor: vars.colors.semantic.info['600'],
   },
 });
 
 export const roleChipActive = style({
-  border: '1px solid #2563eb',
-  background: '#2563eb',
+  border: `1px solid ${vars.colors.semantic.info['600']}`,
+  background: vars.colors.semantic.info['600'],
   color: 'white',
 });
 
@@ -90,29 +92,29 @@ export const tableHeader = style({
   padding: '0.75rem 1rem',
   fontWeight: '600',
   fontSize: '0.8rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   textTransform: 'uppercase',
   letterSpacing: '0.05em',
-  borderBottom: '1px solid #e5e7eb',
+  borderBottom: `1px solid ${vars.border.color.primary}`,
 });
 
 export const tableRow = style({
   background: 'transparent',
   ':hover': {
-    background: '#f9fafb',
+    background: vars.background.primary,
   },
 });
 
 export const tableRowModified = style({
-  background: '#fffbeb',
+  background: vars.colors.semantic.warning['50'],
   ':hover': {
-    background: '#fef3c7',
+    background: vars.colors.semantic.warning['100'],
   },
 });
 
 export const tableCell = style({
   padding: '0.75rem 1rem',
-  borderBottom: '1px solid #f3f4f6',
+  borderBottom: `1px solid ${vars.background.tertiary}`,
   fontSize: '0.875rem',
 });
 
@@ -120,59 +122,59 @@ export const fieldName = style({
   fontFamily: "'Fira Code', 'Consolas', monospace",
   fontSize: '0.8rem',
   padding: '0.125rem 0.375rem',
-  background: '#f3f4f6',
+  background: vars.background.tertiary,
   borderRadius: '4px',
 });
 
 export const accessSelectWrite = style({
   padding: '0.375rem 0.75rem',
   borderRadius: '6px',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   fontSize: '0.8rem',
   fontWeight: '500',
   cursor: 'pointer',
-  background: '#dcfce7',
-  color: '#166534',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 export const accessSelectRead = style({
   padding: '0.375rem 0.75rem',
   borderRadius: '6px',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   fontSize: '0.8rem',
   fontWeight: '500',
   cursor: 'pointer',
-  background: '#dbeafe',
-  color: '#1e40af',
+  background: vars.colors.semantic.info['100'],
+  color: vars.colors.semantic.info['800'],
 });
 
 export const accessSelectNone = style({
   padding: '0.375rem 0.75rem',
   borderRadius: '6px',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   fontSize: '0.8rem',
   fontWeight: '500',
   cursor: 'pointer',
-  background: '#fee2e2',
-  color: '#991b1b',
+  background: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['800'],
 });
 
 export const accessSelectDefault = style({
   padding: '0.375rem 0.75rem',
   borderRadius: '6px',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   fontSize: '0.8rem',
   fontWeight: '500',
   cursor: 'pointer',
   background: 'white',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const overrideBadge = style({
   fontSize: '0.7rem',
   padding: '0.125rem 0.5rem',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
   borderRadius: '10px',
   fontWeight: '600',
   marginLeft: '0.5rem',
@@ -183,7 +185,7 @@ export const statusBar = style({
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: '0.75rem 1rem',
-  background: '#f9fafb',
+  background: vars.background.primary,
   borderRadius: '8px',
   marginBottom: '1rem',
   fontSize: '0.875rem',

--- a/app.admin/src/pages/LoginPage.css.ts
+++ b/app.admin/src/pages/LoginPage.css.ts
@@ -1,19 +1,21 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const registerPrompt = style({
   textAlign: 'center',
   marginTop: '1.5rem',
   paddingTop: '1.5rem',
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.primary}`,
 });
 
 globalStyle(`${registerPrompt} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${registerPrompt} a`, {
-  color: '#667eea',
+  color: vars.colors.primary['500'],
   textDecoration: 'none',
   fontWeight: '500',
 });
@@ -29,11 +31,11 @@ export const manageCookies = style({
 
 export const helperText = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: 1.4,
   marginTop: '0.5rem',
 });
 
 globalStyle(`${helperText} strong`, {
-  color: '#374151',
+  color: vars.text.secondary,
 });

--- a/app.admin/src/pages/Messages.css.ts
+++ b/app.admin/src/pages/Messages.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const messagePreview = style({
   display: 'flex',
   flexDirection: 'column',
@@ -12,18 +14,18 @@ export const messageParticipants = style({
   alignItems: 'center',
   gap: '0.5rem',
   fontSize: '0.875rem',
-  color: '#111827',
+  color: vars.text.primary,
   fontWeight: '600',
 });
 
 globalStyle(`${messageParticipants} svg`, {
   fontSize: '0.875rem',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
 });
 
 export const messageSubject = style({
   fontSize: '0.8125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
@@ -33,7 +35,7 @@ export const messageMeta = style({
   display: 'flex',
   gap: '0.75rem',
   fontSize: '0.75rem',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
 });
 
 export const participantInfo = style({
@@ -44,13 +46,13 @@ export const participantInfo = style({
 
 export const participantName = style({
   fontSize: '0.875rem',
-  color: '#111827',
+  color: vars.text.primary,
   fontWeight: '500',
 });
 
 export const participantRole = style({
   fontSize: '0.75rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const actionButtons = style({
@@ -64,16 +66,16 @@ export const actionButton = style({
   justifyContent: 'center',
   width: '32px',
   height: '32px',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '6px',
-  background: '#ffffff',
-  color: '#6b7280',
+  background: vars.background.secondary,
+  color: vars.text.tertiary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    background: '#f9fafb',
-    color: '#111827',
-    borderColor: '#d1d5db',
+    background: vars.background.primary,
+    color: vars.text.primary,
+    borderColor: vars.border.color.secondary,
   },
   ':active': {
     transform: 'scale(0.95)',
@@ -84,7 +86,7 @@ export const statusDotActive = style({
   width: '8px',
   height: '8px',
   borderRadius: '50%',
-  background: '#10b981',
+  background: vars.colors.semantic.success['500'],
   flexShrink: 0,
 });
 
@@ -92,7 +94,7 @@ export const statusDotFlagged = style({
   width: '8px',
   height: '8px',
   borderRadius: '50%',
-  background: '#f59e0b',
+  background: vars.colors.semantic.warning['500'],
   flexShrink: 0,
 });
 
@@ -100,7 +102,7 @@ export const statusDotArchived = style({
   width: '8px',
   height: '8px',
   borderRadius: '50%',
-  background: '#9ca3af',
+  background: vars.text.quaternary,
   flexShrink: 0,
 });
 
@@ -108,6 +110,6 @@ export const statusDotDefault = style({
   width: '8px',
   height: '8px',
   borderRadius: '50%',
-  background: '#6b7280',
+  background: vars.text.tertiary,
   flexShrink: 0,
 });

--- a/app.admin/src/pages/Moderation.css.ts
+++ b/app.admin/src/pages/Moderation.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   display: 'flex',
   flexDirection: 'column',
@@ -19,13 +21,13 @@ export const headerLeft = style({});
 globalStyle(`${headerLeft} h1`, {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${headerLeft} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -37,8 +39,8 @@ export const statsBar = style({
 });
 
 export const statCard = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.25rem',
   display: 'flex',
@@ -54,18 +56,18 @@ export const statDetails = style({
 
 export const statLabel = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const statValue = style({
   fontSize: '1.5rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const filterBar = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.5rem',
   display: 'flex',
@@ -85,24 +87,24 @@ export const filterGroup = style({
 export const filterLabel = style({
   fontSize: '0.875rem',
   fontWeight: '600',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const select = style({
   padding: '0.625rem 1rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#111827',
-  background: '#ffffff',
+  color: vars.text.primary,
+  background: vars.background.secondary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    borderColor: '#9ca3af',
+    borderColor: vars.text.quaternary,
   },
   ':focus': {
     outline: 'none',
-    borderColor: '#3b82f6',
+    borderColor: vars.colors.semantic.info['500'],
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',
   },
 });
@@ -118,7 +120,7 @@ export const searchIcon = style({
   left: '1rem',
   top: '50%',
   transform: 'translateY(-50%)',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   pointerEvents: 'none',
 });
 
@@ -128,8 +130,8 @@ export const badgeSuccess = style({
   fontSize: '0.75rem',
   fontWeight: '600',
   display: 'inline-block',
-  background: '#dcfce7',
-  color: '#15803d',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['700'],
 });
 
 export const badgeDanger = style({
@@ -138,8 +140,8 @@ export const badgeDanger = style({
   fontSize: '0.75rem',
   fontWeight: '600',
   display: 'inline-block',
-  background: '#fee2e2',
-  color: '#dc2626',
+  background: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['600'],
 });
 
 export const badgeInfo = style({
@@ -148,8 +150,8 @@ export const badgeInfo = style({
   fontSize: '0.75rem',
   fontWeight: '600',
   display: 'inline-block',
-  background: '#dbeafe',
-  color: '#1e40af',
+  background: vars.colors.semantic.info['100'],
+  color: vars.colors.semantic.info['800'],
 });
 
 export const badgeNeutral = style({
@@ -158,15 +160,15 @@ export const badgeNeutral = style({
   fontSize: '0.75rem',
   fontWeight: '600',
   display: 'inline-block',
-  background: '#f3f4f6',
-  color: '#4b5563',
+  background: vars.background.tertiary,
+  color: vars.colors.neutral['600'],
 });
 
 export const priorityIndicatorCritical = style({
   width: '8px',
   height: '8px',
   borderRadius: '50%',
-  background: '#dc2626',
+  background: vars.colors.semantic.error['600'],
   flexShrink: 0,
 });
 
@@ -190,7 +192,7 @@ export const priorityIndicatorLow = style({
   width: '8px',
   height: '8px',
   borderRadius: '50%',
-  background: '#2563eb',
+  background: vars.colors.semantic.info['600'],
   flexShrink: 0,
 });
 
@@ -198,7 +200,7 @@ export const priorityIndicatorDefault = style({
   width: '8px',
   height: '8px',
   borderRadius: '50%',
-  background: '#9ca3af',
+  background: vars.text.quaternary,
   flexShrink: 0,
 });
 
@@ -207,7 +209,7 @@ export const priorityLabel = style({
   alignItems: 'center',
   gap: '0.5rem',
   fontSize: '0.875rem',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const actionButtons = style({
@@ -221,16 +223,16 @@ export const iconButton = style({
   justifyContent: 'center',
   width: '32px',
   height: '32px',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '6px',
-  background: '#ffffff',
-  color: '#6b7280',
+  background: vars.background.secondary,
+  color: vars.text.tertiary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    background: '#f9fafb',
-    color: '#111827',
-    borderColor: '#d1d5db',
+    background: vars.background.primary,
+    color: vars.text.primary,
+    borderColor: vars.border.color.secondary,
   },
   ':active': {
     transform: 'scale(0.95)',
@@ -251,8 +253,8 @@ export const contentTypeTagMessage = style({
   borderRadius: '6px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#dbeafe',
-  color: '#1e40af',
+  background: vars.colors.semantic.info['100'],
+  color: vars.colors.semantic.info['800'],
 });
 
 export const contentTypeTagUser = style({
@@ -269,8 +271,8 @@ export const contentTypeTagRescue = style({
   borderRadius: '6px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 export const contentTypeTagDefault = style({
@@ -278,8 +280,8 @@ export const contentTypeTagDefault = style({
   borderRadius: '6px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#f3f4f6',
-  color: '#374151',
+  background: vars.background.tertiary,
+  color: vars.text.secondary,
 });
 
 export const reportTitle = style({
@@ -289,7 +291,7 @@ export const reportTitle = style({
 
 export const reportSummary = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginBottom: '0.25rem',
 });
 
@@ -299,13 +301,13 @@ export const reportTagRow = style({
 
 export const reportedAt = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const errorBanner = style({
   padding: '2rem',
   textAlign: 'center',
-  color: '#dc2626',
+  color: vars.colors.semantic.error['600'],
 });
 
 const statIconBase = style({
@@ -318,13 +320,22 @@ const statIconBase = style({
   fontSize: '1.5rem',
 });
 
-export const statIconRed = style([statIconBase, { background: '#dc262620', color: '#dc2626' }]);
+export const statIconRed = style([
+  statIconBase,
+  { background: '#dc262620', color: vars.colors.semantic.error['600'] },
+]);
 
-export const statIconBlue = style([statIconBase, { background: '#3b82f620', color: '#3b82f6' }]);
+export const statIconBlue = style([
+  statIconBase,
+  { background: '#3b82f620', color: vars.colors.semantic.info['500'] },
+]);
 
 export const statIconOrange = style([statIconBase, { background: '#ea580c20', color: '#ea580c' }]);
 
-export const statIconGreen = style([statIconBase, { background: '#16a34a20', color: '#16a34a' }]);
+export const statIconGreen = style([
+  statIconBase,
+  { background: '#16a34a20', color: vars.colors.semantic.success['600'] },
+]);
 
 export const searchInputPadded = style({
   paddingLeft: '2.75rem',

--- a/app.admin/src/pages/Pets.css.ts
+++ b/app.admin/src/pages/Pets.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   display: 'flex',
   flexDirection: 'column',
@@ -19,13 +21,13 @@ export const headerLeft = style({});
 globalStyle(`${headerLeft} h1`, {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 export const filterBar = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.5rem',
   display: 'flex',
@@ -45,7 +47,7 @@ export const filterGroup = style({
 export const filterLabel = style({
   fontSize: '0.875rem',
   fontWeight: '500',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const searchInputWrapper = style({
@@ -59,7 +61,7 @@ globalStyle(`${searchInputWrapper} svg`, {
   left: '0.75rem',
   top: '50%',
   transform: 'translateY(-50%)',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   fontSize: '1.125rem',
 });
 
@@ -69,19 +71,19 @@ globalStyle(`${searchInputWrapper} input`, {
 
 export const select = style({
   padding: '0.625rem 0.875rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#111827',
-  background: '#ffffff',
+  color: vars.text.primary,
+  background: vars.background.secondary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    borderColor: '#9ca3af',
+    borderColor: vars.text.quaternary,
   },
   ':focus': {
     outline: 'none',
-    borderColor: '#667eea',
+    borderColor: vars.colors.primary['500'],
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
   },
 });
@@ -93,8 +95,8 @@ export const badgeSuccess = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#d1fae5',
-  color: '#065f46',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 export const badgeWarning = style({
@@ -104,8 +106,8 @@ export const badgeWarning = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 export const badgeInfo = style({
@@ -115,8 +117,8 @@ export const badgeInfo = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#dbeafe',
-  color: '#1e40af',
+  background: vars.colors.semantic.info['100'],
+  color: vars.colors.semantic.info['800'],
 });
 
 export const badgeNeutral = style({
@@ -126,8 +128,8 @@ export const badgeNeutral = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#f3f4f6',
-  color: '#374151',
+  background: vars.background.tertiary,
+  color: vars.text.secondary,
 });
 
 export const petInfo = style({
@@ -138,26 +140,26 @@ export const petInfo = style({
 
 export const petName = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const petDetail = style({
   fontSize: '0.8125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   display: 'flex',
   alignItems: 'center',
   gap: '0.25rem',
 });
 
 export const errorMessage = style({
-  background: '#fee2e2',
-  border: '1px solid #fecaca',
+  background: vars.colors.semantic.error['100'],
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
   borderRadius: '8px',
   padding: '1rem',
-  color: '#991b1b',
+  color: vars.colors.semantic.error['800'],
   fontSize: '0.875rem',
 });
 
 export const dimDash = style({
-  color: '#9ca3af',
+  color: vars.text.quaternary,
 });

--- a/app.admin/src/pages/RegisterPage.css.ts
+++ b/app.admin/src/pages/RegisterPage.css.ts
@@ -1,19 +1,21 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const loginPrompt = style({
   textAlign: 'center',
   marginTop: '1.5rem',
   paddingTop: '1.5rem',
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.primary}`,
 });
 
 globalStyle(`${loginPrompt} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${loginPrompt} a`, {
-  color: '#667eea',
+  color: vars.colors.primary['500'],
   textDecoration: 'none',
   fontWeight: '500',
 });
@@ -24,10 +26,10 @@ globalStyle(`${loginPrompt} a:hover`, {
 
 export const helperText = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: 1.4,
 });
 
 globalStyle(`${helperText} strong`, {
-  color: '#374151',
+  color: vars.text.secondary,
 });

--- a/app.admin/src/pages/Reports.css.ts
+++ b/app.admin/src/pages/Reports.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const headerActions = style({
   display: 'flex',
   gap: '0.75rem',
@@ -16,7 +18,7 @@ export const reportCard = style({
   transition: 'all 0.2s ease',
   position: 'relative',
   ':hover': {
-    borderColor: '#d1d5db',
+    borderColor: vars.border.color.secondary,
     boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
     transform: 'translateY(-2px)',
   },
@@ -25,13 +27,13 @@ export const reportCard = style({
 export const reportTitle = style({
   fontSize: '1.125rem',
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 export const reportDescription = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: '0 0 1rem 0',
   lineHeight: 1.5,
 });
@@ -41,7 +43,7 @@ export const reportMeta = style({
   justifyContent: 'space-between',
   alignItems: 'center',
   paddingTop: '1rem',
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.primary}`,
 });
 
 export const reportFrequency = style({
@@ -49,7 +51,7 @@ export const reportFrequency = style({
   alignItems: 'center',
   gap: '0.375rem',
   fontSize: '0.75rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 globalStyle(`${reportFrequency} svg`, {
@@ -73,13 +75,13 @@ export const scheduledReportItem = style({
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '1.25rem',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
-  background: '#ffffff',
+  background: vars.background.secondary,
   transition: 'all 0.2s ease',
   ':hover': {
-    background: '#f9fafb',
-    borderColor: '#d1d5db',
+    background: vars.background.primary,
+    borderColor: vars.border.color.secondary,
   },
 });
 
@@ -98,13 +100,13 @@ export const scheduledReportDetails = style({
 
 export const scheduledReportName = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
   fontSize: '0.9375rem',
 });
 
 export const scheduledReportSchedule = style({
   fontSize: '0.8125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const scheduledReportStatus = style({
@@ -115,7 +117,7 @@ export const scheduledReportStatus = style({
 
 export const lastRun = style({
   fontSize: '0.75rem',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
 });
 
 export const quickStatsGrid = style({
@@ -126,8 +128,8 @@ export const quickStatsGrid = style({
 });
 
 export const quickStatCard = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.25rem',
   display: 'flex',
@@ -143,13 +145,13 @@ export const quickStatDetails = style({
 
 export const quickStatLabel = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const quickStatValue = style({
   fontSize: '1.5rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const buttonIcon = style({
@@ -166,19 +168,19 @@ export const reportRow = style({
   display: 'flex',
   justifyContent: 'space-between',
   padding: '12px',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
   textDecoration: 'none',
   color: 'inherit',
 });
 
 export const subtleSmall = style({
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '13px',
 });
 
 export const subtleScope = style({
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '12px',
 });
 
@@ -195,14 +197,14 @@ export const templatesGrid = style({
 export const templateCard = style({
   display: 'block',
   padding: '14px',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
   textDecoration: 'none',
   color: 'inherit',
 });
 
 export const templateDescription = style({
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '12px',
   marginTop: '4px',
 });

--- a/app.admin/src/pages/Rescues.css.ts
+++ b/app.admin/src/pages/Rescues.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   display: 'flex',
   flexDirection: 'column',
@@ -19,13 +21,13 @@ export const headerLeft = style({});
 globalStyle(`${headerLeft} h1`, {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${headerLeft} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -35,8 +37,8 @@ export const headerActions = style({
 });
 
 export const filterBar = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.5rem',
   display: 'flex',
@@ -56,7 +58,7 @@ export const filterGroup = style({
 export const filterLabel = style({
   fontSize: '0.875rem',
   fontWeight: '500',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const searchInputWrapper = style({
@@ -70,7 +72,7 @@ globalStyle(`${searchInputWrapper} svg`, {
   left: '0.75rem',
   top: '50%',
   transform: 'translateY(-50%)',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   fontSize: '1.125rem',
 });
 
@@ -80,19 +82,19 @@ globalStyle(`${searchInputWrapper} input`, {
 
 export const select = style({
   padding: '0.625rem 0.875rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#111827',
-  background: '#ffffff',
+  color: vars.text.primary,
+  background: vars.background.secondary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    borderColor: '#9ca3af',
+    borderColor: vars.text.quaternary,
   },
   ':focus': {
     outline: 'none',
-    borderColor: '#667eea',
+    borderColor: vars.colors.primary['500'],
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
   },
 });
@@ -104,8 +106,8 @@ export const badgeSuccess = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#d1fae5',
-  color: '#065f46',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 export const badgeWarning = style({
@@ -115,8 +117,8 @@ export const badgeWarning = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 export const badgeDanger = style({
@@ -126,8 +128,8 @@ export const badgeDanger = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fee2e2',
-  color: '#991b1b',
+  background: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['800'],
 });
 
 export const badgeNeutral = style({
@@ -137,8 +139,8 @@ export const badgeNeutral = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#f3f4f6',
-  color: '#374151',
+  background: vars.background.tertiary,
+  color: vars.text.secondary,
 });
 
 export const rescueInfo = style({
@@ -149,12 +151,12 @@ export const rescueInfo = style({
 
 export const rescueName = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const rescueDetail = style({
   fontSize: '0.8125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   display: 'flex',
   alignItems: 'center',
   gap: '0.375rem',
@@ -175,16 +177,16 @@ export const iconButton = style({
   justifyContent: 'center',
   width: '32px',
   height: '32px',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '6px',
-  background: '#ffffff',
-  color: '#6b7280',
+  background: vars.background.secondary,
+  color: vars.text.tertiary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    background: '#f9fafb',
-    color: '#111827',
-    borderColor: '#d1d5db',
+    background: vars.background.primary,
+    color: vars.text.primary,
+    borderColor: vars.border.color.secondary,
   },
   ':active': {
     transform: 'scale(0.95)',
@@ -192,11 +194,11 @@ export const iconButton = style({
 });
 
 export const errorMessage = style({
-  background: '#fee2e2',
-  border: '1px solid #fecaca',
+  background: vars.colors.semantic.error['100'],
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
   borderRadius: '8px',
   padding: '1rem',
-  color: '#991b1b',
+  color: vars.colors.semantic.error['800'],
   fontSize: '0.875rem',
   display: 'flex',
   alignItems: 'center',

--- a/app.admin/src/pages/SecurityCenter.css.ts
+++ b/app.admin/src/pages/SecurityCenter.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   padding: '2rem',
   maxWidth: '1100px',
@@ -13,13 +15,13 @@ export const pageHeader = style({
 globalStyle(`${pageHeader} h1`, {
   fontSize: '2rem',
   fontWeight: 700,
-  color: '#1f2937',
+  color: vars.colors.neutral['800'],
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${pageHeader} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -27,7 +29,7 @@ export const tabBar = style({
   display: 'flex',
   flexWrap: 'wrap',
   gap: '0.25rem',
-  borderBottom: '1px solid #e5e7eb',
+  borderBottom: `1px solid ${vars.border.color.primary}`,
   marginBottom: '1.5rem',
 });
 
@@ -36,23 +38,23 @@ export const tabButton = style({
   border: 'none',
   padding: '0.75rem 1rem',
   fontSize: '0.95rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   cursor: 'pointer',
   borderBottom: '2px solid transparent',
   transition: 'all 120ms ease',
   selectors: {
-    '&:hover': { color: '#111827' },
+    '&:hover': { color: vars.text.primary },
     '&[aria-selected="true"]': {
-      color: '#1d4ed8',
-      borderBottomColor: '#1d4ed8',
+      color: vars.colors.semantic.info['700'],
+      borderBottomColor: vars.colors.semantic.info['700'],
       fontWeight: 600,
     },
   },
 });
 
 export const section = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '0.75rem',
   padding: '1.5rem',
   marginBottom: '1.25rem',
@@ -60,13 +62,13 @@ export const section = style({
 
 globalStyle(`${section} h2`, {
   fontSize: '1.15rem',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${section} > p`, {
   fontSize: '0.9rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: '0 0 1rem 0',
 });
 
@@ -78,14 +80,14 @@ export const table = style({
 globalStyle(`${table} th, ${table} td`, {
   padding: '0.5rem 0.75rem',
   textAlign: 'left',
-  borderBottom: '1px solid #f3f4f6',
+  borderBottom: `1px solid ${vars.background.tertiary}`,
   fontSize: '0.875rem',
 });
 
 globalStyle(`${table} th`, {
   fontWeight: 600,
-  color: '#374151',
-  background: '#f9fafb',
+  color: vars.text.secondary,
+  background: vars.background.primary,
 });
 
 export const inlineForm = style({
@@ -98,7 +100,7 @@ export const inlineForm = style({
 
 export const input = style({
   padding: '0.4rem 0.6rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '0.375rem',
   fontSize: '0.875rem',
   minWidth: '140px',
@@ -107,7 +109,7 @@ export const input = style({
 export const select = style([input]);
 
 export const dangerButton = style({
-  background: '#dc2626',
+  background: vars.colors.semantic.error['600'],
   color: 'white',
   border: 'none',
   padding: '0.4rem 0.75rem',
@@ -115,13 +117,13 @@ export const dangerButton = style({
   fontSize: '0.85rem',
   cursor: 'pointer',
   selectors: {
-    '&:hover': { background: '#b91c1c' },
+    '&:hover': { background: vars.colors.semantic.error['700'] },
     '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
   },
 });
 
 export const primaryButton = style({
-  background: '#1d4ed8',
+  background: vars.colors.semantic.info['700'],
   color: 'white',
   border: 'none',
   padding: '0.4rem 0.75rem',
@@ -129,34 +131,34 @@ export const primaryButton = style({
   fontSize: '0.85rem',
   cursor: 'pointer',
   selectors: {
-    '&:hover': { background: '#1e40af' },
+    '&:hover': { background: vars.colors.semantic.info['800'] },
     '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
   },
 });
 
 export const secondaryButton = style({
   background: 'white',
-  color: '#374151',
-  border: '1px solid #d1d5db',
+  color: vars.text.secondary,
+  border: `1px solid ${vars.border.color.secondary}`,
   padding: '0.4rem 0.75rem',
   borderRadius: '0.375rem',
   fontSize: '0.85rem',
   cursor: 'pointer',
-  selectors: { '&:hover': { background: '#f9fafb' } },
+  selectors: { '&:hover': { background: vars.background.primary } },
 });
 
 export const emptyState = style({
   padding: '1.5rem',
   textAlign: 'center',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '0.9rem',
 });
 
 export const errorBanner = style({
   padding: '0.75rem 1rem',
-  background: '#fef2f2',
-  border: '1px solid #fecaca',
-  color: '#991b1b',
+  background: vars.colors.semantic.error['50'],
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
+  color: vars.colors.semantic.error['800'],
   borderRadius: '0.375rem',
   marginBottom: '1rem',
   fontSize: '0.875rem',
@@ -170,12 +172,21 @@ export const statusPill = style({
   fontWeight: 600,
 });
 
-export const statusSuccess = style([statusPill, { background: '#dcfce7', color: '#166534' }]);
-export const statusFailure = style([statusPill, { background: '#fee2e2', color: '#991b1b' }]);
-export const statusNeutral = style([statusPill, { background: '#e5e7eb', color: '#374151' }]);
+export const statusSuccess = style([
+  statusPill,
+  { background: vars.colors.semantic.success['100'], color: vars.colors.semantic.success['800'] },
+]);
+export const statusFailure = style([
+  statusPill,
+  { background: vars.colors.semantic.error['100'], color: vars.colors.semantic.error['800'] },
+]);
+export const statusNeutral = style([
+  statusPill,
+  { background: vars.border.color.primary, color: vars.text.secondary },
+]);
 
 export const userIdSubtext = style({
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '0.75rem',
 });
 
@@ -184,6 +195,6 @@ export const successBanner = style([
   {
     background: '#ecfdf5',
     borderColor: '#a7f3d0',
-    color: '#065f46',
+    color: vars.colors.semantic.success['800'],
   },
 ]);

--- a/app.admin/src/pages/Support.css.ts
+++ b/app.admin/src/pages/Support.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   display: 'flex',
   flexDirection: 'column',
@@ -19,13 +21,13 @@ export const headerLeft = style({});
 globalStyle(`${headerLeft} h1`, {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${headerLeft} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -37,8 +39,8 @@ export const statsBar = style({
 });
 
 export const statCard = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.25rem',
   display: 'flex',
@@ -54,18 +56,18 @@ export const statDetails = style({
 
 export const statLabel = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const statValue = style({
   fontSize: '1.5rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const filterBar = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.5rem',
   display: 'flex',
@@ -85,7 +87,7 @@ export const filterGroup = style({
 export const filterLabel = style({
   fontSize: '0.875rem',
   fontWeight: '500',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const searchInputWrapper = style({
@@ -99,7 +101,7 @@ globalStyle(`${searchInputWrapper} svg`, {
   left: '0.75rem',
   top: '50%',
   transform: 'translateY(-50%)',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   fontSize: '1.125rem',
 });
 
@@ -109,19 +111,19 @@ globalStyle(`${searchInputWrapper} input`, {
 
 export const select = style({
   padding: '0.625rem 0.875rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#111827',
-  background: '#ffffff',
+  color: vars.text.primary,
+  background: vars.background.secondary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    borderColor: '#9ca3af',
+    borderColor: vars.text.quaternary,
   },
   ':focus': {
     outline: 'none',
-    borderColor: '#667eea',
+    borderColor: vars.colors.primary['500'],
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
   },
 });
@@ -133,8 +135,8 @@ export const badgeSuccess = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#d1fae5',
-  color: '#065f46',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 export const badgeWarning = style({
@@ -144,8 +146,8 @@ export const badgeWarning = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 export const badgeDanger = style({
@@ -155,8 +157,8 @@ export const badgeDanger = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fee2e2',
-  color: '#991b1b',
+  background: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['800'],
 });
 
 export const badgeInfo = style({
@@ -166,8 +168,8 @@ export const badgeInfo = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#dbeafe',
-  color: '#1e40af',
+  background: vars.colors.semantic.info['100'],
+  color: vars.colors.semantic.info['800'],
 });
 
 export const badgeNeutral = style({
@@ -177,8 +179,8 @@ export const badgeNeutral = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#f3f4f6',
-  color: '#374151',
+  background: vars.background.tertiary,
+  color: vars.text.secondary,
 });
 
 export const ticketInfo = style({
@@ -189,12 +191,12 @@ export const ticketInfo = style({
 
 export const ticketSubject = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const ticketMeta = style({
   fontSize: '0.8125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const priorityBadgeUrgent = style({
@@ -205,8 +207,8 @@ export const priorityBadgeUrgent = style({
   borderRadius: '6px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fee2e2',
-  color: '#991b1b',
+  background: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['800'],
 });
 
 globalStyle(`${priorityBadgeUrgent} svg`, {
@@ -237,8 +239,8 @@ export const priorityBadgeMedium = style({
   borderRadius: '6px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 globalStyle(`${priorityBadgeMedium} svg`, {
@@ -269,8 +271,8 @@ export const priorityBadgeDefault = style({
   borderRadius: '6px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#f3f4f6',
-  color: '#374151',
+  background: vars.background.tertiary,
+  color: vars.text.secondary,
 });
 
 globalStyle(`${priorityBadgeDefault} svg`, {
@@ -281,13 +283,13 @@ export const replyCount = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.5rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const errorState = style({
   padding: '2rem',
   textAlign: 'center',
-  color: '#ef4444',
+  color: vars.colors.semantic.error['500'],
 });
 
 const statIconBase = style({
@@ -300,10 +302,22 @@ const statIconBase = style({
   fontSize: '1.5rem',
 });
 
-export const statIconRed = style([statIconBase, { background: '#ef444420', color: '#ef4444' }]);
+export const statIconRed = style([
+  statIconBase,
+  { background: '#ef444420', color: vars.colors.semantic.error['500'] },
+]);
 
-export const statIconBlue = style([statIconBase, { background: '#3b82f620', color: '#3b82f6' }]);
+export const statIconBlue = style([
+  statIconBase,
+  { background: '#3b82f620', color: vars.colors.semantic.info['500'] },
+]);
 
-export const statIconAmber = style([statIconBase, { background: '#f59e0b20', color: '#f59e0b' }]);
+export const statIconAmber = style([
+  statIconBase,
+  { background: '#f59e0b20', color: vars.colors.semantic.warning['500'] },
+]);
 
-export const statIconGreen = style([statIconBase, { background: '#10b98120', color: '#10b981' }]);
+export const statIconGreen = style([
+  statIconBase,
+  { background: '#10b98120', color: vars.colors.semantic.success['500'] },
+]);

--- a/app.admin/src/pages/Users.css.ts
+++ b/app.admin/src/pages/Users.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   display: 'flex',
   flexDirection: 'column',
@@ -19,13 +21,13 @@ export const headerLeft = style({});
 globalStyle(`${headerLeft} h1`, {
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${headerLeft} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -35,8 +37,8 @@ export const headerActions = style({
 });
 
 export const filterBar = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '1.5rem',
   display: 'flex',
@@ -56,7 +58,7 @@ export const filterGroup = style({
 export const filterLabel = style({
   fontSize: '0.875rem',
   fontWeight: '500',
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const searchInputWrapper = style({
@@ -70,7 +72,7 @@ globalStyle(`${searchInputWrapper} svg`, {
   left: '0.75rem',
   top: '50%',
   transform: 'translateY(-50%)',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   fontSize: '1.125rem',
 });
 
@@ -80,19 +82,19 @@ globalStyle(`${searchInputWrapper} input`, {
 
 export const select = style({
   padding: '0.625rem 0.875rem',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#111827',
-  background: '#ffffff',
+  color: vars.text.primary,
+  background: vars.background.secondary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    borderColor: '#9ca3af',
+    borderColor: vars.text.quaternary,
   },
   ':focus': {
     outline: 'none',
-    borderColor: '#667eea',
+    borderColor: vars.colors.primary['500'],
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
   },
 });
@@ -104,8 +106,8 @@ export const badgeSuccess = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#d1fae5',
-  color: '#065f46',
+  background: vars.colors.semantic.success['100'],
+  color: vars.colors.semantic.success['800'],
 });
 
 export const badgeWarning = style({
@@ -115,8 +117,8 @@ export const badgeWarning = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fef3c7',
-  color: '#92400e',
+  background: vars.colors.semantic.warning['100'],
+  color: vars.colors.semantic.warning['800'],
 });
 
 export const badgeDanger = style({
@@ -126,8 +128,8 @@ export const badgeDanger = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#fee2e2',
-  color: '#991b1b',
+  background: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['800'],
 });
 
 export const badgeInfo = style({
@@ -137,8 +139,8 @@ export const badgeInfo = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#dbeafe',
-  color: '#1e40af',
+  background: vars.colors.semantic.info['100'],
+  color: vars.colors.semantic.info['800'],
 });
 
 export const badgeNeutral = style({
@@ -148,19 +150,19 @@ export const badgeNeutral = style({
   borderRadius: '9999px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  background: '#f3f4f6',
-  color: '#374151',
+  background: vars.background.tertiary,
+  color: vars.text.secondary,
 });
 
 export const userAvatar = style({
   width: '32px',
   height: '32px',
   borderRadius: '50%',
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  background: vars.colors.gradients.primary,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  color: '#ffffff',
+  color: vars.background.secondary,
   fontWeight: '600',
   fontSize: '0.875rem',
 });
@@ -179,12 +181,12 @@ export const userDetails = style({
 
 export const userName = style({
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const userEmail = style({
   fontSize: '0.8125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const actionButtons = style({
@@ -198,16 +200,16 @@ export const iconButton = style({
   justifyContent: 'center',
   width: '32px',
   height: '32px',
-  border: '1px solid #e5e7eb',
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '6px',
-  background: '#ffffff',
-  color: '#6b7280',
+  background: vars.background.secondary,
+  color: vars.text.tertiary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   ':hover': {
-    background: '#f9fafb',
-    color: '#111827',
-    borderColor: '#d1d5db',
+    background: vars.background.primary,
+    color: vars.text.primary,
+    borderColor: vars.border.color.secondary,
   },
   ':active': {
     transform: 'scale(0.95)',

--- a/app.admin/src/setup-tests.ts
+++ b/app.admin/src/setup-tests.ts
@@ -48,8 +48,66 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
   Container: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', props, children),
+  Stack: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
+    React.createElement('div', props, children),
   Card: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', props, children),
+  EmptyState: ({
+    title,
+    description,
+    ...props
+  }: {
+    title: string;
+    description?: string;
+    [k: string]: unknown;
+  }) =>
+    React.createElement(
+      'div',
+      { role: 'status', ...props },
+      React.createElement('h3', null, title),
+      description ? React.createElement('p', null, description) : null
+    ),
+  FormSection: ({
+    title,
+    description,
+    children,
+    ...props
+  }: {
+    title?: string;
+    description?: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) =>
+    React.createElement(
+      'section',
+      props,
+      title ? React.createElement('h3', null, title) : null,
+      description ? React.createElement('p', null, description) : null,
+      children
+    ),
+  FormRow: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
+    React.createElement('div', props, children),
+  FormField: ({
+    label,
+    error,
+    description,
+    children,
+    ...props
+  }: {
+    label?: string;
+    error?: string;
+    description?: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) =>
+    React.createElement(
+      'div',
+      props,
+      label ? React.createElement('label', null, label) : null,
+      children,
+      error ? React.createElement('span', { role: 'alert' }, error) : null,
+      description ? React.createElement('span', null, description) : null
+    ),
   Button: ({ children, ...props }: React.ComponentPropsWithoutRef<'button'>) =>
     React.createElement('button', props, children),
   Text: ({ children, ...props }: React.ComponentPropsWithoutRef<'span'>) =>

--- a/app.client/src/pages/ApplicationDetailsPage.css.ts
+++ b/app.client/src/pages/ApplicationDetailsPage.css.ts
@@ -1,4 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 import { recipe } from '@vanilla-extract/recipes';
 
 export const container = style({
@@ -18,17 +20,17 @@ export const header = style({
 
 globalStyle(`${header} h1`, {
   fontSize: '2rem',
-  color: '#111827',
+  color: vars.text.primary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${header} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const section = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '2rem',
   marginBottom: '2rem',
@@ -36,7 +38,7 @@ export const section = style({
 
 export const sectionTitle = style({
   fontSize: '1.25rem',
-  color: '#111827',
+  color: vars.text.primary,
   marginBottom: '1rem',
 });
 
@@ -50,7 +52,7 @@ export const infoItem = style({
   justifyContent: 'space-between',
   alignItems: 'flex-start',
   padding: '0.75rem 0',
-  borderBottom: '1px solid #e5e7eb',
+  borderBottom: `1px solid ${vars.border.color.primary}`,
   selectors: {
     '&:last-child': {
       borderBottom: 'none',
@@ -60,12 +62,12 @@ export const infoItem = style({
 
 export const infoLabel = style({
   fontWeight: '500',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   minWidth: '120px',
 });
 
 export const infoValue = style({
-  color: '#111827',
+  color: vars.text.primary,
   textAlign: 'right',
   flex: '1',
 });
@@ -85,21 +87,21 @@ export const statusBadge = recipe({
         color: '#6d28d9',
       },
       approved: {
-        background: '#d1fae5',
-        color: '#065f46',
+        background: vars.colors.semantic.success['100'],
+        color: vars.colors.semantic.success['800'],
       },
       rejected: {
-        background: '#fee2e2',
-        color: '#991b1b',
+        background: vars.colors.semantic.error['100'],
+        color: vars.colors.semantic.error['800'],
       },
       withdrawn: {
-        background: '#e5e7eb',
-        color: '#4b5563',
-        border: '1px solid #d1d5db',
+        background: vars.border.color.primary,
+        color: vars.colors.neutral['600'],
+        border: `1px solid ${vars.border.color.secondary}`,
       },
       default: {
-        background: '#f3f4f6',
-        color: '#374151',
+        background: vars.background.tertiary,
+        color: vars.text.secondary,
       },
     },
   },

--- a/app.client/src/pages/ApplicationPage.css.ts
+++ b/app.client/src/pages/ApplicationPage.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const container = style({
   maxWidth: '800px',
   margin: '0 auto',
@@ -12,12 +14,12 @@ export const header = style({
 });
 
 globalStyle(`${header} h1`, {
-  color: '#111827',
+  color: vars.text.primary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${header} p`, {
-  color: '#4b5563',
+  color: vars.colors.neutral['600'],
   fontSize: '1.1rem',
 });
 

--- a/app.client/src/pages/BlogPage.css.ts
+++ b/app.client/src/pages/BlogPage.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   padding: '3rem 0',
   minHeight: 'calc(100vh - 200px)',
@@ -13,13 +15,13 @@ export const pageHeader = style({
 globalStyle(`${pageHeader} h1`, {
   fontSize: '2.5rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 1rem 0',
 });
 
 globalStyle(`${pageHeader} p`, {
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   maxWidth: '600px',
   margin: '0 auto',
 });
@@ -33,8 +35,8 @@ export const postGrid = style({
 export const postCard = style({
   display: 'flex',
   flexDirection: 'column',
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   overflow: 'hidden',
   textDecoration: 'none',
@@ -54,7 +56,7 @@ export const postImage = style({
 export const postImagePlaceholder = style({
   width: '100%',
   height: '200px',
-  background: '#f9fafb',
+  background: vars.background.primary,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -72,14 +74,14 @@ export const postBody = style({
 export const postTitle = style({
   fontSize: '1.25rem',
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0',
   lineHeight: '1.4',
 });
 
 export const postExcerpt = style({
   fontSize: '0.9rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: '0',
   lineHeight: '1.6',
   flex: '1',
@@ -91,14 +93,14 @@ export const postExcerpt = style({
 
 export const postDate = style({
   fontSize: '0.8rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginTop: '0.5rem',
 });
 
 export const emptyState = style({
   textAlign: 'center',
   padding: '4rem 2rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '1.1rem',
 });
 

--- a/app.client/src/pages/BlogPostPage.css.ts
+++ b/app.client/src/pages/BlogPostPage.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   padding: '3rem 0',
   maxWidth: '800px',
@@ -9,12 +11,12 @@ export const backLink = style({
   display: 'inline-flex',
   alignItems: 'center',
   gap: '0.5rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   textDecoration: 'none',
   fontSize: '0.9rem',
   marginBottom: '2rem',
   ':hover': {
-    color: '#111827',
+    color: vars.text.primary,
   },
 });
 
@@ -29,7 +31,7 @@ export const featuredImage = style({
 export const postTitle = style({
   fontSize: '2.5rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 1rem 0',
   lineHeight: '1.3',
   '@media': {
@@ -42,15 +44,15 @@ export const postTitle = style({
 export const postMeta = style({
   display: 'flex',
   gap: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '0.9rem',
   marginBottom: '2.5rem',
   paddingBottom: '1.5rem',
-  borderBottom: '1px solid #e5e7eb',
+  borderBottom: `1px solid ${vars.border.color.primary}`,
 });
 
 export const postContent = style({
-  color: '#111827',
+  color: vars.text.primary,
   lineHeight: '1.8',
   fontSize: '1.05rem',
 });
@@ -58,7 +60,7 @@ export const postContent = style({
 globalStyle(
   `${postContent} h1, ${postContent} h2, ${postContent} h3, ${postContent} h4, ${postContent} h5, ${postContent} h6`,
   {
-    color: '#111827',
+    color: vars.text.primary,
     margin: '2rem 0 1rem',
   }
 );
@@ -68,7 +70,7 @@ globalStyle(`${postContent} p`, {
 });
 
 globalStyle(`${postContent} a`, {
-  color: '#2563eb',
+  color: vars.colors.semantic.info['600'],
 });
 
 globalStyle(`${postContent} a:hover`, {
@@ -87,10 +89,10 @@ globalStyle(`${postContent} ul, ${postContent} ol`, {
 });
 
 globalStyle(`${postContent} blockquote`, {
-  borderLeft: '4px solid #2563eb',
+  borderLeft: `4px solid ${vars.colors.semantic.info['600']}`,
   margin: '1.5rem 0',
   padding: '0.5rem 1.5rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontStyle: 'italic',
 });
 
@@ -103,5 +105,5 @@ export const spinnerWrapper = style({
 export const notFound = style({
   textAlign: 'center',
   padding: '4rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });

--- a/app.client/src/pages/CheckYourEmailPage.css.ts
+++ b/app.client/src/pages/CheckYourEmailPage.css.ts
@@ -1,12 +1,14 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const container = style({
   minHeight: 'calc(100vh - 200px)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   padding: '2rem',
-  background: 'linear-gradient(135deg, #ffffff 0%, #f9fafb 100%)',
+  background: `linear-gradient(135deg, ${vars.background.secondary} 0%, ${vars.background.primary} 100%)`,
 });
 
 export const card = style({
@@ -29,11 +31,11 @@ export const header = style({
 globalStyle(`${header} h1`, {
   fontSize: '2rem',
   marginBottom: '0.5rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${header} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: '1.6',
   fontSize: '1rem',
 });
@@ -49,11 +51,11 @@ export const resendSection = style({
   textAlign: 'center',
   marginTop: '1.5rem',
   paddingTop: '1.5rem',
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.primary}`,
 });
 
 globalStyle(`${resendSection} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginBottom: '1rem',
   fontSize: '0.95rem',
 });

--- a/app.client/src/pages/ForgotPasswordPage.css.ts
+++ b/app.client/src/pages/ForgotPasswordPage.css.ts
@@ -1,12 +1,14 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const container = style({
   minHeight: 'calc(100vh - 200px)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   padding: '2rem',
-  background: 'linear-gradient(135deg, #ffffff 0%, #f9fafb 100%)',
+  background: `linear-gradient(135deg, ${vars.background.secondary} 0%, ${vars.background.primary} 100%)`,
 });
 
 export const forgotPasswordCard = style({
@@ -23,11 +25,11 @@ export const header = style({
 globalStyle(`${header} h1`, {
   fontSize: '2rem',
   marginBottom: '0.5rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${header} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: '1.6',
 });
 
@@ -45,7 +47,7 @@ export const formGroup = style({
 
 export const backToLoginLink = style({
   fontSize: '0.9rem',
-  color: '#6366f1',
+  color: vars.colors.primary['500'],
   textDecoration: 'none',
   textAlign: 'center',
   marginTop: '1rem',
@@ -70,19 +72,19 @@ globalStyle(`${successContainer} h2`, {
 });
 
 globalStyle(`${successContainer} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: '1.6',
   marginBottom: '1.5rem',
 });
 
 globalStyle(`${successContainer} .email-highlight`, {
-  color: '#111827',
+  color: vars.text.primary,
   fontWeight: '600',
 });
 
 export const infoBox = style({
-  background: '#f9fafb',
-  border: '1px solid #e5e7eb',
+  background: vars.background.primary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
   padding: '1rem',
   marginTop: '1rem',
@@ -90,11 +92,11 @@ export const infoBox = style({
 
 globalStyle(`${infoBox} p`, {
   fontSize: '0.9rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: '0',
   lineHeight: '1.5',
 });
 
 globalStyle(`${infoBox} strong`, {
-  color: '#111827',
+  color: vars.text.primary,
 });

--- a/app.client/src/pages/HelpArticlePage.css.ts
+++ b/app.client/src/pages/HelpArticlePage.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   padding: '3rem 0',
   maxWidth: '800px',
@@ -9,19 +11,19 @@ export const backLink = style({
   display: 'inline-flex',
   alignItems: 'center',
   gap: '0.5rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   textDecoration: 'none',
   fontSize: '0.9rem',
   marginBottom: '2rem',
   ':hover': {
-    color: '#111827',
+    color: vars.text.primary,
   },
 });
 
 export const articleTitle = style({
   fontSize: '2rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 2rem 0',
   lineHeight: '1.3',
   '@media': {
@@ -32,7 +34,7 @@ export const articleTitle = style({
 });
 
 export const articleContent = style({
-  color: '#111827',
+  color: vars.text.primary,
   lineHeight: '1.8',
   fontSize: '1.05rem',
 });
@@ -40,7 +42,7 @@ export const articleContent = style({
 globalStyle(
   `${articleContent} h1, ${articleContent} h2, ${articleContent} h3, ${articleContent} h4, ${articleContent} h5, ${articleContent} h6`,
   {
-    color: '#111827',
+    color: vars.text.primary,
     margin: '2rem 0 1rem',
   }
 );
@@ -50,7 +52,7 @@ globalStyle(`${articleContent} p`, {
 });
 
 globalStyle(`${articleContent} a`, {
-  color: '#2563eb',
+  color: vars.colors.semantic.info['600'],
 });
 
 globalStyle(`${articleContent} a:hover`, {
@@ -69,10 +71,10 @@ globalStyle(`${articleContent} ul, ${articleContent} ol`, {
 });
 
 globalStyle(`${articleContent} blockquote`, {
-  borderLeft: '4px solid #2563eb',
+  borderLeft: `4px solid ${vars.colors.semantic.info['600']}`,
   margin: '1.5rem 0',
   padding: '0.5rem 1.5rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontStyle: 'italic',
 });
 

--- a/app.client/src/pages/HelpPage.css.ts
+++ b/app.client/src/pages/HelpPage.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   padding: '3rem 0',
   minHeight: 'calc(100vh - 200px)',
@@ -13,13 +15,13 @@ export const pageHeader = style({
 globalStyle(`${pageHeader} h1`, {
   fontSize: '2.5rem',
   fontWeight: '700',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 1rem 0',
 });
 
 globalStyle(`${pageHeader} p`, {
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   maxWidth: '600px',
   margin: '0 auto',
 });
@@ -35,13 +37,13 @@ export const articleList = style({
 export const articleCard = style({
   display: 'block',
   padding: '1.5rem',
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '10px',
   textDecoration: 'none',
   transition: 'border-color 0.2s, box-shadow 0.2s',
   ':hover': {
-    borderColor: '#2563eb',
+    borderColor: vars.colors.semantic.info['600'],
     boxShadow: '0 2px 12px rgba(37, 99, 235, 0.1)',
   },
 });
@@ -49,13 +51,13 @@ export const articleCard = style({
 export const articleTitle = style({
   fontSize: '1.1rem',
   fontWeight: '600',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.4rem 0',
 });
 
 export const articleExcerpt = style({
   fontSize: '0.9rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: '0',
   lineHeight: '1.5',
 });
@@ -63,7 +65,7 @@ export const articleExcerpt = style({
 export const emptyState = style({
   textAlign: 'center',
   padding: '4rem 2rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '1.1rem',
 });
 

--- a/app.client/src/pages/LoginPage.css.ts
+++ b/app.client/src/pages/LoginPage.css.ts
@@ -1,19 +1,21 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const signupPrompt = style({
   textAlign: 'center',
   marginTop: '1.5rem',
   paddingTop: '1.5rem',
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.primary}`,
 });
 
 globalStyle(`${signupPrompt} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${signupPrompt} a`, {
-  color: '#6366f1',
+  color: vars.colors.primary['500'],
   textDecoration: 'none',
   fontWeight: '500',
 });

--- a/app.client/src/pages/NotFoundPage.css.ts
+++ b/app.client/src/pages/NotFoundPage.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 // ADS-480: catch-all 404 page. Brand colors hard-coded here (matching
 // the original styled-components version) — out of scope to refactor
 // to theme tokens; this file only exists to drop the styled-components
@@ -17,28 +19,28 @@ export const container = style({
 export const code = style({
   fontSize: '4rem',
   margin: 0,
-  color: '#2563eb',
+  color: vars.colors.semantic.info['600'],
 });
 
 export const title = style({
   margin: '0.5rem 0 1rem',
   fontSize: '1.5rem',
-  color: '#1f2937',
+  color: vars.colors.neutral['800'],
 });
 
 export const body = style({
-  color: '#4b5563',
+  color: vars.colors.neutral['600'],
   maxWidth: '32rem',
   margin: '0 0 1.5rem',
 });
 
 export const homeLink = style({
   color: 'white',
-  backgroundColor: '#2563eb',
+  backgroundColor: vars.colors.semantic.info['600'],
   padding: '0.5rem 1rem',
   borderRadius: '0.375rem',
   textDecoration: 'none',
   ':hover': {
-    backgroundColor: '#1d4ed8',
+    backgroundColor: vars.colors.semantic.info['700'],
   },
 });

--- a/app.client/src/pages/NotificationsPage.css.ts
+++ b/app.client/src/pages/NotificationsPage.css.ts
@@ -1,4 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 import { recipe } from '@vanilla-extract/recipes';
 
 export const container = style({
@@ -16,7 +18,7 @@ export const header = style({
 
 globalStyle(`${header} h1`, {
   margin: '0',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const notificationCard = recipe({
@@ -49,23 +51,23 @@ export const notificationContent = style({
 globalStyle(`${notificationContent} .title`, {
   fontWeight: '600',
   marginBottom: '0.5rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${notificationContent} .message`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${notificationContent} .timestamp`, {
   fontSize: '0.875rem',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
 });
 
 export const emptyState = style({
   textAlign: 'center',
   padding: '3rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 globalStyle(`${emptyState} .icon`, {

--- a/app.client/src/pages/ProfilePage.css.ts
+++ b/app.client/src/pages/ProfilePage.css.ts
@@ -1,4 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 import { recipe } from '@vanilla-extract/recipes';
 
 export const container = style({
@@ -23,13 +25,13 @@ export const header = style({
 
 globalStyle(`${header} h1`, {
   fontSize: '2.5rem',
-  color: '#111827',
+  color: vars.text.primary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${header} p`, {
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 globalStyle(`${header} h1`, {
@@ -41,7 +43,7 @@ globalStyle(`${header} h1`, {
 });
 
 export const tabContainer = style({
-  borderBottom: '1px solid #e5e7eb',
+  borderBottom: `1px solid ${vars.border.color.primary}`,
   marginBottom: '2rem',
 });
 
@@ -60,17 +62,17 @@ export const tab = recipe({
     cursor: 'pointer',
     transition: 'all 0.2s ease',
     ':hover': {
-      color: '#4f46e5',
+      color: vars.colors.primary['600'],
     },
   },
   variants: {
     active: {
       true: {
-        color: '#4f46e5',
+        color: vars.colors.primary['600'],
         borderBottom: '2px solid #4f46e5',
       },
       false: {
-        color: '#6b7280',
+        color: vars.text.tertiary,
         borderBottom: '2px solid transparent',
       },
     },
@@ -78,8 +80,8 @@ export const tab = recipe({
 });
 
 export const section = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '12px',
   padding: '2rem',
   marginBottom: '2rem',
@@ -87,7 +89,7 @@ export const section = style({
 
 export const sectionTitle = style({
   fontSize: '1.5rem',
-  color: '#111827',
+  color: vars.text.primary,
   marginBottom: '1rem',
 });
 
@@ -101,7 +103,7 @@ export const infoItem = style({
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '1rem 0',
-  borderBottom: '1px solid #e5e7eb',
+  borderBottom: `1px solid ${vars.border.color.primary}`,
   selectors: {
     '&:last-child': {
       borderBottom: 'none',
@@ -111,11 +113,11 @@ export const infoItem = style({
 
 export const infoLabel = style({
   fontWeight: '500',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const infoValue = style({
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const applicationsGrid = style({
@@ -124,8 +126,8 @@ export const applicationsGrid = style({
 });
 
 export const applicationCard = style({
-  background: '#f9fafb',
-  border: '1px solid #e5e7eb',
+  background: vars.background.primary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
   padding: '1.5rem',
   display: 'flex',
@@ -137,12 +139,12 @@ export const applicationInfo = style({});
 
 globalStyle(`${applicationInfo} h3`, {
   fontSize: '1.1rem',
-  color: '#111827',
+  color: vars.text.primary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${applicationInfo} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '0.875rem',
 });
 
@@ -161,16 +163,16 @@ export const statusBadge = recipe({
         color: '#6d28d9',
       },
       approved: {
-        background: '#d1fae5',
-        color: '#065f46',
+        background: vars.colors.semantic.success['100'],
+        color: vars.colors.semantic.success['800'],
       },
       rejected: {
-        background: '#fee2e2',
-        color: '#991b1b',
+        background: vars.colors.semantic.error['100'],
+        color: vars.colors.semantic.error['800'],
       },
       default: {
-        background: '#f3f4f6',
-        color: '#374151',
+        background: vars.background.tertiary,
+        color: vars.text.secondary,
       },
     },
   },

--- a/app.client/src/pages/RegisterPage.css.ts
+++ b/app.client/src/pages/RegisterPage.css.ts
@@ -1,19 +1,21 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const loginPrompt = style({
   textAlign: 'center',
   marginTop: '1.5rem',
   paddingTop: '1.5rem',
-  borderTop: '1px solid #d1d5db',
+  borderTop: `1px solid ${vars.border.color.secondary}`,
 });
 
 globalStyle(`${loginPrompt} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginBottom: '0.5rem',
 });
 
 globalStyle(`${loginPrompt} a`, {
-  color: '#4f46e5',
+  color: vars.colors.primary['600'],
   textDecoration: 'none',
   fontWeight: '500',
 });

--- a/app.client/src/pages/RescueDetailsPage.css.ts
+++ b/app.client/src/pages/RescueDetailsPage.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   maxWidth: '1200px',
   margin: '0 auto',
@@ -11,7 +13,7 @@ export const backButton = style({
 });
 
 export const rescueHeader = style({
-  background: '#f9fafb',
+  background: vars.background.primary,
   borderRadius: '16px',
   padding: '3rem',
   marginBottom: '3rem',
@@ -22,7 +24,7 @@ globalStyle(`${rescueHeader} h1`, {
   fontSize: '3rem',
   fontWeight: '700',
   marginBottom: '1rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${rescueHeader} .rescue-meta`, {
@@ -39,7 +41,7 @@ globalStyle(`${rescueHeader} .rescue-meta .meta-item`, {
   alignItems: 'center',
   gap: '0.5rem',
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 globalStyle(`${rescueHeader} .rescue-meta .meta-item .icon`, {
@@ -79,19 +81,19 @@ globalStyle(`${descriptionCard} h2`, {
   fontSize: '1.5rem',
   fontWeight: '600',
   marginBottom: '1.5rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${descriptionCard} h3`, {
   fontSize: '1.2rem',
   fontWeight: '600',
   margin: '2rem 0 1rem 0',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${descriptionCard} p`, {
   lineHeight: '1.6',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   whiteSpace: 'pre-wrap',
 });
 
@@ -103,7 +105,7 @@ globalStyle(`${contactCard} h2`, {
   fontSize: '1.5rem',
   fontWeight: '600',
   marginBottom: '1.5rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${contactCard} .contact-item`, {
@@ -112,35 +114,35 @@ globalStyle(`${contactCard} .contact-item`, {
   gap: '1rem',
   marginBottom: '1rem',
   padding: '1rem',
-  background: '#ffffff',
+  background: vars.background.secondary,
   borderRadius: '8px',
 });
 
 globalStyle(`${contactCard} .contact-item .icon`, {
   width: '20px',
   height: '20px',
-  fill: '#6b7280',
+  fill: vars.text.tertiary,
   flexShrink: 0,
 });
 
 globalStyle(`${contactCard} .contact-item .details .label`, {
   fontWeight: '500',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '0.9rem',
 });
 
 globalStyle(`${contactCard} .contact-item .details .value`, {
-  color: '#111827',
+  color: vars.text.primary,
   fontWeight: '600',
 });
 
 globalStyle(`${contactCard} .website-link`, {
-  color: '#2563eb',
+  color: vars.colors.semantic.info['600'],
   textDecoration: 'none',
 });
 
 globalStyle(`${contactCard} .website-link:hover`, {
-  color: '#1d4ed8',
+  color: vars.colors.semantic.info['700'],
   textDecoration: 'underline',
 });
 
@@ -150,7 +152,7 @@ globalStyle(`${petsSection} h2`, {
   fontSize: '2rem',
   fontWeight: '600',
   marginBottom: '2rem',
-  color: '#111827',
+  color: vars.text.primary,
   textAlign: 'center',
 });
 
@@ -165,7 +167,7 @@ globalStyle(`${petsSection} .pets-header`, {
 
 globalStyle(`${petsSection} .pets-header .pets-count`, {
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 globalStyle(`${petsSection} .pets-header .view-toggle`, {
@@ -190,13 +192,13 @@ export const loadingContainer = style({
   alignItems: 'center',
   minHeight: '400px',
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const errorContainer = style({
   textAlign: 'center',
   padding: '3rem',
-  color: '#ef4444',
+  color: vars.colors.semantic.error['500'],
 });
 
 globalStyle(`${errorContainer} h2`, {
@@ -211,7 +213,7 @@ globalStyle(`${errorContainer} p`, {
 export const emptyState = style({
   textAlign: 'center',
   padding: '3rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 globalStyle(`${emptyState} .icon`, {
@@ -225,7 +227,7 @@ globalStyle(`${emptyState} .icon`, {
 globalStyle(`${emptyState} h3`, {
   fontSize: '1.5rem',
   marginBottom: '1rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${emptyState} p`, {

--- a/app.client/src/pages/ResetPasswordPage.css.ts
+++ b/app.client/src/pages/ResetPasswordPage.css.ts
@@ -1,12 +1,14 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const container = style({
   minHeight: 'calc(100vh - 200px)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   padding: '2rem',
-  background: 'linear-gradient(135deg, #ffffff 0%, #f9fafb 100%)',
+  background: `linear-gradient(135deg, ${vars.background.secondary} 0%, ${vars.background.primary} 100%)`,
 });
 
 export const resetPasswordCard = style({
@@ -23,11 +25,11 @@ export const header = style({
 globalStyle(`${header} h1`, {
   fontSize: '2rem',
   marginBottom: '0.5rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${header} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: '1.6',
 });
 
@@ -44,8 +46,8 @@ export const formGroup = style({
 });
 
 export const passwordRequirements = style({
-  background: '#f9fafb',
-  border: '1px solid #e5e7eb',
+  background: vars.background.primary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '8px',
   padding: '1rem',
   marginTop: '0.5rem',
@@ -53,7 +55,7 @@ export const passwordRequirements = style({
 
 globalStyle(`${passwordRequirements} h4`, {
   fontSize: '0.9rem',
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
@@ -65,13 +67,13 @@ globalStyle(`${passwordRequirements} ul`, {
 
 globalStyle(`${passwordRequirements} li`, {
   fontSize: '0.85rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: '1.5',
 });
 
 export const backToLoginLink = style({
   fontSize: '0.9rem',
-  color: '#6366f1',
+  color: vars.colors.primary['500'],
   textDecoration: 'none',
   textAlign: 'center',
   marginTop: '1rem',
@@ -96,14 +98,14 @@ globalStyle(`${successContainer} h2`, {
 });
 
 globalStyle(`${successContainer} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: '1.6',
   marginBottom: '1.5rem',
 });
 
 globalStyle(`${successContainer} .redirect-message`, {
   fontSize: '0.9rem',
-  color: '#9ca3af',
+  color: vars.text.quaternary,
   fontStyle: 'italic',
 });
 

--- a/app.client/src/pages/VerifyEmailPage.css.ts
+++ b/app.client/src/pages/VerifyEmailPage.css.ts
@@ -1,12 +1,14 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const container = style({
   minHeight: 'calc(100vh - 200px)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   padding: '2rem',
-  background: 'linear-gradient(135deg, #ffffff 0%, #f9fafb 100%)',
+  background: `linear-gradient(135deg, ${vars.background.secondary} 0%, ${vars.background.primary} 100%)`,
 });
 
 export const verifyEmailCard = style({
@@ -23,11 +25,11 @@ export const header = style({
 globalStyle(`${header} h1`, {
   fontSize: '2rem',
   marginBottom: '0.5rem',
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${header} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: '1.6',
   fontSize: '1rem',
 });
@@ -54,8 +56,8 @@ export const loadingSpinner = style({
     content: '""',
     width: '48px',
     height: '48px',
-    border: '5px solid #e5e7eb',
-    borderBottomColor: '#6366f1',
+    border: `5px solid ${vars.border.color.primary}`,
+    borderBottomColor: vars.colors.primary['500'],
     borderRadius: '50%',
     animationName: 'rotation',
     animationDuration: '1s',
@@ -68,11 +70,11 @@ export const resendSection = style({
   textAlign: 'center',
   marginTop: '1.5rem',
   paddingTop: '1.5rem',
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.primary}`,
 });
 
 globalStyle(`${resendSection} p`, {
-  color: '#6b7280',
+  color: vars.text.tertiary,
   marginBottom: '1rem',
   fontSize: '0.95rem',
 });

--- a/app.rescue/src/components/rescue/AdoptionPolicyForm.tsx
+++ b/app.rescue/src/components/rescue/AdoptionPolicyForm.tsx
@@ -6,6 +6,8 @@ import {
   TextArea as LibTextArea,
   Alert,
   CheckboxInput,
+  FormSection,
+  FormRow,
 } from '@adopt-dont-shop/lib.components';
 import type { AdoptionPolicy } from '../../types/rescue';
 import * as styles from './AdoptionPolicyForm.css';
@@ -190,35 +192,29 @@ const AdoptionPolicyForm: React.FC<AdoptionPolicyFormProps> = ({
           )}
         </div>
 
-        <div className={styles.formSection}>
-          <h3 className={styles.sectionTitle}>Adoption Fees</h3>
-          <div className={styles.formRow}>
-            <div className={styles.formGroup}>
-              <TextInput
-                label="Minimum Fee (£)"
-                type="number"
-                min={0}
-                step={0.01}
-                value={formData.adoptionFeeRange.min.toString()}
-                onChange={e => handleFeeChange('min', e.target.value)}
-                fullWidth
-              />
-            </div>
-
-            <div className={styles.formGroup}>
-              <TextInput
-                label="Maximum Fee (£)"
-                type="number"
-                min={0}
-                step={0.01}
-                value={formData.adoptionFeeRange.max.toString()}
-                onChange={e => handleFeeChange('max', e.target.value)}
-                helperText="Set the range for your adoption fees"
-                fullWidth
-              />
-            </div>
-          </div>
-        </div>
+        <FormSection title="Adoption Fees">
+          <FormRow columns="two">
+            <TextInput
+              label="Minimum Fee (£)"
+              type="number"
+              min={0}
+              step={0.01}
+              value={formData.adoptionFeeRange.min.toString()}
+              onChange={e => handleFeeChange('min', e.target.value)}
+              fullWidth
+            />
+            <TextInput
+              label="Maximum Fee (£)"
+              type="number"
+              min={0}
+              step={0.01}
+              value={formData.adoptionFeeRange.max.toString()}
+              onChange={e => handleFeeChange('max', e.target.value)}
+              helperText="Set the range for your adoption fees"
+              fullWidth
+            />
+          </FormRow>
+        </FormSection>
 
         <div className={styles.formSection}>
           <h3 className={styles.sectionTitle}>Adoption Requirements</h3>

--- a/app.rescue/src/pages/AcceptInvitation.css.ts
+++ b/app.rescue/src/pages/AcceptInvitation.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style, keyframes } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 const spin = keyframes({
   '0%': { transform: 'rotate(0deg)' },
   '100%': { transform: 'rotate(360deg)' },
@@ -7,7 +9,7 @@ const spin = keyframes({
 
 export const pageContainer = style({
   minHeight: '100vh',
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  background: vars.colors.gradients.primary,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -24,7 +26,7 @@ export const card = style({
 });
 
 export const cardHeader = style({
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  background: vars.colors.gradients.primary,
   color: 'white',
   padding: '2rem',
   textAlign: 'center',
@@ -79,7 +81,7 @@ export const formLabel = style({
 });
 
 export const requiredIndicator = style({
-  color: '#dc3545',
+  color: vars.colors.semantic.error['600'],
 });
 
 export const formInput = style({
@@ -93,7 +95,7 @@ export const formInput = style({
   selectors: {
     '&:focus': {
       outline: 'none',
-      borderColor: '#667eea',
+      borderColor: vars.colors.primary['500'],
     },
     '&:disabled': {
       backgroundColor: '#f8f9fa',
@@ -103,18 +105,18 @@ export const formInput = style({
 });
 
 export const formInputError = style({
-  borderColor: '#dc3545',
+  borderColor: vars.colors.semantic.error['600'],
   selectors: {
     '&:focus': {
       outline: 'none',
-      borderColor: '#dc3545',
+      borderColor: vars.colors.semantic.error['600'],
     },
   },
 });
 
 export const formError = style({
   display: 'block',
-  color: '#dc3545',
+  color: vars.colors.semantic.error['600'],
   fontSize: '0.875rem',
   marginTop: '0.25rem',
 });
@@ -122,7 +124,7 @@ export const formError = style({
 export const submitButton = style({
   width: '100%',
   padding: '0.875rem',
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  background: vars.colors.gradients.primary,
   color: 'white',
   border: 'none',
   borderRadius: '8px',
@@ -202,7 +204,7 @@ export const successIcon = style({
 
 export const loginButton = style({
   padding: '0.875rem 2rem',
-  background: '#667eea',
+  background: vars.colors.primary['500'],
   color: 'white',
   border: 'none',
   borderRadius: '8px',

--- a/app.rescue/src/pages/Analytics.css.ts
+++ b/app.rescue/src/pages/Analytics.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   maxWidth: '100%',
   margin: 0,
@@ -29,13 +31,13 @@ export const headerTitle = style({});
 globalStyle(`${headerTitle} h1`, {
   fontSize: '2rem',
   fontWeight: 700,
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${headerTitle} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -61,20 +63,20 @@ export const filterBar = style({
 export const filterSelect = style({
   padding: '0.625rem 1rem',
   background: 'white',
-  border: '1px solid #d1d5db',
+  border: `1px solid ${vars.border.color.secondary}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  color: '#111827',
+  color: vars.text.primary,
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   selectors: {
     '&:hover': {
-      borderColor: '#60a5fa',
+      borderColor: vars.colors.semantic.info['400'],
     },
     '&:focus': {
       outline: 'none',
-      borderColor: '#60a5fa',
-      boxShadow: '0 0 0 3px #dbeafe',
+      borderColor: vars.colors.semantic.info['400'],
+      boxShadow: `0 0 0 3px ${vars.colors.semantic.info['100']}`,
     },
   },
 });
@@ -106,7 +108,7 @@ export const twoColumnGrid = style({
 
 export const cardHeader = style({
   padding: '1.5rem 1.5rem 1rem 1.5rem',
-  borderBottom: '1px solid #e5e7eb',
+  borderBottom: `1px solid ${vars.border.color.primary}`,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
@@ -122,11 +124,11 @@ globalStyle(`${cardTitle} h3`, {
   margin: 0,
   fontSize: '1.125rem',
   fontWeight: 600,
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 globalStyle(`${cardTitle} svg`, {
-  color: '#2563eb',
+  color: vars.colors.semantic.info['600'],
   fontSize: '1.25rem',
 });
 
@@ -137,19 +139,19 @@ export const cardBody = style({
 export const emptyState = style({
   textAlign: 'center',
   padding: '3rem 1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 globalStyle(`${emptyState} svg`, {
   fontSize: '3rem',
-  color: '#d1d5db',
+  color: vars.border.color.secondary,
   marginBottom: '1rem',
 });
 
 globalStyle(`${emptyState} h3`, {
   fontSize: '1.125rem',
   fontWeight: 600,
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
@@ -160,9 +162,9 @@ globalStyle(`${emptyState} p`, {
 export const errorState = style({
   textAlign: 'center',
   padding: '2rem',
-  color: '#dc2626',
-  background: '#fef2f2',
-  border: '1px solid #fecaca',
+  color: vars.colors.semantic.error['600'],
+  background: vars.colors.semantic.error['50'],
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
   borderRadius: '8px',
 });
 

--- a/app.rescue/src/pages/Communication.css.ts
+++ b/app.rescue/src/pages/Communication.css.ts
@@ -1,16 +1,18 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
-  background: '#ffffff',
+  background: vars.background.secondary,
 });
 
 export const pageHeader = style({
   padding: '1.5rem 2rem',
-  background: '#ffffff',
-  borderBottom: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  borderBottom: `1px solid ${vars.border.color.primary}`,
   '@media': {
     'screen and (max-width: 768px)': {
       padding: '1rem 1.25rem',
@@ -22,13 +24,13 @@ globalStyle(`${pageHeader} h1`, {
   margin: 0,
   fontSize: '1.875rem',
   fontWeight: 700,
-  color: '#111827',
+  color: vars.text.primary,
   letterSpacing: '-0.025em',
 });
 
 globalStyle(`${pageHeader} p`, {
   margin: '0.5rem 0 0 0',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   fontSize: '1rem',
 });
 
@@ -102,26 +104,26 @@ export const toolbar = style({
 export const filterTab = style({
   padding: '0.375rem 0.875rem',
   borderRadius: '9999px',
-  border: '1px solid #d1d5db',
-  background: '#ffffff',
-  color: '#374151',
+  border: `1px solid ${vars.border.color.secondary}`,
+  background: vars.background.secondary,
+  color: vars.text.secondary,
   fontWeight: 500,
   fontSize: '0.875rem',
   cursor: 'pointer',
   selectors: {
     '&:hover': {
-      background: '#f3f4f6',
+      background: vars.background.tertiary,
     },
   },
 });
 
 export const filterTabActive = style({
-  background: '#2563eb',
-  borderColor: '#2563eb',
-  color: '#ffffff',
+  background: vars.colors.semantic.info['600'],
+  borderColor: vars.colors.semantic.info['600'],
+  color: vars.background.secondary,
   selectors: {
     '&:hover': {
-      background: '#1d4ed8',
+      background: vars.colors.semantic.info['700'],
     },
   },
 });

--- a/app.rescue/src/pages/Dashboard.css.ts
+++ b/app.rescue/src/pages/Dashboard.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const dashboardContainer = style({
   maxWidth: 'none',
   margin: 0,
@@ -14,19 +16,19 @@ export const dashboardHeader = style({
 globalStyle(`${dashboardHeader} h1`, {
   fontSize: '2.5rem',
   fontWeight: 700,
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${dashboardHeader} p`, {
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
 export const welcomeMessage = style({
-  background: 'linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%)',
-  border: '1px solid #bfdbfe',
+  background: `linear-gradient(135deg, ${vars.colors.semantic.info['50']} 0%, ${vars.colors.semantic.info['100']} 100%)`,
+  border: `1px solid ${vars.colors.semantic.info['200']}`,
   borderRadius: '12px',
   padding: '1.5rem',
   marginBottom: '2rem',
@@ -34,13 +36,13 @@ export const welcomeMessage = style({
 
 globalStyle(`${welcomeMessage} h2`, {
   margin: '0 0 0.5rem 0',
-  color: '#1e40af',
+  color: vars.colors.semantic.info['800'],
   fontSize: '1.25rem',
 });
 
 globalStyle(`${welcomeMessage} p`, {
   margin: 0,
-  color: '#1d4ed8',
+  color: vars.colors.semantic.info['700'],
 });
 
 export const metricsGrid = style({

--- a/app.rescue/src/pages/Events.css.ts
+++ b/app.rescue/src/pages/Events.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   maxWidth: '100%',
   margin: 0,
@@ -29,13 +31,13 @@ export const headerTitle = style({});
 globalStyle(`${headerTitle} h1`, {
   fontSize: '2rem',
   fontWeight: 700,
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${headerTitle} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -55,7 +57,7 @@ export const primaryButton = style({
   alignItems: 'center',
   gap: '0.5rem',
   padding: '0.75rem 1.5rem',
-  background: '#2563eb',
+  background: vars.colors.semantic.info['600'],
   color: 'white',
   border: 'none',
   borderRadius: '8px',
@@ -65,7 +67,7 @@ export const primaryButton = style({
   transition: 'all 0.2s ease',
   selectors: {
     '&:hover': {
-      background: '#1d4ed8',
+      background: vars.colors.semantic.info['700'],
       transform: 'translateY(-1px)',
       boxShadow: '0 4px 12px rgba(37, 99, 235, 0.2)',
     },
@@ -74,10 +76,10 @@ export const primaryButton = style({
     },
     '&:focus': {
       outline: 'none',
-      boxShadow: '0 0 0 3px #dbeafe',
+      boxShadow: `0 0 0 3px ${vars.colors.semantic.info['100']}`,
     },
     '&:disabled': {
-      background: '#d1d5db',
+      background: vars.border.color.secondary,
       cursor: 'not-allowed',
       transform: 'none',
       boxShadow: 'none',
@@ -98,9 +100,9 @@ export const contentArea = style({
 export const errorState = style({
   textAlign: 'center',
   padding: '2rem',
-  color: '#dc2626',
-  background: '#fef2f2',
-  border: '1px solid #fecaca',
+  color: vars.colors.semantic.error['600'],
+  background: vars.colors.semantic.error['50'],
+  border: `1px solid ${vars.colors.semantic.error['200']}`,
   borderRadius: '8px',
   marginBottom: '1.5rem',
 });
@@ -147,7 +149,7 @@ export const modalHeader = style({
   top: 0,
   background: 'white',
   padding: '1.5rem',
-  borderBottom: '1px solid #e5e7eb',
+  borderBottom: `1px solid ${vars.border.color.primary}`,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
@@ -159,21 +161,21 @@ export const modalTitle = style({
   margin: 0,
   fontSize: '1.5rem',
   fontWeight: 600,
-  color: '#111827',
+  color: vars.text.primary,
 });
 
 export const closeButton = style({
   background: 'none',
   border: 'none',
   fontSize: '1.5rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   cursor: 'pointer',
   padding: '0.25rem',
   lineHeight: 1,
   transition: 'all 0.2s ease',
   selectors: {
     '&:hover': {
-      color: '#111827',
+      color: vars.text.primary,
     },
   },
 });
@@ -185,19 +187,19 @@ export const modalBody = style({
 export const emptyState = style({
   textAlign: 'center',
   padding: '3rem 1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 globalStyle(`${emptyState} svg`, {
   fontSize: '3rem',
-  color: '#d1d5db',
+  color: vars.border.color.secondary,
   marginBottom: '1rem',
 });
 
 globalStyle(`${emptyState} h3`, {
   fontSize: '1.125rem',
   fontWeight: 600,
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 

--- a/app.rescue/src/pages/LoginPage.css.ts
+++ b/app.rescue/src/pages/LoginPage.css.ts
@@ -1,19 +1,21 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const helperText = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: 1.4,
   marginTop: '0.5rem',
 });
 
 globalStyle(`${helperText} strong`, {
-  color: '#374151',
+  color: vars.text.secondary,
 });
 
 export const manageCookies = style({
   textAlign: 'center',
   marginTop: '1rem',
   paddingTop: '1rem',
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.primary}`,
 });

--- a/app.rescue/src/pages/NotFoundPage.css.ts
+++ b/app.rescue/src/pages/NotFoundPage.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 // ADS-480: catch-all 404 page for app.rescue. Brand colors hard-coded
 // (matching the original styled-components version); refactoring to
 // theme tokens is out of scope.
@@ -16,28 +18,28 @@ export const container = style({
 export const code = style({
   fontSize: '4rem',
   margin: 0,
-  color: '#15803d',
+  color: vars.colors.semantic.success['700'],
 });
 
 export const title = style({
   margin: '0.5rem 0 1rem',
   fontSize: '1.5rem',
-  color: '#1f2937',
+  color: vars.colors.neutral['800'],
 });
 
 export const body = style({
-  color: '#4b5563',
+  color: vars.colors.neutral['600'],
   maxWidth: '32rem',
   margin: '0 0 1.5rem',
 });
 
 export const homeLink = style({
   color: 'white',
-  backgroundColor: '#15803d',
+  backgroundColor: vars.colors.semantic.success['700'],
   padding: '0.5rem 1rem',
   borderRadius: '0.375rem',
   textDecoration: 'none',
   ':hover': {
-    backgroundColor: '#166534',
+    backgroundColor: vars.colors.semantic.success['800'],
   },
 });

--- a/app.rescue/src/pages/PetManagement.css.ts
+++ b/app.rescue/src/pages/PetManagement.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   maxWidth: '1200px',
   margin: '0 auto',
@@ -43,13 +45,13 @@ export const headerContent = style({
 globalStyle(`${headerContent} h1`, {
   fontSize: '2.5rem',
   fontWeight: 700,
-  color: '#111827',
+  color: vars.text.primary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${headerContent} p`, {
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
@@ -96,13 +98,13 @@ export const statCard = style({
 export const statNumber = style({
   fontSize: '2rem',
   fontWeight: 700,
-  color: '#2563eb',
+  color: vars.colors.semantic.info['600'],
   marginBottom: '0.5rem',
 });
 
 export const statLabel = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   textTransform: 'uppercase',
   letterSpacing: '0.05em',
 });
@@ -112,14 +114,14 @@ export const loadingContainer = style({
   justifyContent: 'center',
   alignItems: 'center',
   height: '150px',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const errorContainer = style({
   padding: '2rem',
   textAlign: 'center',
-  border: '1px solid #ef4444',
-  backgroundColor: '#fef2f2',
-  color: '#dc2626',
+  border: `1px solid ${vars.colors.semantic.error['500']}`,
+  backgroundColor: vars.colors.semantic.error['50'],
+  color: vars.colors.semantic.error['600'],
   borderRadius: '0.5rem',
 });

--- a/app.rescue/src/pages/RegisterPage.css.ts
+++ b/app.rescue/src/pages/RegisterPage.css.ts
@@ -1,11 +1,13 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const helperText = style({
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   lineHeight: 1.4,
 });
 
 globalStyle(`${helperText} strong`, {
-  color: '#374151',
+  color: vars.text.secondary,
 });

--- a/app.rescue/src/pages/RescueSettings.css.ts
+++ b/app.rescue/src/pages/RescueSettings.css.ts
@@ -1,5 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
 export const pageContainer = style({
   padding: '2rem',
   maxWidth: '1200px',
@@ -13,18 +15,18 @@ export const pageHeader = style({
 globalStyle(`${pageHeader} h1`, {
   fontSize: '2rem',
   fontWeight: 700,
-  color: '#1f2937',
+  color: vars.colors.neutral['800'],
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${pageHeader} p`, {
   fontSize: '1.1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
 export const tabContainer = style({
-  borderBottom: '2px solid #e5e7eb',
+  borderBottom: `2px solid ${vars.border.color.primary}`,
   marginBottom: '2rem',
 });
 
@@ -41,20 +43,20 @@ export const tab = style({
   background: 'none',
   cursor: 'pointer',
   borderBottom: '2px solid transparent',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   transition: 'all 0.2s',
   position: 'relative',
   bottom: '-2px',
   selectors: {
     '&:hover': {
-      color: '#3b82f6',
+      color: vars.colors.semantic.info['500'],
     },
   },
 });
 
 export const tabActive = style({
-  color: '#3b82f6',
-  borderBottomColor: '#3b82f6',
+  color: vars.colors.semantic.info['500'],
+  borderBottomColor: vars.colors.semantic.info['500'],
 });
 
 export const tabPanel = style({
@@ -71,12 +73,12 @@ export const loadingContainer = style({
   alignItems: 'center',
   height: '400px',
   fontSize: '1.125rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
 });
 
 export const errorContainer = style({
-  backgroundColor: '#fee2e2',
-  color: '#991b1b',
+  backgroundColor: vars.colors.semantic.error['100'],
+  color: vars.colors.semantic.error['800'],
   padding: '2rem',
   borderRadius: '0.5rem',
   textAlign: 'center',
@@ -92,8 +94,8 @@ globalStyle(`${errorContainer} p`, {
 });
 
 export const placeholderSection = style({
-  background: '#f9fafb',
-  border: '2px dashed #d1d5db',
+  background: vars.background.primary,
+  border: `2px dashed ${vars.border.color.secondary}`,
   borderRadius: '0.75rem',
   padding: '3rem',
   textAlign: 'center',
@@ -101,31 +103,31 @@ export const placeholderSection = style({
 
 globalStyle(`${placeholderSection} h2`, {
   fontSize: '1.5rem',
-  color: '#374151',
+  color: vars.text.secondary,
   margin: '0 0 1rem 0',
 });
 
 globalStyle(`${placeholderSection} p`, {
   fontSize: '1rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: 0,
 });
 
 export const securitySection = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
+  background: vars.background.secondary,
+  border: `1px solid ${vars.border.color.primary}`,
   borderRadius: '0.75rem',
   padding: '2rem',
 });
 
 globalStyle(`${securitySection} h2`, {
   fontSize: '1.25rem',
-  color: '#374151',
+  color: vars.text.secondary,
   margin: '0 0 0.5rem 0',
 });
 
 globalStyle(`${securitySection} > p`, {
   fontSize: '0.875rem',
-  color: '#6b7280',
+  color: vars.text.tertiary,
   margin: '0 0 1.5rem 0',
 });

--- a/app.rescue/src/setup-tests.ts
+++ b/app.rescue/src/setup-tests.ts
@@ -135,6 +135,31 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   TextInput: ({ children, ...props }: any) =>
     React.createElement('input', { type: 'text', ...props }),
   TextArea: ({ children, ...props }: any) => React.createElement('textarea', props, children),
+  EmptyState: ({ title, description, ...props }: any) =>
+    React.createElement(
+      'div',
+      { role: 'status', ...props },
+      React.createElement('h3', null, title),
+      description ? React.createElement('p', null, description) : null
+    ),
+  FormSection: ({ title, description, children, ...props }: any) =>
+    React.createElement(
+      'section',
+      props,
+      title ? React.createElement('h3', null, title) : null,
+      description ? React.createElement('p', null, description) : null,
+      children
+    ),
+  FormRow: ({ children, ...props }: any) => React.createElement('div', props, children),
+  FormField: ({ label, error, description, children, ...props }: any) =>
+    React.createElement(
+      'div',
+      props,
+      label ? React.createElement('label', null, label) : null,
+      children,
+      error ? React.createElement('span', { role: 'alert' }, error) : null,
+      description ? React.createElement('span', null, description) : null
+    ),
   // ADS-586: useConfirm / ConfirmDialog mocks so tests can intercept the
   // promise-based confirm flow without rendering the real modal. Default
   // returns `true` so existing flows don't break.

--- a/lib.components/src/components/form/FormField/FormField.css.ts
+++ b/lib.components/src/components/form/FormField/FormField.css.ts
@@ -1,0 +1,114 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { vars } from '../../../styles/theme.css';
+
+export const section = style({
+  marginBottom: vars.spacing.xl,
+  selectors: {
+    '&:last-child': {
+      marginBottom: 0,
+    },
+  },
+});
+
+export const sectionHeader = style({
+  marginBottom: vars.spacing.md,
+  paddingBottom: vars.spacing.sm,
+  borderBottom: `1px solid ${vars.border.color.primary}`,
+});
+
+export const sectionTitle = style({
+  fontSize: vars.typography.size.lg,
+  fontWeight: vars.typography.weight.semibold,
+  color: vars.text.primary,
+  margin: 0,
+});
+
+export const sectionDescription = style({
+  marginTop: vars.spacing.xs,
+  marginBottom: 0,
+  fontSize: vars.typography.size.sm,
+  color: vars.text.tertiary,
+});
+
+const baseRow = {
+  display: 'grid',
+  gap: vars.spacing.lg,
+  marginBottom: vars.spacing.lg,
+  selectors: {
+    '&:last-child': {
+      marginBottom: 0,
+    },
+  },
+};
+
+export const row = styleVariants({
+  auto: {
+    ...baseRow,
+    gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
+  },
+  single: {
+    ...baseRow,
+    gridTemplateColumns: '1fr',
+  },
+  two: {
+    ...baseRow,
+    gridTemplateColumns: '1fr',
+    '@media': {
+      '(min-width: 640px)': {
+        gridTemplateColumns: 'repeat(2, 1fr)',
+      },
+    },
+  },
+  three: {
+    ...baseRow,
+    gridTemplateColumns: '1fr',
+    '@media': {
+      '(min-width: 640px)': {
+        gridTemplateColumns: 'repeat(2, 1fr)',
+      },
+      '(min-width: 768px)': {
+        gridTemplateColumns: 'repeat(3, 1fr)',
+      },
+    },
+  },
+});
+
+export const field = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing.xs,
+  minWidth: 0,
+});
+
+export const fieldFullWidth = style({
+  gridColumn: '1 / -1',
+});
+
+export const fieldLabel = style({
+  fontSize: vars.typography.size.sm,
+  fontWeight: vars.typography.weight.medium,
+  color: vars.text.secondary,
+});
+
+export const fieldLabelRequired = style({
+  selectors: {
+    '&::after': {
+      content: ' *',
+      color: vars.colors.semantic.error['600'],
+      marginLeft: vars.spacing['0.5'],
+    },
+  },
+});
+
+export const fieldDescription = style({
+  fontSize: vars.typography.size.xs,
+  color: vars.text.tertiary,
+  marginTop: vars.spacing['0.5'],
+});
+
+export const fieldError = style({
+  fontSize: vars.typography.size.xs,
+  color: vars.text.error,
+  marginTop: vars.spacing['0.5'],
+});

--- a/lib.components/src/components/form/FormField/FormField.test.tsx
+++ b/lib.components/src/components/form/FormField/FormField.test.tsx
@@ -1,0 +1,88 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { FormField, FormRow, FormSection } from './FormField';
+
+describe('FormSection', () => {
+  it('renders a title and description in a header', () => {
+    render(
+      <FormSection title='Basic Information' description='Tell us about yourself'>
+        <p>child</p>
+      </FormSection>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Basic Information' })).toBeInTheDocument();
+    expect(screen.getByText('Tell us about yourself')).toBeInTheDocument();
+    expect(screen.getByText('child')).toBeInTheDocument();
+  });
+
+  it('omits the header when neither title nor description is provided', () => {
+    render(
+      <FormSection>
+        <p>child</p>
+      </FormSection>
+    );
+
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+});
+
+describe('FormRow', () => {
+  it('renders children in a grid', () => {
+    render(
+      <FormRow>
+        <span>one</span>
+        <span>two</span>
+      </FormRow>
+    );
+
+    expect(screen.getByText('one')).toBeInTheDocument();
+    expect(screen.getByText('two')).toBeInTheDocument();
+  });
+});
+
+describe('FormField', () => {
+  it('renders a label tied to its control', () => {
+    render(
+      <FormField label='Email' htmlFor='email-input'>
+        <input id='email-input' />
+      </FormField>
+    );
+
+    const input = screen.getByLabelText('Email');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('id', 'email-input');
+  });
+
+  it('shows description when no error is set', () => {
+    render(
+      <FormField label='Email' description='Used for login'>
+        <input />
+      </FormField>
+    );
+
+    expect(screen.getByText('Used for login')).toBeInTheDocument();
+  });
+
+  it('shows error and hides description when error is set', () => {
+    render(
+      <FormField label='Email' description='Used for login' error='Email is required'>
+        <input />
+      </FormField>
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Email is required');
+    expect(screen.queryByText('Used for login')).not.toBeInTheDocument();
+  });
+
+  it('renders without crashing when marked required', () => {
+    render(
+      <FormField label='Email' required>
+        <input />
+      </FormField>
+    );
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+  });
+});

--- a/lib.components/src/components/form/FormField/FormField.tsx
+++ b/lib.components/src/components/form/FormField/FormField.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import clsx from 'clsx';
+
+import * as styles from './FormField.css';
+
+export type FormSectionProps = {
+  title?: string;
+  description?: string;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const FormSection = ({ title, description, children, className }: FormSectionProps) => (
+  <section className={clsx(styles.section, className)}>
+    {(title || description) && (
+      <header className={styles.sectionHeader}>
+        {title && <h3 className={styles.sectionTitle}>{title}</h3>}
+        {description && <p className={styles.sectionDescription}>{description}</p>}
+      </header>
+    )}
+    {children}
+  </section>
+);
+
+export type FormRowColumns = 'auto' | 'single' | 'two' | 'three';
+
+export type FormRowProps = {
+  columns?: FormRowColumns;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const FormRow = ({ columns = 'auto', children, className }: FormRowProps) => (
+  <div className={clsx(styles.row[columns], className)}>{children}</div>
+);
+
+export type FormFieldProps = {
+  label?: string;
+  htmlFor?: string;
+  required?: boolean;
+  description?: string;
+  error?: string;
+  fullWidth?: boolean;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const FormField = ({
+  label,
+  htmlFor,
+  required = false,
+  description,
+  error,
+  fullWidth = false,
+  children,
+  className,
+}: FormFieldProps) => (
+  <div className={clsx(styles.field, fullWidth && styles.fieldFullWidth, className)}>
+    {label && (
+      <label
+        htmlFor={htmlFor}
+        className={clsx(styles.fieldLabel, required && styles.fieldLabelRequired)}
+      >
+        {label}
+      </label>
+    )}
+    {children}
+    {description && !error && <span className={styles.fieldDescription}>{description}</span>}
+    {error && (
+      <span className={styles.fieldError} role='alert'>
+        {error}
+      </span>
+    )}
+  </div>
+);

--- a/lib.components/src/components/form/FormField/index.ts
+++ b/lib.components/src/components/form/FormField/index.ts
@@ -1,0 +1,2 @@
+export { FormField, FormRow, FormSection } from './FormField';
+export type { FormFieldProps, FormRowColumns, FormRowProps, FormSectionProps } from './FormField';

--- a/lib.components/src/components/ui/EmptyState/EmptyState.css.ts
+++ b/lib.components/src/components/ui/EmptyState/EmptyState.css.ts
@@ -126,7 +126,7 @@ export const actionContainer = style({
   gap: vars.spacing.sm,
   alignItems: 'center',
   '@media': {
-    [`(min-width: ${vars.breakpoints.sm})`]: {
+    '(min-width: 640px)': {
       flexDirection: 'row',
       justifyContent: 'center',
     },

--- a/lib.components/src/index.ts
+++ b/lib.components/src/index.ts
@@ -47,6 +47,13 @@ export type { SelectOption } from './components/form/SelectInput/';
 export { TextArea } from './components/form/TextArea';
 export { TextInput } from './components/form/TextInput';
 export { Input } from './components/ui/Input';
+export { FormField, FormRow, FormSection } from './components/form/FormField';
+export type {
+  FormFieldProps,
+  FormRowColumns,
+  FormRowProps,
+  FormSectionProps,
+} from './components/form/FormField';
 
 // Feedback Components
 export { Alert } from './components/ui/Alert';
@@ -67,7 +74,7 @@ export * from './components/form/FileUpload';
 // export * from './components/form/RadioInput';
 
 // UI components - commenting out problematic ones
-// export * from './components/ui/EmptyState';
+export * from './components/ui/EmptyState';
 // export * from './components/ui/Pagination';
 // export * from './components/ui/ProgressBar';
 export { Toast, ToastContainer } from './components/ui/Toast';


### PR DESCRIPTION
## Summary

Visual-design pass across the three React apps + `lib.components`. The library already has a polished token system (light/dark/high-contrast themes), but app pages were ignoring it — 891 hardcoded hex codes in `app.*/src/pages/*.css.ts` couldn't follow theme changes. This branch fixes that and adds the layout primitives the apps were reinventing in every form.

## Changes

**Foundation (commit 1)**
- New `FormSection` / `FormRow` / `FormField` primitives in `lib.components/src/components/form/FormField/` — replace the `formSection > formRow > formGroup` div boilerplate pattern repeated across all three apps. 7 tests added.
- Re-enable the existing `EmptyState` export (previously commented out in `lib.components/src/index.ts`).
- Fix a latent media-query bug in `EmptyState.css.ts` — CSS-var-backed breakpoint tokens can't be used inside `@media` rules; literal pixel values are required (matches the `Container` pattern).
- New `DESIGN_TOKENS.md` at the repo root documenting the `vars.*` contract, import paths, and a review checklist.
- `app.admin/src/pages/Audit.css.ts` migrated by hand as the worked example.

**Color token sweep (commit 2)**
- Codemod over every `app.*/src/pages/*.css.ts`: 891 → 74 hardcoded hex codes (-92%).
  - Standalone string literals (`'#6b7280'`) → `vars.text.tertiary` etc.
  - Compound shorthand strings (`'1px solid #e5e7eb'`) rewritten as template literals.
  - Brand gradient `linear-gradient(135deg, #667eea 0%, #764ba2 100%)` → `vars.colors.gradients.primary`.
- 43 files touched. Remaining 74 hex codes are either gradient endpoints worth manual review or one-off shades outside the Tailwind palette.

**Layout-primitive migration (commit 3)**
- `app.admin/src/pages/Dashboard.tsx` — replaces the hand-rolled flex container with `<Stack spacing='xl'>` and the placeholder "more widgets coming soon" div block with `<EmptyState variant='loading'>`. Dashboard.css.ts borderRadius onto token scale; skeleton gradient onto theme tokens.
- `app.rescue/src/components/rescue/AdoptionPolicyForm.tsx` — "Adoption Fees" section migrated to `<FormSection title=… > <FormRow columns='two'>`, dropping six layers of div/className boilerplate.
- `setup-tests.ts` mocks in `app.admin` + `app.rescue` extended for the newly used exports.

## Test plan

- [x] `lib.components` build + tests (457/457 passing)
- [x] `app.admin` build (only pre-existing TS errors in `Users.tsx` remain; unrelated to this branch)
- [x] `app.client` + `app.rescue` builds clean
- [x] `app.admin` tests at baseline (53 pre-existing failures, 0 new)
- [x] `app.rescue` tests 185/185 passing
- [ ] Visual QA in browser across light / dark / high-contrast themes — not done in this environment
- [ ] Tackle the remaining 74 hex codes (gradients, one-off shades) in a follow-up

## Why this matters

Every hardcoded hex code locked light-mode colors into dark mode and broke high-contrast accessibility. Centralising on the token contract means brand updates, dark-mode polish, and a11y fixes become one-line changes in `lib.components/src/styles/theme.css.ts` instead of search-and-replace across 40+ page files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwNYegsZbn44hsfgBCd5pT)_