### PR TITLE
refactor: replace static React inline styles with vanilla-extract

### DIFF
--- a/app.admin/src/components/modals/ApplicationDetailModal.css.ts
+++ b/app.admin/src/components/modals/ApplicationDetailModal.css.ts
@@ -1,0 +1,12 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'grid',
+  gap: '0.75rem',
+});
+
+export const detailGrid = style({
+  display: 'grid',
+  gridTemplateColumns: '8rem 1fr',
+  gap: '0.25rem 1rem',
+});

--- a/app.admin/src/components/modals/ApplicationDetailModal.tsx
+++ b/app.admin/src/components/modals/ApplicationDetailModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, Heading, Text } from '@adopt-dont-shop/lib.components';
 import type { AdminApplication } from '@/services/applicationService';
+import * as styles from './ApplicationDetailModal.css';
 
 type ApplicationDetailModalProps = {
   isOpen: boolean;
@@ -25,7 +26,7 @@ export const ApplicationDetailModal: React.FC<ApplicationDetailModalProps> = ({
   }
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={`Application ${application.applicationId}`}>
-      <div style={{ display: 'grid', gap: '0.75rem' }}>
+      <div className={styles.container}>
         <section>
           <Heading level='h3'>Status</Heading>
           <Text>{application.status}</Text>
@@ -33,7 +34,7 @@ export const ApplicationDetailModal: React.FC<ApplicationDetailModalProps> = ({
 
         <section>
           <Heading level='h3'>Applicant</Heading>
-          <dl style={{ display: 'grid', gridTemplateColumns: '8rem 1fr', gap: '0.25rem 1rem' }}>
+          <dl className={styles.detailGrid}>
             <dt>
               <Text>Name</Text>
             </dt>
@@ -51,7 +52,7 @@ export const ApplicationDetailModal: React.FC<ApplicationDetailModalProps> = ({
 
         <section>
           <Heading level='h3'>Pet</Heading>
-          <dl style={{ display: 'grid', gridTemplateColumns: '8rem 1fr', gap: '0.25rem 1rem' }}>
+          <dl className={styles.detailGrid}>
             <dt>
               <Text>Name</Text>
             </dt>
@@ -75,7 +76,7 @@ export const ApplicationDetailModal: React.FC<ApplicationDetailModalProps> = ({
 
         <section>
           <Heading level='h3'>Rescue</Heading>
-          <dl style={{ display: 'grid', gridTemplateColumns: '8rem 1fr', gap: '0.25rem 1rem' }}>
+          <dl className={styles.detailGrid}>
             <dt>
               <Text>Name</Text>
             </dt>
@@ -93,7 +94,7 @@ export const ApplicationDetailModal: React.FC<ApplicationDetailModalProps> = ({
 
         <section>
           <Heading level='h3'>Timestamps</Heading>
-          <dl style={{ display: 'grid', gridTemplateColumns: '8rem 1fr', gap: '0.25rem 1rem' }}>
+          <dl className={styles.detailGrid}>
             <dt>
               <Text>Created</Text>
             </dt>

--- a/app.admin/src/components/modals/ChatDetailModal.css.ts
+++ b/app.admin/src/components/modals/ChatDetailModal.css.ts
@@ -405,3 +405,112 @@ export const deletePromptActions = style({
   gap: '0.75rem',
   justifyContent: 'flex-end',
 });
+
+export const headerBadgeRow = style({
+  display: 'flex',
+  gap: '0.5rem',
+  flexWrap: 'wrap',
+});
+
+export const closeButtonWrapper = style({
+  marginLeft: 'auto',
+});
+
+export const messagesContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+export const loadMoreWrapper = style({
+  textAlign: 'center',
+  padding: '1rem',
+});
+
+export const moderationHelpText = style({
+  marginTop: '0.5rem',
+  fontSize: '0.875rem',
+  color: '#6b7280',
+});
+
+export const reportList = style({
+  maxHeight: '300px',
+  overflowY: 'auto',
+});
+
+export const reportCard = style({
+  padding: '0.75rem',
+  marginBottom: '0.5rem',
+  backgroundColor: '#f9fafb',
+  borderRadius: '0.375rem',
+  border: '1px solid #e5e7eb',
+});
+
+export const reportCardHeader = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginBottom: '0.25rem',
+});
+
+export const reportCategoryLabel = style({
+  textTransform: 'capitalize',
+});
+
+export const reportStatusBadge = style({
+  padding: '0.125rem 0.5rem',
+  borderRadius: '0.25rem',
+  fontSize: '0.75rem',
+  fontWeight: '500',
+});
+
+export const reportDescription = style({
+  fontSize: '0.875rem',
+  color: '#6b7280',
+});
+
+export const reportMeta = style({
+  fontSize: '0.75rem',
+  color: '#9ca3af',
+  marginTop: '0.25rem',
+});
+
+export const noReportsMessage = style({
+  padding: '1rem',
+  textAlign: 'center',
+  color: '#6b7280',
+});
+
+export const moderationLink = style({
+  color: '#2563eb',
+  textDecoration: 'none',
+  fontWeight: '500',
+  ':hover': {
+    textDecoration: 'underline',
+  },
+});
+
+export const participantHelpText = style({
+  marginBottom: '0.5rem',
+  fontSize: '0.875rem',
+  color: '#6b7280',
+});
+
+export const moderationParticipantList = style({
+  listStyle: 'none',
+  padding: 0,
+});
+
+export const participantRow = style({
+  padding: '0.5rem',
+  marginBottom: '0.25rem',
+  backgroundColor: '#f9fafb',
+  borderRadius: '0.25rem',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const participantViewLink = style({
+  fontSize: '0.875rem',
+  color: '#2563eb',
+});

--- a/app.admin/src/components/modals/ChatDetailModal/MessagesTab.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/MessagesTab.tsx
@@ -17,10 +17,18 @@ const formatTimestamp = (timestamp: string) => {
   const diffHours = Math.floor(diffMs / 3600000);
   const diffDays = Math.floor(diffMs / 86400000);
 
-  if (diffMins < 1) return 'Just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffMins < 1) {
+    return 'Just now';
+  }
+  if (diffMins < 60) {
+    return `${diffMins}m ago`;
+  }
+  if (diffHours < 24) {
+    return `${diffHours}h ago`;
+  }
+  if (diffDays < 7) {
+    return `${diffDays}d ago`;
+  }
   return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 };
 
@@ -53,7 +61,9 @@ export const MessagesTab: React.FC<MessagesTabProps> = ({ chatId, onMessageDelet
   };
 
   const handleDeleteMessage = async () => {
-    if (!messageToDelete) return;
+    if (!messageToDelete) {
+      return;
+    }
 
     try {
       await deleteMessage.mutateAsync({ chatId, messageId: messageToDelete });
@@ -100,7 +110,7 @@ export const MessagesTab: React.FC<MessagesTabProps> = ({ chatId, onMessageDelet
 
   return (
     <>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div className={styles.messagesContainer}>
         <div className={styles.messageTimeline}>
           {messages.map(message => {
             const isDeleted = message.content === '[Message deleted]';
@@ -137,7 +147,7 @@ export const MessagesTab: React.FC<MessagesTabProps> = ({ chatId, onMessageDelet
         </div>
 
         {hasMorePages && (
-          <div style={{ textAlign: 'center', padding: '1rem' }}>
+          <div className={styles.loadMoreWrapper}>
             <Button
               variant='secondary'
               onClick={() => setPage(p => p + 1)}

--- a/app.admin/src/components/modals/ChatDetailModal/ModerationTab.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/ModerationTab.tsx
@@ -80,7 +80,7 @@ export const ModerationTab: React.FC<ModerationTabProps> = ({ chat, chatId }) =>
           >
             {flaggingConversation ? 'Flagging...' : 'Report This Conversation'}
           </Button>
-          <p style={{ marginTop: '0.5rem', fontSize: '0.875rem', color: '#6b7280' }}>
+          <p className={styles.moderationHelpText}>
             Flag this conversation for moderator review if it contains inappropriate content, spam,
             harassment, or policy violations.
           </p>
@@ -96,34 +96,16 @@ export const ModerationTab: React.FC<ModerationTabProps> = ({ chat, chatId }) =>
           {loadingReports ? (
             'Loading reports...'
           ) : reports.length > 0 ? (
-            <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+            <div className={styles.reportList}>
               {reports.map(report => (
-                <div
-                  key={report.reportId}
-                  style={{
-                    padding: '0.75rem',
-                    marginBottom: '0.5rem',
-                    backgroundColor: '#f9fafb',
-                    borderRadius: '0.375rem',
-                    border: '1px solid #e5e7eb',
-                  }}
-                >
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      marginBottom: '0.25rem',
-                    }}
-                  >
-                    <strong style={{ textTransform: 'capitalize' }}>
+                <div key={report.reportId} className={styles.reportCard}>
+                  <div className={styles.reportCardHeader}>
+                    <strong className={styles.reportCategoryLabel}>
                       {report.category.replace('_', ' ')}
                     </strong>
                     <span
+                      className={styles.reportStatusBadge}
                       style={{
-                        padding: '0.125rem 0.5rem',
-                        borderRadius: '0.25rem',
-                        fontSize: '0.75rem',
-                        fontWeight: '500',
                         backgroundColor:
                           report.status === 'resolved'
                             ? '#d1fae5'
@@ -141,19 +123,17 @@ export const ModerationTab: React.FC<ModerationTabProps> = ({ chat, chatId }) =>
                       {report.status}
                     </span>
                   </div>
-                  <div style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+                  <div className={styles.reportDescription}>
                     {report.description || 'No description provided'}
                   </div>
-                  <div style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '0.25rem' }}>
+                  <div className={styles.reportMeta}>
                     Reported: {new Date(report.createdAt).toLocaleString()}
                   </div>
                 </div>
               ))}
             </div>
           ) : (
-            <div style={{ padding: '1rem', textAlign: 'center', color: '#6b7280' }}>
-              No reports filed for this conversation
-            </div>
+            <div className={styles.noReportsMessage}>No reports filed for this conversation</div>
           )}
         </div>
       </div>
@@ -166,13 +146,11 @@ export const ModerationTab: React.FC<ModerationTabProps> = ({ chat, chatId }) =>
         <div className={styles.detailValue}>
           <a
             href={`/moderation?entity=conversation&id=${chatId}`}
-            style={{ color: '#2563eb', textDecoration: 'none', fontWeight: '500' }}
-            onMouseOver={e => (e.currentTarget.style.textDecoration = 'underline')}
-            onMouseOut={e => (e.currentTarget.style.textDecoration = 'none')}
+            className={styles.moderationLink}
           >
             View in Moderation Dashboard →
           </a>
-          <p style={{ marginTop: '0.5rem', fontSize: '0.875rem', color: '#6b7280' }}>
+          <p className={styles.moderationHelpText}>
             View complete moderation history, take actions, and manage reports in the dedicated
             moderation interface.
           </p>
@@ -187,29 +165,16 @@ export const ModerationTab: React.FC<ModerationTabProps> = ({ chat, chatId }) =>
         <div className={styles.detailValue}>
           {chat.participants && chat.participants.length > 0 ? (
             <div>
-              <p style={{ marginBottom: '0.5rem', fontSize: '0.875rem', color: '#6b7280' }}>
-                Moderate individual participants:
-              </p>
-              <ul style={{ listStyle: 'none', padding: 0 }}>
+              <p className={styles.participantHelpText}>Moderate individual participants:</p>
+              <ul className={styles.moderationParticipantList}>
                 {chat.participants.map((participant: Participant) => (
-                  <li
-                    key={participant.id}
-                    style={{
-                      padding: '0.5rem',
-                      marginBottom: '0.25rem',
-                      backgroundColor: '#f9fafb',
-                      borderRadius: '0.25rem',
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                    }}
-                  >
+                  <li key={participant.id} className={styles.participantRow}>
                     <span>
                       {participant.name} ({participant.type})
                     </span>
                     <a
                       href={`/moderation?user=${participant.id}`}
-                      style={{ fontSize: '0.875rem', color: '#2563eb' }}
+                      className={styles.participantViewLink}
                     >
                       View User
                     </a>

--- a/app.admin/src/components/modals/ChatDetailModal/index.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/index.tsx
@@ -54,7 +54,9 @@ export const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
   const { data: chat, isLoading: chatLoading } = useAdminChatById(chatId);
   const { deleteChat, updateChatStatus } = useAdminChatMutations();
 
-  if (!chatId) return null;
+  if (!chatId) {
+    return null;
+  }
 
   const conversation = chat as Conversation | undefined;
 
@@ -66,7 +68,9 @@ export const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
       cancelText: 'Cancel',
       variant: 'warning',
     });
-    if (!confirmed) return;
+    if (!confirmed) {
+      return;
+    }
 
     try {
       await updateChatStatus.mutateAsync({ chatId, status: 'archived' });
@@ -93,7 +97,9 @@ export const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
       cancelText: 'Cancel',
       variant: 'danger',
     });
-    if (!confirmed) return;
+    if (!confirmed) {
+      return;
+    }
 
     try {
       await deleteChat.mutateAsync(chatId);
@@ -123,9 +129,7 @@ export const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
           {conversation && (
             <>
               <span className={styles.chatId}>Chat #{conversation.id.slice(-8)}</span>
-              <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-                {getStatusBadge(conversation.status)}
-              </div>
+              <div className={styles.headerBadgeRow}>{getStatusBadge(conversation.status)}</div>
             </>
           )}
         </div>
@@ -194,7 +198,7 @@ export const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
           <Button variant='danger' leftIcon={<FiTrash2 />} onClick={handleDeleteChat}>
             Delete
           </Button>
-          <div style={{ marginLeft: 'auto' }}>
+          <div className={styles.closeButtonWrapper}>
             <Button variant='secondary' leftIcon={<FiX />} onClick={onClose}>
               Close
             </Button>

--- a/app.admin/src/components/modals/PetDetailModal.css.ts
+++ b/app.admin/src/components/modals/PetDetailModal.css.ts
@@ -1,0 +1,12 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'grid',
+  gap: '0.75rem',
+});
+
+export const detailGrid = style({
+  display: 'grid',
+  gridTemplateColumns: '8rem 1fr',
+  gap: '0.25rem 1rem',
+});

--- a/app.admin/src/components/modals/PetDetailModal.tsx
+++ b/app.admin/src/components/modals/PetDetailModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, Heading, Text } from '@adopt-dont-shop/lib.components';
 import type { AdminPet } from '@/services/petService';
+import * as styles from './PetDetailModal.css';
 
 type PetDetailModalProps = {
   isOpen: boolean;
@@ -21,10 +22,10 @@ export const PetDetailModal: React.FC<PetDetailModalProps> = ({ isOpen, onClose,
   }
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={`Pet: ${pet.name}`}>
-      <div style={{ display: 'grid', gap: '0.75rem' }}>
+      <div className={styles.container}>
         <section>
           <Heading level='h3'>Overview</Heading>
-          <dl style={{ display: 'grid', gridTemplateColumns: '8rem 1fr', gap: '0.25rem 1rem' }}>
+          <dl className={styles.detailGrid}>
             <dt>
               <Text>ID</Text>
             </dt>
@@ -72,7 +73,7 @@ export const PetDetailModal: React.FC<PetDetailModalProps> = ({ isOpen, onClose,
 
         <section>
           <Heading level='h3'>Rescue</Heading>
-          <dl style={{ display: 'grid', gridTemplateColumns: '8rem 1fr', gap: '0.25rem 1rem' }}>
+          <dl className={styles.detailGrid}>
             <dt>
               <Text>Rescue</Text>
             </dt>

--- a/app.admin/src/components/modals/RescueDetailModal.css.ts
+++ b/app.admin/src/components/modals/RescueDetailModal.css.ts
@@ -376,3 +376,133 @@ export const invitationBadgeDefault = style({
   background: '#e5e7eb',
   color: '#374151',
 });
+
+export const skeletonRow = style({
+  display: 'flex',
+  gap: '0.5rem',
+});
+
+export const tableWrapper = style({
+  overflowX: 'auto',
+});
+
+export const dataTable = style({
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: '0.875rem',
+});
+
+export const tableHeadRow = style({
+  textAlign: 'left',
+  borderBottom: '1px solid #e5e7eb',
+});
+
+export const tableCell = style({
+  padding: '0.5rem',
+});
+
+export const tableBodyRow = style({
+  borderBottom: '1px solid #f3f4f6',
+});
+
+export const manageLinkRow = style({
+  marginTop: '0.75rem',
+});
+
+export const inviteFormSpacing = style({
+  marginTop: '1.5rem',
+});
+
+export const planSectionTitle = style({
+  margin: '0 0 1rem',
+  fontSize: '0.9375rem',
+  color: '#111827',
+});
+
+export const errorMessageSpacing = style({
+  marginBottom: '1rem',
+});
+
+export const staffSectionHeader = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const userPlusIcon = style({
+  marginRight: '0.5rem',
+});
+
+export const staffSectionSubtitle = style({
+  margin: 0,
+  fontSize: '0.9375rem',
+  color: '#111827',
+});
+
+export const skeletonStaffList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  padding: '1rem 0',
+});
+
+export const skeletonStaffRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+});
+
+export const skeletonStaffText = style({
+  flex: 1,
+});
+
+export const skeletonStaffName = style({
+  marginBottom: '0.25rem',
+});
+
+export const acceptedBadge = style({
+  display: 'inline-block',
+  marginLeft: '0.5rem',
+  color: '#10b981',
+});
+
+export const staffRowFlex = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+});
+
+export const headerSpacing = style({
+  marginTop: '0.5rem',
+});
+
+export const skeletonContent = style({
+  padding: '2rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+});
+
+export const skeletonAvatarRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1rem',
+});
+
+export const skeletonAvatarText = style({
+  flex: 1,
+});
+
+export const skeletonName = style({
+  marginBottom: '0.5rem',
+});
+
+export const successMessage = style({
+  padding: '0.75rem',
+  marginBottom: '1rem',
+  background: '#f0fdf4',
+  border: '1px solid #bbf7d0',
+  borderRadius: '0.375rem',
+  color: '#166534',
+  fontSize: '0.875rem',
+});

--- a/app.admin/src/components/modals/RescueDetailModal/ListingsTab.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal/ListingsTab.tsx
@@ -71,7 +71,7 @@ export const ListingsTab: React.FC<ListingsTabProps> = ({ rescueId }) => {
         {error && <div className={styles.errorMessage}>{error}</div>}
 
         {loading && (
-          <div aria-label='Loading listings' style={{ display: 'flex', gap: '0.5rem' }}>
+          <div aria-label='Loading listings' className={styles.skeletonRow}>
             {Array.from({ length: 4 }, (_, i) => (
               <Skeleton key={i} height='4rem' width='8rem' />
             ))}
@@ -103,23 +103,23 @@ export const ListingsTab: React.FC<ListingsTabProps> = ({ rescueId }) => {
       {!loading && !error && recent.length > 0 && (
         <div className={styles.section}>
           <h3 className={styles.sectionTitle}>Recent Listings</h3>
-          <div style={{ overflowX: 'auto' }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+          <div className={styles.tableWrapper}>
+            <table className={styles.dataTable}>
               <thead>
-                <tr style={{ textAlign: 'left', borderBottom: '1px solid #e5e7eb' }}>
-                  <th style={{ padding: '0.5rem' }}>Name</th>
-                  <th style={{ padding: '0.5rem' }}>Type</th>
-                  <th style={{ padding: '0.5rem' }}>Breed</th>
-                  <th style={{ padding: '0.5rem' }}>Listed</th>
+                <tr className={styles.tableHeadRow}>
+                  <th className={styles.tableCell}>Name</th>
+                  <th className={styles.tableCell}>Type</th>
+                  <th className={styles.tableCell}>Breed</th>
+                  <th className={styles.tableCell}>Listed</th>
                 </tr>
               </thead>
               <tbody>
                 {recent.map(pet => (
-                  <tr key={pet.petId} style={{ borderBottom: '1px solid #f3f4f6' }}>
-                    <td style={{ padding: '0.5rem' }}>{pet.name}</td>
-                    <td style={{ padding: '0.5rem' }}>{pet.type}</td>
-                    <td style={{ padding: '0.5rem' }}>{pet.breed}</td>
-                    <td style={{ padding: '0.5rem' }}>
+                  <tr key={pet.petId} className={styles.tableBodyRow}>
+                    <td className={styles.tableCell}>{pet.name}</td>
+                    <td className={styles.tableCell}>{pet.type}</td>
+                    <td className={styles.tableCell}>{pet.breed}</td>
+                    <td className={styles.tableCell}>
                       <DateTime timestamp={pet.createdAt} />
                     </td>
                   </tr>
@@ -127,7 +127,7 @@ export const ListingsTab: React.FC<ListingsTabProps> = ({ rescueId }) => {
               </tbody>
             </table>
           </div>
-          <div style={{ marginTop: '0.75rem' }}>
+          <div className={styles.manageLinkRow}>
             <Link to='/pets'>Manage all pets →</Link>
           </div>
         </div>

--- a/app.admin/src/components/modals/RescueDetailModal/PlanTab.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal/PlanTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import * as styles from '../RescueDetailModal.css';
 import { Button } from '@adopt-dont-shop/lib.components';
 import type { AdminRescue, RescuePlan } from '@/types/rescue';
@@ -93,29 +94,13 @@ export const PlanTab: React.FC<PlanTabProps> = ({
         )}
       </div>
 
-      <div className={styles.inviteForm} style={{ marginTop: '1.5rem' }}>
-        <h4 style={{ margin: '0 0 1rem', fontSize: '0.9375rem', color: '#111827' }}>Change Plan</h4>
+      <div className={clsx(styles.inviteForm, styles.inviteFormSpacing)}>
+        <h4 className={styles.planSectionTitle}>Change Plan</h4>
 
         {planError && (
-          <div className={styles.errorMessage} style={{ marginBottom: '1rem' }}>
-            {planError}
-          </div>
+          <div className={clsx(styles.errorMessage, styles.errorMessageSpacing)}>{planError}</div>
         )}
-        {planSuccess && (
-          <div
-            style={{
-              padding: '0.75rem',
-              marginBottom: '1rem',
-              background: '#f0fdf4',
-              border: '1px solid #bbf7d0',
-              borderRadius: '0.375rem',
-              color: '#166534',
-              fontSize: '0.875rem',
-            }}
-          >
-            Plan updated successfully.
-          </div>
-        )}
+        {planSuccess && <div className={styles.successMessage}>Plan updated successfully.</div>}
 
         <div className={styles.formRow}>
           <div className={styles.formGroup}>

--- a/app.admin/src/components/modals/RescueDetailModal/StaffTab.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal/StaffTab.tsx
@@ -22,7 +22,9 @@ export const StaffTab: React.FC<StaffTabProps> = ({ rescueId }) => {
 
   const fetchStaff = async (showLoading = true) => {
     try {
-      if (showLoading) setLoadingStaff(true);
+      if (showLoading) {
+        setLoadingStaff(true);
+      }
       setStaffError(null);
 
       const [staffData, invitationsData] = await Promise.all([
@@ -35,7 +37,9 @@ export const StaffTab: React.FC<StaffTabProps> = ({ rescueId }) => {
     } catch (err) {
       setStaffError(err instanceof Error ? err.message : 'Failed to load staff');
     } finally {
-      if (showLoading) setLoadingStaff(false);
+      if (showLoading) {
+        setLoadingStaff(false);
+      }
     }
   };
 
@@ -79,7 +83,9 @@ export const StaffTab: React.FC<StaffTabProps> = ({ rescueId }) => {
       cancelText: 'Cancel',
       variant: 'danger',
     });
-    if (!confirmed) return;
+    if (!confirmed) {
+      return;
+    }
 
     try {
       setLoadingStaff(true);
@@ -110,10 +116,10 @@ export const StaffTab: React.FC<StaffTabProps> = ({ rescueId }) => {
     <>
       <div className={styles.section}>
         <h3 className={styles.sectionTitle}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div className={styles.staffSectionHeader}>
             <span>Staff Members ({staff?.length || 0})</span>
             <Button variant='primary' size='sm' onClick={() => setShowInviteForm(!showInviteForm)}>
-              <FiUserPlus style={{ marginRight: '0.5rem' }} />
+              <FiUserPlus className={styles.userPlusIcon} />
               Invite Staff
             </Button>
           </div>
@@ -123,9 +129,7 @@ export const StaffTab: React.FC<StaffTabProps> = ({ rescueId }) => {
 
         {showInviteForm && (
           <div className={styles.inviteForm}>
-            <h4 style={{ margin: 0, fontSize: '0.9375rem', color: '#111827' }}>
-              Invite New Staff Member
-            </h4>
+            <h4 className={styles.staffSectionSubtitle}>Invite New Staff Member</h4>
             <div className={styles.formRow}>
               <div className={styles.formGroup}>
                 <label className={styles.label} htmlFor='invite-email'>
@@ -183,15 +187,12 @@ export const StaffTab: React.FC<StaffTabProps> = ({ rescueId }) => {
         )}
 
         {loadingStaff && (
-          <div
-            aria-label='Loading staff'
-            style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', padding: '1rem 0' }}
-          >
+          <div aria-label='Loading staff' className={styles.skeletonStaffList}>
             {Array.from({ length: 3 }, (_, i) => (
-              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+              <div key={i} className={styles.skeletonStaffRow}>
                 <Skeleton width='2.5rem' height='2.5rem' radius='50%' />
-                <div style={{ flex: 1 }}>
-                  <Skeleton height='0.875rem' width='40%' style={{ marginBottom: '0.25rem' }} />
+                <div className={styles.skeletonStaffText}>
+                  <Skeleton height='0.875rem' width='40%' className={styles.skeletonStaffName} />
                   <Skeleton height='0.75rem' width='60%' />
                 </div>
               </div>
@@ -212,12 +213,7 @@ export const StaffTab: React.FC<StaffTabProps> = ({ rescueId }) => {
                 <div className={styles.staffInfo}>
                   <div className={styles.staffName}>
                     {member.firstName} {member.lastName}
-                    {member.isVerified && (
-                      <FiCheck
-                        style={{ display: 'inline-block', marginLeft: '0.5rem', color: '#10b981' }}
-                        size={16}
-                      />
-                    )}
+                    {member.isVerified && <FiCheck className={styles.acceptedBadge} size={16} />}
                   </div>
                   <div className={styles.staffEmail}>{member.email}</div>
                   <div className={styles.staffMeta}>
@@ -257,7 +253,7 @@ export const StaffTab: React.FC<StaffTabProps> = ({ rescueId }) => {
                     <span>• Expires {<DateTime timestamp={invitation.expiresAt} />}</span>
                   </div>
                 </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                <div className={styles.staffRowFlex}>
                   <span
                     className={
                       invitation.status === 'pending'

--- a/app.admin/src/components/modals/RescueDetailModal/index.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal/index.tsx
@@ -22,7 +22,9 @@ type RescueDetailModalProps = {
 type ActiveTab = 'overview' | 'contact' | 'policies' | 'staff' | 'listings' | 'plan';
 
 const formatDate = (dateString?: string): string => {
-  if (!dateString) return 'N/A';
+  if (!dateString) {
+    return 'N/A';
+  }
   return new Date(dateString).toLocaleDateString('en-GB', {
     day: '2-digit',
     month: 'short',
@@ -75,7 +77,9 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
   }, [rescueId]);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) onClose();
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
   };
 
   const tabs: { id: ActiveTab; label: string }[] = [
@@ -99,7 +103,7 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
           <div className={styles.headerContent}>
             <Heading level='h2'>{rescue?.name || 'Rescue Details'}</Heading>
             {rescue && (
-              <Text style={{ marginTop: '0.5rem' }}>
+              <Text className={styles.headerSpacing}>
                 {getStatusBadge(rescue.status)} • Registered {formatDate(rescue.createdAt)}
               </Text>
             )}
@@ -123,14 +127,11 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
 
         <div className={styles.modalBody}>
           {loading && (
-            <div
-              aria-label='Loading rescue details'
-              style={{ padding: '2rem', display: 'flex', flexDirection: 'column', gap: '1.5rem' }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <div aria-label='Loading rescue details' className={styles.skeletonContent}>
+              <div className={styles.skeletonAvatarRow}>
                 <Skeleton width='4rem' height='4rem' radius='50%' />
-                <div style={{ flex: 1 }}>
-                  <Skeleton height='1.25rem' width='50%' style={{ marginBottom: '0.5rem' }} />
+                <div className={styles.skeletonAvatarText}>
+                  <Skeleton height='1.25rem' width='50%' className={styles.skeletonName} />
                   <Skeleton height='0.875rem' width='30%' />
                 </div>
               </div>

--- a/app.admin/src/components/modals/SendEmailModal.css.ts
+++ b/app.admin/src/components/modals/SendEmailModal.css.ts
@@ -197,3 +197,20 @@ export const footerButtons = style({
   justifyContent: 'flex-end',
   gap: '0.75rem',
 });
+
+export const modalHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+});
+
+export const modalHeaderTitle = style({
+  fontWeight: 600,
+  fontSize: '1.125rem',
+});
+
+export const modalHeaderSubtitle = style({
+  fontSize: '0.875rem',
+  opacity: 0.8,
+  marginTop: '0.125rem',
+});

--- a/app.admin/src/components/modals/SendEmailModal.tsx
+++ b/app.admin/src/components/modals/SendEmailModal.tsx
@@ -116,13 +116,11 @@ export const SendEmailModal: React.FC<SendEmailModalProps> = ({
   const selectedTemplateData = EMAIL_TEMPLATES.find(t => t.id === selectedTemplate);
 
   const modalHeader = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+    <div className={styles.modalHeader}>
       <FiMail size={20} />
       <div>
-        <div style={{ fontWeight: 600, fontSize: '1.125rem' }}>Send Email</div>
-        <div style={{ fontSize: '0.875rem', opacity: 0.8, marginTop: '0.125rem' }}>
-          Send an email to {rescue.name}
-        </div>
+        <div className={styles.modalHeaderTitle}>Send Email</div>
+        <div className={styles.modalHeaderSubtitle}>Send an email to {rescue.name}</div>
       </div>
     </div>
   );

--- a/app.admin/src/components/modals/TicketDetailModal.css.ts
+++ b/app.admin/src/components/modals/TicketDetailModal.css.ts
@@ -235,3 +235,27 @@ export const internalBadge = style({
   background: '#92400e',
   color: '#ffffff',
 });
+
+export const detailValueSecondary = style({
+  fontSize: '0.8125rem',
+  color: '#6b7280',
+});
+
+export const detailValueMeta = style({
+  fontSize: '0.75rem',
+  color: '#6b7280',
+  marginTop: '0.25rem',
+});
+
+export const internalNotesSection = style({
+  background: '#fef3c7',
+  borderColor: '#fbbf24',
+});
+
+export const internalNotesLabel = style({
+  color: '#92400e',
+});
+
+export const internalBadgeSpacing = style({
+  marginLeft: '0.5rem',
+});

--- a/app.admin/src/components/modals/TicketDetailModal.tsx
+++ b/app.admin/src/components/modals/TicketDetailModal.tsx
@@ -133,7 +133,7 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
             <div className={styles.detailValue}>
               {ticket.userName || <span className={styles.emptyValue}>Not provided</span>}
             </div>
-            <div className={styles.detailValue} style={{ fontSize: '0.8125rem', color: '#6b7280' }}>
+            <div className={clsx(styles.detailValue, styles.detailValueSecondary)}>
               {ticket.userEmail}
             </div>
           </div>
@@ -155,9 +155,7 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
             </div>
             <div className={styles.detailValue}>
               {formatDate(ticket.createdAt)}
-              <div style={{ fontSize: '0.75rem', color: '#6b7280', marginTop: '0.25rem' }}>
-                ({formatRelativeTime(ticket.createdAt)})
-              </div>
+              <div className={styles.detailValueMeta}>({formatRelativeTime(ticket.createdAt)})</div>
             </div>
           </div>
 
@@ -168,9 +166,7 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
             </div>
             <div className={styles.detailValue}>
               {formatDate(ticket.updatedAt)}
-              <div style={{ fontSize: '0.75rem', color: '#6b7280', marginTop: '0.25rem' }}>
-                ({formatRelativeTime(ticket.updatedAt)})
-              </div>
+              <div className={styles.detailValueMeta}>({formatRelativeTime(ticket.updatedAt)})</div>
             </div>
           </div>
 
@@ -201,11 +197,8 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
         </div>
 
         {ticket.internalNotes && (
-          <div
-            className={styles.descriptionSection}
-            style={{ background: '#fef3c7', borderColor: '#fbbf24' }}
-          >
-            <div className={styles.descriptionLabel} style={{ color: '#92400e' }}>
+          <div className={clsx(styles.descriptionSection, styles.internalNotesSection)}>
+            <div className={clsx(styles.descriptionLabel, styles.internalNotesLabel)}>
               Internal Notes
             </div>
             <div className={styles.descriptionText}>{ticket.internalNotes}</div>
@@ -232,7 +225,7 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
                     <div className={styles.responderInfo}>
                       {response.responderType === 'staff' ? 'Staff' : 'Customer'} Response
                       {response.isInternal && (
-                        <span className={styles.internalBadge} style={{ marginLeft: '0.5rem' }}>
+                        <span className={clsx(styles.internalBadge, styles.internalBadgeSpacing)}>
                           Internal
                         </span>
                       )}

--- a/app.admin/src/components/modals/UserDetailModal.css.ts
+++ b/app.admin/src/components/modals/UserDetailModal.css.ts
@@ -137,3 +137,10 @@ export const emptyValue = style({
   color: '#9ca3af',
   fontStyle: 'italic',
 });
+
+export const headerBadges = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  alignItems: 'flex-end',
+});

--- a/app.admin/src/components/modals/UserDetailModal.tsx
+++ b/app.admin/src/components/modals/UserDetailModal.tsx
@@ -56,14 +56,7 @@ export const UserDetailModal: React.FC<UserDetailModalProps> = ({ isOpen, onClos
             </h3>
             <p className={styles.userEmail}>{user.email}</p>
           </div>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '0.5rem',
-              alignItems: 'flex-end',
-            }}
-          >
+          <div className={styles.headerBadges}>
             {getUserTypeBadge(user.userType)}
             {getStatusBadge(user.status, user.emailVerified ?? false)}
           </div>

--- a/app.admin/src/components/moderation/ReportDetailModal.css.ts
+++ b/app.admin/src/components/moderation/ReportDetailModal.css.ts
@@ -265,3 +265,12 @@ export const warningBox = style({
   alignItems: 'flex-start',
   gap: '0.5rem',
 });
+
+export const monospaceId = style({
+  fontFamily: 'monospace',
+  fontSize: '0.75rem',
+});
+
+export const viewContentButtonSpacing = style({
+  marginTop: '1rem',
+});

--- a/app.admin/src/components/moderation/ReportDetailModal.tsx
+++ b/app.admin/src/components/moderation/ReportDetailModal.tsx
@@ -184,10 +184,7 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
               </div>
               <div className={styles.infoItem}>
                 <div className={styles.infoLabel}>Report ID</div>
-                <div
-                  className={styles.infoValue}
-                  style={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
-                >
+                <div className={clsx(styles.infoValue, styles.monospaceId)}>
                   {report.reportId.substring(0, 8)}...
                 </div>
               </div>
@@ -282,29 +279,22 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
             <div className={styles.infoGrid}>
               <div className={styles.infoItem}>
                 <div className={styles.infoLabel}>Reporter ID</div>
-                <div
-                  className={styles.infoValue}
-                  style={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
-                >
+                <div className={clsx(styles.infoValue, styles.monospaceId)}>
                   {report.reporterId.substring(0, 8)}...
                 </div>
               </div>
               {report.reportedUserId && (
                 <div className={styles.infoItem}>
                   <div className={styles.infoLabel}>Reported User ID</div>
-                  <div
-                    className={styles.infoValue}
-                    style={{ fontFamily: 'monospace', fontSize: '0.75rem' }}
-                  >
+                  <div className={clsx(styles.infoValue, styles.monospaceId)}>
                     {report.reportedUserId.substring(0, 8)}...
                   </div>
                 </div>
               )}
             </div>
             <button
-              className={styles.viewContentButton}
+              className={clsx(styles.viewContentButton, styles.viewContentButtonSpacing)}
               onClick={() => openExternal(`${window.location.origin}/users/${report.reporterId}`)}
-              style={{ marginTop: '1rem' }}
             >
               <FiExternalLink size={16} />
               View Reporter Profile

--- a/app.admin/src/pages/Analytics.css.ts
+++ b/app.admin/src/pages/Analytics.css.ts
@@ -222,3 +222,65 @@ export const errorBanner = style({
   color: vars.colors.semantic.error['800'],
   fontSize: '0.875rem',
 });
+
+export const filterBarOverride = style({
+  padding: '0.5rem 0.75rem',
+  marginBottom: 0,
+});
+
+export const filterGroupOverride = style({
+  minWidth: '140px',
+  marginBottom: 0,
+});
+
+export const exportIcon = style({
+  marginRight: '0.5rem',
+});
+
+export const skeletonStat80 = style({
+  width: '80px',
+  height: '1.5rem',
+});
+
+export const skeletonStat60 = style({
+  width: '60px',
+  height: '1.5rem',
+});
+
+export const skeletonFullHeight = style({
+  height: '100%',
+});
+
+export const skeletonRow3rem = style({
+  height: '3rem',
+});
+
+export const skeletonPie = style({
+  width: '200px',
+  height: '200px',
+  borderRadius: '50%',
+});
+
+export const chartEmptyState = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  color: '#9ca3af',
+  fontSize: '0.875rem',
+});
+
+export const pieEmptyState = style({
+  color: '#9ca3af',
+  fontSize: '0.875rem',
+});
+
+export const emptyStatePadded = style({
+  color: '#9ca3af',
+  fontSize: '0.875rem',
+  padding: '1rem 0',
+});
+
+export const barLabelCapitalize = style({
+  textTransform: 'capitalize',
+});

--- a/app.admin/src/pages/Analytics.tsx
+++ b/app.admin/src/pages/Analytics.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import clsx from 'clsx';
 import { Heading, Text, Button } from '@adopt-dont-shop/lib.components';
 import {
   FiTrendingUp,
@@ -121,8 +122,8 @@ const Analytics: React.FC = () => {
           <Text>Comprehensive analytics and data insights</Text>
         </HeaderLeft>
         <div className={styles.headerActions}>
-          <FilterBar style={{ padding: '0.5rem 0.75rem', marginBottom: 0 }}>
-            <FilterGroup style={{ minWidth: '140px', marginBottom: 0 }}>
+          <FilterBar className={styles.filterBarOverride}>
+            <FilterGroup className={styles.filterGroupOverride}>
               <Select value={timeRange} onChange={e => setTimeRange(e.target.value)}>
                 <option value='7days'>Last 7 Days</option>
                 <option value='30days'>Last 30 Days</option>
@@ -132,7 +133,7 @@ const Analytics: React.FC = () => {
             </FilterGroup>
           </FilterBar>
           <Button variant='outline' size='md'>
-            <FiDownload style={{ marginRight: '0.5rem' }} />
+            <FiDownload className={styles.exportIcon} />
             Export Report
           </Button>
         </div>
@@ -152,7 +153,7 @@ const Analytics: React.FC = () => {
           <StatDetails>
             <StatLabel>Total Users</StatLabel>
             {isLoading ? (
-              <div className={styles.skeletonBlock} style={{ width: '80px', height: '1.5rem' }} />
+              <div className={clsx(styles.skeletonBlock, styles.skeletonStat80)} />
             ) : (
               <StatValue>{totalAdopters.toLocaleString()}</StatValue>
             )}
@@ -172,7 +173,7 @@ const Analytics: React.FC = () => {
           <StatDetails>
             <StatLabel>Active Rescues</StatLabel>
             {isLoading ? (
-              <div className={styles.skeletonBlock} style={{ width: '60px', height: '1.5rem' }} />
+              <div className={clsx(styles.skeletonBlock, styles.skeletonStat60)} />
             ) : (
               <StatValue>{activeRescues.toLocaleString()}</StatValue>
             )}
@@ -190,7 +191,7 @@ const Analytics: React.FC = () => {
           <StatDetails>
             <StatLabel>Weekly Adoptions</StatLabel>
             {isLoading ? (
-              <div className={styles.skeletonBlock} style={{ width: '60px', height: '1.5rem' }} />
+              <div className={clsx(styles.skeletonBlock, styles.skeletonStat60)} />
             ) : (
               <StatValue>{weeklyAdoptions.toLocaleString()}</StatValue>
             )}
@@ -214,7 +215,7 @@ const Analytics: React.FC = () => {
           <StatDetails>
             <StatLabel>Active Listings</StatLabel>
             {isLoading ? (
-              <div className={styles.skeletonBlock} style={{ width: '80px', height: '1.5rem' }} />
+              <div className={clsx(styles.skeletonBlock, styles.skeletonStat80)} />
             ) : (
               <StatValue>{totalListings.toLocaleString()}</StatValue>
             )}
@@ -234,7 +235,7 @@ const Analytics: React.FC = () => {
           <CardContent>
             <div className={styles.chartContainer}>
               {isLoading ? (
-                <div className={styles.skeletonBlock} style={{ height: '100%' }} />
+                <div className={clsx(styles.skeletonBlock, styles.skeletonFullHeight)} />
               ) : adoptionTrends.length > 0 ? (
                 <div className={styles.barChart}>
                   {adoptionTrends.map(d => (
@@ -252,18 +253,7 @@ const Analytics: React.FC = () => {
                   ))}
                 </div>
               ) : (
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                    color: '#9ca3af',
-                    fontSize: '0.875rem',
-                  }}
-                >
-                  No adoption data for this period
-                </div>
+                <div className={styles.chartEmptyState}>No adoption data for this period</div>
               )}
             </div>
           </CardContent>
@@ -276,7 +266,7 @@ const Analytics: React.FC = () => {
           <CardContent>
             <div className={styles.chartContainer}>
               {isLoading ? (
-                <div className={styles.skeletonBlock} style={{ height: '100%' }} />
+                <div className={clsx(styles.skeletonBlock, styles.skeletonFullHeight)} />
               ) : analyticsData ? (
                 (() => {
                   const statusData = Object.entries(analyticsData.applications.statusMetrics).map(
@@ -299,7 +289,7 @@ const Analytics: React.FC = () => {
                           }}
                         >
                           <div className={styles.barValue}>{s.count}</div>
-                          <div className={styles.barLabel} style={{ textTransform: 'capitalize' }}>
+                          <div className={clsx(styles.barLabel, styles.barLabelCapitalize)}>
                             {s.status}
                           </div>
                         </div>
@@ -308,18 +298,7 @@ const Analytics: React.FC = () => {
                   );
                 })()
               ) : (
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                    color: '#9ca3af',
-                    fontSize: '0.875rem',
-                  }}
-                >
-                  No application data available
-                </div>
+                <div className={styles.chartEmptyState}>No application data available</div>
               )}
             </div>
           </CardContent>
@@ -332,10 +311,7 @@ const Analytics: React.FC = () => {
           <CardContent>
             <div className={styles.pieChartContainer}>
               {isLoading ? (
-                <div
-                  className={styles.skeletonBlock}
-                  style={{ width: '200px', height: '200px', borderRadius: '50%' }}
-                />
+                <div className={clsx(styles.skeletonBlock, styles.skeletonPie)} />
               ) : petPieSlices.length > 0 ? (
                 <>
                   <svg className={styles.pieChart} viewBox='0 0 200 200'>
@@ -360,9 +336,7 @@ const Analytics: React.FC = () => {
                   </div>
                 </>
               ) : (
-                <div style={{ color: '#9ca3af', fontSize: '0.875rem' }}>
-                  No pet type data for this period
-                </div>
+                <div className={styles.pieEmptyState}>No pet type data for this period</div>
               )}
             </div>
           </CardContent>
@@ -376,7 +350,7 @@ const Analytics: React.FC = () => {
             {isLoading ? (
               <div className={styles.topItemsList}>
                 {Array.from({ length: 5 }).map((_, i) => (
-                  <div key={i} className={styles.skeletonBlock} style={{ height: '3rem' }} />
+                  <div key={i} className={clsx(styles.skeletonBlock, styles.skeletonRow3rem)} />
                 ))}
               </div>
             ) : topRescues.length > 0 ? (
@@ -397,7 +371,7 @@ const Analytics: React.FC = () => {
                 ))}
               </div>
             ) : (
-              <div style={{ color: '#9ca3af', fontSize: '0.875rem', padding: '1rem 0' }}>
+              <div className={styles.emptyStatePadded}>
                 No rescue performance data for this period
               </div>
             )}

--- a/app.admin/src/pages/Configuration.css.ts
+++ b/app.admin/src/pages/Configuration.css.ts
@@ -145,3 +145,12 @@ export const statsigLink = style({
     textDecoration: 'underline',
   },
 });
+
+export const inlineIcon = style({
+  marginRight: '0.5rem',
+});
+
+export const sectionIcon = style({
+  display: 'inline',
+  marginRight: '0.5rem',
+});

--- a/app.admin/src/pages/Configuration.tsx
+++ b/app.admin/src/pages/Configuration.tsx
@@ -96,7 +96,7 @@ const Configuration: React.FC = () => {
         </HeaderLeft>
         <div className={styles.headerActions}>
           <Button variant='outline' size='md' onClick={handleRefresh}>
-            <FiRefreshCw style={{ marginRight: '0.5rem' }} />
+            <FiRefreshCw className={styles.inlineIcon} />
             Reload
           </Button>
           <Button
@@ -104,7 +104,7 @@ const Configuration: React.FC = () => {
             size='md'
             onClick={() => openExternal('https://console.statsig.com')}
           >
-            <FiExternalLink style={{ marginRight: '0.5rem' }} />
+            <FiExternalLink className={styles.inlineIcon} />
             Open Statsig Console
           </Button>
         </div>
@@ -132,7 +132,7 @@ const Configuration: React.FC = () => {
         <Card className={styles.sectionCard}>
           <CardHeader>
             <CardTitle>
-              <FiFlag style={{ display: 'inline', marginRight: '0.5rem' }} />
+              <FiFlag className={styles.sectionIcon} />
               Feature Gates
             </CardTitle>
           </CardHeader>
@@ -146,7 +146,7 @@ const Configuration: React.FC = () => {
               size='sm'
               onClick={() => openExternal('https://console.statsig.com')}
             >
-              <FiExternalLink style={{ marginRight: '0.5rem' }} />
+              <FiExternalLink className={styles.inlineIcon} />
               Manage gates in Statsig
             </Button>
           </CardContent>
@@ -155,7 +155,7 @@ const Configuration: React.FC = () => {
         <Card className={styles.sectionCard}>
           <CardHeader>
             <CardTitle>
-              <FiSettings style={{ display: 'inline', marginRight: '0.5rem' }} />
+              <FiSettings className={styles.sectionIcon} />
               Application Settings
             </CardTitle>
           </CardHeader>
@@ -192,7 +192,7 @@ const Configuration: React.FC = () => {
         <Card className={styles.sectionCard}>
           <CardHeader>
             <CardTitle>
-              <FiSettings style={{ display: 'inline', marginRight: '0.5rem' }} />
+              <FiSettings className={styles.sectionIcon} />
               System Settings
             </CardTitle>
           </CardHeader>
@@ -219,7 +219,7 @@ const Configuration: React.FC = () => {
         <Card className={styles.sectionCard}>
           <CardHeader>
             <CardTitle>
-              <FiSettings style={{ display: 'inline', marginRight: '0.5rem' }} />
+              <FiSettings className={styles.sectionIcon} />
               Moderation Settings
             </CardTitle>
           </CardHeader>

--- a/app.admin/src/pages/ContentManagement.css.ts
+++ b/app.admin/src/pages/ContentManagement.css.ts
@@ -425,3 +425,34 @@ export const seoTitle = style({
   color: vars.text.secondary,
   margin: 0,
 });
+
+export const slugCell = style({
+  fontFamily: 'monospace',
+  fontSize: '0.8rem',
+  color: '#6b7280',
+});
+
+export const capitalize = style({
+  textTransform: 'capitalize',
+});
+
+export const slugInputRow = style({
+  display: 'flex',
+  gap: '0.5rem',
+});
+
+export const slugInputFlex = style({
+  flex: 1,
+});
+
+export const excerptTextarea = style({
+  minHeight: '80px',
+});
+
+export const metaDescTextarea = style({
+  minHeight: '70px',
+});
+
+export const menuModalWidth = style({
+  maxWidth: '480px',
+});

--- a/app.admin/src/pages/ContentManagement.tsx
+++ b/app.admin/src/pages/ContentManagement.tsx
@@ -447,12 +447,7 @@ const ContentManagement: React.FC = () => {
                     <td className={styles.td}>
                       <strong>{item.title}</strong>
                     </td>
-                    <td
-                      className={styles.td}
-                      style={{ fontFamily: 'monospace', fontSize: '0.8rem', color: '#6b7280' }}
-                    >
-                      /{item.slug}
-                    </td>
+                    <td className={clsx(styles.td, styles.slugCell)}>/{item.slug}</td>
                     <td className={styles.td}>{CONTENT_TYPE_LABELS[item.contentType]}</td>
                     <td className={styles.td}>
                       <span className={getStatusBadgeClass(item.status)}>{item.status}</span>
@@ -536,9 +531,7 @@ const ContentManagement: React.FC = () => {
                     <td className={styles.td}>
                       <strong>{menu.name}</strong>
                     </td>
-                    <td className={styles.td} style={{ textTransform: 'capitalize' }}>
-                      {menu.location}
-                    </td>
+                    <td className={clsx(styles.td, styles.capitalize)}>{menu.location}</td>
                     <td className={styles.td}>{menu.items.length} items</td>
                     <td className={styles.td}>
                       <span
@@ -606,11 +599,10 @@ const ContentManagement: React.FC = () => {
                 <label className={styles.formLabel} htmlFor='cm-slug'>
                   Slug
                 </label>
-                <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <div className={styles.slugInputRow}>
                   <input
                     id='cm-slug'
-                    className={styles.formInput}
-                    style={{ flex: 1 }}
+                    className={clsx(styles.formInput, styles.slugInputFlex)}
                     value={contentForm.slug}
                     onChange={e => setContentForm(f => ({ ...f, slug: e.target.value }))}
                     placeholder='auto-generated'
@@ -663,8 +655,7 @@ const ContentManagement: React.FC = () => {
                 </label>
                 <textarea
                   id='cm-excerpt'
-                  className={styles.formTextarea}
-                  style={{ minHeight: '80px' }}
+                  className={clsx(styles.formTextarea, styles.excerptTextarea)}
                   value={contentForm.excerpt}
                   onChange={e => setContentForm(f => ({ ...f, excerpt: e.target.value }))}
                   placeholder='Short summary for listings and SEO'
@@ -690,8 +681,7 @@ const ContentManagement: React.FC = () => {
                   </label>
                   <textarea
                     id='cm-meta-desc'
-                    className={styles.formTextarea}
-                    style={{ minHeight: '70px' }}
+                    className={clsx(styles.formTextarea, styles.metaDescTextarea)}
                     value={contentForm.metaDescription}
                     onChange={e => setContentForm(f => ({ ...f, metaDescription: e.target.value }))}
                     placeholder='SEO description'
@@ -789,7 +779,7 @@ const ContentManagement: React.FC = () => {
           onKeyDown={e => e.key === 'Escape' && setShowMenuModal(false)}
           role='presentation'
         >
-          <div className={styles.modal} style={{ maxWidth: '480px' }}>
+          <div className={clsx(styles.modal, styles.menuModalWidth)}>
             <div className={styles.modalHeader}>
               <h2>{editingMenu ? 'Edit Menu' : 'New Navigation Menu'}</h2>
               <button className={styles.closeButton} onClick={() => setShowMenuModal(false)}>

--- a/app.admin/src/pages/Dashboard.css.ts
+++ b/app.admin/src/pages/Dashboard.css.ts
@@ -89,3 +89,38 @@ export const errorBanner = style({
   color: vars.colors.semantic.error['800'],
   fontSize: '0.875rem',
 });
+
+export const skeletonIcon = style({
+  width: '32px',
+  height: '32px',
+});
+
+export const skeletonLabel = style({
+  width: '120px',
+  height: '0.875rem',
+});
+
+export const skeletonValue = style({
+  width: '80px',
+  height: '2.25rem',
+  marginBottom: '0.5rem',
+});
+
+export const skeletonChange = style({
+  width: '140px',
+  height: '0.875rem',
+});
+
+export const widgetPlaceholder = style({
+  background: '#ffffff',
+  border: '1px solid #e5e7eb',
+  borderRadius: '12px',
+  padding: '2rem',
+  textAlign: 'center',
+  color: '#6b7280',
+});
+
+export const widgetPlaceholderText = style({
+  margin: 0,
+  fontSize: '0.875rem',
+});

--- a/app.admin/src/pages/Dashboard.tsx
+++ b/app.admin/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import { EmptyState, Heading, Stack, Text } from '@adopt-dont-shop/lib.components';
 import { usePlatformMetrics } from '../hooks';
 import * as styles from './Dashboard.css';
@@ -95,20 +96,11 @@ const Dashboard: React.FC = () => {
           ? Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className={styles.metricCard} aria-busy='true'>
                 <div className={styles.metricHeader}>
-                  <div className={styles.skeletonBlock} style={{ width: '32px', height: '32px' }} />
-                  <div
-                    className={styles.skeletonBlock}
-                    style={{ width: '120px', height: '0.875rem' }}
-                  />
+                  <div className={clsx(styles.skeletonBlock, styles.skeletonIcon)} />
+                  <div className={clsx(styles.skeletonBlock, styles.skeletonLabel)} />
                 </div>
-                <div
-                  className={styles.skeletonBlock}
-                  style={{ width: '80px', height: '2.25rem', marginBottom: '0.5rem' }}
-                />
-                <div
-                  className={styles.skeletonBlock}
-                  style={{ width: '140px', height: '0.875rem' }}
-                />
+                <div className={clsx(styles.skeletonBlock, styles.skeletonValue)} />
+                <div className={clsx(styles.skeletonBlock, styles.skeletonChange)} />
               </div>
             ))
           : metrics.map(metric => (

--- a/app.admin/src/pages/FieldPermissions.css.ts
+++ b/app.admin/src/pages/FieldPermissions.css.ts
@@ -190,3 +190,26 @@ export const statusBar = style({
   marginBottom: '1rem',
   fontSize: '0.875rem',
 });
+
+export const statusBarError = style({
+  background: '#fee2e2',
+  color: '#991b1b',
+});
+
+export const statusBarWarning = style({
+  background: '#fffbeb',
+  color: '#92400e',
+});
+
+export const skeletonList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+});
+
+export const skeletonRow = style({
+  display: 'grid',
+  gridTemplateColumns: '2fr 1fr 1fr 1fr',
+  gap: '1rem',
+  alignItems: 'center',
+});

--- a/app.admin/src/pages/FieldPermissions.tsx
+++ b/app.admin/src/pages/FieldPermissions.tsx
@@ -242,14 +242,10 @@ const FieldPermissions: React.FC = () => {
         ))}
       </div>
 
-      {error && (
-        <div className={styles.statusBar} style={{ background: '#fee2e2', color: '#991b1b' }}>
-          {error}
-        </div>
-      )}
+      {error && <div className={clsx(styles.statusBar, styles.statusBarError)}>{error}</div>}
 
       {pendingCount > 0 && (
-        <div className={styles.statusBar} style={{ background: '#fffbeb', color: '#92400e' }}>
+        <div className={clsx(styles.statusBar, styles.statusBarWarning)}>
           {pendingCount} unsaved change{pendingCount > 1 ? 's' : ''}
         </div>
       )}
@@ -262,20 +258,9 @@ const FieldPermissions: React.FC = () => {
         </CardHeader>
         <CardContent>
           {loading ? (
-            <div
-              aria-label='Loading field permissions'
-              style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}
-            >
+            <div aria-label='Loading field permissions' className={styles.skeletonList}>
               {Array.from({ length: 6 }, (_, i) => (
-                <div
-                  key={i}
-                  style={{
-                    display: 'grid',
-                    gridTemplateColumns: '2fr 1fr 1fr 1fr',
-                    gap: '1rem',
-                    alignItems: 'center',
-                  }}
-                >
+                <div key={i} className={styles.skeletonRow}>
                   <Skeleton height='0.875rem' width={i % 2 === 0 ? '70%' : '50%'} />
                   <Skeleton height='1.5rem' width='80%' radius='6px' />
                   <Skeleton height='1.5rem' width='80%' radius='6px' />

--- a/app.admin/src/pages/Messages.css.ts
+++ b/app.admin/src/pages/Messages.css.ts
@@ -113,3 +113,32 @@ export const statusDotDefault = style({
   background: vars.text.tertiary,
   flexShrink: 0,
 });
+
+export const lastMessageCell = style({
+  maxWidth: '250px',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const noMessagesPlaceholder = style({
+  color: '#9ca3af',
+  fontStyle: 'italic',
+});
+
+export const participantsList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+});
+
+export const participantMore = style({
+  fontSize: '0.75rem',
+  color: '#9ca3af',
+});
+
+export const errorBanner = style({
+  padding: '2rem',
+  textAlign: 'center',
+  color: '#ef4444',
+});

--- a/app.admin/src/pages/Messages.tsx
+++ b/app.admin/src/pages/Messages.tsx
@@ -226,16 +226,9 @@ const Messages: React.FC = () => {
       id: 'lastMessage',
       header: 'Last Message',
       accessor: row => (
-        <div
-          style={{
-            maxWidth: '250px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
+        <div className={styles.lastMessageCell}>
           {row.lastMessage?.content || (
-            <span style={{ color: '#9ca3af', fontStyle: 'italic' }}>No messages</span>
+            <span className={styles.noMessagesPlaceholder}>No messages</span>
           )}
         </div>
       ),
@@ -245,7 +238,7 @@ const Messages: React.FC = () => {
       id: 'participants',
       header: 'Participants',
       accessor: row => (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <div className={styles.participantsList}>
           {row.participants.slice(0, 2).map(p => (
             <div key={p.id} className={styles.participantInfo}>
               <div className={styles.participantName}>{p.name}</div>
@@ -253,9 +246,7 @@ const Messages: React.FC = () => {
             </div>
           ))}
           {row.participants.length > 2 && (
-            <div style={{ fontSize: '0.75rem', color: '#9ca3af' }}>
-              +{row.participants.length - 2} more
-            </div>
+            <div className={styles.participantMore}>+{row.participants.length - 2} more</div>
           )}
         </div>
       ),
@@ -379,7 +370,7 @@ const Messages: React.FC = () => {
       </FilterBar>
 
       {chatsError && (
-        <div style={{ padding: '2rem', textAlign: 'center', color: '#ef4444' }}>
+        <div className={styles.errorBanner}>
           Error loading chats: {chatsError instanceof Error ? chatsError.message : 'Unknown error'}
         </div>
       )}

--- a/app.admin/src/pages/Pets.css.ts
+++ b/app.admin/src/pages/Pets.css.ts
@@ -163,3 +163,7 @@ export const errorMessage = style({
 export const dimDash = style({
   color: vars.text.quaternary,
 });
+
+export const checkboxSpacing = style({
+  marginRight: '0.375rem',
+});

--- a/app.admin/src/pages/Pets.tsx
+++ b/app.admin/src/pages/Pets.tsx
@@ -231,7 +231,7 @@ const Pets: React.FC = () => {
               type='checkbox'
               checked={includeArchived}
               onChange={e => setIncludeArchived(e.target.checked)}
-              style={{ marginRight: '0.375rem' }}
+              className={styles.checkboxSpacing}
             />
             Show archived
           </label>

--- a/app.admin/src/pages/PrivacyTools.css.ts
+++ b/app.admin/src/pages/PrivacyTools.css.ts
@@ -1,0 +1,47 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  padding: '1.5rem',
+  display: 'grid',
+  gap: '1.5rem',
+  maxWidth: '48rem',
+});
+
+export const fieldGroup = style({
+  display: 'grid',
+  gap: '0.5rem',
+});
+
+export const fieldGroupSpaced = style({
+  display: 'grid',
+  gap: '0.5rem',
+  marginTop: '0.5rem',
+});
+
+export const section = style({
+  borderTop: '1px solid #e5e7eb',
+  paddingTop: '1rem',
+});
+
+export const buttonIcon = style({
+  marginRight: '0.5rem',
+});
+
+export const deleteButton = style({
+  marginTop: '0.5rem',
+});
+
+export const message = style({
+  padding: '0.75rem',
+  borderRadius: '0.375rem',
+});
+
+export const messageSuccess = style({
+  background: '#dcfce7',
+  color: '#166534',
+});
+
+export const messageError = style({
+  background: '#fee2e2',
+  color: '#991b1b',
+});

--- a/app.admin/src/pages/PrivacyTools.tsx
+++ b/app.admin/src/pages/PrivacyTools.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import { Heading, Text, Input, Button } from '@adopt-dont-shop/lib.components';
 import { FiDownload, FiAlertTriangle } from 'react-icons/fi';
 import { apiService } from '../services/libraryServices';
+import * as styles from './PrivacyTools.css';
 
 const PrivacyTools: React.FC = () => {
   const [userId, setUserId] = useState('');
@@ -72,7 +74,7 @@ const PrivacyTools: React.FC = () => {
   };
 
   return (
-    <div style={{ padding: '1.5rem', display: 'grid', gap: '1.5rem', maxWidth: '48rem' }}>
+    <div className={styles.container}>
       <div>
         <Heading level='h1'>Privacy Tools</Heading>
         <Text>
@@ -80,7 +82,7 @@ const PrivacyTools: React.FC = () => {
         </Text>
       </div>
 
-      <div style={{ display: 'grid', gap: '0.5rem' }}>
+      <div className={styles.fieldGroup}>
         <label htmlFor='privacy-user-id'>User ID</label>
         <Input
           id='privacy-user-id'
@@ -91,22 +93,22 @@ const PrivacyTools: React.FC = () => {
         />
       </div>
 
-      <section style={{ borderTop: '1px solid #e5e7eb', paddingTop: '1rem' }}>
+      <section className={styles.section}>
         <Heading level='h2'>Data Export (GDPR Art. 20)</Heading>
         <Text>Downloads a JSON archive of user-owned data.</Text>
         <Button variant='primary' onClick={handleExport} disabled={busy !== null}>
-          <FiDownload style={{ marginRight: '0.5rem' }} />
+          <FiDownload className={styles.buttonIcon} />
           {busy === 'export' ? 'Exporting…' : 'Export user data'}
         </Button>
       </section>
 
-      <section style={{ borderTop: '1px solid #e5e7eb', paddingTop: '1rem' }}>
+      <section className={styles.section}>
         <Heading level='h2'>Account Deletion (GDPR Art. 17)</Heading>
         <Text>
           Schedules account deletion with a 30-day grace window. Data is hard-anonymised after the
           grace period.
         </Text>
-        <div style={{ display: 'grid', gap: '0.5rem', marginTop: '0.5rem' }}>
+        <div className={styles.fieldGroupSpaced}>
           <label htmlFor='privacy-reason'>Reason (optional, internal audit log)</label>
           <Input
             id='privacy-reason'
@@ -120,21 +122,19 @@ const PrivacyTools: React.FC = () => {
           variant='outline'
           onClick={handleDelete}
           disabled={busy !== null}
-          style={{ marginTop: '0.5rem' }}
+          className={styles.deleteButton}
         >
-          <FiAlertTriangle style={{ marginRight: '0.5rem' }} />
+          <FiAlertTriangle className={styles.buttonIcon} />
           {busy === 'delete' ? 'Scheduling…' : 'Schedule deletion'}
         </Button>
       </section>
 
       {message && (
         <div
-          style={{
-            padding: '0.75rem',
-            borderRadius: '0.375rem',
-            background: message.kind === 'success' ? '#dcfce7' : '#fee2e2',
-            color: message.kind === 'success' ? '#166534' : '#991b1b',
-          }}
+          className={clsx(
+            styles.message,
+            message.kind === 'success' ? styles.messageSuccess : styles.messageError
+          )}
         >
           {message.text}
         </div>

--- a/app.admin/src/pages/ReportBuilderPage.css.ts
+++ b/app.admin/src/pages/ReportBuilderPage.css.ts
@@ -1,0 +1,23 @@
+import { style } from '@vanilla-extract/css';
+
+export const formGrid = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '16px',
+  padding: '12px',
+  background: '#f9fafb',
+  borderRadius: '8px',
+  marginBottom: '16px',
+});
+
+export const fieldLabel = style({
+  fontSize: '12px',
+  color: '#6b7280',
+});
+
+export const textInput = style({
+  width: '100%',
+  padding: '8px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '6px',
+});

--- a/app.admin/src/pages/ReportBuilderPage.tsx
+++ b/app.admin/src/pages/ReportBuilderPage.tsx
@@ -15,6 +15,7 @@ import {
   type ReportConfig,
 } from '@adopt-dont-shop/lib.analytics';
 import { PageContainer, PageHeader, HeaderLeft } from '../components/ui';
+import * as styles from './ReportBuilderPage.css';
 
 /**
  * ADS-105: Custom report builder page.
@@ -119,43 +120,23 @@ const ReportBuilderPage: React.FC = () => {
         </button>
       </PageHeader>
 
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          gap: '16px',
-          padding: '12px',
-          background: '#f9fafb',
-          borderRadius: '8px',
-          marginBottom: '16px',
-        }}
-      >
+      <div className={styles.formGrid}>
         <label>
-          <span style={{ fontSize: '12px', color: '#6b7280' }}>Name</span>
+          <span className={styles.fieldLabel}>Name</span>
           <input
             type='text'
             value={name}
             onChange={e => setName(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '8px',
-              border: '1px solid #e5e7eb',
-              borderRadius: '6px',
-            }}
+            className={styles.textInput}
           />
         </label>
         <label>
-          <span style={{ fontSize: '12px', color: '#6b7280' }}>Description (optional)</span>
+          <span className={styles.fieldLabel}>Description (optional)</span>
           <input
             type='text'
             value={description}
             onChange={e => setDescription(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '8px',
-              border: '1px solid #e5e7eb',
-              borderRadius: '6px',
-            }}
+            className={styles.textInput}
           />
         </label>
       </div>

--- a/app.admin/src/pages/ReportViewPage.css.ts
+++ b/app.admin/src/pages/ReportViewPage.css.ts
@@ -1,0 +1,44 @@
+import { style } from '@vanilla-extract/css';
+
+export const headerActions = style({
+  display: 'flex',
+  gap: '8px',
+});
+
+export const panel = style({
+  padding: '12px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '8px',
+  marginBottom: '12px',
+});
+
+export const schedulePanel = style({
+  background: '#f9fafb',
+});
+
+export const sharePanel = style({
+  background: '#ecfdf5',
+});
+
+export const scheduleRow = style({
+  display: 'flex',
+  gap: '8px',
+  marginTop: '8px',
+});
+
+export const cronInput = style({
+  padding: '6px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '6px',
+});
+
+export const emailInput = style({
+  flex: 1,
+  padding: '6px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '6px',
+});
+
+export const shareCode = style({
+  wordBreak: 'break-all',
+});

--- a/app.admin/src/pages/ReportViewPage.tsx
+++ b/app.admin/src/pages/ReportViewPage.tsx
@@ -15,7 +15,9 @@ import {
   useUpsertSchedule,
   useCreateTokenShare,
 } from '@adopt-dont-shop/lib.analytics';
+import clsx from 'clsx';
 import { PageContainer, PageHeader, HeaderLeft } from '../components/ui';
+import * as styles from './ReportViewPage.css';
 
 /**
  * ADS-105: View page for a saved report.
@@ -103,7 +105,7 @@ const ReportViewPage: React.FC = () => {
           <Heading level='h1'>{reportQuery.data.name}</Heading>
           {reportQuery.data.description ? <Text>{reportQuery.data.description}</Text> : null}
         </HeaderLeft>
-        <div style={{ display: 'flex', gap: '8px' }}>
+        <div className={styles.headerActions}>
           <Link to={`/reports/${id}/edit`}>
             <Button variant='outline'>Edit</Button>
           </Link>
@@ -120,35 +122,22 @@ const ReportViewPage: React.FC = () => {
       </PageHeader>
 
       {scheduleOpen ? (
-        <div
-          style={{
-            padding: '12px',
-            border: '1px solid #e5e7eb',
-            borderRadius: '8px',
-            marginBottom: '12px',
-            background: '#f9fafb',
-          }}
-        >
+        <div className={clsx(styles.panel, styles.schedulePanel)}>
           <Text>Schedule (cron + recipient)</Text>
-          <div style={{ display: 'flex', gap: '8px', marginTop: '8px' }}>
+          <div className={styles.scheduleRow}>
             <input
               type='text'
               value={cron}
               onChange={e => setCron(e.target.value)}
               placeholder='0 9 * * 1'
-              style={{ padding: '6px', border: '1px solid #e5e7eb', borderRadius: '6px' }}
+              className={styles.cronInput}
             />
             <input
               type='email'
               value={recipientEmail}
               onChange={e => setRecipientEmail(e.target.value)}
               placeholder='recipient@example.com'
-              style={{
-                flex: 1,
-                padding: '6px',
-                border: '1px solid #e5e7eb',
-                borderRadius: '6px',
-              }}
+              className={styles.emailInput}
             />
             <Button variant='primary' onClick={handleSchedule}>
               Save schedule
@@ -158,17 +147,9 @@ const ReportViewPage: React.FC = () => {
       ) : null}
 
       {shareUrl ? (
-        <div
-          style={{
-            padding: '12px',
-            border: '1px solid #e5e7eb',
-            borderRadius: '8px',
-            marginBottom: '12px',
-            background: '#ecfdf5',
-          }}
-        >
+        <div className={clsx(styles.panel, styles.sharePanel)}>
           <Text>Share link (expires in 7 days):</Text>
-          <code style={{ wordBreak: 'break-all' }}>{shareUrl}</code>
+          <code className={styles.shareCode}>{shareUrl}</code>
         </div>
       ) : null}
 

--- a/app.admin/src/pages/Rescues.css.ts
+++ b/app.admin/src/pages/Rescues.css.ts
@@ -208,3 +208,13 @@ export const errorMessage = style({
 globalStyle(`${errorMessage} svg`, {
   flexShrink: 0,
 });
+
+export const approveButton = style({
+  color: '#10b981',
+  borderColor: '#10b981',
+});
+
+export const rejectButton = style({
+  color: '#ef4444',
+  borderColor: '#ef4444',
+});

--- a/app.admin/src/pages/Rescues.tsx
+++ b/app.admin/src/pages/Rescues.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import clsx from 'clsx';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Heading, Text, Button, Input } from '@adopt-dont-shop/lib.components';
 import {
@@ -246,17 +247,15 @@ const Rescues: React.FC = () => {
           {row.status === 'pending' && (
             <>
               <button
-                className={styles.iconButton}
+                className={clsx(styles.iconButton, styles.approveButton)}
                 title='Approve'
-                style={{ color: '#10b981', borderColor: '#10b981' }}
                 onClick={() => handleApprove(row)}
               >
                 <FiCheckCircle />
               </button>
               <button
-                className={styles.iconButton}
+                className={clsx(styles.iconButton, styles.rejectButton)}
                 title='Reject'
-                style={{ color: '#ef4444', borderColor: '#ef4444' }}
                 onClick={() => handleReject(row)}
               >
                 <FiXCircle />

--- a/app.admin/src/pages/Users.css.ts
+++ b/app.admin/src/pages/Users.css.ts
@@ -215,3 +215,26 @@ export const iconButton = style({
     transform: 'scale(0.95)',
   },
 });
+
+export const errorPanel = style({
+  background: '#fee2e2',
+  border: '1px solid #fecaca',
+  borderRadius: '12px',
+  padding: '2rem',
+  textAlign: 'center',
+  color: '#991b1b',
+});
+
+export const errorTitle = style({
+  margin: '0 0 1rem 0',
+  fontWeight: 600,
+});
+
+export const errorMessage = style({
+  margin: '0',
+  fontSize: '0.875rem',
+});
+
+export const addUserIcon = style({
+  marginRight: '0.5rem',
+});

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -303,18 +303,9 @@ const Users: React.FC = () => {
             <Heading level='h1'>User Management</Heading>
           </div>
         </div>
-        <div
-          style={{
-            background: '#fee2e2',
-            border: '1px solid #fecaca',
-            borderRadius: '12px',
-            padding: '2rem',
-            textAlign: 'center',
-            color: '#991b1b',
-          }}
-        >
-          <p style={{ margin: '0 0 1rem 0', fontWeight: 600 }}>Failed to load users</p>
-          <p style={{ margin: '0', fontSize: '0.875rem' }}>{(error as Error).message}</p>
+        <div className={styles.errorPanel}>
+          <p className={styles.errorTitle}>Failed to load users</p>
+          <p className={styles.errorMessage}>{(error as Error).message}</p>
         </div>
       </div>
     );
@@ -464,7 +455,7 @@ const Users: React.FC = () => {
         <div className={styles.headerActions}>
           <ExportButton onExport={handleExport} disabled={isLoading || users.length === 0} />
           <Button variant='primary' size='md' onClick={() => setIsAddModalOpen(true)}>
-            <FiUserPlus style={{ marginRight: '0.5rem' }} />
+            <FiUserPlus className={styles.addUserIcon} />
             Add User
           </Button>
         </div>

--- a/app.client/src/components/PetCard.css.ts
+++ b/app.client/src/components/PetCard.css.ts
@@ -181,3 +181,7 @@ globalStyle(`${distanceBadge} svg`, {
   flexShrink: 0,
   color: '#6ee7b7',
 });
+
+export const actionButton = style({
+  flex: 1,
+});

--- a/app.client/src/components/PetCard.tsx
+++ b/app.client/src/components/PetCard.tsx
@@ -257,11 +257,16 @@ export const PetCard: React.FC<PetCardProps> = ({
         {pet.rescue_id && <div className={styles.rescueInfo}>Rescue ID: {pet.rescue_id}</div>}
 
         <div className={styles.cardActions}>
-          <Button size='sm' variant='primary' style={{ flex: 1 }}>
+          <Button size='sm' variant='primary' className={styles.actionButton}>
             View Details
           </Button>
           {pet.status === 'available' && (
-            <Button size='sm' variant='outline' style={{ flex: 1 }} onClick={handleApplyClick}>
+            <Button
+              size='sm'
+              variant='outline'
+              className={styles.actionButton}
+              onClick={handleApplyClick}
+            >
               Apply
             </Button>
           )}

--- a/app.client/src/components/notifications/NotificationBell.css.ts
+++ b/app.client/src/components/notifications/NotificationBell.css.ts
@@ -323,3 +323,15 @@ export const emptyState = style({
   color: vars.text.secondary,
   fontSize: '0.875rem',
 });
+
+export const fullCenterModal = style({
+  position: 'fixed',
+  top: '5vh',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: 1002,
+  maxHeight: '90vh',
+  width: '90vw',
+  maxWidth: '800px',
+  overflow: 'auto',
+});

--- a/app.client/src/components/notifications/NotificationBell.tsx
+++ b/app.client/src/components/notifications/NotificationBell.tsx
@@ -221,19 +221,7 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
             }}
             aria-label='Close notification center'
           />
-          <div
-            style={{
-              position: 'fixed',
-              top: '5vh',
-              left: '50%',
-              transform: 'translateX(-50%)',
-              zIndex: 1002,
-              maxHeight: '90vh',
-              width: '90vw',
-              maxWidth: '800px',
-              overflow: 'auto',
-            }}
-          >
+          <div className={styles.fullCenterModal}>
             <NotificationCenterComponent onClose={closeFullCenter} />
           </div>
         </>

--- a/app.client/src/pages/ApplicationDetailsPage.css.ts
+++ b/app.client/src/pages/ApplicationDetailsPage.css.ts
@@ -119,3 +119,9 @@ export const buttonGroup = style({
   gap: '1rem',
   marginTop: '2rem',
 });
+
+export const withdrawButton = style({
+  backgroundColor: '#dc2626',
+  borderColor: '#dc2626',
+  color: 'white',
+});

--- a/app.client/src/pages/ApplicationDetailsPage.tsx
+++ b/app.client/src/pages/ApplicationDetailsPage.tsx
@@ -202,11 +202,7 @@ export const ApplicationDetailsPage: React.FC = () => {
           <Button
             variant='secondary'
             onClick={() => setIsWithdrawModalOpen(true)}
-            style={{
-              backgroundColor: '#dc2626',
-              borderColor: '#dc2626',
-              color: 'white',
-            }}
+            className={styles.withdrawButton}
           >
             Withdraw Application
           </Button>

--- a/app.client/src/pages/HomePage.css.ts
+++ b/app.client/src/pages/HomePage.css.ts
@@ -189,3 +189,19 @@ export const errorMessage = style({
   borderRadius: vars.border.radius.lg,
   margin: '2rem 0',
 });
+
+export const heroPrimaryButton = style({
+  background: 'white',
+  color: '#BE123C',
+  borderColor: 'white',
+});
+
+export const heroSecondaryButton = style({
+  color: 'white',
+  borderColor: 'rgba(255,255,255,0.5)',
+  background: 'rgba(255,255,255,0.08)',
+});
+
+export const centerAlign = style({
+  textAlign: 'center',
+});

--- a/app.client/src/pages/HomePage.tsx
+++ b/app.client/src/pages/HomePage.tsx
@@ -157,15 +157,7 @@ export const HomePage: React.FC = () => {
             </p>
             <div className={styles.heroActions}>
               <Link to='/search' onClick={() => handleCTAClick('browse_pets')}>
-                <Button
-                  variant='primary'
-                  size='lg'
-                  style={{
-                    background: 'white',
-                    color: '#BE123C',
-                    borderColor: 'white',
-                  }}
-                >
+                <Button variant='primary' size='lg' className={styles.heroPrimaryButton}>
                   Start Browsing Pets
                 </Button>
               </Link>
@@ -173,11 +165,7 @@ export const HomePage: React.FC = () => {
                 variant='outline'
                 size='lg'
                 onClick={() => handleCTAClick('get_started')}
-                style={{
-                  color: 'white',
-                  borderColor: 'rgba(255,255,255,0.5)',
-                  background: 'rgba(255,255,255,0.08)',
-                }}
+                className={styles.heroSecondaryButton}
               >
                 Learn More
               </Button>
@@ -209,7 +197,7 @@ export const HomePage: React.FC = () => {
                 ))}
               </div>
 
-              <div style={{ textAlign: 'center' }}>
+              <div className={styles.centerAlign}>
                 <Link to='/search' onClick={handleViewAllPetsClick}>
                   <Button variant='outline'>View All Pets</Button>
                 </Link>

--- a/app.rescue/src/components/ApplicationCard.css.ts
+++ b/app.rescue/src/components/ApplicationCard.css.ts
@@ -207,3 +207,18 @@ export const skeletonBox = style({
   borderRadius: '0.25rem',
   animation: `${pulse} 2s cubic-bezier(0.4, 0, 0.6, 1) infinite`,
 });
+
+export const timelineSkeleton = style({
+  height: '120px',
+  marginBottom: '1rem',
+});
+
+export const noActivityPlaceholder = style({
+  padding: '1rem',
+  textAlign: 'center',
+  color: '#6b7280',
+  fontSize: '0.875rem',
+  border: '1px dashed #d1d5db',
+  borderRadius: '0.375rem',
+  marginBottom: '1rem',
+});

--- a/app.rescue/src/components/ApplicationCard.tsx
+++ b/app.rescue/src/components/ApplicationCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import { TimelineWidget } from './TimelineWidget';
 import { useTimelineWidget, useTimelineSummary } from '../hooks/useTimelineWidget';
 import { formatDate, formatDateTime } from '@adopt-dont-shop/lib.utils';
@@ -112,7 +113,7 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({
       </div>
 
       {timelineLoading ? (
-        <div className={styles.skeletonBox} style={{ height: '120px', marginBottom: '1rem' }} />
+        <div className={clsx(styles.skeletonBox, styles.timelineSkeleton)} />
       ) : hasEvents ? (
         <TimelineWidget
           events={events}
@@ -121,19 +122,7 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({
           onViewAll={handleViewTimeline}
         />
       ) : (
-        <div
-          style={{
-            padding: '1rem',
-            textAlign: 'center',
-            color: '#6b7280',
-            fontSize: '0.875rem',
-            border: '1px dashed #d1d5db',
-            borderRadius: '0.375rem',
-            marginBottom: '1rem',
-          }}
-        >
-          No recent activity
-        </div>
+        <div className={styles.noActivityPlaceholder}>No recent activity</div>
       )}
 
       <div className={styles.cardActions}>

--- a/app.rescue/src/components/applications/ApplicationReview.css.ts
+++ b/app.rescue/src/components/applications/ApplicationReview.css.ts
@@ -975,3 +975,29 @@ globalStyle(`${visitDetailsHeader} h4`, {
   fontWeight: '600',
   color: '#111827',
 });
+
+export const noStatusOptionsText = style({
+  fontSize: '0.75rem',
+  color: '#6b7280',
+  marginTop: '0.25rem',
+});
+
+export const statusChangeBlock = style({
+  marginTop: '0.5rem',
+});
+
+export const oldStatusText = style({
+  color: '#ef4444',
+});
+
+export const newStatusText = style({
+  color: '#10b981',
+});
+
+export const notesText = style({
+  color: '#6b7280',
+});
+
+export const visitDetailsBody = style({
+  padding: '1rem',
+});

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -763,7 +763,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                 ))}
               </select>
               {getValidStatusOptions(currentStatus).length === 0 && (
-                <p style={{ fontSize: '0.75rem', color: '#6b7280', marginTop: '0.25rem' }}>
+                <p className={styles.noStatusOptionsText}>
                   No status changes available for {formatStatusName(currentStatus)}.
                 </p>
               )}
@@ -1824,18 +1824,18 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                               <div className={styles.timelineData}>
                                 <strong>Additional Details:</strong>
                                 {event.data.oldStatus && event.data.newStatus ? (
-                                  <div style={{ marginTop: '0.5rem' }}>
-                                    <span style={{ color: '#ef4444' }}>
+                                  <div className={styles.statusChangeBlock}>
+                                    <span className={styles.oldStatusText}>
                                       From: {formatStatusName(event.data.oldStatus)}
                                     </span>
                                     <br />
-                                    <span style={{ color: '#10b981' }}>
+                                    <span className={styles.newStatusText}>
                                       To: {formatStatusName(event.data.newStatus)}
                                     </span>
                                     {event.data.notes && (
                                       <>
                                         <br />
-                                        <span style={{ color: '#6b7280' }}>
+                                        <span className={styles.notesText}>
                                           Notes: {event.data.notes}
                                         </span>
                                       </>
@@ -1878,7 +1878,7 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                 ×
               </button>
             </div>
-            <div style={{ padding: '1rem' }}>
+            <div className={styles.visitDetailsBody}>
               {(() => {
                 const visit = homeVisits.find(v => v.id === viewingVisit);
                 if (!visit) {

--- a/app.rescue/src/components/applications/ApplicationStageCard.css.ts
+++ b/app.rescue/src/components/applications/ApplicationStageCard.css.ts
@@ -167,3 +167,8 @@ export const actionButton = recipe({
     variant: 'secondary',
   },
 });
+
+export const closedBadge = style({
+  background: '#dbeafe',
+  color: '#2563eb',
+});

--- a/app.rescue/src/components/applications/ApplicationStageCard.tsx
+++ b/app.rescue/src/components/applications/ApplicationStageCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import { ApplicationListItem } from '../../types/applications';
 import { ApplicationStage, StageAction, OUTCOME_CONFIG } from '../../types/applicationStages';
 import { formatRelativeDate } from '@adopt-dont-shop/lib.utils';
@@ -157,9 +158,7 @@ const ApplicationStageCard: React.FC<ApplicationStageCardProps> = ({
         )}
 
         {isTerminalStatus() && (
-          <div className={styles.outcomeBadge} style={{ background: '#dbeafe', color: '#2563eb' }}>
-            🔒 Application Closed
-          </div>
+          <div className={clsx(styles.outcomeBadge, styles.closedBadge)}>🔒 Application Closed</div>
         )}
       </div>
 

--- a/app.rescue/src/components/applications/BulkActionBar.css.ts
+++ b/app.rescue/src/components/applications/BulkActionBar.css.ts
@@ -1,0 +1,53 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  gap: '0.75rem',
+  alignItems: 'center',
+  padding: '0.75rem 1rem',
+  background: '#f3f4f6',
+  borderRadius: '0.375rem',
+  marginBottom: '0.75rem',
+  flexWrap: 'wrap',
+});
+
+export const spacer = style({
+  flex: 1,
+});
+
+export const approveButton = style({
+  background: '#16a34a',
+  color: 'white',
+  padding: '0.25rem 0.75rem',
+});
+
+export const rejectButton = style({
+  background: '#dc2626',
+  color: 'white',
+  padding: '0.25rem 0.75rem',
+});
+
+export const neutralButton = style({
+  padding: '0.25rem 0.75rem',
+});
+
+export const fullWidthRow = style({
+  width: '100%',
+});
+
+export const confirmRow = style({
+  width: '100%',
+  display: 'flex',
+  gap: '0.5rem',
+  alignItems: 'center',
+  paddingTop: '0.5rem',
+  borderTop: '1px solid #d1d5db',
+  marginTop: '0.5rem',
+  flexWrap: 'wrap',
+});
+
+export const reasonInput = style({
+  flex: 1,
+  minWidth: '12rem',
+  padding: '0.25rem 0.5rem',
+});

--- a/app.rescue/src/components/applications/BulkActionBar.tsx
+++ b/app.rescue/src/components/applications/BulkActionBar.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import * as styles from './BulkActionBar.css';
 
 type BulkAction = 'approve' | 'reject' | 'withdraw';
 
@@ -36,18 +37,7 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
   };
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        gap: '0.75rem',
-        alignItems: 'center',
-        padding: '0.75rem 1rem',
-        background: '#f3f4f6',
-        borderRadius: '0.375rem',
-        marginBottom: '0.75rem',
-        flexWrap: 'wrap',
-      }}
-    >
+    <div className={styles.container}>
       {selectedCount > 0 && (
         <>
           <span>
@@ -56,12 +46,12 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
           <button type="button" onClick={onClearSelection} disabled={busy}>
             Clear
           </button>
-          <span style={{ flex: 1 }} />
+          <span className={styles.spacer} />
           <button
             type="button"
             onClick={() => setPendingAction('approve')}
             disabled={busy}
-            style={{ background: '#16a34a', color: 'white', padding: '0.25rem 0.75rem' }}
+            className={styles.approveButton}
           >
             Approve
           </button>
@@ -69,7 +59,7 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
             type="button"
             onClick={() => setPendingAction('reject')}
             disabled={busy}
-            style={{ background: '#dc2626', color: 'white', padding: '0.25rem 0.75rem' }}
+            className={styles.rejectButton}
           >
             Reject
           </button>
@@ -77,7 +67,7 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
             type="button"
             onClick={() => setPendingAction('withdraw')}
             disabled={busy}
-            style={{ padding: '0.25rem 0.75rem' }}
+            className={styles.neutralButton}
           >
             Withdraw
           </button>
@@ -85,25 +75,14 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
       )}
 
       {resultSummary && (
-        <span style={{ width: '100%' }}>
+        <span className={styles.fullWidthRow}>
           Bulk action complete: <strong>{resultSummary.successCount}</strong> succeeded,{' '}
           <strong>{resultSummary.failedCount}</strong> failed.
         </span>
       )}
 
       {pendingAction && (
-        <div
-          style={{
-            width: '100%',
-            display: 'flex',
-            gap: '0.5rem',
-            alignItems: 'center',
-            paddingTop: '0.5rem',
-            borderTop: '1px solid #d1d5db',
-            marginTop: '0.5rem',
-            flexWrap: 'wrap',
-          }}
-        >
+        <div className={styles.confirmRow}>
           <span>
             Confirm <strong>{pendingAction}</strong> for {selectedCount} application
             {selectedCount === 1 ? '' : 's'}?
@@ -114,14 +93,14 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
               placeholder="Reason (required for rejection)"
               value={reason}
               onChange={e => setReason(e.target.value)}
-              style={{ flex: 1, minWidth: '12rem', padding: '0.25rem 0.5rem' }}
+              className={styles.reasonInput}
             />
           )}
           <button
             type="button"
             onClick={handleConfirm}
             disabled={busy || (requireReason && reason.trim().length === 0)}
-            style={{ padding: '0.25rem 0.75rem' }}
+            className={styles.neutralButton}
           >
             {busy ? 'Working…' : 'Confirm'}
           </button>
@@ -132,7 +111,7 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
               setReason('');
             }}
             disabled={busy}
-            style={{ padding: '0.25rem 0.75rem' }}
+            className={styles.neutralButton}
           >
             Cancel
           </button>

--- a/app.rescue/src/components/applications/StageTransitionModal.css.ts
+++ b/app.rescue/src/components/applications/StageTransitionModal.css.ts
@@ -177,3 +177,10 @@ export const button = recipe({
     variant: 'secondary',
   },
 });
+
+export const noActionsMessage = style({
+  fontSize: '0.875rem',
+  color: '#6b7280',
+  textAlign: 'center',
+  padding: '1rem',
+});

--- a/app.rescue/src/components/applications/StageTransitionModal.tsx
+++ b/app.rescue/src/components/applications/StageTransitionModal.tsx
@@ -105,14 +105,7 @@ const StageTransitionModal: React.FC<StageTransitionModalProps> = ({
 
         {availableActions.length === 0 ? (
           <div className={styles.formField}>
-            <p
-              style={{
-                fontSize: '0.875rem',
-                color: '#6b7280',
-                textAlign: 'center',
-                padding: '1rem',
-              }}
-            >
+            <p className={styles.noActionsMessage}>
               No stage transitions available for {STAGE_CONFIG[currentStage]?.label || currentStage}
               .
             </p>

--- a/app.rescue/src/components/pets/PetCard.css.ts
+++ b/app.rescue/src/components/pets/PetCard.css.ts
@@ -212,3 +212,17 @@ export const statusBadge = recipe({
     status: 'default',
   },
 });
+
+export const dangerText = style({
+  color: '#ef4444',
+});
+
+export const deleteWarning = style({
+  marginBottom: '1rem',
+  color: '#666',
+});
+
+export const dangerButton = style({
+  backgroundColor: '#ef4444',
+  borderColor: '#ef4444',
+});

--- a/app.rescue/src/components/pets/PetCard.tsx
+++ b/app.rescue/src/components/pets/PetCard.tsx
@@ -177,7 +177,7 @@ const PetCard: React.FC<PetCardProps> = ({ pet, onStatusChange, onEdit, onDelete
               size="sm"
               onClick={handleDelete}
               disabled={isDeleting}
-              style={{ color: '#ef4444' }}
+              className={styles.dangerText}
             >
               {isDeleting ? 'Deleting...' : 'Delete'}
             </Button>
@@ -252,7 +252,7 @@ const PetCard: React.FC<PetCardProps> = ({ pet, onStatusChange, onEdit, onDelete
           >
             <h3>Delete Pet: {pet.name}</h3>
 
-            <p style={{ marginBottom: '1rem', color: '#666' }}>
+            <p className={styles.deleteWarning}>
               Are you sure you want to delete this pet? This action cannot be undone.
             </p>
 
@@ -275,7 +275,7 @@ const PetCard: React.FC<PetCardProps> = ({ pet, onStatusChange, onEdit, onDelete
                 variant="primary"
                 onClick={confirmDelete}
                 disabled={isDeleting}
-                style={{ backgroundColor: '#ef4444', borderColor: '#ef4444' }}
+                className={styles.dangerButton}
               >
                 {isDeleting ? 'Deleting...' : 'Delete Pet'}
               </Button>

--- a/app.rescue/src/components/pets/PetCsvImportModal.css.ts
+++ b/app.rescue/src/components/pets/PetCsvImportModal.css.ts
@@ -123,3 +123,33 @@ export const warning = style({
   fontSize: '0.85rem',
   color: '#92400e',
 });
+
+export const helpText = style({
+  fontSize: '0.85rem',
+  color: '#6b7280',
+});
+
+export const hiddenInput = style({
+  display: 'none',
+});
+
+export const stepDescription = style({
+  margin: 0,
+  fontSize: '0.9rem',
+  color: '#374151',
+});
+
+export const scrollableTable = style({
+  maxHeight: '320px',
+  overflow: 'auto',
+});
+
+export const importingMessage = style({
+  padding: '2rem',
+  textAlign: 'center',
+});
+
+export const failureTable = style({
+  maxHeight: '240px',
+  overflow: 'auto',
+});

--- a/app.rescue/src/components/pets/PetCsvImportModal.tsx
+++ b/app.rescue/src/components/pets/PetCsvImportModal.tsx
@@ -212,7 +212,7 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
               <p>
                 <strong>Click to upload a CSV</strong>
               </p>
-              <p style={{ fontSize: '0.85rem', color: '#6b7280' }}>
+              <p className={styles.helpText}>
                 First row must be column headers. Required columns:{' '}
                 {IMPORTABLE_FIELDS.filter(f => f.required)
                   .map(f => f.label)
@@ -223,7 +223,7 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
                 ref={fileRef}
                 type="file"
                 accept=".csv,text/csv"
-                style={{ display: 'none' }}
+                className={styles.hiddenInput}
                 onChange={e => {
                   const file = e.target.files?.[0];
                   if (file) {
@@ -242,7 +242,7 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
 
         {step === 'map' && parsed && (
           <>
-            <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
+            <p className={styles.stepDescription}>
               We auto-matched columns by header name. Adjust any that look wrong, then continue to
               the preview step.
             </p>
@@ -315,7 +315,7 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
                 de-duplication across imports.
               </div>
             )}
-            <div style={{ maxHeight: '320px', overflow: 'auto' }}>
+            <div className={styles.scrollableTable}>
               <table className={styles.previewTable}>
                 <thead>
                   <tr>
@@ -367,9 +367,7 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
           </>
         )}
 
-        {step === 'importing' && (
-          <p style={{ padding: '2rem', textAlign: 'center' }}>Importing pets…</p>
-        )}
+        {step === 'importing' && <p className={styles.importingMessage}>Importing pets…</p>}
 
         {step === 'done' && summary && (
           <>
@@ -388,7 +386,7 @@ const PetCsvImportModal: React.FC<Props> = ({ isOpen, rescueId, onClose, onImpor
               </div>
             </div>
             {summary.failed.length > 0 && (
-              <div style={{ maxHeight: '240px', overflow: 'auto' }}>
+              <div className={styles.failureTable}>
                 <table className={styles.previewTable}>
                   <thead>
                     <tr>

--- a/app.rescue/src/components/pets/PetGrid.css.ts
+++ b/app.rescue/src/components/pets/PetGrid.css.ts
@@ -84,3 +84,20 @@ export const paginationContainer = style({
     },
   },
 });
+
+export const pageButton = style({
+  minWidth: '40px',
+  height: '40px',
+  padding: '0.5rem',
+});
+
+export const pageButtonCurrent = style({
+  backgroundColor: '#2563eb',
+  color: 'white',
+});
+
+export const pageCounter = style({
+  fontSize: '0.875rem',
+  color: '#6b7280',
+  whiteSpace: 'nowrap',
+});

--- a/app.rescue/src/components/pets/PetGrid.tsx
+++ b/app.rescue/src/components/pets/PetGrid.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import { Card, Button, Text } from '@adopt-dont-shop/lib.components';
 import { Pet, PetStatus } from '@adopt-dont-shop/lib.pets';
 import PetCard from './PetCard.tsx';
@@ -88,7 +89,7 @@ const PetGrid: React.FC<PetGridProps> = ({
           variant="outline"
           disabled={!hasPrev}
           onClick={() => onPageChange(currentPage - 1)}
-          style={{ minWidth: '40px', height: '40px', padding: '0.5rem' }}
+          className={styles.pageButton}
         >
           ←
         </Button>
@@ -101,12 +102,10 @@ const PetGrid: React.FC<PetGridProps> = ({
               <Button
                 variant="outline"
                 onClick={() => onPageChange(page as number)}
-                style={{
-                  minWidth: '40px',
-                  height: '40px',
-                  padding: '0.5rem',
-                  ...(page === currentPage ? { backgroundColor: '#2563eb', color: 'white' } : {}),
-                }}
+                className={clsx(
+                  styles.pageButton,
+                  page === currentPage && styles.pageButtonCurrent
+                )}
               >
                 {page}
               </Button>
@@ -118,12 +117,12 @@ const PetGrid: React.FC<PetGridProps> = ({
           variant="outline"
           disabled={!hasNext}
           onClick={() => onPageChange(currentPage + 1)}
-          style={{ minWidth: '40px', height: '40px', padding: '0.5rem' }}
+          className={styles.pageButton}
         >
           →
         </Button>
 
-        <Text style={{ fontSize: '0.875rem', color: '#6b7280', whiteSpace: 'nowrap' }}>
+        <Text className={styles.pageCounter}>
           Page {currentPage} of {totalPages}
         </Text>
       </div>

--- a/app.rescue/src/components/rescue/QuestionsBuilder.css.ts
+++ b/app.rescue/src/components/rescue/QuestionsBuilder.css.ts
@@ -307,3 +307,21 @@ export const loadingState = style({
   padding: '3rem',
   color: '#6b7280',
 });
+
+export const questionTextEnabled = style({
+  textDecoration: 'none',
+  color: '#111827',
+});
+
+export const questionTextDisabled = style({
+  textDecoration: 'line-through',
+  color: '#9ca3af',
+});
+
+export const helpTextEnabled = style({
+  color: '#6b7280',
+});
+
+export const helpTextDisabled = style({
+  color: '#d1d5db',
+});

--- a/app.rescue/src/components/rescue/QuestionsBuilder.tsx
+++ b/app.rescue/src/components/rescue/QuestionsBuilder.tsx
@@ -753,15 +753,20 @@ const QuestionsBuilder: React.FC<QuestionsBuilderProps> = ({ rescueId }) => {
 
                   <div className={styles.questionText}>
                     <p
-                      style={{
-                        textDecoration: question.isEnabled ? 'none' : 'line-through',
-                        color: question.isEnabled ? '#111827' : '#9ca3af',
-                      }}
+                      className={
+                        question.isEnabled
+                          ? styles.questionTextEnabled
+                          : styles.questionTextDisabled
+                      }
                     >
                       {question.questionText}
                     </p>
                     {question.helpText && (
-                      <span style={{ color: question.isEnabled ? '#6b7280' : '#d1d5db' }}>
+                      <span
+                        className={
+                          question.isEnabled ? styles.helpTextEnabled : styles.helpTextDisabled
+                        }
+                      >
                         {question.helpText}
                       </span>
                     )}

--- a/app.rescue/src/pages/Analytics.css.ts
+++ b/app.rescue/src/pages/Analytics.css.ts
@@ -171,3 +171,33 @@ export const errorState = style({
 globalStyle(`${errorState} p`, {
   margin: 0,
 });
+
+export const breedList = style({
+  display: 'grid',
+  gap: '1rem',
+});
+
+export const breedRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '1rem',
+  background: '#F9FAFB',
+  borderRadius: '8px',
+});
+
+export const breedTitle = style({
+  fontWeight: 600,
+  marginBottom: '0.25rem',
+});
+
+export const breedSubtitle = style({
+  fontSize: '0.875rem',
+  color: '#6B7280',
+});
+
+export const breedCount = style({
+  fontSize: '1.5rem',
+  fontWeight: 700,
+  color: '#3B82F6',
+});

--- a/app.rescue/src/pages/Analytics.tsx
+++ b/app.rescue/src/pages/Analytics.tsx
@@ -382,36 +382,18 @@ const Analytics: React.FC = () => {
           </div>
           <div className={styles.cardBody}>
             {petPerformance?.mostPopularBreeds && petPerformance.mostPopularBreeds.length > 0 ? (
-              <div style={{ display: 'grid', gap: '1rem' }}>
+              <div className={styles.breedList}>
                 {petPerformance.mostPopularBreeds.map((breed, index) => (
-                  <div
-                    key={breed.breed}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      padding: '1rem',
-                      background: '#F9FAFB',
-                      borderRadius: '8px',
-                    }}
-                  >
+                  <div key={breed.breed} className={styles.breedRow}>
                     <div>
-                      <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>
+                      <div className={styles.breedTitle}>
                         #{index + 1} {breed.breed}
                       </div>
-                      <div style={{ fontSize: '0.875rem', color: '#6B7280' }}>
+                      <div className={styles.breedSubtitle}>
                         Avg. {breed.averageAdoptionTime.toFixed(1)} days to adoption
                       </div>
                     </div>
-                    <div
-                      style={{
-                        fontSize: '1.5rem',
-                        fontWeight: 700,
-                        color: '#3B82F6',
-                      }}
-                    >
-                      {breed.count}
-                    </div>
+                    <div className={styles.breedCount}>{breed.count}</div>
                   </div>
                 ))}
               </div>

--- a/app.rescue/src/pages/Dashboard.css.ts
+++ b/app.rescue/src/pages/Dashboard.css.ts
@@ -65,3 +65,335 @@ export const analyticsGrid = style({
     },
   },
 });
+
+export const loadingState = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '200px',
+});
+
+export const errorCard = style({
+  padding: '1.5rem',
+  textAlign: 'center',
+});
+
+export const errorMessage = style({
+  color: '#ef4444',
+  marginBottom: '1rem',
+});
+
+export const errorHint = style({
+  color: '#6b7280',
+  marginBottom: '1rem',
+});
+
+export const errorActions = style({
+  display: 'flex',
+  justifyContent: 'center',
+  gap: '1rem',
+  marginTop: '1rem',
+});
+
+export const refreshButton = style({
+  backgroundColor: '#3b82f6',
+  color: 'white',
+  padding: '0.5rem 1rem',
+  border: 'none',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+});
+
+export const clearAuthButton = style({
+  backgroundColor: '#ef4444',
+  color: 'white',
+  padding: '0.5rem 1rem',
+  border: 'none',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+});
+
+export const metricCardBody = style({
+  padding: '1.5rem',
+});
+
+export const metricCardHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  marginBottom: '1rem',
+});
+
+export const metricEmoji = style({
+  fontSize: '1.5rem',
+  marginRight: '0.75rem',
+});
+
+export const metricLabel = style({
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  color: '#6b7280',
+  textTransform: 'uppercase',
+  letterSpacing: '0.025em',
+});
+
+export const metricValue = style({
+  fontSize: '2.25rem',
+  fontWeight: 700,
+  marginBottom: '0.5rem',
+});
+
+export const metricDeltaUp = style({
+  fontSize: '0.875rem',
+  color: '#10b981',
+});
+
+export const metricDeltaDown = style({
+  fontSize: '0.875rem',
+  color: '#ef4444',
+});
+
+export const cardSectionHeader = style({
+  padding: '1.5rem 1.5rem 1rem 1.5rem',
+  borderBottom: '1px solid #e5e7eb',
+});
+
+export const cardSectionHeading = style({
+  margin: 0,
+});
+
+export const cardSectionBody = style({
+  padding: '1.5rem',
+});
+
+export const chartArea = style({
+  display: 'flex',
+  alignItems: 'end',
+  height: '180px',
+  gap: '0.5rem',
+  marginBottom: '1rem',
+});
+
+export const chartColumn = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  height: '100%',
+});
+
+export const chartBar = style({
+  background: 'linear-gradient(180deg, #3b82f6 0%, #1d4ed8 100%)',
+  borderRadius: '4px 4px 0 0',
+  width: '100%',
+  minHeight: '4px',
+  transition: 'all 0.3s ease',
+  cursor: 'pointer',
+});
+
+export const chartMonthLabel = style({
+  fontSize: '0.75rem',
+  color: '#6b7280',
+  marginTop: '0.5rem',
+  fontWeight: 500,
+});
+
+export const chartValueLabel = style({
+  fontSize: '0.875rem',
+  fontWeight: 600,
+  marginTop: '0.25rem',
+});
+
+export const chartSummary = style({
+  paddingTop: '1rem',
+  borderTop: '1px solid #e5e7eb',
+  fontSize: '0.875rem',
+});
+
+export const chartSummaryRow = style({
+  margin: '0.25rem 0',
+  color: '#4b5563',
+});
+
+export const statusList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+export const statusRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const statusLabelWrap = style({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+export const statusDot = style({
+  width: '12px',
+  height: '12px',
+  borderRadius: '50%',
+  marginRight: '0.75rem',
+});
+
+export const statusName = style({
+  fontWeight: 500,
+});
+
+export const statusValueChip = style({
+  fontWeight: 600,
+  backgroundColor: '#f3f4f6',
+  padding: '0.25rem 0.75rem',
+  borderRadius: '12px',
+  fontSize: '0.875rem',
+});
+
+export const activityList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+export const activityItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  paddingBottom: '1rem',
+  borderBottom: '1px solid #e5e7eb',
+});
+
+export const activityItemLast = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  paddingBottom: '0',
+  borderBottom: 'none',
+});
+
+export const activityTimestamp = style({
+  fontSize: '0.75rem',
+  color: '#6b7280',
+  fontWeight: 500,
+});
+
+export const activityMessage = style({
+  fontSize: '0.875rem',
+  lineHeight: 1.4,
+});
+
+export const emptyActivityMessage = style({
+  fontSize: '0.875rem',
+  color: '#6b7280',
+  textAlign: 'center',
+});
+
+export const notificationsCard = style({
+  gridColumn: '1 / -1',
+});
+
+export const notificationsHeading = style({
+  margin: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+});
+
+export const unreadBadge = style({
+  backgroundColor: '#ef4444',
+  color: 'white',
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  padding: '0.25rem 0.5rem',
+  borderRadius: '10px',
+  minWidth: '1.25rem',
+  textAlign: 'center',
+});
+
+export const notificationsBody = style({
+  padding: '1rem',
+});
+
+export const notificationRowBase = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '0.75rem',
+  padding: '0.75rem',
+  borderRadius: '8px',
+  marginBottom: '0.5rem',
+  position: 'relative',
+});
+
+export const notificationRowRead = style({
+  backgroundColor: '#f9fafb',
+});
+
+export const notificationRowUnread = style({
+  backgroundColor: '#eff6ff',
+});
+
+export const notificationIcon = style({
+  fontSize: '1.25rem',
+  marginTop: '0.125rem',
+});
+
+export const notificationContent = style({
+  flex: 1,
+});
+
+export const notificationTitle = style({
+  fontWeight: 600,
+  fontSize: '0.875rem',
+  marginBottom: '0.25rem',
+});
+
+export const notificationBody = style({
+  color: '#4b5563',
+  fontSize: '0.875rem',
+  lineHeight: 1.4,
+  marginBottom: '0.25rem',
+});
+
+export const notificationTimestamp = style({
+  color: '#6b7280',
+  fontSize: '0.75rem',
+});
+
+export const unreadDot = style({
+  position: 'absolute',
+  top: '0.75rem',
+  right: '0.75rem',
+  width: '8px',
+  height: '8px',
+  backgroundColor: '#3b82f6',
+  borderRadius: '50%',
+});
+
+export const emptyNotifications = style({
+  color: '#6b7280',
+  textAlign: 'center',
+  padding: '2rem',
+});
+
+export const notificationsFooter = style({
+  padding: '1rem 1.5rem',
+  borderTop: '1px solid #e5e7eb',
+  textAlign: 'center',
+});
+
+export const viewAllButton = style({
+  background: 'none',
+  border: '1px solid #d1d5db',
+  color: '#374151',
+  padding: '0.5rem 1rem',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  transition: 'all 0.2s ease',
+});

--- a/app.rescue/src/pages/Dashboard.tsx
+++ b/app.rescue/src/pages/Dashboard.tsx
@@ -16,14 +16,7 @@ const Dashboard: React.FC = () => {
           <Heading level="h1">Rescue Dashboard</Heading>
           <Text>Loading dashboard data...</Text>
         </div>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '200px',
-          }}
-        >
+        <div className={styles.loadingState}>
           <Text>📊 Loading...</Text>
         </div>
       </Container>
@@ -38,29 +31,13 @@ const Dashboard: React.FC = () => {
           <Text>Welcome back! Here's what's happening with your rescue today.</Text>
         </div>
         <Card>
-          <div style={{ padding: '1.5rem', textAlign: 'center' }}>
-            <Text style={{ color: '#ef4444', marginBottom: '1rem' }}>
-              ⚠️ Unable to load dashboard data: {error}
-            </Text>
-            <Text style={{ color: '#6b7280', marginBottom: '1rem' }}>
+          <div className={styles.errorCard}>
+            <Text className={styles.errorMessage}>⚠️ Unable to load dashboard data: {error}</Text>
+            <Text className={styles.errorHint}>
               This usually indicates an authentication issue. Please try logging in again.
             </Text>
-            <div
-              style={{ display: 'flex', justifyContent: 'center', gap: '1rem', marginTop: '1rem' }}
-            >
-              <button
-                onClick={() => window.location.reload()}
-                style={{
-                  backgroundColor: '#3b82f6',
-                  color: 'white',
-                  padding: '0.5rem 1rem',
-                  border: 'none',
-                  borderRadius: '6px',
-                  cursor: 'pointer',
-                  fontSize: '0.875rem',
-                  fontWeight: 500,
-                }}
-              >
+            <div className={styles.errorActions}>
+              <button onClick={() => window.location.reload()} className={styles.refreshButton}>
                 Refresh Page
               </button>
               <button
@@ -68,16 +45,7 @@ const Dashboard: React.FC = () => {
                   localStorage.clear();
                   window.location.reload();
                 }}
-                style={{
-                  backgroundColor: '#ef4444',
-                  color: 'white',
-                  padding: '0.5rem 1rem',
-                  border: 'none',
-                  borderRadius: '6px',
-                  cursor: 'pointer',
-                  fontSize: '0.875rem',
-                  fontWeight: 500,
-                }}
+                className={styles.clearAuthButton}
               >
                 Clear Auth & Restart
               </button>
@@ -127,94 +95,46 @@ const Dashboard: React.FC = () => {
       {/* Key Metrics Row */}
       <div className={styles.metricsGrid}>
         <Card>
-          <div style={{ padding: '1.5rem' }}>
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
-              <span style={{ fontSize: '1.5rem', marginRight: '0.75rem' }}>🐕</span>
-              <Text
-                style={{
-                  fontSize: '0.875rem',
-                  fontWeight: 500,
-                  color: '#6b7280',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.025em',
-                }}
-              >
-                Total Pets
-              </Text>
+          <div className={styles.metricCardBody}>
+            <div className={styles.metricCardHeader}>
+              <span className={styles.metricEmoji}>🐕</span>
+              <Text className={styles.metricLabel}>Total Pets</Text>
             </div>
-            <Text style={{ fontSize: '2.25rem', fontWeight: 700, marginBottom: '0.5rem' }}>
-              {totalPets}
-            </Text>
-            <Text style={{ fontSize: '0.875rem', color: '#10b981' }}>↑ 5% from last month</Text>
+            <Text className={styles.metricValue}>{totalPets}</Text>
+            <Text className={styles.metricDeltaUp}>↑ 5% from last month</Text>
           </div>
         </Card>
 
         <Card>
-          <div style={{ padding: '1.5rem' }}>
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
-              <span style={{ fontSize: '1.5rem', marginRight: '0.75rem' }}>❤️</span>
-              <Text
-                style={{
-                  fontSize: '0.875rem',
-                  fontWeight: 500,
-                  color: '#6b7280',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.025em',
-                }}
-              >
-                Successful Adoptions
-              </Text>
+          <div className={styles.metricCardBody}>
+            <div className={styles.metricCardHeader}>
+              <span className={styles.metricEmoji}>❤️</span>
+              <Text className={styles.metricLabel}>Successful Adoptions</Text>
             </div>
-            <Text style={{ fontSize: '2.25rem', fontWeight: 700, marginBottom: '0.5rem' }}>
-              {successfulAdoptions}
-            </Text>
-            <Text style={{ fontSize: '0.875rem', color: '#10b981' }}>↑ 12% from last month</Text>
+            <Text className={styles.metricValue}>{successfulAdoptions}</Text>
+            <Text className={styles.metricDeltaUp}>↑ 12% from last month</Text>
           </div>
         </Card>
 
         <Card>
-          <div style={{ padding: '1.5rem' }}>
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
-              <span style={{ fontSize: '1.5rem', marginRight: '0.75rem' }}>📋</span>
-              <Text
-                style={{
-                  fontSize: '0.875rem',
-                  fontWeight: 500,
-                  color: '#6b7280',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.025em',
-                }}
-              >
-                Pending Applications
-              </Text>
+          <div className={styles.metricCardBody}>
+            <div className={styles.metricCardHeader}>
+              <span className={styles.metricEmoji}>📋</span>
+              <Text className={styles.metricLabel}>Pending Applications</Text>
             </div>
-            <Text style={{ fontSize: '2.25rem', fontWeight: 700, marginBottom: '0.5rem' }}>
-              {pendingApplications}
-            </Text>
-            <Text style={{ fontSize: '0.875rem', color: '#ef4444' }}>↓ 2% from last month</Text>
+            <Text className={styles.metricValue}>{pendingApplications}</Text>
+            <Text className={styles.metricDeltaDown}>↓ 2% from last month</Text>
           </div>
         </Card>
 
         <Card>
-          <div style={{ padding: '1.5rem' }}>
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
-              <span style={{ fontSize: '1.5rem', marginRight: '0.75rem' }}>📊</span>
-              <Text
-                style={{
-                  fontSize: '0.875rem',
-                  fontWeight: 500,
-                  color: '#6b7280',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.025em',
-                }}
-              >
-                Adoption Rate
-              </Text>
+          <div className={styles.metricCardBody}>
+            <div className={styles.metricCardHeader}>
+              <span className={styles.metricEmoji}>📊</span>
+              <Text className={styles.metricLabel}>Adoption Rate</Text>
             </div>
-            <Text style={{ fontSize: '2.25rem', fontWeight: 700, marginBottom: '0.5rem' }}>
-              {adoptionRate}%
-            </Text>
-            <Text style={{ fontSize: '0.875rem', color: '#10b981' }}>↑ 3% from last month</Text>
+            <Text className={styles.metricValue}>{adoptionRate}%</Text>
+            <Text className={styles.metricDeltaUp}>↑ 3% from last month</Text>
           </div>
         </Card>
       </div>
@@ -222,68 +142,31 @@ const Dashboard: React.FC = () => {
       {/* Charts and Analytics Row */}
       <div className={styles.analyticsGrid}>
         <Card>
-          <div style={{ padding: '1.5rem 1.5rem 1rem 1.5rem', borderBottom: '1px solid #e5e7eb' }}>
-            <Heading level="h3" style={{ margin: 0 }}>
+          <div className={styles.cardSectionHeader}>
+            <Heading level="h3" className={styles.cardSectionHeading}>
               Monthly Adoptions
             </Heading>
           </div>
-          <div style={{ padding: '1.5rem' }}>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'end',
-                height: '180px',
-                gap: '0.5rem',
-                marginBottom: '1rem',
-              }}
-            >
+          <div className={styles.cardSectionBody}>
+            <div className={styles.chartArea}>
               {monthlyAdoptions.map(item => (
-                <div
-                  key={item.month}
-                  style={{
-                    flex: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    height: '100%',
-                  }}
-                >
+                <div key={item.month} className={styles.chartColumn}>
                   <div
-                    style={{
-                      background: 'linear-gradient(180deg, #3b82f6 0%, #1d4ed8 100%)',
-                      borderRadius: '4px 4px 0 0',
-                      width: '100%',
-                      height: `${(item.adoptions / 23) * 100}%`,
-                      minHeight: '4px',
-                      transition: 'all 0.3s ease',
-                      cursor: 'pointer',
-                    }}
+                    className={styles.chartBar}
+                    style={{ height: `${(item.adoptions / 23) * 100}%` }}
                     title={`${item.month}: ${item.adoptions} adoptions`}
                   />
-                  <Text
-                    style={{
-                      fontSize: '0.75rem',
-                      color: '#6b7280',
-                      marginTop: '0.5rem',
-                      fontWeight: 500,
-                    }}
-                  >
-                    {item.month}
-                  </Text>
-                  <Text style={{ fontSize: '0.875rem', fontWeight: 600, marginTop: '0.25rem' }}>
-                    {item.adoptions}
-                  </Text>
+                  <Text className={styles.chartMonthLabel}>{item.month}</Text>
+                  <Text className={styles.chartValueLabel}>{item.adoptions}</Text>
                 </div>
               ))}
             </div>
-            <div
-              style={{ paddingTop: '1rem', borderTop: '1px solid #e5e7eb', fontSize: '0.875rem' }}
-            >
-              <Text style={{ margin: '0.25rem 0', color: '#4b5563' }}>
+            <div className={styles.chartSummary}>
+              <Text className={styles.chartSummaryRow}>
                 <strong>Total Adoptions: </strong>
                 {monthlyAdoptions.reduce((sum, item) => sum + item.adoptions, 0)}
               </Text>
-              <Text style={{ margin: '0.25rem 0', color: '#4b5563' }}>
+              <Text className={styles.chartSummaryRow}>
                 <strong>Best Month: </strong>
                 {
                   monthlyAdoptions.reduce((best, current) =>
@@ -296,41 +179,20 @@ const Dashboard: React.FC = () => {
         </Card>
 
         <Card>
-          <div style={{ padding: '1.5rem 1.5rem 1rem 1.5rem', borderBottom: '1px solid #e5e7eb' }}>
-            <Heading level="h3" style={{ margin: 0 }}>
+          <div className={styles.cardSectionHeader}>
+            <Heading level="h3" className={styles.cardSectionHeading}>
               Pet Status Distribution
             </Heading>
           </div>
-          <div style={{ padding: '1.5rem' }}>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <div className={styles.cardSectionBody}>
+            <div className={styles.statusList}>
               {petStatusDistribution.map(status => (
-                <div
-                  key={status.name}
-                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <div
-                      style={{
-                        width: '12px',
-                        height: '12px',
-                        borderRadius: '50%',
-                        backgroundColor: status.color,
-                        marginRight: '0.75rem',
-                      }}
-                    />
-                    <Text style={{ fontWeight: 500 }}>{status.name}</Text>
+                <div key={status.name} className={styles.statusRow}>
+                  <div className={styles.statusLabelWrap}>
+                    <div className={styles.statusDot} style={{ backgroundColor: status.color }} />
+                    <Text className={styles.statusName}>{status.name}</Text>
                   </div>
-                  <Text
-                    style={{
-                      fontWeight: 600,
-                      backgroundColor: '#f3f4f6',
-                      padding: '0.25rem 0.75rem',
-                      borderRadius: '12px',
-                      fontSize: '0.875rem',
-                    }}
-                  >
-                    {status.value}
-                  </Text>
+                  <Text className={styles.statusValueChip}>{status.value}</Text>
                 </div>
               ))}
             </div>
@@ -338,40 +200,30 @@ const Dashboard: React.FC = () => {
         </Card>
 
         <Card>
-          <div style={{ padding: '1.5rem 1.5rem 1rem 1.5rem', borderBottom: '1px solid #e5e7eb' }}>
-            <Heading level="h3" style={{ margin: 0 }}>
+          <div className={styles.cardSectionHeader}>
+            <Heading level="h3" className={styles.cardSectionHeading}>
               Recent Activity
             </Heading>
           </div>
-          <div style={{ padding: '1.5rem' }}>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <div className={styles.cardSectionBody}>
+            <div className={styles.activityList}>
               {recentActivities.length > 0 ? (
                 recentActivities.map((activity, index) => {
                   const isLast = index === recentActivities.length - 1;
                   return (
                     <div
                       key={activity.id}
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '0.25rem',
-                        paddingBottom: isLast ? '0' : '1rem',
-                        borderBottom: isLast ? 'none' : '1px solid #e5e7eb',
-                      }}
+                      className={isLast ? styles.activityItemLast : styles.activityItem}
                     >
-                      <Text style={{ fontSize: '0.75rem', color: '#6b7280', fontWeight: 500 }}>
+                      <Text className={styles.activityTimestamp}>
                         {formatRelativeDate(activity.timestamp)}
                       </Text>
-                      <Text style={{ fontSize: '0.875rem', lineHeight: 1.4 }}>
-                        {activity.message}
-                      </Text>
+                      <Text className={styles.activityMessage}>{activity.message}</Text>
                     </div>
                   );
                 })
               ) : (
-                <Text style={{ fontSize: '0.875rem', color: '#6b7280', textAlign: 'center' }}>
-                  No recent activities
-                </Text>
+                <Text className={styles.emptyActivityMessage}>No recent activities</Text>
               )}
             </div>
           </div>
@@ -379,32 +231,18 @@ const Dashboard: React.FC = () => {
       </div>
 
       {/* Notifications */}
-      <Card style={{ gridColumn: '1 / -1' }}>
-        <div style={{ padding: '1.5rem 1.5rem 1rem 1.5rem', borderBottom: '1px solid #e5e7eb' }}>
-          <Heading
-            level="h3"
-            style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.5rem' }}
-          >
+      <Card className={styles.notificationsCard}>
+        <div className={styles.cardSectionHeader}>
+          <Heading level="h3" className={styles.notificationsHeading}>
             Recent Notifications
             {notifications.filter(n => !n.read).length > 0 && (
-              <span
-                style={{
-                  backgroundColor: '#ef4444',
-                  color: 'white',
-                  fontSize: '0.75rem',
-                  fontWeight: 600,
-                  padding: '0.25rem 0.5rem',
-                  borderRadius: '10px',
-                  minWidth: '1.25rem',
-                  textAlign: 'center',
-                }}
-              >
+              <span className={styles.unreadBadge}>
                 {notifications.filter(n => !n.read).length}
               </span>
             )}
           </Heading>
         </div>
-        <div style={{ padding: '1rem' }}>
+        <div className={styles.notificationsBody}>
           {notifications.length > 0 ? (
             notifications.map(notification => {
               const getNotificationIcon = (type: string) => {
@@ -423,80 +261,30 @@ const Dashboard: React.FC = () => {
               return (
                 <div
                   key={notification.id}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    gap: '0.75rem',
-                    padding: '0.75rem',
-                    borderRadius: '8px',
-                    marginBottom: '0.5rem',
-                    backgroundColor: notification.read ? '#f9fafb' : '#eff6ff',
-                    position: 'relative',
-                  }}
+                  className={`${styles.notificationRowBase} ${
+                    notification.read ? styles.notificationRowRead : styles.notificationRowUnread
+                  }`}
                 >
-                  <div style={{ fontSize: '1.25rem', marginTop: '0.125rem' }}>
+                  <div className={styles.notificationIcon}>
                     {getNotificationIcon(notification.type)}
                   </div>
-                  <div style={{ flex: 1 }}>
-                    <Text
-                      style={{ fontWeight: 600, fontSize: '0.875rem', marginBottom: '0.25rem' }}
-                    >
-                      {notification.title}
-                    </Text>
-                    <Text
-                      style={{
-                        color: '#4b5563',
-                        fontSize: '0.875rem',
-                        lineHeight: 1.4,
-                        marginBottom: '0.25rem',
-                      }}
-                    >
-                      {notification.message}
-                    </Text>
-                    <Text style={{ color: '#6b7280', fontSize: '0.75rem' }}>
+                  <div className={styles.notificationContent}>
+                    <Text className={styles.notificationTitle}>{notification.title}</Text>
+                    <Text className={styles.notificationBody}>{notification.message}</Text>
+                    <Text className={styles.notificationTimestamp}>
                       {formatRelativeDate(notification.timestamp)}
                     </Text>
                   </div>
-                  {!notification.read && (
-                    <div
-                      style={{
-                        position: 'absolute',
-                        top: '0.75rem',
-                        right: '0.75rem',
-                        width: '8px',
-                        height: '8px',
-                        backgroundColor: '#3b82f6',
-                        borderRadius: '50%',
-                      }}
-                    />
-                  )}
+                  {!notification.read && <div className={styles.unreadDot} />}
                 </div>
               );
             })
           ) : (
-            <Text style={{ color: '#6b7280', textAlign: 'center', padding: '2rem' }}>
-              No notifications
-            </Text>
+            <Text className={styles.emptyNotifications}>No notifications</Text>
           )}
         </div>
-        <div
-          style={{ padding: '1rem 1.5rem', borderTop: '1px solid #e5e7eb', textAlign: 'center' }}
-        >
-          <button
-            style={{
-              background: 'none',
-              border: '1px solid #d1d5db',
-              color: '#374151',
-              padding: '0.5rem 1rem',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontSize: '0.875rem',
-              fontWeight: 500,
-              transition: 'all 0.2s ease',
-            }}
-          >
-            View All Notifications
-          </button>
+        <div className={styles.notificationsFooter}>
+          <button className={styles.viewAllButton}>View All Notifications</button>
         </div>
       </Card>
     </Container>

--- a/app.rescue/src/pages/Events.css.ts
+++ b/app.rescue/src/pages/Events.css.ts
@@ -206,3 +206,8 @@ globalStyle(`${emptyState} h3`, {
 globalStyle(`${emptyState} p`, {
   margin: '0 0 1.5rem 0',
 });
+
+export const loadingState = style({
+  padding: '3rem',
+  textAlign: 'center',
+});

--- a/app.rescue/src/pages/Events.tsx
+++ b/app.rescue/src/pages/Events.tsx
@@ -355,7 +355,7 @@ const Events: React.FC = () => {
       <div className={styles.contentArea}>
         {loading ? (
           <Card>
-            <div style={{ padding: '3rem', textAlign: 'center' }}>
+            <div className={styles.loadingState}>
               <p>Loading events...</p>
             </div>
           </Card>

--- a/app.rescue/src/pages/FosterCoordination.css.ts
+++ b/app.rescue/src/pages/FosterCoordination.css.ts
@@ -1,0 +1,69 @@
+import { style } from '@vanilla-extract/css';
+
+export const pageContainer = style({
+  padding: '1.5rem',
+});
+
+export const pageHeader = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+});
+
+export const errorBanner = style({
+  background: '#fee2e2',
+  color: '#991b1b',
+  padding: '0.75rem',
+  margin: '1rem 0',
+});
+
+export const filterRow = style({
+  margin: '1rem 0',
+});
+
+export const table = style({
+  width: '100%',
+  borderCollapse: 'collapse',
+});
+
+export const tableHeadRow = style({
+  borderBottom: '1px solid #e5e7eb',
+  textAlign: 'left',
+});
+
+export const tableCell = style({
+  padding: '0.5rem',
+});
+
+export const monoCell = style({
+  padding: '0.5rem',
+  fontFamily: 'monospace',
+});
+
+export const tableBodyRow = style({
+  borderBottom: '1px solid #f3f4f6',
+});
+
+export const modalOverlay = style({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.4)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+});
+
+export const modalForm = style({
+  background: 'white',
+  padding: '1.5rem',
+  borderRadius: '0.5rem',
+  minWidth: '24rem',
+  display: 'grid',
+  gap: '0.5rem',
+});
+
+export const modalActions = style({
+  display: 'flex',
+  gap: '0.5rem',
+  justifyContent: 'flex-end',
+});

--- a/app.rescue/src/pages/FosterCoordination.tsx
+++ b/app.rescue/src/pages/FosterCoordination.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fosterService, type FosterPlacement } from '../services/fosterService';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
+import * as styles from './FosterCoordination.css';
 
 const FosterCoordination: React.FC = () => {
   const { user } = useAuth();
@@ -81,8 +82,8 @@ const FosterCoordination: React.FC = () => {
   };
 
   return (
-    <div className="page-container" style={{ padding: '1.5rem' }}>
-      <div className="page-header" style={{ display: 'flex', justifyContent: 'space-between' }}>
+    <div className={`page-container ${styles.pageContainer}`}>
+      <div className={`page-header ${styles.pageHeader}`}>
         <div>
           <h1>Foster Coordination</h1>
           <p>Manage active and historical foster placements for your rescue.</p>
@@ -92,15 +93,9 @@ const FosterCoordination: React.FC = () => {
         </button>
       </div>
 
-      {error && (
-        <div
-          style={{ background: '#fee2e2', color: '#991b1b', padding: '0.75rem', margin: '1rem 0' }}
-        >
-          {error}
-        </div>
-      )}
+      {error && <div className={styles.errorBanner}>{error}</div>}
 
-      <div style={{ margin: '1rem 0' }}>
+      <div className={styles.filterRow}>
         <label>
           Filter:{' '}
           <select
@@ -119,30 +114,30 @@ const FosterCoordination: React.FC = () => {
       ) : placements.length === 0 ? (
         <p>No foster placements found.</p>
       ) : (
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table className={styles.table}>
           <thead>
-            <tr style={{ borderBottom: '1px solid #e5e7eb', textAlign: 'left' }}>
-              <th style={{ padding: '0.5rem' }}>Pet</th>
-              <th style={{ padding: '0.5rem' }}>Foster user</th>
-              <th style={{ padding: '0.5rem' }}>Start</th>
-              <th style={{ padding: '0.5rem' }}>End</th>
-              <th style={{ padding: '0.5rem' }}>Status</th>
-              <th style={{ padding: '0.5rem' }}>Actions</th>
+            <tr className={styles.tableHeadRow}>
+              <th className={styles.tableCell}>Pet</th>
+              <th className={styles.tableCell}>Foster user</th>
+              <th className={styles.tableCell}>Start</th>
+              <th className={styles.tableCell}>End</th>
+              <th className={styles.tableCell}>Status</th>
+              <th className={styles.tableCell}>Actions</th>
             </tr>
           </thead>
           <tbody>
             {placements.map(p => (
-              <tr key={p.placementId} style={{ borderBottom: '1px solid #f3f4f6' }}>
-                <td style={{ padding: '0.5rem', fontFamily: 'monospace' }}>{p.petId}</td>
-                <td style={{ padding: '0.5rem', fontFamily: 'monospace' }}>{p.fosterUserId}</td>
-                <td style={{ padding: '0.5rem' }}>
+              <tr key={p.placementId} className={styles.tableBodyRow}>
+                <td className={styles.monoCell}>{p.petId}</td>
+                <td className={styles.monoCell}>{p.fosterUserId}</td>
+                <td className={styles.tableCell}>
                   {new Date(p.startDate).toLocaleDateString('en-GB')}
                 </td>
-                <td style={{ padding: '0.5rem' }}>
+                <td className={styles.tableCell}>
                   {p.endDate ? new Date(p.endDate).toLocaleDateString('en-GB') : '—'}
                 </td>
-                <td style={{ padding: '0.5rem' }}>{p.status}</td>
-                <td style={{ padding: '0.5rem' }}>
+                <td className={styles.tableCell}>{p.status}</td>
+                <td className={styles.tableCell}>
                   {p.status === 'active' && (
                     <button type="button" onClick={() => setEndingId(p.placementId)}>
                       End placement
@@ -156,28 +151,8 @@ const FosterCoordination: React.FC = () => {
       )}
 
       {showCreate && (
-        <div
-          style={{
-            position: 'fixed',
-            inset: 0,
-            background: 'rgba(0,0,0,0.4)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-        >
-          <form
-            onSubmit={handleCreate}
-            style={{
-              background: 'white',
-              padding: '1.5rem',
-              borderRadius: '0.5rem',
-              minWidth: '24rem',
-              display: 'grid',
-              gap: '0.5rem',
-            }}
-          >
+        <div className={styles.modalOverlay}>
+          <form onSubmit={handleCreate} className={styles.modalForm}>
             <h2>New Foster Placement</h2>
             <label>
               Pet ID
@@ -211,7 +186,7 @@ const FosterCoordination: React.FC = () => {
                 onChange={e => setForm({ ...form, notes: e.target.value })}
               />
             </label>
-            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <div className={styles.modalActions}>
               <button type="button" onClick={() => setShowCreate(false)}>
                 Cancel
               </button>
@@ -222,28 +197,8 @@ const FosterCoordination: React.FC = () => {
       )}
 
       {endingId && (
-        <div
-          style={{
-            position: 'fixed',
-            inset: 0,
-            background: 'rgba(0,0,0,0.4)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-        >
-          <form
-            onSubmit={handleEnd}
-            style={{
-              background: 'white',
-              padding: '1.5rem',
-              borderRadius: '0.5rem',
-              minWidth: '24rem',
-              display: 'grid',
-              gap: '0.5rem',
-            }}
-          >
+        <div className={styles.modalOverlay}>
+          <form onSubmit={handleEnd} className={styles.modalForm}>
             <h2>End Foster Placement</h2>
             <label>
               Outcome
@@ -265,7 +220,7 @@ const FosterCoordination: React.FC = () => {
                 onChange={e => setEndForm({ ...endForm, notes: e.target.value })}
               />
             </label>
-            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <div className={styles.modalActions}>
               <button type="button" onClick={() => setEndingId(null)}>
                 Cancel
               </button>

--- a/app.rescue/src/pages/PetManagement.css.ts
+++ b/app.rescue/src/pages/PetManagement.css.ts
@@ -125,3 +125,53 @@ export const errorContainer = style({
   color: vars.colors.semantic.error['600'],
   borderRadius: '0.5rem',
 });
+
+export const retryButton = style({
+  marginTop: '1rem',
+});
+
+export const setupCard = style({
+  padding: '2rem',
+  textAlign: 'center',
+  maxWidth: '600px',
+  margin: '1rem auto',
+});
+
+export const setupEmoji = style({
+  fontSize: '3rem',
+  marginBottom: '1rem',
+});
+
+export const setupHint = style({
+  marginBottom: '1.5rem',
+  color: '#6b7280',
+});
+
+export const setupActions = style({
+  display: 'flex',
+  gap: '1rem',
+  justifyContent: 'center',
+  flexWrap: 'wrap',
+});
+
+export const devNote = style({
+  marginTop: '1.5rem',
+  padding: '1rem',
+  background: '#f3f4f6',
+  borderRadius: '8px',
+});
+
+export const devNoteIntro = style({
+  margin: '0.5rem 0',
+  fontSize: '0.875rem',
+});
+
+export const devNoteSteps = style({
+  textAlign: 'left',
+  fontSize: '0.875rem',
+  margin: 0,
+});
+
+export const dismissButton = style({
+  marginTop: '0.5rem',
+});

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -256,7 +256,7 @@ const PetManagement: React.FC = () => {
         <div className={styles.errorContainer}>
           <Heading level="h3">Error Loading Pets</Heading>
           <Text>{error}</Text>
-          <Button onClick={() => fetchPets()} style={{ marginTop: '1rem' }}>
+          <Button onClick={() => fetchPets()} className={styles.retryButton}>
             Try Again
           </Button>
         </div>
@@ -275,17 +275,15 @@ const PetManagement: React.FC = () => {
           </div>
         </div>
 
-        <Card
-          style={{ padding: '2rem', textAlign: 'center', maxWidth: '600px', margin: '1rem auto' }}
-        >
-          <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>🏠</div>
+        <Card className={styles.setupCard}>
+          <div className={styles.setupEmoji}>🏠</div>
           <h2>Create Your Rescue Organization</h2>
-          <p style={{ marginBottom: '1.5rem', color: '#6b7280' }}>
+          <p className={styles.setupHint}>
             To start managing pets, you first need to create or join a rescue organization. This
             will allow you to add pets, manage applications, and track adoptions.
           </p>
 
-          <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+          <div className={styles.setupActions}>
             <Button variant="primary" onClick={handleCreateDemoRescue} disabled={loading}>
               {loading ? 'Creating...' : 'Create Demo Rescue (Dev)'}
             </Button>
@@ -302,19 +300,10 @@ const PetManagement: React.FC = () => {
             </Button>
           </div>
 
-          <div
-            style={{
-              marginTop: '1.5rem',
-              padding: '1rem',
-              background: '#f3f4f6',
-              borderRadius: '8px',
-            }}
-          >
+          <div className={styles.devNote}>
             <strong>Development Note:</strong>
-            <p style={{ margin: '0.5rem 0', fontSize: '0.875rem' }}>
-              To test the pet management system, you need to:
-            </p>
-            <ol style={{ textAlign: 'left', fontSize: '0.875rem', margin: 0 }}>
+            <p className={styles.devNoteIntro}>To test the pet management system, you need to:</p>
+            <ol className={styles.devNoteSteps}>
               <li>Create a rescue via API: POST /api/v1/rescues</li>
               <li>Update your user with the rescue ID</li>
               <li>Or use the seed data if available</li>
@@ -454,7 +443,7 @@ const PetManagement: React.FC = () => {
               onClick={() => setError(null)}
               variant="outline"
               size="sm"
-              style={{ marginTop: '0.5rem' }}
+              className={styles.dismissButton}
             >
               Dismiss
             </Button>

--- a/app.rescue/src/pages/ReportBuilderPage.css.ts
+++ b/app.rescue/src/pages/ReportBuilderPage.css.ts
@@ -1,0 +1,35 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  padding: '24px',
+});
+
+export const headerRow = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const formGrid = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '16px',
+  padding: '12px',
+  background: '#f9fafb',
+  borderRadius: '8px',
+});
+
+export const fieldLabel = style({
+  fontSize: '12px',
+  color: '#6b7280',
+});
+
+export const textInput = style({
+  width: '100%',
+  padding: '8px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '6px',
+});

--- a/app.rescue/src/pages/ReportBuilderPage.tsx
+++ b/app.rescue/src/pages/ReportBuilderPage.tsx
@@ -14,6 +14,7 @@ import {
   useUpdateReport,
   type ReportConfig,
 } from '@adopt-dont-shop/lib.analytics';
+import * as styles from './ReportBuilderPage.css';
 
 /**
  * ADS-105: Custom report builder for rescue staff.
@@ -26,13 +27,6 @@ const emptyConfig: ReportBuilderConfig = {
   filters: { groupBy: 'day' },
   layout: { columns: 2 },
   widgets: [],
-};
-
-const containerStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '16px',
-  padding: '24px',
 };
 
 const ReportBuilderPage: React.FC = () => {
@@ -105,8 +99,8 @@ const ReportBuilderPage: React.FC = () => {
   );
 
   return (
-    <div style={containerStyle}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+    <div className={styles.container}>
+      <div className={styles.headerRow}>
         <div>
           <Heading level="h1">{id ? 'Edit report' : 'New report'}</Heading>
           <Text>Build a custom report. Click Preview to run it.</Text>
@@ -116,42 +110,23 @@ const ReportBuilderPage: React.FC = () => {
         </button>
       </div>
 
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          gap: '16px',
-          padding: '12px',
-          background: '#f9fafb',
-          borderRadius: '8px',
-        }}
-      >
+      <div className={styles.formGrid}>
         <label>
-          <span style={{ fontSize: '12px', color: '#6b7280' }}>Name</span>
+          <span className={styles.fieldLabel}>Name</span>
           <input
             type="text"
             value={name}
             onChange={e => setName(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '8px',
-              border: '1px solid #e5e7eb',
-              borderRadius: '6px',
-            }}
+            className={styles.textInput}
           />
         </label>
         <label>
-          <span style={{ fontSize: '12px', color: '#6b7280' }}>Description</span>
+          <span className={styles.fieldLabel}>Description</span>
           <input
             type="text"
             value={description}
             onChange={e => setDescription(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '8px',
-              border: '1px solid #e5e7eb',
-              borderRadius: '6px',
-            }}
+            className={styles.textInput}
           />
         </label>
       </div>

--- a/app.rescue/src/pages/ReportViewPage.css.ts
+++ b/app.rescue/src/pages/ReportViewPage.css.ts
@@ -1,0 +1,56 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  padding: '24px',
+});
+
+export const headerRow = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const headerActions = style({
+  display: 'flex',
+  gap: '8px',
+});
+
+export const panel = style({
+  padding: '12px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '8px',
+});
+
+export const schedulePanel = style({
+  background: '#f9fafb',
+});
+
+export const sharePanel = style({
+  background: '#ecfdf5',
+});
+
+export const scheduleRow = style({
+  display: 'flex',
+  gap: '8px',
+  marginTop: '8px',
+});
+
+export const cronInput = style({
+  padding: '6px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '6px',
+});
+
+export const emailInput = style({
+  flex: 1,
+  padding: '6px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '6px',
+});
+
+export const shareCode = style({
+  wordBreak: 'break-all',
+});

--- a/app.rescue/src/pages/ReportViewPage.tsx
+++ b/app.rescue/src/pages/ReportViewPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
   ConfirmDialog,
@@ -14,17 +15,11 @@ import {
   useUpsertSchedule,
   useCreateTokenShare,
 } from '@adopt-dont-shop/lib.analytics';
+import * as styles from './ReportViewPage.css';
 
 /**
  * ADS-105: Rescue report viewer with schedule + share actions.
  */
-
-const containerStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '16px',
-  padding: '24px',
-};
 
 const ReportViewPage: React.FC = () => {
   const { id } = useParams();
@@ -44,14 +39,14 @@ const ReportViewPage: React.FC = () => {
 
   if (!id) {
     return (
-      <div style={containerStyle}>
+      <div className={styles.container}>
         <Text>Missing report id.</Text>
       </div>
     );
   }
   if (reportQuery.isLoading || !reportQuery.data) {
     return (
-      <div style={containerStyle}>
+      <div className={styles.container}>
         <Text>Loading…</Text>
       </div>
     );
@@ -99,13 +94,13 @@ const ReportViewPage: React.FC = () => {
   };
 
   return (
-    <div style={containerStyle}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+    <div className={styles.container}>
+      <div className={styles.headerRow}>
         <div>
           <Heading level="h1">{reportQuery.data.name}</Heading>
           {reportQuery.data.description ? <Text>{reportQuery.data.description}</Text> : null}
         </div>
-        <div style={{ display: 'flex', gap: '8px' }}>
+        <div className={styles.headerActions}>
           <Link to={`/reports/${id}/edit`}>
             <button type="button">Edit</button>
           </Link>
@@ -122,33 +117,21 @@ const ReportViewPage: React.FC = () => {
       </div>
 
       {scheduleOpen ? (
-        <div
-          style={{
-            padding: '12px',
-            border: '1px solid #e5e7eb',
-            borderRadius: '8px',
-            background: '#f9fafb',
-          }}
-        >
+        <div className={clsx(styles.panel, styles.schedulePanel)}>
           <Text>Schedule (cron + recipient email)</Text>
-          <div style={{ display: 'flex', gap: '8px', marginTop: '8px' }}>
+          <div className={styles.scheduleRow}>
             <input
               type="text"
               value={cron}
               onChange={e => setCron(e.target.value)}
-              style={{ padding: '6px', border: '1px solid #e5e7eb', borderRadius: '6px' }}
+              className={styles.cronInput}
             />
             <input
               type="email"
               value={recipientEmail}
               onChange={e => setRecipientEmail(e.target.value)}
               placeholder="recipient@example.com"
-              style={{
-                flex: 1,
-                padding: '6px',
-                border: '1px solid #e5e7eb',
-                borderRadius: '6px',
-              }}
+              className={styles.emailInput}
             />
             <button type="button" onClick={handleSchedule}>
               Save schedule
@@ -158,16 +141,9 @@ const ReportViewPage: React.FC = () => {
       ) : null}
 
       {shareUrl ? (
-        <div
-          style={{
-            padding: '12px',
-            border: '1px solid #e5e7eb',
-            borderRadius: '8px',
-            background: '#ecfdf5',
-          }}
-        >
+        <div className={clsx(styles.panel, styles.sharePanel)}>
           <Text>Share link (expires in 7 days):</Text>
-          <code style={{ wordBreak: 'break-all' }}>{shareUrl}</code>
+          <code className={styles.shareCode}>{shareUrl}</code>
         </div>
       ) : null}
 

--- a/app.rescue/src/pages/Reports.css.ts
+++ b/app.rescue/src/pages/Reports.css.ts
@@ -1,0 +1,65 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  padding: '24px',
+});
+
+export const header = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const section = style({
+  padding: '16px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '8px',
+  background: '#fff',
+});
+
+export const reportList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  marginTop: '12px',
+});
+
+export const reportRow = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '12px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '8px',
+  textDecoration: 'none',
+  color: 'inherit',
+});
+
+export const updatedMeta = style({
+  color: '#6b7280',
+  fontSize: '12px',
+});
+
+export const templateGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+  gap: '12px',
+  marginTop: '12px',
+});
+
+export const templateCard = style({
+  display: 'block',
+  padding: '12px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '8px',
+  textDecoration: 'none',
+  color: 'inherit',
+});
+
+export const templateMeta = style({
+  color: '#6b7280',
+  fontSize: '12px',
+  marginTop: '4px',
+});

--- a/app.rescue/src/pages/Reports.tsx
+++ b/app.rescue/src/pages/Reports.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Heading, Text } from '@adopt-dont-shop/lib.components';
 import { useReports, useReportTemplates } from '@adopt-dont-shop/lib.analytics';
+import * as styles from './Reports.css';
 
 /**
  * ADS-105: Rescue Reports list page.
@@ -11,26 +12,13 @@ import { useReports, useReportTemplates } from '@adopt-dont-shop/lib.analytics';
  * is enforced at the backend.
  */
 
-const containerStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '16px',
-  padding: '24px',
-};
-
-const headerStyle: React.CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-};
-
 const ReportsPage: React.FC = () => {
   const reportsQuery = useReports();
   const templatesQuery = useReportTemplates();
 
   return (
-    <div style={containerStyle}>
-      <div style={headerStyle}>
+    <div className={styles.container}>
+      <div className={styles.header}>
         <div>
           <Heading level="h1">Reports</Heading>
           <Text>Build custom reports for your rescue, schedule them, and share with the team.</Text>
@@ -40,37 +28,22 @@ const ReportsPage: React.FC = () => {
         </Link>
       </div>
 
-      <section
-        style={{
-          padding: '16px',
-          border: '1px solid #e5e7eb',
-          borderRadius: '8px',
-          background: '#fff',
-        }}
-      >
+      <section className={styles.section}>
         <Heading level="h2">Your reports</Heading>
         {reportsQuery.isLoading ? (
           <Text>Loading…</Text>
         ) : (reportsQuery.data ?? []).length === 0 ? (
           <Text>No saved reports yet — pick a template below to start.</Text>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '12px' }}>
+          <div className={styles.reportList}>
             {(reportsQuery.data ?? []).map(report => (
               <Link
                 key={report.saved_report_id}
                 to={`/reports/${report.saved_report_id}`}
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  padding: '12px',
-                  border: '1px solid #e5e7eb',
-                  borderRadius: '8px',
-                  textDecoration: 'none',
-                  color: 'inherit',
-                }}
+                className={styles.reportRow}
               >
                 <strong>{report.name}</strong>
-                <span style={{ color: '#6b7280', fontSize: '12px' }}>
+                <span className={styles.updatedMeta}>
                   Updated {new Date(report.updated_at).toLocaleDateString()}
                 </span>
               </Link>
@@ -79,38 +52,17 @@ const ReportsPage: React.FC = () => {
         )}
       </section>
 
-      <section
-        style={{
-          padding: '16px',
-          border: '1px solid #e5e7eb',
-          borderRadius: '8px',
-          background: '#fff',
-        }}
-      >
+      <section className={styles.section}>
         <Heading level="h2">Templates</Heading>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
-            gap: '12px',
-            marginTop: '12px',
-          }}
-        >
+        <div className={styles.templateGrid}>
           {(templatesQuery.data ?? []).map(template => (
             <Link
               key={template.template_id}
               to={`/reports/new?template=${template.template_id}`}
-              style={{
-                display: 'block',
-                padding: '12px',
-                border: '1px solid #e5e7eb',
-                borderRadius: '8px',
-                textDecoration: 'none',
-                color: 'inherit',
-              }}
+              className={styles.templateCard}
             >
               <strong>{template.name}</strong>
-              <div style={{ color: '#6b7280', fontSize: '12px', marginTop: '4px' }}>
+              <div className={styles.templateMeta}>
                 {template.description ?? `${template.category} report`}
               </div>
             </Link>

--- a/lib.components/src/components/charts/ChartFrame.css.ts
+++ b/lib.components/src/components/charts/ChartFrame.css.ts
@@ -1,0 +1,54 @@
+import { style } from '@vanilla-extract/css';
+
+export const frame = style({
+  display: 'flex',
+  flexDirection: 'column',
+  background: 'var(--color-surface, #fff)',
+  border: '1px solid var(--color-border, #e5e7eb)',
+  borderRadius: '8px',
+  padding: '16px',
+  height: '100%',
+  minHeight: '220px',
+  boxSizing: 'border-box',
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  justifyContent: 'space-between',
+  gap: '8px',
+  marginBottom: '12px',
+});
+
+export const title = style({
+  fontSize: '14px',
+  fontWeight: 600,
+  color: 'var(--color-text, #111827)',
+  margin: 0,
+});
+
+export const subtitle = style({
+  fontSize: '12px',
+  color: 'var(--color-text-muted, #6b7280)',
+  marginTop: '2px',
+});
+
+export const body = style({
+  flex: 1,
+  position: 'relative',
+  minHeight: 0,
+});
+
+export const state = style({
+  position: 'absolute',
+  inset: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: 'var(--color-text-muted, #6b7280)',
+  fontSize: '13px',
+});
+
+export const stateError = style({
+  color: 'var(--color-danger, #dc2626)',
+});

--- a/lib.components/src/components/charts/ChartFrame.tsx
+++ b/lib.components/src/components/charts/ChartFrame.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import clsx from 'clsx';
+import * as styles from './ChartFrame.css';
 
 /**
  * ADS-105: Common frame around a chart widget.
@@ -22,55 +24,6 @@ export type ChartFrameProps = {
   onClick?: () => void;
 };
 
-const frameStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  background: 'var(--color-surface, #fff)',
-  border: '1px solid var(--color-border, #e5e7eb)',
-  borderRadius: '8px',
-  padding: '16px',
-  height: '100%',
-  minHeight: '220px',
-  boxSizing: 'border-box',
-};
-
-const headerStyle: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'baseline',
-  justifyContent: 'space-between',
-  gap: '8px',
-  marginBottom: '12px',
-};
-
-const titleStyle: React.CSSProperties = {
-  fontSize: '14px',
-  fontWeight: 600,
-  color: 'var(--color-text, #111827)',
-  margin: 0,
-};
-
-const subtitleStyle: React.CSSProperties = {
-  fontSize: '12px',
-  color: 'var(--color-text-muted, #6b7280)',
-  marginTop: '2px',
-};
-
-const bodyStyle: React.CSSProperties = {
-  flex: 1,
-  position: 'relative',
-  minHeight: 0,
-};
-
-const stateStyle: React.CSSProperties = {
-  position: 'absolute',
-  inset: 0,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: 'var(--color-text-muted, #6b7280)',
-  fontSize: '13px',
-};
-
 export const ChartFrame: React.FC<ChartFrameProps> = ({
   title,
   subtitle,
@@ -83,7 +36,7 @@ export const ChartFrame: React.FC<ChartFrameProps> = ({
   onClick,
 }) => (
   <div
-    style={frameStyle}
+    className={styles.frame}
     onClick={onClick}
     onKeyDown={
       onClick
@@ -99,27 +52,24 @@ export const ChartFrame: React.FC<ChartFrameProps> = ({
     tabIndex={onClick ? 0 : undefined}
     data-testid='chart-frame'
   >
-    <div style={headerStyle}>
+    <div className={styles.header}>
       <div>
-        <h4 style={titleStyle}>{title}</h4>
-        {subtitle ? <div style={subtitleStyle}>{subtitle}</div> : null}
+        <h4 className={styles.title}>{title}</h4>
+        {subtitle ? <div className={styles.subtitle}>{subtitle}</div> : null}
       </div>
       {actions ? <div>{actions}</div> : null}
     </div>
-    <div style={bodyStyle}>
+    <div className={styles.body}>
       {isLoading ? (
-        <div style={stateStyle} data-testid='chart-loading'>
+        <div className={styles.state} data-testid='chart-loading'>
           Loading…
         </div>
       ) : error ? (
-        <div
-          style={{ ...stateStyle, color: 'var(--color-danger, #dc2626)' }}
-          data-testid='chart-error'
-        >
+        <div className={clsx(styles.state, styles.stateError)} data-testid='chart-error'>
           {error.message}
         </div>
       ) : isEmpty ? (
-        <div style={stateStyle} data-testid='chart-empty'>
+        <div className={styles.state} data-testid='chart-empty'>
           {emptyMessage}
         </div>
       ) : (

--- a/lib.components/src/components/charts/DataTable.css.ts
+++ b/lib.components/src/components/charts/DataTable.css.ts
@@ -1,0 +1,47 @@
+import { style } from '@vanilla-extract/css';
+
+export const scrollContainer = style({
+  height: '100%',
+  overflow: 'auto',
+});
+
+export const table = style({
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: '13px',
+});
+
+export const th = style({
+  textAlign: 'left',
+  padding: '8px 12px',
+  borderBottom: '1px solid var(--color-border, #e5e7eb)',
+  cursor: 'pointer',
+  color: 'var(--color-text-muted, #6b7280)',
+  fontWeight: 600,
+  background: 'var(--color-surface-muted, #f9fafb)',
+  position: 'sticky',
+  top: 0,
+});
+
+export const td = style({
+  padding: '8px 12px',
+  borderBottom: '1px solid var(--color-border, #e5e7eb)',
+  color: 'var(--color-text, #111827)',
+});
+
+export const rowClickable = style({
+  cursor: 'pointer',
+});
+
+export const rowDefault = style({
+  cursor: 'default',
+});
+
+export const pagination = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '8px',
+  fontSize: '12px',
+  color: 'var(--color-text-muted, #6b7280)',
+  paddingTop: '8px',
+});

--- a/lib.components/src/components/charts/DataTable.tsx
+++ b/lib.components/src/components/charts/DataTable.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { ChartFrame, type ChartFrameProps } from './ChartFrame';
+import * as styles from './DataTable.css';
 
 export type DataTableColumn = {
   key: string;
@@ -14,36 +15,6 @@ export type DataTableProps = Omit<ChartFrameProps, 'children' | 'isEmpty'> & {
   pageSize?: number;
   /** Optional callback when a row is clicked (used for drill-down). */
   onRowClick?: (row: Record<string, unknown>) => void;
-};
-
-const tableStyle: React.CSSProperties = {
-  width: '100%',
-  borderCollapse: 'collapse',
-  fontSize: '13px',
-};
-const thStyle: React.CSSProperties = {
-  textAlign: 'left',
-  padding: '8px 12px',
-  borderBottom: '1px solid var(--color-border, #e5e7eb)',
-  cursor: 'pointer',
-  color: 'var(--color-text-muted, #6b7280)',
-  fontWeight: 600,
-  background: 'var(--color-surface-muted, #f9fafb)',
-  position: 'sticky',
-  top: 0,
-};
-const tdStyle: React.CSSProperties = {
-  padding: '8px 12px',
-  borderBottom: '1px solid var(--color-border, #e5e7eb)',
-  color: 'var(--color-text, #111827)',
-};
-const paginationStyle: React.CSSProperties = {
-  display: 'flex',
-  justifyContent: 'flex-end',
-  gap: '8px',
-  fontSize: '12px',
-  color: 'var(--color-text-muted, #6b7280)',
-  paddingTop: '8px',
 };
 
 const compareCells = (a: unknown, b: unknown): number => {
@@ -94,14 +65,14 @@ export const DataTable: React.FC<DataTableProps> = ({
 
   return (
     <ChartFrame {...frame} isEmpty={rows.length === 0}>
-      <div style={{ height: '100%', overflow: 'auto' }}>
-        <table style={tableStyle}>
+      <div className={styles.scrollContainer}>
+        <table className={styles.table}>
           <thead>
             <tr>
               {columns.map(col => (
                 <th
                   key={col.key}
-                  style={thStyle}
+                  className={styles.th}
                   onClick={() => handleSort(col.key)}
                   data-testid={`th-${col.key}`}
                 >
@@ -116,10 +87,10 @@ export const DataTable: React.FC<DataTableProps> = ({
               <tr
                 key={i}
                 onClick={() => onRowClick?.(row)}
-                style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+                className={onRowClick ? styles.rowClickable : styles.rowDefault}
               >
                 {columns.map(col => (
-                  <td key={col.key} style={tdStyle}>
+                  <td key={col.key} className={styles.td}>
                     {col.render ? col.render(row[col.key], row) : String(row[col.key] ?? '')}
                   </td>
                 ))}
@@ -128,7 +99,7 @@ export const DataTable: React.FC<DataTableProps> = ({
           </tbody>
         </table>
         {totalPages > 1 ? (
-          <div style={paginationStyle}>
+          <div className={styles.pagination}>
             <button
               type='button'
               disabled={safePage === 0}

--- a/lib.components/src/components/charts/MetricCard.css.ts
+++ b/lib.components/src/components/charts/MetricCard.css.ts
@@ -1,0 +1,38 @@
+import { style } from '@vanilla-extract/css';
+
+export const card = style({
+  display: 'flex',
+  flexDirection: 'column',
+  background: 'var(--color-surface, #fff)',
+  border: '1px solid var(--color-border, #e5e7eb)',
+  borderRadius: '8px',
+  padding: '16px',
+  height: '100%',
+  minHeight: '110px',
+  boxSizing: 'border-box',
+});
+
+export const label = style({
+  fontSize: '12px',
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  color: 'var(--color-text-muted, #6b7280)',
+  margin: 0,
+});
+
+export const value = style({
+  fontSize: '28px',
+  fontWeight: 700,
+  color: 'var(--color-text, #111827)',
+  margin: '4px 0',
+});
+
+export const delta = style({
+  fontSize: '12px',
+  fontWeight: 600,
+});
+
+export const helper = style({
+  fontSize: '12px',
+  color: 'var(--color-text-muted, #6b7280)',
+});

--- a/lib.components/src/components/charts/MetricCard.tsx
+++ b/lib.components/src/components/charts/MetricCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as styles from './MetricCard.css';
 
 export type MetricCardFormat = 'number' | 'percent' | 'currency' | 'duration';
 
@@ -10,38 +11,6 @@ export type MetricCardProps = {
   deltaInverted?: boolean;
   format?: MetricCardFormat;
   helperText?: string;
-};
-
-const cardStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  background: 'var(--color-surface, #fff)',
-  border: '1px solid var(--color-border, #e5e7eb)',
-  borderRadius: '8px',
-  padding: '16px',
-  height: '100%',
-  minHeight: '110px',
-  boxSizing: 'border-box',
-};
-
-const labelStyle: React.CSSProperties = {
-  fontSize: '12px',
-  textTransform: 'uppercase',
-  letterSpacing: '0.04em',
-  color: 'var(--color-text-muted, #6b7280)',
-  margin: 0,
-};
-
-const valueStyle: React.CSSProperties = {
-  fontSize: '28px',
-  fontWeight: 700,
-  color: 'var(--color-text, #111827)',
-  margin: '4px 0',
-};
-
-const helperStyle: React.CSSProperties = {
-  fontSize: '12px',
-  color: 'var(--color-text-muted, #6b7280)',
 };
 
 const formatValue = (value: number | string, format: MetricCardFormat | undefined): string => {
@@ -88,21 +57,15 @@ export const MetricCard: React.FC<MetricCardProps> = ({
   format,
   helperText,
 }) => (
-  <div style={cardStyle} data-testid='metric-card'>
-    <h4 style={labelStyle}>{label}</h4>
-    <div style={valueStyle}>{formatValue(value, format)}</div>
+  <div className={styles.card} data-testid='metric-card'>
+    <h4 className={styles.label}>{label}</h4>
+    <div className={styles.value}>{formatValue(value, format)}</div>
     {typeof delta === 'number' ? (
-      <div
-        style={{
-          fontSize: '12px',
-          fontWeight: 600,
-          color: deltaColor(delta, !!deltaInverted),
-        }}
-      >
+      <div className={styles.delta} style={{ color: deltaColor(delta, !!deltaInverted) }}>
         {delta > 0 ? '+' : ''}
         {(delta * 100).toFixed(1)}%
       </div>
     ) : null}
-    {helperText ? <div style={helperStyle}>{helperText}</div> : null}
+    {helperText ? <div className={styles.helper}>{helperText}</div> : null}
   </div>
 );

--- a/lib.components/src/components/reports/ReportBuilder.css.ts
+++ b/lib.components/src/components/reports/ReportBuilder.css.ts
@@ -1,0 +1,96 @@
+import { style } from '@vanilla-extract/css';
+
+export const layout = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 2fr',
+  gap: '16px',
+  alignItems: 'start',
+});
+
+export const sidebar = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+});
+
+export const widgetRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '8px 12px',
+  border: '1px solid var(--color-border, #e5e7eb)',
+  borderRadius: '6px',
+  background: 'var(--color-surface, #fff)',
+  fontSize: '13px',
+});
+
+export const buttonRow = style({
+  display: 'flex',
+  gap: '8px',
+  marginTop: '12px',
+});
+
+export const columnsBar = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '8px 12px',
+  border: '1px solid var(--color-border, #e5e7eb)',
+  borderRadius: '8px',
+});
+
+export const columnsLabel = style({
+  fontSize: '13px',
+});
+
+export const columnsButtons = style({
+  display: 'flex',
+  gap: '4px',
+});
+
+export const columnsButton = style({
+  padding: '4px 10px',
+  border: '1px solid var(--color-border, #e5e7eb)',
+  borderRadius: '4px',
+  background: 'transparent',
+  color: 'inherit',
+  cursor: 'pointer',
+});
+
+export const columnsButtonActive = style({
+  background: 'var(--color-primary, #2563eb)',
+  color: '#fff',
+});
+
+export const widgetsHeading = style({
+  fontSize: '13px',
+  margin: '8px 0',
+});
+
+export const widgetsList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+});
+
+export const widgetMeta = style({
+  fontSize: '11px',
+  color: '#6b7280',
+});
+
+export const widgetActions = style({
+  display: 'flex',
+  gap: '4px',
+});
+
+export const saveButton = style({
+  marginLeft: 'auto',
+});
+
+export const emptyPreview = style({
+  border: '1px dashed var(--color-border, #e5e7eb)',
+  borderRadius: '8px',
+  padding: '40px',
+  textAlign: 'center',
+  color: '#6b7280',
+});

--- a/lib.components/src/components/reports/ReportBuilder.tsx
+++ b/lib.components/src/components/reports/ReportBuilder.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import { FilterPanel, type FilterPanelValue } from './FilterPanel';
 import { WidgetPicker, type WidgetPreset } from './WidgetPicker';
 import { ReportRenderer, type ReportRendererWidget } from './ReportRenderer';
+import * as styles from './ReportBuilder.css';
 
 /**
  * ADS-105: Form-based custom report builder.
@@ -36,36 +38,6 @@ export type ReportBuilderProps = {
   /** Save action — typically calls useSaveReport / useUpdateReport. */
   onSave?: () => void;
   isSaving?: boolean;
-};
-
-const layoutStyle: React.CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: '1fr 2fr',
-  gap: '16px',
-  alignItems: 'start',
-};
-
-const sidebarStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '12px',
-};
-
-const widgetRowStyle: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  padding: '8px 12px',
-  border: '1px solid var(--color-border, #e5e7eb)',
-  borderRadius: '6px',
-  background: 'var(--color-surface, #fff)',
-  fontSize: '13px',
-};
-
-const buttonRowStyle: React.CSSProperties = {
-  display: 'flex',
-  gap: '8px',
-  marginTop: '12px',
 };
 
 const generateId = (): string => {
@@ -131,40 +103,26 @@ export const ReportBuilder: React.FC<ReportBuilderProps> = ({
   };
 
   return (
-    <div data-testid='report-builder' style={layoutStyle}>
-      <div style={sidebarStyle}>
+    <div data-testid='report-builder' className={styles.layout}>
+      <div className={styles.sidebar}>
         <FilterPanel
           value={config.filters}
           onChange={filters => onChange({ ...config, filters })}
           extraFields={filterExtras}
         />
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '8px 12px',
-            border: '1px solid var(--color-border, #e5e7eb)',
-            borderRadius: '8px',
-          }}
-        >
-          <span style={{ fontSize: '13px' }}>Grid columns</span>
-          <div style={{ display: 'flex', gap: '4px' }}>
+        <div className={styles.columnsBar}>
+          <span className={styles.columnsLabel}>Grid columns</span>
+          <div className={styles.columnsButtons}>
             {[1, 2, 3, 4].map(n => (
               <button
                 key={n}
                 type='button'
                 onClick={() => handleColumns(n as 1 | 2 | 3 | 4)}
                 aria-pressed={config.layout.columns === n}
-                style={{
-                  padding: '4px 10px',
-                  border: '1px solid var(--color-border, #e5e7eb)',
-                  borderRadius: '4px',
-                  background:
-                    config.layout.columns === n ? 'var(--color-primary, #2563eb)' : 'transparent',
-                  color: config.layout.columns === n ? '#fff' : 'inherit',
-                  cursor: 'pointer',
-                }}
+                className={clsx(
+                  styles.columnsButton,
+                  config.layout.columns === n && styles.columnsButtonActive
+                )}
               >
                 {n}
               </button>
@@ -172,17 +130,17 @@ export const ReportBuilder: React.FC<ReportBuilderProps> = ({
           </div>
         </div>
         <div>
-          <h4 style={{ fontSize: '13px', margin: '8px 0' }}>Widgets ({config.widgets.length})</h4>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <h4 className={styles.widgetsHeading}>Widgets ({config.widgets.length})</h4>
+          <div className={styles.widgetsList}>
             {config.widgets.map((widget, i) => (
-              <div key={widget.id} style={widgetRowStyle}>
+              <div key={widget.id} className={styles.widgetRow}>
                 <div>
                   <strong>{widget.title}</strong>
-                  <div style={{ fontSize: '11px', color: '#6b7280' }}>
+                  <div className={styles.widgetMeta}>
                     {widget.metric} · {widget.chartType}
                   </div>
                 </div>
-                <div style={{ display: 'flex', gap: '4px' }}>
+                <div className={styles.widgetActions}>
                   <button type='button' onClick={() => handleMove(i, -1)} aria-label='Move up'>
                     ↑
                   </button>
@@ -201,7 +159,7 @@ export const ReportBuilder: React.FC<ReportBuilderProps> = ({
             ))}
           </div>
         </div>
-        <div style={buttonRowStyle}>
+        <div className={styles.buttonRow}>
           <button type='button' onClick={() => setPickerOpen(true)} data-testid='add-widget'>
             Add widget
           </button>
@@ -211,7 +169,7 @@ export const ReportBuilder: React.FC<ReportBuilderProps> = ({
               onClick={onSave}
               disabled={isSaving}
               data-testid='save-report'
-              style={{ marginLeft: 'auto' }}
+              className={styles.saveButton}
             >
               {isSaving ? 'Saving…' : 'Save'}
             </button>
@@ -220,17 +178,7 @@ export const ReportBuilder: React.FC<ReportBuilderProps> = ({
       </div>
       <div>
         {config.widgets.length === 0 ? (
-          <div
-            style={{
-              border: '1px dashed var(--color-border, #e5e7eb)',
-              borderRadius: '8px',
-              padding: '40px',
-              textAlign: 'center',
-              color: '#6b7280',
-            }}
-          >
-            Add a widget to start building your report.
-          </div>
+          <div className={styles.emptyPreview}>Add a widget to start building your report.</div>
         ) : (
           <ReportRenderer
             config={{

--- a/lib.components/src/components/reports/WidgetPicker.css.ts
+++ b/lib.components/src/components/reports/WidgetPicker.css.ts
@@ -1,0 +1,60 @@
+import { style } from '@vanilla-extract/css';
+
+export const overlay = style({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(15, 23, 42, 0.4)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 50,
+});
+
+export const panel = style({
+  background: 'var(--color-surface, #fff)',
+  borderRadius: '12px',
+  padding: '20px',
+  width: 'min(640px, 90vw)',
+  maxHeight: '80vh',
+  overflowY: 'auto',
+});
+
+export const heading = style({
+  marginTop: 0,
+});
+
+export const presetGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+  gap: '8px',
+});
+
+export const presetButton = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  textAlign: 'left',
+  padding: '12px',
+  border: '1px solid var(--color-border, #e5e7eb)',
+  borderRadius: '8px',
+  background: 'var(--color-surface, #fff)',
+  cursor: 'pointer',
+  width: '100%',
+});
+
+export const presetLabel = style({
+  fontSize: '13px',
+});
+
+export const presetDescription = style({
+  fontSize: '12px',
+  color: 'var(--color-text-muted, #6b7280)',
+  marginTop: '4px',
+});
+
+export const footer = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '8px',
+  marginTop: '16px',
+});

--- a/lib.components/src/components/reports/WidgetPicker.tsx
+++ b/lib.components/src/components/reports/WidgetPicker.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import * as styles from './WidgetPicker.css';
 
 /**
  * ADS-105: Modal/picker for adding a widget.
@@ -104,38 +105,6 @@ export type WidgetPickerProps = {
   onClose?: () => void;
 };
 
-const overlayStyle: React.CSSProperties = {
-  position: 'fixed',
-  inset: 0,
-  background: 'rgba(15, 23, 42, 0.4)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  zIndex: 50,
-};
-
-const panelStyle: React.CSSProperties = {
-  background: 'var(--color-surface, #fff)',
-  borderRadius: '12px',
-  padding: '20px',
-  width: 'min(640px, 90vw)',
-  maxHeight: '80vh',
-  overflowY: 'auto',
-};
-
-const presetStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-start',
-  textAlign: 'left',
-  padding: '12px',
-  border: '1px solid var(--color-border, #e5e7eb)',
-  borderRadius: '8px',
-  background: 'var(--color-surface, #fff)',
-  cursor: 'pointer',
-  width: '100%',
-};
-
 export const WidgetPicker: React.FC<WidgetPickerProps> = ({
   presets = DEFAULT_PRESETS,
   onAdd,
@@ -157,38 +126,24 @@ export const WidgetPicker: React.FC<WidgetPickerProps> = ({
   }, [onClose]);
 
   return (
-    <div style={overlayStyle} role='presentation'>
-      <div style={panelStyle} role='dialog' aria-modal='true'>
-        <h3 style={{ marginTop: 0 }}>Add a widget</h3>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
-            gap: '8px',
-          }}
-        >
+    <div className={styles.overlay} role='presentation'>
+      <div className={styles.panel} role='dialog' aria-modal='true'>
+        <h3 className={styles.heading}>Add a widget</h3>
+        <div className={styles.presetGrid}>
           {presets.map(preset => (
             <button
               key={preset.id}
               type='button'
-              style={presetStyle}
+              className={styles.presetButton}
               onClick={() => onAdd(preset)}
               data-testid={`widget-preset-${preset.id}`}
             >
-              <strong style={{ fontSize: '13px' }}>{preset.label}</strong>
-              <span
-                style={{
-                  fontSize: '12px',
-                  color: 'var(--color-text-muted, #6b7280)',
-                  marginTop: '4px',
-                }}
-              >
-                {preset.description}
-              </span>
+              <strong className={styles.presetLabel}>{preset.label}</strong>
+              <span className={styles.presetDescription}>{preset.description}</span>
             </button>
           ))}
         </div>
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '16px' }}>
+        <div className={styles.footer}>
           <button type='button' onClick={onClose}>
             Close
           </button>

--- a/lib.components/src/components/ui/Logo.css.ts
+++ b/lib.components/src/components/ui/Logo.css.ts
@@ -21,3 +21,11 @@ export const wordmark = style({
 export const wordmarkDark = style({
   color: '#FFFFFF',
 });
+
+export const wordmarkBold = style({
+  fontWeight: 700,
+});
+
+export const wordmarkSemibold = style({
+  fontWeight: 600,
+});

--- a/lib.components/src/components/ui/Logo.tsx
+++ b/lib.components/src/components/ui/Logo.tsx
@@ -123,8 +123,8 @@ export const Logo: React.FC<LogoProps> = ({
         data-dark={darkBg ? 'true' : undefined}
         aria-label='AdoptDontShop'
       >
-        <span style={{ fontWeight: 700 }}>Adopt</span>
-        <span style={{ fontWeight: 600 }}>DontShop</span>
+        <span className={styles.wordmarkBold}>Adopt</span>
+        <span className={styles.wordmarkSemibold}>DontShop</span>
       </span>
     </span>
   );


### PR DESCRIPTION
## Summary

- Continues the ADS-522 migration by replacing static `style={{...}}` blocks across `app.admin`, `app.client`, `app.rescue`, and `lib.components` with vanilla-extract `.css.ts` classes.
- Adds 15 new `.css.ts` files for components that didn't have one yet (e.g. `BulkActionBar`, `FosterCoordination`, `ChartFrame`, `MetricCard`, `WidgetPicker`, `ReportBuilder`, `PrivacyTools`, several admin & rescue `ReportBuilderPage`/`ReportViewPage`/`Reports`).
- Extends 30+ existing `.css.ts` files with new exports and rewrites the corresponding `.tsx` files to use `className={styles.foo}` (often via `clsx`) instead of inline `style` attributes.
- Truly dynamic styles are intentionally left inline per agreement: react-spring animated transforms (`SwipeCard`, `SwipeStack`), data-driven gradients / heights (`Analytics` bars, `AdoptionChart`, `ApplicationTimeline`, `EventCalendar` event colors, `ApplicationStageCard` outcome colors, etc.), per-instance widths from props (`Skeleton`, `Table` column widths, progress bars), and runtime DOM-manipulation targets (`PetDetailsPage` image fallbacks).
- A few stylistic side-effects: where `style={{}}` had to be removed from a component prop (`Button`, `FilterBar`, `Skeleton`, `Text`, `Card`), the equivalent class is forwarded via the component's existing `className` prop instead.

## Test plan

- [ ] `npx turbo run type-check --filter=…` passes for `app.admin`, `app.client`, `app.rescue`, `lib.components` (only pre-existing `Users.tsx` toast-signature errors remain, unrelated to this PR — verified by stashing the diff).
- [ ] `npx turbo run lint --filter=…` reports **0 errors** across the four packages (warnings are pre-existing).
- [ ] `npx turbo run test --filter=…` passes for `app.client`, `app.rescue`, `lib.components`; `app.admin` retains the same 53 pre-existing failures as `main` (unrelated `useCreateUser` mock issue).
- [ ] Manually verify in a running app that:
  - Admin modals (Application/Pet/User/Ticket/Rescue/Chat detail, ReportDetail, SendEmail) still render with correct spacing and grid layouts.
  - Admin pages (Dashboard, Analytics, Configuration, ContentManagement, FieldPermissions, Messages, Pets, PrivacyTools, Rescues, Users, ReportBuilder, ReportView) look unchanged.
  - Rescue Dashboard metric cards, charts, status distribution, notifications panel render correctly (this file was the largest rewrite — 74 inline styles → classes).
  - Rescue Foster Coordination modals still center over the overlay.
  - Client home page hero buttons keep their custom white/transparent variants.
  - `lib.components` charts (ChartFrame, DataTable, MetricCard) and report builder (ReportBuilder, WidgetPicker) keep their visual layout.

https://claude.ai/code/session_01SEWgGTbP2xtYzMU9twusEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEWgGTbP2xtYzMU9twusEV)_