### PR TITLE
fix(security): strict auth-bound user id on discovery queue

### DIFF
--- a/service.backend/src/__tests__/routes/discovery.routes.test.ts
+++ b/service.backend/src/__tests__/routes/discovery.routes.test.ts
@@ -1,0 +1,165 @@
+import { vi } from 'vitest';
+import express, { NextFunction, Response } from 'express';
+import request from 'supertest';
+import { AuthenticatedRequest } from '../../types';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn() },
+}));
+
+vi.mock('../../config/env', () => ({
+  env: {
+    JWT_SECRET: 'test-secret-min-32-characters-long-12345',
+    JWT_REFRESH_SECRET: 'test-refresh-secret-min-32-chars-12345',
+    SESSION_SECRET: 'test-session-secret',
+    CSRF_SECRET: 'test-csrf-secret',
+  },
+}));
+
+const { getDiscoveryQueueMock } = vi.hoisted(() => ({
+  getDiscoveryQueueMock: vi.fn(),
+}));
+
+vi.mock('../../services/discovery.service', () => {
+  class DiscoveryService {
+    getDiscoveryQueue = getDiscoveryQueueMock;
+    loadMorePets = vi.fn();
+  }
+  return { DiscoveryService };
+});
+
+vi.mock('../../services/swipe.service', () => {
+  class SwipeService {
+    recordSwipeAction = vi.fn();
+    getUserSwipeStats = vi.fn();
+    getSessionStats = vi.fn();
+  }
+  return { SwipeService };
+});
+
+vi.mock('../../sequelize', () => ({
+  default: { query: vi.fn() },
+}));
+
+const optionalAuthMock = vi.fn();
+vi.mock('../../middleware/auth', () => ({
+  authenticateToken: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  optionalAuth: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    optionalAuthMock(req, res, next),
+}));
+
+vi.mock('../../middleware/idempotency', () => ({
+  idempotency: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+}));
+
+import discoveryRouter from '../../routes/discovery.routes';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/discovery', discoveryRouter);
+  return app;
+};
+
+const AUTH_USER_ID = 'a1111111-1111-4111-8111-111111111111';
+const OTHER_USER_ID = 'b2222222-2222-4222-8222-222222222222';
+
+const mockAuthedUser = {
+  userId: AUTH_USER_ID,
+  email: 'user@example.com',
+  userType: 'adopter',
+};
+
+describe('Discovery routes - user id binding (security)', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getDiscoveryQueueMock.mockResolvedValue({
+      pets: [],
+      sessionId: 'session-1',
+      hasMore: false,
+    });
+    app = buildApp();
+  });
+
+  describe('GET /api/v1/discovery/pets', () => {
+    it('uses authenticated user id and ignores ?userId override', async () => {
+      optionalAuthMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockAuthedUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+
+      const res = await request(app).get('/api/v1/discovery/pets').query({ userId: OTHER_USER_ID });
+
+      expect(res.status).toBe(200);
+      expect(getDiscoveryQueueMock).toHaveBeenCalledTimes(1);
+      const [, , passedUserId] = getDiscoveryQueueMock.mock.calls[0];
+      expect(passedUserId).toBe(AUTH_USER_ID);
+      expect(passedUserId).not.toBe(OTHER_USER_ID);
+    });
+
+    it('passes undefined user id when caller is anonymous', async () => {
+      optionalAuthMock.mockImplementation(
+        (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+      );
+
+      const res = await request(app).get('/api/v1/discovery/pets');
+
+      expect(res.status).toBe(200);
+      expect(getDiscoveryQueueMock).toHaveBeenCalledTimes(1);
+      const [, , passedUserId] = getDiscoveryQueueMock.mock.calls[0];
+      expect(passedUserId).toBeUndefined();
+    });
+
+    it('ignores ?userId even when caller is anonymous (no preference oracle)', async () => {
+      optionalAuthMock.mockImplementation(
+        (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+      );
+
+      const res = await request(app).get('/api/v1/discovery/pets').query({ userId: OTHER_USER_ID });
+
+      expect(res.status).toBe(200);
+      const [, , passedUserId] = getDiscoveryQueueMock.mock.calls[0];
+      expect(passedUserId).toBeUndefined();
+    });
+  });
+
+  describe('POST /api/v1/discovery/queue', () => {
+    it('uses authenticated user id and ignores body userId override', async () => {
+      optionalAuthMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockAuthedUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+
+      const res = await request(app)
+        .post('/api/v1/discovery/queue')
+        .send({ userId: OTHER_USER_ID, filters: {}, limit: 5 });
+
+      expect(res.status).toBe(200);
+      expect(getDiscoveryQueueMock).toHaveBeenCalledTimes(1);
+      const [, , passedUserId] = getDiscoveryQueueMock.mock.calls[0];
+      expect(passedUserId).toBe(AUTH_USER_ID);
+      expect(passedUserId).not.toBe(OTHER_USER_ID);
+    });
+
+    it('ignores body userId when caller is anonymous', async () => {
+      optionalAuthMock.mockImplementation(
+        (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+      );
+
+      const res = await request(app)
+        .post('/api/v1/discovery/queue')
+        .send({ userId: OTHER_USER_ID, filters: {}, limit: 5 });
+
+      expect(res.status).toBe(200);
+      const [, , passedUserId] = getDiscoveryQueueMock.mock.calls[0];
+      expect(passedUserId).toBeUndefined();
+    });
+  });
+});

--- a/service.backend/src/controllers/discovery.controller.ts
+++ b/service.backend/src/controllers/discovery.controller.ts
@@ -90,10 +90,10 @@ export class DiscoveryController {
       default: DEFAULT_PAGE_SIZE,
       max: MAX_PAGE_SIZE,
     });
-    // Authenticated user takes precedence so personalised matching engages
-    // even when the client omits the query param. Explicit `?userId=` still
-    // wins (admin / debug surfaces).
-    const userId = (req.query.userId as string | undefined) ?? req.user?.userId;
+    // Always bind to the authenticated user — never trust a client-supplied
+    // userId. Allowing `?userId=` to override would let an attacker probe a
+    // victim's personalised re-ranking as a preference oracle.
+    const userId = req.user?.userId;
 
     const discoveryQueue = await this.discoveryService.getDiscoveryQueue(filters, limit, userId);
 
@@ -232,20 +232,15 @@ export class DiscoveryController {
       return;
     }
 
-    const {
-      filters = {},
-      userId: bodyUserId,
-      limit = 20,
-    } = req.body as {
+    const { filters = {}, limit = 20 } = req.body as {
       filters?: DiscoveryFilters;
-      userId?: string;
       limit?: number;
     };
 
-    // Prefer the authenticated user over a body-supplied id so personalised
-    // matching kicks in even when the client doesn't plumb the id through.
-    // Body still wins when present (admin tools / debug flows).
-    const userId = bodyUserId ?? req.user?.userId;
+    // Always bind to the authenticated user — never trust a client-supplied
+    // userId. Allowing the body to override would let an attacker probe a
+    // victim's personalised re-ranking as a preference oracle.
+    const userId = req.user?.userId;
 
     logger.info('Discovery queue request received', {
       service: 'discovery',


### PR DESCRIPTION
## Summary

- `GET /api/v1/discovery/pets` and `POST /api/v1/discovery/queue` previously let a client-supplied `userId` (query string / request body) override the authenticated user when ranking the personalised discovery feed. Inline comments called this an "admin / debug" override, but no role check enforced it.
- Because the feed is personalised via `matchService.rankPets(userId, ...)`, an attacker could call either endpoint repeatedly with a victim's `userId` and infer the victim's top breeds / types from the re-ranking — a preference oracle.
- Fix: always bind personalised ranking to `req.user?.userId`. Both endpoints use `optionalAuth`, so anonymous callers still get the non-personalised feed; the override is simply dropped (no admin pattern matched in the codebase, so the safer/simpler removal was chosen per `CLAUDE.md` surgical-change guidance). The express-validator `query('userId').optional().isUUID()` rule is left in place — harmless and no longer load-bearing.

## Test plan

- [x] New behaviour tests in `service.backend/src/__tests__/routes/discovery.routes.test.ts`:
  - GET with `?userId=<other-uuid>` while authenticated -> service called with the authenticated id, not the query value
  - POST with `userId: <other-uuid>` in the body while authenticated -> service called with the authenticated id
  - Anonymous GET -> service called with `undefined`
  - Anonymous GET / POST with override attempt -> service called with `undefined` (no oracle for unauth callers either)
- [x] `npx vitest run src/__tests__/routes/discovery.routes.test.ts src/__tests__/services/discovery.service.test.ts` -> 14 passed
- [x] `npx tsc --noEmit` clean (after building `lib.types` + `lib.validation`)
- [x] `npx eslint` on changed files clean

https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_