### PR TITLE
ADS-652: Resolve the "System" sidebar junk drawer

### DIFF
--- a/app.admin/src/components/layout/AdminSidebar.test.tsx
+++ b/app.admin/src/components/layout/AdminSidebar.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, within } from '@testing-library/react';
+
+// The global setup-tests.ts mock of @adopt-dont-shop/lib.components doesn't
+// export Logo (which AdminSidebar pulls in for the header), so stub it here.
+vi.mock('@adopt-dont-shop/lib.components', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@adopt-dont-shop/lib.components');
+  return {
+    ...actual,
+    Logo: () => null,
+  };
+});
+
+import { AdminSidebar } from './AdminSidebar';
+
+const renderSidebar = () =>
+  render(
+    <MemoryRouter>
+      <AdminSidebar collapsed={false} onToggle={() => undefined} />
+    </MemoryRouter>
+  );
+
+/**
+ * ADS-652: The "System" sidebar section was a junk drawer of six items in
+ * an order driven by no particular logic. We reorder by frequency-of-use
+ * (the items admins reach for most often appear first) and ensure no
+ * sidebar entry points to a known-stub page.
+ */
+describe('AdminSidebar System section [ADS-652]', () => {
+  const expectedSystemOrder = [
+    { label: 'Audit Logs', href: '/audit' },
+    { label: 'Security Center', href: '/security' },
+    { label: 'Privacy Tools', href: '/privacy-tools' },
+    { label: 'Configuration', href: '/configuration' },
+    { label: 'Field Permissions', href: '/field-permissions' },
+    { label: 'Reports', href: '/reports' },
+  ];
+
+  it('lists System items ordered by frequency-of-use', () => {
+    renderSidebar();
+
+    const systemHeading = screen.getByText('System');
+    const systemSection = systemHeading.parentElement;
+    expect(systemSection).not.toBeNull();
+    if (!systemSection) {
+      return;
+    }
+
+    const links = within(systemSection).getAllByRole('link');
+    const visibleOrder = links.map(link => ({
+      label: link.textContent?.trim() ?? '',
+      href: link.getAttribute('href') ?? '',
+    }));
+
+    expect(visibleOrder).toEqual(expectedSystemOrder);
+  });
+
+  it('does not link to any known-stub pages', () => {
+    renderSidebar();
+
+    // Sentinel list: if a future page is added to System but is a stub,
+    // add its path here and the test will fail until it is removed from
+    // the sidebar or completed. Reports (ADS-105) is fully implemented
+    // and is intentionally NOT in this list.
+    const knownStubRoutes: string[] = [];
+
+    const allLinks = screen.getAllByRole('link');
+    const hrefs = allLinks.map(link => link.getAttribute('href') ?? '');
+
+    for (const stub of knownStubRoutes) {
+      expect(hrefs).not.toContain(stub);
+    }
+  });
+});

--- a/app.admin/src/components/layout/AdminSidebar.tsx
+++ b/app.admin/src/components/layout/AdminSidebar.tsx
@@ -187,38 +187,11 @@ export const AdminSidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) =>
 
         <div className={styles.navDivider({ collapsed })} />
 
-        {/* System Section */}
+        {/* System Section — ordered by frequency-of-use (ADS-652) */}
         <div
           className={`${styles.navSection({ collapsed })} ${styles.navSectionPadding({ collapsed })}`}
         >
           <div className={styles.navSectionTitle({ collapsed })}>System</div>
-          <NavLink
-            to='/configuration'
-            className={({ isActive }) =>
-              styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
-            }
-          >
-            <FiSettings />
-            <span className={styles.navLinkSpan({ collapsed })}>Configuration</span>
-          </NavLink>
-          <NavLink
-            to='/field-permissions'
-            className={({ isActive }) =>
-              styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
-            }
-          >
-            <FiSliders />
-            <span className={styles.navLinkSpan({ collapsed })}>Field Permissions</span>
-          </NavLink>
-          <NavLink
-            to='/privacy-tools'
-            className={({ isActive }) =>
-              styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
-            }
-          >
-            <FiShield />
-            <span className={styles.navLinkSpan({ collapsed })}>Privacy Tools</span>
-          </NavLink>
           <NavLink
             to='/audit'
             className={({ isActive }) =>
@@ -236,6 +209,33 @@ export const AdminSidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) =>
           >
             <FiShield />
             <span className={styles.navLinkSpan({ collapsed })}>Security Center</span>
+          </NavLink>
+          <NavLink
+            to='/privacy-tools'
+            className={({ isActive }) =>
+              styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
+            }
+          >
+            <FiShield />
+            <span className={styles.navLinkSpan({ collapsed })}>Privacy Tools</span>
+          </NavLink>
+          <NavLink
+            to='/configuration'
+            className={({ isActive }) =>
+              styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
+            }
+          >
+            <FiSettings />
+            <span className={styles.navLinkSpan({ collapsed })}>Configuration</span>
+          </NavLink>
+          <NavLink
+            to='/field-permissions'
+            className={({ isActive }) =>
+              styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
+            }
+          >
+            <FiSliders />
+            <span className={styles.navLinkSpan({ collapsed })}>Field Permissions</span>
           </NavLink>
           <NavLink
             to='/reports'


### PR DESCRIPTION
## Summary

Resolves [ADS-652](https://linear.app/ideasquared/issue/ADS-652) — the admin "System" sidebar section was a grab bag of six items in no particular order. This PR reorders them by frequency-of-use and locks the order in with a behaviour test.

## Acceptance criteria

- [x] **Stubbed Reports page is either completed or removed from nav.** Verified Reports is **not** a stub: `Reports.tsx`, `ReportBuilderPage.tsx`, and `ReportViewPage.tsx` are the ADS-105 live implementation, backed by `useReports`, `useReportTemplates`, `useExecuteReportPreview`, `useSaveReport`, `useUpdateReport`, `useDeleteReport`, `useExecuteSavedReport`, `useUpsertSchedule`, and `useCreateTokenShare` from `@adopt-dont-shop/lib.analytics`. The ticket's "appears mostly stubbed" framing was incorrect. **Verdict: keep Reports in the nav.**
- [x] **System section reordered by frequency-of-use, with rationale.** See below.
- [x] **No nav item routes to a known empty/stub page.** New behaviour test enforces this via a sentinel list (currently empty).
- [x] **Existing direct links continue to work.** No routes were changed; `App.tsx` still registers `/audit`, `/security`, `/privacy-tools`, `/configuration`, `/field-permissions`, `/reports` (plus `/reports/new`, `/reports/:id`, `/reports/:id/edit`).

## Decision: reorder over searchable settings portal

The ticket's "decision guide" recommends reorder unless a portal can be shipped cleanly within scope. A searchable portal is a much larger build (UI, fuzzy search, settings registry), and there are only six items, so the cost/benefit clearly favours the reorder.

## New System order and rationale

| Order | Item | Why this rank |
|---|---|---|
| 1 | Audit Logs | First stop for any incident or "what changed?" question — touched most days. |
| 2 | Security Center | Auth, sessions, 2FA, password policy — frequent during user-support escalations. |
| 3 | Privacy Tools | GDPR/erasure/data-export tooling — periodic but high-priority when invoked. |
| 4 | Configuration | Feature flags + platform settings — changes are deliberate and less frequent. |
| 5 | Field Permissions | Role-based field masking — set-and-forget once configured. |
| 6 | Reports | Authored once, then largely consumed via direct links or scheduled emails. |

This matches the order the ticket itself called out as "rough frequency-of-use".

## Test plan

- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.admin` — all 20 tasks green; 328 tests pass including 2 new ones.
- [x] New behaviour test `AdminSidebar.test.tsx`:
  - asserts the System section renders items in `[Audit Logs, Security Center, Privacy Tools, Configuration, Field Permissions, Reports]` order with the correct `href`s;
  - asserts no sidebar link points to any path in the `knownStubRoutes` sentinel list (extendable as future stub pages emerge).
- [ ] Manual smoke: confirm `/audit`, `/security`, `/privacy-tools`, `/configuration`, `/field-permissions`, `/reports`, `/reports/new`, `/reports/:id`, `/reports/:id/edit` all resolve from the admin app.

## Files touched

- `app.admin/src/components/layout/AdminSidebar.tsx` — reorder the six `NavLink`s in the System section; add an inline comment naming the ticket.
- `app.admin/src/components/layout/AdminSidebar.test.tsx` — new behaviour test.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_