### PR TITLE
fix(security): harden Socket.IO transport check + Vary: Origin

### DIFF
--- a/service.backend/src/__tests__/security/cors-and-transport.test.ts
+++ b/service.backend/src/__tests__/security/cors-and-transport.test.ts
@@ -1,0 +1,90 @@
+import express from 'express';
+import cors from 'cors';
+import request from 'supertest';
+import { isProductionLike } from '../../config/env';
+
+describe('isProductionLike', () => {
+  // Misconfigured NODE_ENV values (e.g. 'Production', 'PROD') previously
+  // tripped a strict-equality check and silently enabled HTTP long-polling
+  // as a Socket.IO transport in production. Lock the case-insensitive
+  // behaviour in.
+  it('returns true for canonical lowercase "production"', () => {
+    expect(isProductionLike('production')).toBe(true);
+  });
+
+  it('returns true for "Production" (mixed case)', () => {
+    expect(isProductionLike('Production')).toBe(true);
+  });
+
+  it('returns true for "PRODUCTION" (uppercase)', () => {
+    expect(isProductionLike('PRODUCTION')).toBe(true);
+  });
+
+  it('returns true for short alias "prod"', () => {
+    expect(isProductionLike('prod')).toBe(true);
+  });
+
+  it('returns true for "PROD" (uppercase alias)', () => {
+    expect(isProductionLike('PROD')).toBe(true);
+  });
+
+  it('trims surrounding whitespace before comparing', () => {
+    expect(isProductionLike(' production ')).toBe(true);
+  });
+
+  it('returns false for "development"', () => {
+    expect(isProductionLike('development')).toBe(false);
+  });
+
+  it('returns false for "test"', () => {
+    expect(isProductionLike('test')).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isProductionLike(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isProductionLike('')).toBe(false);
+  });
+});
+
+describe('Vary: Origin middleware', () => {
+  // ADS-defense-in-depth: without an explicit Vary: Origin a CDN / shared
+  // cache could serve an origin-A response to an origin-B request. The
+  // explicit middleware after cors() guarantees the header is set on every
+  // response regardless of which CORS code path the request went through.
+  const buildApp = () => {
+    const app = express();
+    app.use(
+      cors({
+        origin: ['http://localhost:3000'],
+        credentials: true,
+      })
+    );
+    app.use((_req, res, next) => {
+      res.vary('Origin');
+      next();
+    });
+    app.get('/health', (_req, res) => res.json({ ok: true }));
+    return app;
+  };
+
+  it('sets Vary: Origin on same-origin (non-CORS) GET responses', async () => {
+    const response = await request(buildApp()).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.vary).toBeDefined();
+    expect(response.headers.vary).toMatch(/Origin/i);
+  });
+
+  it('sets Vary: Origin on cross-origin GET responses', async () => {
+    const response = await request(buildApp())
+      .get('/health')
+      .set('Origin', 'http://localhost:3000');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.vary).toBeDefined();
+    expect(response.headers.vary).toMatch(/Origin/i);
+  });
+});

--- a/service.backend/src/config/env.ts
+++ b/service.backend/src/config/env.ts
@@ -61,6 +61,20 @@ type ValidatedEnv = {
   ANON_SWIPE_LIMIT?: string;
 };
 
+/**
+ * Case-insensitive check for "production-like" NODE_ENV values.
+ *
+ * The strict equality check `nodeEnv === 'production'` silently treats any
+ * casing other than the canonical lowercase string as non-production. That
+ * misconfiguration can downgrade prod-only hardening (e.g. enabling HTTP
+ * long-polling as a Socket.IO transport, which weakens cookie/CSRF posture)
+ * without surfacing as an error. Accept the common variants instead.
+ */
+export const isProductionLike = (nodeEnv: string | undefined): boolean => {
+  const normalised = nodeEnv?.trim().toLowerCase();
+  return normalised === 'production' || normalised === 'prod';
+};
+
 export type DbSslMode = 'disable' | 'require' | 'verify-ca' | 'verify-full';
 
 const DB_SSL_MODES: readonly DbSslMode[] = ['disable', 'require', 'verify-ca', 'verify-full'];

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -9,6 +9,7 @@ import helmet from 'helmet';
 import { createServer } from 'http';
 import { Server as SocketIOServer } from 'socket.io';
 import { config } from './config';
+import { isProductionLike } from './config/env';
 import { HSTS_MAX_AGE_ONE_YEAR_SECONDS } from './constants/security';
 import { errorHandler } from './middleware/error-handler';
 import { csrfProtection, csrfErrorHandler, getCsrfToken } from './middleware/csrf';
@@ -116,7 +117,7 @@ const io = new SocketIOServer(server, {
     allowedHeaders: ALLOWED_CORS_HEADERS,
     credentials: true,
   },
-  transports: config.nodeEnv === 'production' ? ['websocket'] : ['websocket', 'polling'],
+  transports: isProductionLike(config.nodeEnv) ? ['websocket'] : ['websocket', 'polling'],
 });
 
 // Apply middleware
@@ -127,6 +128,17 @@ app.use(
     allowedHeaders: ALLOWED_CORS_HEADERS,
   })
 );
+
+// Defence in depth: explicitly append `Vary: Origin` on every response so a
+// CDN / shared cache can't serve an origin-A response to an origin-B
+// request. The `cors` middleware already sets Vary on the responses it
+// directly handles (preflights, reflected origins), but not consistently on
+// pass-through GETs. `res.vary` appends rather than overwrites, so it's safe
+// alongside any future Vary setters.
+app.use((_req, res, next) => {
+  res.vary('Origin');
+  next();
+});
 
 // Sentry instrumentation - automatically instruments Express
 // Note: In Sentry v8+, instrumentation is automatic with setupExpressErrorHandler


### PR DESCRIPTION
## Summary

Two small defence-in-depth fixes on the HTTP entry point (`service.backend/src/index.ts`):

- **Socket.IO transports — case-insensitive prod check.** The previous `config.nodeEnv === 'production'` strict-equality check silently degraded to the dev transport list (`['websocket', 'polling']`) on any misconfigured casing (`Production`, `PROD`, `prod`, surrounding whitespace, etc.). That re-enabled HTTP long-polling in prod and weakened cookie/CSRF posture. Replaced with a tiny case-insensitive `isProductionLike` helper in `config/env.ts` so the normalisation is unit-testable.
- **`Vary: Origin` on every CORS response.** The `cors` middleware sets `Vary: Origin` for the responses it directly handles (preflights, reflected origins), but not consistently for pass-through GETs. Without it, a future CDN / shared cache could serve an origin-A response to an origin-B request. Added an explicit `app.use((_req, res, next) => { res.vary('Origin'); next(); })` immediately after `cors(...)`. `res.vary` appends rather than overwrites, so it stays safe alongside any future Vary setters.

Behaviour-driven tests live in `service.backend/src/__tests__/security/cors-and-transport.test.ts`:
- `isProductionLike` covers `'production'`, `'Production'`, `'PRODUCTION'`, `'prod'`, `'PROD'`, `' production '`, `'development'`, `'test'`, `undefined`, `''`.
- A supertest harness asserts `Vary` contains `Origin` on both same-origin and cross-origin GETs.

## Test plan

- [ ] `npx vitest run src/__tests__/security/cors-and-transport.test.ts` passes (12/12)
- [ ] `npx vitest run src/__tests__/security/` stays green (74/74)
- [ ] `npx tsc --noEmit` clean in `service.backend`
- [ ] `npx eslint --fix` on touched files shows no new errors
- [ ] Manual: boot with `NODE_ENV=Production` and confirm Socket.IO advertises only `websocket`
- [ ] Manual: `curl -i http://localhost:5000/api/v1/health` shows a `Vary: Origin` header

https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_