### PR TITLE
chore(infra): pin nginx and redis base images to patch versions (ADS-664)

### DIFF
--- a/Dockerfile.app.optimized
+++ b/Dockerfile.app.optimized
@@ -216,7 +216,7 @@ RUN --mount=type=cache,target=/app/.turbo \
 # ============================================================================
 # PRODUCTION STAGE - Minimal Nginx image for static assets
 # ============================================================================
-FROM nginx:alpine AS production
+FROM nginx:1.27-alpine AS production
 ARG APP_NAME
 
 # Install security updates

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
 
   # Redis - Production configuration
   redis:
-    image: redis:7-alpine
+    image: redis:7.4-alpine
     container_name: ads_prod_redis
     restart: always
     ports: []  # Don't expose Redis port to host in production
@@ -299,7 +299,7 @@ services:
   # Public TLS is handled by the gateway stack — this nginx only listens on
   # the internal network and is reverse-proxied by the gateway.
   nginx:
-    image: nginx:alpine
+    image: nginx:1.27-alpine
     container_name: ads_prod_nginx
     restart: always
     volumes:


### PR DESCRIPTION
Pins floating Docker base image tags to specific minor (patch-tracking) versions for reproducibility.

Linear ticket: https://linear.app/ideasquared/issue/ADS-664

## Changes

- `docker-compose.prod.yml`
  - `redis:7-alpine` -> `redis:7.4-alpine`
  - `nginx:alpine` -> `nginx:1.27-alpine`
- `Dockerfile.app.optimized`
  - `nginx:alpine` -> `nginx:1.27-alpine` (production stage)

## Out of scope / left as-is

- `postgis/postgis:16-3.4` is already pinned to major+minor. The `postgis/postgis` image does not publish an `-alpine` variant, so it is left unchanged.
- Other compose files (`docker-compose.yml`, `docker-compose.staging.yml`, `docker-compose.ci.yml`) and `service.backend/Dockerfile` were not in scope per the ticket. They contain similar unpinned tags (`redis:7-alpine`, `nginx:alpine`, `node:22-alpine`, `postgis/postgis:16-3.4`) and can be addressed in a follow-up.

https://claude.ai/code/session_01MZ1rFv3YqfJvfUGxULzXBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZ1rFv3YqfJvfUGxULzXBc)_