### PR TITLE
fix(security): magic-byte validation on file uploads

### DIFF
--- a/service.backend/src/__tests__/services/file-upload.service.test.ts
+++ b/service.backend/src/__tests__/services/file-upload.service.test.ts
@@ -8,13 +8,14 @@ vi.mock('fs', () => {
   const readFile = vi.fn().mockResolvedValue(Buffer.from('file-content'));
   const writeFile = vi.fn().mockResolvedValue(undefined);
   const unlink = vi.fn().mockResolvedValue(undefined);
+  const rename = vi.fn().mockResolvedValue(undefined);
   const existsSync = vi.fn().mockReturnValue(true);
   const mkdirSync = vi.fn();
   return {
-    default: { existsSync, mkdirSync, promises: { stat, readFile, writeFile, unlink } },
+    default: { existsSync, mkdirSync, promises: { stat, readFile, writeFile, unlink, rename } },
     existsSync,
     mkdirSync,
-    promises: { stat, readFile, writeFile, unlink },
+    promises: { stat, readFile, writeFile, unlink, rename },
   };
 });
 
@@ -112,8 +113,19 @@ const makeMockRecord = (overrides: Record<string, unknown> = {}) => ({
  * - fs.promises.readFile returns a buffer (used by generateChecksum)
  * - FileUpload.create returns a mock record
  */
+const mimeToExt: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'application/pdf': 'pdf',
+};
+
 const setupSuccessfulUpload = (mimetype = 'image/jpeg') => {
-  vi.mocked(fileTypeFromFile).mockResolvedValue({ mime: mimetype, ext: 'jpg' });
+  vi.mocked(fileTypeFromFile).mockResolvedValue({
+    mime: mimetype,
+    ext: mimeToExt[mimetype] ?? 'bin',
+  });
   vi.mocked(fs.promises.stat).mockResolvedValue({
     mtime: new Date('2024-01-01'),
   } as unknown as import('fs').Stats);
@@ -245,6 +257,52 @@ describe('FileUploadService', () => {
       await expect(
         FileUploadService.uploadFile(file, 'pets', { uploadedBy: 'user-456' })
       ).rejects.toThrow('File upload failed');
+    });
+
+    it('normalises the stored filename extension to match the verified MIME, regardless of user-supplied extension', async () => {
+      // Attacker uploads with double-extension `evil.exe.pdf` claiming application/pdf;
+      // actual bytes are a real PDF. The stored filename must end with `.pdf` (the
+      // canonical extension for the verified MIME), so direct-URL access can't
+      // present the file with a misleading extension downstream.
+      const file = makeFile({
+        originalname: 'evil.exe.pdf',
+        mimetype: 'application/pdf',
+        filename: 'documents_1234_uuid.pdf',
+        path: '/test-uploads/documents/documents_1234_uuid.pdf',
+      });
+      setupSuccessfulUpload('application/pdf');
+
+      const result = await FileUploadService.uploadFile(file, 'documents', {
+        uploadedBy: 'user-456',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.file?.filename).toMatch(/\.pdf$/);
+      expect(result.file?.filename).not.toMatch(/\.exe/);
+    });
+
+    it('rewrites the on-disk filename when the user-supplied extension does not match the verified MIME', async () => {
+      // User-supplied originalname has `.jpg` but the declared+detected MIME is
+      // application/pdf. The on-disk filename should be renamed so its extension
+      // matches the verified MIME (`.pdf`), not the user-supplied `.jpg`.
+      const file = makeFile({
+        originalname: 'photo.jpg',
+        mimetype: 'application/pdf',
+        filename: 'documents_1234_uuid.jpg',
+        path: '/test-uploads/documents/documents_1234_uuid.jpg',
+      });
+      setupSuccessfulUpload('application/pdf');
+
+      const result = await FileUploadService.uploadFile(file, 'documents', {
+        uploadedBy: 'user-456',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.file?.filename).toBe('documents_1234_uuid.pdf');
+      expect(vi.mocked(fs.promises.rename)).toHaveBeenCalledWith(
+        '/test-uploads/documents/documents_1234_uuid.jpg',
+        '/test-uploads/documents/documents_1234_uuid.pdf'
+      );
     });
   });
 

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -465,7 +465,15 @@ export class FileUploadService {
   }
 
   /**
-   * Validate file content matches declared MIME type using magic byte checking
+   * Validate file content matches declared MIME type using magic byte checking.
+   *
+   * Defence-in-depth against stored XSS / content spoofing: after confirming
+   * the file's magic bytes match the declared MIME, normalise the on-disk
+   * extension to the canonical extension reported by `file-type`. This
+   * prevents an attacker who learns the storage path from being able to
+   * request the file with a misleading extension (e.g. a PDF stored as
+   * `evil.html.jpg` would otherwise round-trip the attacker's chosen
+   * extension into the served URL).
    */
   private static async validateFileContent(file: Express.Multer.File): Promise<void> {
     try {
@@ -493,6 +501,12 @@ export class FileUploadService {
         );
       }
 
+      // Normalise the on-disk extension to the canonical extension for the
+      // verified MIME. Renames `file.path` and updates `file.filename` /
+      // `file.path` in place so downstream steps (metadata, storage transfer)
+      // see the canonical name.
+      await this.normaliseStoredExtension(file, fileTypeResult.ext);
+
       logger.info('File content validation passed', {
         filename: file.originalname,
         mimeType: file.mimetype,
@@ -502,6 +516,30 @@ export class FileUploadService {
       logger.error('File content validation failed:', error);
       throw error;
     }
+  }
+
+  /**
+   * Rename the on-disk file so its extension matches the canonical extension
+   * for the verified MIME type. No-op when the current extension already
+   * matches.
+   */
+  private static async normaliseStoredExtension(
+    file: Express.Multer.File,
+    canonicalExt: string
+  ): Promise<void> {
+    const currentExt = path.extname(file.filename).toLowerCase().replace(/^\./, '');
+    const targetExt = canonicalExt.toLowerCase();
+    if (currentExt === targetExt) {
+      return;
+    }
+    const safeCurrentPath = this.safeResolveUploadPath(file.path);
+    const dir = path.dirname(safeCurrentPath);
+    const base = path.basename(file.filename, path.extname(file.filename));
+    const newFilename = `${base}.${targetExt}`;
+    const newPath = path.join(dir, newFilename);
+    await fs.promises.rename(safeCurrentPath, newPath);
+    file.filename = newFilename;
+    file.path = newPath;
   }
 
   /**


### PR DESCRIPTION
## Summary

- After magic-byte validation passes, normalise the on-disk filename's extension to the canonical extension reported by `file-type`. The pre-existing magic-byte check already rejected MIME spoofing, but the stored file kept the user-supplied extension — an attacker who learned the storage scheme could request the file via a misleading extension (e.g. `.html.pdf`) and rely on downstream sniffing.
- The fix is additive: SVG allowlist drop and the `Content-Disposition: attachment` logic in `upload-serve.routes.ts` are untouched.
- New behaviour tests cover both the double-extension case and the user-supplied-extension-vs-verified-MIME mismatch case.

## Test plan

- [x] `npx vitest run src/__tests__/services/file-upload.service.test.ts` — 33 passed
- [x] `npx vitest run src/__tests__/services/file-upload-image-processing.test.ts src/__tests__/routes/upload.routes.test.ts src/__tests__/routes/upload-serve.routes.test.ts src/__tests__/middleware/upload-mime-guard.middleware.test.ts` — 61 passed
- [x] `npx eslint --fix` on touched files — clean
- [x] `npx prettier --check` on touched files — clean
- [x] `npx tsc --noEmit` on service.backend — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_