### PR TITLE
fix(security): drop SVG uploads + force attachment on legacy SVGs (ADS-598)

### DIFF
--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -291,6 +291,22 @@ http {
 
             # Pass the original URI to the backend so it can log/audit it.
             auth_request_set $auth_original_uri $request_uri;
+
+            # ADS-598: any historical SVG already on disk must be downloaded,
+            # not rendered. New SVG uploads are rejected by the backend
+            # allowlist, but this is belt-and-braces for legacy files.
+            # Browsers won't execute embedded <script> / event handlers
+            # when the response is application/octet-stream + attachment.
+            location ~* \.svgz?$ {
+                auth_request /_auth_uploads;
+                root /srv;
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+                add_header Content-Disposition "attachment" always;
+                add_header X-Content-Type-Options "nosniff" always;
+                default_type application/octet-stream;
+                types { }
+            }
         }
 
         # Internal-only location: forwards the auth subrequest to the backend.

--- a/service.backend/src/__tests__/routes/upload-serve.routes.test.ts
+++ b/service.backend/src/__tests__/routes/upload-serve.routes.test.ts
@@ -411,6 +411,28 @@ describe('GET /uploads/:path — Express fallback streaming route', () => {
     expect(response.status).toBe(400);
   });
 
+  // ADS-598: SVGs from the legacy on-disk corpus must be served as a
+  // downloadable attachment with X-Content-Type-Options: nosniff so a
+  // browser navigating directly to the URL cannot execute the script
+  // payload same-origin.
+  it('forces Content-Disposition: attachment and nosniff on .svg responses', async () => {
+    authenticateTokenMock.mockImplementation(
+      (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+        req.user = mockUser as AuthenticatedRequest['user'];
+        next();
+      }
+    );
+
+    fs.mkdirSync(path.join(TEST_UPLOAD_DIR, 'pets'), { recursive: true });
+    fs.writeFileSync(path.join(TEST_UPLOAD_DIR, 'pets', 'legacy.svg'), '<svg onload="alert(1)"/>');
+
+    const response = await request(app).get('/uploads/pets/legacy.svg');
+    expect(response.status).toBe(200);
+    expect(response.headers['content-disposition']).toBe('attachment');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['content-type']).toMatch(/application\/octet-stream/);
+  });
+
   // ── per-resource ACL wiring ────────────────────────────────────────────────
   //
   // The streaming route must invoke decideUploadAccess and honour its verdict,

--- a/service.backend/src/__tests__/services/file-upload.service.test.ts
+++ b/service.backend/src/__tests__/services/file-upload.service.test.ts
@@ -248,7 +248,13 @@ describe('FileUploadService', () => {
     });
   });
 
-  describe('sanitizeSvgFile() — XSS prevention', () => {
+  describe('SVG uploads rejected at allowlist level (ADS-598)', () => {
+    // ADS-598: `image/svg+xml` was dropped from the image allowlist because
+    // SVGs execute same-origin and DOMPurify SVG sanitisation has a long
+    // CVE history. Any attempt to upload one — clean or malicious — is
+    // rejected. The `sanitizeSvgFile` helper is kept as defence-in-depth
+    // for non-multer code paths but the normal upload pipeline never
+    // reaches it.
     const makeSvgFile = () =>
       makeFile({
         originalname: 'icon.svg',
@@ -257,72 +263,25 @@ describe('FileUploadService', () => {
         filename: 'icon_123.svg',
       });
 
-    const setupSvgUpload = (rawSvg: string, sanitizedSvg: string) => {
+    it('rejects an SVG upload even when the content is clean', async () => {
       vi.mocked(fileTypeFromFile).mockResolvedValue({ mime: 'image/svg+xml', ext: 'svg' });
-      vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from(rawSvg));
-      vi.mocked(DOMPurify.sanitize).mockReturnValue(sanitizedSvg);
-      vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
-      vi.mocked(fs.promises.stat).mockResolvedValue({
-        mtime: new Date('2024-01-01'),
-      } as unknown as import('fs').Stats);
-      vi.mocked(FileUpload.create).mockResolvedValue(
-        makeMockRecord({ mime_type: 'image/svg+xml' })
-      );
-    };
-
-    it('strips script tags from SVG content and allows the upload', async () => {
-      const rawSvg = '<svg><script>alert("xss")</script><circle r="5"/></svg>';
-      const cleanSvg = '<svg><circle r="5"/></svg>';
-      setupSvgUpload(rawSvg, cleanSvg);
-
-      const result = await FileUploadService.uploadFile(makeSvgFile(), 'pets', {
-        uploadedBy: 'user-456',
-      });
-
-      expect(result.success).toBe(true);
-      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
-        '/test-uploads/icon.svg',
-        cleanSvg,
-        'utf-8'
-      );
-    });
-
-    it('strips event handler attributes from SVG content', async () => {
-      const rawSvg = '<svg><circle onclick="evil()" r="5"/></svg>';
-      const cleanSvg = '<svg><circle r="5"/></svg>';
-      setupSvgUpload(rawSvg, cleanSvg);
-
-      const result = await FileUploadService.uploadFile(makeSvgFile(), 'pets', {
-        uploadedBy: 'user-456',
-      });
-
-      expect(result.success).toBe(true);
-      expect(vi.mocked(DOMPurify.sanitize)).toHaveBeenCalled();
-    });
-
-    it('rejects an SVG when sanitisation removes all meaningful content', async () => {
-      setupSvgUpload('<svg><script>alert(1)</script></svg>', '');
 
       await expect(
         FileUploadService.uploadFile(makeSvgFile(), 'pets', { uploadedBy: 'user-456' })
-      ).rejects.toThrow('File upload failed');
+      ).rejects.toThrow(/image\/svg\+xml/);
+      expect(vi.mocked(DOMPurify.sanitize)).not.toHaveBeenCalled();
+      expect(vi.mocked(FileUpload.create)).not.toHaveBeenCalled();
     });
 
-    it('passes a clean SVG through unchanged', async () => {
-      const cleanSvg =
-        '<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="5"/></svg>';
-      setupSvgUpload(cleanSvg, cleanSvg);
+    it('rejects an SVG upload containing <script> without ever invoking the sanitiser', async () => {
+      const rawSvg = '<svg><script>alert("xss")</script><circle r="5"/></svg>';
+      vi.mocked(fileTypeFromFile).mockResolvedValue({ mime: 'image/svg+xml', ext: 'svg' });
+      vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from(rawSvg));
 
-      const result = await FileUploadService.uploadFile(makeSvgFile(), 'pets', {
-        uploadedBy: 'user-456',
-      });
-
-      expect(result.success).toBe(true);
-      expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalledWith(
-        '/test-uploads/icon.svg',
-        cleanSvg,
-        'utf-8'
-      );
+      await expect(
+        FileUploadService.uploadFile(makeSvgFile(), 'pets', { uploadedBy: 'user-456' })
+      ).rejects.toThrow(/image\/svg\+xml/);
+      expect(vi.mocked(DOMPurify.sanitize)).not.toHaveBeenCalled();
     });
   });
 

--- a/service.backend/src/routes/upload-serve.routes.ts
+++ b/service.backend/src/routes/upload-serve.routes.ts
@@ -168,6 +168,16 @@ const streamFile = (resolved: string, res: Response): void => {
     if (ext === '.pdf') {
       res.setHeader('Content-Disposition', 'inline');
     }
+    // ADS-598: any historical SVG already on disk must be downloaded,
+    // not rendered. New SVG uploads are rejected upstream by the
+    // file-upload allowlist, but the Express fallback still serves
+    // legacy files for environments where this code runs without nginx
+    // in front. Forcing `attachment` prevents stored XSS via SVG
+    // payloads (event hooks, foreign content) executing same-origin.
+    if (ext === '.svg' || ext === '.svgz') {
+      res.setHeader('Content-Disposition', 'attachment');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+    }
     // Authenticated content must NEVER be cached by shared caches —
     // they can't replay the auth check on a follow-up requester.
     res.setHeader('Cache-Control', 'private, max-age=300');

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -16,10 +16,23 @@ import { getStorageProvider } from './storage';
 import { StorageCategory } from './storage/base-provider';
 
 // File upload configuration
+//
+// ADS-598: `image/svg+xml` is intentionally absent from the `images`
+// allowlist. SVGs render as same-origin documents and stored XSS via
+// DOMPurify bypass (mutation XSS, foreign content, animate/set event
+// hooks) has shipped in CVEs before. JPEG/PNG/GIF/WebP cover every
+// current product use case for user-uploaded images. The
+// `sanitizeSvgFile` helper and its caller in `processFile` are kept
+// as defence-in-depth for any code path that bypasses the multer
+// filter (e.g. seeders), but no normal user upload path will ever
+// reach it. The production serving path additionally forces
+// `Content-Disposition: attachment` and `Content-Type:
+// application/octet-stream` for any historical `.svg` already on disk
+// (see `streamFile` here and the `~* \\.svg$` block in `nginx.prod.conf`).
 const UPLOAD_CONFIG = {
   maxFileSize: config.storage.local.maxFileSize,
   allowedMimeTypes: {
-    images: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'],
+    images: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
     documents: [
       'application/pdf',
       'application/msword',


### PR DESCRIPTION
## Summary

Fixes [ADS-598](https://linear.app/ideasquared/issue/ADS-598/svg-upload-allowlist-nginx-serving-creates-stored-xss-surface). The image upload pipeline accepted `image/svg+xml`, ran the file through DOMPurify, and stored it on disk. In production, nginx then served the SVG with its `mime.types`-determined `image/svg+xml` content type — bypassing the Express `application/octet-stream` fallback — so a browser navigating to the URL renders the SVG as a same-origin document. Any DOMPurify miss (mutation XSS, `<set>`/`<animate>` event hooks, `xlink:href="javascript:..."`, foreign content tricks) executes with the victim's cookie context.

Picked options 1 + 2 from the ticket: drop SVG from the allowlist outright, and force `Content-Disposition: attachment` on any legacy `.svg` already on disk. DOMPurify stays in place as defence-in-depth.

## Changes

- `service.backend/src/services/file-upload.service.ts` — remove `image/svg+xml` from the `images` allowlist. Multer's `fileFilter` and `FileUploadService.validateFile()` now both reject SVG (including spoofed-mime payloads — the magic-byte check matches against the post-spoof MIME and the `validateFile` allowlist filters before reaching it). `sanitizeSvgFile` + its call site are kept as dead-code defence-in-depth for any non-multer caller.
- `service.backend/src/routes/upload-serve.routes.ts` — the Express fallback streamer now sets `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff` for `.svg` / `.svgz`, on top of the existing `application/octet-stream` MIME for unknown extensions. Handles legacy SVGs in environments that run without nginx in front.
- `nginx/nginx.prod.conf` — add a nested `location ~* \.svgz?$` inside `/uploads/` that re-applies `auth_request`, forces `add_header Content-Disposition "attachment" always`, `add_header X-Content-Type-Options "nosniff" always`, and overrides `default_type` to `application/octet-stream` with an empty `types { }` block so the bundled MIME map can't promote it back to `image/svg+xml`.

### Tests

- `service.backend/src/__tests__/services/file-upload.service.test.ts` — replace the four `sanitizeSvgFile()` happy-path tests with two assertions that any SVG upload is rejected without invoking DOMPurify or the DB.
- `service.backend/src/__tests__/routes/upload-serve.routes.test.ts` — new case streaming a `legacy.svg` containing an `onload="alert(1)"` payload and asserting the response carries `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff`, and `Content-Type: application/octet-stream`.

## Acceptance criteria

- [x] An attempt to upload an SVG with `<script>` is rejected outright.
- [x] Pre-existing SVGs are served with `Content-Disposition: attachment` so a browser cannot render them inline.
- [x] Both the nginx production path and the Express fallback are covered.
- [x] DOMPurify stays in place as defence-in-depth.
- [x] nginx config explicitly documents the chosen mitigation.

## Test plan

- [x] `npx vitest run src/__tests__/services/file-upload.service.test.ts src/__tests__/routes/upload-serve.routes.test.ts` — 78/78 pass.
- [x] `npx vitest run src/__tests__/services/ src/__tests__/routes/` — 1268/1270 pass (2 pre-existing skips).
- [x] `npx eslint` on the five touched files — clean.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_