### PR TITLE
feat(ADS-7): consolidate preference enums into lib.types shared package

### DIFF
--- a/app.client/package.json
+++ b/app.client/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@adopt-dont-shop/lib.analytics": "*",
     "@adopt-dont-shop/lib.api": "*",
+    "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/lib.applications": "*",
     "@adopt-dont-shop/lib.auth": "*",
     "@adopt-dont-shop/lib.chat": "*",

--- a/app.client/src/components/profile/SettingsForm.tsx
+++ b/app.client/src/components/profile/SettingsForm.tsx
@@ -2,6 +2,7 @@ import notificationService from '@/services/notificationService';
 import { User } from '@/types';
 import { Button, ThemeToggle } from '@adopt-dont-shop/lib.components';
 import { TwoFactorSettings } from '@adopt-dont-shop/lib.auth';
+import { ProfileVisibility } from '@adopt-dont-shop/lib.types';
 import React, { useEffect, useState } from 'react';
 import * as styles from './SettingsForm.css';
 
@@ -19,7 +20,7 @@ interface UserSettings {
     quietHoursEnd?: string;
   };
   privacy: {
-    profileVisibility: 'public' | 'private';
+    profileVisibility: ProfileVisibility;
     showEmail: boolean;
     showPhone: boolean;
   };
@@ -57,7 +58,7 @@ export const SettingsForm: React.FC<SettingsFormProps> = ({
       quietHoursEnd: '08:00',
     },
     privacy: {
-      profileVisibility: 'public',
+      profileVisibility: ProfileVisibility.PUBLIC,
       showEmail: false,
       showPhone: false,
     },
@@ -349,11 +350,18 @@ export const SettingsForm: React.FC<SettingsFormProps> = ({
               <select
                 className={styles.select}
                 value={settings.privacy.profileVisibility}
-                onChange={e => handleSelectChange('privacy', 'profileVisibility', e.target.value)}
+                onChange={e =>
+                  handleSelectChange(
+                    'privacy',
+                    'profileVisibility',
+                    e.target.value as ProfileVisibility
+                  )
+                }
                 disabled={isLoading}
               >
-                <option value='public'>Public</option>
-                <option value='private'>Private</option>
+                <option value={ProfileVisibility.PUBLIC}>Public</option>
+                <option value={ProfileVisibility.RESCUES_ONLY}>Rescues only</option>
+                <option value={ProfileVisibility.PRIVATE}>Private</option>
               </select>
             </div>
           </div>
@@ -516,7 +524,7 @@ export const SettingsForm: React.FC<SettingsFormProps> = ({
                     quietHoursEnd: '08:00',
                   },
                   privacy: {
-                    profileVisibility: 'public',
+                    profileVisibility: ProfileVisibility.PUBLIC,
                     showEmail: false,
                     showPhone: false,
                   },

--- a/app.client/src/pages/ProfilePage.tsx
+++ b/app.client/src/pages/ProfilePage.tsx
@@ -5,6 +5,7 @@ import {
   SettingsForm,
 } from '@/components/profile';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
+import { ProfileVisibility } from '@adopt-dont-shop/lib.types';
 import { applicationService, authService, Application, User } from '@/services';
 import {
   Alert,
@@ -37,7 +38,7 @@ interface UserSettings {
     marketing?: boolean;
   };
   privacy?: {
-    profileVisibility?: 'public' | 'private';
+    profileVisibility?: ProfileVisibility;
     showEmail?: boolean;
     showPhone?: boolean;
   };

--- a/app.client/src/types/index.ts
+++ b/app.client/src/types/index.ts
@@ -1,3 +1,7 @@
+import { ProfileVisibility } from '@adopt-dont-shop/lib.types';
+
+export { ProfileVisibility };
+
 // User and Authentication Types
 export interface User {
   userId: string;
@@ -26,7 +30,7 @@ export interface User {
     country?: string;
   };
   privacySettings?: {
-    profileVisibility?: string;
+    profileVisibility?: ProfileVisibility;
     showLocation?: boolean;
     allowMessages?: boolean;
     showAdoptionHistory?: boolean;

--- a/lib.types/src/index.ts
+++ b/lib.types/src/index.ts
@@ -1,6 +1,9 @@
 // Core RBAC types
 export * from './types';
 
+// User preference enums
+export * from './types/preferences';
+
 // Rescue-specific permission constants
 export * from './types/rescue-permissions';
 

--- a/lib.types/src/types/preferences.ts
+++ b/lib.types/src/types/preferences.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// User preference enums — single source of truth shared across backend models
+// and frontend forms. No runtime dependencies; safe for both environments.
+// ---------------------------------------------------------------------------
+
+export enum ProfileVisibility {
+  PUBLIC = 'public',
+  RESCUES_ONLY = 'rescues_only',
+  PRIVATE = 'private',
+}
+
+export enum DigestFrequency {
+  IMMEDIATE = 'immediate',
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  NEVER = 'never',
+}

--- a/lib.types/tsconfig.cjs.json
+++ b/lib.types/tsconfig.cjs.json
@@ -4,7 +4,7 @@
     "target": "ES2020",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "declaration": false,
     "declarationMap": false,
     "sourceMap": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,6 +187,7 @@
         "@adopt-dont-shop/lib.pets": "*",
         "@adopt-dont-shop/lib.rescue": "*",
         "@adopt-dont-shop/lib.search": "*",
+        "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/lib.validation": "*",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -690,8 +691,8 @@
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-tooltip": "^1.0.7",
         "clsx": "^2.1.1",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "react-world-flags": "^1.6.0",
         "recharts": "^2.12.6",
         "sonner": "^2.0.7"

--- a/service.backend/src/models/UserNotificationPrefs.ts
+++ b/service.backend/src/models/UserNotificationPrefs.ts
@@ -1,13 +1,9 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getUuidType } from '../sequelize';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+import { DigestFrequency } from '@adopt-dont-shop/lib.types';
 
-export enum DigestFrequency {
-  IMMEDIATE = 'immediate',
-  DAILY = 'daily',
-  WEEKLY = 'weekly',
-  NEVER = 'never',
-}
+export { DigestFrequency };
 
 /**
  * Per-user notification preferences (plan 5.6 — typed preference table

--- a/service.backend/src/models/UserPrivacyPrefs.ts
+++ b/service.backend/src/models/UserPrivacyPrefs.ts
@@ -1,12 +1,9 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getUuidType } from '../sequelize';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+import { ProfileVisibility } from '@adopt-dont-shop/lib.types';
 
-export enum ProfileVisibility {
-  PUBLIC = 'public',
-  RESCUES_ONLY = 'rescues_only',
-  PRIVATE = 'private',
-}
+export { ProfileVisibility };
 
 /**
  * Per-user privacy preferences (plan 5.6 — typed preference table


### PR DESCRIPTION
## Summary

Closes [ADS-7](https://linear.app/ideasquared/issue/ADS-7/consolidate-fragmented-user-preference-models-into-a-shared-library)

- Move `ProfileVisibility` and `DigestFrequency` enums from backend-only model files into `lib.types` so both backend and frontend share a single source of truth
- Backend models (`UserPrivacyPrefs`, `UserNotificationPrefs`) now import from `@adopt-dont-shop/lib.types` and re-export for full backward compatibility — no service imports needed changing
- `app.client` gains `lib.types` as a direct dependency; `User.privacySettings.profileVisibility` is now typed as `ProfileVisibility` instead of `string`
- `SettingsForm` and `ProfilePage` updated to use the `ProfileVisibility` enum; the previously missing `rescues_only` option is also added to the visibility dropdown
- Fix pre-existing `ignoreDeprecations` version in `lib.types/tsconfig.cjs.json` (TypeScript 6.x requires `"6.0"` not `"5.0"`)

## Test plan

- [x] `lib.types` type-check passes (`tsc --noEmit`)
- [x] `lib.types` tests pass (34/34)
- [x] `lib.types` build produces ESM + CJS dist cleanly
- [x] `service.backend` type-check passes with updated model imports
- [x] No new type errors introduced in `app.client` files (pre-existing errors are unrelated missing builds)
- [ ] Verify profile settings page renders `Rescues only` visibility option in browser

---
_Generated by [Claude Code](https://claude.ai/code/session_014M16BY23vK5Cx7ysCDeCFQ)_