### PR TITLE
fix(app.client): stabilize distance-sorting behaviour test under parallel load

### DIFF
--- a/app.client/src/__tests__/distance-sorting.behavior.test.tsx
+++ b/app.client/src/__tests__/distance-sorting.behavior.test.tsx
@@ -326,30 +326,37 @@ describe('Distance Sorting - Behavioral Tests', () => {
       });
     });
 
-    it('detects location after successfully geocoding typed location', async () => {
-      server.use(
-        http.get('https://nominatim.openstreetmap.org/search', () => {
-          return HttpResponse.json([
-            { lat: '40.7128', lon: '-74.0060', display_name: 'New York, NY, USA' },
-          ]);
-        })
-      );
+    it(
+      'detects location after successfully geocoding typed location',
+      { timeout: 15_000 },
+      async () => {
+        server.use(
+          http.get('https://nominatim.openstreetmap.org/search', () => {
+            return HttpResponse.json([
+              { lat: '40.7128', lon: '-74.0060', display_name: 'New York, NY, USA' },
+            ]);
+          })
+        );
 
-      renderWithProviders(<SearchPage />);
+        renderWithProviders(<SearchPage />);
 
-      const locationInput = await screen.findByLabelText(/^location$/i);
-      const user = userEvent.setup();
-      await user.type(locationInput, 'New York, NY');
+        const locationInput = await screen.findByLabelText(/^location$/i);
+        const user = userEvent.setup();
+        await user.type(locationInput, 'New York, NY');
 
-      const useAsLocationButton = await screen.findByRole('button', { name: /search nearby/i });
-      await user.click(useAsLocationButton);
+        const useAsLocationButton = await screen.findByRole('button', { name: /search nearby/i });
+        await user.click(useAsLocationButton);
 
-      await waitFor(() => {
-        expect(screen.getByText(/location detected/i)).toBeInTheDocument();
-      });
-    });
+        await waitFor(
+          () => {
+            expect(screen.getByText(/location detected/i)).toBeInTheDocument();
+          },
+          { timeout: 10_000 }
+        );
+      }
+    );
 
-    it('shows error when typed location cannot be geocoded', async () => {
+    it('shows error when typed location cannot be geocoded', { timeout: 15_000 }, async () => {
       server.use(
         http.get('https://nominatim.openstreetmap.org/search', () => {
           return HttpResponse.json([]);
@@ -365,9 +372,12 @@ describe('Distance Sorting - Behavioral Tests', () => {
       const useAsLocationButton = await screen.findByRole('button', { name: /search nearby/i });
       await user.click(useAsLocationButton);
 
-      await waitFor(() => {
-        expect(screen.getByText(/location not found/i)).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(screen.getByText(/location not found/i)).toBeInTheDocument();
+        },
+        { timeout: 10_000 }
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

`app.client/src/__tests__/distance-sorting.behavior.test.tsx` was intermittently timing out (~10-20% on full-suite runs, fine in isolation) under parallel turbo execution. Multiple agents have now flagged it as a real CI risk.

Root cause: under a saturated worker pool (vitest uses 4 threads here), MSW handler resolution + React render work for the two "Manual Location Entry" tests routinely creeps past the default 5s test timeout. The handlers and assertions are correct; they just need headroom.

## Option chosen: 1 — bump the test-level timeout for just the two slow tests

Picked the cheapest viable fix from the list:

- The test logic is fine — both tests pass cleanly in isolation.
- Only two tests are affected (the ones that wait for geocoding-driven sorting/error to render), so a per-test timeout bump is correctly scoped.
- No production code or geocoding service changes.
- No new module mocks or `vi.mock` indirection — kept the MSW behaviour test surface intact.

Changes: raised the per-test timeout to `15_000` and the inner `waitFor` timeout to `10_000` for the two affected tests:

- `detects location after successfully geocoding typed location`
- `shows error when typed location cannot be geocoded`

If this fix is ever insufficient again, the next escalation is option 3 (mock `@/utils/geocoding` directly with `vi.mock`).

## Verification

- `npm --prefix app.client test -- src/__tests__/distance-sorting.behavior.test.tsx --reporter=verbose` — 13/13 pass in isolation.
- `npx turbo test --filter=@adopt-dont-shop/app.client --force` x3 from a clean cache — all three runs green (54 files / 392 tests each).
  - Run 1: 1m20.977s
  - Run 2: 1m14.514s
  - Run 3: 2m10.608s (system was clearly under heavier load on this run — exactly the condition that previously caused flakes; the higher timeouts absorbed it cleanly)

## Test plan

- [x] Test passes in isolation
- [x] `app.client` turbo test suite passes 3x in a row from clean cache
- [x] No production code changes
- [x] No other tests modified

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_