### PR TITLE
fix(security): escape user content in report HTML + disable raw HTML in marked

### DIFF
--- a/service.backend/src/__tests__/services/report-renderer.service.test.ts
+++ b/service.backend/src/__tests__/services/report-renderer.service.test.ts
@@ -169,4 +169,109 @@ describe('ReportRenderer.renderInlineHtml', () => {
     expect(html).toContain('<!doctype html>');
     expect(html).toContain('</html>');
   });
+
+  describe('HTML escaping of user-controlled content', () => {
+    it('escapes script tags in the report name', () => {
+      const report = makeReport({ name: '<script>alert(1)</script>' });
+      const html = ReportRenderer.renderInlineHtml(report, makeExecuted());
+      expect(html).not.toContain('<script>alert(1)</script>');
+      expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+
+    it('escapes script tags in widget titles', () => {
+      const report = makeReport({
+        config: {
+          widgets: [{ id: 'w1', title: '<script>alert(2)</script>', chartType: 'bar' }],
+        },
+      });
+      const executed: ExecutedReport = {
+        computedAt: '2026-01-01T00:00:00.000Z',
+        cacheHit: false,
+        filters: {},
+        widgets: [{ id: 'w1', meta: metaStub, data: [{ month: 'Jan', count: 1 }] }],
+      };
+      const html = ReportRenderer.renderInlineHtml(report, executed);
+      expect(html).not.toContain('<script>alert(2)</script>');
+      expect(html).toContain('&lt;script&gt;alert(2)&lt;/script&gt;');
+    });
+
+    it('escapes injection attempts in table header keys', () => {
+      const executed: ExecutedReport = {
+        computedAt: '2026-01-01T00:00:00.000Z',
+        cacheHit: false,
+        filters: {},
+        widgets: [
+          {
+            id: 'w1',
+            meta: metaStub,
+            data: [{ '"><img src=x onerror=alert(1)>': 'value' }],
+          },
+        ],
+      };
+      const html = ReportRenderer.renderInlineHtml(makeReport(), executed);
+      expect(html).not.toContain('<img src=x onerror=alert(1)>');
+      expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    });
+
+    it('escapes injection attempts in table cell values', () => {
+      const executed: ExecutedReport = {
+        computedAt: '2026-01-01T00:00:00.000Z',
+        cacheHit: false,
+        filters: {},
+        widgets: [
+          {
+            id: 'w1',
+            meta: metaStub,
+            data: [{ month: '<script>alert(3)</script>' }],
+          },
+        ],
+      };
+      const html = ReportRenderer.renderInlineHtml(makeReport(), executed);
+      expect(html).not.toContain('<script>alert(3)</script>');
+      expect(html).toContain('&lt;script&gt;alert(3)&lt;/script&gt;');
+    });
+
+    it('escapes injection attempts in metric object keys and values', () => {
+      const executed: ExecutedReport = {
+        computedAt: '2026-01-01T00:00:00.000Z',
+        cacheHit: false,
+        filters: {},
+        widgets: [
+          {
+            id: 'w1',
+            meta: metaStub,
+            data: { '<b>key</b>': '<script>alert(4)</script>' },
+          },
+        ],
+      };
+      const html = ReportRenderer.renderInlineHtml(makeReport(), executed);
+      expect(html).not.toContain('<b>key</b>');
+      expect(html).not.toContain('<script>alert(4)</script>');
+      expect(html).toContain('&lt;b&gt;key&lt;/b&gt;');
+      expect(html).toContain('&lt;script&gt;alert(4)&lt;/script&gt;');
+    });
+
+    it('escapes scalar widget data containing HTML', () => {
+      const executed: ExecutedReport = {
+        computedAt: '2026-01-01T00:00:00.000Z',
+        cacheHit: false,
+        filters: {},
+        widgets: [{ id: 'w1', meta: metaStub, data: '<script>alert(5)</script>' }],
+      };
+      const html = ReportRenderer.renderInlineHtml(makeReport(), executed);
+      expect(html).not.toContain('<script>alert(5)</script>');
+      expect(html).toContain('&lt;script&gt;alert(5)&lt;/script&gt;');
+    });
+
+    it('leaves alphanumeric content unchanged (regression)', () => {
+      const html = ReportRenderer.renderInlineHtml(makeReport(), makeExecuted());
+      expect(html).toContain('Monthly Adoptions');
+      expect(html).toContain('Total Adoptions');
+      expect(html).toContain('Active Rescues');
+      expect(html).toContain('Jan');
+      expect(html).toContain('Feb');
+      expect(html).toContain('total');
+      expect(html).toContain('42');
+    });
+  });
 });

--- a/service.backend/src/__tests__/services/rich-text-processing.service.test.ts
+++ b/service.backend/src/__tests__/services/rich-text-processing.service.test.ts
@@ -94,3 +94,16 @@ describe('RichTextProcessingService.sanitize', () => {
     });
   });
 });
+
+describe('RichTextProcessingService.processMarkdown', () => {
+  it('does not pass raw <script> HTML through from markdown input', async () => {
+    const result = await RichTextProcessingService.processMarkdown('<script>alert(1)</script>');
+    expect(result.html).not.toContain('<script>');
+    expect(result.html).not.toContain('alert(1)');
+  });
+
+  it('still converts markdown bold to <strong>', async () => {
+    const result = await RichTextProcessingService.processMarkdown('**bold**');
+    expect(result.html).toContain('<strong>bold</strong>');
+  });
+});

--- a/service.backend/src/services/report-renderer.service.ts
+++ b/service.backend/src/services/report-renderer.service.ts
@@ -21,6 +21,16 @@ import type SavedReport from '../models/SavedReport';
 
 type WidgetTitle = { id: string; title: string; chartType: string };
 
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+const escapeHtml = (value: string): string => value.replace(/[&<>"']/g, ch => HTML_ESCAPE_MAP[ch]);
+
 const titlesFromReport = (report: SavedReport): WidgetTitle[] => {
   const config = report.config as {
     widgets?: Array<{ id: string; title: string; chartType: string }>;
@@ -120,7 +130,8 @@ export const ReportRenderer = {
           const headers = Object.keys(rows[0]);
           body = `<table style="border-collapse:collapse;width:100%"><thead><tr>${headers
             .map(
-              h => `<th style="text-align:left;border-bottom:1px solid #ccc;padding:4px">${h}</th>`
+              h =>
+                `<th style="text-align:left;border-bottom:1px solid #ccc;padding:4px">${escapeHtml(h)}</th>`
             )
             .join('')}</tr></thead><tbody>${rows
             .slice(0, 50)
@@ -129,7 +140,7 @@ export const ReportRenderer = {
                 `<tr>${headers
                   .map(
                     h =>
-                      `<td style="padding:4px;border-bottom:1px solid #eee">${String(row[h] ?? '')}</td>`
+                      `<td style="padding:4px;border-bottom:1px solid #eee">${escapeHtml(String(row[h] ?? ''))}</td>`
                   )
                   .join('')}</tr>`
             )
@@ -138,17 +149,17 @@ export const ReportRenderer = {
           body = `<dl>${Object.entries(data as Record<string, unknown>)
             .map(
               ([k, v]) =>
-                `<dt style="font-weight:bold">${k}</dt><dd>${
+                `<dt style="font-weight:bold">${escapeHtml(k)}</dt><dd>${escapeHtml(
                   typeof v === 'object' ? JSON.stringify(v) : String(v ?? '')
-                }</dd>`
+                )}</dd>`
             )
             .join('')}</dl>`;
         } else {
-          body = `<p>${String(data ?? '')}</p>`;
+          body = `<p>${escapeHtml(String(data ?? ''))}</p>`;
         }
-        return `<section style="margin-bottom:24px"><h3>${title}</h3>${body}</section>`;
+        return `<section style="margin-bottom:24px"><h3>${escapeHtml(title)}</h3>${body}</section>`;
       })
       .join('');
-    return `<!doctype html><html><body style="font-family:system-ui,sans-serif"><h1>${report.name}</h1><p style="color:#666">Computed at: ${executed.computedAt}</p>${widgetHtml}</body></html>`;
+    return `<!doctype html><html><body style="font-family:system-ui,sans-serif"><h1>${escapeHtml(report.name)}</h1><p style="color:#666">Computed at: ${escapeHtml(executed.computedAt)}</p>${widgetHtml}</body></html>`;
   },
 };

--- a/service.backend/src/services/rich-text-processing.service.ts
+++ b/service.backend/src/services/rich-text-processing.service.ts
@@ -2,6 +2,20 @@ import DOMPurify from 'isomorphic-dompurify';
 import { marked } from 'marked';
 import { logger } from '../utils/logger';
 
+// Configure marked once at module load. `marked.use({ tokenizer: { html } })`
+// is the modern equivalent of marked's removed `html: false` flag — by
+// overriding the html tokenizer to never match, raw HTML in markdown input
+// is never tokenized as HTML, so dangerous tags never reach the renderer.
+// This is defense-in-depth alongside the DOMPurify sanitization performed
+// in sanitizeHtml().
+marked.use({
+  tokenizer: {
+    html() {
+      return undefined;
+    },
+  },
+});
+
 export interface RichTextOptions {
   allowedTags?: string[];
   allowedAttributes?: Record<string, string[]>;


### PR DESCRIPTION
## Summary

Two related server-side HTML-injection fixes:

- **Report renderer** (`service.backend/src/services/report-renderer.service.ts`): `renderInlineHtml` built HTML by string concatenation and interpolated user-controlled values (report name, widget titles, table headers, cell values, metric keys/values, scalar widget data) without escaping. Email clients usually ignore JS but the same renderer is used by a web-preview/archive path, making this stored XSS. Added a small in-file `escapeHtml` helper (`&`, `<`, `>`, `"`, `'`) and applied it to every interpolation.
- **Markdown processing** (`service.backend/src/services/rich-text-processing.service.ts`): `marked` was configured with `gfm: true` and no `html` guard. The installed `marked@18` removed the `html: false` flag — the modern equivalent is a tokenizer override. Added `marked.use({ tokenizer: { html() { return undefined; } } })` at module load so raw HTML in markdown is never tokenized as HTML. DOMPurify remains as defense-in-depth.

## Test plan

- [x] `npx vitest run` for `report-renderer.service.test.ts` and `rich-text-processing.service.test.ts` — new behavioural tests cover `<script>`, `"><img onerror>`, and `<b>` injections through report name, widget titles, table header keys, cell values, metric keys/values, and scalar widget data; plus markdown bold regression and `<script>` markdown input.
- [x] Full backend suite (`cd service.backend && npx vitest run`) — 2499 passed / 210 skipped, no regressions.
- [x] `npx eslint --fix` on the four touched files — clean.
- [x] `npx tsc --noEmit` in `service.backend` — clean (after `npm run build:libs`).



---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_