### PR TITLE
fix(security): rate limit /verify-email endpoint

### DIFF
--- a/service.backend/src/__tests__/routes/auth.routes.test.ts
+++ b/service.backend/src/__tests__/routes/auth.routes.test.ts
@@ -61,8 +61,13 @@ vi.mock('../../services/user.service', () => ({
   },
 }));
 
+const authLimiterImpl = vi.hoisted(() => ({
+  current: (_req: unknown, _res: unknown, next: () => void): void => next(),
+}));
+
 vi.mock('../../middleware/rate-limiter', () => ({
-  authLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  authLimiter: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authLimiterImpl.current(req, res, next),
   passwordResetLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
   twoFactorLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
   generalLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
@@ -315,6 +320,45 @@ describe('Auth routes', () => {
       const res = await request(buildApp()).post('/api/v1/auth/verify-email').send({});
 
       expect(res.status).toBe(400);
+    });
+
+    it('applies the auth IP rate limiter so the endpoint cannot be brute-forced', async () => {
+      // Swap the shared authLimiter mock for a counter that 429s after N
+      // calls. This verifies the /verify-email route is actually wired to
+      // authLimiter (otherwise the counter is never incremented and the
+      // limit never fires).
+      const MAX = 5;
+      let calls = 0;
+      authLimiterImpl.current = (
+        _req: AuthenticatedRequest,
+        res: Response,
+        next: NextFunction
+      ): void => {
+        calls += 1;
+        if (calls > MAX) {
+          res.status(429).json({ error: 'Too many requests' });
+          return;
+        }
+        next();
+      };
+
+      try {
+        // First MAX requests reach the controller and return the usual 400.
+        for (let i = 0; i < MAX; i += 1) {
+          const res = await request(buildApp()).post('/api/v1/auth/verify-email').send({});
+          expect(res.status).toBe(400);
+        }
+
+        // The (MAX + 1)-th request is rate-limited.
+        const blocked = await request(buildApp()).post('/api/v1/auth/verify-email').send({});
+        expect(blocked.status).toBe(429);
+      } finally {
+        authLimiterImpl.current = (
+          _req: AuthenticatedRequest,
+          _res: Response,
+          next: NextFunction
+        ): void => next();
+      }
     });
   });
 

--- a/service.backend/src/routes/auth.routes.ts
+++ b/service.backend/src/routes/auth.routes.ts
@@ -394,7 +394,7 @@ router.post(
  *       409:
  *         description: Email already verified
  */
-router.post('/verify-email', AuthController.verifyEmail);
+router.post('/verify-email', authLimiter, AuthController.verifyEmail);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary

- `POST /api/v1/auth/verify-email` had no rate-limit middleware, only Zod body validation. The 128-bit token makes single-target brute force infeasible, but the missing limiter allowed unrestricted token-enumeration attempts across many target accounts with no per-IP throttling or observability.
- The sibling `/resend-verification` route already applies `authLimiter` (5 / 15 min / IP, `skipSuccessfulRequests`). Reuse the same limiter on `/verify-email` for symmetry and minimal diff. Success-skip means legitimate flows (valid tokens) aren't penalised, while failed-token enumeration trips the limit quickly.
- Added a route test that swaps the shared `authLimiter` mock for a counter to verify the middleware is actually wired up on `/verify-email`.

## Test plan

- [x] `npx vitest run src/__tests__/routes/auth.routes.test.ts` — 24/24 passing, including the new limiter assertion
- [x] `npx tsc --noEmit` clean in `service.backend`
- [x] `npx eslint --fix` clean on touched files
- [x] `npx prettier --check` clean on touched files
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_