### PR TITLE
feat(discover): "It's a Match!" modal on first anonymous like (ADS-626)

### DIFF
--- a/app.client/src/components/discovery/AnonymousFirstLikeModal.css.ts
+++ b/app.client/src/components/discovery/AnonymousFirstLikeModal.css.ts
@@ -1,0 +1,76 @@
+import { style } from '@vanilla-extract/css';
+
+export const backdrop = style({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0, 0, 0, 0.65)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1100,
+  padding: '1rem',
+});
+
+export const card = style({
+  position: 'relative',
+  background: 'white',
+  borderRadius: '16px',
+  overflow: 'hidden',
+  maxWidth: '24rem',
+  width: '100%',
+  boxShadow: '0 20px 60px rgba(0,0,0,0.4)',
+});
+
+export const close = style({
+  position: 'absolute',
+  top: '0.5rem',
+  right: '0.5rem',
+  background: 'rgba(0,0,0,0.45)',
+  color: 'white',
+  border: 'none',
+  borderRadius: '999px',
+  width: '2rem',
+  height: '2rem',
+  fontSize: '1.5rem',
+  cursor: 'pointer',
+  lineHeight: 1,
+  zIndex: 1,
+});
+
+export const image = style({
+  width: '100%',
+  height: '14rem',
+  objectFit: 'cover',
+});
+
+export const body = style({
+  padding: '1.25rem 1.5rem 1.5rem',
+  textAlign: 'center',
+});
+
+export const title = style({
+  fontSize: '1.75rem',
+  fontWeight: 800,
+  margin: '0 0 0.5rem 0',
+  background: 'linear-gradient(135deg, #f5576c 0%, #f093fb 100%)',
+  WebkitBackgroundClip: 'text',
+  WebkitTextFillColor: 'transparent',
+  backgroundClip: 'text',
+});
+
+export const subtitle = style({
+  fontSize: '1rem',
+  color: '#333',
+  margin: '0 0 1.25rem 0',
+});
+
+export const cta = style({
+  display: 'inline-block',
+  padding: '0.75rem 1.5rem',
+  background: '#f5576c',
+  color: 'white',
+  borderRadius: '999px',
+  fontWeight: 700,
+  textDecoration: 'none',
+  ':hover': { background: '#dc2626' },
+});

--- a/app.client/src/components/discovery/AnonymousFirstLikeModal.test.tsx
+++ b/app.client/src/components/discovery/AnonymousFirstLikeModal.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils';
+import { AnonymousFirstLikeModal } from './AnonymousFirstLikeModal';
+
+describe('AnonymousFirstLikeModal (ADS-626)', () => {
+  it('renders the pet name + image and a sign-up CTA pointing at /register?petId=...', () => {
+    renderWithProviders(
+      <AnonymousFirstLikeModal
+        petId='pet-buddy'
+        petName='Buddy'
+        petImage='https://cdn/buddy.jpg'
+        onDismiss={vi.fn()}
+        onCtaClick={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/You and Buddy could be a match/)).toBeInTheDocument();
+    expect(screen.getByAltText('Buddy')).toHaveAttribute('src', 'https://cdn/buddy.jpg');
+    expect(screen.getByRole('link', { name: 'Sign up to apply' })).toHaveAttribute(
+      'href',
+      '/register?petId=pet-buddy'
+    );
+  });
+
+  it('invokes onDismiss when the close button is clicked', () => {
+    const onDismiss = vi.fn();
+    renderWithProviders(
+      <AnonymousFirstLikeModal
+        petId='pet-1'
+        petName='Buddy'
+        onDismiss={onDismiss}
+        onCtaClick={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('invokes onCtaClick when the CTA link is clicked', () => {
+    const onCtaClick = vi.fn();
+    renderWithProviders(
+      <AnonymousFirstLikeModal
+        petId='pet-1'
+        petName='Buddy'
+        onDismiss={vi.fn()}
+        onCtaClick={onCtaClick}
+      />
+    );
+    fireEvent.click(screen.getByRole('link', { name: 'Sign up to apply' }));
+    expect(onCtaClick).toHaveBeenCalled();
+  });
+
+  it('omits the image when no petImage prop is provided', () => {
+    renderWithProviders(
+      <AnonymousFirstLikeModal
+        petId='pet-1'
+        petName='Buddy'
+        onDismiss={vi.fn()}
+        onCtaClick={vi.fn()}
+      />
+    );
+    expect(screen.queryByAltText('Buddy')).toBeNull();
+  });
+
+  it('encodes the petId for URL safety', () => {
+    renderWithProviders(
+      <AnonymousFirstLikeModal
+        petId='abc 1/2'
+        petName='Test'
+        onDismiss={vi.fn()}
+        onCtaClick={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('link', { name: 'Sign up to apply' })).toHaveAttribute(
+      'href',
+      '/register?petId=abc%201%2F2'
+    );
+  });
+});

--- a/app.client/src/components/discovery/AnonymousFirstLikeModal.tsx
+++ b/app.client/src/components/discovery/AnonymousFirstLikeModal.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import * as styles from './AnonymousFirstLikeModal.css';
+
+export type AnonymousFirstLikeModalProps = {
+  petId: string;
+  petName: string;
+  petImage?: string;
+  onDismiss: () => void;
+  onCtaClick: () => void;
+};
+
+/**
+ * ADS-626: shown exactly once per browser session when an anonymous
+ * user issues their first "like". The CTA deep-links to /register
+ * with a petId query so the registration flow can redirect back to
+ * /pets/:id on completion. Dismiss is a no-op against ADS-625's
+ * swipe-budget — that counter is decremented in DiscoveryPage's
+ * handler, not here.
+ */
+export const AnonymousFirstLikeModal: React.FC<AnonymousFirstLikeModalProps> = ({
+  petId,
+  petName,
+  petImage,
+  onDismiss,
+  onCtaClick,
+}) => {
+  return (
+    <div
+      className={styles.backdrop}
+      role='dialog'
+      aria-modal='true'
+      aria-labelledby='anon-like-title'
+    >
+      <div className={styles.card}>
+        <button type='button' className={styles.close} aria-label='Dismiss' onClick={onDismiss}>
+          ×
+        </button>
+        {petImage && <img src={petImage} alt={petName} className={styles.image} />}
+        <div className={styles.body}>
+          <h2 id='anon-like-title' className={styles.title}>
+            It&apos;s a Match!
+          </h2>
+          <p className={styles.subtitle}>You and {petName} could be a match. Sign up to apply.</p>
+          <Link
+            to={`/register?petId=${encodeURIComponent(petId)}`}
+            className={styles.cta}
+            onClick={onCtaClick}
+          >
+            Sign up to apply
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const ANON_FIRST_LIKE_FIRED_KEY = 'anon_first_like.fired';

--- a/app.client/src/components/discovery/DiscoveryPage.tsx
+++ b/app.client/src/components/discovery/DiscoveryPage.tsx
@@ -6,14 +6,17 @@ import {
   discoveryService,
 } from '@/services';
 import { Container } from '@adopt-dont-shop/lib.components';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { loadDiscoveryState, recordViewedPet } from '@/utils/discoverySession';
+import { useStatsig } from '@/hooks/useStatsig';
 import { MdWarning } from 'react-icons/md';
 import { Link, useNavigate } from 'react-router-dom';
 import * as styles from './DiscoveryPage.css';
 import { SwipeControls } from '../swipe/SwipeControls';
 import { SwipeStack } from '../swipe/SwipeStack';
 import { EndOfQueueEmptyState } from './EndOfQueueEmptyState';
+import { ANON_FIRST_LIKE_FIRED_KEY, AnonymousFirstLikeModal } from './AnonymousFirstLikeModal';
 
 export const DiscoveryPage: React.FC = () => {
   const navigate = useNavigate();
@@ -35,6 +38,10 @@ export const DiscoveryPage: React.FC = () => {
   const [viewedPetIds, setViewedPetIds] = useState<string[]>(persistedState.viewedPetIds);
   const [currentPetIndex, setCurrentPetIndex] = useState(0);
   const [undoStack, setUndoStack] = useState<SwipeAction[]>([]);
+  // ADS-626: first-like modal state for anonymous users.
+  const { isAuthenticated } = useAuth();
+  const { logEvent } = useStatsig();
+  const [anonLikeModalPet, setAnonLikeModalPet] = useState<DiscoveryPet | null>(null);
   // ADS-630: track whether `loadMorePets` has ever returned an empty page
   // — that's how we differentiate "queue truly exhausted" from "first
   // batch not arrived yet". Reset to true whenever the filter set
@@ -80,6 +87,25 @@ export const DiscoveryPage: React.FC = () => {
   }, []);
   const handleSwipe = useCallback(
     async (action: SwipeAction) => {
+      // ADS-626: surface the celebratory match modal on the *first*
+      // anonymous like in this browser session. The flag lives in
+      // sessionStorage so re-mounts within the same tab don't refire.
+      // Only fires for `like` / `super_like` — `pass` is not a peak
+      // emotional moment.
+      if (
+        !isAuthenticated &&
+        (action.action === 'like' || action.action === 'super_like') &&
+        typeof window !== 'undefined' &&
+        window.sessionStorage.getItem(ANON_FIRST_LIKE_FIRED_KEY) !== 'true'
+      ) {
+        const likedPet = pets.find(p => p.petId === action.petId) ?? pets[currentPetIndex];
+        if (likedPet) {
+          window.sessionStorage.setItem(ANON_FIRST_LIKE_FIRED_KEY, 'true');
+          setAnonLikeModalPet(likedPet);
+          logEvent('anon_first_like_modal_shown', 1, { pet_id: likedPet.petId });
+        }
+      }
+
       // Update session stats
       setSession(prev => ({
         ...prev,
@@ -109,7 +135,7 @@ export const DiscoveryPage: React.FC = () => {
         console.error('Failed to record swipe action:', error);
       }
     },
-    [session.sessionId]
+    [session.sessionId, isAuthenticated, pets, currentPetIndex, logEvent]
   );
 
   const handleEndReached = useCallback(async () => {
@@ -192,8 +218,31 @@ export const DiscoveryPage: React.FC = () => {
   // already enforced by the parent ternary.
   const isQueueExhausted = !loading && !error && hasNoPets && !hasMore;
 
+  const handleAnonModalDismiss = useCallback(() => {
+    if (anonLikeModalPet) {
+      logEvent('anon_first_like_modal_dismissed', 1, { pet_id: anonLikeModalPet.petId });
+    }
+    setAnonLikeModalPet(null);
+  }, [anonLikeModalPet, logEvent]);
+
+  const handleAnonModalCta = useCallback(() => {
+    if (anonLikeModalPet) {
+      logEvent('anon_first_like_modal_clicked', 1, { pet_id: anonLikeModalPet.petId });
+    }
+    setAnonLikeModalPet(null);
+  }, [anonLikeModalPet, logEvent]);
+
   return (
     <Container className={styles.pageContainer}>
+      {anonLikeModalPet && (
+        <AnonymousFirstLikeModal
+          petId={anonLikeModalPet.petId}
+          petName={anonLikeModalPet.name}
+          petImage={anonLikeModalPet.images?.[0]}
+          onDismiss={handleAnonModalDismiss}
+          onCtaClick={handleAnonModalCta}
+        />
+      )}
       <div className={styles.header}>
         <h1 className={styles.title}>Discover Pets</h1>
         <div className={styles.headerActions}>


### PR DESCRIPTION
## Summary

Implements [ADS-626](https://linear.app/ideasquared/issue/ADS-626/its-a-match-celebratory-modal-on-first-anonymous-like). When an unauthenticated user issues their first like (or super-like) in a browser session, surface a celebratory match modal showing the pet's photo + name and a sign-up CTA that deep-links to `/register?petId=<id>`.

## Changes

- `AnonymousFirstLikeModal.{tsx,css.ts}`: new modal component owning the layout, image, and CTA. The CTA URL-encodes the `petId` for safety. Exports `ANON_FIRST_LIKE_FIRED_KEY` so the DiscoveryPage and tests share the storage key.
- `DiscoveryPage.tsx`: hook the first-anonymous-like detection into `handleSwipe`. Only fires for `like` / `super_like` — `pass` is not a peak emotional moment. Uses `sessionStorage` so remounts within the tab don't refire. Logs three Statsig events:
  - `anon_first_like_modal_shown` (on display)
  - `anon_first_like_modal_clicked` (on CTA)
  - `anon_first_like_modal_dismissed` (on close button)
- `AnonymousFirstLikeModal.test.tsx`: five cases covering renders pet + image + encoded CTA, close fires onDismiss, CTA fires onCtaClick, image hidden when not provided, petId URL-encoded.

## Acceptance criteria

- [x] Modal fires exactly once per browser session for the first like by an anonymous user (sessionStorage flag).
- [x] Includes the specific pet's name and primary photo.
- [x] CTA navigates to `/register?petId=<id>`.
- [ ] **Register-flow petId redirect is intentionally out of scope for this PR.** The CTA carries the query; honouring it on signup completion is a tiny follow-up on the register/login flow that ADS-627 will land next to.
- [x] Tapping dismiss does not consume any swipe budget — `onDismiss` is a pure UI close.
- [x] Logs `anon_first_like_modal_shown`, `_clicked`, `_dismissed` with petId.

## Test plan

- [x] Vitest covers all five behavioural assertions (verified locally before push).

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_