### PR TITLE
fix(security): auth + entropy on discovery session stats

### DIFF
--- a/service.backend/src/__tests__/routes/discovery.routes.test.ts
+++ b/service.backend/src/__tests__/routes/discovery.routes.test.ts
@@ -17,9 +17,17 @@ vi.mock('../../config/env', () => ({
   },
 }));
 
-const { getDiscoveryQueueMock, recordSwipeActionMock, optionalAuthMock } = vi.hoisted(() => ({
+const {
+  getDiscoveryQueueMock,
+  recordSwipeActionMock,
+  getSessionStatsMock,
+  authenticateTokenMock,
+  optionalAuthMock,
+} = vi.hoisted(() => ({
   getDiscoveryQueueMock: vi.fn(),
   recordSwipeActionMock: vi.fn(),
+  getSessionStatsMock: vi.fn(),
+  authenticateTokenMock: vi.fn(),
   optionalAuthMock: vi.fn(),
 }));
 
@@ -35,7 +43,7 @@ vi.mock('../../services/swipe.service', () => {
   class SwipeService {
     recordSwipeAction = recordSwipeActionMock;
     getUserSwipeStats = vi.fn();
-    getSessionStats = vi.fn();
+    getSessionStats = getSessionStatsMock;
   }
   return { SwipeService };
 });
@@ -45,7 +53,8 @@ vi.mock('../../sequelize', () => ({
 }));
 
 vi.mock('../../middleware/auth', () => ({
-  authenticateToken: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authenticateTokenMock(req, res, next),
   optionalAuth: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
     optionalAuthMock(req, res, next),
 }));
@@ -76,6 +85,11 @@ const mockAuthedUser = {
   userType: 'adopter',
 };
 
+const passAuth = (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+  req.user = mockAuthedUser as AuthenticatedRequest['user'];
+  next();
+};
+
 describe('Discovery routes - user id binding (security)', () => {
   let app: express.Application;
 
@@ -86,17 +100,13 @@ describe('Discovery routes - user id binding (security)', () => {
       sessionId: 'session-1',
       hasMore: false,
     });
+    authenticateTokenMock.mockImplementation(passAuth);
     app = buildApp();
   });
 
   describe('GET /api/v1/discovery/pets', () => {
     it('uses authenticated user id and ignores ?userId override', async () => {
-      optionalAuthMock.mockImplementation(
-        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
-          req.user = mockAuthedUser as AuthenticatedRequest['user'];
-          next();
-        }
-      );
+      optionalAuthMock.mockImplementation(passAuth);
 
       const res = await request(app).get('/api/v1/discovery/pets').query({ userId: OTHER_USER_ID });
 
@@ -135,12 +145,7 @@ describe('Discovery routes - user id binding (security)', () => {
 
   describe('POST /api/v1/discovery/queue', () => {
     it('uses authenticated user id and ignores body userId override', async () => {
-      optionalAuthMock.mockImplementation(
-        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
-          req.user = mockAuthedUser as AuthenticatedRequest['user'];
-          next();
-        }
-      );
+      optionalAuthMock.mockImplementation(passAuth);
 
       const res = await request(app)
         .post('/api/v1/discovery/queue')
@@ -232,5 +237,44 @@ describe('POST /api/v1/discovery/swipe/action', () => {
     const persisted = recordSwipeActionMock.mock.calls[0][0];
     expect(persisted.userId).toBeNull();
     expect(persisted.userId).not.toBe(forgedUserId);
+  });
+});
+
+describe('Discovery routes — session stats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateTokenMock.mockImplementation(passAuth);
+    optionalAuthMock.mockImplementation(
+      (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+    );
+  });
+
+  describe('GET /api/v1/discovery/swipe/session/:sessionId', () => {
+    it('returns 401 when unauthenticated', async () => {
+      authenticateTokenMock.mockImplementation((_req: AuthenticatedRequest, res: Response) => {
+        res.status(401).json({ error: 'unauthenticated' });
+      });
+
+      const res = await request(buildApp()).get(
+        '/api/v1/discovery/swipe/session/session_abcdef1234567890abcdef1234567890'
+      );
+
+      expect(res.status).toBe(401);
+      expect(getSessionStatsMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 with session stats when authenticated', async () => {
+      const stats = { sessionId: 'session_abc', totalSwipes: 3 };
+      getSessionStatsMock.mockResolvedValue(stats);
+
+      const res = await request(buildApp()).get(
+        '/api/v1/discovery/swipe/session/session_abcdef1234567890abcdef1234567890'
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual(stats);
+      expect(getSessionStatsMock).toHaveBeenCalledWith('session_abcdef1234567890abcdef1234567890');
+    });
   });
 });

--- a/service.backend/src/__tests__/services/discovery.service.test.ts
+++ b/service.backend/src/__tests__/services/discovery.service.test.ts
@@ -228,6 +228,20 @@ describe('DiscoveryService', () => {
       expect(typeof sessionId1).toBe('string');
       expect(sessionId1.length).toBeGreaterThan(0);
     });
+
+    it('should use 16 bytes of random material with no timestamp prefix', () => {
+      // 32 hex chars = 128 bits of entropy. The id must NOT embed Date.now(),
+      // which would shrink the search space an attacker has to brute-force.
+      const sessionId = (discoveryService as unknown).generateSessionId();
+      const now = Date.now();
+
+      expect(sessionId).toMatch(/^session_[0-9a-f]{32}$/);
+      // None of the recent timestamp values should appear in the id.
+      const recentTimestamps = Array.from({ length: 5 }, (_, i) => String(now - i * 1000));
+      for (const ts of recentTimestamps) {
+        expect(sessionId).not.toContain(ts);
+      }
+    });
   });
 
   describe('calculateCompatibilityScore', () => {

--- a/service.backend/src/routes/discovery.routes.ts
+++ b/service.backend/src/routes/discovery.routes.ts
@@ -481,8 +481,12 @@ router.get(
   discoveryController.getSwipeStats
 );
 
+// TODO: per-session ownership enforcement is a follow-up; for now any
+// authenticated user can read stats for a known session id, but ids are
+// random enough to make enumeration impractical.
 router.get(
   '/swipe/session/:sessionId',
+  authenticateToken,
   DiscoveryController.validateSessionId,
   discoveryController.getSessionStats
 );

--- a/service.backend/src/services/discovery.service.ts
+++ b/service.backend/src/services/discovery.service.ts
@@ -481,6 +481,6 @@ export class DiscoveryService {
    * Generate a unique session ID
    */
   private generateSessionId(): string {
-    return `session_${Date.now()}_${randomBytes(5).toString('hex')}`;
+    return `session_${randomBytes(16).toString('hex')}`;
   }
 }


### PR DESCRIPTION
## Summary

`GET /api/v1/discovery/swipe/session/:sessionId` had two coupled issues that, combined, let an unauthenticated attacker enumerate live sessions and read swipe activity:

1. The route had no authentication middleware at all.
2. Session ids were minted as `session_${Date.now()}_${randomBytes(5).toString('hex')}` — a known timestamp prefix plus only 40 bits of random material.

### Fixes
- Add `authenticateToken` middleware on the session stats route (`service.backend/src/routes/discovery.routes.ts`).
- Mint session ids from 16 random bytes (128 bits) with no timestamp prefix (`service.backend/src/services/discovery.service.ts`). Confirmed via grep that the timestamp prefix isn't parsed anywhere in the discovery flow.
- Add a TODO near the route noting that per-session ownership enforcement is a deliberate follow-up — sessions are currently ephemeral counters with no owner column.

### Tests
- New `service.backend/src/__tests__/routes/discovery.routes.test.ts` asserts 401 for unauthenticated GET and 200 for authenticated GET.
- Updated `discovery.service.test.ts` `generateSessionId` test asserts the new shape (`^session_[0-9a-f]{32}$`) and that recent `Date.now()` values do not appear in the id.

## Test plan
- [x] `npx turbo test --filter=@adopt-dont-shop/service-backend` — 2423 tests pass, 210 skipped.
- [x] `npx turbo lint --filter=@adopt-dont-shop/service-backend` — 0 errors (190 pre-existing warnings unchanged).
- [x] `npx turbo type-check --filter=@adopt-dont-shop/service-backend` — passes.
- [ ] Manually verify via curl that the endpoint now returns 401 without a token and 200 with a valid one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_