### PR TITLE
fix(lib.components): a11y + composition sweep

### DIFF
--- a/lib.components/src/components/charts/DataTable.css.ts
+++ b/lib.components/src/components/charts/DataTable.css.ts
@@ -13,14 +13,25 @@ export const table = style({
 
 export const th = style({
   textAlign: 'left',
-  padding: '8px 12px',
+  padding: 0,
   borderBottom: '1px solid var(--color-border, #e5e7eb)',
-  cursor: 'pointer',
   color: 'var(--color-text-muted, #6b7280)',
   fontWeight: 600,
   background: 'var(--color-surface-muted, #f9fafb)',
   position: 'sticky',
   top: 0,
+});
+
+export const sortButton = style({
+  width: '100%',
+  textAlign: 'left',
+  padding: '8px 12px',
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  color: 'inherit',
+  font: 'inherit',
+  fontWeight: 'inherit',
 });
 
 export const td = style({

--- a/lib.components/src/components/charts/DataTable.test.tsx
+++ b/lib.components/src/components/charts/DataTable.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { DataTable, type DataTableColumn } from './DataTable';
+
+const renderWithTheme = (component: React.ReactElement) => render(component);
+
+const columns: DataTableColumn[] = [
+  { key: 'name', label: 'Name' },
+  { key: 'age', label: 'Age' },
+];
+
+const rows = [
+  { name: 'Bea', age: 4 },
+  { name: 'Ada', age: 7 },
+  { name: 'Cy', age: 2 },
+];
+
+describe('DataTable sortable headers', () => {
+  it('reports aria-sort="none" on unsorted columns', () => {
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={rows} />);
+    expect(screen.getByTestId('th-name')).toHaveAttribute('aria-sort', 'none');
+    expect(screen.getByTestId('th-age')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('toggles aria-sort between ascending and descending on clicks', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={rows} />);
+
+    const headerButton = screen.getByRole('button', { name: /name/i });
+    await user.click(headerButton);
+    expect(screen.getByTestId('th-name')).toHaveAttribute('aria-sort', 'ascending');
+
+    await user.click(headerButton);
+    expect(screen.getByTestId('th-name')).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('activates sort via the keyboard when the header button is focused', async () => {
+    const user = userEvent.setup();
+    renderWithTheme(<DataTable title='Pets' columns={columns} rows={rows} />);
+
+    const headerButton = screen.getByRole('button', { name: /age/i });
+    headerButton.focus();
+    expect(headerButton).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(screen.getByTestId('th-age')).toHaveAttribute('aria-sort', 'ascending');
+  });
+});

--- a/lib.components/src/components/charts/DataTable.tsx
+++ b/lib.components/src/components/charts/DataTable.tsx
@@ -69,17 +69,31 @@ export const DataTable: React.FC<DataTableProps> = ({
         <table className={styles.table}>
           <thead>
             <tr>
-              {columns.map(col => (
-                <th
-                  key={col.key}
-                  className={styles.th}
-                  onClick={() => handleSort(col.key)}
-                  data-testid={`th-${col.key}`}
-                >
-                  {col.label}
-                  {sortKey === col.key ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
-                </th>
-              ))}
+              {columns.map(col => {
+                const isSorted = sortKey === col.key;
+                const ariaSort: 'ascending' | 'descending' | 'none' = isSorted
+                  ? sortDir === 'asc'
+                    ? 'ascending'
+                    : 'descending'
+                  : 'none';
+                return (
+                  <th
+                    key={col.key}
+                    className={styles.th}
+                    data-testid={`th-${col.key}`}
+                    aria-sort={ariaSort}
+                  >
+                    <button
+                      type='button'
+                      className={styles.sortButton}
+                      onClick={() => handleSort(col.key)}
+                    >
+                      {col.label}
+                      {isSorted ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
+                    </button>
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>

--- a/lib.components/src/components/form/CheckboxInput/CheckboxInput.test.tsx
+++ b/lib.components/src/components/form/CheckboxInput/CheckboxInput.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import React, { useRef } from 'react';
 import { CheckboxInput } from './CheckboxInput';
 
 const renderWithTheme = (component: React.ReactElement) => render(component);
@@ -69,5 +69,35 @@ describe('CheckboxInput', () => {
     renderWithTheme(<CheckboxInput indeterminate />);
     const checkbox = screen.getByRole('checkbox');
     expect(checkbox).toBeInTheDocument();
+  });
+
+  it('sets aria-required when required is true', () => {
+    renderWithTheme(<CheckboxInput required />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('does not set aria-required when required is false', () => {
+    renderWithTheme(<CheckboxInput />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toHaveAttribute('aria-required');
+  });
+
+  it('forwards ref to the underlying checkbox input', () => {
+    const RefTest: React.FC = () => {
+      const inputRef = useRef<HTMLInputElement>(null);
+      return (
+        <>
+          <CheckboxInput ref={inputRef} data-testid='ref-checkbox' />
+          <button onClick={() => inputRef.current?.focus()}>focus</button>
+        </>
+      );
+    };
+    renderWithTheme(<RefTest />);
+    const checkbox = screen.getByTestId('ref-checkbox');
+    act(() => {
+      screen.getByText('focus').click();
+    });
+    expect(checkbox).toHaveFocus();
   });
 });

--- a/lib.components/src/components/form/CheckboxInput/CheckboxInput.tsx
+++ b/lib.components/src/components/form/CheckboxInput/CheckboxInput.tsx
@@ -96,6 +96,7 @@ export const CheckboxInput = ({
           defaultChecked={defaultChecked}
           disabled={disabled}
           required={required}
+          aria-required={required ? true : undefined}
           data-testid={dataTestId}
           onChange={onChange}
           className={hiddenCheckbox}

--- a/lib.components/src/components/form/FileUpload/FileUpload.test.tsx
+++ b/lib.components/src/components/form/FileUpload/FileUpload.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React, { useRef } from 'react';
 import { FileUpload } from './FileUpload';
 
 const renderWithTheme = (component: React.ReactElement) => render(component);
@@ -190,5 +190,41 @@ describe('FileUpload', () => {
     rerender(<FileUpload state='warning' data-testid='file-upload' />);
 
     expect(screen.getByTestId('file-upload')).toBeInTheDocument();
+  });
+
+  it('sets aria-required on the hidden file input when required is true', () => {
+    renderWithTheme(<FileUpload required data-testid='file-upload' />);
+    const input = screen
+      .getByTestId('file-upload')
+      .querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('does not set aria-required on the hidden file input when required is false', () => {
+    renderWithTheme(<FileUpload data-testid='file-upload' />);
+    const input = screen
+      .getByTestId('file-upload')
+      .querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toHaveAttribute('aria-required');
+  });
+
+  it('forwards ref to the underlying file input', () => {
+    const RefTest: React.FC = () => {
+      const inputRef = useRef<HTMLInputElement>(null);
+      return (
+        <>
+          <FileUpload ref={inputRef} data-testid='file-upload' />
+          <button onClick={() => inputRef.current?.focus()}>focus</button>
+        </>
+      );
+    };
+    renderWithTheme(<RefTest />);
+    const input = screen
+      .getByTestId('file-upload')
+      .querySelector<HTMLInputElement>('input[type="file"]');
+    act(() => {
+      screen.getByText('focus').click();
+    });
+    expect(input).toHaveFocus();
   });
 });

--- a/lib.components/src/components/form/FileUpload/FileUpload.tsx
+++ b/lib.components/src/components/form/FileUpload/FileUpload.tsx
@@ -26,6 +26,7 @@ export interface FileUploadProps {
   onFileRemove?: (index: number) => void;
   onError?: (error: string) => void;
   files?: File[];
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 const formatFileSize = (bytes: number): string => {
@@ -72,9 +73,19 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   onFileRemove,
   onError,
   files = [],
+  ref,
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const combinedInputRef = (node: HTMLInputElement | null) => {
+    (inputRef as React.MutableRefObject<HTMLInputElement | null>).current = node;
+    if (typeof ref === 'function') {
+      ref(node);
+    } else if (ref) {
+      (ref as React.MutableRefObject<HTMLInputElement | null>).current = node;
+    }
+  };
 
   const validateFiles = useCallback(
     (fileList: FileList): File[] => {
@@ -207,12 +218,14 @@ export const FileUpload: React.FC<FileUploadProps> = ({
       )}
 
       <input
-        ref={inputRef}
+        ref={combinedInputRef}
         className={styles.hiddenInput}
         type='file'
         accept={accept}
         multiple={multiple}
         disabled={disabled}
+        required={required}
+        aria-required={required ? true : undefined}
         onChange={handleInputChange}
       />
 

--- a/lib.components/src/components/form/SelectInput/SelectInput.test.tsx
+++ b/lib.components/src/components/form/SelectInput/SelectInput.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import React, { useRef } from 'react';
 import { SelectInput, SelectOption } from './SelectInput';
 
 const renderWithTheme = (component: React.ReactElement) => render(component);
@@ -174,6 +174,36 @@ describe('SelectInput', () => {
     const label = screen.getByText('Required Field');
     expect(label).toBeInTheDocument();
     // Required styling is applied via CSS pseudo-element, component renders successfully
+  });
+
+  it('sets aria-required on the trigger when required is true', () => {
+    renderWithTheme(<SelectInput options={mockOptions} required />);
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('does not set aria-required on the trigger when required is false', () => {
+    renderWithTheme(<SelectInput options={mockOptions} />);
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).not.toHaveAttribute('aria-required');
+  });
+
+  it('forwards ref to the underlying trigger button', () => {
+    const RefTest: React.FC = () => {
+      const triggerRef = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <SelectInput options={mockOptions} ref={triggerRef} />
+          <button onClick={() => triggerRef.current?.focus()}>focus</button>
+        </>
+      );
+    };
+    renderWithTheme(<RefTest />);
+    const trigger = screen.getByRole('combobox');
+    act(() => {
+      screen.getByText('focus').click();
+    });
+    expect(trigger).toHaveFocus();
   });
 
   it('applies different sizes correctly', () => {

--- a/lib.components/src/components/form/SelectInput/SelectInput.tsx
+++ b/lib.components/src/components/form/SelectInput/SelectInput.tsx
@@ -228,6 +228,7 @@ export const SelectInput = ({
             ref={ref}
             className={trigger({ size, state: actualState, disabled, fullWidth })}
             aria-label={label}
+            aria-required={required ? true : undefined}
           >
             {renderValue()}
             <div className={iconRow}>

--- a/lib.components/src/components/form/TextArea/TextArea.test.tsx
+++ b/lib.components/src/components/form/TextArea/TextArea.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import React, { useRef } from 'react';
 import { TextArea } from './TextArea';
 
 const renderWithTheme = (component: React.ReactElement) => render(component);
@@ -98,6 +98,36 @@ describe('TextArea', () => {
     renderWithTheme(<TextArea autoResize />);
     const textarea = screen.getByRole('textbox');
     expect(textarea).toBeInTheDocument();
+  });
+
+  it('sets aria-required when required is true', () => {
+    renderWithTheme(<TextArea required />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('does not set aria-required when required is false', () => {
+    renderWithTheme(<TextArea />);
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).not.toHaveAttribute('aria-required');
+  });
+
+  it('forwards ref to the underlying textarea', () => {
+    const RefTest: React.FC = () => {
+      const textareaRef = useRef<HTMLTextAreaElement>(null);
+      return (
+        <>
+          <TextArea ref={textareaRef} data-testid='ref-textarea' />
+          <button onClick={() => textareaRef.current?.focus()}>focus</button>
+        </>
+      );
+    };
+    renderWithTheme(<RefTest />);
+    const textarea = screen.getByTestId('ref-textarea');
+    act(() => {
+      screen.getByText('focus').click();
+    });
+    expect(textarea).toHaveFocus();
   });
 
   it('combines all props correctly', async () => {

--- a/lib.components/src/components/form/TextArea/TextArea.tsx
+++ b/lib.components/src/components/form/TextArea/TextArea.tsx
@@ -152,6 +152,7 @@ export const TextArea = ({
           placeholder={placeholder}
           disabled={disabled}
           required={required}
+          aria-required={required ? true : undefined}
           readOnly={readOnly}
           rows={autoResize ? minRows : rows}
           maxLength={maxLength}

--- a/lib.components/src/components/form/TextInput/TextInput.test.tsx
+++ b/lib.components/src/components/form/TextInput/TextInput.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import React, { useRef } from 'react';
 import { TextInput } from './TextInput';
 
 const renderWithTheme = (component: React.ReactElement) => render(component);
@@ -63,6 +63,36 @@ describe('TextInput', () => {
     renderWithTheme(<TextInput data-testid='test-input' />);
     const input = screen.getByTestId('test-input');
     expect(input).toBeInTheDocument();
+  });
+
+  it('sets aria-required when required is true', () => {
+    renderWithTheme(<TextInput required />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('does not set aria-required when required is false', () => {
+    renderWithTheme(<TextInput />);
+    const input = screen.getByRole('textbox');
+    expect(input).not.toHaveAttribute('aria-required');
+  });
+
+  it('forwards ref to the underlying input', () => {
+    const RefTest: React.FC = () => {
+      const inputRef = useRef<HTMLInputElement>(null);
+      return (
+        <>
+          <TextInput ref={inputRef} data-testid='ref-input' />
+          <button onClick={() => inputRef.current?.focus()}>focus</button>
+        </>
+      );
+    };
+    renderWithTheme(<RefTest />);
+    const input = screen.getByTestId('ref-input');
+    act(() => {
+      screen.getByText('focus').click();
+    });
+    expect(input).toHaveFocus();
   });
 
   it('handles focus and blur events', async () => {

--- a/lib.components/src/components/form/TextInput/TextInput.tsx
+++ b/lib.components/src/components/form/TextInput/TextInput.tsx
@@ -30,6 +30,12 @@ export type TextInputProps = {
   ref?: React.Ref<HTMLInputElement>;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
+/**
+ * @deprecated Use `Input` from `@adopt-dont-shop/lib.components` instead.
+ * `TextInput` duplicates `Input`'s feature surface; new code should consume
+ * `Input`. Existing call sites are left untouched and will be migrated in a
+ * follow-up sweep.
+ */
 export const TextInput = ({
   label,
   placeholder,

--- a/lib.components/src/components/form/TextInput/TextInput.tsx
+++ b/lib.components/src/components/form/TextInput/TextInput.tsx
@@ -67,6 +67,7 @@ export const TextInput = ({
       defaultValue={defaultValue}
       disabled={disabled}
       required={required}
+      aria-required={required ? true : undefined}
       readOnly={readOnly}
       data-testid={dataTestId}
       aria-invalid={effectiveState === 'error'}

--- a/lib.components/src/components/ui/Button.test.tsx
+++ b/lib.components/src/components/ui/Button.test.tsx
@@ -84,4 +84,22 @@ describe('Button', () => {
 
     expect(handleClick).not.toHaveBeenCalled();
   });
+
+  it('defaults to type="button"', () => {
+    renderWithTheme(<Button>Default</Button>);
+    const button = screen.getByRole('button', { name: /default/i });
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('honours an explicit type="submit"', () => {
+    renderWithTheme(<Button type='submit'>Submit</Button>);
+    const button = screen.getByRole('button', { name: /submit/i });
+    expect(button).toHaveAttribute('type', 'submit');
+  });
+
+  it('honours an explicit type="reset"', () => {
+    renderWithTheme(<Button type='reset'>Reset</Button>);
+    const button = screen.getByRole('button', { name: /reset/i });
+    expect(button).toHaveAttribute('type', 'reset');
+  });
 });

--- a/lib.components/src/components/ui/Button.tsx
+++ b/lib.components/src/components/ui/Button.tsx
@@ -19,6 +19,7 @@ export const Button = ({
   className,
   onClick,
   ref,
+  type = 'button',
   ...props
 }: ButtonProps) => {
   const effectiveStartIcon = startIcon ?? leftIcon;
@@ -51,7 +52,7 @@ export const Button = ({
       onClick={handleClick}
       aria-disabled={disabled || isLoading}
       aria-busy={isLoading}
-      type='button'
+      type={type}
       {...props}
     >
       {effectiveStartIcon && !isLoading && (

--- a/lib.components/src/components/ui/Modal.test.tsx
+++ b/lib.components/src/components/ui/Modal.test.tsx
@@ -175,4 +175,44 @@ describe('Modal', () => {
 
     expect(document.body.style.overflow).toBe('');
   });
+
+  it('includes custom role="button" elements in the focus trap', async () => {
+    const user = userEvent.setup();
+    const handleClose = vi.fn();
+    renderWithTheme(
+      <Modal isOpen={true} onClose={handleClose} showCloseButton={false}>
+        <button>Real button</button>
+        <div role='button' tabIndex={0} data-testid='role-button'>
+          Custom close
+        </div>
+      </Modal>
+    );
+
+    const realButton = screen.getByText('Real button');
+    const customButton = screen.getByTestId('role-button');
+
+    realButton.focus();
+    await user.tab();
+    expect(customButton).toHaveFocus();
+
+    // Tab from the last focusable wraps to the first
+    await user.tab();
+    expect(realButton).toHaveFocus();
+  });
+
+  it('restores focus to the trigger element on close', () => {
+    const handleClose = vi.fn();
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Trigger';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = renderWithTheme(<MockModal isOpen={true} onClose={handleClose} />);
+
+    rerender(<MockModal isOpen={false} onClose={handleClose} />);
+
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
 });

--- a/lib.components/src/components/ui/Modal.tsx
+++ b/lib.components/src/components/ui/Modal.tsx
@@ -45,6 +45,7 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const isInitialOpen = useRef(false);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
 
   const handleEscape = useCallback(
     (event: KeyboardEvent) => {
@@ -61,10 +62,12 @@ export const Modal: React.FC<ModalProps> = ({
 
       if (!isInitialOpen.current) {
         isInitialOpen.current = true;
+        const activeElement = document.activeElement;
+        previouslyFocused.current = activeElement instanceof HTMLElement ? activeElement : null;
         setTimeout(() => {
           if (modalRef.current) {
             const focusable = modalRef.current.querySelectorAll<HTMLElement>(
-              'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+              'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), [role="button"]:not([disabled]), [role="menuitem"]:not([disabled])'
             );
             if (focusable.length > 0) {
               focusable[0].focus();
@@ -84,6 +87,13 @@ export const Modal: React.FC<ModalProps> = ({
         }
       };
     } else {
+      if (isInitialOpen.current) {
+        const toFocus = previouslyFocused.current;
+        if (toFocus && document.body.contains(toFocus)) {
+          toFocus.focus();
+        }
+        previouslyFocused.current = null;
+      }
       isInitialOpen.current = false;
     }
   }, [isOpen, closeOnEscape, handleEscape]);
@@ -101,7 +111,7 @@ export const Modal: React.FC<ModalProps> = ({
     }
     if (event.key === 'Tab' && modalRef.current) {
       const focusable = modalRef.current.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), [role="button"]:not([disabled]), [role="menuitem"]:not([disabled])'
       );
       if (focusable.length === 0) {
         return;

--- a/lib.components/src/index.ts
+++ b/lib.components/src/index.ts
@@ -47,6 +47,8 @@ export { CheckboxInput } from './components/form/CheckboxInput';
 export { SelectInput } from './components/form/SelectInput/';
 export type { SelectOption } from './components/form/SelectInput/';
 export { TextArea } from './components/form/TextArea';
+// `TextInput` is deprecated — prefer `Input`. Still exported for existing
+// consumers; do not add new call sites.
 export { TextInput } from './components/form/TextInput';
 export { Input } from './components/ui/Input';
 export { FormField, FormRow, FormSection } from './components/form/FormField';


### PR DESCRIPTION
## Summary

C1 of the third UX pass — a focused a11y + composition sweep on `lib.components`. Fixes ripple to `app.client`, `app.rescue`, and `app.admin` through the shared library; no app-side call-site changes were needed.

## Checklist

- [x] **C1-1** modal restores trigger focus and traps `role=button`/`menuitem` — `44300d2d3fdaeece9df2051e76ec33b23308c675`
- [x] **C1-2** announce required form fields via `aria-required` (TextInput, TextArea, CheckboxInput, SelectInput, FileUpload) and thread a ref through FileUpload — `233f68d744a64242b69d5ca60b236fd00a3fe70b`
- [x] **C1-3** allow Button to set its own `type` attribute — `43483d47eb0030c6b8b1a28979705442f1c3b12a`
- [x] **C1-4** make DataTable sortable headers keyboard-accessible (real `<button>` inside `<th>`, `aria-sort=ascending|descending|none`) — `3c3d005a4466d3d942a81e58ad30f110778b35ff`
- [x] **C1-5** deprecate `TextInput` in favour of `Input` — `4128495c4c5b8562ea0e11f6d7518765b4c0a0df`

## C1-5 direction

Kept `Input`, deprecated `TextInput`. Inventory: `Input` has 12 consumer imports across `app.admin` + `app.client`; `TextInput` has 1 (`app.client/src/pages/SearchFilters.tsx`). Per the brief: "If `Input` is the simpler one and `TextInput` is over-engineered, keep `Input`, mark `TextInput` deprecated… Less work; keeps the diff bounded." Added a JSDoc `@deprecated` on `TextInput` and a comment in the package index next to the export. No call-site changes — both still work.

## Consumer-app changes

None. The ref types on form inputs were already in place (React 19 ref-as-prop) — C1-2 just added a ref prop to `FileUpload` (no existing consumer was passing one) and added `aria-required` markup. No app needed updating.

## Test plan

- [x] `npx turbo lint test --filter=@adopt-dont-shop/lib.components --filter=@adopt-dont-shop/app.client --filter=@adopt-dont-shop/app.rescue --filter=@adopt-dont-shop/app.admin` — green (32/32 tasks)
- [x] `npx turbo type-check --filter=@adopt-dont-shop/lib.components` — green
- [x] `lib.components`: 457 → 475 tests (+18). Modal +2, TextInput +3, TextArea +3, CheckboxInput +3, SelectInput +3, FileUpload +3, Button +3, DataTable +3 (new file)
- [x] `app.admin` / `app.client` / `app.rescue` test counts unchanged (404 / 404 / unchanged on the gate run)

> Type-check is currently broken on `main` in `app.client`/`app.rescue` `ChatContext.tsx` (`tokenProvider` missing from `ChatProviderProps`), so type-check is excluded from the full-monorepo gate per the brief. `lib.components` type-check is green and no new app-side type errors were introduced.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_