### PR TITLE
fix(ci): use hex (URL-safe) for REDIS_PASSWORD in the E2E .env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,7 +426,14 @@ jobs:
             # docker-compose.yml; the CI stack-up step refuses to
             # start without it. Generate it here so every E2E run
             # gets a fresh, non-default value.
-            echo "REDIS_PASSWORD=$(openssl rand -base64 32)"
+            #
+            # Hex (not base64) because docker-compose interpolates
+            # this into REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
+            # and `openssl rand -base64` includes `/`, `+`, `=` —
+            # `/` terminates the URL userinfo so the backend's
+            # `new URL(REDIS_URL)` rejects it with "Invalid URL"
+            # before validateEnv can finish.
+            echo "REDIS_PASSWORD=$(openssl rand -hex 32)"
             # ADS-542 made UPLOAD_SIGNING_SECRET a required env var on
             # the backend (32+ chars). Without it the /health probe
             # never goes ready and the Wait-for-services step times


### PR DESCRIPTION
## Summary

The root cause of every "Wait for services" E2E timeout since #612 merged. The backend doesn't time out — it **exits at boot** with `REDIS_URL: Invalid URL`, so the health endpoint never goes ready and the CI's curl loop polls a dead port for 180s.

## What the log shows

From a real CI run (provided by the user):

```
service-backend-1 | (node:29) [DEP0170] DeprecationWarning:
  The URL redis://:u+f+LCt4uVHkXK4M4nA/VICIp6saEeu+crh5pvMK/9Q=@redis:6379 is invalid.
service-backend-1 | 10:16:46.397 [error]: Environment validation failed
service-backend-1 | 10:16:46.397 [error]:   - REDIS_URL: Invalid URL
service-backend-1 | 10:16:46.409 [error]: Failed to start server: Environment validation failed.
```

`openssl rand -base64 32` produces values containing `+`, `/`, and `=`. docker-compose interpolates the password into

```
REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
```

and `/` terminates the userinfo segment, so `new URL(REDIS_URL)` throws.

## Fix

Single-line change in `.github/workflows/ci.yml`:

```diff
- echo "REDIS_PASSWORD=$(openssl rand -base64 32)"
+ echo "REDIS_PASSWORD=$(openssl rand -hex 32)"
```

Hex output is 64 chars (still >= the 32-char minimum) and contains only `[0-9a-f]` — completely URL-safe. The other secrets stay base64 since they're consumed as opaque strings.

## Test plan

- [x] Verified the failure mode against the actual CI backend log.
- [ ] CI green on this PR.
- [ ] Open PRs (#604 / #605 / #606 / #607 / #608 / #609 / #610 / #611) rebased onto this fix pass their E2E job.

Once this lands I'll rebase the eight open PR branches so they all pick up the fix.

---
_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBr6PxTi7CLUipphXQpLxC)_