### PR TITLE
chore(app.rescue): remove dead stage-transition client call

### DIFF
--- a/app.rescue/src/hooks/useApplications.ts
+++ b/app.rescue/src/hooks/useApplications.ts
@@ -216,7 +216,12 @@ export const useApplicationDetails = (applicationId: string | null) => {
       }
 
       try {
-        await applicationService.transitionStage(applicationId, action.type, notes);
+        await applicationService.transitionStage(
+          applicationId,
+          action.type,
+          action.nextStage,
+          notes
+        );
         await fetchApplicationDetails(); // Refresh data
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to transition application stage');

--- a/app.rescue/src/services/applicationService.test.ts
+++ b/app.rescue/src/services/applicationService.test.ts
@@ -3,6 +3,7 @@ import type { ApplicationFilter } from '../types/applications';
 
 const apiServiceMock = vi.hoisted(() => ({
   get: vi.fn<(url: string) => Promise<unknown>>(),
+  patch: vi.fn<(url: string, body: unknown) => Promise<unknown>>(),
 }));
 
 vi.mock('./libraryServices', () => ({
@@ -89,5 +90,72 @@ describe('RescueApplicationService.getApplications query parameters (ADS-575)', 
     expect(params.get('petBreed')).toBeNull();
     expect(params.get('submittedFrom')).toBeNull();
     expect(params.get('submittedTo')).toBeNull();
+  });
+});
+
+/**
+ * ADS-642: stage transitions go through the bulk-update endpoint —
+ * there is no dedicated stage-transition route on the backend. These
+ * tests pin down that single-row transitions dispatch a one-item batch
+ * with the correct updates payload for each StageAction type.
+ */
+describe('RescueApplicationService.transitionStage (ADS-642)', () => {
+  const service = new RescueApplicationService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiServiceMock.patch.mockResolvedValue({ updatedCount: 1 });
+  });
+
+  const getBulkRequest = (): {
+    url: string;
+    body: { applicationIds: string[]; updates: Record<string, unknown> };
+  } => {
+    expect(apiServiceMock.patch).toHaveBeenCalledTimes(1);
+    const [url, body] = apiServiceMock.patch.mock.calls[0];
+    return { url, body: body as { applicationIds: string[]; updates: Record<string, unknown> } };
+  };
+
+  it('targets the bulk-update endpoint with a single-element applicationIds batch', async () => {
+    await service.transitionStage('app-1', 'START_REVIEW', 'REVIEWING');
+
+    const { url, body } = getBulkRequest();
+    expect(url).toBe('/api/v1/applications/bulk-update');
+    expect(body.applicationIds).toEqual(['app-1']);
+  });
+
+  it('writes the lowercased next stage for non-terminal transitions', async () => {
+    await service.transitionStage('app-1', 'SCHEDULE_VISIT', 'VISITING');
+
+    expect(getBulkRequest().body.updates).toEqual({ stage: 'visiting' });
+  });
+
+  it('resolves the application with rejected status when the action is REJECT', async () => {
+    await service.transitionStage('app-1', 'REJECT', 'RESOLVED', 'incomplete references');
+
+    expect(getBulkRequest().body.updates).toEqual({
+      status: 'rejected',
+      stage: 'resolved',
+      finalOutcome: 'rejected',
+      rejectionReason: 'incomplete references',
+    });
+  });
+
+  it('marks the application as withdrawn when the action is WITHDRAW', async () => {
+    await service.transitionStage('app-1', 'WITHDRAW', 'RESOLVED', 'applicant changed mind');
+
+    expect(getBulkRequest().body.updates).toEqual({
+      status: 'withdrawn',
+      stage: 'withdrawn',
+      finalOutcome: 'withdrawn',
+      withdrawalReason: 'applicant changed mind',
+    });
+  });
+
+  it('throws when a non-terminal action is missing its nextStage', async () => {
+    await expect(service.transitionStage('app-1', 'START_REVIEW', undefined)).rejects.toThrow(
+      /nextStage/
+    );
+    expect(apiServiceMock.patch).not.toHaveBeenCalled();
   });
 });

--- a/app.rescue/src/services/applicationService.ts
+++ b/app.rescue/src/services/applicationService.ts
@@ -13,6 +13,39 @@ import type { ApplicationStage } from '../types/applicationStages';
 import type { ApplicationPriority } from '@adopt-dont-shop/lib.applications';
 
 /**
+ * ADS-642: translate a StageAction (e.g. START_REVIEW, REJECT) into the
+ * `updates` payload accepted by the bulk-update endpoint. Single-row
+ * stage transitions reuse the same backend route as bulk transitions —
+ * there is no dedicated stage-transition route.
+ */
+const buildSingleStageTransitionUpdates = (
+  stageAction: string,
+  nextStage: string | undefined,
+  notes: string | undefined
+): Record<string, unknown> => {
+  if (stageAction === 'REJECT') {
+    return {
+      status: 'rejected',
+      stage: 'resolved',
+      finalOutcome: 'rejected',
+      rejectionReason: notes,
+    };
+  }
+  if (stageAction === 'WITHDRAW') {
+    return {
+      status: 'withdrawn',
+      stage: 'withdrawn',
+      finalOutcome: 'withdrawn',
+      withdrawalReason: notes,
+    };
+  }
+  if (!nextStage) {
+    throw new Error(`Stage action ${stageAction} requires a nextStage`);
+  }
+  return { stage: nextStage.toLowerCase() };
+};
+
+/**
  * Application Service for Rescue App
  * Uses the configured API service with authentication
  */
@@ -248,21 +281,21 @@ export class RescueApplicationService {
   }
 
   /**
-   * Transition application to a new stage using the 5-stage workflow system
-   * @param id Application ID
-   * @param stageAction The stage action to perform (from STAGE_ACTIONS)
-   * @param notes Optional notes about the transition
+   * Transition application to a new stage using the 5-stage workflow system.
+   *
+   * ADS-642: single-row transitions go through the bulk-update endpoint
+   * (there is no dedicated stage-transition route on the backend). We
+   * translate the StageAction's nextStage / terminal outcome into the same
+   * `updates` shape `performBulkUpdates` builds, then dispatch a one-item
+   * batch.
    */
-  async transitionStage(id: string, stageAction: string, notes?: string) {
+  async transitionStage(id: string, stageAction: string, nextStage?: string, notes?: string) {
+    const updates = buildSingleStageTransitionUpdates(stageAction, nextStage, notes);
     try {
-      const response = await this.apiService.post<any>(
-        `/api/v1/applications/${id}/stage-transition`,
-        {
-          action: stageAction,
-          notes,
-          timestamp: new Date().toISOString(),
-        }
-      );
+      const response = await this.apiService.patch<any>('/api/v1/applications/bulk-update', {
+        applicationIds: [id],
+        updates,
+      });
       return response.data || response; // Extract data field from API response wrapper
     } catch (error) {
       console.error(`Failed to transition stage for application ${id}:`, error);


### PR DESCRIPTION
## Summary

The rescue app's `applicationService.transitionStage` was POSTing to `/api/v1/applications/:id/stage-transition`, a route that does not exist on the backend — every call 404'd silently. Per ADS-642, single-row stage transitions go through the same `bulk-update` endpoint that the queue's `BulkActionBar` already uses.

### Where the dead call lived
- `app.rescue/src/services/applicationService.ts` — `transitionStage` method (POSTed to non-existent route)

### Callers found
- `app.rescue/src/hooks/useApplications.ts` — `useApplicationDetails.transitionStage`
- `app.rescue/src/pages/Applications.tsx` — `handleStageTransition` (wired to `ApplicationReview`)
- `app.rescue/src/components/applications/ApplicationReview.tsx` — "Transition Stage" button + handler
- `app.rescue/src/components/applications/StageTransitionModal.tsx` — modal that calls `onTransition`

### Migration
The chain is live UI (the single-row "Transition Stage" modal inside the application review), so following the task's "smallest viable migration" guidance the service method is ported to the bulk endpoint with a one-element `applicationIds` array. The `StageAction` (`START_REVIEW`, `SCHEDULE_VISIT`, `COMPLETE_VISIT`, `MAKE_DECISION`, `REJECT`, `WITHDRAW`) is translated into the `updates` shape the bulk-update endpoint already accepts:

- `REJECT` → `{ status: 'rejected', stage: 'resolved', finalOutcome: 'rejected', rejectionReason: notes }`
- `WITHDRAW` → `{ status: 'withdrawn', stage: 'withdrawn', finalOutcome: 'withdrawn', withdrawalReason: notes }`
- everything else → `{ stage: <nextStage>.toLowerCase() }`

The hook now forwards `action.nextStage` alongside `action.type`. No backend changes; no new route invented.

## Test plan
- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.rescue` passes (267 tests).
- [x] `grep -r "stage-transition" .` yields only comments and DOM ids; no live `/stage-transition` API call remains.
- [ ] Manual smoke: open an application in the rescue review modal, click "Transition Stage", confirm the request hits `PATCH /api/v1/applications/bulk-update` with a one-element batch.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_