### PR TITLE
fix(gdpr): record acting admin on admin-triggered export/delete (ADS-605)

### DIFF
--- a/service.backend/src/__tests__/services/data-deletion.test.ts
+++ b/service.backend/src/__tests__/services/data-deletion.test.ts
@@ -1,5 +1,60 @@
-import { describe, it, expect } from 'vitest';
-import { buildAnonymousPlaceholder } from '../../services/data-deletion.service';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ADS-605: behaviour tests for the admin-acting-on-subject audit trail.
+// Models and the AuditLogService are stubbed so we can assert which
+// userId the audit row is attributed to without touching a database.
+
+const mockUser = {
+  userId: 'subject-user-1',
+  email: 'subject@example.com',
+  status: 'active',
+  save: vi.fn().mockResolvedValue(undefined),
+  destroy: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('../../models/User', () => {
+  const findByPk = vi.fn();
+  return {
+    default: { findByPk },
+    UserStatus: { DEACTIVATED: 'deactivated' },
+  };
+});
+
+vi.mock('../../models/Application', () => ({
+  default: { update: vi.fn().mockResolvedValue([0]) },
+}));
+vi.mock('../../models/RefreshToken', () => ({
+  default: { update: vi.fn().mockResolvedValue([0]) },
+}));
+vi.mock('../../models/UserFavorite', () => ({
+  default: { destroy: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock('../../models/ChatParticipant', () => ({
+  default: { destroy: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('../../services/auditLog.service', () => ({
+  AuditLogService: { log: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import User from '../../models/User';
+import { AuditLogService } from '../../services/auditLog.service';
+import {
+  buildAnonymousPlaceholder,
+  requestAccountDeletion,
+} from '../../services/data-deletion.service';
+
+const mockFindByPk = User.findByPk as ReturnType<typeof vi.fn>;
+const mockAuditLog = AuditLogService.log as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFindByPk.mockResolvedValue({ ...mockUser });
+});
 
 describe('buildAnonymousPlaceholder', () => {
   it('returns a deterministic placeholder for the same userId', () => {
@@ -20,5 +75,62 @@ describe('buildAnonymousPlaceholder', () => {
   it('produces a value short enough to fit in firstName/lastName (≤100 chars)', () => {
     const placeholder = buildAnonymousPlaceholder('verylongidentifier-' + 'x'.repeat(200));
     expect(placeholder.length).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('requestAccountDeletion audit trail (ADS-605)', () => {
+  it('writes exactly one audit entry attributed to the subject for self-service deletion', async () => {
+    await requestAccountDeletion('subject-user-1', 'no longer needed');
+
+    expect(mockAuditLog).toHaveBeenCalledTimes(1);
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'subject-user-1',
+        action: 'GDPR_DELETE_REQUESTED',
+        entityId: 'subject-user-1',
+      })
+    );
+  });
+
+  it('writes a second audit entry attributed to the admin when an admin triggers the deletion', async () => {
+    await requestAccountDeletion('subject-user-1', 'support request', {
+      userId: 'admin-user-7',
+      userType: 'admin',
+    });
+
+    expect(mockAuditLog).toHaveBeenCalledTimes(2);
+    expect(mockAuditLog).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        userId: 'subject-user-1',
+        action: 'GDPR_DELETE_REQUESTED',
+        entityId: 'subject-user-1',
+      })
+    );
+    expect(mockAuditLog).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        userId: 'admin-user-7',
+        action: 'GDPR_DELETE_REQUESTED_BY_ADMIN',
+        entityId: 'subject-user-1',
+        details: expect.objectContaining({
+          reason: 'support request',
+          actorUserType: 'admin',
+          targetUserId: 'subject-user-1',
+        }),
+      })
+    );
+  });
+
+  it('does not write a second entry when the actor IS the subject (self-service path passing actor)', async () => {
+    await requestAccountDeletion('subject-user-1', undefined, {
+      userId: 'subject-user-1',
+      userType: 'adopter',
+    });
+
+    expect(mockAuditLog).toHaveBeenCalledTimes(1);
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'GDPR_DELETE_REQUESTED' })
+    );
   });
 });

--- a/service.backend/src/__tests__/services/data-export.service.test.ts
+++ b/service.backend/src/__tests__/services/data-export.service.test.ts
@@ -89,13 +89,20 @@ vi.mock('../../models/UserPrivacyPrefs', () => ({
   default: { findOne: vi.fn().mockResolvedValue(null) },
 }));
 
+vi.mock('../../services/auditLog.service', () => ({
+  AuditLogService: { log: vi.fn().mockResolvedValue(undefined) },
+}));
+
 import User from '../../models/User';
+import { AuditLogService } from '../../services/auditLog.service';
 import { exportUserData } from '../../services/data-export.service';
 
 const mockFindByPk = User.findByPk as ReturnType<typeof vi.fn>;
+const mockAuditLog = AuditLogService.log as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mockFindByPk.mockResolvedValue(mockUser);
+  mockAuditLog.mockClear();
 });
 
 describe('exportUserData', () => {
@@ -148,6 +155,42 @@ describe('exportUserData', () => {
     expect(bundle.supportTickets).toEqual([]);
     expect(bundle.notifications).toEqual([]);
     expect(bundle.auditLogs).toEqual([]);
+  });
+
+  // ADS-605: when an admin triggers the export on behalf of a user, the
+  // audit log must attribute the action to the admin's userId — not the
+  // data subject — so we can answer "which admin exported Alice's data?".
+  it('writes no audit row for self-service export (no actor supplied)', async () => {
+    await exportUserData('user-export-1');
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('writes no audit row when the actor IS the subject', async () => {
+    await exportUserData('user-export-1', {
+      userId: 'user-export-1',
+      userType: 'adopter',
+    });
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('writes an audit row attributed to the admin when an admin triggers the export', async () => {
+    await exportUserData('user-export-1', {
+      userId: 'admin-user-7',
+      userType: 'admin',
+    });
+
+    expect(mockAuditLog).toHaveBeenCalledTimes(1);
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'admin-user-7',
+        action: 'GDPR_EXPORT_BY_ADMIN',
+        entityId: 'user-export-1',
+        details: expect.objectContaining({
+          actorUserType: 'admin',
+          targetUserId: 'user-export-1',
+        }),
+      })
+    );
   });
 
   it('includes application references nested under their parent application', async () => {

--- a/service.backend/src/routes/privacy.routes.ts
+++ b/service.backend/src/routes/privacy.routes.ts
@@ -152,7 +152,10 @@ router.get('/admin/users/:userId/export', async (req: AuthenticatedRequest, res:
     res.status(400).json({ error: 'Invalid userId' });
     return;
   }
-  const bundle = await exportUserData(parsed.data.userId);
+  // ADS-605: thread the acting admin through so the audit row records
+  // the admin's userId, not the data subject's.
+  const actor = req.user ? { userId: req.user.userId, userType: req.user.userType } : undefined;
+  const bundle = await exportUserData(parsed.data.userId, actor);
   res.setHeader(
     'Content-Disposition',
     `attachment; filename="adopt-dont-shop-export-${parsed.data.userId}.json"`
@@ -177,7 +180,11 @@ router.post(
       return;
     }
     const body = req.body as z.infer<typeof AdminDeleteSchema>;
-    const result = await requestAccountDeletion(parsed.data.userId, body.reason);
+    // ADS-605: thread the acting admin through so a second audit row
+    // attributed to the admin is written alongside the subject-scoped
+    // GDPR_DELETE_REQUESTED entry.
+    const actor = req.user ? { userId: req.user.userId, userType: req.user.userType } : undefined;
+    const result = await requestAccountDeletion(parsed.data.userId, body.reason, actor);
     res.status(202).json({
       data: {
         ...result,

--- a/service.backend/src/services/data-deletion.service.ts
+++ b/service.backend/src/services/data-deletion.service.ts
@@ -53,9 +53,22 @@ export type DeletionResult = {
   applicationsSoftDeleted: number;
 };
 
+/**
+ * ADS-605: when the deletion is triggered by an admin on behalf of a
+ * subject (not self-service), the caller passes the acting admin's
+ * identity so a second audit entry attributed to the admin is written
+ * alongside the subject-scoped entry. Without this, audit logs can't
+ * distinguish self-service deletions from admin-triggered ones.
+ */
+export type DeletionActor = {
+  userId: string;
+  userType: string;
+};
+
 export const requestAccountDeletion = async (
   userId: string,
-  reason?: string
+  reason?: string,
+  actor?: DeletionActor
 ): Promise<DeletionResult> => {
   const user = await User.findByPk(userId);
   if (!user) {
@@ -91,6 +104,23 @@ export const requestAccountDeletion = async (
       emailSnapshot: redactEmail(user.email),
     },
   });
+
+  // ADS-605: when an admin triggered this on behalf of the subject,
+  // write a second audit row attributed to the admin so the trail can
+  // answer "which admin deleted Alice's account?".
+  if (actor && actor.userId !== userId) {
+    await AuditLogService.log({
+      userId: actor.userId,
+      action: 'GDPR_DELETE_REQUESTED_BY_ADMIN',
+      entity: 'User',
+      entityId: userId,
+      details: {
+        reason: reason ?? null,
+        actorUserType: actor.userType,
+        targetUserId: userId,
+      },
+    });
+  }
 
   logger.info('Account soft-deleted at user request (GDPR phase 1)', {
     userId,

--- a/service.backend/src/services/data-export.service.ts
+++ b/service.backend/src/services/data-export.service.ts
@@ -11,6 +11,7 @@ import UserApplicationPrefs from '../models/UserApplicationPrefs';
 import UserFavorite from '../models/UserFavorite';
 import UserNotificationPrefs from '../models/UserNotificationPrefs';
 import UserPrivacyPrefs from '../models/UserPrivacyPrefs';
+import { AuditLogService } from './auditLog.service';
 import { logger } from '../utils/logger';
 
 /**
@@ -86,7 +87,22 @@ const pickSafeUserFields = (user: User): Record<string, unknown> => {
   return Object.fromEntries(SAFE_USER_FIELDS.map(key => [key, json[key]]));
 };
 
-export const exportUserData = async (userId: string): Promise<DataExportBundle> => {
+/**
+ * ADS-605: when the export is triggered by an admin on behalf of a
+ * subject (rather than the subject themself via /me/export), the caller
+ * passes the acting admin's identity so an audit entry attributed to
+ * the admin is written. Without this, the action is invisible to the
+ * audit log.
+ */
+export type ExportActor = {
+  userId: string;
+  userType: string;
+};
+
+export const exportUserData = async (
+  userId: string,
+  actor?: ExportActor
+): Promise<DataExportBundle> => {
   const user = await User.findByPk(userId);
   if (!user) {
     throw new Error('User not found');
@@ -152,6 +168,22 @@ export const exportUserData = async (userId: string): Promise<DataExportBundle> 
     notificationCount: notifications.length,
     auditLogCount: auditLogs.length,
   });
+
+  // ADS-605: when an admin triggered this on behalf of the subject,
+  // write an audit row attributed to the admin so the trail can answer
+  // "which admin exported Alice's data?".
+  if (actor && actor.userId !== userId) {
+    await AuditLogService.log({
+      userId: actor.userId,
+      action: 'GDPR_EXPORT_BY_ADMIN',
+      entity: 'User',
+      entityId: userId,
+      details: {
+        actorUserType: actor.userType,
+        targetUserId: userId,
+      },
+    });
+  }
 
   return bundle;
 };


### PR DESCRIPTION
## Summary

- Admin-scoped `GET /api/v1/privacy/admin/users/:userId/export` and `POST /api/v1/privacy/admin/users/:userId/delete-request` called the underlying services with only the target user's id, so the resulting audit log row was attributed to the data subject — not the admin who triggered the action. This is a GDPR Art. 30 record-of-processing gap and made self-service vs admin-triggered deletions indistinguishable in the audit trail.
- Add an optional `actor: { userId, userType }` parameter to `requestAccountDeletion` and `exportUserData`. When the actor differs from the subject, write a second audit entry attributed to the admin (`GDPR_DELETE_REQUESTED_BY_ADMIN` / `GDPR_EXPORT_BY_ADMIN`) with `entityId = subject userId`.
- Self-service `/me/export` and `/me/delete` are unchanged — they pass no actor and keep their existing single-row behaviour.

## Acceptance Criteria

- [x] Admin `/admin/users/:id/delete-request` writes an audit row with `userId = admin.userId` and `entityId = target.userId` (alongside the existing subject-scoped row).
- [x] Admin `/admin/users/:id/export` writes an audit row with `userId = admin.userId` and `entityId = target.userId`.
- [x] Self-service deletion still writes one audit row, unchanged.
- [x] Behaviour tests assert both actor and subject are captured.

## Test plan

- [x] `npx vitest run src/__tests__/services/data-deletion.test.ts` — 7 passed
- [x] `npx vitest run src/__tests__/services/data-export.service.test.ts` — 11 passed
- [x] `npm run lint` (service.backend) — 0 errors
- [x] `npx tsc --noEmit` (service.backend) — no new errors introduced (only pre-existing migration runner errors)
- [x] Full `service.backend` test suite — 2316 passed, 1 unrelated flake in `email-queue-concurrency` (timing-based; passes when re-run in isolation)

Closes ADS-605.

https://linear.app/ideasquared/issue/ADS-605/daily-code-review-2026-05-19-admin-triggered-gdpr-exportdelete

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67)_