### PR TITLE
ADS-644: Cross-link pets, fosters, and applications

### DIFF
--- a/app.rescue/src/components/applications/ApplicationReview.test.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.test.tsx
@@ -13,6 +13,14 @@
 import React, { useState } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ADS-644: ApplicationReview now renders cross-link <Link>s and calls
+// fosterService.list to find the pet's active foster placement. Stub the
+// service so tests don't need network access.
+vi.mock('../../services/fosterService', () => ({
+  fosterService: { list: vi.fn().mockResolvedValue([]) },
+}));
 
 // vanilla-extract CSS objects evaluated at import time are noisy in JSDOM and
 // not what these tests care about. Replace with simple class strings.
@@ -226,21 +234,23 @@ const renderReview = (props: RenderProps = {}) => {
     stage: 'PENDING' as const,
   };
   render(
-    <ApplicationReview
-      application={baseApplication}
-      references={[]}
-      homeVisits={[]}
-      timeline={[]}
-      loading={false}
-      error={null}
-      onClose={vi.fn()}
-      onStatusUpdate={onStatusUpdate}
-      onStageTransition={vi.fn().mockResolvedValue(undefined)}
-      onReferenceUpdate={vi.fn()}
-      onScheduleVisit={vi.fn()}
-      onUpdateVisit={vi.fn()}
-      onAddTimelineEvent={vi.fn()}
-    />
+    <MemoryRouter>
+      <ApplicationReview
+        application={baseApplication}
+        references={[]}
+        homeVisits={[]}
+        timeline={[]}
+        loading={false}
+        error={null}
+        onClose={vi.fn()}
+        onStatusUpdate={onStatusUpdate}
+        onStageTransition={vi.fn().mockResolvedValue(undefined)}
+        onReferenceUpdate={vi.fn()}
+        onScheduleVisit={vi.fn()}
+        onUpdateVisit={vi.fn()}
+        onAddTimelineEvent={vi.fn()}
+      />
+    </MemoryRouter>
   );
   return { onStatusUpdate };
 };
@@ -313,5 +323,107 @@ describe('ApplicationReview - ADS-579 rejection confirmation', () => {
     });
     // No confirm dialog opened.
     expect(screen.queryByTestId('reject-confirm-dialog')).not.toBeInTheDocument();
+  });
+});
+
+// ADS-644: cross-links from an application back to the pet card and the
+// pet's current active foster placement.
+import { fosterService as fosterServiceForLinks } from '../../services/fosterService';
+
+describe('ApplicationReview cross-links (ADS-644)', () => {
+  const mockedFoster = fosterServiceForLinks as unknown as {
+    list: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mockedFoster.list.mockReset();
+    mockedFoster.list.mockResolvedValue([]);
+  });
+
+  const renderWithPet = (petId: string | undefined) => {
+    const baseApplication = {
+      id: 'app-1',
+      status: 'submitted',
+      petName: 'Buddy',
+      petId,
+      applicantName: 'John Doe',
+      submittedDaysAgo: 2,
+      stage: 'PENDING' as const,
+    };
+    render(
+      <MemoryRouter>
+        <ApplicationReview
+          application={baseApplication}
+          references={[]}
+          homeVisits={[]}
+          timeline={[]}
+          loading={false}
+          error={null}
+          onClose={vi.fn()}
+          onStatusUpdate={vi.fn().mockResolvedValue(undefined)}
+          onStageTransition={vi.fn().mockResolvedValue(undefined)}
+          onReferenceUpdate={vi.fn()}
+          onScheduleVisit={vi.fn()}
+          onUpdateVisit={vi.fn()}
+          onAddTimelineEvent={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+  };
+
+  it('shows a link to the pet card when the application has a petId', async () => {
+    renderWithPet('pet-1');
+    const link = await screen.findByRole('link', { name: 'View pet card' });
+    expect(link).toHaveAttribute('href', '/pets?petId=pet-1');
+  });
+
+  it('does not show pet links when the application has no petId', async () => {
+    renderWithPet(undefined);
+    expect(screen.queryByRole('link', { name: /view pet/i })).toBeNull();
+    expect(screen.queryByRole('link', { name: /foster placement/i })).toBeNull();
+  });
+
+  it('adds a foster placement link only when the pet has an active placement', async () => {
+    mockedFoster.list.mockResolvedValueOnce([
+      {
+        placementId: 'pl-1',
+        petId: 'pet-1',
+        fosterUserId: 'staff-1',
+        rescueId: 'rescue-1',
+        startDate: '2026-01-01',
+        endDate: null,
+        status: 'active',
+        notes: null,
+        createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
+      },
+    ]);
+    renderWithPet('pet-1');
+    const link = await screen.findByRole('link', { name: 'View foster placement' });
+    expect(link).toHaveAttribute('href', '/foster?petId=pet-1');
+  });
+
+  it('omits the foster placement link when the pet has no active placement', async () => {
+    mockedFoster.list.mockResolvedValueOnce([
+      {
+        placementId: 'pl-1',
+        petId: 'other-pet',
+        fosterUserId: 'staff-1',
+        rescueId: 'rescue-1',
+        startDate: '2026-01-01',
+        endDate: null,
+        status: 'active',
+        notes: null,
+        createdAt: '2026-01-01',
+        updatedAt: '2026-01-01',
+      },
+    ]);
+    renderWithPet('pet-1');
+    // Wait for the placement lookup to settle, then assert the link is absent.
+    await screen.findByRole('link', { name: 'View pet card' });
+    await waitFor(() => {
+      expect(mockedFoster.list).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('link', { name: 'View foster placement' })).toBeNull();
   });
 });

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { ConfirmDialog, toast, useConfirm } from '@adopt-dont-shop/lib.components';
 import { formatStatusName } from '../../utils/statusUtils';
 import {
@@ -8,6 +9,7 @@ import {
   type ApplicationTimeline,
 } from '../../types/applications';
 import { useStaff } from '../../hooks/useStaff';
+import { fosterService, type FosterPlacement } from '../../services/fosterService';
 import StageTransitionModal from './StageTransitionModal';
 import { ApplicationStage, STAGE_CONFIG, StageAction } from '../../types/applicationStages';
 import * as styles from './ApplicationReview.css';
@@ -16,6 +18,7 @@ type ApplicationData = {
   id: string;
   status: string;
   petName?: string;
+  petId?: string;
   applicantName?: string;
   userName?: string;
   submittedDaysAgo?: number;
@@ -96,6 +99,38 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
 
   // Stage transition state
   const [showStageTransition, setShowStageTransition] = useState(false);
+
+  // ADS-644: look up the pet's current active foster placement so we can
+  // surface a deep link to it from the application header. We hit the
+  // existing list endpoint and filter client-side rather than adding a new
+  // backend route — applications typically reference one pet, and rescues
+  // have a small number of active placements at any time.
+  const [activePlacementForPet, setActivePlacementForPet] = useState<FosterPlacement | null>(null);
+  const petIdForLinks = application?.petId;
+  useEffect(() => {
+    if (!petIdForLinks) {
+      setActivePlacementForPet(null);
+      return;
+    }
+    let cancelled = false;
+    fosterService
+      .list({ status: 'active' })
+      .then(placements => {
+        if (cancelled) {
+          return;
+        }
+        const match = placements.find(p => p.petId === petIdForLinks);
+        setActivePlacementForPet(match ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setActivePlacementForPet(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [petIdForLinks]);
 
   // ADS-579: confirmation modal for destructive status transitions (rejection)
   const { confirm, confirmProps } = useConfirm();
@@ -707,6 +742,19 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                     ? `${Math.floor((new Date().getTime() - new Date(application.submittedAt).getTime()) / (1000 * 60 * 60 * 24))} days ago`
                     : 'Recently'}
               </p>
+              {/* ADS-644: cross-links from an application back to the pet
+                  card and (when present) the pet's active foster placement. */}
+              {petIdForLinks && (
+                <p className={styles.headerSubtitle}>
+                  <Link to={`/pets?petId=${petIdForLinks}`}>View pet card</Link>
+                  {activePlacementForPet && (
+                    <>
+                      {' · '}
+                      <Link to={`/foster?petId=${petIdForLinks}`}>View foster placement</Link>
+                    </>
+                  )}
+                </p>
+              )}
             </div>
             <div className={styles.headerRight}>
               {/* Stage Badge - Prominent display */}

--- a/app.rescue/src/components/pets/PetCard.test.tsx
+++ b/app.rescue/src/components/pets/PetCard.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Behaviour tests for the rescue PetCard component.
+ *
+ * Documents:
+ *   - ADS-644: the foster status badge is a link to /foster?petId=... when
+ *     the pet is in foster, and a non-interactive badge otherwise. This is
+ *     the cross-link path staff use to jump from a pet to its placement.
+ */
+
+import type { Pet } from '@adopt-dont-shop/lib.pets';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, screen } from '../../test-utils/render';
+import PetCard from './PetCard';
+
+const buildPet = (overrides: Partial<Pet> = {}): Pet => {
+  // Pet has many backend fields the card never reads. Justified assertion:
+  // keep the fixture focused on the fields exercised by the render path.
+  const base = {
+    pet_id: 'pet-1',
+    name: 'Buddy',
+    type: 'dog',
+    status: 'available',
+    breed: 'Labrador',
+    gender: 'male',
+    size: 'medium',
+    adoption_fee: 0,
+    age_years: 3,
+    age_months: 0,
+    images: [],
+  } as unknown as Pet;
+  return { ...base, ...overrides };
+};
+
+describe('PetCard foster cross-link (ADS-644)', () => {
+  it('renders the foster status as a link to the pet-scoped foster page', () => {
+    renderWithProviders(
+      <PetCard
+        pet={buildPet({ status: 'foster' })}
+        onStatusChange={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    const link = screen.getByRole('link', { name: /foster placement for buddy/i });
+    expect(link).toHaveAttribute('href', '/foster?petId=pet-1');
+    expect(link).toHaveTextContent('Foster');
+  });
+
+  it('does not render a foster link when the pet is not in foster', () => {
+    renderWithProviders(
+      <PetCard
+        pet={buildPet({ status: 'available' })}
+        onStatusChange={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('link', { name: /foster placement/i })).toBeNull();
+    expect(screen.getByText('Available')).toBeInTheDocument();
+  });
+});

--- a/app.rescue/src/components/pets/PetCard.tsx
+++ b/app.rescue/src/components/pets/PetCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Card, Button, ProgressiveImage } from '@adopt-dont-shop/lib.components';
 import { Pet, PetStatus } from '@adopt-dont-shop/lib.pets';
 import { formatRelativeDate } from '@adopt-dont-shop/lib.utils';
@@ -122,9 +123,21 @@ const PetCard: React.FC<PetCardProps> = ({ pet, onStatusChange, onEdit, onDelete
             <div className={styles.placeholderImage}>🐾</div>
           )}
           <div className={styles.statusBadgeContainer}>
-            <span className={styles.statusBadge({ status: getStatusVariant(pet.status) })}>
-              {getStatusLabel(pet.status)}
-            </span>
+            {pet.status === 'foster' ? (
+              // ADS-644: link the foster badge to the foster page filtered to
+              // this pet so staff can jump to the placement from the pet card.
+              <Link
+                to={`/foster?petId=${pet.pet_id}`}
+                aria-label={`View foster placement for ${pet.name}`}
+                className={styles.statusBadge({ status: 'foster' })}
+              >
+                {getStatusLabel(pet.status)}
+              </Link>
+            ) : (
+              <span className={styles.statusBadge({ status: getStatusVariant(pet.status) })}>
+                {getStatusLabel(pet.status)}
+              </span>
+            )}
           </div>
         </div>
 

--- a/app.rescue/src/pages/Applications.tsx
+++ b/app.rescue/src/pages/Applications.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useApplications, useApplicationDetails } from '../hooks/useApplications';
 import ApplicationList from '../components/applications/ApplicationList';
 import ApplicationReview from '../components/applications/ApplicationReview';
@@ -7,6 +8,10 @@ import { applicationService } from '../services/applicationService';
 import type { ApplicationListItem } from '../types/applications';
 
 const Applications: React.FC = () => {
+  // ADS-644: when deep-linked from a pet card or foster row, scope the
+  // application list to that pet via the existing petId filter.
+  const [searchParams] = useSearchParams();
+  const initialPetId = searchParams.get('petId');
   const [selectedApplication, setSelectedApplication] = useState<ApplicationListItem | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
@@ -28,6 +33,16 @@ const Applications: React.FC = () => {
     updateApplicationStatus,
     refetch,
   } = useApplications();
+
+  // ADS-644: apply the petId from the URL once on mount so the listing
+  // hook fetches the scoped slice. We deliberately don't re-apply on every
+  // searchParams change so the user can clear the filter in the UI.
+  useEffect(() => {
+    if (initialPetId) {
+      updateFilter({ petId: initialPetId });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional mount-only
+  }, []);
 
   // Selected application details
   const {

--- a/app.rescue/src/pages/FosterCoordination.test.tsx
+++ b/app.rescue/src/pages/FosterCoordination.test.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import FosterCoordination from './FosterCoordination';
 import { fosterService } from '../services/fosterService';
 import { petService } from '../services/libraryServices';
 import { staffService } from '../services/staffService';
+
+const renderAt = (initialEntry: string) =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <FosterCoordination />
+    </MemoryRouter>
+  );
 
 vi.mock('@adopt-dont-shop/lib.auth', () => ({
   useAuth: () => ({
@@ -106,7 +114,7 @@ describe('FosterCoordination', () => {
   });
 
   it('renders pet and staff pickers populated from the rescue services', async () => {
-    render(<FosterCoordination />);
+    renderAt('/foster');
     fireEvent.click(screen.getByRole('button', { name: 'New Placement' }));
 
     await waitFor(() => {
@@ -117,7 +125,7 @@ describe('FosterCoordination', () => {
   });
 
   it('creates a placement using the picker-selected pet and foster user', async () => {
-    render(<FosterCoordination />);
+    renderAt('/foster');
     fireEvent.click(screen.getByRole('button', { name: 'New Placement' }));
 
     await waitFor(() => {
@@ -161,7 +169,7 @@ describe('FosterCoordination', () => {
       },
     ]);
 
-    render(<FosterCoordination />);
+    renderAt('/foster');
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'End placement' })).toBeInTheDocument();
@@ -183,6 +191,48 @@ describe('FosterCoordination', () => {
     });
   });
 
+  // ADS-644: cross-links + deep linking to a single pet's placement.
+  describe('cross-links (ADS-644)', () => {
+    const placement = {
+      placementId: 'pl-1',
+      petId: 'pet-1',
+      fosterUserId: 'staff-1',
+      rescueId: 'rescue-1',
+      startDate: '2026-01-01',
+      endDate: null,
+      status: 'active' as const,
+      notes: null,
+      createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
+    };
+
+    it('renders View pet and Applications links pointing at the placement pet', async () => {
+      mockedFoster.list.mockResolvedValueOnce([placement]);
+
+      renderAt('/foster');
+
+      const petLink = await screen.findByRole('link', { name: 'View pet' });
+      const appsLink = screen.getByRole('link', { name: 'Applications' });
+      expect(petLink).toHaveAttribute('href', '/pets?petId=pet-1');
+      expect(appsLink).toHaveAttribute('href', '/applications?petId=pet-1');
+    });
+
+    it('scopes the visible placements to the petId from the URL', async () => {
+      mockedFoster.list.mockResolvedValueOnce([
+        placement,
+        { ...placement, placementId: 'pl-2', petId: 'pet-other' },
+      ]);
+
+      renderAt('/foster?petId=pet-1');
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('link', { name: 'View pet' })).toHaveLength(1);
+      });
+      const links = screen.getAllByRole('link', { name: 'View pet' });
+      expect(links[0]).toHaveAttribute('href', '/pets?petId=pet-1');
+    });
+  });
+
   it('does not call fosterService.end when confirmation is dismissed', async () => {
     confirmSpy.mockResolvedValueOnce(false);
     mockedFoster.list.mockResolvedValueOnce([
@@ -200,7 +250,7 @@ describe('FosterCoordination', () => {
       },
     ]);
 
-    render(<FosterCoordination />);
+    renderAt('/foster');
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'End placement' })).toBeInTheDocument();

--- a/app.rescue/src/pages/FosterCoordination.tsx
+++ b/app.rescue/src/pages/FosterCoordination.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import { fosterService, type FosterPlacement } from '../services/fosterService';
 import { petService } from '../services/libraryServices';
 import { staffService, type StaffMember } from '../services/staffService';
@@ -11,6 +12,10 @@ const FosterCoordination: React.FC = () => {
   const { user } = useAuth();
   const rescueId = user?.rescueId ?? null;
   const { confirm, confirmProps } = useConfirm();
+  // ADS-644: cross-linking. When deep-linked from a pet card we scope the
+  // placement list to that pet so the user lands on the relevant placement.
+  const [searchParams] = useSearchParams();
+  const petIdFilter = searchParams.get('petId');
 
   const [placements, setPlacements] = useState<FosterPlacement[]>([]);
   const [loading, setLoading] = useState(true);
@@ -122,6 +127,13 @@ const FosterCoordination: React.FC = () => {
     return match ? `${match.name} (${match.breed ?? 'unknown breed'})` : id;
   };
 
+  // ADS-644: scope the visible placements to a single pet when the page is
+  // opened via /foster?petId=... from a pet card or application detail.
+  const visiblePlacements = useMemo(
+    () => (petIdFilter ? placements.filter(p => p.petId === petIdFilter) : placements),
+    [placements, petIdFilter]
+  );
+
   const staffLabel = (id: string): string => {
     const match = staff.find(s => s.userId === id);
     return match ? `${match.firstName} ${match.lastName} <${match.email}>` : id;
@@ -157,7 +169,7 @@ const FosterCoordination: React.FC = () => {
 
       {loading ? (
         <p>Loading placements…</p>
-      ) : placements.length === 0 ? (
+      ) : visiblePlacements.length === 0 ? (
         <p>No foster placements found.</p>
       ) : (
         <table className={styles.table}>
@@ -168,11 +180,12 @@ const FosterCoordination: React.FC = () => {
               <th className={styles.tableCell}>Start</th>
               <th className={styles.tableCell}>End</th>
               <th className={styles.tableCell}>Status</th>
+              <th className={styles.tableCell}>Links</th>
               <th className={styles.tableCell}>Actions</th>
             </tr>
           </thead>
           <tbody>
-            {placements.map(p => (
+            {visiblePlacements.map(p => (
               <tr key={p.placementId} className={styles.tableBodyRow}>
                 <td className={styles.tableCell}>{petLabel(p.petId)}</td>
                 <td className={styles.tableCell}>{staffLabel(p.fosterUserId)}</td>
@@ -183,6 +196,13 @@ const FosterCoordination: React.FC = () => {
                   {p.endDate ? new Date(p.endDate).toLocaleDateString('en-GB') : '—'}
                 </td>
                 <td className={styles.tableCell}>{p.status}</td>
+                {/* ADS-644: cross-links so a placement row points at the
+                    pet card and the active applications for that pet. */}
+                <td className={styles.tableCell}>
+                  <Link to={`/pets?petId=${p.petId}`}>View pet</Link>
+                  {' · '}
+                  <Link to={`/applications?petId=${p.petId}`}>Applications</Link>
+                </td>
                 <td className={styles.tableCell}>
                   {p.status === 'active' && (
                     <button type="button" onClick={() => setEndingId(p.placementId)}>

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Card, Container, Button, Text, Heading, toast } from '@adopt-dont-shop/lib.components';
 import { Pet, PetStatus, petManagementService } from '@adopt-dont-shop/lib.pets';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
@@ -64,6 +65,10 @@ const PetManagement: React.FC = () => {
   };
 
   const { user, refreshUser } = useAuth();
+  // ADS-644: cross-linking. When deep-linked via /pets?petId=... we use the
+  // petId as the search filter so the matching pet card surfaces immediately.
+  const [searchParams] = useSearchParams();
+  const initialPetId = searchParams.get('petId');
   const [pets, setPets] = useState<Pet[]>([]);
   const [stats, setStats] = useState<PetStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -74,7 +79,7 @@ const PetManagement: React.FC = () => {
 
   // Filter states
   const [statusFilter, setStatusFilter] = useState<PetStatus | 'all'>('all');
-  const [searchFilter, setSearchFilter] = useState('');
+  const [searchFilter, setSearchFilter] = useState(initialPetId ?? '');
   const [typeFilter, setTypeFilter] = useState<string>('');
   const [sizeFilter, setSizeFilter] = useState<string>('');
   const [breedFilter, setBreedFilter] = useState<string>('');


### PR DESCRIPTION
## Summary

ADS-644: surface existing relationships between pets, foster placements, and applications in `app.rescue` so staff can navigate between them without losing context. **Badges and links only — no new pages, no new backend endpoints.**

## What links exist now

```
Pet card  ── (status === foster) ──►  /foster?petId=<id>   (scopes the placement list)

Foster row  ──►  /pets?petId=<id>           (search-filters the pet grid)
            ──►  /applications?petId=<id>   (filters by petId on mount)

Application review modal header
            ──►  /pets?petId=<id>                   (always shown when application has a petId)
            ──►  /foster?petId=<id>                 (only when fosterService reports an active
                                                     placement for that pet)
```

The "current active foster placement for pet" lookup uses the existing `GET /api/v1/foster/placements?status=active` endpoint, filtered client-side by `petId` in the application review component. No new selector module — the lookup is small enough to live inline.

## Acceptance criteria

- [x] Pet card and pet detail show a foster status badge with a link to the foster placement when applicable
- [x] Foster placement shows the pet and active applications for that pet
- [x] Application detail links to the pet card and to the pet's current foster placement (if any)
- [x] No new pages introduced; only links/badges in existing views

## Files touched

- `app.rescue/src/components/pets/PetCard.tsx` (+ new `PetCard.test.tsx`)
- `app.rescue/src/pages/PetManagement.tsx`
- `app.rescue/src/pages/FosterCoordination.tsx` (+ test additions)
- `app.rescue/src/pages/Applications.tsx`
- `app.rescue/src/components/applications/ApplicationReview.tsx` (+ test additions)

## Test plan

- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.rescue` passes (203 tests, 0 lint errors)
- [ ] Manually: navigate /pets → foster badge → /foster scoped to pet → "Applications" link → /applications scoped to pet → open review → "View pet card" + "View foster placement"
- [ ] Manually: open an application whose pet has no active placement and confirm only the pet-card link shows

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_