### PR TITLE
fix(admin): correct bulkUpdateUsers endpoint and payload shape

### DIFF
--- a/app.admin/src/__tests__/bulk-update-users-request.behavior.test.ts
+++ b/app.admin/src/__tests__/bulk-update-users-request.behavior.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Behavioral test for the admin bulk-update-users wire contract.
+ *
+ * The backend route lives at `POST /api/v1/users/bulk-update` and its
+ * `BulkUserUpdateRequestSchema` (lib.validation) is strict about both keys
+ * and key names: `{ userIds, updateData, reason }`. This test pins the
+ * frontend service to that contract so a future rename can't silently
+ * regress to the old broken shape (`/api/v1/admin/users/bulk-update` with
+ * `{ user_ids, updates }`).
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const postMock = vi.fn();
+const patchMock = vi.fn();
+
+vi.mock('../services/libraryServices', () => ({
+  apiService: {
+    post: (...args: unknown[]) => postMock(...args),
+    patch: (...args: unknown[]) => patchMock(...args),
+    get: vi.fn(),
+  },
+}));
+
+import { userManagementService } from '../services/userManagementService';
+
+describe('userManagementService.bulkUpdateUsers — wire contract', () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    patchMock.mockReset();
+    postMock.mockResolvedValue({ success: 2, failed: 0 });
+  });
+
+  it('POSTs to /api/v1/users/bulk-update (not the old /admin/users path)', async () => {
+    await userManagementService.bulkUpdateUsers(
+      ['11111111-1111-1111-1111-111111111111'],
+      { status: 'active' },
+      'reason'
+    );
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    const [url] = postMock.mock.calls[0];
+    expect(url).toBe('/api/v1/users/bulk-update');
+  });
+
+  it('sends the canonical { userIds, updateData, reason } payload keys', async () => {
+    await userManagementService.bulkUpdateUsers(
+      ['11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222'],
+      { status: 'inactive' },
+      'Operator deactivated stale accounts'
+    );
+
+    const [, body] = postMock.mock.calls[0];
+    expect(body).toEqual({
+      userIds: ['11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222'],
+      updateData: { status: 'inactive' },
+      reason: 'Operator deactivated stale accounts',
+    });
+  });
+
+  it('does not use the old snake_case keys (user_ids / updates)', async () => {
+    await userManagementService.bulkUpdateUsers(
+      ['11111111-1111-1111-1111-111111111111'],
+      { status: 'active' },
+      'reason'
+    );
+
+    const [, body] = postMock.mock.calls[0];
+    const bodyKeys = Object.keys(body as Record<string, unknown>);
+    expect(bodyKeys).not.toContain('user_ids');
+    expect(bodyKeys).not.toContain('updates');
+  });
+
+  it('does not use PATCH (backend route is POST)', async () => {
+    await userManagementService.bulkUpdateUsers(['11111111-1111-1111-1111-111111111111'], {
+      status: 'active',
+    });
+
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards reason unchanged through the rename (ADS-651)', async () => {
+    await userManagementService.bulkUpdateUsers(
+      ['11111111-1111-1111-1111-111111111111'],
+      { status: 'inactive' },
+      'GDPR cleanup batch'
+    );
+
+    const [, body] = postMock.mock.calls[0];
+    expect((body as { reason?: string }).reason).toBe('GDPR cleanup batch');
+  });
+});

--- a/app.admin/src/hooks/useUsers.ts
+++ b/app.admin/src/hooks/useUsers.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import type { BulkUserUpdateData } from '@adopt-dont-shop/lib.validation';
 import { userManagementService } from '../services/userManagementService';
 
 // Re-export UserFilters type for convenience
@@ -139,13 +140,13 @@ export const useBulkUpdateUsers = () => {
   return useMutation({
     mutationFn: ({
       userIds,
-      updates,
+      updateData,
       reason,
     }: {
       userIds: string[];
-      updates: { userType?: string; is_active?: boolean };
+      updateData: BulkUserUpdateData;
       reason?: string;
-    }) => userManagementService.bulkUpdateUsers(userIds, updates, reason),
+    }) => userManagementService.bulkUpdateUsers(userIds, updateData, reason),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['users'] });
     },

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -275,13 +275,13 @@ const Users: React.FC = () => {
     if (bulkAction === 'activate') {
       result = await bulkUpdateUsers.mutateAsync({
         userIds,
-        updates: { is_active: true },
+        updateData: { status: 'active' },
         reason,
       });
     } else if (bulkAction === 'deactivate') {
       result = await bulkUpdateUsers.mutateAsync({
         userIds,
-        updates: { is_active: false },
+        updateData: { status: 'inactive' },
         reason,
       });
     } else {

--- a/app.admin/src/services/userManagementService.ts
+++ b/app.admin/src/services/userManagementService.ts
@@ -1,3 +1,4 @@
+import type { BulkUserUpdateData } from '@adopt-dont-shop/lib.validation';
 import { apiService } from './libraryServices';
 import { User, PaginatedResponse } from '@/types';
 
@@ -232,18 +233,24 @@ class UserManagementService {
 
   /**
    * Bulk update users
+   *
+   * Hits the backend bulk endpoint (`POST /api/v1/users/bulk-update`) with the
+   * shape defined by `BulkUserUpdateRequestSchema` in lib.validation:
+   * `{ userIds, updateData, reason }`. The backend's `updateData` schema is
+   * strict — only `status` is accepted — so callers translate UI-level intent
+   * (activate/deactivate) into a `status` value here.
    */
   async bulkUpdateUsers(
     userIds: string[],
-    updates: { userType?: string; is_active?: boolean },
+    updateData: BulkUserUpdateData,
     reason?: string
   ): Promise<{ success: number; failed: number }> {
     try {
       // ADS-651: forward the operator-supplied reason so the backend
       // bulk endpoint can persist it against each affected user's audit row.
-      return await apiService.patch('/api/v1/admin/users/bulk-update', {
-        user_ids: userIds,
-        updates,
+      return await apiService.post('/api/v1/users/bulk-update', {
+        userIds,
+        updateData,
         reason,
       });
     } catch (error) {


### PR DESCRIPTION
## Root cause

Admin bulk activate/deactivate was a no-op in production. The frontend service and backend route disagreed on the URL, the HTTP method, and the payload shape, so every bulk action returned a 404 (or, against a permissive proxy, fell off into nothing):

| | Before (frontend) | Backend contract |
|---|---|---|
| URL | `PATCH /api/v1/admin/users/bulk-update` | `POST  /api/v1/users/bulk-update` |
| Body | `{ user_ids, updates, reason }` | `{ userIds, updateData, reason }` |

The backend route is registered in `service.backend/src/routes/user.routes.ts` and validated by `BulkUserUpdateRequestSchema` in `lib.validation/src/schemas/user.ts`. That schema's `updateData` is `.strict()` and only accepts `status`. ADS-651 (already on `main`) added the `reason` field, but the contract mismatch meant the new audit-reason path was never reached on the Users page.

## The fix

Trust the backend as the source of truth:

- `app.admin/src/services/userManagementService.ts` — `bulkUpdateUsers` now `POST`s `/api/v1/users/bulk-update` with `{ userIds, updateData, reason }`. The parameter type is `BulkUserUpdateData` from `@adopt-dont-shop/lib.validation`.
- `app.admin/src/hooks/useUsers.ts` — `useBulkUpdateUsers` mutation input renamed `updates` -> `updateData` with the canonical type.
- `app.admin/src/pages/Users.tsx` — activate/deactivate callers now pass `updateData: { status: 'active' | 'inactive' }` (the only field the strict schema accepts).
- `reason` is forwarded through unchanged so ADS-651's audit-reason path actually fires on Users.

## Tested

- New behavior test `app.admin/src/__tests__/bulk-update-users-request.behavior.test.ts` (5 cases) pins:
  - URL is `/api/v1/users/bulk-update` (not the old `/admin/users/...` path)
  - body uses `{ userIds, updateData, reason }` exactly
  - old `user_ids` / `updates` keys are not present
  - method is POST, not PATCH
  - `reason` survives the rename end-to-end
- `npx turbo lint test --filter=@adopt-dont-shop/app.admin` -> all 385 tests pass, lint clean
- `npx turbo lint test --filter=@adopt-dont-shop/service-backend` -> all 2742 tests pass, lint clean
- `type-check` for `app.admin` has pre-existing failures on `main` in `components/moderation/ReportDetailModal.tsx` and `pages/Moderation.tsx` that are unrelated to this change (confirmed by stashing and re-running on `main`).

## Unblocks

ADS-651's bulk-action `reason` path on the Users page — operators can now actually deactivate users in bulk, and the audit log will receive their reason.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_