### PR TITLE
chore(lib.audit-logs): add lint, type-check, format, test:coverage scripts (ADS-613)

### DIFF
--- a/lib.audit-logs/package.json
+++ b/lib.audit-logs/package.json
@@ -14,9 +14,16 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest",
-    "clean": "rm -rf dist"
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
+    "type-check": "tsc --noEmit",
+    "prepublishOnly": "npm run clean && npm run build"
   },
   "keywords": [
     "audit",
@@ -31,7 +38,14 @@
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-base": "*",
     "@types/node": "^20.11.19",
+    "@typescript-eslint/eslint-plugin": "^8.59.1",
+    "@typescript-eslint/parser": "^8.59.1",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^10.0.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "prettier": "^3.2.5",
     "typescript": "^5.4.5",
+    "typescript-eslint": "^8.0.0",
     "vitest": "^4.0.8",
     "@vitest/coverage-v8": "^4.0.8"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -550,8 +550,15 @@
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-base": "*",
         "@types/node": "^20.11.19",
+        "@typescript-eslint/eslint-plugin": "^8.59.1",
+        "@typescript-eslint/parser": "^8.59.1",
         "@vitest/coverage-v8": "^4.0.8",
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^10.0.0",
+        "eslint-plugin-prettier": "^5.1.3",
+        "prettier": "^3.2.5",
         "typescript": "^5.4.5",
+        "typescript-eslint": "^8.0.0",
         "vitest": "^4.0.8"
       }
     },
@@ -675,8 +682,8 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-tooltip": "^1.0.7",
         "clsx": "^2.1.1",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-world-flags": "^1.6.0",
         "recharts": "^2.12.6",
         "sonner": "^2.0.7"


### PR DESCRIPTION
## Summary

`lib.audit-logs/package.json` previously only declared `build`, `dev`, `test`, `test:watch`, and `clean`. Every other `lib.*` package declares the full canonical set, and Turbo silently skips packages that don't define a task — so:

- `npx turbo run lint --filter=@adopt-dont-shop/lib.audit-logs` was a **no-op** (ESLint never ran against the source).
- `npx turbo run type-check --filter=@adopt-dont-shop/lib.audit-logs` was a **no-op** (`tsc --noEmit` never ran).
- The `test-libs` job in `.github/workflows/ci.yml` passed regardless of this package's contents.

This change mirrors the script set used by `lib.notifications` (the closest non-React peer that also depends on `lib.api`) and adds the matching devDependencies so each script actually executes.

### Scripts added

- `lint` / `lint:fix` — `eslint src`
- `type-check` — `tsc --noEmit`
- `test:coverage` — `vitest run --coverage`
- `format` / `format:check` — `prettier` over `src/**/*.{ts,tsx,js,jsx,json}`
- `prepublishOnly` — `npm run clean && npm run build`

### devDependencies added

`@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint`, `eslint-config-prettier`, `eslint-plugin-prettier`, `prettier`, `typescript-eslint` (versions pinned to match the rest of the monorepo).

### Latent issues surfaced

None — `lint`, `type-check`, `format:check`, and `test:coverage` all pass cleanly against the current source. No changes to `src/**` were required.

## Acceptance Criteria

- [x] `lib.audit-logs/package.json` declares the same script set as `lib.legal` / `lib.observability` / other libs.
- [x] `npx turbo run lint --filter=@adopt-dont-shop/lib.audit-logs` actually executes ESLint against `lib.audit-logs/src/**`.
- [x] `npx turbo run type-check --filter=@adopt-dont-shop/lib.audit-logs` actually runs `tsc --noEmit`.
- [x] Both commands pass without errors.
- [x] `npm run test:coverage --workspace=@adopt-dont-shop/lib.audit-logs` produces a coverage report under `lib.audit-logs/coverage/` (100% statements / 100% lines / 100% functions / 95.23% branches).

## Test plan

- [x] `cd lib.audit-logs && npm run lint` → exits 0.
- [x] `cd lib.audit-logs && npm run type-check` → exits 0 (after `lib.api` is built; Turbo handles this via `^build`).
- [x] `cd lib.audit-logs && npm run format:check` → all files use Prettier code style.
- [x] `cd lib.audit-logs && npm run test:coverage` → 8 tests pass, coverage report written to `lib.audit-logs/coverage/`.
- [x] `cd lib.audit-logs && npm run build` → clean tsc build.
- [x] `npx turbo run lint --filter=@adopt-dont-shop/lib.audit-logs` → 1 task successful (no longer a no-op).
- [x] `npx turbo run type-check --filter=@adopt-dont-shop/lib.audit-logs` → 1 task successful (no longer a no-op).

Linear: https://linear.app/ideasquared/issue/ADS-613

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67)_