### PR TITLE
fix(security): harden socket chat authorization

### DIFF
--- a/service.backend/src/__tests__/socket/socket-handlers.test.ts
+++ b/service.backend/src/__tests__/socket/socket-handlers.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Behaviour tests for the socket chat authorisation hardening (ADS-708):
+ *
+ *  - Revocation lookup runs on every event (no 30s cache window).
+ *  - `requireChatAccess` resolves BEFORE socket.join, so a slow access
+ *    check cannot let a non-participant temporarily land in the room.
+ *  - Attachment URLs are constrained to this server's own upload paths.
+ *
+ * These tests drive the public socket-handler surface through stub IO
+ * and Socket objects. No network, no real Socket.IO server — we only
+ * care that the handler logic enforces the invariants above.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../models/RevokedToken', () => ({
+  __esModule: true,
+  default: {
+    findByPk: vi.fn(),
+  },
+}));
+
+vi.mock('../../models/User', () => ({
+  __esModule: true,
+  default: { findByPk: vi.fn() },
+  UserStatus: { ACTIVE: 'active' },
+  UserType: { ADOPTER: 'adopter', RESCUE_STAFF: 'rescue_staff' },
+}));
+
+vi.mock('../../models/StaffMember', () => ({
+  __esModule: true,
+  default: { findOne: vi.fn() },
+}));
+
+vi.mock('../../models/Role', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+vi.mock('../../models/MessageReaction', () => ({
+  __esModule: true,
+  default: { findAll: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('../../services/chat.service', () => ({
+  ChatService: {
+    getChatById: vi.fn(),
+    sendMessage: vi.fn(),
+    markMessagesAsRead: vi.fn(),
+    addMessageReaction: vi.fn(),
+    removeMessageReaction: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/health-check.service', () => ({
+  HealthCheckService: { updateActiveConnections: vi.fn() },
+}));
+
+vi.mock('../../services/messageBroker.service', () => ({
+  getMessageBroker: () => null,
+}));
+
+vi.mock('../../utils/jwt', () => ({
+  verifyAccessToken: vi.fn(),
+}));
+
+vi.mock('../../controllers/chat.controller', () => ({
+  toFrontendMessage: (m: unknown) => m,
+}));
+
+vi.mock('../analytics-emitter', () => ({
+  setAnalyticsIo: vi.fn(),
+}));
+
+vi.mock('../socket-registry', () => ({
+  setLiveIo: vi.fn(),
+  getLiveIo: vi.fn(),
+  disconnectAllSockets: vi.fn(),
+}));
+
+import RevokedToken from '../../models/RevokedToken';
+import { ChatService } from '../../services/chat.service';
+import { verifyAccessToken } from '../../utils/jwt';
+import { SocketHandlers, SendMessageSchema } from '../../socket/socket-handlers';
+
+type EventHandler = (data: unknown) => void | Promise<void>;
+type MiddlewareFn = (event: unknown[], next: (err?: Error) => void) => void;
+
+type FakeSocket = {
+  id: string;
+  userId: string;
+  authJti?: string;
+  handshake: { auth: { token: string }; headers: Record<string, string> };
+  rooms: Set<string>;
+  joined: string[];
+  middlewares: MiddlewareFn[];
+  handlers: Map<string, EventHandler>;
+  emitted: Array<{ event: string; payload: unknown }>;
+  disconnected: boolean;
+  use: (fn: MiddlewareFn) => void;
+  on: (event: string, fn: EventHandler) => void;
+  join: (room: string) => void;
+  leave: (room: string) => void;
+  to: (room: string) => { emit: (event: string, payload: unknown) => void };
+  emit: (event: string, payload: unknown) => void;
+  disconnect: (close?: boolean) => void;
+};
+
+const createFakeSocket = (overrides: Partial<FakeSocket> = {}): FakeSocket => {
+  const socket: FakeSocket = {
+    id: 'socket-1',
+    userId: 'user-1',
+    authJti: 'jti-1',
+    handshake: { auth: { token: 'tok' }, headers: {} },
+    rooms: new Set<string>(),
+    joined: [],
+    middlewares: [],
+    handlers: new Map(),
+    emitted: [],
+    disconnected: false,
+    use(fn) {
+      this.middlewares.push(fn);
+    },
+    on(event, fn) {
+      this.handlers.set(event, fn);
+    },
+    join(room) {
+      this.rooms.add(room);
+      this.joined.push(room);
+    },
+    leave(room) {
+      this.rooms.delete(room);
+    },
+    to() {
+      return { emit: () => undefined };
+    },
+    emit(event, payload) {
+      this.emitted.push({ event, payload });
+    },
+    disconnect() {
+      this.disconnected = true;
+    },
+    ...overrides,
+  };
+  return socket;
+};
+
+type FakeIo = {
+  connectionHandler: ((socket: FakeSocket) => void) | null;
+  use: (fn: (socket: FakeSocket, next: (err?: Error) => void) => void) => void;
+  on: (event: string, fn: (socket: FakeSocket) => void) => void;
+  to: () => { emit: () => void };
+};
+
+const createFakeIo = (): FakeIo => {
+  const io: FakeIo = {
+    connectionHandler: null,
+    use: () => undefined,
+    on(event, fn) {
+      if (event === 'connection') {
+        this.connectionHandler = fn;
+      }
+    },
+    to: () => ({ emit: () => undefined }),
+  };
+  return io;
+};
+
+/**
+ * Construct a SocketHandlers wired to a fake IO, then drive the
+ * connection callback with a fake socket so the test can interact with
+ * the registered middlewares and event handlers directly.
+ */
+const buildHandlersWithSocket = (
+  socketOverrides: Partial<FakeSocket> = {}
+): { socket: FakeSocket; io: FakeIo } => {
+  const io = createFakeIo();
+  // Cast through unknown: the fake intentionally implements only the
+  // surface SocketHandlers uses. The cast is contained to test setup.
+  new SocketHandlers(io as unknown as ConstructorParameters<typeof SocketHandlers>[0]);
+  const socket = createFakeSocket(socketOverrides);
+  io.connectionHandler?.(socket);
+  return { socket, io };
+};
+
+describe('socket-handlers attachment URL validation (ADS-708)', () => {
+  const baseMessage = {
+    chatId: '00000000-0000-4000-8000-000000000001',
+    content: 'hello',
+  };
+
+  it('accepts a /uploads/ relative path', () => {
+    const parsed = SendMessageSchema.safeParse({
+      ...baseMessage,
+      attachments: [{ type: 'image/png', url: '/uploads/chat/abc.png', name: 'abc.png' }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts a /uploads-signed/ path', () => {
+    const parsed = SendMessageSchema.safeParse({
+      ...baseMessage,
+      attachments: [
+        {
+          type: 'image/png',
+          url: '/uploads-signed/1700000000/deadbeef/chat/abc.png',
+          name: 'abc.png',
+        },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an external https URL', () => {
+    const parsed = SendMessageSchema.safeParse({
+      ...baseMessage,
+      attachments: [{ type: 'image/png', url: 'https://attacker.example/x.png', name: 'x.png' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a protocol-relative URL', () => {
+    const parsed = SendMessageSchema.safeParse({
+      ...baseMessage,
+      attachments: [{ type: 'image/png', url: '//attacker.example/x.png', name: 'x.png' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an unrelated absolute path', () => {
+    const parsed = SendMessageSchema.safeParse({
+      ...baseMessage,
+      attachments: [{ type: 'image/png', url: '/etc/passwd', name: 'p' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a javascript: URL', () => {
+    const parsed = SendMessageSchema.safeParse({
+      ...baseMessage,
+      attachments: [{ type: 'text/html', url: 'javascript:alert(1)', name: 'x' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('socket-handlers per-event revocation (ADS-708)', () => {
+  beforeEach(() => {
+    vi.mocked(verifyAccessToken).mockReturnValue({
+      userId: 'user-1',
+      email: 'u@example.com',
+      jti: 'jti-1',
+    });
+    vi.mocked(RevokedToken.findByPk).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const runMiddleware = (socket: FakeSocket): Promise<{ called: boolean; err?: Error }> =>
+    new Promise(resolve => {
+      const [mw] = socket.middlewares;
+      mw([], err => resolve({ called: true, err }));
+    });
+
+  it('queries the RevokedToken table on every event (no cache window)', async () => {
+    const { socket } = buildHandlersWithSocket();
+
+    await runMiddleware(socket);
+    await runMiddleware(socket);
+    await runMiddleware(socket);
+
+    expect(vi.mocked(RevokedToken.findByPk)).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(RevokedToken.findByPk)).toHaveBeenCalledWith('jti-1');
+    expect(socket.disconnected).toBe(false);
+  });
+
+  it('disconnects the socket the moment the token is revoked, even after prior valid events', async () => {
+    const { socket } = buildHandlersWithSocket();
+
+    // First event: token is valid.
+    vi.mocked(RevokedToken.findByPk).mockResolvedValueOnce(null);
+    await runMiddleware(socket);
+    expect(socket.disconnected).toBe(false);
+
+    // Revocation happens between events. The next event must see it.
+    vi.mocked(RevokedToken.findByPk).mockResolvedValueOnce({
+      jti: 'jti-1',
+    } as unknown as Awaited<ReturnType<typeof RevokedToken.findByPk>>);
+    await new Promise<void>(resolve => {
+      const [mw] = socket.middlewares;
+      mw([], () => resolve());
+      // Allow the rejection branch to run.
+      setTimeout(resolve, 50);
+    });
+
+    expect(socket.disconnected).toBe(true);
+  });
+});
+
+describe('socket-handlers join_chat race (ADS-708)', () => {
+  beforeEach(() => {
+    vi.mocked(verifyAccessToken).mockReturnValue({
+      userId: 'user-1',
+      email: 'u@example.com',
+      jti: 'jti-1',
+    });
+    vi.mocked(RevokedToken.findByPk).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not join the chat room until requireChatAccess resolves', async () => {
+    let resolveAccess: ((value: unknown) => void) | null = null;
+    vi.mocked(ChatService.getChatById).mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveAccess = resolve;
+        }) as unknown as ReturnType<typeof ChatService.getChatById>
+    );
+
+    const { socket } = buildHandlersWithSocket();
+    const joinHandler = socket.handlers.get('join_chat');
+    expect(joinHandler).toBeDefined();
+
+    const joinPromise = joinHandler!({
+      chatId: '00000000-0000-4000-8000-000000000001',
+    });
+
+    // Yield so any (incorrect) synchronous join would have executed.
+    await new Promise(r => setTimeout(r, 10));
+    expect(socket.rooms.has('chat:00000000-0000-4000-8000-000000000001')).toBe(false);
+
+    // Resolve the access check; the join must run only after this.
+    resolveAccess?.({ chatId: '00000000-0000-4000-8000-000000000001' });
+    await joinPromise;
+
+    expect(socket.rooms.has('chat:00000000-0000-4000-8000-000000000001')).toBe(true);
+  });
+
+  it('does not join the chat room when requireChatAccess rejects', async () => {
+    vi.mocked(ChatService.getChatById).mockRejectedValue(new Error('Access denied'));
+
+    const { socket } = buildHandlersWithSocket();
+    const joinHandler = socket.handlers.get('join_chat');
+    await joinHandler!({ chatId: '00000000-0000-4000-8000-000000000002' });
+
+    expect(socket.rooms.has('chat:00000000-0000-4000-8000-000000000002')).toBe(false);
+    expect(socket.emitted.some(e => e.event === 'error')).toBe(true);
+  });
+});

--- a/service.backend/src/socket/socket-handlers.ts
+++ b/service.backend/src/socket/socket-handlers.ts
@@ -45,7 +45,22 @@ function isRateLimited(socketId: string, event: string, limit: number, windowMs:
 // Zod schemas for socket event payloads
 const JoinChatSchema = z.object({ chatId: z.string().uuid() });
 const LeaveChatSchema = z.object({ chatId: z.string().uuid() });
-const SendMessageSchema = z.object({
+
+// ADS-708: attachment URLs must point at this service's own upload routes.
+// Accepting arbitrary strings let a client paste `https://attacker.example/x`
+// (or `//attacker.example/x`, or even another local route) into a chat
+// message, which the frontend would then render — a stored-link / SSRF
+// vector. Restrict to the canonical upload paths produced by the
+// file-upload service (`/uploads/<category>/<filename>`) or the signed-URL
+// helper (`/uploads-signed/<expiresAt>/<signature>/...`). Anything else,
+// including absolute URLs and protocol-relative URLs, is rejected at the
+// schema level.
+const ATTACHMENT_URL_PATTERN = /^\/uploads(?:-signed)?\/[^\s?#]+$/;
+export const AttachmentUrlSchema = z.string().max(500).regex(ATTACHMENT_URL_PATTERN, {
+  message: 'Attachment URL must be a /uploads/ or /uploads-signed/ path on this server',
+});
+
+export const SendMessageSchema = z.object({
   chatId: z.string().uuid(),
   content: z.string().min(1).max(10_000),
   messageType: z.enum(['text', 'file', 'image']).optional(),
@@ -53,13 +68,7 @@ const SendMessageSchema = z.object({
     .array(
       z.object({
         type: z.string().max(50),
-        // Attachment URLs must be relative paths (no external SSRF vector)
-        url: z
-          .string()
-          .max(500)
-          .refine(u => !u.startsWith('http'), {
-            message: 'Attachment URL must be a relative path',
-          }),
+        url: AttachmentUrlSchema,
         name: z.string().max(255),
         size: z.number().int().nonnegative().optional(),
       })
@@ -90,14 +99,14 @@ interface AuthenticatedSocket extends Socket {
 }
 
 /**
- * ADS-597: per-event re-validation cache. We re-verify the JWT signature
- * and check the RevokedToken table on every inbound event, but bound the
- * DB cost by caching the "still valid" result for a short sliding
- * window. JWT verify is cheap (HMAC) and runs every time; only the
- * RevokedToken DB read is skipped while the window is open.
+ * ADS-708: revocation must be authoritative on every event. The previous
+ * 30s "still valid" cache meant a logged-out user could keep sending
+ * socket events for up to 30s after their token was revoked. We now
+ * query RevokedToken on every inbound event — the table
+ * is keyed by jti (indexed PK) so the read is a single point lookup, and
+ * Socket.IO middleware already serialises per-socket so a chatty client
+ * cannot stack concurrent reads here.
  */
-const REVALIDATE_CACHE_MS = 30_000;
-const socketRevalidateUntil = new Map<string, number>();
 
 /**
  * ADS-597: periodic re-fetch of authoritative auth state. Every
@@ -290,10 +299,11 @@ export class SocketHandlers {
   }
 
   /**
-   * ADS-597: per-event re-validation. JWT verify runs on every event
-   * (cheap); the RevokedToken DB read is gated by a 30s sliding cache so
-   * a chatty client doesn't slam the table. On failure we tear the
-   * socket down so no further events are processed.
+   * ADS-597 / ADS-708: per-event re-validation. JWT verify runs on every
+   * event, and the RevokedToken DB read also runs on every event so a
+   * revoked / logged-out token cannot keep emitting for any window of
+   * time. On failure we tear the socket down so no further events are
+   * processed.
    */
   private installPerEventRevalidation(socket: AuthenticatedSocket) {
     socket.use((_event, next) => {
@@ -313,14 +323,11 @@ export class SocketHandlers {
         return;
       }
 
-      const cachedUntil = socketRevalidateUntil.get(socket.id) ?? 0;
-      if (Date.now() < cachedUntil) {
-        next();
-        return;
-      }
-
       if (!decoded.jti) {
-        socketRevalidateUntil.set(socket.id, Date.now() + REVALIDATE_CACHE_MS);
+        // No jti means we cannot consult the revocation list — accept the
+        // event since the signature already verified. Tokens minted by
+        // this service always carry a jti (see utils/jwt); a missing jti
+        // is only possible on legacy tokens during a deploy.
         next();
         return;
       }
@@ -331,7 +338,6 @@ export class SocketHandlers {
             socket.disconnect(true);
             return;
           }
-          socketRevalidateUntil.set(socket.id, Date.now() + REVALIDATE_CACHE_MS);
           next();
         })
         .catch(err => {
@@ -450,9 +456,12 @@ export class SocketHandlers {
         }
         const { chatId } = parsed.data;
 
-        // Verify user has access to chat before joining
+        // ADS-708: socket.join() MUST NOT run until requireChatAccess
+        // resolves successfully. If the promise rejects, the throw
+        // skips the join and the catch below emits an error to the
+        // client. Do not reorder — a join before the check would put
+        // a non-participant in the room and leak broadcasts.
         await this.requireChatAccess(socket, chatId);
-
         socket.join(`chat:${chatId}`);
         logger.info(`User ${socket.userId} joined chat ${chatId}`);
 
@@ -839,14 +848,13 @@ export class SocketHandlers {
       // Release per-socket rate-limit state
       socketEventTimestamps.delete(socket.id);
 
-      // ADS-597: stop the auth-refresh timer and drop the revalidation
-      // cache entry so they don't leak past the socket lifetime.
+      // ADS-597: stop the auth-refresh timer so it doesn't leak past the
+      // socket lifetime.
       const timer = socketAuthRefreshTimers.get(socket.id);
       if (timer) {
         clearInterval(timer);
         socketAuthRefreshTimers.delete(socket.id);
       }
-      socketRevalidateUntil.delete(socket.id);
     });
   }
 


### PR DESCRIPTION
## Summary

- **Revocation cache lag (HIGH):** the per-event revalidation middleware cached "token still valid" for 30s, so a revoked / logged-out user could keep sending socket events for up to that window. Dropped the cache — `RevokedToken.findByPk` now runs on every inbound event (single indexed PK lookup).
- **Chat-join race (HIGH):** made the ordering invariant explicit in the `join_chat` handler — `socket.join(chat:<id>)` MUST NOT run until `requireChatAccess` resolves successfully. Added a regression test that gates the access check on an external promise and asserts the socket is not in the room until that promise resolves.
- **Attachment URL not validated (MEDIUM):** the `send_message` Zod schema accepted any non-`http` string for `attachment.url`, leaving room for stored-link / SSRF payloads (`//attacker.example/...`, `/etc/passwd`, `javascript:...`). Restricted to the canonical `/uploads/<...>` and `/uploads-signed/<...>` paths produced by this service's file-upload and signed-URL helpers; everything else is rejected at the schema level.

## Test plan

- [x] New behaviour tests in `service.backend/src/__tests__/socket/socket-handlers.test.ts`:
  - [x] Revocation lookup runs on every event (no cache window).
  - [x] Socket is disconnected the moment the token is revoked, even after prior valid events.
  - [x] Slow `requireChatAccess` — socket is NOT in `chat:<id>` room until the promise resolves.
  - [x] Rejected `requireChatAccess` — socket never joins, error emitted.
  - [x] Attachment URL schema accepts `/uploads/...` and `/uploads-signed/...`, rejects `https://`, protocol-relative `//`, unrelated absolute paths, and `javascript:` URLs.
- [x] `npx vitest run` in `service.backend/` — 167 files / 2447 tests passing.
- [x] `npx tsc --noEmit` clean for changed files.
- [x] `npx eslint` clean for changed files (one pre-existing warning unrelated to this PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_