### PR TITLE
fix(foster): persist Pet.status alongside placement transitions (ADS-603)

### DIFF
--- a/service.backend/src/__tests__/services/foster.service.test.ts
+++ b/service.backend/src/__tests__/services/foster.service.test.ts
@@ -1,0 +1,202 @@
+import { vi } from 'vitest';
+import FosterPlacement from '../../models/FosterPlacement';
+import Pet, {
+  AgeGroup,
+  EnergyLevel,
+  Gender,
+  PetStatus,
+  PetType,
+  Size,
+  SpayNeuterStatus,
+  VaccinationStatus,
+} from '../../models/Pet';
+import PetStatusTransition from '../../models/PetStatusTransition';
+import Rescue from '../../models/Rescue';
+import User, { UserStatus, UserType } from '../../models/User';
+import { fosterService } from '../../services/foster.service';
+
+// ADS-603: foster.service must keep Pet.status in sync with the placement
+// lifecycle. createPlacement should flip status to FOSTER; endPlacement
+// should restore AVAILABLE (or set ADOPTED when outcome is adopted_by_foster).
+describe('FosterService - Pet.status sync (ADS-603)', () => {
+  let testRescue: Rescue;
+  let testFosterUser: User;
+  let testActorId: string;
+  let testCounter = 0;
+
+  const uniqueId = (prefix: string) => `${prefix}-${Date.now()}-${testCounter++}`;
+
+  beforeEach(async () => {
+    const timestamp = Date.now();
+    testRescue = await Rescue.create({
+      rescueId: uniqueId('rescue'),
+      name: `Foster Test Rescue ${timestamp}`,
+      email: `foster-rescue-${timestamp}-${testCounter}@test.com`,
+      address: '1 Foster Lane',
+      city: 'Fostertown',
+      postcode: 'FOST123',
+      contactPerson: 'Foster Contact',
+      status: 'verified',
+      country: 'GB',
+    });
+
+    testFosterUser = await User.create({
+      userId: uniqueId('foster-user'),
+      email: `foster-user-${timestamp}-${testCounter}@test.com`,
+      firstName: 'Foster',
+      lastName: 'Carer',
+      password: 'hashed-password',
+      userType: UserType.ADOPTER,
+      emailVerified: true,
+      status: UserStatus.ACTIVE,
+    });
+
+    const actor = await User.create({
+      userId: uniqueId('actor'),
+      email: `actor-${timestamp}-${testCounter}@test.com`,
+      firstName: 'Actor',
+      lastName: 'Staff',
+      password: 'hashed-password',
+      userType: UserType.RESCUE_STAFF,
+      emailVerified: true,
+      status: UserStatus.ACTIVE,
+    });
+    testActorId = actor.userId;
+  });
+
+  const createAvailablePet = async (): Promise<Pet> =>
+    Pet.create({
+      petId: uniqueId('pet'),
+      name: 'Foster Pet',
+      type: PetType.DOG,
+      status: PetStatus.AVAILABLE,
+      breed: 'Mixed',
+      size: Size.MEDIUM,
+      ageGroup: AgeGroup.ADULT,
+      gender: Gender.MALE,
+      energyLevel: EnergyLevel.MEDIUM,
+      vaccinationStatus: VaccinationStatus.UP_TO_DATE,
+      spayNeuterStatus: SpayNeuterStatus.NEUTERED,
+      featured: false,
+      priorityListing: false,
+      rescueId: testRescue.rescueId,
+      archived: false,
+    });
+
+  describe('createPlacement', () => {
+    it('flips the pet to FOSTER in the same transaction', async () => {
+      const pet = await createAvailablePet();
+      expect(pet.status).toBe(PetStatus.AVAILABLE);
+
+      await fosterService.createPlacement(
+        {
+          petId: pet.petId,
+          fosterUserId: testFosterUser.userId,
+          rescueId: testRescue.rescueId,
+          startDate: new Date(),
+        },
+        testActorId
+      );
+
+      const refreshed = await Pet.findByPk(pet.petId);
+      expect(refreshed?.status).toBe(PetStatus.FOSTER);
+    });
+
+    it('rolls back the pet update and the placement when the transition write fails', async () => {
+      const pet = await createAvailablePet();
+      const originalStatus = pet.status;
+
+      const createSpy = vi
+        .spyOn(PetStatusTransition, 'create')
+        .mockRejectedValueOnce(new Error('transition write failed'));
+
+      await expect(
+        fosterService.createPlacement(
+          {
+            petId: pet.petId,
+            fosterUserId: testFosterUser.userId,
+            rescueId: testRescue.rescueId,
+            startDate: new Date(),
+          },
+          testActorId
+        )
+      ).rejects.toThrow('transition write failed');
+
+      const refreshed = await Pet.findByPk(pet.petId);
+      expect(refreshed?.status).toBe(originalStatus);
+
+      const placements = await FosterPlacement.findAll({ where: { petId: pet.petId } });
+      expect(placements).toHaveLength(0);
+
+      createSpy.mockRestore();
+    });
+  });
+
+  describe('endPlacement', () => {
+    it('returns the pet to AVAILABLE when outcome is return_to_rescue', async () => {
+      const pet = await createAvailablePet();
+      const placement = await fosterService.createPlacement(
+        {
+          petId: pet.petId,
+          fosterUserId: testFosterUser.userId,
+          rescueId: testRescue.rescueId,
+          startDate: new Date(),
+        },
+        testActorId
+      );
+
+      await fosterService.endPlacement(
+        placement.placementId,
+        { outcome: 'return_to_rescue' },
+        testActorId
+      );
+
+      const refreshed = await Pet.findByPk(pet.petId);
+      expect(refreshed?.status).toBe(PetStatus.AVAILABLE);
+    });
+
+    it('marks the pet ADOPTED when outcome is adopted_by_foster', async () => {
+      const pet = await createAvailablePet();
+      const placement = await fosterService.createPlacement(
+        {
+          petId: pet.petId,
+          fosterUserId: testFosterUser.userId,
+          rescueId: testRescue.rescueId,
+          startDate: new Date(),
+        },
+        testActorId
+      );
+
+      await fosterService.endPlacement(
+        placement.placementId,
+        { outcome: 'adopted_by_foster' },
+        testActorId
+      );
+
+      const refreshed = await Pet.findByPk(pet.petId);
+      expect(refreshed?.status).toBe(PetStatus.ADOPTED);
+    });
+
+    it('returns the pet to AVAILABLE when outcome is cancelled', async () => {
+      const pet = await createAvailablePet();
+      const placement = await fosterService.createPlacement(
+        {
+          petId: pet.petId,
+          fosterUserId: testFosterUser.userId,
+          rescueId: testRescue.rescueId,
+          startDate: new Date(),
+        },
+        testActorId
+      );
+
+      await fosterService.endPlacement(
+        placement.placementId,
+        { outcome: 'cancelled' },
+        testActorId
+      );
+
+      const refreshed = await Pet.findByPk(pet.petId);
+      expect(refreshed?.status).toBe(PetStatus.AVAILABLE);
+    });
+  });
+});

--- a/service.backend/src/services/foster.service.ts
+++ b/service.backend/src/services/foster.service.ts
@@ -74,6 +74,9 @@ class FosterService {
         { transaction: t }
       );
 
+      pet.status = PetStatus.FOSTER;
+      await pet.save({ transaction: t });
+
       return placement.get({ plain: true });
     });
   }
@@ -120,6 +123,9 @@ class FosterService {
           },
           { transaction: t }
         );
+
+        pet.status = nextStatus;
+        await pet.save({ transaction: t });
       }
 
       return placement.get({ plain: true });


### PR DESCRIPTION
## Summary

Fixes [ADS-603](https://linear.app/ideasquared/issue/ADS-603): `fosterService.createPlacement` and `fosterService.endPlacement` wrote `PetStatusTransition` log rows but never updated the canonical `pets.status` column, leaving foster pets in `AVAILABLE` on the discovery feed and never flipping `adopted_by_foster` ends to `ADOPTED`.

- Inside the existing `sequelize.transaction`, set `pet.status` to `FOSTER` on create and to `ADOPTED` / `AVAILABLE` on end, then `pet.save({ transaction: t })` so the transition log and the parent column commit atomically.
- Adds behaviour tests covering both lifecycle directions plus the transaction-rollback invariant when the transition write fails.

## Test plan

- [x] `npx vitest run src/__tests__/services/foster.service.test.ts` — 5 new tests pass.
- [x] `npx vitest run src/__tests__/services/foster.service.test.ts src/__tests__/models/PetStatusTransition.test.ts src/__tests__/services/pet.service.test.ts` — 64 tests pass, no regressions in related areas.
- [x] `npm run lint` — 0 new errors / warnings introduced.
- [x] `npx tsc --noEmit` — 0 new type errors introduced (pre-existing errors unaffected).

Note: this branch is stacked on the (unmerged) foster placement coordination feature commit it patches, so the diff includes both that feature and the ADS-603 fix on top.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67)_