### PR TITLE
fix(security): redact internal fields on reporter-facing support tickets

### DIFF
--- a/service.backend/src/__tests__/routes/userSupport.routes.test.ts
+++ b/service.backend/src/__tests__/routes/userSupport.routes.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Authorization / data-exposure regression tests for the reporter-facing
+ * support-ticket endpoints (`/api/v1/support/*`).
+ *
+ * A ticket reporter must never see internal triage state: internal notes,
+ * the identity of the assigned support agent, escalation metadata, due
+ * dates, or operational SLA timers. The conversation messages returned to
+ * the reporter must also exclude internal staff-only responses.
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import express, { NextFunction, Response } from 'express';
+import request from 'supertest';
+import { AuthenticatedRequest } from '../../types';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../middleware/rate-limiter', () => ({
+  generalLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../../middleware/idempotency', () => ({
+  idempotency: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+}));
+
+const mockSupportTicketService = vi.hoisted(() => ({
+  getTicketById: vi.fn(),
+  getUserTickets: vi.fn(),
+  createTicket: vi.fn(),
+  addResponse: vi.fn(),
+}));
+
+vi.mock('../../services/supportTicket.service', () => ({
+  default: mockSupportTicketService,
+}));
+
+const mockUser = vi.hoisted(() => ({
+  findByPk: vi.fn(),
+}));
+
+vi.mock('../../models/User', () => ({
+  default: mockUser,
+}));
+
+const authenticateTokenMock = vi.fn();
+const requirePermissionMock = vi.fn();
+
+vi.mock('../../middleware/auth', () => ({
+  authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authenticateTokenMock(req, res, next),
+}));
+
+vi.mock('../../middleware/rbac', () => ({
+  requirePermission:
+    (perm: string) => (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+      requirePermissionMock(perm, req, res, next),
+}));
+
+import userSupportRouter from '../../routes/userSupport.routes';
+
+const reporterUserId = '11111111-2222-3333-4444-555555555555';
+const otherUserId = '99999999-8888-7777-6666-555555555555';
+const ticketId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/support', userSupportRouter);
+  return app;
+};
+
+const reporterPrincipal = {
+  userId: reporterUserId,
+  email: 'reporter@example.com',
+  userType: 'ADOPTER',
+  role: 'ADOPTER',
+};
+
+// Full ticket including every field a real Sequelize fetch would surface,
+// so the sanitizer is exercised against the actual exposure surface.
+const buildFullTicket = (overrides: Record<string, unknown> = {}) => ({
+  ticketId,
+  userId: reporterUserId,
+  userEmail: 'reporter@example.com',
+  userName: 'Reporter Name',
+  subject: 'Something is broken',
+  description: 'A long description of the issue.',
+  status: 'open',
+  priority: 'high',
+  category: 'technical_issue',
+  tags: ['tag-a'],
+  attachments: [],
+  createdAt: new Date('2026-05-01T10:00:00Z').toISOString(),
+  updatedAt: new Date('2026-05-01T10:00:00Z').toISOString(),
+  // The following are staff-internal and must be stripped before reaching
+  // the reporter:
+  internalNotes: 'SECRET STAFF NOTE: user is suspected of abuse',
+  assignedTo: 'agent-uuid-1',
+  AssignedAgent: {
+    userId: 'agent-uuid-1',
+    firstName: 'Staff',
+    lastName: 'Agent',
+    email: 'agent@internal.example',
+  },
+  escalatedTo: 'agent-uuid-2',
+  escalationReason: 'Customer threatened legal action',
+  escalatedAt: new Date('2026-05-02T12:00:00Z').toISOString(),
+  metadata: { internalScore: 0.97, riskFlag: 'high' },
+  dueDate: new Date('2026-05-05T10:00:00Z').toISOString(),
+  estimatedResolutionTime: 48,
+  actualResolutionTime: 36,
+  Responses: [
+    {
+      responseId: 'resp-1',
+      content: 'Public reply from agent',
+      isInternal: false,
+      createdAt: new Date('2026-05-01T11:00:00Z').toISOString(),
+    },
+    {
+      responseId: 'resp-2',
+      content: 'INTERNAL: please escalate, customer is hostile',
+      isInternal: true,
+      createdAt: new Date('2026-05-01T11:30:00Z').toISOString(),
+    },
+  ],
+  ...overrides,
+});
+
+const REPORTER_FORBIDDEN_FIELDS = [
+  'internalNotes',
+  'assignedTo',
+  'AssignedAgent',
+  'escalatedTo',
+  'escalationReason',
+  'escalatedAt',
+  'metadata',
+  'dueDate',
+  'estimatedResolutionTime',
+  'actualResolutionTime',
+] as const;
+
+const assertNoInternalFields = (ticket: Record<string, unknown>) => {
+  for (const field of REPORTER_FORBIDDEN_FIELDS) {
+    expect(ticket, `field "${field}" leaked to reporter`).not.toHaveProperty(field);
+  }
+};
+
+describe('Reporter-facing support ticket endpoints — internal field exposure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateTokenMock.mockImplementation(
+      (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+        req.user = reporterPrincipal as AuthenticatedRequest['user'];
+        next();
+      }
+    );
+    requirePermissionMock.mockImplementation(
+      (_perm: string, _req: AuthenticatedRequest, _res: Response, next: NextFunction) => next()
+    );
+  });
+
+  describe('GET /api/v1/support/tickets/:ticketId', () => {
+    it('does not return internal-only fields to the reporter', async () => {
+      mockSupportTicketService.getTicketById.mockResolvedValue(buildFullTicket());
+
+      const res = await request(buildApp()).get(`/api/v1/support/tickets/${ticketId}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      assertNoInternalFields(res.body.data);
+      // Sanity check that the legitimate fields still survive
+      expect(res.body.data.ticketId).toBe(ticketId);
+      expect(res.body.data.subject).toBe('Something is broken');
+    });
+
+    it('strips internal staff replies from the conversation thread', async () => {
+      mockSupportTicketService.getTicketById.mockResolvedValue(buildFullTicket());
+
+      const res = await request(buildApp()).get(`/api/v1/support/tickets/${ticketId}`);
+
+      expect(res.status).toBe(200);
+      const responses = res.body.data.Responses ?? res.body.data.responses ?? [];
+      expect(Array.isArray(responses)).toBe(true);
+      expect(responses).toHaveLength(1);
+      expect(responses[0].responseId).toBe('resp-1');
+      expect(responses[0].isInternal).toBe(false);
+    });
+
+    it('returns 403 when the ticket does not belong to the authenticated user', async () => {
+      mockSupportTicketService.getTicketById.mockResolvedValue(
+        buildFullTicket({ userId: otherUserId })
+      );
+
+      const res = await request(buildApp()).get(`/api/v1/support/tickets/${ticketId}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('GET /api/v1/support/my-tickets', () => {
+    it('does not return internal-only fields on any ticket in the list', async () => {
+      mockSupportTicketService.getUserTickets.mockResolvedValue({
+        tickets: [buildFullTicket(), buildFullTicket({ ticketId: 'other-ticket' })],
+        pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+      });
+
+      const res = await request(buildApp()).get('/api/v1/support/my-tickets');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(2);
+      for (const ticket of res.body.data as Record<string, unknown>[]) {
+        assertNoInternalFields(ticket);
+      }
+    });
+  });
+
+  describe('POST /api/v1/support/tickets/:ticketId/reply', () => {
+    it('strips internal-only fields from the ticket returned after a reply', async () => {
+      mockSupportTicketService.getTicketById.mockResolvedValue(buildFullTicket());
+      mockSupportTicketService.addResponse.mockResolvedValue(buildFullTicket());
+      mockUser.findByPk.mockResolvedValue({
+        userId: reporterUserId,
+        firstName: 'R',
+        lastName: 'Eporter',
+      });
+
+      const res = await request(buildApp())
+        .post(`/api/v1/support/tickets/${ticketId}/reply`)
+        .send({ content: 'Thanks for getting back to me.' });
+
+      expect(res.status).toBe(200);
+      assertNoInternalFields(res.body.data);
+    });
+  });
+
+  describe('POST /api/v1/support/tickets', () => {
+    it('strips internal-only fields from the newly created ticket payload', async () => {
+      mockUser.findByPk.mockResolvedValue({
+        userId: reporterUserId,
+        firstName: 'R',
+        lastName: 'Eporter',
+        email: 'reporter@example.com',
+      });
+      mockSupportTicketService.createTicket.mockResolvedValue(buildFullTicket());
+
+      const res = await request(buildApp()).post('/api/v1/support/tickets').send({
+        subject: 'Hello',
+        description: 'A long enough description goes here.',
+        category: 'general_question',
+      });
+
+      expect(res.status).toBe(201);
+      assertNoInternalFields(res.body.data);
+    });
+  });
+});

--- a/service.backend/src/__tests__/security/feature-flags-endpoints.test.ts
+++ b/service.backend/src/__tests__/security/feature-flags-endpoints.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression guard for the feature-flag HTTP surface.
+ *
+ * The shared library `@adopt-dont-shop/lib.feature-flags` declares endpoint
+ * constants such as `/api/v1/features`, `/api/v1/features/user/:userId` and
+ * `/api/v1/config/remote`. Today these endpoints are *not* implemented in
+ * the backend — feature gates are evaluated client-side through Statsig and
+ * the constants are unused, leaving no server attack surface.
+ *
+ * If somebody adds a real backend handler for these paths in the future,
+ * this test will fail and force the author to (a) confirm the new handler
+ * requires `authenticateToken`, and (b) for the `:userId` evaluation route,
+ * confirm an ownership / admin guard is present. The point is to make any
+ * accidental "leak the list of unreleased feature names to an unauthenticated
+ * client" addition impossible without a deliberate review.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { resolve } from 'path';
+
+// The global test setup mocks `fs`, so we use `vi.importActual` to read the
+// real source from disk. Tests run with cwd = service.backend.
+const { readFileSync } = await vi.importActual<typeof import('node:fs')>('node:fs');
+const indexSource = readFileSync(resolve(process.cwd(), 'src/index.ts'), 'utf8');
+
+// The library currently exposes these path *literals* via
+// lib.feature-flags/src/constants/endpoints.ts. We hardcode them here rather
+// than importing the constants so that renaming the lib path would not
+// silently invalidate the guard.
+const FEATURE_FLAG_PATHS_THAT_MUST_REMAIN_UNMOUNTED = [
+  "'/api/v1/features'",
+  "'/api/v1/features/user'",
+  "'/api/v1/features/analytics'",
+  "'/api/v1/features/experiments'",
+  "'/api/v1/admin/features'",
+  "'/api/v1/config/remote'",
+] as const;
+
+describe('feature-flag endpoint surface', () => {
+  it.each(FEATURE_FLAG_PATHS_THAT_MUST_REMAIN_UNMOUNTED)(
+    'does not mount %s on the backend without explicit review',
+    path => {
+      // Whole-string match — guards against `app.use('/api/v1/features', ...)`
+      // style mounts that would expose flag names to anonymous clients.
+      expect(indexSource).not.toContain(path);
+    }
+  );
+});

--- a/service.backend/src/controllers/userSupport.controller.ts
+++ b/service.backend/src/controllers/userSupport.controller.ts
@@ -11,6 +11,60 @@ type PaginationOptions = {
   limit?: number;
 };
 
+/**
+ * Fields on SupportTicket that contain staff-only internal state and must
+ * NEVER be returned to the reporting user (the ticket's owner). These include
+ * internal triage notes, assigned-agent identity, escalation metadata and
+ * service-level operational timers. Reporters can see the public conversation
+ * and their own submitted data only.
+ */
+const REPORTER_FORBIDDEN_TICKET_FIELDS = [
+  'internalNotes',
+  'assignedTo',
+  'AssignedAgent',
+  'escalatedTo',
+  'escalationReason',
+  'escalatedAt',
+  'metadata',
+  'dueDate',
+  'estimatedResolutionTime',
+  'actualResolutionTime',
+] as const;
+
+type RawTicket = Record<string, unknown> & {
+  toJSON?: () => Record<string, unknown>;
+  Responses?: Array<Record<string, unknown> & { isInternal?: boolean }>;
+  responses?: Array<Record<string, unknown> & { isInternal?: boolean }>;
+};
+
+/**
+ * Strips internal-only fields from a ticket before returning to the reporter
+ * and drops any internal-only response messages. Operates on a plain object
+ * so callers may pass either a Sequelize instance or a plain object.
+ */
+const sanitizeTicketForReporter = (ticket: RawTicket): Record<string, unknown> => {
+  const plain: Record<string, unknown> =
+    typeof ticket.toJSON === 'function' ? ticket.toJSON() : { ...ticket };
+
+  for (const field of REPORTER_FORBIDDEN_TICKET_FIELDS) {
+    delete plain[field];
+  }
+
+  const responses =
+    (plain.Responses as RawTicket['Responses']) ?? (plain.responses as RawTicket['responses']);
+  if (Array.isArray(responses)) {
+    const publicResponses = responses.filter(r => !r.isInternal);
+    if ('Responses' in plain) {
+      plain.Responses = publicResponses;
+    }
+    if ('responses' in plain) {
+      plain.responses = publicResponses;
+    }
+  }
+
+  return plain;
+};
+
 export class UserSupportController {
   /**
    * POST /api/v1/support/tickets
@@ -56,7 +110,7 @@ export class UserSupportController {
 
     res.status(201).json({
       success: true,
-      data: ticket,
+      data: sanitizeTicketForReporter(ticket as unknown as RawTicket),
     });
   }
 
@@ -95,7 +149,7 @@ export class UserSupportController {
 
     res.json({
       success: true,
-      data: result.tickets,
+      data: result.tickets.map(t => sanitizeTicketForReporter(t as unknown as RawTicket)),
       pagination: result.pagination,
     });
   }
@@ -121,7 +175,7 @@ export class UserSupportController {
 
       res.json({
         success: true,
-        data: ticket,
+        data: sanitizeTicketForReporter(ticket as unknown as RawTicket),
       });
     } catch (error: unknown) {
       logger.error('Error in getMyTicket:', error);
@@ -183,7 +237,7 @@ export class UserSupportController {
 
       res.json({
         success: true,
-        data: updatedTicket,
+        data: sanitizeTicketForReporter(updatedTicket as unknown as RawTicket),
       });
     } catch (error: unknown) {
       logger.error('Error in replyToMyTicket:', error);


### PR DESCRIPTION
## Audit findings

### A. Feature-flag endpoints (`lib.feature-flags`) — CLEAN

`lib.feature-flags/src/constants/endpoints.ts` declares `FEATURE_FLAGS_ENDPOINTS` for `/api/v1/features`, `/api/v1/features/user/:userId`, `/api/v1/config/remote`, etc. However:

- **No backend handler exists for any of these paths.** Searched `service.backend/src` for route definitions; nothing mounts `/features`, `/features/user/:userId`, `/admin/features`, or `/config/remote`. The constants are unused dead exports.
- Feature gates are evaluated client-side via Statsig (`lib.feature-flags/src/hooks/useFeatureGate.ts` reads from `StatsigContext`), so there is no server attack surface to authenticate or scope.
- `/api/v1/config` IS mounted (in `service.backend/src/index.ts`) but it is a separate, deliberately public endpoint backed by `ConfigurationService.getPublicConfigurations()` which only returns configs flagged `isPublic=true`. It is unrelated to feature flags.

**No fix needed for concern A.** A regression test (`feature-flags-endpoints.test.ts`) was added to ensure that any future addition of one of these endpoints to `service.backend/src/index.ts` will force a deliberate review (so an authenticated/owner-scoped guard is added at the same time).

### B. Support-ticket field exposure (`UserSupportController`) — VULNERABLE, fixed

The reporter-facing controller methods returned full ticket rows including staff-internal state:

| Field | Source | Risk |
|---|---|---|
| `internalNotes` | model attribute | Free-text staff notes (`SupportTicket.ts:287-291`) — may include abuse flags, internal opinions about the user |
| `assignedTo` + `AssignedAgent` | service eager-loads agent's `userId/firstName/lastName/email` | Reveals identity & PII of the triage agent (`supportTicket.service.ts:162-166`) |
| `escalatedTo`, `escalationReason`, `escalatedAt` | model attributes | Reveals internal escalation routing and rationale |
| `metadata` | JSON | Free-form internal scoring/risk fields |
| `dueDate`, `estimatedResolutionTime`, `actualResolutionTime` | SLA timers | Reveals internal operational targets |

Affected endpoints (all under `/api/v1/support`, all returned full ticket objects):
- `POST /tickets` → `createMyTicket` (`userSupport.controller.ts:57`)
- `GET /my-tickets` → `getMyTickets` (`userSupport.controller.ts:96-100`)
- `GET /tickets/:ticketId` → `getMyTicket` (`userSupport.controller.ts:122-125`)
- `POST /tickets/:ticketId/reply` → `replyToMyTicket` (`userSupport.controller.ts:184-187`)

Note: `getMyTicketMessages` already filtered internal *responses*, but the ticket-row endpoints did not strip internal *fields* on the ticket itself. The field-permission middleware does not cover this resource — `FieldPermissionResource` in `lib.types/src/types/field-permissions.ts:20` is restricted to `'users' | 'pets' | 'applications' | 'rescues'`, so the existing fieldMask infrastructure cannot be applied here today.

### Fix

Added a small `sanitizeTicketForReporter` helper in `userSupport.controller.ts` that strips the staff-only fields and filters internal-only responses out of the conversation thread. Applied to all four reporter-facing endpoints.

## Test plan

- [x] `npx vitest run src/__tests__/routes/userSupport.routes.test.ts` — 6 new tests pass (one per affected endpoint, plus an ownership-403 case and an internal-response-stripping case)
- [x] `npx vitest run src/__tests__/security/feature-flags-endpoints.test.ts` — 6 new guard tests pass
- [x] `npx vitest run` (full service.backend suite) — 169 files / 2502 tests pass, 0 failures
- [x] `npx tsc --noEmit` (service.backend) — clean
- [x] `npx eslint --fix` on touched files — clean (only pre-existing warnings, not introduced by this PR)

https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_