### PR TITLE
UX & accessibility audit: High + Medium fixes

### DIFF
--- a/app.admin/src/__tests__/bulk-operations.behavior.test.tsx
+++ b/app.admin/src/__tests__/bulk-operations.behavior.test.tsx
@@ -334,7 +334,7 @@ describe('Bulk operations — Users page', () => {
       await user.click(within(toolbar).getByRole('button', { name: /^activate$/i }));
 
       expect(screen.getByTestId('bulk-confirmation-modal')).toBeInTheDocument();
-      expect(screen.getByTestId('modal-title')).toHaveTextContent('Activate Users');
+      expect(screen.getByTestId('modal-title')).toHaveTextContent(/Activate \d+ users?\?/);
     });
 
     it('opens the bulk confirmation modal when Deactivate is clicked', async () => {
@@ -347,7 +347,7 @@ describe('Bulk operations — Users page', () => {
       await user.click(within(toolbar).getByRole('button', { name: /^deactivate$/i }));
 
       expect(screen.getByTestId('bulk-confirmation-modal')).toBeInTheDocument();
-      expect(screen.getByTestId('modal-title')).toHaveTextContent('Deactivate Users');
+      expect(screen.getByTestId('modal-title')).toHaveTextContent(/Deactivate \d+ users?\?/);
     });
 
     it('opens the bulk confirmation modal when Delete is clicked', async () => {
@@ -360,7 +360,7 @@ describe('Bulk operations — Users page', () => {
       await user.click(within(toolbar).getByRole('button', { name: /^delete$/i }));
 
       expect(screen.getByTestId('bulk-confirmation-modal')).toBeInTheDocument();
-      expect(screen.getByTestId('modal-title')).toHaveTextContent('Delete Users');
+      expect(screen.getByTestId('modal-title')).toHaveTextContent(/Delete \d+ users?\?/);
     });
 
     it('shows the number of selected items in the confirmation modal', async () => {

--- a/app.admin/src/components/layout/AdminLayout.css.ts
+++ b/app.admin/src/components/layout/AdminLayout.css.ts
@@ -44,3 +44,29 @@ export const layoutFooter = style({
   justifyContent: 'flex-end',
   background: '#ffffff',
 });
+
+export const skipLink = style({
+  position: 'absolute',
+  left: '-9999px',
+  top: 'auto',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden',
+  zIndex: 9999,
+  selectors: {
+    '&:focus': {
+      left: '0.75rem',
+      top: '0.75rem',
+      width: 'auto',
+      height: 'auto',
+      padding: '0.5rem 0.875rem',
+      background: '#111827',
+      color: '#ffffff',
+      borderRadius: '0.375rem',
+      textDecoration: 'none',
+      fontWeight: 600,
+      outline: '2px solid #fff',
+      outlineOffset: '2px',
+    },
+  },
+});

--- a/app.admin/src/components/layout/AdminLayout.tsx
+++ b/app.admin/src/components/layout/AdminLayout.tsx
@@ -17,10 +17,15 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
 
   return (
     <div className={styles.layoutContainer}>
+      <a href='#main-content' className={styles.skipLink}>
+        Skip to main content
+      </a>
       <AdminSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
       <main className={styles.mainContent({ sidebarCollapsed })}>
         <AdminHeader sidebarCollapsed={sidebarCollapsed} />
-        <div className={styles.contentWrapper}>{children}</div>
+        <div id='main-content' className={styles.contentWrapper} tabIndex={-1}>
+          {children}
+        </div>
         <footer className={styles.layoutFooter}>
           <ManageCookiesLink />
         </footer>

--- a/app.admin/src/pages/Pets.tsx
+++ b/app.admin/src/pages/Pets.tsx
@@ -287,13 +287,13 @@ const Pets: React.FC = () => {
         isOpen={bulkAction !== null}
         onClose={handleBulkModalClose}
         onConfirm={handleBulkConfirm}
-        title={
-          bulkAction === 'publish'
-            ? 'Publish Pets'
-            : bulkAction === 'unpublish'
-              ? 'Unpublish Pets'
-              : 'Archive Pets'
-        }
+        title={(() => {
+          const count = selectedRows.size;
+          const noun = `${count} pet${count !== 1 ? 's' : ''}`;
+          if (bulkAction === 'publish') return `Publish ${noun}?`;
+          if (bulkAction === 'unpublish') return `Unpublish ${noun}?`;
+          return `Archive ${noun}?`;
+        })()}
         description={
           bulkAction === 'publish'
             ? 'Set the selected pets as available for adoption.'

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -590,13 +590,13 @@ const Users: React.FC = () => {
         isOpen={bulkAction !== null}
         onClose={handleBulkModalClose}
         onConfirm={handleBulkConfirm}
-        title={
-          bulkAction === 'delete'
-            ? 'Delete Users'
-            : bulkAction === 'activate'
-              ? 'Activate Users'
-              : 'Deactivate Users'
-        }
+        title={(() => {
+          const count = selectedRows.size;
+          const noun = `${count} user${count !== 1 ? 's' : ''}`;
+          if (bulkAction === 'delete') return `Delete ${noun}?`;
+          if (bulkAction === 'activate') return `Activate ${noun}?`;
+          return `Deactivate ${noun}?`;
+        })()}
         description={
           bulkAction === 'delete'
             ? 'This will permanently delete the selected users. This action cannot be undone.'

--- a/app.client/src/components/layout/AppShell.css.ts
+++ b/app.client/src/components/layout/AppShell.css.ts
@@ -9,3 +9,29 @@ export const shell = style({
 export const main = style({
   flex: '1',
 });
+
+export const skipLink = style({
+  position: 'absolute',
+  left: '-9999px',
+  top: 'auto',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden',
+  zIndex: 9999,
+  selectors: {
+    '&:focus': {
+      left: '0.75rem',
+      top: '0.75rem',
+      width: 'auto',
+      height: 'auto',
+      padding: '0.5rem 0.875rem',
+      background: '#111827',
+      color: '#ffffff',
+      borderRadius: '0.375rem',
+      textDecoration: 'none',
+      fontWeight: 600,
+      outline: '2px solid #fff',
+      outlineOffset: '2px',
+    },
+  },
+});

--- a/app.client/src/components/layout/AppShell.tsx
+++ b/app.client/src/components/layout/AppShell.tsx
@@ -13,8 +13,13 @@ export const AppShell: React.FC = () => {
 
   return (
     <div className={styles.shell}>
-      <AppNavbar />
-      <main className={styles.main}>
+      <a href='#main-content' className={styles.skipLink}>
+        Skip to main content
+      </a>
+      <header>
+        <AppNavbar />
+      </header>
+      <main id='main-content' className={styles.main} tabIndex={-1}>
         <Outlet />
       </main>
       <SwipeFloatingButton />

--- a/app.client/src/pages/ApplicationPage.tsx
+++ b/app.client/src/pages/ApplicationPage.tsx
@@ -296,6 +296,13 @@ export const ApplicationPage: React.FC = () => {
     setCurrentStep(prev => Math.max(1, prev - 1));
   }, []);
 
+  // Without this, moving between steps leaves the user mid-page on the
+  // bottom of the previous form. Scroll back to the top so the new step's
+  // heading is the first thing in view.
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [currentStep]);
+
   const handleSubmit = async () => {
     if (!pet) {
       return;

--- a/app.client/src/pages/PetDetailsPage.css.ts
+++ b/app.client/src/pages/PetDetailsPage.css.ts
@@ -14,9 +14,12 @@ export const backLink = style({
   marginBottom: '2rem',
   textDecoration: 'none',
   color: vars.text.secondary,
+  background: 'transparent',
   border: `1px solid ${vars.border.color.primary}`,
   borderRadius: vars.border.radius.md,
   fontSize: '0.9rem',
+  font: 'inherit',
+  cursor: 'pointer',
   transition: `all ${vars.transitions.fast}`,
   ':hover': {
     color: vars.text.primary,

--- a/app.client/src/pages/PetDetailsPage.tsx
+++ b/app.client/src/pages/PetDetailsPage.tsx
@@ -25,7 +25,19 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
   const [isFavorite, setIsFavorite] = useState(false);
   const [favoriteLoading, setFavoriteLoading] = useState(false);
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
+  const [loginPromptAction, setLoginPromptAction] = useState('apply for adoption');
   const navigate = useNavigate();
+
+  // Use real browser history so the back button returns to wherever the
+  // user actually came from (favourites, home, search). Falls back to the
+  // home page when there's no history (e.g. user opened a shared link).
+  const handleBackClick = () => {
+    if (window.history.length > 1) {
+      navigate(-1);
+      return;
+    }
+    navigate('/');
+  };
 
   useEffect(() => {
     const fetchPet = async () => {
@@ -142,13 +154,27 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
         error_message: error instanceof Error ? error.message : 'unknown_error',
         user_authenticated: isAuthenticated.toString(),
       });
+
+      // Surface failure to the user — without this the button silently
+      // snaps back and the user assumes the save succeeded.
+      toast.error(
+        isFavorite
+          ? 'Could not remove from favorites. Please try again.'
+          : 'Could not save to favorites. Please try again.',
+        { action: { label: 'Retry', onClick: handleFavoriteToggle } }
+      );
     } finally {
       setFavoriteLoading(false);
     }
   };
 
   const handleContactRescue = async () => {
-    if (!pet?.rescue_id || !isAuthenticated) {
+    if (!pet?.rescue_id) {
+      return;
+    }
+    if (!isAuthenticated) {
+      setLoginPromptAction('contact this rescue');
+      setShowLoginPrompt(true);
       return;
     }
 
@@ -221,6 +247,7 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
     // Check if user is authenticated
     if (!isAuthenticated) {
       e.preventDefault();
+      setLoginPromptAction('apply for adoption');
       setShowLoginPrompt(true);
       return;
     }
@@ -358,9 +385,9 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
 
   return (
     <div className={styles.pageContainer}>
-      <Link className={styles.backLink} to='/'>
-        ← Back to Search
-      </Link>
+      <button type='button' className={styles.backLink} onClick={handleBackClick}>
+        ← Back
+      </button>
 
       <div className={styles.petHeader}>
         <div className={styles.petTitle}>
@@ -488,9 +515,15 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
 
           <Card className={styles.actionCard}>
             <h3>Interested in {pet.name}?</h3>
-            {pet.rescue_id && (
+            {pet.rescue_id && pet.rescue?.name && (
               <div className='rescue-info'>
-                <div className='rescue-name'>Rescue ID: {pet.rescue_id}</div>
+                <div className='rescue-name'>
+                  From{' '}
+                  <Link to={`/rescues/${pet.rescue_id}`} onClick={handleRescueProfileClick}>
+                    {pet.rescue.name}
+                  </Link>
+                  {pet.rescue.location ? ` · ${pet.rescue.location}` : ''}
+                </div>
               </div>
             )}
             <div className='actions'>
@@ -512,7 +545,7 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
                   View Rescue Profile
                 </Link>
               )}
-              {pet.rescue_id && isAuthenticated && (
+              {pet.rescue_id && (
                 <Button
                   className={styles.contactButton}
                   variant='primary'
@@ -537,7 +570,7 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
       <LoginPromptModal
         isOpen={showLoginPrompt}
         onClose={handleCloseLoginPrompt}
-        action='apply for adoption'
+        action={loginPromptAction}
       />
     </div>
   );

--- a/app.rescue/src/components/shared/Layout.css.ts
+++ b/app.rescue/src/components/shared/Layout.css.ts
@@ -31,3 +31,29 @@ export const layoutFooter = style({
   justifyContent: 'flex-end',
   background: vars.background.secondary,
 });
+
+export const skipLink = style({
+  position: 'absolute',
+  left: '-9999px',
+  top: 'auto',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden',
+  zIndex: 9999,
+  selectors: {
+    '&:focus': {
+      left: '0.75rem',
+      top: '0.75rem',
+      width: 'auto',
+      height: 'auto',
+      padding: '0.5rem 0.875rem',
+      background: vars.text.primary,
+      color: vars.background.primary,
+      borderRadius: '0.375rem',
+      textDecoration: 'none',
+      fontWeight: 600,
+      outline: `2px solid ${vars.background.primary}`,
+      outlineOffset: '2px',
+    },
+  },
+});

--- a/app.rescue/src/components/shared/Layout.tsx
+++ b/app.rescue/src/components/shared/Layout.tsx
@@ -10,9 +10,14 @@ interface LayoutProps {
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
     <div className={styles.appLayout}>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to main content
+      </a>
       <Navigation />
       <div className={styles.mainColumn}>
-        <main className={styles.mainContent}>{children}</main>
+        <main id="main-content" className={styles.mainContent} tabIndex={-1}>
+          {children}
+        </main>
         <footer className={styles.layoutFooter}>
           <ManageCookiesLink />
         </footer>

--- a/lib.components/src/components/form/SelectInput/SelectInput.tsx
+++ b/lib.components/src/components/form/SelectInput/SelectInput.tsx
@@ -256,6 +256,7 @@ export const SelectInput = ({
                   <input
                     className={searchInput}
                     placeholder='Search options...'
+                    aria-label='Search options'
                     value={searchQuery}
                     onChange={handleSearchChange}
                     onClick={e => e.stopPropagation()}

--- a/lib.components/src/components/ui/DropdownMenu/DropdownMenu.css.ts
+++ b/lib.components/src/components/ui/DropdownMenu/DropdownMenu.css.ts
@@ -3,6 +3,10 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '../../../styles/theme.css';
 
 export const trigger = style({
+  background: 'transparent',
+  border: 'none',
+  padding: 0,
+  font: 'inherit',
   color: vars.text.primary,
   fontWeight: vars.typography.weight.bold,
   cursor: 'pointer',

--- a/lib.components/src/components/ui/DropdownMenu/DropdownMenu.tsx
+++ b/lib.components/src/components/ui/DropdownMenu/DropdownMenu.tsx
@@ -17,7 +17,9 @@ interface DropdownProps {
 const Dropdown: React.FC<DropdownProps> = ({ triggerLabel, items }) => (
   <DropdownMenuPrimitive.Root>
     <DropdownMenuPrimitive.Trigger asChild>
-      <span className={styles.trigger}>{triggerLabel}</span>
+      <button type='button' className={styles.trigger}>
+        {triggerLabel}
+      </button>
     </DropdownMenuPrimitive.Trigger>
     <DropdownMenuPrimitive.Content className={styles.content}>
       {items.map((item, index) => (

--- a/lib.components/src/components/ui/ImageGallery/ImageGallery.test.tsx
+++ b/lib.components/src/components/ui/ImageGallery/ImageGallery.test.tsx
@@ -108,7 +108,7 @@ describe('ImageGallery Component', () => {
   it('updates the image index when a dot is clicked in carousel view', () => {
     renderWithTheme(<ImageGallery images={initialImages} viewMode='carousel' />);
 
-    const dots = screen.getAllByRole('button', { name: /dot/i }); // Ensure dots have accessible names
+    const dots = screen.getAllByRole('button', { name: /view image \d+ of \d+/i });
     expect(dots).toHaveLength(initialImages.length);
 
     fireEvent.click(dots[1]); // Click the second dot

--- a/lib.components/src/components/ui/ImageGallery/ImageGallery.tsx
+++ b/lib.components/src/components/ui/ImageGallery/ImageGallery.tsx
@@ -157,9 +157,11 @@ const ImageGallery: React.FC<ImageGalleryProps> = ({ images, viewMode, onUpload,
             {galleryImages.map((_, index) => (
               <button
                 key={index}
+                type='button'
                 className={clsx(dot({ active: index === currentImageIndex }))}
                 onClick={() => setCurrentImageIndex(index)}
-                aria-label={`dot ${index + 1}`}
+                aria-label={`View image ${index + 1} of ${galleryImages.length}`}
+                aria-current={index === currentImageIndex ? 'true' : undefined}
               />
             ))}
           </div>

--- a/lib.components/src/components/ui/Modal.tsx
+++ b/lib.components/src/components/ui/Modal.tsx
@@ -124,14 +124,7 @@ export const Modal: React.FC<ModalProps> = ({
   }
 
   const modalContent = (
-    <div
-      className={styles.overlay}
-      onClick={handleOverlayClick}
-      onKeyDown={handleKeyDown}
-      role='button'
-      tabIndex={-1}
-      aria-label='Modal backdrop'
-    >
+    <div className={styles.overlay} onClick={handleOverlayClick} onKeyDown={handleKeyDown}>
       <div
         ref={modalRef}
         className={clsx(styles.modalContainer({ size, centered }), className)}

--- a/lib.components/src/components/ui/Modal.tsx
+++ b/lib.components/src/components/ui/Modal.tsx
@@ -124,7 +124,13 @@ export const Modal: React.FC<ModalProps> = ({
   }
 
   const modalContent = (
-    <div className={styles.overlay} onClick={handleOverlayClick} onKeyDown={handleKeyDown}>
+    // Overlay captures click-outside-to-close. The Tab focus trap and
+    // Escape handling are both managed via the inner dialog's onKeyDown
+    // below (with a document-level Escape listener as backup) — no
+    // keyboard handler is needed on the overlay itself.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+    <div className={styles.overlay} onClick={handleOverlayClick}>
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <div
         ref={modalRef}
         className={clsx(styles.modalContainer({ size, centered }), className)}
@@ -132,6 +138,7 @@ export const Modal: React.FC<ModalProps> = ({
         aria-modal='true'
         aria-labelledby={title ? 'modal-title' : undefined}
         data-testid={dataTestId}
+        onKeyDown={handleKeyDown}
       >
         {(title || header) && (
           <div className={styles.modalHeader}>

--- a/lib.components/src/components/ui/ProgressBar/ProgressBar.css.ts
+++ b/lib.components/src/components/ui/ProgressBar/ProgressBar.css.ts
@@ -74,11 +74,18 @@ export const progressFill = recipe({
       false: {},
     },
     animated: {
-      true: { animation: `${pulseStripes} 2s infinite linear` },
+      true: {
+        animation: `${pulseStripes} 2s infinite linear`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none' } },
+      },
       false: {},
     },
     indeterminate: {
-      true: { width: '25%', animation: `${indeterminateSlide} 2s infinite linear` },
+      true: {
+        width: '25%',
+        animation: `${indeterminateSlide} 2s infinite linear`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none' } },
+      },
       false: {},
     },
   },

--- a/lib.components/src/components/ui/Spinner.css.ts
+++ b/lib.components/src/components/ui/Spinner.css.ts
@@ -24,6 +24,11 @@ export const spinner = recipe({
     borderRadius: '50%',
     borderStyle: 'solid',
     animation: `${spin} 0.75s linear infinite`,
+    '@media': {
+      '(prefers-reduced-motion: reduce)': {
+        animation: 'none',
+      },
+    },
   },
   variants: {
     size: {
@@ -74,6 +79,11 @@ export const dot = recipe({
     borderRadius: '50%',
     animation: `${pulse} 1.4s ease-in-out infinite both`,
     animationDelay: 'var(--dot-delay)',
+    '@media': {
+      '(prefers-reduced-motion: reduce)': {
+        animation: 'none',
+      },
+    },
   },
   variants: {
     size: {

--- a/lib.components/src/components/ui/Toast/Toast.css.ts
+++ b/lib.components/src/components/ui/Toast/Toast.css.ts
@@ -82,12 +82,30 @@ export const toastWrapper = recipe({
       },
     },
     position: {
-      'top-left': { animation: `${slideInLeft} 300ms ease-out` },
-      'top-center': { animation: `${slideInTop} 300ms ease-out` },
-      'top-right': { animation: `${slideInRight} 300ms ease-out` },
-      'bottom-left': { animation: `${slideInLeft} 300ms ease-out` },
-      'bottom-center': { animation: `${slideInBottom} 300ms ease-out` },
-      'bottom-right': { animation: `${slideInRight} 300ms ease-out` },
+      'top-left': {
+        animation: `${slideInLeft} 300ms ease-out`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none' } },
+      },
+      'top-center': {
+        animation: `${slideInTop} 300ms ease-out`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none' } },
+      },
+      'top-right': {
+        animation: `${slideInRight} 300ms ease-out`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none' } },
+      },
+      'bottom-left': {
+        animation: `${slideInLeft} 300ms ease-out`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none' } },
+      },
+      'bottom-center': {
+        animation: `${slideInBottom} 300ms ease-out`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none' } },
+      },
+      'bottom-right': {
+        animation: `${slideInRight} 300ms ease-out`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none' } },
+      },
     },
     exiting: {
       true: {},
@@ -97,27 +115,45 @@ export const toastWrapper = recipe({
   compoundVariants: [
     {
       variants: { position: 'top-left', exiting: true },
-      style: { animation: `${slideOutLeft} 200ms ease-in-out forwards` },
+      style: {
+        animation: `${slideOutLeft} 200ms ease-in-out forwards`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none', opacity: 0 } },
+      },
     },
     {
       variants: { position: 'bottom-left', exiting: true },
-      style: { animation: `${slideOutLeft} 200ms ease-in-out forwards` },
+      style: {
+        animation: `${slideOutLeft} 200ms ease-in-out forwards`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none', opacity: 0 } },
+      },
     },
     {
       variants: { position: 'top-right', exiting: true },
-      style: { animation: `${slideOutRight} 200ms ease-in-out forwards` },
+      style: {
+        animation: `${slideOutRight} 200ms ease-in-out forwards`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none', opacity: 0 } },
+      },
     },
     {
       variants: { position: 'bottom-right', exiting: true },
-      style: { animation: `${slideOutRight} 200ms ease-in-out forwards` },
+      style: {
+        animation: `${slideOutRight} 200ms ease-in-out forwards`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none', opacity: 0 } },
+      },
     },
     {
       variants: { position: 'top-center', exiting: true },
-      style: { animation: `${slideOutTop} 200ms ease-in-out forwards` },
+      style: {
+        animation: `${slideOutTop} 200ms ease-in-out forwards`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none', opacity: 0 } },
+      },
     },
     {
       variants: { position: 'bottom-center', exiting: true },
-      style: { animation: `${slideOutBottom} 200ms ease-in-out forwards` },
+      style: {
+        animation: `${slideOutBottom} 200ms ease-in-out forwards`,
+        '@media': { '(prefers-reduced-motion: reduce)': { animation: 'none', opacity: 0 } },
+      },
     },
   ],
   defaultVariants: { type: 'info', position: 'top-right', exiting: false },


### PR DESCRIPTION
## Summary

Acts on the High and Medium findings from a UX and accessibility audit of `app.client`, `app.admin`, `app.rescue`, and the shared `lib.components` package. Most fixes land in `lib.components` so they apply to all three apps.

Four commits, grouped by area:

1. **`lib.components` a11y primitives** — Modal backdrop role fixed; `prefers-reduced-motion` guards on Spinner/Toast/ProgressBar; `SelectInput` search input labelled; `DropdownMenu` trigger is now a real `<button>`; `ImageGallery` navigation dots have meaningful labels and `aria-current`.
2. **Layout landmarks + skip links** — All three apps now expose a "Skip to main content" link as the first focusable element, target `<main id="main-content">`, and `app.client` gains a `<header>` landmark wrapping its navbar.
3. **`app.client` pet detail / application flows** — Favourite-toggle failures now surface as a toast with a Retry action (was silently console-logged); the rescue is shown by name and linked instead of a raw UUID; "Contact Rescue" is visible to anonymous visitors and opens the existing `LoginPromptModal`; back button uses real browser history with a home-page fallback; application form scrolls to top on step change.
4. **`app.admin` bulk modals** — Confirmation modal title now includes the selected count ("Delete 12 users?", "Archive 3 pets?") instead of generic "Delete Users", on both the Users and Pets pages.

### Findings investigated but skipped

A few audit findings turned out to be false positives or already implemented, so no change was needed:

- **"Mobile chat has no back button"** — `lib.chat/ChatWindow.tsx` already renders a back button visible only via a `(min-width: 769px) { display: none }` media query, and it calls `setActiveConversation(null)` which unwinds the rescue Communication mobile view.
- **"Truncated 'Failed to suspend user —' on empty error message"** — the existing code already falls through to a generic message when `errorReason` is empty (empty string is falsy in JS).
- **"`SearchPage` refetches on every render due to unstable analytics deps"** — `useStatsig`'s `logEvent` is `useCallback`-stable and `AnalyticsContext`'s `value` is memoised, so the deps are stable in practice.

### Findings deferred

Lower-priority items not addressed here:

- **U10 Loading skeletons** across `SearchPage` / `PetDetailsPage` / rescue Dashboard — meaningful work that deserves its own pass with a shared `<Skeleton>` primitive in `lib.components`.
- **U11 Active-filter pills** on the admin `Pets` page — current filter bar is already visible above the table, so the user impact is small.
- **A8 `ProgressBar` value text contrast** — `neutral-600` on white is ~6.8:1, passes AA, only marginal for AAA.
- **U13 Always-visible char counter** on `ProfileEditForm` bio — minor.

### Tests

- `lib.components`: 450/450 pass
- `app.client`: 256/256 pass
- `app.rescue`: pass
- `app.admin`: pre-existing failures on this branch (test mock for `../hooks` is missing `useCreateUser` and `useRescuesList`, both already imported by `Users.tsx` before this PR). Same tests fail without these changes; tracked separately.

### Type-check

- `lib.components`, `app.client`, `app.rescue`: clean
- `app.admin`: two pre-existing errors in `Users.tsx` (lines 253, 578) caused by `showToast({ message, type })` vs `showToast(string, type)` — pre-existing on this branch, untouched by this PR.

## Test plan

- [ ] Tab from a freshly loaded page on each app — the first focusable element should be the visible "Skip to main content" link, and pressing Enter should jump focus to page content.
- [ ] On the pet detail page, simulate a failed `addToFavorites` call (network offline) — confirm the user sees the toast with Retry, and Retry attempts the toggle again.
- [ ] On the pet detail page as an anonymous user, click "Contact Rescue" — confirm the login prompt appears with copy that mentions contacting the rescue.
- [ ] Apply for a pet, advance between steps — confirm the page scrolls to the top of the new step.
- [ ] In the admin Users page, select 3 rows and click Delete — confirm the modal title reads "Delete 3 users?". Do the same with 1 row to confirm singular/plural.
- [ ] Enable OS-level "Reduce motion" — confirm Spinner/Toast/ProgressBar animations are disabled.
- [ ] With a screen reader, open the `SelectInput` search field — confirm it announces "Search options" rather than being unlabelled.

https://claude.ai/code/session_01QWdcG5NR1fopwS8Lniy3w5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWdcG5NR1fopwS8Lniy3w5)_