### PR TITLE
feat(swipe): server-driven activity labels on swipe cards (ADS-632)

### DIFF
--- a/app.client/src/components/swipe/SwipeCard.activity-label.test.tsx
+++ b/app.client/src/components/swipe/SwipeCard.activity-label.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders, screen } from '../../test-utils';
+import { SwipeCard } from './SwipeCard';
+import type { DiscoveryPet } from '@/services';
+
+const mockLogEvent = vi.fn();
+
+vi.mock('@/hooks/useStatsig', () => ({
+  useStatsig: () => ({ logEvent: mockLogEvent }),
+}));
+
+vi.mock('@adopt-dont-shop/lib.auth', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}));
+
+const makePet = (overrides: Partial<DiscoveryPet> = {}): DiscoveryPet => ({
+  petId: 'pet-1',
+  name: 'Buddy',
+  type: 'dog',
+  ageGroup: 'adult',
+  size: 'medium',
+  gender: 'male',
+  images: [],
+  rescueName: 'Test Rescue',
+  ...overrides,
+});
+
+describe('SwipeCard — activity label (ADS-632)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render the activity label when the pet has none', () => {
+    renderWithProviders(<SwipeCard pet={makePet()} onSwipe={vi.fn()} isTop zIndex={1} />);
+    expect(screen.queryByTestId('activity-label')).toBeNull();
+  });
+
+  it('renders the activity label text + icon when the backend provides one', () => {
+    renderWithProviders(
+      <SwipeCard
+        pet={makePet({
+          activityLabel: { kind: 'views_today', text: '47 views today', icon: '👀' },
+        })}
+        onSwipe={vi.fn()}
+        isTop
+        zIndex={1}
+      />
+    );
+    const label = screen.getByTestId('activity-label');
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveTextContent('47 views today');
+    expect(label).toHaveAttribute('data-label-kind', 'views_today');
+  });
+
+  it('logs card_activity_label_shown when the card is on top', () => {
+    renderWithProviders(
+      <SwipeCard
+        pet={makePet({
+          petId: 'pet-buddy',
+          activityLabel: { kind: 'days_waiting', text: 'Waiting 89 days', icon: '🕒' },
+        })}
+        onSwipe={vi.fn()}
+        isTop
+        zIndex={1}
+      />
+    );
+    expect(mockLogEvent).toHaveBeenCalledWith('card_activity_label_shown', 1, {
+      pet_id: 'pet-buddy',
+      label_kind: 'days_waiting',
+    });
+  });
+
+  it('does not log the impression for cards below the top of the stack', () => {
+    renderWithProviders(
+      <SwipeCard
+        pet={makePet({
+          activityLabel: {
+            kind: 'similar_adopted_fast',
+            text: 'Pets like Buddy adopted in <30 days',
+          },
+        })}
+        onSwipe={vi.fn()}
+        isTop={false}
+        zIndex={0}
+      />
+    );
+    expect(mockLogEvent).not.toHaveBeenCalledWith(
+      'card_activity_label_shown',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+});

--- a/app.client/src/components/swipe/SwipeCard.css.ts
+++ b/app.client/src/components/swipe/SwipeCard.css.ts
@@ -455,3 +455,19 @@ export const promptButton = style({
     boxShadow: '0 8px 24px rgba(78, 205, 196, 0.5)',
   },
 });
+
+// ADS-632: activity label (views/waiting/social-proof) sits in the
+// top-badges stack so it never competes with the match badge for
+// screen position — the existing flex column there lays them out.
+export const activityLabel = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.25rem',
+  padding: '0.25rem 0.5rem',
+  background: 'rgba(0, 0, 0, 0.55)',
+  color: 'white',
+  borderRadius: '999px',
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  backdropFilter: 'blur(8px)',
+});

--- a/app.client/src/components/swipe/SwipeCard.tsx
+++ b/app.client/src/components/swipe/SwipeCard.tsx
@@ -132,6 +132,19 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
     }
   }, [isTop, pet, logEvent]);
 
+  // ADS-632: log activity-label impressions when the card is on top so
+  // the planned A/B can compare like-rate on cards with vs. without
+  // a label.
+  React.useEffect(() => {
+    if (!isTop || !pet.activityLabel) {
+      return;
+    }
+    logEvent('card_activity_label_shown', 1, {
+      pet_id: pet.petId,
+      label_kind: pet.activityLabel.kind,
+    });
+  }, [isTop, pet.petId, pet.activityLabel, logEvent]);
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (!isTop) {
@@ -405,6 +418,7 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
         {(pet.isSponsored ||
           !isAuthenticated ||
           matchTier !== null ||
+          pet.activityLabel ||
           (pet.matchReasons && pet.matchReasons.length > 0)) && (
           <div className={styles.topBadges}>
             {!isAuthenticated ? (
@@ -426,6 +440,15 @@ export const SwipeCard: React.FC<SwipeCardProps> = ({
             {pet.isSponsored && (
               <span className={styles.topBadge({ variant: 'sponsored' })}>
                 <MdStar /> Featured
+              </span>
+            )}
+            {pet.activityLabel && (
+              <span
+                className={styles.activityLabel}
+                data-testid='activity-label'
+                data-label-kind={pet.activityLabel.kind}
+              >
+                {pet.activityLabel.icon ?? ''} {pet.activityLabel.text}
               </span>
             )}
             {pet.matchReasons && pet.matchReasons.length > 0 && (

--- a/lib.discovery/src/types/index.ts
+++ b/lib.discovery/src/types/index.ts
@@ -101,6 +101,14 @@ export interface DiscoveryPet {
     kind: 'pref_match' | 'lifestyle' | 'distance' | 'similar_to_liked' | 'fresh';
     label: string;
   }>;
+  // ADS-632: server-driven activity label. Max one per card. Backend
+  // picks the most relevant one (views > waiting > social-proof,
+  // subject to sample-size threshold for `similar_adopted_fast`).
+  activityLabel?: {
+    kind: 'views_today' | 'days_waiting' | 'similar_adopted_fast';
+    text: string;
+    icon?: string;
+  };
 }
 
 export interface DiscoveryQueue {


### PR DESCRIPTION
## Summary

Implements [ADS-632](https://linear.app/ideasquared/issue/ADS-632/activity-labels-on-swipe-cards-views-days-waiting-social-proof). Add a server-driven activity label on swipe cards when the backend chooses to surface one — "👀 47 views today", "🕒 Waiting 89 days", or "🔥 Pets like Buddy adopted in <30 days". Max one label per card; the backend picks which.

## Changes

- `lib.discovery/src/types/index.ts`: extend `DiscoveryPet` with an optional `activityLabel: { kind, text, icon? }`. The three kinds match the ticket's three label types.
- `app.client/src/components/swipe/SwipeCard.tsx`:
  - Render the label inside the existing top-badges stack so it inherits the column layout and never overlaps the match badge.
  - Log `card_activity_label_shown` exactly once per (card, label) when the card is on top.
- `app.client/src/components/swipe/SwipeCard.css.ts`: new `activityLabel` pill style (blurred dark background, white text, rounded).
- `app.client/src/components/swipe/SwipeCard.activity-label.test.tsx`: four cases — no label → no render; label → text + `data-label-kind`; impression logs on top; impression does not log for stacked cards.

## Acceptance criteria

- [x] Labels are server-driven (backend decides which to show) — the type is opaque to the client; only renders what the backend sends.
- [x] Labels never compete with the match badge for the same screen position — they sit in the same `topBadges` flex column.
- [x] Logs `card_activity_label_shown` with label type + petId.
- [ ] **Server-side population is documented as follow-up.** This PR ships the contract; the backend's view-counter, days-waiting threshold (≥ 30 days), and sample-size guard for `similar_adopted_fast` are tracked separately so we don't ship a partial server change.

## Test plan

- [x] `npx vitest run src/components/swipe/SwipeCard.activity-label.test.tsx` — 4/4 pass (verified locally before push).

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_