### PR TITLE
fix(docker): fail-fast on missing dev secrets — Redis/JWT/CORS (ADS-600)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,8 +81,11 @@ DB_SSL_MODE=disable
 # -----------------------------------------------------------------------------
 REDIS_HOST=redis
 REDIS_PORT=6379
-# For production, set a strong password:
-# REDIS_PASSWORD=CHANGE_THIS_SECURE_REDIS_PASSWORD
+# REDIS_PASSWORD is now required by docker-compose.yml (ADS-600) — Compose
+# will refuse to start without it. Replace the placeholder before deploying
+# to anything network-exposed; for production generate with:
+#   openssl rand -base64 32
+REDIS_PASSWORD=CHANGE_THIS_SECURE_REDIS_PASSWORD
 # REDIS_URL is the canonical connection string used by the backend
 # (lib/redis.ts) and BullMQ. docker-compose.yml derives a default from
 # REDIS_HOST/REDIS_PORT/REDIS_PASSWORD, but you can override here for

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - '127.0.0.1:6379:6379'
     volumes:
       - redis_data:/data
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-devredispassword}
+    command: "redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?Error: REDIS_PASSWORD required (run `npm run secrets:generate` or copy .env.example)}"
 
   # ============================================================================
   # BACKEND SERVICE
@@ -91,10 +91,10 @@ services:
       # from the discrete vars so existing per-component overrides still work.
       REDIS_HOST: ${REDIS_HOST:-redis}
       REDIS_PORT: ${REDIS_PORT:-6379}
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-devredispassword}
-      REDIS_URL: ${REDIS_URL:-redis://:${REDIS_PASSWORD:-devredispassword}@${REDIS_HOST:-redis}:${REDIS_PORT:-6379}}
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?Error: REDIS_PASSWORD required}"
+      REDIS_URL: ${REDIS_URL:-redis://:${REDIS_PASSWORD}@${REDIS_HOST:-redis}:${REDIS_PORT:-6379}}
       # Security - JWT tokens (REQUIRED)
-      JWT_SECRET: ${JWT_SECRET}
+      JWT_SECRET: "${JWT_SECRET:?Error: JWT_SECRET required}"
       JWT_REFRESH_SECRET: "${JWT_REFRESH_SECRET:?Error: JWT_REFRESH_SECRET required}"
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-1h}
       JWT_REFRESH_EXPIRES_IN: ${JWT_REFRESH_EXPIRES_IN:-7d}
@@ -108,7 +108,7 @@ services:
       # URL the user clicks in verification / password-reset emails.
       # Default to app.client (3000); override per-env.
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
-      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:5000}
+      CORS_ORIGIN: "${CORS_ORIGIN:?Error: CORS_ORIGIN required (set to comma-separated allowed origins, e.g. http://localhost:3000,http://localhost:3001,http://localhost:3002)}"
       # File watching for hot reload (critical for Windows/Docker)
       CHOKIDAR_USEPOLLING: true
       CHOKIDAR_INTERVAL: 1000


### PR DESCRIPTION
## Summary

Fixes [ADS-600](https://linear.app/ideasquared/issue/ADS-600/insecure-defaults-in-docker-composeyml-redis-password-jwt-secret). The dev `docker-compose.yml` shipped three weak defaults that could leak into non-dev environments:

1. **Hardcoded `devredispassword`** on `REDIS_PASSWORD` (in both the `redis` `command` and the `service-backend` env) — an operator copying the dev compose to an exposed host inherits a well-known cache credential.
2. **`JWT_SECRET` lacked the `:?Error:` enforcement** that `JWT_REFRESH_SECRET`/`SESSION_SECRET`/`CSRF_SECRET` already use — a missing secret started the container and let it crash-loop instead of failing at compose-time.
3. **`CORS_ORIGIN` defaulted to a long localhost allowlist** — habituation risk and a missing override in staging/prod could silently leave the permissive list in place.

## Changes

- `docker-compose.yml`
  - `redis.command`: `${REDIS_PASSWORD:-devredispassword}` → `${REDIS_PASSWORD:?Error: REDIS_PASSWORD required ...}`
  - `service-backend.environment.REDIS_PASSWORD`: same `:?` enforcement.
  - `service-backend.environment.REDIS_URL`: now references the (now-required) `REDIS_PASSWORD` directly — no more duplicated default.
  - `service-backend.environment.JWT_SECRET`: `${JWT_SECRET}` → `"${JWT_SECRET:?Error: JWT_SECRET required}"`.
  - `service-backend.environment.CORS_ORIGIN`: localhost allowlist default removed; now `:?Error: CORS_ORIGIN required (...example...)`.
- `.env.example`
  - Uncomment `REDIS_PASSWORD=CHANGE_THIS_SECURE_REDIS_PASSWORD` so the `cp .env.example .env` onboarding flow keeps working.

`docker-compose.prod.yml` is unchanged.

## Acceptance criteria

- [x] `docker-compose up` with no `.env` fails fast with explicit errors naming the missing secret (verified — first `REDIS_PASSWORD`, then `JWT_SECRET`, then `CORS_ORIGIN`).
- [x] No `devredispassword` default anywhere.
- [x] `JWT_SECRET` line uses the same `:?Error:` pattern as its siblings.
- [x] `docker-compose.prod.yml` unchanged.

## Test plan

- [x] `docker compose -f docker-compose.yml config` with no env → fails on `REDIS_PASSWORD`.
- [x] With `REDIS_PASSWORD` set, missing `JWT_SECRET` → fails on `JWT_SECRET`.
- [x] With both set, missing `CORS_ORIGIN` → fails on `CORS_ORIGIN`.
- [x] With all secrets set → `docker compose config` returns successfully.
- [x] `git diff docker-compose.prod.yml` is empty.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_