### PR TITLE
ADS-634: Surface unread messages and rescue contact on application pages

### DIFF
--- a/app.client/src/pages/ApplicationDashboard.css.ts
+++ b/app.client/src/pages/ApplicationDashboard.css.ts
@@ -43,7 +43,60 @@ export const applicationCard = style({
 export const petInfo = style({
   display: 'flex',
   alignItems: 'center',
+  gap: '1rem',
   marginBottom: '1rem',
+});
+
+export const petThumbnail = style({
+  width: '64px',
+  height: '64px',
+  borderRadius: vars.border.radius.base,
+  objectFit: 'cover',
+  flexShrink: 0,
+  background: vars.background.muted,
+});
+
+export const petThumbnailPlaceholder = style([
+  petThumbnail,
+  {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: vars.text.muted,
+    fontSize: '0.75rem',
+  },
+]);
+
+export const rescueName = style({
+  margin: '0',
+  color: vars.text.secondary,
+  fontSize: '0.875rem',
+  fontWeight: vars.typography.weight.medium,
+});
+
+export const cardTopRow = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
+  gap: '0.5rem',
+});
+
+export const messagesButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.375rem',
+  background: 'transparent',
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.base,
+  padding: '0.25rem 0.625rem',
+  cursor: 'pointer',
+  fontSize: '0.75rem',
+  fontWeight: vars.typography.weight.medium,
+  color: vars.text.secondary,
+  ':hover': {
+    color: vars.text.primary,
+    borderColor: vars.border.color.strong,
+  },
 });
 
 export const petDetailsH3 = style({

--- a/app.client/src/pages/ApplicationDashboard.test.tsx
+++ b/app.client/src/pages/ApplicationDashboard.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * ADS-634: Surface unread messages and rescue contact on application pages.
+ *
+ * Behaviours covered:
+ * - Cards render pet thumbnail and rescue name
+ * - Unread badge appears only when the application's conversation has unread
+ *   messages, and clicking the messages affordance routes to the conversation
+ * - Works with 0, 1, and many applications; with and without unread messages
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/test-utils/render';
+import userEvent from '@testing-library/user-event';
+
+const navigateMock = vi.fn();
+const getUserApplicationsMock = vi.fn();
+const getPetByIdMock = vi.fn();
+
+type MockConversation = {
+  id: string;
+  petId?: string;
+  rescueId?: string;
+};
+
+const chatStateMock: { conversations: MockConversation[] } = { conversations: [] };
+const unreadStateMock: { unreadByConversationId: Record<string, number> } = {
+  unreadByConversationId: {},
+};
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: { userId: 'u-1', email: 'a@b.c' },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/contexts/ChatContext', () => ({
+  useChat: () => ({ conversations: chatStateMock.conversations }),
+}));
+
+vi.mock('@adopt-dont-shop/lib.chat', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.chat')>(
+    '@adopt-dont-shop/lib.chat'
+  );
+  return {
+    ...actual,
+    useUnreadConversations: () => ({
+      totalUnread: 0,
+      unreadByConversationId: unreadStateMock.unreadByConversationId,
+      markRead: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/services', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/services');
+  return {
+    ...actual,
+    applicationService: {
+      getUserApplications: (...args: unknown[]) => getUserApplicationsMock(...args),
+    },
+    petService: {
+      getPetById: (...args: unknown[]) => getPetByIdMock(...args),
+    },
+  };
+});
+
+import { ApplicationDashboard } from './ApplicationDashboard';
+
+const makeApplication = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 'app-1',
+  petId: 'pet-1',
+  userId: 'u-1',
+  rescueId: 'rescue-1',
+  status: 'submitted',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-02T00:00:00Z',
+  submittedAt: '2025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const makePet = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  pet_id: 'pet-1',
+  name: 'Luna',
+  breed: 'Labrador',
+  age_years: 3,
+  images: [
+    {
+      url: 'https://cdn.example.com/luna.jpg',
+      image_id: 'img-1',
+      is_primary: true,
+      order_index: 0,
+      uploaded_at: '2025-01-01T00:00:00Z',
+    },
+  ],
+  rescue: { name: 'Happy Tails Rescue' },
+  ...overrides,
+});
+
+describe('ApplicationDashboard (ADS-634)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    getUserApplicationsMock.mockReset();
+    getPetByIdMock.mockReset();
+    chatStateMock.conversations = [];
+    unreadStateMock.unreadByConversationId = {};
+  });
+
+  it('renders the empty state when the user has no applications', async () => {
+    getUserApplicationsMock.mockResolvedValue([]);
+
+    render(<ApplicationDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /no applications yet/i })).toBeInTheDocument();
+    });
+  });
+
+  it('renders pet thumbnail and rescue name on each card', async () => {
+    getUserApplicationsMock.mockResolvedValue([makeApplication()]);
+    getPetByIdMock.mockResolvedValue(makePet());
+
+    render(<ApplicationDashboard />);
+
+    const image = await screen.findByAltText('Luna');
+    expect(image).toHaveAttribute('src', expect.stringContaining('luna.jpg'));
+    expect(screen.getByText('Happy Tails Rescue')).toBeInTheDocument();
+  });
+
+  it('shows multiple application cards with correct counts when the user has many', async () => {
+    getUserApplicationsMock.mockResolvedValue([
+      makeApplication({ id: 'app-1', petId: 'pet-1' }),
+      makeApplication({ id: 'app-2', petId: 'pet-2' }),
+      makeApplication({ id: 'app-3', petId: 'pet-3' }),
+    ]);
+    getPetByIdMock.mockImplementation((petId: string) =>
+      Promise.resolve(makePet({ pet_id: petId, name: `Pet-${petId}` }))
+    );
+
+    render(<ApplicationDashboard />);
+
+    expect(await screen.findByText('Pet-pet-1')).toBeInTheDocument();
+    expect(screen.getByText('Pet-pet-2')).toBeInTheDocument();
+    expect(screen.getByText('Pet-pet-3')).toBeInTheDocument();
+  });
+
+  it('does not show a messages affordance for applications without an existing conversation', async () => {
+    getUserApplicationsMock.mockResolvedValue([makeApplication()]);
+    getPetByIdMock.mockResolvedValue(makePet());
+
+    render(<ApplicationDashboard />);
+
+    await screen.findByText('Luna');
+    expect(screen.queryByRole('button', { name: /messages/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a messages affordance with no unread badge when conversation has 0 unread', async () => {
+    chatStateMock.conversations = [{ id: 'conv-1', petId: 'pet-1', rescueId: 'rescue-1' }];
+    unreadStateMock.unreadByConversationId = { 'conv-1': 0 };
+    getUserApplicationsMock.mockResolvedValue([makeApplication()]);
+    getPetByIdMock.mockResolvedValue(makePet());
+
+    render(<ApplicationDashboard />);
+
+    expect(
+      await screen.findByRole('button', { name: /messages from rescue/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('unread-badge')).not.toBeInTheDocument();
+  });
+
+  it('shows the unread badge with the count when there are unread messages', async () => {
+    chatStateMock.conversations = [{ id: 'conv-1', petId: 'pet-1', rescueId: 'rescue-1' }];
+    unreadStateMock.unreadByConversationId = { 'conv-1': 3 };
+    getUserApplicationsMock.mockResolvedValue([makeApplication()]);
+    getPetByIdMock.mockResolvedValue(makePet());
+
+    render(<ApplicationDashboard />);
+
+    const badge = await screen.findByTestId('unread-badge');
+    expect(badge).toHaveTextContent('3');
+    expect(
+      screen.getByRole('button', { name: /messages from rescue: 3 unread/i })
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to the conversation when the messages button is clicked', async () => {
+    chatStateMock.conversations = [{ id: 'conv-99', petId: 'pet-1', rescueId: 'rescue-1' }];
+    unreadStateMock.unreadByConversationId = { 'conv-99': 2 };
+    getUserApplicationsMock.mockResolvedValue([makeApplication()]);
+    getPetByIdMock.mockResolvedValue(makePet());
+
+    const user = userEvent.setup();
+    render(<ApplicationDashboard />);
+
+    const button = await screen.findByRole('button', { name: /messages from rescue: 2 unread/i });
+    await user.click(button);
+
+    expect(navigateMock).toHaveBeenCalledWith('/chat/conv-99');
+  });
+});

--- a/app.client/src/pages/ApplicationDashboard.tsx
+++ b/app.client/src/pages/ApplicationDashboard.tsx
@@ -1,17 +1,27 @@
-import { Button, Card } from '@adopt-dont-shop/lib.components';
-import React, { useEffect, useState } from 'react';
+import { Badge, Button, Card } from '@adopt-dont-shop/lib.components';
+import { useChat } from '@/contexts/ChatContext';
+import { useUnreadConversations } from '@adopt-dont-shop/lib.chat';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { applicationService, petService, Application, Pet } from '@/services';
+import { resolveFileUrl } from '../utils/fileUtils';
 import * as styles from './ApplicationDashboard.css';
 
 interface ApplicationWithPet extends Application {
   pet?: Pet;
 }
 
+const getPrimaryThumbnailUrl = (pet: Pet | undefined): string | undefined => {
+  const primary = pet?.images?.find(img => img.is_primary) ?? pet?.images?.[0];
+  return resolveFileUrl(primary?.thumbnail_url ?? primary?.url);
+};
+
 export const ApplicationDashboard: React.FC = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { conversations } = useChat();
+  const { unreadByConversationId } = useUnreadConversations();
   const [applications, setApplications] = useState<ApplicationWithPet[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -47,9 +57,34 @@ export const ApplicationDashboard: React.FC = () => {
     }
   };
 
+  // Map an application to the corresponding conversation (if any).
+  // Conversations are tagged with petId + rescueId server-side; we use both
+  // because a rescue can have many pets and an adopter could have multiple
+  // open threads with the same rescue.
+  const conversationByApplicationId = useMemo(() => {
+    const lookup: Record<string, string> = {};
+    for (const application of applications) {
+      const match = conversations.find(
+        c => c.petId === application.petId && c.rescueId === application.rescueId
+      );
+      if (match) {
+        lookup[application.id] = match.id;
+      }
+    }
+    return lookup;
+  }, [applications, conversations]);
+
   const handleApplicationClick = (application: ApplicationWithPet) => {
     // Navigate to application details view
     navigate(`/applications/${application.id}`);
+  };
+
+  const handleOpenMessages = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    conversationId: string
+  ) => {
+    event.stopPropagation();
+    navigate(`/chat/${conversationId}`);
   };
 
   if (!user) {
@@ -111,67 +146,106 @@ export const ApplicationDashboard: React.FC = () => {
       </div>
 
       <div className={styles.applicationGrid}>
-        {applications.map(application => (
-          <Card
-            key={application.id}
-            className={styles.applicationCard}
-            onClick={() => handleApplicationClick(application)}
-          >
-            <div className={styles.petInfo}>
-              <div>
-                <h3 className={styles.petDetailsH3}>
-                  {application.pet?.name || 'Pet Name Unavailable'}
-                </h3>
-                <p className={styles.petDetailsP}>
-                  {application.pet?.breed} • {application.pet?.age_years} years old
+        {applications.map(application => {
+          const thumbnailUrl = getPrimaryThumbnailUrl(application.pet);
+          const rescueName = application.pet?.rescue?.name;
+          const conversationId = conversationByApplicationId[application.id];
+          const unread = conversationId ? (unreadByConversationId[conversationId] ?? 0) : 0;
+
+          return (
+            <Card
+              key={application.id}
+              className={styles.applicationCard}
+              onClick={() => handleApplicationClick(application)}
+            >
+              <div className={styles.cardTopRow}>
+                <div className={styles.petInfo}>
+                  {thumbnailUrl ? (
+                    <img
+                      className={styles.petThumbnail}
+                      src={thumbnailUrl}
+                      alt={application.pet?.name ?? 'Pet'}
+                    />
+                  ) : (
+                    <div className={styles.petThumbnailPlaceholder} aria-hidden='true'>
+                      No photo
+                    </div>
+                  )}
+                  <div>
+                    <h3 className={styles.petDetailsH3}>
+                      {application.pet?.name || 'Pet Name Unavailable'}
+                    </h3>
+                    <p className={styles.petDetailsP}>
+                      {application.pet?.breed} • {application.pet?.age_years} years old
+                    </p>
+                    {rescueName && <p className={styles.rescueName}>{rescueName}</p>}
+                  </div>
+                </div>
+
+                {conversationId && (
+                  <button
+                    type='button'
+                    className={styles.messagesButton}
+                    onClick={event => handleOpenMessages(event, conversationId)}
+                    aria-label={
+                      unread > 0 ? `Messages from rescue: ${unread} unread` : 'Messages from rescue'
+                    }
+                  >
+                    Messages
+                    {unread > 0 && (
+                      <Badge variant='count' size='xs' max={99} data-testid='unread-badge'>
+                        {unread}
+                      </Badge>
+                    )}
+                  </button>
+                )}
+              </div>
+
+              <span
+                className={styles.statusBadge({
+                  status: (['submitted', 'under_review', 'approved', 'rejected'].includes(
+                    application.status
+                  )
+                    ? application.status
+                    : 'default') as
+                    | 'submitted'
+                    | 'under_review'
+                    | 'approved'
+                    | 'rejected'
+                    | 'default',
+                })}
+              >
+                {application.status.replace('_', ' ')}
+              </span>
+
+              <div className={styles.applicationDetails}>
+                {application.submittedAt && (
+                  <p>
+                    <strong>Submitted:</strong>{' '}
+                    {new Date(application.submittedAt).toLocaleDateString()}
+                  </p>
+                )}
+                <p>
+                  <strong>Last Updated:</strong>{' '}
+                  {new Date(application.updatedAt).toLocaleDateString()}
                 </p>
               </div>
-            </div>
 
-            <span
-              className={styles.statusBadge({
-                status: (['submitted', 'under_review', 'approved', 'rejected'].includes(
-                  application.status
-                )
-                  ? application.status
-                  : 'default') as
-                  | 'submitted'
-                  | 'under_review'
-                  | 'approved'
-                  | 'rejected'
-                  | 'default',
-              })}
-            >
-              {application.status.replace('_', ' ')}
-            </span>
-
-            <div className={styles.applicationDetails}>
-              {application.submittedAt && (
-                <p>
-                  <strong>Submitted:</strong>{' '}
-                  {new Date(application.submittedAt).toLocaleDateString()}
-                </p>
-              )}
-              <p>
-                <strong>Last Updated:</strong>{' '}
-                {new Date(application.updatedAt).toLocaleDateString()}
-              </p>
-            </div>
-
-            <div className={styles.actionButtons}>
-              <Button
-                size='sm'
-                variant='outline'
-                onClick={e => {
-                  e.stopPropagation();
-                  handleApplicationClick(application);
-                }}
-              >
-                View Details
-              </Button>
-            </div>
-          </Card>
-        ))}
+              <div className={styles.actionButtons}>
+                <Button
+                  size='sm'
+                  variant='outline'
+                  onClick={e => {
+                    e.stopPropagation();
+                    handleApplicationClick(application);
+                  }}
+                >
+                  View Details
+                </Button>
+              </div>
+            </Card>
+          );
+        })}
       </div>
     </div>
   );

--- a/app.client/src/pages/ApplicationDetailsPage.css.ts
+++ b/app.client/src/pages/ApplicationDetailsPage.css.ts
@@ -18,6 +18,13 @@ export const header = style({
   marginBottom: '2rem',
 });
 
+export const messageRescueRow = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  marginBottom: '2rem',
+});
+
 globalStyle(`${header} h1`, {
   fontSize: '2rem',
   color: vars.text.primary,

--- a/app.client/src/pages/ApplicationDetailsPage.test.tsx
+++ b/app.client/src/pages/ApplicationDetailsPage.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * ADS-634: Inline "Message rescue" CTA on the application details page.
+ *
+ * Behaviours covered:
+ * - CTA is rendered above the fold
+ * - When a conversation already exists for this pet + rescue, clicking the
+ *   CTA navigates straight to it without creating a new conversation
+ * - When no conversation exists, the CTA creates one and then navigates
+ * - Navigation always carries the application's return path as router state
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/test-utils/render';
+import userEvent from '@testing-library/user-event';
+
+const navigateMock = vi.fn();
+const getApplicationByIdMock = vi.fn();
+const startConversationMock = vi.fn();
+
+type MockConversation = {
+  id: string;
+  petId?: string;
+  rescueId?: string;
+};
+
+const chatStateMock: { conversations: MockConversation[] } = { conversations: [] };
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => ({ id: 'app-1' }),
+  };
+});
+
+vi.mock('@/contexts/ChatContext', () => ({
+  useChat: () => ({
+    conversations: chatStateMock.conversations,
+    startConversation: startConversationMock,
+  }),
+}));
+
+vi.mock('@/services', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/services');
+  return {
+    ...actual,
+    applicationService: {
+      getApplicationById: (...args: unknown[]) => getApplicationByIdMock(...args),
+      withdrawApplication: vi.fn(),
+    },
+  };
+});
+
+import { ApplicationDetailsPage } from './ApplicationDetailsPage';
+
+const makeApplication = () => ({
+  id: 'app-1',
+  petId: 'pet-1',
+  userId: 'u-1',
+  rescueId: 'rescue-1',
+  status: 'submitted',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-02T00:00:00Z',
+  submittedAt: '2025-01-01T00:00:00Z',
+});
+
+describe('ApplicationDetailsPage Message rescue CTA (ADS-634)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    getApplicationByIdMock.mockReset();
+    startConversationMock.mockReset();
+    chatStateMock.conversations = [];
+  });
+
+  it('shows a "Message rescue" CTA once the application loads', async () => {
+    getApplicationByIdMock.mockResolvedValue(makeApplication());
+
+    render(<ApplicationDetailsPage />);
+
+    expect(await screen.findByRole('button', { name: /message rescue/i })).toBeInTheDocument();
+  });
+
+  it('navigates to the existing conversation when one already covers this pet + rescue', async () => {
+    chatStateMock.conversations = [{ id: 'conv-7', petId: 'pet-1', rescueId: 'rescue-1' }];
+    getApplicationByIdMock.mockResolvedValue(makeApplication());
+
+    const user = userEvent.setup();
+    render(<ApplicationDetailsPage />);
+
+    const cta = await screen.findByRole('button', { name: /message rescue/i });
+    await user.click(cta);
+
+    expect(startConversationMock).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/chat/conv-7', {
+      state: { from: '/applications/app-1' },
+    });
+  });
+
+  it('creates a new conversation when none exists, then navigates to it', async () => {
+    getApplicationByIdMock.mockResolvedValue(makeApplication());
+    startConversationMock.mockResolvedValue({ id: 'conv-new' });
+
+    const user = userEvent.setup();
+    render(<ApplicationDetailsPage />);
+
+    const cta = await screen.findByRole('button', { name: /message rescue/i });
+    await user.click(cta);
+
+    await waitFor(() => {
+      expect(startConversationMock).toHaveBeenCalledWith('rescue-1', 'pet-1');
+    });
+    expect(navigateMock).toHaveBeenCalledWith('/chat/conv-new', {
+      state: { from: '/applications/app-1' },
+    });
+  });
+
+  it('surfaces an error and does not navigate when conversation creation fails', async () => {
+    getApplicationByIdMock.mockResolvedValue(makeApplication());
+    startConversationMock.mockRejectedValue(new Error('network down'));
+
+    const user = userEvent.setup();
+    render(<ApplicationDetailsPage />);
+
+    const cta = await screen.findByRole('button', { name: /message rescue/i });
+    await user.click(cta);
+
+    expect(await screen.findByText(/failed to start a conversation/i)).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^\/chat\//),
+      expect.anything()
+    );
+  });
+});

--- a/app.client/src/pages/ApplicationDetailsPage.tsx
+++ b/app.client/src/pages/ApplicationDetailsPage.tsx
@@ -1,5 +1,6 @@
 import { applicationService, Application } from '@/services';
 import { Alert, Button, Spinner } from '@adopt-dont-shop/lib.components';
+import { useChat } from '@/contexts/ChatContext';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { WithdrawApplicationModal } from '../components/application';
@@ -14,6 +15,9 @@ export const ApplicationDetailsPage: React.FC = () => {
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
   const [isWithdrawing, setIsWithdrawing] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [isOpeningMessages, setIsOpeningMessages] = useState(false);
+  const [messageError, setMessageError] = useState<string | null>(null);
+  const { conversations, startConversation } = useChat();
 
   useEffect(() => {
     const loadApplication = async () => {
@@ -63,6 +67,38 @@ export const ApplicationDetailsPage: React.FC = () => {
     }
   };
 
+  const handleMessageRescue = async () => {
+    if (!application) {
+      return;
+    }
+    setMessageError(null);
+
+    // Reuse an existing conversation when one already covers this
+    // pet + rescue pair; otherwise create a fresh one so the adopter
+    // can message the rescue from the application context.
+    const existing = conversations.find(
+      c => c.petId === application.petId && c.rescueId === application.rescueId
+    );
+
+    const returnPath = `/applications/${application.id}`;
+
+    if (existing) {
+      navigate(`/chat/${existing.id}`, { state: { from: returnPath } });
+      return;
+    }
+
+    try {
+      setIsOpeningMessages(true);
+      const conversation = await startConversation(application.rescueId, application.petId);
+      navigate(`/chat/${conversation.id}`, { state: { from: returnPath } });
+    } catch (error) {
+      console.error('Failed to start conversation:', error);
+      setMessageError('Failed to start a conversation. Please try again.');
+    } finally {
+      setIsOpeningMessages(false);
+    }
+  };
+
   const formatDate = (dateString?: string | null) => {
     if (!dateString) {
       return 'Not available';
@@ -102,6 +138,18 @@ export const ApplicationDetailsPage: React.FC = () => {
       <div className={styles.header}>
         <h1>Application Details</h1>
         <p>Application #{application.id.slice(-6)}</p>
+      </div>
+
+      <div className={styles.messageRescueRow}>
+        <Button
+          variant='primary'
+          onClick={handleMessageRescue}
+          isLoading={isOpeningMessages}
+          disabled={isOpeningMessages}
+        >
+          Message rescue
+        </Button>
+        {messageError && <Alert variant='error'>{messageError}</Alert>}
       </div>
 
       {successMessage && (


### PR DESCRIPTION
## Summary

Adds adopter-facing unread-message visibility and a "Message rescue" CTA on the application pages in `app.client`:

- `ApplicationDashboard` cards now show a pet thumbnail, the rescue name and a per-card unread-message badge sourced from `useUnreadConversations` (added in ADS-655). A "Messages" affordance opens the relevant conversation at `/chat/:conversationId`.
- `ApplicationDetailsPage` gains an above-the-fold "Message rescue" CTA. It reuses an existing conversation when present, otherwise creates one via `startConversation(rescueId, petId)` — copying the established `PetDetailsPage.handleContactRescue` flow. Navigation preserves the originating application path via router state (`state: { from: '/applications/:id' }`) so a future "back" affordance can return cleanly without a new prop on `ChatPage`.

## Acceptance criteria

- [x] `ApplicationDashboard` cards show pet thumbnail, rescue name, and unread-message count badge
- [x] Clicking the badge / "Messages" affordance opens the relevant conversation in `/chat/:conversationId`
- [x] `ApplicationDetailsPage` shows an inline "Message rescue" CTA above the fold, preserving application context on return
- [x] Unread counts update in real time via `useUnreadConversations` (no new fetching layer)
- [x] Works when the application's conversation doesn't yet exist — CTA creates it
- [x] Behaviour tests cover 0, 1, and >1 active applications; 0 and >0 unread counts; existing-conversation vs create-new flow; conversation-create failure

## How I found the conversation ID

`lib.chat`'s `ConversationSchema` already carries `petId` and `rescueId`, and `ChatProvider` exposes the full `conversations` array through `useChat()`. I match an application to a conversation by `petId + rescueId` (both — a rescue can have many open threads). For creating a new conversation I reuse the existing `startConversation(rescueId, petId)` flow that `PetDetailsPage.handleContactRescue` already calls.

## Assumptions

- **Pet thumbnail** is derived from `pet.images.find(img => img.is_primary) ?? pet.images[0]`, preferring `thumbnail_url` over `url`. This mirrors `PetCard.tsx` and avoids reaching for any new backend field.
- **App → rescue lookup** uses `application.rescueId` (already on `ApplicationSchema`) and the rescue display name comes from `pet.rescue.name` (already returned by `petService.getPetById`). No backend changes were introduced.
- "Preserves return context" is implemented as `navigate('/chat/:id', { state: { from: '/applications/:id' } })`. The browser back button already returns to the application page; the router state lets a future `ChatPage` enhancement render an explicit "Back to application" link without touching this PR's surface.

## Test plan

- [ ] `npx turbo test --filter=@adopt-dont-shop/app.client` — 376 tests pass (11 new)
- [ ] `npx turbo lint --filter=@adopt-dont-shop/app.client` — 0 errors
- [ ] Manual: dashboard with no apps shows existing empty state
- [ ] Manual: dashboard with mixed apps (some with conversations, some without) shows badge only where unread > 0
- [ ] Manual: details page "Message rescue" CTA opens existing chat without re-creation; creates one when none exists; surfaces an error alert on failure

## Notes

- `npx turbo type-check --filter=@adopt-dont-shop/app.client` fails on `main` with a pre-existing `TS5101: baseUrl deprecated` error in `tsconfig.json`. Not introduced by this PR.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_