### PR TITLE
fix: web-app UX pass — P2 polish + pattern sweeps

### DIFF
--- a/app.admin/src/__tests__/rescues.behavior.test.tsx
+++ b/app.admin/src/__tests__/rescues.behavior.test.tsx
@@ -222,8 +222,10 @@ describe('Rescue Management page', () => {
     it('shows an error message when the rescue API fails', async () => {
       mockGetAll.mockRejectedValue(new Error('Failed to load rescue data'));
       renderWithProviders(<Rescues />);
+      // UX P2 H: the error now surfaces both as the top banner AND the inline
+      // DataTable error row, so there can be more than one match.
       await waitFor(() => {
-        expect(screen.getByText('Failed to load rescue data')).toBeInTheDocument();
+        expect(screen.getAllByText('Failed to load rescue data').length).toBeGreaterThan(0);
       });
     });
 
@@ -231,7 +233,7 @@ describe('Rescue Management page', () => {
       mockGetAll.mockRejectedValue(new Error('Failed to fetch rescues'));
       renderWithProviders(<Rescues />);
       await waitFor(() => {
-        expect(screen.getByText(/failed to fetch rescues/i)).toBeInTheDocument();
+        expect(screen.getAllByText(/failed to fetch rescues/i).length).toBeGreaterThan(0);
       });
     });
   });

--- a/app.admin/src/components/data/DataTable.test.tsx
+++ b/app.admin/src/components/data/DataTable.test.tsx
@@ -109,6 +109,36 @@ describe('DataTable accessibility', () => {
   });
 });
 
+describe('DataTable pagination accessibility (UX P2 C)', () => {
+  it('marks the current page button with aria-current="page"', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={rows}
+        currentPage={2}
+        totalPages={5}
+        onPageChange={vi.fn()}
+      />
+    );
+    const currentPageButton = screen.getByRole('button', { name: '2' });
+    expect(currentPageButton).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not mark non-current page buttons with aria-current', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={rows}
+        currentPage={2}
+        totalPages={5}
+        onPageChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: '1' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('button', { name: '3' })).not.toHaveAttribute('aria-current');
+  });
+});
+
 describe('DataTable load-state differentiation', () => {
   it('renders skeleton rows when loading', () => {
     render(<DataTable columns={columns} data={[]} loading />);

--- a/app.admin/src/components/data/DataTable.tsx
+++ b/app.admin/src/components/data/DataTable.tsx
@@ -280,6 +280,7 @@ export function DataTable<T extends object>({
                   key={pageNum}
                   className={styles.pageButton({ active: currentPage === pageNum })}
                   onClick={() => onPageChange(pageNum)}
+                  aria-current={currentPage === pageNum ? 'page' : undefined}
                 >
                   {pageNum}
                 </button>

--- a/app.admin/src/components/modals/BulkConfirmationModal.css.ts
+++ b/app.admin/src/components/modals/BulkConfirmationModal.css.ts
@@ -180,3 +180,10 @@ export const requiredMark = style({
   color: '#ef4444',
   marginLeft: '0.25rem',
 });
+
+export const failureGuidance = style({
+  margin: '0',
+  fontSize: '0.8125rem',
+  color: '#6b7280',
+  lineHeight: '1.5',
+});

--- a/app.admin/src/components/modals/BulkConfirmationModal.test.tsx
+++ b/app.admin/src/components/modals/BulkConfirmationModal.test.tsx
@@ -56,3 +56,58 @@ describe('BulkConfirmationModal accessibility', () => {
     expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
   });
 });
+
+/**
+ * UX P2 D — Failure visibility + retry
+ *
+ * The bulk endpoints return only aggregate {succeeded, failed} counts today,
+ * so the modal can't render a per-item failed list. Instead it surfaces the
+ * partial-failure case with explicit guidance text and offers the operator a
+ * "Try again" button that re-runs the whole batch (parent retains userIds +
+ * reason and is responsible for re-invoking the mutation).
+ */
+describe('BulkConfirmationModal — partial-failure retry (UX P2 D)', () => {
+  it('renders failure guidance and a Try again button when failures > 0', () => {
+    const onRetry = vi.fn();
+    render(
+      <BulkConfirmationModal
+        {...defaultProps}
+        resultSummary={{ succeeded: 2, failed: 1 }}
+        onRetry={onRetry}
+      />
+    );
+
+    expect(screen.getByText(/2 succeeded, 1 failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Some items couldn't be updated/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('invokes onRetry when the Try again button is pressed', () => {
+    const onRetry = vi.fn();
+    render(
+      <BulkConfirmationModal
+        {...defaultProps}
+        resultSummary={{ succeeded: 2, failed: 1 }}
+        onRetry={onRetry}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the Try again button when all items succeeded', () => {
+    const onRetry = vi.fn();
+    render(
+      <BulkConfirmationModal
+        {...defaultProps}
+        resultSummary={{ succeeded: 3, failed: 0 }}
+        onRetry={onRetry}
+      />
+    );
+
+    expect(screen.getByText(/3 succeeded/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Some items couldn't be updated/i)).not.toBeInTheDocument();
+  });
+});

--- a/app.admin/src/components/modals/BulkConfirmationModal.tsx
+++ b/app.admin/src/components/modals/BulkConfirmationModal.tsx
@@ -19,6 +19,13 @@ type BulkConfirmationModalProps = {
   reasonPlaceholder?: string;
   isLoading?: boolean;
   resultSummary?: { succeeded: number; failed: number } | null;
+  // UX P2 D: when the bulk action partially failed, give the operator a way
+  // to re-run the action without rebuilding the selection. The backend bulk
+  // endpoints (POST /api/v1/users/bulk-update, etc.) only return aggregate
+  // {success, failed} counts today — there is no per-item failed-IDs payload
+  // — so retry must re-attempt the same userIds the parent originally
+  // submitted. A backend follow-up is required to enable retry-failed-only.
+  onRetry?: () => void | Promise<void>;
 };
 
 const variantIcon: Record<BulkConfirmationVariant, React.ReactNode> = {
@@ -41,6 +48,7 @@ export const BulkConfirmationModal: React.FC<BulkConfirmationModalProps> = ({
   reasonPlaceholder = 'Enter reason...',
   isLoading = false,
   resultSummary,
+  onRetry,
 }) => {
   const [reason, setReason] = useState('');
   const titleId = useId();
@@ -114,11 +122,19 @@ export const BulkConfirmationModal: React.FC<BulkConfirmationModalProps> = ({
 
         <div className={styles.modalBody}>
           {resultSummary ? (
-            <div className={styles.resultBanner({ hasFailures: resultSummary.failed > 0 })}>
-              <FiCheckCircle className={styles.resultIcon} />
-              {resultSummary.succeeded} succeeded
-              {resultSummary.failed > 0 && `, ${resultSummary.failed} failed`}
-            </div>
+            <>
+              <div className={styles.resultBanner({ hasFailures: resultSummary.failed > 0 })}>
+                <FiCheckCircle className={styles.resultIcon} />
+                {resultSummary.succeeded} succeeded
+                {resultSummary.failed > 0 && `, ${resultSummary.failed} failed`}
+              </div>
+              {resultSummary.failed > 0 && (
+                <p className={styles.failureGuidance}>
+                  Some items couldn&apos;t be updated. Close this dialog and check the table for
+                  per-row status, or try the action again.
+                </p>
+              )}
+            </>
           ) : (
             <>
               <p className={styles.description}>{description}</p>
@@ -147,9 +163,16 @@ export const BulkConfirmationModal: React.FC<BulkConfirmationModalProps> = ({
 
         <div className={styles.modalFooter}>
           {resultSummary ? (
-            <Button variant='primary' onClick={onClose}>
-              Done
-            </Button>
+            <>
+              {resultSummary.failed > 0 && onRetry && (
+                <Button variant='outline' onClick={onRetry} disabled={isLoading}>
+                  {isLoading ? 'Retrying...' : 'Try again'}
+                </Button>
+              )}
+              <Button variant='primary' onClick={onClose}>
+                Done
+              </Button>
+            </>
           ) : (
             <>
               <Button variant='outline' onClick={onClose} disabled={isLoading}>

--- a/app.admin/src/pages/Applications.test.tsx
+++ b/app.admin/src/pages/Applications.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * UX P2 H: when the underlying applications query errors, the DataTable now
+ * renders the inline error row (introduced by UX #5) in addition to whatever
+ * top-of-page error treatment already existed. This pins down the wiring so
+ * future refactors don't silently drop the inline affordance.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+
+vi.mock('../hooks', () => ({
+  useApplications: () => ({
+    data: undefined,
+    isLoading: false,
+    error: new Error('Failed to fetch applications from server'),
+  }),
+  useBulkUpdateApplications: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRescuesList: () => ({ data: { data: [] } }),
+}));
+
+vi.mock('../components/modals', () => ({
+  BulkConfirmationModal: () => null,
+  ApplicationDetailModal: () => null,
+}));
+
+import Applications from './Applications';
+
+describe('Applications page error wiring (UX P2 H)', () => {
+  it('renders the inline DataTable error row when the applications query fails', () => {
+    renderWithProviders(<Applications />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/failed to fetch applications/i);
+  });
+});

--- a/app.admin/src/pages/Applications.tsx
+++ b/app.admin/src/pages/Applications.tsx
@@ -245,6 +245,7 @@ const Applications: React.FC = () => {
         columns={columns}
         data={applications}
         loading={isLoading}
+        error={error instanceof Error ? error.message : null}
         emptyMessage='No applications found matching your criteria'
         currentPage={page}
         totalPages={totalPages}

--- a/app.admin/src/pages/Pets.test.tsx
+++ b/app.admin/src/pages/Pets.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * UX P2 H: when the underlying pets query errors, the DataTable now renders
+ * the inline error row (introduced by UX #5) in addition to whatever top-of-page
+ * error treatment already existed. This pins down the wiring so future
+ * refactors don't silently drop the inline affordance.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+
+vi.mock('../hooks', () => ({
+  usePets: () => ({
+    data: undefined,
+    isLoading: false,
+    error: new Error('Failed to fetch pets from server'),
+  }),
+  useBulkUpdatePets: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRescuesList: () => ({ data: { data: [] } }),
+}));
+
+vi.mock('../components/modals', () => ({
+  BulkConfirmationModal: () => null,
+  PetDetailModal: () => null,
+}));
+
+import Pets from './Pets';
+
+describe('Pets page error wiring (UX P2 H)', () => {
+  it('renders the inline DataTable error row when the pets query fails', () => {
+    renderWithProviders(<Pets />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/failed to fetch pets/i);
+  });
+});

--- a/app.admin/src/pages/Pets.tsx
+++ b/app.admin/src/pages/Pets.tsx
@@ -282,6 +282,7 @@ const Pets: React.FC = () => {
         columns={columns}
         data={pets}
         loading={isLoading}
+        error={error instanceof Error ? error.message : null}
         emptyMessage='No pets found matching your criteria'
         currentPage={page}
         totalPages={totalPages}

--- a/app.admin/src/pages/Rescues.tsx
+++ b/app.admin/src/pages/Rescues.tsx
@@ -364,6 +364,7 @@ const Rescues: React.FC = () => {
         columns={columns}
         data={rescues}
         loading={loading}
+        error={error}
         emptyMessage='No rescue organizations found matching your criteria'
         onRowClick={rescue => handleViewDetails(rescue.rescueId)}
         currentPage={currentPage}

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -117,6 +117,13 @@ const Users: React.FC = () => {
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<BulkActionType | null>(null);
   const [bulkResult, setBulkResult] = useState<{ succeeded: number; failed: number } | null>(null);
+  // UX P2 D: keep the last submitted batch around so the "Try again" button on
+  // the result view can re-run the same userIds + reason without the operator
+  // rebuilding the selection. Cleared on close.
+  const [lastBulkSubmission, setLastBulkSubmission] = useState<{
+    userIds: string[];
+    reason?: string;
+  } | null>(null);
   const bulkUpdateUsers = useBulkUpdateUsers();
 
   const { data, isLoading, error, refetch } = useUsers({
@@ -264,21 +271,20 @@ const Users: React.FC = () => {
     }
   };
 
-  const handleBulkConfirm = async (reason?: string) => {
-    if (!bulkAction) {
-      return;
-    }
-
-    const userIds = Array.from(selectedRows);
+  const runBulkAction = async (
+    action: BulkActionType,
+    userIds: string[],
+    reason?: string
+  ): Promise<{ succeeded: number; failed: number }> => {
     let result: { successCount?: number; failedCount?: number; success?: number; failed?: number };
 
-    if (bulkAction === 'activate') {
+    if (action === 'activate') {
       result = await bulkUpdateUsers.mutateAsync({
         userIds,
         updateData: { status: 'active' },
         reason,
       });
-    } else if (bulkAction === 'deactivate') {
+    } else if (action === 'deactivate') {
       result = await bulkUpdateUsers.mutateAsync({
         userIds,
         updateData: { status: 'inactive' },
@@ -293,16 +299,43 @@ const Users: React.FC = () => {
       }));
     }
 
-    setBulkResult({
+    return {
       succeeded: result.successCount ?? result.success ?? 0,
       failed: result.failedCount ?? result.failed ?? 0,
-    });
+    };
+  };
+
+  const handleBulkConfirm = async (reason?: string) => {
+    if (!bulkAction) {
+      return;
+    }
+    const userIds = Array.from(selectedRows);
+    const summary = await runBulkAction(bulkAction, userIds, reason);
+    setBulkResult(summary);
+    setLastBulkSubmission({ userIds, reason });
     setSelectedRows(new Set());
+  };
+
+  // UX P2 D: re-run the entire batch with the same userIds + reason. The backend
+  // bulk endpoints return only aggregate counts, so we cannot retry just the
+  // failed subset without a per-item failed-IDs response shape — that's a
+  // follow-up.
+  const handleBulkRetry = async () => {
+    if (!bulkAction || !lastBulkSubmission) {
+      return;
+    }
+    const summary = await runBulkAction(
+      bulkAction,
+      lastBulkSubmission.userIds,
+      lastBulkSubmission.reason
+    );
+    setBulkResult(summary);
   };
 
   const handleBulkModalClose = () => {
     setBulkAction(null);
     setBulkResult(null);
+    setLastBulkSubmission(null);
   };
 
   if (error) {
@@ -642,6 +675,7 @@ const Users: React.FC = () => {
         }
         isLoading={bulkUpdateUsers.isPending || deleteUser.isPending}
         resultSummary={bulkResult}
+        onRetry={handleBulkRetry}
       />
 
       <ToastContainer position='top-right'>

--- a/app.client/src/components/application/BooleanTiles.tsx
+++ b/app.client/src/components/application/BooleanTiles.tsx
@@ -7,14 +7,30 @@ type Props = {
   value: boolean | undefined;
   onChange: (value: boolean | undefined) => void;
   hasError?: boolean;
+  // UX P2 F: forwarded by QuestionField when isRequired so the radiogroup
+  // announces "required" to screen readers.
+  isRequired?: boolean;
+  ariaLabel?: string;
 };
 
-export const BooleanTiles: React.FC<Props> = ({ name, value, onChange, hasError = false }) => {
+export const BooleanTiles: React.FC<Props> = ({
+  name,
+  value,
+  onChange,
+  hasError = false,
+  isRequired = false,
+  ariaLabel,
+}) => {
   const yesSelected = value === true;
   const noSelected = value === false;
 
   return (
-    <div className={styles.group} role='radiogroup'>
+    <div
+      className={styles.group}
+      role='radiogroup'
+      aria-required={isRequired ? true : undefined}
+      aria-label={ariaLabel}
+    >
       <label
         className={clsx(
           styles.tile,

--- a/app.client/src/components/application/OptionTiles.tsx
+++ b/app.client/src/components/application/OptionTiles.tsx
@@ -9,6 +9,10 @@ type Props = {
   onChange: (value: string | undefined) => void;
   iconFor: (option: string) => string;
   hasError?: boolean;
+  // UX P2 F: forwarded by QuestionField when isRequired so the radiogroup
+  // announces "required" to screen readers.
+  isRequired?: boolean;
+  ariaLabel?: string;
 };
 
 export const OptionTiles: React.FC<Props> = ({
@@ -18,8 +22,15 @@ export const OptionTiles: React.FC<Props> = ({
   onChange,
   iconFor,
   hasError = false,
+  isRequired = false,
+  ariaLabel,
 }) => (
-  <div className={styles.grid} role='radiogroup'>
+  <div
+    className={styles.grid}
+    role='radiogroup'
+    aria-required={isRequired ? true : undefined}
+    aria-label={ariaLabel}
+  >
     {options.map(option => {
       const selected = value === option;
       return (

--- a/app.client/src/components/application/QuestionCategoryStep.test.tsx
+++ b/app.client/src/components/application/QuestionCategoryStep.test.tsx
@@ -158,3 +158,46 @@ describe('QuestionCategoryStep accessibility — validation errors', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });
+
+/**
+ * UX P2 F — Required-field markers for screen readers.
+ *
+ * The `*` is rendered visually (aria-hidden) for sighted users. To surface the
+ * required state to assistive tech, every input control that backs an
+ * isRequired question must carry aria-required="true". Optional fields must
+ * not.
+ */
+describe('QuestionCategoryStep — required-field markers (UX P2 F)', () => {
+  const optionalMiddleName: Question = {
+    questionId: 'q5',
+    questionKey: 'middle_name',
+    scope: 'core',
+    category: 'about',
+    questionType: 'text',
+    questionText: 'What is your middle name?',
+    helpText: null,
+    placeholder: null,
+    options: null,
+    isRequired: false,
+    isEnabled: true,
+    displayOrder: 3,
+  };
+
+  it('renders aria-required on required inputs and the visible legend, and does not mark optional inputs', () => {
+    render(<Wrapper questions={[firstName, optionalMiddleName]} initialAnswers={{}} />);
+
+    // Legend explaining the * marker is shown when there is at least one required field.
+    expect(screen.getByText(/Fields marked with \* are required/i)).toBeInTheDocument();
+
+    const requiredInput = screen.getByRole('textbox', {
+      name: /what is your first name\? \(required\)/i,
+    });
+    expect(requiredInput).toHaveAttribute('aria-required', 'true');
+
+    // The optional input is not addressable by a (required) label and does not
+    // carry aria-required.
+    const optionalInput = screen.getAllByRole('textbox').find(el => el !== requiredInput);
+    expect(optionalInput).toBeDefined();
+    expect(optionalInput).not.toHaveAttribute('aria-required');
+  });
+});

--- a/app.client/src/components/application/QuestionField.tsx
+++ b/app.client/src/components/application/QuestionField.tsx
@@ -56,6 +56,13 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
   const { questionType, questionKey, questionText, helpText, placeholder, options, isRequired } =
     question;
 
+  // UX P2 F: surface required-state to assistive tech. The visible `*` is
+  // aria-hidden (intentional — sighted users see a coloured glyph, screen
+  // readers should not announce literal "asterisk"), so each control owns its
+  // own aria-required to expose "required field" semantically.
+  const ariaRequired = isRequired ? true : undefined;
+  const ariaLabel = isRequired ? `${questionText} (required)` : undefined;
+
   const renderInput = () => {
     if (questionKey === 'household_members') {
       return <HouseholdMembersField value={value} onChange={onChange} hasError={!!error} />;
@@ -73,6 +80,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             value={typeof value === 'boolean' ? value : undefined}
             onChange={onChange}
             hasError={!!error}
+            isRequired={isRequired}
+            ariaLabel={ariaLabel}
           />
         );
 
@@ -86,6 +95,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
               onChange={next => onChange(next)}
               iconFor={getIconFor(questionKey)}
               hasError={!!error}
+              isRequired={isRequired}
+              ariaLabel={ariaLabel}
             />
           );
         }
@@ -94,6 +105,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             className={styles.select({ hasError: !!error })}
             value={asString(value)}
             onChange={e => onChange(e.target.value || undefined)}
+            aria-required={ariaRequired}
+            aria-label={ariaLabel}
           >
             <option value=''>Select an option…</option>
             {options?.map(opt => (
@@ -106,8 +119,10 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
 
       case 'multi_select': {
         const selected = asStringArray(value);
+        // aria-required is not supported on role="group"; surface required
+        // semantics on each individual checkbox input instead.
         return (
-          <div className={styles.checkboxGroup}>
+          <div className={styles.checkboxGroup} role='group' aria-label={ariaLabel}>
             {options?.map(opt => (
               <label key={opt} className={styles.checkboxLabel}>
                 <input
@@ -119,6 +134,7 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
                       : selected.filter(s => s !== opt);
                     onChange(next.length > 0 ? next : undefined);
                   }}
+                  aria-required={ariaRequired}
                 />
                 {opt}
               </label>
@@ -135,6 +151,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             value={typeof value === 'number' ? value : ''}
             placeholder={placeholder ?? undefined}
             onChange={e => onChange(e.target.value !== '' ? Number(e.target.value) : undefined)}
+            aria-required={ariaRequired}
+            aria-label={ariaLabel}
           />
         );
 
@@ -145,6 +163,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             className={styles.input({ hasError: !!error })}
             value={asString(value)}
             onChange={e => onChange(e.target.value || undefined)}
+            aria-required={ariaRequired}
+            aria-label={ariaLabel}
           />
         );
 
@@ -156,6 +176,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             placeholder={placeholder ?? undefined}
             rows={3}
             onChange={e => onChange(e.target.value || undefined)}
+            aria-required={ariaRequired}
+            aria-label={ariaLabel}
           />
         );
 
@@ -167,6 +189,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             value={asString(value)}
             placeholder={placeholder ?? undefined}
             onChange={e => onChange(e.target.value || undefined)}
+            aria-required={ariaRequired}
+            aria-label={ariaLabel}
           />
         );
 
@@ -178,6 +202,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             value={asString(value)}
             placeholder={placeholder ?? undefined}
             onChange={e => onChange(e.target.value || undefined)}
+            aria-required={ariaRequired}
+            aria-label={ariaLabel}
           />
         );
 
@@ -187,6 +213,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             type='file'
             className={styles.input({ hasError: !!error })}
             onChange={e => onChange(e.target.files?.[0]?.name ?? undefined)}
+            aria-required={ariaRequired}
+            aria-label={ariaLabel}
           />
         );
 
@@ -198,6 +226,8 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
             value={asString(value)}
             placeholder={placeholder ?? undefined}
             onChange={e => onChange(e.target.value || undefined)}
+            aria-required={ariaRequired}
+            aria-label={ariaLabel}
           />
         );
     }

--- a/app.client/src/components/modals/LoginPromptModal.test.tsx
+++ b/app.client/src/components/modals/LoginPromptModal.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * UX P2 I: the modal backdrop used to claim role="button" with a tabIndex
+ * and an aria-label purely so the click-to-dismiss handler satisfied lint.
+ * That announced a phantom button to screen readers — the real close
+ * affordance is the explicit ✕ button inside the modal. The backdrop
+ * should be role="presentation".
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/render';
+import { LoginPromptModal } from './LoginPromptModal';
+
+describe('LoginPromptModal backdrop accessibility (UX P2 I)', () => {
+  it('renders the modal backdrop without role="button"', () => {
+    renderWithProviders(<LoginPromptModal isOpen={true} onClose={vi.fn()} />);
+
+    // No backdrop "Close modal" button should be announced.
+    expect(screen.queryByRole('button', { name: /close modal/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /close notifications/i })).toBeNull();
+  });
+
+  it('keeps the explicit close affordance inside the modal', () => {
+    const onClose = vi.fn();
+    renderWithProviders(<LoginPromptModal isOpen={true} onClose={onClose} />);
+
+    // The "Continue browsing" skip button is still a real affordance.
+    expect(screen.getByRole('button', { name: /continue browsing/i })).toBeInTheDocument();
+  });
+});

--- a/app.client/src/components/modals/LoginPromptModal.tsx
+++ b/app.client/src/components/modals/LoginPromptModal.tsx
@@ -40,13 +40,15 @@ export const LoginPromptModal: React.FC<LoginPromptModalProps> = ({
   };
 
   return (
+    // UX P2 I: backdrop is a click-target convenience, not an interactive
+    // control — the accessible close affordance is the ✕ button inside the
+    // modal content.
     <div
       className={styles.modalOverlay({ isOpen })}
       onClick={onClose}
-      role='button'
-      tabIndex={0}
+      role='presentation'
       onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Escape') {
+        if (e.key === 'Escape') {
           onClose();
         }
       }}

--- a/app.client/src/components/notifications/NotificationBell.test.tsx
+++ b/app.client/src/components/notifications/NotificationBell.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * UX P2 I: the mobile dropdown overlay and the full-center overlay used to
+ * carry role="button" so the click-to-dismiss div didn't trip lint. That
+ * announced a phantom "Close notifications" / "Close notification center"
+ * button to screen readers. Both are now role="presentation"; the explicit
+ * bell button toggles the dropdown.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/render';
+
+// jsdom doesn't define the Notification web API; the component calls
+// Notification.permission inside the bell toggle handler.
+beforeAll(() => {
+  type NotificationStub = { permission: 'default' | 'granted' | 'denied' };
+  (globalThis as { Notification?: NotificationStub }).Notification = { permission: 'granted' };
+});
+
+vi.mock('@/contexts/NotificationContext', () => ({
+  useNotifications: () => ({
+    unreadCount: 0,
+    recentNotifications: [],
+    isLoading: false,
+    markAsRead: vi.fn(),
+    refreshUnreadCount: vi.fn(),
+  }),
+}));
+
+vi.mock('@/services/notificationService', () => ({
+  default: {
+    markAllAsRead: vi.fn(),
+  },
+}));
+
+vi.mock('./NotificationCenter', () => ({
+  NotificationCenterComponent: () => <div data-testid='stub-notification-center' />,
+}));
+
+import { NotificationBell } from './NotificationBell';
+
+describe('NotificationBell backdrop accessibility (UX P2 I)', () => {
+  it('does not expose the mobile overlay as a button when the dropdown opens', () => {
+    renderWithProviders(<NotificationBell />);
+
+    // Open the dropdown via the actual bell button.
+    fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+
+    expect(screen.queryByRole('button', { name: /close notifications/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /close notification center/i })).toBeNull();
+  });
+});

--- a/app.client/src/components/notifications/NotificationBell.tsx
+++ b/app.client/src/components/notifications/NotificationBell.tsx
@@ -193,33 +193,33 @@ export const NotificationBell: React.FC<NotificationBellProps> = ({ className })
       </div>
 
       {/* Overlay for mobile */}
+      {/* UX P2 I: backdrop is a click-target convenience, not an interactive
+          control — the accessible close affordance is the bell button itself. */}
       <div
         className={styles.overlay({ isOpen })}
         onClick={() => setIsOpen(false)}
-        role='button'
-        tabIndex={0}
+        role='presentation'
         onKeyDown={e => {
           if (e.key === 'Escape') {
             setIsOpen(false);
           }
         }}
-        aria-label='Close notifications'
       />
 
       {/* Full Notification Center Modal */}
       {showFullCenter && (
         <>
+          {/* UX P2 I: backdrop is a click-target convenience, not an interactive
+              control — the explicit close affordance lives inside fullCenterModal. */}
           <div
             className={styles.overlay({ isOpen: true })}
             onClick={closeFullCenter}
-            role='button'
-            tabIndex={0}
+            role='presentation'
             onKeyDown={e => {
               if (e.key === 'Escape') {
                 closeFullCenter();
               }
             }}
-            aria-label='Close notification center'
           />
           <div className={styles.fullCenterModal}>
             <NotificationCenterComponent onClose={closeFullCenter} />

--- a/app.client/src/components/onboarding/SwipeOnboarding.test.tsx
+++ b/app.client/src/components/onboarding/SwipeOnboarding.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * UX P2 I: the onboarding overlay used to claim role="button" purely so the
+ * click-to-dismiss div didn't trip lint. Screen readers announced a phantom
+ * button for the backdrop. Replaced with role="presentation"; the explicit
+ * ✕ button inside (aria-label="Close") is the accessible close affordance.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils/render';
+import { SwipeOnboarding } from './SwipeOnboarding';
+
+describe('SwipeOnboarding backdrop accessibility (UX P2 I)', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('hasSeenSwipeOnboarding');
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const advancePastShowTimer = () => {
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+  };
+
+  it('renders the backdrop without role="button" once shown', () => {
+    renderWithProviders(<SwipeOnboarding onClose={vi.fn()} />);
+    advancePastShowTimer();
+
+    // The only button labelled "Close" should be the explicit one inside the modal.
+    const closeButtons = screen.queryAllByRole('button', { name: /close/i });
+    expect(closeButtons.length).toBe(1);
+  });
+
+  it('keeps the explicit ✕ close affordance inside the modal', () => {
+    renderWithProviders(<SwipeOnboarding onClose={vi.fn()} />);
+    advancePastShowTimer();
+
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+  });
+});

--- a/app.client/src/components/onboarding/SwipeOnboarding.tsx
+++ b/app.client/src/components/onboarding/SwipeOnboarding.tsx
@@ -40,13 +40,14 @@ export const SwipeOnboarding: React.FC<SwipeOnboardingProps> = ({ onClose }) => 
   }
 
   return (
+    // UX P2 I: backdrop is a click-target convenience, not an interactive
+    // control — the accessible close affordance is the ✕ button inside.
     <div
       className={styles.overlay({ show: true })}
       onClick={handleClose}
-      role='button'
-      tabIndex={0}
+      role='presentation'
       onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Escape') {
+        if (e.key === 'Escape') {
           handleClose();
         }
       }}

--- a/app.client/src/pages/ApplicationDashboard.test.tsx
+++ b/app.client/src/pages/ApplicationDashboard.test.tsx
@@ -216,4 +216,18 @@ describe('ApplicationDashboard (ADS-634)', () => {
 
     expect(navigateMock).toHaveBeenCalledWith('/chat/conv-99');
   });
+
+  // UX P2 E: when an application's pet lookup fails or returns no record,
+  // the card used to display "Pet Name Unavailable" — a phrase that reads
+  // like a system error to applicants. Replace with "Unknown pet" and keep
+  // the card rendering normally.
+  it('renders "Unknown pet" instead of the old placeholder when pet data is missing', async () => {
+    getUserApplicationsMock.mockResolvedValue([makeApplication()]);
+    getPetByIdMock.mockResolvedValue(null);
+
+    render(<ApplicationDashboard />);
+
+    expect(await screen.findByText(/unknown pet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/pet name unavailable/i)).not.toBeInTheDocument();
+  });
 });

--- a/app.client/src/pages/ApplicationDashboard.tsx
+++ b/app.client/src/pages/ApplicationDashboard.tsx
@@ -173,7 +173,7 @@ export const ApplicationDashboard: React.FC = () => {
                   )}
                   <div>
                     <h3 className={styles.petDetailsH3}>
-                      {application.pet?.name || 'Pet Name Unavailable'}
+                      {application.pet?.name || 'Unknown pet'}
                     </h3>
                     <p className={styles.petDetailsP}>
                       {application.pet?.breed} • {application.pet?.age_years} years old

--- a/app.rescue/src/components/applications/ApplicationReview.test.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.test.tsx
@@ -117,6 +117,7 @@ vi.mock('./ApplicationReview.css', () => {
     'visitDetailsModal',
     'visitHeader',
     'visitInfo',
+    'visitDetailsBody',
     'visitNotes',
     'visitOutcome',
     'visitStaff',
@@ -434,13 +435,58 @@ describe('ApplicationReview cross-links (ADS-644)', () => {
  * button to screen readers — the real close button inside the modal is the
  * accessible affordance. The backdrop should be `role="presentation"`.
  */
-describe('ApplicationReview backdrop accessibility (UX P0/P1 #7)', () => {
+describe('ApplicationReview backdrop accessibility (UX P0/P1 #7 + UX P2 I)', () => {
   it('renders the modal backdrop without role="button"', () => {
     renderReview();
 
     // No button on the page should be labelled "Close modal" — the only
     // close affordance is the explicit Close button inside the modal.
     expect(screen.queryByRole('button', { name: /close modal/i })).toBeNull();
+  });
+
+  it('renders the visit-details backdrop without role="button" (UX P2 I)', () => {
+    const completedVisit = {
+      id: 'visit-1',
+      applicationId: 'app-1',
+      scheduledDate: '2026-06-01',
+      scheduledTime: '10:00',
+      assignedStaff: 'staff-1',
+      status: 'completed' as const,
+      outcome: 'approved' as const,
+    };
+    const baseApplication = {
+      id: 'app-1',
+      status: 'submitted',
+      petName: 'Buddy',
+      applicantName: 'John Doe',
+      submittedDaysAgo: 2,
+      stage: 'PENDING' as const,
+    };
+    render(
+      <MemoryRouter>
+        <ApplicationReview
+          application={baseApplication}
+          references={[]}
+          homeVisits={[completedVisit]}
+          timeline={[]}
+          loading={false}
+          error={null}
+          onClose={vi.fn()}
+          onStatusUpdate={vi.fn().mockResolvedValue(undefined)}
+          onStageTransition={vi.fn().mockResolvedValue(undefined)}
+          onReferenceUpdate={vi.fn()}
+          onScheduleVisit={vi.fn()}
+          onUpdateVisit={vi.fn()}
+          onAddTimelineEvent={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /home visits/i }));
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+
+    // The "Close details" backdrop label should no longer be announced as a button.
+    expect(screen.queryByRole('button', { name: /close details/i })).toBeNull();
   });
 });
 

--- a/app.rescue/src/components/applications/ApplicationReview.test.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.test.tsx
@@ -450,6 +450,64 @@ describe('ApplicationReview backdrop accessibility (UX P0/P1 #7)', () => {
  * cancellation reason is now collected via an inline modal form that matches
  * the existing reschedule/complete patterns and requires a non-empty reason.
  */
+/**
+ * UX P2 G: when references or home-visits fail to load, the rest of the
+ * applicant data should still render and the user should see a per-section
+ * inline error rather than a generic "Failed to load application details".
+ */
+describe('ApplicationReview per-section error indicators (UX P2 G)', () => {
+  const renderWithErrors = (errors: { referencesError?: string; homeVisitsError?: string }) => {
+    const baseApplication = {
+      id: 'app-1',
+      status: 'submitted',
+      petName: 'Buddy',
+      applicantName: 'John Doe',
+      submittedDaysAgo: 2,
+      stage: 'PENDING' as const,
+    };
+    render(
+      <MemoryRouter>
+        <ApplicationReview
+          application={baseApplication}
+          references={[]}
+          homeVisits={[]}
+          timeline={[]}
+          referencesError={errors.referencesError ?? null}
+          homeVisitsError={errors.homeVisitsError ?? null}
+          loading={false}
+          error={null}
+          onClose={vi.fn()}
+          onStatusUpdate={vi.fn().mockResolvedValue(undefined)}
+          onStageTransition={vi.fn().mockResolvedValue(undefined)}
+          onReferenceUpdate={vi.fn()}
+          onScheduleVisit={vi.fn()}
+          onUpdateVisit={vi.fn()}
+          onAddTimelineEvent={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+  };
+
+  it('surfaces a references load error without taking down the modal', () => {
+    renderWithErrors({ referencesError: 'network down' });
+
+    fireEvent.click(screen.getByRole('button', { name: /references/i }));
+    const alert = screen.getByText(/failed to load reference checks/i);
+    expect(alert).toBeInTheDocument();
+    // Surrounding screen still renders: the section header is still visible.
+    expect(screen.getByRole('heading', { name: /reference checks/i })).toBeInTheDocument();
+  });
+
+  it('surfaces a home-visits load error without taking down the modal', () => {
+    renderWithErrors({ homeVisitsError: 'network down' });
+
+    fireEvent.click(screen.getByRole('button', { name: /home visits/i }));
+    expect(screen.getByText(/failed to load home visits/i)).toBeInTheDocument();
+    // The "Schedule Visit" affordance still renders.
+    expect(screen.getByRole('button', { name: /schedule visit/i })).toBeInTheDocument();
+  });
+});
+
 describe('ApplicationReview cancel-visit modal (UX P2 B)', () => {
   const scheduledVisit = {
     id: 'visit-1',

--- a/app.rescue/src/components/applications/ApplicationReview.test.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.test.tsx
@@ -443,3 +443,115 @@ describe('ApplicationReview backdrop accessibility (UX P0/P1 #7)', () => {
     expect(screen.queryByRole('button', { name: /close modal/i })).toBeNull();
   });
 });
+
+/**
+ * UX P2 B: cancelling a home visit used to call window.prompt(), which is
+ * not accessible, can't be styled, and is blocked by some browsers. The
+ * cancellation reason is now collected via an inline modal form that matches
+ * the existing reschedule/complete patterns and requires a non-empty reason.
+ */
+describe('ApplicationReview cancel-visit modal (UX P2 B)', () => {
+  const scheduledVisit = {
+    id: 'visit-1',
+    applicationId: 'app-1',
+    scheduledDate: '2026-06-01',
+    scheduledTime: '10:00',
+    assignedStaff: 'staff-1',
+    status: 'scheduled' as const,
+  };
+
+  const renderWithVisit = () => {
+    const onUpdateVisit = vi.fn().mockResolvedValue(undefined);
+    const baseApplication = {
+      id: 'app-1',
+      status: 'submitted',
+      petName: 'Buddy',
+      applicantName: 'John Doe',
+      submittedDaysAgo: 2,
+      stage: 'PENDING' as const,
+    };
+    render(
+      <MemoryRouter>
+        <ApplicationReview
+          application={baseApplication}
+          references={[]}
+          homeVisits={[scheduledVisit]}
+          timeline={[]}
+          loading={false}
+          error={null}
+          onClose={vi.fn()}
+          onStatusUpdate={vi.fn().mockResolvedValue(undefined)}
+          onStageTransition={vi.fn().mockResolvedValue(undefined)}
+          onReferenceUpdate={vi.fn()}
+          onScheduleVisit={vi.fn()}
+          onUpdateVisit={onUpdateVisit}
+          onAddTimelineEvent={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+    return { onUpdateVisit };
+  };
+
+  const openCancelModal = () => {
+    // Switch to Home Visits tab.
+    fireEvent.click(screen.getByRole('button', { name: /home visits/i }));
+    // Click the visit's Cancel Visit button.
+    fireEvent.click(screen.getByRole('button', { name: /cancel visit/i }));
+  };
+
+  let promptSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    promptSpy = vi.spyOn(window, 'prompt').mockImplementation(() => {
+      throw new Error('window.prompt must not be used — use the cancel modal');
+    });
+  });
+
+  it('opens an in-page dialog instead of calling window.prompt', () => {
+    renderWithVisit();
+    openCancelModal();
+
+    expect(screen.getByRole('dialog', { name: /cancel home visit/i })).toBeInTheDocument();
+    expect(promptSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks submit while the reason is empty or whitespace', () => {
+    const { onUpdateVisit } = renderWithVisit();
+    openCancelModal();
+
+    const submit = screen.getByRole('button', { name: /confirm cancellation/i });
+    expect(submit).toBeDisabled();
+
+    const reasonInput = screen.getByLabelText(/reason for cancellation/i);
+    expect(reasonInput).toBeRequired();
+    expect(reasonInput).toHaveAttribute('aria-required', 'true');
+
+    fireEvent.change(reasonInput, { target: { value: '   ' } });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(reasonInput, { target: { value: 'Family emergency' } });
+    expect(submit).not.toBeDisabled();
+
+    expect(onUpdateVisit).not.toHaveBeenCalled();
+  });
+
+  it('calls onUpdateVisit with the typed reason when submitted', async () => {
+    const { onUpdateVisit } = renderWithVisit();
+    openCancelModal();
+
+    fireEvent.change(screen.getByLabelText(/reason for cancellation/i), {
+      target: { value: 'Family emergency' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /confirm cancellation/i }));
+
+    await waitFor(() => {
+      expect(onUpdateVisit).toHaveBeenCalledWith(
+        'visit-1',
+        expect.objectContaining({
+          status: 'cancelled',
+          cancelReason: 'Family emergency',
+        })
+      );
+    });
+  });
+});

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -162,6 +162,9 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
     conditions: '',
   });
   const [viewingVisit, setViewingVisit] = useState<string | null>(null);
+  // UX P2 B: replace window.prompt() with a modal for cancel-visit reason.
+  const [cancellingVisit, setCancellingVisit] = useState<string | null>(null);
+  const [cancelReason, setCancelReason] = useState('');
 
   // Helper functions for timeline
   const formatTimelineTimestamp = (timestamp: string) => {
@@ -267,6 +270,8 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
     setEditingVisit(null);
     setCompletingVisit(null);
     setViewingVisit(null);
+    setCancellingVisit(null);
+    setCancelReason('');
     setVisitForm({
       scheduledDate: '',
       scheduledTime: '',
@@ -564,9 +569,12 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
   };
 
   const handleCancelVisit = async (visitId: string) => {
-    const reason = prompt('Please enter a reason for cancelling this visit:');
+    // UX P2 B: validation is enforced by the disabled submit + HTML `required`
+    // attribute on the textarea, but guard here as a belt-and-braces measure
+    // in case a future caller invokes this without going through the modal.
+    const reason = cancelReason.trim();
     if (!reason) {
-      return; // User cancelled or didn't provide reason
+      return;
     }
 
     try {
@@ -575,6 +583,9 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
         cancelReason: reason,
         cancelledAt: new Date().toISOString(),
       });
+
+      setCancellingVisit(null);
+      setCancelReason('');
 
       if (onRefresh) {
         onRefresh();
@@ -1470,7 +1481,10 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                             </button>
                             <button
                               className={styles.button({ variant: 'danger' })}
-                              onClick={() => handleCancelVisit(visit.id)}
+                              onClick={() => {
+                                setCancellingVisit(visit.id);
+                                setCancelReason('');
+                              }}
                             >
                               ❌ Cancel Visit
                             </button>
@@ -1487,7 +1501,10 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                             </button>
                             <button
                               className={styles.button({ variant: 'danger' })}
-                              onClick={() => handleCancelVisit(visit.id)}
+                              onClick={() => {
+                                setCancellingVisit(visit.id);
+                                setCancelReason('');
+                              }}
                             >
                               ❌ Cancel Visit
                             </button>
@@ -1722,6 +1739,61 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                               disabled={!completeForm.outcome || !completeForm.notes}
                             >
                               Complete Visit
+                            </button>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* UX P2 B: Cancel Visit Form (replaces window.prompt) */}
+                      {cancellingVisit === visit.id && (
+                        <div
+                          className={styles.rescheduleForm}
+                          role="dialog"
+                          aria-modal="true"
+                          aria-labelledby={`cancel-visit-title-${visit.id}`}
+                        >
+                          <h5
+                            id={`cancel-visit-title-${visit.id}`}
+                            className={styles.rescheduleTitle}
+                          >
+                            Cancel Home Visit
+                          </h5>
+                          <div className={styles.formRow}>
+                            <div className={styles.formGroup}>
+                              <label
+                                className={styles.formLabel}
+                                htmlFor={`cancel-reason-${visit.id}`}
+                              >
+                                Reason for Cancellation
+                              </label>
+                              <textarea
+                                id={`cancel-reason-${visit.id}`}
+                                className={styles.formTextarea}
+                                value={cancelReason}
+                                onChange={e => setCancelReason(e.target.value)}
+                                placeholder="Why is this visit being cancelled?"
+                                rows={3}
+                                required
+                                aria-required="true"
+                              />
+                            </div>
+                          </div>
+                          <div className={styles.formActions}>
+                            <button
+                              className={styles.button({ variant: 'secondary' })}
+                              onClick={() => {
+                                setCancellingVisit(null);
+                                setCancelReason('');
+                              }}
+                            >
+                              Keep Visit
+                            </button>
+                            <button
+                              className={styles.button({ variant: 'danger' })}
+                              onClick={() => handleCancelVisit(visit.id)}
+                              disabled={!cancelReason.trim()}
+                            >
+                              Confirm Cancellation
                             </button>
                           </div>
                         </div>

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -46,6 +46,8 @@ interface ApplicationReviewProps {
   homeVisits: HomeVisit[];
   timeline: ApplicationTimeline[];
   timelineError?: string | null;
+  referencesError?: string | null;
+  homeVisitsError?: string | null;
   loading: boolean;
   error: string | null;
   onClose: () => void;
@@ -68,6 +70,8 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
   homeVisits,
   timeline,
   timelineError = null,
+  referencesError = null,
+  homeVisitsError = null,
   loading,
   error,
   onClose,
@@ -1132,6 +1136,12 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
           <div className={styles.tabPanel({ active: activeTab === 'references' })}>
             <div className={styles.section}>
               <h3 className={styles.sectionTitle}>Reference Checks</h3>
+              {referencesError && (
+                <div className={styles.card} role="alert">
+                  <p>Failed to load reference checks.</p>
+                  <p>{referencesError}</p>
+                </div>
+              )}
               {extractedReferences.length === 0 ? (
                 <div className={styles.card}>
                   <p>No references found for this application.</p>
@@ -1268,6 +1278,13 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
                     : 'Schedule Visit'}
                 </button>
               </div>
+
+              {homeVisitsError && (
+                <div className={styles.card} role="alert">
+                  <p>Failed to load home visits.</p>
+                  <p>{homeVisitsError}</p>
+                </div>
+              )}
 
               {showScheduleVisit && (
                 <div className={styles.scheduleVisitForm}>

--- a/app.rescue/src/components/applications/ApplicationReview.tsx
+++ b/app.rescue/src/components/applications/ApplicationReview.tsx
@@ -1998,13 +1998,14 @@ const ApplicationReview: React.FC<ApplicationReviewProps> = ({
 
       {/* Visit Details Modal */}
       {viewingVisit && homeVisits.find(v => v.id === viewingVisit) && (
+        // UX P2 I: backdrop is a click-target convenience, not an interactive
+        // control — the explicit × close button below is the accessible
+        // affordance. Matches the other modal-backdrop patterns in this file.
         <div
           className={styles.visitDetailsModal}
           onClick={e => e.target === e.currentTarget && setViewingVisit(null)}
           onKeyDown={e => e.key === 'Escape' && setViewingVisit(null)}
-          role="button"
-          tabIndex={-1}
-          aria-label="Close details"
+          role="presentation"
         >
           <div className={styles.visitDetailsContent}>
             <div className={styles.visitDetailsHeader}>

--- a/app.rescue/src/components/staff/InviteStaffModal.test.tsx
+++ b/app.rescue/src/components/staff/InviteStaffModal.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * UX P2 I: the modal backdrop used to claim role="button" with tabIndex={-1}
+ * and aria-label="Close modal" purely so the click-to-dismiss div didn't
+ * trip lint. That announced a phantom button to screen readers. The real
+ * close affordance is the ✕ button inside the modal header.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import InviteStaffModal from './InviteStaffModal';
+
+// vanilla-extract CSS modules can't be evaluated in JSDOM; replace with
+// simple class-string exports so the component renders.
+vi.mock('./InviteStaffModal.css', () => {
+  const EXPORTS = [
+    'actionButton',
+    'closeButton',
+    'form',
+    'formActions',
+    'formError',
+    'formGroup',
+    'formHelp',
+    'formInfo',
+    'formInput',
+    'formLabel',
+    'formModal',
+    'formOverlay',
+    'infoSection',
+    'loadingSpinner',
+    'modalHeader',
+    'modalTitle',
+    'requiredIndicator',
+  ] as const;
+  const out: Record<string, unknown> = {};
+  for (const name of EXPORTS) {
+    // Provide both call signature (for vanilla-extract recipes) and string
+    // value (for plain class names). Object.assign keeps the function but
+    // overrides toString to return the recipe name.
+    const fn = (..._args: unknown[]) => name;
+    out[name] = Object.assign(fn, { toString: () => name });
+  }
+  return out;
+});
+
+describe('InviteStaffModal backdrop accessibility (UX P2 I)', () => {
+  it('renders the modal backdrop without role="button"', () => {
+    render(<InviteStaffModal onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    // No backdrop "Close modal" button should be announced.
+    expect(screen.queryByRole('button', { name: /close modal/i })).toBeNull();
+  });
+
+  it('keeps the explicit ✕ close affordance inside the modal header', () => {
+    render(<InviteStaffModal onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    // The header carries an unlabelled ✕ button — find it by its text content.
+    const closeButton = screen.getByText('✕').closest('button');
+    expect(closeButton).not.toBeNull();
+  });
+});

--- a/app.rescue/src/components/staff/InviteStaffModal.tsx
+++ b/app.rescue/src/components/staff/InviteStaffModal.tsx
@@ -67,6 +67,9 @@ const InviteStaffModal: React.FC<InviteStaffModalProps> = ({
   };
 
   return (
+    // UX P2 I: the backdrop is a click-target convenience, not an interactive
+    // control — the accessible close affordance is the ✕ button below.
+    // role="presentation" matches the sibling modal patterns.
     <div
       className={styles.formOverlay}
       onClick={e => {
@@ -75,9 +78,7 @@ const InviteStaffModal: React.FC<InviteStaffModalProps> = ({
         }
       }}
       onKeyDown={e => e.key === 'Escape' && onCancel()}
-      role="button"
-      tabIndex={-1}
-      aria-label="Close modal"
+      role="presentation"
     >
       <div className={styles.formModal}>
         <div className={styles.modalHeader}>

--- a/app.rescue/src/hooks/useApplications.ts
+++ b/app.rescue/src/hooks/useApplications.ts
@@ -111,6 +111,10 @@ export const useApplicationDetails = (applicationId: string | null) => {
   const [homeVisits, setHomeVisits] = useState<HomeVisit[]>([]);
   const [timeline, setTimeline] = useState<ApplicationTimeline[]>([]);
   const [timelineError, setTimelineError] = useState<string | null>(null);
+  // UX P2 G: surface per-section failures independently so a single broken
+  // sub-resource doesn't blow away the rest of the modal.
+  const [referencesError, setReferencesError] = useState<string | null>(null);
+  const [homeVisitsError, setHomeVisitsError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -123,15 +127,25 @@ export const useApplicationDetails = (applicationId: string | null) => {
       setLoading(true);
       setError(null);
       setTimelineError(null);
+      setReferencesError(null);
+      setHomeVisitsError(null);
 
-      // UX P0/P1 #6: timeline failures used to be swallowed inside the
-      // service and returned as `[]`. They now throw, so we handle them
-      // independently here — a failed timeline shouldn't blow away the
-      // applicant data the rest of the modal needs.
-      const [appData, referencesData, visitsData, timelineResult] = await Promise.all([
+      // UX P0/P1 #6 + P2 G: sub-resource failures (timeline, references,
+      // home visits) used to either swallow to `[]` or take down the whole
+      // modal via Promise.all rejection. They now surface per-section so
+      // the rest of the applicant data remains visible.
+      const [appData, referencesResult, visitsResult, timelineResult] = await Promise.all([
         applicationService.getApplicationById(applicationId),
-        applicationService.getReferenceChecks(applicationId),
-        applicationService.getHomeVisits(applicationId),
+        applicationService.getReferenceChecks(applicationId).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : 'Failed to load reference checks';
+          setReferencesError(message);
+          return [] as ReferenceCheck[];
+        }),
+        applicationService.getHomeVisits(applicationId).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : 'Failed to load home visits';
+          setHomeVisitsError(message);
+          return [] as HomeVisit[];
+        }),
         applicationService.getApplicationTimeline(applicationId).catch((err: unknown) => {
           const message = err instanceof Error ? err.message : 'Failed to load timeline';
           setTimelineError(message);
@@ -140,8 +154,8 @@ export const useApplicationDetails = (applicationId: string | null) => {
       ]);
 
       setApplication(appData);
-      setReferences(referencesData);
-      setHomeVisits(visitsData);
+      setReferences(referencesResult);
+      setHomeVisits(visitsResult);
       setTimeline(timelineResult);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch application details');
@@ -251,6 +265,8 @@ export const useApplicationDetails = (applicationId: string | null) => {
     homeVisits,
     timeline,
     timelineError,
+    referencesError,
+    homeVisitsError,
     loading,
     error,
     updateReferenceCheck,

--- a/app.rescue/src/pages/Applications.tsx
+++ b/app.rescue/src/pages/Applications.tsx
@@ -57,6 +57,8 @@ const Applications: React.FC = () => {
     homeVisits,
     timeline,
     timelineError,
+    referencesError,
+    homeVisitsError,
     loading: detailsLoading,
     error: detailsError,
     updateReferenceCheck,
@@ -201,6 +203,8 @@ const Applications: React.FC = () => {
           homeVisits={homeVisits}
           timeline={timeline}
           timelineError={timelineError}
+          referencesError={referencesError}
+          homeVisitsError={homeVisitsError}
           loading={detailsLoading}
           error={detailsError}
           onClose={handleCloseReview}

--- a/app.rescue/src/services/applicationService.test.ts
+++ b/app.rescue/src/services/applicationService.test.ts
@@ -185,3 +185,32 @@ describe('RescueApplicationService.getApplicationTimeline error propagation (UX 
     await expect(service.getApplicationTimeline('app-1')).resolves.toEqual([]);
   });
 });
+
+/**
+ * UX P2 G: getHomeVisits used to fall back to the application data when
+ * the dedicated home-visits endpoint failed; if THAT fallback also failed
+ * it returned `[]` — indistinguishable from "no visits scheduled" — which
+ * masked outages from rescue staff. The double-failure path now propagates
+ * the error so the consuming hook can surface an inline error indicator.
+ */
+describe('RescueApplicationService.getHomeVisits error propagation (UX P2 G)', () => {
+  const service = new RescueApplicationService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects when both the dedicated endpoint and the application fallback fail', async () => {
+    apiServiceMock.get
+      .mockRejectedValueOnce(new Error('home-visits endpoint down'))
+      .mockRejectedValueOnce(new Error('application endpoint down'));
+
+    await expect(service.getHomeVisits('app-1')).rejects.toThrow(/application endpoint down/);
+  });
+
+  it('still resolves with an empty array when the dedicated endpoint succeeds with no visits', async () => {
+    apiServiceMock.get.mockResolvedValueOnce({ success: true, visits: [] });
+
+    await expect(service.getHomeVisits('app-1')).resolves.toEqual([]);
+  });
+});

--- a/app.rescue/src/services/applicationService.ts
+++ b/app.rescue/src/services/applicationService.ts
@@ -429,8 +429,14 @@ export class RescueApplicationService {
 
         return [];
       } catch (fallbackError) {
+        // UX P2 G: previously returned `[]` here, which was indistinguishable
+        // from "no home visits scheduled" — the UI rendered an empty section
+        // even when the entire request had failed. Re-throw so the consuming
+        // hook can surface an inline error.
         console.error('Error fetching application data for home visit fallback:', fallbackError);
-        return [];
+        throw fallbackError instanceof Error
+          ? fallbackError
+          : new Error('Failed to load home visits');
       }
     }
   }


### PR DESCRIPTION
## Summary

Batch of P2 polish + bounded pattern sweeps following the P0/P1 UX pass in #672. One commit per item, structured for commit-by-commit review.

## Checklist

| Letter | SHA | Severity | App | One-line |
|---|---|---|---|---|
| A | (none) | P2 | app.client | **Verified clean** — `/discover` route exists in App.tsx (line 134) and resolves to DiscoveryPage; the FavoritesPage empty state intentionally offers both `/discover` ("Start Swiping") and `/search` ("Browse All Pets") buttons. No change made. |
| B | c46a6d4 | P2 | app.rescue | Replaced `window.prompt()` for cancel-visit reason with an inline modal form matching the sibling reschedule/complete patterns; reason is `required` + `aria-required="true"`; submit blocked while empty/whitespace. |
| C | 6005939 | P2 | app.admin | Added `aria-current="page"` to the current page button in the DataTable pagination row. No visual change. |
| D | c7186ee | P2 | app.admin | BulkConfirmationModal now distinguishes partial-failure from all-success: when `failed > 0` it shows explicit "Some items couldn't be updated…" guidance and a "Try again" button. Users.tsx is wired up to retain the previous batch's userIds + reason so retry re-runs the same operation without rebuilding the selection. **Approach D2 (whole-batch retry, not retry-failed-only)** because the bulk endpoints currently return only aggregate `{success, failed}` counts — surfacing per-item failure IDs needs a backend response-shape change (follow-up). |
| E | 2ccfc4f | P2 | app.client | "Pet Name Unavailable" → "Unknown pet" on ApplicationDashboard cards when the pet lookup returns no data. Reads as a graceful fallback rather than a system error. |
| F | 76443e5 | P2 | app.client | Application form inputs now carry `aria-required="true"` and an `aria-label` that includes "(required)" when the question's `isRequired` is true. The visible `*` marker (already aria-hidden) and the per-step "Fields marked with * are required" legend (already conditionally rendered) continue to serve sighted users; this adds the matching SR semantics. Covers all QuestionField branches — bare inputs, select, address textarea, multi_select checkboxes, and the radiogroup-based BooleanTiles / OptionTiles. Submit-time validation timing unchanged (separate UX work per the audit). |
| G | 6e8057a | P2 | app.rescue | Sweep of `[]`-on-error catches: `getHomeVisits` inner fallback now re-throws; `useApplicationDetails` catches references + home-visit failures locally so per-section errors no longer take down the whole modal. (Note: `getReferenceChecks` was already throwing — only the hook-side plumbing needed adding for it.) |
| H | 9a69093 | P2 | app.admin | Wired `query.error?.message` into DataTable on Pets, Applications, Rescues. Users.tsx and Moderation.tsx return early with a full-page error panel — wiring the DataTable error prop there would be a no-op without a larger refactor; noted as skipped per the brief. |
| I | e62d772 | P2 | apps | Removed `role="button"` from 5 more modal backdrops: LoginPromptModal, NotificationBell (×2 overlays), SwipeOnboarding (all app.client), InviteStaffModal and the visit-details modal in ApplicationReview (app.rescue). Each backdrop is now `role="presentation"`; the explicit close affordance inside each modal is preserved. Other `role="button"` sites (SwipeCard, NotificationCenter list items, PetDetailsPage thumbnails, Navbar brand, FileUpload drop zone, EventCard/EventCalendar day buttons, ApplicationStageCard, PetCsvImportModal drop zone) are legitimate interactive elements, not backdrops, and were left alone. |

## Follow-ups noted while shipping D and F

- **D — per-item retry:** the bulk endpoints (`POST /api/v1/users/bulk-update`, etc.) currently return only aggregate `{success, failed}` counts. To enable "retry failed only", the backend response shape needs to expose either `failedIds: string[]` or `results: Array<{id, success, error}>`. Out of scope for this batch.
- **F — shared form components:** other forms across `app.rescue` and `app.admin` (and any `lib.components` form primitives) likely need the same `aria-required` treatment for full coverage. Intentionally scoped to `app.client/src/components/application/**` for this commit per the brief.

## Pre-existing issues observed but not fixed

- `app.client/src/contexts/ChatContext.tsx:117` and `app.rescue/src/contexts/ChatContext.tsx:39` both fail `tsc --noEmit` with `Property 'tokenProvider' is missing` from `ChatProviderProps`. Reproduces on `main`; outside the scope of this batch.

## Verification

`npx turbo lint test --filter=@adopt-dont-shop/app.client --filter=@adopt-dont-shop/app.rescue --filter=@adopt-dont-shop/app.admin` — all tasks pass:
- app.client: 404 tests (60 files) — +1 behaviour test for required-field markers (UX P2 F)
- app.rescue: 250+ tests
- app.admin: 397 tests (36 files) — +3 behaviour tests for bulk-action failure guidance + retry (UX P2 D)

`type-check` not run in the gate because of the two pre-existing ChatContext errors above; new changes do not add any new type errors.

## Test plan

- [x] All affected unit + behaviour tests pass locally
- [x] Lint passes for app.client, app.rescue, app.admin
- [ ] Manual smoke: cancel a home visit and confirm the modal collects the reason (no `window.prompt`)
- [ ] Manual smoke: load an admin Pets/Applications/Rescues page with the API offline and confirm the inline error row renders
- [ ] Manual smoke: trigger a bulk user update where some IDs fail (e.g., mix valid + non-existent user IDs) and confirm the modal shows the failure guidance + "Try again" button, and that "Try again" re-runs the same batch
- [ ] Screen-reader smoke: NVDA/VoiceOver on FavoritesPage empty state, DataTable pagination, a swipe-onboarding modal, and the application form — confirm no phantom "Close" buttons announced, and that required application-form fields are announced as "required"

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_