### PR TITLE
security: pass-10 fixes (bulk-op hooks, anti-abuse caps, JWT forced rotation, 2FA recovery, session UX)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -373,6 +373,20 @@ EXPOSE_API_DOCS=true
 RATE_LIMIT_DEV_BYPASS=false
 
 # -----------------------------------------------------------------------------
+# Cloudflare Turnstile (signup CAPTCHA)
+# -----------------------------------------------------------------------------
+# Backend secret used to validate the turnstileToken submitted by /register.
+# Required in production — if unset in a production-like env the registration
+# endpoint will refuse all requests rather than silently disable the CAPTCHA.
+# Leave unset in dev/test to bypass.
+# TURNSTILE_SECRET_KEY=
+
+# Public site key consumed by the frontend Turnstile widget (Vite-exposed).
+# Frontend integration is intentionally a follow-up; this env var is reserved
+# here so deployment configs can be kept in sync.
+# VITE_TURNSTILE_SITE_KEY=
+
+# -----------------------------------------------------------------------------
 # Seeder Demo Data (dev/test only — ALLOW_DEMO_SEED=true to activate)
 # -----------------------------------------------------------------------------
 # Counts for the demo seeder. Defaults are sensible; override to stress-test.

--- a/app.client/src/pages/PetDetailsPage.tsx
+++ b/app.client/src/pages/PetDetailsPage.tsx
@@ -518,47 +518,75 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
 
           <Card className={styles.actionCard}>
             <h3>Interested in {pet.name}?</h3>
-            {pet.rescue_id && pet.rescue?.name && (
-              <div className='rescue-info'>
-                <div className='rescue-name'>
-                  From{' '}
-                  <Link to={`/rescues/${pet.rescue_id}`} onClick={handleRescueProfileClick}>
-                    {pet.rescue.name}
-                  </Link>
-                  {pet.rescue.location ? ` · ${pet.rescue.location}` : ''}
-                </div>
-              </div>
-            )}
-            <div className='actions'>
-              {pet.status === 'available' && (
-                <Link
-                  className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
-                  to={`/apply/${pet.pet_id}`}
-                  onClick={handleApplyClick}
-                >
-                  Apply to Adopt
-                </Link>
-              )}
-              {pet.rescue_id && (
-                <Link
-                  className={`${styles.actionLink} ${styles.actionLinkOutline}`}
-                  to={`/rescues/${pet.rescue_id}`}
-                  onClick={handleRescueProfileClick}
-                >
-                  View Rescue Profile
-                </Link>
-              )}
-              {pet.rescue_id && (
-                <Button
-                  className={styles.contactButton}
-                  variant='primary'
-                  size='lg'
-                  onClick={handleContactRescue}
-                >
-                  Contact Rescue
-                </Button>
-              )}
-            </div>
+            {(() => {
+              // A13: surface rescue verification state. `status` is missing
+              // on legacy API responses and isn't part of the lib.pets
+              // PetRescueSchema type yet — read it through a narrowed
+              // index access so the call site stays type-safe.
+              const rescueStatus = (pet.rescue as { status?: string } | undefined)?.status;
+              const isUnverified = !!rescueStatus && rescueStatus !== 'verified';
+              const verificationTooltip =
+                'This rescue is awaiting verification — please check back soon';
+              return (
+                <>
+                  {pet.rescue_id && pet.rescue?.name && (
+                    <div className='rescue-info'>
+                      <div className='rescue-name'>
+                        From{' '}
+                        <Link to={`/rescues/${pet.rescue_id}`} onClick={handleRescueProfileClick}>
+                          {pet.rescue.name}
+                        </Link>
+                        {pet.rescue.location ? ` · ${pet.rescue.location}` : ''}
+                      </div>
+                      {isUnverified && <Badge variant='warning'>Pending verification</Badge>}
+                    </div>
+                  )}
+                  <div className='actions'>
+                    {pet.status === 'available' &&
+                      (isUnverified ? (
+                        <Button
+                          className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
+                          variant='primary'
+                          size='lg'
+                          disabled
+                          title={verificationTooltip}
+                        >
+                          Apply to Adopt
+                        </Button>
+                      ) : (
+                        <Link
+                          className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
+                          to={`/apply/${pet.pet_id}`}
+                          onClick={handleApplyClick}
+                        >
+                          Apply to Adopt
+                        </Link>
+                      ))}
+                    {pet.rescue_id && (
+                      <Link
+                        className={`${styles.actionLink} ${styles.actionLinkOutline}`}
+                        to={`/rescues/${pet.rescue_id}`}
+                        onClick={handleRescueProfileClick}
+                      >
+                        View Rescue Profile
+                      </Link>
+                    )}
+                    {pet.rescue_id && (
+                      <Button
+                        className={styles.contactButton}
+                        variant='primary'
+                        size='lg'
+                        onClick={handleContactRescue}
+                        disabled={isUnverified}
+                        title={isUnverified ? verificationTooltip : undefined}
+                      >
+                        Contact Rescue
+                      </Button>
+                    )}
+                  </div>
+                </>
+              );
+            })()}
           </Card>
         </div>
 

--- a/app.client/src/types/index.ts
+++ b/app.client/src/types/index.ts
@@ -159,6 +159,10 @@ export interface Pet {
     location?: string;
     phone?: string;
     email?: string;
+    // A13: surfaces verification state to the client so the apply/message
+    // affordances can be disabled and a "Pending verification" badge can
+    // be shown next to the rescue name.
+    status?: 'pending' | 'verified' | 'suspended' | 'inactive' | 'rejected';
   };
 }
 

--- a/lib.pets/src/schemas.ts
+++ b/lib.pets/src/schemas.ts
@@ -107,6 +107,10 @@ export const PetRescueSchema = z.object({
   location: z.string().optional(),
   phone: z.string().optional(),
   email: z.string().optional(),
+  // A13: verification state surfaced to the client so adopter UIs can
+  // show a "Pending verification" badge and disable apply/message
+  // affordances on unverified rescues.
+  status: z.enum(['pending', 'verified', 'suspended', 'inactive', 'rejected']).optional(),
 });
 
 // ── Pet schema ─────────────────────────────────────────────────────────────────

--- a/lib.validation/src/schemas/user.ts
+++ b/lib.validation/src/schemas/user.ts
@@ -164,6 +164,19 @@ export const ResetPasswordSchema = z.object({
 });
 export type ResetPassword = z.infer<typeof ResetPasswordSchema>;
 
+// ADS Batch KK: email-bootstrapped 2FA recovery. Request mirrors the
+// password-reset shape (email only); confirm takes only the token from
+// the email link — the capability IS the token.
+export const RequestTwoFactorRecoverySchema = z.object({
+  email: EmailSchema,
+});
+export type RequestTwoFactorRecovery = z.infer<typeof RequestTwoFactorRecoverySchema>;
+
+export const ConfirmTwoFactorRecoverySchema = z.object({
+  token: z.string().min(1, 'Recovery token is required'),
+});
+export type ConfirmTwoFactorRecovery = z.infer<typeof ConfirmTwoFactorRecoverySchema>;
+
 /**
  * Inline location block on profile update. Mirrors the express-validator
  * chain in auth.controller.validateUpdateProfile so behaviour is unchanged.

--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -17,6 +17,7 @@ import ApplicationReferenceModel, {
 } from '../../models/ApplicationReference';
 import ApplicationStatusTransition from '../../models/ApplicationStatusTransition';
 import Pet, { PetStatus, PetType, AgeGroup, Gender } from '../../models/Pet';
+import Rescue from '../../models/Rescue';
 import StaffMember from '../../models/StaffMember';
 import User, { UserStatus, UserType } from '../../models/User';
 import { ApplicationService } from '../../services/application.service';
@@ -36,6 +37,7 @@ vi.mock('../../models/ApplicationAnswer');
 vi.mock('../../models/ApplicationReference');
 vi.mock('../../models/ApplicationStatusTransition');
 vi.mock('../../models/Pet');
+vi.mock('../../models/Rescue');
 vi.mock('../../models/StaffMember');
 vi.mock('../../models/User');
 vi.mock('../../services/auditLog.service');
@@ -58,6 +60,7 @@ const MockedApplicationStatusTransition = ApplicationStatusTransition as vi.Mock
   typeof ApplicationStatusTransition
 >;
 const MockedPet = Pet as vi.MockedObject<Pet>;
+const MockedRescue = Rescue as vi.MockedObject<typeof Rescue>;
 const MockedStaffMember = StaffMember as vi.MockedObject<typeof StaffMember>;
 const MockedUser = User as vi.MockedObject<User>;
 const MockedAuditLogService = AuditLogService as vi.MockedObject<AuditLogService>;
@@ -77,6 +80,13 @@ describe('Application Submission Workflow Integration Tests', () => {
 
     // Setup default audit log mocks
     MockedAuditLogService.log = vi.fn().mockResolvedValue(undefined as never);
+
+    // A13: default to a verified rescue so existing happy-path tests
+    // are unaffected by the application-creation gate.
+    MockedRescue.findByPk = vi.fn().mockResolvedValue({
+      rescueId,
+      status: 'verified',
+    } as never);
 
     // Setup default timeline mocks
     MockedApplicationTimelineService.createEvent = vi.fn().mockResolvedValue(undefined as never);

--- a/service.backend/src/__tests__/middleware/auth.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/auth.middleware.test.ts
@@ -642,6 +642,141 @@ describe('Authentication Middleware', () => {
       });
     });
 
+    describe('when tokens_invalid_before is set on the user', () => {
+      it('rejects an access token whose iat predates the rotation timestamp', async () => {
+        const rotatedAt = new Date('2026-05-22T10:00:00Z');
+        const payload: JWTPayload = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          // iat one minute before the rotation
+          iat: Math.floor(rotatedAt.getTime() / 1000) - 60,
+        };
+        const mockUser = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          status: 'active',
+          emailVerified: true,
+          tokensInvalidBefore: rotatedAt,
+          Roles: [],
+        };
+
+        mockRequest.headers = { authorization: 'Bearer stale-token' };
+        (jwt.verify as vi.Mock).mockReturnValue(payload);
+        (User.findByPk as vi.Mock).mockResolvedValue(mockUser);
+
+        await authenticateToken(
+          mockRequest as AuthenticatedRequest,
+          mockResponse as Response,
+          mockNext
+        );
+
+        expect(mockResponse.status).toHaveBeenCalledWith(401);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          error: 'Token revoked due to credential change',
+        });
+        expect(mockNext).not.toHaveBeenCalled();
+      });
+
+      it('accepts an access token whose iat is at or after the rotation timestamp', async () => {
+        const rotatedAt = new Date('2026-05-22T10:00:00Z');
+        const payload: JWTPayload = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          iat: Math.floor(rotatedAt.getTime() / 1000) + 60,
+        };
+        const mockUser = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          status: 'active',
+          emailVerified: true,
+          tokensInvalidBefore: rotatedAt,
+          Roles: [],
+        };
+
+        mockRequest.headers = { authorization: 'Bearer fresh-token' };
+        (jwt.verify as vi.Mock).mockReturnValue(payload);
+        (User.findByPk as vi.Mock).mockResolvedValue(mockUser);
+
+        await authenticateToken(
+          mockRequest as AuthenticatedRequest,
+          mockResponse as Response,
+          mockNext
+        );
+
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockResponse.status).not.toHaveBeenCalled();
+      });
+
+      it('accepts an access token when tokens_invalid_before is null', async () => {
+        const payload: JWTPayload = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          iat: 1000,
+        };
+        const mockUser = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          status: 'active',
+          emailVerified: true,
+          tokensInvalidBefore: null,
+          Roles: [],
+        };
+
+        mockRequest.headers = { authorization: 'Bearer valid-token' };
+        (jwt.verify as vi.Mock).mockReturnValue(payload);
+        (User.findByPk as vi.Mock).mockResolvedValue(mockUser);
+
+        await authenticateToken(
+          mockRequest as AuthenticatedRequest,
+          mockResponse as Response,
+          mockNext
+        );
+
+        expect(mockNext).toHaveBeenCalled();
+      });
+    });
+
+    describe('when the JWT userType claim disagrees with the DB', () => {
+      it('logs the drift and uses the DB value as the source of truth on req.user', async () => {
+        const payload: JWTPayload = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          userType: 'admin',
+        };
+        const mockUser = {
+          userId: 'user-123',
+          email: 'test@example.com',
+          // DB says adopter — the JWT's admin claim must NOT win.
+          userType: 'adopter',
+          status: 'active',
+          emailVerified: true,
+          Roles: [],
+        };
+
+        mockRequest.headers = { authorization: 'Bearer drifted-token' };
+        (jwt.verify as vi.Mock).mockReturnValue(payload);
+        (User.findByPk as vi.Mock).mockResolvedValue(mockUser);
+
+        await authenticateToken(
+          mockRequest as AuthenticatedRequest,
+          mockResponse as Response,
+          mockNext
+        );
+
+        expect(mockRequest.user).toBe(mockUser);
+        expect(mockRequest.user?.userType).toBe('adopter');
+        expect(loggerHelpers.logSecurity).toHaveBeenCalledWith(
+          'JWT userType drift; using DB value',
+          expect.objectContaining({
+            userId: 'user-123',
+            jwtUserType: 'admin',
+            dbUserType: 'adopter',
+          })
+        );
+        expect(mockNext).toHaveBeenCalled();
+      });
+    });
+
     describe('when unexpected errors occur', () => {
       it('should return 500 for unexpected errors', async () => {
         mockRequest.headers = { authorization: 'Bearer valid-token' };

--- a/service.backend/src/__tests__/middleware/turnstile.test.ts
+++ b/service.backend/src/__tests__/middleware/turnstile.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Behaviour tests for the Cloudflare Turnstile verification middleware (A9).
+ */
+import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { verifyTurnstileToken } from '../../middleware/turnstile';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.post('/register', verifyTurnstileToken, (_req, res) => {
+    res.status(204).end();
+  });
+  return app;
+};
+
+describe('verifyTurnstileToken', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    delete process.env.TURNSTILE_SECRET_KEY;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('bypasses when the secret is unset outside production', async () => {
+    const res = await request(buildApp()).post('/register').send({});
+    expect(res.status).toBe(204);
+  });
+
+  it('refuses every request when the secret is unset in production', async () => {
+    process.env.NODE_ENV = 'production';
+    const res = await request(buildApp()).post('/register').send({});
+    expect(res.status).toBe(503);
+  });
+
+  it('rejects requests with no turnstileToken when secret is configured', async () => {
+    process.env.TURNSTILE_SECRET_KEY = 'fake-secret';
+    const res = await request(buildApp()).post('/register').send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid CAPTCHA token' });
+  });
+
+  it('rejects when Cloudflare reports failure', async () => {
+    process.env.TURNSTILE_SECRET_KEY = 'fake-secret';
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: false, 'error-codes': ['invalid-input-response'] }),
+    }) as unknown as typeof fetch;
+
+    const res = await request(buildApp()).post('/register').send({ turnstileToken: 'bad' });
+    expect(res.status).toBe(400);
+  });
+
+  it('passes through when Cloudflare reports success', async () => {
+    process.env.TURNSTILE_SECRET_KEY = 'fake-secret';
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    }) as unknown as typeof fetch;
+
+    const res = await request(buildApp()).post('/register').send({ turnstileToken: 'good' });
+    expect(res.status).toBe(204);
+  });
+
+  it('rejects when the siteverify call itself fails', async () => {
+    process.env.TURNSTILE_SECRET_KEY = 'fake-secret';
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+
+    const res = await request(buildApp()).post('/register').send({ turnstileToken: 'good' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/service.backend/src/__tests__/middleware/user-abuse-rate-limit.test.ts
+++ b/service.backend/src/__tests__/middleware/user-abuse-rate-limit.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Behaviour tests for the per-user anti-abuse rate limiters. Verifies that
+ * each limiter buckets per `req.user.userId` and 429s on the (max+1)th
+ * request while leaving other users unaffected.
+ */
+import { vi, beforeEach, describe, it, expect } from 'vitest';
+import express, { type NextFunction, type Response } from 'express';
+import request from 'supertest';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../lib/redis', () => ({
+  getRedis: () => null,
+}));
+
+import {
+  applicationCreateDailyLimiter,
+  applicationCreateWeeklyLimiter,
+  reportCreateDailyLimiter,
+} from '../../middleware/user-abuse-rate-limit';
+
+type FakeAuthedRequest = express.Request & { user?: { userId: string } };
+
+const buildApp = (
+  middleware: (req: express.Request, res: Response, next: NextFunction) => void,
+  userId: string
+) => {
+  const app = express();
+  app.use((req: FakeAuthedRequest, _res, next) => {
+    req.user = { userId };
+    next();
+  });
+  app.post('/', middleware, (_req, res) => {
+    res.status(204).end();
+  });
+  return app;
+};
+
+describe('user-abuse-rate-limit', () => {
+  beforeEach(() => {
+    delete process.env.RATE_LIMIT_DEV_BYPASS;
+    process.env.NODE_ENV = 'test';
+  });
+
+  it('lets the first 5 application create requests through and 429s the 6th', async () => {
+    const app = buildApp(applicationCreateDailyLimiter, 'user-A');
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await request(app).post('/');
+      expect(res.status).toBe(204);
+    }
+    const blocked = await request(app).post('/');
+    expect(blocked.status).toBe(429);
+  });
+
+  it('allows up to 20 application creates in the weekly bucket', async () => {
+    const app = buildApp(applicationCreateWeeklyLimiter, 'user-B');
+    for (let i = 0; i < 20; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await request(app).post('/');
+      expect(res.status).toBe(204);
+    }
+    const blocked = await request(app).post('/');
+    expect(blocked.status).toBe(429);
+  });
+
+  it('reports limiter 429s the 6th report from one user', async () => {
+    const app = buildApp(reportCreateDailyLimiter, 'user-C');
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await request(app).post('/');
+      expect(res.status).toBe(204);
+    }
+    const blocked = await request(app).post('/');
+    expect(blocked.status).toBe(429);
+  });
+
+  it('bypasses limiting when RATE_LIMIT_DEV_BYPASS=true outside production', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.RATE_LIMIT_DEV_BYPASS = 'true';
+    const app = buildApp(reportCreateDailyLimiter, 'user-D');
+    for (let i = 0; i < 10; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await request(app).post('/');
+      expect(res.status).toBe(204);
+    }
+  });
+});

--- a/service.backend/src/__tests__/models/Application.statusTransition.test.ts
+++ b/service.backend/src/__tests__/models/Application.statusTransition.test.ts
@@ -147,4 +147,18 @@ describe('Application status transition (model-layer invariant)', () => {
     expect(app.status).toBe(ApplicationStatus.APPROVED);
     expect(app.notes).toBe('some notes');
   });
+
+  it('rejects forbidden transitions via bulk Application.update with individualHooks', async () => {
+    // The two bulk-update callsites in application.service.ts (home-visit
+    // scheduling and outcome propagation) must run with individualHooks:true
+    // so the beforeUpdate state-machine guard fires per row. Without that
+    // flag, a forbidden REJECTED -> APPROVED transition silently commits.
+    const app = await newApplication(ApplicationStatus.REJECTED);
+    await expect(
+      Application.update(
+        { status: ApplicationStatus.APPROVED },
+        { where: { applicationId: app.applicationId }, individualHooks: true }
+      )
+    ).rejects.toThrow(/Invalid application status transition/);
+  });
 });

--- a/service.backend/src/__tests__/routes/application.routes.test.ts
+++ b/service.backend/src/__tests__/routes/application.routes.test.ts
@@ -80,6 +80,38 @@ vi.mock('../../middleware/rate-limiter', () => ({
   generalLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
 }));
 
+// Module-level mutable counters so the per-test handlers can simulate the
+// real express-rate-limit behaviour (429 on the (max+1)th request).
+const dailyCounter = { count: 0, max: 5 };
+const weeklyCounter = { count: 0, max: 20 };
+
+vi.mock('../../middleware/user-abuse-rate-limit', () => ({
+  applicationCreateDailyLimiter: (
+    _req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+  ) => {
+    dailyCounter.count += 1;
+    if (dailyCounter.count > dailyCounter.max) {
+      res.status(429).json({ error: 'daily limit' });
+      return;
+    }
+    next();
+  },
+  applicationCreateWeeklyLimiter: (
+    _req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+  ) => {
+    weeklyCounter.count += 1;
+    if (weeklyCounter.count > weeklyCounter.max) {
+      res.status(429).json({ error: 'weekly limit' });
+      return;
+    }
+    next();
+  },
+}));
+
 vi.mock('../../middleware/idempotency', () => ({
   idempotency: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
 }));
@@ -151,6 +183,9 @@ const buildApp = () => {
 describe('Application routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset the per-user limiter counters so each test starts clean.
+    dailyCounter.count = 0;
+    weeklyCounter.count = 0;
     // Default: authenticated as adopter, role check passes
     authenticateTokenMock.mockImplementation(
       (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
@@ -217,6 +252,40 @@ describe('Application routes', () => {
       const res = await request(buildApp()).post('/api/v1/applications').send({ answers: {} });
 
       expect(res.status).toBe(422);
+    });
+
+    it('allows up to 5 applications per user within the daily window', async () => {
+      // Service returns success so the route reaches a 2xx response and
+      // we can confirm the limiter let it through.
+      vi.mocked(ApplicationService.createApplication).mockResolvedValue({
+        applicationId: 'app-1',
+      } as unknown as Awaited<ReturnType<typeof ApplicationService.createApplication>>);
+
+      const app = buildApp();
+      for (let i = 0; i < 4; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        const res = await request(app)
+          .post('/api/v1/applications')
+          .send({ petId: 'pet-uuid-1', answers: {} });
+        expect(res.status).not.toBe(429);
+      }
+    });
+
+    it('rejects the 6th application in a 24h window with 429', async () => {
+      vi.mocked(ApplicationService.createApplication).mockResolvedValue({
+        applicationId: 'app-1',
+      } as unknown as Awaited<ReturnType<typeof ApplicationService.createApplication>>);
+
+      const app = buildApp();
+      // First 5 pass through the daily limiter.
+      for (let i = 0; i < 5; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await request(app).post('/api/v1/applications').send({ petId: 'pet-uuid-1', answers: {} });
+      }
+      const res = await request(app)
+        .post('/api/v1/applications')
+        .send({ petId: 'pet-uuid-1', answers: {} });
+      expect(res.status).toBe(429);
     });
   });
 

--- a/service.backend/src/__tests__/routes/auth.routes.test.ts
+++ b/service.backend/src/__tests__/routes/auth.routes.test.ts
@@ -45,6 +45,8 @@ vi.mock('../../services/auth.service', () => ({
   AuthService: class {
     requestPasswordReset = vi.fn();
     confirmPasswordReset = vi.fn();
+    requestTwoFactorRecovery = vi.fn();
+    confirmTwoFactorRecovery = vi.fn();
     verifyEmail = vi.fn();
     resendVerificationEmail = vi.fn();
   },
@@ -392,6 +394,30 @@ describe('Auth routes', () => {
       const res = await request(buildApp())
         .post('/api/v1/auth/forgot-password')
         .send({ email: 'not-valid' });
+
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe('POST /api/v1/auth/2fa/recover', () => {
+    it('returns 422 when email is missing', async () => {
+      const res = await request(buildApp()).post('/api/v1/auth/2fa/recover').send({});
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 when email is not a valid address', async () => {
+      const res = await request(buildApp())
+        .post('/api/v1/auth/2fa/recover')
+        .send({ email: 'not-valid' });
+
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe('POST /api/v1/auth/2fa/recover/confirm', () => {
+    it('returns 422 when token is missing', async () => {
+      const res = await request(buildApp()).post('/api/v1/auth/2fa/recover/confirm').send({});
 
       expect(res.status).toBe(422);
     });

--- a/service.backend/src/__tests__/routes/auth.routes.test.ts
+++ b/service.backend/src/__tests__/routes/auth.routes.test.ts
@@ -81,6 +81,10 @@ vi.mock('../../middleware/auth-rate-limit', () => ({
   loginIpLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
 }));
 
+vi.mock('../../middleware/turnstile', () => ({
+  verifyTurnstileToken: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+}));
+
 vi.mock('../../middleware/ip-rules', () => ({
   enforceIpRules: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
 }));

--- a/service.backend/src/__tests__/routes/session.routes.test.ts
+++ b/service.backend/src/__tests__/routes/session.routes.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Behaviour coverage for the user-facing session routes:
+ *   - GET /api/v1/sessions returns the caller's own active sessions;
+ *   - DELETE /api/v1/sessions/:sessionId revokes one belonging to the
+ *     caller; missing auth → 401; another user's session → 404 (does
+ *     not reveal whether the id exists for someone else).
+ */
+
+import express, { NextFunction, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthenticatedRequest } from '../../types/auth';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  loggerHelpers: { logSecurity: vi.fn(), logBusiness: vi.fn() },
+}));
+
+vi.mock('../../models/RefreshToken', () => ({
+  default: {
+    findByPk: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/security.service', () => ({
+  default: {
+    listSessions: vi.fn(),
+    revokeSession: vi.fn(),
+  },
+}));
+
+const authenticateTokenMock = vi.fn();
+vi.mock('../../middleware/auth', () => ({
+  authenticateToken: (req: AuthenticatedRequest, res: Response, next: NextFunction) =>
+    authenticateTokenMock(req, res, next),
+}));
+
+import RefreshToken from '../../models/RefreshToken';
+import sessionRouter from '../../routes/session.routes';
+import SecurityService from '../../services/security.service';
+
+const mockedRefreshToken = RefreshToken as unknown as {
+  findByPk: ReturnType<typeof vi.fn>;
+};
+const mockedSecurityService = SecurityService as unknown as {
+  listSessions: ReturnType<typeof vi.fn>;
+  revokeSession: ReturnType<typeof vi.fn>;
+};
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/sessions', sessionRouter);
+  return app;
+};
+
+const authenticateAs = (userId: string): void => {
+  authenticateTokenMock.mockImplementation(
+    (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+      req.user = { userId, userType: 'adopter' } as AuthenticatedRequest['user'];
+      next();
+    }
+  );
+};
+
+const denyAuth = (): void => {
+  authenticateTokenMock.mockImplementation(
+    (_req: AuthenticatedRequest, res: Response, _next: NextFunction) => {
+      res.status(401).json({ error: 'Authentication required' });
+    }
+  );
+};
+
+describe('GET /api/v1/sessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the caller’s active sessions only', async () => {
+    authenticateAs('user-1');
+    mockedSecurityService.listSessions.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'sess-1',
+          userId: 'user-1',
+          familyId: 'fam-1',
+          isRevoked: false,
+          expiresAt: new Date('2026-12-31'),
+          createdAt: new Date('2026-01-01'),
+          user: null,
+        },
+      ],
+      total: 1,
+      page: 1,
+      totalPages: 1,
+    });
+
+    const res = await request(buildApp()).get('/api/v1/sessions');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].sessionId).toBe('sess-1');
+    expect(mockedSecurityService.listSessions).toHaveBeenCalledWith({ userId: 'user-1' });
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    denyAuth();
+    const res = await request(buildApp()).get('/api/v1/sessions');
+    expect(res.status).toBe(401);
+    expect(mockedSecurityService.listSessions).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/v1/sessions/:sessionId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('revokes a session owned by the caller', async () => {
+    authenticateAs('user-1');
+    mockedRefreshToken.findByPk.mockResolvedValue({
+      token_id: 'sess-1',
+      user_id: 'user-1',
+    });
+    mockedSecurityService.revokeSession.mockResolvedValue({ userId: 'user-1' });
+
+    const res = await request(buildApp()).delete('/api/v1/sessions/sess-1');
+
+    expect(res.status).toBe(204);
+    expect(mockedSecurityService.revokeSession).toHaveBeenCalledWith('sess-1', 'user-1');
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    denyAuth();
+    const res = await request(buildApp()).delete('/api/v1/sessions/sess-1');
+    expect(res.status).toBe(401);
+    expect(mockedSecurityService.revokeSession).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the session belongs to another user (no cross-user revoke)', async () => {
+    authenticateAs('user-1');
+    mockedRefreshToken.findByPk.mockResolvedValue({
+      token_id: 'sess-2',
+      user_id: 'user-2',
+    });
+
+    const res = await request(buildApp()).delete('/api/v1/sessions/sess-2');
+
+    expect(res.status).toBe(404);
+    expect(mockedSecurityService.revokeSession).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the session does not exist', async () => {
+    authenticateAs('user-1');
+    mockedRefreshToken.findByPk.mockResolvedValue(null);
+
+    const res = await request(buildApp()).delete('/api/v1/sessions/missing');
+
+    expect(res.status).toBe(404);
+    expect(mockedSecurityService.revokeSession).not.toHaveBeenCalled();
+  });
+});

--- a/service.backend/src/__tests__/services/admin.service.test.ts
+++ b/service.backend/src/__tests__/services/admin.service.test.ts
@@ -176,6 +176,62 @@ describe('AdminService', () => {
     });
   });
 
+  describe('verifyUser (mixed-script email gate)', () => {
+    it('rejects verification when the email local part mixes scripts', async () => {
+      // Pass-9 blocks mixed-script emails at registration via the
+      // User model's beforeValidate hook, but user.update({
+      // emailVerified: true }) doesn't trigger that hook. Without
+      // an explicit gate here, an admin could mark a homograph
+      // email as verified anyway. The verifyUser path re-checks
+      // the local part and refuses.
+      //
+      // To stage a mixed-script email past registration (so we
+      // can test the admin path itself), bypass the hook with
+      // { hooks: false } — this is the same way a row could end
+      // up in production if it predates the gate or comes in via
+      // a future migration/import.
+      const mixedScriptEmail = 'аdmin@example.com'; // leading 'а' is Cyrillic U+0430
+      const user = await User.create(
+        {
+          userId: 'user-mixed-1',
+          firstName: 'Mixed',
+          lastName: 'Script',
+          email: mixedScriptEmail,
+          password: 'hashedPassword123!',
+          status: UserStatus.ACTIVE,
+          userType: UserType.ADOPTER,
+          emailVerified: false,
+        },
+        { hooks: false }
+      );
+
+      await expect(AdminService.verifyUser(user.userId, 'admin-1')).rejects.toThrow(
+        /mixed-script email/
+      );
+
+      const after = await User.findByPk(user.userId);
+      expect(after?.emailVerified).toBe(false);
+    });
+
+    it('verifies a user whose email local part is single-script', async () => {
+      const user = await User.create({
+        userId: 'user-clean-1',
+        firstName: 'Clean',
+        lastName: 'Email',
+        email: 'clean@example.com',
+        password: 'hashedPassword123!',
+        status: UserStatus.ACTIVE,
+        userType: UserType.ADOPTER,
+        emailVerified: false,
+      });
+
+      await AdminService.verifyUser(user.userId, 'admin-1');
+
+      const after = await User.findByPk(user.userId);
+      expect(after?.emailVerified).toBe(true);
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle errors in getUsers gracefully', async () => {
       await expect(AdminService.getUsers({ page: -1, limit: 0 })).resolves.toBeDefined();

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -1126,6 +1126,117 @@ describe('ApplicationService - Business Logic', () => {
     });
   });
 
+  describe('Business Rule: Bulk Update Atomicity', () => {
+    /**
+     * Per-iteration transactionality: when the audit-log write fails
+     * for a particular item, the application update for that item
+     * must roll back too, so the response's success/failure counts
+     * match the real DB state. Previously, a successful update
+     * followed by a failed audit insert was counted as a failure but
+     * left the update committed.
+     */
+    it('rolls back the DB write for an item whose audit-log write fails', async () => {
+      const goodId1 = 'app-good-1';
+      const goodId2 = 'app-good-2';
+      const badId = 'app-audit-fail';
+
+      const goodApp1 = createMockApplication(ApplicationStatus.SUBMITTED, {
+        applicationId: goodId1,
+      });
+      const goodApp2 = createMockApplication(ApplicationStatus.SUBMITTED, {
+        applicationId: goodId2,
+      });
+      const badApp = createMockApplication(ApplicationStatus.SUBMITTED, {
+        applicationId: badId,
+      });
+
+      MockedApplication.findByPk = vi.fn().mockImplementation(async (id: string) => {
+        if (id === goodId1) return goodApp1;
+        if (id === goodId2) return goodApp2;
+        if (id === badId) return badApp;
+        return null;
+      });
+
+      const { AuditLogService } = await import('../../services/auditLog.service');
+      const logSpy = vi
+        .spyOn(AuditLogService, 'log')
+        .mockImplementation(async (data: { entityId: string }) => {
+          if (data.entityId === badId) {
+            throw new Error('audit insert blocked');
+          }
+          return undefined as never;
+        });
+
+      const result = await ApplicationService.bulkUpdateApplications(
+        {
+          applicationIds: [goodId1, badId, goodId2],
+          updates: { priority: ApplicationPriority.HIGH },
+        },
+        'staff-123'
+      );
+
+      // Counts must match the real outcome: 2 fully-committed
+      // updates, 1 rolled-back failure.
+      expect(result.successCount).toBe(2);
+      expect(result.failureCount).toBe(1);
+      expect(result.successes).toEqual([goodId1, goodId2]);
+      expect(result.failures[0]).toMatchObject({ applicationId: badId });
+
+      // Exactly one audit-log attempt per item — successes get one
+      // call each, the failed item gets one attempt that throws.
+      const auditCallsByEntity = logSpy.mock.calls.map(([data]) => data.entityId);
+      expect(auditCallsByEntity).toEqual([goodId1, badId, goodId2]);
+
+      // The application.update must have been rolled back for the
+      // failed item — assert update was attempted (the model would
+      // have applied it) but the surrounding transaction will revert
+      // it. Because Application here is a mock, "rollback" means the
+      // tx wrapper threw and the bulk loop counted it as a failure
+      // (no mutation persisted in real DB).
+      expect(badApp.update).toHaveBeenCalled();
+
+      logSpy.mockRestore();
+    });
+
+    it('returns 404-style failure for missing applications without writing audit', async () => {
+      const presentId = 'app-present';
+      const missingId = 'app-missing';
+      const presentApp = createMockApplication(ApplicationStatus.SUBMITTED, {
+        applicationId: presentId,
+      });
+
+      MockedApplication.findByPk = vi.fn().mockImplementation(async (id: string) => {
+        if (id === presentId) return presentApp;
+        return null;
+      });
+
+      const { AuditLogService } = await import('../../services/auditLog.service');
+      const logSpy = vi.spyOn(AuditLogService, 'log').mockResolvedValue(undefined as never);
+
+      const result = await ApplicationService.bulkUpdateApplications(
+        {
+          applicationIds: [presentId, missingId],
+          updates: { priority: ApplicationPriority.HIGH },
+        },
+        'staff-123'
+      );
+
+      expect(result.successCount).toBe(1);
+      expect(result.failureCount).toBe(1);
+      expect(result.successes).toEqual([presentId]);
+      expect(result.failures[0]).toMatchObject({
+        applicationId: missingId,
+        error: 'Application not found',
+      });
+
+      // Audit only fires for the row that actually exists.
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0][0].entityId).toBe(presentId);
+
+      logSpy.mockRestore();
+    });
+  });
+
   describe('Error Handling', () => {
     it('throws error when application not found', async () => {
       // Given: Application does not exist

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -30,6 +30,7 @@ import ApplicationAnswer from '../../models/ApplicationAnswer';
 import ApplicationReferenceModel from '../../models/ApplicationReference';
 import ApplicationStatusTransition from '../../models/ApplicationStatusTransition';
 import Pet, { PetStatus } from '../../models/Pet';
+import Rescue from '../../models/Rescue';
 import StaffMember from '../../models/StaffMember';
 import User, { UserType } from '../../models/User';
 import emailService from '../../services/email.service';
@@ -43,6 +44,7 @@ const MockedApplicationReference = ApplicationReferenceModel as vi.MockedObject<
   typeof ApplicationReferenceModel
 >;
 const MockedPet = Pet as vi.MockedObject<Pet>;
+const MockedRescue = Rescue as vi.MockedObject<typeof Rescue>;
 const MockedStaffMember = StaffMember as vi.MockedObject<typeof StaffMember>;
 const MockedUser = User as vi.MockedObject<User>;
 const MockedApplicationStatusTransition = ApplicationStatusTransition as vi.MockedObject<
@@ -139,6 +141,13 @@ describe('ApplicationService - Business Logic', () => {
     MockedApplicationAnswer.bulkCreate = vi.fn().mockResolvedValue([] as never);
     MockedApplicationAnswer.findAll = vi.fn().mockResolvedValue([] as never);
     MockedApplicationAnswer.destroy = vi.fn().mockResolvedValue(0 as never);
+    // A13: createApplication looks up the rescue and refuses unverified
+    // ones. Default mock returns a verified rescue so existing tests
+    // are unaffected; tests that exercise the gate override this.
+    MockedRescue.findByPk = vi.fn().mockResolvedValue({
+      rescueId: mockRescueId,
+      status: 'verified',
+    } as never);
   });
 
   describe('Business Rule: Application Creation', () => {
@@ -253,6 +262,26 @@ describe('ApplicationService - Business Logic', () => {
       // When & Then: Application is rejected
       await expect(ApplicationService.createApplication(request, mockUserId)).rejects.toThrow(
         'Pet not found'
+      );
+    });
+
+    it('rejects applications to an unverified rescue', async () => {
+      // A13: even when the pet itself is available, an application
+      // targeting a rescue that is still pending verification must be
+      // refused so unverified rescues can't accept adopter data.
+      const mockUser = createMockUser();
+      const mockPet = createMockPet();
+      const request = createValidApplicationRequest();
+
+      MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser);
+      MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet);
+      MockedRescue.findByPk = vi.fn().mockResolvedValue({
+        rescueId: mockRescueId,
+        status: 'pending',
+      } as never);
+
+      await expect(ApplicationService.createApplication(request, mockUserId)).rejects.toThrow(
+        'Cannot interact with unverified rescue'
       );
     });
   });

--- a/service.backend/src/__tests__/services/auth.service.test.ts
+++ b/service.backend/src/__tests__/services/auth.service.test.ts
@@ -27,8 +27,18 @@ vi.mock('../../models/User');
 vi.mock('../../models/AuditLog');
 vi.mock('../../models/RefreshToken');
 vi.mock('../../models/RevokedToken');
+vi.mock('../../models/TwoFactorRecovery');
 vi.mock('../../services/auditLog.service');
 vi.mock('../../utils/logger');
+vi.mock('../../lib/auth-cache', () => ({
+  invalidateAuthCache: vi.fn(),
+}));
+vi.mock('../../socket/socket-registry', () => ({
+  disconnectAllSockets: vi.fn(),
+}));
+vi.mock('../../utils/url-allowlist', () => ({
+  getValidatedFrontendOrigin: vi.fn().mockReturnValue('https://app.example.com'),
+}));
 vi.mock('jsonwebtoken');
 vi.mock('bcryptjs');
 vi.mock('crypto');
@@ -582,6 +592,217 @@ describe('AuthService', () => {
       await expect(
         authService.confirmPasswordReset({ token: 'bogus', newPassword: 'NewPassword123!' })
       ).rejects.toThrow(/invalid or expired/i);
+    });
+  });
+
+  describe('Two-Factor Recovery (Batch KK)', () => {
+    // Mock the sequelize.transaction wrapper used by confirmTwoFactorRecovery.
+    // Pass-through so the callback runs with a stub transaction object.
+    let sequelizeMock: ReturnType<typeof vi.fn>;
+    let TwoFactorRecoveryMock: {
+      create: ReturnType<typeof vi.fn>;
+      findOne: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(async () => {
+      const sequelizeModule = await import('../../sequelize');
+      sequelizeMock = vi.fn(async (cb: (t: unknown) => Promise<unknown>) => cb({}));
+      vi.spyOn(sequelizeModule.default, 'transaction').mockImplementation(
+        sequelizeMock as unknown as typeof sequelizeModule.default.transaction
+      );
+
+      const recoveryModule = await import('../../models/TwoFactorRecovery');
+      TwoFactorRecoveryMock = recoveryModule.default as unknown as typeof TwoFactorRecoveryMock;
+      TwoFactorRecoveryMock.create = vi.fn().mockResolvedValue({} as unknown);
+      TwoFactorRecoveryMock.findOne = vi.fn();
+      TwoFactorRecoveryMock.update = vi.fn().mockResolvedValue([1]);
+    });
+
+    describe('requestTwoFactorRecovery', () => {
+      it('issues a recovery row + audit log when the email matches a 2FA-enabled user', async () => {
+        const mockUser = {
+          userId: 'user-2fa-1',
+          email: 'twofa@example.com',
+          firstName: 'Two',
+          lastName: 'Fa',
+          twoFactorEnabled: true,
+        };
+        MockedUser.findOne = vi.fn().mockResolvedValue(mockUser as unknown);
+
+        const authService = new AuthService();
+        const result = await authService.requestTwoFactorRecovery(
+          { email: 'twofa@example.com' },
+          '203.0.113.5',
+          'jest-ua'
+        );
+
+        expect(TwoFactorRecoveryMock.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            user_id: 'user-2fa-1',
+            token: expect.any(String),
+            expires_at: expect.any(Date),
+          })
+        );
+        expect(MockedAuditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: 'TWO_FACTOR_RECOVERY_REQUESTED',
+            entity: 'User',
+            entityId: 'user-2fa-1',
+            userId: 'user-2fa-1',
+            ipAddress: '203.0.113.5',
+            userAgent: 'jest-ua',
+          })
+        );
+        expect(result.message).toMatch(/if the email matches/i);
+      });
+
+      it('returns the generic message + does not issue a row when email is unknown', async () => {
+        MockedUser.findOne = vi.fn().mockResolvedValue(null);
+
+        const authService = new AuthService();
+        const result = await authService.requestTwoFactorRecovery({
+          email: 'ghost@example.com',
+        });
+
+        expect(TwoFactorRecoveryMock.create).not.toHaveBeenCalled();
+        expect(result.message).toMatch(/if the email matches/i);
+        // We still audit the attempt (subjectless) so brute force is visible.
+        expect(MockedAuditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: 'TWO_FACTOR_RECOVERY_REQUESTED',
+            entityId: 'unknown',
+            details: expect.objectContaining({ reason: 'unknown_email' }),
+          })
+        );
+      });
+
+      it('returns the generic message + does not issue a row when 2FA is not enabled', async () => {
+        const mockUser = {
+          userId: 'user-no-2fa',
+          email: 'no2fa@example.com',
+          twoFactorEnabled: false,
+        };
+        MockedUser.findOne = vi.fn().mockResolvedValue(mockUser as unknown);
+
+        const authService = new AuthService();
+        const result = await authService.requestTwoFactorRecovery({
+          email: 'no2fa@example.com',
+        });
+
+        expect(TwoFactorRecoveryMock.create).not.toHaveBeenCalled();
+        expect(MockedAuditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: 'TWO_FACTOR_RECOVERY_REQUESTED',
+            details: expect.objectContaining({ reason: 'two_factor_not_enabled' }),
+          })
+        );
+        expect(result.message).toMatch(/if the email matches/i);
+      });
+
+      it('normalises the email before lookup so case differences match the stored value', async () => {
+        const mockUser = {
+          userId: 'user-norm',
+          email: 'norm@example.com',
+          firstName: 'N',
+          lastName: 'M',
+          twoFactorEnabled: true,
+        };
+        MockedUser.findOne = vi.fn().mockResolvedValue(mockUser as unknown);
+
+        const authService = new AuthService();
+        await authService.requestTwoFactorRecovery({ email: 'NORM@EXAMPLE.COM' });
+
+        expect(MockedUser.findOne).toHaveBeenCalledWith({
+          where: { email: 'norm@example.com' },
+        });
+      });
+    });
+
+    describe('confirmTwoFactorRecovery', () => {
+      const buildRecoveryRow = (overrides: Record<string, unknown> = {}) => ({
+        recovery_id: 'rec-123',
+        user_id: 'user-2fa-1',
+        token: 'hashed-token',
+        expires_at: new Date(Date.now() + 60 * 60 * 1000),
+        used: false,
+        used_at: null,
+        ...overrides,
+      });
+
+      const build2FaUser = (overrides: Record<string, unknown> = {}) => ({
+        userId: 'user-2fa-1',
+        email: 'twofa@example.com',
+        firstName: 'Two',
+        lastName: 'Fa',
+        twoFactorEnabled: true,
+        twoFactorSecret: 'encrypted',
+        twoFactorPendingSecret: null,
+        twoFactorPendingExpiresAt: null,
+        backupCodes: ['$2$hashed'],
+        save: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+      });
+
+      it('disables 2FA, revokes refresh tokens, emits audit logs on valid token', async () => {
+        TwoFactorRecoveryMock.findOne = vi.fn().mockResolvedValue(buildRecoveryRow());
+        TwoFactorRecoveryMock.update = vi.fn().mockResolvedValue([1]);
+        const user = build2FaUser();
+        MockedUser.findByPk = vi.fn().mockResolvedValue(user as unknown);
+        MockedRefreshToken.update = vi.fn().mockResolvedValue([3]);
+
+        const authService = new AuthService();
+        const result = await authService.confirmTwoFactorRecovery({ token: 'plaintext' });
+
+        expect(user.twoFactorEnabled).toBe(false);
+        expect(user.twoFactorSecret).toBeNull();
+        expect(user.backupCodes).toBeNull();
+        expect(user.save).toHaveBeenCalled();
+
+        expect(MockedRefreshToken.update).toHaveBeenCalledWith(
+          { is_revoked: true },
+          { where: { user_id: 'user-2fa-1', is_revoked: false } }
+        );
+
+        expect(MockedAuditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({ action: 'TWO_FACTOR_RECOVERED', userId: 'user-2fa-1' })
+        );
+        expect(MockedAuditLogService.log).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: 'REFRESH_TOKENS_REVOKED',
+            details: expect.objectContaining({ reason: 'two_factor_recovered', count: 3 }),
+          })
+        );
+
+        expect(result.message).toMatch(/two-factor authentication has been disabled/i);
+      });
+
+      it('rejects when no matching recovery row exists (bogus or expired)', async () => {
+        TwoFactorRecoveryMock.findOne = vi.fn().mockResolvedValue(null);
+
+        const authService = new AuthService();
+        await expect(authService.confirmTwoFactorRecovery({ token: 'bogus' })).rejects.toThrow(
+          /invalid or expired/i
+        );
+
+        // No state change: no user load, no audit entry, no refresh-token revoke.
+        expect(MockedRefreshToken.update).not.toHaveBeenCalled();
+        expect(MockedAuditLogService.log).not.toHaveBeenCalled();
+      });
+
+      it('rejects when the conditional UPDATE loses the race (already-used token)', async () => {
+        TwoFactorRecoveryMock.findOne = vi.fn().mockResolvedValue(buildRecoveryRow());
+        // Another concurrent confirm already flipped used=true; our UPDATE
+        // affects 0 rows and we must fail closed.
+        TwoFactorRecoveryMock.update = vi.fn().mockResolvedValue([0]);
+
+        const authService = new AuthService();
+        await expect(authService.confirmTwoFactorRecovery({ token: 'plaintext' })).rejects.toThrow(
+          /invalid or expired/i
+        );
+
+        expect(MockedRefreshToken.update).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/service.backend/src/__tests__/services/notification.service.test.ts
+++ b/service.backend/src/__tests__/services/notification.service.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sequelize from '../../sequelize';
 import EmailQueue, { EmailStatus, EmailPriority, EmailType } from '../../models/EmailQueue';
+import Notification, {
+  NotificationChannel,
+  NotificationPriority,
+  NotificationStatus,
+  NotificationType,
+} from '../../models/Notification';
+import User, { UserStatus, UserType } from '../../models/User';
+import { AuditLogService } from '../../services/auditLog.service';
+import { NotificationService } from '../../services/notification.service';
 
 describe('NotificationService', () => {
   beforeEach(async () => {
@@ -85,6 +94,49 @@ describe('NotificationService', () => {
     it('should handle empty email queue gracefully', async () => {
       const emails = await EmailQueue.findAll();
       expect(emails).toHaveLength(0);
+    });
+  });
+
+  describe('Audit attribution (actor vs subject)', () => {
+    it('records the notification owner as subjectId in the audit details on markAllAsRead', async () => {
+      // The audit row's top-level user column carries the actor (the
+      // caller of markAllAsRead). The details payload now uses
+      // `subjectId` for the notification owner so on-behalf-of writes by
+      // an admin can be told apart from self-service writes. The two
+      // collapse to the same id in the self-service case below.
+      const user = await User.create({
+        email: 'audit-1@test.dev',
+        password: 'Hash$ed1234',
+        firstName: 'Audit',
+        lastName: 'User',
+        status: UserStatus.ACTIVE,
+        userType: UserType.ADOPTER,
+      });
+      const userId = user.userId;
+      await Notification.create({
+        user_id: userId,
+        type: NotificationType.SYSTEM_ANNOUNCEMENT,
+        channel: NotificationChannel.IN_APP,
+        priority: NotificationPriority.NORMAL,
+        status: NotificationStatus.PENDING,
+        title: 't',
+        message: 'm',
+      });
+
+      const logSpy = vi.spyOn(AuditLogService, 'log').mockResolvedValue(undefined as never);
+
+      await NotificationService.markAllAsRead(userId);
+
+      const call = logSpy.mock.calls.find(([data]) => data.action === 'MARK_ALL_READ');
+      expect(call).toBeDefined();
+      const data = call![0];
+      expect(data.userId).toBe(userId); // actor on the audit row
+      expect(data.details).toMatchObject({ subjectId: userId, updatedCount: 1 });
+      // Stale `userId` key in details (the ambiguous one) is removed —
+      // future on-behalf-of paths must use subjectId instead.
+      expect(data.details).not.toHaveProperty('userId');
+
+      logSpy.mockRestore();
     });
   });
 });

--- a/service.backend/src/__tests__/services/pet-business-logic.test.ts
+++ b/service.backend/src/__tests__/services/pet-business-logic.test.ts
@@ -142,7 +142,8 @@ describe('PetService - Business Logic', () => {
         expect.objectContaining({
           petId: mockPetId,
           toStatus: PetStatus.PENDING,
-        })
+        }),
+        expect.anything()
       );
       expect(result).toBeDefined();
     });
@@ -166,13 +167,15 @@ describe('PetService - Business Logic', () => {
       expect(mockPet.update).toHaveBeenCalledWith(
         expect.objectContaining({
           adoptedDate: expect.any(Date),
-        })
+        }),
+        expect.anything()
       );
       expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
         expect.objectContaining({
           petId: mockPetId,
           toStatus: PetStatus.ADOPTED,
-        })
+        }),
+        expect.anything()
       );
     });
 
@@ -194,13 +197,15 @@ describe('PetService - Business Logic', () => {
       expect(mockPet.update).toHaveBeenCalledWith(
         expect.objectContaining({
           fosterStartDate: expect.any(Date),
-        })
+        }),
+        expect.anything()
       );
       expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
         expect.objectContaining({
           petId: mockPetId,
           toStatus: PetStatus.FOSTER,
-        })
+        }),
+        expect.anything()
       );
     });
 
@@ -223,7 +228,8 @@ describe('PetService - Business Logic', () => {
         expect.objectContaining({
           petId: mockPetId,
           toStatus: PetStatus.MEDICAL_HOLD,
-        })
+        }),
+        expect.anything()
       );
       expect(result).toBeDefined();
     });
@@ -247,13 +253,15 @@ describe('PetService - Business Logic', () => {
       expect(mockPet.update).toHaveBeenCalledWith(
         expect.objectContaining({
           availableSince: expect.any(Date),
-        })
+        }),
+        expect.anything()
       );
       expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
         expect.objectContaining({
           petId: mockPetId,
           toStatus: PetStatus.AVAILABLE,
-        })
+        }),
+        expect.anything()
       );
     });
 
@@ -275,13 +283,15 @@ describe('PetService - Business Logic', () => {
       expect(mockPet.update).toHaveBeenCalledWith(
         expect.objectContaining({
           adoptedDate: expect.any(Date),
-        })
+        }),
+        expect.anything()
       );
       expect(MockedPetStatusTransition.create).toHaveBeenCalledWith(
         expect.objectContaining({
           petId: mockPetId,
           toStatus: PetStatus.ADOPTED,
-        })
+        }),
+        expect.anything()
       );
     });
   });

--- a/service.backend/src/__tests__/services/pet.service.test.ts
+++ b/service.backend/src/__tests__/services/pet.service.test.ts
@@ -1000,6 +1000,70 @@ describe('PetService', () => {
       expect(result.failedCount).toBe(1);
       expect(result.errors[0].error).toContain('Unknown operation: invalid_operation');
     });
+
+    it('rolls back the per-item DB write when the audit-log write fails (delete)', async () => {
+      // Per-iteration transaction means a failed audit insert rolls
+      // back the pet.destroy() for that same item, so result counts
+      // and the actual DB state stay in sync. Sandwich the failing
+      // audit call between two successes — only the middle pet must
+      // remain non-deleted.
+      const pet3Id = uniqueId('bulk-pet3');
+      await Pet.create({
+        petId: pet3Id,
+        name: 'Pet 3',
+        type: PetType.DOG,
+        status: PetStatus.AVAILABLE,
+        breed: 'Mixed',
+        size: Size.MEDIUM,
+        ageGroup: AgeGroup.ADULT,
+        gender: Gender.MALE,
+        energyLevel: EnergyLevel.MEDIUM,
+        vaccinationStatus: VaccinationStatus.UP_TO_DATE,
+        spayNeuterStatus: SpayNeuterStatus.NEUTERED,
+        rescueId: testRescue.rescueId,
+        archived: false,
+      });
+
+      // Fail the DELETE audit emission for the middle pet only.
+      mockAuditLog.mockImplementation(async (data: { entityId: string; action: string }) => {
+        if (data.action === 'DELETE' && data.entityId === pet2Id) {
+          throw new Error('audit insert blocked');
+        }
+        return {} as AuditLog;
+      });
+
+      const operation: BulkPetOperation = {
+        petIds: [pet1Id, pet2Id, pet3Id],
+        operation: 'delete',
+        reason: 'bulk cleanup',
+      };
+      const result = await PetService.bulkUpdatePets(operation, testCallerId);
+
+      expect(result.successCount).toBe(2);
+      expect(result.failedCount).toBe(1);
+      expect(result.errors[0]).toMatchObject({ petId: pet2Id });
+
+      // The two flanking writes committed (soft-deleted).
+      const after1 = await Pet.findByPk(pet1Id, { paranoid: false });
+      const after2 = await Pet.findByPk(pet2Id, { paranoid: false });
+      const after3 = await Pet.findByPk(pet3Id, { paranoid: false });
+      expect(after1?.deletedAt).not.toBeNull();
+      expect(after3?.deletedAt).not.toBeNull();
+      // The middle delete rolled back — record is still present.
+      expect(after2).not.toBeNull();
+      expect(after2?.deletedAt).toBeNull();
+
+      // Exactly two DELETE audit emissions succeeded (the third was
+      // the one we made throw). The middle audit call still fires
+      // (and throws) so it's present in the spy history.
+      const deleteCalls = mockAuditLog.mock.calls.filter(
+        ([data]) => data.action === 'DELETE' && data.entity === 'Pet'
+      );
+      const successfulDeleteIds = deleteCalls
+        .map(([data]) => data.entityId)
+        .filter(id => id !== pet2Id);
+      expect(successfulDeleteIds.sort()).toEqual([pet1Id, pet3Id].sort());
+    });
   });
 
   describe('getPetActivity', () => {

--- a/service.backend/src/__tests__/services/rescue.service.test.ts
+++ b/service.backend/src/__tests__/services/rescue.service.test.ts
@@ -360,6 +360,54 @@ describe('RescueService - Behavioral Testing', () => {
         } as unknown)
       ).rejects.toThrow();
     });
+
+    it('rejects a 4th rescue created by the same user with the per-user cap message', async () => {
+      // Founder user already exists (seeded by sequelize.sync default scope) —
+      // create a real user row so the FK on rescues.created_by holds.
+      const founder = await User.create({
+        firstName: 'Founder',
+        lastName: 'User',
+        email: 'founder@example.com',
+        password: 'hashed-password',
+        userType: UserType.RESCUE_STAFF,
+        status: UserStatus.ACTIVE,
+        emailVerified: true,
+      });
+
+      const baseData = {
+        phone: '555-0123',
+        address: '123 Main St',
+        city: 'London',
+        postcode: 'SW1A 1AA',
+        country: 'GB',
+        contactPerson: 'Jane Smith',
+      };
+
+      // Seed 3 rescues authored by this user at the cap. created_by is
+      // not part of RescueAttributes (it comes from the audit-columns
+      // mixin), so the literal is cast.
+      for (let i = 0; i < 3; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await Rescue.create({
+          ...baseData,
+          name: `Cap Rescue ${i}`,
+          email: `cap-${i}@rescue.org`,
+          status: 'verified',
+          created_by: founder.userId,
+        } as unknown as Parameters<typeof Rescue.create>[0]);
+      }
+
+      await expect(
+        RescueService.createRescue(
+          {
+            ...baseData,
+            name: 'Fourth Rescue',
+            email: 'fourth@rescue.org',
+          },
+          founder.userId
+        )
+      ).rejects.toThrow('Maximum number of rescues per user reached');
+    });
   });
 
   describe('updateRescue', () => {

--- a/service.backend/src/__tests__/services/user.service.test.ts
+++ b/service.backend/src/__tests__/services/user.service.test.ts
@@ -334,6 +334,34 @@ describe('UserService', () => {
 
       expect(vi.mocked(emitAuthRoleChanged)).toHaveBeenCalledWith(user.userId);
     });
+
+    it('stamps tokens_invalid_before on the user row so access tokens issued before the role change are rejected by the auth middleware', async () => {
+      const user = await User.create({
+        email: 'rolechange-invalidates@example.com',
+        password: 'hashedpassword',
+        firstName: 'Test',
+        lastName: 'User',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+      });
+      const admin = await User.create({
+        email: 'admin-invalidates@example.com',
+        password: 'hashedpassword',
+        firstName: 'Admin',
+        lastName: 'User',
+        userType: UserType.ADMIN,
+        status: UserStatus.ACTIVE,
+      });
+
+      expect(user.tokensInvalidBefore).toBeFalsy();
+      const before = Date.now();
+
+      await UserService.updateUserRole(user.userId, UserType.RESCUE_STAFF, admin.userId);
+
+      const reloaded = await User.findByPk(user.userId);
+      expect(reloaded?.tokensInvalidBefore).toBeTruthy();
+      expect(reloaded?.tokensInvalidBefore?.getTime() ?? 0).toBeGreaterThanOrEqual(before);
+    });
   });
 
   describe('deactivateUser', () => {

--- a/service.backend/src/__tests__/services/user.service.test.ts
+++ b/service.backend/src/__tests__/services/user.service.test.ts
@@ -6,7 +6,7 @@ import UserFavorite from '../../models/UserFavorite';
 import { AuditLogService } from '../../services/auditLog.service';
 import { UserService } from '../../services/user.service';
 import { emitAuthRoleChanged } from '../../socket/socket-registry';
-import { UserUpdateData } from '../../types/user';
+import { BulkUserUpdateData, UserUpdateData } from '../../types/user';
 
 // Mock only non-database dependencies
 // Logger is already mocked in setup-tests.ts
@@ -456,6 +456,48 @@ describe('UserService', () => {
       const updatedUser2 = await User.findByPk(user2.userId);
       expect(updatedUser1?.firstName).toBe('Updated');
       expect(updatedUser2?.firstName).toBe('Updated');
+    });
+
+    it('should hash passwords via beforeUpdate hook when bulk updating', async () => {
+      // The bulk update path must pass individualHooks:true so the User
+      // model's beforeUpdate hook fires per row and bcrypt-hashes the
+      // password. Otherwise a plaintext password sits in the DB.
+      const user = await User.create({
+        email: 'bulkpw@example.com',
+        password: 'hashedpassword',
+        firstName: 'PW',
+        lastName: 'User',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+      });
+
+      const admin = await User.create({
+        email: 'admin-pw@example.com',
+        password: 'hashedpassword',
+        firstName: 'Admin',
+        lastName: 'User',
+        userType: UserType.ADMIN,
+        status: UserStatus.ACTIVE,
+      });
+
+      const plaintext = 'plaintext-pw-1234567890';
+      // Password isn't part of the BulkUserUpdateData surface, but the
+      // service passes its `updates` payload straight through to User.update,
+      // so this test confirms the model hook still hashes anything that
+      // reaches it. Parse from JSON to construct without a type assertion.
+      const updates: BulkUserUpdateData[] = JSON.parse(
+        JSON.stringify([{ userIds: [user.userId], updates: { password: plaintext } }])
+      );
+      await UserService.bulkUpdateUsers(updates, admin.userId);
+
+      // bcryptjs is globally mocked in setup-tests.ts to return
+      // 'hashed-password'. That stub value landing in the DB proves the
+      // beforeUpdate hook ran per row (it's the hook that calls bcrypt).
+      // Without individualHooks:true the plaintext would persist unchanged.
+      const reloaded = await User.findByPk(user.userId);
+      expect(reloaded?.password).toBeDefined();
+      expect(reloaded?.password).not.toBe(plaintext);
+      expect(reloaded?.password).toBe('hashed-password');
     });
   });
 

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -343,6 +343,13 @@ export class ApplicationController extends BaseController {
         });
       }
 
+      if (errorMessage.includes('unverified rescue')) {
+        return res.status(403).json({
+          success: false,
+          message: errorMessage,
+        });
+      }
+
       if (
         errorMessage.includes('not available') ||
         errorMessage.includes('already have an active')

--- a/service.backend/src/controllers/auth.controller.ts
+++ b/service.backend/src/controllers/auth.controller.ts
@@ -2,9 +2,11 @@ import { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { z } from 'zod';
 import {
+  ConfirmTwoFactorRecoverySchema,
   LoginRequestSchema,
   RegisterRequestSchema,
   RequestPasswordResetSchema,
+  RequestTwoFactorRecoverySchema,
   ResetPasswordSchema,
   UpdateProfileRequestSchema,
 } from '@adopt-dont-shop/lib.validation';
@@ -38,6 +40,8 @@ export const authValidation = {
   login: validateBody(LoginRequestSchema),
   forgotPassword: validateBody(RequestPasswordResetSchema),
   resetPassword: validateBody(ResetPasswordSchema),
+  requestTwoFactorRecovery: validateBody(RequestTwoFactorRecoverySchema),
+  confirmTwoFactorRecovery: validateBody(ConfirmTwoFactorRecoverySchema),
   resendVerification: validateBody(RequestPasswordResetSchema.pick({ email: true })),
   updateProfile: validateBody(UpdateProfileRequestSchema),
 
@@ -368,6 +372,53 @@ export class AuthController {
     loggerHelpers.logSecurity('2FA backup codes regenerated', { userId: user.userId });
 
     res.json({ success: true, backupCodes });
+  }
+
+  /**
+   * Batch KK: request an email-bootstrapped 2FA recovery link.
+   *
+   * Pre-auth. Always returns the same generic 200 message regardless of
+   * whether the email matches a user or whether that user has 2FA on —
+   * enumeration-resistant, same shape as forgot-password.
+   *
+   * TODO(frontend): wire up the "Lost your 2FA device?" link on the 2FA
+   * challenge page (app.client, app.admin, app.rescue) to call this
+   * endpoint, and add a /auth/2fa/recover page that consumes the token
+   * query param and posts to /2fa/recover/confirm below. Deferred from
+   * the backend batch — see Batch KK report.
+   */
+  async requestTwoFactorRecovery(req: Request, res: Response): Promise<void> {
+    const authService = new AuthService();
+    const result = await authService.requestTwoFactorRecovery(
+      req.body,
+      req.ip,
+      req.get('user-agent')
+    );
+    res.json(result);
+  }
+
+  /**
+   * Batch KK: confirm a 2FA recovery token from the emailed link.
+   *
+   * Pre-auth. Disables 2FA + revokes all sessions atomically and emails
+   * the user a heads-up so they can react if the recovery wasn't theirs.
+   */
+  async confirmTwoFactorRecovery(req: Request, res: Response): Promise<void> {
+    try {
+      const authService = new AuthService();
+      const result = await authService.confirmTwoFactorRecovery(req.body);
+      res.json(result);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('2FA recovery confirmation failed:', error);
+
+      if (errorMessage.includes('Invalid or expired')) {
+        res.status(400).json({ error: errorMessage });
+        return;
+      }
+
+      res.status(500).json({ error: 'Failed to confirm two-factor recovery' });
+    }
   }
 
   /**

--- a/service.backend/src/controllers/chat.controller.ts
+++ b/service.backend/src/controllers/chat.controller.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import { DEFAULT_PAGE_SIZE, LARGE_PAGE_SIZE } from '../constants/pagination';
 import { ChatParticipant } from '../models/ChatParticipant';
+import Rescue from '../models/Rescue';
 import User, { UserType } from '../models/User';
 import { ChatService } from '../services/chat.service';
 import { FileUploadService, sanitizeDisplayFilename } from '../services/file-upload.service';
@@ -195,6 +196,21 @@ export class ChatController {
 
     const { rescueId, petId, applicationId, type, initialMessage } = req.body;
     const createdBy = req.user!.userId;
+
+    // A13: a user cannot open a conversation with an unverified rescue.
+    // The rescue still appears in the UI with a pending-verification
+    // badge, but the "Message" affordance is disabled. Verifying here
+    // closes the loop for any caller that hits the API directly.
+    if (rescueId && rescueId !== createdBy) {
+      const rescue = await Rescue.findByPk(rescueId);
+      if (!rescue || rescue.status !== 'verified') {
+        res.status(403).json({
+          success: false,
+          message: 'Cannot interact with unverified rescue',
+        });
+        return;
+      }
+    }
 
     // Create participant IDs array: start with the user who created the chat
     const participantIds = [createdBy];

--- a/service.backend/src/controllers/rescue.controller.ts
+++ b/service.backend/src/controllers/rescue.controller.ts
@@ -153,6 +153,13 @@ export class RescueController {
         });
       }
 
+      if (errorMessage.includes('Maximum number of rescues')) {
+        return res.status(403).json({
+          success: false,
+          message: errorMessage,
+        });
+      }
+
       res.status(500).json({
         success: false,
         message: 'Failed to create rescue organization',

--- a/service.backend/src/index.ts
+++ b/service.backend/src/index.ts
@@ -62,6 +62,7 @@ import reportsRoutes from './routes/reports.routes';
 import legalRoutes from './routes/legal.routes';
 import privacyRoutes from './routes/privacy.routes';
 import deviceTokenRoutes from './routes/device-token.routes';
+import sessionRoutes from './routes/session.routes';
 import fosterRoutes from './routes/foster.routes';
 import uploadRoutes from './routes/upload.routes';
 import uploadServeRoutes from './routes/upload-serve.routes';
@@ -336,6 +337,7 @@ app.use('/api/v1/reports', reportsRoutes); // ADS-105: custom analytics reports
 app.use('/api/v1/legal', legalRoutes); // ADS-495: public terms / privacy
 app.use('/api/v1/privacy', privacyRoutes); // ADS-427/496/497: GDPR delete + export + consent
 app.use('/api/v1/devices', deviceTokenRoutes); // device token registration for push notifications
+app.use('/api/v1/sessions', sessionRoutes); // user-facing session list + revoke
 app.use('/api/v1/foster', fosterRoutes); // foster placement coordination
 app.use('/api/v1/uploads', uploadRoutes); // ADS-588: staged image upload (POST /images)
 

--- a/service.backend/src/lib/invalidate-user-tokens.ts
+++ b/service.backend/src/lib/invalidate-user-tokens.ts
@@ -1,0 +1,43 @@
+/**
+ * Canonical "kick every active session for this user" helper. Combines
+ * the three knobs the platform uses to force a re-auth:
+ *
+ *   1. Set `users.tokens_invalid_before = NOW()` so the auth middleware
+ *      rejects any access token whose `iat` predates this call (covers
+ *      the 15-min stale-JWT window even if the access token survived
+ *      the refresh-token revocation below).
+ *   2. Revoke every active refresh-token row for the user so the next
+ *      `/auth/refresh` call falls into the reuse-detection branch
+ *      instead of minting a new access token.
+ *   3. Disconnect every live Socket.IO connection for the user so a
+ *      stale WebSocket can't keep emitting past the credential change.
+ *
+ * Used by credential-change events (password reset, 2FA enable, 2FA
+ * disable, 2FA recovery). NOT used by `updateUserRole` — a role change
+ * is a softer event: the User model's `beforeUpdate` hook bumps
+ * `tokens_invalid_before` automatically and the frontend re-fetches its
+ * role-gated state via the `auth:role-changed` socket event without
+ * tearing down the WebSocket or forcing a re-login.
+ */
+import type { Transaction } from 'sequelize';
+import User from '../models/User';
+import RefreshToken from '../models/RefreshToken';
+import { disconnectAllSockets } from '../socket/socket-registry';
+import { invalidateAuthCache } from './auth-cache';
+
+export async function invalidateUserTokens(
+  userId: string,
+  transaction?: Transaction
+): Promise<{ refreshTokensRevoked: number }> {
+  await User.update({ tokensInvalidBefore: new Date() }, { where: { userId }, transaction });
+
+  const [refreshTokensRevoked] = await RefreshToken.update(
+    { is_revoked: true },
+    { where: { user_id: userId, is_revoked: false }, transaction }
+  );
+
+  invalidateAuthCache(userId);
+  disconnectAllSockets(userId);
+
+  return { refreshTokensRevoked };
+}

--- a/service.backend/src/middleware/auth-rate-limit.ts
+++ b/service.backend/src/middleware/auth-rate-limit.ts
@@ -84,11 +84,13 @@ const emailKey = (req: Request): string => {
  * IP-keyed registration limiter — stricter than the IP-keyed auth limiter
  * since registration is the primary fake-account-flooding vector.
  *
- * 20 registrations per hour per IP.
+ * 5 registrations per hour per IP. Tightened from 20/h (A9) now that the
+ * Turnstile middleware sits in front and absorbs scripted spam before it
+ * reaches this bucket.
  */
 export const registrationIpLimiter = buildLimiter('register-ip', {
   windowMs: ONE_HOUR_MS,
-  max: 20,
+  max: 5,
 });
 
 /**

--- a/service.backend/src/middleware/auth.ts
+++ b/service.backend/src/middleware/auth.ts
@@ -102,6 +102,36 @@ const authenticateRequest = async (token: string): Promise<User> => {
     throw new AuthError(401, 'ACCOUNT_INACTIVE', 'Account is not active');
   }
 
+  // ADS: forced-rotation gate. Any credential-change event (role
+  // change, password reset, 2FA enable/disable) bumps
+  // tokensInvalidBefore on the user row. Access tokens whose `iat` is
+  // older than that timestamp are rejected here — that closes the
+  // 15-min window where a downgraded user's old JWT would otherwise
+  // still authorise requests until natural expiry. Refresh tokens go
+  // through a different code path (services/auth.service.refreshToken)
+  // and mint a new access token with a fresh `iat`, so a legitimate
+  // refresh after a credential change continues to work.
+  if (user.tokensInvalidBefore && typeof decoded.iat === 'number') {
+    const invalidBeforeSec = Math.floor(user.tokensInvalidBefore.getTime() / 1000);
+    if (decoded.iat < invalidBeforeSec) {
+      throw new AuthError(401, 'TOKEN_ROTATED', 'Token revoked due to credential change');
+    }
+  }
+
+  // ADS: cross-check the JWT's embedded userType against the current DB
+  // value. The DB is the source of truth (the JWT is only a hint that
+  // lets downstream code skip a lookup); a mismatch means the token
+  // was minted before a role change that didn't get caught by the iat
+  // gate above (legacy tokens without `iat`, clock skew, …). Log it
+  // and continue with req.user from the DB lookup.
+  if (decoded.userType && decoded.userType !== user.userType) {
+    loggerHelpers.logSecurity('JWT userType drift; using DB value', {
+      userId: user.userId,
+      jwtUserType: decoded.userType,
+      dbUserType: user.userType,
+    });
+  }
+
   // ADS-538: defence in depth. Even if a future code path activates a
   // user pre-verification, an unverified-email account must not be able
   // to ride an auth token through this middleware. The status check

--- a/service.backend/src/middleware/turnstile.ts
+++ b/service.backend/src/middleware/turnstile.ts
@@ -1,0 +1,92 @@
+/**
+ * Cloudflare Turnstile CAPTCHA verification (A9).
+ *
+ * Validates `req.body.turnstileToken` against Cloudflare's siteverify
+ * endpoint before downstream handlers run. Mounted in front of the
+ * registration rate limiter so scripted spam is rejected before it
+ * consumes any rate-limit budget.
+ *
+ * Dev/test bypass — mirrors the METRICS_AUTH_TOKEN pattern. If
+ * `TURNSTILE_SECRET_KEY` is unset:
+ *
+ *   - In production-like envs the middleware refuses every request
+ *     (fail-closed; misconfigured prod must NOT silently disable a
+ *     spam control).
+ *   - Outside production-like envs the middleware bypasses entirely
+ *     so local dev / CI don't need to plumb a real Cloudflare token.
+ */
+import type { NextFunction, Request, Response } from 'express';
+import { isProductionLike } from '../config/env';
+import { logger } from '../utils/logger';
+
+const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+type SiteVerifyResponse = {
+  success: boolean;
+  'error-codes'?: string[];
+};
+
+const verifyToken = async (token: string, secret: string, clientIp?: string): Promise<boolean> => {
+  const params = new URLSearchParams({ secret, response: token });
+  if (clientIp) {
+    params.set('remoteip', clientIp);
+  }
+  try {
+    const response = await fetch(SITEVERIFY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+    if (!response.ok) {
+      logger.warn('Turnstile siteverify non-2xx response', { status: response.status });
+      return false;
+    }
+    const data = (await response.json()) as SiteVerifyResponse;
+    if (!data.success) {
+      logger.warn('Turnstile token rejected by Cloudflare', {
+        errorCodes: data['error-codes'],
+      });
+    }
+    return data.success === true;
+  } catch (err) {
+    logger.warn('Turnstile siteverify call failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+};
+
+export const verifyTurnstileToken = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+
+  if (!secret) {
+    if (isProductionLike(process.env.NODE_ENV)) {
+      logger.error('TURNSTILE_SECRET_KEY missing in production — registration disabled');
+      res.status(503).json({
+        error: 'Registration temporarily unavailable.',
+      });
+      return;
+    }
+    // Dev/test convenience: no secret configured -> middleware no-ops.
+    next();
+    return;
+  }
+
+  const body = req.body as Record<string, unknown> | undefined;
+  const token = typeof body?.turnstileToken === 'string' ? body.turnstileToken : '';
+  if (!token) {
+    res.status(400).json({ error: 'Invalid CAPTCHA token' });
+    return;
+  }
+
+  const ok = await verifyToken(token, secret, req.ip);
+  if (!ok) {
+    res.status(400).json({ error: 'Invalid CAPTCHA token' });
+    return;
+  }
+  next();
+};

--- a/service.backend/src/middleware/user-abuse-rate-limit.ts
+++ b/service.backend/src/middleware/user-abuse-rate-limit.ts
@@ -1,0 +1,100 @@
+/**
+ * Per-user anti-abuse rate limiters keyed by `req.user.userId`.
+ *
+ * These complement the IP-keyed limiters in `rate-limiter.ts` for user-
+ * initiated actions where a malicious account (not a network egress)
+ * is the abuse vector — e.g. spammy applications, spammy reports.
+ *
+ * Redis-backed via the same singleton client as auth-rate-limit so
+ * limits are shared across replicas. Falls back to in-memory only when
+ * Redis is unconfigured.
+ *
+ * In dev, behaviour matches auth-rate-limit: limiters enforce unless
+ * `RATE_LIMIT_DEV_BYPASS=true`.
+ */
+import type { Request, Response } from 'express';
+import rateLimit, { type Options as RateLimitOptions, type Store } from 'express-rate-limit';
+import RedisStore from 'rate-limit-redis';
+import { getRedis } from '../lib/redis';
+import { logger } from '../utils/logger';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ONE_WEEK_MS = 7 * ONE_DAY_MS;
+
+const devBypass = (): boolean =>
+  process.env.NODE_ENV !== 'production' && process.env.RATE_LIMIT_DEV_BYPASS === 'true';
+
+type RequestWithUser = Request & { user?: { userId?: string } };
+
+const userIdOrIp = (req: RequestWithUser): string => req.user?.userId || req.ip || 'unknown';
+
+const buildStore = (prefix: string): Store | undefined => {
+  const redis = getRedis();
+  if (!redis) {
+    return undefined;
+  }
+  return new RedisStore({
+    prefix: `rl:abuse:${prefix}:`,
+    sendCommand: (...args: string[]) => redis.call(args[0], ...args.slice(1)) as Promise<number>,
+  });
+};
+
+const buildLimiter = (
+  name: string,
+  message: string,
+  base: Pick<RateLimitOptions, 'windowMs' | 'max'>
+) => {
+  const handler = (req: Request, res: Response): void => {
+    const userId = (req as RequestWithUser).user?.userId;
+    logger.warn(`${name} rate limit exceeded`, {
+      userId,
+      ip: req.ip,
+      path: req.path,
+    });
+    res.status(429).json({
+      error: message,
+      retryAfter: Math.ceil(base.windowMs / 1000),
+    });
+  };
+
+  return rateLimit({
+    windowMs: base.windowMs,
+    max: base.max,
+    keyGenerator: userIdOrIp,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => devBypass(),
+    store: buildStore(name),
+    handler,
+  });
+};
+
+/**
+ * Per-user application creation: 5/day. Combined with `applicationCreateWeeklyLimiter`,
+ * caps burst submissions from a single account.
+ */
+export const applicationCreateDailyLimiter = buildLimiter(
+  'application-create-daily',
+  'You have submitted too many applications today. Please try again tomorrow.',
+  { windowMs: ONE_DAY_MS, max: 5 }
+);
+
+/**
+ * Per-user application creation: 20/week.
+ */
+export const applicationCreateWeeklyLimiter = buildLimiter(
+  'application-create-weekly',
+  'You have submitted too many applications this week. Please try again later.',
+  { windowMs: ONE_WEEK_MS, max: 20 }
+);
+
+/**
+ * Per-user report rate limit across all report types (pet reports,
+ * moderation reports, etc.): 5/day. Pairs with the existing per-pet
+ * idempotency check that caps to 1 report per pet per user.
+ */
+export const reportCreateDailyLimiter = buildLimiter(
+  'report-create-daily',
+  'You have submitted too many reports today. Please try again tomorrow.',
+  { windowMs: ONE_DAY_MS, max: 5 }
+);

--- a/service.backend/src/migrations/05-add-user-tokens-invalid-before.ts
+++ b/service.backend/src/migrations/05-add-user-tokens-invalid-before.ts
@@ -1,0 +1,37 @@
+/**
+ * Add `tokens_invalid_before` to users so the auth middleware can reject
+ * stale access tokens issued before a security-state change (role
+ * change, password reset, 2FA toggle, …).
+ *
+ * Semantics:
+ *   - NULL          → no rotation enforced; every valid JWT passes the iat check.
+ *   - TIMESTAMP X   → any access token with `iat < X` is rejected at the next request.
+ *
+ * Set by the User model `beforeUpdate` hook when `userType` changes,
+ * and by explicit `invalidateUserTokens()` calls from credential-change
+ * code paths (password reset, 2FA enable/disable).
+ */
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { runInTransaction } from './_helpers';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.addColumn(
+        'users',
+        'tokens_invalid_before',
+        {
+          type: DataTypes.DATE,
+          allowNull: true,
+        },
+        { transaction: t }
+      );
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.removeColumn('users', 'tokens_invalid_before', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/migrations/05-create-two-factor-recoveries.ts
+++ b/service.backend/src/migrations/05-create-two-factor-recoveries.ts
@@ -1,0 +1,114 @@
+/**
+ * ADS (Batch KK): create the `two_factor_recoveries` table.
+ *
+ * Backs the email-bootstrapped 2FA recovery flow: a user with 2FA enabled
+ * who has lost their TOTP device and all backup codes posts their email
+ * to `/api/v1/auth/2fa/recover`; we issue a signed, single-use token (the
+ * plaintext travels only in the email link, the SHA-256 hash lives here),
+ * and on confirm we disable 2FA + revoke all sessions.
+ *
+ * Frozen createTable body matches `models/TwoFactorRecovery.ts`. Schema:
+ *   - recovery_id  UUID PK   — uuidv7 client-side
+ *   - user_id      UUID FK   — users.user_id, CASCADE on user delete
+ *   - token        TEXT UQ   — SHA-256 hash of the emailed plaintext
+ *   - expires_at   TIMESTAMP — 1 hour from issue
+ *   - used         BOOLEAN   — flips on confirm; row preserved for audit
+ *   - used_at      TIMESTAMP — when the token was consumed
+ *   - created_by / updated_by audit columns + standard timestamps
+ *
+ * Indexes: token (unique), user_id, plus the audit_columns pair.
+ */
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
+const MIGRATION_KEY = '05-create-two-factor-recoveries';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.createTable(
+        'two_factor_recoveries',
+        {
+          recovery_id: {
+            type: DataTypes.UUID,
+            primaryKey: true,
+            allowNull: false,
+          },
+          user_id: {
+            type: DataTypes.UUID,
+            allowNull: false,
+            references: { model: 'users', key: 'user_id' },
+            onDelete: 'CASCADE',
+          },
+          token: {
+            type: DataTypes.STRING,
+            allowNull: false,
+          },
+          expires_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          used: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false,
+          },
+          used_at: {
+            type: DataTypes.DATE,
+            allowNull: true,
+          },
+          created_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+            references: { model: 'users', key: 'user_id' },
+            onDelete: 'SET NULL',
+          },
+          updated_by: {
+            type: DataTypes.UUID,
+            allowNull: true,
+            references: { model: 'users', key: 'user_id' },
+            onDelete: 'SET NULL',
+          },
+          created_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+          updated_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex('two_factor_recoveries', {
+        fields: ['token'],
+        unique: true,
+        name: 'two_factor_recoveries_token_unique',
+        transaction,
+      });
+      await queryInterface.addIndex('two_factor_recoveries', {
+        fields: ['user_id'],
+        name: 'two_factor_recoveries_user_id_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('two_factor_recoveries', {
+        fields: ['created_by'],
+        name: 'two_factor_recoveries_created_by_idx',
+        transaction,
+      });
+      await queryInterface.addIndex('two_factor_recoveries', {
+        fields: ['updated_by'],
+        name: 'two_factor_recoveries_updated_by_idx',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    assertDestructiveDownAcknowledged(MIGRATION_KEY);
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.dropTable('two_factor_recoveries', { transaction });
+    });
+  },
+};

--- a/service.backend/src/models/Rescue.ts
+++ b/service.backend/src/models/Rescue.ts
@@ -10,7 +10,7 @@ import { generateUuidV7 } from '../utils/uuid';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 import type { RescuePlan } from '@adopt-dont-shop/lib.types';
 
-interface RescueAttributes {
+export interface RescueAttributes {
   rescueId: string;
   name: string;
   email: string;

--- a/service.backend/src/models/TwoFactorRecovery.ts
+++ b/service.backend/src/models/TwoFactorRecovery.ts
@@ -1,0 +1,122 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize, { getUuidType } from '../sequelize';
+import { hashToken } from '../utils/secrets';
+import { generateUuidV7 } from '../utils/uuid';
+import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
+
+/**
+ * ADS: email-bootstrapped 2FA recovery (Batch KK).
+ *
+ * Issued when a user with 2FA enabled loses both their TOTP device and
+ * all backup codes. The plaintext token only travels in the recovery
+ * email link; the SHA-256 hash is stored here (mirrors Invitation /
+ * password-reset token storage). One-shot: `used` flips to true on
+ * confirm and the row is left in place for audit forensics.
+ */
+interface TwoFactorRecoveryAttributes {
+  recovery_id: string;
+  user_id: string;
+  token: string;
+  expires_at: Date;
+  used: boolean;
+  used_at?: Date | null;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+type TwoFactorRecoveryCreationAttributes = Optional<
+  TwoFactorRecoveryAttributes,
+  'recovery_id' | 'used' | 'used_at'
+>;
+
+class TwoFactorRecovery
+  extends Model<TwoFactorRecoveryAttributes, TwoFactorRecoveryCreationAttributes>
+  implements TwoFactorRecoveryAttributes
+{
+  public recovery_id!: string;
+  public user_id!: string;
+  public token!: string;
+  public expires_at!: Date;
+  public used!: boolean;
+  public used_at!: Date | null;
+  public created_at!: Date;
+  public updated_at!: Date;
+}
+
+TwoFactorRecovery.init(
+  {
+    recovery_id: {
+      type: getUuidType(),
+      defaultValue: () => generateUuidV7(),
+      primaryKey: true,
+    },
+    user_id: {
+      type: getUuidType(),
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'user_id',
+      },
+      onDelete: 'CASCADE',
+    },
+    token: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    expires_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    used: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    used_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    ...auditColumns,
+  },
+  withAuditHooks({
+    sequelize,
+    tableName: 'two_factor_recoveries',
+    timestamps: true,
+    underscored: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['token'],
+        name: 'two_factor_recoveries_token_unique',
+      },
+      {
+        fields: ['user_id'],
+        name: 'two_factor_recoveries_user_id_idx',
+      },
+      ...auditIndexes('two_factor_recoveries'),
+    ],
+    hooks: {
+      beforeSave: (recovery: TwoFactorRecovery) => {
+        // Mirrors Invitation: callers write the raw token; the model
+        // SHA-256-hashes it before persistence so a DB leak can't
+        // forge a working recovery link.
+        if (recovery.changed('token') && recovery.token) {
+          recovery.token = hashToken(recovery.token);
+        }
+      },
+    },
+  })
+);
+
+export default TwoFactorRecovery;

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -86,6 +86,11 @@ interface UserAttributes {
   // admin triggers it on their behalf). Cleared by the retention
   // worker when phase-2 anonymization runs. See GdprService.
   pendingAnonymizationAt?: Date | null;
+  // ADS: forced-rotation marker for access tokens. The auth middleware
+  // rejects any JWT whose `iat` is older than this timestamp, so a role
+  // change / password reset / 2FA toggle invalidates every access token
+  // issued before that mutation. NULL means no rotation enforced.
+  tokensInvalidBefore?: Date | null;
   country?: string;
   city?: string;
   addressLine1?: string | null;
@@ -161,6 +166,7 @@ class User extends Model<UserAttributes, UserCreationAttributes> implements User
   public updatedAt!: Date;
   public deletedAt!: Date | null;
   public pendingAnonymizationAt!: Date | null;
+  public tokensInvalidBefore!: Date | null;
   public country!: string;
   public city!: string;
   public addressLine1!: string | null;
@@ -461,6 +467,11 @@ User.init(
       allowNull: true,
       field: 'pending_anonymization_at',
     },
+    tokensInvalidBefore: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'tokens_invalid_before',
+    },
     // rescueId is intentionally not a DB column — see UserAttributes
     // comment. Sequelize won't persist it, but the model class exposes it
     // for the auth middleware to populate.
@@ -597,6 +608,15 @@ User.init(
       beforeUpdate: async (user: User) => {
         if (user.changed('password') && user.password) {
           user.password = await hashPassword(user.password);
+        }
+        // ADS: any userType change must invalidate every access token
+        // issued before this write. Setting the column here covers both
+        // single-instance updates (UserService.updateUserRole) and bulk
+        // updates that opt into individualHooks (bulkUpdateUsers, plan
+        // 10-HH). For paths that DON'T fire per-instance hooks the
+        // caller must bump the column itself.
+        if (user.changed('userType') && !user.changed('tokensInvalidBefore')) {
+          user.tokensInvalidBefore = new Date();
         }
         await protectSecretsIfChanged(user);
       },

--- a/service.backend/src/models/index.ts
+++ b/service.backend/src/models/index.ts
@@ -48,6 +48,7 @@ import IdempotencyKey from './IdempotencyKey';
 import Invitation from './Invitation';
 import Rating from './Rating';
 import StaffMember from './StaffMember';
+import TwoFactorRecovery from './TwoFactorRecovery';
 
 // Content Moderation Models
 import ModeratorAction from './ModeratorAction';
@@ -130,6 +131,7 @@ const models = {
   Rating,
   StaffMember,
   Invitation,
+  TwoFactorRecovery,
   ModeratorAction,
   ModerationEvidence,
   Report,
@@ -451,6 +453,12 @@ try {
   User.hasMany(Invitation, { foreignKey: 'user_id', as: 'acceptedInvitations' });
   Invitation.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
 
+  // TwoFactorRecovery — email-bootstrapped 2FA recovery tokens. CASCADE
+  // on user delete: the row has no purpose once the owning account is
+  // gone.
+  User.hasMany(TwoFactorRecovery, { foreignKey: 'user_id', as: 'TwoFactorRecoveries' });
+  TwoFactorRecovery.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
+
   // Content Moderation associations
   User.hasMany(Report, { foreignKey: 'reporterId', as: 'SubmittedReports' });
   Report.belongsTo(User, { foreignKey: 'reporterId', as: 'Reporter' });
@@ -751,6 +759,7 @@ export {
   StaffMember,
   SupportTicket,
   SupportTicketResponse,
+  TwoFactorRecovery,
   SwipeAction,
   SwipeSession,
   User,

--- a/service.backend/src/routes/application.routes.ts
+++ b/service.backend/src/routes/application.routes.ts
@@ -5,6 +5,10 @@ import { fieldMask, fieldWriteGuard } from '../middleware/field-permissions';
 import { idempotency } from '../middleware/idempotency';
 import { requireRole } from '../middleware/rbac';
 import { uploadLimiter } from '../middleware/rate-limiter';
+import {
+  applicationCreateDailyLimiter,
+  applicationCreateWeeklyLimiter,
+} from '../middleware/user-abuse-rate-limit';
 import { enforceUploadMime } from '../middleware/upload-mime-guard';
 import { handleValidationErrors } from '../middleware/validation';
 import { UserType } from '../models/User';
@@ -207,6 +211,12 @@ router.get(
 router.post(
   '/',
   requireRole(UserType.ADOPTER),
+  // Per-user anti-abuse caps: 5/day AND 20/week. Keyed by req.user.userId,
+  // applied after requireRole so the userId is reliably populated. Each
+  // limiter has its own Redis bucket, so a request that trips either
+  // window returns 429 without consuming budget on the other.
+  applicationCreateDailyLimiter,
+  applicationCreateWeeklyLimiter,
   // Idempotency-Key header is optional; when provided, a retry of the
   // same submission replays the cached response instead of creating a
   // duplicate application. Plan 5.5.13.

--- a/service.backend/src/routes/auth.routes.ts
+++ b/service.backend/src/routes/auth.routes.ts
@@ -13,6 +13,7 @@ import {
   passwordResetLimiter,
   twoFactorLimiter,
 } from '../middleware/rate-limiter';
+import { verifyTurnstileToken } from '../middleware/turnstile';
 
 const router = Router();
 
@@ -87,6 +88,9 @@ const router = Router();
  */
 router.post(
   '/register',
+  // CAPTCHA runs FIRST so scripted spam is rejected before it touches
+  // the rate-limit buckets. A9.
+  verifyTurnstileToken,
   registrationIpLimiter,
   registrationEmailLimiter,
   authValidation.register,

--- a/service.backend/src/routes/auth.routes.ts
+++ b/service.backend/src/routes/auth.routes.ts
@@ -565,6 +565,23 @@ router.get('/me', authenticateToken, AuthController.getCurrentUser);
  */
 router.put('/me', authenticateToken, authValidation.updateProfile, AuthController.updateProfile);
 
+// Batch KK: email-bootstrapped 2FA recovery (pre-auth). Pre-existing
+// passwordResetLimiter is reused: same shape (3/hr by IP) and the same
+// risk model — a low-volume, email-bound, slow flow whose security
+// envelope is dominated by the cryptographic token in the email link.
+router.post(
+  '/2fa/recover',
+  passwordResetLimiter,
+  authValidation.requestTwoFactorRecovery,
+  AuthController.requestTwoFactorRecovery
+);
+router.post(
+  '/2fa/recover/confirm',
+  passwordResetLimiter,
+  authValidation.confirmTwoFactorRecovery,
+  AuthController.confirmTwoFactorRecovery
+);
+
 // Two-Factor Authentication routes
 router.post('/2fa/setup', authenticateToken, twoFactorLimiter, AuthController.twoFactorSetup);
 router.post(

--- a/service.backend/src/routes/moderation.routes.ts
+++ b/service.backend/src/routes/moderation.routes.ts
@@ -4,6 +4,7 @@ import { authenticateToken } from '../middleware/auth';
 import { idempotency } from '../middleware/idempotency';
 import { requirePermission } from '../middleware/rbac';
 import { generalLimiter } from '../middleware/rate-limiter';
+import { reportCreateDailyLimiter } from '../middleware/user-abuse-rate-limit';
 import { handleValidationErrors } from '../middleware/validation';
 import { PERMISSIONS } from '../types/rbac';
 import { moderationValidation } from '../validation/moderation.validation';
@@ -146,6 +147,10 @@ router.post(
   '/reports',
   requirePermission(PERMISSIONS.MODERATION_REPORTS_CREATE),
   generalLimiter,
+  // Per-user 5/day cap shared with pet reports — see A15. Idempotency
+  // still caps duplicates on the same entity; this is the additive
+  // per-day cap across all reportable entity types.
+  reportCreateDailyLimiter,
   idempotency,
   moderationValidation.submitReport,
   handleValidationErrors,

--- a/service.backend/src/routes/pet.routes.ts
+++ b/service.backend/src/routes/pet.routes.ts
@@ -4,6 +4,7 @@ import { authenticateToken, authenticateOptionalToken } from '../middleware/auth
 import { fieldMask, fieldWriteGuard } from '../middleware/field-permissions';
 import { idempotency } from '../middleware/idempotency';
 import { sensitiveWriteLimiter } from '../middleware/rate-limiter';
+import { reportCreateDailyLimiter } from '../middleware/user-abuse-rate-limit';
 import { requirePermission } from '../middleware/rbac';
 import { requirePlanFeature } from '../middleware/plan-gate';
 import { handleValidationErrors } from '../middleware/validation';
@@ -1425,6 +1426,7 @@ router.get(
 router.post(
   '/:petId/report',
   authenticateToken,
+  reportCreateDailyLimiter,
   idempotency,
   PetController.validateReportPet,
   petController.reportPet

--- a/service.backend/src/routes/session.routes.ts
+++ b/service.backend/src/routes/session.routes.ts
@@ -1,0 +1,71 @@
+import { Response, Router } from 'express';
+import { param, validationResult } from 'express-validator';
+import { authenticateToken } from '../middleware/auth';
+import RefreshToken from '../models/RefreshToken';
+import SecurityService from '../services/security.service';
+import { AuthenticatedRequest } from '../types/auth';
+import { logger } from '../utils/logger';
+
+const router = Router();
+
+router.use(authenticateToken);
+
+/**
+ * GET /api/v1/sessions
+ * Return the caller's own active (non-revoked, non-expired) refresh-token
+ * rows so they can review where they're signed in.
+ */
+router.get('/', async (req: AuthenticatedRequest, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  try {
+    const result = await SecurityService.listSessions({ userId: req.user.userId });
+    return res.json({
+      data: result.sessions.map(s => ({
+        sessionId: s.sessionId,
+        familyId: s.familyId,
+        expiresAt: s.expiresAt,
+        createdAt: s.createdAt,
+      })),
+    });
+  } catch (error) {
+    logger.error('Failed to list sessions', { error });
+    return res.status(500).json({ error: 'Failed to list sessions' });
+  }
+});
+
+/**
+ * DELETE /api/v1/sessions/:sessionId
+ * Revoke a single session belonging to the caller. The ownership check is
+ * load-bearing: without it a user could revoke any session by guessing the
+ * id. Non-existent or other-user sessions both return 404 so we don't leak
+ * the existence of an id that belongs to a different account.
+ */
+router.delete(
+  '/:sessionId',
+  [param('sessionId').isString().notEmpty().withMessage('sessionId is required')],
+  async (req: AuthenticatedRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    if (!req.user) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    try {
+      const row = await RefreshToken.findByPk(req.params.sessionId);
+      if (!row || row.user_id !== req.user.userId) {
+        return res.status(404).json({ error: 'Session not found' });
+      }
+      await SecurityService.revokeSession(row.token_id, req.user.userId);
+      return res.status(204).send();
+    } catch (error) {
+      logger.error('Failed to revoke session', { error });
+      return res.status(500).json({ error: 'Failed to revoke session' });
+    }
+  }
+);
+
+export default router;

--- a/service.backend/src/services/admin.service.ts
+++ b/service.backend/src/services/admin.service.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'stream';
 import { ModelStatic, Model, Op, QueryTypes, WhereOptions } from 'sequelize';
+import { isSingleScriptLocalPart } from '@adopt-dont-shop/lib.validation';
 import Application from '../models/Application';
 import AuditLog from '../models/AuditLog';
 import Pet from '../models/Pet';
@@ -948,6 +949,21 @@ class AdminService {
       const user = await User.findByPk(userId);
       if (!user) {
         throw new Error('User not found');
+      }
+
+      // Pass-9 added a mixed-script gate to the User model's
+      // beforeValidate hook so an attacker can't register a
+      // homograph email (e.g. Cyrillic "а" in admin@…). But
+      // user.update({ emailVerified: true }) doesn't touch the
+      // email column and so doesn't re-run the hook, which means
+      // an admin could otherwise stamp a previously-bypassed
+      // mixed-script email as verified. Re-run the gate here so
+      // the admin path can't sidestep the registration policy.
+      const localPart = user.email.split('@')[0] ?? '';
+      if (!isSingleScriptLocalPart(localPart)) {
+        throw new Error(
+          'Cannot verify user with mixed-script email — user must update their email first'
+        );
       }
 
       // Update user verification status using the correct field name

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -309,6 +309,15 @@ export class ApplicationService {
           throw new Error('Pet not found');
         }
 
+        // A13: applications may only be submitted to a verified rescue.
+        // Frontends still SHOW the rescue (with a pending-verification
+        // badge) but the "Apply" affordance is disabled. Verifying here
+        // closes the loop for any caller that hits the API directly.
+        const rescue = await Rescue.findByPk(pet.rescueId, { transaction: t });
+        if (!rescue || rescue.status !== 'verified') {
+          throw new Error('Cannot interact with unverified rescue');
+        }
+
         if (pet.status !== 'available') {
           throw new Error('Pet is not available for adoption');
         }

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1903,28 +1903,32 @@ export class ApplicationService {
 
       for (const applicationId of bulkUpdate.applicationIds) {
         try {
-          const application = await Application.findByPk(applicationId);
-          if (!application) {
-            results.failures.push({
-              applicationId: applicationId,
-              error: 'Application not found',
-            });
-            results.failureCount++;
-            continue;
-          }
+          // Per-item transaction: the application update and the
+          // accompanying audit-log row commit or roll back together,
+          // so the failure counts in the response match the real DB
+          // state — no more "audit logged success but DB unchanged"
+          // (or vice versa) on partial failure.
+          await sequelize.transaction(async tx => {
+            const application = await Application.findByPk(applicationId, { transaction: tx });
+            if (!application) {
+              // Throw to skip success-side bookkeeping; caught below
+              // and recorded as a failure with this exact message.
+              throw new Error('Application not found');
+            }
 
-          await application.update(bulkUpdate.updates);
+            await application.update(bulkUpdate.updates, { transaction: tx });
+
+            await AuditLogService.log({
+              action: 'BULK_UPDATE',
+              entity: 'Application',
+              entityId: applicationId,
+              details: { updates: bulkUpdate.updates, bulk_operation: true },
+              userId,
+              transaction: tx,
+            });
+          });
           results.successes.push(applicationId);
           results.successCount++;
-
-          // Log bulk update
-          await AuditLogService.log({
-            action: 'BULK_UPDATE',
-            entity: 'Application',
-            entityId: applicationId,
-            details: { updates: bulkUpdate.updates, bulk_operation: true },
-            userId,
-          });
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
           results.failures.push({ applicationId: applicationId, error: errorMessage });

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -173,7 +173,10 @@ export class ApplicationService {
       reason: 'Visit scheduled',
     });
 
-    await Application.update({ status: ApplicationStatus.SUBMITTED }, { where: { applicationId } });
+    await Application.update(
+      { status: ApplicationStatus.SUBMITTED },
+      { where: { applicationId }, individualHooks: true }
+    );
 
     return formatHomeVisit(visit);
   }
@@ -271,7 +274,10 @@ export class ApplicationService {
         applicationStatus = ApplicationStatus.REJECTED;
       }
 
-      await Application.update({ status: applicationStatus }, { where: { applicationId } });
+      await Application.update(
+        { status: applicationStatus },
+        { where: { applicationId }, individualHooks: true }
+      );
     }
 
     return formatHomeVisit(visit);

--- a/service.backend/src/services/auditLog.service.ts
+++ b/service.backend/src/services/auditLog.service.ts
@@ -1,4 +1,4 @@
-import { Op, WhereOptions } from 'sequelize';
+import { Op, Transaction, WhereOptions } from 'sequelize';
 import { AuditLog, withAuditMutationAllowed } from '../models/AuditLog';
 import User from '../models/User';
 import sequelize from '../sequelize';
@@ -31,6 +31,16 @@ export interface AuditLogData {
   service?: string;
   level?: 'INFO' | 'WARNING' | 'ERROR';
   status?: 'success' | 'failure';
+  /**
+   * Optional Sequelize transaction to pair the audit write with the
+   * caller's DB writes. When supplied the audit row is created inside
+   * the same transaction so partial-failure scenarios (DB write
+   * commits, audit write fails, or vice versa) can no longer drift the
+   * two out of sync. The user-email snapshot lookup intentionally runs
+   * OUTSIDE the transaction — it's a best-effort read that mustn't
+   * pollute the caller's tx with read locks.
+   */
+  transaction?: Transaction;
 }
 
 export class AuditLogService {
@@ -53,25 +63,28 @@ export class AuditLogService {
         }
       }
 
-      const auditLog = await AuditLog.create({
-        service: data.service || 'adopt-dont-shop-backend',
-        user: data.userId,
-        user_email_snapshot: userEmailSnapshot,
-        action: data.action,
-        level: data.level || 'INFO',
-        status: data.status,
-        timestamp: new Date(),
-        metadata: {
-          entity: data.entity,
-          entityId: data.entityId,
-          details: data.details || {},
-          ipAddress: data.ipAddress,
-          userAgent: data.userAgent,
+      const auditLog = await AuditLog.create(
+        {
+          service: data.service || 'adopt-dont-shop-backend',
+          user: data.userId,
+          user_email_snapshot: userEmailSnapshot,
+          action: data.action,
+          level: data.level || 'INFO',
+          status: data.status,
+          timestamp: new Date(),
+          metadata: {
+            entity: data.entity,
+            entityId: data.entityId,
+            details: data.details || {},
+            ipAddress: data.ipAddress,
+            userAgent: data.userAgent,
+          },
+          category: data.entity || 'GENERAL',
+          ip_address: data.ipAddress,
+          user_agent: data.userAgent,
         },
-        category: data.entity || 'GENERAL',
-        ip_address: data.ipAddress,
-        user_agent: data.userAgent,
-      });
+        data.transaction ? { transaction: data.transaction } : undefined
+      );
 
       logger.info(`Audit log created: ${data.action} on ${data.entity} by ${data.userId}`);
       return auditLog;

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -9,6 +9,7 @@ import { normalizeEmail } from '@adopt-dont-shop/lib.validation';
 import User, { UserStatus, UserType } from '../models/User';
 import RefreshToken from '../models/RefreshToken';
 import RevokedToken from '../models/RevokedToken';
+import TwoFactorRecovery from '../models/TwoFactorRecovery';
 import EmailQueue, { EmailStatus, EmailType, EmailPriority } from '../models/EmailQueue';
 import { logger, loggerHelpers } from '../utils/logger';
 import { decryptSecret, encryptSecret, hashToken, verifyBackupCode } from '../utils/secrets';
@@ -788,6 +789,388 @@ Need help? Contact us at support@adoptdontshop.com
       return { message: 'Password reset successfully' };
     } catch (error) {
       logger.error('Password reset confirmation failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Batch KK: request an email-bootstrapped 2FA recovery link.
+   *
+   * Pre-auth endpoint for users who have lost both their TOTP device and
+   * all backup codes. Mirrors requestPasswordReset's enumeration-resistant
+   * shape — always returns the same generic 200 message; only emails a
+   * link when the email matches a user who actually has 2FA enabled.
+   *
+   * Token: 32 random bytes hex. Plaintext only travels in the email link;
+   * the SHA-256 hash is persisted on a new TwoFactorRecovery row with a
+   * 1-hour expiry (model hook hashes on save, same as Invitation).
+   */
+  async requestTwoFactorRecovery(data: { email: string }, ipAddress?: string, userAgent?: string) {
+    const genericMessage =
+      'If the email matches an account with two-factor authentication, a recovery link has been sent.';
+
+    try {
+      const user = await User.findOne({
+        where: { email: normalizeEmail(data.email) },
+      });
+
+      if (!user) {
+        // Don't reveal if email exists — same shape as password-reset.
+        // No audit-log subject (the email isn't tied to a real user);
+        // the IP/UA are still captured via subjectless event below.
+        logger.info('2FA recovery requested for non-existent email', {
+          email: redactEmail(data.email),
+          ipAddress,
+        });
+        await AuditLogService.log({
+          action: 'TWO_FACTOR_RECOVERY_REQUESTED',
+          entity: 'User',
+          entityId: 'unknown',
+          userId: '',
+          ipAddress,
+          userAgent,
+          details: { email: redactEmail(data.email), reason: 'unknown_email' },
+        }).catch(err => {
+          logger.warn('Failed to write 2FA recovery audit (unknown email)', { err });
+        });
+        return { message: genericMessage };
+      }
+
+      if (!user.twoFactorEnabled) {
+        // User exists but 2FA isn't on — silently no-op to avoid leaking
+        // 2FA-enrollment state via timing or response shape. Still audit.
+        logger.info('2FA recovery requested for user without 2FA enabled', {
+          userId: user.userId,
+        });
+        await AuditLogService.log({
+          action: 'TWO_FACTOR_RECOVERY_REQUESTED',
+          entity: 'User',
+          entityId: user.userId,
+          userId: user.userId,
+          ipAddress,
+          userAgent,
+          details: { email: user.email, reason: 'two_factor_not_enabled' },
+        }).catch(err => {
+          logger.warn('Failed to write 2FA recovery audit (2FA off)', { err });
+        });
+        return { message: genericMessage };
+      }
+
+      const plaintextToken = crypto.randomBytes(32).toString('hex');
+      const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+      await TwoFactorRecovery.create({
+        user_id: user.userId,
+        token: plaintextToken, // beforeSave hook hashes
+        expires_at: expiresAt,
+      });
+
+      await AuditLogService.log({
+        action: 'TWO_FACTOR_RECOVERY_REQUESTED',
+        entity: 'User',
+        entityId: user.userId,
+        userId: user.userId,
+        ipAddress,
+        userAgent,
+        details: { email: user.email },
+      });
+
+      loggerHelpers.logSecurity('2FA recovery requested', {
+        userId: user.userId,
+        email: redactEmail(user.email),
+      });
+
+      try {
+        const emailService = (await import('./email.service')).default;
+        // ADS-438: validate FRONTEND_URL origin before building the link.
+        const recoveryUrl = `${getValidatedFrontendOrigin()}/auth/2fa/recover?token=${plaintextToken}`;
+
+        await emailService.sendEmail({
+          toEmail: user.email,
+          toName: `${user.firstName} ${user.lastName}`,
+          subject: "Two-Factor Recovery Request - Adopt Don't Shop",
+          htmlContent: `
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>Two-Factor Recovery Request</title>
+            </head>
+            <body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+              <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f4; padding: 20px;">
+                <tr>
+                  <td align="center">
+                    <table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                      <tr>
+                        <td style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 40px 20px; text-align: center;">
+                          <h1 style="color: #ffffff; margin: 0; font-size: 28px;">Two-Factor Recovery</h1>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 40px 30px;">
+                          <p style="font-size: 16px; color: #333333; margin: 0 0 20px 0;">Hi ${user.firstName},</p>
+                          <p style="font-size: 16px; color: #333333; margin: 0 0 20px 0; line-height: 1.6;">
+                            We received a request to recover access to your Adopt Don't Shop account by
+                            disabling two-factor authentication. Click the button below to continue.
+                          </p>
+                          <p style="font-size: 16px; color: #333333; margin: 0 0 20px 0; line-height: 1.6;">
+                            <strong>Confirming this link will turn off two-factor authentication and sign
+                            you out of all active sessions.</strong> You will be able to sign in with just
+                            your password until you re-enable two-factor authentication.
+                          </p>
+                          <table width="100%" cellpadding="0" cellspacing="0" style="margin: 30px 0;">
+                            <tr>
+                              <td align="center">
+                                <a href="${recoveryUrl}" style="display: inline-block; padding: 16px 40px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: bold; font-size: 16px;">Recover My Account</a>
+                              </td>
+                            </tr>
+                          </table>
+                          <p style="font-size: 14px; color: #666666; margin: 20px 0 10px 0; line-height: 1.6;">
+                            Or copy and paste this link into your browser:
+                          </p>
+                          <p style="font-size: 14px; color: #667eea; word-break: break-all; margin: 0 0 20px 0;">
+                            ${recoveryUrl}
+                          </p>
+                          <div style="background-color: #fff3cd; border-left: 4px solid #ffc107; padding: 16px; margin: 30px 0;">
+                            <p style="font-size: 14px; color: #856404; margin: 0; line-height: 1.6;">
+                              <strong>This link will expire in 1 hour</strong> for your security.
+                            </p>
+                          </div>
+                          <p style="font-size: 14px; color: #666666; margin: 20px 0 0 0; line-height: 1.6;">
+                            If you didn't request this, you can safely ignore this email — your
+                            two-factor authentication will remain active.
+                          </p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="background-color: #f8f9fa; padding: 30px; text-align: center; border-top: 1px solid #e9ecef;">
+                          <p style="font-size: 14px; color: #6c757d; margin: 0 0 10px 0;">
+                            Need help? Contact us at <a href="mailto:support@adoptdontshop.com" style="color: #667eea; text-decoration: none;">support@adoptdontshop.com</a>
+                          </p>
+                          <p style="font-size: 12px; color: #adb5bd; margin: 0;">
+                            © ${new Date().getFullYear()} Adopt Don't Shop. All rights reserved.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </body>
+            </html>
+          `,
+          textContent: `Hi ${user.firstName},
+
+We received a request to recover access to your Adopt Don't Shop account by disabling two-factor authentication.
+
+Confirming this link will turn off two-factor authentication and sign you out of all active sessions. You will be able to sign in with just your password until you re-enable two-factor authentication.
+
+To continue, click the link below or copy and paste it into your browser:
+
+${recoveryUrl}
+
+This link will expire in 1 hour for your security.
+
+If you didn't request this, you can safely ignore this email — your two-factor authentication will remain active.
+
+Need help? Contact us at support@adoptdontshop.com
+
+© ${new Date().getFullYear()} Adopt Don't Shop. All rights reserved.
+`,
+          templateData: {
+            firstName: user.firstName,
+            // Bare token intentionally omitted — the signed recoveryUrl
+            // already embeds it (mirrors the password-reset template).
+            recoveryUrl,
+            expiresAt: expiresAt.toISOString(),
+          },
+          type: 'transactional',
+          priority: 'high',
+        });
+
+        logger.info('2FA recovery email sent', {
+          userId: user.userId,
+          email: redactEmail(user.email),
+        });
+      } catch (emailError) {
+        logger.error('Failed to send 2FA recovery email:', emailError);
+        // Don't throw — still return success to user for security.
+      }
+
+      return { message: genericMessage };
+    } catch (error) {
+      logger.error('2FA recovery request failed:', {
+        error: error instanceof Error ? error.message : String(error),
+        email: redactEmail(data.email),
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Batch KK: confirm a 2FA recovery token from the emailed link.
+   *
+   * Atomic single-use claim: inside one transaction we flip the recovery
+   * row to used=true (gated by used=false in the WHERE so concurrent
+   * confirms can't both win) and tear down 2FA on the user. Then revoke
+   * every active refresh token and disconnect live sockets so any session
+   * predating the recovery cannot continue, and email the user a heads-up
+   * so they can react if the recovery wasn't theirs.
+   */
+  async confirmTwoFactorRecovery(data: { token: string }) {
+    const hashedToken = hashToken(data.token);
+    let userId: string | null = null;
+
+    try {
+      await sequelize.transaction(async transaction => {
+        const recovery = await TwoFactorRecovery.findOne({
+          where: {
+            token: hashedToken,
+            used: false,
+            expires_at: { [Op.gt]: new Date() },
+          },
+          transaction,
+        });
+
+        if (!recovery) {
+          throw new Error('Invalid or expired recovery token');
+        }
+
+        // Conditional UPDATE provides the atomic single-use claim:
+        // two concurrent confirms with the same token both pass the
+        // findOne, but only one wins the WHERE used=false write. The
+        // loser sees affectedCount=0 and throws the same generic error.
+        const [affectedCount] = await TwoFactorRecovery.update(
+          { used: true, used_at: new Date() },
+          {
+            where: {
+              recovery_id: recovery.recovery_id,
+              used: false,
+              expires_at: { [Op.gt]: new Date() },
+            },
+            transaction,
+          }
+        );
+
+        if (affectedCount === 0) {
+          throw new Error('Invalid or expired recovery token');
+        }
+
+        const user = await User.findByPk(recovery.user_id, { transaction });
+        if (!user) {
+          // Should not happen — FK CASCADE keeps these in sync — but be
+          // defensive: a missing user means the row is orphaned and the
+          // token must not be honoured.
+          throw new Error('Invalid or expired recovery token');
+        }
+
+        user.twoFactorEnabled = false;
+        user.twoFactorSecret = null;
+        user.twoFactorPendingSecret = null;
+        user.twoFactorPendingExpiresAt = null;
+        user.backupCodes = null;
+        await user.save({ transaction });
+
+        userId = user.userId;
+      });
+
+      if (!userId) {
+        // Defensive: the transaction body always assigns userId on success.
+        throw new Error('Invalid or expired recovery token');
+      }
+
+      // Out-of-transaction cleanup (mirrors disableTwoFactor): a 2FA
+      // recovery is a security downgrade — revoke every active refresh
+      // token and disconnect live sockets so no session predating the
+      // recovery can continue.
+      const revokedCount = await RefreshToken.update(
+        { is_revoked: true },
+        { where: { user_id: userId, is_revoked: false } }
+      );
+      invalidateAuthCache(userId);
+      disconnectAllSockets(userId);
+
+      await AuditLogService.log({
+        action: 'TWO_FACTOR_RECOVERED',
+        entity: 'User',
+        entityId: userId,
+        userId,
+        details: { reason: 'email_recovery' },
+      });
+
+      await AuditLogService.log({
+        action: 'REFRESH_TOKENS_REVOKED',
+        entity: 'User',
+        entityId: userId,
+        userId,
+        details: { reason: 'two_factor_recovered', count: revokedCount[0] },
+      });
+
+      loggerHelpers.logSecurity('2FA recovered via email link', { userId });
+
+      // Send a confirmation email so the legitimate owner is notified
+      // even if the recovery wasn't theirs (mitigates the risk that email
+      // is now the single auth factor during the recovery window).
+      try {
+        const user = await User.findByPk(userId);
+        if (user) {
+          const emailService = (await import('./email.service')).default;
+          const loginUrl = `${getValidatedFrontendOrigin()}/login`;
+
+          await emailService.sendEmail({
+            toEmail: user.email,
+            toName: `${user.firstName} ${user.lastName}`,
+            subject: "Two-Factor Authentication Disabled - Adopt Don't Shop",
+            htmlContent: `
+              <!DOCTYPE html>
+              <html>
+              <body style="font-family: Arial, sans-serif; background: #f4f4f4; padding: 20px;">
+                <div style="max-width: 600px; margin: 0 auto; background: #fff; padding: 30px; border-radius: 8px;">
+                  <h2 style="color: #333;">Two-Factor Authentication Disabled</h2>
+                  <p>Hi ${user.firstName},</p>
+                  <p>Two-factor authentication has just been disabled on your account using the
+                  email recovery link. All active sessions have been signed out for your security.</p>
+                  <p>You can now sign in with just your password. We recommend re-enabling
+                  two-factor authentication as soon as you can.</p>
+                  <p><a href="${loginUrl}" style="display:inline-block;padding:12px 24px;background:#667eea;color:#fff;border-radius:6px;text-decoration:none;">Sign in</a></p>
+                  <div style="background:#fff3cd;border-left:4px solid #ffc107;padding:12px;margin:20px 0;">
+                    <p style="margin:0;color:#856404;"><strong>If this wasn't you</strong>, your account
+                    may be compromised. Reset your password immediately and contact support at
+                    support@adoptdontshop.com.</p>
+                  </div>
+                  <p style="font-size:12px;color:#999;">© ${new Date().getFullYear()} Adopt Don't Shop.</p>
+                </div>
+              </body>
+              </html>
+            `,
+            textContent: `Hi ${user.firstName},
+
+Two-factor authentication has just been disabled on your account using the email recovery link. All active sessions have been signed out for your security.
+
+You can now sign in with just your password: ${loginUrl}
+
+We recommend re-enabling two-factor authentication as soon as you can.
+
+If this wasn't you, your account may be compromised. Reset your password immediately and contact support at support@adoptdontshop.com.
+
+© ${new Date().getFullYear()} Adopt Don't Shop.
+`,
+            type: 'transactional',
+            priority: 'high',
+          });
+        }
+      } catch (emailError) {
+        // Notification is best-effort — the recovery itself already
+        // succeeded. Log but don't fail the request.
+        logger.error('Failed to send 2FA recovery confirmation email:', emailError);
+      }
+
+      return {
+        message: 'Two-factor authentication has been disabled. Please sign in with your password.',
+      };
+    } catch (error) {
+      logger.error('2FA recovery confirmation failed:', error);
       throw error;
     }
   }

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -18,6 +18,7 @@ import { AuditLogService } from './auditLog.service';
 import { redactEmail } from './redact';
 import { env } from '../config/env';
 import { invalidateAuthCache } from '../lib/auth-cache';
+import { invalidateUserTokens } from '../lib/invalidate-user-tokens';
 import { disconnectAllSockets } from '../socket/socket-registry';
 
 import {
@@ -755,19 +756,16 @@ Need help? Contact us at support@adoptdontshop.com
         throw new Error('Invalid or expired reset token');
       }
 
-      const revokedCount = await RefreshToken.update(
-        { is_revoked: true },
-        { where: { user_id: user.userId, is_revoked: false } }
-      );
-      invalidateAuthCache(user.userId);
+      // ADS: full session kick — bumps tokens_invalid_before (so any
+      // surviving access token's iat is now in the past and the auth
+      // middleware rejects it), revokes refresh tokens, busts the auth
+      // cache, and disconnects live Socket.IO connections. Belt and
+      // braces: the refresh-revoke alone forces re-login at next
+      // refresh; the iat bump catches the up-to-15-min access-token
+      // window in between.
+      const { refreshTokensRevoked: revokedCount } = await invalidateUserTokens(user.userId);
 
       logger.info('Password reset completed', { userId: user.userId });
-
-      // ADS-597: a password reset invalidates the user's sessions on
-      // the HTTP path (refresh-token family rotation / forced relogin);
-      // tear down any live Socket.IO connections too so an attacker
-      // who'd hijacked a WebSocket can't continue past the reset.
-      disconnectAllSockets(user.userId);
 
       // Log password reset
       await AuditLogService.log({
@@ -782,7 +780,7 @@ Need help? Contact us at support@adoptdontshop.com
         action: 'REFRESH_TOKENS_REVOKED',
         entity: 'User',
         entityId: user.userId,
-        details: { reason: 'password_reset', count: revokedCount[0] },
+        details: { reason: 'password_reset', count: revokedCount },
         userId: user.userId,
       });
 
@@ -1738,6 +1736,12 @@ If this wasn't you, your account may be compromised. Reset your password immedia
     user.backupCodes = backupCodes;
     await user.save();
 
+    // ADS: enabling 2FA is a security-state change. Force-rotate any
+    // access token issued before this point so the user can't keep
+    // riding a pre-2FA session that bypassed the second factor at login
+    // time. Complements pass-10 batch HH's refresh-token revocation.
+    await invalidateUserTokens(user.userId);
+
     await AuditLogService.log({
       userId: user.userId,
       action: 'TWO_FACTOR_ENABLED',
@@ -1762,18 +1766,12 @@ If this wasn't you, your account may be compromised. Reset your password immedia
     user.backupCodes = null;
     await user.save();
 
-    // ADS-589: a 2FA disable downgrades the account's security posture
-    // — revoke every active refresh token so any session that
-    // pre-dates the disable can't continue to refresh.
-    const revokedCount = await RefreshToken.update(
-      { is_revoked: true },
-      { where: { user_id: userId, is_revoked: false } }
-    );
-    invalidateAuthCache(userId);
-
-    // ADS-597: a 2FA disable is a security-state change; force live
-    // sockets to reconnect so they pick up the new state.
-    disconnectAllSockets(user.userId);
+    // ADS-589 / ADS-597: a 2FA disable downgrades the account's
+    // security posture — kick every session (refresh tokens, live
+    // sockets, auth cache) and bump tokens_invalid_before so any
+    // unexpired access token in flight is rejected by the auth
+    // middleware on its next request.
+    const { refreshTokensRevoked: revokedCount } = await invalidateUserTokens(userId);
 
     await AuditLogService.log({
       userId: user.userId,
@@ -1788,7 +1786,7 @@ If this wasn't you, your account may be compromised. Reset your password immedia
       action: 'REFRESH_TOKENS_REVOKED',
       entity: 'User',
       entityId: userId,
-      details: { reason: '2fa_disabled', count: revokedCount[0] },
+      details: { reason: '2fa_disabled', count: revokedCount },
     });
 
     loggerHelpers.logSecurity('2FA disabled', { userId: user.userId });

--- a/service.backend/src/services/notification.service.ts
+++ b/service.backend/src/services/notification.service.ts
@@ -248,7 +248,13 @@ export class NotificationService {
   }
 
   /**
-   * Mark notification as read
+   * Mark notification as read.
+   *
+   * Audit attribution convention: the top-level audit row's `user` column
+   * holds the actor (the caller). The details payload uses `subjectId`
+   * for the notification owner so admin-on-behalf flows can be told
+   * apart from self-service actions (actor != subject ⇒ on-behalf-of).
+   * In the self-service path actor and subject collapse to the same id.
    */
   static async markAsRead(notificationId: string, userId: string): Promise<void> {
     const startTime = Date.now();
@@ -274,7 +280,7 @@ export class NotificationService {
         action: 'NOTIFICATION_READ',
         entity: 'Notification',
         entityId: notificationId,
-        details: { notificationId },
+        details: { notificationId, subjectId: userId },
       });
 
       loggerHelpers.logBusiness('Notification Marked as Read', {
@@ -294,7 +300,10 @@ export class NotificationService {
   }
 
   /**
-   * Mark all notifications as read for a user
+   * Mark all notifications as read for a user.
+   *
+   * Audit attribution convention: see markAsRead. `subjectId` carries
+   * the notification owner; the actor is on the top-level audit row.
    */
   static async markAllAsRead(userId: string) {
     const startTime = Date.now();
@@ -315,7 +324,7 @@ export class NotificationService {
         entity: 'Notification',
         entityId: 'multiple',
         details: {
-          userId,
+          subjectId: userId,
           updatedCount: affectedRows,
         },
         userId,
@@ -339,7 +348,10 @@ export class NotificationService {
   }
 
   /**
-   * Delete notification
+   * Delete notification.
+   *
+   * Audit attribution convention: see markAsRead. `subjectId` carries
+   * the notification owner; the actor is on the top-level audit row.
    */
   static async deleteNotification(notificationId: string, userId: string): Promise<void> {
     const startTime = Date.now();
@@ -365,7 +377,7 @@ export class NotificationService {
         action: 'NOTIFICATION_DELETED',
         entity: 'Notification',
         entityId: notificationId,
-        details: { notificationId },
+        details: { notificationId, subjectId: userId },
       });
 
       loggerHelpers.logBusiness('Notification Deleted', {

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -1,4 +1,4 @@
-import { col, fn, literal, Op, WhereOptions } from 'sequelize';
+import { col, fn, literal, Op, Transaction, WhereOptions } from 'sequelize';
 import { cached, invalidateNamespace } from '../cache/redis-cache';
 import Breed from '../models/Breed';
 import Pet, { AgeGroup, PetStatus, PetType, Size } from '../models/Pet';
@@ -895,7 +895,8 @@ export class PetService {
   static async updatePetStatus(
     petId: string,
     statusUpdate: PetStatusUpdate,
-    updatedBy: string
+    updatedBy: string,
+    transaction?: Transaction
   ): Promise<Pet> {
     const startTime = Date.now();
 
@@ -917,18 +918,21 @@ export class PetService {
         sideEffects.fosterStartDate = new Date();
       }
       if (Object.keys(sideEffects).length > 0) {
-        await pet.update(sideEffects);
+        await pet.update(sideEffects, { transaction });
       }
 
       // Append the transition; the AFTER INSERT trigger (Postgres) /
       // afterCreate hook (SQLite) propagates to_status onto pets.status.
-      await PetStatusTransition.create({
-        petId,
-        fromStatus: originalStatus,
-        toStatus: statusUpdate.status,
-        transitionedBy: updatedBy,
-        reason: statusUpdate.reason || null,
-      });
+      await PetStatusTransition.create(
+        {
+          petId,
+          fromStatus: originalStatus,
+          toStatus: statusUpdate.status,
+          transitionedBy: updatedBy,
+          reason: statusUpdate.reason || null,
+        },
+        { transaction }
+      );
 
       // Log status update
       await AuditLogService.log({
@@ -942,6 +946,7 @@ export class PetService {
           updatedBy,
         },
         userId: updatedBy,
+        transaction,
       });
 
       if (loggerHelpers && loggerHelpers.logBusiness) {
@@ -979,7 +984,8 @@ export class PetService {
   static async deletePet(
     petId: string,
     deletedBy: string,
-    reason?: string
+    reason?: string,
+    transaction?: Transaction
   ): Promise<{ message: string }> {
     const startTime = Date.now();
 
@@ -987,7 +993,7 @@ export class PetService {
       const pet = await PetService.assertCallerOwnsPet(petId, deletedBy);
 
       // Soft delete the pet
-      await pet.destroy();
+      await pet.destroy({ transaction });
 
       // Log deletion
       await AuditLogService.log({
@@ -1000,6 +1006,7 @@ export class PetService {
           petData: JSON.parse(JSON.stringify(pet.toJSON())),
         },
         userId: deletedBy,
+        transaction,
       });
 
       if (loggerHelpers && loggerHelpers.logBusiness) {
@@ -1397,34 +1404,52 @@ export class PetService {
 
       for (const petId of petIds) {
         try {
-          switch (operationType) {
-            case 'update_status':
-              if (data) {
-                await this.updatePetStatus(petId, data as unknown as PetStatusUpdate, updatedBy);
-              }
-              break;
-            case 'archive': {
-              // ADS-372: per-iteration ownership check defends against TOCTOU
-              // (a pet moved to a different rescue between pre-flight and the
-              // update) and prevents future bulk operation types from
-              // accidentally bypassing the pre-flight by forgetting it.
-              await PetService.assertCallerOwnsPet(petId, updatedBy);
-              await Pet.update({ archived: true }, { where: { petId } });
-              break;
-            }
-            case 'feature': {
-              if (data && typeof data.featured === 'boolean') {
+          // Per-item transaction pairs the pet write with whatever
+          // audit log the helper emits — if the audit insert fails,
+          // the pet write rolls back too, so the success/failure
+          // counts returned to the caller always match the real DB
+          // state. Without this, a successful pet.update followed by
+          // a failed AuditLogService.log throws into the catch below
+          // and is counted as a failure while the pet write is
+          // already committed.
+          await sequelize.transaction(async tx => {
+            switch (operationType) {
+              case 'update_status':
+                if (data) {
+                  await this.updatePetStatus(
+                    petId,
+                    data as unknown as PetStatusUpdate,
+                    updatedBy,
+                    tx
+                  );
+                }
+                break;
+              case 'archive': {
+                // ADS-372: per-iteration ownership check defends against TOCTOU
+                // (a pet moved to a different rescue between pre-flight and the
+                // update) and prevents future bulk operation types from
+                // accidentally bypassing the pre-flight by forgetting it.
                 await PetService.assertCallerOwnsPet(petId, updatedBy);
-                await Pet.update({ featured: data.featured }, { where: { petId } });
+                await Pet.update({ archived: true }, { where: { petId }, transaction: tx });
+                break;
               }
-              break;
+              case 'feature': {
+                if (data && typeof data.featured === 'boolean') {
+                  await PetService.assertCallerOwnsPet(petId, updatedBy);
+                  await Pet.update(
+                    { featured: data.featured },
+                    { where: { petId }, transaction: tx }
+                  );
+                }
+                break;
+              }
+              case 'delete':
+                await this.deletePet(petId, updatedBy, reason, tx);
+                break;
+              default:
+                throw new Error(`Unknown operation: ${operationType}`);
             }
-            case 'delete':
-              await this.deletePet(petId, updatedBy, reason);
-              break;
-            default:
-              throw new Error(`Unknown operation: ${operationType}`);
-          }
+          });
           results.successCount++;
         } catch (error) {
           results.failedCount++;

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -2,6 +2,7 @@ import { Op, Order, WhereOptions } from 'sequelize';
 import EmailService from './email.service';
 import { EmailType, EmailPriority } from '../models/EmailQueue';
 import { Application, Pet, Rescue, StaffMember, User, Role, UserRole } from '../models';
+import type { RescueAttributes, RescueCreationAttributes } from '../models/Rescue';
 import { logger, loggerHelpers } from '../utils/logger';
 import { invalidateAuthCache } from '../lib/auth-cache';
 import { cached, invalidateNamespace } from '../cache/redis-cache';
@@ -337,6 +338,9 @@ export class RescueService {
   /**
    * Create new rescue organization
    */
+  /** Per-user cap on rescues an individual account may create. */
+  static readonly RESCUE_CREATION_CAP_PER_USER = 3;
+
   static async createRescue(rescueData: CreateRescueRequest, createdBy: string): Promise<Rescue> {
     const startTime = Date.now();
 
@@ -348,6 +352,29 @@ export class RescueService {
 
     let rescue: Rescue;
     try {
+      // Per-user cap (A14): block a single account from spinning up an
+      // unbounded number of rescue organisations. Counts live rescues
+      // (paranoid scope) authored by this user via the standard
+      // `created_by` audit column (auto-stamped by the model hook from
+      // the request context). Rescues seeded outside a request context
+      // have NULL created_by and are excluded.
+      //
+      // Skip the cap when createdBy is not supplied — system-initiated
+      // creates (seeders, jobs) are out of scope for an anti-abuse
+      // limit aimed at individual user accounts.
+      //
+      // `created_by` is added via `auditColumns` and isn't part of the
+      // Rescue model's attribute type, so the where clause is cast.
+      if (createdBy) {
+        const existingCount = await Rescue.count({
+          where: { created_by: createdBy } as unknown as WhereOptions<RescueAttributes>,
+          transaction,
+        });
+        if (existingCount >= RescueService.RESCUE_CREATION_CAP_PER_USER) {
+          throw new Error('Maximum number of rescues per user reached');
+        }
+      }
+
       // Check for duplicate email
       const existingByEmail = await Rescue.findOne({
         where: { email: rescueData.email },
@@ -378,11 +405,18 @@ export class RescueService {
       }
 
       // Create the rescue in pending state — verification runs after commit.
+      // created_by is also stamped by the audit hook from the request
+      // context; pass it explicitly so the per-user cap (A14) attributes
+      // correctly even in code paths that bypass the request middleware
+      // (e.g. background jobs). The cast is required because created_by
+      // is added via the audit-columns mixin and isn't typed on
+      // RescueCreationAttributes.
       rescue = await Rescue.create(
         {
           ...rescueData,
           status: 'pending',
-        },
+          created_by: createdBy,
+        } as unknown as RescueCreationAttributes,
         { transaction }
       );
 

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -1311,19 +1311,18 @@ export class UserService {
     const startTime = Date.now();
 
     try {
+      // individualHooks:true so the per-row beforeValidate (email NFKC +
+      // mixed-script reject) and beforeUpdate (password hashing) hooks fire
+      // for each user. Also makes afterSave fire per row, which busts the
+      // auth cache — so no explicit invalidation loop is needed here.
       const [affectedRows] = await User.update(updates[0].updates, {
         where: {
           userId: {
             [Op.in]: updates[0].userIds,
           },
         },
+        individualHooks: true,
       });
-
-      // ADS-596: Model.update bypasses the per-instance afterSave hook that
-      // normally busts the auth cache, so we have to do it explicitly here.
-      for (const userId of updates[0].userIds) {
-        invalidateAuthCache(userId);
-      }
 
       // Log bulk update
       await AuditLogService.log({

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -1311,11 +1311,21 @@ export class UserService {
     const startTime = Date.now();
 
     try {
-      // individualHooks:true so the per-row beforeValidate (email NFKC +
-      // mixed-script reject) and beforeUpdate (password hashing) hooks fire
-      // for each user. Also makes afterSave fire per row, which busts the
-      // auth cache — so no explicit invalidation loop is needed here.
-      const [affectedRows] = await User.update(updates[0].updates, {
+      // individualHooks:true (below) so the per-row beforeValidate (email NFKC +
+      // mixed-script reject), beforeUpdate (password hashing + tokens_invalid_before
+      // bump on userType change), and afterSave (auth-cache invalidation) hooks
+      // fire for each user.
+      //
+      // The inline tokens_invalid_before bump below is belt-and-braces — the
+      // beforeUpdate hook already covers it, but the explicit payload guarantees
+      // the column is bumped even if individualHooks were ever removed.
+      const payload = updates[0].updates;
+      const userTypeChange = Object.prototype.hasOwnProperty.call(payload, 'userType');
+      const effectiveUpdates = userTypeChange
+        ? { ...payload, tokensInvalidBefore: new Date() }
+        : payload;
+
+      const [affectedRows] = await User.update(effectiveUpdates, {
         where: {
           userId: {
             [Op.in]: updates[0].userIds,


### PR DESCRIPTION
## Summary

Security review pass 10 — 16 commits across 5 batches. Stacked on `claude/security-review-pass-7` (which has pass-7+8+9 stacked). Biggest pass yet: hook-bypass fixes + product-decided anti-abuse policies + JWT forced rotation + 2FA recovery flow.

### Branch context
Main is still at pass-6; pass-7 branch holds the running stack of 7+8+9 and now 10.

### Batch HH — HIGH-severity correctness fixes
- **#1** Application status state-machine bypass via `Model.update` without `individualHooks: true` — pass-5 added the hook, two bulk callsites in `application.service.ts` (lines 176, 274) silently bypassed it. Two-line fix; tests asserting forbidden `REJECTED → APPROVED` now rejected.
- **#2** User bulk update (`bulkUpdateUsers` line 1310) skipped `beforeValidate` (pass-9 email NFKC) AND `beforeUpdate` (pass-2 password hash). Added `individualHooks: true`. Explicit `invalidateAuthCache` loop became redundant (afterSave covers it) — dropped.
- **#3 (deferred to LL)** — 2FA enable session revocation was implemented twice (HH inline, LL via shared helper). HH's commit dropped from cherry-pick; LL's helper version landed instead.

### Batch II — session UX + bulk-op hygiene
- **#10** New `GET /api/v1/sessions` + `DELETE /api/v1/sessions/:sessionId` routes wired to existing `SecurityService.listSessions/revokeSession` (service code already existed, just lacked HTTP). Cross-user revoke returns 404 (doesn't leak existence).
- **#13** Notification audit logs now use `subject_id` in details (actor is already in the top-level `user_id` column via `AuditLogService.log`). Three callsites updated for consistency; only `markAllAsRead` had the actual ambiguity.
- **#12** Bulk pet + application updates now wrap each iteration in `sequelize.transaction()` so audit entries roll back with their DB writes on partial failure. `PetService.updatePetStatus`/`deletePet` gained an optional `transaction?: Transaction` parameter; `AuditLogData` extended with the same. 6 test fallout assertions in `pet-business-logic.test.ts` updated to `expect.anything()` for the new positional arg.
- **#14** `AdminService.verifyUser` now re-runs `isSingleScriptLocalPart` from `lib.validation` before flipping `emailVerified: true` — closes the admin-path bypass of pass-9's mixed-script gate.

### Batch JJ — anti-abuse rate limits (per product policy)
- **A8** Per-user application rate limit: 5/day, 20/week via new `applicationCreateDailyLimiter` + `applicationCreateWeeklyLimiter` middlewares (Redis-backed, same store as existing rate limits). Stacked on `POST /api/v1/applications`.
- **A14** Per-user rescue creation cap: 3 per user. Service-layer check in `RescueService.createRescue` counts `Rescue.count({ where: { created_by } })` inside the same transaction. Uses the existing `auditColumns` `created_by` (no migration needed). NULL `created_by` rows excluded — legacy data unaffected.
- **A15** Per-user report rate limit: 5/day across pet reports + admin moderation reports. Same Redis-backed pattern.
- **A9** Signup rate limit tightened from 20/h/IP → 5/h/IP. New `verifyTurnstileToken` middleware mounted BEFORE the rate limiter on `/register`. `TURNSTILE_SECRET_KEY` + `VITE_TURNSTILE_SITE_KEY` env vars added to `.env.example`. Pattern matches pass-8 metrics token: fail-closed in prod, bypass in dev/test if unset. **Scope-down**: backend middleware only; frontend widget integration (`@marsidev/react-turnstile` across all three apps) is a separate UX story.
- **A13** Verified-rescue gate: `ApplicationService.createApplication` and `ChatController.createChat` reject with 403 if `rescue.status !== 'verified'`. `app.client/PetDetailsPage` shows "Pending verification" badge and disables Apply / Contact Rescue buttons with tooltip. `lib.pets PetRescueSchema` gains optional `status` field.

### Batch KK — 2FA email recovery flow
- **S11/A?** New flow for users who lost both TOTP device AND backup codes:
  - **POST /api/v1/auth/2fa/recover** (pre-auth, email-rate-limited via existing `passwordResetLimiter`): accepts `{ email }`, finds user, generates a `crypto.randomBytes(32)` token, stores SHA-256 hash + 1h expiry in new `TwoFactorRecovery` table. Sends email with link. Always returns generic 200 (no enumeration). Audit log: `TWO_FACTOR_RECOVERY_REQUESTED`.
  - **POST /api/v1/auth/2fa/recover/confirm** (pre-auth): accepts `{ token }`, atomic UPDATE-WHERE-used=false pattern (mirrors `confirmPasswordReset`), disables 2FA, nulls TOTP secret + backup codes, revokes all sessions, sends second notification email. Audit log: `TWO_FACTOR_RECOVERED`.
  - New `TwoFactorRecovery` model + migration `05-create-two-factor-recoveries.ts`. Hashing via `beforeSave` hook (same pattern as `Invitation`).
- **Scope-down**: frontend "Lost your 2FA device?" affordance is deferred — touches 6+ files per app across three apps with divergent auth flows. `TODO(frontend)` block in `auth.controller.ts` documents the surfaces needed.

### Batch LL — JWT forced rotation
- **#4 / S3** Close the 15-min stale-JWT role-escalation window:
  - New `tokens_invalid_before TIMESTAMP NULL` column on User (migration `05-add-user-tokens-invalid-before.ts`).
  - `userType` now embedded in access JWT payload at sign time.
  - Auth middleware adds an `iat` gate: if `user.tokens_invalid_before !== null && decoded.iat < user.tokens_invalid_before/1000`, reject with `'Token revoked due to credential change'`. Also cross-checks JWT `userType` against DB and prefers DB.
  - User model `beforeUpdate` hook stamps `tokens_invalid_before = NOW()` when `userType` changes. Fires on per-instance updates and bulk-updates with `individualHooks: true` (which HH provides).
  - Bulk update inline bump also added as belt-and-braces (see merge resolution note below).
  - New shared helper `service.backend/src/lib/invalidate-user-tokens.ts` exports `invalidateUserTokens(userId, transaction?)` that does the four things: stamp `tokens_invalid_before`, revoke refresh tokens, bust auth cache, disconnect sockets. Wired into `confirmPasswordReset`, `enableTwoFactor` (replacing HH's inline version), `disableTwoFactor`.
  - **Design choice**: `updateUserRole` deliberately does NOT call the full helper — softer event. The model hook stamps `tokens_invalid_before` (which kicks API requests via the iat gate), and pass-9's `auth:role-changed` socket emit lets the frontend self-heal without forcibly destroying the WebSocket. Trade-off documented inline.
  - **Refresh path verified safe**: `refreshTokens()` doesn't go through `authenticateToken` middleware, so the iat gate doesn't false-positive on legitimate refreshes after credential change.

### Cherry-pick merge resolution
One conflict at `user.service.ts:bulkUpdateUsers` between HH (added `individualHooks: true`) and LL (added inline `tokensInvalidBefore` bump). Both wanted; combined them with merged comment explaining the inline is belt-and-braces over the hook-driven path.

### Migration filename collision (noted, not action-needed)
Both KK and LL added `05-*` migrations:
- `05-add-user-tokens-invalid-before.ts` (LL)
- `05-create-two-factor-recoveries.ts` (KK)

Alphabetical order is correct: `add-` runs before `create-`. Both migrations are independent — no FK between them.

## Test plan

- [x] `lib.validation` — pass (new TwoFactorRecovery Zod schemas covered)
- [x] `lib.pets` — pass (PetRescueSchema.status optional field)
- [x] `service.backend` — 2689 passed, 210 skipped (combined branch; up from 2649 in pass-9 baseline)
- [x] `app.client` — 352 passed (badge + disabled buttons + new tests)
- [x] Combined-branch `tsc --noEmit` clean
- [x] `turbo type-check` 29 tasks green
- [ ] Manual smoke: try `REJECTED → APPROVED` via bulk update (should now 400). Enable 2FA in tab A, confirm tab B session is killed. Submit 6 applications in a day, confirm 6th returns 429. Sign up 6 times from same IP in an hour, confirm 6th returns 429 (and Turnstile token required if envs set). Try to read a stale admin JWT after role downgrade, confirm rejected.

## Deferred / out of scope from pass-10

- **JJ Turnstile frontend widget** — backend middleware in place; frontend widget integration is its own UX story across all three apps.
- **KK 2FA recovery frontend** — backend endpoints complete + tested; UI surfaces (login challenge "Lost your device?" link + `/auth/2fa/recover` page) documented in controller TODO.
- **S2 email change** — flow doesn't exist; future feature with documented revocation requirement.
- **S5 new-device login notification** — `LOGIN_FROM_NEW_DEVICE` enum exists but isn't triggered; defensive feature for later.
- **B3 raw `sequelize.query` in swipe.service** — analytics-only, not security-relevant; documented as defensive note.

## Coverage notes

Pass-10 audit also reconfirmed clean: CMS / rich-text editor inputs (RichTextProcessingService at write + SafeHtml + DOMPurify at render, consistently applied), outgoing webhooks (only Companies House + Charity Commission, both hardcoded with encodeURIComponent), frontend bundle (sourcemaps hidden, no server secrets in VITE_ env, no admin URL leakage). Full audit reports in session transcript.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxiFw2tNVhTai3B8Ws1a67)_