### PR TITLE
ADS-651: Consistent bulk-action reasons across user management

### DIFF
--- a/app.admin/src/__tests__/bulk-operations.behavior.test.tsx
+++ b/app.admin/src/__tests__/bulk-operations.behavior.test.tsx
@@ -477,7 +477,7 @@ describe('Bulk operations — Rescues page', () => {
       await user.click(within(toolbar).getByRole('button', { name: /^approve$/i }));
 
       expect(screen.getByTestId('bulk-confirmation-modal')).toBeInTheDocument();
-      expect(screen.getByTestId('modal-title')).toHaveTextContent('Approve Rescues');
+      expect(screen.getByTestId('modal-title')).toHaveTextContent(/Approve \d+ rescues?\?/);
     });
 
     it('opens the confirmation modal when Suspend is clicked', async () => {
@@ -493,7 +493,7 @@ describe('Bulk operations — Rescues page', () => {
       await user.click(within(toolbar).getByRole('button', { name: /^suspend$/i }));
 
       expect(screen.getByTestId('bulk-confirmation-modal')).toBeInTheDocument();
-      expect(screen.getByTestId('modal-title')).toHaveTextContent('Suspend Rescues');
+      expect(screen.getByTestId('modal-title')).toHaveTextContent(/Suspend \d+ rescues?\?/);
     });
 
     it('calls bulkUpdateRescues when Approve is confirmed', async () => {
@@ -512,6 +512,122 @@ describe('Bulk operations — Rescues page', () => {
       await waitFor(() => {
         expect(mockMutationResult.mutateAsync).toHaveBeenCalled();
       });
+    });
+  });
+});
+
+// ── ADS-651: consistent bulk-action reasons ───────────────────────────────────
+
+describe('ADS-651 — bulk-action reasons are required and captured', () => {
+  beforeEach(() => {
+    mockMutationResult.mutateAsync.mockClear();
+    setupUsers();
+    setupRescues();
+  });
+
+  describe('Users page', () => {
+    it.each([
+      ['activate', /^activate$/i],
+      ['deactivate', /^deactivate$/i],
+      ['delete', /^delete$/i],
+    ])('requires a reason when bulk %s is triggered', async (_label, buttonName) => {
+      const user = userEvent.setup();
+      renderWithProviders(<Users />);
+
+      await user.click(screen.getAllByRole('checkbox')[1]);
+      const toolbar = screen.getByRole('toolbar', { name: /bulk actions/i });
+      await user.click(within(toolbar).getByRole('button', { name: buttonName }));
+
+      // The modal renders a reason textarea — proves requireReason is on
+      // for this action.
+      expect(screen.getByTestId('reason-textarea')).toBeInTheDocument();
+    });
+
+    it.each([
+      ['activate', /^activate$/i],
+      ['deactivate', /^deactivate$/i],
+    ])(
+      'passes the captured reason through to bulkUpdateUsers for %s',
+      async (_label, buttonName) => {
+        const user = userEvent.setup();
+        renderWithProviders(<Users />);
+
+        await user.click(screen.getAllByRole('checkbox')[1]);
+        const toolbar = screen.getByRole('toolbar', { name: /bulk actions/i });
+        await user.click(within(toolbar).getByRole('button', { name: buttonName }));
+        await user.click(screen.getByTestId('confirm-btn'));
+
+        await waitFor(() => {
+          expect(mockMutationResult.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({ reason: 'test reason' })
+          );
+        });
+      }
+    );
+
+    it('shows confirmation copy that names the action and the row count', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<Users />);
+
+      // Select two rows.
+      await user.click(screen.getAllByRole('checkbox')[1]);
+      await user.click(screen.getAllByRole('checkbox')[2]);
+      const toolbar = screen.getByRole('toolbar', { name: /bulk actions/i });
+      await user.click(within(toolbar).getByRole('button', { name: /^deactivate$/i }));
+
+      // Title states the action and the count explicitly.
+      expect(screen.getByTestId('modal-title')).toHaveTextContent(/Deactivate 2 users\?/);
+      expect(screen.getByTestId('modal-count')).toHaveTextContent('2 items selected');
+    });
+  });
+
+  describe('Rescues page', () => {
+    it.each([
+      ['approve', /^approve$/i],
+      ['suspend', /^suspend$/i],
+    ])('requires a reason when bulk %s is triggered', async (_label, buttonName) => {
+      const user = userEvent.setup();
+      renderWithProviders(<Rescues />);
+      await waitFor(() => {
+        expect(screen.getByText('Happy Paws')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getAllByRole('checkbox')[1]);
+      const toolbar = screen.getByRole('toolbar', { name: /bulk actions/i });
+      await user.click(within(toolbar).getByRole('button', { name: buttonName }));
+
+      expect(screen.getByTestId('reason-textarea')).toBeInTheDocument();
+    });
+
+    it.each([
+      ['approve', /^approve$/i],
+      ['suspend', /^suspend$/i],
+    ])('passes the reason through to bulkUpdateRescues for %s', async (action, buttonName) => {
+      const user = userEvent.setup();
+      renderWithProviders(<Rescues />);
+      await waitFor(() => {
+        expect(screen.getByText('Happy Paws')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getAllByRole('checkbox')[1]);
+      const toolbar = screen.getByRole('toolbar', { name: /bulk actions/i });
+      await user.click(within(toolbar).getByRole('button', { name: buttonName }));
+      await user.click(screen.getByTestId('confirm-btn'));
+
+      await waitFor(() => {
+        expect(mockMutationResult.mutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({ action, reason: 'test reason' })
+        );
+      });
+    });
+  });
+
+  describe('Single-row actions are unchanged', () => {
+    it('still renders the per-row actions menu and edit/email buttons', () => {
+      renderWithProviders(<Users />);
+      // Per-row UserActionsMenu (mocked) is present for every row.
+      expect(screen.getByTestId('actions-user-1')).toBeInTheDocument();
+      expect(screen.getByTestId('actions-user-2')).toBeInTheDocument();
     });
   });
 });

--- a/app.admin/src/hooks/useUsers.ts
+++ b/app.admin/src/hooks/useUsers.ts
@@ -140,10 +140,12 @@ export const useBulkUpdateUsers = () => {
     mutationFn: ({
       userIds,
       updates,
+      reason,
     }: {
       userIds: string[];
       updates: { userType?: string; is_active?: boolean };
-    }) => userManagementService.bulkUpdateUsers(userIds, updates),
+      reason?: string;
+    }) => userManagementService.bulkUpdateUsers(userIds, updates, reason),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['users'] });
     },

--- a/app.admin/src/pages/Applications.tsx
+++ b/app.admin/src/pages/Applications.tsx
@@ -266,18 +266,30 @@ const Applications: React.FC = () => {
         isOpen={bulkAction !== null}
         onClose={handleBulkModalClose}
         onConfirm={handleBulkConfirm}
-        title={bulkAction === 'approve' ? 'Approve Applications' : 'Reject Applications'}
-        description={
-          bulkAction === 'approve'
-            ? 'Approve the selected adoption applications.'
-            : 'Reject the selected adoption applications. Applicants will be notified.'
-        }
+        title={(() => {
+          const count = selectedRows.size;
+          const noun = `${count} application${count !== 1 ? 's' : ''}`;
+          return bulkAction === 'approve' ? `Approve ${noun}?` : `Reject ${noun}?`;
+        })()}
+        description={(() => {
+          const count = selectedRows.size;
+          const noun = `${count} adoption application${count !== 1 ? 's' : ''}`;
+          if (bulkAction === 'approve') {
+            return `This will approve ${noun}. Applicants will be notified of the decision.`;
+          }
+          return `This will reject ${noun}. Applicants will be notified of the decision.`;
+        })()}
         selectedCount={selectedRows.size}
         confirmLabel={bulkAction === 'approve' ? 'Approve Applications' : 'Reject Applications'}
         variant={bulkAction === 'reject' ? 'danger' : 'info'}
-        requireReason={bulkAction === 'reject'}
-        reasonLabel='Rejection reason'
-        reasonPlaceholder='Explain why these applications are being rejected...'
+        // ADS-651: every bulk state-change records a reason in the audit log.
+        requireReason
+        reasonLabel={bulkAction === 'approve' ? 'Reason for approval' : 'Reason for rejection'}
+        reasonPlaceholder={
+          bulkAction === 'approve'
+            ? 'Explain why these applications are being approved...'
+            : 'Explain why these applications are being rejected...'
+        }
         isLoading={bulkUpdateApplications.isPending}
         resultSummary={bulkResult}
       />

--- a/app.admin/src/pages/Pets.tsx
+++ b/app.admin/src/pages/Pets.tsx
@@ -82,7 +82,7 @@ const Pets: React.FC = () => {
 
   const pets: AdminPet[] = data?.data ?? [];
 
-  const handleBulkConfirm = async (): Promise<void> => {
+  const handleBulkConfirm = async (reason?: string): Promise<void> => {
     if (!bulkAction) {
       return;
     }
@@ -91,12 +91,13 @@ const Pets: React.FC = () => {
     let result: { successCount: number; failedCount: number };
 
     if (bulkAction === 'archive') {
-      result = await bulkUpdatePets.mutateAsync({ petIds, operation: 'archive' });
+      result = await bulkUpdatePets.mutateAsync({ petIds, operation: 'archive', reason });
     } else {
       result = await bulkUpdatePets.mutateAsync({
         petIds,
         operation: 'update_status',
         data: { status: bulkAction === 'publish' ? 'available' : 'not_available' },
+        reason,
       });
     }
 
@@ -313,13 +314,17 @@ const Pets: React.FC = () => {
           }
           return `Archive ${noun}?`;
         })()}
-        description={
-          bulkAction === 'publish'
-            ? 'Set the selected pets as available for adoption.'
-            : bulkAction === 'unpublish'
-              ? 'Set the selected pets as unavailable. They will no longer appear in listings.'
-              : 'Archive the selected pets. This marks them as inactive.'
-        }
+        description={(() => {
+          const count = selectedRows.size;
+          const noun = `${count} pet${count !== 1 ? 's' : ''}`;
+          if (bulkAction === 'publish') {
+            return `This will set ${noun} to available for adoption and they will appear in public listings.`;
+          }
+          if (bulkAction === 'unpublish') {
+            return `This will set ${noun} to unavailable and they will be removed from public listings.`;
+          }
+          return `This will archive ${noun} and mark them as inactive.`;
+        })()}
         selectedCount={selectedRows.size}
         confirmLabel={
           bulkAction === 'publish'
@@ -330,6 +335,22 @@ const Pets: React.FC = () => {
         }
         variant={
           bulkAction === 'archive' ? 'danger' : bulkAction === 'unpublish' ? 'warning' : 'info'
+        }
+        // ADS-651: every bulk state-change records a reason in the audit log.
+        requireReason
+        reasonLabel={
+          bulkAction === 'publish'
+            ? 'Reason for publishing'
+            : bulkAction === 'unpublish'
+              ? 'Reason for unpublishing'
+              : 'Reason for archiving'
+        }
+        reasonPlaceholder={
+          bulkAction === 'publish'
+            ? 'Explain why these pets are being published...'
+            : bulkAction === 'unpublish'
+              ? 'Explain why these pets are being unpublished...'
+              : 'Explain why these pets are being archived...'
         }
         isLoading={bulkUpdatePets.isPending}
         resultSummary={bulkResult}

--- a/app.admin/src/pages/Rescues.tsx
+++ b/app.admin/src/pages/Rescues.tsx
@@ -183,12 +183,16 @@ const Rescues: React.FC = () => {
     exportData(rescues, rescueExportColumns, 'rescues-export', 'Rescue Management Export', format);
   };
 
-  const handleBulkRescueConfirm = async (): Promise<void> => {
+  const handleBulkRescueConfirm = async (reason?: string): Promise<void> => {
     if (!bulkRescueAction) {
       return;
     }
     const rescueIds = Array.from(selectedRows);
-    const result = await bulkUpdateRescues.mutateAsync({ rescueIds, action: bulkRescueAction });
+    const result = await bulkUpdateRescues.mutateAsync({
+      rescueIds,
+      action: bulkRescueAction,
+      reason,
+    });
     setBulkResult({ succeeded: result.successCount, failed: result.failedCount });
     setSelectedRows(new Set());
     fetchRescues();
@@ -401,15 +405,32 @@ const Rescues: React.FC = () => {
         isOpen={bulkRescueAction !== null}
         onClose={handleBulkModalClose}
         onConfirm={handleBulkRescueConfirm}
-        title={bulkRescueAction === 'approve' ? 'Approve Rescues' : 'Suspend Rescues'}
-        description={
-          bulkRescueAction === 'approve'
-            ? 'Verify and approve the selected rescue organizations on the platform.'
-            : 'Suspend the selected rescue organizations. They will be unable to operate on the platform.'
-        }
+        title={(() => {
+          const count = selectedRows.size;
+          const noun = `${count} rescue${count !== 1 ? 's' : ''}`;
+          return bulkRescueAction === 'approve' ? `Approve ${noun}?` : `Suspend ${noun}?`;
+        })()}
+        description={(() => {
+          const count = selectedRows.size;
+          const noun = `${count} rescue organization${count !== 1 ? 's' : ''}`;
+          if (bulkRescueAction === 'approve') {
+            return `This will verify and approve ${noun}. They will be able to list pets and accept applications.`;
+          }
+          return `This will suspend ${noun}. They will be unable to operate on the platform until reinstated.`;
+        })()}
         selectedCount={selectedRows.size}
         confirmLabel={bulkRescueAction === 'approve' ? 'Approve Rescues' : 'Suspend Rescues'}
         variant={bulkRescueAction === 'suspend' ? 'danger' : 'info'}
+        // ADS-651: every bulk state-change records a reason in the audit log.
+        requireReason
+        reasonLabel={
+          bulkRescueAction === 'approve' ? 'Reason for approval' : 'Reason for suspension'
+        }
+        reasonPlaceholder={
+          bulkRescueAction === 'approve'
+            ? 'Explain why these rescues are being approved...'
+            : 'Explain why these rescues are being suspended...'
+        }
         isLoading={bulkUpdateRescues.isPending}
         resultSummary={bulkResult}
       />

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -276,11 +276,13 @@ const Users: React.FC = () => {
       result = await bulkUpdateUsers.mutateAsync({
         userIds,
         updates: { is_active: true },
+        reason,
       });
     } else if (bulkAction === 'deactivate') {
       result = await bulkUpdateUsers.mutateAsync({
         userIds,
         updates: { is_active: false },
+        reason,
       });
     } else {
       result = await Promise.all(
@@ -600,13 +602,17 @@ const Users: React.FC = () => {
           }
           return `Deactivate ${noun}?`;
         })()}
-        description={
-          bulkAction === 'delete'
-            ? 'This will permanently delete the selected users. This action cannot be undone.'
-            : bulkAction === 'activate'
-              ? 'Activate the selected user accounts.'
-              : 'Deactivate the selected user accounts. They will be unable to log in.'
-        }
+        description={(() => {
+          const count = selectedRows.size;
+          const noun = `${count} user account${count !== 1 ? 's' : ''}`;
+          if (bulkAction === 'delete') {
+            return `This will permanently delete ${noun}. This action cannot be undone.`;
+          }
+          if (bulkAction === 'activate') {
+            return `This will activate ${noun}. The affected users will regain access to the platform.`;
+          }
+          return `This will deactivate ${noun}. The affected users will be unable to log in until reactivated.`;
+        })()}
         selectedCount={selectedRows.size}
         confirmLabel={
           bulkAction === 'delete'
@@ -618,9 +624,22 @@ const Users: React.FC = () => {
         variant={
           bulkAction === 'delete' ? 'danger' : bulkAction === 'deactivate' ? 'warning' : 'info'
         }
-        requireReason={bulkAction === 'delete'}
-        reasonLabel='Reason for deletion'
-        reasonPlaceholder='Explain why these users are being deleted...'
+        // ADS-651: every bulk state-change records a reason in the audit log.
+        requireReason
+        reasonLabel={
+          bulkAction === 'delete'
+            ? 'Reason for deletion'
+            : bulkAction === 'activate'
+              ? 'Reason for activation'
+              : 'Reason for deactivation'
+        }
+        reasonPlaceholder={
+          bulkAction === 'delete'
+            ? 'Explain why these users are being deleted...'
+            : bulkAction === 'activate'
+              ? 'Explain why these users are being activated...'
+              : 'Explain why these users are being deactivated...'
+        }
         isLoading={bulkUpdateUsers.isPending || deleteUser.isPending}
         resultSummary={bulkResult}
       />

--- a/app.admin/src/services/userManagementService.ts
+++ b/app.admin/src/services/userManagementService.ts
@@ -235,12 +235,16 @@ class UserManagementService {
    */
   async bulkUpdateUsers(
     userIds: string[],
-    updates: { userType?: string; is_active?: boolean }
+    updates: { userType?: string; is_active?: boolean },
+    reason?: string
   ): Promise<{ success: number; failed: number }> {
     try {
+      // ADS-651: forward the operator-supplied reason so the backend
+      // bulk endpoint can persist it against each affected user's audit row.
       return await apiService.patch('/api/v1/admin/users/bulk-update', {
         user_ids: userIds,
         updates,
+        reason,
       });
     } catch (error) {
       console.error('❌ UserManagementService: Failed to bulk update users:', error);

--- a/lib.validation/src/schemas/__tests__/application.test.ts
+++ b/lib.validation/src/schemas/__tests__/application.test.ts
@@ -346,5 +346,25 @@ describe('Application schemas', () => {
       expect(parsed.updates.rejectionReason).toBe('duplicate application');
       expect(parsed.updates.finalOutcome).toBe('rejected');
     });
+
+    // ADS-651: operator-supplied reason flows through bulk endpoints.
+    it('accepts an optional reason string for the audit log', () => {
+      const parsed = ApplicationBulkUpdateRequestSchema.parse({
+        applicationIds: [someUuid],
+        updates: { status: 'approved' },
+        reason: 'Reviewed in weekly committee meeting',
+      });
+      expect(parsed.reason).toBe('Reviewed in weekly committee meeting');
+    });
+
+    it('rejects a reason longer than 500 characters', () => {
+      expect(() =>
+        ApplicationBulkUpdateRequestSchema.parse({
+          applicationIds: [someUuid],
+          updates: { status: 'approved' },
+          reason: 'x'.repeat(501),
+        })
+      ).toThrow();
+    });
   });
 });

--- a/lib.validation/src/schemas/__tests__/user.test.ts
+++ b/lib.validation/src/schemas/__tests__/user.test.ts
@@ -266,5 +266,36 @@ describe('User schemas', () => {
         })
       ).toThrow();
     });
+
+    // ADS-651: bulk-action reasons are accepted by the schema and capped
+    // so the audit log doesn't take unbounded text.
+    it('accepts an optional reason string for the audit log', () => {
+      const parsed = BulkUserUpdateRequestSchema.parse({
+        userIds: validUserIds,
+        updateData: { status: 'active' },
+        reason: 'Routine reactivation after policy review',
+      });
+      expect(parsed.reason).toBe('Routine reactivation after policy review');
+    });
+
+    it('rejects a reason longer than 500 characters', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: validUserIds,
+          updateData: { status: 'active' },
+          reason: 'x'.repeat(501),
+        })
+      ).toThrow();
+    });
+
+    it('rejects an empty-string reason', () => {
+      expect(() =>
+        BulkUserUpdateRequestSchema.parse({
+          userIds: validUserIds,
+          updateData: { status: 'active' },
+          reason: '   ',
+        })
+      ).toThrow();
+    });
   });
 });

--- a/lib.validation/src/schemas/application.ts
+++ b/lib.validation/src/schemas/application.ts
@@ -300,6 +300,9 @@ export const ApplicationBulkUpdateRequestSchema = z.object({
       notes: NotesSchema.optional(),
     })
     .refine((v) => Object.keys(v).length > 0, 'updates must contain at least one field to apply'),
+  // ADS-651: operator-supplied reason captured in the audit log for every
+  // application touched by the bulk update.
+  reason: z.string().trim().min(1, 'Reason is required').max(500).optional(),
 });
 export type ApplicationBulkUpdateRequest = z.infer<typeof ApplicationBulkUpdateRequestSchema>;
 

--- a/lib.validation/src/schemas/user.ts
+++ b/lib.validation/src/schemas/user.ts
@@ -235,5 +235,8 @@ export const BulkUserUpdateRequestSchema = z.object({
     .min(1, 'At least one user ID is required')
     .max(100, 'Cannot update more than 100 users at a time'),
   updateData: BulkUserUpdateDataSchema,
+  // ADS-651: capture the operator's reason for the bulk state change so it
+  // can be surfaced in the audit log alongside the per-user update list.
+  reason: z.string().trim().min(1, 'Reason is required').max(500).optional(),
 });
 export type BulkUserUpdateRequest = z.infer<typeof BulkUserUpdateRequestSchema>;

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -1259,6 +1259,67 @@ describe('ApplicationService - Business Logic', () => {
       // result.
       logSpy.mockRestore();
     });
+
+    // ADS-651: operator reason must be persisted on each application's
+    // audit row so the trail explains *why* every bulk-updated
+    // application changed state.
+    it('persists the operator-supplied reason on every per-application audit row', async () => {
+      const idA = 'app-reason-a';
+      const idB = 'app-reason-b';
+      const apps = [idA, idB].map(applicationId =>
+        createMockApplication(ApplicationStatus.SUBMITTED, { applicationId })
+      );
+
+      MockedApplication.findAll = vi.fn().mockResolvedValue(apps as never);
+      MockedApplication.update = vi.fn().mockResolvedValue([apps.length] as never);
+
+      const { AuditLogService } = await import('../../services/auditLog.service');
+      const logSpy = vi.spyOn(AuditLogService, 'log').mockResolvedValue(undefined as never);
+
+      const reason = 'Reviewed in weekly committee meeting';
+      await ApplicationService.bulkUpdateApplications(
+        {
+          applicationIds: [idA, idB],
+          updates: { status: ApplicationStatus.REJECTED },
+          reason,
+        },
+        'staff-123'
+      );
+
+      const detailsPerEntity = new Map<string, Record<string, unknown>>();
+      logSpy.mock.calls.forEach(([data]) => {
+        detailsPerEntity.set(data.entityId as string, data.details as Record<string, unknown>);
+      });
+
+      expect(detailsPerEntity.get(idA)).toMatchObject({ reason, bulk_operation: true });
+      expect(detailsPerEntity.get(idB)).toMatchObject({ reason, bulk_operation: true });
+
+      logSpy.mockRestore();
+    });
+
+    it('records reason as null when none is supplied', async () => {
+      const id = 'app-noreason';
+      const app = createMockApplication(ApplicationStatus.SUBMITTED, { applicationId: id });
+      MockedApplication.findAll = vi.fn().mockResolvedValue([app] as never);
+      MockedApplication.update = vi.fn().mockResolvedValue([1] as never);
+
+      const { AuditLogService } = await import('../../services/auditLog.service');
+      const logSpy = vi.spyOn(AuditLogService, 'log').mockResolvedValue(undefined as never);
+
+      await ApplicationService.bulkUpdateApplications(
+        {
+          applicationIds: [id],
+          updates: { priority: ApplicationPriority.HIGH },
+        },
+        'staff-123'
+      );
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const [call] = logSpy.mock.calls;
+      expect(call[0].details).toMatchObject({ reason: null, bulk_operation: true });
+
+      logSpy.mockRestore();
+    });
   });
 
   describe('Error Handling', () => {

--- a/service.backend/src/__tests__/services/user.service.test.ts
+++ b/service.backend/src/__tests__/services/user.service.test.ts
@@ -641,6 +641,90 @@ describe('UserService', () => {
         'Only super_admin can assign super_admin role'
       );
     });
+
+    // ADS-651: bulk state-change reasons must be captured per affected user
+    // so the audit trail explains *why* every row changed.
+    it('records the operator-supplied reason on each affected user audit row', async () => {
+      const userA = await User.create({
+        email: 'bulk-reason-a@example.com',
+        password: 'hashedpassword',
+        firstName: 'A',
+        lastName: 'User',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+      });
+      const userB = await User.create({
+        email: 'bulk-reason-b@example.com',
+        password: 'hashedpassword',
+        firstName: 'B',
+        lastName: 'User',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+      });
+      const admin = await User.create({
+        email: 'admin-reason@example.com',
+        password: 'hashedpassword',
+        firstName: 'Admin',
+        lastName: 'Reason',
+        userType: UserType.ADMIN,
+        status: UserStatus.ACTIVE,
+      });
+
+      const reason = 'Policy violation cleanup — Q1 2026';
+      const updates: BulkUserUpdateData[] = [
+        {
+          userIds: [userA.userId, userB.userId],
+          updates: { status: UserStatus.INACTIVE },
+          reason,
+        },
+      ];
+
+      await UserService.bulkUpdateUsers(updates, admin.userId);
+
+      const auditCalls = (AuditLogService.log as ReturnType<typeof vi.fn>).mock.calls.map(
+        c => c[0]
+      );
+      const bulkCalls = auditCalls.filter(c => c.action === 'BULK_UPDATE' && c.entity === 'User');
+
+      expect(bulkCalls).toHaveLength(2);
+      expect(bulkCalls.map(c => c.entityId).sort()).toEqual([userA.userId, userB.userId].sort());
+      bulkCalls.forEach(call => {
+        expect(call.details).toMatchObject({ reason, bulk_operation: true });
+      });
+    });
+
+    it('records reason as null when none is supplied', async () => {
+      const user = await User.create({
+        email: 'bulk-noreason@example.com',
+        password: 'hashedpassword',
+        firstName: 'No',
+        lastName: 'Reason',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+      });
+      const admin = await User.create({
+        email: 'admin-noreason@example.com',
+        password: 'hashedpassword',
+        firstName: 'Admin',
+        lastName: 'NoReason',
+        userType: UserType.ADMIN,
+        status: UserStatus.ACTIVE,
+      });
+
+      await UserService.bulkUpdateUsers(
+        [{ userIds: [user.userId], updates: { firstName: 'Renamed' } }],
+        admin.userId
+      );
+
+      const auditCalls = (AuditLogService.log as ReturnType<typeof vi.fn>).mock.calls.map(
+        c => c[0]
+      );
+      const bulkCall = auditCalls.find(
+        c => c.action === 'BULK_UPDATE' && c.entityId === user.userId
+      );
+      expect(bulkCall).toBeDefined();
+      expect(bulkCall?.details).toMatchObject({ reason: null });
+    });
   });
 
   describe('canUserSeePrivateData', () => {

--- a/service.backend/src/controllers/user.controller.ts
+++ b/service.backend/src/controllers/user.controller.ts
@@ -242,14 +242,14 @@ export class UserController {
    */
   async bulkUpdateUsers(req: AuthenticatedRequest, res: Response): Promise<void> {
     try {
-      const { userIds, updateData } = req.body;
+      const { userIds, updateData, reason } = req.body;
       const requestingUserId = req.user!.userId;
 
       // Prevent including own account in bulk operations
       UserService.validateBulkOperation(requestingUserId, userIds, 'update');
 
       const result = await UserService.bulkUpdateUsers(
-        [{ userIds, updates: updateData }],
+        [{ userIds, updates: updateData, reason }],
         requestingUserId
       );
       res.json(result);

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1930,7 +1930,13 @@ export class ApplicationService {
           action: 'BULK_UPDATE',
           entity: 'Application',
           entityId: application.applicationId,
-          details: { updates, bulk_operation: true },
+          // ADS-651: persist the operator's reason on each affected
+          // application's audit row so the trail tells you *why*.
+          details: {
+            updates,
+            bulk_operation: true,
+            reason: bulkUpdate.reason ?? null,
+          },
           userId,
           transaction: tx,
         });

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -1372,21 +1372,25 @@ export class UserService {
         individualHooks: true,
       });
 
-      // Log bulk update
-      await AuditLogService.log({
-        action: 'BULK_UPDATE',
-        entity: 'User',
-        entityId: 'multiple',
-        details: {
-          updateCount: updates.length,
-          updatedBy,
-          updates: updates[0].userIds.map(userId => ({
-            userId,
-            fields: Object.keys(updates[0].updates),
-          })),
-        },
-        userId: updatedBy,
-      });
+      // Log bulk update — ADS-651: per-user entries each carry the
+      // operator reason so the audit log captures *why* every affected
+      // user changed state, not just that they were part of a bulk job.
+      const reason = updates[0].reason ?? null;
+      await Promise.all(
+        updates[0].userIds.map(userId =>
+          AuditLogService.log({
+            action: 'BULK_UPDATE',
+            entity: 'User',
+            entityId: userId,
+            details: {
+              fields: Object.keys(updates[0].updates),
+              reason,
+              bulk_operation: true,
+            },
+            userId: updatedBy,
+          })
+        )
+      );
 
       if (loggerHelpers && loggerHelpers.logBusiness) {
         loggerHelpers.logBusiness(

--- a/service.backend/src/types/application.ts
+++ b/service.backend/src/types/application.ts
@@ -275,6 +275,8 @@ export interface BulkApplicationUpdate {
     notes?: string;
     actionedBy?: string;
   };
+  // ADS-651: operator reason recorded in the per-application audit log.
+  reason?: string;
 }
 
 export interface BulkApplicationResult {

--- a/service.backend/src/types/user.ts
+++ b/service.backend/src/types/user.ts
@@ -282,6 +282,8 @@ export interface UserCreateData {
 export interface BulkUserUpdateData {
   userIds: string[];
   updates: Partial<UserUpdateData>;
+  // ADS-651: operator reason recorded in the audit log for the bulk change.
+  reason?: string;
 }
 
 export interface UserActivitySummary {


### PR DESCRIPTION
## Summary

- Every bulk state-change on Users, Rescues, Pets, and Applications now requires an operator reason in the confirmation modal — closing the gap where bulk delete on Users required a reason but bulk activate / deactivate did not, and the same inconsistency on the other three pages.
- The captured reason is forwarded to the bulk-update endpoint and persisted on **each affected entity's** audit row so the trail tells you *why* every row changed.
- Per-action confirmation copy now names the action and the row count (e.g. "Deactivate 2 users?", "This will deactivate 2 user accounts. The affected users will be unable to log in until reactivated.").
- Single-row action flows (suspend, unsuspend, verify, delete, edit, message, etc.) are untouched.

## Endpoints & UIs changed

### Frontend — `app.admin`
- `pages/Users.tsx`, `Rescues.tsx`, `Pets.tsx`, `Applications.tsx`: `requireReason` on every bulk action, per-action labels/placeholders, action+count confirmation copy.
- `hooks/useUsers.ts`: `useBulkUpdateUsers` now accepts `reason`.
- `services/userManagementService.ts`: `bulkUpdateUsers` forwards `reason` to the backend payload.

### Backend — `service-backend`
- `BulkUserUpdateRequestSchema`, `ApplicationBulkUpdateRequestSchema` (lib.validation): accept an optional trimmed 1–500 char `reason`.
- `UserService.bulkUpdateUsers`: writes one `BULK_UPDATE` audit row **per affected userId** with the reason in `details` (replaces the previous single 'multiple' row).
- `ApplicationService.bulkUpdateApplications`: attaches `reason` to each per-application `BULK_UPDATE` audit row.
- Rescue and Pet bulk paths already audit-logged the reason; only the frontend was missing it.

## Acceptance criteria

- [x] All bulk state-change actions on Users, Rescues, Pets, and Applications capture a reason.
- [x] Reasons are stored in the audit log against each affected entity (per-row, not a single bulk summary).
- [x] Per-action confirmation copy clearly states what will change and on how many rows.
- [x] No regression to existing single-row action flows.

## Test plan

- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.admin --filter=@adopt-dont-shop/service-backend` passes (2693 backend tests pass; admin app tests pass).
- [x] Behavioural test: bulk activate / deactivate / delete on Users renders the reason textarea (requireReason on).
- [x] Behavioural test: bulk approve / suspend on Rescues renders the reason textarea.
- [x] Behavioural test: the captured reason is passed through to `bulkUpdateUsers` and `bulkUpdateRescues` mutations.
- [x] Backend behavioural test: `UserService.bulkUpdateUsers` records the operator reason on each affected user's audit row, and `null` when none is supplied.
- [x] Backend behavioural test: `ApplicationService.bulkUpdateApplications` persists the reason on every per-application audit row.
- [x] Schema test: `reason` is accepted, rejected when over 500 chars, rejected when empty/whitespace (User schema).
- [x] Existing single-row action menu still renders per row.

Linear: [ADS-651](https://linear.app/ideasquared/issue/ADS-651)

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_