### PR TITLE
fix(security): escape user-supplied notification message in email HTML body (ADS-607)

### DIFF
--- a/service.backend/src/__tests__/services/notificationChannelService.test.ts
+++ b/service.backend/src/__tests__/services/notificationChannelService.test.ts
@@ -1,0 +1,123 @@
+/**
+ * ADS-607: behaviour tests for the email-channel path of
+ * NotificationChannelService. The HTML body interpolates the
+ * caller-supplied `notification.message`, so anything that flows in from
+ * chat previews, application notes, or broadcast messages must be
+ * HTML-escaped before it lands in a recipient's inbox.
+ *
+ * Tests assert through `deliverToChannels` (the public API) and inspect
+ * the payload handed to the mocked emailService.sendEmail.
+ */
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../models/User', () => ({
+  default: { findByPk: vi.fn() },
+}));
+
+vi.mock('../../models/DeviceToken', () => ({
+  default: { count: vi.fn(), findAll: vi.fn() },
+}));
+
+vi.mock('../../models/UserNotificationPrefs', () => ({
+  default: { findOne: vi.fn() },
+}));
+
+vi.mock('../../services/email.service', () => ({
+  default: { sendEmail: vi.fn().mockResolvedValue('email-id-xyz') },
+}));
+
+import User from '../../models/User';
+import emailService from '../../services/email.service';
+import { NotificationChannelService } from '../../services/notificationChannelService';
+
+const mockUserFindByPk = vi.mocked(User.findByPk);
+const mockSendEmail = vi.mocked(emailService.sendEmail);
+
+const buildNotification = (message: string) => ({
+  userId: 'user-1',
+  title: 'A notification',
+  message,
+  type: 'message.chat',
+});
+
+const recipient = {
+  email: 'recipient@example.com',
+  firstName: 'Sam',
+  lastName: 'Adopter',
+};
+
+describe('NotificationChannelService email delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFindByPk.mockResolvedValue(recipient as never);
+  });
+
+  it('escapes <script> tags injected via notification.message in the HTML body', async () => {
+    const malicious = '<script>alert(1)</script>';
+    const results = await NotificationChannelService.deliverToChannels(
+      buildNotification(malicious),
+      ['email']
+    );
+
+    expect(results).toEqual([{ channel: 'email', success: true, deliveryId: 'email-id-xyz' }]);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    const payload = mockSendEmail.mock.calls[0][0];
+    expect(payload.htmlContent).toBe('<p>&lt;script&gt;alert(1)&lt;&#x2F;script&gt;</p>');
+    expect(payload.htmlContent).not.toContain('<script>');
+  });
+
+  it('escapes inline event handlers such as <img onerror=...> so they cannot fire in email clients', async () => {
+    const malicious = '<img src=x onerror="alert(1)">';
+    await NotificationChannelService.deliverToChannels(buildNotification(malicious), ['email']);
+
+    const payload = mockSendEmail.mock.calls[0][0];
+    // The angle brackets are escaped so the email client cannot parse this
+    // as an <img> tag, neutering the onerror handler regardless of the
+    // attribute text surviving as literal characters in the entity body.
+    expect(payload.htmlContent).not.toContain('<img');
+    expect(payload.htmlContent).toContain('&lt;img');
+    expect(payload.htmlContent).toContain('&quot;');
+  });
+
+  it('escapes attacker-crafted anchor tags so phishing links cannot be smuggled in', async () => {
+    const malicious = '<a href="https://phishing.example">Click here</a>';
+    await NotificationChannelService.deliverToChannels(buildNotification(malicious), ['email']);
+
+    const payload = mockSendEmail.mock.calls[0][0];
+    expect(payload.htmlContent).not.toMatch(/<a\s/);
+    expect(payload.htmlContent).toContain(
+      '&lt;a href=&quot;https:&#x2F;&#x2F;phishing.example&quot;&gt;'
+    );
+  });
+
+  it('escapes ampersands so existing entities are not double-decoded by the email client', async () => {
+    await NotificationChannelService.deliverToChannels(buildNotification('Tom & Jerry <3'), [
+      'email',
+    ]);
+
+    const payload = mockSendEmail.mock.calls[0][0];
+    expect(payload.htmlContent).toBe('<p>Tom &amp; Jerry &lt;3</p>');
+  });
+
+  it('passes the raw, unescaped message through in the plain-text body', async () => {
+    const malicious = '<script>alert(1)</script>';
+    await NotificationChannelService.deliverToChannels(buildNotification(malicious), ['email']);
+
+    const payload = mockSendEmail.mock.calls[0][0];
+    expect(payload.textContent).toBe(malicious);
+  });
+
+  it('leaves benign messages with normal punctuation rendering correctly', async () => {
+    const normal = 'Your application for Buddy has been approved!';
+    await NotificationChannelService.deliverToChannels(buildNotification(normal), ['email']);
+
+    const payload = mockSendEmail.mock.calls[0][0];
+    expect(payload.htmlContent).toBe('<p>Your application for Buddy has been approved!</p>');
+    expect(payload.textContent).toBe(normal);
+  });
+});

--- a/service.backend/src/services/notificationChannelService.ts
+++ b/service.backend/src/services/notificationChannelService.ts
@@ -9,6 +9,22 @@ interface NotificationData {
   [key: string]: string | number | boolean | null;
 }
 
+/**
+ * Escape HTML special characters so user-supplied notification text cannot
+ * inject markup (links, scripts, inline event handlers) when interpolated
+ * into an email's HTML body. Matches the standard OWASP HTML-context escape
+ * set: &, <, >, ", ', /.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/\//g, '&#x2F;');
+}
+
 export interface ChannelDeliveryResult {
   channel: 'email' | 'push' | 'sms';
   success: boolean;
@@ -273,7 +289,7 @@ export class NotificationChannelService {
         toEmail: user.email,
         toName: userName,
         subject: notification.title,
-        htmlContent: `<p>${notification.message}</p>`,
+        htmlContent: `<p>${escapeHtml(notification.message)}</p>`,
         textContent: notification.message,
         type: 'notification',
         userId: notification.userId,


### PR DESCRIPTION
## Summary

`NotificationChannelService.sendEmailNotification` interpolated `notification.message` directly into the email HTML body: `<p>${notification.message}</p>`. That string can originate from chat-message previews, application status notes, or broadcast messages — any of which can carry user-authored content. No escape, no sanitiser.

This change HTML-escapes `notification.message` before interpolation (angle brackets, quotes, ampersands, slashes). `textContent` is left untouched because the plain-text body is never parsed as markup.

- Linear ticket: [ADS-607](https://linear.app/ideasquared/issue/ADS-607/daily-code-review-2026-05-19-notification-email-body-wraps-raw-user)
- File touched: `service.backend/src/services/notificationChannelService.ts`
- New tests: `service.backend/src/__tests__/services/notificationChannelService.test.ts`

## Behaviour assertions

The new test file exercises `NotificationChannelService.deliverToChannels` (public API) with a mocked `emailService.sendEmail` and asserts:

- `<script>alert(1)</script>` arrives in `htmlContent` as fully entity-encoded text (no `<script>` substring).
- ``&lt;img src=x onerror="..."&gt;`` cannot be parsed as an `<img>` tag in the email client — `<img` becomes `&lt;img`.
- `<a href="...">` phishing-link attempts arrive escaped — no `<a ` tag survives.
- Ampersands escape to `&amp;` so existing entities are not double-decoded.
- Benign messages render unchanged.
- `textContent` still receives the raw message (plain-text body is safe).

## Test plan

- [x] `npx vitest run --root service.backend src/__tests__/services/notificationChannelService.test.ts` — 6/6 passing
- [x] `npx vitest run --root service.backend src/__tests__/services/broadcast.service.test.ts src/__tests__/services/notification.service.test.ts` — 14/14 passing (no regression in dependents)
- [x] `npx eslint` on changed files — clean
- [x] `npx tsc --noEmit` — no new errors

https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67)_