### PR TITLE
ADS-642: Stage-aware bulk actions and per-stage counts on applications queue

### DIFF
--- a/app.rescue/src/components/applications/BulkActionBar.test.tsx
+++ b/app.rescue/src/components/applications/BulkActionBar.test.tsx
@@ -1,9 +1,44 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import BulkActionBar from './BulkActionBar';
+import type { ApplicationListItem } from '../../types/applications';
+import type { ApplicationStage } from '../../types/applicationStages';
 
-describe('BulkActionBar', () => {
+/**
+ * ADS-642: behaviour tests for the stage-aware bulk action bar.
+ * Documents the contract the queue depends on:
+ *  - each stage transition exposes its own button
+ *  - rows that fail preconditions are shown to the user before they
+ *    confirm
+ *  - rejection captures a shared reason applied to every selected row
+ */
+
+const buildApp = (overrides: Partial<ApplicationListItem> & { id: string }): ApplicationListItem =>
+  ({
+    petId: 'pet-1',
+    petName: 'Bella',
+    petType: 'Dog',
+    petBreed: 'Mix',
+    userId: 'user-1',
+    rescueId: 'rescue-1',
+    status: 'submitted',
+    submittedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    data: undefined,
+    applicantName: `Applicant ${overrides.id}`,
+    submittedDaysAgo: 1,
+    priority: 'normal',
+    referencesStatus: 'pending',
+    homeVisitStatus: 'not_scheduled',
+    stage: 'PENDING' as ApplicationStage,
+    stageProgressPercentage: 10,
+    tags: [],
+    ...overrides,
+  }) as ApplicationListItem;
+
+describe('BulkActionBar (ADS-642)', () => {
   const onClearSelection = vi.fn();
   const onBulkAction = vi.fn().mockResolvedValue(undefined);
 
@@ -14,7 +49,7 @@ describe('BulkActionBar', () => {
   it('renders nothing when nothing is selected and there is no result summary', () => {
     const { container } = render(
       <BulkActionBar
-        selectedCount={0}
+        selectedApplications={[]}
         onClearSelection={onClearSelection}
         onBulkAction={onBulkAction}
       />
@@ -22,38 +57,96 @@ describe('BulkActionBar', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('shows the selection count and the three action buttons when at least one row is selected', () => {
+  it('shows the stage-aware action buttons when at least one row is selected', () => {
     render(
       <BulkActionBar
-        selectedCount={3}
+        selectedApplications={[buildApp({ id: 'a' }), buildApp({ id: 'b' }), buildApp({ id: 'c' })]}
         onClearSelection={onClearSelection}
         onBulkAction={onBulkAction}
       />
     );
     expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Move to next stage' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Withdraw' })).toBeInTheDocument();
   });
 
-  it('invokes onBulkAction("approve") without a reason after confirming approve', async () => {
+  it('advances eligible rows to the next stage and skips resolved rows', async () => {
+    const apps = [
+      buildApp({ id: 'a', stage: 'PENDING' }),
+      buildApp({ id: 'b', stage: 'REVIEWING' }),
+      buildApp({ id: 'c', stage: 'RESOLVED' }),
+    ];
     render(
       <BulkActionBar
-        selectedCount={2}
+        selectedApplications={apps}
+        onClearSelection={onClearSelection}
+        onBulkAction={onBulkAction}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Move to next stage' }));
+
+    // Confirmation should show 2 of 3 eligible
+    expect(screen.getByText(/2/)).toBeInTheDocument();
+    const blocked = screen.getByTestId('bulk-blocked-list');
+    expect(within(blocked).getByText(/already resolved/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onBulkAction).toHaveBeenCalledWith('advance', ['a', 'b'], undefined);
+  });
+
+  it('blocks approve when the application is not in the DECIDING stage and reports the reason', () => {
+    render(
+      <BulkActionBar
+        selectedApplications={[buildApp({ id: 'a', stage: 'REVIEWING' })]}
+        onClearSelection={onClearSelection}
+        onBulkAction={onBulkAction}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    const blocked = screen.getByTestId('bulk-blocked-list');
+    expect(within(blocked).getByText(/DECIDING/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+  });
+
+  it('blocks approve when home visit is not completed even in the DECIDING stage', () => {
+    render(
+      <BulkActionBar
+        selectedApplications={[
+          buildApp({ id: 'a', stage: 'DECIDING', homeVisitStatus: 'scheduled' }),
+        ]}
+        onClearSelection={onClearSelection}
+        onBulkAction={onBulkAction}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    const blocked = screen.getByTestId('bulk-blocked-list');
+    expect(within(blocked).getByText(/home visit/i)).toBeInTheDocument();
+  });
+
+  it('approves a DECIDING application whose home visit is completed', () => {
+    render(
+      <BulkActionBar
+        selectedApplications={[
+          buildApp({ id: 'a', stage: 'DECIDING', homeVisitStatus: 'completed' }),
+        ]}
         onClearSelection={onClearSelection}
         onBulkAction={onBulkAction}
       />
     );
     fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-
-    expect(onBulkAction).toHaveBeenCalledWith('approve', undefined);
+    expect(onBulkAction).toHaveBeenCalledWith('approve', ['a'], undefined);
   });
 
-  it('blocks the reject confirm until a reason is entered', () => {
+  it('blocks the reject confirm until a shared reason is entered and forwards it', () => {
     render(
       <BulkActionBar
-        selectedCount={2}
+        selectedApplications={[
+          buildApp({ id: 'a', stage: 'PENDING' }),
+          buildApp({ id: 'b', stage: 'REVIEWING' }),
+        ]}
         onClearSelection={onClearSelection}
         onBulkAction={onBulkAction}
       />
@@ -69,19 +162,20 @@ describe('BulkActionBar', () => {
     expect(confirmButton).not.toBeDisabled();
 
     fireEvent.click(confirmButton);
-    expect(onBulkAction).toHaveBeenCalledWith('reject', 'duplicate application');
+    expect(onBulkAction).toHaveBeenCalledWith('reject', ['a', 'b'], 'duplicate application');
   });
 
   it('disables all controls when busy is true', () => {
     render(
       <BulkActionBar
-        selectedCount={3}
+        selectedApplications={[buildApp({ id: 'a' }), buildApp({ id: 'b' }), buildApp({ id: 'c' })]}
         onClearSelection={onClearSelection}
         onBulkAction={onBulkAction}
         busy
       />
     );
     expect(screen.getByRole('button', { name: 'Clear' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Move to next stage' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Approve' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Reject' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Withdraw' })).toBeDisabled();
@@ -90,7 +184,7 @@ describe('BulkActionBar', () => {
   it('renders the result summary when provided', () => {
     render(
       <BulkActionBar
-        selectedCount={0}
+        selectedApplications={[]}
         onClearSelection={onClearSelection}
         onBulkAction={onBulkAction}
         resultSummary={{ successCount: 7, failedCount: 1 }}

--- a/app.rescue/src/components/applications/BulkActionBar.tsx
+++ b/app.rescue/src/components/applications/BulkActionBar.tsx
@@ -1,40 +1,92 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import * as styles from './BulkActionBar.css';
+import type { ApplicationListItem } from '../../types/applications';
+import { canApplyBulkAction, type BulkStageAction } from '../../utils/applicationStageTransitions';
 
-type BulkAction = 'approve' | 'reject' | 'withdraw';
+type BlockedRow = {
+  application: ApplicationListItem;
+  message: string;
+};
 
-type BulkActionBarProps = {
-  selectedCount: number;
+export type BulkActionBarProps = {
+  selectedApplications: ApplicationListItem[];
   onClearSelection: () => void;
-  onBulkAction: (action: BulkAction, reason?: string) => Promise<void>;
+  onBulkAction: (action: BulkStageAction, eligibleIds: string[], reason?: string) => Promise<void>;
   busy?: boolean;
   resultSummary?: { successCount: number; failedCount: number } | null;
 };
 
+const ACTION_LABEL: Record<BulkStageAction, string> = {
+  advance: 'Move to next stage',
+  approve: 'Approve',
+  reject: 'Reject',
+  withdraw: 'Withdraw',
+};
+
+const splitSelection = (action: BulkStageAction, apps: ApplicationListItem[]) => {
+  const eligible: ApplicationListItem[] = [];
+  const blocked: BlockedRow[] = [];
+  for (const app of apps) {
+    const result = canApplyBulkAction(action, app);
+    if (result.eligible) {
+      eligible.push(app);
+    } else {
+      blocked.push({ application: app, message: result.message });
+    }
+  }
+  return { eligible, blocked };
+};
+
 const BulkActionBar: React.FC<BulkActionBarProps> = ({
-  selectedCount,
+  selectedApplications,
   onClearSelection,
   onBulkAction,
   busy = false,
   resultSummary,
 }) => {
-  const [pendingAction, setPendingAction] = useState<BulkAction | null>(null);
+  const selectedCount = selectedApplications.length;
+  const [pendingAction, setPendingAction] = useState<BulkStageAction | null>(null);
   const [reason, setReason] = useState('');
+
+  const split = useMemo(
+    () => (pendingAction ? splitSelection(pendingAction, selectedApplications) : null),
+    [pendingAction, selectedApplications]
+  );
 
   if (selectedCount === 0 && !resultSummary) {
     return null;
   }
 
   const requireReason = pendingAction === 'reject';
+  const canConfirm =
+    !!split && split.eligible.length > 0 && (!requireReason || reason.trim().length > 0);
 
   const handleConfirm = async () => {
-    if (!pendingAction) {
+    if (!pendingAction || !split) {
       return;
     }
-    await onBulkAction(pendingAction, requireReason ? reason : undefined);
+    await onBulkAction(
+      pendingAction,
+      split.eligible.map(a => a.id),
+      requireReason ? reason : undefined
+    );
     setPendingAction(null);
     setReason('');
   };
+
+  const renderButton = (action: BulkStageAction, className?: string) => (
+    <button
+      type="button"
+      onClick={() => {
+        setPendingAction(action);
+        setReason('');
+      }}
+      disabled={busy}
+      className={className ?? styles.neutralButton}
+    >
+      {ACTION_LABEL[action]}
+    </button>
+  );
 
   return (
     <div className={styles.container}>
@@ -47,30 +99,10 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
             Clear
           </button>
           <span className={styles.spacer} />
-          <button
-            type="button"
-            onClick={() => setPendingAction('approve')}
-            disabled={busy}
-            className={styles.approveButton}
-          >
-            Approve
-          </button>
-          <button
-            type="button"
-            onClick={() => setPendingAction('reject')}
-            disabled={busy}
-            className={styles.rejectButton}
-          >
-            Reject
-          </button>
-          <button
-            type="button"
-            onClick={() => setPendingAction('withdraw')}
-            disabled={busy}
-            className={styles.neutralButton}
-          >
-            Withdraw
-          </button>
+          {renderButton('advance')}
+          {renderButton('approve', styles.approveButton)}
+          {renderButton('reject', styles.rejectButton)}
+          {renderButton('withdraw')}
         </>
       )}
 
@@ -81,10 +113,11 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
         </span>
       )}
 
-      {pendingAction && (
+      {pendingAction && split && (
         <div className={styles.confirmRow}>
           <span>
-            Confirm <strong>{pendingAction}</strong> for {selectedCount} application
+            Confirm <strong>{ACTION_LABEL[pendingAction]}</strong> for{' '}
+            <strong>{split.eligible.length}</strong> of {selectedCount} application
             {selectedCount === 1 ? '' : 's'}?
           </span>
           {requireReason && (
@@ -99,7 +132,7 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
           <button
             type="button"
             onClick={handleConfirm}
-            disabled={busy || (requireReason && reason.trim().length === 0)}
+            disabled={busy || !canConfirm}
             className={styles.neutralButton}
           >
             {busy ? 'Working…' : 'Confirm'}
@@ -115,6 +148,19 @@ const BulkActionBar: React.FC<BulkActionBarProps> = ({
           >
             Cancel
           </button>
+          {split.blocked.length > 0 && (
+            <ul
+              aria-label="Blocked applications"
+              data-testid="bulk-blocked-list"
+              className={styles.fullWidthRow}
+            >
+              {split.blocked.map(b => (
+                <li key={b.application.id}>
+                  <strong>{b.application.applicantName}</strong>: {b.message}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
     </div>

--- a/app.rescue/src/components/applications/StageCountSummary.css.ts
+++ b/app.rescue/src/components/applications/StageCountSummary.css.ts
@@ -1,0 +1,22 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  listStyle: 'none',
+  margin: 0,
+  padding: '0.5rem 0.75rem',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '1rem',
+  background: vars.background.muted,
+  borderRadius: vars.border.radius.sm,
+  marginBottom: '0.75rem',
+});
+
+export const item = style({
+  fontSize: '0.875rem',
+});
+
+export const label = style({
+  color: vars.text.secondary,
+});

--- a/app.rescue/src/components/applications/StageCountSummary.tsx
+++ b/app.rescue/src/components/applications/StageCountSummary.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import * as styles from './StageCountSummary.css';
+import { countByStage } from '../../utils/applicationStageTransitions';
+import { STAGE_CONFIG, type ApplicationStage } from '../../types/applicationStages';
+import type { ApplicationListItem } from '../../types/applications';
+
+/**
+ * ADS-642: per-stage count summary above the applications queue so
+ * rescue staff can see at a glance how many applications are sitting
+ * in each stage (Pending: 5, Reviewing: 3, …) before they pick a
+ * bulk action.
+ */
+
+const ORDER: ApplicationStage[] = ['PENDING', 'REVIEWING', 'VISITING', 'DECIDING', 'RESOLVED'];
+
+type Props = {
+  applications: ReadonlyArray<Pick<ApplicationListItem, 'stage'>>;
+};
+
+const StageCountSummary: React.FC<Props> = ({ applications }) => {
+  const counts = countByStage(applications);
+
+  return (
+    <ul className={styles.container} aria-label="Applications per stage">
+      {ORDER.map(stage => {
+        const cfg = STAGE_CONFIG[stage];
+        return (
+          <li key={stage} className={styles.item}>
+            <span aria-hidden="true">{cfg.emoji}</span>{' '}
+            <span className={styles.label}>{cfg.label}:</span>{' '}
+            <strong data-testid={`stage-count-${stage.toLowerCase()}`}>{counts[stage]}</strong>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default StageCountSummary;

--- a/app.rescue/src/pages/Applications.tsx
+++ b/app.rescue/src/pages/Applications.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useApplications, useApplicationDetails } from '../hooks/useApplications';
 import ApplicationList from '../components/applications/ApplicationList';
 import ApplicationReview from '../components/applications/ApplicationReview';
 import BulkActionBar from '../components/applications/BulkActionBar';
+import StageCountSummary from '../components/applications/StageCountSummary';
 import { applicationService } from '../services/applicationService';
 import type { ApplicationListItem } from '../types/applications';
+import { buildBulkUpdatePayload, type BulkStageAction } from '../utils/applicationStageTransitions';
 
 const Applications: React.FC = () => {
   // ADS-644: when deep-linked from a pet card or foster row, scope the
@@ -13,7 +15,11 @@ const Applications: React.FC = () => {
   const [searchParams] = useSearchParams();
   const initialPetId = searchParams.get('petId');
   const [selectedApplication, setSelectedApplication] = useState<ApplicationListItem | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // ADS-642: selection is stored as a map of id → application snapshot
+  // so it survives pagination/filter changes (the user can select rows
+  // on page 1, paginate to page 2, and the BulkActionBar still knows
+  // each row's stage and home-visit status when computing eligibility).
+  const [selectedById, setSelectedById] = useState<Map<string, ApplicationListItem>>(new Map());
   const [bulkBusy, setBulkBusy] = useState(false);
   const [bulkResult, setBulkResult] = useState<{
     successCount: number;
@@ -86,6 +92,71 @@ const Applications: React.FC = () => {
     }
   };
 
+  // ADS-642: derive the Set passed to ApplicationList from the
+  // selection map. The list only owns the id-level toggles; this page
+  // tracks the full snapshot so the BulkActionBar can compute
+  // preconditions on rows that may no longer be on the current page.
+  const selectedIds = useMemo(() => new Set(selectedById.keys()), [selectedById]);
+
+  const updateSelection = (next: Set<string>) => {
+    // Merge: keep snapshots for ids that are still selected, learn new
+    // snapshots from rows currently rendered. Rows selected on previous
+    // pages that aren't in `applications` keep their stored snapshot.
+    const nextMap = new Map<string, ApplicationListItem>();
+    for (const id of next) {
+      const existing = selectedById.get(id);
+      const fresh = applications.find(a => a.id === id);
+      const snapshot = fresh ?? existing;
+      if (snapshot) {
+        nextMap.set(id, snapshot);
+      }
+    }
+    setSelectedById(nextMap);
+  };
+
+  const handleBulkAction = async (
+    action: BulkStageAction,
+    eligibleIds: string[],
+    reason?: string
+  ) => {
+    setBulkBusy(true);
+    setBulkResult(null);
+    try {
+      // Group eligible rows by the payload shape we'd POST so we issue
+      // one bulk-update call per distinct target stage (e.g. all rows
+      // advancing to REVIEWING vs. all rows advancing to VISITING).
+      const groups = new Map<
+        string,
+        { applicationIds: string[]; updates: Record<string, unknown> }
+      >();
+      for (const id of eligibleIds) {
+        const app = selectedById.get(id);
+        if (!app) {
+          continue;
+        }
+        const payload = buildBulkUpdatePayload(action, app, reason);
+        const key = JSON.stringify(payload);
+        const existing = groups.get(key);
+        if (existing) {
+          existing.applicationIds.push(id);
+        } else {
+          groups.set(key, { applicationIds: [id], updates: payload });
+        }
+      }
+      const result = await applicationService.performBulkUpdates(Array.from(groups.values()));
+      setBulkResult({
+        successCount: result.successCount,
+        failedCount: result.failureCount,
+      });
+      setSelectedById(new Map());
+      refetch();
+    } catch {
+      setBulkResult({ successCount: 0, failedCount: eligibleIds.length });
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+
   return (
     <div className="page-container">
       <div className="page-header">
@@ -93,35 +164,17 @@ const Applications: React.FC = () => {
         <p>Review and process adoption applications.</p>
       </div>
 
+      <StageCountSummary applications={applications} />
+
       <BulkActionBar
-        selectedCount={selectedIds.size}
+        selectedApplications={Array.from(selectedById.values())}
         onClearSelection={() => {
-          setSelectedIds(new Set());
+          setSelectedById(new Map());
           setBulkResult(null);
         }}
         busy={bulkBusy}
         resultSummary={bulkResult}
-        onBulkAction={async (action, reason) => {
-          setBulkBusy(true);
-          setBulkResult(null);
-          try {
-            const result = await applicationService.performBulkAction({
-              type: action,
-              applicationIds: Array.from(selectedIds),
-              data: reason ? { reason } : undefined,
-            });
-            setBulkResult({
-              successCount: result?.successCount ?? selectedIds.size,
-              failedCount: result?.failureCount ?? 0,
-            });
-            setSelectedIds(new Set());
-            refetch();
-          } catch (err) {
-            setBulkResult({ successCount: 0, failedCount: selectedIds.size });
-          } finally {
-            setBulkBusy(false);
-          }
-        }}
+        onBulkAction={handleBulkAction}
       />
 
       {/* Applications List */}
@@ -136,7 +189,7 @@ const Applications: React.FC = () => {
         onSortChange={updateSort}
         onApplicationSelect={handleApplicationSelect}
         selectedIds={selectedIds}
-        onSelectionChange={setSelectedIds}
+        onSelectionChange={updateSelection}
       />
 
       {/* Application Review Modal */}

--- a/app.rescue/src/services/applicationService.ts
+++ b/app.rescue/src/services/applicationService.ts
@@ -670,6 +670,59 @@ export class RescueApplicationService {
   }
 
   /**
+   * ADS-642: dispatch a set of per-application bulk updates. Each group
+   * shares one `updates` payload (e.g. all rows advancing to REVIEWING
+   * vs. all rows advancing to VISITING), so the bulk-update endpoint
+   * still does the heavy lifting and we only fan out by distinct
+   * payload shape. Returns an aggregate {successCount, failureCount}
+   * matching the existing single-action response shape.
+   */
+  async performBulkUpdates(
+    groups: ReadonlyArray<{ applicationIds: string[]; updates: Record<string, unknown> }>
+  ): Promise<{
+    successCount: number;
+    failureCount: number;
+    failures: Array<{ applicationId: string; error: string }>;
+  }> {
+    let successCount = 0;
+    let failureCount = 0;
+    const failures: Array<{ applicationId: string; error: string }> = [];
+    for (const group of groups) {
+      if (group.applicationIds.length === 0) {
+        continue;
+      }
+      try {
+        const response = await this.apiService.patch<{
+          data?: {
+            successCount?: number;
+            failureCount?: number;
+            failures?: Array<{ applicationId: string; error: string }>;
+          };
+          successCount?: number;
+          failureCount?: number;
+          failures?: Array<{ applicationId: string; error: string }>;
+        }>('/api/v1/applications/bulk-update', {
+          applicationIds: group.applicationIds,
+          updates: group.updates,
+        });
+        const payload = response.data || response;
+        successCount += payload.successCount ?? group.applicationIds.length;
+        failureCount += payload.failureCount ?? 0;
+        if (payload.failures) {
+          failures.push(...payload.failures);
+        }
+      } catch (error) {
+        failureCount += group.applicationIds.length;
+        const message = error instanceof Error ? error.message : 'Bulk update failed';
+        for (const id of group.applicationIds) {
+          failures.push({ applicationId: id, error: message });
+        }
+      }
+    }
+    return { successCount, failureCount, failures };
+  }
+
+  /**
    * Transform application data for list display
    */
   private transformApplicationForList = (app: any): ApplicationListItem => {

--- a/app.rescue/src/utils/applicationStageTransitions.test.ts
+++ b/app.rescue/src/utils/applicationStageTransitions.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBulkUpdatePayload,
+  canApplyBulkAction,
+  countByStage,
+} from './applicationStageTransitions';
+import type { ApplicationListItem } from '../types/applications';
+import type { ApplicationStage } from '../types/applicationStages';
+
+/**
+ * ADS-642: per-stage rules for the rescue queue's bulk action bar.
+ * These tests document the contract the queue and the BulkActionBar
+ * rely on — change them and you change which rows the queue claims
+ * are eligible for each action.
+ */
+
+const buildApp = (overrides: Partial<ApplicationListItem>): ApplicationListItem =>
+  ({
+    id: 'app-1',
+    petId: 'pet-1',
+    petName: 'Bella',
+    petType: 'Dog',
+    petBreed: 'Mix',
+    userId: 'user-1',
+    rescueId: 'rescue-1',
+    status: 'submitted',
+    submittedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    data: undefined,
+    applicantName: 'Test Person',
+    submittedDaysAgo: 1,
+    priority: 'normal',
+    referencesStatus: 'pending',
+    homeVisitStatus: 'not_scheduled',
+    stage: 'PENDING',
+    stageProgressPercentage: 10,
+    tags: [],
+    ...overrides,
+  }) as ApplicationListItem;
+
+describe('canApplyBulkAction (ADS-642)', () => {
+  describe('advance (move to next stage)', () => {
+    it.each<ApplicationStage>(['PENDING', 'REVIEWING', 'VISITING'])(
+      'is eligible for an application in the %s stage',
+      stage => {
+        expect(canApplyBulkAction('advance', buildApp({ stage })).eligible).toBe(true);
+      }
+    );
+
+    it('blocks an application already in DECIDING with a clear message about resolving instead', () => {
+      const result = canApplyBulkAction('advance', buildApp({ stage: 'DECIDING' }));
+      expect(result.eligible).toBe(false);
+      if (!result.eligible) {
+        expect(result.reason).toBe('no-next-stage');
+        expect(result.message.toLowerCase()).toContain('approve');
+      }
+    });
+
+    it('blocks an application already in RESOLVED', () => {
+      const result = canApplyBulkAction('advance', buildApp({ stage: 'RESOLVED' }));
+      expect(result.eligible).toBe(false);
+      if (!result.eligible) {
+        expect(result.reason).toBe('already-resolved');
+      }
+    });
+  });
+
+  describe('approve', () => {
+    it('only allows approval when the application is in the DECIDING stage', () => {
+      const earlyStage = canApplyBulkAction(
+        'approve',
+        buildApp({ stage: 'REVIEWING', homeVisitStatus: 'completed' })
+      );
+      expect(earlyStage.eligible).toBe(false);
+      if (!earlyStage.eligible) {
+        expect(earlyStage.reason).toBe('not-in-deciding-stage');
+      }
+    });
+
+    it('refuses approval when the home visit is not completed', () => {
+      const result = canApplyBulkAction(
+        'approve',
+        buildApp({ stage: 'DECIDING', homeVisitStatus: 'scheduled' })
+      );
+      expect(result.eligible).toBe(false);
+      if (!result.eligible) {
+        expect(result.reason).toBe('home-visit-not-completed');
+      }
+    });
+
+    it('allows approval for a DECIDING application with a completed home visit', () => {
+      expect(
+        canApplyBulkAction('approve', buildApp({ stage: 'DECIDING', homeVisitStatus: 'completed' }))
+          .eligible
+      ).toBe(true);
+    });
+  });
+
+  describe('reject and withdraw', () => {
+    it.each<ApplicationStage>(['PENDING', 'REVIEWING', 'VISITING', 'DECIDING'])(
+      'allow rejection for any non-terminal stage (%s)',
+      stage => {
+        expect(canApplyBulkAction('reject', buildApp({ stage })).eligible).toBe(true);
+      }
+    );
+
+    it('blocks reject on a resolved application', () => {
+      expect(canApplyBulkAction('reject', buildApp({ stage: 'RESOLVED' })).eligible).toBe(false);
+    });
+
+    it.each<ApplicationStage>(['PENDING', 'REVIEWING', 'VISITING', 'DECIDING'])(
+      'allow withdrawal for any non-terminal stage (%s)',
+      stage => {
+        expect(canApplyBulkAction('withdraw', buildApp({ stage })).eligible).toBe(true);
+      }
+    );
+
+    it('blocks withdraw on a resolved application', () => {
+      expect(canApplyBulkAction('withdraw', buildApp({ stage: 'RESOLVED' })).eligible).toBe(false);
+    });
+  });
+});
+
+describe('buildBulkUpdatePayload (ADS-642)', () => {
+  it('advances PENDING to REVIEWING by setting the stage column', () => {
+    expect(buildBulkUpdatePayload('advance', buildApp({ stage: 'PENDING' }))).toEqual({
+      stage: 'reviewing',
+    });
+  });
+
+  it('advances VISITING to DECIDING', () => {
+    expect(buildBulkUpdatePayload('advance', buildApp({ stage: 'VISITING' }))).toEqual({
+      stage: 'deciding',
+    });
+  });
+
+  it('builds the approve payload with terminal status and final outcome', () => {
+    expect(
+      buildBulkUpdatePayload(
+        'approve',
+        buildApp({ stage: 'DECIDING', homeVisitStatus: 'completed' })
+      )
+    ).toEqual({ status: 'approved', stage: 'resolved', finalOutcome: 'approved' });
+  });
+
+  it('embeds the shared rejection reason in the reject payload', () => {
+    expect(
+      buildBulkUpdatePayload('reject', buildApp({ stage: 'REVIEWING' }), 'duplicate application')
+    ).toEqual({
+      status: 'rejected',
+      stage: 'resolved',
+      finalOutcome: 'rejected',
+      rejectionReason: 'duplicate application',
+    });
+  });
+
+  it('embeds the withdrawal reason in the withdraw payload', () => {
+    expect(
+      buildBulkUpdatePayload('withdraw', buildApp({ stage: 'PENDING' }), 'applicant changed mind')
+    ).toEqual({
+      status: 'withdrawn',
+      stage: 'withdrawn',
+      finalOutcome: 'withdrawn',
+      withdrawalReason: 'applicant changed mind',
+    });
+  });
+});
+
+describe('countByStage (ADS-642)', () => {
+  it('returns zero for every stage when given an empty list', () => {
+    expect(countByStage([])).toEqual({
+      PENDING: 0,
+      REVIEWING: 0,
+      VISITING: 0,
+      DECIDING: 0,
+      RESOLVED: 0,
+    });
+  });
+
+  it('aggregates a mixed list correctly', () => {
+    const apps = [
+      { stage: 'PENDING' as const },
+      { stage: 'PENDING' as const },
+      { stage: 'REVIEWING' as const },
+      { stage: 'VISITING' as const },
+      { stage: 'DECIDING' as const },
+      { stage: 'RESOLVED' as const },
+      { stage: 'RESOLVED' as const },
+      { stage: 'RESOLVED' as const },
+    ];
+    expect(countByStage(apps)).toEqual({
+      PENDING: 2,
+      REVIEWING: 1,
+      VISITING: 1,
+      DECIDING: 1,
+      RESOLVED: 3,
+    });
+  });
+});

--- a/app.rescue/src/utils/applicationStageTransitions.ts
+++ b/app.rescue/src/utils/applicationStageTransitions.ts
@@ -1,0 +1,173 @@
+/**
+ * ADS-642: stage-aware bulk actions on the rescue applications queue.
+ *
+ * Backend status state-machine is intentionally simple — `submitted →
+ * {approved, rejected, withdrawn}` is the only resolution path. The
+ * five "stages" (PENDING → REVIEWING → VISITING → DECIDING → RESOLVED)
+ * are a richer workflow layered on top via the `stage` column. This
+ * module is the single source of truth for which bulk action can apply
+ * to a row given its current stage and supporting data, so the queue's
+ * "Move to next stage" button and per-stage Reject/Approve/Withdraw
+ * buttons stay honest about which rows are eligible.
+ *
+ * Preconditions are evaluated client-side for UX (so we can tell the
+ * user which rows blocked the action before any HTTP traffic). The
+ * authoritative state still lives in the backend — failed rows surface
+ * via the bulk-update response's `failures` array.
+ */
+import type { ApplicationListItem } from '../types/applications';
+import type { ApplicationStage } from '../types/applicationStages';
+
+export type BulkStageAction = 'advance' | 'approve' | 'reject' | 'withdraw';
+
+export type NextStageMap = Partial<Record<ApplicationStage, ApplicationStage>>;
+
+/**
+ * Linear forward progression between non-terminal stages. RESOLVED is
+ * terminal — there is no "next" so advance is blocked for resolved
+ * rows. From DECIDING, "advance" resolves the application (which we
+ * gate behind explicit Approve, not the generic advance button — see
+ * canApplyBulkAction).
+ */
+export const NEXT_STAGE: NextStageMap = {
+  PENDING: 'REVIEWING',
+  REVIEWING: 'VISITING',
+  VISITING: 'DECIDING',
+};
+
+export type BlockedReason =
+  | 'already-resolved'
+  | 'home-visit-not-completed'
+  | 'not-in-deciding-stage'
+  | 'no-next-stage';
+
+export type ActionEligibility =
+  | { eligible: true }
+  | { eligible: false; reason: BlockedReason; message: string };
+
+const RESOLVED_STAGE: ApplicationStage = 'RESOLVED';
+
+const isResolved = (app: Pick<ApplicationListItem, 'stage'>): boolean =>
+  app.stage === RESOLVED_STAGE;
+
+/**
+ * Whether the given bulk action can apply to this row right now. The
+ * caller uses this to split the selection into "will run" vs
+ * "blocked" so the UI can report what was skipped and why.
+ */
+export const canApplyBulkAction = (
+  action: BulkStageAction,
+  app: ApplicationListItem
+): ActionEligibility => {
+  if (isResolved(app)) {
+    return {
+      eligible: false,
+      reason: 'already-resolved',
+      message: 'Application is already resolved',
+    };
+  }
+
+  if (action === 'advance') {
+    const next = NEXT_STAGE[app.stage];
+    if (!next) {
+      return {
+        eligible: false,
+        reason: 'no-next-stage',
+        message: 'No next stage from DECIDING — use Approve or Reject to resolve',
+      };
+    }
+    return { eligible: true };
+  }
+
+  if (action === 'approve') {
+    if (app.stage !== 'DECIDING') {
+      return {
+        eligible: false,
+        reason: 'not-in-deciding-stage',
+        message: 'Approve only applies to DECIDING applications',
+      };
+    }
+    if (app.homeVisitStatus !== 'completed') {
+      return {
+        eligible: false,
+        reason: 'home-visit-not-completed',
+        message: 'Home visit must be completed before approval',
+      };
+    }
+    return { eligible: true };
+  }
+
+  // 'reject' and 'withdraw' apply to any non-resolved application.
+  return { eligible: true };
+};
+
+/**
+ * The update payload to send to the backend bulk-update endpoint for a
+ * given action. Stage advances write `stage`; resolutions write
+ * `status` + `stage` + `finalOutcome` (+ optional reason) so the row
+ * lands in a consistent state.
+ */
+export type BulkUpdatePayload = {
+  status?: 'approved' | 'rejected' | 'withdrawn';
+  stage?: 'pending' | 'reviewing' | 'visiting' | 'deciding' | 'resolved' | 'withdrawn';
+  finalOutcome?: 'approved' | 'rejected' | 'withdrawn';
+  rejectionReason?: string;
+  withdrawalReason?: string;
+};
+
+export const buildBulkUpdatePayload = (
+  action: BulkStageAction,
+  app: ApplicationListItem,
+  reason?: string
+): BulkUpdatePayload => {
+  if (action === 'advance') {
+    const next = NEXT_STAGE[app.stage];
+    if (!next) {
+      throw new Error('buildBulkUpdatePayload called for advance on a row with no next stage');
+    }
+    return { stage: next.toLowerCase() as BulkUpdatePayload['stage'] };
+  }
+  if (action === 'approve') {
+    return { status: 'approved', stage: 'resolved', finalOutcome: 'approved' };
+  }
+  if (action === 'reject') {
+    return {
+      status: 'rejected',
+      stage: 'resolved',
+      finalOutcome: 'rejected',
+      rejectionReason: reason,
+    };
+  }
+  // withdraw
+  return {
+    status: 'withdrawn',
+    stage: 'withdrawn',
+    finalOutcome: 'withdrawn',
+    withdrawalReason: reason,
+  };
+};
+
+/**
+ * Per-stage counts derived from a list of applications. Pure function
+ * so the queue's count summary and any other consumer can share the
+ * same accounting rules.
+ */
+export type StageCounts = Record<ApplicationStage, number>;
+
+export const countByStage = (
+  apps: ReadonlyArray<Pick<ApplicationListItem, 'stage'>>
+): StageCounts => {
+  const counts: StageCounts = {
+    PENDING: 0,
+    REVIEWING: 0,
+    VISITING: 0,
+    DECIDING: 0,
+    RESOLVED: 0,
+  };
+  for (const app of apps) {
+    if (app.stage in counts) {
+      counts[app.stage] += 1;
+    }
+  }
+  return counts;
+};

--- a/lib.validation/src/schemas/__tests__/application.test.ts
+++ b/lib.validation/src/schemas/__tests__/application.test.ts
@@ -324,5 +324,27 @@ describe('Application schemas', () => {
         ApplicationBulkUpdateRequestSchema.parse({ applicationIds: [someUuid], updates: {} })
       ).toThrow();
     });
+
+    it('accepts a stage update (ADS-642 stage-aware bulk actions)', () => {
+      const parsed = ApplicationBulkUpdateRequestSchema.parse({
+        applicationIds: [someUuid],
+        updates: { stage: 'reviewing' },
+      });
+      expect(parsed.updates.stage).toBe('reviewing');
+    });
+
+    it('accepts a bulk reject with a shared rejection reason (ADS-642)', () => {
+      const parsed = ApplicationBulkUpdateRequestSchema.parse({
+        applicationIds: [someUuid],
+        updates: {
+          status: 'rejected',
+          stage: 'resolved',
+          finalOutcome: 'rejected',
+          rejectionReason: 'duplicate application',
+        },
+      });
+      expect(parsed.updates.rejectionReason).toBe('duplicate application');
+      expect(parsed.updates.finalOutcome).toBe('rejected');
+    });
   });
 });

--- a/lib.validation/src/schemas/application.ts
+++ b/lib.validation/src/schemas/application.ts
@@ -277,6 +277,12 @@ export type ApplicationSearchQuery = z.infer<typeof ApplicationSearchQuerySchema
  * POST /api/v1/applications/bulk — staff-side bulk update. The
  * controller accepts an `applicationIds` array plus an `updates`
  * record; we mirror that here.
+ *
+ * ADS-642: `stage`, `finalOutcome`, `rejectionReason`, `withdrawalReason`
+ * are accepted so the rescue queue's stage-aware bulk actions
+ * ("Move to next stage", bulk reject with shared reason, etc.) can
+ * persist their changes through the same endpoint instead of needing
+ * a parallel route.
  */
 export const ApplicationBulkUpdateRequestSchema = z.object({
   applicationIds: z
@@ -286,6 +292,10 @@ export const ApplicationBulkUpdateRequestSchema = z.object({
     .object({
       status: ApplicationStatusSchema.optional(),
       priority: ApplicationPrioritySchema.optional(),
+      stage: ApplicationStageSchema.optional(),
+      finalOutcome: ApplicationOutcomeSchema.optional(),
+      rejectionReason: NotesSchema.optional(),
+      withdrawalReason: NotesSchema.optional(),
       tags: z.array(TagSchema).max(20).optional(),
       notes: NotesSchema.optional(),
     })


### PR DESCRIPTION
## Summary

Replaces the rescue applications queue's flat Approve/Reject/Withdraw bulk bar with stage-aware actions, adds a per-stage count summary above the queue, and makes selection survive pagination so multi-page bulk operations are practical.

## Acceptance criteria

- [x] Applications list shows a per-stage count summary at the top (Pending / Reviewing / Visiting / Deciding / Resolved) — new `StageCountSummary` component
- [x] Bulk actions include **Move to next stage** plus stage-specific transitions (Approve / Reject / Withdraw), not just Approve/Reject
- [x] Bulk reject prompts for a shared reason applied to all selected applications
- [x] Bulk approve refuses to act on rows that fail preconditions (must be in `DECIDING`, must have a completed home visit) and lists the blocked rows in the confirmation dialog before the user confirms
- [x] Filters and bulk actions persist across pagination — selection is stored as an id → snapshot map at the page level so eligibility checks keep working for rows selected on earlier pages
- [x] Unit tests cover each stage transition's preconditions (`app.rescue/src/utils/applicationStageTransitions.test.ts`) and the BulkActionBar's behaviour (`app.rescue/src/components/applications/BulkActionBar.test.tsx`)

## Transition map

| Action | Eligibility | Backend write |
|---|---|---|
| Move to next stage | `PENDING → REVIEWING`, `REVIEWING → VISITING`, `VISITING → DECIDING` (blocked from `DECIDING`/`RESOLVED`) | `stage` only |
| Approve | Must be in `DECIDING` **and** `homeVisitStatus === 'completed'` | `status='approved'`, `stage='resolved'`, `finalOutcome='approved'` |
| Reject | Any non-resolved row; shared reason required | `status='rejected'`, `stage='resolved'`, `finalOutcome='rejected'`, `rejectionReason` |
| Withdraw | Any non-resolved row | `status='withdrawn'`, `stage='withdrawn'`, `finalOutcome='withdrawn'`, `withdrawalReason` (optional) |

## Decisions

- **Where preconditions are validated.** Client-side for UX (so we can list every blocked row and the reason before any HTTP traffic). The backend remains authoritative — failures from `bulk-update` still surface in the response's `failures` array.
- **How "Move to next stage" handles mixed-stage selections.** It splits the selection: rows whose stage has a successor are advanced; rows with no successor (`DECIDING` or `RESOLVED`) are listed in the confirmation dialog with the reason ("No next stage from DECIDING — use Approve or Reject to resolve" / "Application is already resolved") and skipped. We deliberately don't block the bulk action entirely because the common case is a queue full of mixed stages and the operator wants to advance whichever ones are eligible.
- **Why we extended `bulk-update` instead of adding a stage-transition endpoint.** Backend has no `/stage-transition` route today (the rescue service's per-row call is dead code against the current API), and the existing `bulk-update` endpoint already does `application.update(updates)`. Extending its zod schema to accept `stage`, `finalOutcome`, `rejectionReason`, `withdrawalReason` was the minimal change.
- **Selection state lives on the page.** `Applications.tsx` now stores `Map<id, ApplicationListItem>` instead of a `Set<id>`. This keeps a snapshot of each selected row so the BulkActionBar can compute eligibility for rows the user paginated away from.

## Backend changes

- `lib.validation/src/schemas/application.ts` — `ApplicationBulkUpdateRequestSchema` now accepts `stage`, `finalOutcome`, `rejectionReason`, and `withdrawalReason` in the `updates` payload (all optional, status/priority/tags/notes still supported).

## Test plan

- [ ] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.rescue --filter=@adopt-dont-shop/service-backend --filter=@adopt-dont-shop/lib.validation` passes (verified locally: 28/28 turbo tasks, 2724 backend tests)
- [ ] Manually verify the stage count summary updates after a bulk advance
- [ ] Manually verify selecting rows on page 1, paginating, and confirming a bulk action targets the rows from both pages

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_