### PR TITLE
feat(security): server-side anonymous swipe limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -273,6 +273,12 @@ VITE_SENTRY_DSN=your-sentry-dsn-url
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
 
+# ADS-625: server-side anon-swipe paywall threshold. After this many swipe
+# actions from a single anonymous client (CSRF session cookie, falling back
+# to hashed IP), the swipe endpoint returns 402 ANON_SWIPE_LIMIT_REACHED.
+# Should match the client's VITE_ANON_SWIPE_LIMIT (default 7).
+ANON_SWIPE_LIMIT=7
+
 # -----------------------------------------------------------------------------
 # Development Options
 # -----------------------------------------------------------------------------

--- a/service.backend/src/__tests__/middleware/anon-swipe-limit.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/anon-swipe-limit.middleware.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { NextFunction, Response } from 'express';
+import { AuthenticatedRequest } from '../../types/auth';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Force the in-process fallback path; getRedis() returning null disables
+// the Redis store, exercising the same arithmetic against an in-memory
+// Map. Behaviour from the caller's perspective is identical.
+vi.mock('../../lib/redis', () => ({
+  getRedis: () => null,
+  ensureRedisReady: async () => false,
+  isRedisReady: () => false,
+}));
+
+type MockRes = Partial<Response> & {
+  status: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+  statusCode: number;
+};
+
+const buildReq = (overrides: Partial<AuthenticatedRequest> = {}): AuthenticatedRequest =>
+  ({
+    method: 'POST',
+    path: '/swipe/action',
+    ip: '203.0.113.5',
+    cookies: {},
+    headers: {},
+    ...overrides,
+  }) as unknown as AuthenticatedRequest;
+
+const buildRes = (): MockRes => {
+  const res: MockRes = {
+    statusCode: 200,
+    status: vi.fn().mockImplementation(function (this: MockRes, code: number) {
+      this.statusCode = code;
+      return this;
+    }),
+    json: vi.fn().mockReturnThis(),
+  };
+  return res;
+};
+
+const loadMiddleware = async () => {
+  // Re-import in each test so the in-process counter map is fresh.
+  vi.resetModules();
+  const mod = await import('../../middleware/anon-swipe-limit');
+  return mod.anonSwipeLimit;
+};
+
+describe('anon-swipe-limit middleware (ADS-625 server enforcement)', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.ANON_SWIPE_LIMIT = '3';
+  });
+
+  it('passes authenticated requests through without counting', async () => {
+    const anonSwipeLimit = await loadMiddleware();
+    const next: NextFunction = vi.fn();
+    const res = buildRes();
+    const authedReq = buildReq({
+      user: { userId: 'user-1' },
+    } as Partial<AuthenticatedRequest>);
+
+    // Many more than the limit — authenticated callers should never block.
+    for (let i = 0; i < 10; i++) {
+      await anonSwipeLimit(authedReq, res as unknown as Response, next);
+    }
+
+    expect(next).toHaveBeenCalledTimes(10);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('lets anonymous callers through while under the limit and increments per call', async () => {
+    const anonSwipeLimit = await loadMiddleware();
+    const next: NextFunction = vi.fn();
+    const res = buildRes();
+    const req = buildReq({ cookies: { 'csrf-session': 'anon-cookie-A' } });
+
+    // Limit is 3 — calls 1, 2, 3 should pass; call 4 should block.
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    await anonSwipeLimit(req, res as unknown as Response, next);
+
+    expect(next).toHaveBeenCalledTimes(3);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('blocks with 402 ANON_SWIPE_LIMIT_REACHED once the limit is reached', async () => {
+    const anonSwipeLimit = await loadMiddleware();
+    const next: NextFunction = vi.fn();
+    const res = buildRes();
+    const req = buildReq({ cookies: { 'csrf-session': 'anon-cookie-B' } });
+
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    expect(next).toHaveBeenCalledTimes(3);
+
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    expect(next).toHaveBeenCalledTimes(3);
+    expect(res.status).toHaveBeenCalledWith(402);
+    const body = res.json.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(body).toMatchObject({
+      success: false,
+      code: 'ANON_SWIPE_LIMIT_REACHED',
+    });
+    expect(typeof body.message).toBe('string');
+    expect(typeof body.timestamp).toBe('string');
+  });
+
+  it('keeps blocking on subsequent attempts without incrementing further', async () => {
+    const anonSwipeLimit = await loadMiddleware();
+    const next: NextFunction = vi.fn();
+    const res = buildRes();
+    const req = buildReq({ cookies: { 'csrf-session': 'anon-cookie-C' } });
+
+    // Burn through the budget.
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    // Now blocked.
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    await anonSwipeLimit(req, res as unknown as Response, next);
+    await anonSwipeLimit(req, res as unknown as Response, next);
+
+    expect(next).toHaveBeenCalledTimes(3);
+    // Every blocked call still returns 402 — there is no escalation/leak.
+    expect(res.status).toHaveBeenCalledWith(402);
+  });
+
+  it('keeps counters independent per CSRF session cookie', async () => {
+    const anonSwipeLimit = await loadMiddleware();
+    const next: NextFunction = vi.fn();
+    const res = buildRes();
+
+    const reqA = buildReq({ cookies: { 'csrf-session': 'cookie-alpha' } });
+    const reqB = buildReq({ cookies: { 'csrf-session': 'cookie-beta' } });
+
+    // Exhaust A's budget.
+    await anonSwipeLimit(reqA, res as unknown as Response, next);
+    await anonSwipeLimit(reqA, res as unknown as Response, next);
+    await anonSwipeLimit(reqA, res as unknown as Response, next);
+    await anonSwipeLimit(reqA, res as unknown as Response, next); // blocked
+    expect(res.status).toHaveBeenCalledWith(402);
+
+    // B starts fresh.
+    const nextB: NextFunction = vi.fn();
+    const resB = buildRes();
+    await anonSwipeLimit(reqB, resB as unknown as Response, nextB);
+    expect(nextB).toHaveBeenCalledTimes(1);
+    expect(resB.status).not.toHaveBeenCalled();
+  });
+
+  it('falls back to req.ip when no CSRF session cookie is present and keeps counters independent', async () => {
+    const anonSwipeLimit = await loadMiddleware();
+    const res = buildRes();
+
+    const reqIp1 = buildReq({ ip: '198.51.100.1', cookies: {} });
+    const reqIp2 = buildReq({ ip: '198.51.100.2', cookies: {} });
+
+    const next: NextFunction = vi.fn();
+    await anonSwipeLimit(reqIp1, res as unknown as Response, next);
+    await anonSwipeLimit(reqIp1, res as unknown as Response, next);
+    await anonSwipeLimit(reqIp1, res as unknown as Response, next);
+    await anonSwipeLimit(reqIp1, res as unknown as Response, next); // blocked at limit=3
+    expect(res.status).toHaveBeenCalledWith(402);
+
+    const next2: NextFunction = vi.fn();
+    const res2 = buildRes();
+    await anonSwipeLimit(reqIp2, res2 as unknown as Response, next2);
+    expect(next2).toHaveBeenCalledTimes(1);
+    expect(res2.status).not.toHaveBeenCalled();
+  });
+});

--- a/service.backend/src/config/env.ts
+++ b/service.backend/src/config/env.ts
@@ -29,6 +29,9 @@ type RequiredEnvVars = {
   WORKER_ENABLED?: string;
   DB_SSL_MODE?: string;
   ALLOW_INSECURE_DB?: string;
+  // ADS-625 server-side anon swipe paywall. Optional — defaults to 7
+  // (matches the client's VITE_ANON_SWIPE_LIMIT default).
+  ANON_SWIPE_LIMIT?: string;
 };
 
 type ValidatedEnv = {
@@ -55,6 +58,7 @@ type ValidatedEnv = {
   WORKER_ENABLED?: string;
   DB_SSL_MODE?: string;
   ALLOW_INSECURE_DB?: string;
+  ANON_SWIPE_LIMIT?: string;
 };
 
 export type DbSslMode = 'disable' | 'require' | 'verify-ca' | 'verify-full';
@@ -310,6 +314,7 @@ const validateEnv = (): ValidatedEnv => {
     WORKER_ENABLED: process.env.WORKER_ENABLED,
     DB_SSL_MODE: process.env.DB_SSL_MODE,
     ALLOW_INSECURE_DB: process.env.ALLOW_INSECURE_DB,
+    ANON_SWIPE_LIMIT: process.env.ANON_SWIPE_LIMIT,
   };
 
   // ADS-540: refuse to boot in production with no TLS to the database

--- a/service.backend/src/middleware/anon-swipe-limit.ts
+++ b/service.backend/src/middleware/anon-swipe-limit.ts
@@ -1,0 +1,148 @@
+import { createHash } from 'crypto';
+import type { NextFunction, Response } from 'express';
+import { getRedis, isRedisReady } from '../lib/redis';
+import { logger } from '../utils/logger';
+import { AuthenticatedRequest } from '../types/auth';
+
+/**
+ * ADS-625 server-side enforcement.
+ *
+ * Counterpart to the client-side anon swipe budget in
+ * `app.client/src/utils/anonSwipeBudget.ts`. The client gate is a UX hint
+ * only — clearing localStorage, opening incognito, or curl-ing the
+ * endpoint bypasses it. This middleware mirrors that limit on the server
+ * so the soft-block actually holds.
+ *
+ * Scope: anonymous callers only. Authenticated requests bypass.
+ *
+ * Identifier (priority order):
+ *   1. CSRF per-browser session cookie (`csrf-session` / `__Host-csrf-session`)
+ *      — the same identifier the CSRF middleware mints, so it survives
+ *      across requests within a browser.
+ *   2. SHA-256(req.ip) — coarse fallback for callers without cookies
+ *      (curl, abuse). `trust proxy` is set at the app level so req.ip is
+ *      the client address, not the loadbalancer.
+ *
+ * Storage: Redis (`INCR` + `EXPIRE`, 24h TTL) when available; otherwise an
+ * in-process Map. Multi-replica deployments should run with Redis.
+ */
+
+const KEY_PREFIX = 'anon:swipe:';
+const TTL_SECONDS = 24 * 60 * 60;
+const DEFAULT_LIMIT = 7;
+
+const CSRF_SESSION_COOKIES = ['__Host-csrf-session', 'csrf-session'] as const;
+
+const resolveLimit = (): number => {
+  const raw = process.env.ANON_SWIPE_LIMIT;
+  if (!raw) {
+    return DEFAULT_LIMIT;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.floor(parsed);
+};
+
+const resolveIdentifier = (req: AuthenticatedRequest): string => {
+  const cookies = (req as AuthenticatedRequest & { cookies?: Record<string, string | undefined> })
+    .cookies;
+  for (const name of CSRF_SESSION_COOKIES) {
+    const value = cookies?.[name];
+    if (typeof value === 'string' && value.length > 0) {
+      return `cookie:${value}`;
+    }
+  }
+  const ip = req.ip ?? 'unknown';
+  return `ip:${createHash('sha256').update(ip).digest('hex')}`;
+};
+
+type MemoryEntry = { count: number; expiresAt: number };
+const memoryStore = new Map<string, MemoryEntry>();
+
+const readMemory = (key: string): number => {
+  const entry = memoryStore.get(key);
+  if (!entry || entry.expiresAt <= Date.now()) {
+    return 0;
+  }
+  return entry.count;
+};
+
+const writeMemoryIncrement = (key: string): void => {
+  const now = Date.now();
+  const existing = memoryStore.get(key);
+  if (!existing || existing.expiresAt <= now) {
+    memoryStore.set(key, { count: 1, expiresAt: now + TTL_SECONDS * 1000 });
+    return;
+  }
+  existing.count += 1;
+};
+
+const readRedis = async (key: string): Promise<number | null> => {
+  const redis = getRedis();
+  if (!redis || !isRedisReady()) {
+    return null;
+  }
+  try {
+    const raw = await redis.get(key);
+    return raw === null ? 0 : Number(raw);
+  } catch (error) {
+    logger.debug('anon-swipe-limit: Redis get failed, falling through to memory', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+};
+
+const writeRedisIncrement = async (key: string): Promise<void> => {
+  const redis = getRedis();
+  if (!redis || !isRedisReady()) {
+    return;
+  }
+  try {
+    const count = await redis.incr(key);
+    if (count === 1) {
+      await redis.expire(key, TTL_SECONDS);
+    }
+  } catch (error) {
+    logger.debug('anon-swipe-limit: Redis incr failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+export const anonSwipeLimit = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  if (req.user) {
+    next();
+    return;
+  }
+
+  const limit = resolveLimit();
+  const key = `${KEY_PREFIX}${resolveIdentifier(req)}`;
+
+  const redisCount = await readRedis(key);
+  const current = redisCount ?? readMemory(key);
+
+  if (current >= limit) {
+    res.status(402).json({
+      success: false,
+      code: 'ANON_SWIPE_LIMIT_REACHED',
+      message: 'Anonymous swipe limit reached. Sign up to keep swiping.',
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+
+  if (redisCount === null) {
+    writeMemoryIncrement(key);
+  } else {
+    await writeRedisIncrement(key);
+  }
+
+  next();
+};

--- a/service.backend/src/routes/discovery.routes.ts
+++ b/service.backend/src/routes/discovery.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { QueryTypes } from 'sequelize';
 import { DiscoveryController } from '../controllers/discovery.controller';
+import { anonSwipeLimit } from '../middleware/anon-swipe-limit';
 import { authenticateToken, optionalAuth } from '../middleware/auth';
 import { idempotency } from '../middleware/idempotency';
 import sequelize from '../sequelize';
@@ -460,9 +461,15 @@ router.post(
 // present, while anonymous browse still works.
 router.post('/queue', optionalAuth, discoveryController.addToQueue);
 
-// Swipe action routes
+// Swipe action routes.
+// optionalAuth attaches `req.user` when a token is present so the anon
+// swipe paywall (ADS-625) can exempt authenticated callers. It is
+// idempotent with respect to the parallel auth fix in
+// `claude/sec-fix-swipe-action-unauth`.
 router.post(
   '/swipe/action',
+  optionalAuth,
+  anonSwipeLimit,
   idempotency,
   DiscoveryController.validateSwipeAction,
   discoveryController.recordSwipeAction


### PR DESCRIPTION
## Summary

The ADS-625 anon-swipe paywall ("soft block after N swipes") was implemented entirely client-side: a `localStorage` counter in `app.client/src/utils/anonSwipeBudget.ts` consumed by `DiscoveryPage.tsx`. Clearing localStorage, opening incognito, or curl-ing `POST /swipe/action` bypassed it completely — there was zero server-side enforcement.

This PR adds a server-side counter on the swipe-action endpoint that mirrors the client gate:

- New `anonSwipeLimit` middleware (`service.backend/src/middleware/anon-swipe-limit.ts`). Anonymous callers only — authenticated requests pass through.
- Counter key: existing CSRF per-browser session cookie (`__Host-csrf-session` in prod, `csrf-session` in dev), falling back to `sha256(req.ip)`. `trust proxy` is already set so `req.ip` is the real client.
- Storage: Redis (`INCR` + `EXPIRE`, 24h TTL, prefix `anon:swipe:`) when available; in-process `Map` fallback so single-replica setups (and tests without Redis) keep working. No new dependency.
- At the limit: HTTP 402 `{ success: false, code: 'ANON_SWIPE_LIMIT_REACHED', message, timestamp }`, matching the response shape used elsewhere in `discovery.controller.ts` so the frontend can show the paywall modal.
- Limit configurable via `ANON_SWIPE_LIMIT` (default 7 — matches the client's `VITE_ANON_SWIPE_LIMIT` default). Documented in `.env.example` and registered in `service.backend/src/config/env.ts`.

Also adds `optionalAuth` to the swipe-action route so the middleware can correctly exempt authenticated callers via `req.user`. This is intentionally complementary to and idempotent with `claude/sec-fix-swipe-action-unauth`, which adds the same `optionalAuth` to fix the unauthenticated-write issue on the same route — merging either order is safe.

The client paywall, the swipe service, and the discovery controller are untouched.

## Test plan

- [x] `npx vitest run src/__tests__/middleware/anon-swipe-limit.middleware.test.ts` — 6/6 pass. Covers: authenticated bypass, anonymous under-limit pass-through, 402 at limit, repeated blocks remain 402, independent counters per CSRF cookie, independent counters per IP fallback.
- [x] `npx vitest run src/__tests__/middleware/` — full middleware suite, 278/278 pass.
- [x] `npx tsc --noEmit` in `service.backend` — clean.
- [x] `npx eslint` on changed files — no new warnings (one pre-existing unused-type warning in `config/env.ts`).
- [ ] Manual: curl the endpoint anonymously N+1 times without cookies, observe 402 on the (N+1)th. Verify same client cookie keeps the same budget across requests.
- [ ] Manual: hit endpoint authenticated, confirm no 402.

https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_