### PR TITLE
fix(security): device-token fingerprint preservation + email header sanitisation

### DIFF
--- a/service.backend/src/__tests__/routes/device-token.routes.test.ts
+++ b/service.backend/src/__tests__/routes/device-token.routes.test.ts
@@ -132,6 +132,106 @@ describe('POST /api/v1/device-tokens (ADS-611)', () => {
     expect(res.status).toBe(400);
     expect(mockedDeviceToken.findOrCreate).not.toHaveBeenCalled();
   });
+
+  it('preserves fingerprint metadata when re-registering an existing token', async () => {
+    // Defense-in-depth: if device fingerprinting / trust scoring is ever
+    // added, an attacker must not be able to overwrite the stored
+    // platform / appVersion / deviceInfo on an existing row by simply
+    // re-POSTing the same token with crafted values.
+    authenticateAs('user-1');
+    const existing = makeDeviceTokenRow({
+      platform: 'ios',
+      app_version: '1.0.0',
+      device_info: { model: 'iPhone' },
+    });
+    mockedDeviceToken.findOrCreate.mockResolvedValue([existing, false]);
+
+    const res = await request(buildApp())
+      .post('/api/v1/device-tokens')
+      .send({
+        token: 'fcm-token-abcdef0123',
+        platform: 'android',
+        appVersion: '9.9.9',
+        deviceInfo: { model: 'attacker-device' },
+      });
+
+    expect(res.status).toBe(201);
+    expect(markAsUsed).toHaveBeenCalled();
+    expect(save).toHaveBeenCalled();
+    // Metadata on the existing row must remain untouched.
+    expect(existing.platform).toBe('ios');
+    expect(existing.app_version).toBe('1.0.0');
+    expect(existing.device_info).toEqual({ model: 'iPhone' });
+  });
+
+  it('persists all metadata when a brand-new token is registered', async () => {
+    authenticateAs('user-1');
+    const created = makeDeviceTokenRow({
+      platform: 'android',
+      app_version: '2.0.0',
+      device_info: { model: 'Pixel' },
+    });
+    mockedDeviceToken.findOrCreate.mockResolvedValue([created, true]);
+
+    const res = await request(buildApp())
+      .post('/api/v1/device-tokens')
+      .send({
+        token: 'fcm-token-newdevice0123',
+        platform: 'android',
+        appVersion: '2.0.0',
+        deviceInfo: { model: 'Pixel' },
+      });
+
+    expect(res.status).toBe(201);
+    // defaults: are what created the row, so the row already carries
+    // the submitted metadata — assert the findOrCreate call captured it.
+    expect(mockedDeviceToken.findOrCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaults: expect.objectContaining({
+          platform: 'android',
+          app_version: '2.0.0',
+          device_info: { model: 'Pixel' },
+        }),
+      })
+    );
+  });
+
+  it('keeps two different tokens for the same user independent', async () => {
+    authenticateAs('user-1');
+    const rowA = makeDeviceTokenRow({ token_id: 'tok-a', device_token: 'token-a-0123456789' });
+    mockedDeviceToken.findOrCreate.mockResolvedValueOnce([rowA, true]);
+
+    const resA = await request(buildApp()).post('/api/v1/device-tokens').send({
+      token: 'token-a-0123456789',
+      platform: 'ios',
+    });
+    expect(resA.status).toBe(201);
+    expect(resA.body.data.tokenId).toBe('tok-a');
+
+    const rowB = makeDeviceTokenRow({ token_id: 'tok-b', device_token: 'token-b-0123456789' });
+    mockedDeviceToken.findOrCreate.mockResolvedValueOnce([rowB, true]);
+
+    const resB = await request(buildApp()).post('/api/v1/device-tokens').send({
+      token: 'token-b-0123456789',
+      platform: 'android',
+    });
+    expect(resB.status).toBe(201);
+    expect(resB.body.data.tokenId).toBe('tok-b');
+
+    // Each registration is scoped by both user_id AND device_token.
+    expect(mockedDeviceToken.findOrCreate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: { user_id: 'user-1', device_token: 'token-a-0123456789' },
+      })
+    );
+    expect(mockedDeviceToken.findOrCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { user_id: 'user-1', device_token: 'token-b-0123456789' },
+      })
+    );
+  });
 });
 
 describe('GET /api/v1/device-tokens (ADS-611)', () => {

--- a/service.backend/src/__tests__/services/email.service.test.ts
+++ b/service.backend/src/__tests__/services/email.service.test.ts
@@ -299,6 +299,72 @@ describe('EmailService - Real Database Testing', () => {
         ).rejects.toThrow('Template is not active');
       });
     });
+
+    describe('header field sanitisation (defense-in-depth)', () => {
+      // If toName / fromName / subject / replyToEmail are ever sourced from
+      // user-controlled input, a `\r\n` in the value would let an attacker
+      // inject extra headers (CC/BCC/X-headers) into the outbound email.
+      // The strip is done before persisting to the EmailQueue row so the
+      // value handed to any provider — Resend, Postmark, future — is clean.
+      it('strips CR/LF from toName before persisting', async () => {
+        const emailId = await emailService.sendEmail({
+          toEmail: 'user@example.com',
+          toName: 'Alice\r\nBcc: attacker@example.com',
+          subject: 'Hi',
+          htmlContent: '<p>Hi</p>',
+          type: EmailType.TRANSACTIONAL,
+        });
+
+        const queued = await EmailQueue.findByPk(emailId);
+        expect(queued?.toName).toBe('AliceBcc: attacker@example.com');
+        expect(queued?.toName).not.toMatch(/[\r\n]/);
+      });
+
+      it('strips CR/LF from subject', async () => {
+        const emailId = await emailService.sendEmail({
+          toEmail: 'user@example.com',
+          subject: 'Hello\nX-Spoof: yes',
+          htmlContent: '<p>body</p>',
+          type: EmailType.TRANSACTIONAL,
+        });
+
+        const queued = await EmailQueue.findByPk(emailId);
+        expect(queued?.subject).toBe('HelloX-Spoof: yes');
+      });
+
+      it('strips CR/LF from fromName (a *Name field paired with an email)', async () => {
+        // The email address fields are guarded by isEmail at the model
+        // level, but the display-name fields are free-form strings —
+        // they're the realistic header-injection surface.
+        const emailId = await emailService.sendEmail({
+          fromName: 'Sender\r\nName',
+          toEmail: 'user@example.com',
+          subject: 'Hi',
+          htmlContent: '<p>Hi</p>',
+          type: EmailType.TRANSACTIONAL,
+        });
+
+        const queued = await EmailQueue.findByPk(emailId);
+        expect(queued?.fromName).toBe('SenderName');
+        expect(queued?.fromName).not.toMatch(/[\r\n]/);
+      });
+
+      it('does NOT strip newlines from the html or text body', async () => {
+        const html = '<p>line one</p>\n<p>line two</p>';
+        const text = 'line one\nline two';
+        const emailId = await emailService.sendEmail({
+          toEmail: 'user@example.com',
+          subject: 'Hi',
+          htmlContent: html,
+          textContent: text,
+          type: EmailType.TRANSACTIONAL,
+        });
+
+        const queued = await EmailQueue.findByPk(emailId);
+        expect(queued?.htmlContent).toBe(html);
+        expect(queued?.textContent).toBe(text);
+      });
+    });
   });
 
   describe('User email preferences', () => {

--- a/service.backend/src/routes/device-token.routes.ts
+++ b/service.backend/src/routes/device-token.routes.ts
@@ -45,14 +45,14 @@ router.post(
         },
       });
 
+      // Defense-in-depth (ADS-611): on re-registration of an EXISTING
+      // token, only bump last-used. Do NOT overwrite platform /
+      // app_version / device_info from the request payload — those
+      // fields are device-fingerprint inputs and any future fraud/
+      // trust-risk scoring must see the original values, not whatever
+      // the latest caller submitted. New tokens get full metadata via
+      // `defaults` above on creation only.
       device.markAsUsed();
-      device.platform = platform;
-      if (appVersion !== undefined) {
-        device.app_version = appVersion;
-      }
-      if (deviceInfo !== undefined) {
-        device.device_info = deviceInfo;
-      }
       await device.save();
 
       return res.status(201).json({ data: { tokenId: device.token_id } });

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -26,6 +26,25 @@ type ProviderInfo = {
   inboxUrl: string;
 } | null;
 
+/**
+ * Defense-in-depth header-injection guard. Any field that ends up in an
+ * email header position (to, from, cc, bcc, replyTo, subject, *Name) is
+ * passed through this before being persisted / handed to the provider.
+ *
+ * Today these values are sourced from trusted internal data, but if any
+ * are ever extended to accept user input (display-name on a profile,
+ * custom subject from an admin tool, etc.) a `\r\n` in the value could
+ * inject additional headers (CC/BCC/X-headers). The underlying provider
+ * SDK probably strips these too, but enforcing it here means we don't
+ * depend on which provider is wired up.
+ *
+ * MUST NOT be applied to the email body — that would corrupt legitimate
+ * line breaks in html/text content.
+ */
+const stripHeaderField = (s: string): string => s.replace(/[\r\n]/g, '');
+const stripHeaderFieldOptional = (s: string | undefined): string | undefined =>
+  typeof s === 'string' ? stripHeaderField(s) : s;
+
 class EmailService {
   private provider: EmailProvider;
   private isProcessing = false;
@@ -479,18 +498,24 @@ class EmailService {
         }
       }
 
+      // Defense-in-depth: strip CR/LF from every field that ends up in
+      // a header position before persisting. See `stripHeaderField` doc
+      // at top of file. Body fields (htmlContent / textContent) MUST
+      // NOT be stripped — legitimate line breaks belong there.
+
       // Create email queue entry
       const email = await EmailQueue.create({
         templateId: options.templateId,
-        fromEmail:
-          options.fromEmail || process.env.DEFAULT_FROM_EMAIL || 'noreply@adoptdontshop.com',
-        fromName: options.fromName || "Adopt Don't Shop",
-        toEmail: options.toEmail,
-        toName: options.toName,
-        ccEmails: options.ccEmails || [],
-        bccEmails: options.bccEmails || [],
-        replyToEmail: options.replyToEmail,
-        subject,
+        fromEmail: stripHeaderField(
+          options.fromEmail || process.env.DEFAULT_FROM_EMAIL || 'noreply@adoptdontshop.com'
+        ),
+        fromName: stripHeaderField(options.fromName || "Adopt Don't Shop"),
+        toEmail: stripHeaderField(options.toEmail),
+        toName: stripHeaderFieldOptional(options.toName),
+        ccEmails: (options.ccEmails || []).map(stripHeaderField),
+        bccEmails: (options.bccEmails || []).map(stripHeaderField),
+        replyToEmail: stripHeaderFieldOptional(options.replyToEmail),
+        subject: stripHeaderField(subject),
         htmlContent,
         textContent,
         templateData: options.templateData || {},


### PR DESCRIPTION
## Summary

Two low-severity defense-in-depth hardenings:

- **Device token re-registration** (`service.backend/src/routes/device-token.routes.ts`) — `findOrCreate` previously called `markAsUsed()` AND overwrote `platform` / `app_version` / `device_info` on every POST, even when the row already existed. These fields are device-fingerprint inputs; if a future fraud / trust-risk score is layered on top, an attacker could overwrite their first-observed fingerprint by re-POSTing the same token. Existing rows now only bump `last_used_at`; new rows still capture full metadata via the `findOrCreate` `defaults`.
- **Email header injection guard** (`service.backend/src/services/email.service.ts`) — added a tiny in-file `stripHeaderField` helper and applied it to every header-bound field (`to`, `from`, `cc`, `bcc`, `replyTo`, `subject`, paired display-names) before persisting to `EmailQueue`. Body fields (`htmlContent` / `textContent`) are deliberately left untouched so legitimate line breaks survive. Defends against future cases where any of these fields starts accepting user-controlled input.

## Test plan

- [x] `npx vitest run src/__tests__/routes/device-token.routes.test.ts` — 10/10 pass (4 new behaviours: existing-token preservation, new-token persistence, two-tokens independence, plus the original coverage)
- [x] `npx vitest run src/__tests__/services/email.service.test.ts` — 17/17 pass (4 new behaviours: toName / subject / fromName stripped, html+text bodies preserved)
- [x] `npx tsc --noEmit` clean for `service.backend`
- [x] `npx eslint` clean on the four touched files

https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1Ls1SusVXZK6rduscgSQq)_