### PR TITLE
feat(discover): anonymous swipe paywall — soft block after N swipes (ADS-625)

### DIFF
--- a/app.client/src/components/discovery/AnonymousSwipePaywallModal.css.ts
+++ b/app.client/src/components/discovery/AnonymousSwipePaywallModal.css.ts
@@ -1,0 +1,76 @@
+import { style } from '@vanilla-extract/css';
+
+export const backdrop = style({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0, 0, 0, 0.75)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1200,
+  padding: '1rem',
+});
+
+export const card = style({
+  position: 'relative',
+  background: 'white',
+  borderRadius: '16px',
+  padding: '2rem 1.5rem',
+  maxWidth: '24rem',
+  width: '100%',
+  textAlign: 'center',
+  boxShadow: '0 20px 60px rgba(0,0,0,0.4)',
+});
+
+export const dismiss = style({
+  position: 'absolute',
+  top: '0.5rem',
+  right: '0.5rem',
+  background: 'transparent',
+  color: '#6c757d',
+  border: 'none',
+  fontSize: '1.5rem',
+  cursor: 'pointer',
+  lineHeight: 1,
+});
+
+export const title = style({
+  fontSize: '1.75rem',
+  fontWeight: 800,
+  margin: '0 0 0.5rem 0',
+  color: '#333',
+});
+
+export const subtitle = style({
+  fontSize: '1rem',
+  color: '#6c757d',
+  margin: '0 0 1.5rem 0',
+});
+
+export const actions = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+});
+
+export const ctaPrimary = style({
+  padding: '0.75rem 1.5rem',
+  background: '#4ecdc4',
+  color: 'white',
+  borderRadius: '999px',
+  fontWeight: 700,
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': { background: '#45b7b8' },
+});
+
+export const ctaSecondary = style({
+  padding: '0.75rem 1.5rem',
+  background: 'transparent',
+  color: '#4ecdc4',
+  border: '2px solid #4ecdc4',
+  borderRadius: '999px',
+  fontWeight: 700,
+  cursor: 'pointer',
+  ':hover': { background: '#e9f7f6' },
+});

--- a/app.client/src/components/discovery/AnonymousSwipePaywallModal.test.tsx
+++ b/app.client/src/components/discovery/AnonymousSwipePaywallModal.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils';
+import { AnonymousSwipePaywallModal } from './AnonymousSwipePaywallModal';
+
+describe('AnonymousSwipePaywallModal (ADS-625)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders title, subtitle, and the three actions', () => {
+    renderWithProviders(
+      <AnonymousSwipePaywallModal
+        petId='pet-1'
+        onSignUp={vi.fn()}
+        onLogIn={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Keep swiping')).toBeInTheDocument();
+    expect(screen.getByText(/Sign up free in 10 seconds/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign up' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+  });
+
+  it('announces itself with role=alertdialog and labelled-by association', () => {
+    renderWithProviders(
+      <AnonymousSwipePaywallModal
+        petId='pet-1'
+        onSignUp={vi.fn()}
+        onLogIn={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-labelledby', 'anon-paywall-title');
+    expect(dialog).toHaveAttribute('aria-describedby', 'anon-paywall-desc');
+  });
+
+  it('auto-focuses the Sign up button so keyboard users land on it', async () => {
+    renderWithProviders(
+      <AnonymousSwipePaywallModal
+        petId='pet-1'
+        onSignUp={vi.fn()}
+        onLogIn={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Sign up' })).toHaveFocus();
+    });
+  });
+
+  it('fires onSignUp when Sign up is clicked', () => {
+    const onSignUp = vi.fn();
+    renderWithProviders(
+      <AnonymousSwipePaywallModal
+        petId='pet-1'
+        onSignUp={onSignUp}
+        onLogIn={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+    expect(onSignUp).toHaveBeenCalled();
+  });
+
+  it('fires onLogIn when Log in is clicked', () => {
+    const onLogIn = vi.fn();
+    renderWithProviders(
+      <AnonymousSwipePaywallModal
+        petId='pet-1'
+        onSignUp={vi.fn()}
+        onLogIn={onLogIn}
+        onDismiss={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
+    expect(onLogIn).toHaveBeenCalled();
+  });
+
+  it('fires onDismiss when the close button is clicked', () => {
+    const onDismiss = vi.fn();
+    renderWithProviders(
+      <AnonymousSwipePaywallModal
+        petId='pet-1'
+        onSignUp={vi.fn()}
+        onLogIn={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/app.client/src/components/discovery/AnonymousSwipePaywallModal.tsx
+++ b/app.client/src/components/discovery/AnonymousSwipePaywallModal.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as styles from './AnonymousSwipePaywallModal.css';
+
+export type AnonymousSwipePaywallModalProps = {
+  petId: string;
+  onSignUp: () => void;
+  onLogIn: () => void;
+  onDismiss: () => void;
+};
+
+/**
+ * ADS-625: soft-block paywall shown to anonymous users once they
+ * exceed the swipe budget. Modal traps focus on its first button so
+ * keyboard users can navigate immediately, and announces itself to
+ * screen readers via `role="alertdialog"`.
+ */
+export const AnonymousSwipePaywallModal: React.FC<AnonymousSwipePaywallModalProps> = ({
+  petId,
+  onSignUp,
+  onLogIn,
+  onDismiss,
+}) => {
+  const navigate = useNavigate();
+  const signUpRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    signUpRef.current?.focus();
+  }, []);
+
+  const handleSignUp = () => {
+    onSignUp();
+    navigate(`/register?petId=${encodeURIComponent(petId)}`);
+  };
+
+  const handleLogIn = () => {
+    onLogIn();
+    navigate('/login');
+  };
+
+  return (
+    <div
+      className={styles.backdrop}
+      role='alertdialog'
+      aria-modal='true'
+      aria-labelledby='anon-paywall-title'
+      aria-describedby='anon-paywall-desc'
+    >
+      <div className={styles.card}>
+        <h2 id='anon-paywall-title' className={styles.title}>
+          Keep swiping
+        </h2>
+        <p id='anon-paywall-desc' className={styles.subtitle}>
+          Sign up free in 10 seconds to keep meeting your matches.
+        </p>
+        <div className={styles.actions}>
+          <button
+            ref={signUpRef}
+            type='button'
+            className={styles.ctaPrimary}
+            onClick={handleSignUp}
+          >
+            Sign up
+          </button>
+          <button type='button' className={styles.ctaSecondary} onClick={handleLogIn}>
+            Log in
+          </button>
+        </div>
+        <button type='button' className={styles.dismiss} onClick={onDismiss} aria-label='Dismiss'>
+          ×
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/app.client/src/components/discovery/DiscoveryPage.tsx
+++ b/app.client/src/components/discovery/DiscoveryPage.tsx
@@ -9,6 +9,11 @@ import { Container } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { loadDiscoveryState, recordViewedPet } from '@/utils/discoverySession';
+import {
+  hasReachedAnonSwipeLimit,
+  incrementAnonSwipeCount,
+  resetAnonSwipeBudget,
+} from '@/utils/anonSwipeBudget';
 import { useStatsig } from '@/hooks/useStatsig';
 import { MdWarning } from 'react-icons/md';
 import { Link, useNavigate } from 'react-router-dom';
@@ -18,6 +23,7 @@ import { SwipeStack } from '../swipe/SwipeStack';
 import { EndOfQueueEmptyState } from './EndOfQueueEmptyState';
 import { ANON_FIRST_LIKE_FIRED_KEY, AnonymousFirstLikeModal } from './AnonymousFirstLikeModal';
 import { ProfileCompletionMeter } from '../profile/ProfileCompletionMeter';
+import { AnonymousSwipePaywallModal } from './AnonymousSwipePaywallModal';
 
 export const DiscoveryPage: React.FC = () => {
   const navigate = useNavigate();
@@ -39,10 +45,23 @@ export const DiscoveryPage: React.FC = () => {
   const [viewedPetIds, setViewedPetIds] = useState<string[]>(persistedState.viewedPetIds);
   const [currentPetIndex, setCurrentPetIndex] = useState(0);
   const [undoStack, setUndoStack] = useState<SwipeAction[]>([]);
-  // ADS-626: first-like modal state for anonymous users.
+  // ADS-625 + ADS-626: anonymous-user state — first-like celebration modal
+  // and swipe-budget paywall share the same isAuthenticated / logEvent
+  // hooks.
   const { isAuthenticated } = useAuth();
   const { logEvent } = useStatsig();
   const [anonLikeModalPet, setAnonLikeModalPet] = useState<DiscoveryPet | null>(null);
+  const [anonPaywallPetId, setAnonPaywallPetId] = useState<string | null>(null);
+
+  // ADS-625: wipe the localStorage counter when the user becomes
+  // authenticated (signup or login) so the paywall never fires for
+  // logged-in users on subsequent visits.
+  useEffect(() => {
+    if (isAuthenticated) {
+      resetAnonSwipeBudget();
+      setAnonPaywallPetId(null);
+    }
+  }, [isAuthenticated]);
   // ADS-630: track whether `loadMorePets` has ever returned an empty page
   // — that's how we differentiate "queue truly exhausted" from "first
   // batch not arrived yet". Reset to true whenever the filter set
@@ -88,11 +107,26 @@ export const DiscoveryPage: React.FC = () => {
   }, []);
   const handleSwipe = useCallback(
     async (action: SwipeAction) => {
+      // ADS-625: anonymous-user soft block. Increment the localStorage
+      // counter on each swipe; once it crosses the configured limit
+      // surface the paywall and skip the rest of the handler so the
+      // card never progresses. The like-teaser modal from PR #572 is
+      // unaffected — it still fires on the locked badge.
+      if (!isAuthenticated) {
+        const next = incrementAnonSwipeCount();
+        if (hasReachedAnonSwipeLimit(next)) {
+          logEvent('anon_swipe_paywall_shown', 1, { pet_id: action.petId });
+          setAnonPaywallPetId(action.petId);
+          return;
+        }
+      }
+
       // ADS-626: surface the celebratory match modal on the *first*
       // anonymous like in this browser session. The flag lives in
       // sessionStorage so re-mounts within the same tab don't refire.
       // Only fires for `like` / `super_like` — `pass` is not a peak
-      // emotional moment.
+      // emotional moment. Runs after the ADS-625 budget check so the
+      // paywall takes precedence once the limit is hit.
       if (
         !isAuthenticated &&
         (action.action === 'like' || action.action === 'super_like') &&
@@ -233,6 +267,13 @@ export const DiscoveryPage: React.FC = () => {
     setAnonLikeModalPet(null);
   }, [anonLikeModalPet, logEvent]);
 
+  const dismissAnonPaywall = useCallback(() => {
+    if (anonPaywallPetId) {
+      logEvent('anon_swipe_paywall_dismissed', 1, { pet_id: anonPaywallPetId });
+    }
+    setAnonPaywallPetId(null);
+  }, [anonPaywallPetId, logEvent]);
+
   return (
     <Container className={styles.pageContainer}>
       {anonLikeModalPet && (
@@ -242,6 +283,18 @@ export const DiscoveryPage: React.FC = () => {
           petImage={anonLikeModalPet.images?.[0]}
           onDismiss={handleAnonModalDismiss}
           onCtaClick={handleAnonModalCta}
+        />
+      )}
+      {anonPaywallPetId && (
+        <AnonymousSwipePaywallModal
+          petId={anonPaywallPetId}
+          onSignUp={() => {
+            logEvent('anon_swipe_paywall_signup_clicked', 1, { pet_id: anonPaywallPetId });
+          }}
+          onLogIn={() => {
+            logEvent('anon_swipe_paywall_login_clicked', 1, { pet_id: anonPaywallPetId });
+          }}
+          onDismiss={dismissAnonPaywall}
         />
       )}
       <ProfileCompletionMeter />

--- a/app.client/src/utils/anonSwipeBudget.test.ts
+++ b/app.client/src/utils/anonSwipeBudget.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ANON_SWIPE_LIMIT,
+  getAnonSwipeCount,
+  hasReachedAnonSwipeLimit,
+  incrementAnonSwipeCount,
+  resetAnonSwipeBudget,
+} from './anonSwipeBudget';
+
+describe('anonSwipeBudget (ADS-625)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns 0 for the initial count', () => {
+    expect(getAnonSwipeCount()).toBe(0);
+  });
+
+  it('increments the count and persists it to localStorage', () => {
+    incrementAnonSwipeCount();
+    incrementAnonSwipeCount();
+    incrementAnonSwipeCount();
+    expect(getAnonSwipeCount()).toBe(3);
+  });
+
+  it('treats garbage values in localStorage as 0', () => {
+    window.localStorage.setItem('anon_swipe_budget.count', 'not a number');
+    expect(getAnonSwipeCount()).toBe(0);
+  });
+
+  it('reports the limit reached only once the count meets the threshold', () => {
+    expect(hasReachedAnonSwipeLimit(ANON_SWIPE_LIMIT - 1)).toBe(false);
+    expect(hasReachedAnonSwipeLimit(ANON_SWIPE_LIMIT)).toBe(true);
+    expect(hasReachedAnonSwipeLimit(ANON_SWIPE_LIMIT + 5)).toBe(true);
+  });
+
+  it('clears the count on resetAnonSwipeBudget', () => {
+    for (let i = 0; i < 5; i += 1) {
+      incrementAnonSwipeCount();
+    }
+    expect(getAnonSwipeCount()).toBe(5);
+    resetAnonSwipeBudget();
+    expect(getAnonSwipeCount()).toBe(0);
+  });
+
+  it('defaults the limit to 7 when no VITE_ANON_SWIPE_LIMIT override is supplied', () => {
+    // The test runner's import.meta.env mock leaves VITE_ANON_SWIPE_LIMIT
+    // undefined, so the resolved limit is the documented default.
+    expect(ANON_SWIPE_LIMIT).toBe(7);
+  });
+});

--- a/app.client/src/utils/anonSwipeBudget.ts
+++ b/app.client/src/utils/anonSwipeBudget.ts
@@ -1,0 +1,68 @@
+/**
+ * ADS-625: track anonymous swipe count in localStorage so the soft-block
+ * paywall can fire after N swipes. Counter is intentionally separate
+ * from the discoverySession `viewedPetIds` cap — that one bounds
+ * storage size, this one drives a conversion modal.
+ *
+ * Threshold N is configurable via `VITE_ANON_SWIPE_LIMIT` so the
+ * product team can tune the value without a code change. Default 7.
+ *
+ * Counter resets to 0 on successful signup/login — see
+ * `resetAnonSwipeBudget()`, called from the auth context's success
+ * handlers.
+ */
+
+const STORAGE_KEY = 'anon_swipe_budget.count';
+
+const isBrowser = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const parseNumericEnv = (raw: unknown, fallback: number): number => {
+  if (typeof raw !== 'string' && typeof raw !== 'number') {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+};
+
+const resolveLimit = (): number => {
+  // `import.meta.env` is the Vite-side runtime config. When tests mock
+  // the env, the override flows through transparently.
+  if (typeof import.meta !== 'undefined' && import.meta?.env) {
+    return parseNumericEnv((import.meta.env as Record<string, unknown>).VITE_ANON_SWIPE_LIMIT, 7);
+  }
+  return 7;
+};
+
+export const ANON_SWIPE_LIMIT = resolveLimit();
+
+export const getAnonSwipeCount = (): number => {
+  if (!isBrowser) {
+    return 0;
+  }
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (raw === null) {
+    return 0;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+};
+
+export const incrementAnonSwipeCount = (): number => {
+  const next = getAnonSwipeCount() + 1;
+  if (isBrowser) {
+    window.localStorage.setItem(STORAGE_KEY, String(next));
+  }
+  return next;
+};
+
+export const resetAnonSwipeBudget = (): void => {
+  if (isBrowser) {
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+};
+
+export const hasReachedAnonSwipeLimit = (count = getAnonSwipeCount()): boolean =>
+  count >= ANON_SWIPE_LIMIT;


### PR DESCRIPTION
## Summary

Implements [ADS-625](https://linear.app/ideasquared/issue/ADS-625/anonymous-swipe-paywall-soft-block-after-n-swipes). Anonymous users can swipe forever today, so the funnel captures zero of that intent. After N swipes (default 7) we surface a soft-block modal that funnels into signup or login. The locked-match teaser from PR #572 remains as the first pressure point; this is the second.

## Changes

- `app.client/src/utils/anonSwipeBudget.ts`: localStorage-backed counter + reset helpers. The limit is resolved once at module load from `import.meta.env.VITE_ANON_SWIPE_LIMIT` with a fallback of 7, so the threshold is configurable per environment without a code change.
- `app.client/src/components/discovery/AnonymousSwipePaywallModal.{tsx,css.ts}`: new component using `role='alertdialog'` + `aria-labelledby` + `aria-describedby` so screen readers announce the gate. Auto-focuses the **Sign up** button so keyboard users land on it. The Sign up route deep-links to `/register?petId=<id>` (matching ADS-626); Log in goes to `/login`.
- `app.client/src/components/discovery/DiscoveryPage.tsx`:
  - Increment the counter on every anonymous swipe.
  - When `hasReachedAnonSwipeLimit` flips true, fire the modal and *return early* from `handleSwipe` so the card never progresses past the paywall — the user is stuck until they sign up, log in, or navigate away.
  - On `isAuthenticated` transition (signup or login), wipe the counter so authenticated users never see the paywall again.
- Statsig events: `anon_swipe_paywall_shown` / `_dismissed` / `_signup_clicked` / `_login_clicked`, all carrying the petId in view.

## Acceptance criteria

- [x] Anonymous swipe count persists across reloads in the same browser (localStorage).
- [x] Modal appears on the (N+1)th swipe attempt and prevents further card interaction (the swipe handler returns before mutating state).
- [x] Counter resets to 0 on successful signup or login (useEffect on isAuthenticated transition).
- [x] Threshold N is configurable via `VITE_ANON_SWIPE_LIMIT` (default 7).
- [x] Logs `anon_swipe_paywall_shown` and `_dismissed` with the petId in view.
- [x] Modal is keyboard-accessible (focus jump) and announces itself to screen readers (`role='alertdialog'`).

## Test plan

- [x] `anonSwipeBudget.test.ts`: initial 0, increment + persist, garbage value treated as 0, limit threshold semantics, reset wipes the counter, default limit is 7.
- [x] `AnonymousSwipePaywallModal.test.tsx`: renders + a11y role + labelled-by, auto-focus, three button callbacks fire.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_