### PR TITLE
ADS-636: Expose Top Picks in primary navigation when preferences are set

### DIFF
--- a/app.client/src/components/home/TopPicksHomeModule.test.tsx
+++ b/app.client/src/components/home/TopPicksHomeModule.test.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, screen, waitFor } from '@/test-utils/render';
+import { TopPicksHomeModule } from './TopPicksHomeModule';
+
+const authState = { isAuthenticated: false };
+const matchPreferencesState = { hasPreferences: false, isLoading: false };
+const apiGet = vi.fn();
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({ isAuthenticated: authState.isAuthenticated }),
+  };
+});
+
+vi.mock('@/hooks/useMatchPreferences', () => ({
+  useMatchPreferences: () => matchPreferencesState,
+}));
+
+vi.mock('@/services', () => ({
+  apiService: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+}));
+
+beforeEach(() => {
+  authState.isAuthenticated = false;
+  matchPreferencesState.hasPreferences = false;
+  matchPreferencesState.isLoading = false;
+  apiGet.mockReset();
+});
+
+describe('TopPicksHomeModule', () => {
+  it('renders nothing for signed-out users', () => {
+    const { container } = renderWithProviders(<TopPicksHomeModule />);
+    expect(container).toBeEmptyDOMElement();
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing for signed-in users without preferences', () => {
+    authState.isAuthenticated = true;
+    const { container } = renderWithProviders(<TopPicksHomeModule />);
+    expect(container).toBeEmptyDOMElement();
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('shows the Your top picks heading and See all link when preferences exist and picks load', async () => {
+    authState.isAuthenticated = true;
+    matchPreferencesState.hasPreferences = true;
+    apiGet.mockResolvedValueOnce({
+      data: [
+        {
+          petId: 'pet-1',
+          name: 'Rex',
+          type: 'dog',
+          ageGroup: 'adult',
+          size: 'medium',
+          score: 87,
+          reasons: [],
+          rescueName: 'Happy Rescue',
+        },
+      ],
+    });
+    renderWithProviders(<TopPicksHomeModule />);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /your top picks/i })).toBeInTheDocument()
+    );
+    expect(screen.getByRole('link', { name: /see all/i })).toHaveAttribute(
+      'href',
+      '/match/top-picks'
+    );
+    expect(screen.getByText('Rex')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the API returns an empty result', async () => {
+    authState.isAuthenticated = true;
+    matchPreferencesState.hasPreferences = true;
+    apiGet.mockResolvedValueOnce({ data: [] });
+    const { container } = renderWithProviders(<TopPicksHomeModule />);
+    await waitFor(() => expect(apiGet).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});

--- a/app.client/src/components/home/TopPicksHomeModule.tsx
+++ b/app.client/src/components/home/TopPicksHomeModule.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Card, Container, MatchReasonChips, Spinner } from '@adopt-dont-shop/lib.components';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+import type { MatchTopPick } from '@adopt-dont-shop/lib.matching';
+import { useMatchPreferences } from '@/hooks/useMatchPreferences';
+import { apiService } from '@/services';
+
+/**
+ * ADS-636: HomePage "Your top picks" module.
+ *
+ * Only renders for authenticated users with completed match preferences.
+ * Hides itself silently on errors/empty results so the home page stays
+ * usable. Acts as a discoverability surface for /match/top-picks.
+ */
+export const TopPicksHomeModule: React.FC = () => {
+  const { isAuthenticated } = useAuth();
+  const { hasPreferences } = useMatchPreferences();
+  const [picks, setPicks] = useState<MatchTopPick[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || !hasPreferences) {
+      return;
+    }
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setLoading(true);
+        setErrored(false);
+        const res = await apiService.get<{ data: MatchTopPick[] }>(
+          '/api/v1/match/top-picks?limit=3'
+        );
+        if (!cancelled) {
+          setPicks(res.data ?? []);
+        }
+      } catch {
+        if (!cancelled) {
+          setErrored(true);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, hasPreferences]);
+
+  if (!isAuthenticated || !hasPreferences || errored) {
+    return null;
+  }
+  if (!loading && picks.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby='top-picks-home-heading'>
+      <Container>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+            marginBottom: '1rem',
+          }}
+        >
+          <h2 id='top-picks-home-heading'>Your top picks</h2>
+          <Link to='/match/top-picks'>See all</Link>
+        </div>
+        {loading ? (
+          <Spinner />
+        ) : (
+          <div style={{ display: 'grid', gap: '1rem' }}>
+            {picks.map(pick => (
+              <Card key={pick.petId}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  <div>
+                    <Link to={`/pets/${pick.petId}`}>
+                      <h3>{pick.name}</h3>
+                    </Link>
+                    <p>
+                      {pick.type} · {pick.ageGroup} · {pick.size} · {pick.rescueName}
+                    </p>
+                    <MatchReasonChips reasons={pick.reasons} />
+                  </div>
+                  <div style={{ fontSize: '1.5rem', fontWeight: 600 }}>{pick.score}</div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </Container>
+    </section>
+  );
+};

--- a/app.client/src/components/navigation/AppNavbar.test.tsx
+++ b/app.client/src/components/navigation/AppNavbar.test.tsx
@@ -8,6 +8,7 @@ type AuthState = { user: User | null; isAuthenticated: boolean };
 const authState: AuthState = { user: null, isAuthenticated: false };
 const notificationsState = { unreadCount: 0 };
 const chatState = { unreadMessageCount: 0 };
+const matchPreferencesState = { hasPreferences: false, isLoading: false };
 
 const baseUser: User = {
   userId: 'u1',
@@ -55,6 +56,10 @@ vi.mock('@/contexts/AnalyticsContext', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useMatchPreferences', () => ({
+  useMatchPreferences: () => matchPreferencesState,
+}));
+
 describe('AppNavbar', () => {
   beforeEach(() => {
     authState.user = null;
@@ -62,6 +67,8 @@ describe('AppNavbar', () => {
     notificationsState.unreadCount = 0;
     chatState.unreadMessageCount = 0;
     trackEventMock.mockClear();
+    matchPreferencesState.hasPreferences = false;
+    matchPreferencesState.isLoading = false;
   });
 
   describe('logged out', () => {
@@ -77,6 +84,11 @@ describe('AppNavbar', () => {
       expect(screen.queryByRole('link', { name: /messages/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: /notifications/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /user menu/i })).not.toBeInTheDocument();
+    });
+
+    it('does not show the Top Picks entry for signed-out users', () => {
+      renderWithProviders(<AppNavbar />);
+      expect(screen.queryByRole('link', { name: /top picks/i })).not.toBeInTheDocument();
     });
 
     it('still shows Discover and Search so visitors can browse', () => {
@@ -174,6 +186,41 @@ describe('AppNavbar', () => {
         action: 'primary_nav_clicked',
         label: 'search',
         properties: { entry_path: 'search', source: 'app_navbar' },
+      });
+    });
+
+    it('routes Top Picks to /match/top-picks when the user has preferences', () => {
+      matchPreferencesState.hasPreferences = true;
+      renderWithProviders(<AppNavbar />);
+      expect(screen.getByRole('link', { name: /top picks/i })).toHaveAttribute(
+        'href',
+        '/match/top-picks'
+      );
+    });
+
+    it('routes Top Picks to onboarding when the user has no preferences set', () => {
+      matchPreferencesState.hasPreferences = false;
+      renderWithProviders(<AppNavbar />);
+      expect(screen.getByRole('link', { name: /top picks/i })).toHaveAttribute(
+        'href',
+        '/match/onboarding'
+      );
+    });
+
+    it('tracks the top_picks analytics entry path when Top Picks is clicked', async () => {
+      const { default: userEvent } = await import('@testing-library/user-event');
+      const user = userEvent.setup();
+      matchPreferencesState.hasPreferences = true;
+      renderWithProviders(<AppNavbar />);
+
+      await user.click(screen.getByRole('link', { name: /top picks/i }));
+
+      const topPicksCall = trackEventMock.mock.calls.find(([event]) => event.label === 'top_picks');
+      expect(topPicksCall?.[0]).toMatchObject({
+        category: 'navigation',
+        action: 'primary_nav_clicked',
+        label: 'top_picks',
+        properties: { entry_path: 'top_picks', source: 'app_navbar' },
       });
     });
   });

--- a/app.client/src/components/navigation/AppNavbar.tsx
+++ b/app.client/src/components/navigation/AppNavbar.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { MdChat, MdFavorite, MdNotifications, MdSearch, MdSwipe } from 'react-icons/md';
+import { MdChat, MdFavorite, MdNotifications, MdSearch, MdStar, MdSwipe } from 'react-icons/md';
 import { Link, useLocation } from 'react-router-dom';
 import { Badge, Logo } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { useChat } from '@/contexts/ChatContext';
 import { useNotifications } from '@/contexts/NotificationsContext';
 import { useAnalytics } from '@/contexts/AnalyticsContext';
+import { useMatchPreferences } from '@/hooks/useMatchPreferences';
 import { AuthCtas } from './AuthCtas';
 import { NavLink } from './NavLink';
 import { NavUserMenu } from './NavUserMenu';
@@ -60,8 +61,9 @@ export const AppNavbar: React.FC<AppNavbarProps> = ({ className }) => {
   const { unreadCount: notificationsUnread } = useNotifications();
   const { unreadMessageCount } = useChat();
   const { trackEvent } = useAnalytics();
+  const { hasPreferences } = useMatchPreferences();
 
-  const trackNavClick = (entryPath: 'discover' | 'search' | 'favorites') => {
+  const trackNavClick = (entryPath: 'discover' | 'search' | 'favorites' | 'top_picks') => {
     trackEvent({
       category: 'navigation',
       action: 'primary_nav_clicked',
@@ -108,6 +110,16 @@ export const AppNavbar: React.FC<AppNavbarProps> = ({ className }) => {
               onClick={() => trackNavClick('favorites')}
             >
               Favorites
+            </NavLink>
+          )}
+          {isAuthenticated && (
+            <NavLink
+              to={hasPreferences ? '/match/top-picks' : '/match/onboarding'}
+              icon={<MdStar aria-hidden='true' />}
+              description='Pets matched to your preferences'
+              onClick={() => trackNavClick('top_picks')}
+            >
+              Top Picks
             </NavLink>
           )}
         </div>

--- a/app.client/src/components/navigation/BottomTabBar.test.tsx
+++ b/app.client/src/components/navigation/BottomTabBar.test.tsx
@@ -8,6 +8,7 @@ const authState: { user: User | null; isAuthenticated: boolean } = {
   isAuthenticated: false,
 };
 const chatState = { unreadMessageCount: 0 };
+const matchPreferencesState = { hasPreferences: false, isLoading: false };
 
 const baseUser: User = {
   userId: 'u1',
@@ -42,11 +43,17 @@ vi.mock('@/contexts/ChatContext', () => ({
   useChat: () => chatState,
 }));
 
+vi.mock('@/hooks/useMatchPreferences', () => ({
+  useMatchPreferences: () => matchPreferencesState,
+}));
+
 describe('BottomTabBar', () => {
   beforeEach(() => {
     authState.user = null;
     authState.isAuthenticated = false;
     chatState.unreadMessageCount = 0;
+    matchPreferencesState.hasPreferences = false;
+    matchPreferencesState.isLoading = false;
   });
 
   it('does not render when the user is unauthenticated', () => {
@@ -54,7 +61,7 @@ describe('BottomTabBar', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders a navigation region with 5 primary tabs when authenticated', () => {
+  it('renders a navigation region with the primary tabs when authenticated', () => {
     authState.user = baseUser;
     authState.isAuthenticated = true;
     renderWithProviders(<BottomTabBar />);
@@ -64,12 +71,35 @@ describe('BottomTabBar', () => {
       '/discover'
     );
     expect(within(nav).getByRole('link', { name: /search/i })).toHaveAttribute('href', '/search');
+    expect(within(nav).getByRole('link', { name: /top picks/i })).toBeInTheDocument();
     expect(within(nav).getByRole('link', { name: /favorites/i })).toHaveAttribute(
       'href',
       '/favorites'
     );
     expect(within(nav).getByRole('link', { name: /messages/i })).toHaveAttribute('href', '/chat');
     expect(within(nav).getByRole('button', { name: /user menu/i })).toBeInTheDocument();
+  });
+
+  it('routes Top Picks to /match/top-picks when preferences are set', () => {
+    authState.user = baseUser;
+    authState.isAuthenticated = true;
+    matchPreferencesState.hasPreferences = true;
+    renderWithProviders(<BottomTabBar />);
+    expect(screen.getByRole('link', { name: /top picks/i })).toHaveAttribute(
+      'href',
+      '/match/top-picks'
+    );
+  });
+
+  it('routes Top Picks to /match/onboarding when no preferences are set', () => {
+    authState.user = baseUser;
+    authState.isAuthenticated = true;
+    matchPreferencesState.hasPreferences = false;
+    renderWithProviders(<BottomTabBar />);
+    expect(screen.getByRole('link', { name: /top picks/i })).toHaveAttribute(
+      'href',
+      '/match/onboarding'
+    );
   });
 
   it('shows the unread-messages badge when unreadMessageCount > 0', () => {

--- a/app.client/src/components/navigation/BottomTabBar.tsx
+++ b/app.client/src/components/navigation/BottomTabBar.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { MdChat, MdFavoriteBorder, MdOutlineSearch, MdSwipe } from 'react-icons/md';
+import { MdChat, MdFavoriteBorder, MdOutlineSearch, MdStarBorder, MdSwipe } from 'react-icons/md';
 import { Link, useLocation } from 'react-router-dom';
 import { Badge } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { useChat } from '@/contexts/ChatContext';
+import { useMatchPreferences } from '@/hooks/useMatchPreferences';
 import { NavUserMenu } from './NavUserMenu';
 import * as styles from './BottomTabBar.css';
 
@@ -17,6 +18,7 @@ type TabDef = {
 export const BottomTabBar: React.FC = () => {
   const { isAuthenticated } = useAuth();
   const { unreadMessageCount } = useChat();
+  const { hasPreferences } = useMatchPreferences();
   const location = useLocation();
 
   if (!isAuthenticated) {
@@ -26,6 +28,11 @@ export const BottomTabBar: React.FC = () => {
   const tabs: TabDef[] = [
     { to: '/discover', label: 'Discover', icon: <MdSwipe aria-hidden='true' /> },
     { to: '/search', label: 'Search', icon: <MdOutlineSearch aria-hidden='true' /> },
+    {
+      to: hasPreferences ? '/match/top-picks' : '/match/onboarding',
+      label: 'Top Picks',
+      icon: <MdStarBorder aria-hidden='true' />,
+    },
     { to: '/favorites', label: 'Favorites', icon: <MdFavoriteBorder aria-hidden='true' /> },
     {
       to: '/chat',

--- a/app.client/src/hooks/useMatchPreferences.test.ts
+++ b/app.client/src/hooks/useMatchPreferences.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMatchPreferences } from './useMatchPreferences';
+
+const authState = { isAuthenticated: false };
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({ isAuthenticated: authState.isAuthenticated }),
+  };
+});
+
+const apiGet = vi.fn();
+vi.mock('@/services', () => ({
+  apiService: {
+    get: (...args: unknown[]) => apiGet(...args),
+  },
+}));
+
+beforeEach(() => {
+  authState.isAuthenticated = false;
+  apiGet.mockReset();
+});
+
+describe('useMatchPreferences', () => {
+  it('reports no preferences for signed-out users and does not call the API', () => {
+    const { result } = renderHook(() => useMatchPreferences());
+    expect(result.current.hasPreferences).toBe(false);
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('reports preferences when the profile has at least one preferred list populated', async () => {
+    authState.isAuthenticated = true;
+    apiGet.mockResolvedValueOnce({ data: { preferred_types: ['dog'] } });
+    const { result } = renderHook(() => useMatchPreferences());
+    await waitFor(() => expect(result.current.hasPreferences).toBe(true));
+  });
+
+  it('reports no preferences when the profile is the empty placeholder', async () => {
+    authState.isAuthenticated = true;
+    apiGet.mockResolvedValueOnce({ data: { lifestyle: {} } });
+    const { result } = renderHook(() => useMatchPreferences());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.hasPreferences).toBe(false);
+  });
+
+  it('treats an empty preferred_types array as no preferences', async () => {
+    authState.isAuthenticated = true;
+    apiGet.mockResolvedValueOnce({
+      data: {
+        preferred_types: [],
+        preferred_sizes: [],
+        preferred_age_groups: [],
+        preferred_energy: [],
+      },
+    });
+    const { result } = renderHook(() => useMatchPreferences());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.hasPreferences).toBe(false);
+  });
+
+  it('reports no preferences if the API fails', async () => {
+    authState.isAuthenticated = true;
+    apiGet.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useMatchPreferences());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.hasPreferences).toBe(false);
+  });
+});

--- a/app.client/src/hooks/useMatchPreferences.ts
+++ b/app.client/src/hooks/useMatchPreferences.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+import type { AdopterMatchProfile } from '@adopt-dont-shop/lib.matching';
+import { apiService } from '@/services';
+
+type UseMatchPreferencesReturn = {
+  hasPreferences: boolean;
+  isLoading: boolean;
+};
+
+const hasAnyPreference = (profile: Partial<AdopterMatchProfile> | null | undefined): boolean => {
+  if (!profile) {
+    return false;
+  }
+  const arrays: Array<readonly string[] | null | undefined> = [
+    profile.preferred_types,
+    profile.preferred_sizes,
+    profile.preferred_age_groups,
+    profile.preferred_energy,
+  ];
+  return arrays.some(arr => Array.isArray(arr) && arr.length > 0);
+};
+
+/**
+ * ADS-636: small reader for the current user's match preferences.
+ *
+ * Returns whether the signed-in user has set any match preference (via the
+ * onboarding wizard). Used by the nav and HomePage to decide whether to
+ * surface Top Picks vs route to onboarding.
+ *
+ * Signed-out users always get `{ hasPreferences: false, isLoading: false }`
+ * so callers can no-op without extra guards.
+ */
+export const useMatchPreferences = (): UseMatchPreferencesReturn => {
+  const { isAuthenticated } = useAuth();
+  const [hasPreferences, setHasPreferences] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setHasPreferences(false);
+      setIsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setIsLoading(true);
+        const res = await apiService.get<{ data: Partial<AdopterMatchProfile> }>(
+          '/api/v1/match/profile'
+        );
+        if (!cancelled) {
+          setHasPreferences(hasAnyPreference(res.data));
+        }
+      } catch {
+        if (!cancelled) {
+          setHasPreferences(false);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
+
+  return { hasPreferences, isLoading };
+};

--- a/app.client/src/pages/HomePage.tsx
+++ b/app.client/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { PetCard } from '@/components/PetCard';
 import { SwipeHero } from '@/components/hero/SwipeHero';
+import { TopPicksHomeModule } from '@/components/home/TopPicksHomeModule';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { useAnalytics } from '@/contexts/AnalyticsContext';
 import { useStatsig } from '@/hooks/useStatsig';
@@ -174,6 +175,9 @@ export const HomePage: React.FC = () => {
       ) : (
         <SwipeHero />
       )}
+
+      {/* ADS-636: surface personalised picks when the user has prefs */}
+      <TopPicksHomeModule />
 
       {/* Featured Pets Section */}
       <section className={styles.section}>

--- a/app.client/src/setup-tests.ts
+++ b/app.client/src/setup-tests.ts
@@ -86,6 +86,7 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   Modal: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', props, children),
   Spinner: () => React.createElement('div', { 'aria-label': 'loading' }),
+  MatchReasonChips: () => React.createElement('div', { 'data-testid': 'match-reason-chips' }),
   Alert: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', { role: 'alert', ...props }, children),
   Badge: ({

--- a/app.client/vite.config.ts
+++ b/app.client/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig(({ mode }) => {
           '@adopt-dont-shop/lib.discovery': resolve(__dirname, '../lib.discovery/src'),
           '@adopt-dont-shop/lib.feature-flags': resolve(__dirname, '../lib.feature-flags/src'),
           '@adopt-dont-shop/lib.legal': resolve(__dirname, '../lib.legal/src'),
+          '@adopt-dont-shop/lib.matching': resolve(__dirname, '../lib.matching/src'),
           '@adopt-dont-shop/lib.notifications': resolve(__dirname, '../lib.notifications/src'),
           '@adopt-dont-shop/lib.observability': resolve(__dirname, '../lib.observability/src'),
           '@adopt-dont-shop/lib.permissions': resolve(__dirname, '../lib.permissions/src'),

--- a/app.client/vitest.config.ts
+++ b/app.client/vitest.config.ts
@@ -123,6 +123,7 @@ export default defineConfig({
       '@adopt-dont-shop/lib.validation': path.resolve(__dirname, '../lib.validation/src/index.ts'),
       '@adopt-dont-shop/lib.utils': path.resolve(__dirname, '../lib.utils/src/index.ts'),
       '@adopt-dont-shop/lib.rescue': path.resolve(__dirname, '../lib.rescue/src/index.ts'),
+      '@adopt-dont-shop/lib.matching': path.resolve(__dirname, '../lib.matching/src/index.ts'),
       '@adopt-dont-shop/lib.types': path.resolve(__dirname, '../lib.types/src/index.ts'),
     },
   },


### PR DESCRIPTION
## Summary

Adds a Top Picks entry to the desktop navbar and the mobile bottom tab bar for signed-in adopters, and surfaces a "Your top picks" module on the HomePage so users who completed match onboarding can actually find their personalised list. Users without preferences get a single nav entry that routes to `/match/onboarding` instead of an empty Top Picks page.

## Acceptance criteria

- [x] Top Picks appears in the primary nav (and the mobile tab bar) for users who have completed match preferences
- [x] Users without preferences see a single nav entry that routes to onboarding instead of an empty Top Picks page
- [x] HomePage shows a "Your top picks" module when preferences exist (with a "See all" link)
- [x] No-op for signed-out users (no broken nav entries)

## How it works

- New `useMatchPreferences` hook fetches `/api/v1/match/profile` once per session for the signed-in user and reports `{ hasPreferences }`. Signed-out users short-circuit to `{ hasPreferences: false }` without hitting the API.
- `AppNavbar` / `BottomTabBar` render a "Top Picks" link only when authenticated; the `to` target swaps between `/match/top-picks` and `/match/onboarding` based on `hasPreferences`.
- `TopPicksHomeModule` is gated on auth + `hasPreferences`, fetches `/api/v1/match/top-picks?limit=3`, and hides itself silently on errors/empty results so the home page stays usable.

## Assumptions

- "Completed match preferences" = at least one of `preferred_types | preferred_sizes | preferred_age_groups | preferred_energy` is a non-empty array on the user's match profile. The backend returns an empty placeholder `{ user_id, lifestyle: {}, inferred_prefs: {} }` for first-time users, so this cleanly distinguishes new users from those who submitted the onboarding wizard.
- One profile fetch per nav render is acceptable for v1; if this becomes hot, lifting it into a context next to `FavoritesContext` would be the natural move.
- Added `@adopt-dont-shop/lib.matching` aliases to `vite.config.ts` and `vitest.config.ts` so the type import resolves the same way the existing `MatchOnboardingPage` does. Added a minimal `MatchReasonChips` stub to `setup-tests.ts` for components that render reason chips in tests.

## Test plan

- [x] `useMatchPreferences` reports preferences correctly for signed-in users with / without prefs, signed-out users, and API failures (5 cases)
- [x] `AppNavbar` hides Top Picks for signed-out users and routes to top-picks vs onboarding based on prefs
- [x] `BottomTabBar` shows the Top Picks tab and routes to top-picks vs onboarding based on prefs
- [x] `TopPicksHomeModule` renders only for signed-in + prefs + non-empty picks; renders nothing otherwise
- [x] `npx turbo lint type-check --filter=@adopt-dont-shop/app.client` passes
- [x] Targeted test runs pass (28/28). Full app.client test run shows 2 pre-existing flaky timeouts in `distance-sorting.behavior.test.tsx` unrelated to this change — the file passes cleanly in isolation on this branch and on `main`.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_