### PR TITLE
fix(security): cap match + notification pagination at controller layer

### DIFF
--- a/service.backend/src/__tests__/security/pagination-bounds.test.ts
+++ b/service.backend/src/__tests__/security/pagination-bounds.test.ts
@@ -1,0 +1,159 @@
+import { vi } from 'vitest';
+import { Response } from 'express';
+
+// Mocks must be hoisted before imports.
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn() },
+}));
+
+vi.mock('../../services/notification.service', () => ({
+  NotificationService: {
+    getUserNotifications: vi.fn(),
+  },
+}));
+
+vi.mock('../../matching', () => ({
+  matchService: {
+    isEnabled: vi.fn(() => true),
+    rankPets: vi.fn(async () => []),
+  },
+}));
+
+vi.mock('../../models/Pet', () => {
+  return {
+    default: { findAll: vi.fn(async () => []) },
+    PetStatus: { AVAILABLE: 'available' },
+  };
+});
+
+vi.mock('../../models/PetMedia', () => ({
+  default: {},
+  PetMediaType: { IMAGE: 'image' },
+}));
+
+vi.mock('../../models/Breed', () => ({ default: {} }));
+vi.mock('../../models/Rescue', () => ({ default: {} }));
+vi.mock('../../models/AdopterMatchProfile', () => ({
+  default: { findByPk: vi.fn() },
+}));
+
+import { MatchController } from '../../controllers/match.controller';
+import { NotificationController } from '../../controllers/notification.controller';
+import { NotificationService } from '../../services/notification.service';
+import Pet from '../../models/Pet';
+import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
+import { AuthenticatedRequest } from '../../types/auth';
+
+const mockUser = { userId: 'user-1' } as AuthenticatedRequest['user'];
+
+const mockRes = (): Partial<Response> => ({
+  json: vi.fn().mockReturnThis(),
+  status: vi.fn().mockReturnThis(),
+});
+
+/**
+ * The express-validator declared on each route ALREADY rejects out-of-range
+ * limits with a 400. These tests exercise the controller directly (no route
+ * middleware) to verify the in-controller cap acts as defense-in-depth: if
+ * any future refactor removes or misconfigures the validator, the service
+ * layer must still receive a bounded limit.
+ */
+describe('Pagination bounds — defense-in-depth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Pet.findAll).mockResolvedValue([]);
+  });
+
+  describe('MatchController.getTopPicks', () => {
+    const MAX_TOP_PICKS = 50;
+    const DEFAULT_TOP_PICKS = 10;
+
+    const buildReq = (limit?: string) =>
+      ({
+        user: mockUser,
+        query: limit === undefined ? {} : { limit },
+      }) as unknown as AuthenticatedRequest;
+
+    it('caps an oversized limit at the maximum allowed value', async () => {
+      const req = buildReq('999999');
+      const res = mockRes();
+
+      await MatchController.getTopPicks(req, res as Response);
+
+      const [args] = vi.mocked(Pet.findAll).mock.calls[0];
+      // candidate pool is limit * 5; verifying the input limit was capped
+      expect(args?.limit).toBe(MAX_TOP_PICKS * 5);
+    });
+
+    it('honours a valid in-range limit', async () => {
+      const req = buildReq('10');
+      const res = mockRes();
+
+      await MatchController.getTopPicks(req, res as Response);
+
+      const [args] = vi.mocked(Pet.findAll).mock.calls[0];
+      expect(args?.limit).toBe(10 * 5);
+    });
+
+    it('uses the default limit when none is provided', async () => {
+      const req = buildReq();
+      const res = mockRes();
+
+      await MatchController.getTopPicks(req, res as Response);
+
+      const [args] = vi.mocked(Pet.findAll).mock.calls[0];
+      expect(args?.limit).toBe(DEFAULT_TOP_PICKS * 5);
+    });
+  });
+
+  describe('NotificationController.getUserNotifications', () => {
+    const NOTIFICATION_MAX = 100;
+
+    const buildReq = (limit?: string) =>
+      ({
+        user: mockUser,
+        query: limit === undefined ? {} : { limit },
+      }) as unknown as AuthenticatedRequest;
+
+    beforeEach(() => {
+      vi.mocked(NotificationService.getUserNotifications).mockResolvedValue({
+        notifications: [],
+        pagination: { page: 1, limit: 20, total: 0 },
+      } as unknown as Awaited<ReturnType<typeof NotificationService.getUserNotifications>>);
+    });
+
+    it('caps an oversized limit at 100', async () => {
+      const controller = new NotificationController();
+      const req = buildReq('999999');
+      const res = mockRes();
+
+      await controller.getUserNotifications(req, res as Response);
+
+      const [, options] = vi.mocked(NotificationService.getUserNotifications).mock.calls[0];
+      expect(options?.limit).toBe(NOTIFICATION_MAX);
+    });
+
+    it('honours a valid in-range limit', async () => {
+      const controller = new NotificationController();
+      const req = buildReq('25');
+      const res = mockRes();
+
+      await controller.getUserNotifications(req, res as Response);
+
+      const [, options] = vi.mocked(NotificationService.getUserNotifications).mock.calls[0];
+      expect(options?.limit).toBe(25);
+    });
+
+    it('uses the default page size when no limit is provided', async () => {
+      const controller = new NotificationController();
+      const req = buildReq();
+      const res = mockRes();
+
+      await controller.getUserNotifications(req, res as Response);
+
+      const [, options] = vi.mocked(NotificationService.getUserNotifications).mock.calls[0];
+      expect(options?.limit).toBe(DEFAULT_PAGE_SIZE);
+    });
+  });
+});

--- a/service.backend/src/controllers/match.controller.ts
+++ b/service.backend/src/controllers/match.controller.ts
@@ -8,6 +8,16 @@ import PetMedia, { PetMediaType } from '../models/PetMedia';
 import Rescue from '../models/Rescue';
 import { AuthenticatedRequest } from '../types/auth';
 import { logger } from '../utils/logger';
+import { parsePaginationLimit } from '../utils/pagination';
+
+/**
+ * Defense-in-depth caps for the top-picks endpoint. The route-level
+ * express-validator declares the same bounds; these constants ensure
+ * the service layer still receives a bounded `limit` if that validator
+ * is ever removed or misconfigured.
+ */
+const TOP_PICKS_DEFAULT_LIMIT = 10;
+const TOP_PICKS_MAX_LIMIT = 50;
 
 /**
  * Match controller — exposes the matching module to clients:
@@ -89,7 +99,10 @@ export class MatchController {
     }
 
     const userId = req.user!.userId;
-    const limit = req.query.limit ? Number(req.query.limit) : 10;
+    const limit = parsePaginationLimit(req.query.limit as string | undefined, {
+      default: TOP_PICKS_DEFAULT_LIMIT,
+      max: TOP_PICKS_MAX_LIMIT,
+    });
 
     if (!matchService.isEnabled()) {
       res.status(200).json({ success: true, data: [], message: 'matching disabled' });

--- a/service.backend/src/controllers/notification.controller.ts
+++ b/service.backend/src/controllers/notification.controller.ts
@@ -5,6 +5,14 @@ import { NotificationService } from '../services/notification.service';
 import { RichTextProcessingService } from '../services/rich-text-processing.service';
 import { AuthenticatedRequest } from '../types/auth';
 import { logger } from '../utils/logger';
+import { parsePaginationLimit } from '../utils/pagination';
+
+/**
+ * Hard cap mirroring the route-level express-validator (max 100). Acts as
+ * defense-in-depth so the service layer always receives a bounded `limit`
+ * even if that validator is later removed or misconfigured.
+ */
+const NOTIFICATION_MAX_LIMIT = 100;
 
 export class NotificationController {
   /**
@@ -20,18 +28,14 @@ export class NotificationController {
       });
     }
 
-    const {
-      page = 1,
-      limit = DEFAULT_PAGE_SIZE,
-      status,
-      type,
-      sortBy = 'createdAt',
-      sortOrder = 'DESC',
-    } = req.query;
+    const { page = 1, status, type, sortBy = 'createdAt', sortOrder = 'DESC' } = req.query;
 
     const options = {
       page: parseInt(page as string) || 1,
-      limit: parseInt(limit as string) || DEFAULT_PAGE_SIZE,
+      limit: parsePaginationLimit(req.query.limit as string | undefined, {
+        default: DEFAULT_PAGE_SIZE,
+        max: NOTIFICATION_MAX_LIMIT,
+      }),
       status: status as 'unread' | 'read',
       type: type as string,
       sortBy: (sortBy === 'readAt' ? 'read_at' : sortBy === 'createdAt' ? 'created_at' : sortBy) as


### PR DESCRIPTION
## Summary

- `GET /api/v1/match/top-picks` and `GET /api/v1/notifications` previously parsed `limit` with `Number(...)` / `parseInt(...)` and trusted the route-level `express-validator` to reject out-of-range values. If that validator is ever removed, swapped, or accidentally skipped, the service layer would pull arbitrarily large rows (`?limit=999999`), turning the endpoint into a cheap DOS vector.
- Both controllers now use the shared `parsePaginationLimit(req.query.limit, { default, max })` helper that the rest of the codebase (discovery, applications, pets) already uses. The express-validator stays in place as the outer 400 defense; the in-controller clamp is a second layer that bounds whatever value ultimately reaches the service.
- Caps mirror the existing route validators: match top-picks default 10 / max 50, notifications default `DEFAULT_PAGE_SIZE` / max 100.

## Test plan

- [x] New `service.backend/src/__tests__/security/pagination-bounds.test.ts` exercises each controller directly (bypassing the validator) to prove the cap holds: `?limit=999999`, valid in-range, and no-limit cases for both endpoints.
- [x] Existing `notification.routes.test.ts` and other security tests still pass.
- [x] `npx eslint --fix` clean on touched files.
- [x] `npx prettier --check` clean on touched files.
- [x] `npx tsc --noEmit` clean for `service.backend`.

https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_