### PR TITLE
fix(vitest): glob-discover lib.* workspaces so new libs auto-register (ADS-615)

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,30 +1,8 @@
 import { defineWorkspace } from 'vitest/config';
 
 /**
- * Vitest workspace — discovers all 21 lib.* packages.
- * Each package has its own vitest.config.ts with lib-specific overrides.
+ * Vitest workspace — discovers every lib.* package via glob so newly added
+ * libraries are picked up automatically. Each package has its own
+ * vitest.config.ts with lib-specific overrides.
  */
-export default defineWorkspace([
-  'lib.analytics/vitest.config.ts',
-  'lib.api/vitest.config.ts',
-  'lib.applications/vitest.config.ts',
-  'lib.audit-logs/vitest.config.ts',
-  'lib.auth/vitest.config.ts',
-  'lib.chat/vitest.config.ts',
-  'lib.components/vitest.config.ts',
-  'lib.dev-tools/vitest.config.ts',
-  'lib.discovery/vitest.config.ts',
-  'lib.feature-flags/vitest.config.ts',
-  'lib.invitations/vitest.config.ts',
-  'lib.matching/vitest.config.ts',
-  'lib.moderation/vitest.config.ts',
-  'lib.notifications/vitest.config.ts',
-  'lib.permissions/vitest.config.ts',
-  'lib.pets/vitest.config.ts',
-  'lib.rescue/vitest.config.ts',
-  'lib.search/vitest.config.ts',
-  'lib.support-tickets/vitest.config.ts',
-  'lib.types/vitest.config.ts',
-  'lib.utils/vitest.config.ts',
-  'lib.validation/vitest.config.ts',
-]);
+export default defineWorkspace(['lib.*/vitest.config.ts']);


### PR DESCRIPTION
## Linear ticket
[ADS-615](https://linear.app/ideasquared/issue/ADS-615) — `vitest.workspace.ts` is missing `lib.legal` and `lib.observability` — their tests don't run via root vitest.

## Change
Replace the hardcoded 21-entry list with a single glob: `lib.*/vitest.config.ts`. This both fixes the immediate drift (lib.legal + lib.observability) and prevents future regressions when new libs are added.

## Why a glob instead of just adding the two missing entries?
The original list was already out of date once; with 23 lib packages and the workspace-consistency guard not yet in place, adding two more entries would only delay the next drift event. The glob has no maintenance cost.

## Verification
The two previously-silent packages (`lib.legal/src/...test.ts`, `lib.observability/src/consent.test.ts`) now resolve under `npx vitest --run` from the repo root.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FF18oAsmXatGjZJ7XMLs67)_