### PR TITLE
security: move access tokens from sessionStorage to httpOnly cookies (ADS-658)

### DIFF
--- a/app.client/src/contexts/ChatContext.tsx
+++ b/app.client/src/contexts/ChatContext.tsx
@@ -18,7 +18,6 @@ import {
   type ConnectionQuality,
 } from '@adopt-dont-shop/lib.chat';
 import {
-  authService,
   chatService,
   type Conversation as LibConversation,
   type Message as LibMessage,
@@ -87,7 +86,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const { user, isAuthenticated } = useAuth();
   const { checkGate, logEvent } = useStatsig();
   const offlineAdapter = useMemo(() => buildOfflineAdapter(), []);
-  const tokenProvider = useMemo(() => () => authService.getToken(), []);
 
   const featureFlags = useMemo<FeatureFlagsAdapter>(
     () => ({
@@ -120,7 +118,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       chatService={chatService}
       user={chatUser}
       isAuthenticated={isAuthenticated}
-      tokenProvider={tokenProvider}
       offlineAdapter={offlineAdapter}
       featureFlags={featureFlags}
       resolveFileUrl={resolveFileUrl}

--- a/app.rescue/src/contexts/ChatContext.tsx
+++ b/app.rescue/src/contexts/ChatContext.tsx
@@ -10,19 +10,18 @@
  * provider as app.client.
  */
 
-import { useMemo, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import {
   ChatProvider as LibChatProvider,
   useChat as useLibChat,
   type ChatContextValue,
 } from '@adopt-dont-shop/lib.chat';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
-import { authService, chatService } from '../services/libraryServices';
+import { chatService } from '../services/libraryServices';
 import { resolveFileUrl } from '../utils/fileUtils';
 
 export function ChatProvider({ children }: { children: ReactNode }) {
   const { user, isAuthenticated } = useAuth();
-  const tokenProvider = useMemo(() => () => authService.getToken(), []);
 
   const chatUser = user
     ? {
@@ -41,7 +40,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       chatService={chatService}
       user={chatUser}
       isAuthenticated={isAuthenticated}
-      tokenProvider={tokenProvider}
       resolveFileUrl={resolveFileUrl}
     >
       {children}

--- a/lib.auth/src/__tests__/auth-service.test.ts
+++ b/lib.auth/src/__tests__/auth-service.test.ts
@@ -21,20 +21,8 @@ const mockLocalStorage = {
   clear: vi.fn(),
 };
 
-// Mock sessionStorage (access tokens are stored here)
-const mockSessionStorage = {
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clear: vi.fn(),
-};
-
 Object.defineProperty(window, 'localStorage', {
   value: mockLocalStorage,
-});
-
-Object.defineProperty(window, 'sessionStorage', {
-  value: mockSessionStorage,
 });
 
 describe('AuthService', () => {
@@ -66,10 +54,6 @@ describe('AuthService', () => {
     mockLocalStorage.getItem.mockClear();
     mockLocalStorage.setItem.mockClear();
     mockLocalStorage.removeItem.mockClear();
-    mockSessionStorage.clear.mockClear();
-    mockSessionStorage.getItem.mockClear();
-    mockSessionStorage.setItem.mockClear();
-    mockSessionStorage.removeItem.mockClear();
   });
 
   describe('initialization', () => {
@@ -85,7 +69,7 @@ describe('AuthService', () => {
   });
 
   describe('login', () => {
-    it('should login successfully and store access token in sessionStorage', async () => {
+    it('should login successfully, store user in localStorage, and not write tokens to JS storage', async () => {
       const credentials: LoginRequest = {
         email: 'test@example.com',
         password: 'password123',
@@ -96,22 +80,20 @@ describe('AuthService', () => {
       const result = await authService.login(credentials);
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/login', credentials);
-      // Access token stored in sessionStorage (not localStorage)
-      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.AUTH_TOKEN,
-        'mock-token'
-      );
-      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.ACCESS_TOKEN,
-        'mock-token'
-      );
       // User stored in localStorage (persists across sessions)
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.USER,
         JSON.stringify(mockUser)
       );
-      // Refresh token NOT stored in localStorage (it's an httpOnly cookie)
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith('refreshToken', expect.any(String));
+      // Access token NOT stored anywhere JS-accessible — it's an httpOnly cookie
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith(
+        STORAGE_KEYS.AUTH_TOKEN,
+        expect.any(String)
+      );
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith(
+        STORAGE_KEYS.ACCESS_TOKEN,
+        expect.any(String)
+      );
       expect(result).toEqual({ ...mockAuthResponse, accessToken: 'mock-token' });
     });
 
@@ -125,7 +107,7 @@ describe('AuthService', () => {
       (apiService.post as ReturnType<typeof vi.fn>).mockRejectedValue(error);
 
       await expect(authService.login(credentials)).rejects.toThrow('Invalid credentials');
-      expect(mockSessionStorage.setItem).not.toHaveBeenCalled();
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
   });
 
@@ -148,24 +130,23 @@ describe('AuthService', () => {
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/register', userData);
       // No tokens — user must verify email + log in to get a session.
-      expect(mockSessionStorage.setItem).not.toHaveBeenCalled();
       expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
       expect(result).toEqual(registerResponse);
     });
   });
 
   describe('logout', () => {
-    it('should logout successfully and clear sessionStorage tokens', async () => {
+    it('should logout successfully and clear user from localStorage', async () => {
       (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
       await authService.logout();
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/logout');
-      // Access tokens removed from sessionStorage
-      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
       // User removed from localStorage
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
+      // Token cookies are cleared server-side — no JS-side removal needed
+      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
+      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
     });
 
     it('should clear storage even if API call fails', async () => {
@@ -175,8 +156,6 @@ describe('AuthService', () => {
       await authService.logout();
 
       expect(consoleSpy).toHaveBeenCalledWith('Logout API call failed:', expect.any(Error));
-      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
 
       consoleSpy.mockRestore();
@@ -203,17 +182,16 @@ describe('AuthService', () => {
   });
 
   describe('isAuthenticated', () => {
-    it('should return true if access token and user exist', () => {
-      mockSessionStorage.getItem.mockReturnValueOnce('mock-token'); // getToken call
-      mockLocalStorage.getItem.mockReturnValueOnce(JSON.stringify(mockUser)); // getCurrentUser call
+    it('should return true when user data exists in localStorage', () => {
+      mockLocalStorage.getItem.mockReturnValueOnce(JSON.stringify(mockUser));
 
       const isAuth = authService.isAuthenticated();
 
       expect(isAuth).toBe(true);
     });
 
-    it('should return false if no access token exists', () => {
-      mockSessionStorage.getItem.mockReturnValue(null);
+    it('should return false when no user data in localStorage', () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
 
       const isAuth = authService.isAuthenticated();
 
@@ -222,51 +200,31 @@ describe('AuthService', () => {
   });
 
   describe('getToken', () => {
-    it('should return auth token from sessionStorage', () => {
-      mockSessionStorage.getItem.mockReturnValueOnce('auth-token');
-
+    it('should return null — access token lives in httpOnly cookie, not JS storage', () => {
       const token = authService.getToken();
 
-      expect(mockSessionStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(token).toBe('auth-token');
-    });
-
-    it('should fallback to access token key if auth token not found', () => {
-      mockSessionStorage.getItem.mockReturnValueOnce(null).mockReturnValueOnce('access-token');
-
-      const token = authService.getToken();
-
-      expect(mockSessionStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockSessionStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
-      expect(token).toBe('access-token');
+      expect(token).toBeNull();
     });
   });
 
   describe('setToken', () => {
-    it('should set token in sessionStorage', () => {
-      authService.setToken('new-token');
+    it('should be a no-op — token is managed as httpOnly cookie by the backend', () => {
+      authService.setToken('some-token');
 
-      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'new-token');
-      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(
-        STORAGE_KEYS.ACCESS_TOKEN,
-        'new-token'
-      );
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
   });
 
   describe('clearTokens', () => {
-    it('should clear access tokens from sessionStorage', () => {
+    it('should be a no-op — token cookies are cleared by the backend logout endpoint', () => {
       authService.clearTokens();
 
-      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
-      // Refresh token is NOT in localStorage/sessionStorage — it's an httpOnly cookie
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith('refreshToken');
+      expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
     });
   });
 
   describe('refreshToken', () => {
-    it('should refresh token via cookie (no body token needed)', async () => {
+    it('should refresh token via cookie and return the new token value', async () => {
       const refreshResponse = {
         token: 'new-token',
         // refreshToken not returned — it's set as httpOnly cookie by backend
@@ -278,7 +236,8 @@ describe('AuthService', () => {
 
       // Should NOT send refresh token in body — cookie is auto-sent by browser
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/refresh-token', {});
-      expect(mockSessionStorage.setItem).toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN, 'new-token');
+      // No token stored in JS-accessible storage
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
       expect(newToken).toBe('new-token');
     });
 

--- a/lib.auth/src/services/auth-service.ts
+++ b/lib.auth/src/services/auth-service.ts
@@ -34,9 +34,10 @@ const AUTH_ENDPOINTS = {
 /**
  * AuthService - Authentication and user management service
  *
- * Access tokens are stored in sessionStorage (cleared on tab close).
- * Refresh tokens are stored in httpOnly cookies (managed by the backend,
- * not accessible to JavaScript — XSS-safe).
+ * Access tokens are stored in httpOnly cookies (managed by the backend,
+ * not accessible to JavaScript — XSS-safe). Refresh tokens use a separate
+ * httpOnly cookie. All authenticated requests rely on the browser sending
+ * these cookies automatically via `credentials: 'include'`.
  */
 export class AuthService {
   constructor() {
@@ -52,8 +53,7 @@ export class AuthService {
   async login(credentials: LoginRequest): Promise<AuthResponse> {
     const response = await apiService.post<AuthResponse>(AUTH_ENDPOINTS.LOGIN, credentials);
 
-    // Store access token in sessionStorage; refresh token is in httpOnly cookie
-    this.setToken(response.token);
+    // Access token is set as httpOnly cookie by the backend; refresh token likewise.
     this.setUser(response.user);
 
     return {
@@ -108,21 +108,20 @@ export class AuthService {
   }
 
   /**
-   * Check if user is authenticated
+   * Check if user is authenticated (user data present in localStorage).
+   * The access token lives in an httpOnly cookie so cannot be read from JS;
+   * user presence is the local indicator of an active session.
    */
   isAuthenticated(): boolean {
-    return !!this.getToken() && !!this.getCurrentUser();
+    return !!this.getCurrentUser();
   }
 
   /**
-   * Refresh access token — refresh token is sent automatically via httpOnly cookie
+   * Refresh access token — refresh token and new access token are both set
+   * as httpOnly cookies by the backend; no JS-side storage needed.
    */
   async refreshToken(): Promise<string> {
     const response = await apiService.post<RefreshTokenResponse>(AUTH_ENDPOINTS.REFRESH, {});
-
-    // Update stored access token only; new refresh token cookie is set by backend
-    this.setToken(response.token);
-
     return response.token;
   }
 
@@ -257,32 +256,29 @@ export class AuthService {
   }
 
   /**
-   * Get stored access token (from sessionStorage)
+   * Returns null — the access token lives in an httpOnly cookie managed by
+   * the backend and is not readable from JavaScript. HTTP requests send it
+   * automatically via `credentials: 'include'`; Socket.IO connections use the
+   * same cookie on the WebSocket upgrade request.
    */
-  getToken(): string | null {
-    return (
-      sessionStorage.getItem(STORAGE_KEYS.AUTH_TOKEN) ||
-      sessionStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)
-    );
+  getToken(): null {
+    return null;
   }
 
   /**
-   * Set access token in storage
+   * No-op — the access token is set as an httpOnly cookie by the backend
+   * login/refresh response and is never written to JS-accessible storage.
    */
-  setToken(token: string | null | undefined): void {
-    if (!token) {
-      return;
-    }
-    sessionStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, token);
-    sessionStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token); // For backward compatibility
+  setToken(_token: string | null | undefined): void {
+    // intentional no-op
   }
 
   /**
-   * Clear all stored authentication data
+   * Clears local user state. The access/refresh token cookies are cleared
+   * by the backend logout endpoint.
    */
   clearTokens(): void {
-    sessionStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
-    sessionStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
+    // Token cookies are cleared server-side on logout; nothing to do here.
   }
 
   // Private helper methods
@@ -291,8 +287,6 @@ export class AuthService {
   }
 
   private clearStorage(): void {
-    sessionStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
-    sessionStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
     localStorage.removeItem(STORAGE_KEYS.USER);
   }
 }

--- a/lib.chat/src/context/ChatProvider.tsx
+++ b/lib.chat/src/context/ChatProvider.tsx
@@ -57,7 +57,6 @@ export function ChatProvider({
   chatService,
   user,
   isAuthenticated,
-  tokenProvider,
   offlineAdapter,
   featureFlags,
   resolveFileUrl,
@@ -152,20 +151,12 @@ export function ChatProvider({
       return;
     }
 
-    const token = tokenProvider();
-    if (!token) {
-      // Auth flipped to authenticated before the token landed in storage
-      // (or the token provider is misconfigured). Don't mark the user as
-      // initialized so the effect retries on the next auth/tokenProvider
-      // dependency change.
-      setError('Waiting for authentication token before connecting chat…');
-      return;
-    }
-
     initializedUserIdRef.current = user.userId;
 
     try {
-      chatService.connect(user.userId, token);
+      // No explicit token needed — the browser sends the httpOnly accessToken
+      // cookie with the WebSocket upgrade request automatically.
+      chatService.connect(user.userId);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to start chat connection');
       initializedUserIdRef.current = null;
@@ -273,7 +264,7 @@ export function ChatProvider({
       chatService.disconnect();
       initializedUserIdRef.current = null;
     };
-  }, [isAuthenticated, user?.userId, chatService, tokenProvider, loadConversations]);
+  }, [isAuthenticated, user?.userId, chatService, loadConversations]);
 
   const loadMessages = useCallback(
     async (conversationId: string) => {

--- a/lib.chat/src/context/__tests__/ChatProvider.test.tsx
+++ b/lib.chat/src/context/__tests__/ChatProvider.test.tsx
@@ -53,7 +53,6 @@ const TestConsumer = ({ onRender }: { onRender: (h: Harness) => void }) => {
 type Harness2 = {
   chatService: ChatService;
   connectSpy: ReturnType<typeof vi.spyOn>;
-  tokenProvider: ReturnType<typeof vi.fn>;
   getConversationsMock: ReturnType<typeof vi.fn>;
 };
 
@@ -71,14 +70,12 @@ const buildHarness = (initialConversations: Conversation[] = [buildConversation(
   const getConversationsMock = vi.fn().mockResolvedValue(initialConversations);
   vi.spyOn(chatService, 'getConversations').mockImplementation(getConversationsMock);
 
-  const tokenProvider = vi.fn(() => 'test-token');
-
-  return { chatService, connectSpy, tokenProvider, getConversationsMock };
+  return { chatService, connectSpy, getConversationsMock };
 };
 
 describe('ChatProvider', () => {
   it('does not connect when the user is not authenticated', () => {
-    const { chatService, connectSpy, tokenProvider } = buildHarness();
+    const { chatService, connectSpy } = buildHarness();
     const onRender = vi.fn();
 
     render(
@@ -86,38 +83,34 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={null}
         isAuthenticated={false}
-        tokenProvider={tokenProvider}
       >
         <TestConsumer onRender={onRender} />
       </ChatProvider>
     );
 
     expect(connectSpy).not.toHaveBeenCalled();
-    expect(tokenProvider).not.toHaveBeenCalled();
   });
 
-  it('connects with the token from tokenProvider when authenticated', async () => {
-    const { chatService, connectSpy, tokenProvider, getConversationsMock } = buildHarness();
+  it('connects when authenticated', async () => {
+    const { chatService, connectSpy, getConversationsMock } = buildHarness();
 
     render(
       <ChatProvider
         chatService={chatService}
         user={{ userId: 'user-1', firstName: 'Alice' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <TestConsumer onRender={vi.fn()} />
       </ChatProvider>
     );
 
-    await waitFor(() => expect(connectSpy).toHaveBeenCalledWith('user-1', 'test-token'));
-    expect(tokenProvider).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(connectSpy).toHaveBeenCalledWith('user-1'));
     await waitFor(() => expect(getConversationsMock).toHaveBeenCalled());
   });
 
   it('appends incoming messages for the active conversation without bumping unread count', async () => {
     const conversation = buildConversation({ id: 'chat-1', unreadCount: 0 });
-    const { chatService, tokenProvider } = buildHarness([conversation]);
+    const { chatService } = buildHarness([conversation]);
 
     let latest: Harness | null = null;
     const onRender = (h: Harness) => {
@@ -154,7 +147,6 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={{ userId: 'user-1', firstName: 'Alice' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <ActiveSetter />
         <TestConsumer onRender={onRender} />
@@ -177,7 +169,7 @@ describe('ChatProvider', () => {
   it('bumps unread count for incoming messages to a non-active conversation', async () => {
     const active = buildConversation({ id: 'chat-1' });
     const other = buildConversation({ id: 'chat-2' });
-    const { chatService, tokenProvider } = buildHarness([active, other]);
+    const { chatService } = buildHarness([active, other]);
 
     let latest: Harness | null = null;
     const onRender = (h: Harness) => {
@@ -189,7 +181,6 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <TestConsumer onRender={onRender} />
       </ChatProvider>
@@ -206,7 +197,7 @@ describe('ChatProvider', () => {
   });
 
   it('registers typing users when ChatService emits a typing indicator', async () => {
-    const { chatService, tokenProvider } = buildHarness();
+    const { chatService } = buildHarness();
 
     let latest: Harness | null = null;
     render(
@@ -214,7 +205,6 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <TestConsumer onRender={(h) => (latest = h)} />
       </ChatProvider>
@@ -248,13 +238,12 @@ describe('ChatProvider', () => {
   });
 
   it('renders the consumer tree', () => {
-    const { chatService, tokenProvider } = buildHarness();
+    const { chatService } = buildHarness();
     render(
       <ChatProvider
         chatService={chatService}
         user={null}
         isAuthenticated={false}
-        tokenProvider={tokenProvider}
       >
         <TestConsumer onRender={vi.fn()} />
       </ChatProvider>
@@ -264,7 +253,7 @@ describe('ChatProvider', () => {
 
   it('optimistically clears unreadCount when markAsRead is called', async () => {
     const conv = buildConversation({ id: 'chat-1', unreadCount: 3 });
-    const { chatService, tokenProvider } = buildHarness([conv]);
+    const { chatService } = buildHarness([conv]);
 
     const markSpy = vi.spyOn(chatService, 'markAsRead').mockImplementation(
       // Hold the promise open so we can assert the optimistic update
@@ -288,7 +277,6 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Caller />
         <TestConsumer onRender={(h) => (latest = h)} />
@@ -304,34 +292,12 @@ describe('ChatProvider', () => {
     expect(latest?.unreadMessageCount).toBe(0);
   });
 
-  it('surfaces a clear error when the tokenProvider returns null at connect time', async () => {
-    const { chatService } = buildHarness();
-    const connectSpy = vi.spyOn(chatService, 'connect');
-    const nullTokenProvider = vi.fn(() => null);
-
-    render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-        tokenProvider={nullTokenProvider}
-      >
-        <TestConsumer onRender={vi.fn()} />
-      </ChatProvider>
-    );
-
-    // connect() must not be called when the token is missing — otherwise
-    // ChatService would throw and we'd swallow the error.
-    await waitFor(() => expect(nullTokenProvider).toHaveBeenCalled());
-    expect(connectSpy).not.toHaveBeenCalled();
-  });
-
   it("appends the sender's own message to the stream after sendMessage resolves", async () => {
     // User journey: I type a message and hit send, I immediately see my
     // own bubble in the message stream and the conversation's lastMessage
     // updates.
     const conv = buildConversation({ id: 'chat-1' });
-    const { chatService, tokenProvider } = buildHarness([conv]);
+    const { chatService } = buildHarness([conv]);
 
     const sent = buildMessage({
       id: 'msg-sent',
@@ -369,7 +335,6 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={{ userId: 'user-1', firstName: 'Alice' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Caller />
         <TestConsumer onRender={(h) => (latest = h)} />
@@ -383,7 +348,7 @@ describe('ChatProvider', () => {
   it('prepends a newly started conversation to the list', async () => {
     // User journey: I click "Contact rescue" on a pet and the new chat
     // appears at the top of my Conversations list without refreshing.
-    const { chatService, tokenProvider, getConversationsMock } = buildHarness([]);
+    const { chatService, getConversationsMock } = buildHarness([]);
     // The initial conversation fetch resolves after the startConversation
     // prepend in this test; hold it open so it doesn't race-overwrite the
     // optimistic list.
@@ -414,7 +379,6 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Caller />
         <TestConsumer onRender={(h) => (latest = h)} />
@@ -437,7 +401,7 @@ describe('ChatProvider', () => {
     // work correctly while fake timers are in effect.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
-      const { chatService, tokenProvider } = buildHarness();
+      const { chatService } = buildHarness();
 
       let latest: Harness | null = null;
       render(
@@ -445,7 +409,6 @@ describe('ChatProvider', () => {
           chatService={chatService}
           user={{ userId: 'user-1' }}
           isAuthenticated
-          tokenProvider={tokenProvider}
         >
           <TestConsumer onRender={(h) => (latest = h)} />
         </ChatProvider>
@@ -483,7 +446,7 @@ describe('ChatProvider', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
       const conv = buildConversation({ id: 'chat-1' });
-      const { chatService, tokenProvider } = buildHarness([conv]);
+      const { chatService } = buildHarness([conv]);
 
       const sendSpy = vi
         .spyOn(chatService, 'sendMessage')
@@ -519,7 +482,6 @@ describe('ChatProvider', () => {
           chatService={chatService}
           user={{ userId: 'user-1', firstName: 'Alice' }}
           isAuthenticated
-          tokenProvider={tokenProvider}
         >
           <Caller />
           <TestConsumer onRender={(h) => (latest = h)} />
@@ -559,7 +521,7 @@ describe('ChatProvider', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
       const conv = buildConversation({ id: 'chat-1' });
-      const { chatService, tokenProvider } = buildHarness([conv]);
+      const { chatService } = buildHarness([conv]);
 
       const sendSpy = vi
         .spyOn(chatService, 'sendMessage')
@@ -597,7 +559,6 @@ describe('ChatProvider', () => {
           chatService={chatService}
           user={{ userId: 'user-1', firstName: 'Alice' }}
           isAuthenticated
-          tokenProvider={tokenProvider}
         >
           <Caller />
           <TestConsumer onRender={(h) => (latest = h)} />
@@ -632,7 +593,7 @@ describe('ChatProvider', () => {
     // provider holds the message locally, surfaces it as `sending`, then
     // flushes through to the server once the socket reaches `connected`.
     const conv = buildConversation({ id: 'chat-1' });
-    const { chatService, connectSpy, tokenProvider } = buildHarness([conv]);
+    const { chatService, connectSpy } = buildHarness([conv]);
 
     // Override the default harness behaviour: keep the socket
     // disconnected on connect() so the send queues into the reconnect
@@ -679,7 +640,6 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={{ userId: 'user-1', firstName: 'Alice' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Caller />
         <TestConsumer onRender={(h) => (latest = h)} />
@@ -706,7 +666,7 @@ describe('ChatProvider', () => {
     // User journey: I scroll to the top of the message stream and older
     // messages are fetched and appear above the ones I was already seeing.
     const conv = buildConversation({ id: 'chat-1' });
-    const { chatService, tokenProvider } = buildHarness([conv]);
+    const { chatService } = buildHarness([conv]);
 
     // First page needs to fill MESSAGES_PAGE_SIZE (50) otherwise the
     // provider treats it as "no more pages" and loadMoreMessages
@@ -757,7 +717,6 @@ describe('ChatProvider', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Caller />
         <TestConsumer onRender={(h) => (latest = h)} />
@@ -777,7 +736,7 @@ describe('ChatProvider', () => {
   describe('updateConversationStatus + auto-reopen', () => {
     it('optimistically updates the local conversation status and calls the service', async () => {
       const conv = buildConversation({ id: 'chat-1', status: 'active' });
-      const { chatService, tokenProvider } = buildHarness([conv]);
+      const { chatService } = buildHarness([conv]);
       const updateSpy = vi
         .spyOn(chatService, 'updateConversationStatus')
         .mockResolvedValue({ ...conv, status: 'archived' });
@@ -793,7 +752,6 @@ describe('ChatProvider', () => {
           chatService={chatService}
           user={{ userId: 'user-1' }}
           isAuthenticated
-          tokenProvider={tokenProvider}
         >
           <Capture />
         </ChatProvider>
@@ -811,7 +769,7 @@ describe('ChatProvider', () => {
 
     it('reverts the optimistic status change when the service call fails', async () => {
       const conv = buildConversation({ id: 'chat-1', status: 'active' });
-      const { chatService, tokenProvider } = buildHarness([conv]);
+      const { chatService } = buildHarness([conv]);
       vi.spyOn(chatService, 'updateConversationStatus').mockRejectedValue(new Error('nope'));
 
       let ctxRef: ReturnType<typeof useChat> | null = null;
@@ -825,7 +783,6 @@ describe('ChatProvider', () => {
           chatService={chatService}
           user={{ userId: 'user-1' }}
           isAuthenticated
-          tokenProvider={tokenProvider}
         >
           <Capture />
         </ChatProvider>
@@ -844,7 +801,7 @@ describe('ChatProvider', () => {
 
     it('reopens an archived conversation when another participant sends a message', async () => {
       const conv = buildConversation({ id: 'chat-1', status: 'archived' });
-      const { chatService, tokenProvider } = buildHarness([conv]);
+      const { chatService } = buildHarness([conv]);
 
       let ctxRef: ReturnType<typeof useChat> | null = null;
       const Capture = () => {
@@ -857,7 +814,6 @@ describe('ChatProvider', () => {
           chatService={chatService}
           user={{ userId: 'user-1' }}
           isAuthenticated
-          tokenProvider={tokenProvider}
         >
           <Capture />
         </ChatProvider>
@@ -880,7 +836,7 @@ describe('ChatProvider', () => {
 
     it('does not reopen when the resolver themselves replies to a resolved conversation', async () => {
       const conv = buildConversation({ id: 'chat-1', status: 'archived' });
-      const { chatService, tokenProvider } = buildHarness([conv]);
+      const { chatService } = buildHarness([conv]);
 
       let ctxRef: ReturnType<typeof useChat> | null = null;
       const Capture = () => {
@@ -893,7 +849,6 @@ describe('ChatProvider', () => {
           chatService={chatService}
           user={{ userId: 'user-1' }}
           isAuthenticated
-          tokenProvider={tokenProvider}
         >
           <Capture />
         </ChatProvider>

--- a/lib.chat/src/context/__tests__/ChatProvider.test.tsx
+++ b/lib.chat/src/context/__tests__/ChatProvider.test.tsx
@@ -79,11 +79,7 @@ describe('ChatProvider', () => {
     const onRender = vi.fn();
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={null}
-        isAuthenticated={false}
-      >
+      <ChatProvider chatService={chatService} user={null} isAuthenticated={false}>
         <TestConsumer onRender={onRender} />
       </ChatProvider>
     );
@@ -177,11 +173,7 @@ describe('ChatProvider', () => {
     };
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <TestConsumer onRender={onRender} />
       </ChatProvider>
     );
@@ -201,11 +193,7 @@ describe('ChatProvider', () => {
 
     let latest: Harness | null = null;
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <TestConsumer onRender={(h) => (latest = h)} />
       </ChatProvider>
     );
@@ -240,11 +228,7 @@ describe('ChatProvider', () => {
   it('renders the consumer tree', () => {
     const { chatService } = buildHarness();
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={null}
-        isAuthenticated={false}
-      >
+      <ChatProvider chatService={chatService} user={null} isAuthenticated={false}>
         <TestConsumer onRender={vi.fn()} />
       </ChatProvider>
     );
@@ -273,11 +257,7 @@ describe('ChatProvider', () => {
     };
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <Caller />
         <TestConsumer onRender={(h) => (latest = h)} />
       </ChatProvider>
@@ -375,11 +355,7 @@ describe('ChatProvider', () => {
     };
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <Caller />
         <TestConsumer onRender={(h) => (latest = h)} />
       </ChatProvider>
@@ -405,11 +381,7 @@ describe('ChatProvider', () => {
 
       let latest: Harness | null = null;
       render(
-        <ChatProvider
-          chatService={chatService}
-          user={{ userId: 'user-1' }}
-          isAuthenticated
-        >
+        <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
           <TestConsumer onRender={(h) => (latest = h)} />
         </ChatProvider>
       );
@@ -713,11 +685,7 @@ describe('ChatProvider', () => {
     };
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <Caller />
         <TestConsumer onRender={(h) => (latest = h)} />
       </ChatProvider>
@@ -748,11 +716,7 @@ describe('ChatProvider', () => {
       };
 
       render(
-        <ChatProvider
-          chatService={chatService}
-          user={{ userId: 'user-1' }}
-          isAuthenticated
-        >
+        <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
           <Capture />
         </ChatProvider>
       );
@@ -779,11 +743,7 @@ describe('ChatProvider', () => {
       };
 
       render(
-        <ChatProvider
-          chatService={chatService}
-          user={{ userId: 'user-1' }}
-          isAuthenticated
-        >
+        <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
           <Capture />
         </ChatProvider>
       );
@@ -810,11 +770,7 @@ describe('ChatProvider', () => {
       };
 
       render(
-        <ChatProvider
-          chatService={chatService}
-          user={{ userId: 'user-1' }}
-          isAuthenticated
-        >
+        <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
           <Capture />
         </ChatProvider>
       );
@@ -845,11 +801,7 @@ describe('ChatProvider', () => {
       };
 
       render(
-        <ChatProvider
-          chatService={chatService}
-          user={{ userId: 'user-1' }}
-          isAuthenticated
-        >
+        <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
           <Capture />
         </ChatProvider>
       );

--- a/lib.chat/src/context/chat-context-types.ts
+++ b/lib.chat/src/context/chat-context-types.ts
@@ -99,8 +99,12 @@ export type ChatProviderProps = {
   user: ChatUser | null;
   /** Gate: chat only connects when true. */
   isAuthenticated: boolean;
-  /** Returns the current auth token (or null) for Socket.IO handshake. */
-  tokenProvider: () => string | null;
+  /**
+   * Returns the current auth token (or null) for Socket.IO handshake.
+   * @deprecated The browser sends the httpOnly accessToken cookie with the
+   * WebSocket upgrade request automatically. Pass undefined or omit this prop.
+   */
+  tokenProvider?: () => string | null;
   /** Optional richer offline behavior. Without it, `navigator.onLine` is used. */
   offlineAdapter?: OfflineAdapter;
   /** Optional feature-flag + analytics adapter (e.g. Statsig). */

--- a/lib.chat/src/hooks/__tests__/use-unread-conversations.test.tsx
+++ b/lib.chat/src/hooks/__tests__/use-unread-conversations.test.tsx
@@ -109,11 +109,7 @@ describe('useUnreadConversations', () => {
     let latest: UseUnreadConversationsResult | null = null;
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <Probe onState={(s) => (latest = s)} />
       </ChatProvider>
     );
@@ -153,11 +149,7 @@ describe('useUnreadConversations', () => {
     };
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <Wrapper />
       </ChatProvider>
     );
@@ -175,11 +167,7 @@ describe('useUnreadConversations', () => {
     let latest: UseUnreadConversationsResult | null = null;
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <Probe onState={(s) => (latest = s)} />
       </ChatProvider>
     );
@@ -231,11 +219,7 @@ describe('useUnreadConversations', () => {
     };
 
     render(
-      <ChatProvider
-        chatService={chatService}
-        user={{ userId: 'user-1' }}
-        isAuthenticated
-      >
+      <ChatProvider chatService={chatService} user={{ userId: 'user-1' }} isAuthenticated>
         <Wrapper />
       </ChatProvider>
     );

--- a/lib.chat/src/hooks/__tests__/use-unread-conversations.test.tsx
+++ b/lib.chat/src/hooks/__tests__/use-unread-conversations.test.tsx
@@ -34,7 +34,6 @@ const buildMessage = (overrides: Partial<Message> = {}): Message => ({
 
 type ProviderHarness = {
   chatService: ChatService;
-  tokenProvider: ReturnType<typeof vi.fn>;
 };
 
 const buildProviderHarness = (initialConversations: Conversation[]): ProviderHarness => {
@@ -44,7 +43,7 @@ const buildProviderHarness = (initialConversations: Conversation[]): ProviderHar
   });
   vi.spyOn(chatService, 'disconnect').mockImplementation(() => {});
   vi.spyOn(chatService, 'getConversations').mockResolvedValue(initialConversations);
-  return { chatService, tokenProvider: vi.fn(() => 'test-token') };
+  return { chatService };
 };
 
 const Probe = ({
@@ -105,7 +104,7 @@ describe('useUnreadConversations', () => {
   it('updates counts in real time when the socket delivers a new message to a non-active conversation', async () => {
     const active = buildConversation({ id: 'chat-1', unreadCount: 0 });
     const other = buildConversation({ id: 'chat-2', unreadCount: 0 });
-    const { chatService, tokenProvider } = buildProviderHarness([active, other]);
+    const { chatService } = buildProviderHarness([active, other]);
 
     let latest: UseUnreadConversationsResult | null = null;
 
@@ -114,7 +113,6 @@ describe('useUnreadConversations', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Probe onState={(s) => (latest = s)} />
       </ChatProvider>
@@ -137,7 +135,7 @@ describe('useUnreadConversations', () => {
 
   it('clears the counter when markRead is called and forwards to the chat service', async () => {
     const conv = buildConversation({ id: 'chat-1', unreadCount: 4 });
-    const { chatService, tokenProvider } = buildProviderHarness([conv]);
+    const { chatService } = buildProviderHarness([conv]);
     const markSpy = vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
 
     let latest: UseUnreadConversationsResult | null = null;
@@ -159,7 +157,6 @@ describe('useUnreadConversations', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Wrapper />
       </ChatProvider>
@@ -172,7 +169,7 @@ describe('useUnreadConversations', () => {
 
   it('clears the counter when another tab broadcasts a mark-read event', async () => {
     const conv = buildConversation({ id: 'chat-1', unreadCount: 3 });
-    const { chatService, tokenProvider } = buildProviderHarness([conv]);
+    const { chatService } = buildProviderHarness([conv]);
     vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
 
     let latest: UseUnreadConversationsResult | null = null;
@@ -182,7 +179,6 @@ describe('useUnreadConversations', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Probe onState={(s) => (latest = s)} />
       </ChatProvider>
@@ -207,7 +203,7 @@ describe('useUnreadConversations', () => {
 
   it('broadcasts mark-read events to other tabs', async () => {
     const conv = buildConversation({ id: 'chat-1', unreadCount: 2 });
-    const { chatService, tokenProvider } = buildProviderHarness([conv]);
+    const { chatService } = buildProviderHarness([conv]);
     vi.spyOn(chatService, 'markAsRead').mockResolvedValue();
 
     const otherTab = new BroadcastChannel(UNREAD_BROADCAST_CHANNEL);
@@ -239,7 +235,6 @@ describe('useUnreadConversations', () => {
         chatService={chatService}
         user={{ userId: 'user-1' }}
         isAuthenticated
-        tokenProvider={tokenProvider}
       >
         <Wrapper />
       </ChatProvider>

--- a/lib.chat/src/services/__tests__/chat-service.test.ts
+++ b/lib.chat/src/services/__tests__/chat-service.test.ts
@@ -167,10 +167,12 @@ describe('ChatService', () => {
       expect(errorCallback).toHaveBeenCalled();
     });
 
-    it('should not attempt connection without authentication token', () => {
+    it('should connect without an explicit token (httpOnly cookie provides auth)', () => {
+      // Empty / omitted token is no longer an error — the browser sends the
+      // httpOnly accessToken cookie with the WebSocket upgrade automatically.
       expect(() => {
-        service.connect('user-123', '');
-      }).toThrow();
+        service.connect('user-123');
+      }).not.toThrow();
     });
 
     it('should not attempt connection without user ID', () => {

--- a/lib.chat/src/services/chat-service.ts
+++ b/lib.chat/src/services/chat-service.ts
@@ -122,7 +122,7 @@ export class ChatService {
 
       // Create socket connection
       this.socket = io(this.config.socketUrl, {
-        ...(token && { auth: { token } }),
+        ...(token ? { auth: { token } } : {}),
         autoConnect: true,
         reconnection: false, // We handle reconnection manually
         transports: ['websocket', 'polling'],

--- a/lib.chat/src/services/chat-service.ts
+++ b/lib.chat/src/services/chat-service.ts
@@ -103,26 +103,26 @@ export class ChatService {
   }
 
   /**
-   * Connect to real-time chat using Socket.IO
+   * Connect to real-time chat using Socket.IO.
+   *
+   * `token` is optional: when omitted the browser sends the httpOnly
+   * `accessToken` cookie with the WebSocket upgrade request, and the
+   * backend socket middleware reads it from `handshake.headers.cookie`.
    */
-  connect(userId: string, token: string): void {
+  connect(userId: string, token?: string | null): void {
     if (!userId) {
       throw new Error('User ID is required for connection');
     }
 
-    if (!token) {
-      throw new Error('Authentication token is required for connection');
-    }
-
     try {
       this.currentUserId = userId;
-      this.currentToken = token;
+      this.currentToken = token ?? null;
 
       this.updateConnectionStatus('connecting');
 
       // Create socket connection
       this.socket = io(this.config.socketUrl, {
-        auth: { token },
+        ...(token && { auth: { token } }),
         autoConnect: true,
         reconnection: false, // We handle reconnection manually
         transports: ['websocket', 'polling'],
@@ -281,8 +281,7 @@ export class ChatService {
     if (
       this.config.reconnection?.enabled &&
       reason !== 'io client disconnect' &&
-      this.currentUserId &&
-      this.currentToken
+      this.currentUserId
     ) {
       this.attemptReconnection();
     }
@@ -301,7 +300,7 @@ export class ChatService {
     this.connectionErrorListeners.forEach((listener) => listener(error));
 
     // Attempt reconnection if enabled
-    if (this.config.reconnection?.enabled && this.currentUserId && this.currentToken) {
+    if (this.config.reconnection?.enabled && this.currentUserId) {
       this.attemptReconnection();
     }
   }
@@ -330,15 +329,16 @@ export class ChatService {
     );
 
     this.reconnectionTimer = setTimeout(() => {
-      if (this.currentUserId && this.currentToken) {
+      if (this.currentUserId) {
         // Disconnect existing socket
         if (this.socket) {
           this.socket.disconnect();
           this.socket = null;
         }
 
-        // Attempt new connection
-        this.connect(this.currentUserId, this.currentToken);
+        // Attempt new connection — token is optional; the browser sends the
+        // httpOnly accessToken cookie with the WebSocket upgrade request.
+        this.connect(this.currentUserId, this.currentToken ?? undefined);
       }
     }, delay);
   }

--- a/service.backend/src/socket/socket-handlers.ts
+++ b/service.backend/src/socket/socket-handlers.ts
@@ -35,15 +35,21 @@ export { disconnectAllSockets } from './socket-registry';
  */
 const extractSocketToken = (socket: Socket): string | null => {
   const authToken = socket.handshake.auth?.token as string | undefined;
-  if (authToken) return authToken;
+  if (authToken) {
+    return authToken;
+  }
 
   const bearer = socket.handshake.headers.authorization?.split(' ')[1];
-  if (bearer) return bearer;
+  if (bearer) {
+    return bearer;
+  }
 
   const cookieStr = socket.handshake.headers.cookie;
   if (cookieStr) {
-    const match = cookieStr.split(';').find((p) => p.trim().startsWith('accessToken='));
-    if (match) return match.trim().slice('accessToken='.length);
+    const match = cookieStr.split(';').find(p => p.trim().startsWith('accessToken='));
+    if (match) {
+      return match.trim().slice('accessToken='.length);
+    }
   }
 
   return null;

--- a/service.backend/src/socket/socket-handlers.ts
+++ b/service.backend/src/socket/socket-handlers.ts
@@ -27,6 +27,28 @@ import { logger } from '../utils/logger';
 // from this module keep working.
 export { disconnectAllSockets } from './socket-registry';
 
+/**
+ * Extracts the access token from a Socket.IO handshake. Checks, in order:
+ *   1. socket.handshake.auth.token  (legacy explicit pass)
+ *   2. Authorization: Bearer <token> header
+ *   3. accessToken httpOnly cookie (browsers send cookies with the WS upgrade)
+ */
+const extractSocketToken = (socket: Socket): string | null => {
+  const authToken = socket.handshake.auth?.token as string | undefined;
+  if (authToken) return authToken;
+
+  const bearer = socket.handshake.headers.authorization?.split(' ')[1];
+  if (bearer) return bearer;
+
+  const cookieStr = socket.handshake.headers.cookie;
+  if (cookieStr) {
+    const match = cookieStr.split(';').find((p) => p.trim().startsWith('accessToken='));
+    if (match) return match.trim().slice('accessToken='.length);
+  }
+
+  return null;
+};
+
 // Track active connections for health monitoring
 let activeConnections = 0;
 
@@ -249,8 +271,7 @@ export class SocketHandlers {
   private setupMiddleware() {
     this.io.use(async (socket: AuthenticatedSocket, next) => {
       try {
-        const token =
-          socket.handshake.auth.token || socket.handshake.headers.authorization?.split(' ')[1];
+        const token = extractSocketToken(socket);
 
         if (!token) {
           return next(new Error('Authentication token required'));
@@ -315,8 +336,7 @@ export class SocketHandlers {
    */
   private installPerEventRevalidation(socket: AuthenticatedSocket) {
     socket.use((_event, next) => {
-      const token =
-        socket.handshake.auth.token || socket.handshake.headers.authorization?.split(' ')[1];
+      const token = extractSocketToken(socket);
 
       if (!token) {
         socket.disconnect(true);


### PR DESCRIPTION
## Summary

- **Closes the sessionStorage XSS amplification vector** (ADS-658): access tokens previously written to `sessionStorage` are now never stored in JS-readable storage; auth relies entirely on the `httpOnly` `accessToken` cookie the backend already sets.
- Extends Socket.IO authentication to read the `accessToken` cookie from `handshake.headers.cookie` as a third fallback, so WebSocket connections authenticate via cookie without any JS token passing.
- Removes the `tokenProvider` prop from `ChatProvider` (deprecated with a JSDoc note retained for any external consumers) and all downstream wiring in `app.client` and `app.rescue`.

## Changes

| File | What changed |
|------|-------------|
| `lib.auth/src/services/auth-service.ts` | `getToken()` → returns `null`; `setToken`/`clearTokens` → intentional no-ops; `isAuthenticated()` → checks localStorage user only |
| `lib.auth/src/__tests__/auth-service.test.ts` | Removed sessionStorage mock; updated assertions to match new no-op behaviour |
| `lib.chat/src/services/chat-service.ts` | `connect(userId, token?)` — token optional; socket `auth.token` only attached when token provided; reconnect guards use `currentUserId` only |
| `lib.chat/src/context/ChatProvider.tsx` | Removed `tokenProvider` prop and token gate; calls `connect(userId)` directly |
| `lib.chat/src/context/chat-context-types.ts` | `tokenProvider` marked `@deprecated` |
| `lib.chat/src/context/__tests__/ChatProvider.test.tsx` | Removed `tokenProvider` harness; updated connect assertion; removed null-token-provider test |
| `service.backend/src/socket/socket-handlers.ts` | `extractSocketToken()` helper reads cookie as third auth source |
| `app.client/src/contexts/ChatContext.tsx` | Removed `tokenProvider` wiring |
| `app.rescue/src/contexts/ChatContext.tsx` | Removed `tokenProvider` wiring |

## Test plan

- [ ] `lib.auth` tests: `getToken` returns null, `setToken`/`clearTokens` are no-ops, `isAuthenticated` uses user presence only, `login`/`logout`/`refreshToken` don't touch sessionStorage
- [ ] `lib.chat` tests: `ChatProvider` connects with userId only (no token arg), all existing provider behaviour tests pass
- [ ] Socket.IO auth: browser sends `accessToken` cookie with WebSocket upgrade; backend `extractSocketToken` resolves it from `handshake.headers.cookie`
- [ ] Manual smoke: login → chat connects → messages send/receive → logout → reconnect blocked
- [ ] XSS check: `sessionStorage` contains no token after login

https://claude.ai/code/session_01TrnN5FpFVtTiyDawSh9Bbm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrnN5FpFVtTiyDawSh9Bbm)_