### PR TITLE
security: pass-13 fixes (exclude backupCodes from User scope, add Invitation defaultScope)

### DIFF
--- a/service.backend/src/models/Invitation.ts
+++ b/service.backend/src/models/Invitation.ts
@@ -119,6 +119,21 @@ Invitation.init(
     tableName: 'invitations',
     timestamps: true,
     underscored: true,
+    // Defensive: the token column stores the SHA-256 hash of the
+    // invite (beforeSave hashes any plaintext write), but downstream
+    // routes should never need to surface even the hash. Exclude by
+    // default so a future `res.json(invitation)` can't accidentally
+    // leak it. Service code that needs the hash (acceptInvitation
+    // lookup) reads it via the explicit attribute selection in its
+    // findOne call.
+    defaultScope: {
+      attributes: { exclude: ['token'] },
+    },
+    scopes: {
+      withToken: {
+        attributes: { include: ['token'] },
+      },
+    },
     indexes: [
       {
         unique: true,

--- a/service.backend/src/models/User.ts
+++ b/service.backend/src/models/User.ts
@@ -530,6 +530,13 @@ User.init(
             'verificationToken',
             'twoFactorSecret',
             'twoFactorPendingSecret',
+            // Backup codes are stored bcrypt-hashed but are still
+            // sensitive: leaking the hashes confirms 2FA enrollment
+            // and exposes a recovery factor to offline cracking.
+            // Routes that need to surface freshly-generated codes
+            // (e.g. /auth/2fa/enable) return them out-of-band rather
+            // than via the User instance, so excluding here is safe.
+            'backupCodes',
           ],
         },
       },


### PR DESCRIPTION
## Summary

Security review pass 13 — model-level data exposure hardening. Single small commit.

After 12 prior passes, the application-layer surface is mature. This pass targeted remaining gaps in Sequelize model-level data exposure (defaultScope correctness), concurrency races on anti-abuse caps, and JWT/parameter-pollution/CSP edges. **Two of three audits returned zero findings.** Only the model-exposure audit surfaced fixable issues.

### Findings fixed

- **M1 (MEDIUM, exposure-shape)** — `User.defaultScope` was excluding `password` / `resetToken` / `verificationToken` / `twoFactorSecret` / `twoFactorPendingSecret` but **not `backupCodes`**. Any route returning a User instance (`res.json(user)` or via eager-load like `include: ['Sender']`) would have surfaced the bcrypt-hashed backup codes. Hashes are offline-attackable + leak 2FA-enrollment status. Now excluded by default. The legitimate consumers (2FA verify path via `withSecrets` scope, `/auth/2fa/enable` returning freshly-generated codes out-of-band) are unaffected — verified via auth.service tests (114/114 pass).

- **M2 (MEDIUM, defensive)** — `Invitation` had no `defaultScope` at all. The `token` column is SHA-256 hashed via `beforeSave`, so current routes (which manually construct responses) don't leak it — but a future refactor doing `res.json(invitation)` would. Added `defaultScope: { exclude: ['token'] }` + a `withToken` scope for explicit opt-in. The existing `acceptInvitation` lookup (`WHERE token = hashToken(input)`) still works — `exclude` affects SELECT, not WHERE — verified via invitation.service tests (30/30 pass).

### Deliberately deferred

- **M3 (LOW)** — `EmailQueue.tracking` JSONB holds user IPs/UAs from open/click pixels. Not currently returned via any public route. Future admin dashboard could leak. Deferred until that dashboard exists; would add a `withTracking` scope split at the same time.

- **R8 (design observation, not a bug)** — Field-permission resolution uses **union** (`.some()`) across roles: a user with Role A (denies field X) + Role B (allows field X) gets allow. Defensible (best-capability inheritance) but worth team confirmation that the intent isn't intersection (`deny wins`). No code change; flagging for review.

## Audits that returned zero findings

- **Concurrency races on anti-abuse caps + lib.permissions fail-open semantics + JWT-claim vs DB authz** — all confirmed clean. Application uniqueness via `UNIQUE (user_id, pet_id)` constraint + service pre-flight + UniqueConstraintError mapping. Rescue creation cap inside `sequelize.transaction()`. `hasPermission` explicitly returns `false` on error (never `undefined`). Redis-down → in-memory fallback (fail-closed). Middleware ordering: `router.use(authenticateToken)` global before all permission checks. JWT iat-gate + DB cross-check + `req.user.userType` from DB (never trusts JWT claim).
- **JWT alg "none" + parameter pollution + JSON prototype pollution + CSP report-uri + X-HTTP-Method-Override + trust-proxy chain + body-parser parameterLimit + error-handler info leak** — all confirmed clean. JWT alg pinned at every sign + verify site. Zod schemas with `.strip()` block prototype pollution. No method-override middleware. CSP report-uri intentionally not configured (avoids the dump-endpoint surface). Trust proxy correctly `1` for nginx topology. Error handler gated by `NODE_ENV !== 'development'`.

## Test plan

- [x] `service.backend` — 2742 passed, 210 skipped, 0 failed (combined branch)
- [x] Auth-service tests — 114/114 pass (covers backup-code consume + regenerate paths that read/write via `withSecrets` scope)
- [x] Invitation-service tests — 30/30 pass (covers `acceptInvitation` lookup-by-token-hash with `exclude` on the column)
- [x] `tsc --noEmit` clean (modulo pre-existing umzug stubs)

## Observation

This is the 13th pass. The marginal yield is now ~2 findings per pass, mostly defensive. After 12 substantive passes plus this one, the codebase is in a strong security posture. Future security work should be feature-driven (new attack surfaces from new features) rather than reactive sweeps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxiFw2tNVhTai3B8Ws1a67)_