### PR TITLE
refactor(backend): consolidate bcrypt usage on bcryptjs (ADS-619)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -675,8 +675,8 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-tooltip": "^1.0.7",
         "clsx": "^2.1.1",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-world-flags": "^1.6.0",
         "recharts": "^2.12.6",
         "sonner": "^2.0.7"
@@ -7163,16 +7163,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/bcryptjs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-3.0.0.tgz",
@@ -9106,20 +9096,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
     },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
@@ -16880,6 +16856,7 @@
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
       "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -16936,17 +16913,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -24041,7 +24007,6 @@
         "@faker-js/faker": "^10.4.0",
         "@sentry/node": "^10.52.0",
         "@sentry/profiling-node": "^10.52.0",
-        "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
         "bullmq": "^5.20.0",
         "cookie-parser": "^1.4.7",
@@ -24087,7 +24052,6 @@
       },
       "devDependencies": {
         "@adopt-dont-shop/eslint-config-node": "*",
-        "@types/bcrypt": "^6.0.0",
         "@types/bcryptjs": "^3.0.0",
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.13",

--- a/service.backend/package.json
+++ b/service.backend/package.json
@@ -42,7 +42,6 @@
     "@faker-js/faker": "^10.4.0",
     "@sentry/node": "^10.52.0",
     "@sentry/profiling-node": "^10.52.0",
-    "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
     "bullmq": "^5.20.0",
     "cookie-parser": "^1.4.7",
@@ -88,7 +87,6 @@
   },
   "devDependencies": {
     "@adopt-dont-shop/eslint-config-node": "*",
-    "@types/bcrypt": "^6.0.0",
     "@types/bcryptjs": "^3.0.0",
     "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.13",

--- a/service.backend/src/__tests__/utils/secrets.test.ts
+++ b/service.backend/src/__tests__/utils/secrets.test.ts
@@ -1,3 +1,6 @@
+import { beforeAll, vi, describe, it, expect } from 'vitest';
+import bcrypt from 'bcryptjs';
+
 import {
   decryptSecret,
   encryptSecret,
@@ -5,6 +8,18 @@ import {
   hashToken,
   verifyBackupCode,
 } from '../../utils/secrets';
+
+// ADS-619: secrets.ts now uses `bcryptjs` (previously the native `bcrypt`).
+// setup-tests.ts globally mocks bcryptjs to return constants for speed in the
+// auth-service suites. These backup-code tests rely on real salted hashes and
+// real verify behaviour. setupFiles mocks can't be undone with vi.unmock, so
+// we splice the real bcryptjs methods onto the mocked module for this suite.
+beforeAll(async () => {
+  const real = await vi.importActual<typeof import('bcryptjs')>('bcryptjs');
+  bcrypt.hash = real.hash;
+  bcrypt.compare = real.compare;
+  bcrypt.genSalt = real.genSalt;
+});
 
 describe('secrets util', () => {
   describe('hashToken', () => {

--- a/service.backend/src/seeders/04-users.ts
+++ b/service.backend/src/seeders/04-users.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto';
-import bcrypt from 'bcrypt';
 import AuditLog from '../models/AuditLog';
 import User, { UserStatus, UserType } from '../models/User';
 import { COOKIES_VERSION, PRIVACY_VERSION, TERMS_VERSION } from '../services/legal-content.service';
@@ -366,6 +365,7 @@ export async function seedUsers() {
   }
 
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console -- existing seeder log; surfaces to dev CLI only.
     console.log(`✅ Created ${testUsers.length} test users (password: ${plainPassword})`);
   }
 }

--- a/service.backend/src/utils/password.test.ts
+++ b/service.backend/src/utils/password.test.ts
@@ -50,3 +50,38 @@ describe('password utilities', () => {
     });
   });
 });
+
+// ADS-619: regression test — bcrypt-2b hashes (previously produced by the native
+// `bcrypt` package) must still validate via `bcryptjs.compare()` after the
+// consolidation. This guards against the worst-case migration failure: existing
+// seeded / production users being unable to log in.
+describe('ADS-619 bcrypt → bcryptjs wire-compatibility', () => {
+  // Pre-computed $2b$ hash (cost factor 10) of the plaintext "DevPassword123!"
+  // produced by the native `bcrypt` package. bcrypt-2b is a documented wire
+  // format; bcryptjs reads and verifies it without modification.
+  const plaintext = 'DevPassword123!';
+  const nativeBcryptHash = '$2b$10$kCjg03m18/TbEiEETpSGN.qJCR1I027RlNDut8PckwBhEuBi2sQQa';
+
+  it('verifies a native-bcrypt-generated 2b hash via bcryptjs.compare()', async () => {
+    // Bypass the global bcryptjs mock from setup-tests.ts so we exercise the
+    // real implementation. Top-level import keeps the existing mocked path
+    // working for the suite above.
+    const realBcrypt = await vi.importActual<typeof import('bcryptjs')>('bcryptjs');
+
+    const matches = await realBcrypt.compare(plaintext, nativeBcryptHash);
+    expect(matches).toBe(true);
+
+    const noMatch = await realBcrypt.compare('wrong-password', nativeBcryptHash);
+    expect(noMatch).toBe(false);
+  });
+
+  it('round-trips a bcryptjs-generated hash back through bcryptjs.compare()', async () => {
+    const realBcrypt = await vi.importActual<typeof import('bcryptjs')>('bcryptjs');
+
+    const salt = await realBcrypt.genSalt(4); // low cost keeps the test fast
+    const hash = await realBcrypt.hash(plaintext, salt);
+
+    expect(hash.startsWith('$2')).toBe(true);
+    expect(await realBcrypt.compare(plaintext, hash)).toBe(true);
+  });
+});

--- a/service.backend/src/utils/secrets.ts
+++ b/service.backend/src/utils/secrets.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
-import bcrypt from 'bcrypt';
+import bcrypt from 'bcryptjs';
 
 /**
  * Hash a high-entropy single-use token (verification, reset, invite,


### PR DESCRIPTION
## Summary

`service.backend` depended on **both** `bcrypt` (native C++ addon, ^6.0.0) and `bcryptjs` (pure JS, ^3.0.2). The auth service and 8/10 call sites already used `bcryptjs`; only `utils/secrets.ts` (2FA backup codes) and `seeders/04-users.ts` still imported the native package — and the latter was a dead import.

This PR consolidates on `bcryptjs` per ADS-619's proposed direction (pure-JS install path, simpler default, no `node-gyp` / Python / C++ build tooling at install time).

### Changes

- `service.backend/src/utils/secrets.ts`: `import bcrypt from 'bcrypt'` → `'bcryptjs'`.
- `service.backend/src/seeders/04-users.ts`: removed dead `bcrypt` import (the seeder never called it — the User model hooks do the hashing). Added an `eslint-disable-next-line no-console` on a pre-existing seeder log line to satisfy lint-staged on the modified file.
- `service.backend/package.json`: removed `bcrypt` and `@types/bcrypt`.
- Root `package-lock.json`: regenerated via `npm install`.

### Regression tests

- `service.backend/src/utils/password.test.ts`: asserts a `$2b$` hash produced by the **native** `bcrypt` package still verifies via `bcryptjs.compare()`. bcrypt-2b is wire-compatible across both libraries — this test guards against the worst-case migration failure of existing seeded / production users being unable to log in.
- `service.backend/src/__tests__/utils/secrets.test.ts`: now that bcryptjs is globally mocked in `setup-tests.ts`, splices the real bcryptjs methods onto the module for this suite so salt + verify behaviour is exercised end-to-end (setupFiles mocks can't be undone with `vi.unmock`).

### Acceptance criteria (from ADS-619)

- [x] Only one of `bcrypt` or `bcryptjs` appears in `service.backend/package.json` (kept `bcryptjs`).
- [x] `grep -rE "from ['\"](bcrypt|bcryptjs)['\"]" service.backend/` returns a single import name (`bcryptjs`) across all files.
- [x] `npm test --workspace=@adopt-dont-shop/service-backend` passes — **2206 passed, 262 skipped, 0 failures** across 143 test files.
- [x] Lint and type-check pass.
- [ ] Auth login against the seeded user `john.smith@gmail.com / DevPassword123!` still succeeds end-to-end. (Covered by the new wire-compat test for the password verification path; full E2E left for the reviewer to confirm in staging.)
- [ ] Backend Docker image build wall-clock unchanged or faster. (Should improve — no `node-gyp` / Python / C++ build during install. Reviewer to capture timings in CI.)

## Test plan

- [ ] CI runs `npm test --workspace=@adopt-dont-shop/service-backend` and is green.
- [ ] Reviewer rebuilds the backend Docker image locally and confirms install no longer pulls `node-gyp` / Python / C++ build tools.
- [ ] Reviewer logs in with a pre-existing seeded user (`john.smith@gmail.com / DevPassword123!`) against a database that holds a bcrypt-2b hash to confirm wire-compat in the auth path.

https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67)_