### PR TITLE
fix(app.client): merge duplicate lib.components import in SwipeCard

### DIFF
--- a/app.client/src/components/swipe/SwipeCard.tsx
+++ b/app.client/src/components/swipe/SwipeCard.tsx
@@ -1,6 +1,6 @@
 import { useStatsig } from '@/hooks/useStatsig';
 import { DiscoveryPet } from '@/services';
-import { ProgressiveImage } from '@adopt-dont-shop/lib.components';
+import { MatchReasonChips, ProgressiveImage } from '@adopt-dont-shop/lib.components';
 import { animated, to, useSpring } from '@react-spring/web';
 import { useDrag } from '@use-gesture/react';
 import React, { useCallback, useRef, useState } from 'react';
@@ -15,7 +15,6 @@ import {
 } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { resolveFileUrl } from '../../utils/fileUtils';
-import { MatchReasonChips } from '@adopt-dont-shop/lib.components';
 import * as styles from './SwipeCard.css';
 
 interface SwipeCardProps {


### PR DESCRIPTION
## Summary
- `app.client/src/components/swipe/SwipeCard.tsx` imported from `@adopt-dont-shop/lib.components` twice — `ProgressiveImage` at the top of the file and `MatchReasonChips` further down — which tripped the `no-duplicate-imports` ESLint rule and broke `main`.
- Merges both named imports into a single statement at the top of the file.

## Test plan
- [ ] `npx turbo lint --filter=@adopt-dont-shop/app.client` passes (no `no-duplicate-imports` error on `SwipeCard.tsx`)
- [ ] `npx turbo type-check --filter=@adopt-dont-shop/app.client` still passes
- [ ] `SwipeCard` still renders `ProgressiveImage` and `MatchReasonChips` correctly in the swipe flow

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPy6CMzmAiobXFxauBMmVv)_