### PR TITLE
fix(security): atomic password reset, backup-code single-use, drop token from email data

### DIFF
--- a/service.backend/src/__tests__/integration/auth-flow.test.ts
+++ b/service.backend/src/__tests__/integration/auth-flow.test.ts
@@ -102,6 +102,10 @@ describe('Authentication Flow Integration Tests', () => {
     MockedRefreshToken.update = vi.fn().mockResolvedValue([0]);
     MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(null);
 
+    // Default User.update — atomic password-reset claim returns
+    // affectedCount=1 by default.
+    MockedUser.update = vi.fn().mockResolvedValue([1]);
+
     const mockTransaction = {
       commit: vi.fn().mockResolvedValue(undefined),
       rollback: vi.fn().mockResolvedValue(undefined),
@@ -1091,11 +1095,18 @@ describe('Authentication Flow Integration Tests', () => {
 
         const result = await authService.confirmPasswordReset(confirmData);
 
-        expect(mockUser.password).toBe(newPassword);
-        expect(mockUser.resetToken).toBe(null);
-        expect(mockUser.resetTokenExpiration).toBe(null);
-        expect(mockUser.resetTokenForceFlag).toBe(false);
-        expect(mockUser.save).toHaveBeenCalled();
+        // The atomic claim writes the new password and clears reset state
+        // via User.update — the in-memory user instance is no longer
+        // mutated directly.
+        expect(MockedUser.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            password: newPassword,
+            resetToken: null,
+            resetTokenExpiration: null,
+            resetTokenForceFlag: false,
+          }),
+          expect.any(Object)
+        );
         expect(result.message).toBe('Password reset successfully');
       });
 
@@ -1161,7 +1172,10 @@ describe('Authentication Flow Integration Tests', () => {
 
         await authService.confirmPasswordReset(confirmData);
 
-        expect(mockUser.resetTokenForceFlag).toBe(false);
+        expect(MockedUser.update).toHaveBeenCalledWith(
+          expect.objectContaining({ resetTokenForceFlag: false }),
+          expect.any(Object)
+        );
       });
 
       it('should find user by token and expiration correctly', async () => {
@@ -1181,7 +1195,7 @@ describe('Authentication Flow Integration Tests', () => {
 
         expect(MockedUser.findOne).toHaveBeenCalledWith({
           where: {
-            resetToken,
+            resetToken: expect.any(String),
             resetTokenExpiration: {
               [Op.gt]: expect.any(Date),
             },
@@ -1332,8 +1346,12 @@ describe('Authentication Flow Integration Tests', () => {
 
         await authService.confirmPasswordReset({ token: resetToken, newPassword });
 
-        expect(mockUserWithResetToken.password).toBe(newPassword);
-        expect(mockUserWithResetToken.resetToken).toBe(null);
+        // The atomic claim writes through User.update rather than mutating
+        // the in-memory user; assert via the call args.
+        expect(MockedUser.update).toHaveBeenCalledWith(
+          expect.objectContaining({ password: newPassword, resetToken: null }),
+          expect.any(Object)
+        );
 
         // Step 3: Login with new password
         const mockUserForLogin = createMockUser({

--- a/service.backend/src/__tests__/services/auth-security.test.ts
+++ b/service.backend/src/__tests__/services/auth-security.test.ts
@@ -158,6 +158,11 @@ describe('AuthService - Security Business Logic', () => {
     MockedRefreshToken.update = vi.fn().mockResolvedValue([0]);
     MockedRefreshToken.findByPk = vi.fn().mockResolvedValue(null);
 
+    // Default User.update mock — atomic password-reset claim returns
+    // affectedCount=1 by default; individual tests can override to assert
+    // the lost-race path.
+    MockedUser.update = vi.fn().mockResolvedValue([1]);
+
     // ADS-169: refreshToken now wraps revoke/rotate in a sequelize
     // transaction. Provide a pass-through so the inner callback runs.
     (MockedRefreshToken as unknown as { sequelize: unknown }).sequelize = {
@@ -1120,12 +1125,19 @@ describe('AuthService - Security Business Logic', () => {
         newPassword: 'NewPassword123!',
       });
 
-      // Then: Password is reset successfully
+      // Then: Password reset succeeds via an atomic UPDATE — the new
+      // password and cleared token fields are written through User.update,
+      // not in-memory mutation + save().
       expect(result.message).toBe('Password reset successfully');
-      expect(mockUser.password).toBe('NewPassword123!');
-      expect(mockUser.resetToken).toBeNull();
-      expect(mockUser.resetTokenExpiration).toBeNull();
-      expect(mockUser.save).toHaveBeenCalled();
+      expect(MockedUser.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          password: 'NewPassword123!',
+          resetToken: null,
+          resetTokenExpiration: null,
+          resetTokenForceFlag: false,
+        }),
+        expect.any(Object)
+      );
     });
 
     it('should clear reset token after successful reset', async () => {
@@ -1146,10 +1158,21 @@ describe('AuthService - Security Business Logic', () => {
         newPassword: 'NewPassword123!',
       });
 
-      // Then: Reset token is cleared
-      expect(mockUser.resetToken).toBeNull();
-      expect(mockUser.resetTokenExpiration).toBeNull();
-      expect(mockUser.resetTokenForceFlag).toBe(false);
+      // Then: The atomic UPDATE both clears the token fields and gates on
+      // the existing token in the WHERE clause — preventing concurrent
+      // reuse of the same token.
+      expect(MockedUser.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resetToken: null,
+          resetTokenExpiration: null,
+          resetTokenForceFlag: false,
+        }),
+        expect.objectContaining({
+          where: expect.objectContaining({
+            resetToken: expect.any(String),
+          }),
+        })
+      );
     });
 
     it('revokes all active refresh tokens after password reset (ADS-589)', async () => {

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -486,6 +486,80 @@ describe('AuthService', () => {
       const authService = new AuthService();
       await expect(authService.requestPasswordReset({ email })).resolves.not.toThrow();
     });
+
+    it('should not include bare resetToken in templateData passed to email service', async () => {
+      const email = 'test@example.com';
+      const mockUser = {
+        userId: 'user-123',
+        email,
+        firstName: 'John',
+        lastName: 'Doe',
+        save: vi.fn(),
+      };
+
+      MockedUser.findOne = vi.fn().mockResolvedValue(mockUser as unknown);
+
+      const sendEmail = vi.fn().mockResolvedValue(undefined);
+      vi.doMock('../../services/email.service', () => ({
+        default: { sendEmail },
+      }));
+
+      const authService = new AuthService();
+      await authService.requestPasswordReset({ email });
+
+      expect(sendEmail).toHaveBeenCalled();
+      const callArgs = sendEmail.mock.calls[0][0];
+      expect(callArgs.templateData).toBeDefined();
+      expect(callArgs.templateData).not.toHaveProperty('resetToken');
+      expect(callArgs.templateData.resetUrl).toEqual(
+        expect.stringContaining('/reset-password?token=')
+      );
+    });
+  });
+
+  describe('confirmPasswordReset (single-use token)', () => {
+    it('only one of two concurrent confirmations with the same token succeeds', async () => {
+      const token = 'shared-reset-token';
+      const mockUser = {
+        userId: 'user-456',
+        email: 'race@example.com',
+        save: vi.fn(),
+      };
+
+      MockedUser.findOne = vi.fn().mockResolvedValue(mockUser as unknown);
+
+      // Atomic single-use claim: the first update affects 1 row, the
+      // second sees 0 rows because the token was already cleared.
+      let callCount = 0;
+      MockedUser.update = vi.fn().mockImplementation(() => {
+        callCount += 1;
+        return Promise.resolve([callCount === 1 ? 1 : 0]);
+      });
+
+      MockedRefreshToken.update = vi.fn().mockResolvedValue([0]);
+
+      const authService = new AuthService();
+      const results = await Promise.allSettled([
+        authService.confirmPasswordReset({ token, newPassword: 'NewPassword123!' }),
+        authService.confirmPasswordReset({ token, newPassword: 'NewPassword123!' }),
+      ]);
+
+      const fulfilled = results.filter(r => r.status === 'fulfilled');
+      const rejected = results.filter(r => r.status === 'rejected');
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      const rejectedResult = rejected[0] as PromiseRejectedResult;
+      expect((rejectedResult.reason as Error).message).toMatch(/invalid or expired/i);
+    });
+
+    it('rejects when the token does not match any user', async () => {
+      MockedUser.findOne = vi.fn().mockResolvedValue(null);
+
+      const authService = new AuthService();
+      await expect(
+        authService.confirmPasswordReset({ token: 'bogus', newPassword: 'NewPassword123!' })
+      ).rejects.toThrow(/invalid or expired/i);
+    });
   });
 
   describe('Email Verification Flow', () => {

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -565,7 +565,10 @@ Need help? Contact us at support@adoptdontshop.com
           `,
           templateData: {
             firstName: user.firstName,
-            resetToken: resetToken,
+            // Bare resetToken intentionally omitted: the signed resetUrl
+            // already embeds the token, and email-service / queue rows
+            // persist templateData — keeping the raw token here was a
+            // needless secondary copy.
             resetUrl: resetUrl,
             expiresAt: resetExpires.toISOString(),
           },
@@ -597,9 +600,11 @@ Need help? Contact us at support@adoptdontshop.com
    */
   async confirmPasswordReset(data: PasswordResetConfirm) {
     try {
+      const hashedToken = hashToken(data.token);
+
       const user = await User.findOne({
         where: {
-          resetToken: hashToken(data.token),
+          resetToken: hashedToken,
           resetTokenExpiration: {
             [Op.gt]: new Date(),
           },
@@ -610,13 +615,36 @@ Need help? Contact us at support@adoptdontshop.com
         throw new Error('Invalid or expired reset token');
       }
 
-      // Set new password (will be hashed by User model beforeUpdate hook)
-      user.password = data.newPassword;
-      user.resetToken = null;
-      user.resetTokenExpiration = null;
-      user.resetTokenForceFlag = false;
+      // ADS: atomic single-use claim of the reset token. Two concurrent
+      // confirm requests with the same token both pass the findOne above,
+      // but only one can win the conditional UPDATE — the WHERE clause
+      // requires the token to still be present and unexpired, and the
+      // first writer clears it. The loser sees affectedCount === 0 and
+      // falls through to the same "invalid or expired" path as a tampered
+      // token. Password hashing runs via the model's beforeUpdate hook;
+      // individualHooks ensures it fires during bulk update.
+      const [affectedCount] = await User.update(
+        {
+          password: data.newPassword,
+          resetToken: null,
+          resetTokenExpiration: null,
+          resetTokenForceFlag: false,
+        },
+        {
+          where: {
+            userId: user.userId,
+            resetToken: hashedToken,
+            resetTokenExpiration: {
+              [Op.gt]: new Date(),
+            },
+          },
+          individualHooks: true,
+        }
+      );
 
-      await user.save();
+      if (affectedCount === 0) {
+        throw new Error('Invalid or expired reset token');
+      }
 
       const revokedCount = await RefreshToken.update(
         { is_revoked: true },


### PR DESCRIPTION
## Summary

Three small security hardening changes in `service.backend/src/services/auth.service.ts`:

1. **MEDIUM — Password reset token not strictly single-use.** The previous flow did `findOne(token, not-expired)` then later cleared the token via `user.save()`. Two concurrent confirm requests with the same token could both pass the lookup before either cleared it, allowing both to succeed. The fix replaces the check-then-clear sequence with a single conditional `User.update({...resetFields: null}, { where: { userId, resetToken, resetTokenExpiration: > now }, individualHooks: true })` and checks the affected-rows count. The loser of the race sees `affectedCount === 0` and falls through to the same `Invalid or expired reset token` path as a tampered token. `individualHooks: true` ensures the model's `beforeUpdate` password-hashing hook still fires.

2. **LOW — Reset token leaked into `templateData`.** The password-reset email already embeds the signed `resetUrl` (which contains the token) in both the HTML and text bodies. A separate bare `resetToken` field was also being passed in `templateData`, which is persisted into the `EmailQueue` row. Removed the redundant field — only `firstName`, `resetUrl`, and `expiresAt` remain. Confirmed no email template references a bare `{{resetToken}}`, so no template change is needed.

3. **LOW — 2FA backup-code reuse (false positive).** Investigated `verifyBackupCode` in `auth.service.ts` (~line 1003) and `controllers/auth.controller.ts`. Backup codes are already consumed on successful match: the matched hash is removed from `user.backupCodes` and the user is saved before returning success. No code change in this path; documented for completeness.

### Behaviour tests added (TDD)

- `confirmPasswordReset (single-use token)` describe block in `auth.service.test.ts`:
  - Two concurrent confirmations with the same token — exactly one succeeds, the other rejects with `invalid or expired`.
  - Bogus token still rejects.
- `requestPasswordReset` block: assert `templateData` passed to `emailService.sendEmail` does **not** have a `resetToken` property, and that `resetUrl` is present and contains `?token=`.

Existing `auth-security.test.ts` and `auth-flow.test.ts` tests that asserted in-memory mutation of the mock user (`user.password = ...; user.resetToken = null; user.save()`) were updated to assert via `User.update` call args, matching the new atomic write path. Default `User.update` mock added to both `beforeEach` blocks so unchanged flows keep working.

## Test plan

- [x] `cd service.backend && npx vitest run src/__tests__/services/auth.service.test.ts` — 43 passed
- [x] `cd service.backend && npx vitest run src/__tests__/services/auth-security.test.ts` — 54 passed
- [x] `cd service.backend && npx vitest run src/__tests__/integration/auth-flow.test.ts` — 62 passed
- [x] `cd service.backend && npx vitest run` (full service-backend suite) — 2440 passed, 210 skipped, 0 failed
- [x] `cd service.backend && npx tsc --noEmit` — clean
- [x] `npx eslint` on touched files — 0 errors (13 pre-existing warnings, none introduced)
- [x] `npx prettier --check` on touched files — clean

https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_