### PR TITLE
fix(app.admin): use useConfirm + design tokens + tests on PrivacyTools (ADS-609)

### DIFF
--- a/app.admin/src/pages/PrivacyTools.css.ts
+++ b/app.admin/src/pages/PrivacyTools.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
 
 export const container = style({
   padding: '1.5rem',
@@ -19,7 +20,7 @@ export const fieldGroupSpaced = style({
 });
 
 export const section = style({
-  borderTop: '1px solid #e5e7eb',
+  borderTop: `1px solid ${vars.border.color.default}`,
   paddingTop: '1rem',
 });
 
@@ -37,11 +38,11 @@ export const message = style({
 });
 
 export const messageSuccess = style({
-  background: '#dcfce7',
-  color: '#166534',
+  background: vars.background.success,
+  color: vars.text.success,
 });
 
 export const messageError = style({
-  background: '#fee2e2',
-  color: '#991b1b',
+  background: vars.background.danger,
+  color: vars.text.danger,
 });

--- a/app.admin/src/pages/PrivacyTools.test.tsx
+++ b/app.admin/src/pages/PrivacyTools.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import PrivacyTools from './PrivacyTools';
+import { apiService } from '../services/libraryServices';
+
+const confirmSpy = vi.fn();
+
+vi.mock('@adopt-dont-shop/lib.components', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@adopt-dont-shop/lib.components');
+  return {
+    ...actual,
+    useConfirm: () => ({
+      isOpen: false,
+      confirm: confirmSpy,
+      confirmProps: {
+        isOpen: false,
+        onClose: () => {},
+        onConfirm: () => {},
+        message: '',
+      },
+    }),
+    ConfirmDialog: () => null,
+  };
+});
+
+vi.mock('../services/libraryServices', () => ({
+  apiService: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const apiServiceMock = apiService as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+describe('PrivacyTools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    confirmSpy.mockResolvedValue(true);
+    apiServiceMock.get.mockReset();
+    apiServiceMock.post.mockReset();
+
+    // jsdom does not implement URL.createObjectURL / revokeObjectURL
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn().mockReturnValue('blob:mock-url'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  const typeUserId = (value = 'user-123') => {
+    const input = screen.getByPlaceholderText('UUID of the target user') as HTMLInputElement;
+    fireEvent.change(input, { target: { value } });
+  };
+
+  it('renders both privacy actions', () => {
+    renderWithProviders(<PrivacyTools />);
+    expect(screen.getByText('Data Export (GDPR Art. 20)')).toBeInTheDocument();
+    expect(screen.getByText('Account Deletion (GDPR Art. 17)')).toBeInTheDocument();
+  });
+
+  it('successfully exports user data when api call resolves', async () => {
+    apiServiceMock.get.mockResolvedValue({ user: { id: 'user-123' }, data: ['record-1'] });
+    renderWithProviders(<PrivacyTools />);
+    typeUserId();
+
+    fireEvent.click(screen.getByRole('button', { name: /Export user data/i }));
+
+    await waitFor(() => {
+      expect(apiServiceMock.get).toHaveBeenCalledWith(
+        '/api/v1/privacy/admin/users/user-123/export'
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Export downloaded.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when export api call fails', async () => {
+    apiServiceMock.get.mockRejectedValue(new Error('Network unreachable'));
+    renderWithProviders(<PrivacyTools />);
+    typeUserId();
+
+    fireEvent.click(screen.getByRole('button', { name: /Export user data/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Network unreachable')).toBeInTheDocument();
+    });
+  });
+
+  it('schedules deletion after user confirms', async () => {
+    confirmSpy.mockResolvedValueOnce(true);
+    apiServiceMock.post.mockResolvedValue(undefined);
+    renderWithProviders(<PrivacyTools />);
+    typeUserId();
+
+    fireEvent.click(screen.getByRole('button', { name: /Schedule deletion/i }));
+
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'danger', title: 'Schedule account deletion?' })
+      );
+    });
+    await waitFor(() => {
+      expect(apiServiceMock.post).toHaveBeenCalledWith(
+        '/api/v1/privacy/admin/users/user-123/delete-request',
+        { reason: undefined }
+      );
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Deletion scheduled. Hard anonymisation runs after the 30-day grace window.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('does not call the delete api when user cancels the confirm dialog', async () => {
+    confirmSpy.mockResolvedValueOnce(false);
+    renderWithProviders(<PrivacyTools />);
+    typeUserId();
+
+    fireEvent.click(screen.getByRole('button', { name: /Schedule deletion/i }));
+
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalled();
+    });
+    expect(apiServiceMock.post).not.toHaveBeenCalled();
+  });
+});

--- a/app.admin/src/pages/PrivacyTools.tsx
+++ b/app.admin/src/pages/PrivacyTools.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 import clsx from 'clsx';
-import { Heading, Text, Input, Button } from '@adopt-dont-shop/lib.components';
+import {
+  Heading,
+  Text,
+  Input,
+  Button,
+  ConfirmDialog,
+  useConfirm,
+} from '@adopt-dont-shop/lib.components';
 import { FiDownload, FiAlertTriangle } from 'react-icons/fi';
 import { apiService } from '../services/libraryServices';
 import * as styles from './PrivacyTools.css';
@@ -10,6 +17,7 @@ const PrivacyTools: React.FC = () => {
   const [reason, setReason] = useState('');
   const [busy, setBusy] = useState<'export' | 'delete' | null>(null);
   const [message, setMessage] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+  const { confirm, confirmProps } = useConfirm();
 
   const handleExport = async () => {
     if (!userId.trim()) {
@@ -45,11 +53,14 @@ const PrivacyTools: React.FC = () => {
       setMessage({ kind: 'error', text: 'Enter a user ID' });
       return;
     }
-    if (
-      !window.confirm(
-        `Schedule account deletion for ${userId.trim()}? Data will be anonymised after the 30-day grace window.`
-      )
-    ) {
+    const confirmed = await confirm({
+      title: 'Schedule account deletion?',
+      message: `Schedule account deletion for ${userId.trim()}? Data will be anonymised after the 30-day grace window.`,
+      confirmText: 'Schedule deletion',
+      cancelText: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) {
       return;
     }
     setBusy('delete');
@@ -139,6 +150,8 @@ const PrivacyTools: React.FC = () => {
           {message.text}
         </div>
       )}
+
+      <ConfirmDialog {...confirmProps} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes [ADS-609](https://linear.app/ideasquared/issue/ADS-609/daily-code-review-2026-05-19-privacytools-page-regresses-windowconfirm). The `PrivacyTools` admin page (added in `4a7abf8`) regressed two recent app-wide cleanups:

1. It used `window.confirm()` on the irreversible "schedule deletion" action, undoing the `useConfirm`/`ConfirmDialog` migration from ADS-585.
2. Its `.css.ts` file inlined hardcoded grey/success/error hex values instead of the design tokens introduced in the `1d5bcdd` sweep.
3. It shipped without any behaviour coverage for a destructive GDPR Art. 17 affordance.

This PR addresses all three.

## Changes

- `app.admin/src/pages/PrivacyTools.tsx` — replace `window.confirm` with `useConfirm({ variant: 'danger', title: 'Schedule account deletion?', confirmText: 'Schedule deletion', ... })`, render `<ConfirmDialog {...confirmProps} />` once at the bottom of the page.
- `app.admin/src/pages/PrivacyTools.css.ts` — switch hardcoded colours to `vars.border.color.default`, `vars.background.success/danger`, and `vars.text.success/danger`.
- `app.admin/src/pages/PrivacyTools.test.tsx` — new test file covering export success, export error, deletion-after-confirm, and confirm-cancel (verifies the delete API is *not* called when the user dismisses the confirm).

## Acceptance criteria

- [x] No `window.confirm` / `window.alert` in this file.
- [x] All styles live in `PrivacyTools.css.ts` using design tokens.
- [x] Behaviour tests added for the four cases described in the ticket.

## Test plan

- [x] `npx vitest run src/pages/PrivacyTools.test.tsx` — 5/5 pass.
- [x] `npx vitest run src/__tests__/no-restricted-globals.lint.test.ts` — 3/3 pass.
- [x] `npx eslint src/pages/PrivacyTools.{tsx,test.tsx,css.ts}` — clean.
- [x] `npx tsc --noEmit` — clean (after `turbo build --filter='./lib.*'`).
- [x] `npx prettier --check` on the three files — pass.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_