### PR TITLE
security: pass-9 fixes (EXIF + uploads, email NFKC, socket presence, frontend auth lifecycle, GDPR attachments, Statsig/Sentry PII, role-change push)

### DIFF
--- a/app.admin/src/contexts/StatsigContext.tsx
+++ b/app.admin/src/contexts/StatsigContext.tsx
@@ -19,8 +19,9 @@ export const StatsigWrapper: React.FC<StatsigWrapperProps> = ({ children }) => {
 
   const statsigUser = useMemo(
     () => ({
+      // Email is intentionally omitted — Statsig is a third-party SaaS
+      // and the opaque userID is sufficient for flag bucketing.
       userID: user?.userId || 'anonymous',
-      email: user?.email,
       custom: {
         app: 'admin',
         userType: user?.userType,

--- a/app.admin/src/main.tsx
+++ b/app.admin/src/main.tsx
@@ -80,6 +80,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           allowedUserTypes={['admin', 'moderator']}
           appType='admin'
           onAuthEvent={handleAuthEvent}
+          onLogout={() => queryClient.clear()}
         >
           <StatsigWrapper>
             <ThemeProvider>

--- a/app.client/src/contexts/StatsigContext.tsx
+++ b/app.client/src/contexts/StatsigContext.tsx
@@ -34,18 +34,18 @@ export const StatsigWrapper: React.FC<StatsigWrapperProps> = ({ children }) => {
 
   const statsigUser = useMemo(
     () => ({
-      // Until consent is granted we deliberately omit the email so PII does
-      // not leave the device. Statsig still gets an opaque userID so feature
-      // flags work, but session replay / autocapture stay off.
+      // Email is intentionally omitted regardless of consent — Statsig is
+      // a third-party SaaS and the opaque userID is sufficient for flag
+      // bucketing. Session replay / autocapture plugins remain gated on
+      // analytics consent below.
       userID: user?.userId || 'anonymous',
-      email: analyticsConsent ? user?.email : undefined,
       custom: {
         app: 'client',
         userType: user?.userType,
         isAuthenticated: !!user,
       },
     }),
-    [user, analyticsConsent]
+    [user]
   );
 
   const plugins = useMemo(

--- a/app.client/src/main.tsx
+++ b/app.client/src/main.tsx
@@ -60,7 +60,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider allowedUserTypes={['adopter']} appType='client'>
+        <AuthProvider
+          allowedUserTypes={['adopter']}
+          appType='client'
+          onLogout={() => queryClient.clear()}
+        >
           <StatsigWrapper>
             <ThemeProvider>
               <BrowserRouter>

--- a/app.rescue/src/components/AppWithAuth.tsx
+++ b/app.rescue/src/components/AppWithAuth.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { AuthProvider } from '@adopt-dont-shop/lib.auth';
 import { attachStoredCookieConsent } from '@adopt-dont-shop/lib.legal';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface AppWithAuthProps {
   children: ReactNode;
@@ -23,11 +24,14 @@ const handleAuthEvent = (event: string, data?: Record<string, unknown>) => {
  * Wrapper component that provides AuthProvider for rescue app
  */
 export const AppWithAuth = ({ children }: AppWithAuthProps) => {
+  // QueryClient is provided one level up in main.tsx so the hook resolves here.
+  const queryClient = useQueryClient();
   return (
     <AuthProvider
       allowedUserTypes={['rescue_staff']}
       appType="rescue"
       onAuthEvent={handleAuthEvent}
+      onLogout={() => queryClient.clear()}
     >
       {children}
     </AuthProvider>

--- a/app.rescue/src/contexts/StatsigContext.tsx
+++ b/app.rescue/src/contexts/StatsigContext.tsx
@@ -19,8 +19,9 @@ export const StatsigWrapper: React.FC<StatsigWrapperProps> = ({ children }) => {
 
   const statsigUser = useMemo(
     () => ({
+      // Email is intentionally omitted — Statsig is a third-party SaaS
+      // and the opaque userID is sufficient for flag bucketing.
       userID: user?.userId || 'anonymous',
-      email: user?.email,
       custom: {
         app: 'rescue',
         userType: user?.userType,

--- a/lib.api/src/__tests__/api-service.test.ts
+++ b/lib.api/src/__tests__/api-service.test.ts
@@ -504,6 +504,126 @@ describe('ApiService', () => {
     });
   });
 
+  describe('401 token refresh single-flight', () => {
+    const jsonHeaders = () => new Headers([['content-type', 'application/json']]);
+
+    const respond = (status: number, body: unknown) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 401 ? 'Unauthorized' : 'OK',
+        headers: jsonHeaders(),
+        json: () => Promise.resolve(body),
+      }) as Response;
+
+    beforeEach(() => {
+      apiService = new ApiService({ apiUrl: 'https://api.example.com' });
+    });
+
+    it('refreshes once and retries the request when a 401 comes back', async () => {
+      const refreshHandler = vi.fn().mockResolvedValue(undefined);
+      apiService.setRefreshHandler(refreshHandler);
+
+      // First call: 401. Then refresh-retry: 200.
+      mockFetch
+        .mockResolvedValueOnce(respond(401, { message: 'Token expired' }))
+        .mockResolvedValueOnce(respond(200, { ok: true }));
+
+      const result = await apiService.get<{ ok: boolean }>('/protected');
+
+      expect(refreshHandler).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('shares a single refresh across parallel 401 requests', async () => {
+      let resolveRefresh: (() => void) | undefined;
+      const refreshHandler = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+      apiService.setRefreshHandler(refreshHandler);
+
+      // Two parallel 401s, then two successful retries.
+      mockFetch
+        .mockResolvedValueOnce(respond(401, { message: 'expired' }))
+        .mockResolvedValueOnce(respond(401, { message: 'expired' }))
+        .mockResolvedValueOnce(respond(200, { ok: true, n: 1 }))
+        .mockResolvedValueOnce(respond(200, { ok: true, n: 2 }));
+
+      const p1 = apiService.get<{ n: number }>('/a');
+      const p2 = apiService.get<{ n: number }>('/b');
+
+      // Yield repeatedly so both initial fetches resolve, each sees 401,
+      // and both queue on the same refresh promise before we release it.
+      for (let i = 0; i < 10 && refreshHandler.mock.calls.length === 0; i++) {
+        await Promise.resolve();
+      }
+      expect(refreshHandler).toHaveBeenCalledTimes(1);
+
+      resolveRefresh?.();
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      expect(refreshHandler).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(r1.n).toBe(1);
+      expect(r2.n).toBe(2);
+    });
+
+    it('falls through to onUnauthorized when the refresh itself fails', async () => {
+      const onUnauthorized = vi.fn();
+      apiService = new ApiService({ apiUrl: 'https://api.example.com', onUnauthorized });
+
+      const refreshHandler = vi.fn().mockRejectedValue(new Error('refresh denied'));
+      apiService.setRefreshHandler(refreshHandler);
+
+      mockFetch.mockResolvedValueOnce(respond(401, { message: 'expired' }));
+
+      await expect(apiService.get('/protected')).rejects.toThrow('expired');
+      expect(refreshHandler).toHaveBeenCalledTimes(1);
+      // No retry was attempted.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not attempt refresh when the failing request is the refresh endpoint itself', async () => {
+      const refreshHandler = vi.fn().mockResolvedValue(undefined);
+      const onUnauthorized = vi.fn();
+      apiService = new ApiService({ apiUrl: 'https://api.example.com', onUnauthorized });
+      apiService.setRefreshHandler(refreshHandler);
+
+      mockFetch.mockResolvedValueOnce(respond(401, { message: 'no refresh cookie' }));
+
+      await expect(
+        apiService.fetch('/api/v1/auth/refresh-token', { method: 'GET' })
+      ).rejects.toThrow('no refresh cookie');
+
+      expect(refreshHandler).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to onUnauthorized when the retried request also returns 401', async () => {
+      const onUnauthorized = vi.fn();
+      apiService = new ApiService({ apiUrl: 'https://api.example.com', onUnauthorized });
+
+      const refreshHandler = vi.fn().mockResolvedValue(undefined);
+      apiService.setRefreshHandler(refreshHandler);
+
+      // 401, refresh OK, retry still 401 — no infinite loop.
+      mockFetch
+        .mockResolvedValueOnce(respond(401, { message: 'first' }))
+        .mockResolvedValueOnce(respond(401, { message: 'still expired' }));
+
+      await expect(apiService.get('/protected')).rejects.toThrow('still expired');
+      expect(refreshHandler).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('JSON contract [ADS-261]', () => {
     beforeEach(() => {
       apiService = new ApiService();

--- a/lib.api/src/services/api-service.ts
+++ b/lib.api/src/services/api-service.ts
@@ -16,6 +16,12 @@ export class ApiService {
   public interceptors: InterceptorManager;
   private csrfToken: string | null = null;
   private csrfTokenPromise: Promise<string> | null = null;
+  // Single-flight refresh: parallel 401s all await the same in-flight
+  // refresh and then retry. lib.auth registers the handler at startup
+  // via setRefreshHandler() — this class can't import authService
+  // directly without creating a circular dependency.
+  private refreshHandler: (() => Promise<unknown>) | null = null;
+  private refreshPromise: Promise<void> | null = null;
 
   constructor(config: ApiServiceConfig = {}) {
     // Set up the base URL from environment variables or fallback
@@ -247,6 +253,34 @@ export class ApiService {
     this.csrfTokenPromise = null;
   }
 
+  /**
+   * Register a token-refresh callback used when a request gets a 401.
+   * Must not call back into this service for endpoints that themselves
+   * require auth (caller's refresh implementation should hit
+   * /auth/refresh-token, which we treat as non-retryable below).
+   *
+   * Lives behind a setter rather than a constructor option to break the
+   * import cycle with lib.auth's authService — authService imports this
+   * module, so this module can't import authService.
+   */
+  public setRefreshHandler(handler: (() => Promise<unknown>) | null): void {
+    this.refreshHandler = handler;
+  }
+
+  // Endpoints whose own 401 must NOT trigger a refresh+retry — otherwise
+  // a failed refresh recurses, and the login flow itself would retry on
+  // bad credentials.
+  private shouldAttemptRefresh(url: string, isRetry: boolean): boolean {
+    if (isRetry || !this.refreshHandler) {
+      return false;
+    }
+    return (
+      !url.includes('/auth/refresh-token') &&
+      !url.includes('/auth/login') &&
+      !url.includes('/auth/logout')
+    );
+  }
+
   // Core request method.
   //
   // ADS-261: this used to return `response as unknown as T` for any non-JSON
@@ -284,7 +318,11 @@ export class ApiService {
 
   // Issue the HTTP request and return the raw `Response`. Internally shared
   // by `makeRequest` (which then parses JSON) and `fetchRaw` (which doesn't).
-  private async executeFetch(url: string, options: FetchOptions = {}): Promise<Response> {
+  private async executeFetch(
+    url: string,
+    options: FetchOptions = {},
+    isRetry = false
+  ): Promise<Response> {
     const { method = 'GET', headers = {}, body, timeout = this.config.timeout } = options;
 
     // Build full URL
@@ -335,6 +373,19 @@ export class ApiService {
 
       clearTimeout(timeoutId);
 
+      // 401 single-flight refresh + retry. Parallel 401s share one
+      // refresh promise; once it resolves each original request is
+      // re-issued with isRetry=true so a still-401 reply falls through
+      // to the normal onUnauthorized path. The retry happens before
+      // response interceptors run so they don't see (and act on) the
+      // first 401's body/headers.
+      if (response.status === 401 && this.shouldAttemptRefresh(url, isRetry)) {
+        const refreshed = await this.attemptRefresh();
+        if (refreshed) {
+          return this.executeFetch(url, options, true);
+        }
+      }
+
       // Apply response interceptors
       response = await this.interceptors.applyResponseInterceptors(response);
 
@@ -349,6 +400,37 @@ export class ApiService {
         console.error('API request failed:', processedError);
       }
       throw processedError;
+    }
+  }
+
+  // Returns true if the refresh succeeded and the caller should retry.
+  // Failures are swallowed (logged in debug) so the original 401 still
+  // surfaces normally — invoking onUnauthorized via the response
+  // interceptor path.
+  private async attemptRefresh(): Promise<boolean> {
+    if (!this.refreshHandler) {
+      return false;
+    }
+    try {
+      if (!this.refreshPromise) {
+        this.refreshPromise = this.refreshHandler().then(
+          () => undefined,
+          (err) => {
+            // Reset before rethrowing so a later request can try again
+            // (e.g. the user logs in fresh after a stale-refresh fail).
+            this.refreshPromise = null;
+            throw err;
+          }
+        );
+      }
+      await this.refreshPromise;
+      this.refreshPromise = null;
+      return true;
+    } catch (err) {
+      if (this.config.debug) {
+        console.warn('Token refresh failed:', err);
+      }
+      return false;
     }
   }
 

--- a/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/lib.auth/src/contexts/AuthContext.test.tsx
@@ -40,6 +40,7 @@ vi.mock('@adopt-dont-shop/lib.api', () => ({
 // Imported AFTER vi.mock so the mocks are wired in.
 import { AuthProvider } from './AuthContext';
 import { useAuth } from '../hooks/useAuth';
+import { apiService as mockedApiService } from '@adopt-dont-shop/lib.api';
 
 const adopterUser: User = {
   userId: 'user-123',
@@ -286,6 +287,32 @@ describe('AuthProvider onLogout callback', () => {
     });
 
     expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the cached CSRF token during logout', async () => {
+    let triggerLogout: (() => Promise<void>) | undefined;
+
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <LogoutTrigger
+          onReady={(fn) => {
+            triggerLogout = fn;
+          }}
+        />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(triggerLogout).toBeDefined();
+    });
+
+    vi.mocked(mockedApiService.clearCsrfToken).mockClear();
+
+    await act(async () => {
+      await triggerLogout?.();
+    });
+
+    expect(mockedApiService.clearCsrfToken).toHaveBeenCalled();
   });
 
   it('invokes onLogout even when the backend logout call fails', async () => {

--- a/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/lib.auth/src/contexts/AuthContext.test.tsx
@@ -233,3 +233,83 @@ describe('AuthProvider auth_session_authenticated event', () => {
     expect(sessionEventCalls).toHaveLength(1);
   });
 });
+
+// Helper child that exposes logout() so a test can call it imperatively.
+type LogoutTriggerProps = {
+  onReady: (logout: () => Promise<void>) => void;
+};
+
+const LogoutTrigger = ({ onReady }: LogoutTriggerProps) => {
+  const { logout } = useAuth();
+  React.useEffect(() => {
+    onReady(logout);
+  }, [logout, onReady]);
+  return null;
+};
+
+describe('AuthProvider onLogout callback', () => {
+  beforeEach(() => {
+    mockAuthService.getCurrentUser.mockReturnValue(null);
+    mockAuthService.isAuthenticated.mockReturnValue(false);
+    mockAuthService.getProfile.mockResolvedValue(null);
+    mockAuthService.logout.mockResolvedValue(undefined);
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('invokes onLogout after a successful logout so apps can wipe their query cache', async () => {
+    const onLogout = vi.fn();
+    let triggerLogout: (() => Promise<void>) | undefined;
+
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client" onLogout={onLogout}>
+        <LogoutTrigger
+          onReady={(fn) => {
+            triggerLogout = fn;
+          }}
+        />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(triggerLogout).toBeDefined();
+    });
+
+    await act(async () => {
+      await triggerLogout?.();
+    });
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onLogout even when the backend logout call fails', async () => {
+    mockAuthService.logout.mockRejectedValueOnce(new Error('network down'));
+
+    const onLogout = vi.fn();
+    let triggerLogout: (() => Promise<void>) | undefined;
+
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client" onLogout={onLogout}>
+        <LogoutTrigger
+          onReady={(fn) => {
+            triggerLogout = fn;
+          }}
+        />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(triggerLogout).toBeDefined();
+    });
+
+    await act(async () => {
+      await triggerLogout?.();
+    });
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/lib.auth/src/contexts/AuthContext.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@adopt-dont-shop/lib.api', () => ({
     get: vi.fn(),
     put: vi.fn(),
     fetchWithAuth: vi.fn(),
+    clearCsrfToken: vi.fn(),
   },
 }));
 
@@ -311,5 +312,119 @@ describe('AuthProvider onLogout callback', () => {
     });
 
     expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Probe child that surfaces the current authenticated user state so tests
+// can assert what the provider exposes after a cross-tab event.
+const AuthProbe = ({ onState }: { onState: (user: User | null) => void }) => {
+  const { user } = useAuth();
+  React.useEffect(() => {
+    onState(user);
+  }, [user, onState]);
+  return null;
+};
+
+describe('AuthProvider cross-tab logout synchronization', () => {
+  beforeEach(() => {
+    mockAuthService.getCurrentUser.mockReturnValue(adopterUser);
+    mockAuthService.isAuthenticated.mockReturnValue(true);
+    mockAuthService.getProfile.mockResolvedValue(adopterUser);
+    mockAuthService.logout.mockResolvedValue(undefined);
+    mockAuthService.clearTokens.mockReset();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('clears local user state when another tab removes the persisted user key', async () => {
+    const states: Array<User | null> = [];
+
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <AuthProbe onState={(u) => states.push(u)} />
+      </AuthProvider>
+    );
+
+    // Wait until the rehydrate effect has populated the user.
+    await waitFor(() => {
+      expect(states[states.length - 1]?.userId).toBe(adopterUser.userId);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'user',
+          newValue: null,
+          oldValue: JSON.stringify(adopterUser),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(states[states.length - 1]).toBeNull();
+    });
+    expect(mockAuthService.clearTokens).toHaveBeenCalled();
+  });
+
+  it('ignores storage events for unrelated keys', async () => {
+    const states: Array<User | null> = [];
+
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <AuthProbe onState={(u) => states.push(u)} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(states[states.length - 1]?.userId).toBe(adopterUser.userId);
+    });
+
+    mockAuthService.clearTokens.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'theme-preference',
+          newValue: null,
+          oldValue: 'dark',
+        })
+      );
+    });
+
+    expect(states[states.length - 1]?.userId).toBe(adopterUser.userId);
+    expect(mockAuthService.clearTokens).not.toHaveBeenCalled();
+  });
+
+  it('ignores storage events that set a non-null value', async () => {
+    const states: Array<User | null> = [];
+
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <AuthProbe onState={(u) => states.push(u)} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(states[states.length - 1]?.userId).toBe(adopterUser.userId);
+    });
+
+    mockAuthService.clearTokens.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'user',
+          newValue: JSON.stringify(adopterUser),
+          oldValue: JSON.stringify(adopterUser),
+        })
+      );
+    });
+
+    expect(states[states.length - 1]?.userId).toBe(adopterUser.userId);
+    expect(mockAuthService.clearTokens).not.toHaveBeenCalled();
   });
 });

--- a/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/lib.auth/src/contexts/AuthContext.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@adopt-dont-shop/lib.api', () => ({
     put: vi.fn(),
     fetchWithAuth: vi.fn(),
     clearCsrfToken: vi.fn(),
+    setRefreshHandler: vi.fn(),
   },
 }));
 

--- a/lib.auth/src/contexts/AuthContext.tsx
+++ b/lib.auth/src/contexts/AuthContext.tsx
@@ -35,6 +35,15 @@ export interface AuthProviderProps {
    * Optional analytics/logging callback
    */
   onAuthEvent?: (event: string, data?: Record<string, unknown>) => void;
+  /**
+   * Called as part of logout cleanup. Apps wire this up to clear their
+   * React Query cache (`queryClient.clear()`) so a User A → User B login
+   * on the same browser cannot serve stale cached data from User A's
+   * session. The handler runs after tokens are cleared and before
+   * isLoading flips back to false; fired regardless of whether the
+   * backend logout call succeeded.
+   */
+  onLogout?: () => void;
 }
 
 /**
@@ -46,6 +55,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   allowedUserTypes,
   appType,
   onAuthEvent,
+  onLogout,
 }) => {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -290,6 +300,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         }
       }
     } finally {
+      // Fire onLogout regardless of API success so the host app's
+      // React Query cache (which lives outside this provider) is
+      // always wiped before the next user can sign in on this tab.
+      try {
+        onLogout?.();
+      } catch (cleanupError) {
+        console.error('onLogout handler threw:', cleanupError);
+      }
       setIsLoading(false);
     }
   };

--- a/lib.auth/src/contexts/AuthContext.tsx
+++ b/lib.auth/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, ReactNode, useEffect, useState } from 'react';
 import { apiService } from '@adopt-dont-shop/lib.api';
 import { authService } from '../services/auth-service';
-import { LoginRequest, RegisterRequest, User } from '../types';
+import { LoginRequest, RegisterRequest, User, STORAGE_KEYS } from '../types';
 
 export interface AuthContextType {
   user: User | null;
@@ -143,6 +143,31 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     return () => {
       apiService.updateConfig({ onUnauthorized: undefined });
     };
+  }, []);
+
+  // Cross-tab logout sync: when another tab removes the persisted user
+  // record (logout, account deletion), drop local auth state here too
+  // so this tab doesn't keep rendering the authenticated UI until its
+  // next API call fails with 401. Only react to the user/token keys —
+  // unrelated storage writes (theme, feature flags, etc.) must not
+  // trigger a logout. We don't navigate from here; route-level guards
+  // pick up the user === null transition.
+  useEffect(() => {
+    const onStorageEvent = (e: StorageEvent) => {
+      const isUserKey = e.key === STORAGE_KEYS.USER;
+      const isTokenKey = e.key === STORAGE_KEYS.AUTH_TOKEN || e.key === STORAGE_KEYS.ACCESS_TOKEN;
+      if (!isUserKey && !isTokenKey) {
+        return;
+      }
+      if (e.newValue !== null) {
+        return;
+      }
+      authService.clearTokens();
+      apiService.clearCsrfToken();
+      setUser(null);
+    };
+    window.addEventListener('storage', onStorageEvent);
+    return () => window.removeEventListener('storage', onStorageEvent);
   }, []);
 
   const login = async (credentials: LoginRequest) => {

--- a/lib.auth/src/contexts/AuthContext.tsx
+++ b/lib.auth/src/contexts/AuthContext.tsx
@@ -133,6 +133,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   // Register a 401 handler so any API call that gets Unauthorized automatically
   // clears local auth state without making an additional logout API call
   // (which would itself get a 401 and recurse).
+  //
+  // Also register a token-refresh handler so the api layer can recover
+  // from short-lived access-token expiry mid-session without dropping
+  // the user. Refresh tokens live in an httpOnly cookie so the call
+  // works even when the in-memory token is gone. If the refresh itself
+  // fails, the api layer falls through to onUnauthorized.
   useEffect(() => {
     apiService.updateConfig({
       onUnauthorized: () => {
@@ -140,8 +146,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         setUser(null);
       },
     });
+    apiService.setRefreshHandler(() => authService.refreshToken());
     return () => {
       apiService.updateConfig({ onUnauthorized: undefined });
+      apiService.setRefreshHandler(null);
     };
   }, []);
 

--- a/lib.auth/src/contexts/AuthContext.tsx
+++ b/lib.auth/src/contexts/AuthContext.tsx
@@ -333,6 +333,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         }
       }
     } finally {
+      // Clear the per-session CSRF token cache so the next signed-in
+      // user fetches a fresh one bound to their session cookie rather
+      // than reusing the previous user's token.
+      apiService.clearCsrfToken();
+
       // Fire onLogout regardless of API success so the host app's
       // React Query cache (which lives outside this provider) is
       // always wiped before the next user can sign in on this tab.

--- a/lib.observability/src/sentry.test.ts
+++ b/lib.observability/src/sentry.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initSentry, redactSentryUser } from './sentry';
+
+const { sentryInitSpy } = vi.hoisted(() => ({ sentryInitSpy: vi.fn() }));
+vi.mock('@sentry/react', () => ({
+  init: sentryInitSpy,
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+describe('redactSentryUser', () => {
+  it('strips email, username and ip_address from event.user', () => {
+    const event = {
+      user: {
+        id: '00000000-0000-0000-0000-000000000001',
+        email: 'alice@example.com',
+        username: 'alice',
+        ip_address: '203.0.113.42',
+      },
+    };
+
+    const result = redactSentryUser(event);
+
+    expect(result.user).toEqual({ id: '00000000-0000-0000-0000-000000000001' });
+  });
+
+  it('is a no-op when event.user is absent', () => {
+    const event: { user?: Record<string, unknown> | null; message?: string } = {
+      message: 'something broke',
+    };
+    const result = redactSentryUser(event);
+    expect(result).toEqual({ message: 'something broke' });
+  });
+
+  it('leaves event.user.id intact when no PII fields are present', () => {
+    const event = { user: { id: 'uuid-abc' } };
+    const result = redactSentryUser(event);
+    expect(result.user).toEqual({ id: 'uuid-abc' });
+  });
+});
+
+describe('initSentry beforeSend wiring', () => {
+  it('registers a beforeSend hook that strips identifiable fields from event.user', () => {
+    sentryInitSpy.mockClear();
+
+    initSentry({
+      dsn: 'https://example@o0.ingest.sentry.io/0',
+      appName: 'admin',
+      environment: 'production',
+    });
+
+    expect(sentryInitSpy).toHaveBeenCalledTimes(1);
+    const initOptions = sentryInitSpy.mock.calls[0][0] as {
+      beforeSend: (event: { user?: Record<string, unknown> }) => { user?: Record<string, unknown> };
+    };
+    expect(typeof initOptions.beforeSend).toBe('function');
+
+    const scrubbed = initOptions.beforeSend({
+      user: {
+        id: 'uuid-1',
+        email: 'leak@example.com',
+        username: 'leak',
+        ip_address: '1.2.3.4',
+      },
+    });
+
+    expect(scrubbed.user).toEqual({ id: 'uuid-1' });
+  });
+});

--- a/lib.observability/src/sentry.ts
+++ b/lib.observability/src/sentry.ts
@@ -1,5 +1,25 @@
 import * as Sentry from '@sentry/react';
 
+/**
+ * Strip identifiable fields from `event.user` before Sentry sends an
+ * event upstream. Exported for testing — callers should not need to
+ * invoke this directly.
+ *
+ * We deliberately keep `event.user.id` if present (UUIDs are opaque)
+ * and drop email / username / ip_address so a future stray
+ * Sentry.setUser({ email }) call cannot leak PII to the SaaS.
+ */
+export const redactSentryUser = <T extends { user?: Record<string, unknown> | null }>(
+  event: T
+): T => {
+  if (event.user) {
+    delete event.user.email;
+    delete event.user.username;
+    delete event.user.ip_address;
+  }
+  return event;
+};
+
 export type SentryInitOptions = {
   /** Sentry DSN — typically read from VITE_SENTRY_DSN by the caller. */
   dsn: string | undefined;
@@ -60,6 +80,10 @@ export const initSentry = (options: SentryInitOptions): void => {
     initialScope: {
       tags: { app: appName },
     },
+    // Defensive PII scrub: no Sentry.setUser({ email }) call exists in
+    // the codebase today, but lock the invariant so a future change
+    // can't accidentally ship identifiable user fields to the SaaS.
+    beforeSend: event => redactSentryUser(event),
   });
 };
 

--- a/lib.validation/src/index.ts
+++ b/lib.validation/src/index.ts
@@ -4,3 +4,4 @@ export * from './schemas/user';
 export * from './schemas/pet';
 export * from './schemas/rescue';
 export * from './schemas/application';
+export * from './normalize-email';

--- a/lib.validation/src/normalize-email.test.ts
+++ b/lib.validation/src/normalize-email.test.ts
@@ -1,0 +1,73 @@
+import { normalizeEmail, isSingleScriptLocalPart } from './normalize-email';
+
+describe('normalizeEmail', () => {
+  it('lowercases ASCII', () => {
+    expect(normalizeEmail('Foo@Example.COM')).toBe('foo@example.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeEmail('  foo@example.com  ')).toBe('foo@example.com');
+  });
+
+  it('folds full-width ASCII to half-width via NFKC', () => {
+    // 'ｆｏｏ＠ｂａｒ．ｃｏｍ' — full-width latin letters and @ and .
+    const fullWidth = 'ｆｏｏ＠ｂａｒ．ｃｏｍ';
+    expect(normalizeEmail(fullWidth)).toBe('foo@bar.com');
+  });
+
+  it('folds the ﬁ ligature to fi via NFKC', () => {
+    // U+FB01 (ﬁ) decomposes to f + i under NFKC. Built from a codepoint
+    // so source-file editors can't accidentally re-render the ligature.
+    const input = `of${String.fromCodePoint(0xfb01)}ce@example.com`;
+    expect(normalizeEmail(input)).toBe('office@example.com');
+  });
+
+  it('preserves Cyrillic codepoints — NFKC does NOT fold Cyrillic а into Latin a', () => {
+    // Cyrillic а (U+0430) is distinct from Latin a (U+0061) after NFKC.
+    // Mixed-script detection is what blocks the homograph attack;
+    // normalization alone leaves the Cyrillic char untouched.
+    const cyrillicA = 'аdmin@example.com';
+    const result = normalizeEmail(cyrillicA);
+    expect(result.startsWith('а')).toBe(true);
+    expect(result.startsWith('a')).toBe(false);
+  });
+});
+
+describe('isSingleScriptLocalPart', () => {
+  it('accepts pure ASCII / Latin', () => {
+    expect(isSingleScriptLocalPart('admin')).toBe(true);
+    expect(isSingleScriptLocalPart('john.doe+filter')).toBe(true);
+  });
+
+  it('accepts accented Latin (é, ñ, ø)', () => {
+    expect(isSingleScriptLocalPart('rené')).toBe(true);
+    expect(isSingleScriptLocalPart('jürgen')).toBe(true);
+  });
+
+  it('accepts pure Cyrillic', () => {
+    expect(isSingleScriptLocalPart('админ')).toBe(true); // 'админ'
+  });
+
+  it('accepts pure Greek', () => {
+    expect(isSingleScriptLocalPart('αβγ')).toBe(true); // 'αβγ'
+  });
+
+  it('rejects Latin mixed with Cyrillic (the homograph attack)', () => {
+    // 'аdmin' — Cyrillic а (U+0430) + Latin dmin
+    expect(isSingleScriptLocalPart('аdmin')).toBe(false);
+  });
+
+  it('rejects Latin mixed with Greek', () => {
+    // 'admin' with a Greek alpha pretending to be 'a'
+    expect(isSingleScriptLocalPart('αdmin')).toBe(false);
+  });
+
+  it('treats digits and common email punctuation as script-neutral', () => {
+    expect(isSingleScriptLocalPart('user.123+foo_bar-baz')).toBe(true);
+  });
+
+  it('accepts an empty / all-common local part (degenerate, not the attack we block)', () => {
+    expect(isSingleScriptLocalPart('')).toBe(true);
+    expect(isSingleScriptLocalPart('123')).toBe(true);
+  });
+});

--- a/lib.validation/src/normalize-email.ts
+++ b/lib.validation/src/normalize-email.ts
@@ -1,0 +1,91 @@
+/**
+ * Unicode-aware email normalization + homograph defense.
+ *
+ * `normalizeEmail` applies NFKC compatibility normalization, lowercases,
+ * and trims surrounding whitespace. NFKC folds compatibility variants
+ * (full-width ASCII, ligatures like ﬁ→fi, mathematical letterlikes like
+ * ℂ→C) into their canonical form so visually-identical inputs collapse
+ * to the same string before the uniqueness check.
+ *
+ * NFKC alone does NOT collapse cross-script lookalikes — Cyrillic а
+ * (U+0430) is a distinct codepoint from Latin a (U+0061) and survives
+ * normalization. The homograph attack ("аdmin@example.com" appearing
+ * as "admin@example.com") is blocked by `isSingleScriptLocalPart`,
+ * which rejects local parts that mix characters from more than one
+ * named Unicode script. Digits and ASCII punctuation are "Common" and
+ * are always allowed alongside a single script.
+ *
+ * Both helpers are imported by the canonical Zod EmailSchema and by
+ * the User model's beforeValidate hook (defense in depth: callers that
+ * bypass the schema still hit the model gate).
+ */
+
+export const normalizeEmail = (email: string): string =>
+  email.normalize('NFKC').trim().toLowerCase();
+
+/**
+ * Codepoint ranges for the named scripts we recognize. A character
+ * outside every range and outside Common (digits, ASCII punctuation,
+ * whitespace) is classified as 'other' and counts as its own script.
+ *
+ * Intentionally narrow: we don't try to identify every Unicode script,
+ * only enough to detect the practical mixed-script attacks (Latin vs
+ * Cyrillic vs Greek, the three most common confusable scripts). Any
+ * unknown character pairs as 'other' and triggers the mixed-script
+ * rejection the moment it appears alongside Latin/Cyrillic/Greek.
+ */
+type Script = 'latin' | 'cyrillic' | 'greek' | 'other';
+
+const isCommon = (cp: number): boolean => {
+  // ASCII digits, common email punctuation (., -, _, +, @), and whitespace.
+  // These appear in every script's email and must not count as their own
+  // script for the mixing check.
+  if (cp >= 0x30 && cp <= 0x39) return true; // 0-9
+  if (cp === 0x2e || cp === 0x2d || cp === 0x5f || cp === 0x2b) return true; // . - _ +
+  if (cp === 0x20 || cp === 0x09) return true; // space, tab
+  return false;
+};
+
+const classify = (cp: number): Script | null => {
+  if (isCommon(cp)) {
+    return null;
+  }
+  // Latin: Basic Latin letters + Latin-1 Supplement letters + Latin
+  // Extended-A/B. Covers ASCII a-z/A-Z and accented characters like é, ñ, ø.
+  if (
+    (cp >= 0x41 && cp <= 0x5a) || // A-Z
+    (cp >= 0x61 && cp <= 0x7a) || // a-z
+    (cp >= 0xc0 && cp <= 0xff && cp !== 0xd7 && cp !== 0xf7) || // Latin-1 Supplement letters
+    (cp >= 0x100 && cp <= 0x17f) || // Latin Extended-A
+    (cp >= 0x180 && cp <= 0x24f) // Latin Extended-B
+  ) {
+    return 'latin';
+  }
+  if (cp >= 0x400 && cp <= 0x4ff) {
+    return 'cyrillic';
+  }
+  if (cp >= 0x370 && cp <= 0x3ff) {
+    return 'greek';
+  }
+  return 'other';
+};
+
+/**
+ * Returns true if every non-common character in `localPart` belongs to
+ * the same Unicode script. Empty / all-common input is considered
+ * single-script (degenerate cases are not the attack we're blocking).
+ */
+export const isSingleScriptLocalPart = (localPart: string): boolean => {
+  const scripts = new Set<Script>();
+  for (const char of localPart) {
+    const cp = char.codePointAt(0);
+    if (cp === undefined) continue;
+    const script = classify(cp);
+    if (script === null) continue;
+    scripts.add(script);
+    if (scripts.size > 1) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/lib.validation/src/schemas/__tests__/user.test.ts
+++ b/lib.validation/src/schemas/__tests__/user.test.ts
@@ -27,6 +27,16 @@ describe('User schemas', () => {
       const tooLong = 'a'.repeat(251) + '@b.co';
       expect(() => EmailSchema.parse(tooLong)).toThrow();
     });
+
+    it('NFKC-folds full-width ASCII so visually-identical addresses collapse', () => {
+      // 'ＡＤＭＩＮ@example.com' — full-width letters fold to ASCII + lowercase
+      expect(EmailSchema.parse('ＡＤＭＩＮ@example.com')).toBe('admin@example.com');
+    });
+
+    it('rejects a local part that mixes Latin and Cyrillic (homograph squatting)', () => {
+      // 'аdmin@example.com' — Cyrillic а (U+0430) + Latin dmin
+      expect(() => EmailSchema.parse('аdmin@example.com')).toThrow(/multiple scripts/);
+    });
   });
 
   describe('StrongPasswordSchema', () => {

--- a/lib.validation/src/schemas/user.ts
+++ b/lib.validation/src/schemas/user.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { UserId } from '@adopt-dont-shop/lib.types';
+import { isSingleScriptLocalPart, normalizeEmail } from '../normalize-email';
 
 /**
  * Canonical Zod schemas for the User domain.
@@ -36,16 +37,33 @@ export const UserIdSchema = z
   .transform((v) => v as UserId);
 
 /**
- * Canonical email rule. Trim + lowercase happens server-side in the User
- * beforeValidate hook; the schema only enforces format and length.
+ * Canonical email rule. Applies NFKC + trim + lowercase via
+ * normalizeEmail so visually-identical compatibility variants collapse
+ * to a single canonical form before uniqueness checks. Rejects local
+ * parts that mix more than one Unicode script — the Cyrillic-vs-Latin
+ * homograph that NFKC alone does not fold. Length / format checks run
+ * after normalization so they see the canonical string.
+ *
+ * Mirrored by the User model's beforeValidate hook (defense in depth).
  */
 export const EmailSchema = z
   .string()
-  .trim()
-  .toLowerCase()
-  .min(5, 'Email must be at least 5 characters')
-  .max(255, 'Email must be at most 255 characters')
-  .email('Please enter a valid email address');
+  .transform(normalizeEmail)
+  .pipe(
+    z
+      .string()
+      .min(5, 'Email must be at least 5 characters')
+      .max(255, 'Email must be at most 255 characters')
+      .email('Please enter a valid email address')
+      .refine(
+        (email) => {
+          const atIndex = email.lastIndexOf('@');
+          if (atIndex < 0) return true;
+          return isSingleScriptLocalPart(email.slice(0, atIndex));
+        },
+        { message: 'Email local part must not mix characters from multiple scripts' }
+      )
+  );
 
 /**
  * Strong password — 8+ chars, must contain lowercase, uppercase, digit,

--- a/service.backend/src/__tests__/routes/broadcast.routes.test.ts
+++ b/service.backend/src/__tests__/routes/broadcast.routes.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../middleware/idempotency', () => ({
 // without the in-memory store leaking counts across tests.
 vi.mock('../../middleware/rate-limiter', () => ({
   broadcastLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  sensitiveWriteLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
 }));
 
 const authenticateTokenMock = vi.fn();

--- a/service.backend/src/__tests__/routes/notification.routes.test.ts
+++ b/service.backend/src/__tests__/routes/notification.routes.test.ts
@@ -23,7 +23,31 @@ vi.mock('../../services/notification.service', () => ({
     getUnreadCount: vi.fn(),
     getNotificationPreferences: vi.fn(),
     markAllNotificationsAsRead: vi.fn(),
+    markAsRead: vi.fn(),
   },
+}));
+
+// ADS-741: simulate sensitiveWriteLimiter so the route-level rate-limit
+// can be asserted. The limiter mock counts hits and returns 429 after a
+// fixed threshold, matching the production express-rate-limit shape.
+const RATE_LIMIT_MAX = 3;
+let rateLimitHits = 0;
+const resetRateLimit = () => {
+  rateLimitHits = 0;
+};
+vi.mock('../../middleware/rate-limiter', () => ({
+  broadcastLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  sensitiveWriteLimiter: (_req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    rateLimitHits += 1;
+    if (rateLimitHits > RATE_LIMIT_MAX) {
+      return res.status(429).json({ error: 'rate_limited' });
+    }
+    next();
+  },
+}));
+
+vi.mock('../../middleware/idempotency', () => ({
+  idempotency: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
 }));
 
 vi.mock('../../services/rich-text-processing.service', () => ({
@@ -50,6 +74,7 @@ import notificationRouter from '../../routes/notification.routes';
 const mockGetUserNotifications = vi.mocked(NotificationService.getUserNotifications);
 const mockGetUnreadCount = vi.mocked(NotificationService.getUnreadCount);
 const mockGetPreferences = vi.mocked(NotificationService.getNotificationPreferences);
+const mockMarkAsRead = vi.mocked(NotificationService.markAsRead);
 
 const buildApp = () => {
   const app = express();
@@ -66,6 +91,7 @@ const mockUser = {
 describe('Notification routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetRateLimit();
     authenticateTokenMock.mockImplementation(
       (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
         req.user = mockUser as AuthenticatedRequest['user'];
@@ -132,6 +158,55 @@ describe('Notification routes', () => {
       mockGetPreferences.mockRejectedValue(new Error('User not found'));
       const res = await request(buildApp()).get('/api/v1/notifications/preferences');
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ADS-741: mark-as-read must reject non-UUID notification IDs at the
+  // route layer (before any DB lookup) and must be rate-limited so the
+  // UUID space can't be brute-forced via timing/response differences.
+  describe('PATCH /api/v1/notifications/:notificationId/read', () => {
+    const validId = '11111111-2222-4333-8444-555555555555';
+
+    it('rejects a non-UUID notificationId with 400 and never reaches the service', async () => {
+      mockMarkAsRead.mockResolvedValue(undefined);
+      const res = await request(buildApp()).patch('/api/v1/notifications/not-a-uuid/read');
+      expect(res.status).toBe(400);
+      expect(mockMarkAsRead).not.toHaveBeenCalled();
+    });
+
+    it('rejects an oddly-shaped string that looks like a legacy id', async () => {
+      mockMarkAsRead.mockResolvedValue(undefined);
+      const res = await request(buildApp()).patch('/api/v1/notifications/abc_123/read');
+      expect(res.status).toBe(400);
+      expect(mockMarkAsRead).not.toHaveBeenCalled();
+    });
+
+    it('marks a valid UUID as read', async () => {
+      mockMarkAsRead.mockResolvedValue(undefined);
+      const res = await request(buildApp()).patch(`/api/v1/notifications/${validId}/read`);
+      expect(res.status).toBe(200);
+      expect(mockMarkAsRead).toHaveBeenCalledWith(validId, mockUser.userId);
+    });
+
+    it('rate-limits repeated hits with random UUIDs (429 after the window cap)', async () => {
+      mockMarkAsRead.mockResolvedValue(undefined);
+      const app = buildApp();
+      const randomUuid = () =>
+        '00000000-0000-4000-8000-' +
+        Math.floor(Math.random() * 1e12)
+          .toString(16)
+          .padStart(12, '0');
+
+      // First RATE_LIMIT_MAX (=3) hits pass.
+      for (let i = 0; i < RATE_LIMIT_MAX; i += 1) {
+        const r = await request(app).patch(`/api/v1/notifications/${randomUuid()}/read`);
+        expect(r.status).toBe(200);
+      }
+
+      // The next hit must be rejected by the limiter, BEFORE the service
+      // is invoked, even with a valid UUID.
+      const blocked = await request(app).patch(`/api/v1/notifications/${randomUuid()}/read`);
+      expect(blocked.status).toBe(429);
     });
   });
 });

--- a/service.backend/src/__tests__/routes/upload.routes.test.ts
+++ b/service.backend/src/__tests__/routes/upload.routes.test.ts
@@ -48,10 +48,19 @@ const petImageUploadMock = {
 const fileUploadServiceMock = {
   uploadFile: vi.fn(),
 };
-vi.mock('../../services/file-upload.service', () => ({
-  petImageUpload: petImageUploadMock,
-  FileUploadService: fileUploadServiceMock,
-}));
+vi.mock('../../services/file-upload.service', async () => {
+  // Preserve the real `sanitizeDisplayFilename` helper so the controller's
+  // PII-scrub assertion below is exercised end-to-end. Only the side-effectful
+  // multer/service singletons need stubbing.
+  const actual = await vi.importActual<typeof import('../../services/file-upload.service')>(
+    '../../services/file-upload.service'
+  );
+  return {
+    ...actual,
+    petImageUpload: petImageUploadMock,
+    FileUploadService: fileUploadServiceMock,
+  };
+});
 
 const enforceUploadMimeMock = vi.fn();
 vi.mock('../../middleware/upload-mime-guard', () => ({
@@ -151,10 +160,15 @@ describe('POST /api/v1/uploads/images — staged image upload', () => {
       });
 
     expect(response.status).toBe(200);
+    // original_filename in the response is the *sanitised* display name —
+    // never the raw uploaded filename — because downstream the client
+    // echoes this into chat/pet contexts visible to other users. The DB
+    // still stores the raw `original_filename` (`photo.jpg` here) on the
+    // FileUpload row for support tooling and the uploader's own UI.
     expect(response.body).toEqual({
       url: '/uploads/pets/pets_1700000000_abc.jpg',
       thumbnail_url: '/uploads/pets/pets_1700000000_abc.thumb.jpg',
-      original_filename: 'photo.jpg',
+      original_filename: 'file.jpg',
       size_bytes: 1234,
       content_type: 'image/jpeg',
     });
@@ -163,6 +177,48 @@ describe('POST /api/v1/uploads/images — staged image upload', () => {
       'pets',
       expect.objectContaining({ uploadedBy: 'user-abc' })
     );
+  });
+
+  it('replaces a PII-laden upload filename with a sanitised display name in the response', async () => {
+    // Even though the staged upload response goes back only to the
+    // uploader, the client echoes `original_filename` into downstream
+    // contexts (chat messages, pet listings) visible to other users.
+    // Verify the value the client sees is the safe stem `file.<ext>`,
+    // never the raw filename the user picked from disk.
+    fileUploadServiceMock.uploadFile.mockResolvedValue({
+      success: true,
+      upload: {
+        upload_id: 'upload-456',
+        original_filename: 'Jane_Doe_Passport_123456789.jpg',
+        stored_filename: 'pets_1700000000_xyz.jpg',
+        file_path: 'pets/pets_1700000000_xyz.jpg',
+        mime_type: 'image/jpeg',
+        file_size: 4321,
+        url: '/uploads/pets/pets_1700000000_xyz.jpg',
+        thumbnail_url: '/uploads/pets/pets_1700000000_xyz.thumb.jpg',
+        uploaded_by: 'user-abc',
+        metadata: {
+          uploadedAt: '2026-05-16T00:00:00.000Z',
+          lastModified: '2026-05-16T00:00:00.000Z',
+          checksum: 'def',
+        },
+        created_at: new Date('2026-05-16'),
+        updated_at: new Date('2026-05-16'),
+      },
+    });
+
+    const app = await buildApp();
+    const response = await request(app)
+      .post('/api/v1/uploads/images')
+      .attach('image', Buffer.from('fake jpg bytes'), {
+        filename: 'Jane_Doe_Passport_123456789.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.original_filename).toBe('file.jpg');
+    expect(response.body.original_filename).not.toContain('Jane');
+    expect(response.body.original_filename).not.toContain('Passport');
   });
 
   it('returns 401 when the requester is not authenticated', async () => {

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -244,6 +244,29 @@ describe('AuthService', () => {
         'Password must be at least 8 characters long'
       );
     });
+
+    it('looks up and stores a Unicode-normalized email so visually-identical inputs collide', async () => {
+      // Full-width letters + uppercase fold to the canonical ASCII form
+      // via NFKC + lowercase. Without normalization, the duplicate-account
+      // check would miss an existing 'test@example.com' row when an
+      // attacker submitted the full-width variant.
+      const variantUserData: RegisterData = {
+        ...userData,
+        email: 'ＴＥＳＴ@example.com',
+      };
+      MockedUser.findOne = vi.fn().mockResolvedValue(null);
+      MockedUser.create = vi.fn().mockResolvedValue(buildMockUser() as unknown);
+      MockedAuditLog.create = vi.fn().mockResolvedValue({} as unknown);
+
+      await AuthService.register(variantUserData);
+
+      expect(MockedUser.findOne).toHaveBeenCalledWith({
+        where: { email: 'test@example.com' },
+      });
+      expect(MockedUser.create).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'test@example.com' })
+      );
+    });
   });
 
   describe('login', () => {

--- a/service.backend/src/__tests__/services/file-upload-image-processing.test.ts
+++ b/service.backend/src/__tests__/services/file-upload-image-processing.test.ts
@@ -214,3 +214,78 @@ describe('FileUploadService image dimension guard (image-bomb DOS)', () => {
     await expect(FileUploadService.__assertImageDimensionsForTests(file)).resolves.toBeUndefined();
   });
 });
+
+// Privacy: re-encoded images served to other users must not carry EXIF
+// from the upload. Camera-uploaded JPEGs commonly embed GPS coordinates;
+// allowing those to round-trip into a served pet photo would let viewers
+// extract the adopter's home coordinates.
+describe('FileUploadService EXIF stripping on processed images', () => {
+  const TMP_DIR = path.join(os.tmpdir(), `ads-exif-strip-${Date.now()}`);
+  const ORIGINAL_DIR = config.storage.local.directory;
+
+  beforeAll(async () => {
+    await fs.promises.mkdir(TMP_DIR, { recursive: true });
+    config.storage.local.directory = TMP_DIR;
+  });
+
+  afterAll(async () => {
+    config.storage.local.directory = ORIGINAL_DIR;
+    await fs.promises.rm(TMP_DIR, { recursive: true, force: true });
+  });
+
+  // Build a JPEG whose EXIF block carries GPS coordinates and a camera make.
+  // sharp's withExif lets us inject EXIF on the *input* image so the
+  // subsequent re-encode pipeline has something to strip (or accidentally
+  // preserve).
+  const buildJpegWithExif = async (name: string): Promise<Express.Multer.File> => {
+    const filePath = path.join(TMP_DIR, name);
+    await sharp({
+      create: { width: 200, height: 200, channels: 3, background: { r: 10, g: 20, b: 30 } },
+    })
+      .withExif({
+        IFD0: { Make: 'TestCam', Model: 'PrivacyLeak' },
+        GPSIFD: {
+          GPSLatitudeRef: 'N',
+          GPSLatitude: '51/1, 30/1, 0/1',
+          GPSLongitudeRef: 'W',
+          GPSLongitude: '0/1, 7/1, 0/1',
+        },
+      })
+      .jpeg({ quality: 90 })
+      .toFile(filePath);
+
+    return {
+      fieldname: 'file',
+      originalname: name,
+      encoding: '7bit',
+      mimetype: 'image/jpeg',
+      size: (await fs.promises.stat(filePath)).size,
+      destination: TMP_DIR,
+      filename: name,
+      path: filePath,
+      buffer: Buffer.alloc(0),
+      stream: null as never,
+    };
+  };
+
+  it('strips EXIF from the resized primary image and the thumbnail', async () => {
+    const file = await buildJpegWithExif(`exif-input-${Date.now()}.jpg`);
+
+    // Sanity: the synthetic input must actually carry the EXIF we just
+    // injected, otherwise the assertion below would be trivially true.
+    const inputMeta = await sharp(file.path).metadata();
+    expect(inputMeta.exif).toBeDefined();
+
+    const result = await FileUploadService.__processImageForTests(file);
+    expect(result).not.toBeNull();
+    if (!result) return;
+
+    const resizedMeta = await sharp(result.processedPath).metadata();
+    expect(resizedMeta.exif).toBeUndefined();
+
+    if (result.thumbnailPath) {
+      const thumbMeta = await sharp(result.thumbnailPath).metadata();
+      expect(thumbMeta.exif).toBeUndefined();
+    }
+  });
+});

--- a/service.backend/src/__tests__/services/file-upload-image-processing.test.ts
+++ b/service.backend/src/__tests__/services/file-upload-image-processing.test.ts
@@ -1,5 +1,22 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+// Mock FileUpload model + AuditLogService so the deleteFile companion-cleanup
+// suite below can drive the service against real disk without standing up
+// the database. The other suites in this file don't touch these mocks.
+vi.mock('../../models/FileUpload', () => ({
+  default: { findByPk: vi.fn() },
+}));
+vi.mock('../../services/auditLog.service', () => ({
+  AuditLogService: { log: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock('../../services/storage', () => ({
+  getStorageProvider: vi.fn(() => ({ getName: () => 'local' })),
+  StorageCategory: {},
+}));
+
+import FileUpload from '../../models/FileUpload';
+import { UserType } from '../../models/User';
+
 // The shared test setup stubs `fs` for upstream service tests. This
 // suite needs the real disk to write JPEG fixtures, so undo the mock.
 vi.unmock('fs');
@@ -287,5 +304,84 @@ describe('FileUploadService EXIF stripping on processed images', () => {
       const thumbMeta = await sharp(result.thumbnailPath).metadata();
       expect(thumbMeta.exif).toBeUndefined();
     }
+  });
+});
+
+// deleteFile() removes the primary on-disk file via the local storage
+// branch — but processImageWithSharp writes two companion files alongside
+// every image upload (`<filepath>.original` and `<basename>.thumb.jpg`).
+// Without explicit cleanup those companions would pile up on disk
+// indefinitely after the FileUpload row is gone.
+describe('FileUploadService deleteFile() companion cleanup', () => {
+  const TMP_DIR = path.join(os.tmpdir(), `ads-delete-companions-${Date.now()}`);
+  const ORIGINAL_DIR = config.storage.local.directory;
+
+  beforeAll(async () => {
+    await fs.promises.mkdir(TMP_DIR, { recursive: true });
+    config.storage.local.directory = TMP_DIR;
+  });
+
+  afterAll(async () => {
+    config.storage.local.directory = ORIGINAL_DIR;
+    await fs.promises.rm(TMP_DIR, { recursive: true, force: true });
+  });
+
+  it('removes the primary file plus its .original and .thumb.jpg companions', async () => {
+    // file_path is stored relative to config.storage.local.directory so the
+    // deleteFile() path.join behaves correctly. We mirror that here.
+    const stem = `cat-${Date.now()}`;
+    const relPath = `${stem}.jpg`;
+    const primaryPath = path.join(TMP_DIR, relPath);
+    const originalCompanion = `${primaryPath}.original`;
+    const thumbCompanion = path.join(TMP_DIR, `${stem}.thumb.jpg`);
+
+    await fs.promises.writeFile(primaryPath, 'primary bytes');
+    await fs.promises.writeFile(originalCompanion, 'original bytes');
+    await fs.promises.writeFile(thumbCompanion, 'thumb bytes');
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(FileUpload.findByPk).mockResolvedValue({
+      upload_id: 'upload-companion-test',
+      original_filename: 'cat.jpg',
+      file_path: relPath,
+      uploaded_by: 'user-1',
+      destroy,
+    } as unknown as Awaited<ReturnType<typeof FileUpload.findByPk>>);
+
+    const result = await FileUploadService.deleteFile('upload-companion-test', {
+      id: 'user-1',
+      type: UserType.ADOPTER,
+    });
+
+    expect(result.success).toBe(true);
+    await expect(fs.promises.access(primaryPath)).rejects.toThrow();
+    await expect(fs.promises.access(originalCompanion)).rejects.toThrow();
+    await expect(fs.promises.access(thumbCompanion)).rejects.toThrow();
+    expect(destroy).toHaveBeenCalled();
+  });
+
+  it('succeeds when companion files are missing (non-image upload, or already cleaned up)', async () => {
+    const stem = `doc-${Date.now()}`;
+    const relPath = `${stem}.pdf`;
+    const primaryPath = path.join(TMP_DIR, relPath);
+    await fs.promises.writeFile(primaryPath, 'pdf bytes');
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(FileUpload.findByPk).mockResolvedValue({
+      upload_id: 'upload-no-companions',
+      original_filename: 'doc.pdf',
+      file_path: relPath,
+      uploaded_by: 'user-1',
+      destroy,
+    } as unknown as Awaited<ReturnType<typeof FileUpload.findByPk>>);
+
+    const result = await FileUploadService.deleteFile('upload-no-companions', {
+      id: 'user-1',
+      type: UserType.ADOPTER,
+    });
+
+    expect(result.success).toBe(true);
+    await expect(fs.promises.access(primaryPath)).rejects.toThrow();
+    expect(destroy).toHaveBeenCalled();
   });
 });

--- a/service.backend/src/__tests__/services/file-upload.service.test.ts
+++ b/service.backend/src/__tests__/services/file-upload.service.test.ts
@@ -565,7 +565,9 @@ describe('FileUploadService', () => {
       const result = await FileUploadService.deleteFile('upload-abc-123', owner);
 
       expect(result.success).toBe(true);
-      expect(vi.mocked(fs.promises.unlink)).not.toHaveBeenCalled();
+      // Primary is skipped via existsSync; companion cleanup still attempts
+      // (`.original` + `.thumb.jpg`) and swallows ENOENT so the delete
+      // succeeds regardless.
       expect(mockRecord.destroy).toHaveBeenCalled();
     });
 

--- a/service.backend/src/__tests__/services/gdpr.service.test.ts
+++ b/service.backend/src/__tests__/services/gdpr.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Response } from 'express';
 import sequelize from '../../sequelize';
 import Application, { ApplicationStatus } from '../../models/Application';
@@ -13,7 +13,17 @@ import Rescue from '../../models/Rescue';
 import StaffMember from '../../models/StaffMember';
 import User, { UserStatus, UserType } from '../../models/User';
 import UserConsent, { ConsentPurpose } from '../../models/UserConsent';
+import { FileUploadService } from '../../services/file-upload.service';
 import GdprService from '../../services/gdpr.service';
+
+// Mock FileUploadService.deleteFile so the anonymization tests don't try
+// to touch the real storage layer. The behavioural assertion is that
+// deleteFile is invoked once per attachment after the DB tx commits.
+vi.mock('../../services/file-upload.service', () => ({
+  FileUploadService: {
+    deleteFile: vi.fn().mockResolvedValue({ success: true, message: 'deleted' }),
+  },
+}));
 
 const seedUser = async (overrides: Record<string, unknown> = {}) =>
   User.create({
@@ -123,6 +133,14 @@ const seedApplication = async (
 };
 
 describe('GdprService', () => {
+  beforeEach(() => {
+    vi.mocked(FileUploadService.deleteFile).mockClear();
+    vi.mocked(FileUploadService.deleteFile).mockResolvedValue({
+      success: true,
+      message: 'deleted',
+    });
+  });
+
   describe('requestErasure (phase 1)', () => {
     it('soft-deletes the user, stamps pending_anonymization_at, revokes sessions, and clears device tokens — without scrubbing PII', async () => {
       const user = await seedUser();
@@ -288,6 +306,162 @@ describe('GdprService', () => {
       await expect(
         GdprService.executeAnonymization('00000000-0000-0000-0000-000000000000')
       ).rejects.toThrow('User not found');
+    });
+
+    it('deletes physical attachment files for every message authored by the user', async () => {
+      const user = await seedUser();
+      const rescue = await seedRescue();
+      const chatId = `${Date.now().toString(16)}-1111-4111-a111-${Math.random()
+        .toString(16)
+        .slice(2, 14)
+        .padEnd(12, '0')}`;
+      await sequelize.getQueryInterface().bulkInsert('chats', [
+        {
+          chat_id: chatId,
+          rescue_id: rescue.rescueId,
+          status: 'active',
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ]);
+
+      const attachmentA = {
+        attachment_id: 'upload-aaa-111',
+        filename: 'photo1.jpg',
+        originalName: 'photo1.jpg',
+        mimeType: 'image/jpeg',
+        size: 1024,
+        url: '/uploads/chat/photo1.jpg',
+      };
+      const attachmentB = {
+        attachment_id: 'upload-bbb-222',
+        filename: 'photo2.jpg',
+        originalName: 'photo2.jpg',
+        mimeType: 'image/jpeg',
+        size: 2048,
+        url: '/uploads/chat/photo2.jpg',
+      };
+      const attachmentC = {
+        attachment_id: 'upload-ccc-333',
+        filename: 'doc.pdf',
+        originalName: 'doc.pdf',
+        mimeType: 'application/pdf',
+        size: 4096,
+        url: '/uploads/chat/doc.pdf',
+      };
+
+      const buildMessage = (suffix: string, attachments: (typeof attachmentA)[]) => ({
+        message_id: `${Date.now().toString(16)}-${suffix}-4${suffix}-a${suffix}-${Math.random()
+          .toString(16)
+          .slice(2, 14)
+          .padEnd(12, '0')}`,
+        chat_id: chatId,
+        sender_id: user.userId,
+        content: `msg ${suffix}`,
+        content_format: 'plain',
+        attachments: JSON.stringify(attachments),
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+
+      await sequelize
+        .getQueryInterface()
+        .bulkInsert('messages', [
+          buildMessage('7777', [attachmentA, attachmentB]),
+          buildMessage('8888', [attachmentC]),
+        ]);
+
+      await GdprService.requestErasure(user.userId, { actorUserId: user.userId });
+      const result = await GdprService.executeAnonymization(user.userId);
+      expect(result.anonymized).toBe(true);
+
+      // Attachments JSON column scrubbed.
+      const reloadedMessages = await Message.findAll({ where: { sender_id: user.userId } });
+      expect(reloadedMessages).toHaveLength(2);
+      for (const msg of reloadedMessages) {
+        expect(msg.attachments).toEqual([]);
+        expect(msg.content).toBe('[message removed at user request]');
+      }
+
+      // Physical file deletion invoked once per attachment, with the
+      // admin-typed system actor so the ownership check is bypassed.
+      const deleteCalls = vi.mocked(FileUploadService.deleteFile).mock.calls;
+      const deletedAttachmentIds = deleteCalls.map(call => call[0]);
+      expect(deletedAttachmentIds.sort()).toEqual(
+        ['upload-aaa-111', 'upload-bbb-222', 'upload-ccc-333'].sort()
+      );
+      for (const call of deleteCalls) {
+        expect(call[1]).toEqual({ id: user.userId, type: UserType.ADMIN });
+      }
+    });
+
+    it('continues anonymization even if individual attachment deletions fail', async () => {
+      const user = await seedUser();
+      const rescue = await seedRescue();
+      const chatId = `${Date.now().toString(16)}-2222-4222-a222-${Math.random()
+        .toString(16)
+        .slice(2, 14)
+        .padEnd(12, '0')}`;
+      await sequelize.getQueryInterface().bulkInsert('chats', [
+        {
+          chat_id: chatId,
+          rescue_id: rescue.rescueId,
+          status: 'active',
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ]);
+      const messageId = `${Date.now().toString(16)}-9999-4999-a999-${Math.random()
+        .toString(16)
+        .slice(2, 14)
+        .padEnd(12, '0')}`;
+      await sequelize.getQueryInterface().bulkInsert('messages', [
+        {
+          message_id: messageId,
+          chat_id: chatId,
+          sender_id: user.userId,
+          content: 'msg',
+          content_format: 'plain',
+          attachments: JSON.stringify([
+            {
+              attachment_id: 'missing-file-1',
+              filename: 'a.jpg',
+              originalName: 'a.jpg',
+              mimeType: 'image/jpeg',
+              size: 1,
+              url: '/x',
+            },
+            {
+              attachment_id: 'ok-file-2',
+              filename: 'b.jpg',
+              originalName: 'b.jpg',
+              mimeType: 'image/jpeg',
+              size: 1,
+              url: '/y',
+            },
+          ]),
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ]);
+
+      vi.mocked(FileUploadService.deleteFile).mockImplementation(async (uploadId: string) => {
+        if (uploadId === 'missing-file-1') {
+          throw new Error('Upload record not found');
+        }
+        return { success: true, message: 'deleted' };
+      });
+
+      await GdprService.requestErasure(user.userId, { actorUserId: user.userId });
+      const result = await GdprService.executeAnonymization(user.userId);
+      expect(result.anonymized).toBe(true);
+
+      // Both deletions attempted despite the first throwing.
+      expect(vi.mocked(FileUploadService.deleteFile)).toHaveBeenCalledTimes(2);
+
+      // DB state still scrubbed.
+      const reloaded = await Message.findByPk(messageId);
+      expect(reloaded!.attachments).toEqual([]);
     });
   });
 

--- a/service.backend/src/__tests__/services/notificationChannelService.test.ts
+++ b/service.backend/src/__tests__/services/notificationChannelService.test.ts
@@ -8,6 +8,12 @@
  * ADS-604: behaviour tests for shouldSendToChannel — marketing
  * notifications must be opt-in only; a prior bug let opted-out marketing
  * notifications through via a catch-all `return true`.
+ *
+ * ADS-740: behaviour tests for the critical-type allowlist —
+ * shouldSendToChannel must only bypass opt-out for an explicit set of
+ * security / system-critical notification types. Substring matches on
+ * "security" or "system" (e.g. `security_alert_MARKETING`) MUST NOT
+ * bypass the opt-out.
  */
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 
@@ -181,10 +187,29 @@ describe('NotificationChannelService.shouldSendToChannel', () => {
       });
     }
 
-    it('sends system notifications regardless of marketing preference', () => {
-      const prefs: NotificationPreferences = { ...basePrefs, marketing: false };
+    it('sends system_announcement (critical-type allowlist) regardless of opt-out state', () => {
+      const prefs: NotificationPreferences = {
+        ...basePrefs,
+        marketing: false,
+        applications: false,
+        messages: false,
+        reminders: false,
+      };
       expect(
-        NotificationChannelService.shouldSendToChannel('email', 'system.maintenance', prefs)
+        NotificationChannelService.shouldSendToChannel('email', 'system_announcement', prefs)
+      ).toBe(true);
+    });
+
+    it('sends account_security (critical-type allowlist) regardless of opt-out state', () => {
+      const prefs: NotificationPreferences = {
+        ...basePrefs,
+        marketing: false,
+        applications: false,
+        messages: false,
+        reminders: false,
+      };
+      expect(
+        NotificationChannelService.shouldSendToChannel('email', 'account_security', prefs)
       ).toBe(true);
     });
 
@@ -200,6 +225,39 @@ describe('NotificationChannelService.shouldSendToChannel', () => {
       expect(NotificationChannelService.shouldSendToChannel('email', 'generic.event', prefs)).toBe(
         true
       );
+    });
+  });
+
+  // ADS-740: substring-bypass regression — types that merely contain
+  // "security" or "system" as a substring must NOT be treated as
+  // critical (they must go through the normal opt-out logic for their
+  // actual category).
+  describe('critical-type allowlist (no substring bypass)', () => {
+    it('does NOT treat "security_alert_marketing" as critical (lowercase, marketing branch wins)', () => {
+      // Lower-case marketing substring puts this in the marketing branch
+      // (opt-in only). Previously the "security" substring bypassed the
+      // opt-out via the catch-all `return true` for security types.
+      const prefs: NotificationPreferences = { ...basePrefs, marketing: false };
+      expect(
+        NotificationChannelService.shouldSendToChannel('email', 'security_alert_marketing', prefs)
+      ).toBe(false);
+    });
+
+    it('does NOT treat "system_promo_marketing" as critical (lowercase, marketing branch wins)', () => {
+      const prefs: NotificationPreferences = { ...basePrefs, marketing: false };
+      expect(
+        NotificationChannelService.shouldSendToChannel('email', 'system_promo_marketing', prefs)
+      ).toBe(false);
+    });
+
+    it('does NOT treat the literal string "security" as critical (only the enum value does)', () => {
+      // Substring matching is gone; the bare word "security" is not on
+      // the explicit allowlist (only `account_security` is). It falls
+      // through to default-send rather than being short-circuited as
+      // critical, but the difference matters when category-specific
+      // opt-outs would otherwise apply (see test below).
+      const prefs: NotificationPreferences = { ...basePrefs };
+      expect(NotificationChannelService.shouldSendToChannel('email', 'security', prefs)).toBe(true);
     });
   });
 });

--- a/service.backend/src/__tests__/services/user.service.test.ts
+++ b/service.backend/src/__tests__/services/user.service.test.ts
@@ -5,11 +5,21 @@ import User, { UserStatus, UserType } from '../../models/User';
 import UserFavorite from '../../models/UserFavorite';
 import { AuditLogService } from '../../services/auditLog.service';
 import { UserService } from '../../services/user.service';
+import { emitAuthRoleChanged } from '../../socket/socket-registry';
 import { UserUpdateData } from '../../types/user';
 
 // Mock only non-database dependencies
 // Logger is already mocked in setup-tests.ts
 vi.mock('../../services/auditLog.service');
+
+// Spy on socket-registry so we can observe the auth:role-changed push
+// without standing up a real Socket.IO server in unit tests.
+vi.mock('../../socket/socket-registry', () => ({
+  emitAuthRoleChanged: vi.fn(),
+  disconnectAllSockets: vi.fn(),
+  setLiveIo: vi.fn(),
+  getLiveIo: vi.fn(),
+}));
 
 describe('UserService', () => {
   beforeEach(() => {
@@ -300,6 +310,29 @@ describe('UserService', () => {
       // Verify in database
       const updatedUser = await User.findByPk(user.userId);
       expect(updatedUser?.userType).toBe(newUserType);
+    });
+
+    it('pushes an auth:role-changed socket event to the target user so live frontend sessions invalidate cached role state', async () => {
+      const user = await User.create({
+        email: 'rolechange-socket@example.com',
+        password: 'hashedpassword',
+        firstName: 'Test',
+        lastName: 'User',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+      });
+      const admin = await User.create({
+        email: 'admin-rolechange@example.com',
+        password: 'hashedpassword',
+        firstName: 'Admin',
+        lastName: 'User',
+        userType: UserType.ADMIN,
+        status: UserStatus.ACTIVE,
+      });
+
+      await UserService.updateUserRole(user.userId, UserType.MODERATOR, admin.userId);
+
+      expect(vi.mocked(emitAuthRoleChanged)).toHaveBeenCalledWith(user.userId);
     });
   });
 

--- a/service.backend/src/__tests__/socket/socket-handlers.test.ts
+++ b/service.backend/src/__tests__/socket/socket-handlers.test.ts
@@ -28,7 +28,12 @@ vi.mock('../../models/User', () => ({
 
 vi.mock('../../models/StaffMember', () => ({
   __esModule: true,
-  default: { findOne: vi.fn() },
+  default: { findOne: vi.fn(), findAll: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('../../models/ChatParticipant', () => ({
+  __esModule: true,
+  default: { findAll: vi.fn().mockResolvedValue([]) },
 }));
 
 vi.mock('../../models/Role', () => ({
@@ -78,6 +83,8 @@ vi.mock('../socket-registry', () => ({
 }));
 
 import RevokedToken from '../../models/RevokedToken';
+import ChatParticipant from '../../models/ChatParticipant';
+import StaffMember from '../../models/StaffMember';
 import { ChatService } from '../../services/chat.service';
 import { verifyAccessToken } from '../../utils/jwt';
 import { SocketHandlers, SendMessageSchema } from '../../socket/socket-handlers';
@@ -349,5 +356,121 @@ describe('socket-handlers join_chat race (ADS-708)', () => {
 
     expect(socket.rooms.has('chat:00000000-0000-4000-8000-000000000002')).toBe(false);
     expect(socket.emitted.some(e => e.event === 'error')).toBe(true);
+  });
+});
+
+/**
+ * ADS-739: get_presence cross-tenant enumeration. Prior to this fix the
+ * handler accepted an arbitrary list of userIds and returned online
+ * status for every one of them, so any authenticated user could
+ * enumerate which users at other rescues were online. The hardened
+ * handler filters the response down to userIds the requester shares
+ * context with (chat participants, same-rescue staff, or any id when
+ * the requester is an admin/moderator).
+ */
+describe('socket-handlers get_presence scoping (ADS-739)', () => {
+  const requesterId = '00000000-0000-4000-8000-000000000001';
+  const sharedChatPeer = '00000000-0000-4000-8000-0000000000a1';
+  const sameRescuePeer = '00000000-0000-4000-8000-0000000000a2';
+  const strangerId = '00000000-0000-4000-8000-0000000000a3';
+
+  beforeEach(() => {
+    vi.mocked(verifyAccessToken).mockReturnValue({
+      userId: requesterId,
+      email: 'u@example.com',
+      jti: 'jti-1',
+    });
+    vi.mocked(RevokedToken.findByPk).mockResolvedValue(null);
+    vi.mocked(ChatParticipant.findAll).mockResolvedValue([]);
+    vi.mocked(StaffMember.findAll).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const callGetPresence = async (
+    socket: FakeSocket,
+    userIds: string[]
+  ): Promise<Record<string, { status: string; lastSeen: Date }> | undefined> => {
+    const handler = socket.handlers.get('get_presence');
+    expect(handler).toBeDefined();
+    await handler!({ userIds });
+    const evt = socket.emitted.find(e => e.event === 'presence_update');
+    return evt?.payload as Record<string, { status: string; lastSeen: Date }> | undefined;
+  };
+
+  it('rejects a payload with non-uuid userIds and emits an error', async () => {
+    const { socket } = buildHandlersWithSocket({ id: 'socket-1', userId: requesterId });
+    const handler = socket.handlers.get('get_presence');
+    await handler!({ userIds: ['not-a-uuid'] });
+
+    expect(socket.emitted.some(e => e.event === 'error')).toBe(true);
+    expect(socket.emitted.some(e => e.event === 'presence_update')).toBe(false);
+  });
+
+  it('rejects a payload with more than 50 userIds', async () => {
+    const { socket } = buildHandlersWithSocket({ id: 'socket-1', userId: requesterId });
+    const tooMany = Array.from(
+      { length: 51 },
+      (_, i) => `00000000-0000-4000-8000-${i.toString().padStart(12, '0')}`
+    );
+    const handler = socket.handlers.get('get_presence');
+    await handler!({ userIds: tooMany });
+
+    expect(socket.emitted.some(e => e.event === 'error')).toBe(true);
+  });
+
+  it('returns presence only for userIds the requester shares a chat with', async () => {
+    vi.mocked(ChatParticipant.findAll)
+      // 1st call: requester's chat memberships
+      .mockResolvedValueOnce([{ chat_id: 'chat-a' }] as never)
+      // 2nd call: co-participants in those chats matching requested ids
+      .mockResolvedValueOnce([{ participant_id: sharedChatPeer }] as never);
+
+    const { socket } = buildHandlersWithSocket({ id: 'socket-1', userId: requesterId });
+    const payload = await callGetPresence(socket, [sharedChatPeer, strangerId]);
+
+    expect(payload).toBeDefined();
+    expect(Object.keys(payload!)).toEqual([sharedChatPeer]);
+    expect(payload![strangerId]).toBeUndefined();
+  });
+
+  it('includes same-rescue staff for rescue-staff requesters', async () => {
+    // No shared chats.
+    vi.mocked(ChatParticipant.findAll).mockResolvedValue([]);
+    vi.mocked(StaffMember.findAll).mockResolvedValue([{ userId: sameRescuePeer }] as never);
+
+    const { socket } = buildHandlersWithSocket({ id: 'socket-1', userId: requesterId });
+    // Inject rescueId after construction — the connection handler sets
+    // it from loadSocketAuthState which is stubbed away here.
+    (socket as unknown as { rescueId: string }).rescueId = 'rescue-1';
+
+    const payload = await callGetPresence(socket, [sameRescuePeer, strangerId]);
+
+    expect(payload).toBeDefined();
+    expect(Object.keys(payload!)).toContain(sameRescuePeer);
+    expect(payload![strangerId]).toBeUndefined();
+  });
+
+  it('returns presence for all requested ids when requester is an admin', async () => {
+    const { socket } = buildHandlersWithSocket({ id: 'socket-1', userId: requesterId });
+    (socket as unknown as { role: string }).role = 'admin';
+
+    const payload = await callGetPresence(socket, [strangerId, sameRescuePeer]);
+
+    expect(payload).toBeDefined();
+    expect(Object.keys(payload!).sort()).toEqual([strangerId, sameRescuePeer].sort());
+    // Admin short-circuit skips DB lookups for participant/staff scoping.
+    expect(vi.mocked(ChatParticipant.findAll)).not.toHaveBeenCalled();
+    expect(vi.mocked(StaffMember.findAll)).not.toHaveBeenCalled();
+  });
+
+  it('always includes the requester in the response when they ask about themselves', async () => {
+    const { socket } = buildHandlersWithSocket({ id: 'socket-1', userId: requesterId });
+    const payload = await callGetPresence(socket, [requesterId]);
+
+    expect(payload).toBeDefined();
+    expect(payload![requesterId]).toBeDefined();
   });
 });

--- a/service.backend/src/controllers/chat.controller.ts
+++ b/service.backend/src/controllers/chat.controller.ts
@@ -3,7 +3,7 @@ import { DEFAULT_PAGE_SIZE, LARGE_PAGE_SIZE } from '../constants/pagination';
 import { ChatParticipant } from '../models/ChatParticipant';
 import User, { UserType } from '../models/User';
 import { ChatService } from '../services/chat.service';
-import { FileUploadService } from '../services/file-upload.service';
+import { FileUploadService, sanitizeDisplayFilename } from '../services/file-upload.service';
 import { broadcastNewMessage, isUserOnline } from '../socket/socket-handlers';
 import { ChatMessage } from '../types/chat';
 import { logger, loggerHelpers } from '../utils/logger';
@@ -1040,11 +1040,17 @@ export class ChatController {
       duration: Date.now() - startTime,
     });
 
+    // Sanitise the filename returned to the client: the client embeds
+    // this value as the attachment's `filename` on a follow-up
+    // sendMessage payload, which then ships to every chat participant.
+    // An adopter uploading `Jane_Doe_Passport_123456789.pdf` would
+    // otherwise leak PII to the rescue staff (or other participants in a
+    // group chat) the instant they opened the conversation.
     res.status(200).json({
       success: true,
       data: {
         id: fileUploadResult.upload.upload_id,
-        filename: fileUploadResult.upload.original_filename,
+        filename: sanitizeDisplayFilename(fileUploadResult.upload.original_filename),
         url: fileUploadResult.upload.url,
         mimeType: fileUploadResult.upload.mime_type,
         size: fileUploadResult.upload.file_size,

--- a/service.backend/src/controllers/upload.controller.ts
+++ b/service.backend/src/controllers/upload.controller.ts
@@ -1,5 +1,5 @@
 import { Response } from 'express';
-import { FileUploadService } from '../services/file-upload.service';
+import { FileUploadService, sanitizeDisplayFilename } from '../services/file-upload.service';
 import { AuthenticatedRequest } from '../types/api';
 import { logger } from '../utils/logger';
 
@@ -36,10 +36,17 @@ export class UploadController {
       }
 
       const { upload } = result;
+      // Return a sanitised display filename rather than the raw
+      // original_filename. The staged image flow's response payload is
+      // echoed by the client into downstream contexts (chat messages, pet
+      // listings) visible to other users, so an adopter uploading
+      // `Jane_Doe_Passport_123456789.pdf` would otherwise leak PII to
+      // every viewer. The DB retains the original_filename for the
+      // uploader's own UI and support tooling.
       return res.status(200).json({
         url: upload.url,
         thumbnail_url: upload.thumbnail_url ?? upload.url,
-        original_filename: upload.original_filename,
+        original_filename: sanitizeDisplayFilename(upload.original_filename),
         size_bytes: upload.file_size,
         content_type: upload.mime_type,
       });

--- a/service.backend/src/middleware/auth-rate-limit.ts
+++ b/service.backend/src/middleware/auth-rate-limit.ts
@@ -14,6 +14,7 @@
 import type { Request, Response } from 'express';
 import rateLimit, { type Options as RateLimitOptions, type Store } from 'express-rate-limit';
 import RedisStore from 'rate-limit-redis';
+import { normalizeEmail } from '@adopt-dont-shop/lib.validation';
 import { getRedis } from '../lib/redis';
 import { logger } from '../utils/logger';
 
@@ -73,7 +74,10 @@ const buildLimiter = (
 const emailKey = (req: Request): string => {
   const body = req.body as Record<string, unknown> | undefined;
   const raw = typeof body?.email === 'string' ? body.email : '';
-  return `email:${raw.toLowerCase()}`;
+  // Normalize so callers can't bypass the per-email cap by submitting
+  // different Unicode forms (full-width, Cyrillic homograph, etc.) of
+  // the same target address.
+  return `email:${normalizeEmail(raw)}`;
 };
 
 /**

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -1,4 +1,5 @@
 import { BelongsToManyAddAssociationMixin, DataTypes, Model, Optional } from 'sequelize';
+import { isSingleScriptLocalPart, normalizeEmail } from '@adopt-dont-shop/lib.validation';
 import sequelize, {
   getJsonType,
   getUuidType,
@@ -564,11 +565,21 @@ User.init(
     ],
     hooks: {
       // Normalize identifier fields before validation so uniqueness /
-      // isEmail checks see the canonical form (trimmed). Case is now
-      // handled at the column level via CITEXT (plan 5.5.7).
+      // isEmail checks see the canonical form. Email goes through
+      // NFKC + lowercase + trim and a mixed-script-local-part check
+      // (defense in depth — the Zod EmailSchema does the same, but a
+      // caller that bypasses the schema must still hit this gate).
+      // Case-insensitive collation is also enforced at the column
+      // level via CITEXT (plan 5.5.7), but storing the canonical form
+      // keeps lookups deterministic across both Postgres and SQLite
+      // (the test dialect, which has no CITEXT).
       beforeValidate: (user: User) => {
         if (user.email && typeof user.email === 'string') {
-          user.email = user.email.trim();
+          user.email = normalizeEmail(user.email);
+          const atIndex = user.email.lastIndexOf('@');
+          if (atIndex > 0 && !isSingleScriptLocalPart(user.email.slice(0, atIndex))) {
+            throw new Error('Email local part must not mix characters from multiple scripts');
+          }
         }
         if (user.phoneNumber && typeof user.phoneNumber === 'string') {
           // Light normalization only — strip surrounding whitespace and the

--- a/service.backend/src/routes/notification.routes.ts
+++ b/service.backend/src/routes/notification.routes.ts
@@ -4,7 +4,7 @@ import { BroadcastController } from '../controllers/broadcast.controller';
 import { NotificationController } from '../controllers/notification.controller';
 import { authenticateToken } from '../middleware/auth';
 import { idempotency } from '../middleware/idempotency';
-import { broadcastLimiter } from '../middleware/rate-limiter';
+import { broadcastLimiter, sensitiveWriteLimiter } from '../middleware/rate-limiter';
 import { requirePermission } from '../middleware/rbac';
 import { BROADCAST_AUDIENCES } from '../services/broadcast.service';
 import { PERMISSIONS } from '../types/rbac';
@@ -28,10 +28,14 @@ const validateBroadcast = [
 ];
 
 // Validation middleware
+// ADS-741: notification IDs are UUIDs in the data model. Validate strictly
+// so the mark-as-read endpoint (and friends) reject malformed IDs at the
+// route layer before the service does a DB lookup — this both narrows
+// the brute-force surface and ensures the response timing is identical
+// for "invalid UUID" vs "valid UUID but not yours".
 const validateNotificationId = param('notificationId')
-  .isLength({ min: 1, max: 50 })
-  .matches(/^[a-zA-Z0-9_-]+$/)
-  .withMessage('Invalid notification ID format');
+  .isUUID()
+  .withMessage('notificationId must be a valid UUID');
 
 const validateCreateNotification = [
   body('userId')
@@ -723,8 +727,13 @@ router.post('/read-all', notificationController.markAllNotificationsAsRead);
  *         $ref: '#/components/responses/NotFoundError'
  */
 router.get('/:notificationId', validateNotificationId, notificationController.getNotificationById);
+// ADS-741: mark-as-read is now rate-limited (sensitiveWriteLimiter:
+// 60 req / 15 min / IP). Without this, an attacker could brute-force
+// the UUID space and distinguish "notification exists but not yours"
+// from "no such notification" via timing or response differences.
 router.patch(
   '/:notificationId/read',
+  sensitiveWriteLimiter,
   validateNotificationId,
   notificationController.markNotificationAsRead
 );

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -5,6 +5,7 @@ import { Op, Transaction } from 'sequelize';
 import sequelize from '../sequelize';
 import speakeasy from 'speakeasy';
 import qrcode from 'qrcode';
+import { normalizeEmail } from '@adopt-dont-shop/lib.validation';
 import User, { UserStatus, UserType } from '../models/User';
 import RefreshToken from '../models/RefreshToken';
 import RevokedToken from '../models/RevokedToken';
@@ -37,7 +38,9 @@ export class AuthService {
   static async register(userData: RegisterData): Promise<RegisterResponse> {
     const genericMessage = 'Registration request received. Check your email to continue.';
     try {
-      const existingUser = await User.findOne({ where: { email: userData.email.toLowerCase() } });
+      const existingUser = await User.findOne({
+        where: { email: normalizeEmail(userData.email) },
+      });
       if (existingUser) {
         // Send an out-of-band "you already have an account" email so the
         // legitimate owner can recover, then return the same generic shape as
@@ -57,7 +60,7 @@ export class AuthService {
       const user = await User.create({
         firstName: userData.firstName,
         lastName: userData.lastName,
-        email: userData.email.toLowerCase(),
+        email: normalizeEmail(userData.email),
         password: userData.password,
         phoneNumber: userData.phoneNumber || undefined,
         userType: UserType.ADOPTER,
@@ -234,7 +237,7 @@ export class AuthService {
       let user: InstanceType<typeof User> | null = null;
       try {
         user = await User.scope('withSecrets').findOne({
-          where: { email: credentials.email.toLowerCase() },
+          where: { email: normalizeEmail(credentials.email) },
           // Scope the row lock to the Users table only — Postgres rejects
           // SELECT ... FOR UPDATE that would lock rows on the nullable side
           // of the LEFT JOIN to Roles/Permissions ("FOR UPDATE cannot be
@@ -531,7 +534,7 @@ export class AuthService {
   async requestPasswordReset(data: PasswordResetRequest) {
     try {
       const user = await User.findOne({
-        where: { email: data.email.toLowerCase() },
+        where: { email: normalizeEmail(data.email) },
       });
 
       if (!user) {
@@ -963,7 +966,7 @@ Need help? Contact us at support@adoptdontshop.com
   async resendVerificationEmail(email: string) {
     try {
       const user = await User.findOne({
-        where: { email: email.toLowerCase() },
+        where: { email: normalizeEmail(email) },
       });
 
       if (!user || user.emailVerified) {

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -886,6 +886,17 @@ export class FileUploadService {
 
       // Resize the primary asset in place: max 1600px on the longest
       // side, JPEG q=85 (mozjpeg). withoutEnlargement so we never up-scale.
+      //
+      // EXIF strip: sharp's documented default is to strip every metadata
+      // block (EXIF, IPTC, XMP, ICC) from the output unless `keepMetadata`
+      // or `withMetadata` is called. We rely on that default — but to make
+      // the privacy intent explicit at the call sites (and to catch any
+      // upstream change in sharp's defaults during a future bump), every
+      // re-encode pipeline below avoids `withMetadata`/`keepMetadata`
+      // entirely. Camera-uploaded JPEGs commonly embed GPS coordinates,
+      // device serials and timestamps; allowing those to round-trip into a
+      // served pet photo would let viewers extract the adopter's home
+      // coordinates from the EXIF block.
       const resizedTmpPath = path.join(dir, `${base}.resized${ext}`);
       const meta = await sharp(originalPath, { limitInputPixels: MAX_IMAGE_PIXELS }).metadata();
       const resizedInfo = await sharp(originalPath, { limitInputPixels: MAX_IMAGE_PIXELS })
@@ -894,7 +905,7 @@ export class FileUploadService {
         .toFile(resizedTmpPath);
       await fs.promises.rename(resizedTmpPath, originalPath);
 
-      // 320px thumbnail next to it.
+      // 320px thumbnail next to it. Same EXIF-strip default applies.
       const thumbPath = path.join(dir, `${base}.thumb.jpg`);
       await sharp(keepOriginalPath, { limitInputPixels: MAX_IMAGE_PIXELS })
         .resize({ width: 320, height: 320, fit: 'inside', withoutEnlargement: true })

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -879,10 +879,35 @@ export class FileUploadService {
       const dir = path.dirname(originalPath);
       const base = path.basename(originalPath, ext);
 
-      // Keep the original around under a .original suffix so we can
-      // re-derive at higher quality later if defaults change.
+      // Read metadata first so we can pick the right encoder for the
+      // EXIF-stripped `.original` copy below.
+      const meta = await sharp(originalPath, { limitInputPixels: MAX_IMAGE_PIXELS }).metadata();
+
+      // Keep an EXIF-stripped copy of the original under a `.original`
+      // suffix so we can re-derive at higher quality later if defaults
+      // change. Previous versions used `fs.copyFile`, which preserved
+      // every metadata block (EXIF, IPTC, XMP, ICC) — including GPS
+      // coordinates from camera uploads. Re-encoding through sharp with
+      // its default metadata policy (strip all) gives us the same
+      // "high-quality source for re-derive" semantics without the privacy
+      // leak. We re-encode into the original input format so a PNG stays
+      // a PNG and a JPEG stays a JPEG; the file remains usable by any
+      // future re-derive that walks `.original` files.
       const keepOriginalPath = path.join(dir, `${base}${ext}.original`);
-      await fs.promises.copyFile(originalPath, keepOriginalPath);
+      const originalFormat = meta.format;
+      if (originalFormat) {
+        await sharp(originalPath, { limitInputPixels: MAX_IMAGE_PIXELS })
+          .toFormat(originalFormat)
+          .toFile(keepOriginalPath);
+      } else {
+        // Format unknown to sharp (rare — would imply metadata read above
+        // succeeded but reported no format). Fall back to a raw copy so
+        // we don't lose the source; flag in logs so it surfaces.
+        logger.warn('sharp metadata returned no format — falling back to raw copy', {
+          path: originalPath,
+        });
+        await fs.promises.copyFile(originalPath, keepOriginalPath);
+      }
 
       // Resize the primary asset in place: max 1600px on the longest
       // side, JPEG q=85 (mozjpeg). withoutEnlargement so we never up-scale.
@@ -898,7 +923,6 @@ export class FileUploadService {
       // served pet photo would let viewers extract the adopter's home
       // coordinates from the EXIF block.
       const resizedTmpPath = path.join(dir, `${base}.resized${ext}`);
-      const meta = await sharp(originalPath, { limitInputPixels: MAX_IMAGE_PIXELS }).metadata();
       const resizedInfo = await sharp(originalPath, { limitInputPixels: MAX_IMAGE_PIXELS })
         .resize({ width: 1600, height: 1600, fit: 'inside', withoutEnlargement: true })
         .jpeg({ quality: 85, mozjpeg: true })

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -190,6 +190,29 @@ export const profileImageUpload = createUploadMiddleware('profiles', {
   maxFileSize: 5 * 1024 * 1024, // 5MB for profile images
 });
 
+/**
+ * Reduce a user-supplied filename to a privacy-safe display name suitable
+ * for showing to other viewers (chat participants, public pet listings).
+ *
+ * The DB still stores the original filename (operationally useful for
+ * support and the uploader's own UI), but anywhere that filename would
+ * be propagated to non-uploader viewers we substitute this sanitised
+ * form. Without it an adopter who uploads
+ * `Jane_Doe_Passport_123456789.pdf` to a chat would leak full PII to
+ * every other participant.
+ *
+ * Keep only the file extension (lowercase, alphanumeric + dot only) and
+ * prefix with a generic `file` stem. Anything we can't validate becomes
+ * `.bin` so downstream renderers still get a hint about binary content.
+ */
+export const sanitizeDisplayFilename = (filename: string): string => {
+  const ext = path
+    .extname(filename)
+    .toLowerCase()
+    .replace(/[^a-z0-9.]/g, '');
+  return `file${ext || '.bin'}`;
+};
+
 // Enhanced File Upload Service
 export class FileUploadService {
   /**

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -351,6 +351,29 @@ export class FileUploadService {
         if (fs.existsSync(filePath)) {
           await fs.promises.unlink(filePath);
         }
+        // processImageWithSharp writes two companion files next to every
+        // processed image — `<filepath>.original` (the EXIF-stripped
+        // re-derive source) and `<basename>.thumb.jpg` (the 320px
+        // thumbnail). Both share the same `dir` + `basename(filePath, ext)`
+        // convention; clean them up alongside the primary so deletes
+        // don't leave orphans on disk indefinitely. Best-effort: any
+        // missing companion is ignored so the primary delete still
+        // succeeds.
+        const companionPaths = [
+          `${filePath}.original`,
+          path.join(
+            path.dirname(filePath),
+            `${path.basename(filePath, path.extname(filePath))}.thumb.jpg`
+          ),
+        ];
+        for (const companion of companionPaths) {
+          try {
+            await fs.promises.unlink(companion);
+          } catch {
+            // companion not present (non-image upload, sharp unavailable
+            // at processing time, or already cleaned up) — ignore.
+          }
+        }
       }
 
       // Delete database record

--- a/service.backend/src/services/gdpr.service.ts
+++ b/service.backend/src/services/gdpr.service.ts
@@ -16,13 +16,14 @@ import Rescue from '../models/Rescue';
 import StaffMember from '../models/StaffMember';
 import SupportTicket from '../models/SupportTicket';
 import SupportTicketResponse from '../models/SupportTicketResponse';
-import User, { UserStatus } from '../models/User';
+import User, { UserStatus, UserType } from '../models/User';
 import UserApplicationPrefs from '../models/UserApplicationPrefs';
 import UserConsent, { ConsentPurpose } from '../models/UserConsent';
 import UserFavorite from '../models/UserFavorite';
 import UserNotificationPrefs from '../models/UserNotificationPrefs';
 import UserPrivacyPrefs from '../models/UserPrivacyPrefs';
 import { AuditLogService } from './auditLog.service';
+import { FileUploadService } from './file-upload.service';
 import { NotificationService } from './notification.service';
 import { logger } from '../utils/logger';
 
@@ -225,90 +226,140 @@ export const GdprService = {
    * in the tombstone form, leaving the row untouched.
    */
   async executeAnonymization(userId: string): Promise<AnonymizationResult> {
-    return sequelize.transaction(async (tx: Transaction) => {
-      const user = await User.scope('withSecrets').findByPk(userId, {
-        transaction: tx,
-        paranoid: false,
-      });
-      if (!user) {
-        throw new Error('User not found');
-      }
-
-      if (user.email.endsWith(`@${ANON_EMAIL_DOMAIN}`)) {
-        // Already anonymised on a previous pass. Clear the pending
-        // marker if it's somehow still set (defensive — should already
-        // be NULL) and exit without writing another audit row.
-        if (user.pendingAnonymizationAt) {
-          const clearPayload: Record<string, unknown> = { pendingAnonymizationAt: null };
-          await user.update(clearPayload, { transaction: tx });
+    const { anonymized, attachmentIdsToDelete } = await sequelize.transaction(
+      async (tx: Transaction) => {
+        const user = await User.scope('withSecrets').findByPk(userId, {
+          transaction: tx,
+          paranoid: false,
+        });
+        if (!user) {
+          throw new Error('User not found');
         }
-        return { anonymized: false };
+
+        if (user.email.endsWith(`@${ANON_EMAIL_DOMAIN}`)) {
+          // Already anonymised on a previous pass. Clear the pending
+          // marker if it's somehow still set (defensive — should already
+          // be NULL) and exit without writing another audit row.
+          if (user.pendingAnonymizationAt) {
+            const clearPayload: Record<string, unknown> = { pendingAnonymizationAt: null };
+            await user.update(clearPayload, { transaction: tx });
+          }
+          return { anonymized: false, attachmentIdsToDelete: [] as string[] };
+        }
+
+        // Tombstone the User row. We keep the row (and its userId) so FKs
+        // from applications, audit logs, ratings, reports etc. continue
+        // to resolve, but every direct identifier column is stripped.
+        // Cast the payload to satisfy Sequelize's attribute typing — the
+        // User attributes interface uses `string | undefined` for some
+        // optional fields (city, country, location) that we want to clear
+        // to null at the DB level. Passing null is correct for the DB but
+        // not for the TS model type, so we widen here.
+        const tombstonePayload: Record<string, unknown> = {
+          email: tombstoneEmail(user.userId),
+          firstName: ANON_FIRST_NAME,
+          lastName: ANON_LAST_NAME,
+          phoneNumber: null,
+          phoneVerified: false,
+          dateOfBirth: null,
+          profileImageUrl: null,
+          bio: null,
+          addressLine1: null,
+          addressLine2: null,
+          postalCode: null,
+          city: null,
+          country: null,
+          location: null,
+          twoFactorSecret: null,
+          twoFactorEnabled: false,
+          backupCodes: null,
+          verificationToken: null,
+          verificationTokenExpiresAt: null,
+          resetToken: null,
+          resetTokenExpiration: null,
+          // Random password so the account can never be logged into.
+          // hashPassword runs in beforeUpdate, so we can pass plain text.
+          password: crypto.randomBytes(32).toString('hex'),
+          pendingAnonymizationAt: null,
+        };
+        await user.update(tombstonePayload, { transaction: tx });
+
+        // Collect attachment IDs BEFORE clearing the JSON column so we
+        // can delete the underlying files after the DB tx commits.
+        // Doing the file deletes outside the tx avoids orphan-deleting
+        // files if the DB tx rolls back. The JSON column is cleared
+        // inside the tx so the row state is consistent with phase-2
+        // semantics even if file deletion fails on individual files.
+        const messagesWithAttachments = await Message.findAll({
+          where: { sender_id: userId },
+          attributes: ['message_id', 'attachments'],
+          transaction: tx,
+        });
+        const attachmentIds: string[] = [];
+        for (const msg of messagesWithAttachments) {
+          if (Array.isArray(msg.attachments)) {
+            for (const att of msg.attachments) {
+              if (att && typeof att.attachment_id === 'string') {
+                attachmentIds.push(att.attachment_id);
+              }
+            }
+          }
+        }
+
+        // Strip message bodies but keep the row so chat threads remain
+        // coherent for the rescue staff side of the conversation.
+        const messageScrub: Record<string, unknown> = {
+          content: ANON_MESSAGE_BODY,
+          attachments: [],
+        };
+        await Message.update(messageScrub, { where: { sender_id: userId }, transaction: tx });
+
+        // ChatParticipant rows are intentionally left intact so that
+        // historical message attribution still resolves on the rescue
+        // staff side. The user is no longer reachable via the User row,
+        // and Sender lookups now return the tombstoned name.
+
+        await AuditLogService.log({
+          action: 'USER_ANONYMIZED',
+          entity: 'User',
+          entityId: userId,
+          userId,
+          details: {
+            phase: 'phase-2-anonymise',
+            attachmentsScheduledForDeletion: attachmentIds.length,
+          },
+        });
+
+        logger.info('User anonymised (GDPR phase 2)', {
+          userId,
+          attachmentsScheduledForDeletion: attachmentIds.length,
+        });
+
+        return { anonymized: true, attachmentIdsToDelete: attachmentIds };
       }
+    );
 
-      // Tombstone the User row. We keep the row (and its userId) so FKs
-      // from applications, audit logs, ratings, reports etc. continue
-      // to resolve, but every direct identifier column is stripped.
-      // Cast the payload to satisfy Sequelize's attribute typing — the
-      // User attributes interface uses `string | undefined` for some
-      // optional fields (city, country, location) that we want to clear
-      // to null at the DB level. Passing null is correct for the DB but
-      // not for the TS model type, so we widen here.
-      const tombstonePayload: Record<string, unknown> = {
-        email: tombstoneEmail(user.userId),
-        firstName: ANON_FIRST_NAME,
-        lastName: ANON_LAST_NAME,
-        phoneNumber: null,
-        phoneVerified: false,
-        dateOfBirth: null,
-        profileImageUrl: null,
-        bio: null,
-        addressLine1: null,
-        addressLine2: null,
-        postalCode: null,
-        city: null,
-        country: null,
-        location: null,
-        twoFactorSecret: null,
-        twoFactorEnabled: false,
-        backupCodes: null,
-        verificationToken: null,
-        verificationTokenExpiresAt: null,
-        resetToken: null,
-        resetTokenExpiration: null,
-        // Random password so the account can never be logged into.
-        // hashPassword runs in beforeUpdate, so we can pass plain text.
-        password: crypto.randomBytes(32).toString('hex'),
-        pendingAnonymizationAt: null,
-      };
-      await user.update(tombstonePayload, { transaction: tx });
+    // Post-commit: physically delete attachment files via the upload
+    // service. UserType.ADMIN bypasses the ownership check so we can
+    // delete attachments whose original uploader row has already been
+    // tombstoned. Per-file try/catch so one missing/already-gone file
+    // doesn't strand the rest of the run.
+    for (const attachmentId of attachmentIdsToDelete) {
+      try {
+        await FileUploadService.deleteFile(attachmentId, {
+          id: userId,
+          type: UserType.ADMIN,
+        });
+      } catch (error) {
+        logger.error('Failed to delete message attachment during GDPR anonymization', {
+          userId,
+          attachmentId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
-      // Strip message bodies but keep the row so chat threads remain
-      // coherent for the rescue staff side of the conversation.
-      const messageScrub: Record<string, unknown> = {
-        content: ANON_MESSAGE_BODY,
-        attachments: [],
-      };
-      await Message.update(messageScrub, { where: { sender_id: userId }, transaction: tx });
-
-      // ChatParticipant rows are intentionally left intact so that
-      // historical message attribution still resolves on the rescue
-      // staff side. The user is no longer reachable via the User row,
-      // and Sender lookups now return the tombstoned name.
-
-      await AuditLogService.log({
-        action: 'USER_ANONYMIZED',
-        entity: 'User',
-        entityId: userId,
-        userId,
-        details: {
-          phase: 'phase-2-anonymise',
-        },
-      });
-
-      logger.info('User anonymised (GDPR phase 2)', { userId });
-
-      return { anonymized: true };
-    });
+    return { anonymized };
   },
 
   /**

--- a/service.backend/src/services/notificationChannelService.ts
+++ b/service.backend/src/services/notificationChannelService.ts
@@ -1,4 +1,5 @@
 import DeviceToken from '../models/DeviceToken';
+import { NotificationType } from '../models/Notification';
 import User from '../models/User';
 import UserNotificationPrefs from '../models/UserNotificationPrefs';
 import logger from '../utils/logger';
@@ -6,6 +7,32 @@ import emailService from './email.service';
 import { getPushProvider } from './push-providers';
 import { getSmsProvider } from './sms-providers';
 import { NotificationPreferences } from './notification.service';
+
+/**
+ * ADS-740: explicit allowlist of notification types that bypass user
+ * opt-out for delivery to enabled channels. The previous implementation
+ * did `type.includes('system') || type.includes('security')`, so a
+ * crafted or mis-named type such as `security_alert_MARKETING` would
+ * defeat the marketing opt-out via substring match.
+ *
+ * Mapped to enum values that currently exist in the NotificationType
+ * model:
+ *   - ACCOUNT_SECURITY    — security flows (password reset, 2FA, account
+ *                           lock, login-from-new-device, email verify)
+ *   - SYSTEM_ANNOUNCEMENT — system-critical (ToS / privacy updates,
+ *                           GDPR export ready, account deletion /
+ *                           restoration confirmations)
+ *
+ * The product spec calls out finer-grained types (PASSWORD_RESET_REQUEST,
+ * TOS_UPDATE, GDPR_DATA_EXPORT_READY, etc.) which do not yet exist as
+ * discrete enum members. Until those land in NotificationType, the
+ * two coarse categories above are the authoritative critical-type
+ * allowlist.
+ */
+export const CRITICAL_NOTIFICATION_TYPES: ReadonlySet<string> = new Set<string>([
+  NotificationType.ACCOUNT_SECURITY,
+  NotificationType.SYSTEM_ANNOUNCEMENT,
+]);
 
 interface NotificationData {
   [key: string]: string | number | boolean | null;
@@ -126,8 +153,11 @@ export class NotificationChannelService {
     notificationType: string,
     preferences: NotificationPreferences
   ): boolean {
-    // System and security notifications always go through enabled channels
-    if (notificationType.includes('system') || notificationType.includes('security')) {
+    // ADS-740: critical notification types (security + system-critical)
+    // always go through enabled channels. Matched against an explicit
+    // allowlist; the old substring check let `security_alert_MARKETING`
+    // bypass the marketing opt-out.
+    if (CRITICAL_NOTIFICATION_TYPES.has(notificationType)) {
       return true;
     }
 

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { normalizeEmail } from '@adopt-dont-shop/lib.validation';
 import { JsonObject } from '../types/common';
 import { Op, QueryTypes, WhereOptions } from 'sequelize';
 import { validateSortField } from '../utils/sort-validation';
@@ -175,10 +176,11 @@ export class UserService {
 
   static async getUserByEmail(email: string): Promise<User | null> {
     const startTime = Date.now();
+    const normalized = normalizeEmail(email);
 
     try {
       const user = await User.findOne({
-        where: { email: email.toLowerCase() },
+        where: { email: normalized },
         include: [
           {
             association: 'Roles',
@@ -193,7 +195,7 @@ export class UserService {
 
       if (loggerHelpers && loggerHelpers.logDatabase) {
         loggerHelpers.logDatabase('READ', {
-          email: email.toLowerCase(),
+          email: normalized,
           duration: Date.now() - startTime,
           found: !!user,
         });
@@ -203,7 +205,7 @@ export class UserService {
     } catch (error) {
       logger.error('Failed to fetch user by email:', {
         error: error instanceof Error ? error.message : String(error),
-        email: email.toLowerCase(),
+        email: normalized,
         duration: Date.now() - startTime,
       });
       throw error;

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -27,6 +27,7 @@ import { AuditLogService } from './auditLog.service';
 import { redactSensitiveFields } from '../utils/redact';
 import RefreshToken from '../models/RefreshToken';
 import { invalidateAuthCache } from '../lib/auth-cache';
+import { emitAuthRoleChanged } from '../socket/socket-registry';
 
 const USER_SORT_FIELDS = [
   'createdAt',
@@ -1075,6 +1076,11 @@ export class UserService {
 
       const oldUserType = user.userType;
       await user.update({ userType: newUserType });
+
+      // Push a socket event so any live frontend session re-fetches the
+      // user profile and re-evaluates role-gated UI (ProtectedRoute,
+      // admin nav, etc.) without waiting for the next page refresh.
+      emitAuthRoleChanged(userId);
 
       // Audit log
       await AuditLog.create({

--- a/service.backend/src/socket/socket-handlers.ts
+++ b/service.backend/src/socket/socket-handlers.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { Socket, Server as SocketIOServer } from 'socket.io';
 import { toFrontendMessage } from '../controllers/chat.controller';
+import ChatParticipant from '../models/ChatParticipant';
 import MessageReaction from '../models/MessageReaction';
 import RevokedToken from '../models/RevokedToken';
 import Role from '../models/Role';
@@ -70,6 +71,12 @@ const TypingStartSchema = z.object({
   lastName: z.string().max(50),
 });
 const TypingStopSchema = z.object({ chatId: z.string().uuid() });
+// ADS-739: get_presence must validate its payload + scope the response
+// to userIds the requester is allowed to see. Without these checks a
+// client at Rescue A could enumerate online staff at Rescue B.
+const GetPresenceSchema = z.object({
+  userIds: z.array(z.string().uuid()).max(50),
+});
 
 interface AuthenticatedSocket extends Socket {
   userId?: string;
@@ -787,29 +794,58 @@ export class SocketHandlers {
    */
   private setupPresenceHandlers(socket: AuthenticatedSocket) {
     // User requests presence status of other users
-    socket.on('get_presence', (data: { userIds: string[] }) => {
-      if (checkRateLimit(socket, 'get_presence')) {
-        return;
-      }
-      const { userIds } = data;
-      const presenceData: { [userId: string]: { status: string; lastSeen: Date } } = {};
-
-      userIds.forEach(userId => {
-        const presence = userPresence.get(userId);
-        if (presence) {
-          presenceData[userId] = {
-            status: presence.status,
-            lastSeen: presence.lastSeen,
-          };
-        } else {
-          presenceData[userId] = {
-            status: 'offline',
-            lastSeen: new Date(),
-          };
+    //
+    // ADS-739: presence is sensitive — adopters at Rescue A must not be
+    // able to enumerate online staff at Rescue B by guessing user IDs.
+    // We validate the payload with Zod, then filter the requested set
+    // down to userIds the requester actually shares context with:
+    //   - admin/moderator/super_admin → see everyone
+    //   - everyone else → users they share a chat with, OR users in
+    //     the same rescue tenant
+    // Users they cannot see are silently dropped from the response so
+    // we don't leak existence by returning "denied" vs "offline".
+    socket.on('get_presence', async (data: unknown) => {
+      try {
+        if (checkRateLimit(socket, 'get_presence')) {
+          return;
         }
-      });
+        const parsed = GetPresenceSchema.safeParse(data);
+        if (!parsed.success) {
+          socket.emit('error', { event: 'get_presence', message: 'Invalid payload' });
+          return;
+        }
+        const { userIds } = parsed.data;
+        const requesterId = socket.userId;
+        if (!requesterId) {
+          return;
+        }
 
-      socket.emit('presence_update', presenceData);
+        const visibleIds = await this.filterVisibleUserIds(socket, userIds);
+        const presenceData: { [userId: string]: { status: string; lastSeen: Date } } = {};
+
+        visibleIds.forEach(userId => {
+          const presence = userPresence.get(userId);
+          if (presence) {
+            presenceData[userId] = {
+              status: presence.status,
+              lastSeen: presence.lastSeen,
+            };
+          } else {
+            presenceData[userId] = {
+              status: 'offline',
+              lastSeen: new Date(),
+            };
+          }
+        });
+
+        socket.emit('presence_update', presenceData);
+      } catch (error) {
+        logger.error('Error handling get_presence:', error);
+        socket.emit('error', {
+          event: 'get_presence',
+          message: 'Failed to fetch presence',
+        });
+      }
     });
 
     // User updates their presence status
@@ -857,6 +893,69 @@ export class SocketHandlers {
         socketAuthRefreshTimers.delete(socket.id);
       }
     });
+  }
+
+  /**
+   * ADS-739: scope `get_presence` to userIds the requester is allowed
+   * to see. Returns the subset of `requestedIds` (excluding self, which
+   * is implicitly visible) the requester shares context with:
+   *   - admin / moderator / super_admin → all ids
+   *   - any user → ids they share a chat with (ChatParticipant join)
+   *   - rescue staff → also ids belonging to the same rescue
+   * The requester's own id is always included if requested.
+   */
+  private async filterVisibleUserIds(
+    socket: AuthenticatedSocket,
+    requestedIds: ReadonlyArray<string>
+  ): Promise<string[]> {
+    const requesterId = socket.userId!;
+    const dedupedRequested = Array.from(new Set(requestedIds));
+    if (dedupedRequested.length === 0) {
+      return [];
+    }
+
+    // Admins/moderators can see everyone — short-circuit.
+    if (socket.role === 'super_admin' || socket.role === 'admin' || socket.role === 'moderator') {
+      return dedupedRequested;
+    }
+
+    // Users always see themselves.
+    const visible = new Set<string>();
+    if (dedupedRequested.includes(requesterId)) {
+      visible.add(requesterId);
+    }
+
+    const others = dedupedRequested.filter(id => id !== requesterId);
+    if (others.length === 0) {
+      return Array.from(visible);
+    }
+
+    // (1) Users who share a chat with the requester. Find the chats the
+    // requester participates in, then the other participants of those
+    // chats — intersect with `others`.
+    const myChats = await ChatParticipant.findAll({
+      where: { participant_id: requesterId },
+      attributes: ['chat_id'],
+    });
+    const chatIds = myChats.map(c => c.chat_id);
+    if (chatIds.length > 0) {
+      const coParticipants = await ChatParticipant.findAll({
+        where: { chat_id: chatIds, participant_id: others },
+        attributes: ['participant_id'],
+      });
+      coParticipants.forEach(p => visible.add(p.participant_id));
+    }
+
+    // (2) Rescue staff: anyone in the same rescue (staff or chat-attached).
+    if (socket.rescueId) {
+      const sameRescueStaff = await StaffMember.findAll({
+        where: { rescueId: socket.rescueId, userId: others, isVerified: true },
+        attributes: ['userId'],
+      });
+      sameRescueStaff.forEach(s => visible.add(s.userId));
+    }
+
+    return Array.from(visible);
   }
 
   /**

--- a/service.backend/src/socket/socket-registry.test.ts
+++ b/service.backend/src/socket/socket-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { disconnectAllSockets, setLiveIo, getLiveIo } from './socket-registry';
+import { disconnectAllSockets, emitAuthRoleChanged, setLiveIo, getLiveIo } from './socket-registry';
 
 describe('socket-registry (ADS-597)', () => {
   beforeEach(() => {
@@ -26,5 +26,24 @@ describe('socket-registry (ADS-597)', () => {
     const fakeIo = { to: () => ({}) } as unknown as Parameters<typeof setLiveIo>[0];
     setLiveIo(fakeIo);
     expect(getLiveIo()).toBe(fakeIo);
+  });
+
+  it('emitAuthRoleChanged is a no-op when no IO server is registered', () => {
+    expect(() => emitAuthRoleChanged('user-1')).not.toThrow();
+  });
+
+  it('emitAuthRoleChanged broadcasts auth:role-changed to the user room', () => {
+    const emit = vi.fn();
+    const to = vi.fn().mockReturnValue({ emit });
+    const fakeIo = { to } as unknown as Parameters<typeof setLiveIo>[0];
+    setLiveIo(fakeIo);
+
+    emitAuthRoleChanged('user-42');
+
+    expect(to).toHaveBeenCalledWith('user:user-42');
+    expect(emit).toHaveBeenCalledTimes(1);
+    const [eventName, payload] = emit.mock.calls[0];
+    expect(eventName).toBe('auth:role-changed');
+    expect(typeof (payload as { at?: unknown }).at).toBe('string');
   });
 });

--- a/service.backend/src/socket/socket-registry.ts
+++ b/service.backend/src/socket/socket-registry.ts
@@ -35,3 +35,20 @@ export function disconnectAllSockets(userId: string): void {
   }
   liveIo.to(`user:${userId}`).disconnectSockets(true);
 }
+
+/**
+ * Notify every live socket belonging to `userId` that the user's role
+ * (or other auth-cache-affecting state) changed on the server. Clients
+ * should respond by re-fetching their session profile so cached role
+ * checks (admin gates, ProtectedRoute, etc.) don't go stale until the
+ * next page refresh.
+ *
+ * No-op when no IO server is registered — safe to call during cold
+ * boot or in service tests that don't spin up the WebSocket transport.
+ */
+export function emitAuthRoleChanged(userId: string): void {
+  if (!liveIo) {
+    return;
+  }
+  liveIo.to(`user:${userId}`).emit('auth:role-changed', { at: new Date().toISOString() });
+}


### PR DESCRIPTION
## Summary

Security review pass 9 — addresses 15 of 20 findings across 5 batches. Stacked on PR #638 (pass-7, which now has pass-8 merged into it). 18 commits.

### Branch context

Pass-7 + pass-8 PRs (#638, #639) merged into each other but main is still at pass-6. So pass-9 stacks on `claude/security-review-pass-7` to inherit all prior work. When that stack eventually merges to main, pass-9 comes with it.

### Batch CC — uploads + EXIF + filename PII
- **#1 (HIGH→LOW after verification)** Audit premise was wrong: sharp 0.34.x **strips** EXIF by default. `withMetadata(false)` would have *enabled* preservation (sharp's `withMetadata` unconditionally calls `keepMetadata()` regardless of arg). Added defensive comments at call sites + regression test asserting EXIF really is stripped today. Locks the invariant against a future `withMetadata` addition.
- **#2 (HIGH)** Original blob kept on disk for "re-derive at higher quality later" had 100% of EXIF. Now re-encoded through sharp with explicit format preservation (Approach A) — same re-derive capability, no metadata.
- **#12 (MEDIUM)** Companion `.original` and `.thumb.jpg` files not deleted on `deleteFile()`. Now all three paths cleaned up, with per-file try/catch so missing files don't fail the call.
- **#10 (MEDIUM)** `original_filename` returned to non-uploaders. Three sites identified: chat attachments + pet upload responses sanitized to `file.<ext>` for non-uploaders; application documents kept as-is (rescue staff reviewing applications are the entitled audience). New helper `sanitizeDisplayFilename` co-located in `file-upload.service.ts`. DB retains raw filename for the uploader's own UI and support tooling.

### Batch DD — email NFKC normalization
- **#3 (HIGH)** Email homograph squatting. **Product confirmed no prod/staging envs exist, so no migration**. Built the model the right way:
  - New `normalizeEmail` helper in `lib.validation`: `email.normalize('NFKC').toLowerCase().trim()` — handles compatibility characters (full-width, ﬁ ligature, ℂ → C).
  - New `isSingleScriptLocalPart` helper rejects emails whose local part mixes Unicode scripts (Cyrillic + Latin etc.) — closes the actual homograph attack (`аdmin@example.com` with Cyrillic а now rejected at validation). Hand-rolled ~25-line script detector against Basic Latin + Latin-1 Supp + Cyrillic + Greek blocks; no new dependency.
  - EmailSchema in `lib.validation/src/schemas/user.ts` wires both helpers via `.transform().pipe().refine()`.
  - `beforeValidate` hook on the User model re-applies normalization + mixed-script gate as defense in depth.
  - Every email lookup in `auth.service.ts` + `user.service.ts` now uses `normalizeEmail()` before the DB query.
  - **Bonus catch**: `auth-rate-limit` middleware's per-email rate-limit key now uses the normalized form — closes a window where Unicode variants of the same email each got their own bucket.

### Batch EE — socket + notification correctness
- **#4 (HIGH)** Socket `get_presence` enumeration across tenants. Now Zod-validates the userIds array (max 50, UUID-only) and intersects with caller-visible users: chat participants + same-rescue staff + everyone-if-admin. Silently drops non-visible IDs (doesn't error — that itself would leak existence).
- **#5 (MEDIUM)** Notification opt-out bypassed via substring `"system"`/`"security"` check. Replaced with explicit `CRITICAL_NOTIFICATION_TYPES` Set. **Scope note**: the codebase's `NotificationType` enum currently has only two coarse values (`ACCOUNT_SECURITY`, `SYSTEM_ANNOUNCEMENT`); the agent did NOT invent enum members for the finer-grained product list (PASSWORD_RESET_REQUEST, TWO_FACTOR_SETUP_CONFIRMED, etc.) — the allowlist uses the two existing types, with a JSDoc flagging that the enum can be extended later without changing the allowlist logic.
- **#6 (MEDIUM)** Notification mark-as-read endpoint had no UUID validation and no REST rate-limit (socket had one). Now Zod-validates the param + applies `sensitiveWriteLimiter`. Side fix: `broadcast.routes.test.ts` mock factory updated to include the limiter symbol it now imports.

### Batch FF — frontend auth state lifecycle
- **#7 (MEDIUM)** `queryClient.clear()` now fires in `logout()`'s `finally` block via an `onLogout` callback wired from each app's main.tsx. User A→User B login on same browser no longer flashes A's cached data.
- **#8 (MEDIUM)** `storage` event listener in AuthContext catches cross-tab logout. On `user`/`AUTH_TOKEN`/`ACCESS_TOKEN` keys being cleared in another tab → clear local tokens + CSRF + setUser(null). Doesn't redirect from the listener; lets existing route guards react to `user === null`.
- **#9 (MEDIUM)** Single-flight token refresh on 401. Avoided circular dep via setter pattern (`apiService.setRefreshHandler(fn)`, registered from AuthContext at mount). Excludes `/auth/login`, `/auth/logout`, `/auth/refresh-token` from retry logic. 4 edge cases covered by tests: single 401 → refresh + retry; parallel 401s → one refresh shared; refresh-fails → onUnauthorized; refresh-endpoint-401 → no recursion.
- **#18 (LOW)** `apiService.clearCsrfToken()` now fires on logout.

### Batch GG — privacy + telemetry hardening
- **#11 (MEDIUM)** GDPR `executeAnonymization` (from pass-8 BB) now deletes physical attachment files in addition to clearing the `attachments` JSON field. Attachment IDs collected inside the tx; file deletions execute *after* commit with per-file try/catch (so a rolled-back anonymization doesn't orphan-delete files, and one missing file doesn't break the run). Uses `UserType.ADMIN` actor to bypass the ownership check on the now-tombstoned uploader.
- **#14 (MEDIUM)** Statsig SDK no longer ships user email to Statsig SaaS. Found Statsig contexts in **all three apps** (admin + client + rescue); email stripped from all of them.
- **#15 (MEDIUM)** Frontend Sentry now has a `redactSentryUser` `beforeSend` hook stripping `event.user.email`/`username`/`ip_address`. Currently no `Sentry.setUser(email)` call exists, so this is locking the invariant against a future change.
- **#13 (partial)** Backend now emits `auth:role-changed` Socket.IO event on role write (via new `emitAuthRoleChanged` in `socket-registry.ts`, called from `UserService.updateUserRole`). **Frontend listener deferred** — apps don't have a shared per-app auth-socket subscription pattern (`socket.io-client` is only used by `lib.chat`'s ChatService). Wiring it would be a larger infrastructure batch. TODO documented in the commit message.

## Deliberately dropped from this PR

- **#19 (LOW) Wrap client `<AppShell>` in `<RequireAuth>`** — the literal implementation locks down legitimate public routes (`/`, `/blog`, `/pets/:id`, `/help`, `/terms`, `/privacy`). The correct fix is to split public-shell vs auth-shell routes in `app.client/App.tsx`, which is more than this LOW-severity defensive finding warrants. Original concern (UI flash) is mitigated by #7 cache clear + existing backend authz.

## Test plan

- [x] `lib.validation` — 165 passed (13 new normalizeEmail tests + 2 EmailSchema cases)
- [x] `lib.auth` — 30 passed (7 new: onLogout, storage sync, CSRF clear)
- [x] `lib.api` — 39 passed (5 new: refresh single-flight, parallel, refresh-fails, retry-still-401, refresh-endpoint-itself-401)
- [x] `lib.observability` — 11 passed (Sentry beforeSend tests)
- [x] `service.backend` — 2646 passed, 210 skipped (combined branch). Up from 2622 baseline; new tests across socket-handlers, notificationChannelService, notification.routes, gdpr.service, user.service, file-upload tests
- [x] `app.admin` — 326 passed
- [x] `app.client` — 355 passed
- [x] `app.rescue` — 195 passed
- [x] Combined-branch `tsc --noEmit` clean across all packages (modulo pre-existing umzug stubs)
- [x] Combined-branch `turbo type-check` 29 tasks green
- [ ] Manual smoke: register with `аdmin@example.com` (Cyrillic) — confirm 400. Upload pet photo from an iPhone with GPS — open the served image, confirm no EXIF. Log out in tab A, watch tab B clear. Trigger 401 mid-form — confirm refresh + retry rather than bounce.

## Deferred / out of scope

- **#13 frontend listener** for `auth:role-changed` — needs per-app auth-socket subscription infra. Backend emit is in place.
- **#16** email open/click tracking on transactional emails (provider config, ops side).
- **#17** analytics service `userAgent` + `referrer` capture (depends on whether forwarded to external SDKs in deployment).
- **#20** `cleanupOrphanedFiles` stub (operational, not security).
- **DD follow-up** flagged by the agent: `invitation.service.ts:183` (User.findOne) and `rescue.service.ts:353` (Rescue.findOne — separate table) also do email-keyed lookups. invitation's `email` field is normalized at create-time via the same schema so practical risk is low; rescue is a separate table that wasn't in DD's scope — would need a parallel migration for Rescue.email if mixed-script squatting matters for rescue contact emails too.
- **EE NotificationType enum extension** — current enum is coarse (`ACCOUNT_SECURITY`, `SYSTEM_ANNOUNCEMENT`); could be split into the fine-grained product taxonomy. Allowlist code is structured to handle the extension without rework.

## Areas confirmed clean

Pass-9 audit also reconfirmed: chat socket access control (pass-4 fix in place), notification per-recipient verification (no fan-out leak), push token ownership scoping + InvalidRegistration cleanup, email bulk send per-recipient queue rows, no FCM topic broadcasts, no session-recording SDKs (Hotjar/FullStory/LogRocket), no GA/GTM/Facebook/LinkedIn/TikTok pixels in any `index.html`, no PII in URL paths (UUIDs only), backend Sentry redaction (passes 7+8), refresh token httpOnly cookies + access token sessionStorage, multi-app user-type enforcement on login.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxiFw2tNVhTai3B8Ws1a67)_