### PR TITLE
chore(deps): resolve moderate npm-audit vulnerabilities (ADS-657)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14821,9 +14821,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.7.tgz",
-      "integrity": "sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==",
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -14835,44 +14835,23 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       },
       "engines": {
         "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3",
+        "ws": "~8.20.1",
         "xmlhttprequest-ssl": "~2.1.1"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/engine.io-parser": {
@@ -14925,27 +14904,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/entities": {
@@ -25108,34 +25066,13 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.18.3"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "ws": "~8.20.1"
       }
     },
     "node_modules/socket.io-client": {
@@ -28434,7 +28371,6 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

Resolves [ADS-657](https://linear.app/ideasquared/issue/ADS-657).

`npm audit --omit=dev` previously flagged **6 moderate** vulnerabilities (3 transitive `ws`, 3 transitive `uuid`). After `npm audit fix` (no `--force`), the `ws` advisory is fully cleared. The remaining 2 `uuid` reports are kept as a documented Path-A exception (see below).

## Changes

- `package-lock.json` only — `npm audit fix` bumped nested `ws` to `>=8.20.1` across `engine.io`, `engine.io-client`, and `socket.io-adapter` (GHSA-58qx-3vcg-4xpx).
- No `package.json` edits. No source changes.
- CI security gate (`.github/workflows/security.yml`) left at `--audit-level=high` — see "CI gate" below.

## Path A: nested `uuid@8.3.2` inside `sequelize@7.0.0-alpha.9`

`npm audit fix --force` would replace `sequelize@7.0.0-alpha.9` with `sequelize@3.30.0` — a multi-major regression. ADS-531 intentionally pins the 7-alpha; downgrading is not acceptable. Per ticket instructions, we stop and document.

The advisory (GHSA-w5hq-g745-h8pq) describes a missing buffer bounds check **only in `uuid.v3()`, `uuid.v5()`, and `uuid.v6()` when a `buf` argument is provided**. The dep tree shows the only consumer of the nested `uuid@8`:

```
adopt-dont-shop-workspace@1.0.0
`-- @adopt-dont-shop/service-backend@1.0.0
  +-- sequelize@7.0.0-alpha.9
  | `-- uuid@8.3.2
  `-- uuid@14.0.0   <-- top-level, application code uses this
```

`grep` of `node_modules/sequelize/lib/**/*.js` confirms Sequelize only calls `uuid.v1()` and `uuid.v4()` (in `lib/utils.js`, `lib/dialects/abstract/query-generator.js`, `lib/dialects/abstract/query-generator/transaction.js`) — never `v3/v5/v6`, never with a `buf` arg. The vulnerable code path is not reachable from our runtime.

Application code uses the top-level `uuid@14.0.0`, which is well above the `<11.1.1` advisory range.

## Before `npm audit --omit=dev`

```
uuid  <11.1.1
Severity: moderate
node_modules/sequelize/node_modules/uuid
  sequelize  0.0.0-development || >=3.30.1
  node_modules/sequelize

ws  8.0.0 - 8.20.0
Severity: moderate
node_modules/engine.io-client/node_modules/ws
node_modules/engine.io/node_modules/ws
node_modules/socket.io-adapter/node_modules/ws
  engine.io  0.7.8 - 0.7.9 || 6.0.0 - 6.6.7
  engine.io-client  0.7.0 || 0.7.8 - 0.7.9 || 6.0.0 - 6.6.4
  socket.io-adapter  2.5.2 - 2.5.6

6 moderate severity vulnerabilities
```

## After `npm audit --omit=dev`

```
uuid  <11.1.1
Severity: moderate
node_modules/sequelize/node_modules/uuid
  sequelize  0.0.0-development || >=3.30.1
  node_modules/sequelize

2 moderate severity vulnerabilities
```

The 4 `ws`-derived reports are resolved (1 direct `ws` + 3 dependent packages). The 2 remaining `uuid` reports are the Path-A exception (1 direct `uuid` + 1 dependent `sequelize`).

## Verification

- `npm run type-check` — passes (52/52 tasks)
- `npm run build` — passes (28/28 tasks, includes Sequelize-typed backend)
- `service.backend` tests — **2689 passed, 210 skipped** (`vitest run`)
- `lib.auth` tests — **30 passed**
- Socket.IO tests specifically (`vitest run socket` in `service.backend`) — **29 passed** across `socket-handlers.test.ts`, `socket-rate-limit.test.ts`, `socket-registry.test.ts`. The `ws` bump did not regress Socket.IO behaviour.

## CI gate

Left at `--audit-level=high` in `.github/workflows/security.yml`. The Path-A `uuid` exception still surfaces as **moderate** in `npm audit`, so raising the gate to `moderate` would immediately fail CI. The gate should be raised in a follow-up once `sequelize@7.0.0-alpha.x` ships a release that depends on `uuid@>=11.1.1`, or when ADS-531's Sequelize pin is revisited.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run build` passes
- [x] `service.backend` test suite passes
- [x] `lib.auth` test suite passes
- [x] Socket.IO tests pass (chat / sockets affected by `ws` upgrade)
- [x] `npm audit --omit=dev` shows only the documented Path-A exception remaining
- [ ] CI green on this PR

https://claude.ai/code/session_01MZ1rFv3YqfJvfUGxULzXBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZ1rFv3YqfJvfUGxULzXBc)_