### PR TITLE
refactor(backend): route foster/privacy admin gating through requireRole (ADS-610)

### DIFF
--- a/service.backend/src/__tests__/routes/foster.routes.test.ts
+++ b/service.backend/src/__tests__/routes/foster.routes.test.ts
@@ -104,6 +104,35 @@ describe('GET /api/v1/foster/placements scope enforcement (ADS-606)', () => {
     expect(mockedList).not.toHaveBeenCalled();
   });
 
+  // ADS-610: requireRole gates support_agent (and other non-foster roles)
+  // at the middleware layer, before the route handler runs — same outcome
+  // regardless of whether they carry a rescueId.
+  it('forbids a support agent even when carrying a rescueId', async () => {
+    authenticateAs({
+      userId: 'support-2',
+      userType: UserType.SUPPORT_AGENT,
+      rescueId: '1ece75b7-956f-420f-8538-91f89b00b30a',
+    });
+
+    const res = await request(buildApp()).get('/api/v1/foster/placements');
+
+    expect(res.status).toBe(403);
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
+  it('forbids an adopter from listing placements', async () => {
+    authenticateAs({
+      userId: 'adopter-1',
+      userType: UserType.ADOPTER,
+      rescueId: null,
+    });
+
+    const res = await request(buildApp()).get('/api/v1/foster/placements');
+
+    expect(res.status).toBe(403);
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
   it('scopes a non-admin caller to their own rescue and ignores any rescueId query override', async () => {
     const callerRescueId = '1ece75b7-956f-420f-8538-91f89b00b30a';
     const otherRescueId = '7bdeed6e-6e22-4b8d-93c4-8a03f46a9910';

--- a/service.backend/src/__tests__/routes/privacy.routes.test.ts
+++ b/service.backend/src/__tests__/routes/privacy.routes.test.ts
@@ -1,0 +1,166 @@
+/**
+ * ADS-610: admin GDPR routes go through `requireRole` instead of the
+ * old inline `ensureAdmin` helper. These tests assert the admin-only
+ * endpoints reject non-admin roles (notably `support_agent`, which the
+ * inline string check would have ignored entirely) before invoking the
+ * underlying service.
+ */
+
+import express, { NextFunction, Response } from 'express';
+import request from 'supertest';
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import type { AuthenticatedRequest } from '../../types/auth';
+import { UserType } from '../../models/User';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn(), logBusiness: vi.fn() },
+}));
+
+vi.mock('../../config/env', () => ({
+  env: {
+    JWT_SECRET: 'test-secret-min-32-characters-long-12345',
+    JWT_REFRESH_SECRET: 'test-refresh-secret-min-32-chars-12345',
+    SESSION_SECRET: 'test-session-secret',
+    CSRF_SECRET: 'test-csrf-secret',
+  },
+}));
+
+vi.mock('../../services/data-export.service', () => ({
+  exportUserData: vi.fn(),
+}));
+
+vi.mock('../../services/data-deletion.service', () => ({
+  requestAccountDeletion: vi.fn(),
+}));
+
+vi.mock('../../services/consent.service', async () => {
+  const { z } = await import('zod');
+  return {
+    ConsentInputSchema: z.object({}).passthrough(),
+    CookiesConsentInputSchema: z.object({}).passthrough(),
+    recordConsent: vi.fn(),
+    recordCookiesConsent: vi.fn(),
+  };
+});
+
+const authenticateTokenMock = vi.fn();
+vi.mock('../../middleware/auth', () => ({
+  authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authenticateTokenMock(req, res, next),
+}));
+
+import { exportUserData } from '../../services/data-export.service';
+import { requestAccountDeletion } from '../../services/data-deletion.service';
+import privacyRouter from '../../routes/privacy.routes';
+
+const mockedExport = vi.mocked(exportUserData);
+const mockedDelete = vi.mocked(requestAccountDeletion);
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/privacy', privacyRouter);
+  return app;
+};
+
+type StubUser = Pick<NonNullable<AuthenticatedRequest['user']>, 'userId' | 'userType'>;
+
+const authenticateAs = (user: StubUser): void => {
+  authenticateTokenMock.mockImplementation(
+    (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+      req.user = user as AuthenticatedRequest['user'];
+      next();
+    }
+  );
+};
+
+describe('Admin privacy endpoints — RBAC (ADS-610)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExport.mockResolvedValue({ user: { userId: 'data-subject' } } as never);
+    mockedDelete.mockResolvedValue({
+      userId: 'data-subject',
+      anonymisationScheduledFor: new Date().toISOString(),
+    } as never);
+  });
+
+  describe('GET /admin/users/:userId/export', () => {
+    it('allows ADMIN', async () => {
+      authenticateAs({ userId: 'admin-1', userType: UserType.ADMIN });
+      const res = await request(buildApp()).get('/api/v1/privacy/admin/users/u-1/export');
+      expect(res.status).toBe(200);
+      expect(mockedExport).toHaveBeenCalledWith('u-1', {
+        userId: 'admin-1',
+        userType: UserType.ADMIN,
+      });
+    });
+
+    it('allows SUPER_ADMIN', async () => {
+      authenticateAs({ userId: 'admin-2', userType: UserType.SUPER_ADMIN });
+      const res = await request(buildApp()).get('/api/v1/privacy/admin/users/u-1/export');
+      expect(res.status).toBe(200);
+      expect(mockedExport).toHaveBeenCalled();
+    });
+
+    it('rejects SUPPORT_AGENT with 403', async () => {
+      authenticateAs({ userId: 'support-1', userType: UserType.SUPPORT_AGENT });
+      const res = await request(buildApp()).get('/api/v1/privacy/admin/users/u-1/export');
+      expect(res.status).toBe(403);
+      expect(mockedExport).not.toHaveBeenCalled();
+    });
+
+    it('rejects MODERATOR with 403', async () => {
+      authenticateAs({ userId: 'mod-1', userType: UserType.MODERATOR });
+      const res = await request(buildApp()).get('/api/v1/privacy/admin/users/u-1/export');
+      expect(res.status).toBe(403);
+      expect(mockedExport).not.toHaveBeenCalled();
+    });
+
+    it('rejects ADOPTER with 403', async () => {
+      authenticateAs({ userId: 'adopter-1', userType: UserType.ADOPTER });
+      const res = await request(buildApp()).get('/api/v1/privacy/admin/users/u-1/export');
+      expect(res.status).toBe(403);
+      expect(mockedExport).not.toHaveBeenCalled();
+    });
+
+    it('rejects RESCUE_STAFF with 403', async () => {
+      authenticateAs({ userId: 'staff-1', userType: UserType.RESCUE_STAFF });
+      const res = await request(buildApp()).get('/api/v1/privacy/admin/users/u-1/export');
+      expect(res.status).toBe(403);
+      expect(mockedExport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /admin/users/:userId/delete-request', () => {
+    it('allows ADMIN', async () => {
+      authenticateAs({ userId: 'admin-1', userType: UserType.ADMIN });
+      const res = await request(buildApp())
+        .post('/api/v1/privacy/admin/users/u-1/delete-request')
+        .send({ reason: 'GDPR request' });
+      expect(res.status).toBe(202);
+      expect(mockedDelete).toHaveBeenCalledWith('u-1', 'GDPR request', {
+        userId: 'admin-1',
+        userType: UserType.ADMIN,
+      });
+    });
+
+    it('rejects SUPPORT_AGENT with 403', async () => {
+      authenticateAs({ userId: 'support-1', userType: UserType.SUPPORT_AGENT });
+      const res = await request(buildApp())
+        .post('/api/v1/privacy/admin/users/u-1/delete-request')
+        .send({ reason: 'should be denied' });
+      expect(res.status).toBe(403);
+      expect(mockedDelete).not.toHaveBeenCalled();
+    });
+
+    it('rejects ADOPTER with 403', async () => {
+      authenticateAs({ userId: 'adopter-1', userType: UserType.ADOPTER });
+      const res = await request(buildApp())
+        .post('/api/v1/privacy/admin/users/u-1/delete-request')
+        .send({});
+      expect(res.status).toBe(403);
+      expect(mockedDelete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/service.backend/src/routes/foster.routes.ts
+++ b/service.backend/src/routes/foster.routes.ts
@@ -1,8 +1,10 @@
 import { Router, type Response } from 'express';
 import { body, param, query, validationResult } from 'express-validator';
 import { authenticateToken } from '../middleware/auth';
+import { requireRole } from '../middleware/rbac';
 import fosterService from '../services/foster.service';
 import { FosterPlacementStatus } from '../models/FosterPlacement';
+import { UserType } from '../models/User';
 import type { AuthenticatedRequest } from '../types/auth';
 import { logger } from '../utils/logger';
 
@@ -10,11 +12,18 @@ const router = Router();
 
 router.use(authenticateToken);
 
+const ADMIN_USER_TYPES = [UserType.ADMIN, UserType.SUPER_ADMIN];
+const FOSTER_ROUTE_USER_TYPES = [...ADMIN_USER_TYPES, UserType.RESCUE_STAFF];
+
 const isAdmin = (req: AuthenticatedRequest): boolean => {
-  const role = req.user?.userType;
-  return role === 'admin' || role === 'super_admin';
+  const role = req.user?.userType as UserType | undefined;
+  return role !== undefined && ADMIN_USER_TYPES.includes(role);
 };
 
+// Per-record scoping check. Distinct from the route-level `requireRole`
+// guard: that filters out roles entirely, this one decides whether an
+// already-authorised caller may operate on a *specific* placement based
+// on its rescueId.
 const rescueScopeOrAdmin = (req: AuthenticatedRequest, rescueId: string): boolean => {
   if (isAdmin(req)) {
     return true;
@@ -24,6 +33,7 @@ const rescueScopeOrAdmin = (req: AuthenticatedRequest, rescueId: string): boolea
 
 router.post(
   '/placements',
+  requireRole(...FOSTER_ROUTE_USER_TYPES),
   [
     body('petId').isUUID(),
     body('fosterUserId').isUUID(),
@@ -65,6 +75,7 @@ router.post(
 
 router.get(
   '/placements',
+  requireRole(...FOSTER_ROUTE_USER_TYPES),
   [
     query('rescueId').optional().isUUID(),
     query('fosterUserId').optional().isUUID(),
@@ -105,6 +116,7 @@ router.get(
 
 router.get(
   '/placements/:id',
+  requireRole(...FOSTER_ROUTE_USER_TYPES),
   [param('id').isUUID()],
   async (req: AuthenticatedRequest, res: Response) => {
     const errors = validationResult(req);
@@ -124,6 +136,7 @@ router.get(
 
 router.post(
   '/placements/:id/end',
+  requireRole(...FOSTER_ROUTE_USER_TYPES),
   [
     param('id').isUUID(),
     body('outcome').isIn(['return_to_rescue', 'adopted_by_foster', 'cancelled']),

--- a/service.backend/src/routes/privacy.routes.ts
+++ b/service.backend/src/routes/privacy.routes.ts
@@ -1,7 +1,9 @@
 import { Router, type Response } from 'express';
 import { z } from 'zod';
 import { authenticateToken } from '../middleware/auth';
+import { requireRole } from '../middleware/rbac';
 import { validateBody } from '../middleware/zod-validate';
+import { UserType } from '../models/User';
 import {
   ConsentInputSchema,
   CookiesConsentInputSchema,
@@ -130,38 +132,32 @@ router.post(
  * exports and deletion requests on behalf of users (e.g. responding to
  * subject access requests received via support channels). Mounted on
  * the same router so the parent `authenticateToken` middleware applies;
- * RBAC gating below restricts to admin/super_admin only.
+ * `requireRole(...)` below restricts to admin/super_admin only.
  */
-const ensureAdmin = (req: AuthenticatedRequest, res: Response): boolean => {
-  const role = req.user?.userType;
-  if (role !== 'admin' && role !== 'super_admin') {
-    res.status(403).json({ error: 'Admin privileges required' });
-    return false;
-  }
-  return true;
-};
+const requireAdminOrSuperAdmin = requireRole(UserType.ADMIN, UserType.SUPER_ADMIN);
 
 const AdminUserIdParamSchema = z.object({ userId: z.string().min(1) });
 
-router.get('/admin/users/:userId/export', async (req: AuthenticatedRequest, res: Response) => {
-  if (!ensureAdmin(req, res)) {
-    return;
+router.get(
+  '/admin/users/:userId/export',
+  requireAdminOrSuperAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const parsed = AdminUserIdParamSchema.safeParse(req.params);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid userId' });
+      return;
+    }
+    // ADS-605: thread the acting admin through so the audit row records
+    // the admin's userId, not the data subject's.
+    const actor = req.user ? { userId: req.user.userId, userType: req.user.userType } : undefined;
+    const bundle = await exportUserData(parsed.data.userId, actor);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="adopt-dont-shop-export-${parsed.data.userId}.json"`
+    );
+    res.json(bundle);
   }
-  const parsed = AdminUserIdParamSchema.safeParse(req.params);
-  if (!parsed.success) {
-    res.status(400).json({ error: 'Invalid userId' });
-    return;
-  }
-  // ADS-605: thread the acting admin through so the audit row records
-  // the admin's userId, not the data subject's.
-  const actor = req.user ? { userId: req.user.userId, userType: req.user.userType } : undefined;
-  const bundle = await exportUserData(parsed.data.userId, actor);
-  res.setHeader(
-    'Content-Disposition',
-    `attachment; filename="adopt-dont-shop-export-${parsed.data.userId}.json"`
-  );
-  res.json(bundle);
-});
+);
 
 const AdminDeleteSchema = z.object({
   reason: z.string().trim().max(500).optional(),
@@ -169,11 +165,9 @@ const AdminDeleteSchema = z.object({
 
 router.post(
   '/admin/users/:userId/delete-request',
+  requireAdminOrSuperAdmin,
   validateBody(AdminDeleteSchema),
   async (req: AuthenticatedRequest, res: Response) => {
-    if (!ensureAdmin(req, res)) {
-      return;
-    }
     const parsed = AdminUserIdParamSchema.safeParse(req.params);
     if (!parsed.success) {
       res.status(400).json({ error: 'Invalid userId' });


### PR DESCRIPTION
## Summary

Fixes [ADS-610](https://linear.app/ideasquared/issue/ADS-610/daily-code-review-2026-05-19-foster-privacy-routes-duplicate-inline). The new `foster.routes.ts` and `privacy.routes.ts` re-implemented admin gating inline (`isAdmin`, `ensureAdmin`) using string literal role comparisons. That bypassed:

1. The shared `requireRole(...UserType[])` middleware in `rbac.ts`, which centralises the 401/403 response shape and warning log.
2. The `UserType` enum, so new roles silently slip through — `support_agent` was added in `4cd8303` but neither inline check knew about it.

## Changes

### `service.backend/src/routes/foster.routes.ts`
- Replace inline `isAdmin` string check with one that consumes the `UserType` enum.
- Add `requireRole(UserType.ADMIN, UserType.SUPER_ADMIN, UserType.RESCUE_STAFF)` middleware on each placement route so off-list roles (adopter, support_agent, moderator) are rejected at the middleware layer with the standard `requireRole` audit log.
- Keep `rescueScopeOrAdmin` for the per-record post-fetch check (a different concern), but it now references `UserType` enum values.

### `service.backend/src/routes/privacy.routes.ts`
- Drop the `ensureAdmin` helper.
- Use `requireRole(UserType.ADMIN, UserType.SUPER_ADMIN)` middleware on the admin export and delete-request endpoints.

### Tests
- `service.backend/src/__tests__/routes/foster.routes.test.ts` — add cases proving `SUPPORT_AGENT` and `ADOPTER` are rejected regardless of `rescueId`, matching the ticket's "support_agent should be 403" criterion.
- `service.backend/src/__tests__/routes/privacy.routes.test.ts` — **new file** exercising `GET /admin/users/:userId/export` and `POST /admin/users/:userId/delete-request` against every `UserType` (ADMIN, SUPER_ADMIN, MODERATOR, SUPPORT_AGENT, ADOPTER, RESCUE_STAFF).

## Acceptance criteria

- [x] No inline role-string comparisons in `foster.routes.ts` and `privacy.routes.ts`.
- [x] All admin gating goes through `requireRole`/`requireAdmin` from `rbac.ts`.
- [x] Existing behaviour tests pass; coverage added for `support_agent` (403 on admin endpoints).

## Test plan

- [x] `npx vitest run src/__tests__/routes/foster.routes.test.ts src/__tests__/routes/privacy.routes.test.ts` — 16/16 pass.
- [x] `npx eslint` on the four touched files — clean.
- [x] `npx tsc --noEmit` — no foster/privacy errors.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_