### PR TITLE
security: pass-14 fixes (worker payload validation, system audit logging, email idempotency, analytics consent + DNT, Statsig rescueId)

### DIFF
--- a/app.admin/src/contexts/StatsigContext.test.tsx
+++ b/app.admin/src/contexts/StatsigContext.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Behaviour test for the admin Statsig user-context shape.
+ *
+ * Locks in the defensive `rescueId` field so future per-rescue gating
+ * rules can bucket admins (who typically have no rescueId — they're
+ * staff/moderators) without a context migration. The mocks below let us
+ * intercept the user object passed to `useClientAsyncInit` without
+ * actually booting the Statsig client.
+ */
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { vi } from 'vitest';
+
+const useClientAsyncInitMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock('@statsig/react-bindings', () => ({
+  StatsigProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useClientAsyncInit: (...args: unknown[]) => useClientAsyncInitMock(...args),
+}));
+
+vi.mock('@adopt-dont-shop/lib.auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+import { StatsigWrapper } from './StatsigContext';
+
+describe('StatsigWrapper (admin)', () => {
+  beforeEach(() => {
+    useClientAsyncInitMock.mockReset();
+    useClientAsyncInitMock.mockReturnValue({ client: { checkGate: () => false } });
+    useAuthMock.mockReset();
+  });
+
+  it('includes rescueId in the Statsig user custom dims', () => {
+    useAuthMock.mockReturnValue({
+      user: {
+        userId: 'u-1',
+        userType: 'admin',
+        rescueId: 'rescue-42',
+      },
+    });
+
+    render(
+      <StatsigWrapper>
+        <div>child</div>
+      </StatsigWrapper>
+    );
+
+    const [, statsigUser] = useClientAsyncInitMock.mock.calls[0];
+    expect(statsigUser.custom).toMatchObject({
+      app: 'admin',
+      rescueId: 'rescue-42',
+    });
+  });
+
+  it('exposes a rescueId key (undefined) when the user has no rescue association', () => {
+    useAuthMock.mockReturnValue({
+      user: { userId: 'u-2', userType: 'admin' },
+    });
+
+    render(
+      <StatsigWrapper>
+        <div>child</div>
+      </StatsigWrapper>
+    );
+
+    const [, statsigUser] = useClientAsyncInitMock.mock.calls[0];
+    expect('rescueId' in statsigUser.custom).toBe(true);
+    expect(statsigUser.custom.rescueId).toBeUndefined();
+  });
+});

--- a/app.admin/src/contexts/StatsigContext.tsx
+++ b/app.admin/src/contexts/StatsigContext.tsx
@@ -26,6 +26,10 @@ export const StatsigWrapper: React.FC<StatsigWrapperProps> = ({ children }) => {
         app: 'admin',
         userType: user?.userType,
         role: user?.userType, // admin or moderator
+        // Defensive: include rescueId so future per-rescue gating rules
+        // can bucket correctly. Admins typically have no rescueId, so
+        // the field is undefined in the common case.
+        rescueId: user?.rescueId,
         isAuthenticated: !!user,
       },
     }),

--- a/app.client/src/contexts/StatsigContext.test.tsx
+++ b/app.client/src/contexts/StatsigContext.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Behaviour test for the client Statsig user-context shape.
+ *
+ * Adopters typically don't carry a `rescueId`, but the context must
+ * still expose the field (as null) so future per-rescue gating rules
+ * can bucket without a context migration.
+ */
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { vi } from 'vitest';
+
+const useClientAsyncInitMock = vi.fn();
+const useAuthMock = vi.fn();
+const hasAnalyticsConsentMock = vi.fn();
+const subscribeToAnalyticsConsentMock = vi.fn();
+
+vi.mock('@statsig/react-bindings', () => ({
+  StatsigProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useClientAsyncInit: (...args: unknown[]) => useClientAsyncInitMock(...args),
+}));
+
+vi.mock('@statsig/session-replay', () => ({
+  StatsigSessionReplayPlugin: vi.fn(),
+}));
+
+vi.mock('@statsig/web-analytics', () => ({
+  StatsigAutoCapturePlugin: vi.fn(),
+}));
+
+vi.mock('@adopt-dont-shop/lib.auth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@adopt-dont-shop/lib.observability', () => ({
+  hasAnalyticsConsent: () => hasAnalyticsConsentMock(),
+  subscribeToAnalyticsConsent: (...args: unknown[]) => subscribeToAnalyticsConsentMock(...args),
+}));
+
+import { StatsigWrapper } from './StatsigContext';
+
+describe('StatsigWrapper (client)', () => {
+  beforeEach(() => {
+    useClientAsyncInitMock.mockReset();
+    useClientAsyncInitMock.mockReturnValue({ client: { checkGate: () => false } });
+    useAuthMock.mockReset();
+    hasAnalyticsConsentMock.mockReset();
+    hasAnalyticsConsentMock.mockReturnValue(false);
+    subscribeToAnalyticsConsentMock.mockReset();
+    subscribeToAnalyticsConsentMock.mockReturnValue(() => undefined);
+  });
+
+  it('exposes a rescueId key (undefined) for adopter users with no rescue association', () => {
+    useAuthMock.mockReturnValue({
+      user: { userId: 'u-1', userType: 'adopter' },
+    });
+
+    render(
+      <StatsigWrapper>
+        <div>child</div>
+      </StatsigWrapper>
+    );
+
+    const [, statsigUser] = useClientAsyncInitMock.mock.calls[0];
+    expect(statsigUser.custom.app).toBe('client');
+    expect('rescueId' in statsigUser.custom).toBe(true);
+    expect(statsigUser.custom.rescueId).toBeUndefined();
+  });
+
+  it('still includes rescueId when an unexpected rescueId is present', () => {
+    useAuthMock.mockReturnValue({
+      user: { userId: 'u-2', userType: 'adopter', rescueId: 'rescue-9' },
+    });
+
+    render(
+      <StatsigWrapper>
+        <div>child</div>
+      </StatsigWrapper>
+    );
+
+    const [, statsigUser] = useClientAsyncInitMock.mock.calls[0];
+    expect(statsigUser.custom.rescueId).toBe('rescue-9');
+  });
+});

--- a/app.client/src/contexts/StatsigContext.tsx
+++ b/app.client/src/contexts/StatsigContext.tsx
@@ -42,6 +42,10 @@ export const StatsigWrapper: React.FC<StatsigWrapperProps> = ({ children }) => {
       custom: {
         app: 'client',
         userType: user?.userType,
+        // Defensive: include rescueId so future per-rescue gating rules
+        // can bucket correctly. Adopters don't have a rescueId, so the
+        // field is undefined in the common case.
+        rescueId: user?.rescueId,
         isAuthenticated: !!user,
       },
     }),

--- a/lib.analytics/src/services/__tests__/analytics-service.test.ts
+++ b/lib.analytics/src/services/__tests__/analytics-service.test.ts
@@ -592,6 +592,37 @@ describe('AnalyticsService', () => {
     });
   });
 
+  describe('do-not-track', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Navigator.prototype, 'doNotTrack');
+
+    afterEach(() => {
+      if (originalDescriptor) {
+        Object.defineProperty(Navigator.prototype, 'doNotTrack', originalDescriptor);
+      }
+    });
+
+    it('drops events when navigator.doNotTrack is "1" even with consent granted', async () => {
+      Object.defineProperty(navigator, 'doNotTrack', { value: '1', configurable: true });
+
+      const dntService = new AnalyticsService({ autoTrackPageViews: false });
+      dntService.setConsent({ analytics: true });
+      const dntApi = dntService['apiService'];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // Justification: assert outbound traffic via the internal apiService
+      // because the public API silently drops DNT-blocked events.
+      const postSpy = (dntApi as any).post as ReturnType<typeof vi.fn>;
+      postSpy.mockResolvedValue({ success: true });
+
+      await dntService.trackEvent({ category: 'test', action: 'click' });
+      await dntService.trackPageView({ url: 'https://example.com/x', title: 'X' });
+
+      vi.advanceTimersByTime(5000);
+
+      expect(postSpy).not.toHaveBeenCalled();
+      dntService.destroy();
+    });
+  });
+
   describe('healthCheck', () => {
     it('should return true when API is healthy', async () => {
       mockApiService.get.mockResolvedValue({ status: 'ok' });

--- a/lib.analytics/src/services/__tests__/analytics-service.test.ts
+++ b/lib.analytics/src/services/__tests__/analytics-service.test.ts
@@ -62,6 +62,12 @@ describe('AnalyticsService', () => {
       debug: false,
       autoTrackPageViews: false, // Disable for testing
     });
+    // The service ships fail-closed: until the host app calls
+    // setConsent({ analytics: true }) no events fire. Most existing
+    // behaviour tests are written against the "user has accepted
+    // analytics" path, so opt in by default and verify the gate in a
+    // dedicated describe block below.
+    service.setConsent({ analytics: true });
 
     mockApiService = service['apiService'];
   });
@@ -365,6 +371,7 @@ describe('AnalyticsService', () => {
         sampleRate: 1,
         autoTrackPageViews: false,
       });
+      sampledService.setConsent({ analytics: true });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       // Justification: shouldSampleEvent is private and cannot be forced to
@@ -517,6 +524,71 @@ describe('AnalyticsService', () => {
 
       expect(newSessionId).not.toBe(originalSessionId);
       expect(newSessionId).toMatch(/^session_\d+_[a-z0-9]+$/);
+    });
+  });
+
+  describe('consent gating', () => {
+    it('drops events when consent has not been granted', async () => {
+      const unconsented = new AnalyticsService({ autoTrackPageViews: false });
+      const unconsentedApi = unconsented['apiService'];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // Justification: the internal apiService is what we need to assert
+      // against — the public API has no "did you send the event" hook
+      // because the contract is "events are silently dropped".
+      const postSpy = (unconsentedApi as any).post as ReturnType<typeof vi.fn>;
+      postSpy.mockResolvedValue({ success: true });
+
+      await unconsented.trackEvent({ category: 'test', action: 'click' });
+      await unconsented.trackPageView({ url: 'https://example.com/x', title: 'X' });
+
+      vi.advanceTimersByTime(5000);
+
+      expect(postSpy).not.toHaveBeenCalled();
+      unconsented.destroy();
+    });
+
+    it('sends events once consent is granted', async () => {
+      const gated = new AnalyticsService({ autoTrackPageViews: false });
+      const gatedApi = gated['apiService'];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // Justification: same as above — observe outbound calls via the
+      // internal apiService since the public API surface has no
+      // "delivered" callback.
+      const postSpy = (gatedApi as any).post as ReturnType<typeof vi.fn>;
+      postSpy.mockResolvedValue({ success: true });
+
+      gated.setConsent({ analytics: true });
+      await gated.trackEvent({ category: 'test', action: 'click' });
+      vi.advanceTimersByTime(5000);
+
+      expect(postSpy).toHaveBeenCalledWith(
+        '/api/v1/analytics/events/batch',
+        expect.objectContaining({
+          events: expect.arrayContaining([
+            expect.objectContaining({ category: 'test', action: 'click' }),
+          ]),
+        })
+      );
+      gated.destroy();
+    });
+
+    it('stops sending events when consent is revoked', async () => {
+      const gated = new AnalyticsService({ autoTrackPageViews: false });
+      const gatedApi = gated['apiService'];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // Justification: same as above — observe outbound calls via the
+      // internal apiService since the public API surface has no
+      // "delivered" callback.
+      const postSpy = (gatedApi as any).post as ReturnType<typeof vi.fn>;
+      postSpy.mockResolvedValue({ success: true });
+
+      gated.setConsent({ analytics: true });
+      gated.setConsent({ analytics: false });
+      await gated.trackEvent({ category: 'test', action: 'click' });
+      vi.advanceTimersByTime(5000);
+
+      expect(postSpy).not.toHaveBeenCalled();
+      gated.destroy();
     });
   });
 

--- a/lib.analytics/src/services/analytics-service.ts
+++ b/lib.analytics/src/services/analytics-service.ts
@@ -197,11 +197,25 @@ export class AnalyticsService {
   }
 
   /**
+   * Honour navigator.doNotTrack. DNT is a binary header — `'1'` means
+   * the user explicitly opted out of tracking. Some browsers default
+   * to `'1'`; others leave it undefined. We block only on an explicit
+   * `'1'`, which is the standard pattern.
+   */
+  private isDoNotTrackEnabled(): boolean {
+    return typeof navigator !== 'undefined' && navigator.doNotTrack === '1';
+  }
+
+  /**
    * Track user engagement event
    */
   public async trackEvent(
     event: Omit<UserEngagementEvent, 'sessionId' | 'timestamp'>
   ): Promise<void> {
+    if (this.isDoNotTrackEnabled()) {
+      return;
+    }
+
     if (!this.consentGranted) {
       return;
     }
@@ -234,6 +248,10 @@ export class AnalyticsService {
   public async trackPageView(
     pageView: Omit<PageViewEvent, 'sessionId' | 'timestamp'> | PageViewEvent
   ): Promise<void> {
+    if (this.isDoNotTrackEnabled()) {
+      return;
+    }
+
     if (!this.consentGranted) {
       return;
     }

--- a/lib.analytics/src/services/analytics-service.ts
+++ b/lib.analytics/src/services/analytics-service.ts
@@ -24,6 +24,11 @@ export class AnalyticsService {
   private sessionId: string;
   private eventQueue: UserEngagementEvent[] = [];
   private flushTimer: NodeJS.Timeout | null = null;
+  // Fail-closed: events are silently dropped until the host app calls
+  // `setConsent({ analytics: true })`. This mirrors the UserConsent
+  // record for the `analytics` purpose — see lib.legal /
+  // lib.observability consent gates.
+  private consentGranted = false;
 
   constructor(config: Partial<AnalyticsServiceConfig> = {}, apiService?: ApiService) {
     this.config = {
@@ -181,11 +186,26 @@ export class AnalyticsService {
   }
 
   /**
+   * Set the user's analytics consent state. Called by host apps after
+   * loading the user's UserConsent record (or after the cookie banner
+   * resolves). Until this is called with `analytics: true`, all event-
+   * emitting methods silently drop their payloads — including any
+   * userAgent / referrer they would otherwise collect.
+   */
+  public setConsent(consent: { analytics: boolean }): void {
+    this.consentGranted = consent.analytics;
+  }
+
+  /**
    * Track user engagement event
    */
   public async trackEvent(
     event: Omit<UserEngagementEvent, 'sessionId' | 'timestamp'>
   ): Promise<void> {
+    if (!this.consentGranted) {
+      return;
+    }
+
     if (!this.shouldSampleEvent()) {
       return;
     }
@@ -214,6 +234,10 @@ export class AnalyticsService {
   public async trackPageView(
     pageView: Omit<PageViewEvent, 'sessionId' | 'timestamp'> | PageViewEvent
   ): Promise<void> {
+    if (!this.consentGranted) {
+      return;
+    }
+
     if (!this.shouldSampleEvent()) {
       return;
     }

--- a/service.backend/src/jobs/match-digest.job.ts
+++ b/service.backend/src/jobs/match-digest.job.ts
@@ -1,5 +1,6 @@
 import type { Worker } from 'bullmq';
 import { Op } from 'sequelize';
+import { z } from 'zod';
 import { matchService } from '../matching';
 import { loadMatchConfig } from '../matching/config';
 import AdopterMatchProfile from '../models/AdopterMatchProfile';
@@ -31,6 +32,14 @@ export const MATCH_DIGEST_REPEAT_KEY = 'match:daily-digest:08utc';
 const MATCH_DIGEST_CRON = process.env.MATCH_DIGEST_CRON ?? '0 8 * * *';
 const TOP_N = 3;
 const FALLBACK_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Defense-in-depth: re-validate job payloads at execution time. The
+ * match digest carries no data — `.strict()` keeps it that way so any
+ * extra producer-added fields fail validation rather than being silently
+ * ignored. Mirrors reports.worker.ts.
+ */
+export const MatchDigestJobSchema = z.object({}).strict();
 
 export const scheduleMatchDigestJob = async (): Promise<void> => {
   const cfg = loadMatchConfig();
@@ -140,6 +149,14 @@ export const startMatchDigestWorker = (): Worker | null => {
   workerInstance = buildWorker(async job => {
     if (job.name !== MATCH_DIGEST_JOB_NAME) {
       return;
+    }
+    const parsed = MatchDigestJobSchema.safeParse(job.data);
+    if (!parsed.success) {
+      logger.warn('match-digest.job: rejecting malformed payload', {
+        jobName: job.name,
+        issues: parsed.error.issues.map(i => ({ path: i.path.join('.'), code: i.code })),
+      });
+      throw new Error('Invalid match digest job payload');
     }
     const result = await runMatchDigest();
     logger.info('Match digest finished', result);

--- a/service.backend/src/jobs/match-digest.job.ts
+++ b/service.backend/src/jobs/match-digest.job.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { matchService } from '../matching';
 import { loadMatchConfig } from '../matching/config';
 import AdopterMatchProfile from '../models/AdopterMatchProfile';
+import AuditLog from '../models/AuditLog';
 import { NotificationType } from '../models/Notification';
 import Pet, { PetStatus } from '../models/Pet';
 import Rescue from '../models/Rescue';
@@ -29,6 +30,7 @@ import { logger } from '../utils/logger';
 
 export const MATCH_DIGEST_JOB_NAME = 'match:daily-digest';
 export const MATCH_DIGEST_REPEAT_KEY = 'match:daily-digest:08utc';
+export const MATCH_DIGEST_RAN_ACTION = 'MATCH_DIGEST_RAN';
 const MATCH_DIGEST_CRON = process.env.MATCH_DIGEST_CRON ?? '0 8 * * *';
 const TOP_N = 3;
 const FALLBACK_LOOKBACK_MS = 24 * 60 * 60 * 1000;
@@ -159,6 +161,23 @@ export const startMatchDigestWorker = (): Worker | null => {
       throw new Error('Invalid match digest job payload');
     }
     const result = await runMatchDigest();
+    // System-level audit row — mirrors legal-reminder.worker.ts. No user
+    // attribution; AuditLog.create directly because the immutable-trigger
+    // only blocks UPDATE/DELETE. Written only on success.
+    await AuditLog.create({
+      service: 'adopt-dont-shop-backend',
+      user: null,
+      user_email_snapshot: null,
+      action: MATCH_DIGEST_RAN_ACTION,
+      level: 'INFO',
+      timestamp: new Date(),
+      metadata: {
+        entity: 'System',
+        entityId: 'match-digest',
+        details: { ...result },
+      },
+      category: 'System',
+    });
     logger.info('Match digest finished', result);
   });
   return workerInstance;

--- a/service.backend/src/jobs/retention.job.ts
+++ b/service.backend/src/jobs/retention.job.ts
@@ -1,4 +1,5 @@
 import type { Worker } from 'bullmq';
+import { z } from 'zod';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
 import { runRetentionEnforcement } from '../services/data-retention.service';
 import { logger } from '../utils/logger';
@@ -23,6 +24,17 @@ import { logger } from '../utils/logger';
 
 export const RETENTION_JOB_NAME = 'privacy:retention-enforcement';
 export const RETENTION_REPEAT_KEY = 'privacy:retention-enforcement:daily';
+
+/**
+ * Defense-in-depth: re-validate job payloads at execution time. BullMQ
+ * persists job.data as JSON in Redis, so a queue compromise or a
+ * mis-deployment that pushed a hand-crafted payload would otherwise hit
+ * the handler with whatever shape it likes. The retention job carries no
+ * data — `.strict()` keeps it that way so any extra producer-added
+ * fields fail validation rather than being silently ignored. Mirrors
+ * reports.worker.ts.
+ */
+export const RetentionJobSchema = z.object({}).strict();
 
 // Default: 03:30 UTC daily. Override via RETENTION_CRON env var. The
 // cron is BullMQ-compatible (5- or 6-field format).
@@ -65,6 +77,17 @@ export const startRetentionWorker = (): Worker | null => {
   workerInstance = buildWorker(async job => {
     if (job.name !== RETENTION_JOB_NAME) {
       return;
+    }
+    const parsed = RetentionJobSchema.safeParse(job.data);
+    if (!parsed.success) {
+      // Don't log job.data verbatim — it may carry attacker-controlled
+      // payload. Throw so BullMQ surfaces the failure rather than letting
+      // the worker silently run the retention sweep on a poisoned job.
+      logger.warn('retention.job: rejecting malformed payload', {
+        jobName: job.name,
+        issues: parsed.error.issues.map(i => ({ path: i.path.join('.'), code: i.code })),
+      });
+      throw new Error('Invalid retention job payload');
     }
     const result = await runRetentionEnforcement();
     logger.info('Retention job finished', { result });

--- a/service.backend/src/jobs/retention.job.ts
+++ b/service.backend/src/jobs/retention.job.ts
@@ -1,6 +1,7 @@
 import type { Worker } from 'bullmq';
 import { z } from 'zod';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
+import AuditLog from '../models/AuditLog';
 import { runRetentionEnforcement } from '../services/data-retention.service';
 import { logger } from '../utils/logger';
 
@@ -24,6 +25,7 @@ import { logger } from '../utils/logger';
 
 export const RETENTION_JOB_NAME = 'privacy:retention-enforcement';
 export const RETENTION_REPEAT_KEY = 'privacy:retention-enforcement:daily';
+export const RETENTION_ENFORCEMENT_RAN_ACTION = 'RETENTION_ENFORCEMENT_RAN';
 
 /**
  * Defense-in-depth: re-validate job payloads at execution time. BullMQ
@@ -90,6 +92,25 @@ export const startRetentionWorker = (): Worker | null => {
       throw new Error('Invalid retention job payload');
     }
     const result = await runRetentionEnforcement();
+    // System-level audit row — mirrors legal-reminder.worker.ts. No user
+    // attribution; AuditLog.create directly because the immutable-trigger
+    // only blocks UPDATE/DELETE. Written only on success — failures
+    // bubble up to BullMQ's retry path and don't leave a misleading
+    // "ran" row behind.
+    await AuditLog.create({
+      service: 'adopt-dont-shop-backend',
+      user: null,
+      user_email_snapshot: null,
+      action: RETENTION_ENFORCEMENT_RAN_ACTION,
+      level: 'INFO',
+      timestamp: new Date(),
+      metadata: {
+        entity: 'System',
+        entityId: 'retention-enforcement',
+        details: { ...result },
+      },
+      category: 'System',
+    });
     logger.info('Retention job finished', { result });
   });
 

--- a/service.backend/src/jobs/revoked-tokens-purge.job.ts
+++ b/service.backend/src/jobs/revoked-tokens-purge.job.ts
@@ -1,5 +1,6 @@
 import type { Worker } from 'bullmq';
 import { Op } from 'sequelize';
+import { z } from 'zod';
 import RevokedToken from '../models/RevokedToken';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
 import { logger } from '../utils/logger';
@@ -19,6 +20,14 @@ import { logger } from '../utils/logger';
 
 export const REVOKED_TOKENS_PURGE_JOB_NAME = 'auth:revoked-tokens-purge';
 export const REVOKED_TOKENS_PURGE_REPEAT_KEY = 'auth:revoked-tokens-purge:daily';
+
+/**
+ * Defense-in-depth: re-validate job payloads at execution time. The
+ * purge job carries no data — `.strict()` keeps it that way so any
+ * extra producer-added fields fail validation rather than being silently
+ * ignored. Mirrors reports.worker.ts.
+ */
+export const RevokedTokensPurgeJobSchema = z.object({}).strict();
 
 // Default: 04:15 UTC daily — offset from retention's 03:30 so the two
 // don't contend for the same worker slot. Override via env.
@@ -67,6 +76,14 @@ export const startRevokedTokensPurgeWorker = (): Worker | null => {
   workerInstance = buildWorker(async job => {
     if (job.name !== REVOKED_TOKENS_PURGE_JOB_NAME) {
       return;
+    }
+    const parsed = RevokedTokensPurgeJobSchema.safeParse(job.data);
+    if (!parsed.success) {
+      logger.warn('revoked-tokens-purge.job: rejecting malformed payload', {
+        jobName: job.name,
+        issues: parsed.error.issues.map(i => ({ path: i.path.join('.'), code: i.code })),
+      });
+      throw new Error('Invalid revoked-tokens purge job payload');
     }
     const deleted = await purgeExpiredRevokedTokens();
     logger.info('Revoked-tokens purge finished', { deleted });

--- a/service.backend/src/jobs/revoked-tokens-purge.job.ts
+++ b/service.backend/src/jobs/revoked-tokens-purge.job.ts
@@ -1,6 +1,7 @@
 import type { Worker } from 'bullmq';
 import { Op } from 'sequelize';
 import { z } from 'zod';
+import AuditLog from '../models/AuditLog';
 import RevokedToken from '../models/RevokedToken';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
 import { logger } from '../utils/logger';
@@ -20,6 +21,7 @@ import { logger } from '../utils/logger';
 
 export const REVOKED_TOKENS_PURGE_JOB_NAME = 'auth:revoked-tokens-purge';
 export const REVOKED_TOKENS_PURGE_REPEAT_KEY = 'auth:revoked-tokens-purge:daily';
+export const REVOKED_TOKENS_PURGE_RAN_ACTION = 'REVOKED_TOKENS_PURGE_RAN';
 
 /**
  * Defense-in-depth: re-validate job payloads at execution time. The
@@ -86,6 +88,23 @@ export const startRevokedTokensPurgeWorker = (): Worker | null => {
       throw new Error('Invalid revoked-tokens purge job payload');
     }
     const deleted = await purgeExpiredRevokedTokens();
+    // System-level audit row — mirrors legal-reminder.worker.ts. No user
+    // attribution; AuditLog.create directly because the immutable-trigger
+    // only blocks UPDATE/DELETE. Written only on success.
+    await AuditLog.create({
+      service: 'adopt-dont-shop-backend',
+      user: null,
+      user_email_snapshot: null,
+      action: REVOKED_TOKENS_PURGE_RAN_ACTION,
+      level: 'INFO',
+      timestamp: new Date(),
+      metadata: {
+        entity: 'System',
+        entityId: 'revoked-tokens-purge',
+        details: { deleted },
+      },
+      category: 'System',
+    });
     logger.info('Revoked-tokens purge finished', { deleted });
   });
 

--- a/service.backend/src/jobs/weekly-digest.job.ts
+++ b/service.backend/src/jobs/weekly-digest.job.ts
@@ -1,4 +1,5 @@
 import type { Worker } from 'bullmq';
+import { z } from 'zod';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
 import { runWeeklyDigest } from '../services/weekly-digest.service';
 import { logger } from '../utils/logger';
@@ -20,6 +21,14 @@ import { logger } from '../utils/logger';
 
 export const WEEKLY_DIGEST_JOB_NAME = 'engagement:weekly-digest';
 export const WEEKLY_DIGEST_REPEAT_KEY = 'engagement:weekly-digest:saturday';
+
+/**
+ * Defense-in-depth: re-validate job payloads at execution time. The
+ * weekly digest carries no data — `.strict()` keeps it that way so any
+ * extra producer-added fields fail validation rather than being silently
+ * ignored. Mirrors reports.worker.ts.
+ */
+export const WeeklyDigestJobSchema = z.object({}).strict();
 
 // Default: Saturday 09:00 UTC. Override via WEEKLY_DIGEST_CRON env var.
 // BullMQ-compatible (5- or 6-field) cron expression.
@@ -62,6 +71,14 @@ export const startWeeklyDigestWorker = (): Worker | null => {
   workerInstance = buildWorker(async job => {
     if (job.name !== WEEKLY_DIGEST_JOB_NAME) {
       return;
+    }
+    const parsed = WeeklyDigestJobSchema.safeParse(job.data);
+    if (!parsed.success) {
+      logger.warn('weekly-digest.job: rejecting malformed payload', {
+        jobName: job.name,
+        issues: parsed.error.issues.map(i => ({ path: i.path.join('.'), code: i.code })),
+      });
+      throw new Error('Invalid weekly digest job payload');
     }
     const result = await runWeeklyDigest();
     logger.info('Weekly digest finished', { result });

--- a/service.backend/src/jobs/weekly-digest.job.ts
+++ b/service.backend/src/jobs/weekly-digest.job.ts
@@ -1,6 +1,7 @@
 import type { Worker } from 'bullmq';
 import { z } from 'zod';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
+import AuditLog from '../models/AuditLog';
 import { runWeeklyDigest } from '../services/weekly-digest.service';
 import { logger } from '../utils/logger';
 
@@ -21,6 +22,7 @@ import { logger } from '../utils/logger';
 
 export const WEEKLY_DIGEST_JOB_NAME = 'engagement:weekly-digest';
 export const WEEKLY_DIGEST_REPEAT_KEY = 'engagement:weekly-digest:saturday';
+export const WEEKLY_DIGEST_RAN_ACTION = 'WEEKLY_DIGEST_RAN';
 
 /**
  * Defense-in-depth: re-validate job payloads at execution time. The
@@ -81,6 +83,23 @@ export const startWeeklyDigestWorker = (): Worker | null => {
       throw new Error('Invalid weekly digest job payload');
     }
     const result = await runWeeklyDigest();
+    // System-level audit row — mirrors legal-reminder.worker.ts. No user
+    // attribution; AuditLog.create directly because the immutable-trigger
+    // only blocks UPDATE/DELETE. Written only on success.
+    await AuditLog.create({
+      service: 'adopt-dont-shop-backend',
+      user: null,
+      user_email_snapshot: null,
+      action: WEEKLY_DIGEST_RAN_ACTION,
+      level: 'INFO',
+      timestamp: new Date(),
+      metadata: {
+        entity: 'System',
+        entityId: 'weekly-digest',
+        details: { ...result },
+      },
+      category: 'System',
+    });
     logger.info('Weekly digest finished', { result });
   });
 

--- a/service.backend/src/migrations/07-add-email-queue-idempotency-key.ts
+++ b/service.backend/src/migrations/07-add-email-queue-idempotency-key.ts
@@ -1,0 +1,58 @@
+/**
+ * Add `idempotency_key` to email_queue to make scheduled-report email
+ * sends idempotent on BullMQ retry.
+ *
+ * The reports.worker render-and-email handler loops over a recipients
+ * array and calls emailService.sendEmail for each one. If the worker
+ * crashes after sending to recipients [0..2] of [0..4], BullMQ retries
+ * the entire job — and the first three recipients get duplicate emails
+ * while the last two finally get the original.
+ *
+ * Fix: callers that need idempotency (reports.worker) compute a stable
+ * key per (schedule, recipient, format, dispatch-window) tuple. The
+ * email service uses findOrCreate on that key. The second attempt with
+ * the same key short-circuits ("already sent") instead of re-queueing.
+ *
+ * Other senders (password-reset, transactional notifications) pass no
+ * key — column stays NULL and the uniqueness predicate does not apply,
+ * so existing call sites are unaffected.
+ *
+ * Index is partial (WHERE idempotency_key IS NOT NULL) so the bulk of
+ * email_queue rows — which have no key — don't bloat the index, and
+ * Postgres can still allow many concurrent NULL rows. Built
+ * CONCURRENTLY because email_queue is a hot, append-only table.
+ */
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { createIndexConcurrently, dropIndexConcurrently, runInTransaction } from './_helpers';
+
+const INDEX_NAME = 'email_queue_idempotency_key_uidx';
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.addColumn(
+        'email_queue',
+        'idempotency_key',
+        {
+          type: DataTypes.STRING(64),
+          allowNull: true,
+        },
+        { transaction: t }
+      );
+    });
+    await createIndexConcurrently(queryInterface.sequelize, {
+      name: INDEX_NAME,
+      table: 'email_queue',
+      columns: ['idempotency_key'],
+      unique: true,
+      where: 'idempotency_key IS NOT NULL',
+    });
+  },
+
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await dropIndexConcurrently(queryInterface.sequelize, INDEX_NAME);
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.removeColumn('email_queue', 'idempotency_key', { transaction: t });
+    });
+  },
+};

--- a/service.backend/src/models/EmailQueue.ts
+++ b/service.backend/src/models/EmailQueue.ts
@@ -90,6 +90,16 @@ interface EmailQueueAttributes {
   userId?: string;
   // createdBy removed — provided by auditColumns helper as `created_by`.
   tags?: string[];
+  /**
+   * ADS-105 follow-up (pass-10 W3): opt-in idempotency key. Callers that
+   * need send-once semantics on retry (currently reports.worker
+   * render-and-email) construct a stable per-(schedule, recipient,
+   * format, dispatch-window) key. EmailService.sendEmail uses
+   * findOrCreate on this column to short-circuit duplicate sends after a
+   * BullMQ retry. Other senders leave it null and behave exactly as
+   * before.
+   */
+  idempotencyKey?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -133,6 +143,7 @@ class EmailQueue
   public campaignId?: string;
   public userId?: string;
   public tags?: string[];
+  public idempotencyKey?: string | null;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
 
@@ -533,6 +544,12 @@ EmailQueue.init(
           this.setDataValue('tags', value || ([] as any));
         }
       },
+    },
+    idempotencyKey: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+      unique: true,
+      field: 'idempotency_key',
     },
     createdAt: {
       type: DataTypes.DATE,

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -504,7 +504,7 @@ class EmailService {
       // NOT be stripped — legitimate line breaks belong there.
 
       // Create email queue entry
-      const email = await EmailQueue.create({
+      const emailDefaults = {
         templateId: options.templateId,
         fromEmail: stripHeaderField(
           options.fromEmail || process.env.DEFAULT_FROM_EMAIL || 'noreply@adoptdontshop.com'
@@ -530,7 +530,34 @@ class EmailService {
         campaignId: options.campaignId,
         tags: options.tags || [],
         metadata: options.metadata || {},
-      });
+        idempotencyKey: options.idempotencyKey ?? null,
+      };
+
+      // Pass-10 W3: opt-in idempotency. When the caller supplies an
+      // idempotencyKey, use findOrCreate so a retry that re-runs the same
+      // send is a no-op rather than a duplicate queue row. Callers that
+      // don't supply a key (transactional emails, password resets,
+      // notifications) go through the plain create path so the unique
+      // index never fires.
+      let email: EmailQueue;
+      let alreadyQueued = false;
+      if (options.idempotencyKey) {
+        const [row, created] = await EmailQueue.findOrCreate({
+          where: { idempotencyKey: options.idempotencyKey },
+          defaults: emailDefaults,
+        });
+        email = row;
+        alreadyQueued = !created;
+        if (alreadyQueued) {
+          logger.info('Skipping duplicate email send — idempotency key already used', {
+            emailId: email.emailId,
+            idempotencyKey: options.idempotencyKey,
+          });
+          return email.emailId;
+        }
+      } else {
+        email = await EmailQueue.create(emailDefaults);
+      }
 
       await AuditLogService.log({
         action: 'EMAIL_QUEUED',

--- a/service.backend/src/types/email.ts
+++ b/service.backend/src/types/email.ts
@@ -45,6 +45,14 @@ export interface SendEmailOptions {
   campaignId?: string;
   tags?: string[];
   metadata?: JsonObject;
+  /**
+   * Opt-in idempotency key. When set, EmailService.sendEmail uses
+   * findOrCreate on EmailQueue.idempotency_key — a second send attempt
+   * with the same key short-circuits ("already queued/sent") instead of
+   * creating a duplicate row. Callers that don't need this leave it
+   * undefined and the column stays NULL. See pass-10 W3.
+   */
+  idempotencyKey?: string;
 }
 
 export interface BulkEmailRecipient {

--- a/service.backend/src/workers/legal-reminder.worker.ts
+++ b/service.backend/src/workers/legal-reminder.worker.ts
@@ -54,6 +54,14 @@ export const RunSummarySchema = z.object({
 });
 export type RunSummary = z.infer<typeof RunSummarySchema>;
 
+/**
+ * Defense-in-depth: re-validate job payloads at execution time. The
+ * cron carries no data — `.strict()` keeps it that way so any extra
+ * producer-added fields fail validation rather than being silently
+ * ignored. Mirrors reports.worker.ts.
+ */
+export const LegalReminderCronJobSchema = z.object({}).strict();
+
 export type RunOptions = {
   dryRun: boolean;
   batchSize?: number;
@@ -230,6 +238,14 @@ export const startLegalReminderWorker = (): Worker | null => {
   workerInstance = buildWorker(async job => {
     if (job.name !== LEGAL_REMINDER_CRON_JOB_NAME) {
       return;
+    }
+    const parsed = LegalReminderCronJobSchema.safeParse(job.data);
+    if (!parsed.success) {
+      logger.warn('legal-reminder.worker: rejecting malformed payload', {
+        jobName: job.name,
+        issues: parsed.error.issues.map(i => ({ path: i.path.join('.'), code: i.code })),
+      });
+      throw new Error('Invalid legal reminder cron job payload');
     }
     await runLegalReminderCron({ dryRun: isDryRun() });
   });

--- a/service.backend/src/workers/reports.worker.ts
+++ b/service.backend/src/workers/reports.worker.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import type { Worker } from 'bullmq';
 import { z } from 'zod';
 import { buildWorker, getReportsQueue, isQueueAvailable } from '../lib/queue';
@@ -66,6 +67,15 @@ const RenderAndEmailJobSchema = z.object({
    * always populate it.
    */
   requestedBy: z.string().optional(),
+  /**
+   * Pass-10 W3: stable dispatch-window anchor used to construct
+   * per-recipient idempotency keys. Set by `handleScheduledRun` to the
+   * schedule's `last_run_at`. Optional for backward compatibility and
+   * for ad-hoc manual sends (which don't need cross-retry idempotency
+   * — the user clicks once, BullMQ retries are the only duplicate
+   * source).
+   */
+  dispatchAt: z.string().optional(),
 });
 
 export type ScheduledRunJob = z.infer<typeof ScheduledRunJobSchema>;
@@ -167,8 +177,9 @@ const handleScheduledRun = async (data: ScheduledRunJob): Promise<void> => {
     return;
   }
 
+  const dispatchAt = new Date();
   schedule.last_status = ScheduledReportStatus.PENDING;
-  schedule.last_run_at = new Date();
+  schedule.last_run_at = dispatchAt;
   await schedule.save();
 
   await getReportsQueue().add(RENDER_AND_EMAIL, {
@@ -178,6 +189,7 @@ const handleScheduledRun = async (data: ScheduledRunJob): Promise<void> => {
     format: schedule.format,
     triggeredBy: 'schedule',
     requestedBy,
+    dispatchAt: dispatchAt.toISOString(),
   } satisfies RenderAndEmailJob);
 };
 
@@ -245,13 +257,27 @@ const handleRenderAndEmail = async (data: RenderAndEmailJob): Promise<void> => {
     }
   }
 
+  // Pass-10 W3: per-recipient idempotency key. If the worker crashes
+  // partway through this loop, BullMQ retries the entire job —
+  // recipients [0..k) would otherwise get duplicate emails. The key is
+  // derived from a stable (schedule, recipient, format, dispatch-window)
+  // tuple so a retry computes the same key and the email service's
+  // findOrCreate short-circuits the second insert. Sha256-truncated to
+  // fit the 64-char column.
   for (const r of data.recipients) {
+    const idempotencyKey =
+      data.scheduleId && data.dispatchAt
+        ? createHash('sha256')
+            .update(`${data.scheduleId}|${r.email}|${data.format}|${data.dispatchAt}`)
+            .digest('hex')
+        : undefined;
     await emailService.sendEmail({
       toEmail: r.email,
       subject,
       htmlContent: html,
       attachments: attachment ? [attachment] : undefined,
       userId: r.userId,
+      idempotencyKey,
     });
   }
 


### PR DESCRIPTION
## Summary

Security review pass 14 — 9 commits across 2 batches. Targets main directly.

After 13 prior passes the application-layer surface is mature. This pass targeted two narrow surfaces that hadn't had a dedicated deep dive: **other workers/cron jobs beyond `reports`/`legal-reminder`** (which got pass-8/9/10 attention), and **`lib.analytics`/`lib.search`/`lib.feature-flags` as standalone packages** (touched tangentially in prior passes but never deep-audited).

### Batch RR — backend workers

Pass-8 added Zod payload validation to `reports.worker`. Pass-9 added system-actor audit logging to `legal-reminder.worker`. Pass-10 noted reports.worker email-sends aren't idempotent on retry. None of those improvements were propagated to the four other cron jobs in `service.backend/src/jobs/`. This batch closes that gap.

- **W1 / W4 (MEDIUM)** — Zod payload validation added to `retention.job`, `weekly-digest.job`, `match-digest.job`, `revoked-tokens-purge.job`, and the previously-missed `legal-reminder.worker` itself. Empty `z.object({}).strict()` where no data is expected — future producers can't sneak extra fields.
- **W2 (MEDIUM)** — system-actor audit rows now written by each of the four cron jobs at successful completion. Mirrors `legal-reminder.worker`'s pattern (`user: null, action: '*_RAN', metadata: { result counts }`). `withAuditMutationAllowed` deliberately not used — confirmed via reading AuditLog hooks that INSERT isn't blocked (only UPDATE/DELETE). New actions: `RETENTION_ENFORCEMENT_RAN`, `WEEKLY_DIGEST_RAN`, `MATCH_DIGEST_RAN`, `REVOKED_TOKENS_PURGE_RAN`.
- **W3 (MEDIUM)** — `reports.worker` render-and-email is now idempotent on retry. New migration `07-add-email-queue-idempotency-key.ts` adds a `idempotency_key VARCHAR(64) UNIQUE NULL` column with a partial unique index (`WHERE idempotency_key IS NOT NULL`, built `CONCURRENTLY` to avoid ShareLock on the hot table). Per-recipient key = `sha256(scheduleId | recipient | format | dispatchAt)`. `dispatchAt` plumbed through the job schema so a BullMQ retry computes the same key. Other email senders (password reset, etc.) leave the column NULL — opt-in.

### Batch SS — frontend lib privacy

- **A1 (MEDIUM)** — `lib.analytics` `trackEvent` / `trackPageView` now check an instance-level `consentGranted` flag before queuing. Defaults to `false` (fail-closed). Host app must call `analyticsService.setConsent({ analytics: true })` after loading the user's consent record. Defers the subscribe-to-consent wiring to the host (cleaner integration with whatever consent storage the host already uses — `lib.observability` already exposes `subscribeToAnalyticsConsent()` which the host can hook in).
- **A2 (MEDIUM)** — `lib.analytics` now honors `navigator.doNotTrack === '1'` unconditionally. Safari's deprecated DNT (undefined) is correctly ignored — only explicit `'1'` blocks.
- **F1 (LOW, defensive)** — Statsig user context across `app.admin` + `app.client` now includes `rescueId` (via `user?.rescueId`). Defensive: not in use today (Statsig rules currently bucket by userType + role only) but ensures future per-rescue gating works without a context refactor. `app.rescue` already included rescueId; left untouched. Used `undefined` (not `null`) per Statsig's type constraint on custom dims.

## Deferred / out of scope

- **F1 useFeatureGate `customContext` parameter** — not added; no caller needs it yet.
- **S1 (search facet count leakage)** — backend concern, not lib.search. Flagged for backend follow-up.
- **S2 (HTML highlight markup in search results)** — pass-9 already flagged this; backend ensures it goes through `SafeHtml`/DOMPurify on the frontend. No fix needed here.
- **W5 (email.service setInterval orphan handling)** — by-design; SENDING-status rows naturally heal at next process restart.
- **Audit-log test coverage for the four new cron audit writes** — existing tests for `runMatchDigest` + `purgeExpiredRevokedTokens` call the helpers directly, bypassing the BullMQ handler closures where the new audit writes live. Could follow `reports.worker`'s `__testables` pattern in a future cleanup.

## Test plan

- [x] `service.backend` — 2742 passed, 210 skipped, 0 failed
- [x] `lib.analytics` — 29/29 passed (incl. 3 new consent-gating + 1 new DNT test)
- [x] `lib.feature-flags` — 7/7 passed
- [x] `app.admin` + `app.client` StatsigContext tests — 4/4 passed (new)
- [x] `tsc --noEmit` clean across the affected packages
- [ ] Manual smoke: trigger a retention job → confirm `RETENTION_ENFORCEMENT_RAN` audit row. Trigger a scheduled report → confirm second BullMQ retry doesn't re-send to already-sent recipients. Trigger an analytics event before consent setter is called → confirm no network request. Set `navigator.doNotTrack = '1'` → confirm analytics is silent.

## Coverage note

The marginal yield of these passes is now low — 5 fixes across 9 audits run during pass-14, mostly defensive. The system is in strong shape after 14 passes. Future security work should be feature-driven (new attack surfaces from new features) rather than reactive sweeps. Recommend pausing periodic passes until product/scope changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxiFw2tNVhTai3B8Ws1a67)_