### PR TITLE
ADS-655: Real-time unread message indicators across apps

### DIFF
--- a/lib.chat/README.md
+++ b/lib.chat/README.md
@@ -18,6 +18,7 @@ See `src/index.ts` for the authoritative list. Primary entry points:
 
 - **`ChatService`** — class-based client for REST + WebSocket messaging. Construct with a `ChatServiceConfig` or leave defaults.
 - **`useConnectionStatus(chatService)`** — React hook that tracks connect / reconnect / disconnect / error state.
+- **`useUnreadConversations()`** — React hook that returns `{ totalUnread, unreadByConversationId, markRead }`. Single source of truth for unread-message indicators across `app.client`, `app.rescue`, and `app.admin`. See [Unread indicators](#unread-indicators) below.
 - **Admin React Query hooks** — `useAdminChats`, `useAdminChatById`, `useAdminChatMessages`, `useAdminChatStats`, `useAdminSearchChats`, `useAdminChatMutations`.
 - **Types** — `Conversation`, `Message`, `Participant`, `MessageAttachment`, `TypingIndicator`, `MessageReaction`, `MessageReadReceipt`, `MessageDeliveryStatus`, `ReconnectionConfig`, `QueuedMessage`, plus response shapes (`BaseResponse`, `ErrorResponse`, `PaginatedResponse`).
 
@@ -48,6 +49,41 @@ Inside a React component:
 ```tsx
 const { isConnected, isReconnecting, reconnectionAttempts } = useConnectionStatus(chat);
 ```
+
+## Unread indicators
+
+`useUnreadConversations` is the single source of truth for unread-message badges across the apps. Wire `ChatProvider` once at the app root, then call the hook anywhere underneath.
+
+```tsx
+import { useUnreadConversations } from '@adopt-dont-shop/lib.chat';
+
+const { totalUnread, unreadByConversationId, markRead } = useUnreadConversations();
+
+// Aggregate header badge:
+<Badge count={totalUnread} />;
+
+// Per-conversation badge:
+const count = unreadByConversationId[conversationId] ?? 0;
+
+// Clear after the user opens a thread:
+await markRead(conversationId);
+```
+
+**Signature**
+
+```ts
+type UseUnreadConversationsResult = {
+  totalUnread: number;
+  unreadByConversationId: Readonly<Record<string, number>>;
+  markRead: (conversationId: string) => Promise<void>;
+};
+```
+
+**Real-time updates** — the hook reads `conversations` from `ChatProvider`, which is already kept in sync with the chat socket. New messages bump `unreadCount` on the affected conversation; the backend's `messages_read` event clears it. No polling, no manual refresh.
+
+**Cross-tab sync** — `markRead` posts a `{ type: 'mark-read', conversationId }` message to a `BroadcastChannel` named `adopt-dont-shop:chat:unread` (also exported as `UNREAD_BROADCAST_CHANNEL`). Other tabs of the same origin listen on the channel and mirror the local clear, so a badge cleared in one tab clears in every other open tab. In environments without `BroadcastChannel` the hook silently skips the broadcast — the in-tab state still updates normally.
+
+**Provider requirement** — must be called inside a `ChatProvider`. Without one it throws the same `useChat must be used within a ChatProvider` error as the rest of the library.
 
 ## Scripts (from `lib.chat/`)
 

--- a/lib.chat/src/hooks/__tests__/use-unread-conversations.test.tsx
+++ b/lib.chat/src/hooks/__tests__/use-unread-conversations.test.tsx
@@ -1,0 +1,253 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { ChatProvider } from '../../context/ChatProvider';
+import { ChatService } from '../../services/chat-service';
+import type { Conversation, Message } from '../../types';
+import {
+  UNREAD_BROADCAST_CHANNEL,
+  useUnreadConversations,
+  type UseUnreadConversationsResult,
+} from '../use-unread-conversations';
+import { buildChatContextValue, renderWithChatContext } from '../../test-utils';
+
+const buildConversation = (overrides: Partial<Conversation> = {}): Conversation => ({
+  id: 'chat-1',
+  participants: [],
+  unreadCount: 0,
+  updatedAt: '2026-01-01T00:00:00Z',
+  createdAt: '2026-01-01T00:00:00Z',
+  isActive: true,
+  ...overrides,
+});
+
+const buildMessage = (overrides: Partial<Message> = {}): Message => ({
+  id: 'msg-1',
+  conversationId: 'chat-1',
+  senderId: 'user-other',
+  senderName: 'Other',
+  content: 'Hello',
+  timestamp: '2026-01-01T00:00:01Z',
+  type: 'text',
+  status: 'sent',
+  ...overrides,
+});
+
+type ProviderHarness = {
+  chatService: ChatService;
+  tokenProvider: ReturnType<typeof vi.fn>;
+};
+
+const buildProviderHarness = (initialConversations: Conversation[]): ProviderHarness => {
+  const chatService = new ChatService();
+  vi.spyOn(chatService, 'connect').mockImplementation(() => {
+    chatService.simulateConnectEvent();
+  });
+  vi.spyOn(chatService, 'disconnect').mockImplementation(() => {});
+  vi.spyOn(chatService, 'getConversations').mockResolvedValue(initialConversations);
+  return { chatService, tokenProvider: vi.fn(() => 'test-token') };
+};
+
+const Probe = ({
+  onState,
+  triggerMarkRead,
+}: {
+  onState: (state: UseUnreadConversationsResult) => void;
+  triggerMarkRead?: string | null;
+}) => {
+  const state = useUnreadConversations();
+  useEffect(() => {
+    onState(state);
+  });
+  useEffect(() => {
+    if (triggerMarkRead) {
+      void state.markRead(triggerMarkRead);
+    }
+    // markRead is intentionally omitted: we want to fire exactly once when
+    // the probed conversationId is supplied, not whenever the callback
+    // identity changes. eslint-disable-next-line react-hooks/exhaustive-deps
+    // is unnecessary here because the rule is project-configured and the
+    // intent is clear from the dep array.
+  }, [triggerMarkRead]); // eslint-disable-line react-hooks/exhaustive-deps
+  return null;
+};
+
+describe('useUnreadConversations', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when used outside a ChatProvider', () => {
+    const BadConsumer = () => {
+      useUnreadConversations();
+      return null;
+    };
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<BadConsumer />)).toThrow(/useChat must be used within a ChatProvider/);
+    spy.mockRestore();
+  });
+
+  it('derives totalUnread and unreadByConversationId from the chat context on initial fetch', () => {
+    const value = buildChatContextValue({
+      conversations: [
+        buildConversation({ id: 'a', unreadCount: 2 }),
+        buildConversation({ id: 'b', unreadCount: 5 }),
+        buildConversation({ id: 'c', unreadCount: 0 }),
+      ],
+    });
+
+    let latest: UseUnreadConversationsResult | null = null;
+    renderWithChatContext(<Probe onState={(s) => (latest = s)} />, { value });
+
+    expect(latest?.totalUnread).toBe(7);
+    expect(latest?.unreadByConversationId).toEqual({ a: 2, b: 5, c: 0 });
+  });
+
+  it('updates counts in real time when the socket delivers a new message to a non-active conversation', async () => {
+    const active = buildConversation({ id: 'chat-1', unreadCount: 0 });
+    const other = buildConversation({ id: 'chat-2', unreadCount: 0 });
+    const { chatService, tokenProvider } = buildProviderHarness([active, other]);
+
+    let latest: UseUnreadConversationsResult | null = null;
+
+    render(
+      <ChatProvider
+        chatService={chatService}
+        user={{ userId: 'user-1' }}
+        isAuthenticated
+        tokenProvider={tokenProvider}
+      >
+        <Probe onState={(s) => (latest = s)} />
+      </ChatProvider>
+    );
+
+    await waitFor(() =>
+      expect(latest?.unreadByConversationId).toEqual({ 'chat-1': 0, 'chat-2': 0 })
+    );
+
+    await act(async () => {
+      chatService.simulateIncomingMessage(
+        buildMessage({ id: 'msg-2', conversationId: 'chat-2', content: 'Ping' })
+      );
+    });
+
+    await waitFor(() => expect(latest?.totalUnread).toBe(1));
+    expect(latest?.unreadByConversationId['chat-2']).toBe(1);
+    expect(latest?.unreadByConversationId['chat-1']).toBe(0);
+  });
+
+  it('clears the counter when markRead is called and forwards to the chat service', async () => {
+    const conv = buildConversation({ id: 'chat-1', unreadCount: 4 });
+    const { chatService, tokenProvider } = buildProviderHarness([conv]);
+    const markSpy = vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
+
+    let latest: UseUnreadConversationsResult | null = null;
+    let triggered = false;
+    const Wrapper = () => {
+      const state = useUnreadConversations();
+      latest = state;
+      useEffect(() => {
+        if (!triggered && state.unreadByConversationId['chat-1'] === 4) {
+          triggered = true;
+          void state.markRead('chat-1');
+        }
+      });
+      return null;
+    };
+
+    render(
+      <ChatProvider
+        chatService={chatService}
+        user={{ userId: 'user-1' }}
+        isAuthenticated
+        tokenProvider={tokenProvider}
+      >
+        <Wrapper />
+      </ChatProvider>
+    );
+
+    await waitFor(() => expect(markSpy).toHaveBeenCalledWith('chat-1'));
+    await waitFor(() => expect(latest?.totalUnread).toBe(0));
+    expect(latest?.unreadByConversationId['chat-1']).toBe(0);
+  });
+
+  it('clears the counter when another tab broadcasts a mark-read event', async () => {
+    const conv = buildConversation({ id: 'chat-1', unreadCount: 3 });
+    const { chatService, tokenProvider } = buildProviderHarness([conv]);
+    vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
+
+    let latest: UseUnreadConversationsResult | null = null;
+
+    render(
+      <ChatProvider
+        chatService={chatService}
+        user={{ userId: 'user-1' }}
+        isAuthenticated
+        tokenProvider={tokenProvider}
+      >
+        <Probe onState={(s) => (latest = s)} />
+      </ChatProvider>
+    );
+
+    await waitFor(() => expect(latest?.unreadByConversationId['chat-1']).toBe(3));
+
+    // Simulate "another tab" by opening a separate BroadcastChannel on the
+    // same name and posting the mark-read event. The hook's listener should
+    // pick it up and clear the badge.
+    const otherTab = new BroadcastChannel(UNREAD_BROADCAST_CHANNEL);
+    await act(async () => {
+      otherTab.postMessage({ type: 'mark-read', conversationId: 'chat-1' });
+      // BroadcastChannel delivery is async — yield to the event loop.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    otherTab.close();
+
+    await waitFor(() => expect(latest?.unreadByConversationId['chat-1']).toBe(0));
+    expect(latest?.totalUnread).toBe(0);
+  });
+
+  it('broadcasts mark-read events to other tabs', async () => {
+    const conv = buildConversation({ id: 'chat-1', unreadCount: 2 });
+    const { chatService, tokenProvider } = buildProviderHarness([conv]);
+    vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
+
+    const otherTab = new BroadcastChannel(UNREAD_BROADCAST_CHANNEL);
+    const received: Array<{ type: string; conversationId: string }> = [];
+    otherTab.addEventListener('message', (event: MessageEvent) => {
+      const data = event.data;
+      if (typeof data === 'object' && data !== null) {
+        const candidate = data as { type?: unknown; conversationId?: unknown };
+        if (typeof candidate.type === 'string' && typeof candidate.conversationId === 'string') {
+          received.push({ type: candidate.type, conversationId: candidate.conversationId });
+        }
+      }
+    });
+
+    let triggered = false;
+    const Wrapper = () => {
+      const state = useUnreadConversations();
+      useEffect(() => {
+        if (!triggered && state.unreadByConversationId['chat-1'] === 2) {
+          triggered = true;
+          void state.markRead('chat-1');
+        }
+      });
+      return null;
+    };
+
+    render(
+      <ChatProvider
+        chatService={chatService}
+        user={{ userId: 'user-1' }}
+        isAuthenticated
+        tokenProvider={tokenProvider}
+      >
+        <Wrapper />
+      </ChatProvider>
+    );
+
+    await waitFor(() =>
+      expect(received).toContainEqual({ type: 'mark-read', conversationId: 'chat-1' })
+    );
+    otherTab.close();
+  });
+});

--- a/lib.chat/src/hooks/index.ts
+++ b/lib.chat/src/hooks/index.ts
@@ -1,1 +1,3 @@
 export { useConnectionStatus } from './use-connection-status';
+export { useUnreadConversations, UNREAD_BROADCAST_CHANNEL } from './use-unread-conversations';
+export type { UseUnreadConversationsResult } from './use-unread-conversations';

--- a/lib.chat/src/hooks/use-unread-conversations.ts
+++ b/lib.chat/src/hooks/use-unread-conversations.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useChat } from '../context/use-chat';
+
+/**
+ * Name of the BroadcastChannel used to sync mark-read events between tabs
+ * of the same origin. Exposed so consumers (and tests) can target it
+ * deterministically; not intended to be reconfigured by host apps.
+ */
+export const UNREAD_BROADCAST_CHANNEL = 'adopt-dont-shop:chat:unread';
+
+type UnreadBroadcastMessage = {
+  type: 'mark-read';
+  conversationId: string;
+};
+
+const isUnreadBroadcastMessage = (data: unknown): data is UnreadBroadcastMessage => {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const candidate = data as { type?: unknown; conversationId?: unknown };
+  return candidate.type === 'mark-read' && typeof candidate.conversationId === 'string';
+};
+
+export type UseUnreadConversationsResult = {
+  /** Total unread messages across every conversation the current user can see. */
+  totalUnread: number;
+  /** Map of conversationId → unread message count. Conversations with 0 unread are still present. */
+  unreadByConversationId: Readonly<Record<string, number>>;
+  /**
+   * Mark a conversation as read. Optimistically clears the local counter via
+   * the shared chat context, fires the backend POST, and broadcasts to other
+   * tabs of this origin so their counters clear too.
+   */
+  markRead: (conversationId: string) => Promise<void>;
+};
+
+/**
+ * `useUnreadConversations` — the single source of truth for unread-message
+ * indicators across `app.client`, `app.rescue`, and `app.admin`.
+ *
+ * Data flow:
+ * - Reads `conversations` from {@link useChat}. The provider already keeps
+ *   `unreadCount` in sync with the live socket (new messages bump it,
+ *   `messages_read` events clear it), so consumers automatically update in
+ *   real time without polling.
+ * - `markRead(conversationId)` calls the context's `markAsRead` (which
+ *   optimistically zeroes the counter + persists via the backend) **and**
+ *   posts a `mark-read` message to a {@link BroadcastChannel} so other
+ *   tabs/windows of the same origin clear their counters too.
+ *
+ * Must be used inside a `ChatProvider`. Apps without a provider will see the
+ * same `useChat must be used within a ChatProvider` error that the rest of
+ * the library throws.
+ *
+ * @example
+ * ```tsx
+ * const { totalUnread, unreadByConversationId, markRead } = useUnreadConversations();
+ *
+ * // Header badge
+ * return <Badge count={totalUnread} />;
+ *
+ * // Per-conversation badge
+ * const count = unreadByConversationId[conversationId] ?? 0;
+ *
+ * // Clear after opening
+ * await markRead(conversationId);
+ * ```
+ */
+export const useUnreadConversations = (): UseUnreadConversationsResult => {
+  const { conversations, markAsRead } = useChat();
+
+  const unreadByConversationId = useMemo<Readonly<Record<string, number>>>(() => {
+    const entries: Record<string, number> = {};
+    for (const conv of conversations) {
+      entries[conv.id] = conv.unreadCount ?? 0;
+    }
+    return entries;
+  }, [conversations]);
+
+  const totalUnread = useMemo(
+    () => conversations.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0),
+    [conversations]
+  );
+
+  // BroadcastChannel handle is held in a ref so the same instance survives
+  // re-renders and the callbacks below can read/post without re-subscribing.
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  // Keep the latest markAsRead in a ref so the BroadcastChannel listener
+  // doesn't need to be torn down + re-attached every time the context's
+  // callback identity changes.
+  const markAsReadRef = useRef(markAsRead);
+  useEffect(() => {
+    markAsReadRef.current = markAsRead;
+  }, [markAsRead]);
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') {
+      return;
+    }
+
+    const channel = new BroadcastChannel(UNREAD_BROADCAST_CHANNEL);
+    channelRef.current = channel;
+
+    const handleMessage = (event: MessageEvent) => {
+      if (!isUnreadBroadcastMessage(event.data)) {
+        return;
+      }
+      // Mirror the mark-read action in this tab. The chat context's
+      // `markAsRead` is optimistic (it zeroes the counter immediately), so
+      // calling it here is what makes the badge clear across tabs. We
+      // intentionally do not re-broadcast — the originating tab already did.
+      void markAsReadRef.current(event.data.conversationId);
+    };
+
+    channel.addEventListener('message', handleMessage);
+    return () => {
+      channel.removeEventListener('message', handleMessage);
+      channel.close();
+      channelRef.current = null;
+    };
+  }, []);
+
+  const markRead = useCallback(
+    async (conversationId: string) => {
+      await markAsRead(conversationId);
+      const channel = channelRef.current;
+      if (channel) {
+        const message: UnreadBroadcastMessage = { type: 'mark-read', conversationId };
+        channel.postMessage(message);
+      }
+    },
+    [markAsRead]
+  );
+
+  return { totalUnread, unreadByConversationId, markRead };
+};

--- a/lib.chat/src/index.ts
+++ b/lib.chat/src/index.ts
@@ -16,7 +16,8 @@ export type {
 } from './types';
 
 // Hooks
-export { useConnectionStatus } from './hooks';
+export { useConnectionStatus, useUnreadConversations, UNREAD_BROADCAST_CHANNEL } from './hooks';
+export type { UseUnreadConversationsResult } from './hooks';
 
 // Admin hooks
 export {


### PR DESCRIPTION
## Summary

Adds `useUnreadConversations` — the single source of truth for unread-message badges across `app.client`, `app.rescue`, and `app.admin`. Infrastructure only; UI consumers (adopter `ApplicationDashboard` badge, rescue dashboard panel, admin inbox counts) land in ADS-634 / ADS-643.

### Hook signature

```ts
const { totalUnread, unreadByConversationId, markRead } = useUnreadConversations();

// totalUnread: number
// unreadByConversationId: Readonly<Record<string, number>>
// markRead: (conversationId: string) => Promise<void>
```

### Real-time mechanism

Reads `conversations` from the existing `ChatProvider`, which is already kept in sync with the chat socket. New messages bump `unreadCount`; the backend's `messages_read` event clears it. No polling, no manual refresh, no new socket plumbing.

### Cross-tab mechanism

`markRead` posts a `{ type: 'mark-read', conversationId }` message to a `BroadcastChannel` named `adopt-dont-shop:chat:unread` (also exported as `UNREAD_BROADCAST_CHANNEL`). Other tabs of the same origin listen on the channel and mirror the local clear via the same optimistic `markAsRead` path. Environments without `BroadcastChannel` silently skip the broadcast — in-tab state still updates.

### Acceptance criteria

- [x] A single unread-count hook/source backs all three apps. Hook exported from `lib.chat`; consumers will land later.
- [x] Counts update in real time via the existing chat socket — no polling.
- [x] Marked-read state syncs across tabs via `BroadcastChannel`.
- [x] Documented — JSDoc on the hook + new "Unread indicators" section in `lib.chat/README.md`.
- [x] Doesn't break existing chat consumers — purely additive to `index.ts`.

### Tests

Behaviour tests in `lib.chat/src/hooks/__tests__/use-unread-conversations.test.tsx` cover:

- Initial fetch — derives totals and per-conversation map from context.
- Socket-driven update — a new incoming message to a non-active conversation bumps the count.
- `markRead` — clears the counter and forwards to `ChatService.markAsRead`.
- Cross-tab sync — receiving a broadcast from another tab clears the counter.
- Cross-tab outbound — calling `markRead` posts a message on the channel.
- Throws when used outside `ChatProvider`.

## Test plan

- [x] `npx turbo build lint type-check test --filter=@adopt-dont-shop/lib.chat` (verified package-locally: `npm run build`, `npm run lint`, `npm run type-check`, `npm test` — all pass; 96/96 tests, 0 lint errors).
- [ ] Consumer integration arrives in ADS-634 / ADS-643.

## Notes

UI consumers (adopter ApplicationDashboard, rescue dashboard panel, admin inbox) will land in ADS-634 / ADS-643. This PR is infra only.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_