### PR TITLE
ci: streamline PR pipeline (smoke E2E, gate prod-image builds on push)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,7 +13,15 @@ This directory contains GitHub Actions workflows for the Adopt Don't Shop platfo
 - ✅ Tests backend with PostgreSQL database
 - ✅ Tests all frontend applications in parallel
 - ✅ Runs linting and builds for all projects
+- ✅ Runs Playwright E2E against the full docker-compose stack
 - ✅ Ensures code quality before merging
+
+**E2E strategy**:
+
+- **Pull request**: runs `--grep @smoke` (2 critical journeys: adopter registration + full adoption journey). ~3-5 min of test runtime on top of the stack-up step.
+- **Push to main/develop**: runs the full Playwright suite as the integration gate before `deploy.yml`.
+
+Tag a test with `@smoke` in its title to add it to the PR set. Keep the smoke set small — its job is to catch obvious integration breaks, not to be a coverage proxy. Unit/integration coverage lives in `test-backend`, `test-frontend`, and `test-libs`.
 
 **Triggers**: Push/PR to `main` or `develop` branches
 
@@ -36,16 +44,20 @@ This directory contains GitHub Actions workflows for the Adopt Don't Shop platfo
 
 ### 🐳 **Docker Workflow** (`docker.yml`)
 
-**Purpose**: Container building and Docker Compose testing.
+**Purpose**: Container build validation and pre-deploy production-image gate.
 
 **What it does**:
 
-- 🏗️ Builds Docker images for all services
-- 🧪 Tests Docker Compose stack
-- ✅ Validates container health and connectivity
+- 🏗️ Builds development images (PR + push)
+- 🚀 Builds production images + runs Trivy vulnerability scan (push to main/develop only)
 - 💾 Uses GitHub Actions cache for faster builds
 
-**Triggers**: Changes to Dockerfiles or service code
+**Triggers**:
+
+- **Pull request**: only on changes to Dockerfiles, `docker-compose*.yml`, or `.dockerignore`. Source-only PRs are validated by `ci.yml` (`test-frontend`/`test-backend` run native `npm run build`, and `test-e2e` brings the dev stack up via `docker compose up --build`).
+- **Push to main/develop**: triggers on the broader source path set so a regression that only manifests inside a container is caught before deploy. Production images and the Trivy scan run only on this branch — `deploy.yml` is the consumer.
+
+**Note**: the previous `test-compose` job (backend-container `/health` probe) was removed; `ci.yml`'s `test-e2e` brings up the full stack and is a strict superset of that signal.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,11 +450,21 @@ jobs:
           done
 
       - name: Run Playwright suite
-        # The backend bootstraps the database (sync + runAllSeeders) on
-        # startup in development mode, so by the time /health responds in
-        # the previous step the seeded data is already available.
+        # PRs run the @smoke subset (~2 critical journeys, ~3-5 min). Push
+        # to main/develop runs the full suite as the integration gate
+        # before deploy. The full set still runs on PR via the smoke
+        # signal + the unit/integration jobs; tagging more tests as
+        # @smoke is the lever if you want broader PR coverage.
+        #
         # Retries are configured in e2e/playwright.config.ts (retries: CI ? 2 : 0).
-        run: npm run test:e2e
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR event — running @smoke subset"
+            npm run test:e2e:smoke
+          else
+            echo "${{ github.event_name }} on ${{ github.ref }} — running full suite"
+            npm run test:e2e
+          fi
 
       # ADS-386: Surface flaky-retry signal so engineers can see which tests
       # needed retries without having to open the full HTML report.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,18 @@
 name: Docker
 
+# Two-tier strategy (ADS-streamline-ci):
+#
+# - Pull requests trigger this workflow ONLY when Docker plumbing actually
+#   changes (Dockerfiles, compose files, .dockerignore). Source-only PRs
+#   are covered by `ci.yml`'s native `npm run build` and by the E2E job,
+#   which does `docker compose up --build` and is the de-facto Dockerfile
+#   smoke test for the dev images.
+# - Push to main/develop keeps the broader source path set so a regression
+#   that only manifests inside a container is caught before deploy.
+# - Production-stage builds + Trivy run only on push events. The PR loop
+#   doesn't deploy prod images, so re-running the multi-stage prod build
+#   on every PR was duplicating native `tsc + vite build` from ci.yml.
+
 on:
   push:
     branches: [main, develop]
@@ -16,11 +29,6 @@ on:
     branches: [main, develop]
     paths:
       - '**/Dockerfile*'
-      - 'service.backend/**'
-      - 'app.client/**'
-      - 'app.admin/**'
-      - 'app.rescue/**'
-      - 'lib.*/**'
       - 'docker-compose*.yml'
       - '.dockerignore'
 
@@ -55,7 +63,7 @@ jobs:
             network=host
 
       - name: Log in to GHCR (for Trivy DB pulls)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.0.0
         with:
           registry: ghcr.io
@@ -74,7 +82,13 @@ jobs:
           cache-to: type=gha,mode=max,ignore-error=true
           build-args: BUILDKIT_INLINE_CACHE=1
 
+      # Production build + Trivy scan are deploy-gating signals, not PR
+      # signals: ci.yml's test-backend already exercises `tsc` natively, so
+      # rebuilding the multi-stage prod image on every PR was duplicative.
+      # Keeping them on push-to-main ensures we still catch prod-only
+      # regressions (npm prune fallout, asset paths) before deploy.yml runs.
       - name: Build production image
+        if: github.event_name == 'push'
         id: build-prod
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
@@ -89,7 +103,7 @@ jobs:
           build-args: BUILDKIT_INLINE_CACHE=1
 
       - name: Run Trivy vulnerability scanner
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -104,7 +118,7 @@ jobs:
               paragonjenko/adoptdontshop:service-backend-prod-${{ github.sha }}
 
       - name: Upload Trivy results to GitHub Security tab
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'push' && always()
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
         with:
           sarif_file: 'trivy-results.sarif'
@@ -145,7 +159,11 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
+      # Push-only: the prod stage re-runs `tsc && vite build` inside Docker,
+      # which ci.yml's test-frontend matrix already runs natively. Keep it
+      # on main pushes as a final pre-deploy gate.
       - name: Build production image
+        if: github.event_name == 'push'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
@@ -159,111 +177,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
-  # ============================================================================
-  # INTEGRATION TEST — verify the backend container starts and is healthy.
-  # Frontend apps are validated via their own build jobs and Vitest test suites;
-  # starting 3 Vite dev servers in compose adds ~15 min for a grep-html check
-  # that provides no real signal.
-  # ============================================================================
-  test-compose:
-    name: Test Docker Compose Stack
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY"
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:latest
-            network=host
-
-      - name: Generate secrets
-        id: secrets
-        run: |
-          echo "JWT_SECRET=$(openssl rand -base64 32)" >> $GITHUB_OUTPUT
-          echo "JWT_REFRESH_SECRET=$(openssl rand -base64 32)" >> $GITHUB_OUTPUT
-          echo "SESSION_SECRET=$(openssl rand -base64 32)" >> $GITHUB_OUTPUT
-          echo "CSRF_SECRET=$(openssl rand -base64 32)" >> $GITHUB_OUTPUT
-          echo "ENCRYPTION_KEY=$(openssl rand -hex 32)" >> $GITHUB_OUTPUT
-          echo "POSTGRES_PASSWORD=$(openssl rand -base64 32)" >> $GITHUB_OUTPUT
-
-      - name: Create environment file
-        run: |
-          {
-            echo "NODE_ENV=development"
-            # Postgres container vars (consumed by the database image itself)
-            echo "POSTGRES_USER=postgres"
-            echo "POSTGRES_PASSWORD=${{ steps.secrets.outputs.POSTGRES_PASSWORD }}"
-            echo "POSTGRES_DB=adopt_dont_shop_dev"
-            # Backend-side DB vars (consumed by service.backend config schema —
-            # ADS-409/452 required these to be distinct from the generic
-            # POSTGRES_* family the postgres image uses).
-            echo "DB_USERNAME=postgres"
-            echo "DB_PASSWORD=${{ steps.secrets.outputs.POSTGRES_PASSWORD }}"
-            echo "DB_HOST=database"
-            echo "DB_PORT=5432"
-            echo "DEV_DB_NAME=adopt_dont_shop_dev"
-            echo "TEST_DB_NAME=adopt_dont_shop_test"
-            echo "PROD_DB_NAME=adopt_dont_shop_prod"
-            # Auth / session secrets
-            echo "JWT_SECRET=${{ steps.secrets.outputs.JWT_SECRET }}"
-            echo "JWT_REFRESH_SECRET=${{ steps.secrets.outputs.JWT_REFRESH_SECRET }}"
-            echo "SESSION_SECRET=${{ steps.secrets.outputs.SESSION_SECRET }}"
-            echo "CSRF_SECRET=${{ steps.secrets.outputs.CSRF_SECRET }}"
-            echo "ENCRYPTION_KEY=${{ steps.secrets.outputs.ENCRYPTION_KEY }}"
-            # CORS / public URLs
-            echo "CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002"
-            echo "FRONTEND_URL=http://localhost:3000"
-            echo "RESCUE_FRONTEND_URL=http://localhost:3002"
-            echo "API_URL=http://localhost:5000"
-          } > .env
-
-      - name: Start database and cache
-        run: |
-          docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d database redis
-          timeout 60 bash -c 'until docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T database pg_isready -U postgres; do sleep 2; done'
-
-      - name: Build and start backend
-        run: |
-          docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d service-backend
-
-          # 180s ceiling: cold ts-node-dev start + 5×5s DB retry loop + 3s PostGIS settle +
-          # citext + immutable-created-at + iso-check trigger DDL + Express listen.
-          # The previous 90s figure was tight even before the audit added Sentry,
-          # prom-client, audit-log triggers, and the retention worker init.
-          #
-          # Inline-stream the backend's stdout/stderr in the background so a
-          # crash-loop or missing-env failure is visible in the CI step output
-          # itself (WebFetch on the run page can't read the post-failure
-          # `docker compose logs` step). Tail keeps running until curl wins,
-          # at which point the script exits and the tail is cleaned up.
-          docker compose -f docker-compose.yml -f docker-compose.ci.yml logs --follow service-backend &
-          tail_pid=$!
-          trap "kill $tail_pid 2>/dev/null || true" EXIT
-          timeout 180 bash -c 'until curl -sf http://localhost:5000/health; do sleep 3; done'
-
-      - name: Verify backend health endpoint
-        run: curl -sf http://localhost:5000/health
-
-      - name: Show container status
-        if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml ps
-
-      - name: Show logs on failure
-        if: failure()
-        run: |
-          echo "=== Backend ==="
-          docker compose -f docker-compose.yml -f docker-compose.ci.yml logs service-backend
-          echo "=== Database ==="
-          docker compose -f docker-compose.yml -f docker-compose.ci.yml logs database
-
-      - name: Cleanup
-        if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
-
+# NOTE: The previous `test-compose` job (backend-container `/health` probe)
+# was removed as part of the CI streamline pass. ci.yml's `test-e2e` brings
+# up the same stack via `docker compose up -d --build` and would fail
+# loudly if the backend didn't reach `/health` — `test-compose` was a
+# strict subset of that signal and added ~5 min on every relevant PR.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,6 +6,7 @@
   "description": "End-to-end tests for adopt-dont-shop. Behaviour-focused journeys across app.client, app.rescue and app.admin driven by Playwright.",
   "scripts": {
     "test": "playwright test",
+    "test:smoke": "playwright test --grep @smoke",
     "test:ui": "playwright test --ui",
     "test:debug": "PWDEBUG=1 playwright test",
     "test:headed": "playwright test --headed",

--- a/e2e/tests/client/adoption-application.spec.ts
+++ b/e2e/tests/client/adoption-application.spec.ts
@@ -1,9 +1,5 @@
 import { test, expect } from '../../fixtures';
-import {
-  SEEDED_PET_IDS,
-  createAdopterApplication,
-  patchWithCsrf,
-} from '../../helpers/seeds';
+import { SEEDED_PET_IDS, createAdopterApplication, patchWithCsrf } from '../../helpers/seeds';
 
 /**
  * Adoption golden path (ADS-420).
@@ -45,7 +41,7 @@ test.describe('adoption application submission', () => {
     await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible({ timeout: 15_000 });
   });
 
-  test('full adoption journey: submit application → rescue approves → adopter sees approval', async ({
+  test('full adoption journey: submit application → rescue approves → adopter sees approval @smoke', async ({
     page,
     apiAs,
   }) => {

--- a/e2e/tests/client/registration-and-login.spec.ts
+++ b/e2e/tests/client/registration-and-login.spec.ts
@@ -4,7 +4,7 @@ import { URLS } from '../../playwright.config';
 import { request as playwrightRequest } from '@playwright/test';
 
 test.describe('adopter registration and login', () => {
-  test('a new adopter can register via the public API', async () => {
+  test('a new adopter can register via the public API @smoke', async () => {
     // Drive registration through the backend directly.  The UI form has a
     // custom-styled Terms checkbox whose onChange handler only fires under
     // an actual user gesture — Playwright's check({ force: true }) under

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "build:apps": "turbo run build --filter='@adopt-dont-shop/app.*'",
     "test": "turbo run test",
     "test:e2e": "npm run -w @adopt-dont-shop/e2e test",
+    "test:e2e:smoke": "npm run -w @adopt-dont-shop/e2e test:smoke",
     "test:e2e:ui": "npm run -w @adopt-dont-shop/e2e test:ui",
     "test:e2e:debug": "npm run -w @adopt-dont-shop/e2e test:debug",
     "test:e2e:headed": "npm run -w @adopt-dont-shop/e2e test:headed",


### PR DESCRIPTION
## Summary

Removes duplicate CI work that was running the same builds across `ci.yml` and `docker.yml` on every PR. Net -65 lines.

## What's redundant today

For each frontend app on every PR, the same code was being type-checked / built **up to 5 times**:

| # | Where | What |
|---|-------|------|
| 1 | `ci.yml test-frontend` | `npm test` (vitest) |
| 2 | `ci.yml test-frontend` | `npx turbo run type-check` |
| 3 | `ci.yml test-frontend` | `npm run build` (`tsc && vite build`) |
| 4 | `docker.yml build-apps` | Dev image build |
| 5 | `docker.yml build-apps` | **Prod image build** (`tsc && vite build` via turbo) |
| 6 | `ci.yml test-e2e` | `docker compose build` of dev images |

A single TS error lit up red across 3+ jobs.

## Changes

**`docker.yml`**

- PR triggers narrowed to Dockerfile/compose/`.dockerignore` only. Source-only PRs are covered by `ci.yml`'s native build + `test-e2e`'s `docker compose up --build`.
- Push to main/develop keeps the broader source path set.
- Production-stage builds + Trivy now run only on push events. Multi-stage prod builds duplicated what `test-backend` / `test-frontend` already exercise natively.
- Removed the `test-compose` job. `test-e2e` brings up the same stack and is a strict superset of the backend `/health` probe.

**`ci.yml`**

- E2E now runs `--grep @smoke` on PRs (~2 critical journeys, ~3-5 min) and the full suite on push to main/develop (the integration gate before `deploy.yml`).

**E2E**

- Tagged two tests with `@smoke`:
  - `client/registration-and-login.spec.ts`: new-adopter registration via the public API
  - `client/adoption-application.spec.ts`: full journey (submit → rescue approves → adopter sees approval)
- Added `test:smoke` / `test:e2e:smoke` scripts.

## E2E on PR rationale

Keeping E2E on PRs but trimmed. Dropping E2E from PR entirely shifts the cost from "PR is broken, fix it" to "main is broken, drop everything to revert," which is too high a blast radius for 3 apps + a backend without a merge queue. The smoke set is the cheapest signal that catches obvious integration breaks.

Tag more tests with `@smoke` if you want broader PR coverage. Keep the set small — coverage lives in `test-backend`, `test-frontend`, and `test-libs`.

## Test plan

- [ ] On this PR (it should run): `docker.yml` does not run (no Dockerfile changes touched). `ci.yml > test-e2e` runs `--grep @smoke` (2 tests).
- [ ] Open a follow-up PR touching `service.backend/Dockerfile`: `docker.yml` runs but the prod-image step is skipped (`if: github.event_name == 'push'`).
- [ ] After merge to main, full E2E + prod-image builds + Trivy all run on the push event.
- [ ] Confirm branch protection (if any rules pin to `Test Docker Compose Stack`) — that check no longer exists.

https://claude.ai/code/session_01M9Ga3BxHSFyxDUaWKezacy

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9Ga3BxHSFyxDUaWKezacy)_