### PR TITLE
feat(onboarding): preference quiz post-signup (ADS-628)

### DIFF
--- a/app.client/src/App.tsx
+++ b/app.client/src/App.tsx
@@ -46,6 +46,9 @@ const TopPicksPage = lazy(() =>
 const MatchOnboardingPage = lazy(() =>
   import('@/pages/MatchOnboardingPage').then(m => ({ default: m.MatchOnboardingPage }))
 );
+const OnboardingQuizPage = lazy(() =>
+  import('@/pages/OnboardingQuizPage').then(m => ({ default: m.OnboardingQuizPage }))
+);
 const NotificationsPage = lazy(() =>
   import('@/pages/NotificationsPage').then(m => ({ default: m.NotificationsPage }))
 );
@@ -150,6 +153,7 @@ function App() {
                     <Route path='/favorites' element={<FavoritesPage />} />
                     <Route path='/match/top-picks' element={<TopPicksPage />} />
                     <Route path='/match/onboarding' element={<MatchOnboardingPage />} />
+                    <Route path='/onboarding/quiz' element={<OnboardingQuizPage />} />
                     <Route path='/notifications' element={<NotificationsPage />} />
                     <Route
                       path='/chat'

--- a/app.client/src/pages/OnboardingQuizPage.css.ts
+++ b/app.client/src/pages/OnboardingQuizPage.css.ts
@@ -1,0 +1,72 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  minHeight: 'calc(100vh - 200px)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '2rem',
+  background: `linear-gradient(135deg, ${vars.background.surface} 0%, ${vars.background.body} 100%)`,
+});
+
+export const card = style({
+  width: '100%',
+  maxWidth: '640px',
+  padding: '2.5rem',
+});
+
+export const header = style({
+  marginBottom: '2rem',
+});
+
+globalStyle(`${header} h1`, {
+  fontSize: '2rem',
+  marginBottom: '0.5rem',
+  color: vars.text.primary,
+});
+
+globalStyle(`${header} p`, {
+  color: vars.text.tertiary,
+  lineHeight: '1.6',
+  fontSize: '1rem',
+});
+
+export const question = style({
+  marginBottom: '1.5rem',
+});
+
+globalStyle(`${question} h3`, {
+  fontSize: '1.125rem',
+  marginBottom: '0.5rem',
+  color: vars.text.primary,
+});
+
+export const choices = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.5rem',
+});
+
+export const choiceLabel = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.375rem',
+  padding: '0.5rem 0.75rem',
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: '0.375rem',
+  cursor: 'pointer',
+  fontSize: '0.95rem',
+});
+
+export const actions = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: '1rem',
+  marginTop: '2rem',
+});
+
+export const warning = style({
+  marginTop: '1rem',
+});

--- a/app.client/src/pages/OnboardingQuizPage.test.tsx
+++ b/app.client/src/pages/OnboardingQuizPage.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const updateProfileMock = vi.fn();
+const navigateMock = vi.fn();
+
+const mockUser = {
+  userId: 'user-1',
+  email: 'adopter@example.com',
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  emailVerified: true,
+  userType: 'adopter' as const,
+  status: 'active' as const,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  preferences: {
+    petTypes: ['dog'],
+    maxDistance: 25,
+    newsletterOptIn: false,
+  },
+};
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: mockUser,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: updateProfileMock,
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+import { OnboardingQuizPage } from './OnboardingQuizPage';
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/onboarding/quiz']}>
+      <OnboardingQuizPage />
+    </MemoryRouter>
+  );
+
+describe('OnboardingQuizPage', () => {
+  beforeEach(() => {
+    updateProfileMock.mockReset();
+    navigateMock.mockReset();
+  });
+
+  it('renders at least 5 questions for the user to answer', () => {
+    renderPage();
+
+    const radioGroups = screen.getAllByRole('radiogroup');
+    expect(radioGroups.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('saves selected answers to user.preferences and navigates to /discover on Finish', async () => {
+    const user = userEvent.setup();
+    updateProfileMock.mockResolvedValue(undefined);
+
+    renderPage();
+
+    // Answer the first two questions to exercise the answer-collection path.
+    await user.click(screen.getByRole('radio', { name: /house with a yard/i }));
+    await user.click(screen.getByRole('radio', { name: /no children/i }));
+
+    await user.click(screen.getByRole('button', { name: /^finish$/i }));
+
+    await waitFor(() => {
+      expect(updateProfileMock).toHaveBeenCalledTimes(1);
+    });
+
+    const patch = updateProfileMock.mock.calls[0][0];
+    expect(patch.preferences).toBeDefined();
+    // Existing preference fields are preserved.
+    expect(patch.preferences.petTypes).toEqual(['dog']);
+    expect(patch.preferences.maxDistance).toBe(25);
+    // Quiz answers are persisted under the `quiz` extension key.
+    expect(patch.preferences.quiz.homeType).toBe('house_with_yard');
+    expect(patch.preferences.quiz.kids).toBe('none');
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/discover');
+    });
+  });
+
+  it('shows a personalisation warning the first time the user clicks Skip', async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(screen.queryByText(/matches won't be personalised/i)).not.toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /^skip$/i }));
+
+    expect(screen.getByText(/matches won't be personalised/i)).toBeInTheDocument();
+    // First skip click only surfaces the warning — it should NOT navigate.
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(updateProfileMock).not.toHaveBeenCalled();
+
+    // Second skip click confirms and redirects to /discover.
+    await user.click(screen.getByRole('button', { name: /^skip$/i }));
+    expect(navigateMock).toHaveBeenCalledWith('/discover');
+  });
+});

--- a/app.client/src/pages/OnboardingQuizPage.tsx
+++ b/app.client/src/pages/OnboardingQuizPage.tsx
@@ -1,0 +1,201 @@
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+import { Alert, Button, Card } from '@adopt-dont-shop/lib.components';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as styles from './OnboardingQuizPage.css';
+
+/**
+ * ADS-628: Onboarding preference quiz.
+ *
+ * Captures 6 quick lifestyle answers post-signup and stores them on
+ * `user.preferences` via `useAuth().updateProfile`. The User type in
+ * lib.auth currently only declares `petTypes`, `maxDistance`, and
+ * `newsletterOptIn` on `preferences`, so the additional quiz answers
+ * are written as an extension blob (`quiz`) within the same object.
+ *
+ * Skippable — but skipping shows a clear warning that matches won't
+ * be personalised, and redirects to /discover so the user isn't
+ * stranded. Backend integration with `matchService.rankPets` is a
+ * follow-up; for now we just persist the answers.
+ */
+
+type HomeType = 'apartment' | 'house_no_yard' | 'house_with_yard';
+type Kids = 'none' | 'young' | 'older';
+type OtherPets = 'none' | 'dogs' | 'cats' | 'mixed';
+type ActivityLevel = 'low' | 'medium' | 'high';
+type Allergies = 'none' | 'dogs' | 'cats' | 'multiple';
+type SizePref = 'small' | 'medium' | 'large' | 'any';
+
+type QuizAnswers = {
+  homeType?: HomeType;
+  kids?: Kids;
+  otherPets?: OtherPets;
+  activityLevel?: ActivityLevel;
+  allergies?: Allergies;
+  sizePreference?: SizePref;
+};
+
+type Question<T extends string> = {
+  key: keyof QuizAnswers;
+  title: string;
+  options: ReadonlyArray<{ value: T; label: string }>;
+};
+
+const QUESTIONS: ReadonlyArray<Question<string>> = [
+  {
+    key: 'homeType',
+    title: 'What kind of home do you live in?',
+    options: [
+      { value: 'apartment', label: 'Apartment / flat' },
+      { value: 'house_no_yard', label: 'House without a yard' },
+      { value: 'house_with_yard', label: 'House with a yard' },
+    ],
+  },
+  {
+    key: 'kids',
+    title: 'Are there children in your home?',
+    options: [
+      { value: 'none', label: 'No children' },
+      { value: 'young', label: 'Young children (under 10)' },
+      { value: 'older', label: 'Older children (10+)' },
+    ],
+  },
+  {
+    key: 'otherPets',
+    title: 'Do you have other pets?',
+    options: [
+      { value: 'none', label: 'No other pets' },
+      { value: 'dogs', label: 'Dog(s)' },
+      { value: 'cats', label: 'Cat(s)' },
+      { value: 'mixed', label: 'A mix' },
+    ],
+  },
+  {
+    key: 'activityLevel',
+    title: 'How active is your household?',
+    options: [
+      { value: 'low', label: 'Pretty relaxed' },
+      { value: 'medium', label: 'Moderately active' },
+      { value: 'high', label: 'Very active' },
+    ],
+  },
+  {
+    key: 'allergies',
+    title: 'Any allergies to consider?',
+    options: [
+      { value: 'none', label: 'No allergies' },
+      { value: 'dogs', label: 'Dogs' },
+      { value: 'cats', label: 'Cats' },
+      { value: 'multiple', label: 'Multiple' },
+    ],
+  },
+  {
+    key: 'sizePreference',
+    title: 'Preferred pet size?',
+    options: [
+      { value: 'small', label: 'Small' },
+      { value: 'medium', label: 'Medium' },
+      { value: 'large', label: 'Large' },
+      { value: 'any', label: 'No preference' },
+    ],
+  },
+];
+
+export const OnboardingQuizPage: React.FC = () => {
+  const { user, updateProfile } = useAuth();
+  const navigate = useNavigate();
+  const [answers, setAnswers] = useState<QuizAnswers>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showSkipWarning, setShowSkipWarning] = useState(false);
+
+  const setAnswer = (key: keyof QuizAnswers, value: string) => {
+    setAnswers(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleFinish = async () => {
+    try {
+      setSaving(true);
+      setError(null);
+      const existing = user?.preferences ?? {};
+      await updateProfile({
+        preferences: {
+          ...existing,
+          // Persist the quiz answers under a dedicated key so the existing
+          // typed fields (petTypes, maxDistance, newsletterOptIn) are
+          // untouched. Cast through unknown because the lib.auth User type
+          // doesn't yet declare the `quiz` field — extending it lives in
+          // lib.auth and is out of scope for this ticket.
+          quiz: answers,
+        } as unknown as typeof existing,
+      });
+      navigate('/discover');
+    } catch (err) {
+      console.error('Failed to save onboarding quiz answers', err);
+      setError(err instanceof Error ? err.message : 'Failed to save your answers.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSkipClick = () => {
+    if (!showSkipWarning) {
+      setShowSkipWarning(true);
+      return;
+    }
+    navigate('/discover');
+  };
+
+  return (
+    <div className={styles.container}>
+      <Card className={styles.card}>
+        <div className={styles.header}>
+          <h1>Tell us about your home</h1>
+          <p>A few quick questions so we can find your Pawfect Match. Takes about a minute.</p>
+        </div>
+
+        {error && <Alert variant='error'>{error}</Alert>}
+
+        {QUESTIONS.map(q => (
+          <div key={q.key} className={styles.question}>
+            <h3>{q.title}</h3>
+            <div className={styles.choices} role='radiogroup' aria-label={q.title}>
+              {q.options.map(opt => (
+                <label key={opt.value} className={styles.choiceLabel}>
+                  <input
+                    type='radio'
+                    name={q.key}
+                    value={opt.value}
+                    checked={answers[q.key] === opt.value}
+                    onChange={() => setAnswer(q.key, opt.value)}
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {showSkipWarning && (
+          <div className={styles.warning}>
+            <Alert variant='warning'>
+              Heads up: if you skip, your matches won&apos;t be personalised. Click Skip again to
+              continue anyway.
+            </Alert>
+          </div>
+        )}
+
+        <div className={styles.actions}>
+          <Button variant='secondary' onClick={handleSkipClick} disabled={saving}>
+            Skip
+          </Button>
+          <Button onClick={handleFinish} disabled={saving}>
+            {saving ? 'Saving…' : 'Finish'}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default OnboardingQuizPage;

--- a/app.client/src/pages/index.ts
+++ b/app.client/src/pages/index.ts
@@ -10,6 +10,7 @@ export { HelpPage } from './HelpPage';
 export { HomePage } from './HomePage';
 export { LoginPage } from './LoginPage';
 export { NotificationsPage } from './NotificationsPage';
+export { OnboardingQuizPage } from './OnboardingQuizPage';
 export { PetDetailsPage } from './PetDetailsPage';
 export { ProfilePage } from './ProfilePage';
 export { RegisterPage } from './RegisterPage';


### PR DESCRIPTION
## Summary

- ADS-628: adds a post-signup preference quiz at `/onboarding/quiz` so the matching service has lifestyle signals to feed `matchService.rankPets` later, instead of falling back to content-quality scoring.
- 6 questions (home type, kids, other pets, activity level, allergies, size preference) persisted to `user.preferences.quiz` via `useAuth().updateProfile`.
- Skip is supported. The first Skip click surfaces a clear "matches won't be personalised" warning; a second click confirms and redirects to `/discover`.

## Changes

- `app.client/src/pages/OnboardingQuizPage.tsx` — new page with the 6-question quiz, Finish/Skip handlers, and answer-state.
- `app.client/src/pages/OnboardingQuizPage.css.ts` — vanilla-extract styles matching the existing auth/page card patterns.
- `app.client/src/pages/OnboardingQuizPage.test.tsx` — Vitest + RTL tests covering question rendering, save-on-Finish, and the skip-warning two-click flow.
- `app.client/src/App.tsx` — lazy-loaded route `/onboarding/quiz` registered under the AppShell layout.
- `app.client/src/pages/index.ts` — barrel export.

## Acceptance criteria

- [x] 5–7 questions covering home type, kids, other pets, activity level, allergies, size preference.
- [x] Answers persist to `user.preferences` via `useAuth().updateProfile` (stored under `preferences.quiz`).
- [x] Existing `preferences` fields (`petTypes`, `maxDistance`, `newsletterOptIn`) are preserved on save.
- [x] Skip is available and shows a personalisation warning before redirecting to `/discover`.
- [x] Route registered at `/onboarding/quiz` in `App.tsx`.
- [x] Tests cover the three behaviours above.

## Test plan

- [x] `npx vitest run src/pages/OnboardingQuizPage.test.tsx` — 3/3 passing.
- [x] `npm run type-check` for `app.client` — clean.
- [x] `npx eslint` on changed files — clean.
- [x] `npx prettier --check` on changed files — clean.
- [ ] CI green on the PR.
- [ ] Manual smoke: navigate to `/onboarding/quiz`, answer questions, Finish → lands on `/discover` with `preferences.quiz` populated. Skip twice → warning shown then redirect.

## Follow-up

- `matchService.rankPets` does not yet read `preferences.quiz`. Wiring the quiz answers into ranking is a separate ticket — out of scope here per the agent brief ("ignore go/no-go, these are dev features").
- The `lib.auth` `User['preferences']` type only declares `petTypes`/`maxDistance`/`newsletterOptIn` today; the new `quiz` field is persisted via a localised cast. Extending the type lives in `lib.auth` and should be done when the matching service consumer lands.

https://claude.ai/code/session_01FFB7tnhDtfaSPC7Q4dMxiU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_