### PR TITLE
ADS-637: Clarify "Discover" vs "Search" entry points

### DIFF
--- a/app.client/src/__tests__/application-routing.behavior.test.tsx
+++ b/app.client/src/__tests__/application-routing.behavior.test.tsx
@@ -32,6 +32,14 @@ vi.mock('@/contexts/ChatContext', () => ({
   useChat: () => ({ unreadMessageCount: 0 }),
 }));
 
+vi.mock('@/contexts/AnalyticsContext', () => ({
+  useAnalytics: () => ({
+    trackEvent: vi.fn(),
+    trackPageView: vi.fn(),
+    analyticsService: {},
+  }),
+}));
+
 vi.mock('@/components/ui/SwipeFloatingButton', () => ({
   SwipeFloatingButton: () => null,
 }));

--- a/app.client/src/components/hero/SwipeHero.tsx
+++ b/app.client/src/components/hero/SwipeHero.tsx
@@ -1,9 +1,26 @@
 import React from 'react';
 import { MdAutoFixHigh, MdFlashOn, MdSearch, MdSwipe, MdTrendingUp } from 'react-icons/md';
 import { Link } from 'react-router-dom';
+import { useAnalytics } from '@/contexts/AnalyticsContext';
 import * as styles from './SwipeHero.css';
 
 export const SwipeHero: React.FC = () => {
+  const { trackEvent } = useAnalytics();
+
+  const trackHeroCtaClick = (entryPath: 'discover' | 'search') => {
+    trackEvent({
+      category: 'homepage',
+      action: 'hero_cta_clicked',
+      label: entryPath,
+      sessionId: 'homepage-session',
+      timestamp: new Date(),
+      properties: {
+        entry_path: entryPath,
+        source: 'swipe_hero',
+      },
+    });
+  };
+
   return (
     <section className={styles.heroContainer}>
       <div className={styles.heroContent}>
@@ -25,11 +42,21 @@ export const SwipeHero: React.FC = () => {
         </p>
 
         <div className={styles.ctaContainer}>
-          <Link className={styles.primaryButton} to='/discover'>
+          <Link
+            className={styles.primaryButton}
+            to='/discover'
+            title='Swipe through matches'
+            onClick={() => trackHeroCtaClick('discover')}
+          >
             <MdSwipe className={styles.primaryButtonIcon} />
             Start Swiping Now
           </Link>
-          <Link className={styles.secondaryButton} to='/search'>
+          <Link
+            className={styles.secondaryButton}
+            to='/search'
+            title='Filter and browse all pets'
+            onClick={() => trackHeroCtaClick('search')}
+          >
             <MdSearch />
             Browse All Pets
           </Link>

--- a/app.client/src/components/layout/AppShell.test.tsx
+++ b/app.client/src/components/layout/AppShell.test.tsx
@@ -34,6 +34,14 @@ vi.mock('@/contexts/ChatContext', () => ({
   useChat: () => ({ unreadMessageCount: 0 }),
 }));
 
+vi.mock('@/contexts/AnalyticsContext', () => ({
+  useAnalytics: () => ({
+    trackEvent: vi.fn(),
+    trackPageView: vi.fn(),
+    analyticsService: {},
+  }),
+}));
+
 vi.mock('@/components/ui/SwipeFloatingButton', () => ({
   SwipeFloatingButton: () => <div data-testid='swipe-fab' />,
 }));

--- a/app.client/src/components/navigation/AppNavbar.test.tsx
+++ b/app.client/src/components/navigation/AppNavbar.test.tsx
@@ -46,12 +46,22 @@ vi.mock('@/contexts/ChatContext', () => ({
   useChat: () => chatState,
 }));
 
+const trackEventMock = vi.fn();
+vi.mock('@/contexts/AnalyticsContext', () => ({
+  useAnalytics: () => ({
+    trackEvent: trackEventMock,
+    trackPageView: vi.fn(),
+    analyticsService: {},
+  }),
+}));
+
 describe('AppNavbar', () => {
   beforeEach(() => {
     authState.user = null;
     authState.isAuthenticated = false;
     notificationsState.unreadCount = 0;
     chatState.unreadMessageCount = 0;
+    trackEventMock.mockClear();
   });
 
   describe('logged out', () => {
@@ -73,6 +83,18 @@ describe('AppNavbar', () => {
       renderWithProviders(<AppNavbar />);
       expect(screen.getByRole('link', { name: /discover/i })).toHaveAttribute('href', '/discover');
       expect(screen.getByRole('link', { name: /search/i })).toHaveAttribute('href', '/search');
+    });
+
+    it('describes Discover and Search so first-time users can tell them apart', () => {
+      renderWithProviders(<AppNavbar />);
+      expect(screen.getByRole('link', { name: /discover/i })).toHaveAttribute(
+        'title',
+        'Swipe through matches'
+      );
+      expect(screen.getByRole('link', { name: /search/i })).toHaveAttribute(
+        'title',
+        'Filter and browse all pets'
+      );
     });
   });
 
@@ -128,6 +150,31 @@ describe('AppNavbar', () => {
     it('does not render the legacy swipe callout', () => {
       renderWithProviders(<AppNavbar />);
       expect(screen.queryByText(/try our new swipe feature/i)).not.toBeInTheDocument();
+    });
+
+    it('tracks distinct analytics entry paths for Discover vs Search', async () => {
+      const { default: userEvent } = await import('@testing-library/user-event');
+      const user = userEvent.setup();
+      renderWithProviders(<AppNavbar />);
+
+      await user.click(screen.getByRole('link', { name: /discover/i }));
+      await user.click(screen.getByRole('link', { name: /search/i }));
+
+      const discoverCall = trackEventMock.mock.calls.find(([event]) => event.label === 'discover');
+      const searchCall = trackEventMock.mock.calls.find(([event]) => event.label === 'search');
+
+      expect(discoverCall?.[0]).toMatchObject({
+        category: 'navigation',
+        action: 'primary_nav_clicked',
+        label: 'discover',
+        properties: { entry_path: 'discover', source: 'app_navbar' },
+      });
+      expect(searchCall?.[0]).toMatchObject({
+        category: 'navigation',
+        action: 'primary_nav_clicked',
+        label: 'search',
+        properties: { entry_path: 'search', source: 'app_navbar' },
+      });
     });
   });
 

--- a/app.client/src/components/navigation/AppNavbar.tsx
+++ b/app.client/src/components/navigation/AppNavbar.tsx
@@ -5,6 +5,7 @@ import { Badge, Logo } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { useChat } from '@/contexts/ChatContext';
 import { useNotifications } from '@/contexts/NotificationsContext';
+import { useAnalytics } from '@/contexts/AnalyticsContext';
 import { AuthCtas } from './AuthCtas';
 import { NavLink } from './NavLink';
 import { NavUserMenu } from './NavUserMenu';
@@ -58,6 +59,22 @@ export const AppNavbar: React.FC<AppNavbarProps> = ({ className }) => {
   const { isAuthenticated } = useAuth();
   const { unreadCount: notificationsUnread } = useNotifications();
   const { unreadMessageCount } = useChat();
+  const { trackEvent } = useAnalytics();
+
+  const trackNavClick = (entryPath: 'discover' | 'search' | 'favorites') => {
+    trackEvent({
+      category: 'navigation',
+      action: 'primary_nav_clicked',
+      label: entryPath,
+      sessionId: 'app-navbar-session',
+      timestamp: new Date(),
+      properties: {
+        entry_path: entryPath,
+        source: 'app_navbar',
+        user_authenticated: isAuthenticated,
+      },
+    });
+  };
 
   return (
     <nav className={`${styles.navbarContainer}${className ? ` ${className}` : ''}`}>
@@ -67,14 +84,29 @@ export const AppNavbar: React.FC<AppNavbarProps> = ({ className }) => {
         </Link>
 
         <div className={styles.primaryLinks}>
-          <NavLink to='/discover' icon={<MdSwipe aria-hidden='true' />} primary>
+          <NavLink
+            to='/discover'
+            icon={<MdSwipe aria-hidden='true' />}
+            primary
+            description='Swipe through matches'
+            onClick={() => trackNavClick('discover')}
+          >
             Discover
           </NavLink>
-          <NavLink to='/search' icon={<MdSearch aria-hidden='true' />}>
+          <NavLink
+            to='/search'
+            icon={<MdSearch aria-hidden='true' />}
+            description='Filter and browse all pets'
+            onClick={() => trackNavClick('search')}
+          >
             Search
           </NavLink>
           {isAuthenticated && (
-            <NavLink to='/favorites' icon={<MdFavorite aria-hidden='true' />}>
+            <NavLink
+              to='/favorites'
+              icon={<MdFavorite aria-hidden='true' />}
+              onClick={() => trackNavClick('favorites')}
+            >
               Favorites
             </NavLink>
           )}

--- a/app.client/src/components/navigation/NavLink.css.ts
+++ b/app.client/src/components/navigation/NavLink.css.ts
@@ -52,3 +52,15 @@ export const navIcon = style({
   fontSize: '1.25rem',
   display: 'inline-flex',
 });
+
+export const srOnly = style({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+});

--- a/app.client/src/components/navigation/NavLink.tsx
+++ b/app.client/src/components/navigation/NavLink.tsx
@@ -7,6 +7,11 @@ export type NavLinkProps = Omit<LinkProps, 'to'> & {
   icon?: React.ReactNode;
   primary?: boolean;
   iconOnly?: boolean;
+  /**
+   * Short description shown as a native tooltip and as accessible hint text,
+   * helping first-time users distinguish similar nav items (e.g. Discover vs Search).
+   */
+  description?: string;
   children?: React.ReactNode;
 };
 
@@ -15,6 +20,7 @@ export const NavLink: React.FC<NavLinkProps> = ({
   icon,
   primary = false,
   iconOnly = false,
+  description,
   children,
   ...rest
 }) => {
@@ -22,9 +28,15 @@ export const NavLink: React.FC<NavLinkProps> = ({
   const active = location.pathname === to || location.pathname.startsWith(`${to}/`);
 
   return (
-    <Link className={styles.styledLink({ active, primary, iconOnly })} to={to} {...rest}>
+    <Link
+      className={styles.styledLink({ active, primary, iconOnly })}
+      to={to}
+      title={description}
+      {...rest}
+    >
       {icon && <span className={styles.navIcon}>{icon}</span>}
       {!iconOnly && children}
+      {!iconOnly && description && <span className={styles.srOnly}>. {description}</span>}
     </Link>
   );
 };

--- a/app.client/src/pages/HomePage.css.ts
+++ b/app.client/src/pages/HomePage.css.ts
@@ -202,6 +202,12 @@ export const heroSecondaryButton = style({
   background: 'rgba(255,255,255,0.08)',
 });
 
+export const ctaSecondaryButton = style({
+  color: 'white',
+  borderColor: 'rgba(255,255,255,0.6)',
+  background: 'transparent',
+});
+
 export const centerAlign = style({
   textAlign: 'center',
 });

--- a/app.client/src/pages/HomePage.tsx
+++ b/app.client/src/pages/HomePage.tsx
@@ -127,6 +127,8 @@ export const HomePage: React.FC = () => {
       timestamp: new Date(),
       properties: {
         cta_action: action,
+        entry_path: action === 'browse_pets' ? 'search' : action,
+        source: 'homepage_cta',
         user_authenticated: isAuthenticated,
         featured_pets_visible: featuredPets.length,
         hero_variant: showNewHero ? 'new_hero' : 'original_hero',
@@ -242,7 +244,7 @@ export const HomePage: React.FC = () => {
           </p>
           {isAuthenticated ? (
             <Link to='/search' onClick={() => handleCTAClick('browse_pets')}>
-              <Button size='lg' variant='secondary'>
+              <Button variant='outline' className={styles.ctaSecondaryButton}>
                 Browse Pets
               </Button>
             </Link>


### PR DESCRIPTION
## Summary

Adds short descriptions to the primary nav in `app.client` so first-time users can tell **Discover** ("Swipe through matches") from **Search** ("Filter and browse all pets"). Removes the duplicate primary Browse CTA on HomePage so there is a single visually-primary path. Adds analytics that distinguish each entry path so we can measure whether the change improves usage.

## Decision: keep both, clarify with copy

Three options were considered:

1. **Keep both nav items, clarify with copy** *(picked)* — Discover (swipe / lean-back / algorithmic) and Search (filter grid / lean-forward / explicit query) serve genuinely different user goals. The confusion is a labelling problem, not a structural one, so it is solvable with a short subtitle/tooltip plus better-distinguished CTAs.
2. Fold Discover into Search as a view toggle — would lose the swipe affordance as a top-level entry and bury the AI matching pitch. Rejected as too destructive for a copy-clarity ticket.
3. Hide one behind a feature flag — defers the decision without educating the user. Rejected.

If post-launch analytics show one path is dominant, options 2/3 become viable follow-ups using the new `navigation.primary_nav_clicked` event with `entry_path` properties.

## Changes

- `AppNavbar`: Discover and Search nav links now carry a `description` ("Swipe through matches" / "Filter and browse all pets") rendered as a native `title` tooltip plus an sr-only hint for assistive tech. Each click dispatches `navigation.primary_nav_clicked` with `entry_path: 'discover' | 'search' | 'favorites'`.
- `NavLink`: new optional `description` prop. Surgical, additive — no existing call-sites change behaviour.
- `SwipeHero` (legacy homepage hero): same tooltip strings on the two CTAs and a new `homepage.hero_cta_clicked` event tagged with `entry_path` and `source: 'swipe_hero'`.
- `HomePage`: bottom "Browse Pets" CTA (authenticated state) downgraded from `size='lg' variant='secondary'` to `variant='outline'` so only the hero CTA reads as the page's primary Browse action. "View All Pets" was already outline. Added `entry_path` + `source` properties to existing CTA tracking.
- Test mocks: added `useAnalytics` mocks to `AppNavbar.test.tsx`, `AppShell.test.tsx`, and `application-routing.behavior.test.tsx` because AppNavbar now depends on `AnalyticsContext`.

Intentionally **not** touched: the navbar's set of items, BottomTabBar (ADS-636 may iterate on it), and any adjacent code/styling.

## Acceptance criteria

- [x] Each nav item has a subtitle/tooltip describing what it does
- [x] HomePage has at most one primary "Browse" CTA; secondary entry points are visually de-prioritised
- [x] Decision recorded above with rationale
- [x] Analytics events distinguish each entry path (`navigation.primary_nav_clicked` with `entry_path`; `homepage.hero_cta_clicked` with `entry_path`/`source`; `homepage.cta_clicked` now includes `entry_path`/`source`)

## Assumptions

- Native `title` tooltips are acceptable — there is no shared `Tooltip` component in `lib.components` and the existing nav uses `aria-label`/title patterns only. If a styled tooltip is preferred, the `description` prop on `NavLink` is the single integration point.
- The bottom "Browse Pets" CTA on HomePage should remain (still useful as a fallback at end-of-page), just visually subordinated. If product would rather remove it entirely, that is a one-line follow-up.
- `app.client/src/__tests__/distance-sorting.behavior.test.tsx > "shows error when typed location cannot be geocoded"` is a pre-existing flaky test (5s timeout under parallel load). It passes in isolation and on `main` and is unrelated to this change.

## Test plan

- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.client` — lint and type-check pass; 354/354 tests pass.
- [x] New AppNavbar tests cover the tooltip strings and distinct analytics events for Discover vs Search.
- [ ] Manual: hover Discover/Search in the navbar, confirm tooltip copy.
- [ ] Manual: load `/`, confirm only one large filled Browse CTA in the hero; subsequent Browse entries are outline.
- [ ] Manual: click each entry path, confirm distinct analytics events in dev tools.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_