### PR TITLE
feat: cross-app real-time + notifications

### DIFF
--- a/app.client/src/contexts/MatchAcknowledgementContext.test.tsx
+++ b/app.client/src/contexts/MatchAcknowledgementContext.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ADS C4-5: behaviour test for the real-time match-acknowledgement path.
+ *
+ * Previously the MatchAcknowledgementProvider only refreshed every 60s.
+ * It now also subscribes to the backend's `application_status_changed`
+ * socket event and re-checks immediately when one arrives, while keeping
+ * the polling timer as a safety net.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@/test-utils/render';
+import type { ApplicationStatusChangedPayload } from '@adopt-dont-shop/lib.analytics';
+
+const getUserApplicationsMock = vi.fn();
+const getPetByIdMock = vi.fn();
+
+// Capture the handler the context subscribes with so we can fire socket
+// events synthetically from the test.
+let lastStatusHandler: ((p: ApplicationStatusChangedPayload) => void) | null = null;
+
+vi.mock('@adopt-dont-shop/lib.analytics', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.analytics')>(
+    '@adopt-dont-shop/lib.analytics'
+  );
+  return {
+    ...actual,
+    useRealtimeAnalytics: (event: string, handler: unknown) => {
+      if (event === 'application_status_changed') {
+        lastStatusHandler = handler as (p: ApplicationStatusChangedPayload) => void;
+      }
+    },
+  };
+});
+
+vi.mock('@adopt-dont-shop/lib.auth', async () => {
+  const actual = await vi.importActual<typeof import('@adopt-dont-shop/lib.auth')>(
+    '@adopt-dont-shop/lib.auth'
+  );
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: { userId: 'u-1', email: 'a@b.c', firstName: 'Ada' },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+      updateProfile: vi.fn(),
+      refreshUser: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/services', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/services');
+  return {
+    ...actual,
+    applicationService: {
+      getUserApplications: (...args: unknown[]) => getUserApplicationsMock(...args),
+    },
+    petService: {
+      getPetById: (...args: unknown[]) => getPetByIdMock(...args),
+    },
+  };
+});
+
+import {
+  MatchAcknowledgementProvider,
+  __resetMatchAcknowledgementStorage,
+} from './MatchAcknowledgementContext';
+
+const sampleApp = (overrides: Record<string, unknown> = {}) => ({
+  id: 'app-1',
+  petId: 'pet-1',
+  userId: 'u-1',
+  rescueId: 'rescue-1',
+  status: 'submitted',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-02T00:00:00Z',
+  submittedAt: '2025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+const samplePet = () => ({
+  pet_id: 'pet-1',
+  name: 'Luna',
+  breed: 'Labrador',
+  age_years: 3,
+  images: [{ url: 'https://cdn.example.com/luna.jpg', is_primary: true }],
+});
+
+describe('MatchAcknowledgementProvider (C4-5)', () => {
+  beforeEach(() => {
+    getUserApplicationsMock.mockReset();
+    getPetByIdMock.mockReset();
+    __resetMatchAcknowledgementStorage();
+    lastStatusHandler = null;
+    // Defeat the navigator.webdriver short-circuit so the mount-time poll
+    // runs and we can observe the event-driven refresh as a *second* call.
+    Object.defineProperty(window.navigator, 'webdriver', {
+      configurable: true,
+      get: () => false,
+    });
+  });
+
+  it('subscribes to application_status_changed at mount', () => {
+    getUserApplicationsMock.mockResolvedValue([]);
+    render(
+      <MatchAcknowledgementProvider>
+        <div />
+      </MatchAcknowledgementProvider>
+    );
+    expect(lastStatusHandler).not.toBeNull();
+  });
+
+  it('refreshes applications when the socket fires application_status_changed', async () => {
+    getUserApplicationsMock.mockResolvedValue([sampleApp()]);
+    getPetByIdMock.mockResolvedValue(samplePet());
+
+    render(
+      <MatchAcknowledgementProvider>
+        <div />
+      </MatchAcknowledgementProvider>
+    );
+
+    await waitFor(() => {
+      expect(getUserApplicationsMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Fire the socket event — this should kick another applicationService
+    // fetch without waiting for the 60s poll interval.
+    lastStatusHandler?.({
+      applicationId: 'app-1',
+      status: 'approved',
+      updatedAt: '2025-01-02T01:00:00Z',
+    });
+
+    await waitFor(() => {
+      expect(getUserApplicationsMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app.client/src/contexts/MatchAcknowledgementContext.tsx
+++ b/app.client/src/contexts/MatchAcknowledgementContext.tsx
@@ -1,6 +1,10 @@
 import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import {
+  useRealtimeAnalytics,
+  type ApplicationStatusChangedPayload,
+} from '@adopt-dont-shop/lib.analytics';
+import {
   applicationService,
   petService,
   type Application,
@@ -171,6 +175,18 @@ export const MatchAcknowledgementProvider = ({ children }: MatchAcknowledgementP
     }, POLL_INTERVAL_MS);
     return () => window.clearInterval(id);
   }, [isAuthenticated, user, checkForMatches]);
+
+  // ADS C4-5: subscribe to backend application_status_changed events so a
+  // status transition surfaces the match modal immediately instead of
+  // waiting up to 60s for the next poll. The polling above stays in
+  // place as a safety net for disconnected sockets / dropped events.
+  const handleStatusChanged = useCallback(
+    (_payload: ApplicationStatusChangedPayload) => {
+      void checkForMatches();
+    },
+    [checkForMatches]
+  );
+  useRealtimeAnalytics('application_status_changed', handleStatusChanged);
 
   const value = useMemo<MatchAcknowledgementContextValue>(
     () => ({

--- a/app.client/src/pages/ApplicationDashboard.css.ts
+++ b/app.client/src/pages/ApplicationDashboard.css.ts
@@ -129,6 +129,7 @@ export const statusBadge = recipe({
       under_review: { background: vars.colors.warning },
       approved: { background: vars.colors.success },
       rejected: { background: vars.colors.danger },
+      withdrawn: { background: vars.text.muted },
       default: { background: vars.text.muted },
     },
   },

--- a/app.client/src/pages/ApplicationDashboard.test.tsx
+++ b/app.client/src/pages/ApplicationDashboard.test.tsx
@@ -217,6 +217,23 @@ describe('ApplicationDashboard (ADS-634)', () => {
     expect(navigateMock).toHaveBeenCalledWith('/chat/conv-99');
   });
 
+  // ADS C4-1: the status-badge selector used to whitelist 'under_review' — a
+  // value the frontend Application type never emits — so 'withdrawn'
+  // applications silently fell through to the 'default' grey badge. Each
+  // reachable status now renders its own readable label.
+  it.each(['submitted', 'approved', 'rejected', 'withdrawn'] as const)(
+    'renders the %s status label on the application card',
+    async status => {
+      getUserApplicationsMock.mockResolvedValue([makeApplication({ status })]);
+      getPetByIdMock.mockResolvedValue(makePet());
+
+      render(<ApplicationDashboard />);
+
+      const label = await screen.findByText(status.replace('_', ' '));
+      expect(label).toBeInTheDocument();
+    }
+  );
+
   // UX P2 E: when an application's pet lookup fails or returns no record,
   // the card used to display "Pet Name Unavailable" — a phrase that reads
   // like a system error to applicants. Replace with "Unknown pet" and keep

--- a/app.client/src/pages/ApplicationDashboard.tsx
+++ b/app.client/src/pages/ApplicationDashboard.tsx
@@ -203,16 +203,17 @@ export const ApplicationDashboard: React.FC = () => {
 
               <span
                 className={styles.statusBadge({
-                  status: (['submitted', 'under_review', 'approved', 'rejected'].includes(
+                  // ADS C4-1: `under_review` was previously in this allowlist but
+                  // ApplicationStatusSchema only emits 'submitted' | 'approved' |
+                  // 'rejected' | 'withdrawn', so the branch was unreachable and the
+                  // 'withdrawn' status fell through to the 'default' badge. List the
+                  // statuses that can actually appear so withdrawn applications get
+                  // their own visual treatment.
+                  status: (['submitted', 'approved', 'rejected', 'withdrawn'].includes(
                     application.status
                   )
                     ? application.status
-                    : 'default') as
-                    | 'submitted'
-                    | 'under_review'
-                    | 'approved'
-                    | 'rejected'
-                    | 'default',
+                    : 'default') as 'submitted' | 'approved' | 'rejected' | 'withdrawn' | 'default',
                 })}
               >
                 {application.status.replace('_', ' ')}

--- a/app.rescue/src/hooks/useApplications.test.ts
+++ b/app.rescue/src/hooks/useApplications.test.ts
@@ -1,0 +1,71 @@
+/**
+ * ADS C4-6: behaviour test for the rescue application list's real-time path.
+ *
+ * The hook still polls / refetches on filter changes, but it now ALSO
+ * subscribes to backend socket events (`application_created`,
+ * `application_updated`) and refetches when either fires.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getApplicationsMock = vi.fn();
+
+vi.mock('../services/applicationService', () => ({
+  RescueApplicationService: class {
+    getApplications = getApplicationsMock;
+  },
+}));
+
+// Capture each event handler the hook subscribes with so we can fire them.
+const handlers: Record<string, ((p: unknown) => void) | undefined> = {};
+
+vi.mock('@adopt-dont-shop/lib.analytics', () => ({
+  useRealtimeAnalytics: (event: string, handler: (p: unknown) => void) => {
+    handlers[event] = handler;
+  },
+}));
+
+import { useApplications } from './useApplications';
+
+describe('useApplications (C4-6)', () => {
+  beforeEach(() => {
+    getApplicationsMock.mockReset();
+    getApplicationsMock.mockResolvedValue({ applications: [], total: 0, totalPages: 0 });
+    handlers.application_created = undefined;
+    handlers.application_updated = undefined;
+  });
+
+  it('subscribes to application_created and application_updated', () => {
+    renderHook(() => useApplications());
+    expect(handlers.application_created).toBeDefined();
+    expect(handlers.application_updated).toBeDefined();
+  });
+
+  it('refetches when application_created fires', async () => {
+    renderHook(() => useApplications());
+
+    await waitFor(() => {
+      expect(getApplicationsMock).toHaveBeenCalledTimes(1);
+    });
+
+    handlers.application_created?.({ applicationId: 'app-99' });
+
+    await waitFor(() => {
+      expect(getApplicationsMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('refetches when application_updated fires', async () => {
+    renderHook(() => useApplications());
+
+    await waitFor(() => {
+      expect(getApplicationsMock).toHaveBeenCalledTimes(1);
+    });
+
+    handlers.application_updated?.({ applicationId: 'app-99' });
+
+    await waitFor(() => {
+      expect(getApplicationsMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app.rescue/src/hooks/useApplications.ts
+++ b/app.rescue/src/hooks/useApplications.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useRealtimeAnalytics } from '@adopt-dont-shop/lib.analytics';
 import { RescueApplicationService } from '../services/applicationService';
 import type {
   ApplicationListItem,
@@ -87,6 +88,13 @@ export const useApplications = () => {
   useEffect(() => {
     fetchApplications();
   }, [fetchApplications]);
+
+  // ADS C4-6: live-update the application list when the backend emits a
+  // new submission or status change for this rescue. Both events trigger
+  // the same plain refetch — no optimistic patching — so the list stays
+  // consistent with the server.
+  useRealtimeAnalytics('application_created', fetchApplications);
+  useRealtimeAnalytics('application_updated', fetchApplications);
 
   return {
     applications,

--- a/lib.analytics/src/hooks/index.ts
+++ b/lib.analytics/src/hooks/index.ts
@@ -24,4 +24,7 @@ export type {
   AnalyticsInvalidatePayload,
   AnalyticsMetricUpdatePayload,
   ReportsScheduledRunCompletePayload,
+  ApplicationStatusChangedPayload,
+  ApplicationListChangePayload,
+  RescueVerifiedPayload,
 } from './useRealtimeAnalytics';

--- a/lib.analytics/src/hooks/useRealtimeAnalytics.ts
+++ b/lib.analytics/src/hooks/useRealtimeAnalytics.ts
@@ -66,10 +66,33 @@ export type ReportsScheduledRunCompletePayload = {
   ts: string;
 };
 
+/** ADS C4-5: pushed to user:{id} when an application's status changes. */
+export type ApplicationStatusChangedPayload = {
+  applicationId: string;
+  status: string;
+  stage?: string;
+  updatedAt: string;
+};
+
+/** ADS C4-6: pushed to rescue:{id} when an application is created / updated. */
+export type ApplicationListChangePayload = {
+  applicationId: string;
+};
+
+/** ADS C4-3: pushed to rescue:{id} when an admin verifies the rescue. */
+export type RescueVerifiedPayload = {
+  rescueId: string;
+  verifiedAt: string;
+};
+
 type EventMap = {
   'analytics:invalidate': AnalyticsInvalidatePayload;
   'analytics:metric-update': AnalyticsMetricUpdatePayload;
   'reports:scheduled-run-complete': ReportsScheduledRunCompletePayload;
+  application_status_changed: ApplicationStatusChangedPayload;
+  application_created: ApplicationListChangePayload;
+  application_updated: ApplicationListChangePayload;
+  'rescue:verified': RescueVerifiedPayload;
 };
 
 export const useRealtimeAnalytics = <K extends keyof EventMap>(

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -33,7 +33,7 @@ vi.mock('../../socket/socket-registry', () => ({
 }));
 
 import { ApplicationService } from '../../services/application.service';
-import { emitToUser } from '../../socket/socket-registry';
+import { emitToUser, emitToRescue } from '../../socket/socket-registry';
 import Application, { ApplicationStatus, ApplicationPriority } from '../../models/Application';
 import ApplicationAnswer from '../../models/ApplicationAnswer';
 import ApplicationReferenceModel from '../../models/ApplicationReference';
@@ -212,6 +212,29 @@ describe('ApplicationService - Business Logic', () => {
       expect(result).toBeDefined();
     });
 
+    // ADS C4-6: when an application is created, the rescue's live
+    // application list should see an `application_created` event so the
+    // rescue dashboard can refetch without waiting for a poll.
+    it('emits application_created to the rescue after successful creation', async () => {
+      const mockUser = createMockUser();
+      const mockPet = createMockPet();
+      const mockApplication = createMockApplication();
+      const request = createValidApplicationRequest();
+
+      MockedUser.findByPk = vi.fn().mockResolvedValue(mockUser);
+      MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet);
+      MockedApplication.findOne = vi.fn().mockResolvedValue(null);
+      MockedApplication.create = vi.fn().mockResolvedValue(mockApplication);
+
+      await ApplicationService.createApplication(request, mockUserId);
+
+      expect(vi.mocked(emitToRescue)).toHaveBeenCalledWith(
+        mockRescueId,
+        'application_created',
+        expect.objectContaining({ applicationId: mockApplicationId })
+      );
+    });
+
     it('prevents duplicate applications for same pet', async () => {
       // Given: User already has an application for this pet
       const mockUser = createMockUser();
@@ -349,6 +372,28 @@ describe('ApplicationService - Business Logic', () => {
         expect.objectContaining({
           applicationId: mockApplicationId,
         })
+      );
+    });
+
+    // ADS C4-6: on a status update, the rescue's live application list
+    // also receives an `application_updated` event so staff dashboards
+    // refetch without polling.
+    it('emits application_updated to the rescue after a status update', async () => {
+      const mockApplication = createMockApplication(ApplicationStatus.SUBMITTED);
+      (mockApplication.canTransitionTo as vi.Mock).mockReturnValue(true);
+
+      MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication);
+
+      await ApplicationService.updateApplicationStatus(
+        mockApplicationId,
+        { status: ApplicationStatus.APPROVED, actionedBy: 'rescue-staff-123' },
+        'rescue-staff-123'
+      );
+
+      expect(vi.mocked(emitToRescue)).toHaveBeenCalledWith(
+        mockRescueId,
+        'application_updated',
+        expect.objectContaining({ applicationId: mockApplicationId })
       );
     });
 

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -24,7 +24,16 @@ vi.mock('../../services/email.service', () => ({
   },
 }));
 
+// ADS C4-5 / C4-6: capture socket emits without requiring a live IO server.
+vi.mock('../../socket/socket-registry', () => ({
+  emitToUser: vi.fn(),
+  emitToRescue: vi.fn(),
+  emitAuthRoleChanged: vi.fn(),
+  disconnectAllSockets: vi.fn(),
+}));
+
 import { ApplicationService } from '../../services/application.service';
+import { emitToUser } from '../../socket/socket-registry';
 import Application, { ApplicationStatus, ApplicationPriority } from '../../models/Application';
 import ApplicationAnswer from '../../models/ApplicationAnswer';
 import ApplicationReferenceModel from '../../models/ApplicationReference';
@@ -314,6 +323,31 @@ describe('ApplicationService - Business Logic', () => {
           applicationId: mockApplicationId,
           toStatus: ApplicationStatus.APPROVED,
           transitionedBy: 'rescue-staff-123',
+        })
+      );
+    });
+
+    // ADS C4-5: after a status update commits, the applicant's personal
+    // user:{id} socket room receives an `application_status_changed`
+    // event so any open client refreshes immediately instead of waiting
+    // up to 60s for the next poll.
+    it('emits application_status_changed to the applicant after a status update', async () => {
+      const mockApplication = createMockApplication(ApplicationStatus.SUBMITTED);
+      (mockApplication.canTransitionTo as vi.Mock).mockReturnValue(true);
+
+      MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication);
+
+      await ApplicationService.updateApplicationStatus(
+        mockApplicationId,
+        { status: ApplicationStatus.APPROVED, actionedBy: 'rescue-staff-123' },
+        'rescue-staff-123'
+      );
+
+      expect(vi.mocked(emitToUser)).toHaveBeenCalledWith(
+        mockUserId,
+        'application_status_changed',
+        expect.objectContaining({
+          applicationId: mockApplicationId,
         })
       );
     });

--- a/service.backend/src/__tests__/services/moderation.service.test.ts
+++ b/service.backend/src/__tests__/services/moderation.service.test.ts
@@ -281,6 +281,68 @@ describe('ModerationService', () => {
       spy.mockRestore();
     });
 
+    // ADS C4-4: when a moderator applies a sanction to a user (warning,
+    // suspension, ban, restriction), the targeted user must receive an
+    // in-app notification documenting it so they have a record once
+    // they're next online. The notification is best-effort and never
+    // affects the sanction itself.
+    it('notifies the sanctioned user when a moderator applies a warning', async () => {
+      const { reporter, reportedUser, moderator } = await seedUsers();
+      const report = await seedReport(reporter.userId, reportedUser.userId);
+
+      const spy = vi
+        .spyOn(NotificationService, 'createNotification')
+        .mockResolvedValue({} as never);
+
+      await moderationService.takeModerationAction(moderator.userId, {
+        reportId: report.reportId,
+        targetEntityType: 'user',
+        targetEntityId: reportedUser.userId,
+        targetUserId: reportedUser.userId,
+        actionType: ActionType.WARNING_ISSUED,
+        severity: ActionSeverity.LOW,
+        reason: 'Inappropriate content',
+        description: 'Please review the community guidelines.',
+      });
+
+      // Two notifications: one to the reporter (C4-2), one to the sanctioned user (C4-4)
+      expect(spy).toHaveBeenCalledTimes(2);
+      const sanctionedCall = spy.mock.calls.find(c => c[0].userId === reportedUser.userId);
+      expect(sanctionedCall).toBeDefined();
+      expect(sanctionedCall?.[0].type).toBe(NotificationType.SYSTEM_ANNOUNCEMENT);
+      expect(sanctionedCall?.[0].data).toMatchObject({
+        actionType: ActionType.WARNING_ISSUED,
+        reason: 'Inappropriate content',
+      });
+
+      spy.mockRestore();
+    });
+
+    it('does not notify the target user for NO_ACTION outcomes (not a sanction)', async () => {
+      const { reporter, reportedUser, moderator } = await seedUsers();
+      const report = await seedReport(reporter.userId, reportedUser.userId);
+
+      const spy = vi
+        .spyOn(NotificationService, 'createNotification')
+        .mockResolvedValue({} as never);
+
+      await moderationService.takeModerationAction(moderator.userId, {
+        reportId: report.reportId,
+        targetEntityType: 'user',
+        targetEntityId: reportedUser.userId,
+        targetUserId: reportedUser.userId,
+        actionType: ActionType.NO_ACTION,
+        severity: ActionSeverity.LOW,
+        reason: 'No violation',
+      });
+
+      // Only the reporter is notified (dismissal); the target user is not.
+      const sanctionedCalls = spy.mock.calls.filter(c => c[0].userId === reportedUser.userId);
+      expect(sanctionedCalls).toHaveLength(0);
+
+      spy.mockRestore();
+    });
+
     it('completes the moderation action even when notifying the reporter fails', async () => {
       const { reporter, reportedUser, moderator } = await seedUsers();
       const report = await seedReport(reporter.userId, reportedUser.userId);

--- a/service.backend/src/__tests__/services/moderation.service.test.ts
+++ b/service.backend/src/__tests__/services/moderation.service.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sequelize from '../../sequelize';
 import User, { UserStatus, UserType } from '../../models/User';
 import Report, { ReportStatus, ReportCategory, ReportSeverity } from '../../models/Report';
 import ModeratorAction, { ActionType, ActionSeverity } from '../../models/ModeratorAction';
+import moderationService from '../../services/moderation.service';
+import { NotificationService } from '../../services/notification.service';
+import { NotificationType } from '../../models/Notification';
 
 describe('ModerationService', () => {
   beforeEach(async () => {
@@ -150,6 +153,153 @@ describe('ModerationService', () => {
     it('should handle empty report queries gracefully', async () => {
       const reports = await Report.findAll();
       expect(reports).toHaveLength(0);
+    });
+  });
+
+  // ADS C4-2: when a moderator resolves / dismisses / escalates a report, the
+  // reporter who filed it must receive an in-app notification documenting the
+  // outcome. The notification side-effect runs after the moderation
+  // transaction commits — failures here must not affect the action itself.
+  describe('Reporter notifications on report resolution (C4-2)', () => {
+    const seedUsers = async () => {
+      const reporter = await User.create({
+        email: 'reporter-c42@example.com',
+        password: 'hashedpassword',
+        firstName: 'Reporter',
+        lastName: 'User',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+      });
+      const reportedUser = await User.create({
+        email: 'reported-c42@example.com',
+        password: 'hashedpassword',
+        firstName: 'Reported',
+        lastName: 'User',
+        userType: UserType.ADOPTER,
+        status: UserStatus.ACTIVE,
+      });
+      const moderator = await User.create({
+        email: 'mod-c42@example.com',
+        password: 'hashedpassword',
+        firstName: 'Mod',
+        lastName: 'User',
+        userType: UserType.ADMIN,
+        status: UserStatus.ACTIVE,
+      });
+      return { reporter, reportedUser, moderator };
+    };
+
+    const seedReport = async (
+      reporterId: string,
+      reportedUserId: string,
+      status: ReportStatus = ReportStatus.UNDER_REVIEW
+    ) =>
+      Report.create({
+        reporterId,
+        reportedEntityType: 'user',
+        reportedEntityId: reportedUserId,
+        reportedUserId,
+        category: ReportCategory.INAPPROPRIATE_CONTENT,
+        severity: ReportSeverity.MEDIUM,
+        title: 'Test report',
+        description: 'Test description',
+        evidence: [],
+        status,
+      });
+
+    it('notifies the reporter when their report is resolved via bulk update', async () => {
+      const { reporter, reportedUser, moderator } = await seedUsers();
+      const report = await seedReport(reporter.userId, reportedUser.userId);
+
+      const spy = vi
+        .spyOn(NotificationService, 'createNotification')
+        .mockResolvedValue({} as never);
+
+      const result = await moderationService.bulkUpdateReports({
+        reportIds: [report.reportId],
+        action: 'resolve',
+        moderatorId: moderator.userId,
+        resolutionNotes: 'Resolved via test',
+      });
+
+      expect(result.updated).toBe(1);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const args = spy.mock.calls[0][0];
+      expect(args.userId).toBe(reporter.userId);
+      expect(args.type).toBe(NotificationType.SYSTEM_ANNOUNCEMENT);
+      expect(args.data).toMatchObject({ reportId: report.reportId, resolution: 'resolved' });
+
+      const refreshed = await Report.findByPk(report.reportId);
+      expect(refreshed?.resolvedAt).toBeTruthy();
+
+      spy.mockRestore();
+    });
+
+    it('notifies the reporter when their report is dismissed via bulk update', async () => {
+      const { reporter, reportedUser, moderator } = await seedUsers();
+      const report = await seedReport(reporter.userId, reportedUser.userId, ReportStatus.PENDING);
+
+      const spy = vi
+        .spyOn(NotificationService, 'createNotification')
+        .mockResolvedValue({} as never);
+
+      await moderationService.bulkUpdateReports({
+        reportIds: [report.reportId],
+        action: 'dismiss',
+        moderatorId: moderator.userId,
+        resolutionNotes: 'No action needed',
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const args = spy.mock.calls[0][0];
+      expect(args.userId).toBe(reporter.userId);
+      expect(args.data).toMatchObject({ resolution: 'dismissed' });
+
+      spy.mockRestore();
+    });
+
+    it('notifies the reporter when their report is escalated via escalateReport', async () => {
+      const { reporter, reportedUser, moderator } = await seedUsers();
+      const report = await seedReport(reporter.userId, reportedUser.userId, ReportStatus.PENDING);
+
+      const spy = vi
+        .spyOn(NotificationService, 'createNotification')
+        .mockResolvedValue({} as never);
+
+      await moderationService.escalateReport(
+        report.reportId,
+        moderator.userId,
+        moderator.userId,
+        'Needs senior review'
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const args = spy.mock.calls[0][0];
+      expect(args.userId).toBe(reporter.userId);
+      expect(args.data).toMatchObject({ reportId: report.reportId, resolution: 'escalated' });
+
+      spy.mockRestore();
+    });
+
+    it('completes the moderation action even when notifying the reporter fails', async () => {
+      const { reporter, reportedUser, moderator } = await seedUsers();
+      const report = await seedReport(reporter.userId, reportedUser.userId);
+
+      const spy = vi
+        .spyOn(NotificationService, 'createNotification')
+        .mockRejectedValue(new Error('notification provider down'));
+
+      const result = await moderationService.bulkUpdateReports({
+        reportIds: [report.reportId],
+        action: 'resolve',
+        moderatorId: moderator.userId,
+      });
+
+      expect(result.updated).toBe(1);
+      const refreshed = await Report.findByPk(report.reportId);
+      expect(refreshed?.resolvedAt).toBeTruthy();
+
+      spy.mockRestore();
     });
   });
 });

--- a/service.backend/src/__tests__/services/rescue.service.test.ts
+++ b/service.backend/src/__tests__/services/rescue.service.test.ts
@@ -4,6 +4,9 @@ import { Rescue, StaffMember, User, Pet, Application } from '../../models';
 import { UserType, UserStatus } from '../../models/User';
 import { PetStatus } from '../../models/Pet';
 import { RescueService } from '../../services/rescue.service';
+import { NotificationService } from '../../services/notification.service';
+import { NotificationType } from '../../models/Notification';
+import { emitToRescue } from '../../socket/socket-registry';
 
 // Mock only external services
 vi.mock('../../services/auditLog.service', () => ({
@@ -21,6 +24,12 @@ vi.mock('../../services/charity-commission.service', () => ({
 }));
 vi.mock('../../services/email.service', () => ({
   default: { sendEmail: vi.fn().mockResolvedValue('email-id') },
+}));
+vi.mock('../../socket/socket-registry', () => ({
+  emitToRescue: vi.fn(),
+  emitToUser: vi.fn(),
+  emitAuthRoleChanged: vi.fn(),
+  disconnectAllSockets: vi.fn(),
 }));
 
 vi.mock('../../utils/logger', () => ({
@@ -532,6 +541,85 @@ describe('RescueService - Behavioral Testing', () => {
       });
 
       await expect(RescueService.verifyRescue(rescue.rescueId, 'admin-123')).rejects.toThrow();
+    });
+
+    // ADS C4-3: when an admin verifies a rescue, every active staff member of
+    // that rescue should receive an in-app notification, and a `rescue:verified`
+    // event should fan out to the rescue:{id} socket room so any open
+    // dashboard refreshes immediately.
+    it('notifies rescue staff and emits rescue:verified after verification', async () => {
+      const spy = vi
+        .spyOn(NotificationService, 'createNotification')
+        .mockResolvedValue({} as never);
+
+      const rescue = await Rescue.create({
+        name: 'Notify Rescue',
+        email: 'notify@rescue.org',
+        phone: '555-0123',
+        address: '123 Main St',
+        city: 'London',
+        postcode: 'SW1A 1AA',
+        country: 'GB',
+        contactPerson: 'Jane Smith',
+        status: 'pending',
+      });
+
+      await StaffMember.create({
+        rescueId: rescue.rescueId,
+        userId: 'user-123',
+        title: 'Founder',
+        isVerified: true,
+        addedBy: 'admin-123',
+        addedAt: new Date(),
+      });
+
+      await RescueService.verifyRescue(rescue.rescueId, 'admin-123');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const args = spy.mock.calls[0][0];
+      expect(args.userId).toBe('user-123');
+      expect(args.type).toBe(NotificationType.SYSTEM_ANNOUNCEMENT);
+      expect(args.data).toMatchObject({ rescueId: rescue.rescueId, event: 'rescue_verified' });
+
+      expect(vi.mocked(emitToRescue)).toHaveBeenCalledWith(
+        rescue.rescueId,
+        'rescue:verified',
+        expect.objectContaining({ rescueId: rescue.rescueId })
+      );
+
+      spy.mockRestore();
+    });
+
+    it('completes verification even when notifying staff fails', async () => {
+      const spy = vi
+        .spyOn(NotificationService, 'createNotification')
+        .mockRejectedValue(new Error('notification down'));
+
+      const rescue = await Rescue.create({
+        name: 'Failing Notify Rescue',
+        email: 'fail@rescue.org',
+        phone: '555-0123',
+        address: '123 Main St',
+        city: 'London',
+        postcode: 'SW1A 1AA',
+        country: 'GB',
+        contactPerson: 'Jane Smith',
+        status: 'pending',
+      });
+
+      await StaffMember.create({
+        rescueId: rescue.rescueId,
+        userId: 'user-123',
+        title: 'Founder',
+        isVerified: true,
+        addedBy: 'admin-123',
+        addedAt: new Date(),
+      });
+
+      const result = await RescueService.verifyRescue(rescue.rescueId, 'admin-123');
+      expect(result.status).toBe('verified');
+
+      spy.mockRestore();
     });
   });
 

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -42,7 +42,7 @@ import emailService from './email.service';
 import { NotificationService } from './notification.service';
 import { NotificationType } from '../models/Notification';
 import { TimelineEventType } from '../models/ApplicationTimeline';
-import { emitToUser } from '../socket/socket-registry';
+import { emitToUser, emitToRescue } from '../socket/socket-registry';
 import { JsonObject, JsonValue } from '../types/common';
 
 import {
@@ -301,7 +301,7 @@ export class ApplicationService {
         throw new Error('User not found');
       }
 
-      return await sequelize.transaction(async t => {
+      const result = await sequelize.transaction(async t => {
         // Lock the pet row to prevent concurrent applications racing on status
         const pet = await Pet.findByPk(applicationData.petId, {
           transaction: t,
@@ -476,6 +476,16 @@ export class ApplicationService {
           answers: incomingAnswers,
         };
       });
+
+      // ADS C4-6: notify the rescue's live application list that a new
+      // submission landed so the rescue dashboard can refetch immediately.
+      if (result.rescueId && result.applicationId) {
+        emitToRescue(result.rescueId, 'application_created', {
+          applicationId: result.applicationId,
+        });
+      }
+
+      return result;
     } catch (error) {
       // Race condition safety net: if two concurrent requests both pass the
       // pre-flight findOne check, the DB unique index rejects the second
@@ -1236,6 +1246,12 @@ export class ApplicationService {
         status: application.status,
         stage: application.stage,
         updatedAt: application.updatedAt,
+      });
+
+      // ADS C4-6: also broadcast to the rescue's live application list so
+      // staff dashboards refetch without polling.
+      emitToRescue(application.rescueId, 'application_updated', {
+        applicationId,
       });
 
       return {

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -42,6 +42,7 @@ import emailService from './email.service';
 import { NotificationService } from './notification.service';
 import { NotificationType } from '../models/Notification';
 import { TimelineEventType } from '../models/ApplicationTimeline';
+import { emitToUser } from '../socket/socket-registry';
 import { JsonObject, JsonValue } from '../types/common';
 
 import {
@@ -1226,6 +1227,17 @@ export class ApplicationService {
       }
 
       await application.reload();
+
+      // ADS C4-5: push the status change to the applicant's personal
+      // user:{id} room so an open ApplicationDashboard / Match flow
+      // doesn't have to wait for the 60s poll.
+      emitToUser(application.userId, 'application_status_changed', {
+        applicationId,
+        status: application.status,
+        stage: application.stage,
+        updatedAt: application.updatedAt,
+      });
+
       return {
         ...(application.toJSON() as ApplicationData),
         answers: await loadAnswersJson(applicationId),

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -490,6 +490,28 @@ class ModerationService {
         });
       }
 
+      // ADS C4-4: notify the sanctioned user (the target of the action) so
+      // they have an in-app record next time they're online. Sanctions
+      // cover warnings, suspensions, bans, and account restrictions —
+      // anything that meaningfully changes how the user can use the
+      // platform. Best-effort: notification failures don't roll back.
+      const SANCTION_ACTIONS: ActionType[] = [
+        ActionType.WARNING_ISSUED,
+        ActionType.USER_SUSPENDED,
+        ActionType.USER_BANNED,
+        ActionType.ACCOUNT_RESTRICTED,
+      ];
+      if (actionData.targetUserId && SANCTION_ACTIONS.includes(actionData.actionType)) {
+        await this.notifySanctionedUser({
+          userId: actionData.targetUserId,
+          actionId: action.actionId,
+          actionType: actionData.actionType,
+          reason: actionData.reason,
+          description: actionData.description,
+          expiresAt: action.expiresAt,
+        });
+      }
+
       await AuditLogService.log({
         userId: moderatorId,
         action: 'MODERATION_ACTION_TAKEN',
@@ -1055,6 +1077,55 @@ class ModerationService {
         reportId,
         reporterId,
         resolution,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * ADS C4-4: Notify a user that a moderation sanction was applied to
+   * their account (warning, suspension, ban, restriction). Best-effort:
+   * the sanction itself has already committed.
+   *
+   * Reuses NotificationType.SYSTEM_ANNOUNCEMENT for the same reason as
+   * notifyReporterOfResolution — the Postgres ENUM for notification.type
+   * can't grow without a migration. The discriminator lives in
+   * `data.actionType` so the UI can pick an appropriate icon / copy.
+   */
+  private async notifySanctionedUser(params: {
+    userId: string;
+    actionId: string;
+    actionType: ActionType;
+    reason: string;
+    description?: string;
+    expiresAt?: Date;
+  }): Promise<void> {
+    const { userId, actionId, actionType, reason, description, expiresAt } = params;
+    const titles: Record<string, string> = {
+      [ActionType.WARNING_ISSUED]: 'A moderator issued you a warning',
+      [ActionType.USER_SUSPENDED]: 'Your account has been suspended',
+      [ActionType.USER_BANNED]: 'Your account has been banned',
+      [ActionType.ACCOUNT_RESTRICTED]: 'Your account has been restricted',
+    };
+    try {
+      await NotificationService.createNotification({
+        userId,
+        type: NotificationType.SYSTEM_ANNOUNCEMENT,
+        title: titles[actionType] ?? 'A moderation action was taken on your account',
+        message: description ?? reason,
+        data: {
+          actionId,
+          actionType,
+          reason,
+          ...(description !== undefined ? { description } : {}),
+          ...(expiresAt !== undefined ? { expiresAt: expiresAt.toISOString() } : {}),
+        },
+      });
+    } catch (error) {
+      logger.warn('Failed to notify sanctioned user', {
+        userId,
+        actionId,
+        actionType,
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -9,7 +9,9 @@ import Pet from '../models/Pet';
 import Rescue from '../models/Rescue';
 import sequelize from '../sequelize';
 import logger from '../utils/logger';
+import { NotificationType } from '../models/Notification';
 import { AuditLogService } from './auditLog.service';
+import { NotificationService } from './notification.service';
 import { JsonObject } from '../types/common';
 import { validateSortField } from '../utils/sort-validation';
 import { escapeLikePattern } from '../utils/escape-like';
@@ -431,6 +433,13 @@ class ModerationService {
       }
 
       // Update related report if provided
+      // ADS C4-2: capture (reporterId, resolution) so we can notify the
+      // reporter once the transaction commits.
+      let resolvedReportContext: {
+        reportId: string;
+        reporterId: string;
+        resolution: 'resolved' | 'dismissed';
+      } | null = null;
       if (actionData.reportId) {
         const report = await Report.findByPk(actionData.reportId, { transaction });
         if (report) {
@@ -460,10 +469,26 @@ class ModerationService {
             },
             { transaction }
           );
+          if (report.reporterId) {
+            resolvedReportContext = {
+              reportId: report.reportId,
+              reporterId: report.reporterId,
+              resolution: newStatus === ReportStatus.DISMISSED ? 'dismissed' : 'resolved',
+            };
+          }
         }
       }
 
       await transaction.commit();
+
+      // ADS C4-2: notify reporter after commit so a notification failure
+      // never rolls back the moderation outcome.
+      if (resolvedReportContext) {
+        await this.notifyReporterOfResolution({
+          ...resolvedReportContext,
+          resolutionNotes: actionData.description,
+        });
+      }
 
       await AuditLogService.log({
         userId: moderatorId,
@@ -737,6 +762,16 @@ class ModerationService {
 
       await transaction.commit();
 
+      // ADS C4-2: notify the reporter that their report has been escalated.
+      if (report.reporterId) {
+        await this.notifyReporterOfResolution({
+          reportId,
+          reporterId: report.reporterId,
+          resolution: 'escalated',
+          resolutionNotes: reason,
+        });
+      }
+
       await AuditLogService.log({
         userId: escalatedBy,
         action: 'REPORT_ESCALATED',
@@ -782,6 +817,14 @@ class ModerationService {
     try {
       let updated = 0;
       const updatedReportIds: string[] = [];
+      // ADS C4-2: collect reporter notification context for resolve / dismiss /
+      // escalate actions. Sent after commit so a notification failure can't
+      // roll back the moderation work.
+      const reporterNotifications: Array<{
+        reportId: string;
+        reporterId: string;
+        resolution: 'resolved' | 'dismissed' | 'escalated';
+      }> = [];
 
       for (const reportId of reportIds) {
         const report = await Report.findByPk(reportId, { transaction });
@@ -813,6 +856,13 @@ class ModerationService {
                 { transaction }
               );
               didUpdate = true;
+              if (report.reporterId) {
+                reporterNotifications.push({
+                  reportId: report.reportId,
+                  reporterId: report.reporterId,
+                  resolution: 'resolved',
+                });
+              }
             }
             break;
 
@@ -837,6 +887,13 @@ class ModerationService {
                 { transaction }
               );
               didUpdate = true;
+              if (report.reporterId) {
+                reporterNotifications.push({
+                  reportId: report.reportId,
+                  reporterId: report.reporterId,
+                  resolution: 'dismissed',
+                });
+              }
             }
             break;
 
@@ -892,6 +949,13 @@ class ModerationService {
                 { transaction }
               );
               didUpdate = true;
+              if (report.reporterId) {
+                reporterNotifications.push({
+                  reportId: report.reportId,
+                  reporterId: report.reporterId,
+                  resolution: 'escalated',
+                });
+              }
             }
             break;
         }
@@ -903,6 +967,16 @@ class ModerationService {
       }
 
       await transaction.commit();
+
+      // ADS C4-2: notify each reporter of their report's outcome. Run after
+      // commit and serially-awaited; createNotification has its own internal
+      // try/catch so one failure won't abort the rest.
+      for (const notif of reporterNotifications) {
+        await this.notifyReporterOfResolution({
+          ...notif,
+          resolutionNotes: action === 'escalate' ? escalationReason : resolutionNotes,
+        });
+      }
 
       // Write one audit log row per affected report so each handled report
       // has a discrete entry, even when actioned via a bulk operation.
@@ -934,6 +1008,55 @@ class ModerationService {
       await transaction.rollback();
       logger.error('Error in bulk update:', error);
       throw error;
+    }
+  }
+
+  /**
+   * ADS C4-2: Notify a reporter that their report reached a resolution
+   * (resolved / dismissed / escalated). Best-effort: failures must not
+   * affect the moderation outcome — the action has already committed.
+   *
+   * We fall back to NotificationType.SYSTEM_ANNOUNCEMENT because the
+   * Postgres ENUM for notification.type cannot grow without a migration
+   * (out of scope for this fix); the `data.reportId` and
+   * `data.resolution` discriminate the moderation context for the UI.
+   */
+  private async notifyReporterOfResolution(params: {
+    reportId: string;
+    reporterId: string;
+    resolution: 'resolved' | 'dismissed' | 'escalated';
+    resolutionNotes?: string;
+  }): Promise<void> {
+    const { reportId, reporterId, resolution, resolutionNotes } = params;
+    const titles: Record<typeof resolution, string> = {
+      resolved: 'Your report was resolved',
+      dismissed: 'Your report was dismissed',
+      escalated: 'Your report was escalated',
+    };
+    const messages: Record<typeof resolution, string> = {
+      resolved: 'A moderator has resolved a report you submitted.',
+      dismissed: 'A moderator reviewed your report and took no further action.',
+      escalated: 'Your report has been escalated for further review.',
+    };
+    try {
+      await NotificationService.createNotification({
+        userId: reporterId,
+        type: NotificationType.SYSTEM_ANNOUNCEMENT,
+        title: titles[resolution],
+        message: messages[resolution],
+        data: {
+          reportId,
+          resolution,
+          ...(resolutionNotes !== undefined ? { resolutionNotes } : {}),
+        },
+      });
+    } catch (error) {
+      logger.warn('Failed to notify reporter of resolution', {
+        reportId,
+        reporterId,
+        resolution,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -7,6 +7,9 @@ import { logger, loggerHelpers } from '../utils/logger';
 import { invalidateAuthCache } from '../lib/auth-cache';
 import { cached, invalidateNamespace } from '../cache/redis-cache';
 import { AuditLogService } from './auditLog.service';
+import { NotificationService } from './notification.service';
+import { NotificationType } from '../models/Notification';
+import { emitToRescue } from '../socket/socket-registry';
 import { validateSortField } from '../utils/sort-validation';
 import { escapeLikePattern } from '../utils/escape-like';
 import { verifyCompaniesHouseNumber } from './companies-house.service';
@@ -664,6 +667,38 @@ export class RescueService {
       );
 
       await transaction.commit();
+
+      // ADS C4-3: notify rescue staff and broadcast a live event to the
+      // rescue:{id} room so an open rescue dashboard can react without
+      // waiting for a poll. Best-effort: failures here must not unwind
+      // the verification itself.
+      try {
+        const staff = await StaffMember.findAll({
+          where: { rescueId, deletedAt: null },
+          attributes: ['userId'],
+        });
+        const recipients = Array.from(new Set(staff.map(s => s.userId)));
+        await Promise.all(
+          recipients.map(userId =>
+            NotificationService.createNotification({
+              userId,
+              type: NotificationType.SYSTEM_ANNOUNCEMENT,
+              title: 'Your rescue has been verified',
+              message: `${rescue.name} is now verified and can publish listings.`,
+              data: { rescueId, event: 'rescue_verified' },
+            })
+          )
+        );
+        emitToRescue(rescueId, 'rescue:verified', {
+          rescueId,
+          verifiedAt: rescue.verifiedAt,
+        });
+      } catch (notifyError) {
+        logger.warn('Failed to notify rescue staff of verification', {
+          rescueId,
+          error: notifyError instanceof Error ? notifyError.message : String(notifyError),
+        });
+      }
 
       logger.info(`Verified rescue: ${rescueId}`);
       return rescue;

--- a/service.backend/src/socket/socket-handlers.ts
+++ b/service.backend/src/socket/socket-handlers.ts
@@ -446,6 +446,11 @@ export class SocketHandlers {
       // a stale token can't keep platform-room access after a demote.
       if (socket.rescueId) {
         socket.join(`analytics:rescue:${socket.rescueId}`);
+        // ADS C4-3 / C4-6: general-purpose rescue room used for non-
+        // analytics events (rescue verification, application list
+        // updates). Kept separate from the analytics room so the
+        // analytics-emitter debounce can't drop fan-out for live data.
+        socket.join(`rescue:${socket.rescueId}`);
       }
       if (socket.role === 'super_admin' || socket.role === 'admin' || socket.role === 'moderator') {
         socket.join('analytics:platform');

--- a/service.backend/src/socket/socket-registry.ts
+++ b/service.backend/src/socket/socket-registry.ts
@@ -117,3 +117,24 @@ export function emitAuthRoleChanged(userId: string): void {
   }
   liveIo.to(`user:${userId}`).emit('auth:role-changed', { at: new Date().toISOString() });
 }
+
+/**
+ * ADS C4-3 / C4-5 / C4-6: thin wrappers around `io.to(room).emit(...)`
+ * so service-layer code can fan out events without having to plumb a
+ * Socket.IO reference or know the room-naming convention. Each is a
+ * no-op when the IO server is not registered, so calling them in
+ * service tests (which don't spin up the WebSocket transport) is safe.
+ */
+export function emitToUser(userId: string, event: string, payload: unknown): void {
+  if (!liveIo) {
+    return;
+  }
+  liveIo.to(`user:${userId}`).emit(event, payload);
+}
+
+export function emitToRescue(rescueId: string, event: string, payload: unknown): void {
+  if (!liveIo) {
+    return;
+  }
+  liveIo.to(`rescue:${rescueId}`).emit(event, payload);
+}


### PR DESCRIPTION
## Summary

C4 of the third UX pass — ships cross-app real-time fan-out and missing notification side-effects without any DB schema changes. Single branch, six commits, one per audit finding.

## Checklist

| Item | Commit |
| --- | --- |
| C4-1: replace unreachable `under_review` status check on ApplicationDashboard | `b4f7c93` |
| C4-2: notify reporter on report resolve / dismiss / escalate | `4ad489c` |
| C4-3: notify rescue staff + emit `rescue:verified` on admin verification | `102e172` |
| C4-4: notify sanctioned user when a moderator action is applied | `aed07fd` |
| C4-5: push `application_status_changed` over Socket.IO (polling kept as fallback) | `a42c2d8` |
| C4-6: live-update rescue application list on create / update | `b554080` |

## Notification types used

The Postgres ENUM on `notifications.type` can't grow without a migration — out of scope for this PR. Every new notification call therefore falls back to the existing `SYSTEM_ANNOUNCEMENT` enum value with a descriptive title and a `data.event` / `data.actionType` / `data.resolution` discriminator the UI can branch on:

- C4-2 reporter notifications — `NotificationType.SYSTEM_ANNOUNCEMENT` (fallback), `data.resolution` in `{'resolved' | 'dismissed' | 'escalated'}`.
- C4-3 rescue verification — `NotificationType.SYSTEM_ANNOUNCEMENT` (fallback), `data.event = 'rescue_verified'`.
- C4-4 sanction notifications — `NotificationType.SYSTEM_ANNOUNCEMENT` (fallback), `data.actionType` carries the ActionType enum value.
- C4-5 / C4-6 are pure socket events; no notification rows.

If the audit calls for dedicated enum values (`MODERATION_REPORT_RESOLVED`, `RESCUE_VERIFIED`, `USER_SANCTIONED`) they can be added in a follow-up enum migration.

## Architecture notes

- New module-level emit helpers in `service.backend/src/socket/socket-registry.ts`: `emitToUser(userId, event, payload)` and `emitToRescue(rescueId, event, payload)`. Each is a no-op when no IO server is registered, mirroring `emitAuthRoleChanged`.
- Rescue staff sockets now also auto-join `rescue:{rescueId}` alongside the existing `analytics:rescue:{rescueId}` room. Kept separate so the analytics debounce can't drop live application / verification events.
- `lib.analytics`'s `useRealtimeAnalytics` EventMap extended with `application_status_changed`, `application_created`, `application_updated`, `rescue:verified` so React consumers get type-safe subscriptions.
- Frontend consumers (`MatchAcknowledgementContext`, `useApplications`) call their existing refetch path on event arrival — no optimistic patching, no React Query restructuring. The 60s polling in `MatchAcknowledgementContext` stays in place as a safety net.

## Held for follow-up (explicitly out of scope per the brief)

- DB schema changes (no new tables / columns / enum values).
- Login-time sanction modal — depends on a sanctions-active endpoint and modal UI work not in this PR; the in-app notification covers ~80% of the C4-4 gap.
- Backfill of unread historical notifications.
- Lamport timestamps / total ordering for chat messages.
- Email template per-role variation.
- Application draft sync to backend.
- Splitting the `under_review` check across `.stage` (in-progress) vs `.status` (terminal) — the frontend Application type schema does not currently expose `stage`, so the C4-1 fix removes the unreachable branch and lights up the existing `withdrawn` status that was silently falling through to the default badge. Adding `stage` to the frontend type would be a wider lib.applications change.

## Test plan

- [ ] CI lint green for service.backend, app.client, app.rescue, app.admin
- [ ] CI tests green for service.backend, app.rescue, app.admin
- [ ] CI tests green for app.client (one pre-existing flake — `distance-sorting.behavior.test.tsx > Manual Location Entry` — passes in isolation; unrelated to this PR)
- [ ] Manual smoke: admin verifies a pending rescue, observe rescue dashboard refresh + in-app notification on staff account
- [ ] Manual smoke: rescue staff approves an application, observe adopter's match modal appearing immediately
- [ ] Manual smoke: adopter submits a new application, observe rescue dashboard list updating live
- [ ] Manual smoke: moderator resolves a report, observe reporter receives an in-app notification
- [ ] Manual smoke: moderator applies a warning, observe sanctioned user receives an in-app notification


---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_