### PR TITLE
fix(ci): generate UPLOAD_SIGNING_SECRET in the E2E .env (follow-up to #612)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,11 @@ jobs:
             # start without it. Generate it here so every E2E run
             # gets a fresh, non-default value.
             echo "REDIS_PASSWORD=$(openssl rand -base64 32)"
+            # ADS-542 made UPLOAD_SIGNING_SECRET a required env var on
+            # the backend (32+ chars). Without it the /health probe
+            # never goes ready and the Wait-for-services step times
+            # out.
+            echo "UPLOAD_SIGNING_SECRET=$(openssl rand -base64 32)"
             echo "CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:3002"
           } > .env
 


### PR DESCRIPTION
## Summary

Follow-up to #612 (which only added `REDIS_PASSWORD`). The docker stack now comes up, but the backend's `/health` probe never goes ready in CI because `validateEnv()` (ADS-542) requires `UPLOAD_SIGNING_SECRET` to be set and 32+ chars. Without it the backend exits at boot and the E2E `Wait for services` step times out, exits 1.

## Fix

Add `UPLOAD_SIGNING_SECRET=$(openssl rand -base64 32)` to the same `.env` generation block in `.github/workflows/ci.yml`.

## Why the two-fix sequence happened

#612 was merged as the first-secret-only commit before I could push my amend. This PR completes the pair so E2E reaches Playwright on every open PR.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_