### PR TITLE
ADS-653: Drill-down navigation across Security Center tabs

### DIFF
--- a/app.admin/src/__tests__/security-center.behavior.test.tsx
+++ b/app.admin/src/__tests__/security-center.behavior.test.tsx
@@ -7,12 +7,17 @@
  * - The IP Rules tab loads existing rules from the backend
  * - Creating an IP rule POSTs to the backend and refreshes the list
  * - The Sessions tab shows an empty-state when no sessions are returned
+ * - Drill-down navigation across tabs (ADS-653) preserves filter state via
+ *   URL search params and survives browser back navigation
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { renderWithProviders, screen } from '../test-utils';
-import { waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@adopt-dont-shop/lib.components';
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -171,5 +176,176 @@ describe('SecurityCenter', () => {
     await user.type(screen.getByPlaceholderText(/User ID/i), 'abc-123');
     expect(unlockBtn).not.toBeDisabled();
     expect(lockBtn).not.toBeDisabled();
+  });
+});
+
+// ── Drill-down navigation (ADS-653) ──────────────────────────────────────────
+
+const BackButton = () => {
+  const navigate = useNavigate();
+  return (
+    <button type='button' onClick={() => navigate(-1)} data-testid='browser-back'>
+      Back
+    </button>
+  );
+};
+
+const renderRouted = (initialRoute: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <ThemeProvider>
+          <BackButton />
+          <Routes>
+            <Route path='/security' element={<SecurityCenter />} />
+            <Route path='/security/:tab' element={<SecurityCenter />} />
+          </Routes>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('SecurityCenter drill-down navigation', () => {
+  it('drills from a suspicious-activity row to that user’s sessions with the userId pre-applied', async () => {
+    getSuspiciousActivity.mockResolvedValueOnce([
+      {
+        userId: 'user-42',
+        userEmail: 'alice@example.com',
+        failureCount: 7,
+        lastAttempt: new Date().toISOString(),
+        lastIp: '198.51.100.4',
+      },
+    ]);
+
+    const user = userEvent.setup();
+    renderRouted('/security/suspicious');
+
+    expect(await screen.findByText('alice@example.com')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^Sessions$/ }));
+
+    await waitFor(() => {
+      expect(listSessions).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-42' }));
+    });
+    expect(screen.getByDisplayValue('user-42')).toBeInTheDocument();
+  });
+
+  it('drills from a suspicious-activity row to that user’s login history with the userId pre-applied', async () => {
+    getSuspiciousActivity.mockResolvedValueOnce([
+      {
+        userId: 'user-99',
+        userEmail: 'bob@example.com',
+        failureCount: 5,
+        lastAttempt: new Date().toISOString(),
+        lastIp: null,
+      },
+    ]);
+
+    const user = userEvent.setup();
+    renderRouted('/security/suspicious');
+
+    expect(await screen.findByText('bob@example.com')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^Login history$/ }));
+
+    await waitFor(() => {
+      expect(getLoginHistory).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-99' }));
+    });
+    expect(screen.getByDisplayValue('user-99')).toBeInTheDocument();
+  });
+
+  it('drills from a session row to the IP Rules tab', async () => {
+    listSessions.mockResolvedValueOnce({
+      data: [
+        {
+          sessionId: 'sess-1',
+          userId: 'user-77',
+          familyId: 'family-abcdefgh',
+          isRevoked: false,
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          createdAt: new Date().toISOString(),
+          user: { userId: 'user-77', email: 'carol@example.com', firstName: null, lastName: null },
+        },
+      ],
+      pagination: {},
+    });
+
+    const user = userEvent.setup();
+    renderRouted('/security/sessions');
+
+    expect(await screen.findByText('carol@example.com')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^IP rules$/ }));
+
+    // Now on IP Rules tab: the IP Rules tab description text is unique.
+    await waitFor(() => {
+      expect(screen.getByText(/Block rules deny logins/i)).toBeInTheDocument();
+    });
+  });
+
+  it('applies an ?ip= filter on the IP Rules tab when arriving via a drill link', async () => {
+    listIpRules.mockResolvedValueOnce([
+      {
+        ipRuleId: 'rule-a',
+        type: 'block',
+        cidr: '198.51.100.0/24',
+        label: 'matches',
+        isActive: true,
+        expiresAt: null,
+        createdBy: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        ipRuleId: 'rule-b',
+        type: 'block',
+        cidr: '203.0.113.0/24',
+        label: 'unrelated',
+        isActive: true,
+        expiresAt: null,
+        createdBy: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ]);
+
+    renderRouted('/security/ip-rules?ip=198.51.100');
+
+    await waitFor(() => {
+      expect(screen.getByText('matches')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('unrelated')).not.toBeInTheDocument();
+  });
+
+  it('restores the originating tab and filter state on browser back', async () => {
+    getSuspiciousActivity.mockResolvedValue([
+      {
+        userId: 'user-back',
+        userEmail: 'dave@example.com',
+        failureCount: 6,
+        lastAttempt: new Date().toISOString(),
+        lastIp: null,
+      },
+    ]);
+
+    const user = userEvent.setup();
+    renderRouted('/security/suspicious');
+
+    expect(await screen.findByText('dave@example.com')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^Sessions$/ }));
+    await waitFor(() => {
+      expect(listSessions).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-back' }));
+    });
+
+    // Simulate browser back (navigate(-1) is what browsers fire on back)
+    await user.click(screen.getByTestId('browser-back'));
+
+    // Suspicious tab content reappears
+    expect(await screen.findByText('dave@example.com')).toBeInTheDocument();
   });
 });

--- a/app.admin/src/pages/SecurityCenter.css.ts
+++ b/app.admin/src/pages/SecurityCenter.css.ts
@@ -198,3 +198,20 @@ export const successBanner = style([
     color: vars.colors.successTextEmphasis,
   },
 ]);
+
+export const drillLink = style({
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  margin: 0,
+  color: vars.colors.infoActive,
+  textDecoration: 'underline',
+  cursor: 'pointer',
+  fontSize: '0.8rem',
+  fontFamily: 'inherit',
+  selectors: {
+    '&:hover': { color: vars.colors.infoTextEmphasis },
+    '&:disabled': { color: vars.text.tertiary, cursor: 'not-allowed' },
+    '&:not(:last-child)': { marginRight: '0.5rem' },
+  },
+});

--- a/app.admin/src/pages/SecurityCenter.tsx
+++ b/app.admin/src/pages/SecurityCenter.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { TwoFactorSettings } from '@adopt-dont-shop/lib.auth';
 import { ConfirmDialog, useConfirm } from '@adopt-dont-shop/lib.components';
 import {
@@ -22,8 +23,36 @@ const TABS: Array<{ key: TabKey; label: string }> = [
   { key: 'recovery', label: 'Account Recovery' },
 ];
 
+const isTabKey = (value: string | undefined): value is TabKey =>
+  value === 'mfa' ||
+  value === 'sessions' ||
+  value === 'ip-rules' ||
+  value === 'login-history' ||
+  value === 'suspicious' ||
+  value === 'recovery';
+
 const SecurityCenter: React.FC = () => {
-  const [tab, setTab] = useState<TabKey>('mfa');
+  const { tab: tabParam } = useParams<{ tab?: string }>();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // The tab is driven by the URL when mounted via /security/:tab, but we also
+  // keep a local fallback so the component works in isolation (e.g. tests, or
+  // the unparameterised /security route) where useParams returns nothing.
+  const urlTab: TabKey | null = isTabKey(tabParam) ? tabParam : null;
+  const [localTab, setLocalTab] = useState<TabKey>(urlTab ?? 'mfa');
+  const tab: TabKey = urlTab ?? localTab;
+
+  const handleTabChange = (next: TabKey) => {
+    // Navigating clears drill-down search params, keeping per-tab filter state
+    // local. Browser back returns the user to the originating tab with its
+    // params intact.
+    setLocalTab(next);
+    navigate(`/security/${next}`);
+  };
+
+  const userIdParam = searchParams.get('userId') ?? '';
+  const ipParam = searchParams.get('ip') ?? '';
 
   return (
     <div className={styles.pageContainer}>
@@ -43,7 +72,7 @@ const SecurityCenter: React.FC = () => {
             role='tab'
             aria-selected={tab === t.key}
             className={styles.tabButton}
-            onClick={() => setTab(t.key)}
+            onClick={() => handleTabChange(t.key)}
           >
             {t.label}
           </button>
@@ -51,9 +80,9 @@ const SecurityCenter: React.FC = () => {
       </div>
 
       {tab === 'mfa' && <MfaTab />}
-      {tab === 'sessions' && <SessionsTab />}
-      {tab === 'ip-rules' && <IpRulesTab />}
-      {tab === 'login-history' && <LoginHistoryTab />}
+      {tab === 'sessions' && <SessionsTab initialUserId={userIdParam} />}
+      {tab === 'ip-rules' && <IpRulesTab initialIp={ipParam} />}
+      {tab === 'login-history' && <LoginHistoryTab initialUserId={userIdParam} />}
       {tab === 'suspicious' && <SuspiciousTab />}
       {tab === 'recovery' && <RecoveryTab />}
     </div>
@@ -75,8 +104,11 @@ const MfaTab: React.FC = () => (
 
 // ----- Sessions -----
 
-const SessionsTab: React.FC = () => {
-  const [userIdFilter, setUserIdFilter] = useState('');
+type SessionsTabProps = { initialUserId?: string };
+
+const SessionsTab: React.FC<SessionsTabProps> = ({ initialUserId = '' }) => {
+  const navigate = useNavigate();
+  const [userIdFilter, setUserIdFilter] = useState(initialUserId);
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -197,6 +229,7 @@ const SessionsTab: React.FC = () => {
               <th>Created</th>
               <th>Expires</th>
               <th>Family</th>
+              <th>Drill-down</th>
               <th />
             </tr>
           </thead>
@@ -219,6 +252,24 @@ const SessionsTab: React.FC = () => {
                 <td>
                   <button
                     type='button'
+                    className={styles.drillLink}
+                    onClick={() => navigate('/security/ip-rules')}
+                  >
+                    IP rules
+                  </button>
+                  <button
+                    type='button'
+                    className={styles.drillLink}
+                    onClick={() =>
+                      navigate(`/security/login-history?userId=${encodeURIComponent(s.userId)}`)
+                    }
+                  >
+                    Login history
+                  </button>
+                </td>
+                <td>
+                  <button
+                    type='button'
                     className={styles.dangerButton}
                     onClick={() => handleRevoke(s.sessionId)}
                   >
@@ -238,17 +289,28 @@ const SessionsTab: React.FC = () => {
 
 // ----- IP Rules -----
 
-const IpRulesTab: React.FC = () => {
+type IpRulesTabProps = { initialIp?: string };
+
+const IpRulesTab: React.FC<IpRulesTabProps> = ({ initialIp = '' }) => {
   const [rules, setRules] = useState<IpRule[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [ipFilter, setIpFilter] = useState(initialIp);
 
   const [type, setType] = useState<IpRuleType>('block');
   const [cidr, setCidr] = useState('');
   const [label, setLabel] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const { confirm, confirmProps } = useConfirm();
+
+  const visibleRules = useMemo(() => {
+    const needle = ipFilter.trim().toLowerCase();
+    if (!needle) {
+      return rules;
+    }
+    return rules.filter(r => r.cidr.toLowerCase().includes(needle));
+  }, [rules, ipFilter]);
 
   useEffect(() => {
     let cancelled = false;
@@ -326,6 +388,21 @@ const IpRulesTab: React.FC = () => {
 
       {error && <div className={styles.errorBanner}>{error}</div>}
 
+      <div className={styles.inlineForm}>
+        <input
+          className={styles.input}
+          placeholder='Filter rules by address'
+          aria-label='Filter IP rules'
+          value={ipFilter}
+          onChange={e => setIpFilter(e.target.value)}
+        />
+        {ipFilter && (
+          <button type='button' className={styles.secondaryButton} onClick={() => setIpFilter('')}>
+            Clear filter
+          </button>
+        )}
+      </div>
+
       <form className={styles.inlineForm} onSubmit={handleAdd}>
         <select
           aria-label='Rule type'
@@ -356,8 +433,10 @@ const IpRulesTab: React.FC = () => {
 
       {loading ? (
         <div className={styles.emptyState}>Loading…</div>
-      ) : rules.length === 0 ? (
-        <div className={styles.emptyState}>No IP rules configured.</div>
+      ) : visibleRules.length === 0 ? (
+        <div className={styles.emptyState}>
+          {ipFilter ? `No IP rules match "${ipFilter}".` : 'No IP rules configured.'}
+        </div>
       ) : (
         <table className={styles.table}>
           <thead>
@@ -371,7 +450,7 @@ const IpRulesTab: React.FC = () => {
             </tr>
           </thead>
           <tbody>
-            {rules.map(r => (
+            {visibleRules.map(r => (
               <tr key={r.ipRuleId}>
                 <td>
                   <span
@@ -408,8 +487,11 @@ const IpRulesTab: React.FC = () => {
 
 // ----- Login history -----
 
-const LoginHistoryTab: React.FC = () => {
-  const [userIdFilter, setUserIdFilter] = useState('');
+type LoginHistoryTabProps = { initialUserId?: string };
+
+const LoginHistoryTab: React.FC<LoginHistoryTabProps> = ({ initialUserId = '' }) => {
+  const navigate = useNavigate();
+  const [userIdFilter, setUserIdFilter] = useState(initialUserId);
   const [statusFilter, setStatusFilter] = useState<'all' | 'success' | 'failure'>('all');
   const [entries, setEntries] = useState<LoginHistoryEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -508,7 +590,26 @@ const LoginHistoryTab: React.FC = () => {
                   </span>
                 </td>
                 <td>{entry.userEmail || entry.userId || '—'}</td>
-                <td>{entry.ipAddress || '—'}</td>
+                <td>
+                  {entry.ipAddress ? (
+                    <>
+                      {entry.ipAddress}{' '}
+                      <button
+                        type='button'
+                        className={styles.drillLink}
+                        onClick={() =>
+                          navigate(
+                            `/security/ip-rules?ip=${encodeURIComponent(entry.ipAddress ?? '')}`
+                          )
+                        }
+                      >
+                        IP rules
+                      </button>
+                    </>
+                  ) : (
+                    '—'
+                  )}
+                </td>
               </tr>
             ))}
           </tbody>
@@ -521,6 +622,7 @@ const LoginHistoryTab: React.FC = () => {
 // ----- Suspicious activity -----
 
 const SuspiciousTab: React.FC = () => {
+  const navigate = useNavigate();
   const [threshold, setThreshold] = useState(5);
   const [windowHours, setWindowHours] = useState(24);
   const [entries, setEntries] = useState<SuspiciousActivityEntry[]>([]);
@@ -599,6 +701,7 @@ const SuspiciousTab: React.FC = () => {
               <th>Failed attempts</th>
               <th>Last attempt</th>
               <th>Last IP</th>
+              <th>Drill-down</th>
             </tr>
           </thead>
           <tbody>
@@ -608,6 +711,34 @@ const SuspiciousTab: React.FC = () => {
                 <td>{entry.failureCount}</td>
                 <td>{new Date(entry.lastAttempt).toLocaleString()}</td>
                 <td>{entry.lastIp || '—'}</td>
+                <td>
+                  <button
+                    type='button'
+                    className={styles.drillLink}
+                    onClick={() =>
+                      navigate(
+                        `/security/sessions?userId=${encodeURIComponent(entry.userId ?? '')}`
+                      )
+                    }
+                    disabled={!entry.userId}
+                    title={entry.userId ? 'View this user’s active sessions' : 'No user ID'}
+                  >
+                    Sessions
+                  </button>
+                  <button
+                    type='button'
+                    className={styles.drillLink}
+                    onClick={() =>
+                      navigate(
+                        `/security/login-history?userId=${encodeURIComponent(entry.userId ?? '')}`
+                      )
+                    }
+                    disabled={!entry.userId}
+                    title={entry.userId ? 'View this user’s login history' : 'No user ID'}
+                  >
+                    Login history
+                  </button>
+                </td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary

The Security Center tabs (MFA, Sessions, IP Rules, Login History, Suspicious Activity, Account Recovery) used to be islands — to investigate a suspicious-activity event you had to copy the user ID and paste it into each tab manually. This PR wires the tabs together with URL-driven drill-down links so an admin can move sideways from any actor row into the related tab with its filter pre-applied, and the browser back button restores prior state automatically.

## Acceptance criteria

- [x] From a suspicious-activity row, an admin can jump to that user's sessions and login history with the user pre-filtered
- [x] From a session row, an admin can jump to the relevant IP rule context (sessions don't carry an IP today, so the drill goes to the IP Rules tab unfiltered; Login History rows do carry IPs and drill to a pre-filtered IP Rules view)
- [x] Browser back returns to the originating tab with state intact (URL-driven, restored via the router history stack)
- [x] No regression to existing per-tab filtering — all 6 existing Security Center behaviour tests still pass; lint, type-check, and the full app.admin test suite are green (331 tests)

## URL-param contract

- `/security/:tab` is the canonical tab URL; tab clicks `navigate()` so the URL is always the source of truth
- `?userId=<id>` on `/security/sessions` or `/security/login-history` pre-fills the user filter on mount
- `?ip=<addr>` on `/security/ip-rules` filters the rule list to entries whose CIDR contains the given substring
- Unknown `:tab` values fall back to `mfa`; missing params leave the tab unfiltered

## Drill links added

| From row | Links to | Pre-applied filter |
|---|---|---|
| Suspicious Activity | Sessions | `?userId` |
| Suspicious Activity | Login History | `?userId` |
| Login History | IP Rules | `?ip` (when row has an IP) |
| Sessions | IP Rules | none (Session payload has no IP today) |

## Test plan

- [x] Added five behaviour tests in `app.admin/src/__tests__/security-center.behavior.test.tsx` covering each drill link, the `?ip` filter applying on mount, and back-navigation restoring the originating tab
- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.admin` passes
- [ ] Manual smoke: open `/security/suspicious`, click "Sessions" on a row, confirm URL becomes `/security/sessions?userId=...` and the user filter input is populated; hit browser back, confirm we land back on Suspicious Activity

## Notes / future work

- Session records don't currently expose `lastIp`. If we want a meaningful "Sessions -> IP Rules" drill with a pre-filter, we'd need to surface that on the API; a follow-up ticket would be more honest than a fake placeholder

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_