### PR TITLE
ADS-643: Surface unread adopter messages on the rescue dashboard

### DIFF
--- a/app.rescue/src/components/dashboard/UnreadMessagesPanel.css.ts
+++ b/app.rescue/src/components/dashboard/UnreadMessagesPanel.css.ts
@@ -1,0 +1,118 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const panel = style({
+  marginBottom: '2rem',
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '1rem 1.5rem',
+  borderBottom: `1px solid ${vars.border.color.default}`,
+});
+
+export const headingGroup = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+});
+
+globalStyle(`${headingGroup} h3`, {
+  margin: 0,
+});
+
+export const countBadge = style({
+  backgroundColor: '#ef4444',
+  color: 'white',
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  padding: '0.25rem 0.5rem',
+  borderRadius: '10px',
+  minWidth: '1.25rem',
+  textAlign: 'center',
+});
+
+export const list = style({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+});
+
+export const rowLink = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  padding: '1rem 1.5rem',
+  borderBottom: `1px solid ${vars.border.color.default}`,
+  textDecoration: 'none',
+  color: 'inherit',
+  ':hover': {
+    backgroundColor: '#f9fafb',
+  },
+});
+
+export const rowTopLine = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '0.5rem',
+});
+
+export const senderName = style({
+  fontWeight: 600,
+  fontSize: '0.95rem',
+});
+
+export const timestamp = style({
+  fontSize: '0.75rem',
+  color: '#6b7280',
+  whiteSpace: 'nowrap',
+});
+
+export const snippet = style({
+  fontSize: '0.875rem',
+  color: '#4b5563',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+});
+
+export const unreadDot = style({
+  display: 'inline-block',
+  width: '8px',
+  height: '8px',
+  backgroundColor: '#3b82f6',
+  borderRadius: '50%',
+  marginRight: '0.5rem',
+});
+
+export const emptyState = style({
+  padding: '1.5rem',
+  textAlign: 'center',
+  color: '#6b7280',
+});
+
+globalStyle(`${emptyState} p`, {
+  margin: '0.25rem 0',
+  fontSize: '0.875rem',
+});
+
+export const footer = style({
+  padding: '0.75rem 1.5rem',
+  textAlign: 'center',
+});
+
+export const viewAllLink = style({
+  color: vars.colors.infoTextEmphasis,
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  textDecoration: 'none',
+  ':hover': {
+    textDecoration: 'underline',
+  },
+});

--- a/app.rescue/src/components/dashboard/UnreadMessagesPanel.test.tsx
+++ b/app.rescue/src/components/dashboard/UnreadMessagesPanel.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * ADS-643: rescue staff need to see unread adopter messages on the dashboard.
+ *
+ * Behaviour under test:
+ * - When unread conversations exist, the panel lists each with sender,
+ *   snippet, and timestamp, capped to the top 5 most-recent.
+ * - The total unread count is shown in the heading.
+ * - When zero unread, an empty state explains how messages reach the panel.
+ * - Clicking a row routes to /communication?conversation=<id>.
+ * - The panel is rendered above other non-urgent widgets (the parent
+ *   Dashboard owns this ordering; here we just verify the panel exists).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { Conversation } from '@adopt-dont-shop/lib.chat';
+
+const mockedUseUnreadConversations = vi.fn();
+const mockedUseChat = vi.fn();
+
+vi.mock('@adopt-dont-shop/lib.chat', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.chat')>(
+    '@adopt-dont-shop/lib.chat'
+  );
+  return {
+    ...actual,
+    useUnreadConversations: () => mockedUseUnreadConversations(),
+    useChat: () => mockedUseChat(),
+  };
+});
+
+import { UnreadMessagesPanel } from './UnreadMessagesPanel';
+
+const baseConversation = (overrides: Partial<Conversation>): Conversation => ({
+  id: 'conv-1',
+  participants: [],
+  unreadCount: 0,
+  updatedAt: '2026-05-01T10:00:00Z',
+  createdAt: '2026-05-01T10:00:00Z',
+  isActive: true,
+  status: 'active',
+  ...overrides,
+});
+
+const renderPanel = () =>
+  render(
+    <MemoryRouter>
+      <UnreadMessagesPanel />
+    </MemoryRouter>
+  );
+
+describe('UnreadMessagesPanel - ADS-643', () => {
+  it('renders one row per unread conversation with sender, snippet, and a deep link', () => {
+    const convA = baseConversation({
+      id: 'conv-a',
+      unreadCount: 2,
+      updatedAt: '2026-05-22T10:00:00Z',
+      lastMessage: {
+        id: 'm-a',
+        conversationId: 'conv-a',
+        senderId: 'u-1',
+        senderName: 'Alice Adopter',
+        content: 'Hi, is Buddy still available?',
+        timestamp: '2026-05-22T10:00:00Z',
+        type: 'text',
+        status: 'delivered',
+      },
+    });
+    const convB = baseConversation({
+      id: 'conv-b',
+      unreadCount: 1,
+      updatedAt: '2026-05-21T10:00:00Z',
+      lastMessage: {
+        id: 'm-b',
+        conversationId: 'conv-b',
+        senderId: 'u-2',
+        senderName: 'Bob Adopter',
+        content: 'Can we schedule a meet-and-greet?',
+        timestamp: '2026-05-21T10:00:00Z',
+        type: 'text',
+        status: 'delivered',
+      },
+    });
+
+    mockedUseUnreadConversations.mockReturnValue({
+      totalUnread: 3,
+      unreadByConversationId: { 'conv-a': 2, 'conv-b': 1 },
+      markRead: vi.fn(),
+    });
+    mockedUseChat.mockReturnValue({ conversations: [convA, convB] });
+
+    renderPanel();
+
+    expect(screen.getByText(/Unread messages/i)).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+
+    expect(screen.getByText('Alice Adopter')).toBeInTheDocument();
+    expect(screen.getByText(/Hi, is Buddy still available\?/)).toBeInTheDocument();
+
+    expect(screen.getByText('Bob Adopter')).toBeInTheDocument();
+    expect(screen.getByText(/Can we schedule a meet-and-greet\?/)).toBeInTheDocument();
+
+    const aLink = screen.getByRole('link', { name: /Alice Adopter/i });
+    expect(aLink).toHaveAttribute('href', '/communication?conversation=conv-a');
+    const bLink = screen.getByRole('link', { name: /Bob Adopter/i });
+    expect(bLink).toHaveAttribute('href', '/communication?conversation=conv-b');
+  });
+
+  it('orders rows by updatedAt descending and caps at 5 entries', () => {
+    const makeConv = (id: string, day: number) =>
+      baseConversation({
+        id,
+        unreadCount: 1,
+        updatedAt: `2026-05-${day.toString().padStart(2, '0')}T10:00:00Z`,
+        lastMessage: {
+          id: `m-${id}`,
+          conversationId: id,
+          senderId: id,
+          senderName: `Sender ${id}`,
+          content: `snippet-${id}`,
+          timestamp: `2026-05-${day.toString().padStart(2, '0')}T10:00:00Z`,
+          type: 'text',
+          status: 'delivered',
+        },
+      });
+    const conversations = [
+      makeConv('old1', 1),
+      makeConv('old2', 2),
+      makeConv('mid1', 10),
+      makeConv('mid2', 11),
+      makeConv('new1', 20),
+      makeConv('new2', 21),
+    ];
+
+    mockedUseUnreadConversations.mockReturnValue({
+      totalUnread: 6,
+      unreadByConversationId: Object.fromEntries(conversations.map(c => [c.id, 1])),
+      markRead: vi.fn(),
+    });
+    mockedUseChat.mockReturnValue({ conversations });
+
+    renderPanel();
+
+    const list = screen.getByTestId('unread-messages-list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(5);
+
+    // newest first
+    const links = within(list).getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', '/communication?conversation=new2');
+    expect(links[1]).toHaveAttribute('href', '/communication?conversation=new1');
+    // oldest should be excluded
+    expect(screen.queryByText('snippet-old1')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state explaining how messages arrive when there are no unread', () => {
+    mockedUseUnreadConversations.mockReturnValue({
+      totalUnread: 0,
+      unreadByConversationId: {},
+      markRead: vi.fn(),
+    });
+    mockedUseChat.mockReturnValue({ conversations: [] });
+
+    renderPanel();
+
+    expect(screen.getByText(/No unread messages/i)).toBeInTheDocument();
+    expect(screen.getByText(/pet/i)).toBeInTheDocument();
+    expect(screen.getByText(/application/i)).toBeInTheDocument();
+    expect(screen.getByText(/direct inquiry/i)).toBeInTheDocument();
+  });
+
+  it('ignores conversations with zero unread even if they are in the conversations list', () => {
+    const read = baseConversation({
+      id: 'read-1',
+      unreadCount: 0,
+      lastMessage: {
+        id: 'm-r',
+        conversationId: 'read-1',
+        senderId: 'u-r',
+        senderName: 'Already Read',
+        content: 'old message',
+        timestamp: '2026-05-22T10:00:00Z',
+        type: 'text',
+        status: 'read',
+      },
+    });
+    const unread = baseConversation({
+      id: 'unread-1',
+      unreadCount: 1,
+      lastMessage: {
+        id: 'm-u',
+        conversationId: 'unread-1',
+        senderId: 'u-u',
+        senderName: 'New Adopter',
+        content: 'fresh message',
+        timestamp: '2026-05-22T10:00:00Z',
+        type: 'text',
+        status: 'delivered',
+      },
+    });
+    mockedUseUnreadConversations.mockReturnValue({
+      totalUnread: 1,
+      unreadByConversationId: { 'unread-1': 1, 'read-1': 0 },
+      markRead: vi.fn(),
+    });
+    mockedUseChat.mockReturnValue({ conversations: [read, unread] });
+
+    renderPanel();
+
+    expect(screen.queryByText('Already Read')).not.toBeInTheDocument();
+    expect(screen.getByText('New Adopter')).toBeInTheDocument();
+  });
+
+  it('renders a "View all" link to the Communication page', () => {
+    mockedUseUnreadConversations.mockReturnValue({
+      totalUnread: 1,
+      unreadByConversationId: { 'unread-1': 1 },
+      markRead: vi.fn(),
+    });
+    mockedUseChat.mockReturnValue({
+      conversations: [
+        baseConversation({
+          id: 'unread-1',
+          unreadCount: 1,
+          lastMessage: {
+            id: 'm-u',
+            conversationId: 'unread-1',
+            senderId: 'u-u',
+            senderName: 'New Adopter',
+            content: 'fresh message',
+            timestamp: '2026-05-22T10:00:00Z',
+            type: 'text',
+            status: 'delivered',
+          },
+        }),
+      ],
+    });
+
+    renderPanel();
+
+    const viewAll = screen.getByRole('link', { name: /view all/i });
+    expect(viewAll).toHaveAttribute('href', '/communication');
+  });
+});

--- a/app.rescue/src/components/dashboard/UnreadMessagesPanel.tsx
+++ b/app.rescue/src/components/dashboard/UnreadMessagesPanel.tsx
@@ -1,0 +1,109 @@
+/**
+ * ADS-643: Surfaces unread adopter messages on the rescue dashboard.
+ *
+ * Uses `useUnreadConversations` for the (real-time) unread counts and pairs
+ * each id with the matching conversation from `useChat` to render sender,
+ * snippet, and timestamp. Each row deep-links to the Communication page
+ * with the conversation pre-selected via the `?conversation=<id>` query
+ * param. Capped at 5 most-recent unread; full inbox via "View all".
+ */
+import { Card, Heading, Text } from '@adopt-dont-shop/lib.components';
+import {
+  safeFormatDistanceToNow,
+  useChat,
+  useUnreadConversations,
+  type Conversation,
+} from '@adopt-dont-shop/lib.chat';
+import { Link } from 'react-router-dom';
+import * as styles from './UnreadMessagesPanel.css';
+
+const MAX_VISIBLE_UNREAD = 5;
+
+const buildConversationLink = (conversationId: string): string =>
+  `/communication?conversation=${encodeURIComponent(conversationId)}`;
+
+type UnreadRowProps = {
+  conversation: Conversation;
+};
+
+const UnreadRow = ({ conversation }: UnreadRowProps) => {
+  const lastMessage = conversation.lastMessage;
+  const senderName = lastMessage?.senderName ?? 'Adopter';
+  const snippet = lastMessage?.content ?? 'New message';
+  const timestamp = lastMessage?.timestamp ?? conversation.updatedAt;
+  const relative = safeFormatDistanceToNow(timestamp);
+
+  return (
+    <li>
+      <Link
+        to={buildConversationLink(conversation.id)}
+        className={styles.rowLink}
+        aria-label={`${senderName}: ${snippet}`}
+      >
+        <div className={styles.rowTopLine}>
+          <span className={styles.senderName}>
+            <span className={styles.unreadDot} aria-hidden="true" />
+            {senderName}
+          </span>
+          <span className={styles.timestamp}>{relative}</span>
+        </div>
+        <Text className={styles.snippet}>{snippet}</Text>
+      </Link>
+    </li>
+  );
+};
+
+const EmptyState = () => (
+  <div className={styles.emptyState}>
+    <Text>No unread messages.</Text>
+    <Text>
+      New messages appear here when an adopter contacts you about a pet, sends a question on an
+      application, or starts a direct inquiry.
+    </Text>
+  </div>
+);
+
+export const UnreadMessagesPanel = () => {
+  const { totalUnread, unreadByConversationId } = useUnreadConversations();
+  const { conversations } = useChat();
+
+  // Pair unread ids with their conversation metadata. Conversations missing
+  // from the list (rare race after socket reset) are skipped — there's
+  // nothing useful to render without lastMessage / sender.
+  const unreadConversations = conversations
+    .filter(conv => (unreadByConversationId[conv.id] ?? 0) > 0)
+    .slice()
+    .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
+    .slice(0, MAX_VISIBLE_UNREAD);
+
+  return (
+    <Card className={styles.panel} data-testid="unread-messages-panel">
+      <div className={styles.header}>
+        <div className={styles.headingGroup}>
+          <Heading level="h3">Unread messages</Heading>
+          {totalUnread > 0 && (
+            <span className={styles.countBadge} aria-label={`${totalUnread} unread`}>
+              {totalUnread}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {unreadConversations.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ul className={styles.list} data-testid="unread-messages-list">
+          {unreadConversations.map(conv => (
+            <UnreadRow key={conv.id} conversation={conv} />
+          ))}
+        </ul>
+      )}
+
+      <div className={styles.footer}>
+        <Link to="/communication" className={styles.viewAllLink}>
+          View all messages
+        </Link>
+      </div>
+    </Card>
+  );
+};

--- a/app.rescue/src/pages/Communication.test.tsx
+++ b/app.rescue/src/pages/Communication.test.tsx
@@ -14,6 +14,7 @@
 import React, { useState } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import type { Conversation } from '@adopt-dont-shop/lib.chat';
 
 type ConfirmOptions = {
@@ -173,12 +174,18 @@ const setupHooks = (opts: BuildOptions = {}) => {
   mockedUseChat.mockReturnValue({
     conversations: opts.conversations ?? [],
     activeConversation: opts.activeConversation ?? null,
+    setActiveConversation: vi.fn(),
     updateConversationStatus,
   });
   return { updateConversationStatus };
 };
 
-const renderPage = () => render(<Communication />);
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <Communication />
+    </MemoryRouter>
+  );
 
 describe('Communication page - ADS-583 mark resolved', () => {
   beforeEach(() => {

--- a/app.rescue/src/pages/Communication.tsx
+++ b/app.rescue/src/pages/Communication.tsx
@@ -10,6 +10,7 @@ import { Button, ConfirmDialog, toast, useConfirm } from '@adopt-dont-shop/lib.c
 import { CHAT_UPDATE } from '@adopt-dont-shop/lib.permissions';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import * as styles from './Communication.css';
 
 // ADS-583: "resolved" maps to the backend's `archived` status. The backend's
@@ -51,12 +52,14 @@ const persistFilter = (filter: 'active' | 'resolved'): void => {
 };
 
 function Communication() {
-  const { activeConversation, updateConversationStatus } = useChat();
+  const { activeConversation, conversations, setActiveConversation, updateConversationStatus } =
+    useChat();
   const { hasPermission } = usePermissions();
   const { confirm, confirmProps } = useConfirm();
   const [isMobile, setIsMobile] = useState(false);
   const [filter, setFilter] = useState<'active' | 'resolved'>(loadInitialFilter);
   const [isUpdating, setIsUpdating] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     const checkMobile = () => {
@@ -70,6 +73,24 @@ function Communication() {
       window.removeEventListener('resize', checkMobile);
     };
   }, []);
+
+  // ADS-643: support deep links from the dashboard (?conversation=<id>). When
+  // the target conversation arrives in the list, select it and consume the
+  // param so refreshing the page after a manual switch doesn't fight the user.
+  useEffect(() => {
+    const requestedId = searchParams.get('conversation');
+    if (!requestedId) {
+      return;
+    }
+    const target = conversations.find(c => c.id === requestedId);
+    if (!target) {
+      return;
+    }
+    setActiveConversation(target);
+    const next = new URLSearchParams(searchParams);
+    next.delete('conversation');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, conversations, setActiveConversation, setSearchParams]);
 
   const showChat = isMobile && activeConversation !== null;
   const canManageChat = hasPermission(CHAT_UPDATE);

--- a/app.rescue/src/pages/Dashboard.tsx
+++ b/app.rescue/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, Container, Heading, Text } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { useDashboardData } from '../hooks';
+import { UnreadMessagesPanel } from '../components/dashboard/UnreadMessagesPanel';
 import { formatRelativeDate } from '@adopt-dont-shop/lib.utils';
 import * as styles from './Dashboard.css';
 
@@ -91,6 +92,10 @@ const Dashboard: React.FC = () => {
           your rescue overview for today.
         </p>
       </div>
+
+      {/* ADS-643: Unread adopter messages — surfaced above the non-urgent
+          metrics so rescue staff see new conversations first on every viewport. */}
+      <UnreadMessagesPanel />
 
       {/* Key Metrics Row */}
       <div className={styles.metricsGrid}>


### PR DESCRIPTION
## Summary

Adds an **Unread messages** panel to the rescue dashboard so staff see new adopter messages without leaving their landing page. The panel is real-time (via `useUnreadConversations` from `lib.chat`), lists the top 5 most-recent unread conversations with sender + snippet, and deep-links each row to the matching conversation.

## Acceptance criteria

- [x] Dashboard shows an "Unread messages" panel with count, last sender, snippet, and a deep link to that conversation.
- [x] Panel updates in real time via existing chat events — `useUnreadConversations` already tracks the live unread map, and `useChat().conversations` carries the live `lastMessage` metadata. No polling.
- [x] Empty state explains where messages come from: linked to a pet, an application, or a direct inquiry.
- [x] Mobile view shows the panel at the top of the dashboard above the non-urgent widgets (metrics, charts, notifications). On desktop it sits in the same position — above the metrics grid — keeping the ordering consistent.

## Panel layout

```
+-----------------------------------------------+
| Unread messages    [ totalUnread badge ]      |
+-----------------------------------------------+
| • Alice Adopter                  2 min ago    |
|   "Hi, is Buddy still available?"             |
| --------------------------------------------- |
| • Bob Adopter                    1 hr ago     |
|   "Can we schedule a meet-and-greet?"         |
|   ... (up to 5 most-recent unread)            |
+-----------------------------------------------+
|              View all messages                |
+-----------------------------------------------+
```

Empty state shows when no conversation has `unreadCount > 0`.

## Assumptions

1. **Deep link target.** The ticket suggested `/chat/:conversationId`, but no such route exists in `app.rescue/src/App.tsx` — the existing chat surface is `/communication`. I link to `/communication?conversation=<id>` and added a small effect in `Communication.tsx` that reads the param, calls `setActiveConversation`, and clears the param from the URL. If a dedicated `/chat/:conversationId` route is preferred, it can be added in a follow-up.
2. **Sender + snippet source.** Sourced from `conversation.lastMessage.senderName` and `conversation.lastMessage.content` — already populated by `useChat()`. Conversations whose `lastMessage` is missing (very rare race condition right after a socket reset) still render with sensible fallbacks.
3. **Top N.** Hard-capped at 5 rows as suggested by the ticket; "View all" routes to `/communication`.
4. **Filter.** Only conversations with `unreadCount > 0` are shown, even if they appear in the broader `conversations` list.

## Test plan

- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.rescue` — passes (208 tests).
- [x] New behaviour tests cover: panel renders with mocked unread items, top-5 cap + recency ordering, empty state, deep-link `href`, ignoring zero-unread conversations, "View all" link.
- [x] Updated `Communication.test.tsx` to provide `setActiveConversation` and wrap the page in a `MemoryRouter` (now required because the component reads `useSearchParams`).
- [ ] Manual smoke: log into rescue app with seeded data; verify panel populates, links open the correct thread, empty state shows when no unread.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_