### PR TITLE
fix(security): rotate CSRF session cookie on login/2FA/logout

### DIFF
--- a/service.backend/src/__tests__/middleware/csrf.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/csrf.middleware.test.ts
@@ -29,6 +29,9 @@ import {
   getCsrfToken,
   csrfErrorHandler,
   resolveCsrfSessionIdentifier,
+  rotateCsrfSessionCookie,
+  clearCsrfSessionCookie,
+  CSRF_SESSION_COOKIE,
 } from '../../middleware/csrf';
 import { logger } from '../../utils/logger';
 import { doubleCsrf } from 'csrf-csrf';
@@ -271,6 +274,58 @@ describe('CSRF Middleware', () => {
       expect(idA).toMatch(/^anon:.+/);
       expect(idA).not.toBe('anon:anonymous');
       expect(idA).not.toBe('anonymous');
+    });
+  });
+
+  // ADS-547: rotation on auth state transitions defeats CSRF-token session
+  // fixation. Called from the login/logout controllers.
+  describe('rotateCsrfSessionCookie - rotation on login / 2FA success', () => {
+    it('clears the existing session cookie and mints a fresh one', () => {
+      const clearCookie = vi.fn();
+      const cookie = vi.fn();
+      const res = { clearCookie, cookie } as unknown as Response;
+
+      rotateCsrfSessionCookie(res);
+
+      expect(clearCookie).toHaveBeenCalledWith(
+        CSRF_SESSION_COOKIE,
+        expect.objectContaining({ httpOnly: true, sameSite: 'strict' })
+      );
+      expect(cookie).toHaveBeenCalledTimes(1);
+      const [name, value, options] = cookie.mock.calls[0];
+      expect(name).toBe(CSRF_SESSION_COOKIE);
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+      expect(options).toMatchObject({ httpOnly: true, sameSite: 'strict' });
+    });
+
+    it('mints the new value via randomUUID rather than echoing any caller-supplied input', () => {
+      // setup-tests.ts stubs randomUUID to `test-uuid-<ts>`; assert that
+      // shape so we know the rotated value comes from the crypto helper and
+      // not from anything an attacker could have planted.
+      const cookie = vi.fn();
+      const res = { clearCookie: vi.fn(), cookie } as unknown as Response;
+
+      rotateCsrfSessionCookie(res);
+
+      const [, value] = cookie.mock.calls[0];
+      expect(value).toMatch(/^test-uuid-\d+$/);
+    });
+  });
+
+  describe('clearCsrfSessionCookie - clear on logout', () => {
+    it('clears the session cookie without minting a new one', () => {
+      const clearCookie = vi.fn();
+      const cookie = vi.fn();
+      const res = { clearCookie, cookie } as unknown as Response;
+
+      clearCsrfSessionCookie(res);
+
+      expect(clearCookie).toHaveBeenCalledWith(
+        CSRF_SESSION_COOKIE,
+        expect.objectContaining({ httpOnly: true, sameSite: 'strict' })
+      );
+      expect(cookie).not.toHaveBeenCalled();
     });
   });
 

--- a/service.backend/src/__tests__/routes/auth.routes.test.ts
+++ b/service.backend/src/__tests__/routes/auth.routes.test.ts
@@ -242,6 +242,64 @@ describe('Auth routes', () => {
 
       expect(res.status).toBe(401);
     });
+
+    // ADS-547: CSRF session-fixation hardening — the per-browser identifier
+    // cookie (csrf-session in dev / __Host-csrf-session in prod) MUST be
+    // rotated on the auth state transition, so an attacker who pre-planted
+    // a value the victim's browser already carries cannot replay a token
+    // bound to it. The same rotation also covers 2FA-gated logins because
+    // AuthService.login verifies the 2FA token before returning success.
+    it('rotates the CSRF session cookie on successful login', async () => {
+      mockLogin.mockResolvedValue({
+        message: 'Login successful',
+        token: 'access-token',
+        refreshToken: 'refresh-token',
+        user: mockUser,
+      });
+
+      const res = await request(buildApp())
+        .post('/api/v1/auth/login')
+        .set('Cookie', 'csrf-session=attacker-planted-id')
+        .send(validBody);
+
+      expect(res.status).toBe(200);
+      const setCookieHeader = res.headers['set-cookie'];
+      const cookies = Array.isArray(setCookieHeader)
+        ? setCookieHeader
+        : setCookieHeader
+          ? [setCookieHeader]
+          : [];
+
+      // Two csrf-session entries: the clear (empty value, past expiry) and
+      // the freshly minted one (non-empty value, non-zero maxAge).
+      const csrfSessionCookies = cookies.filter((c: string) => c.startsWith('csrf-session='));
+      expect(csrfSessionCookies.length).toBeGreaterThanOrEqual(2);
+
+      const newSessionCookie = csrfSessionCookies.find(
+        (c: string) => !c.startsWith('csrf-session=;')
+      );
+      expect(newSessionCookie).toBeDefined();
+      // The rotated value must NOT match what the attacker planted.
+      expect(newSessionCookie).not.toContain('attacker-planted-id');
+    });
+
+    it('does not rotate the CSRF session cookie on failed login', async () => {
+      mockLogin.mockRejectedValue(new Error('Invalid credentials'));
+
+      const res = await request(buildApp())
+        .post('/api/v1/auth/login')
+        .set('Cookie', 'csrf-session=attacker-planted-id')
+        .send(validBody);
+
+      expect(res.status).toBe(401);
+      const setCookieHeader = res.headers['set-cookie'];
+      const cookies = Array.isArray(setCookieHeader)
+        ? setCookieHeader
+        : setCookieHeader
+          ? [setCookieHeader]
+          : [];
+      expect(cookies.some((c: string) => c.startsWith('csrf-session='))).toBe(false);
+    });
   });
 
   describe('POST /api/v1/auth/logout', () => {
@@ -259,6 +317,26 @@ describe('Auth routes', () => {
       // real DB but auth is not the failure mode under test here.
       const res = await request(buildApp()).post('/api/v1/auth/logout');
       expect(res.status).not.toBe(401);
+    });
+
+    // ADS-547: logout must also clear the CSRF session identifier cookie so
+    // a subsequent anonymous request mints a fresh one rather than reusing
+    // the identifier bound to the now-terminated authenticated session.
+    it('clears the CSRF session cookie on logout', async () => {
+      const res = await request(buildApp())
+        .post('/api/v1/auth/logout')
+        .set('Cookie', 'csrf-session=prior-session-id')
+        .send({ refreshToken: 'placeholder' });
+
+      const setCookieHeader = res.headers['set-cookie'];
+      const cookies = Array.isArray(setCookieHeader)
+        ? setCookieHeader
+        : setCookieHeader
+          ? [setCookieHeader]
+          : [];
+      // A cleared cookie is expressed as `name=; Expires=...` — value empty.
+      const csrfSessionClear = cookies.find((c: string) => c.startsWith('csrf-session=;'));
+      expect(csrfSessionClear).toBeDefined();
     });
   });
 

--- a/service.backend/src/controllers/auth.controller.ts
+++ b/service.backend/src/controllers/auth.controller.ts
@@ -13,6 +13,7 @@ import { UserService } from '../services/user.service';
 import User from '../models/User';
 import { AuthenticatedRequest } from '../types';
 import { validateBody } from '../middleware/zod-validate';
+import { clearCsrfSessionCookie, rotateCsrfSessionCookie } from '../middleware/csrf';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from '../services/auditLog.service';
 
@@ -83,6 +84,13 @@ export class AuthController {
       res.cookie(REFRESH_TOKEN_COOKIE, result.refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
       res.cookie(ACCESS_TOKEN_COOKIE, result.token, ACCESS_TOKEN_COOKIE_OPTIONS);
 
+      // ADS-547: rotate the CSRF session identifier on the auth state
+      // transition (covers both password-only and 2FA-gated logins —
+      // AuthService.login performs the 2FA check inline before returning a
+      // token) so an attacker who pre-planted a session cookie on the
+      // victim's browser cannot reuse the bound CSRF token post-login.
+      rotateCsrfSessionCookie(res);
+
       const { refreshToken: _, ...responseBody } = result;
       res.json(responseBody);
     } catch (error) {
@@ -113,6 +121,10 @@ export class AuthController {
 
     res.clearCookie(REFRESH_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE_OPTIONS);
     res.clearCookie(ACCESS_TOKEN_COOKIE, ACCESS_TOKEN_COOKIE_OPTIONS);
+    // ADS-547: clear the CSRF session identifier alongside the auth tokens so
+    // the next anonymous request mints a fresh identifier instead of reusing
+    // the one tied to the now-terminated authenticated session.
+    clearCsrfSessionCookie(res);
 
     res.json({ message: 'Logged out successfully' });
   }

--- a/service.backend/src/middleware/csrf.ts
+++ b/service.backend/src/middleware/csrf.ts
@@ -9,11 +9,13 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 // ADS-546: per-browser session identifier cookie. Set the first time we see
 // a request without a userId or an existing session cookie; rotated by the
-// auth flow on login (handled in csrfErrorHandler / login controller —
-// future hardening). `__Host-` prefix in prod pins the cookie to the
-// current host with no Domain attribute, blocking subdomain CSRF.
-const CSRF_SESSION_COOKIE = isProduction ? '__Host-csrf-session' : 'csrf-session';
-const CSRF_SESSION_COOKIE_OPTIONS = {
+// auth flow on every authentication state transition (see
+// rotateCsrfSessionCookie / clearCsrfSessionCookie, called from the login
+// and logout controllers) to defeat CSRF-token session fixation. `__Host-`
+// prefix in prod pins the cookie to the current host with no Domain
+// attribute, blocking subdomain CSRF.
+export const CSRF_SESSION_COOKIE = isProduction ? '__Host-csrf-session' : 'csrf-session';
+export const CSRF_SESSION_COOKIE_OPTIONS = {
   httpOnly: true,
   secure: isProduction,
   sameSite: 'strict' as const,
@@ -150,6 +152,26 @@ export const getCsrfToken = (req: Request, res: Response): void => {
     logger.error('Failed to generate CSRF token', { error });
     throw error;
   }
+};
+
+/**
+ * Rotate the CSRF session identifier cookie. Called on every authentication
+ * state transition (login success, 2FA verification success) to invalidate
+ * any attacker-planted pre-existing session id and prevent CSRF-token
+ * session fixation against the freshly-authenticated user.
+ */
+export const rotateCsrfSessionCookie = (res: Response): void => {
+  res.clearCookie(CSRF_SESSION_COOKIE, CSRF_SESSION_COOKIE_OPTIONS);
+  res.cookie(CSRF_SESSION_COOKIE, randomUUID(), CSRF_SESSION_COOKIE_OPTIONS);
+};
+
+/**
+ * Clear the CSRF session identifier cookie. Called on logout so the next
+ * anonymous request mints a fresh identifier rather than reusing one tied
+ * to the previous authenticated session.
+ */
+export const clearCsrfSessionCookie = (res: Response): void => {
+  res.clearCookie(CSRF_SESSION_COOKIE, CSRF_SESSION_COOKIE_OPTIONS);
 };
 
 /**


### PR DESCRIPTION
## Summary

- The per-browser CSRF session identifier cookie (`csrf-session` in dev / `__Host-csrf-session` in prod) was not rotated on authentication. An attacker who pre-planted a known session id on the victim's browser (cookie tossing, subdomain quirk, etc) could replay a CSRF token bound to that id after the victim logged in — CSRF-token session fixation.
- Rotate (clear + reissue) the cookie on every auth state transition. Two new exports from `middleware/csrf` (`rotateCsrfSessionCookie`, `clearCsrfSessionCookie`) keep the cookie name + options in one place so the auth controller cannot drift from the source of truth.

## Transition points covered

1. **Login success** — `auth.controller.login` calls `rotateCsrfSessionCookie(res)` after issuing the access/refresh tokens.
2. **2FA verification success** — same path as (1); `AuthService.login` verifies the 2FA token inline before returning success rather than via a separate verify endpoint, so the login rotation covers 2FA-gated logins.
3. **Logout** — `auth.controller.logout` clears the CSRF session cookie alongside the access/refresh token cookies.
4. **Registration auto-login** — N/A. `AuthService.register` returns 201 without issuing tokens and requires email verification + a real login before any authenticated request, so the login rotation already covers the transition.

## Test plan

- [x] `service.backend/src/__tests__/middleware/csrf.middleware.test.ts` — new behaviour tests for the rotate/clear helpers (clears + mints a fresh value; clear-only path doesn't reissue).
- [x] `service.backend/src/__tests__/routes/auth.routes.test.ts` — new supertest assertions: successful login response includes a `csrf-session` Set-Cookie whose value differs from a pre-planted one; failed login does not rotate; logout response clears the cookie.
- [x] `tsc --noEmit` clean (after building lib.validation).
- [x] `npx eslint --fix` on touched files clean; prettier clean.
- [x] Existing auth + integration suites (`auth.routes.test.ts`, `auth-flow.test.ts`, `auth.service.test.ts`, `auth-security.test.ts`, `csrf.middleware.test.ts`) still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_