### PR TITLE
chore(app.client): add type-check script so CI matrix exercises tsc (ADS-614)

### DIFF
--- a/app.client/package.json
+++ b/app.client/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
+    "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Adds `"type-check": "tsc --noEmit"` to `app.client/package.json`, mirroring `app.admin` and `app.rescue`. The CI matrix step `npx turbo run type-check --filter='@adopt-dont-shop/${{ matrix.app }}'` previously treated the missing task as a no-op and exited 0, so the per-app type-check for `app.client` was a silent green checkmark. This change makes that step actually run `tsc --noEmit` for `app.client`.

Linear: [ADS-614](https://linear.app/ideasquared/issue/ADS-614/appclient-is-missing-a-type-check-script-ci-type-check-silently-passes)

## Changes

- `app.client/package.json`: add `"type-check": "tsc --noEmit"` in the scripts block (placed between `format:check` and `clean` to match `app.rescue`).

## Acceptance Criteria

- [x] `app.client/package.json` declares `"type-check": "tsc --noEmit"`.
- [x] `npx turbo run type-check --filter=@adopt-dont-shop/app.client` executes `tsc --noEmit` and reports any errors (verified locally — passes with no errors on current `main`).
- [x] CI's per-app "Type check" matrix step for `app.client` now exercises real type-checking. Confirmed locally by temporarily introducing `const __testTypeError: number = 'should fail';` — `tsc` reported `TS2322: Type 'string' is not assignable to type 'number'.` as expected, then reverted.
- [x] The three app `package.json` files have a consistent script set (all three now declare `type-check`).

## Test plan

- [ ] CI green: per-app "Type check" step for `app.client` runs `tsc --noEmit` and the job stays green.
- [ ] Sanity check (manual): introduce a temporary type error in `app.client/src/**`, push, observe the `app.client` matrix step fail; revert.

https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67)_