### PR TITLE
fix: mobile + keyboard a11y sweep

### DIFF
--- a/app.admin/src/components/layout/AdminHeader.css.ts
+++ b/app.admin/src/components/layout/AdminHeader.css.ts
@@ -39,7 +39,7 @@ export const searchInput = style({
   fontSize: '0.875rem',
   background: '#f9fafb',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     background: '#ffffff',

--- a/app.admin/src/components/layout/AdminLayout.css.ts
+++ b/app.admin/src/components/layout/AdminLayout.css.ts
@@ -44,29 +44,3 @@ export const layoutFooter = style({
   justifyContent: 'flex-end',
   background: '#ffffff',
 });
-
-export const skipLink = style({
-  position: 'absolute',
-  left: '-9999px',
-  top: 'auto',
-  width: '1px',
-  height: '1px',
-  overflow: 'hidden',
-  zIndex: 9999,
-  selectors: {
-    '&:focus': {
-      left: '0.75rem',
-      top: '0.75rem',
-      width: 'auto',
-      height: 'auto',
-      padding: '0.5rem 0.875rem',
-      background: '#111827',
-      color: '#ffffff',
-      borderRadius: '0.375rem',
-      textDecoration: 'none',
-      fontWeight: 600,
-      outline: '2px solid #fff',
-      outlineOffset: '2px',
-    },
-  },
-});

--- a/app.admin/src/components/layout/AdminLayout.tsx
+++ b/app.admin/src/components/layout/AdminLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SkipLink } from '@adopt-dont-shop/lib.components';
 import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import { AdminSidebar } from './AdminSidebar';
 import { AdminHeader } from './AdminHeader';
@@ -17,9 +18,7 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
 
   return (
     <div className={styles.layoutContainer}>
-      <a href='#main-content' className={styles.skipLink}>
-        Skip to main content
-      </a>
+      <SkipLink />
       <AdminSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
       <main className={styles.mainContent({ sidebarCollapsed })}>
         <AdminHeader sidebarCollapsed={sidebarCollapsed} />

--- a/app.admin/src/components/modals/BulkConfirmationModal.css.ts
+++ b/app.admin/src/components/modals/BulkConfirmationModal.css.ts
@@ -138,7 +138,7 @@ export const textArea = style({
   color: '#111827',
   resize: 'vertical',
   boxSizing: 'border-box',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,

--- a/app.admin/src/components/modals/ChatDetailModal.css.ts
+++ b/app.admin/src/components/modals/ChatDetailModal.css.ts
@@ -393,7 +393,7 @@ export const textArea = style({
   fontFamily: 'inherit',
   resize: 'vertical',
   marginBottom: '1.5rem',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',

--- a/app.admin/src/components/modals/CreateSupportTicketModal.css.ts
+++ b/app.admin/src/components/modals/CreateSupportTicketModal.css.ts
@@ -30,7 +30,7 @@ export const select = style({
   ':hover': {
     borderColor: '#9ca3af',
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
@@ -51,7 +51,7 @@ export const textArea = style({
   ':hover': {
     borderColor: '#9ca3af',
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/components/modals/EditUserModal.css.ts
+++ b/app.admin/src/components/modals/EditUserModal.css.ts
@@ -31,7 +31,7 @@ export const select = style({
   ':hover': {
     borderColor: '#9ca3af',
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,

--- a/app.admin/src/components/modals/RescueDetailModal.css.ts
+++ b/app.admin/src/components/modals/RescueDetailModal.css.ts
@@ -326,7 +326,7 @@ export const input = style({
   fontSize: '0.875rem',
   color: '#111827',
   background: '#ffffff',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/components/modals/RescueDetailModal.css.ts
+++ b/app.admin/src/components/modals/RescueDetailModal.css.ts
@@ -41,8 +41,9 @@ export const closeButton = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '36px',
-  height: '36px',
+  // WCAG 2.5.5 AA: 44x44 minimum touch target.
+  minWidth: '44px',
+  minHeight: '44px',
   border: 'none',
   borderRadius: '8px',
   background: '#f3f4f6',

--- a/app.admin/src/components/modals/RescueDetailModal.touch-target.test.ts
+++ b/app.admin/src/components/modals/RescueDetailModal.touch-target.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+// WCAG 2.5.5 AA recommends 44x44 minimum touch target. This test reads the
+// vanilla-extract source so the constraint is enforced regardless of how the
+// test environment stubs the CSS modules.
+describe('RescueDetailModal close button touch target', () => {
+  it('declares a 44x44 minimum tap area on the close button', () => {
+    const source = readFileSync(path.resolve(__dirname, './RescueDetailModal.css.ts'), 'utf8');
+
+    const closeButtonBlock = source.match(/export const closeButton = style\(\{[\s\S]*?\}\);/);
+    expect(closeButtonBlock).not.toBeNull();
+    const block = closeButtonBlock?.[0] ?? '';
+
+    expect(block).toMatch(/minWidth:\s*['"]44px['"]/);
+    expect(block).toMatch(/minHeight:\s*['"]44px['"]/);
+  });
+});

--- a/app.admin/src/components/modals/RescueVerificationModal.css.ts
+++ b/app.admin/src/components/modals/RescueVerificationModal.css.ts
@@ -100,7 +100,7 @@ export const textArea = style({
   color: '#111827',
   resize: 'vertical',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/components/modals/SendEmailModal.css.ts
+++ b/app.admin/src/components/modals/SendEmailModal.css.ts
@@ -29,7 +29,7 @@ export const textArea = style({
   background: '#ffffff',
   resize: 'vertical',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/components/modals/TicketDetailModal.css.ts
+++ b/app.admin/src/components/modals/TicketDetailModal.css.ts
@@ -192,7 +192,7 @@ export const textArea = style({
   ':hover': {
     borderColor: '#9ca3af',
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/components/modals/UserActionsMenu.css.ts
+++ b/app.admin/src/components/modals/UserActionsMenu.css.ts
@@ -37,7 +37,7 @@ export const reasonTextArea = style({
   ':hover': {
     borderColor: '#9ca3af',
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,

--- a/app.admin/src/components/moderation/ActionSelectionModal.css.ts
+++ b/app.admin/src/components/moderation/ActionSelectionModal.css.ts
@@ -105,7 +105,7 @@ export const select = style({
   background: '#ffffff',
   color: '#111827',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
@@ -124,7 +124,7 @@ export const textArea = style({
   resize: 'vertical',
   fontFamily: 'inherit',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
@@ -140,7 +140,7 @@ export const input = style({
   background: '#ffffff',
   color: '#111827',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#667eea',
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/components/ui/ActionMenu.css.ts
+++ b/app.admin/src/components/ui/ActionMenu.css.ts
@@ -25,7 +25,7 @@ export const triggerButton = style({
     borderColor: '#9ca3af',
     color: '#374151',
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
   },

--- a/app.admin/src/components/ui/ActionMenu.focus-visible.test.ts
+++ b/app.admin/src/components/ui/ActionMenu.focus-visible.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+// Keyboard a11y: outline:none was previously stripping the browser-default
+// focus ring without providing a replacement. We standardised on the
+// :focus-visible pattern so keyboard users still get a visible focus
+// indicator while mouse focus stays clean. This is a representative
+// assertion for the wider sweep across app.admin/app.client/app.rescue
+// css.ts files.
+describe('ActionMenu css honours the :focus-visible focus-ring pattern', () => {
+  it('declares a :focus-visible block on the trigger style', () => {
+    const source = readFileSync(path.resolve(__dirname, './ActionMenu.css.ts'), 'utf8');
+
+    expect(source).toMatch(/':focus-visible'/);
+    expect(source).not.toMatch(/'\:focus'\s*:\s*\{[^{}]*outline:\s*'none'/);
+  });
+});

--- a/app.admin/src/components/ui/FilterPanel.css.ts
+++ b/app.admin/src/components/ui/FilterPanel.css.ts
@@ -83,7 +83,7 @@ export const select = style({
   backgroundRepeat: 'no-repeat',
   backgroundPosition: 'right 0.75rem center',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,
@@ -103,7 +103,7 @@ export const input = style({
   fontSize: '0.875rem',
   color: '#111827',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,

--- a/app.admin/src/components/ui/SharedComponents.css.ts
+++ b/app.admin/src/components/ui/SharedComponents.css.ts
@@ -128,7 +128,7 @@ export const select = style({
   ':hover': {
     borderColor: '#9ca3af',
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,

--- a/app.admin/src/pages/Applications.css.ts
+++ b/app.admin/src/pages/Applications.css.ts
@@ -81,7 +81,7 @@ export const select = style({
   ':hover': {
     borderColor: vars.text.muted,
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/pages/ContentManagement.css.ts
+++ b/app.admin/src/pages/ContentManagement.css.ts
@@ -345,7 +345,7 @@ export const formInput = style({
   border: `1px solid ${vars.border.color.muted}`,
   borderRadius: '8px',
   fontSize: '0.875rem',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.infoHover,
   },
@@ -363,7 +363,7 @@ export const formTextarea = style({
   resize: 'vertical',
   minHeight: '200px',
   fontFamily: 'monospace',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.infoHover,
   },

--- a/app.admin/src/pages/Moderation.css.ts
+++ b/app.admin/src/pages/Moderation.css.ts
@@ -102,7 +102,7 @@ export const select = style({
   ':hover': {
     borderColor: vars.text.muted,
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.info,
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',

--- a/app.admin/src/pages/Pets.css.ts
+++ b/app.admin/src/pages/Pets.css.ts
@@ -81,7 +81,7 @@ export const select = style({
   ':hover': {
     borderColor: vars.text.muted,
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/pages/Rescues.css.ts
+++ b/app.admin/src/pages/Rescues.css.ts
@@ -92,7 +92,7 @@ export const select = style({
   ':hover': {
     borderColor: vars.text.muted,
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/pages/Support.css.ts
+++ b/app.admin/src/pages/Support.css.ts
@@ -121,7 +121,7 @@ export const select = style({
   ':hover': {
     borderColor: vars.text.muted,
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/pages/Users.css.ts
+++ b/app.admin/src/pages/Users.css.ts
@@ -92,7 +92,7 @@ export const select = style({
   ':hover': {
     borderColor: vars.text.muted,
   },
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',

--- a/app.admin/src/setup-tests.ts
+++ b/app.admin/src/setup-tests.ts
@@ -121,6 +121,13 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   DateTime: ({ value }: { value: string }) => React.createElement('span', null, value),
   ConfirmDialog: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', props, children),
+  SkipLink: ({
+    href = '#main-content',
+    children = 'Skip to main content',
+  }: {
+    href?: string;
+    children?: React.ReactNode;
+  }) => React.createElement('a', { href }, children),
   // ADS-585: useConfirm mock returns both `confirm` and `confirmProps` so tests
   // covering pages that spread `confirmProps` into ConfirmDialog don't crash.
   useConfirm: () => ({

--- a/app.client/src/components/ItsAMatchModal.css.ts
+++ b/app.client/src/components/ItsAMatchModal.css.ts
@@ -23,6 +23,9 @@ export const celebration = style({
   animationName: slideUp,
   animationDuration: '0.4s',
   animationTimingFunction: 'ease-out',
+  '@media': {
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
+  },
 });
 
 export const headline = style({
@@ -56,6 +59,9 @@ export const photoFrame = style({
   animationDuration: '2s',
   animationIterationCount: 'infinite',
   animationTimingFunction: 'ease-in-out',
+  '@media': {
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
+  },
 });
 
 export const photo = style({

--- a/app.client/src/components/application/MemberField.css.ts
+++ b/app.client/src/components/application/MemberField.css.ts
@@ -160,6 +160,10 @@ export const ageInput = style({
   ':focus': {
     borderColor: vars.colors.primary,
   },
+  ':focus-visible': {
+    outline: `2px solid ${vars.colors.primary}`,
+    outlineOffset: '2px',
+  },
 });
 
 export const ageInputNarrow = style({
@@ -174,6 +178,10 @@ export const ageInputNarrow = style({
   textAlign: 'center',
   ':focus': {
     borderColor: vars.colors.primary,
+  },
+  ':focus-visible': {
+    outline: `2px solid ${vars.colors.primary}`,
+    outlineOffset: '2px',
   },
 });
 

--- a/app.client/src/components/application/QuestionField.css.ts
+++ b/app.client/src/components/application/QuestionField.css.ts
@@ -34,6 +34,10 @@ const baseInputStyle = {
   boxSizing: 'border-box' as const,
   outline: 'none',
   transition: 'border-color 0.15s',
+  ':focus-visible': {
+    outline: `2px solid ${vars.colors.primary}`,
+    outlineOffset: '2px',
+  },
 };
 
 export const input = recipe({

--- a/app.client/src/components/application/WithdrawApplicationModal.css.ts
+++ b/app.client/src/components/application/WithdrawApplicationModal.css.ts
@@ -38,7 +38,7 @@ export const textArea = style({
   fontFamily: 'inherit',
   fontSize: '0.9rem',
   resize: 'vertical',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,

--- a/app.client/src/components/discovery/DiscoveryPage.css.ts
+++ b/app.client/src/components/discovery/DiscoveryPage.css.ts
@@ -149,12 +149,12 @@ globalStyle(`${filterGroup} input`, {
   fontSize: '0.9rem',
 });
 
-globalStyle(`${filterGroup} select:focus`, {
+globalStyle(`${filterGroup} select:focus-visible`, {
   outline: 'none',
   borderColor: '#4ecdc4',
 });
 
-globalStyle(`${filterGroup} input:focus`, {
+globalStyle(`${filterGroup} input:focus-visible`, {
   outline: 'none',
   borderColor: '#4ecdc4',
 });

--- a/app.client/src/components/layout/AppShell.css.ts
+++ b/app.client/src/components/layout/AppShell.css.ts
@@ -9,29 +9,3 @@ export const shell = style({
 export const main = style({
   flex: '1',
 });
-
-export const skipLink = style({
-  position: 'absolute',
-  left: '-9999px',
-  top: 'auto',
-  width: '1px',
-  height: '1px',
-  overflow: 'hidden',
-  zIndex: 9999,
-  selectors: {
-    '&:focus': {
-      left: '0.75rem',
-      top: '0.75rem',
-      width: 'auto',
-      height: 'auto',
-      padding: '0.5rem 0.875rem',
-      background: '#111827',
-      color: '#ffffff',
-      borderRadius: '0.375rem',
-      textDecoration: 'none',
-      fontWeight: 600,
-      outline: '2px solid #fff',
-      outlineOffset: '2px',
-    },
-  },
-});

--- a/app.client/src/components/layout/AppShell.test.tsx
+++ b/app.client/src/components/layout/AppShell.test.tsx
@@ -83,6 +83,13 @@ describe('AppShell', () => {
     expect(screen.getByTestId('swipe-fab')).toBeInTheDocument();
   });
 
+  it('renders a skip-to-main-content link pointing at the main region', () => {
+    renderShell();
+    const skip = screen.getByRole('link', { name: /skip to main content/i });
+    expect(skip).toHaveAttribute('href', '#main-content');
+    expect(screen.getByRole('main')).toHaveAttribute('id', 'main-content');
+  });
+
   it('clears the stored consent record when the footer "Manage cookies" link is clicked', async () => {
     window.localStorage.setItem(
       COOKIE_CONSENT_STORAGE_KEY,

--- a/app.client/src/components/layout/AppShell.tsx
+++ b/app.client/src/components/layout/AppShell.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
-import { Footer, InstallPwaBanner } from '@adopt-dont-shop/lib.components';
+import { Footer, InstallPwaBanner, SkipLink } from '@adopt-dont-shop/lib.components';
 import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import { AppNavbar } from '@/components/navigation/AppNavbar';
 import { BottomTabBar } from '@/components/navigation/BottomTabBar';
@@ -13,9 +13,7 @@ export const AppShell: React.FC = () => {
 
   return (
     <div className={styles.shell}>
-      <a href='#main-content' className={styles.skipLink}>
-        Skip to main content
-      </a>
+      <SkipLink />
       <header>
         <AppNavbar />
       </header>

--- a/app.client/src/components/notifications/NotificationCenter.css.ts
+++ b/app.client/src/components/notifications/NotificationCenter.css.ts
@@ -47,7 +47,7 @@ export const filterSelect = style({
   background: vars.background.body,
   color: vars.text.primary,
   fontSize: '0.875rem',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
   },

--- a/app.client/src/components/onboarding/SwipeOnboarding.css.ts
+++ b/app.client/src/components/onboarding/SwipeOnboarding.css.ts
@@ -35,6 +35,9 @@ export const overlay = recipe({
     animationName: fadeIn,
     animationDuration: '0.3s',
     animationTimingFunction: 'ease-out',
+    '@media': {
+      '(prefers-reduced-motion: reduce)': { animation: 'none' },
+    },
   },
   variants: {
     show: {
@@ -66,6 +69,7 @@ export const modalContent = style({
       padding: '2rem',
       margin: '1rem',
     },
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
   },
 });
 
@@ -103,6 +107,9 @@ export const swipeIcon = style({
   animationDuration: '3s',
   animationTimingFunction: 'ease-in-out',
   animationIterationCount: 'infinite',
+  '@media': {
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
+  },
 });
 
 export const title = style({

--- a/app.client/src/components/profile/ProfileEditForm.css.ts
+++ b/app.client/src/components/profile/ProfileEditForm.css.ts
@@ -38,7 +38,7 @@ export const select = style({
   background: vars.background.body,
   color: vars.text.primary,
   fontSize: '1rem',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,

--- a/app.client/src/components/profile/SettingsForm.css.ts
+++ b/app.client/src/components/profile/SettingsForm.css.ts
@@ -121,7 +121,7 @@ export const select = style({
   color: vars.text.primary,
   fontSize: '0.875rem',
   minWidth: '150px',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
   },

--- a/app.client/src/components/swipe/SwipeCard.css.ts
+++ b/app.client/src/components/swipe/SwipeCard.css.ts
@@ -80,6 +80,9 @@ export const placeholderIconSpin = style({
   animationDuration: '2s',
   animationTimingFunction: 'linear',
   animationIterationCount: 'infinite',
+  '@media': {
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
+  },
 });
 
 export const placeholderText = style({

--- a/app.client/src/components/swipe/SwipeStack.css.ts
+++ b/app.client/src/components/swipe/SwipeStack.css.ts
@@ -75,5 +75,6 @@ export const skeletonCard = style({
       maxWidth: 'min(92vw, 420px)',
       height: 'min(70vh, 640px)',
     },
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
   },
 });

--- a/app.client/src/components/swipe/SwipeStack.reduced-motion.test.ts
+++ b/app.client/src/components/swipe/SwipeStack.reduced-motion.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+// Vestibular sensitivity: users with prefers-reduced-motion: reduce should
+// not see the infinite shimmer on the swipe skeleton. The CSS stub used in
+// vitest can't compute media-query-aware styles so we assert the source-of-
+// truth contains the guard.
+describe('SwipeStack skeleton card honours prefers-reduced-motion', () => {
+  it('disables the shimmer animation when prefers-reduced-motion is reduce', () => {
+    const source = readFileSync(path.resolve(__dirname, './SwipeStack.css.ts'), 'utf8');
+
+    const skeletonBlock = source.match(/export const skeletonCard = style\(\{[\s\S]*?\}\);/);
+    expect(skeletonBlock).not.toBeNull();
+    const block = skeletonBlock?.[0] ?? '';
+
+    expect(block).toMatch(/'\(prefers-reduced-motion: reduce\)':\s*\{\s*animation:\s*['"]none['"]/);
+  });
+});

--- a/app.client/src/components/ui/SwipeFloatingButton.css.ts
+++ b/app.client/src/components/ui/SwipeFloatingButton.css.ts
@@ -31,6 +31,9 @@ export const floatingContainer = recipe({
     animationName: slideUp,
     animationDuration: '0.5s',
     animationTimingFunction: 'ease-out',
+    // Desktop-only floating CTA. On mobile the "Discover" action is already
+    // surfaced as the first tab in BottomTabBar, so we hide this nudge to
+    // avoid duplication and to keep clear of the bottom nav.
     '@media': {
       '(max-width: 768px)': {
         display: 'none',

--- a/app.client/src/components/ui/SwipeFloatingButton.css.ts
+++ b/app.client/src/components/ui/SwipeFloatingButton.css.ts
@@ -112,15 +112,17 @@ export const calloutBubble = recipe({
 
 export const closeButton = style({
   position: 'absolute',
-  top: '0.5rem',
-  right: '0.5rem',
-  background: 'none',
+  top: '-0.5rem',
+  right: '-0.5rem',
+  background: 'transparent',
   border: 'none',
   color: '#999',
   cursor: 'pointer',
   padding: 0,
-  width: '20px',
-  height: '20px',
+  // WCAG 2.5.5 AA: 44x44 minimum touch target. Visible icon stays small;
+  // tap area is enlarged via min dimensions on a transparent background.
+  minWidth: '44px',
+  minHeight: '44px',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/app.client/src/components/ui/SwipeFloatingButton.css.ts
+++ b/app.client/src/components/ui/SwipeFloatingButton.css.ts
@@ -38,6 +38,7 @@ export const floatingContainer = recipe({
       '(max-width: 768px)': {
         display: 'none',
       },
+      '(prefers-reduced-motion: reduce)': { animation: 'none' },
     },
   },
   variants: {
@@ -81,6 +82,7 @@ export const calloutBubbleBase = style({
       maxWidth: '160px',
       padding: '0.875rem 1.25rem',
     },
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
   },
 });
 
@@ -161,6 +163,7 @@ export const floatingButton = style({
       width: '56px',
       height: '56px',
     },
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
   },
 });
 

--- a/app.client/src/components/ui/SwipeFloatingButton.touch-target.test.ts
+++ b/app.client/src/components/ui/SwipeFloatingButton.touch-target.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+// WCAG 2.5.5 AA recommends 44x44 minimum touch target. This test reads the
+// vanilla-extract source so the constraint is enforced regardless of how the
+// test environment stubs the CSS modules.
+describe('SwipeFloatingButton close button touch target', () => {
+  it('declares a 44x44 minimum tap area on the close button', () => {
+    const source = readFileSync(path.resolve(__dirname, './SwipeFloatingButton.css.ts'), 'utf8');
+
+    const closeButtonBlock = source.match(/export const closeButton = style\(\{[\s\S]*?\}\);/);
+    expect(closeButtonBlock).not.toBeNull();
+    const block = closeButtonBlock?.[0] ?? '';
+
+    expect(block).toMatch(/minWidth:\s*['"]44px['"]/);
+    expect(block).toMatch(/minHeight:\s*['"]44px['"]/);
+  });
+});

--- a/app.client/src/setup-tests.ts
+++ b/app.client/src/setup-tests.ts
@@ -165,6 +165,13 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   }: React.ComponentPropsWithoutRef<'footer'> & { extraLinks?: React.ReactNode }) =>
     React.createElement('footer', props, children, extraLinks),
   InstallPwaBanner: () => null,
+  SkipLink: ({
+    href = '#main-content',
+    children = 'Skip to main content',
+  }: {
+    href?: string;
+    children?: React.ReactNode;
+  }) => React.createElement('a', { href }, children),
   TextInput: ({
     label,
     id,

--- a/app.rescue/src/components/ApplicationTimeline.css.ts
+++ b/app.rescue/src/components/ApplicationTimeline.css.ts
@@ -134,7 +134,7 @@ export const noteInput = style({
   borderRadius: '0.375rem',
   fontSize: '0.875rem',
   resize: 'vertical',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',
@@ -146,7 +146,7 @@ export const noteTypeSelect = style({
   border: '1px solid #d1d5db',
   borderRadius: '0.375rem',
   fontSize: '0.875rem',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',

--- a/app.rescue/src/components/analytics/DateRangePicker.css.ts
+++ b/app.rescue/src/components/analytics/DateRangePicker.css.ts
@@ -123,7 +123,7 @@ export const dateInput = style({
   fontSize: '0.875rem',
   color: vars.text.primary,
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: vars.colors.primary,
     boxShadow: `0 0 0 3px ${vars.colors.primaryBgSubtle}`,

--- a/app.rescue/src/components/applications/ApplicationFilters.css.ts
+++ b/app.rescue/src/components/applications/ApplicationFilters.css.ts
@@ -52,7 +52,7 @@ export const filterInput = style({
   fontSize: '0.875rem',
   fontFamily: 'inherit',
   background: 'white',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',
@@ -67,7 +67,7 @@ export const filterSelect = style({
   fontSize: '0.875rem',
   fontFamily: 'inherit',
   background: 'white',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',

--- a/app.rescue/src/components/applications/ApplicationReview.css.ts
+++ b/app.rescue/src/components/applications/ApplicationReview.css.ts
@@ -422,7 +422,7 @@ export const formSelect = style({
   fontSize: '0.875rem',
   background: 'white',
   transition: 'border-color 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',
@@ -440,7 +440,7 @@ export const formTextarea = style({
   fontFamily: 'inherit',
   transition: 'border-color 0.2s ease',
   boxSizing: 'border-box',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',
@@ -595,7 +595,7 @@ export const select = style({
   borderRadius: '0.375rem',
   fontSize: '0.875rem',
   background: 'white',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',
@@ -611,7 +611,7 @@ export const textArea = style({
   resize: 'vertical',
   minHeight: '100px',
   boxSizing: 'border-box',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',
@@ -698,7 +698,7 @@ export const statusSelect = style({
   borderRadius: '0.375rem',
   background: 'white',
   marginBottom: '0.5rem',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 2px rgba(59, 130, 246, 0.1)',
@@ -715,7 +715,7 @@ export const notesInput = style({
   minHeight: '80px',
   margin: '0.5rem 0',
   boxSizing: 'border-box',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 2px rgba(59, 130, 246, 0.1)',
@@ -770,7 +770,7 @@ export const formInput = style({
   background: 'white',
   transition: 'border-color 0.2s ease',
   boxSizing: 'border-box',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',

--- a/app.rescue/src/components/applications/StageTransitionModal.css.ts
+++ b/app.rescue/src/components/applications/StageTransitionModal.css.ts
@@ -83,7 +83,7 @@ export const textArea = style({
   resize: 'vertical',
   minHeight: '100px',
   boxSizing: 'border-box',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',

--- a/app.rescue/src/components/events/EventDetails.css.ts
+++ b/app.rescue/src/components/events/EventDetails.css.ts
@@ -155,7 +155,7 @@ export const statusSelect = style({
   background: 'white',
   cursor: 'pointer',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
   },

--- a/app.rescue/src/components/events/EventFilters.css.ts
+++ b/app.rescue/src/components/events/EventFilters.css.ts
@@ -42,7 +42,7 @@ export const select = style({
   color: '#111827',
   cursor: 'pointer',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px #dbeafe',
@@ -60,7 +60,7 @@ export const searchInput = style({
   background: 'white',
   color: '#111827',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px #dbeafe',
@@ -86,7 +86,7 @@ export const viewButton = recipe({
     fontWeight: '500',
     cursor: 'pointer',
     transition: 'all 0.2s ease',
-    ':focus': {
+    ':focus-visible': {
       outline: 'none',
       boxShadow: '0 0 0 3px #dbeafe',
     },

--- a/app.rescue/src/components/events/EventForm.css.ts
+++ b/app.rescue/src/components/events/EventForm.css.ts
@@ -40,7 +40,7 @@ export const input = style({
   borderRadius: '8px',
   fontSize: '0.875rem',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px #dbeafe',
@@ -56,7 +56,7 @@ export const textArea = style({
   resize: 'vertical',
   fontFamily: 'inherit',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px #dbeafe',
@@ -71,7 +71,7 @@ export const select = style({
   background: 'white',
   cursor: 'pointer',
   transition: 'all 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px #dbeafe',
@@ -119,7 +119,7 @@ export const button = recipe({
     fontWeight: '500',
     cursor: 'pointer',
     transition: 'all 0.2s ease',
-    ':focus': {
+    ':focus-visible': {
       outline: 'none',
       boxShadow: '0 0 0 3px #dbeafe',
     },

--- a/app.rescue/src/components/pets/PetFormModal.test.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.test.tsx
@@ -464,6 +464,64 @@ describe('PetFormModal — image upload field (ADS-574)', () => {
     expect(submitted.images).toEqual(['/uploads/pets/pets_b.png', '/uploads/pets/pets_a.png']);
   });
 
+  it('exposes keyboard-accessible Move up / Move down controls that reorder images', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
+    const uploadImage = vi
+      .fn<(file: File) => Promise<ImageUploadResponse>>()
+      .mockResolvedValueOnce(makeUploadResponse('a'))
+      .mockResolvedValueOnce(makeUploadResponse('b'))
+      .mockResolvedValueOnce(makeUploadResponse('c'));
+
+    renderWithProviders(
+      <PetFormModal
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={onSubmit}
+        uploadImage={uploadImage}
+      />
+    );
+
+    await fillRequiredFields(user);
+
+    const fileInput = screen.getByLabelText(/add pet photos/i);
+    await act(async () => {
+      fireEvent.change(fileInput, {
+        target: {
+          files: [makeImageFile('a.png'), makeImageFile('b.png'), makeImageFile('c.png')],
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(uploadImage).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /move down: a\.png/i })).toBeEnabled();
+    });
+
+    // Click "Move down" on the first photo — a.png moves to index 1, b.png
+    // moves to index 0 (becoming the cover).
+    await user.click(screen.getByRole('button', { name: /move down: a\.png/i }));
+
+    // After the move the aria-labels reflect the new positions: the first
+    // row can no longer move up; the last row can no longer move down.
+    expect(screen.getByRole('button', { name: /move up: b\.png/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /move down: c\.png/i })).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: /add pet/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.images).toEqual([
+      '/uploads/pets/pets_b.png',
+      '/uploads/pets/pets_a.png',
+      '/uploads/pets/pets_c.png',
+    ]);
+  });
+
   it('refuses to add more files once the max count is reached', async () => {
     const onSubmit = vi.fn((_data: SubmitArg) => Promise.resolve());
     const uploadImage = vi

--- a/app.rescue/src/components/pets/PetFormModal.tsx
+++ b/app.rescue/src/components/pets/PetFormModal.tsx
@@ -655,6 +655,24 @@ const PetFormModal: React.FC<PetFormModalProps> = ({
                           >
                             Make primary
                           </button>
+                          {/* Keyboard-accessible reorder controls — the drag handlers
+                              above are mouse-only, so AT users need explicit buttons. */}
+                          <button
+                            type="button"
+                            onClick={() => reorderImages(index, index - 1)}
+                            disabled={index === 0 || img.status !== 'uploaded'}
+                            aria-label={`Move up: ${img.filename}`}
+                          >
+                            Move up
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => reorderImages(index, index + 1)}
+                            disabled={index === images.length - 1 || img.status !== 'uploaded'}
+                            aria-label={`Move down: ${img.filename}`}
+                          >
+                            Move down
+                          </button>
                           <button
                             type="button"
                             onClick={() => removeImage(img.localId)}

--- a/app.rescue/src/components/rescue/AdoptionPolicyForm.css.ts
+++ b/app.rescue/src/components/rescue/AdoptionPolicyForm.css.ts
@@ -55,7 +55,7 @@ export const listItemInput = style({
   borderRadius: '0.5rem',
   fontSize: '0.875rem',
   transition: 'border-color 0.2s',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 3px rgba(59, 130, 246, 0.1)',

--- a/app.rescue/src/components/rescue/NotificationPreferencesForm.css.ts
+++ b/app.rescue/src/components/rescue/NotificationPreferencesForm.css.ts
@@ -174,7 +174,7 @@ export const timeInput = style({
   color: '#111827',
   background: '#ffffff',
   boxSizing: 'border-box',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 2px rgba(59, 130, 246, 0.2)',
@@ -190,7 +190,7 @@ export const select = style({
   color: '#111827',
   background: '#ffffff',
   boxSizing: 'border-box',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 2px rgba(59, 130, 246, 0.2)',

--- a/app.rescue/src/components/rescue/QuestionsBuilder.css.ts
+++ b/app.rescue/src/components/rescue/QuestionsBuilder.css.ts
@@ -206,7 +206,7 @@ export const input = style({
   fontSize: '0.875rem',
   color: '#1f2937',
   outline: 'none',
-  ':focus': {
+  ':focus-visible': {
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 2px rgba(59, 130, 246, 0.2)',
   },
@@ -221,7 +221,7 @@ export const textArea = style({
   outline: 'none',
   resize: 'vertical',
   minHeight: '80px',
-  ':focus': {
+  ':focus-visible': {
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 2px rgba(59, 130, 246, 0.2)',
   },
@@ -235,7 +235,7 @@ export const select = style({
   color: '#1f2937',
   outline: 'none',
   background: 'white',
-  ':focus': {
+  ':focus-visible': {
     borderColor: '#3b82f6',
     boxShadow: '0 0 0 2px rgba(59, 130, 246, 0.2)',
   },

--- a/app.rescue/src/components/shared/Layout.css.ts
+++ b/app.rescue/src/components/shared/Layout.css.ts
@@ -31,29 +31,3 @@ export const layoutFooter = style({
   justifyContent: 'flex-end',
   background: vars.background.surface,
 });
-
-export const skipLink = style({
-  position: 'absolute',
-  left: '-9999px',
-  top: 'auto',
-  width: '1px',
-  height: '1px',
-  overflow: 'hidden',
-  zIndex: 9999,
-  selectors: {
-    '&:focus': {
-      left: '0.75rem',
-      top: '0.75rem',
-      width: 'auto',
-      height: 'auto',
-      padding: '0.5rem 0.875rem',
-      background: vars.text.primary,
-      color: vars.background.body,
-      borderRadius: '0.375rem',
-      textDecoration: 'none',
-      fontWeight: 600,
-      outline: `2px solid ${vars.background.body}`,
-      outlineOffset: '2px',
-    },
-  },
-});

--- a/app.rescue/src/components/shared/Layout.tsx
+++ b/app.rescue/src/components/shared/Layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InstallPwaBanner } from '@adopt-dont-shop/lib.components';
+import { InstallPwaBanner, SkipLink } from '@adopt-dont-shop/lib.components';
 import { ManageCookiesLink } from '@adopt-dont-shop/lib.legal';
 import Navigation from './Navigation';
 import * as styles from './Layout.css';
@@ -11,9 +11,7 @@ interface LayoutProps {
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
     <div className={styles.appLayout}>
-      <a href="#main-content" className={styles.skipLink}>
-        Skip to main content
-      </a>
+      <SkipLink />
       <Navigation />
       <div className={styles.mainColumn}>
         <main id="main-content" className={styles.mainContent} tabIndex={-1}>

--- a/app.rescue/src/components/staff/InviteStaffModal.css.ts
+++ b/app.rescue/src/components/staff/InviteStaffModal.css.ts
@@ -90,7 +90,7 @@ export const formInput = recipe({
     fontSize: '1rem',
     transition: 'border-color 0.2s ease',
     boxSizing: 'border-box',
-    ':focus': {
+    ':focus-visible': {
       outline: 'none',
     },
     ':disabled': {

--- a/app.rescue/src/components/staff/StaffForm.css.ts
+++ b/app.rescue/src/components/staff/StaffForm.css.ts
@@ -90,7 +90,7 @@ export const formInput = recipe({
     fontSize: '1rem',
     transition: 'border-color 0.2s ease',
     boxSizing: 'border-box',
-    ':focus': {
+    ':focus-visible': {
       outline: 'none',
     },
     ':disabled': {

--- a/app.rescue/src/components/staff/StaffList.css.ts
+++ b/app.rescue/src/components/staff/StaffList.css.ts
@@ -37,7 +37,7 @@ export const searchInput = style({
   borderRadius: '8px',
   fontSize: '1rem',
   transition: 'border-color 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#1976d2',
   },
@@ -49,7 +49,7 @@ export const filterSelect = style({
   borderRadius: '8px',
   fontSize: '1rem',
   transition: 'border-color 0.2s ease',
-  ':focus': {
+  ':focus-visible': {
     outline: 'none',
     borderColor: '#1976d2',
   },

--- a/app.rescue/src/pages/AcceptInvitation.css.ts
+++ b/app.rescue/src/pages/AcceptInvitation.css.ts
@@ -93,7 +93,7 @@ export const formInput = style({
   transition: 'border-color 0.2s ease',
   boxSizing: 'border-box',
   selectors: {
-    '&:focus': {
+    '&:focus-visible': {
       outline: 'none',
       borderColor: vars.colors.primary,
     },
@@ -107,7 +107,7 @@ export const formInput = style({
 export const formInputError = style({
   borderColor: vars.colors.dangerHover,
   selectors: {
-    '&:focus': {
+    '&:focus-visible': {
       outline: 'none',
       borderColor: vars.colors.dangerHover,
     },

--- a/app.rescue/src/pages/Analytics.css.ts
+++ b/app.rescue/src/pages/Analytics.css.ts
@@ -73,7 +73,7 @@ export const filterSelect = style({
     '&:hover': {
       borderColor: vars.colors.info,
     },
-    '&:focus': {
+    '&:focus-visible': {
       outline: 'none',
       borderColor: vars.colors.info,
       boxShadow: `0 0 0 3px ${vars.colors.infoBgSubtle}`,

--- a/app.rescue/src/pages/Events.css.ts
+++ b/app.rescue/src/pages/Events.css.ts
@@ -74,7 +74,7 @@ export const primaryButton = style({
     '&:active': {
       transform: 'translateY(0)',
     },
-    '&:focus': {
+    '&:focus-visible': {
       outline: 'none',
       boxShadow: `0 0 0 3px ${vars.colors.infoBgSubtle}`,
     },

--- a/app.rescue/src/setup-tests.ts
+++ b/app.rescue/src/setup-tests.ts
@@ -195,6 +195,13 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
         )
       : null,
   InstallPwaBanner: () => null,
+  SkipLink: ({
+    href = '#main-content',
+    children = 'Skip to main content',
+  }: {
+    href?: string;
+    children?: React.ReactNode;
+  }) => React.createElement('a', { href }, children),
   toast: Object.assign(vi.fn(), {
     success: vi.fn(),
     error: vi.fn(),

--- a/lib.components/src/components/form/SelectInput/SelectInput.css.ts
+++ b/lib.components/src/components/form/SelectInput/SelectInput.css.ts
@@ -204,6 +204,9 @@ export const content = style({
       animationName: slideRightAndFade,
     },
   },
+  '@media': {
+    '(prefers-reduced-motion: reduce)': { animation: 'none' },
+  },
 });
 
 export const viewport = style({

--- a/lib.components/src/components/ui/SkipLink.css.ts
+++ b/lib.components/src/components/ui/SkipLink.css.ts
@@ -1,0 +1,30 @@
+import { style } from '@vanilla-extract/css';
+
+// Visually hidden until focused. The :focus reveal pattern is repeated across
+// all three apps; consolidated here so the keyboard-only skip-to-main link
+// behaves consistently.
+export const skipLink = style({
+  position: 'absolute',
+  left: '-9999px',
+  top: 'auto',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden',
+  zIndex: 9999,
+  selectors: {
+    '&:focus': {
+      left: '0.75rem',
+      top: '0.75rem',
+      width: 'auto',
+      height: 'auto',
+      padding: '0.5rem 0.875rem',
+      background: '#111827',
+      color: '#ffffff',
+      borderRadius: '0.375rem',
+      textDecoration: 'none',
+      fontWeight: 600,
+      outline: '2px solid #ffffff',
+      outlineOffset: '2px',
+    },
+  },
+});

--- a/lib.components/src/components/ui/SkipLink.test.tsx
+++ b/lib.components/src/components/ui/SkipLink.test.tsx
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { SkipLink } from './SkipLink';
+
+describe('SkipLink', () => {
+  it('renders an anchor pointing to the main content region by default', () => {
+    render(<SkipLink />);
+    const link = screen.getByRole('link', { name: /skip to main content/i });
+    expect(link).toHaveAttribute('href', '#main-content');
+  });
+
+  it('respects a custom href and label', () => {
+    render(<SkipLink href='#search-results'>Skip to results</SkipLink>);
+    const link = screen.getByRole('link', { name: /skip to results/i });
+    expect(link).toHaveAttribute('href', '#search-results');
+  });
+
+  it('declares a visually-hidden base style that reveals on :focus', () => {
+    // jsdom does not run CSS so we assert the styling intent via the source.
+    const source = readFileSync(path.resolve(__dirname, './SkipLink.css.ts'), 'utf8');
+
+    // Off-screen by default.
+    expect(source).toMatch(/left:\s*['"]-9999px['"]/);
+    // Revealed inside the viewport when focused.
+    expect(source).toMatch(/'&:focus':\s*\{[\s\S]*left:\s*['"]0\.75rem['"]/);
+  });
+});

--- a/lib.components/src/components/ui/SkipLink.tsx
+++ b/lib.components/src/components/ui/SkipLink.tsx
@@ -1,0 +1,27 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import * as styles from './SkipLink.css';
+
+export type SkipLinkProps = {
+  /** Anchor target id of the main content area. Defaults to "main-content". */
+  href?: string;
+  /** Link label. Defaults to "Skip to main content". */
+  children?: React.ReactNode;
+  className?: string;
+};
+
+/**
+ * Visually hidden link that becomes visible when focused via keyboard. Lets
+ * keyboard and screen reader users bypass the navigation chrome and jump
+ * straight to the main content region.
+ */
+export const SkipLink = ({
+  href = '#main-content',
+  children = 'Skip to main content',
+  className,
+}: SkipLinkProps) => (
+  <a href={href} className={clsx(styles.skipLink, className)}>
+    {children}
+  </a>
+);

--- a/lib.components/src/index.ts
+++ b/lib.components/src/index.ts
@@ -155,3 +155,7 @@ export type { ProgressiveImageProps } from './components/ui/ProgressiveImage';
 // PWA install prompt
 export { InstallPwaBanner } from './components/ui/InstallPwaBanner';
 export type { InstallPwaBannerProps } from './components/ui/InstallPwaBanner';
+
+// A11y primitives
+export { SkipLink } from './components/ui/SkipLink';
+export type { SkipLinkProps } from './components/ui/SkipLink';


### PR DESCRIPTION
## Summary

C3 of the third UX pass — mobile and keyboard a11y polish.

This PR ships six items: tap-target enlargement on two close buttons, a documented decision on the desktop-only floating CTA, an outline:none → :focus-visible sweep across all three apps, a keyboard fallback for the pet-image drag-reorder, a shared SkipLink primitive consolidating three local duplicates, and a prefers-reduced-motion guard on the highest-traffic animation hotspots.

## Items

- [x] **C3-1** Enlarge close buttons to 44x44 — `1f6bb9a`
- [x] **C3-2** Document desktop-only floating Discover CTA — `b44f5e9`
  - The mobile audit assumed the action was unreachable; in fact `BottomTabBar` already surfaces `/discover` as the first tab on every viewport. The floating UI is now explicitly desktop-only with a code comment; no new mobile variant was added because it would duplicate the existing bottom-tab destination.
- [x] **C3-3** `outline: none` → `:focus-visible` sweep — `ddc9c06`
  - **45 of 47 sites covered.** The two deferred files (`app.client/src/components/navigation/NavUserMenu.css.ts` and `app.client/src/components/swipe/SwipeCard.css.ts`) already shipped `:focus-visible` counterparts in earlier work, so per the brief's discipline they were skipped.
- [x] **C3-4** Keyboard fallback for pet-image reorder — `e32a457`
- [x] **C3-5** Shared SkipLink primitive — `8f1a3bc`
  - All three apps already shipped a local skip-to-main-content link. Consolidated into `lib.components/SkipLink` and replaced the three inline implementations.
- [x] **C3-6** Honour prefers-reduced-motion on hotspots — `7390f84`
  - **11 of ~14 motion hotspots covered.** Most `lib.components` animations (Alert, Modal, Spinner, ProgressBar, Toast, Table, Button) were already guarded in earlier work; `SelectInput` was the one remaining lib animation. The swipe stack shimmer, swipe card placeholder spinner, floating button bounce/pulse/slideUp, swipe onboarding overlay/modal/icon, and the ItsAMatchModal celebration + photoFrame pulse are now all guarded. Subtle hover-transition micro-animations (<200ms) were intentionally deferred per the brief's "skip subtle hover transitions" guidance.

## Test plan

- [x] `npx turbo lint test --filter=@adopt-dont-shop/lib.components --filter=@adopt-dont-shop/app.client --filter=@adopt-dont-shop/app.rescue --filter=@adopt-dont-shop/app.admin`
- [ ] Manual: tab through each app's root layout and verify the skip-link reveals and jumps to `#main-content`.
- [ ] Manual: open a pet edit modal and use Move up/Move down to reorder photos via the keyboard.
- [ ] Manual: set `prefers-reduced-motion: reduce` and verify swipe stack shimmer, ItsAMatchModal pulse and SwipeOnboarding icon no longer animate.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_