### PR TITLE
ADS-638: Show signed-out state on PetDetailsPage instead of post-click login modal

### DIFF
--- a/app.client/src/pages/LoginPage.test.tsx
+++ b/app.client/src/pages/LoginPage.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AuthContext, type AuthContextType } from '@adopt-dont-shop/lib.auth';
@@ -67,5 +67,89 @@ describe('LoginPage social sign-in', () => {
     await user.click(screen.getByRole('button', { name: /sign in with google/i }));
 
     expect(screen.getByText(/google sign-in is a dev placeholder/i)).toBeInTheDocument();
+  });
+});
+
+/**
+ * ADS-638: When a signed-out user lands on `/login?redirect=…`, the
+ * LoginPage must send them back to that path on success — but only
+ * if the path is safe (same-origin, no protocol-relative URLs).
+ */
+describe('LoginPage redirect query param', () => {
+  const authenticatedAuthValue: AuthContextType = {
+    user: {
+      userId: 'u-1',
+      email: 'user@example.com',
+      firstName: 'A',
+      lastName: 'B',
+      userType: 'adopter',
+      emailVerified: true,
+      status: 'active',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    },
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    updateProfile: vi.fn(),
+    refreshUser: vi.fn(),
+  };
+
+  const LocationProbe = () => {
+    const location = useLocation();
+    return (
+      <div data-testid='probe'>
+        {location.pathname}
+        {location.search}
+      </div>
+    );
+  };
+
+  const renderWithEntry = (entry: string) =>
+    render(
+      <ThemeProvider>
+        <AuthContext.Provider value={authenticatedAuthValue}>
+          <MemoryRouter initialEntries={[entry]}>
+            <Routes>
+              <Route path='/login' element={<LoginPage />} />
+              <Route path='*' element={<LocationProbe />} />
+            </Routes>
+          </MemoryRouter>
+        </AuthContext.Provider>
+      </ThemeProvider>
+    );
+
+  it('redirects an already-authenticated user to the safe redirect path', async () => {
+    renderWithEntry('/login?redirect=/apply/pet-1');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toBe('/apply/pet-1');
+    });
+  });
+
+  it('preserves nested query strings on the redirect target', async () => {
+    renderWithEntry(`/login?redirect=${encodeURIComponent('/pets/pet-1?action=contact')}`);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toBe('/pets/pet-1?action=contact');
+    });
+  });
+
+  it('ignores protocol-relative redirect targets to prevent open redirects', async () => {
+    renderWithEntry('/login?redirect=//evil.com/steal');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toBe('/');
+    });
+  });
+
+  it('ignores absolute external URLs in the redirect param', async () => {
+    renderWithEntry(`/login?redirect=${encodeURIComponent('https://evil.com/steal')}`);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toBe('/');
+    });
   });
 });

--- a/app.client/src/pages/LoginPage.tsx
+++ b/app.client/src/pages/LoginPage.tsx
@@ -1,14 +1,36 @@
 import { AuthLayout, LoginForm, SocialSignInButtons, useAuth } from '@adopt-dont-shop/lib.auth';
 import React, { useEffect } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import * as styles from './LoginPage.css';
+
+// ADS-638: callers can pass `?redirect=<path>` to bring the user back to
+// where they came from (e.g. a pet details page) so the original action
+// can resume after sign-in. We only accept same-origin paths to prevent
+// open-redirect abuse — a leading `/` followed by anything other than
+// `/` or `\` is required.
+const isSafeRedirectPath = (value: string | null): value is string => {
+  if (!value) {
+    return false;
+  }
+  if (!value.startsWith('/')) {
+    return false;
+  }
+  // Block protocol-relative URLs like `//evil.com` and back-slash variants.
+  if (value.startsWith('//') || value.startsWith('/\\')) {
+    return false;
+  }
+  return true;
+};
 
 export const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const [searchParams] = useSearchParams();
   const { isAuthenticated } = useAuth();
 
-  const from = location.state?.from?.pathname || '/';
+  const redirectParam = searchParams.get('redirect');
+  const safeRedirect = isSafeRedirectPath(redirectParam) ? redirectParam : null;
+  const from = safeRedirect ?? location.state?.from?.pathname ?? '/';
 
   useEffect(() => {
     if (isAuthenticated) {

--- a/app.client/src/pages/PetDetailsPage.test.tsx
+++ b/app.client/src/pages/PetDetailsPage.test.tsx
@@ -2,6 +2,11 @@
  * ADS-587: When chat init fails on the pet details page, we surface a
  * `toast.error` with a "Retry" action — replacing the legacy native alert.
  * Chat init failures are usually transient, so the retry is genuinely useful.
+ *
+ * ADS-638: Signed-out users now see auth-aware CTAs that route to
+ * `/login?redirect=…` rather than opening a post-click modal. After
+ * sign-in the user returns to the pet page (for contact) or jumps to
+ * the application flow (for apply).
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@/test-utils/render';
@@ -11,6 +16,10 @@ import { toast } from '@adopt-dont-shop/lib.components';
 const startConversationMock = vi.fn();
 const getPetByIdMock = vi.fn();
 const isFavoriteMock = vi.fn();
+
+const authStateMock = {
+  isAuthenticated: true,
+};
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -28,8 +37,8 @@ vi.mock('@adopt-dont-shop/lib.auth', async () => {
   return {
     ...actual,
     useAuth: () => ({
-      user: { userId: 'u-1', email: 'a@b.c' },
-      isAuthenticated: true,
+      user: authStateMock.isAuthenticated ? { userId: 'u-1', email: 'a@b.c' } : null,
+      isAuthenticated: authStateMock.isAuthenticated,
       isLoading: false,
       login: vi.fn(),
       register: vi.fn(),
@@ -88,6 +97,7 @@ const isActionObject = (
 
 describe('PetDetailsPage chat init failure', () => {
   beforeEach(() => {
+    authStateMock.isAuthenticated = true;
     startConversationMock.mockReset();
     getPetByIdMock.mockReset();
     isFavoriteMock.mockReset();
@@ -129,5 +139,105 @@ describe('PetDetailsPage chat init failure', () => {
     if (isActionObject(action)) {
       expect(action.label).toBe('Retry');
     }
+  });
+});
+
+describe('PetDetailsPage signed-out CTAs (ADS-638)', () => {
+  beforeEach(() => {
+    authStateMock.isAuthenticated = false;
+    startConversationMock.mockReset();
+    getPetByIdMock.mockReset();
+    isFavoriteMock.mockReset();
+
+    getPetByIdMock.mockResolvedValue({
+      pet_id: 'pet-1',
+      name: 'Luna',
+      type: 'dog',
+      status: 'available',
+      rescue_id: 'rescue-1',
+      images: [],
+    });
+    isFavoriteMock.mockResolvedValue(false);
+  });
+
+  it('still renders pet details for a signed-out visitor (deep-link sharing works)', async () => {
+    render(<PetDetailsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1, name: /luna/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows a "Sign in to apply" CTA linking to /login with a return URL to the apply page', async () => {
+    render(<PetDetailsPage />);
+
+    const applyLink = await screen.findByRole('link', { name: /sign in to apply/i });
+    expect(applyLink).toHaveAttribute(
+      'href',
+      `/login?redirect=${encodeURIComponent('/apply/pet-1')}`
+    );
+  });
+
+  it('shows a "Sign in to message rescue" CTA that returns the user back to the pet page with action=contact', async () => {
+    render(<PetDetailsPage />);
+
+    const contactLink = await screen.findByRole('link', { name: /sign in to message rescue/i });
+    expect(contactLink).toHaveAttribute(
+      'href',
+      `/login?redirect=${encodeURIComponent('/pets/pet-1?action=contact')}`
+    );
+  });
+
+  it('does not show the original "Apply to Adopt" or "Contact Rescue" buttons to signed-out users', async () => {
+    render(<PetDetailsPage />);
+
+    await screen.findByRole('link', { name: /sign in to apply/i });
+
+    expect(screen.queryByRole('link', { name: /^apply to adopt$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^contact rescue$/i })).not.toBeInTheDocument();
+  });
+
+  it('does not open a login modal when the page renders for a signed-out visitor', async () => {
+    render(<PetDetailsPage />);
+
+    await screen.findByRole('link', { name: /sign in to apply/i });
+
+    expect(
+      screen.queryByRole('heading', { name: /join adopt don't shop/i })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('PetDetailsPage signed-in CTAs (ADS-638 regression)', () => {
+  beforeEach(() => {
+    authStateMock.isAuthenticated = true;
+    startConversationMock.mockReset();
+    getPetByIdMock.mockReset();
+    isFavoriteMock.mockReset();
+
+    getPetByIdMock.mockResolvedValue({
+      pet_id: 'pet-1',
+      name: 'Luna',
+      type: 'dog',
+      status: 'available',
+      rescue_id: 'rescue-1',
+      images: [],
+    });
+    isFavoriteMock.mockResolvedValue(false);
+  });
+
+  it('renders the "Apply to Adopt" link pointing at the apply route', async () => {
+    render(<PetDetailsPage />);
+
+    const applyLink = await screen.findByRole('link', { name: /^apply to adopt$/i });
+    expect(applyLink).toHaveAttribute('href', '/apply/pet-1');
+  });
+
+  it('renders the "Contact Rescue" button for signed-in users', async () => {
+    render(<PetDetailsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^contact rescue$/i })).toBeInTheDocument();
+    });
   });
 });

--- a/app.client/src/pages/PetDetailsPage.tsx
+++ b/app.client/src/pages/PetDetailsPage.tsx
@@ -4,13 +4,111 @@ import { useChat } from '@/contexts/ChatContext';
 import { useStatsig } from '@/hooks/useStatsig';
 import { petService, Pet } from '@/services';
 import { Badge, Button, Card, toast } from '@adopt-dont-shop/lib.components';
-import React, { useEffect, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
-import { LoginPromptModal } from '../components/modals/LoginPromptModal';
+import React, { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { resolveFileUrl } from '../utils/fileUtils';
 import * as styles from './PetDetailsPage.css';
 
 interface PetDetailsPageProps {}
+
+// ADS-638: signed-out visitors must see auth-aware CTAs that route to
+// `/login?redirect=<returnPath>` so the original action resumes after
+// sign-in. The Apply flow redirects straight to `/apply/:petId`;
+// Contact returns to the pet details page with `?action=contact`,
+// which we auto-trigger once auth completes.
+const buildApplyLoginPath = (petId: string): string =>
+  `/login?redirect=${encodeURIComponent(`/apply/${petId}`)}`;
+
+const buildContactLoginPath = (petId: string): string =>
+  `/login?redirect=${encodeURIComponent(`/pets/${petId}?action=contact`)}`;
+
+type ApplyCtaProps = {
+  isAuthenticated: boolean;
+  isUnverified: boolean;
+  verificationTooltip: string;
+  petId: string;
+  onApplyClick: () => void;
+};
+
+const renderApplyCta = ({
+  isAuthenticated,
+  isUnverified,
+  verificationTooltip,
+  petId,
+  onApplyClick,
+}: ApplyCtaProps): React.ReactNode => {
+  if (isUnverified) {
+    return (
+      <Button
+        className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
+        variant='primary'
+        size='lg'
+        disabled
+        title={verificationTooltip}
+      >
+        Apply to Adopt
+      </Button>
+    );
+  }
+  if (!isAuthenticated) {
+    return (
+      <Link
+        className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
+        to={buildApplyLoginPath(petId)}
+      >
+        Sign in to apply
+      </Link>
+    );
+  }
+  return (
+    <Link
+      className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
+      to={`/apply/${petId}`}
+      onClick={onApplyClick}
+    >
+      Apply to Adopt
+    </Link>
+  );
+};
+
+type ContactCtaProps = {
+  isAuthenticated: boolean;
+  isUnverified: boolean;
+  verificationTooltip: string;
+  petId: string;
+  onContactClick: () => void;
+};
+
+const renderContactCta = ({
+  isAuthenticated,
+  isUnverified,
+  verificationTooltip,
+  petId,
+  onContactClick,
+}: ContactCtaProps): React.ReactNode => {
+  if (!isAuthenticated) {
+    return (
+      <Link
+        className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
+        to={buildContactLoginPath(petId)}
+      >
+        Sign in to message rescue
+      </Link>
+    );
+  }
+  return (
+    <Button
+      className={styles.contactButton}
+      variant='primary'
+      size='lg'
+      onClick={onContactClick}
+      disabled={isUnverified}
+      title={isUnverified ? verificationTooltip : undefined}
+    >
+      Contact Rescue
+    </Button>
+  );
+};
 
 export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
   const { id } = useParams<{ id: string }>();
@@ -24,9 +122,13 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [isFavorite, setIsFavorite] = useState(false);
   const [favoriteLoading, setFavoriteLoading] = useState(false);
-  const [showLoginPrompt, setShowLoginPrompt] = useState(false);
-  const [loginPromptAction, setLoginPromptAction] = useState('apply for adoption');
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  // ADS-638: after a signed-out user clicks "Sign in to message rescue"
+  // and completes auth, they land back here with `?action=contact`. We
+  // auto-trigger the contact flow once (per page load) so they don't
+  // have to click again.
+  const pendingContactRef = useRef(false);
 
   // Use real browser history so the back button returns to wherever the
   // user actually came from (favourites, home, search). Falls back to the
@@ -173,8 +275,6 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
       return;
     }
     if (!isAuthenticated) {
-      setLoginPromptAction('contact this rescue');
-      setShowLoginPrompt(true);
       return;
     }
 
@@ -227,6 +327,30 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
     }
   };
 
+  // ADS-638: resume the original action when a signed-out user returns
+  // from `/login?redirect=…&action=contact`. We strip the param off the
+  // URL after firing so refreshing the page doesn't re-trigger the
+  // chat creation flow.
+  useEffect(() => {
+    if (!isAuthenticated || !pet?.rescue_id) {
+      return;
+    }
+    if (searchParams.get('action') !== 'contact') {
+      return;
+    }
+    if (pendingContactRef.current) {
+      return;
+    }
+    pendingContactRef.current = true;
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete('action');
+    setSearchParams(nextParams, { replace: true });
+    void handleContactRescue();
+    // handleContactRescue is recreated on every render but is stable
+    // enough for this one-shot resume — guarded by pendingContactRef.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, pet?.rescue_id, searchParams]);
+
   const handleImageSelect = (index: number) => {
     setSelectedImageIndex(index);
 
@@ -243,15 +367,7 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
     }
   };
 
-  const handleApplyClick = (e: React.MouseEvent) => {
-    // Check if user is authenticated
-    if (!isAuthenticated) {
-      e.preventDefault();
-      setLoginPromptAction('apply for adoption');
-      setShowLoginPrompt(true);
-      return;
-    }
-
+  const handleApplyClick = () => {
     if (pet) {
       // Track with new analytics service
       trackEvent({
@@ -284,10 +400,6 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
         user_authenticated: isAuthenticated.toString(),
       });
     }
-  };
-
-  const handleCloseLoginPrompt = () => {
-    setShowLoginPrompt(false);
   };
 
   const handleRescueProfileClick = () => {
@@ -543,25 +655,13 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
                   )}
                   <div className='actions'>
                     {pet.status === 'available' &&
-                      (isUnverified ? (
-                        <Button
-                          className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
-                          variant='primary'
-                          size='lg'
-                          disabled
-                          title={verificationTooltip}
-                        >
-                          Apply to Adopt
-                        </Button>
-                      ) : (
-                        <Link
-                          className={`${styles.actionLink} ${styles.actionLinkPrimary} ${styles.actionLinkLarge}`}
-                          to={`/apply/${pet.pet_id}`}
-                          onClick={handleApplyClick}
-                        >
-                          Apply to Adopt
-                        </Link>
-                      ))}
+                      renderApplyCta({
+                        isAuthenticated,
+                        isUnverified,
+                        verificationTooltip,
+                        petId: pet.pet_id,
+                        onApplyClick: handleApplyClick,
+                      })}
                     {pet.rescue_id && (
                       <Link
                         className={`${styles.actionLink} ${styles.actionLinkOutline}`}
@@ -571,18 +671,14 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
                         View Rescue Profile
                       </Link>
                     )}
-                    {pet.rescue_id && (
-                      <Button
-                        className={styles.contactButton}
-                        variant='primary'
-                        size='lg'
-                        onClick={handleContactRescue}
-                        disabled={isUnverified}
-                        title={isUnverified ? verificationTooltip : undefined}
-                      >
-                        Contact Rescue
-                      </Button>
-                    )}
+                    {pet.rescue_id &&
+                      renderContactCta({
+                        isAuthenticated,
+                        isUnverified,
+                        verificationTooltip,
+                        petId: pet.pet_id,
+                        onContactClick: handleContactRescue,
+                      })}
                   </div>
                 </>
               );
@@ -597,12 +693,6 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
           </Card>
         )}
       </div>
-
-      <LoginPromptModal
-        isOpen={showLoginPrompt}
-        onClose={handleCloseLoginPrompt}
-        action={loginPromptAction}
-      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Replaces the post-click `LoginPromptModal` on `PetDetailsPage` with auth-aware CTAs so signed-out visitors see their next step before clicking. After sign-in, the user resumes the original action automatically.

- "Apply to Adopt" -> "Sign in to apply" (links to `/login?redirect=/apply/:petId`)
- "Contact Rescue" -> "Sign in to message rescue" (links to `/login?redirect=/pets/:petId?action=contact`)
- After login the user is sent back; if `?action=contact` is present on the pet page and they're authenticated, the chat flow auto-fires once and the param is stripped from the URL.
- `LoginPage` now reads `?redirect=` and sanitises it (path must start with `/` and cannot be protocol-relative or absolute), preventing open-redirect abuse.
- `LoginPromptModal` remains in the codebase (still used by `PetCard`) but is no longer wired into `PetDetailsPage`.

## Acceptance criteria

- [x] Signed-out CTAs render as "Sign in to apply" / "Sign in to message rescue"
- [x] Clicking routes to `/login` with a return URL that brings the user back and triggers the original action automatically
- [x] The login modal pattern is removed from this page (only `PetCard` still uses the modal for unrelated flows)
- [x] Direct deep-link sharing still works for signed-out users (page renders fully, only the CTAs change)

## Assumptions

- Apply flow: after sign-in, `/apply/:petId` already gates on auth itself, so no auto-trigger is needed - we just land the user there directly.
- Contact flow: the chat creation needs the loaded pet + an authenticated user, so we deep-link back to `/pets/:petId?action=contact` and let the page resume the action. The `action` param is removed from the URL after firing so a refresh doesn't re-open chat.
- "View Rescue Profile" is left unchanged - it's a public link and doesn't require auth.
- Open-redirect protection rejects any `redirect` value that doesn't begin with a single `/` (also blocks `//evil.com` and `/\evil` variants). External absolute URLs fall back to `/`.
- ADS-639 will rework CTA hierarchy on this page; this PR keeps existing button order and styling so the two changes don't collide.

## Test plan

- [x] Vitest covers signed-out and signed-in rendering on `PetDetailsPage`, plus the LoginPage redirect sanitisation (safe path, nested query string, protocol-relative URL, absolute external URL).
- [x] `npx turbo lint type-check --filter=@adopt-dont-shop/app.client` passes.
- [x] `npx turbo test --filter=@adopt-dont-shop/app.client` passes (363/363; one geocoding test flakes under full-suite concurrency on both main and this branch).
- [ ] Manual smoke: sign out, open a pet page, click "Sign in to message rescue", finish login, confirm chat opens.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_