### PR TITLE
docs(runbooks): add production incident runbooks (ADS-661)

### DIFF
--- a/docs/observability-alerting.md
+++ b/docs/observability-alerting.md
@@ -45,7 +45,7 @@ groups:
           severity: critical
         annotations:
           summary: "Backend 5xx rate >1% (5m)"
-          runbook: "https://wiki.example.com/runbooks/5xx-spike"
+          runbook: "docs/runbooks/5xx-spike.md"
 
       # Latency regression
       - alert: P95LatencyHigh
@@ -59,6 +59,7 @@ groups:
           severity: warning
         annotations:
           summary: "Backend p95 latency >500ms (10m)"
+          runbook: "docs/runbooks/db-pool-exhaustion.md"
 
       # Event-loop lag
       - alert: EventLoopLag
@@ -68,6 +69,7 @@ groups:
           severity: warning
         annotations:
           summary: "Node.js event-loop lag p99 >200ms"
+          runbook: "docs/runbooks/5xx-spike.md"
 
       # Memory headroom
       - alert: HeapUsageHigh
@@ -80,6 +82,7 @@ groups:
           severity: warning
         annotations:
           summary: "Backend RSS >80% of node memory"
+          runbook: "docs/runbooks/5xx-spike.md"
 
       # Readiness flapping
       - alert: ReadinessProbeFailing
@@ -89,6 +92,7 @@ groups:
           severity: critical
         annotations:
           summary: "Backend /health/ready failing (DB/Redis/BullMQ)"
+          runbook: "docs/runbooks/redis-outage.md"
 ```
 
 ## Dashboards
@@ -106,6 +110,7 @@ Recommended Grafana panels:
 
 1. **Page received** → ack within 5 min (PagerDuty)
 2. **Triage** — open the runbook linked from the alert annotation
+   (index at [`docs/runbooks/README.md`](./runbooks/README.md))
 3. **Mitigate** — restart, scale, or roll back. Record the action in
    `#oncall-page` thread.
 4. **Post-incident** — file a follow-up ticket in Linear and link the

--- a/docs/runbooks/5xx-spike.md
+++ b/docs/runbooks/5xx-spike.md
@@ -1,0 +1,96 @@
+# 5xx Spike
+
+**Page severity:** `critical` (`HighFiveHundredRate`, ratio >1% for 5m)
+
+## Symptoms
+
+- PagerDuty: `HighFiveHundredRate — Backend 5xx rate >1% (5m)`.
+- Grafana "Error rate by route" panel shows one or more routes climbing.
+- Users / support reporting "internal server error".
+- `/health/simple` may still return 200 (LB probe is liveness-only).
+
+## Triage in 60 seconds
+
+```bash
+# 1. Confirm the alert is still firing (not a stale page).
+curl -s -H "Authorization: Bearer $METRICS_AUTH_TOKEN" \
+  https://${PROD_HOSTNAME}/metrics \
+  | grep -E '^http_requests_total{.*status_code="5'
+
+# 2. Which routes are bleeding? (last 30m of logs, group by status)
+docker compose -f docker-compose.prod.yml logs --since 30m service-backend \
+  | grep -E '"statusCode":5[0-9]{2}' \
+  | head -50
+```
+
+In Grafana, open the **Error rate by route** panel:
+
+```promql
+sum by (route, status_code) (rate(http_requests_total{status_code=~"5.."}[5m]))
+```
+
+The route with the highest rate is your starting point.
+
+## Diagnosis
+
+Match the symptom to a cause:
+
+| Signal                                                       | Likely cause                                | Jump to                                  |
+| ------------------------------------------------------------ | ------------------------------------------- | ---------------------------------------- |
+| Started immediately after a deploy                           | Bad release                                 | [`deploy-rollback.md`](./deploy-rollback.md) |
+| `redis` failing in `/api/v1/health`; auth routes 503         | Redis outage                                | [`redis-outage.md`](./redis-outage.md)   |
+| `acquire timeout` / `pool` errors in logs                    | DB pool exhaustion                          | [`db-pool-exhaustion.md`](./db-pool-exhaustion.md) |
+| `service-backend-migrate` exited non-zero recently           | Migration failure                           | [`migration-failure.md`](./migration-failure.md) |
+| Errors confined to one route, no other signal                | Application bug on a code path              | continue below                           |
+
+Check `/api/v1/health` for an authoritative per-dependency status:
+
+```bash
+curl -sf https://${PROD_HOSTNAME}/api/v1/health | jq '.services'
+```
+
+Any `"status": "unhealthy"` in `database`, `redis`, or `queue` points
+directly at the dependency to investigate.
+
+## Mitigation
+
+Pick the fastest reversible action:
+
+1. **Recent deploy** — roll back per
+   [`deploy-rollback.md`](./deploy-rollback.md). This is the most
+   common cause; do it before deeper debugging.
+2. **One bad pod** — restart it:
+   ```bash
+   docker compose -f docker-compose.prod.yml restart service-backend
+   ```
+   Watch the 5xx rate fall in Grafana. If it doesn't, the cause isn't
+   pod-local.
+3. **Specific route hot** — if the failing route is non-critical (e.g.
+   `/api/v1/reports/*`), consider flipping a feature flag to disable
+   the code path. See [`maintenance-mode.md`](./maintenance-mode.md)
+   for the kill-switch pattern.
+4. **All else** — flip `APPLICATION_SETTINGS.maintenance_mode = true`
+   to shed traffic while you investigate. See
+   [`maintenance-mode.md`](./maintenance-mode.md).
+
+## Verify
+
+- Grafana error rate drops below 1% and stays there for 5 min.
+- `HighFiveHundredRate` alert resolves (Alertmanager `resolved` event
+  in `#oncall-page`).
+- `curl -sf https://${PROD_HOSTNAME}/api/v1/health` returns
+  `"status": "healthy"`.
+
+## Capture before you leave
+
+```bash
+# Logs, scoped to the spike window
+docker compose -f docker-compose.prod.yml logs --since 1h --no-color \
+  service-backend > /tmp/incident-$(date +%s).log
+
+# Image SHA actually running
+docker compose -f docker-compose.prod.yml images service-backend
+```
+
+Attach both to the Linear follow-up ticket along with the Grafana
+screenshot.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,90 @@
+# Production Runbooks (ADS-661)
+
+One-page playbooks for the Adopt Don't Shop backend, written for the
+on-call engineer who has shell access on the prod host but no context.
+Each runbook is symptom → diagnosis → mitigation, ordered so you can
+decide in 10 seconds whether to escalate.
+
+## Index
+
+| Runbook                                          | When to open it                                          |
+| ------------------------------------------------ | -------------------------------------------------------- |
+| [`5xx-spike.md`](./5xx-spike.md)                 | `HighFiveHundredRate` page; 5xx ratio >1% over 5m        |
+| [`redis-outage.md`](./redis-outage.md)           | Readiness flap on `redis`; auth `429`s spike or vanish   |
+| [`db-pool-exhaustion.md`](./db-pool-exhaustion.md) | `acquire timeout` errors; p95 latency climbs in lockstep |
+| [`deploy-rollback.md`](./deploy-rollback.md)     | Bad deploy: image is live but error rate is up           |
+| [`migration-failure.md`](./migration-failure.md) | `service-backend-migrate` exited non-zero; backend won't start |
+| [`maintenance-mode.md`](./maintenance-mode.md)   | Planned outage, controlled brownout, or kill-switch needed |
+
+## On-call principles
+
+These are deliberately short. The whole point of paging at 03:00 is
+that the rules are simple enough to follow when you're half-awake.
+
+### When to page (`critical`)
+
+- A `critical` alert fired and stayed firing past its `for:` window
+  (see [`docs/observability-alerting.md`](../observability-alerting.md)).
+- `/api/v1/ready` returns `503` and the load balancer is dropping pods.
+- A deploy is in flight and the health-check loop in
+  `.github/workflows/deploy.yml` has timed out.
+- Customer-visible 5xx rate is above 1% for >5 min.
+
+If any of the above is true, ack the page, open the runbook linked
+from the alert annotation, post a 1-line status in `#oncall-page`,
+**then** start mitigating.
+
+### When to wait (`warning` / `info`)
+
+- A `warning` fired but has not been firing for 30+ minutes.
+- p95 latency is high but error rate is flat — start investigating
+  in `#alerts`, don't escalate.
+- A single readiness probe failed and recovered within 2 min — the
+  `ReadinessProbeFailing` rule requires `for: 2m`, so a single blip
+  won't page. Investigate, don't escalate.
+- Heap usage warning during a known batch job (reports, exports).
+
+### Mitigate before you debug
+
+The order is always:
+
+1. **Stop the bleeding** — roll back, flip the maintenance flag, drop
+   the bad pod. Pick the fastest reversible action.
+2. **Confirm the bleeding stopped** — refresh the dashboard, re-curl
+   `/health`, watch error rate fall.
+3. **Capture evidence** — `docker compose logs --since 30m`, screenshot
+   the Grafana panel, copy the offending SQL. The post-incident review
+   needs this and the data is gone in an hour.
+4. **Then debug** — root cause can wait until business hours if the
+   bleeding has stopped.
+
+### Severity / routing recap
+
+See [`docs/observability-alerting.md`](../observability-alerting.md)
+for the authoritative table. Quick version:
+
+- `critical` → PagerDuty + `#oncall-page` → ack in 5 min
+- `warning`  → `#alerts` → review in 30 min
+- `info`     → `#alerts-noise` → best effort
+
+### What every runbook assumes you have
+
+- SSH to the prod host running `docker-compose.prod.yml`.
+- `docker compose -f docker-compose.prod.yml` works without `sudo`.
+- `psql` available either on the host or via
+  `docker compose exec database psql`.
+- Grafana / Prometheus URL bookmarked.
+- The on-call rotation knows who can authorise destructive actions
+  (DB restore, force-merge, schema rollback) — if you don't have that
+  authority, page the secondary.
+
+### Post-incident
+
+After mitigation:
+
+1. File a follow-up ticket in Linear linking the alert.
+2. Update the relevant runbook if the steps were wrong or missing.
+3. Bring it to the next on-call handoff.
+
+Runbooks are living docs — if you found a gap at 03:00, fix it at 10:00
+so the next person doesn't hit the same wall.

--- a/docs/runbooks/db-pool-exhaustion.md
+++ b/docs/runbooks/db-pool-exhaustion.md
@@ -1,0 +1,120 @@
+# Database Pool Exhaustion
+
+**Page severity:** `critical` if it causes `HighFiveHundredRate`;
+otherwise `warning` (`P95LatencyHigh`).
+
+## Symptoms
+
+- p95 latency climbs across many unrelated routes simultaneously.
+- Errors in backend logs include
+  `SequelizeConnectionAcquireTimeoutError`, `pool is draining`, or
+  `acquire timeout`.
+- `process_cpu_*` looks fine; the bottleneck isn't CPU.
+- Postgres `pg_stat_activity` shows many `idle in transaction` or
+  long-running queries.
+- 5xx may rise once the `DB_POOL_ACQUIRE_MS` timeout (default 30s) is
+  hit — see `service.backend/src/sequelize.ts`.
+
+## Pool config (current defaults)
+
+From `service.backend/src/sequelize.ts:40-51`:
+
+| Env var                              | Default | Meaning                                   |
+| ------------------------------------ | ------- | ----------------------------------------- |
+| `DB_POOL_MAX`                        | `20`    | Max concurrent connections per replica    |
+| `DB_POOL_MIN`                        | `2`     | Min idle connections held                 |
+| `DB_POOL_ACQUIRE_MS`                 | `30000` | How long a request waits for a connection |
+| `DB_POOL_IDLE_MS`                    | `10000` | Idle connection eviction                  |
+| `DB_STATEMENT_TIMEOUT_MS`            | `30000` | Per-query ceiling                         |
+| `DB_LOCK_TIMEOUT_MS`                 | `10000` | Lock-wait ceiling                         |
+| `DB_IDLE_IN_TRANSACTION_TIMEOUT_MS`  | `60000` | Kills idle-in-tx sessions                 |
+
+Effective settings are logged at boot:
+`[db] pool max=20 min=2 acquireMs=30000 ...`
+
+## Triage in 60 seconds
+
+```bash
+# 1. Confirm pool-acquire errors are firing (not generic DB errors).
+docker compose -f docker-compose.prod.yml logs --since 15m service-backend \
+  | grep -iE 'acquire timeout|pool is draining|connectionacquire'
+
+# 2. How many sessions are open on the DB right now?
+docker compose -f docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c \
+  "SELECT state, count(*) FROM pg_stat_activity WHERE datname=current_database() GROUP BY state;"
+
+# 3. Top long-running queries.
+docker compose -f docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c \
+  "SELECT pid, state, now()-query_start AS age, left(query, 100) AS q
+   FROM pg_stat_activity
+   WHERE datname=current_database() AND state <> 'idle'
+   ORDER BY age DESC LIMIT 10;"
+```
+
+## Diagnosis
+
+| Signal in `pg_stat_activity`                            | Cause                                |
+| ------------------------------------------------------- | ------------------------------------ |
+| Many `idle in transaction` rows, `age` > 1m             | A handler is leaking a transaction   |
+| One query holding for minutes, others queued behind it  | Missing index / runaway report query |
+| `active` count == `DB_POOL_MAX * replicas`              | Traffic genuinely exceeds capacity   |
+| Many sessions holding the same table-level lock         | Migration / VACUUM FULL in flight    |
+
+Cross-check with the Grafana **Request volume** panel. If volume is
+flat but the pool is saturated, a slow query is the cause. If volume
+is up and tracking the saturation, capacity is the cause.
+
+## Mitigation
+
+1. **Kill the offending query** (if one query is the obvious cause):
+   ```bash
+   docker compose -f docker-compose.prod.yml exec -T database \
+     psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c \
+     "SELECT pg_terminate_backend(<pid>);"
+   ```
+   Watch the `state` distribution drop back to mostly `idle`.
+
+2. **Bump the pool** (temporary; requires backend restart):
+   ```bash
+   # Edit .env on the prod host
+   DB_POOL_MAX=40
+   docker compose -f docker-compose.prod.yml up -d service-backend
+   ```
+   Do **not** exceed the Postgres `max_connections` ceiling
+   (typically 100 on a small managed instance) — leaving headroom for
+   `service-backend-migrate`, `psql`, and the operator is mandatory.
+
+3. **Disable a hot endpoint** — if a known feature is driving the
+   load (e.g. a search endpoint hitting a missing index), flip its
+   feature gate. The `ALLOW_BULK_OPERATIONS` gate in
+   `lib.feature-flags/src/types/index.ts` can be turned off to drop
+   bulk write traffic.
+
+4. **If still failing** — declare maintenance mode per
+   [`maintenance-mode.md`](./maintenance-mode.md) and call DB on-call.
+
+## Verify
+
+- `pg_stat_activity` count returns to baseline (`active` <
+  `DB_POOL_MAX`).
+- p95 latency drops below 500ms; `P95LatencyHigh` resolves.
+- No new `acquire timeout` lines in the last 5 min of logs.
+
+## Capture
+
+```bash
+# Snapshot the long-running queries before you kill them.
+docker compose -f docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -c "SELECT * FROM pg_stat_activity WHERE datname=current_database() AND state <> 'idle';" \
+  > /tmp/pgstat-$(date +%s).txt
+
+# Pool config + boot env that was in effect
+docker compose -f docker-compose.prod.yml logs service-backend \
+  | grep '\[db\] pool' | tail -1
+```
+
+The query snapshot is gone the moment you `pg_terminate_backend` —
+capture it first, then mitigate.

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -1,0 +1,121 @@
+# Deploy Rollback
+
+**Page severity:** depends on the trigger. Usually accompanies
+`HighFiveHundredRate` (`critical`) or a manual decision after a bad
+release.
+
+## When to roll back
+
+- Error rate spiked immediately after the new image went live.
+- A user-visible feature regressed (functional bug, not a perf blip).
+- The post-deploy smoke check in `.github/workflows/deploy.yml`
+  failed.
+
+If a **migration** also ran in this deploy, read the
+[Schema-compatibility caveat](#schema-compatibility-caveat) before
+rolling the image back.
+
+## Symptoms that look like a deploy regression
+
+- Error rate change time-aligns with the deploy timestamp (check
+  Grafana annotations).
+- New error class in logs that didn't exist on the previous SHA.
+- Latency regression localised to specific routes touched by the
+  release.
+
+## Image-tag refresher
+
+From [`docs/operations/deploy.md`](../operations/deploy.md): production
+runs immutable `:sha-<long>` or `:vX.Y.Z` tags, never `:latest`. The
+previous good tag is in the deploy log / release notes.
+
+```bash
+# What's running right now?
+docker compose -f docker-compose.prod.yml images service-backend
+```
+
+## Rollback procedure
+
+```bash
+# 1. Identify the previous good tag.
+export IMAGE_TAG=v1.2.3        # or sha-<long> from release notes
+
+# 2. Pull + restart with the old tag.
+DEPLOY_SHA=${IMAGE_TAG} \
+  docker compose -f docker-compose.prod.yml pull service-backend
+DEPLOY_SHA=${IMAGE_TAG} \
+  docker compose -f docker-compose.prod.yml up -d service-backend
+
+# 3. Confirm the new (old) image is live.
+docker compose -f docker-compose.prod.yml images service-backend
+
+# 4. Health check.
+curl -sf https://${PROD_HOSTNAME}/health
+curl -sf https://${PROD_HOSTNAME}/api/v1/ready | jq
+```
+
+The `service-backend-migrate` init container also pins to
+`${DEPLOY_SHA}`, so re-running it would replay the migration set the
+*old* tag knows about. **Do not** restart `service-backend-migrate`
+during an image rollback unless you're also reverting a migration —
+see below.
+
+## Schema-compatibility caveat
+
+The deploy contract is **forward-only schemas**: a deploy may add
+columns but the previous binary must still run against the new schema.
+That assumption is documented in
+[`docs/operations/deploy.md`](../operations/deploy.md#rollback).
+
+If the failed deploy ran a migration that the previous binary cannot
+tolerate (e.g. removed a column it still reads, added a `NOT NULL`
+constraint it doesn't populate):
+
+```bash
+# 1. Roll the migration back FIRST.
+docker compose -f docker-compose.prod.yml run --rm service-backend-migrate \
+  npx sequelize-cli db:migrate:undo
+
+# 2. Then roll the image back per the procedure above.
+```
+
+Confirm the migration that ran during this deploy actually has a
+working `down()` — many do not (see
+`db-backup-runbook.md` for the broader "forward-only" warning). If
+`down()` is missing, you cannot roll back cleanly; jump to
+[`migration-failure.md`](./migration-failure.md) and call the on-call
+DBA.
+
+## Verify
+
+- Error rate drops to pre-deploy baseline within 5 min.
+- `/api/v1/ready` returns 200.
+- `HighFiveHundredRate` (and any latency alerts) resolve.
+- `docker compose ... images service-backend` shows the old tag.
+
+## Capture
+
+```bash
+# Record the bad image SHA before it scrolls out of logs.
+docker compose -f docker-compose.prod.yml logs --since 2h --no-color \
+  service-backend > /tmp/rollback-incident-$(date +%s).log
+
+# Note in the Linear follow-up:
+#  - bad tag, previous good tag, time window of the spike, link to
+#    the failing CI build.
+```
+
+Open a Linear ticket on the offending release and link the original
+PR. If the migration also needed reverting, attach the `db:migrate:undo`
+output too.
+
+## When NOT to roll back
+
+- Migration succeeded but the binary is fine — the issue is data, not
+  code. Roll back makes it worse.
+- The spike started >30 min after the deploy with no other deploy in
+  between — likely traffic / dependency, not the release. Investigate
+  via [`5xx-spike.md`](./5xx-spike.md) first.
+- You're not sure which tag is the previous good one — pull the
+  release notes / `git log` on `main` before issuing `docker compose
+  up`. A rollback to a worse tag costs more than 5 min of investigation.

--- a/docs/runbooks/maintenance-mode.md
+++ b/docs/runbooks/maintenance-mode.md
@@ -1,0 +1,141 @@
+# Maintenance Mode
+
+**Page severity:** N/A — this is an action, not an alarm. Used to
+shed traffic during another incident, a planned outage, or a
+controlled brownout.
+
+## What "maintenance mode" means here
+
+The kill switch is the dynamic config
+`APPLICATION_SETTINGS.maintenance_mode` (boolean), declared in
+`lib.feature-flags/src/types/index.ts:69-76`:
+
+```ts
+export interface ApplicationSettingsConfig {
+  max_applications_per_user: number;
+  auto_approve_verified_rescues: boolean;
+  maintenance_mode: boolean;
+  new_registrations_enabled: boolean;
+  adoption_approval_workflow_enabled: boolean;
+}
+```
+
+There is also a coarser per-feature gate
+`ALLOW_BULK_OPERATIONS` in `KNOWN_GATES` for shedding bulk write
+traffic without taking the whole app down.
+
+**When set to `true`**, the frontends consume the flag via the
+`useDynamicConfig(KNOWN_CONFIGS.APPLICATION_SETTINGS)` hook and
+render the maintenance banner / block protected actions. The backend
+continues to serve `/health`, `/api/v1/ready`, and read endpoints
+unless you also stop the container.
+
+## When to use it
+
+| Situation                                         | Action                            |
+| ------------------------------------------------- | --------------------------------- |
+| Another incident is in flight, error rate climbing | `maintenance_mode = true`         |
+| Planned migration with destructive cutover         | `maintenance_mode = true` window  |
+| Bulk-write feature misbehaving, rest of app fine   | `ALLOW_BULK_OPERATIONS = false`   |
+| Need to register no new users for an hour          | `new_registrations_enabled = false` |
+| You want to take the site fully offline            | Stop nginx (not maintenance mode) |
+
+Maintenance mode does **not** prevent direct API hits — it's a UX
+contract enforced by the frontend. Determined clients can still call
+the API. If you need a hard block, scale `service-backend` to zero
+or stop nginx.
+
+## Flipping the flag
+
+The flag is stored in the feature-flags backend (see
+`lib.feature-flags`). Use the admin UI when you have a browser; use
+the API when you have a terminal at 03:00.
+
+### Via the admin UI
+
+1. Sign in to `https://admin.${PROD_HOSTNAME}` as an admin.
+2. Navigate to **Feature Flags → Dynamic Configs**.
+3. Edit `application_settings`.
+4. Toggle `maintenance_mode` → `true`. Save.
+5. Open the public site in an incognito window to confirm the
+   banner appears (frontend polls every ~30s).
+
+### Via the API (terminal-only fallback)
+
+```bash
+# Replace the JSON below with your real admin token + base URL.
+ADMIN_TOKEN="..."
+
+# 1. Read the current config so you don't clobber other fields.
+curl -sf -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  https://${PROD_HOSTNAME}/api/v1/feature-flags/configs/application_settings \
+  | jq
+
+# 2. PATCH only the field you're changing. The exact route shape is
+#    in lib.feature-flags / the admin app's services layer — confirm
+#    against the admin UI's network tab if uncertain.
+curl -sf -X PATCH -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"value":{"maintenance_mode":true}}' \
+  https://${PROD_HOSTNAME}/api/v1/feature-flags/configs/application_settings
+```
+
+**Always read-then-write.** PUT-ing a fresh body without reading
+first will silently wipe `max_applications_per_user`, etc.
+
+## Verify maintenance mode is active
+
+- Hit the public site in an incognito window — maintenance banner is
+  visible within 30s.
+- `curl -sf https://${PROD_HOSTNAME}/api/v1/feature-flags/configs/application_settings | jq '.value.maintenance_mode'`
+  returns `true`.
+- Backend logs do **not** show a flood of errors — maintenance mode
+  shouldn't be generating its own noise. If they do, the frontends
+  aren't honouring it; investigate before assuming traffic is shed.
+
+## Lifting maintenance mode
+
+```bash
+# Same as above, with maintenance_mode flipped back.
+curl -sf -X PATCH -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"value":{"maintenance_mode":false}}' \
+  https://${PROD_HOSTNAME}/api/v1/feature-flags/configs/application_settings
+```
+
+Confirm:
+
+- Banner disappears from the public site within 30s.
+- A test write path (e.g. submit a saved-pet) succeeds end-to-end.
+- Watch `http_requests_total` and error rate for 5 min after
+  lifting; surfacing a still-broken dependency immediately after the
+  flag flips is a common pattern.
+
+## Hard offline (when maintenance mode isn't enough)
+
+If determined direct-API traffic is making the underlying incident
+worse:
+
+```bash
+# Take nginx down — returns connection-refused, not 5xx.
+docker compose -f docker-compose.prod.yml stop nginx
+# ...incident work...
+docker compose -f docker-compose.prod.yml start nginx
+```
+
+This is louder than maintenance mode (no friendly banner, just a
+connection failure) but it's the cleanest way to guarantee zero
+traffic reaches the backend.
+
+## Capture
+
+In the post-incident write-up, record:
+
+- Time maintenance mode was enabled and lifted.
+- Who flipped the flag.
+- Which dependent flags (`new_registrations_enabled`,
+  `ALLOW_BULK_OPERATIONS`) were also touched and whether they were
+  restored.
+
+A maintenance flag left on after the incident is the most common
+follow-up bug — double-check the config on the morning after.

--- a/docs/runbooks/migration-failure.md
+++ b/docs/runbooks/migration-failure.md
@@ -1,0 +1,169 @@
+# Migration Failure
+
+**Page severity:** `critical` — `service-backend` will not start until
+`service-backend-migrate` exits 0. Site is effectively down.
+
+## Symptoms
+
+- Deploy job's health-check loop in `.github/workflows/deploy.yml`
+  times out and exits non-zero.
+- `docker compose ps` shows `service-backend-migrate` as `exited (1)`
+  and `service-backend` as not started (blocked by compose's
+  `service_completed_successfully` dependency — see
+  [`docs/operations/deploy.md`](../operations/deploy.md)).
+- Old backend container is still running on the previous tag — **no
+  traffic is shifted to the failed image**. Site stays up on the old
+  release.
+
+The good news: the deploy gate worked. The old binary is still
+serving. You have time to triage; you do not need to mitigate user
+impact first.
+
+## Triage in 60 seconds
+
+```bash
+# 1. Read the failing migration name + error.
+docker compose -f docker-compose.prod.yml logs --no-color \
+  service-backend-migrate
+
+# 2. What's actually been applied?
+docker compose -f docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -c 'SELECT name FROM "SequelizeMeta" ORDER BY name DESC LIMIT 10;'
+```
+
+The failing migration is logged at the top of `service-backend-migrate`'s
+output. Note its filename — you'll need it to decide recovery path.
+
+## Diagnosis — choose ONE recovery path
+
+These mirror the four documented modes in
+[`docs/operations/deploy.md`](../operations/deploy.md#when-the-migration-init-container-fails).
+
+### A. Migration code bug → fix forward
+
+The failing migration has a logic error.
+
+- The migration's row will **not** be in `SequelizeMeta` (sequelize-cli
+  only writes it after `up()` returns).
+- Re-running `db:migrate` will replay the whole `up()`.
+
+```bash
+# 1. Author the corrective migration on a branch, get it merged.
+# 2. Wait for CI to build a new image tag.
+# 3. Re-deploy with the new tag.
+```
+
+The site continues to serve on the old binary while you do this. No
+emergency action needed beyond a fast PR review.
+
+### B. Migration partially applied (multi-statement, no tx)
+
+Some DDL landed, the rest failed. `SequelizeMeta` is still missing
+the migration's row, so a re-run will try to land the already-applied
+DDL again.
+
+```bash
+# 1. Identify what landed.
+docker compose -f docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+# ... inspect schema by hand: \d <table>
+
+# 2. Hand-revert the partial changes via psql so the migration's
+#    up() can run cleanly from scratch.
+
+# 3. Re-run the migration init container.
+docker compose -f docker-compose.prod.yml run --rm service-backend-migrate
+```
+
+This is the most dangerous path — make a backup first (see
+[`docs/db-backup-runbook.md`](../db-backup-runbook.md#pre-migration-backup-checklist))
+and have the DBA on the line.
+
+### C. Lock contention (`could not obtain lock`)
+
+A long-running query is holding the table. The migration exits on
+`DB_LOCK_TIMEOUT_MS` (default 10s — see
+`service.backend/src/sequelize.ts`).
+
+```bash
+# Find the blocker.
+docker compose -f docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c \
+  "SELECT pid, state, now()-query_start AS age, left(query, 100) AS q
+   FROM pg_stat_activity
+   WHERE datname=current_database() AND state <> 'idle'
+   ORDER BY age DESC LIMIT 10;"
+
+# Wait it out, or terminate it.
+docker compose -f docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -c "SELECT pg_terminate_backend(<pid>);"
+
+# Re-run the migration.
+docker compose -f docker-compose.prod.yml run --rm service-backend-migrate
+```
+
+### D. Migration succeeded but health-check failed
+
+`SequelizeMeta` **does** contain the migration. The schema is ahead
+of the old binary that's still serving traffic. This is the "schema
+is ahead of binary" failure mode.
+
+```bash
+# 1. Decide: forward-fix (deploy a new image that handles the new
+#    schema) or back out (run the migration's down()).
+docker compose -f docker-compose.prod.yml run --rm service-backend-migrate \
+  npx sequelize-cli db:migrate:undo
+```
+
+If `down()` is a no-op or destructive, **stop and call the DBA**.
+Backing out a forward-only schema change is a one-way door — restore
+from the pre-migration backup is sometimes the only safe option.
+
+## Mitigation
+
+The old binary is still serving. Don't break that:
+
+- **Do not** restart `service-backend` until the migration succeeds —
+  compose will block startup on the failed init container, leaving
+  you with zero replicas.
+- **Do not** delete `service-backend-migrate`'s container before
+  reading its logs — you lose the failure diagnostic.
+
+If business pressure forces serving while the migration is being
+authored, enable maintenance mode per
+[`maintenance-mode.md`](./maintenance-mode.md) for write paths and
+let reads continue on the old binary.
+
+## Verify
+
+```bash
+# 1. Migration applied cleanly.
+docker compose -f docker-compose.prod.yml logs service-backend-migrate \
+  | tail -20
+
+# 2. SequelizeMeta now contains the migration row.
+docker compose -f docker-compose.prod.yml exec -T database \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  -c 'SELECT name FROM "SequelizeMeta" ORDER BY name DESC LIMIT 5;'
+
+# 3. Backend starts and is healthy.
+docker compose -f docker-compose.prod.yml up -d service-backend
+curl -sf https://${PROD_HOSTNAME}/api/v1/ready | jq
+```
+
+## Capture
+
+```bash
+# The init container's logs are your post-mortem.
+docker compose -f docker-compose.prod.yml logs --no-color \
+  service-backend-migrate > /tmp/migration-incident-$(date +%s).log
+
+# Note the backup filename you took before the deploy.
+ls -lh /var/backups/adopt-dont-shop/ | tail
+```
+
+File a Linear follow-up linking the PR that introduced the bad
+migration. If recovery used path B or D, schedule a restore drill
+sooner than the next quarterly cycle.

--- a/docs/runbooks/redis-outage.md
+++ b/docs/runbooks/redis-outage.md
@@ -1,0 +1,117 @@
+# Redis Outage
+
+**Page severity:** `critical` (`ReadinessProbeFailing` when `redis`
+probe fails for 2m)
+
+## Symptoms
+
+- `/api/v1/ready` returns `503` with
+  `failures: [{ service: 'redis', ... }]`.
+- Kubernetes / LB drops pods from rotation; effective capacity falls.
+- BullMQ reports queue stops processing (the `queue` probe fails
+  alongside Redis — see
+  `service.backend/src/services/health-check.service.ts`).
+- Auth `/login`, `/register` either rate-limit oddly or fail to
+  enforce limits across replicas (see
+  `service.backend/src/middleware/auth-rate-limit.ts` — Redis-backed
+  `RedisStore` falls back to in-memory **per-replica** when Redis is
+  unconfigured, but **errors out** mid-request if Redis was up and
+  then dies).
+- Cache-fronted endpoints stay up but slow down — the read-through
+  helper in `service.backend/src/cache/redis-cache.ts` falls through
+  to the loader on any Redis failure.
+
+## What still works vs. what doesn't
+
+| Subsystem            | Behaviour without Redis                                  |
+| -------------------- | -------------------------------------------------------- |
+| `cached()` helper    | Falls through to loader. Slower but correct.             |
+| Auth rate-limiters   | **Degraded** — per-replica only, shared state lost.      |
+| BullMQ reports queue | Down. New jobs cannot be enqueued; existing jobs stall.  |
+| Readiness probe      | Returns 503. LB drops pods until Redis recovers.         |
+
+The cache fallthrough is safe; the rate-limiter and queue are not.
+Plan to enable maintenance mode for write-heavy flows if the outage
+runs long.
+
+## Triage in 60 seconds
+
+```bash
+# 1. Confirm Redis itself, not the network in between.
+docker compose -f docker-compose.prod.yml exec -T redis \
+  redis-cli -a "$REDIS_PASSWORD" ping
+# Expect: PONG
+
+# 2. Container state + last 100 log lines
+docker compose -f docker-compose.prod.yml ps redis
+docker compose -f docker-compose.prod.yml logs --tail=100 --no-color redis
+
+# 3. From the backend's perspective (proves DNS + creds work).
+docker compose -f docker-compose.prod.yml exec -T service-backend \
+  sh -c 'curl -sf http://localhost:5000/api/v1/health | jq .services.redis'
+```
+
+## Diagnosis
+
+Match the symptom:
+
+- `redis-cli ping` fails, container `unhealthy` → Redis crashed or
+  OOMed. Check `docker compose logs redis` for `OOM`, `MISCONF`,
+  `Background save terminated`.
+- `redis-cli ping` works from inside the redis container but the
+  backend probe fails → network / `REDIS_URL` / `REDIS_PASSWORD`
+  mismatch. Re-check the backend's `REDIS_HOST` and `REDIS_PASSWORD`
+  env in `docker-compose.prod.yml`.
+- Disk full inside the redis container (`MISCONF`) → AOF write
+  failed. Free space on the host or grow the `redis_data` volume.
+
+## Mitigation
+
+1. **Restart Redis** (fastest, usually enough):
+   ```bash
+   docker compose -f docker-compose.prod.yml restart redis
+   # Wait for healthcheck to pass (~10s)
+   docker compose -f docker-compose.prod.yml ps redis
+   ```
+   The backend's `ensureRedisReady()` lazy-reconnects on the next
+   request, so no backend restart is needed.
+
+2. **If restart fails** — check the AOF / RDB on the `redis_data`
+   volume. If corrupt, accept data loss:
+   ```bash
+   docker compose -f docker-compose.prod.yml stop redis
+   docker volume rm $(docker compose -f docker-compose.prod.yml \
+     config --volumes | grep redis_data)
+   docker compose -f docker-compose.prod.yml up -d redis
+   ```
+   Cost: rate-limit windows reset, in-flight BullMQ jobs lost,
+   namespace version stamps reset (full cache miss for ~minutes).
+   Acceptable in an outage.
+
+3. **If Redis is down for >5 min** — flip
+   `APPLICATION_SETTINGS.maintenance_mode = true` to shed write
+   traffic that depends on auth rate-limiting. See
+   [`maintenance-mode.md`](./maintenance-mode.md).
+
+4. **Confirm BullMQ recovers** — once Redis is back, the queue probe
+   should clear within one health-check interval:
+   ```bash
+   curl -sf https://${PROD_HOSTNAME}/api/v1/ready | jq
+   ```
+
+## Verify
+
+- `/api/v1/ready` returns 200.
+- `ReadinessProbeFailing` alert resolves.
+- Pods rejoin LB rotation; request volume returns to baseline.
+
+## Capture
+
+```bash
+docker compose -f docker-compose.prod.yml logs --since 1h --no-color \
+  redis service-backend > /tmp/redis-incident-$(date +%s).log
+```
+
+File the Linear follow-up. If this is the second Redis outage in a
+quarter, raise it at on-call handoff — persistence settings or
+host-resource limits likely need revisiting.


### PR DESCRIPTION
## Summary

Adds `docs/runbooks/` with six one-page incident playbooks plus an index, written for an on-call engineer at 03:00 with shell access and no context. Each runbook leads with **Symptoms** and **Page severity** so an oncall can decide whether to escalate in 10 seconds, and is grounded in real env vars, file paths, and `docker compose -f docker-compose.prod.yml` commands from this codebase.

- `README.md` — index + on-call principles (when to page, when to wait, mitigate-before-debug)
- `5xx-spike.md` — triage tree for `HighFiveHundredRate`
- `redis-outage.md` — cache fallthrough vs. rate-limiter/queue degradation, restart vs. volume-wipe trade-off
- `db-pool-exhaustion.md` — `DB_POOL_MAX` / `DB_STATEMENT_TIMEOUT_MS` defaults, `pg_stat_activity` triage
- `deploy-rollback.md` — image-tag rollback, schema-compat caveat
- `migration-failure.md` — four recovery paths from `docs/operations/deploy.md`
- `maintenance-mode.md` — `APPLICATION_SETTINGS.maintenance_mode` kill switch + `ALLOW_BULK_OPERATIONS` gate

Also updates `docs/observability-alerting.md` to replace the `https://wiki.example.com/runbooks/*` placeholder with a relative link into `docs/runbooks/`, and adds `runbook:` annotations to the other alert rules so they all link somewhere useful.

Linear: [ADS-661](https://linear.app/ideasquared/issue/ADS-661)

## Test plan

- [ ] Spot-check each runbook renders cleanly on GitHub (headings, code fences, tables).
- [ ] Verify every relative link in the runbooks index resolves to a sibling file.
- [ ] Confirm `docs/observability-alerting.md` no longer contains `wiki.example.com`.
- [ ] Sanity-check that every `docker compose`, `psql`, and env-var reference matches the current codebase (no invented commands or paths).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZ1rFv3YqfJvfUGxULzXBc)_