### PR TITLE
fix(ci): generate REDIS_PASSWORD in the E2E .env (post-ADS-600)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,11 @@ jobs:
             echo "SESSION_SECRET=$(openssl rand -base64 32)"
             echo "CSRF_SECRET=$(openssl rand -base64 32)"
             echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"
+            # ADS-600 made REDIS_PASSWORD a required secret in
+            # docker-compose.yml; the CI stack-up step refuses to
+            # start without it. Generate it here so every E2E run
+            # gets a fresh, non-default value.
+            echo "REDIS_PASSWORD=$(openssl rand -base64 32)"
             echo "CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002"
           } > .env
 


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring "infrastructure" E2E Playwright failures across every open PR since ADS-600 (#599) merged.

## What broke

ADS-600 (#599) hardened `docker-compose.yml` so `REDIS_PASSWORD` is a required secret — the `:-devredispassword` default was removed. The dev compose now refuses to come up without one:

```
error while interpolating services.redis.command: required variable
REDIS_PASSWORD is missing a value
```

The CI E2E job builds its own `.env` on the fly (it doesn't `cp .env.example .env`), and that block was not updated alongside the compose change. So every E2E run since #599 has been bailing at `docker compose up -d database redis` in ~1m54s, before Playwright is even invoked. That's the "Start database and cache" / "Tear down stack" annotation pattern we've been seeing on PRs #607, #608, #610.

## Fix

Add a single line to the E2E `.env` generation in `.github/workflows/ci.yml`:

```yaml
echo "REDIS_PASSWORD=$(openssl rand -base64 32)"
```

generated alongside the existing JWT / session / CSRF / encryption secrets. Each run gets a fresh value, no default leakage.

## Test plan

- [x] Local unit suites still pass (backend 2406, app.client 283, app.admin 326, app.rescue 195).
- [ ] CI green on this PR (verifies the compose stack now comes up with the new secret).
- [ ] Open PRs rebased onto this fix pass their E2E job.

Once this lands, I'll rebase #604/#605/#606/#607/#608/#609/#610/#611 onto the updated main so they all pick up the fix.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_