### PR TITLE
fix(security): tenant-scoped application statistics

### DIFF
--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -509,6 +509,9 @@ describe('Application Submission Workflow Integration Tests', () => {
           rows: mockApplications,
           count: 2,
         } as never);
+        MockedStaffMember.findOne = vi
+          .fn()
+          .mockResolvedValue({ userId: rescueStaffId, rescueId: rescueId, isVerified: true });
 
         const result = await ApplicationService.searchApplications(
           { rescueId: rescueId, status: [ApplicationStatus.SUBMITTED] },

--- a/service.backend/src/__tests__/routes/application.routes.test.ts
+++ b/service.backend/src/__tests__/routes/application.routes.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../services/application.service', () => ({
     withdrawApplication: vi.fn(),
     deleteApplication: vi.fn(),
     getApplicationStatistics: vi.fn(),
+    getStaffRescueIdForUser: vi.fn(),
     bulkUpdateApplications: vi.fn(),
     getApplicationHistory: vi.fn(),
     getApplicationFormStructure: vi.fn(),
@@ -52,6 +53,7 @@ vi.mock('../../services/application.service', () => ({
     withdrawApplication: vi.fn(),
     deleteApplication: vi.fn(),
     getApplicationStatistics: vi.fn(),
+    getStaffRescueIdForUser: vi.fn(),
     bulkUpdateApplications: vi.fn(),
     getApplicationHistory: vi.fn(),
     getApplicationFormStructure: vi.fn(),
@@ -110,6 +112,7 @@ vi.mock('../../middleware/rbac', () => ({
 }));
 
 import applicationRouter from '../../routes/application.routes';
+import { ApplicationService } from '../../services/application.service';
 
 const mockAdopterUser = {
   userId: 'adopter-uuid-1',
@@ -125,7 +128,16 @@ const mockRescueStaffUser = {
   email: 'staff@example.com',
   firstName: 'Staff',
   lastName: 'Member',
-  userType: 'RESCUE_STAFF',
+  userType: 'rescue_staff',
+  Roles: [],
+};
+
+const mockAdminUser = {
+  userId: 'admin-uuid-1',
+  email: 'admin@example.com',
+  firstName: 'Admin',
+  lastName: 'User',
+  userType: 'admin',
   Roles: [],
 };
 
@@ -248,6 +260,123 @@ describe('Application routes', () => {
         .send({});
 
       expect(res.status).toBe(422);
+    });
+  });
+
+  describe('GET /api/v1/applications/statistics', () => {
+    const emptyStats = {
+      totalApplications: 0,
+      applicationsByStatus: {},
+      applicationsByPriority: {},
+      averageProcessingTime: 0,
+      approvalRate: 0,
+      rejectionRate: 0,
+      withdrawalRate: 0,
+      applicationsThisMonth: 0,
+      applicationsLastMonth: 0,
+      growthRate: 0,
+      averageScore: 0,
+      pendingApplications: 0,
+      overdueApplications: 0,
+      topRejectionReasons: [],
+      applicationsByRescue: [],
+      applicationsByMonth: [],
+    };
+
+    beforeEach(() => {
+      vi.mocked(ApplicationService.getApplicationStatistics).mockResolvedValue(emptyStats);
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+      authenticateTokenMock.mockImplementation((_req: AuthenticatedRequest, res: Response) => {
+        res.status(401).json({ error: 'Access token required' });
+      });
+
+      const res = await request(buildApp()).get('/api/v1/applications/statistics');
+      expect(res.status).toBe(401);
+      expect(ApplicationService.getApplicationStatistics).not.toHaveBeenCalled();
+    });
+
+    it("scopes statistics to the rescue staff member's own rescue", async () => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockRescueStaffUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+      vi.mocked(ApplicationService.getStaffRescueIdForUser).mockResolvedValue('rescue-A');
+
+      const res = await request(buildApp()).get('/api/v1/applications/statistics');
+
+      expect(res.status).toBe(200);
+      expect(ApplicationService.getStaffRescueIdForUser).toHaveBeenCalledWith(
+        mockRescueStaffUser.userId
+      );
+      expect(ApplicationService.getApplicationStatistics).toHaveBeenCalledWith('rescue-A');
+    });
+
+    it('ignores ?rescueId query overrides from rescue staff', async () => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockRescueStaffUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+      vi.mocked(ApplicationService.getStaffRescueIdForUser).mockResolvedValue('rescue-A');
+
+      const res = await request(buildApp())
+        .get('/api/v1/applications/statistics')
+        .query({ rescueId: 'rescue-B' });
+
+      expect(res.status).toBe(200);
+      expect(ApplicationService.getApplicationStatistics).toHaveBeenCalledWith('rescue-A');
+      expect(ApplicationService.getApplicationStatistics).not.toHaveBeenCalledWith('rescue-B');
+    });
+
+    it('forbids rescue staff who are not linked to a verified rescue', async () => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockRescueStaffUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+      vi.mocked(ApplicationService.getStaffRescueIdForUser).mockResolvedValue(null);
+
+      const res = await request(buildApp()).get('/api/v1/applications/statistics');
+
+      expect(res.status).toBe(403);
+      expect(ApplicationService.getApplicationStatistics).not.toHaveBeenCalled();
+    });
+
+    it('returns global statistics for an admin with no rescueId query', async () => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockAdminUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+
+      const res = await request(buildApp()).get('/api/v1/applications/statistics');
+
+      expect(res.status).toBe(200);
+      expect(ApplicationService.getStaffRescueIdForUser).not.toHaveBeenCalled();
+      expect(ApplicationService.getApplicationStatistics).toHaveBeenCalledWith(undefined);
+    });
+
+    it('lets an admin scope statistics to a specific rescue via ?rescueId', async () => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockAdminUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+
+      const res = await request(buildApp())
+        .get('/api/v1/applications/statistics')
+        .query({ rescueId: 'rescue-B' });
+
+      expect(res.status).toBe(200);
+      expect(ApplicationService.getApplicationStatistics).toHaveBeenCalledWith('rescue-B');
     });
   });
 });

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -1069,6 +1069,63 @@ describe('ApplicationService - Business Logic', () => {
     });
   });
 
+  describe('Business Rule: Search Tenancy (IDOR)', () => {
+    // Rescue staff must never be able to list another rescue's applications
+    // by supplying ?rescueId=B. The service always derives rescueId from
+    // the caller's verified StaffMember row and ignores filters.rescueId.
+    const mockApplicationRow = () => {
+      const app = createMockApplication();
+      return {
+        ...app,
+        toJSON: vi.fn().mockReturnValue(app),
+        Answers: [],
+      };
+    };
+
+    beforeEach(() => {
+      MockedApplication.findAndCountAll = vi.fn().mockResolvedValue({
+        rows: [mockApplicationRow()],
+        count: 1,
+      });
+    });
+
+    it('forces rescue staff queries to their own rescueId regardless of filter', async () => {
+      MockedStaffMember.findOne = vi.fn().mockResolvedValue({
+        userId: 'staff-A-user',
+        rescueId: 'rescue-A',
+        isVerified: true,
+      });
+
+      await ApplicationService.searchApplications(
+        { rescueId: 'rescue-B' },
+        { page: 1, limit: 10 },
+        'staff-A-user',
+        UserType.RESCUE_STAFF
+      );
+
+      expect(MockedApplication.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ rescueId: 'rescue-A' }),
+        })
+      );
+    });
+
+    it('allows admin to filter by any rescueId', async () => {
+      await ApplicationService.searchApplications(
+        { rescueId: 'rescue-B' },
+        { page: 1, limit: 10 },
+        'admin-user',
+        UserType.ADMIN
+      );
+
+      expect(MockedApplication.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ rescueId: 'rescue-B' }),
+        })
+      );
+    });
+  });
+
   describe('Error Handling', () => {
     it('throws error when application not found', async () => {
       // Given: Application does not exist

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -850,8 +850,18 @@ export class ApplicationController extends BaseController {
     const userType = req.user!.userType as UserType;
     const userId = req.user!.userId;
 
+    // Tenancy scoping: rescue staff must never see another rescue's stats.
+    // We always derive rescueId from the verified StaffMember row — any
+    // ?rescueId= query supplied by a staff caller is ignored. Only platform
+    // admins (ADMIN, SUPER_ADMIN, MODERATOR) are permitted to view global
+    // stats or scope to an arbitrary rescue via ?rescueId=.
+    const isPlatformAdmin =
+      userType === UserType.ADMIN ||
+      userType === UserType.SUPER_ADMIN ||
+      userType === UserType.MODERATOR;
+
     let rescueId: string | undefined;
-    if (userType === UserType.ADMIN || userType === UserType.MODERATOR) {
+    if (isPlatformAdmin) {
       rescueId = req.query.rescueId as string | undefined;
     } else {
       const staffRescueId = await ApplicationService.getStaffRescueIdForUser(userId);

--- a/service.backend/src/routes/application.routes.ts
+++ b/service.backend/src/routes/application.routes.ts
@@ -216,6 +216,95 @@ router.post(
   applicationController.createApplication
 );
 
+// Get application statistics (rescue staff/admin only).
+// IMPORTANT: this route must be registered before GET /:applicationId,
+// otherwise Express resolves /statistics as an applicationId path param
+// and never reaches the statistics handler.
+
+/**
+ * @swagger
+ * /api/v1/applications/statistics:
+ *   get:
+ *     tags: [Application Management]
+ *     summary: Get application statistics
+ *     description: Get statistical data about applications for dashboard and reporting. Only rescue staff and admins can access this data.
+ *     security:
+ *       - bearerAuth: []
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: rescueId
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Filter statistics by rescue organization (admin only — staff are always scoped to their own rescue)
+ *       - in: query
+ *         name: startDate
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: Start date for statistics period
+ *       - in: query
+ *         name: endDate
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: End date for statistics period
+ *     responses:
+ *       200:
+ *         description: Application statistics retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 statistics:
+ *                   type: object
+ *                   properties:
+ *                     totalApplications:
+ *                       type: integer
+ *                       description: Total number of applications
+ *                     applicationsByStatus:
+ *                       type: object
+ *                       properties:
+ *                         SUBMITTED:
+ *                           type: integer
+ *                         APPROVED:
+ *                           type: integer
+ *                         REJECTED:
+ *                           type: integer
+ *                         WITHDRAWN:
+ *                           type: integer
+ *                     averageProcessingTime:
+ *                       type: number
+ *                       description: Average time to process applications (in days)
+ *                     approvalRate:
+ *                       type: number
+ *                       description: Percentage of applications approved
+ *                     trendsOverTime:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           date:
+ *                             type: string
+ *                             format: date
+ *                           count:
+ *                             type: integer
+ *       401:
+ *         $ref: '#/components/responses/UnauthorizedError'
+ *       403:
+ *         $ref: '#/components/responses/ForbiddenError'
+ */
+router.get(
+  '/statistics',
+  requireRole(UserType.RESCUE_STAFF, UserType.ADMIN),
+  applicationController.getApplicationStatistics
+);
+
 /**
  * @swagger
  * /api/v1/applications/{applicationId}:
@@ -964,92 +1053,6 @@ router.post(
   applicationValidation.validateAnswers,
   handleValidationErrors,
   applicationController.validateApplicationAnswers
-);
-
-// Get application statistics (rescue staff/admin only)
-
-/**
- * @swagger
- * /api/v1/applications/statistics:
- *   get:
- *     tags: [Application Management]
- *     summary: Get application statistics
- *     description: Get statistical data about applications for dashboard and reporting. Only rescue staff and admins can access this data.
- *     security:
- *       - bearerAuth: []
- *       - cookieAuth: []
- *     parameters:
- *       - in: query
- *         name: rescueId
- *         schema:
- *           type: string
- *           format: uuid
- *         description: Filter statistics by rescue organization
- *       - in: query
- *         name: startDate
- *         schema:
- *           type: string
- *           format: date
- *         description: Start date for statistics period
- *       - in: query
- *         name: endDate
- *         schema:
- *           type: string
- *           format: date
- *         description: End date for statistics period
- *     responses:
- *       200:
- *         description: Application statistics retrieved successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 success:
- *                   type: boolean
- *                   example: true
- *                 statistics:
- *                   type: object
- *                   properties:
- *                     totalApplications:
- *                       type: integer
- *                       description: Total number of applications
- *                     applicationsByStatus:
- *                       type: object
- *                       properties:
- *                         SUBMITTED:
- *                           type: integer
- *                         APPROVED:
- *                           type: integer
- *                         REJECTED:
- *                           type: integer
- *                         WITHDRAWN:
- *                           type: integer
- *                     averageProcessingTime:
- *                       type: number
- *                       description: Average time to process applications (in days)
- *                     approvalRate:
- *                       type: number
- *                       description: Percentage of applications approved
- *                     trendsOverTime:
- *                       type: array
- *                       items:
- *                         type: object
- *                         properties:
- *                           date:
- *                             type: string
- *                             format: date
- *                           count:
- *                             type: integer
- *       401:
- *         $ref: '#/components/responses/UnauthorizedError'
- *       403:
- *         $ref: '#/components/responses/ForbiddenError'
- */
-router.get(
-  '/statistics',
-  requireRole(UserType.RESCUE_STAFF, UserType.ADMIN),
-  applicationController.getApplicationStatistics
 );
 
 // Bulk update applications (admin only)

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -603,8 +603,12 @@ export class ApplicationService {
         whereConditions.userId = userId;
       }
 
-      // Auto-filter by rescue for rescue staff (unless rescueId explicitly provided)
-      if (userId && userType === UserType.RESCUE_STAFF && !filters.rescueId) {
+      // Force-filter by rescue for rescue staff. We always derive the rescue
+      // from the verified StaffMember row and force the filter to that value
+      // — any ?rescueId= supplied by the caller is ignored so a staff
+      // member of Rescue A cannot list Rescue B's applications.
+      let staffRescueIdOverride: string | undefined;
+      if (userId && userType === UserType.RESCUE_STAFF) {
         const StaffMember = (await import('../models/StaffMember')).default;
         const staffMember = await StaffMember.findOne({
           where: {
@@ -619,6 +623,7 @@ export class ApplicationService {
           });
         }
 
+        staffRescueIdOverride = staffMember.rescueId;
         whereConditions.rescueId = staffMember.rescueId;
         logger.info('Auto-filtering applications by user rescue:', {
           userId: userId,
@@ -651,7 +656,7 @@ export class ApplicationService {
       if (filters.petId) {
         whereConditions.petId = filters.petId;
       }
-      if (filters.rescueId) {
+      if (filters.rescueId && !staffRescueIdOverride) {
         whereConditions.rescueId = filters.rescueId;
       }
       if (filters.actionedBy) {


### PR DESCRIPTION
## Summary

- The application statistics endpoint (`GET /api/v1/applications/statistics`) was shadowed by the earlier-registered `GET /:applicationId` route, so it was never reachable in production. Reorder the routes so the literal path wins.
- Now that it is reachable, scope the response to the caller's rescue. Rescue staff get stats for their own rescue only; any `?rescueId=` they supply is ignored. Platform admins (`ADMIN`, `SUPER_ADMIN`, `MODERATOR`) keep global access and may optionally scope with `?rescueId=`. `SUPER_ADMIN` was previously missing from the admin branch and would have been treated as a non-staff caller.
- Apply the same fix to `GET /api/v1/applications`: `searchApplications` previously skipped the staff auto-filter when `filters.rescueId` was provided, so a staff member of Rescue A could list Rescue B's applications by passing `?rescueId=B`. Always force the staff caller's own `rescueId` on the where clause; admin filtering is unchanged.

## Test plan

- [x] `npx vitest run src/__tests__/routes/application.routes.test.ts` — covers 401, rescue-staff scoped to own rescue, rescue-staff `?rescueId=` ignored, missing StaffMember -> 403, admin global stats, admin scoped via `?rescueId=`
- [x] `npx vitest run src/__tests__/services/application.service.test.ts` — adds IDOR coverage for `searchApplications` (staff override ignored, admin filter preserved)
- [x] Full `service.backend` Vitest suite (2447 passing, 210 skipped)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` / `npx prettier --check` clean on touched files

https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_