### PR TITLE
ADS-654: Define an entity-detail pattern shared across apps

### DIFF
--- a/app.admin/src/App.tsx
+++ b/app.admin/src/App.tsx
@@ -16,6 +16,7 @@ const RegisterPage = lazy(() =>
 );
 const Dashboard = lazy(() => import('./pages/Dashboard'));
 const Users = lazy(() => import('./pages/Users'));
+const UsersSplitPaneDemo = lazy(() => import('./pages/UsersSplitPaneDemo'));
 const Rescues = lazy(() => import('./pages/Rescues'));
 const Pets = lazy(() => import('./pages/Pets'));
 const Applications = lazy(() => import('./pages/Applications'));
@@ -92,6 +93,9 @@ const AdminApp: React.FC = () => {
 
               {/* User Management */}
               <Route path='/users' element={<Users />} />
+              {/* ADS-654: split-pane entity-detail reference implementation */}
+              <Route path='/users/split-pane' element={<UsersSplitPaneDemo />} />
+              <Route path='/users/split-pane/:userId' element={<UsersSplitPaneDemo />} />
               <Route path='/users/:userId' element={<Users />} />
 
               {/* Rescue Management */}

--- a/app.admin/src/pages/UsersSplitPaneDemo.css.ts
+++ b/app.admin/src/pages/UsersSplitPaneDemo.css.ts
@@ -1,0 +1,76 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const pageContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['4'],
+  padding: vars.spacing['4'],
+  height: '100%',
+});
+
+export const pageHeader = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['1'],
+});
+
+export const splitPaneContainer = style({
+  flex: '1 1 auto',
+  minHeight: '400px',
+});
+
+export const listRow = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['1'],
+});
+
+export const listRowName = style({
+  fontWeight: 600,
+});
+
+export const listRowEmail = style({
+  color: vars.text.muted,
+  fontSize: vars.typography.size.sm,
+});
+
+export const detailHeader = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['1'],
+  marginBottom: vars.spacing['3'],
+  paddingBottom: vars.spacing['3'],
+  borderBottom: `1px solid ${vars.border.color.default}`,
+});
+
+export const detailField = style({
+  display: 'grid',
+  gridTemplateColumns: '160px 1fr',
+  gap: vars.spacing['2'],
+  padding: `${vars.spacing['1']} 0`,
+});
+
+export const detailFieldLabel = style({
+  color: vars.text.muted,
+  fontSize: vars.typography.size.sm,
+});
+
+export const detailFieldValue = style({
+  color: vars.text.primary,
+});
+
+export const loading = style({
+  padding: vars.spacing['4'],
+  textAlign: 'center',
+  color: vars.text.muted,
+});
+
+export const errorBox = style({
+  padding: vars.spacing['3'],
+  border: `1px solid ${vars.border.color.danger}`,
+  background: vars.background.danger,
+  color: vars.text.danger,
+  borderRadius: vars.border.radius.base,
+});

--- a/app.admin/src/pages/UsersSplitPaneDemo.tsx
+++ b/app.admin/src/pages/UsersSplitPaneDemo.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Heading, SplitPaneDetail, Text } from '@adopt-dont-shop/lib.components';
+
+import { useUsers } from '../hooks';
+import type { AdminUser } from '../services/libraryServices';
+import * as styles from './UsersSplitPaneDemo.css';
+
+/**
+ * ADS-654 reference implementation of the entity-detail split-pane pattern.
+ *
+ * This is intentionally a small, read-only surface: it shares the existing
+ * admin Users list data but renders detail in a non-modal pane. The full
+ * Users page migration is tracked under ADS-650.
+ */
+const displayName = (user: AdminUser): string => {
+  const first = user.firstName ?? '';
+  const last = user.lastName ?? '';
+  const joined = `${first} ${last}`.trim();
+  return joined.length > 0 ? joined : user.email;
+};
+
+const formatDateTime = (value: string | null | undefined): string => {
+  if (!value) {
+    return '—';
+  }
+  return new Date(value).toLocaleString('en-GB');
+};
+
+const DetailField: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+  <div className={styles.detailField}>
+    <span className={styles.detailFieldLabel}>{label}</span>
+    <span className={styles.detailFieldValue}>{value}</span>
+  </div>
+);
+
+const UsersSplitPaneDemo: React.FC = () => {
+  const { userId } = useParams<{ userId?: string }>();
+  const navigate = useNavigate();
+
+  const { data, isLoading, error } = useUsers({ limit: 25 });
+
+  const users: ReadonlyArray<AdminUser> = data?.data ?? [];
+
+  const handleSelect = (id: string | null) => {
+    if (id === null) {
+      navigate('/users/split-pane', { replace: true });
+      return;
+    }
+    navigate(`/users/split-pane/${id}`, { replace: true });
+  };
+
+  return (
+    <div className={styles.pageContainer}>
+      <div className={styles.pageHeader}>
+        <Heading level='h1'>Users (split-pane preview)</Heading>
+        <Text>
+          ADS-654 reference: same admin user data as <code>/users</code>, rendered with the new{' '}
+          <code>SplitPaneDetail</code> layout.
+        </Text>
+      </div>
+
+      {error instanceof Error && (
+        <div className={styles.errorBox}>Failed to load users: {error.message}</div>
+      )}
+
+      {isLoading ? (
+        <div className={styles.loading}>Loading users…</div>
+      ) : (
+        <SplitPaneDetail<AdminUser>
+          items={users}
+          getItemId={user => user.userId}
+          selectedId={userId ?? null}
+          onSelect={handleSelect}
+          renderListItem={user => (
+            <div className={styles.listRow}>
+              <span className={styles.listRowName}>{displayName(user)}</span>
+              <span className={styles.listRowEmail}>{user.email}</span>
+            </div>
+          )}
+          renderDetail={user => (
+            <div data-testid='user-detail'>
+              <div className={styles.detailHeader}>
+                <Heading level='h2'>{displayName(user)}</Heading>
+                <Text>{user.email}</Text>
+              </div>
+              <DetailField label='User type' value={user.userType} />
+              <DetailField label='Status' value={user.status} />
+              <DetailField label='Email verified' value={user.emailVerified ? 'Yes' : 'No'} />
+              <DetailField label='Phone' value={user.phoneNumber ?? '—'} />
+              <DetailField label='City' value={user.city ?? '—'} />
+              <DetailField label='Country' value={user.country ?? '—'} />
+              <DetailField label='Last login' value={formatDateTime(user.lastLoginAt)} />
+              <DetailField label='Joined' value={formatDateTime(user.createdAt)} />
+            </div>
+          )}
+          emptyList={<Text>No users to display.</Text>}
+          emptyDetail={<Text>Select a user from the list to view their details.</Text>}
+          listAriaLabel='Users'
+          detailAriaLabel='User details'
+          className={styles.splitPaneContainer}
+          data-testid='users-split-pane'
+        />
+      )}
+    </div>
+  );
+};
+
+export default UsersSplitPaneDemo;

--- a/docs/adr/0001-entity-detail-pattern.md
+++ b/docs/adr/0001-entity-detail-pattern.md
@@ -1,0 +1,143 @@
+# ADR 0001 — Entity-Detail Pattern
+
+- Status: Accepted
+- Date: 2026-05-22
+- Linear: ADS-654 (foundation for ADS-650 split-pane refactor)
+
+## Context
+
+The three React apps (`app.admin`, `app.rescue`, `app.client`) each implement
+entity-detail views differently:
+
+- `app.admin` opens stacked modals on top of list pages (`PetDetailModal`,
+  `RescueDetailModal`, `SendEmailModal`, verification modals, …). With several
+  modals visible at once, users lose their place in the underlying list and
+  deep-linking is awkward.
+- `app.rescue` and `app.client` mix modal flows with full-page navigation,
+  inconsistently from screen to screen.
+
+We want a single preferred pattern shared across apps so engineers don't
+re-litigate the choice on every list-and-detail screen, and so future work
+(deep-linking, keyboard shortcuts, layout density) can move forward without
+auditing each surface.
+
+## Decision
+
+**The preferred pattern for entity-detail views is a split-pane layout: a list
+of entities on the left, the selected entity's detail on the right.**
+
+Concretely:
+
+- A reusable `SplitPaneDetail` component ships from `@adopt-dont-shop/lib.components`.
+- The list keeps its filters, search, and pagination — nothing moves into the
+  detail pane.
+- Selecting a row updates the detail pane in place. Selection is driven by an
+  `id` that lives in the URL (e.g. `/rescues/:rescueId`), so deep links and
+  back/forward navigation work.
+- The empty state (no selection) is part of the detail pane, not a placeholder
+  page.
+- On narrow viewports the layout collapses: the list is shown when no entity is
+  selected, and the detail replaces the list when one is.
+
+This is a layout pattern, not a data pattern. Pages still own their queries,
+mutations, filters, and toolbars.
+
+## When modals are still appropriate
+
+Split-pane is the default. Modals remain the right choice for:
+
+- **Confirmations** — destructive actions, bulk-action recap, "are you sure?"
+  prompts.
+- **Single-field or single-question edits** — renaming an item, picking a date,
+  resetting a password.
+- **Step-by-step flows** that are clearly orthogonal to the list, where the
+  user must finish or cancel before continuing (e.g. verification wizard,
+  invitation flow).
+- **Quick previews launched from a non-list surface** — e.g. opening a related
+  entity from a dashboard tile, where there is no list to anchor the
+  split-pane.
+
+If you find yourself stacking two modals, the second one is almost certainly a
+sign that the first should have been a split-pane detail.
+
+## Rationale
+
+- **Context preservation.** The list stays visible, so users keep their search,
+  filters, sort, and pagination state while inspecting individual records.
+- **Bulk-friendly.** Admin workflows often involve scanning many records;
+  split-pane lets you click through a list without closing/opening a modal
+  each time.
+- **Deep-linking.** A URL like `/rescues/:rescueId` is just another selection;
+  the page renders the same way whether it was reached by clicking a row or by
+  pasting a link.
+- **Stops modal stacking.** The current admin codebase has flows that open
+  three modals on top of each other (detail → verification → confirmation).
+  That's a UX smell the split-pane removes by giving non-blocking detail a
+  proper home.
+- **Foundation for ADS-650.** The upcoming split-pane refactor needs one
+  agreed component to migrate onto.
+
+## Alternatives considered
+
+- **Full-page detail (`/rescues/:rescueId` as a separate route, list left
+  behind).** Simpler to build but loses list context and forces a round-trip
+  through filters/pagination on every selection. Rejected for list-heavy admin
+  surfaces; still acceptable for client-facing flows where deep context is
+  needed (e.g. pet profile pages for adopters).
+- **Keep modals everywhere.** Cheapest in the short term, but the stacking
+  problem already exists and ADS-650 explicitly asks us to move away.
+- **Drawer / off-canvas panel.** A middle ground, but suffers the same
+  context-blocking problem as a modal on smaller screens, and is only a slight
+  improvement on desktop. Not worth a separate primitive.
+
+## Component API
+
+The component lives at `lib.components/src/components/layout/SplitPaneDetail`.
+
+```tsx
+import { SplitPaneDetail } from '@adopt-dont-shop/lib.components';
+
+<SplitPaneDetail
+  items={rescues}
+  getItemId={(r) => r.rescueId}
+  selectedId={selectedId}
+  onSelect={setSelectedId}
+  renderListItem={(rescue, { isSelected }) => (
+    <RescueRow rescue={rescue} isSelected={isSelected} />
+  )}
+  renderDetail={(rescue) => <RescueDetail rescue={rescue} />}
+  emptyDetail={<p>Select a rescue to view details.</p>}
+  emptyList={<p>No rescues match your filters.</p>}
+  data-testid='rescues-split-pane'
+/>;
+```
+
+Key properties:
+
+- The component is generic in the list-item shape (`<T>`); no `any`.
+- Selection is controlled — pages own `selectedId`, typically driven from the
+  URL.
+- Rendering of each list row and the detail body is delegated to the page;
+  the component owns only the layout and the empty/responsive states.
+- Below `768px` the detail collapses over the list; pressing the built-in
+  "Back to list" control clears the selection.
+
+## Adoption / migration plan
+
+- **Reference implementation:** `app.admin` ships a small read-only demo route
+  at `/users/split-pane` that uses the new component against the admin user
+  list. This is intentionally a low-risk surface — the existing modal-based
+  Users page is unchanged.
+- **ADS-650 (next ticket):** migrate Rescues, Pets, Applications, and Users
+  list pages off modal stacks onto `SplitPaneDetail`. Confirmation /
+  verification flows stay as modals per the rules above.
+- **Rescue and client apps:** adopt opportunistically as their list pages are
+  touched. No big-bang rewrite.
+
+## Consequences
+
+- New shared component to maintain.
+- Pages currently using modal detail will eventually need a small refactor
+  (move the modal body into a `renderDetail`-shaped component, delete the
+  modal trigger). That's planned work for ADS-650, not this ticket.
+- Confirmation/verification modals stay where they are.

--- a/lib.components/src/components/layout/SplitPaneDetail/SplitPaneDetail.css.ts
+++ b/lib.components/src/components/layout/SplitPaneDetail/SplitPaneDetail.css.ts
@@ -1,0 +1,174 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '../../../styles/theme.css';
+
+const NARROW = '(max-width: 768px)';
+
+export const root = recipe({
+  base: {
+    display: 'flex',
+    width: '100%',
+    minHeight: '0',
+    gap: vars.spacing['3'],
+    '@media': {
+      [NARROW]: {
+        display: 'block',
+      },
+    },
+  },
+  variants: {
+    detailOpen: {
+      true: {},
+      false: {},
+    },
+  },
+  defaultVariants: {
+    detailOpen: false,
+  },
+});
+
+export const listPane = recipe({
+  base: {
+    flex: '0 0 320px',
+    minWidth: '0',
+    overflowY: 'auto',
+    borderRight: `1px solid ${vars.border.color.default}`,
+    paddingRight: vars.spacing['3'],
+  },
+  variants: {
+    hiddenOnNarrow: {
+      true: {
+        '@media': {
+          [NARROW]: {
+            display: 'none',
+          },
+        },
+      },
+      false: {
+        '@media': {
+          [NARROW]: {
+            display: 'block',
+            flex: '1 1 auto',
+            borderRight: 'none',
+            paddingRight: '0',
+          },
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    hiddenOnNarrow: false,
+  },
+});
+
+export const detailPane = recipe({
+  base: {
+    flex: '1 1 auto',
+    minWidth: '0',
+    overflowY: 'auto',
+    paddingLeft: vars.spacing['2'],
+    '@media': {
+      [NARROW]: {
+        paddingLeft: '0',
+      },
+    },
+  },
+  variants: {
+    visibleOnNarrow: {
+      true: {
+        '@media': {
+          [NARROW]: {
+            display: 'block',
+          },
+        },
+      },
+      false: {
+        '@media': {
+          [NARROW]: {
+            display: 'none',
+          },
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    visibleOnNarrow: false,
+  },
+});
+
+export const list = style({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing['1'],
+});
+
+export const listItemButton = recipe({
+  base: {
+    width: '100%',
+    textAlign: 'left',
+    background: 'transparent',
+    border: '1px solid transparent',
+    borderRadius: vars.border.radius.base,
+    padding: vars.spacing['2'],
+    cursor: 'pointer',
+    color: 'inherit',
+    font: 'inherit',
+    ':hover': {
+      background: vars.background.muted,
+    },
+    ':focus-visible': {
+      outline: `2px solid ${vars.border.color.focus}`,
+      outlineOffset: '2px',
+    },
+  },
+  variants: {
+    selected: {
+      true: {
+        background: vars.background.muted,
+        borderColor: vars.border.color.default,
+      },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    selected: false,
+  },
+});
+
+export const backButton = style({
+  display: 'none',
+  '@media': {
+    [NARROW]: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: vars.spacing['1'],
+      background: 'transparent',
+      border: `1px solid ${vars.border.color.default}`,
+      borderRadius: vars.border.radius.base,
+      padding: `${vars.spacing['1']} ${vars.spacing['2']}`,
+      marginBottom: vars.spacing['2'],
+      cursor: 'pointer',
+      color: 'inherit',
+      font: 'inherit',
+    },
+  },
+});
+
+export const emptyDetail = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  minHeight: '200px',
+  color: vars.text.muted,
+});
+
+export const emptyList = style({
+  padding: vars.spacing['3'],
+  color: vars.text.muted,
+  textAlign: 'center',
+});

--- a/lib.components/src/components/layout/SplitPaneDetail/SplitPaneDetail.test.tsx
+++ b/lib.components/src/components/layout/SplitPaneDetail/SplitPaneDetail.test.tsx
@@ -1,0 +1,236 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SplitPaneDetail } from './SplitPaneDetail';
+
+type Pet = { petId: string; name: string };
+
+const PETS: ReadonlyArray<Pet> = [
+  { petId: 'p1', name: 'Biscuit' },
+  { petId: 'p2', name: 'Luna' },
+  { petId: 'p3', name: 'Mochi' },
+];
+
+const renderListItem = (pet: Pet) => <span>{pet.name}</span>;
+const renderDetail = (pet: Pet) => <div data-testid='detail-body'>Detail for {pet.name}</div>;
+
+describe('SplitPaneDetail', () => {
+  it('renders every item from the list', () => {
+    render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId={null}
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+        data-testid='pets'
+      />
+    );
+
+    expect(screen.getByText('Biscuit')).toBeInTheDocument();
+    expect(screen.getByText('Luna')).toBeInTheDocument();
+    expect(screen.getByText('Mochi')).toBeInTheDocument();
+  });
+
+  it('shows the empty-detail placeholder when nothing is selected', () => {
+    render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId={null}
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+        emptyDetail={<p>Pick a pet to begin.</p>}
+        data-testid='pets'
+      />
+    );
+
+    expect(screen.getByText('Pick a pet to begin.')).toBeInTheDocument();
+    expect(screen.queryByTestId('detail-body')).not.toBeInTheDocument();
+  });
+
+  it('falls back to a default empty-detail message when none is provided', () => {
+    render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId={null}
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+      />
+    );
+
+    expect(screen.getByText('Select an item to view details.')).toBeInTheDocument();
+  });
+
+  it('renders the detail for the selected item', () => {
+    render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId='p2'
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+      />
+    );
+
+    expect(screen.getByText('Detail for Luna')).toBeInTheDocument();
+  });
+
+  it('marks the selected row with aria-current', () => {
+    render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId='p2'
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+      />
+    );
+
+    const lunaButton = screen.getByRole('button', { name: 'Luna' });
+    const biscuitButton = screen.getByRole('button', { name: 'Biscuit' });
+
+    expect(lunaButton).toHaveAttribute('aria-current', 'true');
+    expect(biscuitButton).not.toHaveAttribute('aria-current');
+  });
+
+  it('calls onSelect with the row id when a list item is clicked', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId={null}
+        onSelect={onSelect}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Mochi' }));
+
+    expect(onSelect).toHaveBeenCalledWith('p3');
+  });
+
+  it('passes isSelected to the list-item renderer so callers can style selection', () => {
+    render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId='p1'
+        onSelect={() => {}}
+        renderListItem={(pet, { isSelected }) => (
+          <span>
+            {pet.name} {isSelected ? '(selected)' : ''}
+          </span>
+        )}
+        renderDetail={renderDetail}
+      />
+    );
+
+    expect(screen.getByText(/Biscuit \(selected\)/)).toBeInTheDocument();
+    expect(screen.getByText('Luna')).toBeInTheDocument();
+  });
+
+  it('shows the empty-list slot when there are no items', () => {
+    render(
+      <SplitPaneDetail
+        items={[]}
+        getItemId={(pet: Pet) => pet.petId}
+        selectedId={null}
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+        emptyList={<p>No pets match your filters.</p>}
+      />
+    );
+
+    expect(screen.getByText('No pets match your filters.')).toBeInTheDocument();
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('treats a selectedId that does not match any item as no selection', () => {
+    render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId='missing'
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+        emptyDetail={<p>nothing selected</p>}
+      />
+    );
+
+    expect(screen.getByText('nothing selected')).toBeInTheDocument();
+    expect(screen.queryByTestId('detail-body')).not.toBeInTheDocument();
+  });
+
+  it('clears the selection when the back-to-list control is activated', async () => {
+    const user = userEvent.setup();
+
+    const Harness = () => {
+      const [selectedId, setSelectedId] = useState<string | null>('p2');
+      return (
+        <SplitPaneDetail
+          items={PETS}
+          getItemId={pet => pet.petId}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          renderListItem={renderListItem}
+          renderDetail={renderDetail}
+          backLabel='Back to list'
+        />
+      );
+    };
+
+    render(<Harness />);
+
+    expect(screen.getByText('Detail for Luna')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Back to list' }));
+
+    expect(screen.queryByText('Detail for Luna')).not.toBeInTheDocument();
+    expect(screen.getByText('Select an item to view details.')).toBeInTheDocument();
+  });
+
+  it('updates the detail pane as a controlled selection changes', () => {
+    const { rerender } = render(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId='p1'
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+      />
+    );
+
+    expect(screen.getByText('Detail for Biscuit')).toBeInTheDocument();
+
+    rerender(
+      <SplitPaneDetail
+        items={PETS}
+        getItemId={pet => pet.petId}
+        selectedId='p3'
+        onSelect={() => {}}
+        renderListItem={renderListItem}
+        renderDetail={renderDetail}
+      />
+    );
+
+    expect(screen.queryByText('Detail for Biscuit')).not.toBeInTheDocument();
+    expect(screen.getByText('Detail for Mochi')).toBeInTheDocument();
+  });
+});

--- a/lib.components/src/components/layout/SplitPaneDetail/SplitPaneDetail.tsx
+++ b/lib.components/src/components/layout/SplitPaneDetail/SplitPaneDetail.tsx
@@ -1,0 +1,119 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import * as styles from './SplitPaneDetail.css';
+
+export type SplitPaneListItemRenderContext = {
+  isSelected: boolean;
+};
+
+export type SplitPaneDetailProps<T> = {
+  /** List of entities to display in the left pane. */
+  items: ReadonlyArray<T>;
+  /** Extracts a stable identifier from an item. */
+  getItemId: (item: T) => string;
+  /** Currently-selected item id, or `null` when nothing is selected. */
+  selectedId: string | null;
+  /** Called with the id of the row the user activated, or `null` when cleared. */
+  onSelect: (id: string | null) => void;
+  /** Renders one row of the list. The button wrapper, selection state, and click handling are owned by the component. */
+  renderListItem: (item: T, context: SplitPaneListItemRenderContext) => React.ReactNode;
+  /** Renders the detail pane for the selected item. */
+  renderDetail: (item: T) => React.ReactNode;
+  /** Shown in the detail pane when no item is selected. */
+  emptyDetail?: React.ReactNode;
+  /** Shown inside the list pane when `items` is empty. */
+  emptyList?: React.ReactNode;
+  /** Accessible label for the list region. Defaults to "Items". */
+  listAriaLabel?: string;
+  /** Accessible label for the detail region. Defaults to "Details". */
+  detailAriaLabel?: string;
+  /** Label for the back-to-list control shown on narrow viewports. */
+  backLabel?: string;
+  className?: string;
+  'data-testid'?: string;
+};
+
+const SplitPaneDetailInner = <T,>({
+  items,
+  getItemId,
+  selectedId,
+  onSelect,
+  renderListItem,
+  renderDetail,
+  emptyDetail,
+  emptyList,
+  listAriaLabel = 'Items',
+  detailAriaLabel = 'Details',
+  backLabel = 'Back to list',
+  className,
+  'data-testid': testId,
+}: SplitPaneDetailProps<T>): React.ReactElement => {
+  const selectedItem =
+    selectedId === null ? null : (items.find(item => getItemId(item) === selectedId) ?? null);
+
+  const detailOpen = selectedItem !== null;
+
+  return (
+    <div className={clsx(styles.root({ detailOpen }), className)} data-testid={testId}>
+      <section
+        className={styles.listPane({ hiddenOnNarrow: detailOpen })}
+        aria-label={listAriaLabel}
+      >
+        {items.length === 0 ? (
+          <div
+            className={styles.emptyList}
+            data-testid={testId ? `${testId}-empty-list` : undefined}
+          >
+            {emptyList ?? 'No items.'}
+          </div>
+        ) : (
+          <ul className={styles.list}>
+            {items.map(item => {
+              const id = getItemId(item);
+              const isSelected = id === selectedId;
+              return (
+                <li key={id}>
+                  <button
+                    type='button'
+                    className={styles.listItemButton({ selected: isSelected })}
+                    aria-current={isSelected ? 'true' : undefined}
+                    onClick={() => onSelect(id)}
+                  >
+                    {renderListItem(item, { isSelected })}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section
+        className={styles.detailPane({ visibleOnNarrow: detailOpen })}
+        aria-label={detailAriaLabel}
+      >
+        {selectedItem === null ? (
+          <div
+            className={styles.emptyDetail}
+            data-testid={testId ? `${testId}-empty-detail` : undefined}
+          >
+            {emptyDetail ?? 'Select an item to view details.'}
+          </div>
+        ) : (
+          <>
+            <button type='button' className={styles.backButton} onClick={() => onSelect(null)}>
+              {backLabel}
+            </button>
+            {renderDetail(selectedItem)}
+          </>
+        )}
+      </section>
+    </div>
+  );
+};
+
+// Re-export with a non-generic alias for ergonomic JSX usage while preserving the generic.
+export const SplitPaneDetail = SplitPaneDetailInner as <T>(
+  props: SplitPaneDetailProps<T>
+) => React.ReactElement;

--- a/lib.components/src/components/layout/SplitPaneDetail/index.ts
+++ b/lib.components/src/components/layout/SplitPaneDetail/index.ts
@@ -1,0 +1,2 @@
+export { SplitPaneDetail } from './SplitPaneDetail';
+export type { SplitPaneDetailProps, SplitPaneListItemRenderContext } from './SplitPaneDetail';

--- a/lib.components/src/index.ts
+++ b/lib.components/src/index.ts
@@ -34,6 +34,11 @@ export { Text } from './components/ui/Text';
 // Layout Components
 export { Container } from './components/layout/Container';
 export { Stack } from './components/layout/Stack';
+export { SplitPaneDetail } from './components/layout/SplitPaneDetail';
+export type {
+  SplitPaneDetailProps,
+  SplitPaneListItemRenderContext,
+} from './components/layout/SplitPaneDetail';
 export { Card, CardContent, CardFooter, CardHeader } from './components/ui/Card';
 
 // Form Components - commenting out problematic ones for now


### PR DESCRIPTION
## Summary

Foundation for ADS-650's split-pane refactor: introduces a documented entity-detail pattern and ships a reusable component in `lib.components`.

- **ADR:** [`docs/adr/0001-entity-detail-pattern.md`](./docs/adr/0001-entity-detail-pattern.md) — describes the preferred split-pane layout, when modals are still appropriate (confirmations, single-field edits, step-by-step flows), rationale, alternatives considered, and the migration plan.
- **Component:** `SplitPaneDetail<T>` in `@adopt-dont-shop/lib.components`. Generic over the list-item shape; controlled selection (designed for URL-driven `selectedId`); slots for `emptyDetail`, `emptyList`, custom list-item and detail rendering; collapses to a single pane below 768px with a built-in "Back to list" control.
- **Reference implementation:** `app.admin` adopts the pattern in a small read-only page at `/users/split-pane`. It renders the same admin user list as `/users`, but in a split-pane layout instead of a modal stack. The existing modal-based Users page is unchanged; full migration of list pages is tracked under ADS-650.

### Component API

```tsx
<SplitPaneDetail<User>
  items={users}
  getItemId={u => u.userId}
  selectedId={selectedId}
  onSelect={setSelectedId}
  renderListItem={(user, { isSelected }) => <Row user={user} isSelected={isSelected} />}
  renderDetail={user => <UserDetail user={user} />}
  emptyDetail={<p>Select a user to view details.</p>}
  emptyList={<p>No users match your filters.</p>}
  data-testid='users-split-pane'
/>
```

Behaviour tests cover: rendering items, empty-list and empty-detail states, selected-row `aria-current`, click → `onSelect(id)`, back-to-list → `onSelect(null)`, controlled selection updates, and unknown `selectedId` treated as no selection.

### Reference page

`/users/split-pane` (and `/users/split-pane/:userId` for deep-linking) renders the existing admin user list with `SplitPaneDetail`: list rows show name + email, the detail pane shows user type, status, contact, location, and timestamps. Selection writes the user id into the URL via `react-router`'s `navigate(..., { replace: true })`, so back/forward and direct links work.

### Scope notes

Per the ticket, the reference-implementation migration was descoped to a new demo route rather than rewriting the existing Users / Rescues / Pets pages, which are tightly coupled to modal-stack flows and out of scope for a one-day change. ADS-650 will migrate those.

## Acceptance criteria

- [x] ADR documents the preferred entity-detail pattern with rationale
- [x] Reusable component ships in `lib.components` for split-pane detail
- [x] At least one app adopts it as a reference implementation (`app.admin` → `/users/split-pane`)
- [x] Doc lists when modal is still appropriate

## Test plan

- [x] `npx turbo build lint type-check test --filter=@adopt-dont-shop/lib.components --filter=@adopt-dont-shop/app.admin` — all 24 tasks pass (326/326 admin tests, 457/457 component tests including 11 new `SplitPaneDetail` tests)
- [ ] Smoke-test the new route locally at `/users/split-pane` and verify deep-linking via `/users/split-pane/:userId`
- [ ] Visual check at narrow viewport (≤768px): list collapses, "Back to list" appears in detail

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_