### PR TITLE
fix(security): worker ownership re-verification

### DIFF
--- a/service.backend/src/__tests__/jobs/match-digest.job.test.ts
+++ b/service.backend/src/__tests__/jobs/match-digest.job.test.ts
@@ -1,0 +1,124 @@
+import { vi, beforeEach, describe, it, expect } from 'vitest';
+
+/**
+ * Defense-in-depth: the digest iterates AdopterMatchProfile rows
+ * (which carry `notify_new_matches=true`) but the underlying User
+ * may have been suspended or deleted since the profile was created.
+ * The handler re-verifies the recipient User still exists and is
+ * ACTIVE before sending a notification. No throw — a missing user
+ * is an authorisation failure, not a transient error.
+ */
+
+vi.mock('../../lib/queue', () => ({
+  isQueueAvailable: vi.fn(() => false),
+  getReportsQueue: vi.fn(),
+  buildWorker: vi.fn(),
+}));
+
+vi.mock('../../models/AdopterMatchProfile', () => ({
+  __esModule: true,
+  default: { findAll: vi.fn() },
+}));
+
+vi.mock('../../models/Pet', () => ({
+  __esModule: true,
+  default: { findAll: vi.fn(() => []) },
+  PetStatus: { AVAILABLE: 'available' },
+}));
+
+vi.mock('../../models/Rescue', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+vi.mock('../../models/Notification', () => ({
+  NotificationType: { PET_AVAILABLE: 'pet_available' },
+}));
+
+vi.mock('../../models/User', () => ({
+  __esModule: true,
+  default: { findByPk: vi.fn() },
+  UserStatus: {
+    ACTIVE: 'active',
+    INACTIVE: 'inactive',
+    SUSPENDED: 'suspended',
+    PENDING_VERIFICATION: 'pending_verification',
+    DEACTIVATED: 'deactivated',
+  },
+}));
+
+vi.mock('../../matching', () => ({
+  matchService: { rankPets: vi.fn(async () => []) },
+}));
+
+vi.mock('../../matching/config', () => ({
+  loadMatchConfig: vi.fn(() => ({ digestEnabled: false })),
+}));
+
+vi.mock('../../services/notification.service', () => ({
+  NotificationService: { createNotification: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import AdopterMatchProfile from '../../models/AdopterMatchProfile';
+import Pet from '../../models/Pet';
+import User, { UserStatus } from '../../models/User';
+import { matchService } from '../../matching';
+import { NotificationService } from '../../services/notification.service';
+import { runMatchDigest } from '../../jobs/match-digest.job';
+
+const buildProfile = (overrides: Record<string, unknown> = {}) => ({
+  user_id: 'user-1',
+  last_notified_at: null,
+  min_notification_score: 0.5,
+  save: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe('runMatchDigest recipient re-verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('notifies when the profile owner is an active user', async () => {
+    const profile = buildProfile();
+    (AdopterMatchProfile.findAll as ReturnType<typeof vi.fn>).mockResolvedValue([profile]);
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: 'user-1',
+      status: UserStatus.ACTIVE,
+    });
+    (Pet.findAll as ReturnType<typeof vi.fn>).mockResolvedValue([{ petId: 'pet-1', name: 'Rex' }]);
+    (matchService.rankPets as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { petId: 'pet-1', score: 0.9 },
+    ]);
+
+    const result = await runMatchDigest();
+
+    expect(NotificationService.createNotification).toHaveBeenCalledTimes(1);
+    expect(result.notified).toBe(1);
+  });
+
+  it('skips notification when the profile owner has been deleted', async () => {
+    const profile = buildProfile();
+    (AdopterMatchProfile.findAll as ReturnType<typeof vi.fn>).mockResolvedValue([profile]);
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const result = await runMatchDigest();
+
+    expect(NotificationService.createNotification).not.toHaveBeenCalled();
+    expect(result.notified).toBe(0);
+  });
+
+  it('skips notification when the profile owner is suspended', async () => {
+    const profile = buildProfile();
+    (AdopterMatchProfile.findAll as ReturnType<typeof vi.fn>).mockResolvedValue([profile]);
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: 'user-1',
+      status: UserStatus.SUSPENDED,
+    });
+
+    const result = await runMatchDigest();
+
+    expect(NotificationService.createNotification).not.toHaveBeenCalled();
+    expect(result.notified).toBe(0);
+  });
+});

--- a/service.backend/src/__tests__/workers/reports.worker.test.ts
+++ b/service.backend/src/__tests__/workers/reports.worker.test.ts
@@ -1,0 +1,306 @@
+import { vi, beforeEach, describe, it, expect } from 'vitest';
+
+/**
+ * Defense-in-depth: even though jobs are enqueued from authenticated
+ * controllers that have already authorised the action, the worker
+ * re-verifies that the requesting user still exists and still has
+ * edit access to the saved report at execution time. This protects
+ * against future "retry job" admin tooling, payload tampering, and
+ * queue replays following permission revocation.
+ *
+ * The worker handlers are exercised via the `__test__` export — the
+ * BullMQ wrapper itself is out of scope here; we drive the same
+ * functions BullMQ would.
+ */
+
+vi.mock('../../lib/queue', () => ({
+  isQueueAvailable: vi.fn(() => false),
+  getReportsQueue: vi.fn(),
+  buildWorker: vi.fn(),
+}));
+
+vi.mock('../../models/SavedReport', () => ({
+  __esModule: true,
+  default: { findByPk: vi.fn() },
+}));
+
+vi.mock('../../models/ScheduledReport', () => ({
+  __esModule: true,
+  default: { findByPk: vi.fn() },
+  ScheduledReportFormat: { PDF: 'pdf', CSV: 'csv', INLINE_HTML: 'inline-html' },
+  ScheduledReportStatus: { PENDING: 'pending', SUCCESS: 'success', FAILED: 'failed' },
+}));
+
+vi.mock('../../models/User', () => ({
+  __esModule: true,
+  default: { findByPk: vi.fn() },
+  UserStatus: {
+    ACTIVE: 'active',
+    INACTIVE: 'inactive',
+    SUSPENDED: 'suspended',
+    PENDING_VERIFICATION: 'pending_verification',
+    DEACTIVATED: 'deactivated',
+  },
+  UserType: {
+    ADOPTER: 'adopter',
+    RESCUE_STAFF: 'rescue_staff',
+    ADMIN: 'admin',
+    MODERATOR: 'moderator',
+    SUPER_ADMIN: 'super_admin',
+    SUPPORT_AGENT: 'support_agent',
+  },
+}));
+
+vi.mock('../../services/reports.service', () => ({
+  ReportsService: {
+    executeReport: vi.fn(),
+    canEdit: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/report-renderer.service', () => ({
+  ReportRenderer: {
+    renderInlineHtml: vi.fn(() => '<p>html</p>'),
+    renderPdf: vi.fn(),
+    renderCsv: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/email.service', () => ({
+  default: { sendEmail: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import SavedReport from '../../models/SavedReport';
+import ScheduledReport from '../../models/ScheduledReport';
+import User, { UserType } from '../../models/User';
+import emailService from '../../services/email.service';
+import { ReportsService } from '../../services/reports.service';
+import { __testables } from '../../workers/reports.worker';
+
+const { handleRenderAndEmail, handleScheduledRun } = __testables;
+
+const baseExecuted = { widgets: [], filters: {}, computedAt: '2026-01-01T00:00:00Z' };
+
+describe('reports.worker: handleRenderAndEmail ownership re-verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (ReportsService.executeReport as ReturnType<typeof vi.fn>).mockResolvedValue(baseExecuted);
+  });
+
+  it('renders and emails when the requesting user still has edit access', async () => {
+    (SavedReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved_report_id: 'report-1',
+      user_id: 'user-1',
+      rescue_id: null,
+      name: 'Report',
+      config: {},
+    });
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: 'user-1',
+      userType: UserType.ADOPTER,
+    });
+    (ReportsService.canEdit as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    await handleRenderAndEmail({
+      savedReportId: 'report-1',
+      recipients: [{ email: 'a@b.c' }],
+      format: 'inline-html',
+      triggeredBy: 'schedule',
+      requestedBy: 'user-1',
+    });
+
+    expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips without sending when the requesting user has been deleted', async () => {
+    (SavedReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved_report_id: 'report-1',
+      user_id: 'user-1',
+      rescue_id: null,
+      name: 'Report',
+      config: {},
+    });
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await handleRenderAndEmail({
+      savedReportId: 'report-1',
+      recipients: [{ email: 'a@b.c' }],
+      format: 'inline-html',
+      triggeredBy: 'schedule',
+      requestedBy: 'user-1',
+    });
+
+    expect(emailService.sendEmail).not.toHaveBeenCalled();
+    expect(ReportsService.executeReport).not.toHaveBeenCalled();
+  });
+
+  it('skips when the requesting user no longer has edit access to the report', async () => {
+    (SavedReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved_report_id: 'report-1',
+      user_id: 'someone-else',
+      rescue_id: null,
+      name: 'Report',
+      config: {},
+    });
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: 'user-1',
+      userType: UserType.ADOPTER,
+    });
+    (ReportsService.canEdit as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    await handleRenderAndEmail({
+      savedReportId: 'report-1',
+      recipients: [{ email: 'a@b.c' }],
+      format: 'inline-html',
+      triggeredBy: 'schedule',
+      requestedBy: 'user-1',
+    });
+
+    expect(emailService.sendEmail).not.toHaveBeenCalled();
+    expect(ReportsService.executeReport).not.toHaveBeenCalled();
+  });
+
+  it('skips when the report no longer exists', async () => {
+    (SavedReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: 'user-1',
+      userType: UserType.ADOPTER,
+    });
+
+    await handleRenderAndEmail({
+      savedReportId: 'report-1',
+      recipients: [{ email: 'a@b.c' }],
+      format: 'inline-html',
+      triggeredBy: 'schedule',
+      requestedBy: 'user-1',
+    });
+
+    expect(emailService.sendEmail).not.toHaveBeenCalled();
+    expect(ReportsService.executeReport).not.toHaveBeenCalled();
+  });
+
+  it('bypasses canEdit for admin users (mirrors route admin-bypass policy)', async () => {
+    (SavedReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved_report_id: 'report-1',
+      user_id: 'other-user',
+      rescue_id: null,
+      name: 'Report',
+      config: {},
+    });
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: 'admin-user',
+      userType: UserType.ADMIN,
+    });
+    (ReportsService.canEdit as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    await handleRenderAndEmail({
+      savedReportId: 'report-1',
+      recipients: [{ email: 'a@b.c' }],
+      format: 'inline-html',
+      triggeredBy: 'schedule',
+      requestedBy: 'admin-user',
+    });
+
+    expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('reports.worker: handleScheduledRun ownership re-verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enqueues render-and-email when the schedule creator still has edit access', async () => {
+    const enqueueSpy = vi.fn().mockResolvedValue(undefined);
+    const { getReportsQueue, isQueueAvailable } = await import('../../lib/queue');
+    (isQueueAvailable as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (getReportsQueue as ReturnType<typeof vi.fn>).mockReturnValue({ add: enqueueSpy });
+
+    const save = vi.fn().mockResolvedValue(undefined);
+    (ScheduledReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      schedule_id: 'sched-1',
+      saved_report_id: 'report-1',
+      is_enabled: true,
+      created_by: 'user-1',
+      recipients: [{ email: 'a@b.c' }],
+      format: 'inline-html',
+      save,
+    });
+    (SavedReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved_report_id: 'report-1',
+      user_id: 'user-1',
+      rescue_id: null,
+    });
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: 'user-1',
+      userType: UserType.ADOPTER,
+    });
+    (ReportsService.canEdit as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    await handleScheduledRun({ scheduleId: 'sched-1' });
+
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    const enqueued = enqueueSpy.mock.calls[0][1] as { requestedBy?: string };
+    expect(enqueued.requestedBy).toBe('user-1');
+  });
+
+  it('does not enqueue render-and-email when the schedule creator has been deleted', async () => {
+    const enqueueSpy = vi.fn().mockResolvedValue(undefined);
+    const { getReportsQueue, isQueueAvailable } = await import('../../lib/queue');
+    (isQueueAvailable as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (getReportsQueue as ReturnType<typeof vi.fn>).mockReturnValue({ add: enqueueSpy });
+
+    const save = vi.fn().mockResolvedValue(undefined);
+    (ScheduledReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      schedule_id: 'sched-1',
+      saved_report_id: 'report-1',
+      is_enabled: true,
+      created_by: 'user-1',
+      recipients: [{ email: 'a@b.c' }],
+      format: 'inline-html',
+      save,
+    });
+    (SavedReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved_report_id: 'report-1',
+      user_id: 'user-1',
+      rescue_id: null,
+    });
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await handleScheduledRun({ scheduleId: 'sched-1' });
+
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not enqueue when the schedule creator no longer has edit access', async () => {
+    const enqueueSpy = vi.fn().mockResolvedValue(undefined);
+    const { getReportsQueue, isQueueAvailable } = await import('../../lib/queue');
+    (isQueueAvailable as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (getReportsQueue as ReturnType<typeof vi.fn>).mockReturnValue({ add: enqueueSpy });
+
+    const save = vi.fn().mockResolvedValue(undefined);
+    (ScheduledReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      schedule_id: 'sched-1',
+      saved_report_id: 'report-1',
+      is_enabled: true,
+      created_by: 'user-1',
+      recipients: [{ email: 'a@b.c' }],
+      format: 'inline-html',
+      save,
+    });
+    (SavedReport.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      saved_report_id: 'report-1',
+      user_id: 'someone-else',
+      rescue_id: null,
+    });
+    (User.findByPk as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: 'user-1',
+      userType: UserType.ADOPTER,
+    });
+    (ReportsService.canEdit as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    await handleScheduledRun({ scheduleId: 'sched-1' });
+
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+});

--- a/service.backend/src/jobs/match-digest.job.ts
+++ b/service.backend/src/jobs/match-digest.job.ts
@@ -6,6 +6,7 @@ import AdopterMatchProfile from '../models/AdopterMatchProfile';
 import { NotificationType } from '../models/Notification';
 import Pet, { PetStatus } from '../models/Pet';
 import Rescue from '../models/Rescue';
+import User, { UserStatus } from '../models/User';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
 import { NotificationService } from '../services/notification.service';
 import { logger } from '../utils/logger';
@@ -64,6 +65,19 @@ export const runMatchDigest = async (): Promise<{ scanned: number; notified: num
   let notified = 0;
   for (const profile of profiles) {
     try {
+      // Defense-in-depth: re-verify the recipient User still exists
+      // and is ACTIVE. The `notify_new_matches=true` WHERE clause
+      // doesn't join through User.status, so a suspended/deleted user
+      // with a stale profile would otherwise still get notifications.
+      const recipient = await User.findByPk(profile.user_id);
+      if (!recipient || recipient.status !== UserStatus.ACTIVE) {
+        logger.warn('match-digest: skipping — recipient missing or inactive', {
+          userId: profile.user_id,
+          status: recipient?.status ?? null,
+        });
+        continue;
+      }
+
       const since = profile.last_notified_at ?? new Date(Date.now() - FALLBACK_LOOKBACK_MS);
       const candidates = await Pet.findAll({
         where: {
@@ -74,12 +88,16 @@ export const runMatchDigest = async (): Promise<{ scanned: number; notified: num
         limit: 50,
       });
 
-      if (candidates.length === 0) continue;
+      if (candidates.length === 0) {
+        continue;
+      }
 
       const scored = await matchService.rankPets(profile.user_id, candidates);
       const top = scored.filter(s => s.score >= profile.min_notification_score).slice(0, TOP_N);
 
-      if (top.length === 0) continue;
+      if (top.length === 0) {
+        continue;
+      }
 
       const petNames = top
         .map(s => candidates.find(c => c.petId === s.petId)?.name)
@@ -112,13 +130,17 @@ export const runMatchDigest = async (): Promise<{ scanned: number; notified: num
 let workerInstance: Worker | null = null;
 
 export const startMatchDigestWorker = (): Worker | null => {
-  if (workerInstance) return workerInstance;
+  if (workerInstance) {
+    return workerInstance;
+  }
   if (!isQueueAvailable()) {
     logger.warn('REDIS_URL not set — match digest worker not started');
     return null;
   }
   workerInstance = buildWorker(async job => {
-    if (job.name !== MATCH_DIGEST_JOB_NAME) return;
+    if (job.name !== MATCH_DIGEST_JOB_NAME) {
+      return;
+    }
     const result = await runMatchDigest();
     logger.info('Match digest finished', result);
   });

--- a/service.backend/src/workers/reports.worker.ts
+++ b/service.backend/src/workers/reports.worker.ts
@@ -9,6 +9,7 @@ import ScheduledReport, {
   ScheduledReportStatus,
   type ScheduledReportRecipient,
 } from '../models/ScheduledReport';
+import User, { UserType } from '../models/User';
 import { logger } from '../utils/logger';
 import type { ReportConfig } from '../schemas/reports.schema';
 
@@ -43,6 +44,14 @@ export type RenderAndEmailJob = {
   recipients: ScheduledReportRecipient[];
   format: ScheduledReportFormat;
   triggeredBy: 'schedule' | 'manual';
+  /**
+   * Defense-in-depth ownership re-check. The worker re-verifies that
+   * this user still exists and still has edit access to the report
+   * before sending. Optional for backward compatibility with any
+   * in-flight legacy jobs; new enqueues from `handleScheduledRun`
+   * always populate it.
+   */
+  requestedBy?: string;
 };
 
 const SCHEDULED_RUN = 'report:scheduled-run';
@@ -88,12 +97,59 @@ export const removeScheduleRepeat = async (schedule: ScheduledReport): Promise<v
   });
 };
 
+/**
+ * Defense-in-depth ownership re-check. Returns true only when the
+ * requester is an admin or `ReportsService.canEdit` still holds at
+ * job execution time. Mirrors the admin-bypass policy used in the
+ * controllers (`reports.read.platform` permission ⇢ admin role).
+ *
+ * Returns false (rather than throwing) on missing requester or
+ * missing report — throwing would retry the job, which is the wrong
+ * behaviour for an authorisation failure.
+ */
+const requesterCanStillEditReport = async (
+  requestedBy: string,
+  report: SavedReport
+): Promise<boolean> => {
+  const requester = await User.findByPk(requestedBy);
+  if (!requester) {
+    return false;
+  }
+  if (requester.userType === UserType.ADMIN || requester.userType === UserType.SUPER_ADMIN) {
+    return true;
+  }
+  return ReportsService.canEdit(report, { userId: requester.userId });
+};
+
 const handleScheduledRun = async (data: ScheduledRunJob): Promise<void> => {
   const schedule = await ScheduledReport.findByPk(data.scheduleId);
   if (!schedule || !schedule.is_enabled) {
     logger.debug('Schedule missing or disabled — skipping', { scheduleId: data.scheduleId });
     return;
   }
+
+  // Defense-in-depth: re-verify the schedule creator still has access
+  // to the report. Falls back to the report owner when `created_by` is
+  // null (legacy schedules created before audit-columns shipped).
+  const report = await SavedReport.findByPk(schedule.saved_report_id);
+  if (!report) {
+    logger.warn('reports.worker: skipping scheduled-run — saved report missing', {
+      scheduleId: schedule.schedule_id,
+      savedReportId: schedule.saved_report_id,
+    });
+    return;
+  }
+  const requestedBy = schedule.created_by ?? report.user_id;
+  const allowed = await requesterCanStillEditReport(requestedBy, report);
+  if (!allowed) {
+    logger.warn('reports.worker: skipping scheduled-run — requester no longer has access', {
+      scheduleId: schedule.schedule_id,
+      savedReportId: report.saved_report_id,
+      requestedBy,
+    });
+    return;
+  }
+
   schedule.last_status = ScheduledReportStatus.PENDING;
   schedule.last_run_at = new Date();
   await schedule.save();
@@ -104,14 +160,38 @@ const handleScheduledRun = async (data: ScheduledRunJob): Promise<void> => {
     recipients: schedule.recipients,
     format: schedule.format,
     triggeredBy: 'schedule',
+    requestedBy,
   } satisfies RenderAndEmailJob);
 };
 
 const handleRenderAndEmail = async (data: RenderAndEmailJob): Promise<void> => {
   const report = await SavedReport.findByPk(data.savedReportId);
   if (!report) {
-    throw new Error(`Report ${data.savedReportId} not found for render-and-email`);
+    // Defense-in-depth: a missing report is not a transient error.
+    // Throwing would retry indefinitely; log and drop instead.
+    logger.warn('reports.worker: skipping render-and-email — saved report missing', {
+      savedReportId: data.savedReportId,
+      scheduleId: data.scheduleId,
+    });
+    return;
   }
+
+  // Defense-in-depth: re-verify the requester still has edit access
+  // at job-execution time. Guards against queue replay after a
+  // permission revocation, and against any future "retry job" admin
+  // tool that lets an operator re-fire a payload.
+  if (data.requestedBy) {
+    const allowed = await requesterCanStillEditReport(data.requestedBy, report);
+    if (!allowed) {
+      logger.warn('reports.worker: skipping render-and-email — requester no longer has access', {
+        savedReportId: report.saved_report_id,
+        scheduleId: data.scheduleId,
+        requestedBy: data.requestedBy,
+      });
+      return;
+    }
+  }
+
   const scope: string | 'platform' = report.rescue_id ?? 'platform';
   const executed = await ReportsService.executeReport(report.config as unknown as ReportConfig, {
     scope,
@@ -212,4 +292,13 @@ export const stopReportsWorker = async (): Promise<void> => {
     await workerInstance.close();
     workerInstance = null;
   }
+};
+
+/**
+ * Internal handlers exposed for behaviour tests only. Not part of the
+ * public worker API — production code dispatches via BullMQ.
+ */
+export const __testables = {
+  handleScheduledRun,
+  handleRenderAndEmail,
 };


### PR DESCRIPTION
## Summary

Defense-in-depth: background worker handlers now re-verify that the requesting user still exists and still has access to the resource referenced in the job payload before acting. Jobs are presently only enqueued from authenticated route handlers that already check permissions, so this protects against three future-facing risks:

- "retry job" / "replay queue" admin tooling exposing a re-fire path
- bugs that allow job payload tampering
- queue replays following a permission revocation

Authorisation failures **log at WARN and return** — they do not throw, because throwing would retry the job indefinitely.

## Inventory of guarded handlers

| Handler | Resource | Check |
|---|---|---|
| `reports.worker.ts` → `handleScheduledRun` | `ScheduledReport` + `SavedReport` | Re-fetch report; verify `schedule.created_by` (or `report.user_id` for legacy null) still has edit access. Skip + WARN otherwise. Propagates validated `requestedBy` into the render-and-email payload. |
| `reports.worker.ts` → `handleRenderAndEmail` | `SavedReport` | When `requestedBy` is present, re-fetch user + re-run `ReportsService.canEdit` (admin/super-admin bypass mirrors controller policy). Skip + WARN otherwise. Missing report also now logs+returns rather than throwing forever. |
| `match-digest.job.ts` → `runMatchDigest` | `User` (recipient) | Per-profile loop now re-verifies the User exists and is `UserStatus.ACTIVE` before notifying. The `notify_new_matches=true` filter on `AdopterMatchProfile` doesn't join through `User.status`, so suspended/deleted users with stale profiles would otherwise still receive digests. |

## Out of scope (verified during survey)

- `legal-reminder.worker.ts`: empty job payload (global cron). `findCandidateUserIds` pre-filters `UserStatus.ACTIVE`; `sendReacceptanceReminder` already calls `User.findByPk` and skips when missing.
- `weekly-digest.job.ts`: empty payload (global cron); service already filters `UserStatus.ACTIVE` at `User.findAll`.
- `retention.job.ts`, `revoked-tokens-purge.job.ts`: inherently global sweeps with no per-user attribution.

## Test plan

- [x] `npx vitest run src/__tests__/workers/reports.worker.test.ts src/__tests__/jobs/match-digest.job.test.ts` — 11 new behaviour tests passing.
- [x] Existing tests still green (`reports.service.test.ts`, `revoked-tokens-purge.test.ts` regression-checked).
- [x] ESLint clean on touched files.
- [x] `tsc --noEmit` clean for touched files (remaining errors are pre-existing missing-lib-build errors unrelated to this change).

### New tests cover

- happy path: requester exists and has access → handler runs normally
- requester deleted → handler logs WARN and returns (no throw, no retry)
- requester loses access → handler logs WARN and returns
- admin bypass: admin user can still execute even when `canEdit` returns false
- missing report → handler logs WARN and returns
- match-digest: ACTIVE owner → notified; missing owner → skipped; SUSPENDED owner → skipped

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_