### PR TITLE
feat(security): rate limit inbound Socket.IO events

### DIFF
--- a/service.backend/src/__tests__/socket/socket-rate-limit.test.ts
+++ b/service.backend/src/__tests__/socket/socket-rate-limit.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Behaviour tests for the per-socket inbound rate limiter (ADS-709).
+ *
+ * The limiter exists to protect the DB from event-spam DOS now that
+ * the chat socket revokes its 30s revocation cache and reads
+ * RevokedToken on every inbound event.
+ *
+ * We assert through the public helpers `checkRateLimit` and
+ * `releaseSocket` — the bucket map itself is implementation detail
+ * and the only internal-touching assertion is via `__test.size()`,
+ * which is a small testing seam exported on purpose.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __test,
+  checkRateLimit,
+  getBudget,
+  releaseSocket,
+} from '../../middleware/socket-rate-limit';
+
+type Captured = { event: string; payload: unknown };
+
+const makeSocket = (id: string, userId?: string) => {
+  const emitted: Captured[] = [];
+  return {
+    id,
+    userId,
+    emit: (event: string, payload: unknown) => {
+      emitted.push({ event, payload });
+    },
+    emitted,
+  };
+};
+
+describe('socket inbound rate limit (ADS-709)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __test.reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __test.reset();
+  });
+
+  it('allows the configured chat-send budget and drops the overflow', () => {
+    const socket = makeSocket('sock-1', 'user-1');
+    const { limit } = getBudget('send_message');
+
+    const blockedFlags: boolean[] = [];
+    for (let i = 0; i < 50; i++) {
+      blockedFlags.push(checkRateLimit(socket, 'send_message'));
+    }
+
+    // First `limit` calls pass; the rest are dropped.
+    const allowed = blockedFlags.filter(b => !b).length;
+    const dropped = blockedFlags.filter(b => b).length;
+    expect(allowed).toBe(limit);
+    expect(dropped).toBe(50 - limit);
+
+    // Every dropped event emits a `rate_limit` notice.
+    const rateLimitEmits = socket.emitted.filter(e => e.event === 'rate_limit');
+    expect(rateLimitEmits.length).toBe(dropped);
+  });
+
+  it('refills the budget after the window elapses', () => {
+    const socket = makeSocket('sock-1', 'user-1');
+    const { limit, windowMs } = getBudget('send_message');
+
+    for (let i = 0; i < limit; i++) {
+      expect(checkRateLimit(socket, 'send_message')).toBe(false);
+    }
+    expect(checkRateLimit(socket, 'send_message')).toBe(true);
+
+    vi.advanceTimersByTime(windowMs + 1);
+
+    expect(checkRateLimit(socket, 'send_message')).toBe(false);
+  });
+
+  it('keeps the chat-send and typing buckets independent', () => {
+    const socket = makeSocket('sock-1', 'user-1');
+    const sendLimit = getBudget('send_message').limit;
+
+    // Drain chat-send fully.
+    for (let i = 0; i < sendLimit; i++) {
+      checkRateLimit(socket, 'send_message');
+    }
+    expect(checkRateLimit(socket, 'send_message')).toBe(true);
+
+    // typing_start has its own bucket and is still wide open.
+    expect(checkRateLimit(socket, 'typing_start')).toBe(false);
+  });
+
+  it('uses independent buckets for different sockets / users', () => {
+    const a = makeSocket('sock-a', 'user-a');
+    const b = makeSocket('sock-b', 'user-b');
+    const limit = getBudget('send_message').limit;
+
+    for (let i = 0; i < limit; i++) {
+      checkRateLimit(a, 'send_message');
+    }
+    expect(checkRateLimit(a, 'send_message')).toBe(true);
+    // Different user — fresh bucket.
+    expect(checkRateLimit(b, 'send_message')).toBe(false);
+  });
+
+  it('frees the bucket on disconnect for anonymous sockets', () => {
+    const socket = makeSocket('anon-1');
+    checkRateLimit(socket, 'send_message');
+    expect(__test.has('anon-1')).toBe(true);
+
+    releaseSocket(socket);
+    expect(__test.has('anon-1')).toBe(false);
+  });
+
+  it('does not leak memory across many reconnects of the same user', () => {
+    // 100 reconnect cycles for the same authenticated user must not
+    // grow the bucket count: the user keeps ONE bucket entry.
+    for (let i = 0; i < 100; i++) {
+      const socket = makeSocket(`sock-${i}`, 'user-stable');
+      checkRateLimit(socket, 'send_message');
+      releaseSocket(socket);
+    }
+    expect(__test.size()).toBe(1);
+    expect(__test.has('user-stable')).toBe(true);
+  });
+
+  it('GC drops user buckets idle longer than the idle window', () => {
+    const socket = makeSocket('sock-x', 'user-x');
+    checkRateLimit(socket, 'send_message');
+    expect(__test.has('user-x')).toBe(true);
+
+    // Run past the 5-minute idle threshold; the 1-minute GC sweep
+    // then drops the entry.
+    vi.advanceTimersByTime(6 * 60_000);
+    expect(__test.has('user-x')).toBe(false);
+  });
+
+  it('applies the generic 60/min budget to unlisted events', () => {
+    const socket = makeSocket('sock-1', 'user-1');
+
+    // Generic budget is 60/min — fire 65 unlisted events.
+    const blocked: boolean[] = [];
+    for (let i = 0; i < 65; i++) {
+      blocked.push(checkRateLimit(socket, 'some_unlisted_event'));
+    }
+    expect(blocked.filter(b => !b).length).toBe(60);
+    expect(blocked.filter(b => b).length).toBe(5);
+  });
+});

--- a/service.backend/src/middleware/socket-rate-limit.ts
+++ b/service.backend/src/middleware/socket-rate-limit.ts
@@ -1,0 +1,174 @@
+/**
+ * ADS-709: per-socket inbound rate limiting for Socket.IO.
+ *
+ * The chat-auth hardening (ADS-708, plan pass 2) removed the 30s
+ * revocation cache, so every inbound event now performs a RevokedToken
+ * point lookup on the DB. Without an inbound limiter a misbehaving or
+ * hostile client could spam events and exhaust the DB connection pool.
+ *
+ * Strategy: fixed-window counters held in process memory.
+ *  - Keyed by userId when the socket is authenticated, so reconnects
+ *    don't reset the budget; falls back to socketId otherwise.
+ *  - Per-event-type budgets: chat-send is tighter than typing or
+ *    read-receipt indicators which are inherently chatty.
+ *  - On overrun: emit `rate_limit` back to the client and drop the
+ *    inbound event. We do NOT disconnect — a single spike from an
+ *    otherwise-well-behaved client should not kill the session.
+ *  - Cleanup: bucket released on socket disconnect; periodic GC drops
+ *    user-keyed buckets idle for > IDLE_MS.
+ */
+import { logger } from '../utils/logger';
+
+type Bucket = {
+  windowStart: number;
+  count: number;
+  lastSeen: number;
+};
+
+type EventBudget = {
+  limit: number;
+  windowMs: number;
+};
+
+const WINDOW_MS = 60_000;
+
+// Event budgets. Numbers chosen to comfortably accommodate normal UX
+// (a user typing a long message will easily fire 30+ typing events in
+// a minute; read receipts fire on scroll). Chat-send is the
+// write-heavy path and is tightest.
+const BUDGETS: Record<string, EventBudget> = {
+  send_message: { limit: 30, windowMs: WINDOW_MS },
+  message_sent_notification: { limit: 30, windowMs: WINDOW_MS },
+  mark_as_read: { limit: 120, windowMs: WINDOW_MS },
+  typing_start: { limit: 60, windowMs: WINDOW_MS },
+  typing_stop: { limit: 60, windowMs: WINDOW_MS },
+  add_reaction: { limit: 30, windowMs: WINDOW_MS },
+  remove_reaction: { limit: 30, windowMs: WINDOW_MS },
+  join_chat: { limit: 20, windowMs: WINDOW_MS },
+  leave_chat: { limit: 20, windowMs: WINDOW_MS },
+};
+
+const DEFAULT_BUDGET: EventBudget = { limit: 60, windowMs: WINDOW_MS };
+
+const IDLE_MS = 5 * 60_000;
+const GC_INTERVAL_MS = 60_000;
+
+// key -> event -> bucket
+const buckets = new Map<string, Map<string, Bucket>>();
+
+let gcTimer: NodeJS.Timeout | null = null;
+
+const ensureGcTimer = (): void => {
+  if (gcTimer) {
+    return;
+  }
+  gcTimer = setInterval(() => {
+    const cutoff = Date.now() - IDLE_MS;
+    for (const [key, events] of buckets) {
+      for (const [event, bucket] of events) {
+        if (bucket.lastSeen < cutoff) {
+          events.delete(event);
+        }
+      }
+      if (events.size === 0) {
+        buckets.delete(key);
+      }
+    }
+  }, GC_INTERVAL_MS);
+  // Don't keep the event loop alive just for this timer.
+  gcTimer.unref?.();
+};
+
+export const getBudget = (event: string): EventBudget => BUDGETS[event] ?? DEFAULT_BUDGET;
+
+/**
+ * Returns true when the event for the given key should be DROPPED
+ * (limit exceeded). Returns false when the event may proceed.
+ *
+ * The caller is responsible for emitting `rate_limit` back to the
+ * client and dropping the inbound event when this returns true; see
+ * `checkRateLimit` for the combined helper.
+ */
+export const consume = (key: string, event: string, now: number = Date.now()): boolean => {
+  ensureGcTimer();
+  const budget = getBudget(event);
+
+  let events = buckets.get(key);
+  if (!events) {
+    events = new Map();
+    buckets.set(key, events);
+  }
+
+  const bucket = events.get(event);
+  if (!bucket || now - bucket.windowStart >= budget.windowMs) {
+    events.set(event, { windowStart: now, count: 1, lastSeen: now });
+    return false;
+  }
+
+  bucket.lastSeen = now;
+  if (bucket.count >= budget.limit) {
+    return true;
+  }
+  bucket.count += 1;
+  return false;
+};
+
+type RateLimitTarget = {
+  emit: (event: string, payload: unknown) => void;
+  id: string;
+  userId?: string;
+};
+
+/**
+ * Returns true when the inbound event MUST be dropped. Side effects:
+ * emits `rate_limit` to the client and logs at INFO.
+ */
+export const checkRateLimit = (socket: RateLimitTarget, event: string): boolean => {
+  const key = socket.userId ?? socket.id;
+  if (!consume(key, event)) {
+    return false;
+  }
+  const budget = getBudget(event);
+  socket.emit('rate_limit', {
+    event,
+    limit: budget.limit,
+    windowMs: budget.windowMs,
+  });
+  logger.info('Socket inbound rate limit exceeded', {
+    socketId: socket.id,
+    userId: socket.userId,
+    event,
+    limit: budget.limit,
+  });
+  return true;
+};
+
+/**
+ * Free the bucket for a key. Called on socket disconnect; for
+ * userId-keyed buckets the GC handles eventual cleanup of stale
+ * entries so reconnects don't lose their budget mid-window.
+ */
+export const releaseSocket = (socket: RateLimitTarget): void => {
+  // Only release socketId-keyed buckets here. For authenticated
+  // sockets the bucket is shared across reconnects on purpose; the GC
+  // sweep handles them when the user goes idle.
+  if (socket.userId) {
+    return;
+  }
+  buckets.delete(socket.id);
+};
+
+// Test-only helpers. Exported under a prefixed name so they're easy to
+// spot in callers; they exist so tests can assert behaviour without
+// reaching into module internals via casts.
+export const __test = {
+  size: (): number => buckets.size,
+  has: (key: string): boolean => buckets.has(key),
+  reset: (): void => {
+    buckets.clear();
+    if (gcTimer) {
+      clearInterval(gcTimer);
+      gcTimer = null;
+    }
+  },
+};

--- a/service.backend/src/socket/socket-handlers.ts
+++ b/service.backend/src/socket/socket-handlers.ts
@@ -11,6 +11,7 @@ import { HealthCheckService } from '../services/health-check.service';
 import { getMessageBroker } from '../services/messageBroker.service';
 import { setAnalyticsIo } from './analytics-emitter';
 import { setLiveIo, getLiveIo } from './socket-registry';
+import { checkRateLimit, releaseSocket } from '../middleware/socket-rate-limit';
 import { JsonObject } from '../types/common';
 import { verifyAccessToken } from '../utils/jwt';
 import { logger } from '../utils/logger';
@@ -21,26 +22,6 @@ export { disconnectAllSockets } from './socket-registry';
 
 // Track active connections for health monitoring
 let activeConnections = 0;
-
-// Per-socket sliding-window rate limiter. Tracks event timestamps in memory;
-// cleaned up on disconnect so memory doesn't grow unbounded.
-const socketEventTimestamps = new Map<string, Map<string, number[]>>();
-
-function isRateLimited(socketId: string, event: string, limit: number, windowMs: number): boolean {
-  if (!socketEventTimestamps.has(socketId)) {
-    socketEventTimestamps.set(socketId, new Map());
-  }
-  const events = socketEventTimestamps.get(socketId)!;
-  const now = Date.now();
-  const cutoff = now - windowMs;
-  const timestamps = (events.get(event) ?? []).filter(t => t > cutoff);
-  if (timestamps.length >= limit) {
-    return true;
-  }
-  timestamps.push(now);
-  events.set(event, timestamps);
-  return false;
-}
 
 // Zod schemas for socket event payloads
 const JoinChatSchema = z.object({ chatId: z.string().uuid() });
@@ -445,8 +426,7 @@ export class SocketHandlers {
     // Join chat room
     socket.on('join_chat', async (data: unknown) => {
       try {
-        if (isRateLimited(socket.id, 'join_chat', 20, 60_000)) {
-          socket.emit('error', { event: 'join_chat', message: 'Rate limit exceeded' });
+        if (checkRateLimit(socket, 'join_chat')) {
           return;
         }
         const parsed = JoinChatSchema.safeParse(data);
@@ -484,6 +464,9 @@ export class SocketHandlers {
     // Leave chat room
     socket.on('leave_chat', async (data: unknown) => {
       try {
+        if (checkRateLimit(socket, 'leave_chat')) {
+          return;
+        }
         const parsed = LeaveChatSchema.safeParse(data);
         if (!parsed.success) {
           socket.emit('error', { event: 'leave_chat', message: 'Invalid payload' });
@@ -519,6 +502,9 @@ export class SocketHandlers {
       'message_sent_notification',
       async (data: { messageId: string; conversationId: string; tempId: string }) => {
         try {
+          if (checkRateLimit(socket, 'message_sent_notification')) {
+            return;
+          }
           const { messageId, conversationId, tempId } = data;
 
           // Verify user has access to chat before sending notification
@@ -550,8 +536,7 @@ export class SocketHandlers {
     // Send message (DEPRECATED - API should be used instead)
     socket.on('send_message', async (data: unknown) => {
       try {
-        if (isRateLimited(socket.id, 'send_message', 10, 10_000)) {
-          socket.emit('error', { event: 'send_message', message: 'Rate limit exceeded' });
+        if (checkRateLimit(socket, 'send_message')) {
           return;
         }
         const parsed = SendMessageSchema.safeParse(data);
@@ -617,6 +602,9 @@ export class SocketHandlers {
     // Mark messages as read
     socket.on('mark_as_read', async (data: unknown) => {
       try {
+        if (checkRateLimit(socket, 'mark_as_read')) {
+          return;
+        }
         const parsed = MarkAsReadSchema.safeParse(data);
         if (!parsed.success) {
           socket.emit('error', { event: 'mark_as_read', message: 'Invalid payload' });
@@ -648,8 +636,7 @@ export class SocketHandlers {
     // Add reaction to message
     socket.on('add_reaction', async (data: unknown) => {
       try {
-        if (isRateLimited(socket.id, 'add_reaction', 30, 60_000)) {
-          socket.emit('error', { event: 'add_reaction', message: 'Rate limit exceeded' });
+        if (checkRateLimit(socket, 'add_reaction')) {
           return;
         }
         const parsed = ReactionSchema.safeParse(data);
@@ -691,6 +678,9 @@ export class SocketHandlers {
     // Remove reaction from message
     socket.on('remove_reaction', async (data: unknown) => {
       try {
+        if (checkRateLimit(socket, 'remove_reaction')) {
+          return;
+        }
         const parsed = ReactionSchema.safeParse(data);
         if (!parsed.success) {
           socket.emit('error', { event: 'remove_reaction', message: 'Invalid payload' });
@@ -733,7 +723,7 @@ export class SocketHandlers {
     // User started typing
     socket.on('typing_start', async (data: unknown) => {
       try {
-        if (isRateLimited(socket.id, 'typing_start', 60, 60_000)) {
+        if (checkRateLimit(socket, 'typing_start')) {
           return;
         }
         const parsed = TypingStartSchema.safeParse(data);
@@ -766,6 +756,9 @@ export class SocketHandlers {
     // User stopped typing
     socket.on('typing_stop', async (data: unknown) => {
       try {
+        if (checkRateLimit(socket, 'typing_stop')) {
+          return;
+        }
         const parsed = TypingStopSchema.safeParse(data);
         if (!parsed.success) {
           return;
@@ -795,6 +788,9 @@ export class SocketHandlers {
   private setupPresenceHandlers(socket: AuthenticatedSocket) {
     // User requests presence status of other users
     socket.on('get_presence', (data: { userIds: string[] }) => {
+      if (checkRateLimit(socket, 'get_presence')) {
+        return;
+      }
       const { userIds } = data;
       const presenceData: { [userId: string]: { status: string; lastSeen: Date } } = {};
 
@@ -818,6 +814,9 @@ export class SocketHandlers {
 
     // User updates their presence status
     socket.on('update_presence', (data: { status: 'online' | 'away' }) => {
+      if (checkRateLimit(socket, 'update_presence')) {
+        return;
+      }
       const { status } = data;
       this.updateUserPresence(socket.userId!, status, socket.id);
 
@@ -845,8 +844,10 @@ export class SocketHandlers {
       // Clear all typing indicators for this user
       this.clearAllTypingIndicators(socket.userId!);
 
-      // Release per-socket rate-limit state
-      socketEventTimestamps.delete(socket.id);
+      // Release per-socket rate-limit state. For authenticated
+      // sockets the limiter keeps the bucket alive across reconnects
+      // (and GCs it on idle); for anonymous sockets it's dropped now.
+      releaseSocket(socket);
 
       // ADS-597: stop the auth-refresh timer so it doesn't leak past the
       // socket lifetime.


### PR DESCRIPTION
## Summary

Pass 2 of the ADS-708 chat-auth hardening dropped the 30s revocation cache, so every inbound Socket.IO event now hits the `RevokedToken` table directly. Without an inbound limiter, a misbehaving or hostile client can spam events and exhaust the DB connection pool. This PR adds a per-socket, per-event-type fixed-window limiter that closes that surface without escalating to a disconnect.

- Adds `service.backend/src/middleware/socket-rate-limit.ts` — fixed-window counters keyed by `userId` when the socket is authenticated (so reconnects do not reset the budget) and by `socket.id` otherwise. On overrun the limiter emits a `rate_limit` event to the client, drops the inbound event, and logs at INFO. Anonymous-socket buckets are released on disconnect; user-keyed buckets are reaped by a 1-minute GC sweep that drops entries idle longer than five minutes.
- Replaces the four ad-hoc inline rate checks in `socket-handlers.ts` with the shared helper and extends coverage to every inbound event. Per-event budgets per minute: `send_message` / `message_sent_notification` / `add_reaction` / `remove_reaction` 30; `join_chat` / `leave_chat` 20; `mark_as_read` 120; `typing_start` / `typing_stop` / `get_presence` / `update_presence` and default 60.

## Test plan

- [x] `npx vitest run src/__tests__/socket/` — 18/18 pass (8 new + 10 existing).
- [x] Full backend suite: `npx vitest run` — 2498 passed, 210 skipped, 0 failures.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint --fix` on the touched files — clean (one pre-existing unused-var warning on `requireChatAccess` left untouched per surgical-change guidance).
- [x] `npx prettier --check` on the touched files — passes.
- [ ] Manual smoke against a real socket connection (left for reviewer; covered by unit-level behaviour tests with `vi.useFakeTimers` for the chat-send budget, window refill, bucket independence across event types and sockets, disconnect cleanup, 100-reconnect memory stability, and idle GC).


---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_