### PR TITLE
feat(applications): expose stage to client + render in-progress badges

### DIFF
--- a/app.client/src/pages/ApplicationDashboard.css.ts
+++ b/app.client/src/pages/ApplicationDashboard.css.ts
@@ -135,6 +135,17 @@ export const statusBadge = recipe({
   },
 });
 
+export const stageBadge = style({
+  display: 'inline-block',
+  marginLeft: '0.5rem',
+  padding: '0.25rem 0.75rem',
+  borderRadius: vars.border.radius.pill,
+  fontSize: '0.75rem',
+  fontWeight: '600',
+  background: vars.colors.warning,
+  color: 'white',
+});
+
 export const applicationDetails = style({
   marginTop: '1rem',
 });

--- a/app.client/src/pages/ApplicationDashboard.test.tsx
+++ b/app.client/src/pages/ApplicationDashboard.test.tsx
@@ -234,6 +234,47 @@ describe('ApplicationDashboard (ADS-634)', () => {
     }
   );
 
+  // ADS C4 (follow-up to PR #676): while status is still 'submitted', surface
+  // the workflow stage so adopters can see e.g. 'home visit scheduled' rather
+  // than just 'submitted'. Terminal statuses keep their own badge.
+  it.each([
+    ['pending', 'Application pending'],
+    ['reviewing', 'Application under review'],
+    ['visiting', 'Home visit scheduled'],
+    ['deciding', 'Awaiting decision'],
+  ] as const)('renders the in-progress stage label for stage %s', async (stage, expectedLabel) => {
+    getUserApplicationsMock.mockResolvedValue([makeApplication({ status: 'submitted', stage })]);
+    getPetByIdMock.mockResolvedValue(makePet());
+
+    render(<ApplicationDashboard />);
+
+    const badge = await screen.findByTestId('stage-badge');
+    expect(badge).toHaveTextContent(expectedLabel);
+  });
+
+  it('does not render a stage badge when the application has no stage', async () => {
+    getUserApplicationsMock.mockResolvedValue([makeApplication({ status: 'submitted' })]);
+    getPetByIdMock.mockResolvedValue(makePet());
+
+    render(<ApplicationDashboard />);
+
+    await screen.findByText('Luna');
+    expect(screen.queryByTestId('stage-badge')).not.toBeInTheDocument();
+  });
+
+  it.each(['approved', 'rejected', 'withdrawn'] as const)(
+    'does not render a stage badge for terminal status %s even when a stage is present',
+    async status => {
+      getUserApplicationsMock.mockResolvedValue([makeApplication({ status, stage: 'reviewing' })]);
+      getPetByIdMock.mockResolvedValue(makePet());
+
+      render(<ApplicationDashboard />);
+
+      await screen.findByText(status);
+      expect(screen.queryByTestId('stage-badge')).not.toBeInTheDocument();
+    }
+  );
+
   // UX P2 E: when an application's pet lookup fails or returns no record,
   // the card used to display "Pet Name Unavailable" — a phrase that reads
   // like a system error to applicants. Replace with "Unknown pet" and keep

--- a/app.client/src/pages/ApplicationDashboard.tsx
+++ b/app.client/src/pages/ApplicationDashboard.tsx
@@ -12,6 +12,19 @@ interface ApplicationWithPet extends Application {
   pet?: Pet;
 }
 
+// ADS C4 (follow-up to PR #676): the backend's ApplicationStage enum carries
+// the in-progress workflow state alongside the terminal `status`. Surface a
+// human-readable label only for stages an adopter would meaningfully see
+// while status is still 'submitted' — `resolved`/`withdrawn` map to a
+// terminal status badge instead. `pending` covers freshly submitted
+// applications that haven't been picked up for review yet.
+const IN_PROGRESS_STAGE_LABELS: Record<string, string> = {
+  pending: 'Application pending',
+  reviewing: 'Application under review',
+  visiting: 'Home visit scheduled',
+  deciding: 'Awaiting decision',
+};
+
 const getPrimaryThumbnailUrl = (pet: Pet | undefined): string | undefined => {
   const primary = pet?.images?.find(img => img.is_primary) ?? pet?.images?.[0];
   return resolveFileUrl(primary?.thumbnail_url ?? primary?.url);
@@ -218,6 +231,19 @@ export const ApplicationDashboard: React.FC = () => {
               >
                 {application.status.replace('_', ' ')}
               </span>
+
+              {/* ADS C4 (follow-up to PR #676): while the terminal status is
+                  still 'submitted', show the workflow stage so adopters can
+                  tell e.g. 'awaiting decision' apart from 'just submitted'.
+                  Don't override the terminal badge — approved/rejected/
+                  withdrawn carry their own meaning. */}
+              {application.status === 'submitted' &&
+                application.stage &&
+                IN_PROGRESS_STAGE_LABELS[application.stage] && (
+                  <span className={styles.stageBadge} data-testid='stage-badge'>
+                    {IN_PROGRESS_STAGE_LABELS[application.stage]}
+                  </span>
+                )}
 
               <div className={styles.applicationDetails}>
                 {application.submittedAt && (

--- a/app.rescue/src/types/applications.ts
+++ b/app.rescue/src/types/applications.ts
@@ -31,8 +31,12 @@ export enum TimelineEventType {
   MANUAL_OVERRIDE = 'manual_override',
 }
 
-// Extended types for rescue app UI
-export interface ApplicationListItem extends ApplicationWithPetInfo {
+// Extended types for rescue app UI. Omit lib.applications' `stage`
+// (lowercase, optional) so the local uppercase ApplicationStage from
+// ./applicationStages stays the source of truth for the rescue UI.
+// The two enums represent the same workflow; aligning them on
+// lowercase is a separate follow-up.
+export interface ApplicationListItem extends Omit<ApplicationWithPetInfo, 'stage'> {
   applicantName: string;
   submittedDaysAgo: number;
   priority: ApplicationPriority;

--- a/lib.applications/src/schemas.test.ts
+++ b/lib.applications/src/schemas.test.ts
@@ -1,0 +1,55 @@
+/**
+ * ADS C4 (follow-up to PR #676): the adopter dashboard could only display
+ * terminal statuses (submitted/approved/rejected/withdrawn) because the
+ * shared schema stripped the workflow `stage` the backend tracks. Widening
+ * the schema lets clients surface in-progress states like "Home visit
+ * scheduled" while the status is still 'submitted'.
+ */
+import { describe, expect, it } from 'vitest';
+import { ApplicationSchema, ApplicationStageSchema } from './schemas';
+
+const baseApplication = {
+  id: 'app-1',
+  petId: 'pet-1',
+  userId: 'user-1',
+  rescueId: 'rescue-1',
+  status: 'submitted' as const,
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-02T00:00:00Z',
+};
+
+describe('ApplicationSchema stage field', () => {
+  it('accepts an application without a stage (backwards compatible)', () => {
+    const result = ApplicationSchema.safeParse(baseApplication);
+    expect(result.success).toBe(true);
+  });
+
+  it.each(['pending', 'reviewing', 'visiting', 'deciding', 'resolved', 'withdrawn'] as const)(
+    'accepts the %s stage emitted by the backend',
+    (stage) => {
+      const result = ApplicationSchema.safeParse({ ...baseApplication, stage });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.stage).toBe(stage);
+      }
+    }
+  );
+
+  it('rejects a stage value the backend never emits', () => {
+    const result = ApplicationSchema.safeParse({ ...baseApplication, stage: 'home_visit' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ApplicationStageSchema', () => {
+  it('exposes the full backend stage enum', () => {
+    expect(ApplicationStageSchema.options).toEqual([
+      'pending',
+      'reviewing',
+      'visiting',
+      'deciding',
+      'resolved',
+      'withdrawn',
+    ]);
+  });
+});

--- a/lib.applications/src/schemas.ts
+++ b/lib.applications/src/schemas.ts
@@ -4,6 +4,20 @@ import { z } from 'zod';
 
 export const ApplicationStatusSchema = z.enum(['submitted', 'approved', 'rejected', 'withdrawn']);
 
+// ADS C4 (follow-up to PR #676): the backend tracks an in-progress workflow
+// `stage` alongside the terminal `status`. Adopter-facing clients need this
+// to differentiate a freshly submitted application from one that is e.g.
+// awaiting a home visit. Values mirror service.backend's ApplicationStage
+// enum (src/models/Application.ts).
+export const ApplicationStageSchema = z.enum([
+  'pending',
+  'reviewing',
+  'visiting',
+  'deciding',
+  'resolved',
+  'withdrawn',
+]);
+
 export const ApplicationPrioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);
 
 // ── ApplicationData sub-schemas ───────────────────────────────────────────────
@@ -168,6 +182,10 @@ export const ApplicationSchema = z.object({
   userId: z.string(),
   rescueId: z.string(),
   status: ApplicationStatusSchema,
+  // Optional for backwards compatibility — older backend responses (and
+  // older clients/tests) may omit it. Present on adopter and rescue reads
+  // from the canonical transformApplicationModel.
+  stage: ApplicationStageSchema.optional(),
   priority: ApplicationPrioritySchema.optional(),
   // These four columns are nullable in the database, so the JSON wire shape
   // can be `null` (not just absent). Use `.nullish()` to accept both null
@@ -242,6 +260,7 @@ export const DocumentsResponseSchema = z.object({
 // ── Inferred types ─────────────────────────────────────────────────────────────
 
 export type ApplicationStatus = z.infer<typeof ApplicationStatusSchema>;
+export type ApplicationStage = z.infer<typeof ApplicationStageSchema>;
 export type ApplicationPriority = z.infer<typeof ApplicationPrioritySchema>;
 export type PersonalInfo = z.infer<typeof PersonalInfoSchema>;
 export type LivingSituation = z.infer<typeof LivingSituationSchema>;

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -180,6 +180,7 @@ export class ApplicationController extends BaseController {
       userId: applicationModel.userId as string,
       rescueId: applicationModel.rescueId as string,
       status: applicationModel.status as ApplicationStatus,
+      stage: applicationModel.stage as string | undefined,
       submittedAt: applicationModel.submittedAt as string,
       reviewedAt: applicationModel.reviewedAt as string,
       reviewedBy: applicationModel.actionedBy as string,

--- a/service.backend/src/types/application.ts
+++ b/service.backend/src/types/application.ts
@@ -65,6 +65,10 @@ export interface FrontendApplication {
   userId: string;
   rescueId: string;
   status: ApplicationStatus;
+  // ADS C4 (follow-up to PR #676): expose the workflow stage to clients so
+  // adopters can see e.g. "Home visit scheduled" while status is still
+  // 'submitted'. Optional because legacy/test fixtures may omit it.
+  stage?: string;
   submittedAt?: string;
   reviewedAt?: string;
   reviewedBy?: string;


### PR DESCRIPTION
## Summary

PR #676 (C4) flagged that `app.client/src/pages/ApplicationDashboard.tsx` could only display terminal statuses (submitted/approved/rejected/withdrawn) because `lib.applications`'s `ApplicationSchema` didn't expose the workflow `stage` enum the backend tracks. This held follow-up widens the shared schema and surfaces stage as an in-progress badge.

- **lib.applications schema**: add optional `stage` field to `ApplicationSchema`, mirroring `service.backend`'s `ApplicationStage` enum (`pending` / `reviewing` / `visiting` / `deciding` / `resolved` / `withdrawn`). Backwards compatible.
- **service.backend**: `transformApplicationModel` now includes `stage` on the wire shape and `FrontendApplication` carries it.
- **app.client `ApplicationDashboard`**: when `status === 'submitted'` and an in-progress stage is present, render a stage badge ("Application pending", "Application under review", "Home visit scheduled", "Awaiting decision"). Terminal status badges are unchanged.

Note on enum values: the held follow-up sketched stages of `reviewing` / `references` / `home_visit` / `decision`, but the canonical backend `ApplicationStage` enum uses `pending` / `reviewing` / `visiting` / `deciding` / `resolved` / `withdrawn`. Aligned the schema and labels to the backend (the source of truth).

## Test plan

- [x] `npx turbo lint test --filter=@adopt-dont-shop/lib.applications` — 27 tests pass (9 new schema tests covering each backend stage value, the missing-field backwards-compat path, and an invalid value)
- [x] `npx turbo lint --filter=@adopt-dont-shop/app.client` — passes
- [x] `npx vitest run src/pages/ApplicationDashboard.test.tsx` in app.client — 20 tests pass (12 existing + 8 new: 4 stage labels render, missing-stage doesn't render the badge, 3 terminal statuses don't render the badge)
- [ ] Manually verify adopter sees a stage badge for a 'submitted' application that has progressed to `reviewing` / `visiting` / `deciding`

Pre-existing flaky timeout in `app.client/src/__tests__/distance-sorting.behavior.test.tsx` when run in the full suite; passes (13/13) in isolation and is unrelated to this change.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_