### PR TITLE
feat(engagement): weekly "new matches" + favourites re-engagement digest (ADS-631)

### DIFF
--- a/service.backend/src/__tests__/services/weekly-digest.service.test.ts
+++ b/service.backend/src/__tests__/services/weekly-digest.service.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Behaviour tests for weekly-digest.service (ADS-631).
+ *
+ * All Sequelize models and the NotificationService are stubbed so we
+ * can focus on payload shape, opt-in gating, and the "skip empty
+ * digests" rule without booting a real database.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../models/Pet', () => ({
+  default: { findAll: vi.fn() },
+  PetStatus: { AVAILABLE: 'available' },
+}));
+vi.mock('../../models/User', () => ({
+  default: { findAll: vi.fn() },
+  UserStatus: { ACTIVE: 'active' },
+}));
+vi.mock('../../models/UserFavorite', () => ({
+  default: { findAll: vi.fn() },
+}));
+vi.mock('../../models/Application', () => ({
+  default: { findAll: vi.fn() },
+}));
+vi.mock('../../models/UserNotificationPrefs', () => ({
+  default: { findByPk: vi.fn() },
+}));
+vi.mock('../../models/Notification', () => ({
+  NotificationType: { PET_AVAILABLE: 'pet_available' },
+}));
+vi.mock('../../services/notification.service', () => ({
+  NotificationService: { createNotification: vi.fn() },
+}));
+
+import Application from '../../models/Application';
+import Pet from '../../models/Pet';
+import User from '../../models/User';
+import UserFavorite from '../../models/UserFavorite';
+import UserNotificationPrefs from '../../models/UserNotificationPrefs';
+import { NotificationService } from '../../services/notification.service';
+import {
+  buildDigestPayload,
+  isOptedIn,
+  runWeeklyDigest,
+  sendWeeklyDigestForUser,
+  NEW_MATCHES_LIMIT,
+  STILL_WAITING_LIMIT,
+} from '../../services/weekly-digest.service';
+
+const mockPetFindAll = Pet.findAll as unknown as ReturnType<typeof vi.fn>;
+const mockUserFindAll = User.findAll as unknown as ReturnType<typeof vi.fn>;
+const mockFavFindAll = UserFavorite.findAll as unknown as ReturnType<typeof vi.fn>;
+const mockAppFindAll = Application.findAll as unknown as ReturnType<typeof vi.fn>;
+const mockPrefsFindByPk = UserNotificationPrefs.findByPk as unknown as ReturnType<typeof vi.fn>;
+const mockCreateNotification = NotificationService.createNotification as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+const makePet = (id: string, name: string) => ({ petId: id, name });
+
+describe('weekly-digest.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isOptedIn', () => {
+    it('returns false when prefs row is missing', () => {
+      expect(isOptedIn(null)).toBe(false);
+    });
+
+    it('returns false when email channel is disabled', () => {
+      const prefs = { email_enabled: false, pet_matches: true } as UserNotificationPrefs;
+      expect(isOptedIn(prefs)).toBe(false);
+    });
+
+    it('returns false when pet_matches preference is disabled', () => {
+      const prefs = { email_enabled: true, pet_matches: false } as UserNotificationPrefs;
+      expect(isOptedIn(prefs)).toBe(false);
+    });
+
+    it('returns true only when both email and pet_matches are enabled', () => {
+      const prefs = { email_enabled: true, pet_matches: true } as UserNotificationPrefs;
+      expect(isOptedIn(prefs)).toBe(true);
+    });
+  });
+
+  describe('buildDigestPayload', () => {
+    it('returns null when user has neither new matches nor favourites', async () => {
+      mockPetFindAll.mockResolvedValue([]);
+      mockFavFindAll.mockResolvedValue([]);
+
+      const payload = await buildDigestPayload('user-1');
+
+      expect(payload).toBeNull();
+    });
+
+    it('builds payload with new matches and no still-waiting when user has no favourites', async () => {
+      mockPetFindAll.mockResolvedValueOnce([makePet('p1', 'Rex'), makePet('p2', 'Mia')]);
+      mockFavFindAll.mockResolvedValueOnce([]);
+
+      const payload = await buildDigestPayload('user-1');
+
+      expect(payload).toEqual({
+        userId: 'user-1',
+        newMatches: [
+          { petId: 'p1', name: 'Rex' },
+          { petId: 'p2', name: 'Mia' },
+        ],
+        stillWaiting: [],
+      });
+    });
+
+    it('builds payload with still-waiting when user has un-applied favourites', async () => {
+      mockPetFindAll
+        .mockResolvedValueOnce([]) // new matches query
+        .mockResolvedValueOnce([makePet('fav1', 'Buddy')]); // still-waiting query
+      mockFavFindAll.mockResolvedValueOnce([
+        { petId: 'fav1', userId: 'user-1' },
+        { petId: 'fav2', userId: 'user-1' },
+      ]);
+      mockAppFindAll.mockResolvedValueOnce([{ petId: 'fav2' }]); // applied to fav2
+
+      const payload = await buildDigestPayload('user-1');
+
+      expect(payload).toEqual({
+        userId: 'user-1',
+        newMatches: [],
+        stillWaiting: [{ petId: 'fav1', name: 'Buddy' }],
+      });
+    });
+
+    it('excludes favourited pets the user has already applied for', async () => {
+      mockPetFindAll
+        .mockResolvedValueOnce([]) // new matches
+        .mockResolvedValueOnce([]); // still-waiting
+      mockFavFindAll.mockResolvedValueOnce([{ petId: 'applied-already', userId: 'user-1' }]);
+      mockAppFindAll.mockResolvedValueOnce([{ petId: 'applied-already' }]);
+
+      const payload = await buildDigestPayload('user-1');
+
+      // All favourites have an application → still-waiting is empty AND
+      // new-matches is empty → no digest at all.
+      expect(payload).toBeNull();
+    });
+
+    it('respects the new-matches limit', async () => {
+      mockPetFindAll.mockResolvedValueOnce([]);
+      mockFavFindAll.mockResolvedValueOnce([]);
+
+      await buildDigestPayload('user-1');
+
+      const firstCall = mockPetFindAll.mock.calls[0][0];
+      expect(firstCall.limit).toBe(NEW_MATCHES_LIMIT);
+    });
+
+    it('respects the still-waiting limit', async () => {
+      mockPetFindAll.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      mockFavFindAll.mockResolvedValueOnce([{ petId: 'fav1', userId: 'user-1' }]);
+      mockAppFindAll.mockResolvedValueOnce([]);
+
+      await buildDigestPayload('user-1');
+
+      const secondCall = mockPetFindAll.mock.calls[1][0];
+      expect(secondCall.limit).toBe(STILL_WAITING_LIMIT);
+    });
+  });
+
+  describe('sendWeeklyDigestForUser', () => {
+    it('skips delivery when user is not opted-in', async () => {
+      mockPrefsFindByPk.mockResolvedValue(null);
+
+      const sent = await sendWeeklyDigestForUser('user-1');
+
+      expect(sent).toBe(false);
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+    });
+
+    it('skips delivery when payload is empty even if opted-in', async () => {
+      mockPrefsFindByPk.mockResolvedValue({
+        email_enabled: true,
+        pet_matches: true,
+      });
+      mockPetFindAll.mockResolvedValue([]);
+      mockFavFindAll.mockResolvedValue([]);
+
+      const sent = await sendWeeklyDigestForUser('user-1');
+
+      expect(sent).toBe(false);
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+    });
+
+    it('creates a notification with the digest payload when there is data and opt-in is true', async () => {
+      mockPrefsFindByPk.mockResolvedValue({
+        email_enabled: true,
+        pet_matches: true,
+      });
+      mockPetFindAll.mockResolvedValueOnce([makePet('p1', 'Rex')]);
+      mockFavFindAll.mockResolvedValueOnce([]);
+      mockCreateNotification.mockResolvedValue({ notification_id: 'n1' });
+
+      const sent = await sendWeeklyDigestForUser('user-1');
+
+      expect(sent).toBe(true);
+      expect(mockCreateNotification).toHaveBeenCalledOnce();
+      const arg = mockCreateNotification.mock.calls[0][0];
+      expect(arg.userId).toBe('user-1');
+      expect(arg.type).toBe('pet_available');
+      expect(arg.title).toBe('Your weekly pet digest');
+      expect(arg.data).toEqual({
+        newMatches: [{ petId: 'p1', name: 'Rex' }],
+        stillWaiting: [],
+      });
+    });
+  });
+
+  describe('runWeeklyDigest', () => {
+    it('returns scan / send counts and continues past per-user failures', async () => {
+      mockUserFindAll.mockResolvedValue([
+        { userId: 'opted-in-with-data' },
+        { userId: 'opted-out' },
+        { userId: 'throws' },
+      ]);
+
+      mockPrefsFindByPk.mockImplementation(async (userId: string) => {
+        if (userId === 'opted-out') {
+          return null;
+        }
+        if (userId === 'throws') {
+          throw new Error('db blew up');
+        }
+        return { email_enabled: true, pet_matches: true };
+      });
+      mockPetFindAll.mockResolvedValue([makePet('p1', 'Rex')]);
+      mockFavFindAll.mockResolvedValue([]);
+      mockCreateNotification.mockResolvedValue({ notification_id: 'n1' });
+
+      const result = await runWeeklyDigest();
+
+      expect(result).toEqual({ scanned: 3, sent: 1 });
+    });
+  });
+});

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -576,6 +576,23 @@ const startServer = async () => {
         });
       }
 
+      // ADS-631: weekly digest — combined "new matches" + "still
+      // waiting" favourites re-engagement. Saturday morning UTC by
+      // default; both calls no-op without REDIS_URL.
+      try {
+        const { scheduleWeeklyDigestJob, startWeeklyDigestWorker } =
+          await import('./jobs/weekly-digest.job');
+        await scheduleWeeklyDigestJob();
+        const w = startWeeklyDigestWorker();
+        if (w) {
+          logger.info('Weekly digest worker started');
+        }
+      } catch (err) {
+        logger.warn('Weekly digest job failed to start (continuing without scheduling)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
       // ADS-544: daily purge of expired RevokedToken rows. Without this
       // the blacklist table grows unbounded since every logout writes a
       // row that's only useful until the token's `exp`.

--- a/service.backend/src/jobs/weekly-digest.job.ts
+++ b/service.backend/src/jobs/weekly-digest.job.ts
@@ -1,0 +1,78 @@
+import type { Worker } from 'bullmq';
+import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
+import { runWeeklyDigest } from '../services/weekly-digest.service';
+import { logger } from '../utils/logger';
+
+/**
+ * ADS-631: weekly "new matches near you" + favourites re-engagement
+ * digest.
+ *
+ * Runs once a week on the shared `reports` queue (same Redis pattern as
+ * retention.job and match-digest.job). Default cadence is Saturday
+ * morning UTC — the user-local Saturday morning rendering belongs in a
+ * follow-up that splits the cron by timezone bucket; for the initial
+ * cut every user gets the same UTC delivery window.
+ *
+ * Both bootstrap functions are no-ops without REDIS_URL so dev/test
+ * environments can boot without Redis, matching the rest of the
+ * monorepo's job convention.
+ */
+
+export const WEEKLY_DIGEST_JOB_NAME = 'engagement:weekly-digest';
+export const WEEKLY_DIGEST_REPEAT_KEY = 'engagement:weekly-digest:saturday';
+
+// Default: Saturday 09:00 UTC. Override via WEEKLY_DIGEST_CRON env var.
+// BullMQ-compatible (5- or 6-field) cron expression.
+const WEEKLY_DIGEST_CRON = process.env.WEEKLY_DIGEST_CRON ?? '0 9 * * 6';
+
+export const scheduleWeeklyDigestJob = async (): Promise<void> => {
+  if (!isQueueAvailable()) {
+    logger.warn('REDIS_URL not set — weekly digest job not scheduled');
+    return;
+  }
+
+  const queue = getReportsQueue();
+  // Strip any previous repeatable so cron changes are observed on next
+  // deploy without leaving the old schedule alongside the new one.
+  await queue.removeRepeatableByKey(WEEKLY_DIGEST_REPEAT_KEY).catch(() => undefined);
+
+  await queue.add(
+    WEEKLY_DIGEST_JOB_NAME,
+    {},
+    {
+      jobId: WEEKLY_DIGEST_REPEAT_KEY,
+      repeat: { pattern: WEEKLY_DIGEST_CRON, tz: 'UTC' },
+    }
+  );
+
+  logger.info('Weekly digest job scheduled', { cron: WEEKLY_DIGEST_CRON });
+};
+
+let workerInstance: Worker | null = null;
+
+export const startWeeklyDigestWorker = (): Worker | null => {
+  if (workerInstance) {
+    return workerInstance;
+  }
+  if (!isQueueAvailable()) {
+    logger.warn('REDIS_URL not set — weekly digest worker not started');
+    return null;
+  }
+
+  workerInstance = buildWorker(async job => {
+    if (job.name !== WEEKLY_DIGEST_JOB_NAME) {
+      return;
+    }
+    const result = await runWeeklyDigest();
+    logger.info('Weekly digest finished', { result });
+  });
+
+  return workerInstance;
+};
+
+export const stopWeeklyDigestWorker = async (): Promise<void> => {
+  if (workerInstance) {
+    await workerInstance.close();
+    workerInstance = null;
+  }
+};

--- a/service.backend/src/services/weekly-digest.service.ts
+++ b/service.backend/src/services/weekly-digest.service.ts
@@ -1,0 +1,215 @@
+import { Op } from 'sequelize';
+import Application from '../models/Application';
+import { NotificationType } from '../models/Notification';
+import Pet, { PetStatus } from '../models/Pet';
+import User, { UserStatus } from '../models/User';
+import UserFavorite from '../models/UserFavorite';
+import UserNotificationPrefs from '../models/UserNotificationPrefs';
+import { logger } from '../utils/logger';
+import { NotificationService } from './notification.service';
+
+/**
+ * ADS-631: Weekly "new matches near you" digest + favourites
+ * re-engagement.
+ *
+ * Single weekly touch combining two sections:
+ *   1. New near you — up to 3 recently-created available pets that
+ *      could match the user. The matching algorithm is intentionally
+ *      stubbed (Pet.findAll ordered by createdAt) — preference-aware
+ *      ranking lands in a follow-up ticket once the scoring service
+ *      exposes a synchronous candidate API.
+ *   2. Still waiting — up to 2 pets the user has favourited but has
+ *      no application against. Drops out silently when the user has
+ *      no unactioned favourites.
+ *
+ * The job no-ops when a user's marketing/digest preference is off, and
+ * when both sections are empty (no point emailing a digest with nothing
+ * in it).
+ */
+
+export const NEW_MATCHES_LIMIT = 3;
+export const STILL_WAITING_LIMIT = 2;
+export const NEW_MATCHES_LOOKBACK_DAYS = 7;
+
+export type DigestPetSummary = {
+  petId: string;
+  name: string;
+};
+
+export type WeeklyDigestPayload = {
+  userId: string;
+  newMatches: DigestPetSummary[];
+  stillWaiting: DigestPetSummary[];
+};
+
+const toSummary = (pet: Pet): DigestPetSummary => ({
+  petId: pet.petId,
+  name: pet.name,
+});
+
+/**
+ * Whether a user has opted in to marketing-style weekly content.
+ *
+ * The digest is "marketing-adjacent" — it surfaces new pets and stale
+ * favourites that the user hasn't acted on. The closest existing flag
+ * is `UserNotificationPrefs.pet_matches`; we also require `email_enabled`
+ * because the deliverable is a weekly email. Falls back to NO send when
+ * the prefs row is missing — opt-in not opt-out for re-engagement.
+ */
+export const isOptedIn = (prefs: UserNotificationPrefs | null): boolean => {
+  if (!prefs) {
+    return false;
+  }
+  return prefs.email_enabled && prefs.pet_matches;
+};
+
+const fetchNewMatches = async (
+  userId: string,
+  lookbackDays: number = NEW_MATCHES_LOOKBACK_DAYS
+): Promise<Pet[]> => {
+  const since = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
+  // Stub matching: most recently listed available pets. Real preference-
+  // aware ranking will replace this query when the matching service has
+  // a synchronous candidate API. The userId argument keeps the signature
+  // ready for that swap.
+  void userId;
+  return Pet.findAll({
+    where: {
+      status: PetStatus.AVAILABLE,
+      createdAt: { [Op.gte]: since },
+    },
+    order: [['createdAt', 'DESC']],
+    limit: NEW_MATCHES_LIMIT,
+  });
+};
+
+const fetchStillWaiting = async (userId: string): Promise<Pet[]> => {
+  const favorites = await UserFavorite.findAll({
+    where: { userId },
+    order: [['createdAt', 'ASC']],
+  });
+
+  if (favorites.length === 0) {
+    return [];
+  }
+
+  const favoritePetIds = favorites.map(f => f.petId);
+
+  // Exclude any favourited pets the user has already applied for —
+  // those have been "actioned" and don't belong in re-engagement.
+  const applications = await Application.findAll({
+    where: {
+      userId,
+      petId: { [Op.in]: favoritePetIds },
+    },
+    attributes: ['petId'],
+  });
+  const appliedPetIds = new Set(applications.map(a => a.petId));
+
+  const unactionedPetIds = favoritePetIds.filter(id => !appliedPetIds.has(id));
+  if (unactionedPetIds.length === 0) {
+    return [];
+  }
+
+  return Pet.findAll({
+    where: {
+      petId: { [Op.in]: unactionedPetIds },
+      status: PetStatus.AVAILABLE,
+    },
+    limit: STILL_WAITING_LIMIT,
+  });
+};
+
+/**
+ * Build a digest payload for a single user. Does not send anything —
+ * returns null when both sections are empty so the caller can skip the
+ * delivery entirely.
+ */
+export const buildDigestPayload = async (userId: string): Promise<WeeklyDigestPayload | null> => {
+  const [newMatchPets, stillWaitingPets] = await Promise.all([
+    fetchNewMatches(userId),
+    fetchStillWaiting(userId),
+  ]);
+
+  if (newMatchPets.length === 0 && stillWaitingPets.length === 0) {
+    return null;
+  }
+
+  return {
+    userId,
+    newMatches: newMatchPets.map(toSummary),
+    stillWaiting: stillWaitingPets.map(toSummary),
+  };
+};
+
+const formatDigestMessage = (payload: WeeklyDigestPayload): string => {
+  const parts: string[] = [];
+  if (payload.newMatches.length > 0) {
+    const names = payload.newMatches.map(p => p.name).join(', ');
+    parts.push(`New near you: ${names}.`);
+  }
+  if (payload.stillWaiting.length > 0) {
+    const names = payload.stillWaiting.map(p => p.name).join(', ');
+    parts.push(`Still waiting on your shortlist: ${names}.`);
+  }
+  return parts.join(' ');
+};
+
+/**
+ * Send the weekly digest for one user. Returns true when a notification
+ * was created, false when skipped (opted out, no payload, etc.).
+ *
+ * Delivery is delegated to NotificationService.createNotification which
+ * fans out to in-app / push / email based on the user's channel prefs
+ * — re-using existing infrastructure rather than calling the email
+ * and push providers directly.
+ */
+export const sendWeeklyDigestForUser = async (userId: string): Promise<boolean> => {
+  const prefs = await UserNotificationPrefs.findByPk(userId);
+  if (!isOptedIn(prefs)) {
+    return false;
+  }
+
+  const payload = await buildDigestPayload(userId);
+  if (!payload) {
+    return false;
+  }
+
+  const message = formatDigestMessage(payload);
+  await NotificationService.createNotification({
+    userId,
+    type: NotificationType.PET_AVAILABLE,
+    title: 'Your weekly pet digest',
+    message,
+    data: {
+      newMatches: payload.newMatches,
+      stillWaiting: payload.stillWaiting,
+    },
+  });
+
+  return true;
+};
+
+export const runWeeklyDigest = async (): Promise<{ scanned: number; sent: number }> => {
+  const users = await User.findAll({
+    where: { status: UserStatus.ACTIVE },
+    attributes: ['userId'],
+  });
+
+  let sent = 0;
+  for (const user of users) {
+    try {
+      const delivered = await sendWeeklyDigestForUser(user.userId);
+      if (delivered) {
+        sent += 1;
+      }
+    } catch (err) {
+      logger.warn('weekly digest failed for user', {
+        userId: user.userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { scanned: users.length, sent };
+};


### PR DESCRIPTION
## Summary

Adds a weekly digest job that surfaces both new pets and unactioned favourites in a single Saturday-morning UTC touch — the primary return-trigger for a goal-oriented product.

- New `weekly-digest.service.ts` builds a typed payload per user with two sections: **New near you** (up to 3 recent available pets) and **Still waiting** (up to 2 favourited pets the user hasn't applied for yet).
- New `weekly-digest.job.ts` registers a BullMQ recurring job on the shared `reports` queue, defaulting to `0 9 * * 6` UTC (override via `WEEKLY_DIGEST_CRON`).
- Wired into `index.ts` alongside the existing retention/match-digest scheduling. Both schedule and worker no-op without `REDIS_URL`, matching the rest of the monorepo's job convention.

## Changes

- `service.backend/src/services/weekly-digest.service.ts` — payload builder, opt-in check, per-user send, batch runner. Delegates delivery to `NotificationService.createNotification` so push/email/in-app fan-out re-uses existing infrastructure (no new provider code).
- `service.backend/src/jobs/weekly-digest.job.ts` — BullMQ schedule + worker, modelled on `retention.job.ts` and `match-digest.job.ts`.
- `service.backend/src/index.ts` — boot-time registration of the schedule + worker.
- `service.backend/src/__tests__/services/weekly-digest.service.test.ts` — 14 behaviour tests covering payload shape, opt-in gating, the "skip empty digest" rule, and continued execution past per-user failures.

## Acceptance criteria

- [x] New BullMQ recurring job scheduled weekly (Saturday morning UTC by default).
- [x] Service builds a typed digest payload with `newMatches` and `stillWaiting` arrays.
- [x] "Still waiting" excludes favourites the user has already applied for.
- [x] Skips users without `email_enabled` + `pet_matches` (marketing opt-in).
- [x] Skips users with empty payload (no point sending an empty digest).
- [x] Delivery delegated to existing `NotificationService` — no changes to email/push providers.

## Test plan

- [x] `npx vitest run src/__tests__/services/weekly-digest.service.test.ts` — 14/14 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` + `npx prettier --check` — clean.
- [ ] Smoke-test against a Redis-enabled environment to confirm the repeatable is picked up by the reports queue.

## Notes / follow-ups

- The "new matches near you" query is intentionally a `Pet.findAll` stub ordered by `createdAt DESC`. Preference-aware ranking lands in a follow-up once the matching service exposes a synchronous candidate API.
- "Saturday morning *local* time" is rendered as a single UTC window for v1; per-timezone splitting is a follow-up that buckets users by their notification-prefs timezone.

https://claude.ai/code/session_01FFB7tnhDtfaSPC7Q4dMxiU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_