### PR TITLE
fix(auth): forms hardening — autocomplete, 2FA regex, session expiry, invitation context

### DIFF
--- a/app.client/src/pages/ForgotPasswordPage.test.tsx
+++ b/app.client/src/pages/ForgotPasswordPage.test.tsx
@@ -73,3 +73,27 @@ describe('ForgotPasswordPage enumeration-resistant response handling [C2-6]', ()
     ).not.toBeInTheDocument();
   });
 });
+
+describe('ForgotPasswordPage async error announcement [C2-7]', () => {
+  const submitForm = async () => {
+    const user = userEvent.setup();
+    render(<ForgotPasswordPage />);
+    await user.type(screen.getByPlaceholderText(/enter your email/i), 'user@example.com');
+    await user.click(screen.getByRole('button', { name: /send reset instructions/i }));
+  };
+
+  beforeEach(() => {
+    forgotPasswordMock.mockReset();
+  });
+
+  it('exposes the 5xx error in a role="alert" live region', async () => {
+    const err = new Error('boom') as Error & { response: { status: number } };
+    err.response = { status: 500 };
+    forgotPasswordMock.mockRejectedValueOnce(err);
+
+    await submitForm();
+
+    const alert = await waitFor(() => screen.getByRole('alert'));
+    expect(alert).toHaveTextContent(/server error/i);
+  });
+});

--- a/app.client/src/pages/ForgotPasswordPage.test.tsx
+++ b/app.client/src/pages/ForgotPasswordPage.test.tsx
@@ -1,0 +1,19 @@
+import { vi, describe, it, expect } from 'vitest';
+import { render, screen } from '@/test-utils/render';
+import { ForgotPasswordPage } from './ForgotPasswordPage';
+
+vi.mock('@/services', () => ({
+  authService: {
+    forgotPassword: vi.fn(),
+  },
+}));
+
+describe('ForgotPasswordPage autocomplete attributes', () => {
+  it('marks the email field as email so managers fill the saved address', () => {
+    render(<ForgotPasswordPage />);
+
+    const emailInput = screen.getByPlaceholderText(/enter your email/i);
+
+    expect(emailInput).toHaveAttribute('autocomplete', 'email');
+  });
+});

--- a/app.client/src/pages/ForgotPasswordPage.test.tsx
+++ b/app.client/src/pages/ForgotPasswordPage.test.tsx
@@ -1,10 +1,13 @@
-import { vi, describe, it, expect } from 'vitest';
-import { render, screen } from '@/test-utils/render';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@/test-utils/render';
 import { ForgotPasswordPage } from './ForgotPasswordPage';
+
+const forgotPasswordMock = vi.fn();
 
 vi.mock('@/services', () => ({
   authService: {
-    forgotPassword: vi.fn(),
+    forgotPassword: (email: string) => forgotPasswordMock(email),
   },
 }));
 
@@ -15,5 +18,58 @@ describe('ForgotPasswordPage autocomplete attributes', () => {
     const emailInput = screen.getByPlaceholderText(/enter your email/i);
 
     expect(emailInput).toHaveAttribute('autocomplete', 'email');
+  });
+});
+
+// C2-6: enumeration-proofing — every 4xx (including 429) must look
+// identical to a 200 so an attacker can't time-correlate response
+// flavour with "this email exists". Only genuine 5xx outages get a
+// distinct error.
+describe('ForgotPasswordPage enumeration-resistant response handling [C2-6]', () => {
+  const submitForm = async () => {
+    const user = userEvent.setup();
+    render(<ForgotPasswordPage />);
+    await user.type(screen.getByPlaceholderText(/enter your email/i), 'user@example.com');
+    await user.click(screen.getByRole('button', { name: /send reset instructions/i }));
+  };
+
+  const errorWithStatus = (status: number): Error & { response: { status: number } } => {
+    const err = new Error('boom') as Error & { response: { status: number } };
+    err.response = { status };
+    return err;
+  };
+
+  beforeEach(() => {
+    forgotPasswordMock.mockReset();
+  });
+
+  it.each([
+    ['200 success', () => Promise.resolve()],
+    ['400 bad request', () => Promise.reject(errorWithStatus(400))],
+    ['404 not found', () => Promise.reject(errorWithStatus(404))],
+    ['429 rate limited', () => Promise.reject(errorWithStatus(429))],
+  ])('shows the generic success screen on %s', async (_label, factory) => {
+    forgotPasswordMock.mockImplementationOnce(factory);
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 2, name: /check your email/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows a generic try-again-later error on 5xx', async () => {
+    forgotPasswordMock.mockRejectedValueOnce(errorWithStatus(500));
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText(/server error\. please try again later/i)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole('heading', { level: 2, name: /check your email/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/app.client/src/pages/ForgotPasswordPage.tsx
+++ b/app.client/src/pages/ForgotPasswordPage.tsx
@@ -128,6 +128,7 @@ export const ForgotPasswordPage: React.FC = () => {
               placeholder='Enter your email'
               error={errors.email?.message}
               autoFocus
+              autoComplete='email'
               {...register('email')}
             />
           </div>

--- a/app.client/src/pages/ForgotPasswordPage.tsx
+++ b/app.client/src/pages/ForgotPasswordPage.tsx
@@ -58,16 +58,16 @@ export const ForgotPasswordPage: React.FC = () => {
         error_message: err instanceof Error ? err.message : 'Unknown error',
       });
 
-      // For security, still show success even on error (don't reveal if email exists)
-      // However, if there's a rate limit or server error, we should show that
-      const error = err as Error & { response?: { status?: number; data?: { message?: string } } };
+      // C2-6: never differentiate 200 / 4xx in the UI — even a distinct
+      // 429 response would let an attacker time-correlate "this email
+      // hit the rate limit" with "this email exists". Show the same
+      // success screen on every response except a genuine 5xx outage,
+      // where there's nothing to enumerate.
+      const error = err as Error & { response?: { status?: number } };
 
-      if (error.response?.status === 429) {
-        setError('Too many requests. Please try again later.');
-      } else if (error.response?.status && error.response.status >= 500) {
+      if (error.response?.status && error.response.status >= 500) {
         setError('Server error. Please try again later.');
       } else {
-        // Don't reveal whether email exists - show success
         setSubmittedEmail(data.email);
         setIsSuccess(true);
       }

--- a/app.client/src/pages/ResetPasswordPage.test.tsx
+++ b/app.client/src/pages/ResetPasswordPage.test.tsx
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { render } from '@/test-utils/render';
+import { render, screen } from '@/test-utils/render';
 import { ResetPasswordPage } from './ResetPasswordPage';
 
 vi.mock('@/services', () => ({
@@ -35,5 +35,20 @@ describe('ResetPasswordPage autocomplete attributes', () => {
     passwordInputs.forEach(input => {
       expect(input).toHaveAttribute('autocomplete', 'new-password');
     });
+  });
+});
+
+describe('ResetPasswordPage submit-gate before token validation [C2-3]', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+  });
+
+  it('renders the submit button disabled when no token is in the URL', () => {
+    searchParamsValue = new URLSearchParams('');
+
+    render(<ResetPasswordPage />);
+
+    const submit = screen.getByRole('button', { name: /reset password/i });
+    expect(submit).toBeDisabled();
   });
 });

--- a/app.client/src/pages/ResetPasswordPage.test.tsx
+++ b/app.client/src/pages/ResetPasswordPage.test.tsx
@@ -1,0 +1,39 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@/test-utils/render';
+import { ResetPasswordPage } from './ResetPasswordPage';
+
+vi.mock('@/services', () => ({
+  authService: {
+    resetPassword: vi.fn(),
+  },
+}));
+
+let searchParamsValue = new URLSearchParams('?token=token-123');
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useSearchParams: () => [searchParamsValue, vi.fn()] as const,
+  };
+});
+
+describe('ResetPasswordPage autocomplete attributes', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    searchParamsValue = new URLSearchParams('?token=token-123');
+  });
+
+  it('marks both password fields as new-password so managers prompt to save', () => {
+    const { container } = render(<ResetPasswordPage />);
+
+    const passwordInputs = container.querySelectorAll('input[type="password"]');
+
+    expect(passwordInputs.length).toBe(2);
+    passwordInputs.forEach(input => {
+      expect(input).toHaveAttribute('autocomplete', 'new-password');
+    });
+  });
+});

--- a/app.client/src/pages/ResetPasswordPage.test.tsx
+++ b/app.client/src/pages/ResetPasswordPage.test.tsx
@@ -52,3 +52,18 @@ describe('ResetPasswordPage submit-gate before token validation [C2-3]', () => {
     expect(submit).toBeDisabled();
   });
 });
+
+describe('ResetPasswordPage async error announcement [C2-7]', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+  });
+
+  it('exposes the missing-token error in a role="alert" live region on mount', async () => {
+    searchParamsValue = new URLSearchParams('');
+
+    render(<ResetPasswordPage />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/invalid or missing reset token/i);
+  });
+});

--- a/app.client/src/pages/ResetPasswordPage.tsx
+++ b/app.client/src/pages/ResetPasswordPage.tsx
@@ -170,6 +170,7 @@ export const ResetPasswordPage: React.FC = () => {
               error={errors.password?.message}
               autoFocus
               disabled={!token}
+              autoComplete='new-password'
               {...register('password')}
             />
             <div className={styles.passwordRequirements}>
@@ -191,6 +192,7 @@ export const ResetPasswordPage: React.FC = () => {
               placeholder='Confirm new password'
               error={errors.confirmPassword?.message}
               disabled={!token}
+              autoComplete='new-password'
               {...register('confirmPassword')}
             />
           </div>

--- a/app.client/src/pages/ResetPasswordPage.tsx
+++ b/app.client/src/pages/ResetPasswordPage.tsx
@@ -32,6 +32,12 @@ export const ResetPasswordPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
   const [redirectCountdown, setRedirectCountdown] = useState(5);
+  // C2-3: keep the submit disabled until the mount-time token check has
+  // finished. Defaulting to `true` means Enter-to-submit before the
+  // useEffect runs can't fire off a request against a missing/invalid
+  // token; we only flip this to `false` once we've confirmed a token is
+  // present in the URL.
+  const [tokenValidated, setTokenValidated] = useState(false);
   const navigate = useNavigate();
   const { logEvent } = useStatsig();
 
@@ -50,7 +56,10 @@ export const ResetPasswordPage: React.FC = () => {
     if (!token) {
       setError('Invalid or missing reset token. Please request a new password reset link.');
       logEvent('password_reset_token_missing', 1, {});
+      return;
     }
+
+    setTokenValidated(true);
   }, [token, logEvent]);
 
   // Countdown and redirect after successful password reset
@@ -201,7 +210,7 @@ export const ResetPasswordPage: React.FC = () => {
             type='submit'
             size='lg'
             variant='primary'
-            disabled={isLoading || !token}
+            disabled={isLoading || !tokenValidated}
             isFullWidth
           >
             {isLoading ? 'Resetting Password...' : 'Reset Password'}

--- a/app.client/src/pages/VerifyEmailPage.test.tsx
+++ b/app.client/src/pages/VerifyEmailPage.test.tsx
@@ -1,6 +1,6 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { render } from '@/test-utils/render';
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { VerifyEmailPage } from './VerifyEmailPage';
 
 const verifyEmailMock = vi.fn();
@@ -65,5 +65,22 @@ describe('VerifyEmailPage [ADS-375]', () => {
     vi.useRealTimers();
 
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('VerifyEmailPage async error announcement [C2-7]', () => {
+  beforeEach(() => {
+    verifyEmailMock.mockReset();
+    navigateMock.mockReset();
+    searchParamsValue = new URLSearchParams('?token=token-bad');
+  });
+
+  it('exposes the verification failure in a role="alert" live region', async () => {
+    verifyEmailMock.mockRejectedValueOnce(new Error('Verification token is malformed'));
+
+    render(<VerifyEmailPage />);
+
+    const alert = await waitFor(() => screen.getByRole('alert'));
+    expect(alert).toHaveTextContent(/verification token is malformed/i);
   });
 });

--- a/app.rescue/src/pages/AcceptInvitation.test.tsx
+++ b/app.rescue/src/pages/AcceptInvitation.test.tsx
@@ -1,0 +1,57 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, waitFor, screen } from '../test-utils';
+import AcceptInvitation from './AcceptInvitation';
+
+const getInvitationDetailsMock = vi.fn();
+
+vi.mock('../services/libraryServices', () => ({
+  invitationService: {
+    getInvitationDetails: (token: string) => getInvitationDetailsMock(token),
+    acceptInvitation: vi.fn(),
+  },
+}));
+
+let searchParamsValue = new URLSearchParams('?token=token-123');
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useSearchParams: () => [searchParamsValue, vi.fn()] as const,
+  };
+});
+
+describe('AcceptInvitation autocomplete attributes', () => {
+  beforeEach(() => {
+    getInvitationDetailsMock.mockReset();
+    searchParamsValue = new URLSearchParams('?token=token-123');
+  });
+
+  it('annotates name and password fields so password managers fill them', async () => {
+    getInvitationDetailsMock.mockResolvedValue({ email: 'invitee@example.com' });
+
+    renderWithProviders(<AcceptInvitation />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/enter your first name/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByPlaceholderText(/enter your first name/i)).toHaveAttribute(
+      'autocomplete',
+      'given-name'
+    );
+    expect(screen.getByPlaceholderText(/enter your last name/i)).toHaveAttribute(
+      'autocomplete',
+      'family-name'
+    );
+    expect(screen.getByPlaceholderText(/create a secure password/i)).toHaveAttribute(
+      'autocomplete',
+      'new-password'
+    );
+    expect(screen.getByPlaceholderText(/re-enter your password/i)).toHaveAttribute(
+      'autocomplete',
+      'new-password'
+    );
+  });
+});

--- a/app.rescue/src/pages/AcceptInvitation.test.tsx
+++ b/app.rescue/src/pages/AcceptInvitation.test.tsx
@@ -93,3 +93,20 @@ describe('AcceptInvitation invitation context [C2-4]', () => {
     expect(screen.getByText(/invited to join a rescue organization/i)).toBeInTheDocument();
   });
 });
+
+describe('AcceptInvitation async error announcement [C2-7]', () => {
+  beforeEach(() => {
+    getInvitationDetailsMock.mockReset();
+    searchParamsValue = new URLSearchParams('?token=bad-token');
+  });
+
+  it('exposes the load failure in a role="alert" live region', async () => {
+    getInvitationDetailsMock.mockRejectedValue(new Error('boom'));
+
+    renderWithProviders(<AcceptInvitation />);
+
+    const alert = await waitFor(() => screen.getByRole('alert'));
+    expect(alert).toHaveTextContent(/failed to load invitation details/i);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+  });
+});

--- a/app.rescue/src/pages/AcceptInvitation.test.tsx
+++ b/app.rescue/src/pages/AcceptInvitation.test.tsx
@@ -55,3 +55,41 @@ describe('AcceptInvitation autocomplete attributes', () => {
     );
   });
 });
+
+describe('AcceptInvitation invitation context [C2-4]', () => {
+  beforeEach(() => {
+    getInvitationDetailsMock.mockReset();
+    searchParamsValue = new URLSearchParams('?token=token-123');
+  });
+
+  it('shows the inviter, rescue, and role when the backend returns them', async () => {
+    getInvitationDetailsMock.mockResolvedValue({
+      email: 'invitee@example.com',
+      rescueName: 'Happy Tails Rescue',
+      invitedByName: 'Jane Doe',
+      role: 'Volunteer Coordinator',
+    });
+
+    renderWithProviders(<AcceptInvitation />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/enter your first name/i)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/invited by Jane Doe to join Happy Tails Rescue as Volunteer Coordinator/i)
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the generic copy when the backend omits the new fields', async () => {
+    getInvitationDetailsMock.mockResolvedValue({ email: 'invitee@example.com' });
+
+    renderWithProviders(<AcceptInvitation />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/enter your first name/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/invited to join a rescue organization/i)).toBeInTheDocument();
+  });
+});

--- a/app.rescue/src/pages/AcceptInvitation.tsx
+++ b/app.rescue/src/pages/AcceptInvitation.tsx
@@ -198,7 +198,7 @@ const AcceptInvitation: React.FC = () => {
             <p>Unable to process invitation</p>
           </div>
           <div className={styles.cardBody}>
-            <div className={styles.errorContainer}>
+            <div className={styles.errorContainer} role="alert" aria-live="assertive">
               <h3>⚠️ Error</h3>
               <p>{error}</p>
             </div>
@@ -244,7 +244,7 @@ const AcceptInvitation: React.FC = () => {
           </div>
 
           {error && (
-            <div className={styles.errorContainer}>
+            <div className={styles.errorContainer} role="alert" aria-live="assertive">
               <h3>⚠️ Error</h3>
               <p>{error}</p>
             </div>

--- a/app.rescue/src/pages/AcceptInvitation.tsx
+++ b/app.rescue/src/pages/AcceptInvitation.tsx
@@ -22,6 +22,9 @@ const AcceptInvitation: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [invitationEmail, setInvitationEmail] = useState<string>('');
+  const [rescueName, setRescueName] = useState<string | null>(null);
+  const [invitedByName, setInvitedByName] = useState<string | null>(null);
+  const [role, setRole] = useState<string | null>(null);
 
   const [formData, setFormData] = useState<AcceptInvitationFormData>({
     firstName: '',
@@ -45,6 +48,9 @@ const AcceptInvitation: React.FC = () => {
         const details = await invitationService.getInvitationDetails(token);
         if (details) {
           setInvitationEmail(details.email);
+          setRescueName(details.rescueName ?? null);
+          setInvitedByName(details.invitedByName ?? null);
+          setRole(details.role ?? null);
         } else {
           setError('Invitation not found or has expired.');
         }
@@ -218,7 +224,21 @@ const AcceptInvitation: React.FC = () => {
         <div className={styles.cardBody}>
           <div className={styles.invitationInfo}>
             <p>
-              <strong>You've been invited to join a rescue organization</strong>
+              <strong>
+                {invitedByName && rescueName ? (
+                  <>
+                    You've been invited by {invitedByName} to join {rescueName}
+                    {role ? <> as {role}</> : null}
+                  </>
+                ) : rescueName ? (
+                  <>
+                    You've been invited to join {rescueName}
+                    {role ? <> as {role}</> : null}
+                  </>
+                ) : (
+                  <>You've been invited to join a rescue organization</>
+                )}
+              </strong>
               You're registering with: {invitationEmail}
             </p>
           </div>

--- a/app.rescue/src/pages/AcceptInvitation.tsx
+++ b/app.rescue/src/pages/AcceptInvitation.tsx
@@ -245,6 +245,7 @@ const AcceptInvitation: React.FC = () => {
                 disabled={submitting}
                 required
                 autoFocus
+                autoComplete="given-name"
               />
               {errors.firstName && <span className={styles.formError}>{errors.firstName}</span>}
             </div>
@@ -262,6 +263,7 @@ const AcceptInvitation: React.FC = () => {
                 placeholder="Enter your last name"
                 disabled={submitting}
                 required
+                autoComplete="family-name"
               />
               {errors.lastName && <span className={styles.formError}>{errors.lastName}</span>}
             </div>
@@ -279,6 +281,7 @@ const AcceptInvitation: React.FC = () => {
                 placeholder="Create a secure password"
                 disabled={submitting}
                 required
+                autoComplete="new-password"
               />
               {errors.password && <span className={styles.formError}>{errors.password}</span>}
               <small className={styles.passwordHint}>Must be at least 8 characters</small>
@@ -297,6 +300,7 @@ const AcceptInvitation: React.FC = () => {
                 placeholder="Re-enter your password"
                 disabled={submitting}
                 required
+                autoComplete="new-password"
               />
               {errors.confirmPassword && (
                 <span className={styles.formError}>{errors.confirmPassword}</span>

--- a/lib.auth/src/__mocks__/vanilla-extract-css.ts
+++ b/lib.auth/src/__mocks__/vanilla-extract-css.ts
@@ -1,0 +1,31 @@
+/**
+ * Vitest stub for @vanilla-extract/css. VE's style() / createTheme() etc.
+ * require a build-time file scope that doesn't exist in jsdom — these
+ * stubs return empty strings (or empty objects) so imports from *.css.ts
+ * files resolve without errors during tests.
+ */
+
+export const style = () => '';
+export const styleVariants = (map: Record<string, unknown>) =>
+  Object.fromEntries(Object.keys(map).map((k) => [k, '']));
+export const globalStyle = () => undefined;
+export const keyframes = () => '';
+export const createVar = () => '';
+export const fallbackVar = () => '';
+export const createTheme = () => ['', {}] as const;
+export const createThemeContract = (contract: unknown): unknown => {
+  if (contract && typeof contract === 'object') {
+    const walk = (input: Record<string, unknown>): Record<string, unknown> =>
+      Object.fromEntries(
+        Object.entries(input).map(([k, v]) => [
+          k,
+          v && typeof v === 'object' ? walk(v as Record<string, unknown>) : '',
+        ])
+      );
+    return walk(contract as Record<string, unknown>);
+  }
+  return {};
+};
+export const createGlobalTheme = () => ({});
+export const assignVars = () => ({});
+export const recipe = () => () => '';

--- a/lib.auth/src/components/LoginForm.test.tsx
+++ b/lib.auth/src/components/LoginForm.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AuthContext, type AuthContextType } from '../contexts/AuthContext';
 import { LoginForm } from './LoginForm';
 
-const buildAuthValue = (): AuthContextType => ({
+const buildAuthValue = (overrides: Partial<AuthContextType> = {}): AuthContextType => ({
   user: null,
   isAuthenticated: false,
   isLoading: false,
@@ -13,11 +14,12 @@ const buildAuthValue = (): AuthContextType => ({
   logout: vi.fn(),
   updateProfile: vi.fn(),
   refreshUser: vi.fn(),
+  ...overrides,
 });
 
-const renderLoginForm = () =>
+const renderLoginForm = (value: AuthContextType = buildAuthValue()) =>
   render(
-    <AuthContext.Provider value={buildAuthValue()}>
+    <AuthContext.Provider value={value}>
       <LoginForm />
     </AuthContext.Provider>
   );
@@ -37,5 +39,40 @@ describe('LoginForm autocomplete attributes', () => {
     const passwordInput = screen.getByPlaceholderText(/enter your password/i);
 
     expect(passwordInput).toHaveAttribute('autocomplete', 'current-password');
+  });
+});
+
+describe('LoginForm 2FA token field [C2-2]', () => {
+  // Step into the 2FA state by stubbing login to throw the well-known
+  // "two-factor required" error the form keys on, then exercise the
+  // hex backup-code path. The 16-char hex codes the backend issues must
+  // survive a paste without being truncated to 8 chars.
+  const enter2faMode = async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue(new Error('Two-factor authentication code required'));
+
+    renderLoginForm(buildAuthValue({ login }));
+
+    await user.type(screen.getByPlaceholderText(/enter your email/i), 'a@b.com');
+    await user.type(screen.getByPlaceholderText(/enter your password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('000000')).toBeInTheDocument();
+    });
+
+    return { user };
+  };
+
+  it('preserves the full 16-char hex backup code the user pastes', async () => {
+    const { user } = await enter2faMode();
+
+    const token = screen.getByPlaceholderText('000000');
+    const backupCode = '0123456789abcdef';
+
+    await user.click(token);
+    await user.paste(backupCode);
+
+    expect(token).toHaveValue(backupCode);
   });
 });

--- a/lib.auth/src/components/LoginForm.test.tsx
+++ b/lib.auth/src/components/LoginForm.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AuthContext, type AuthContextType } from '../contexts/AuthContext';
+import { LoginForm } from './LoginForm';
+
+const buildAuthValue = (): AuthContextType => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  updateProfile: vi.fn(),
+  refreshUser: vi.fn(),
+});
+
+const renderLoginForm = () =>
+  render(
+    <AuthContext.Provider value={buildAuthValue()}>
+      <LoginForm />
+    </AuthContext.Provider>
+  );
+
+describe('LoginForm autocomplete attributes', () => {
+  it('marks the email field as the username for password managers', () => {
+    renderLoginForm();
+
+    const emailInput = screen.getByPlaceholderText(/enter your email/i);
+
+    expect(emailInput).toHaveAttribute('autocomplete', 'username');
+  });
+
+  it('marks the password field as the current password so managers fill it', () => {
+    renderLoginForm();
+
+    const passwordInput = screen.getByPlaceholderText(/enter your password/i);
+
+    expect(passwordInput).toHaveAttribute('autocomplete', 'current-password');
+  });
+});

--- a/lib.auth/src/components/LoginForm.test.tsx
+++ b/lib.auth/src/components/LoginForm.test.tsx
@@ -76,3 +76,20 @@ describe('LoginForm 2FA token field [C2-2]', () => {
     expect(token).toHaveValue(backupCode);
   });
 });
+
+describe('LoginForm async error announcement [C2-7]', () => {
+  it('exposes the form-level error in a role="alert" live region', async () => {
+    const user = userEvent.setup();
+    const login = vi.fn().mockRejectedValue(new Error('Invalid email or password.'));
+
+    renderLoginForm(buildAuthValue({ login }));
+
+    await user.type(screen.getByPlaceholderText(/enter your email/i), 'a@b.com');
+    await user.type(screen.getByPlaceholderText(/enter your password/i), 'wrong');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    const alert = await waitFor(() => screen.getByRole('alert'));
+    expect(alert).toHaveTextContent(/invalid email or password/i);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+  });
+});

--- a/lib.auth/src/components/LoginForm.tsx
+++ b/lib.auth/src/components/LoginForm.tsx
@@ -132,6 +132,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
                 value={formData.email}
                 onChange={handleChange}
                 error={fieldErrors.email}
+                autoComplete="username"
                 required
               />
             </div>
@@ -145,6 +146,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
                 value={formData.password}
                 onChange={handleChange}
                 error={fieldErrors.password}
+                autoComplete="current-password"
                 required
               />
               {showForgotPassword && onForgotPassword && (
@@ -180,6 +182,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
               placeholder="000000"
               value={twoFactorToken}
               onChange={(e) => setTwoFactorToken(e.target.value.replace(/[^a-fA-F0-9]/g, ''))}
+              autoComplete="one-time-code"
               autoFocus
             />
             <button className={styles.backLink} type="button" onClick={handleBack}>

--- a/lib.auth/src/components/LoginForm.tsx
+++ b/lib.auth/src/components/LoginForm.tsx
@@ -178,10 +178,10 @@ export const LoginForm: React.FC<LoginFormProps> = ({
               className={styles.tokenInput}
               type="text"
               inputMode="numeric"
-              maxLength={8}
+              maxLength={16}
               placeholder="000000"
               value={twoFactorToken}
-              onChange={(e) => setTwoFactorToken(e.target.value.replace(/[^a-fA-F0-9]/g, ''))}
+              onChange={(e) => setTwoFactorToken(e.target.value.replace(/[^a-zA-Z0-9]/g, ''))}
               autoComplete="one-time-code"
               autoFocus
             />

--- a/lib.auth/src/components/RegisterForm.test.tsx
+++ b/lib.auth/src/components/RegisterForm.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AuthContext, type AuthContextType } from '../contexts/AuthContext';
+import { RegisterForm } from './RegisterForm';
+
+const buildAuthValue = (): AuthContextType => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  updateProfile: vi.fn(),
+  refreshUser: vi.fn(),
+});
+
+const renderRegisterForm = (requirePhoneNumber = false) =>
+  render(
+    <AuthContext.Provider value={buildAuthValue()}>
+      <RegisterForm requirePhoneNumber={requirePhoneNumber} />
+    </AuthContext.Provider>
+  );
+
+describe('RegisterForm autocomplete attributes', () => {
+  it('marks the name fields with given-name and family-name', () => {
+    renderRegisterForm();
+
+    expect(screen.getByPlaceholderText(/enter your first name/i)).toHaveAttribute(
+      'autocomplete',
+      'given-name'
+    );
+    expect(screen.getByPlaceholderText(/enter your last name/i)).toHaveAttribute(
+      'autocomplete',
+      'family-name'
+    );
+  });
+
+  it('marks the email field as email', () => {
+    renderRegisterForm();
+
+    expect(screen.getByPlaceholderText(/enter your email/i)).toHaveAttribute(
+      'autocomplete',
+      'email'
+    );
+  });
+
+  it('marks the phone number field as tel when present', () => {
+    renderRegisterForm(true);
+
+    expect(screen.getByPlaceholderText(/\(555\) 123-4567/)).toHaveAttribute('autocomplete', 'tel');
+  });
+
+  it('marks both password fields as new-password so managers prompt to save', () => {
+    renderRegisterForm();
+
+    expect(screen.getByPlaceholderText(/create a strong password/i)).toHaveAttribute(
+      'autocomplete',
+      'new-password'
+    );
+    expect(screen.getByPlaceholderText(/confirm your password/i)).toHaveAttribute(
+      'autocomplete',
+      'new-password'
+    );
+  });
+});

--- a/lib.auth/src/components/RegisterForm.test.tsx
+++ b/lib.auth/src/components/RegisterForm.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AuthContext, type AuthContextType } from '../contexts/AuthContext';
 import { RegisterForm } from './RegisterForm';
 
-const buildAuthValue = (): AuthContextType => ({
+const buildAuthValue = (overrides: Partial<AuthContextType> = {}): AuthContextType => ({
   user: null,
   isAuthenticated: false,
   isLoading: false,
@@ -13,11 +14,15 @@ const buildAuthValue = (): AuthContextType => ({
   logout: vi.fn(),
   updateProfile: vi.fn(),
   refreshUser: vi.fn(),
+  ...overrides,
 });
 
-const renderRegisterForm = (requirePhoneNumber = false) =>
+const renderRegisterForm = (
+  requirePhoneNumber = false,
+  value: AuthContextType = buildAuthValue()
+) =>
   render(
-    <AuthContext.Provider value={buildAuthValue()}>
+    <AuthContext.Provider value={value}>
       <RegisterForm requirePhoneNumber={requirePhoneNumber} />
     </AuthContext.Provider>
   );
@@ -62,5 +67,31 @@ describe('RegisterForm autocomplete attributes', () => {
       'autocomplete',
       'new-password'
     );
+  });
+});
+
+describe('RegisterForm async error announcement [C2-7]', () => {
+  it('exposes the form-level error in a role="alert" live region', async () => {
+    const user = userEvent.setup();
+    const registerMock = vi.fn().mockRejectedValue(new Error('Email already in use.'));
+
+    renderRegisterForm(true, buildAuthValue({ register: registerMock }));
+
+    await user.type(screen.getByPlaceholderText(/enter your first name/i), 'Ada');
+    await user.type(screen.getByPlaceholderText(/enter your last name/i), 'Lovelace');
+    await user.type(screen.getByPlaceholderText(/enter your email/i), 'ada@example.com');
+    await user.type(screen.getByPlaceholderText(/\(555\) 123-4567/), '5551234567');
+    await user.type(screen.getByPlaceholderText(/create a strong password/i), 'Password1!');
+    await user.type(screen.getByPlaceholderText(/confirm your password/i), 'Password1!');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalled();
+    });
+
+    const alert = await waitFor(() => screen.getByRole('alert'));
+    expect(alert).toHaveTextContent(/email already in use/i);
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
   });
 });

--- a/lib.auth/src/components/RegisterForm.tsx
+++ b/lib.auth/src/components/RegisterForm.tsx
@@ -147,6 +147,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
               value={formData.firstName}
               onChange={handleChange}
               error={fieldErrors.firstName}
+              autoComplete="given-name"
               required
             />
           </div>
@@ -158,6 +159,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
               value={formData.lastName}
               onChange={handleChange}
               error={fieldErrors.lastName}
+              autoComplete="family-name"
               required
             />
           </div>
@@ -172,6 +174,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
             value={formData.email}
             onChange={handleChange}
             error={fieldErrors.email}
+            autoComplete="email"
             required
           />
         </div>
@@ -186,6 +189,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
               value={formData.phoneNumber}
               onChange={handleChange}
               error={fieldErrors.phoneNumber}
+              autoComplete="tel"
               required={requirePhoneNumber}
             />
           </div>
@@ -201,6 +205,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
             onChange={handleChange}
             error={fieldErrors.password}
             variant={allRequirementsMet ? 'success' : 'default'}
+            autoComplete="new-password"
             required
           />
           {formData.password && !allRequirementsMet && (
@@ -234,6 +239,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
             value={formData.confirmPassword}
             onChange={handleChange}
             error={fieldErrors.confirmPassword}
+            autoComplete="new-password"
             required
           />
         </div>

--- a/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/lib.auth/src/contexts/AuthContext.test.tsx
@@ -37,6 +37,13 @@ vi.mock('@adopt-dont-shop/lib.api', () => ({
   },
 }));
 
+// C2-5: stub the toast bridge so the session-expired notification is
+// observable without dragging in sonner's real toast machinery.
+const mockToastError = vi.hoisted(() => vi.fn());
+vi.mock('@adopt-dont-shop/lib.components', () => ({
+  toast: { error: mockToastError },
+}));
+
 // Imported AFTER vi.mock so the mocks are wired in.
 import { AuthProvider } from './AuthContext';
 import { useAuth } from '../hooks/useAuth';
@@ -454,5 +461,81 @@ describe('AuthProvider cross-tab logout synchronization', () => {
 
     expect(states[states.length - 1]?.userId).toBe(adopterUser.userId);
     expect(mockAuthService.clearTokens).not.toHaveBeenCalled();
+  });
+});
+
+// C2-5: surface a toast when a 401 fires for an authenticated user so
+// the session-expired redirect doesn't appear to come out of nowhere.
+describe('AuthProvider session-expiry toast [C2-5]', () => {
+  beforeEach(() => {
+    mockAuthService.getCurrentUser.mockReturnValue(adopterUser);
+    mockAuthService.isAuthenticated.mockReturnValue(true);
+    mockAuthService.getProfile.mockResolvedValue(adopterUser);
+    mockAuthService.clearTokens.mockReset();
+    mockToastError.mockClear();
+    window.localStorage.clear();
+  });
+
+  // Grab the latest onUnauthorized callback the provider registered.
+  const getOnUnauthorized = (): (() => void) | undefined => {
+    const updateConfigMock = vi.mocked(mockedApiService.updateConfig);
+    for (let i = updateConfigMock.mock.calls.length - 1; i >= 0; i--) {
+      const arg = updateConfigMock.mock.calls[i][0];
+      if (arg && typeof arg.onUnauthorized === 'function') {
+        return arg.onUnauthorized;
+      }
+    }
+    return undefined;
+  };
+
+  it('shows the session-expired toast when a 401 fires for a signed-in user', async () => {
+    const states: Array<User | null> = [];
+
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <AuthProbe onState={(u) => states.push(u)} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(states[states.length - 1]?.userId).toBe(adopterUser.userId);
+    });
+
+    const onUnauthorized = getOnUnauthorized();
+    expect(onUnauthorized).toBeDefined();
+
+    await act(async () => {
+      onUnauthorized?.();
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith('Your session has expired. Please log in again.');
+    expect(mockAuthService.clearTokens).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(states[states.length - 1]).toBeNull();
+    });
+  });
+
+  it('does not show the toast when a 401 fires before the user is signed in', async () => {
+    mockAuthService.getCurrentUser.mockReturnValue(null);
+    mockAuthService.isAuthenticated.mockReturnValue(false);
+    mockAuthService.getProfile.mockResolvedValue(null);
+
+    render(
+      <AuthProvider allowedUserTypes={ALLOWED_ADOPTER} appType="client">
+        <></>
+      </AuthProvider>
+    );
+
+    // Wait for the rehydrate effect (which would set user) to finish.
+    await waitFor(() => {
+      expect(getOnUnauthorized()).toBeDefined();
+    });
+
+    const onUnauthorized = getOnUnauthorized();
+    await act(async () => {
+      onUnauthorized?.();
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 });

--- a/lib.auth/src/contexts/AuthContext.tsx
+++ b/lib.auth/src/contexts/AuthContext.tsx
@@ -1,7 +1,10 @@
-import React, { createContext, ReactNode, useEffect, useState } from 'react';
+import React, { createContext, ReactNode, useEffect, useRef, useState } from 'react';
 import { apiService } from '@adopt-dont-shop/lib.api';
+import { toast } from '@adopt-dont-shop/lib.components';
 import { authService } from '../services/auth-service';
 import { LoginRequest, RegisterRequest, User, STORAGE_KEYS } from '../types';
+
+const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please log in again.';
 
 export interface AuthContextType {
   user: User | null;
@@ -59,6 +62,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
 }) => {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  // C2-5: keep the latest user reference accessible inside the stable
+  // onUnauthorized callback registered with apiService. We only want
+  // to surface the session-expired toast for users who were actually
+  // signed in — a 401 returned to the login form is "bad credentials",
+  // not session expiry, and that flow shows its own error.
+  const sessionUserRef = useRef<User | null>(null);
+  useEffect(() => {
+    sessionUserRef.current = user;
+  }, [user]);
 
   // Fire a single post-authentication signal so consuming apps can run
   // session-scoped setup (e.g. initialize notifications) for both fresh
@@ -142,6 +154,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   useEffect(() => {
     apiService.updateConfig({
       onUnauthorized: () => {
+        // C2-5: only surface the toast when the user was actually
+        // signed in (using the ref so the latest value is read inside
+        // this stable callback). Showing the toast on the unauthed
+        // login screen would be confusing — the cause there is bad
+        // credentials, not session expiry.
+        if (sessionUserRef.current) {
+          toast.error(SESSION_EXPIRED_MESSAGE);
+        }
         authService.clearTokens();
         setUser(null);
       },

--- a/lib.auth/vitest.config.ts
+++ b/lib.auth/vitest.config.ts
@@ -14,9 +14,21 @@ export default mergeConfig(
     resolve: {
       alias: {
         '@adopt-dont-shop/lib.api': path.resolve(__dirname, '../lib.api/src/index.ts'),
+        '@adopt-dont-shop/lib.components/theme': path.resolve(
+          __dirname,
+          '../lib.components/src/styles/theme.css.ts'
+        ),
         '@adopt-dont-shop/lib.components': path.resolve(
           __dirname,
           '../lib.components/src/index.ts'
+        ),
+        // VE's style() / createThemeContract() need a build-time file
+        // scope that doesn't exist in jsdom; stub it so the
+        // lib.components source can be imported in component tests.
+        '@vanilla-extract/css': path.resolve(__dirname, './src/__mocks__/vanilla-extract-css.ts'),
+        '@vanilla-extract/recipes': path.resolve(
+          __dirname,
+          './src/__mocks__/vanilla-extract-css.ts'
         ),
       },
     },

--- a/lib.components/src/components/ui/Alert.test.tsx
+++ b/lib.components/src/components/ui/Alert.test.tsx
@@ -64,4 +64,23 @@ describe('Alert', () => {
       expect(alert).toBeInTheDocument();
     });
   });
+
+  // C2-7: explicit aria-live keeps screen readers reliably announcing
+  // async errors/warnings when they appear; success/info stay polite
+  // so they don't interrupt the user mid-task.
+  it('announces error and warning variants assertively', () => {
+    const { rerender } = renderWithTheme(<Alert variant='error'>Async error</Alert>);
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+
+    rerender(<Alert variant='warning'>Watch out</Alert>);
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('announces success and info variants politely', () => {
+    const { rerender } = renderWithTheme(<Alert variant='success'>Saved</Alert>);
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'polite');
+
+    rerender(<Alert variant='info'>Heads up</Alert>);
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'polite');
+  });
 });

--- a/lib.components/src/components/ui/Alert.tsx
+++ b/lib.components/src/components/ui/Alert.tsx
@@ -86,10 +86,19 @@ export const Alert: React.FC<AlertProps> = ({
 }) => {
   const displayIcon = icon ?? (showIcon ? defaultIcons[variant] : null);
 
+  // C2-7: explicit aria-live so screen readers announce async error /
+  // warning alerts when they appear (the role="alert" default is
+  // sufficient on most engines but a handful of AT/browser pairings
+  // miss the announcement without the explicit attribute). 'polite'
+  // for success/info so they don't interrupt the user mid-task.
+  const ariaLive: 'assertive' | 'polite' =
+    variant === 'error' || variant === 'warning' ? 'assertive' : 'polite';
+
   return (
     <div
       className={clsx(styles.alertContainer({ variant, size }), className)}
       role='alert'
+      aria-live={ariaLive}
       data-testid={dataTestId}
     >
       {displayIcon && (

--- a/lib.invitations/src/types/index.ts
+++ b/lib.invitations/src/types/index.ts
@@ -38,10 +38,18 @@ export interface InvitationPayload {
 
 /**
  * Invitation details (public - no auth)
+ *
+ * C2-4: `rescueName`, `invitedByName`, and `role` are surfaced so the
+ * AcceptInvitation page can give the invitee context about who invited
+ * them and where to. All three are optional to remain backward-
+ * compatible with older backend deployments that don't return them.
  */
 export interface InvitationDetails {
   email: string;
   expiresAt: string;
+  rescueName?: string | null;
+  invitedByName?: string | null;
+  role?: string | null;
 }
 
 /**

--- a/service.backend/src/routes/invitation.routes.ts
+++ b/service.backend/src/routes/invitation.routes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { body, param, validationResult } from 'express-validator';
 import { sensitiveWriteLimiter } from '../middleware/rate-limiter';
 import { InvitationService } from '../services/invitation.service';
+import User from '../models/User';
 import { logger } from '../utils/logger';
 
 const router = Router();
@@ -109,11 +110,36 @@ router.get(
         });
       }
 
+      // C2-4: surface rescue / inviter / role so the AcceptInvitation
+      // page can show the invitee who invited them and where to. The
+      // `rescue` is an eager-loaded include on the service side; the
+      // `invited_by` column stores a userId with no association on
+      // that FK, so we resolve the name with a separate lookup.
+      const invitationWithRescue = invitation as typeof invitation & {
+        rescue?: { name?: string | null } | null;
+      };
+      const rescueName = invitationWithRescue.rescue?.name ?? null;
+
+      let invitedByName: string | null = null;
+      if (invitation.invited_by) {
+        const inviter = await User.findOne({
+          where: { userId: invitation.invited_by },
+          attributes: ['firstName', 'lastName'],
+        });
+        if (inviter) {
+          const fullName = `${inviter.firstName} ${inviter.lastName}`.trim();
+          invitedByName = fullName.length > 0 ? fullName : null;
+        }
+      }
+
       res.json({
         success: true,
         invitation: {
           email: invitation.email,
           expiresAt: invitation.expiration,
+          rescueName,
+          invitedByName,
+          role: invitation.title ?? null,
         },
       });
     } catch (error) {

--- a/service.backend/src/services/invitation.service.ts
+++ b/service.backend/src/services/invitation.service.ts
@@ -23,6 +23,14 @@ export class InvitationService {
           used: false,
           expiration: { [Op.gt]: new Date() },
         },
+        include: [
+          {
+            model: Rescue,
+            as: 'rescue',
+            attributes: ['rescueId', 'name'],
+            required: false,
+          },
+        ],
       });
 
       return invitation;


### PR DESCRIPTION
## Summary

C2 of the third UX pass — hardening of auth + onboarding forms across `lib.auth`, `app.client`, and `app.rescue`. Seven items, one commit each.

Originally the agent shipping this hit a session limit before pushing; I (continuation Claude) reviewed the work in the worktree, finished C2-7's last commit, ran the lint+test gate, and opened this PR.

## Checklist

- [x] **C2-1** `autocomplete` attrs on all sensitive auth inputs — `819bb99`
- [x] **C2-2** widen 2FA backup-code regex + `maxLength` (was hex-only, dropped valid alphanumeric codes silently) — `2b80d7e`
- [x] **C2-3** gate `ResetPasswordPage` submit until token validation completes — `d9ca6f1`
- [x] **C2-4** `AcceptInvitation` shows inviter, rescue name, and offered role before account creation — `11388a8`
- [x] **C2-5** surface a "Session expired" toast on 401 instead of silent redirect — `820c072`
- [x] **C2-6** uniform `ForgotPassword` response across 4xx (close the rate-limit enumeration hint) — `a10c2be`
- [x] **C2-7** async error states use `role="alert"` + explicit `aria-live` — `1ae46ad`

## Held for follow-up (explicitly out of scope per the brief)

- 2FA auto-advance on 6 digits.
- "Copy all backup codes" button.
- Shared `PasswordInput` primitive with show/hide toggle.

## Verification

`npx turbo lint test --filter=@adopt-dont-shop/lib.components --filter=@adopt-dont-shop/lib.auth --filter=@adopt-dont-shop/app.client --filter=@adopt-dont-shop/app.rescue` — 29/29 tasks green, 0 lint errors.

Type-check intentionally not in the gate per the brief — but verified clean separately against latest `main` (the prior agents' "pre-existing `ChatContext` `tokenProvider` error" was a worktree-stale-dist artifact, not actually on main; type-check on main is currently green).

---
_Continuation of an agent run; opened by the supervising session after the agent's quota reset._

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_