### PR TITLE
fix(foster): add FosterPlacement migration (ADS-601)

### DIFF
--- a/service.backend/src/__tests__/migrations/foster-placements.test.ts
+++ b/service.backend/src/__tests__/migrations/foster-placements.test.ts
@@ -1,0 +1,152 @@
+/**
+ * ADS-601: round-trip test for the `foster_placements` forward migration.
+ *
+ * Mirrors the per-model baseline test pattern in `baseline-pets.test.ts`:
+ *   1. Drop the table sync() left behind so up() has work to do.
+ *   2. Run up() and assert the table, columns, indexes (incl. the partial
+ *      unique index that enforces one ACTIVE placement per pet), and
+ *      enum type are created.
+ *   3. Run down() with the destructive-down acknowledgement and assert
+ *      the table and enum type are gone.
+ *
+ * Postgres-only — the migration uses a Postgres ENUM type and a partial
+ * unique index, neither of which has a SQLite-equivalent we exercise.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import sequelize from '../../sequelize';
+import * as models from '../../models';
+import createFosterPlacements from '../../migrations/03-create-foster-placements';
+
+// Force model side effects so sync() registers everything.
+void models;
+
+const isPostgres = sequelize.getDialect() === 'postgres';
+const describeIfPostgres = isPostgres ? describe : describe.skip;
+
+const queryInterface = sequelize.getQueryInterface();
+
+const tableExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.tables WHERE table_name = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const columnExists = async (table: string, column: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM information_schema.columns
+       WHERE table_name = '${table}' AND column_name = '${column}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const indexExists = async (table: string, name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM pg_indexes WHERE tablename = '${table}' AND indexname = '${name}'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const indexDefinition = async (table: string, name: string): Promise<string> => {
+  const [rows] = await sequelize.query(
+    `SELECT indexdef FROM pg_indexes WHERE tablename = '${table}' AND indexname = '${name}'`
+  );
+  return (rows as Array<{ indexdef: string }>)[0]?.indexdef ?? '';
+};
+
+const enumExists = async (name: string): Promise<boolean> => {
+  const [rows] = await sequelize.query(
+    `SELECT 1 FROM pg_type WHERE typname = '${name}' AND typtype = 'e'`
+  );
+  return (rows as unknown[]).length > 0;
+};
+
+const ackKey = (key: string): void => {
+  process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN = '1';
+  process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY = key;
+};
+
+const clearAck = (): void => {
+  delete process.env.MIGRATION_ALLOW_DESTRUCTIVE_DOWN;
+  delete process.env.MIGRATION_DESTRUCTIVE_DOWN_KEY;
+};
+
+describeIfPostgres('03-create-foster-placements (round trip)', () => {
+  beforeAll(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  beforeEach(async () => {
+    await sequelize.query('DROP TABLE IF EXISTS foster_placements CASCADE');
+    await sequelize.query('DROP TYPE IF EXISTS "enum_foster_placements_status" CASCADE');
+  });
+
+  afterEach(() => {
+    clearAck();
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  it('up() creates the foster_placements table with the expected columns', async () => {
+    expect(await tableExists('foster_placements')).toBe(false);
+
+    await createFosterPlacements.up(queryInterface);
+
+    expect(await tableExists('foster_placements')).toBe(true);
+    expect(await columnExists('foster_placements', 'placement_id')).toBe(true);
+    expect(await columnExists('foster_placements', 'pet_id')).toBe(true);
+    expect(await columnExists('foster_placements', 'foster_user_id')).toBe(true);
+    expect(await columnExists('foster_placements', 'rescue_id')).toBe(true);
+    expect(await columnExists('foster_placements', 'start_date')).toBe(true);
+    expect(await columnExists('foster_placements', 'end_date')).toBe(true);
+    expect(await columnExists('foster_placements', 'status')).toBe(true);
+    expect(await columnExists('foster_placements', 'notes')).toBe(true);
+    expect(await columnExists('foster_placements', 'created_at')).toBe(true);
+    expect(await columnExists('foster_placements', 'updated_at')).toBe(true);
+    expect(await columnExists('foster_placements', 'deleted_at')).toBe(true);
+
+    expect(await enumExists('enum_foster_placements_status')).toBe(true);
+  });
+
+  it('up() creates the four standard indexes and the active-pet partial unique index', async () => {
+    await createFosterPlacements.up(queryInterface);
+
+    expect(await indexExists('foster_placements', 'foster_placements_pet_id_idx')).toBe(true);
+    expect(await indexExists('foster_placements', 'foster_placements_foster_user_id_idx')).toBe(
+      true
+    );
+    expect(await indexExists('foster_placements', 'foster_placements_rescue_id_idx')).toBe(true);
+    expect(await indexExists('foster_placements', 'foster_placements_status_idx')).toBe(true);
+    expect(await indexExists('foster_placements', 'foster_placements_active_pet_unique')).toBe(
+      true
+    );
+
+    const partialDef = await indexDefinition(
+      'foster_placements',
+      'foster_placements_active_pet_unique'
+    );
+    expect(partialDef).toContain('UNIQUE');
+    expect(partialDef).toContain('pet_id');
+    expect(partialDef).toMatch(/status = 'active'/);
+    expect(partialDef).toMatch(/deleted_at IS NULL/);
+  });
+
+  it('down() refuses without the destructive-down acknowledgement', async () => {
+    await createFosterPlacements.up(queryInterface);
+
+    await expect(createFosterPlacements.down(queryInterface)).rejects.toThrow(/destructive down/i);
+    expect(await tableExists('foster_placements')).toBe(true);
+  });
+
+  it('down() drops the table and its status enum type when acknowledged', async () => {
+    await createFosterPlacements.up(queryInterface);
+    ackKey('03-create-foster-placements');
+
+    await createFosterPlacements.down(queryInterface);
+
+    expect(await tableExists('foster_placements')).toBe(false);
+    expect(await enumExists('enum_foster_placements_status')).toBe(false);
+  });
+});

--- a/service.backend/src/migrations/03-create-foster-placements.ts
+++ b/service.backend/src/migrations/03-create-foster-placements.ts
@@ -1,0 +1,129 @@
+/**
+ * ADS-601: create the `foster_placements` table.
+ *
+ * The `FosterPlacement` model (commit 3590d66, "feat(foster): add foster
+ * placement coordination") was shipped without a matching migration, so
+ * any environment that has run migrations is missing the table and all
+ * `/api/v1/foster/placements` requests fail with "relation does not exist".
+ *
+ * Frozen `createTable` body matches `models/FosterPlacement.ts`:
+ *   - paranoid + timestamped + underscored
+ *   - 4 standard indexes (pet_id, foster_user_id, rescue_id, status)
+ *   - 1 partial unique index enforcing one ACTIVE placement per pet,
+ *     soft-deletes excluded so historical rows do not block a new
+ *     placement after the previous one is cancelled or completed.
+ *
+ * FK references are declared inline; the parent tables (pets, users,
+ * rescues) already exist when this forward migration runs.
+ */
+import { DataTypes, type QueryInterface } from 'sequelize';
+import {
+  assertDestructiveDownAcknowledged,
+  dropEnumTypeIfExists,
+  runInTransaction,
+} from './_helpers';
+
+const MIGRATION_KEY = '03-create-foster-placements';
+
+const FOSTER_PLACEMENT_STATUSES = ['active', 'completed', 'cancelled'] as const;
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'foster_placements',
+        {
+          placement_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          pet_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            references: { model: 'pets', key: 'pet_id' },
+            onDelete: 'CASCADE',
+          },
+          foster_user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            references: { model: 'users', key: 'user_id' },
+            onDelete: 'RESTRICT',
+          },
+          rescue_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            references: { model: 'rescues', key: 'rescue_id' },
+            onDelete: 'CASCADE',
+          },
+          start_date: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          end_date: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          status: {
+            type: DataTypes.ENUM(...FOSTER_PLACEMENT_STATUSES),
+            allowNull: false,
+            defaultValue: 'active',
+          },
+          notes: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          deleted_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('foster_placements', {
+        fields: ['pet_id'],
+        name: 'foster_placements_pet_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('foster_placements', {
+        fields: ['foster_user_id'],
+        name: 'foster_placements_foster_user_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('foster_placements', {
+        fields: ['rescue_id'],
+        name: 'foster_placements_rescue_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('foster_placements', {
+        fields: ['status'],
+        name: 'foster_placements_status_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('foster_placements', {
+        fields: ['pet_id'],
+        name: 'foster_placements_active_pet_unique',
+        unique: true,
+        where: { status: 'active', deleted_at: null },
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('foster_placements', { transaction });
+    });
+    await dropEnumTypeIfExists(queryInterface.sequelize, 'enum_foster_placements_status');
+  },
+};


### PR DESCRIPTION
## Summary

Fixes [ADS-601](https://linear.app/ideasquared/issue/ADS-601/daily-code-review-2026-05-19-fosterplacement-model-has-no-migration).

The `FosterPlacement` model was shipped in commit `3590d66` ("feat(foster): add foster placement coordination") without a matching migration. Every environment that runs `npm run db:migrate` is therefore missing the `foster_placements` table, and the entire `/api/v1/foster/placements` API fails with `relation "foster_placements" does not exist`.

This PR adds `service.backend/src/migrations/03-create-foster-placements.ts`, which creates the table to match the model definition exactly:

- Paranoid soft-deletes (`deleted_at`), `underscored` snake_case columns, standard `created_at`/`updated_at` timestamps.
- Status ENUM with values `active`, `completed`, `cancelled`.
- Four standard indexes: `pet_id`, `foster_user_id`, `rescue_id`, `status`.
- One partial unique index `foster_placements_active_pet_unique` (UNIQUE on `pet_id` WHERE `status = 'active' AND deleted_at IS NULL`) so only one ACTIVE placement per pet is allowed, while historical cancelled/completed rows remain.
- Inline foreign key references to `pets`, `users`, and `rescues` (the parent tables already exist when this forward migration runs).
- `down()` drops the table inside a transaction and then drops the `enum_foster_placements_status` type, guarded by `assertDestructiveDownAcknowledged` since the table can accumulate data post-deploy.

## Test plan

- [x] `npx tsc --noEmit` passes for `service.backend` with no new errors.
- [x] `npx eslint` + `npx prettier --check` clean on the new files.
- [x] New Postgres-gated round-trip test (`src/__tests__/migrations/foster-placements.test.ts`) verifying:
  - `up()` creates the table with the expected columns and the `enum_foster_placements_status` type.
  - `up()` creates all four standard indexes plus the partial unique index, with `UNIQUE`, `pet_id`, `status = 'active'`, and `deleted_at IS NULL` in its definition.
  - `down()` refuses without `MIGRATION_ALLOW_DESTRUCTIVE_DOWN=1` and `MIGRATION_DESTRUCTIVE_DOWN_KEY=03-create-foster-placements`.
  - `down()` drops the table and the enum type when acknowledged.
- [x] The test file follows the existing `describeIfPostgres` pattern from `baseline-pets.test.ts`; it skips cleanly on the default SQLite test env (verified: `Test Files 1 skipped`).
- [ ] Acceptance criteria from the ticket — run `npm run db:migrate` against a fresh database, POST to `/api/v1/foster/placements`, confirm no "relation does not exist" error (manual smoke).

https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67)_