### PR TITLE
feat(notifications): add dedicated enum values for moderation/rescue events

### DIFF
--- a/lib.components/src/types/notifications.ts
+++ b/lib.components/src/types/notifications.ts
@@ -16,6 +16,11 @@ export enum NotificationType {
   STAFF_ASSIGNMENT = 'staff_assignment',
   PET_UPDATE = 'pet_update',
   FOLLOW_UP = 'follow_up',
+  // ADS C4: dedicated values for the rescue/moderation flows that
+  // originally landed under SYSTEM_ANNOUNCEMENT in PR #676.
+  RESCUE_VERIFIED = 'rescue_verified',
+  MODERATION_REPORT_RESOLVED = 'moderation_report_resolved',
+  USER_SANCTIONED = 'user_sanctioned',
 }
 
 export enum NotificationPriority {
@@ -69,6 +74,9 @@ export const getNotificationTypeLabel = (type: string): string => {
     [NotificationType.STAFF_ASSIGNMENT]: 'Staff Assignments',
     [NotificationType.PET_UPDATE]: 'Pet Updates',
     [NotificationType.FOLLOW_UP]: 'Follow Ups',
+    [NotificationType.RESCUE_VERIFIED]: 'Rescue Verified',
+    [NotificationType.MODERATION_REPORT_RESOLVED]: 'Report Update',
+    [NotificationType.USER_SANCTIONED]: 'Account Action',
   };
 
   return labels[type] || type;

--- a/service.backend/src/__tests__/services/moderation.service.test.ts
+++ b/service.backend/src/__tests__/services/moderation.service.test.ts
@@ -226,7 +226,7 @@ describe('ModerationService', () => {
       expect(spy).toHaveBeenCalledTimes(1);
       const args = spy.mock.calls[0][0];
       expect(args.userId).toBe(reporter.userId);
-      expect(args.type).toBe(NotificationType.SYSTEM_ANNOUNCEMENT);
+      expect(args.type).toBe(NotificationType.MODERATION_REPORT_RESOLVED);
       expect(args.data).toMatchObject({ reportId: report.reportId, resolution: 'resolved' });
 
       const refreshed = await Report.findByPk(report.reportId);
@@ -253,6 +253,7 @@ describe('ModerationService', () => {
       expect(spy).toHaveBeenCalledTimes(1);
       const args = spy.mock.calls[0][0];
       expect(args.userId).toBe(reporter.userId);
+      expect(args.type).toBe(NotificationType.MODERATION_REPORT_RESOLVED);
       expect(args.data).toMatchObject({ resolution: 'dismissed' });
 
       spy.mockRestore();
@@ -276,6 +277,7 @@ describe('ModerationService', () => {
       expect(spy).toHaveBeenCalledTimes(1);
       const args = spy.mock.calls[0][0];
       expect(args.userId).toBe(reporter.userId);
+      expect(args.type).toBe(NotificationType.MODERATION_REPORT_RESOLVED);
       expect(args.data).toMatchObject({ reportId: report.reportId, resolution: 'escalated' });
 
       spy.mockRestore();
@@ -309,7 +311,7 @@ describe('ModerationService', () => {
       expect(spy).toHaveBeenCalledTimes(2);
       const sanctionedCall = spy.mock.calls.find(c => c[0].userId === reportedUser.userId);
       expect(sanctionedCall).toBeDefined();
-      expect(sanctionedCall?.[0].type).toBe(NotificationType.SYSTEM_ANNOUNCEMENT);
+      expect(sanctionedCall?.[0].type).toBe(NotificationType.USER_SANCTIONED);
       expect(sanctionedCall?.[0].data).toMatchObject({
         actionType: ActionType.WARNING_ISSUED,
         reason: 'Inappropriate content',

--- a/service.backend/src/__tests__/services/rescue.service.test.ts
+++ b/service.backend/src/__tests__/services/rescue.service.test.ts
@@ -578,7 +578,7 @@ describe('RescueService - Behavioral Testing', () => {
       expect(spy).toHaveBeenCalledTimes(1);
       const args = spy.mock.calls[0][0];
       expect(args.userId).toBe('user-123');
-      expect(args.type).toBe(NotificationType.SYSTEM_ANNOUNCEMENT);
+      expect(args.type).toBe(NotificationType.RESCUE_VERIFIED);
       expect(args.data).toMatchObject({ rescueId: rescue.rescueId, event: 'rescue_verified' });
 
       expect(vi.mocked(emitToRescue)).toHaveBeenCalledWith(

--- a/service.backend/src/migrations/08-add-notification-c4-enum-values.ts
+++ b/service.backend/src/migrations/08-add-notification-c4-enum-values.ts
@@ -1,0 +1,91 @@
+/**
+ * Add dedicated `enum_notifications_type` values for the three C4
+ * notification flows (PR #676) and backfill any rows that landed under
+ * the temporary `system_announcement` fallback.
+ *
+ * Why the two-phase shape:
+ *   `ALTER TYPE ... ADD VALUE` cannot be used in the same transaction
+ *   that subsequently references the new value (Postgres error
+ *   "unsafe use of new value of enum type"). The enum mutations
+ *   therefore run on the raw connection without a transaction wrapper,
+ *   and the backfill `UPDATE`s run in a separate transaction once the
+ *   new labels are committed.
+ *
+ * Why the backfill SQL filters by `data` discriminators:
+ *   The C4 work shipped before the enum migration was possible, so the
+ *   three flows tagged their notifications with `data.event`,
+ *   `data.resolution`, and `data.actionType` to discriminate within the
+ *   single `system_announcement` value. Those discriminators are the
+ *   only way to identify which existing rows belong to which new typed
+ *   value.
+ *
+ * Down:
+ *   Postgres has no `DROP VALUE` for enum types prior to PG 15, and
+ *   even on PG 15+ it only works when no rows reference the value.
+ *   We therefore only revert the backfill (typed rows -> back to
+ *   `system_announcement`); the new enum labels remain in pg_type.
+ *   This is the documented limitation from `_helpers.ts`.
+ */
+import type { QueryInterface } from 'sequelize';
+import { runInTransaction } from './_helpers';
+
+export default {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const sequelize = queryInterface.sequelize;
+
+    // Phase 1: add the new enum values. Each runs as its own statement
+    // outside a transaction so the labels are committed before the
+    // backfill references them.
+    await sequelize.query(
+      `ALTER TYPE "enum_notifications_type" ADD VALUE IF NOT EXISTS 'rescue_verified'`
+    );
+    await sequelize.query(
+      `ALTER TYPE "enum_notifications_type" ADD VALUE IF NOT EXISTS 'moderation_report_resolved'`
+    );
+    await sequelize.query(
+      `ALTER TYPE "enum_notifications_type" ADD VALUE IF NOT EXISTS 'user_sanctioned'`
+    );
+
+    // Phase 2: backfill C4 rows that landed under the temporary
+    // `system_announcement` fallback. Wrapped in a transaction so a
+    // partial failure leaves the table consistent.
+    await runInTransaction(queryInterface, async t => {
+      await sequelize.query(
+        `UPDATE notifications
+           SET type = 'rescue_verified'
+         WHERE type = 'system_announcement'
+           AND data->>'event' = 'rescue_verified'`,
+        { transaction: t }
+      );
+      await sequelize.query(
+        `UPDATE notifications
+           SET type = 'moderation_report_resolved'
+         WHERE type = 'system_announcement'
+           AND data->>'resolution' IN ('resolved', 'dismissed', 'escalated')`,
+        { transaction: t }
+      );
+      await sequelize.query(
+        `UPDATE notifications
+           SET type = 'user_sanctioned'
+         WHERE type = 'system_announcement'
+           AND data->>'actionType' IS NOT NULL`,
+        { transaction: t }
+      );
+    });
+  },
+
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    // Revert the backfill only. Pre-PG15 has no DROP VALUE for enums,
+    // and even on PG15+ DROP VALUE fails if rows still reference the
+    // value. Leaving the labels in pg_type is harmless: nothing reads
+    // them once the rows revert.
+    await runInTransaction(queryInterface, async t => {
+      await queryInterface.sequelize.query(
+        `UPDATE notifications
+           SET type = 'system_announcement'
+         WHERE type IN ('rescue_verified', 'moderation_report_resolved', 'user_sanctioned')`,
+        { transaction: t }
+      );
+    });
+  },
+};

--- a/service.backend/src/models/Notification.ts
+++ b/service.backend/src/models/Notification.ts
@@ -22,6 +22,11 @@ export enum NotificationType {
   STAFF_ASSIGNMENT = 'staff_assignment',
   PET_UPDATE = 'pet_update',
   FOLLOW_UP = 'follow_up',
+  // ADS C4: dedicated values for the rescue/moderation flows that
+  // originally landed under SYSTEM_ANNOUNCEMENT in PR #676.
+  RESCUE_VERIFIED = 'rescue_verified',
+  MODERATION_REPORT_RESOLVED = 'moderation_report_resolved',
+  USER_SANCTIONED = 'user_sanctioned',
 }
 
 // Notification channel enum

--- a/service.backend/src/seeders/demo/notifications-faker.ts
+++ b/service.backend/src/seeders/demo/notifications-faker.ts
@@ -27,6 +27,9 @@ const TYPE_TITLE: Record<NotificationType, string> = {
   [NotificationType.STAFF_ASSIGNMENT]: 'You have been assigned a new task',
   [NotificationType.PET_UPDATE]: 'Pet profile updated',
   [NotificationType.FOLLOW_UP]: 'Follow-up check-in',
+  [NotificationType.RESCUE_VERIFIED]: 'Your rescue has been verified',
+  [NotificationType.MODERATION_REPORT_RESOLVED]: 'Report update',
+  [NotificationType.USER_SANCTIONED]: 'Account action',
 };
 
 const TYPE_BAG: NotificationType[] = (() => {

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -1038,10 +1038,10 @@ class ModerationService {
    * (resolved / dismissed / escalated). Best-effort: failures must not
    * affect the moderation outcome — the action has already committed.
    *
-   * We fall back to NotificationType.SYSTEM_ANNOUNCEMENT because the
-   * Postgres ENUM for notification.type cannot grow without a migration
-   * (out of scope for this fix); the `data.reportId` and
-   * `data.resolution` discriminate the moderation context for the UI.
+   * Uses NotificationType.MODERATION_REPORT_RESOLVED (added by
+   * migration 08-add-notification-c4-enum-values). The `data.reportId`
+   * and `data.resolution` discriminators stay in place so UI consumers
+   * that already parse them continue to work.
    */
   private async notifyReporterOfResolution(params: {
     reportId: string;
@@ -1063,7 +1063,7 @@ class ModerationService {
     try {
       await NotificationService.createNotification({
         userId: reporterId,
-        type: NotificationType.SYSTEM_ANNOUNCEMENT,
+        type: NotificationType.MODERATION_REPORT_RESOLVED,
         title: titles[resolution],
         message: messages[resolution],
         data: {
@@ -1087,10 +1087,10 @@ class ModerationService {
    * their account (warning, suspension, ban, restriction). Best-effort:
    * the sanction itself has already committed.
    *
-   * Reuses NotificationType.SYSTEM_ANNOUNCEMENT for the same reason as
-   * notifyReporterOfResolution — the Postgres ENUM for notification.type
-   * can't grow without a migration. The discriminator lives in
-   * `data.actionType` so the UI can pick an appropriate icon / copy.
+   * Uses NotificationType.USER_SANCTIONED (added by migration
+   * 08-add-notification-c4-enum-values). The `data.actionType`
+   * discriminator stays in place so UI consumers can still pick an
+   * appropriate icon / copy.
    */
   private async notifySanctionedUser(params: {
     userId: string;
@@ -1110,7 +1110,7 @@ class ModerationService {
     try {
       await NotificationService.createNotification({
         userId,
-        type: NotificationType.SYSTEM_ANNOUNCEMENT,
+        type: NotificationType.USER_SANCTIONED,
         title: titles[actionType] ?? 'A moderation action was taken on your account',
         message: description ?? reason,
         data: {

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -682,7 +682,7 @@ export class RescueService {
           recipients.map(userId =>
             NotificationService.createNotification({
               userId,
-              type: NotificationType.SYSTEM_ANNOUNCEMENT,
+              type: NotificationType.RESCUE_VERIFIED,
               title: 'Your rescue has been verified',
               message: `${rescue.name} is now verified and can publish listings.`,
               data: { rescueId, event: 'rescue_verified' },


### PR DESCRIPTION
## Background

PR #676 (C4) shipped three new in-app notification flows:

- **C4-2** report-resolved notifications (`moderation.service.notifyReporterOfResolution`)
- **C4-3** rescue-verified notifications (`rescue.service.verifyRescue`)
- **C4-4** sanction notifications (`moderation.service.notifySanctionedUser`)

Because `ALTER TYPE ... ADD VALUE` requires its own migration (and Postgres rejects subsequent use of a freshly-added enum value inside the same transaction), C4 reused the existing `system_announcement` enum value and discriminated each flow via the `data` JSONB column (`data.event`, `data.resolution`, `data.actionType`). That left the production enum without explicit values for these flows, so downstream consumers could not filter or route on `type` alone.

## Changes

Three commits, in dependency order:

1. **Migration `08-add-notification-c4-enum-values.ts`** — adds `rescue_verified`, `moderation_report_resolved`, `user_sanctioned` to `enum_notifications_type`. Enum-add statements run outside a transaction (Postgres constraint), backfill runs inside one for atomicity. Backfill SQL identifies the C4 rows by the same `data` discriminators they were written with:

   ```sql
   UPDATE notifications SET type = 'rescue_verified'
    WHERE type = 'system_announcement' AND data->>'event' = 'rescue_verified';

   UPDATE notifications SET type = 'moderation_report_resolved'
    WHERE type = 'system_announcement'
      AND data->>'resolution' IN ('resolved', 'dismissed', 'escalated');

   UPDATE notifications SET type = 'user_sanctioned'
    WHERE type = 'system_announcement' AND data->>'actionType' IS NOT NULL;
   ```

   Down reverts the backfill only — Postgres has no `DROP VALUE` pre-15 and the limitation is documented in `migrations/_helpers.ts`.

2. **NotificationType enum** — adds the three values to `service.backend/src/models/Notification.ts` (the canonical backend enum; `Object.values(NotificationType)` feeds the Sequelize ENUM column so the model picks them up automatically) and to the `lib.components/src/types/notifications.ts` mirror, including friendly labels for the UI.

   _Note: the task brief referred to "lib.notifications NotificationType enum" but that package only exposes a different `NotificationCategory` type. The canonical `NotificationType` enum lives in `service.backend/src/models/Notification.ts`, mirrored in `lib.components`._

3. **Call sites + tests** — three service call sites switch from `SYSTEM_ANNOUNCEMENT` to the new typed values. The `data` payload structure stays unchanged so UI consumers continue to work. Existing C4 tests are extended to assert the correct new type on every branch (resolved, dismissed, escalated, sanctioned, rescue-verified).

## Test plan

- [x] `npx turbo lint test --filter=@adopt-dont-shop/service-backend --filter=@adopt-dont-shop/lib.notifications` — 7/7 tasks successful, 2753 tests passing in service-backend.
- [ ] Run migration `08-add-notification-c4-enum-values` against a staging DB and verify backfill count (expected zero in fresh envs; PR #676 only just landed).
- [ ] Verify down migration in staging reverts typed rows back to `system_announcement`.

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_