### PR TITLE
feat(auth): add Google + Apple social sign-in scaffold (ADS-627)

### DIFF
--- a/app.client/src/App.test.tsx
+++ b/app.client/src/App.test.tsx
@@ -66,6 +66,15 @@ vi.mock('@adopt-dont-shop/lib.auth', async () => {
   return {
     ...actual,
     useAuth: () => useAuthMock(),
+    // ADS-627 also stub the auth forms so the cookie-banner test's
+    // `initialEntries: ['/login']` doesn't render the real LoginForm —
+    // its relative `../hooks/useAuth` import bypasses the mock above
+    // and demands an AuthProvider. Sibling test files (LoginPage.test,
+    // RegisterPage.test) preload the LoginPage module, so when run
+    // together the lazy <LoginPage /> resolves synchronously and the
+    // form would otherwise crash this suite.
+    LoginForm: () => null,
+    RegisterForm: () => null,
   };
 });
 

--- a/app.client/src/pages/LoginPage.test.tsx
+++ b/app.client/src/pages/LoginPage.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AuthContext, type AuthContextType } from '@adopt-dont-shop/lib.auth';
+import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+
+import { LoginPage } from './LoginPage';
+
+// ADS-627: provide a real AuthContext value so the LoginForm's internal
+// `useAuth()` call resolves without needing to mock the whole module —
+// `vi.mock` of `@adopt-dont-shop/lib.auth` would leak across files run
+// in the same vitest worker and break sibling suites (App.test.tsx).
+const authValue: AuthContextType = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  updateProfile: vi.fn(),
+  refreshUser: vi.fn(),
+};
+
+const renderLoginPage = () =>
+  render(
+    <ThemeProvider>
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter initialEntries={['/login']}>
+          <LoginPage />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    </ThemeProvider>
+  );
+
+describe('LoginPage social sign-in', () => {
+  it('renders Google and Apple sign-in buttons above the email form', () => {
+    renderLoginPage();
+
+    const googleButton = screen.getByRole('button', { name: /sign in with google/i });
+    const appleButton = screen.getByRole('button', { name: /sign in with apple/i });
+    // The lib.components `Input` is mocked in setup-tests.ts as a plain
+    // <input> so labels aren't real DOM labels. Match on placeholder
+    // text from the real LoginForm instead.
+    const emailField = screen.getByPlaceholderText(/enter your email/i);
+
+    expect(googleButton).toBeInTheDocument();
+    expect(appleButton).toBeInTheDocument();
+
+    // The social buttons must appear before the email input in the DOM
+    expect(
+      googleButton.compareDocumentPosition(emailField) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('shows a dev placeholder notice so the stub limitation is obvious', () => {
+    renderLoginPage();
+
+    expect(screen.getByText(/dev placeholder/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a stub message when a provider button is clicked', async () => {
+    const user = userEvent.setup();
+    renderLoginPage();
+
+    await user.click(screen.getByRole('button', { name: /sign in with google/i }));
+
+    expect(screen.getByText(/google sign-in is a dev placeholder/i)).toBeInTheDocument();
+  });
+});

--- a/app.client/src/pages/LoginPage.tsx
+++ b/app.client/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { AuthLayout, LoginForm, useAuth } from '@adopt-dont-shop/lib.auth';
+import { AuthLayout, LoginForm, SocialSignInButtons, useAuth } from '@adopt-dont-shop/lib.auth';
 import React, { useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import * as styles from './LoginPage.css';
@@ -35,6 +35,7 @@ export const LoginPage: React.FC = () => {
         </div>
       }
     >
+      <SocialSignInButtons actionLabel='Sign in' />
       <LoginForm
         onSuccess={handleSuccess}
         showForgotPassword={true}

--- a/app.client/src/pages/RegisterPage.test.tsx
+++ b/app.client/src/pages/RegisterPage.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AuthContext, type AuthContextType } from '@adopt-dont-shop/lib.auth';
+import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+
+import { RegisterPage } from './RegisterPage';
+
+// ADS-627: provide a real AuthContext value so the RegisterForm's
+// internal `useAuth()` call resolves without needing to mock the whole
+// module — `vi.mock` of `@adopt-dont-shop/lib.auth` would leak across
+// files run in the same vitest worker and break sibling suites
+// (App.test.tsx).
+const authValue: AuthContextType = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  updateProfile: vi.fn(),
+  refreshUser: vi.fn(),
+};
+
+const renderRegisterPage = () =>
+  render(
+    <ThemeProvider>
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter initialEntries={['/register']}>
+          <RegisterPage />
+        </MemoryRouter>
+      </AuthContext.Provider>
+    </ThemeProvider>
+  );
+
+describe('RegisterPage social sign-in', () => {
+  it('renders Google and Apple sign-up buttons above the email form', () => {
+    renderRegisterPage();
+
+    const googleButton = screen.getByRole('button', { name: /sign up with google/i });
+    const appleButton = screen.getByRole('button', { name: /sign up with apple/i });
+    // The lib.components `Input` is mocked in setup-tests.ts as a plain
+    // <input> so labels aren't real DOM labels. Match on placeholder
+    // text from the real RegisterForm instead.
+    const firstNameField = screen.getByPlaceholderText(/enter your first name/i);
+
+    expect(googleButton).toBeInTheDocument();
+    expect(appleButton).toBeInTheDocument();
+
+    // The social buttons must appear before the form fields in the DOM
+    expect(
+      googleButton.compareDocumentPosition(firstNameField) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('shows a dev placeholder notice so the stub limitation is obvious', () => {
+    renderRegisterPage();
+
+    expect(screen.getByText(/dev placeholder/i)).toBeInTheDocument();
+  });
+});

--- a/app.client/src/pages/RegisterPage.tsx
+++ b/app.client/src/pages/RegisterPage.tsx
@@ -1,4 +1,4 @@
-import { AuthLayout, RegisterForm } from '@adopt-dont-shop/lib.auth';
+import { AuthLayout, RegisterForm, SocialSignInButtons } from '@adopt-dont-shop/lib.auth';
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import * as styles from './RegisterPage.css';
@@ -21,6 +21,7 @@ export const RegisterPage: React.FC = () => {
         </div>
       }
     >
+      <SocialSignInButtons actionLabel='Sign up' />
       <RegisterForm
         onSuccess={handleSuccess}
         requirePhoneNumber={false}

--- a/lib.auth/src/components/SocialSignInButtons.css.ts
+++ b/lib.auth/src/components/SocialSignInButtons.css.ts
@@ -1,0 +1,79 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['3'],
+  marginBottom: vars.spacing['5'],
+});
+
+export const buttonGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['2'],
+});
+
+export const providerButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.spacing['2'],
+  width: '100%',
+  padding: `${vars.spacing['3']} ${vars.spacing['4']}`,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.base,
+  background: vars.background.body,
+  color: vars.text.primary,
+  fontSize: vars.typography.size.base,
+  fontWeight: vars.typography.weight.medium,
+  cursor: 'pointer',
+  transition: 'all 0.15s ease',
+  selectors: {
+    '&:hover:not(:disabled)': {
+      background: vars.background.surface,
+      borderColor: vars.colors.primary,
+    },
+    '&:focus-visible': {
+      outline: 'none',
+      boxShadow: vars.shadows.focus,
+    },
+    '&:disabled': {
+      opacity: 0.6,
+      cursor: 'not-allowed',
+    },
+  },
+});
+
+export const providerIcon = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '20px',
+  height: '20px',
+  flexShrink: 0,
+});
+
+export const divider = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing['3'],
+  margin: `${vars.spacing['2']} 0`,
+  color: vars.text.tertiary,
+  fontSize: vars.typography.size.sm,
+});
+
+globalStyle(`${divider}::before, ${divider}::after`, {
+  content: '""',
+  flex: '1',
+  height: '1px',
+  background: vars.border.color.default,
+});
+
+export const devNotice = style({
+  fontSize: vars.typography.size.xs,
+  color: vars.text.tertiary,
+  textAlign: 'center',
+  margin: '0',
+});

--- a/lib.auth/src/components/SocialSignInButtons.tsx
+++ b/lib.auth/src/components/SocialSignInButtons.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import { Alert } from '@adopt-dont-shop/lib.components';
+import * as styles from './SocialSignInButtons.css';
+
+export type SocialProvider = 'google' | 'apple';
+
+export interface SocialSignInButtonsProps {
+  /**
+   * Label prefix shown on each button (e.g. "Sign in" or "Sign up")
+   */
+  actionLabel?: 'Sign in' | 'Sign up' | 'Continue';
+  /**
+   * Callback invoked when a provider button is clicked.
+   * In dev-stub mode, the default handler shows a placeholder notice.
+   */
+  onProviderSelected?: (provider: SocialProvider) => void;
+  /**
+   * Whether to show the "or continue with email" divider beneath the buttons.
+   * Defaults to true.
+   */
+  showDivider?: boolean;
+}
+
+const GoogleIcon: React.FC = () => (
+  <svg
+    className={styles.providerIcon}
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path
+      fill="#4285F4"
+      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.07 5.07 0 0 1-2.2 3.32v2.76h3.56c2.08-1.92 3.28-4.74 3.28-8.09Z"
+    />
+    <path
+      fill="#34A853"
+      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.56-2.76c-.99.66-2.25 1.06-3.72 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23Z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M5.84 14.11A6.6 6.6 0 0 1 5.5 12c0-.73.13-1.44.34-2.11V7.05H2.18A11 11 0 0 0 1 12c0 1.78.43 3.46 1.18 4.95l3.66-2.84Z"
+    />
+    <path
+      fill="#EA4335"
+      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.05l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38Z"
+    />
+  </svg>
+);
+
+const AppleIcon: React.FC = () => (
+  <svg
+    className={styles.providerIcon}
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path
+      fill="currentColor"
+      d="M16.37 12.6c-.03-2.78 2.27-4.11 2.37-4.18-1.29-1.89-3.3-2.15-4.02-2.18-1.71-.17-3.34 1.01-4.21 1.01-.87 0-2.21-.99-3.63-.96-1.87.03-3.6 1.09-4.56 2.76-1.94 3.37-.5 8.36 1.4 11.1.93 1.34 2.04 2.85 3.46 2.79 1.39-.06 1.91-.9 3.59-.9 1.68 0 2.15.9 3.62.87 1.5-.03 2.45-1.36 3.36-2.71 1.06-1.55 1.5-3.06 1.52-3.13-.03-.01-2.92-1.12-2.9-4.47ZM13.6 4.43c.77-.93 1.29-2.22 1.15-3.51-1.11.05-2.46.74-3.26 1.67-.71.82-1.34 2.13-1.17 3.4 1.24.1 2.51-.63 3.28-1.56Z"
+    />
+  </svg>
+);
+
+const PROVIDERS: ReadonlyArray<{ id: SocialProvider; label: string; Icon: React.FC }> = [
+  { id: 'google', label: 'Google', Icon: GoogleIcon },
+  { id: 'apple', label: 'Apple', Icon: AppleIcon },
+];
+
+/**
+ * Social sign-in buttons (Google + Apple).
+ *
+ * This is a development scaffold: clicking a provider does NOT trigger a real
+ * OAuth flow. Instead, the component renders a "dev placeholder" notice. A
+ * future change will wire these buttons to real OAuth endpoints once the
+ * backend supports provider redirect/callback and account linking by verified
+ * email.
+ */
+export const SocialSignInButtons: React.FC<SocialSignInButtonsProps> = ({
+  actionLabel = 'Sign in',
+  onProviderSelected,
+  showDivider = true,
+}) => {
+  const [stubMessage, setStubMessage] = useState<string | null>(null);
+
+  const handleClick = (provider: SocialProvider) => {
+    if (onProviderSelected) {
+      onProviderSelected(provider);
+      return;
+    }
+    const friendly = provider === 'google' ? 'Google' : 'Apple';
+    setStubMessage(
+      `${friendly} sign-in is a dev placeholder. Real OAuth flow is not wired up yet — use the email form below.`
+    );
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.buttonGroup} role="group" aria-label="Social sign-in providers">
+        {PROVIDERS.map(({ id, label, Icon }) => (
+          <button
+            key={id}
+            type="button"
+            className={styles.providerButton}
+            onClick={() => handleClick(id)}
+            data-provider={id}
+            aria-label={`${actionLabel} with ${label} (dev stub)`}
+          >
+            <Icon />
+            <span>
+              {actionLabel} with {label}
+            </span>
+          </button>
+        ))}
+      </div>
+      {stubMessage && (
+        <Alert variant="info" size="sm">
+          {stubMessage}
+        </Alert>
+      )}
+      <p className={styles.devNotice}>Dev placeholder — real OAuth flow not yet implemented.</p>
+      {showDivider && <div className={styles.divider}>or continue with email</div>}
+    </div>
+  );
+};

--- a/lib.auth/src/index.ts
+++ b/lib.auth/src/index.ts
@@ -15,6 +15,8 @@ export { LoginForm } from './components/LoginForm';
 export type { LoginFormProps } from './components/LoginForm';
 export { RegisterForm } from './components/RegisterForm';
 export type { RegisterFormProps } from './components/RegisterForm';
+export { SocialSignInButtons } from './components/SocialSignInButtons';
+export type { SocialSignInButtonsProps, SocialProvider } from './components/SocialSignInButtons';
 export { TwoFactorSettings } from './components/TwoFactorSettings';
 export type { TwoFactorSettingsProps } from './components/TwoFactorSettings';
 


### PR DESCRIPTION
## Summary

Adds a frontend scaffold for Google + Apple social sign-in on `/login` and `/register`. Six-field signup is the single biggest drop-off in the funnel and OAuth typically reclaims 20-40% of abandons (ADS-627).

**This is a dev-mode stub, not a wired-up OAuth flow.** Clicking a provider button shows a "dev placeholder" notice instead of redirecting to a real OAuth provider. A separate ticket will wire up backend OAuth endpoints and account linking by verified email.

## Changes

- **`lib.auth`**: new `SocialSignInButtons` component (`SocialSignInButtons.tsx` + `.css.ts`) exporting Google and Apple provider buttons with inline SVG icons. Accepts `actionLabel` ("Sign in" / "Sign up" / "Continue"), an optional `onProviderSelected` callback, and a `showDivider` toggle. Default click handler renders an inline "dev placeholder" Alert so testers know real OAuth is not yet wired up.
- **`lib.auth/src/index.ts`**: re-exports `SocialSignInButtons` and its prop types.
- **`app.client/src/pages/LoginPage.tsx`**: renders `<SocialSignInButtons actionLabel="Sign in" />` above the email form.
- **`app.client/src/pages/RegisterPage.tsx`**: renders `<SocialSignInButtons actionLabel="Sign up" />` above the email form.
- **`app.client/src/pages/LoginPage.test.tsx`** (new) and **`RegisterPage.test.tsx`** (new): behaviour tests verifying the provider buttons render above the email form, the dev placeholder notice is visible, and clicking a provider surfaces the stub message.

## Acceptance criteria

- [x] Google + Apple provider buttons appear above the email form on `/login`
- [x] Google + Apple provider buttons appear above the email form on `/register`
- [x] Action label adapts ("Sign in with Google" on login, "Sign up with Google" on register)
- [x] Component lives in `@adopt-dont-shop/lib.auth` and is exported from the public surface
- [x] A "dev placeholder" notice makes the stub limitation obvious to QA / product
- [x] Tests cover the social sign-in behaviour
- [ ] Real Google OAuth flow (deferred — backend endpoints needed)
- [ ] Real Apple Sign in with Apple flow (deferred — backend endpoints needed)
- [ ] Account linking by verified email (deferred — depends on real OAuth)

## Stub limitations / next steps

- No real OAuth: clicking Google/Apple shows a notice and does not redirect. To go live, add `/auth/oauth/google` and `/auth/oauth/apple` redirect + callback routes to `service.backend` and wire `onProviderSelected` to `window.location.assign(...)`.
- No account linking: the backend must look up users by verified email and either link or create the account on first sign-in.
- No backend changes in this PR (per ticket scope: "Skip backend changes if they require new OAuth endpoints").

## Test plan

- [x] `npx vitest run src/pages/LoginPage.test.tsx src/pages/RegisterPage.test.tsx` in `app.client` — 5 tests pass
- [x] `npx eslint` on every touched file — clean
- [x] `npx prettier --check` on every touched file — clean
- [ ] Manual smoke: load `/login` and `/register` in app.client, click each provider button, confirm dev-placeholder notice renders and the email form still works.

https://claude.ai/code/session_01FFB7tnhDtfaSPC7Q4dMxiU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_