### PR TITLE
fix(backend): translate snake_case home-visit fields in updateHomeVisit controller

### DIFF
--- a/service.backend/src/__tests__/routes/application.routes.test.ts
+++ b/service.backend/src/__tests__/routes/application.routes.test.ts
@@ -43,6 +43,7 @@ vi.mock('../../services/application.service', () => ({
     getApplicationHistory: vi.fn(),
     getApplicationFormStructure: vi.fn(),
     validateApplicationAnswers: vi.fn(),
+    updateHomeVisit: vi.fn(),
   },
   default: {
     getApplications: vi.fn(),
@@ -58,6 +59,7 @@ vi.mock('../../services/application.service', () => ({
     getApplicationHistory: vi.fn(),
     getApplicationFormStructure: vi.fn(),
     validateApplicationAnswers: vi.fn(),
+    updateHomeVisit: vi.fn(),
   },
 }));
 
@@ -446,6 +448,72 @@ describe('Application routes', () => {
 
       expect(res.status).toBe(200);
       expect(ApplicationService.getApplicationStatistics).toHaveBeenCalledWith('rescue-B');
+    });
+  });
+
+  describe('PUT /api/v1/applications/:applicationId/home-visits/:visitId', () => {
+    const applicationId = '11111111-1111-1111-1111-111111111111';
+    const visitId = '22222222-2222-2222-2222-222222222222';
+
+    beforeEach(() => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockRescueStaffUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+      vi.mocked(ApplicationService.updateHomeVisit).mockResolvedValue({
+        id: visitId,
+      } as unknown as Awaited<ReturnType<typeof ApplicationService.updateHomeVisit>>);
+    });
+
+    it('translates snake_case body fields to camelCase before calling the service', async () => {
+      const res = await request(buildApp())
+        .put(`/api/v1/applications/${applicationId}/home-visits/${visitId}`)
+        .send({
+          scheduled_date: '2026-06-01',
+          scheduled_time: '14:00',
+          assigned_staff: 'staff-uuid-1',
+          notes: 'bring paperwork',
+          outcome: 'approved',
+          outcome_notes: 'all good',
+          reschedule_reason: 'weather',
+          cancelled_reason: 'no-show',
+          status: 'completed',
+        });
+
+      expect(res.status).toBe(200);
+      expect(ApplicationService.updateHomeVisit).toHaveBeenCalledTimes(1);
+      const [passedApplicationId, , passedUpdate, passedActor] = vi.mocked(
+        ApplicationService.updateHomeVisit
+      ).mock.calls[0];
+      expect(passedApplicationId).toBe(applicationId);
+      expect(passedActor).toBe(mockRescueStaffUser.userId);
+      expect(passedUpdate).toMatchObject({
+        scheduledDate: '2026-06-01',
+        scheduledTime: '14:00',
+        assignedStaff: 'staff-uuid-1',
+        notes: 'bring paperwork',
+        outcome: 'approved',
+        outcomeNotes: 'all good',
+        rescheduleReason: 'weather',
+        cancelledReason: 'no-show',
+        status: 'completed',
+      });
+      // Service must NOT receive snake_case keys it would silently ignore.
+      expect(passedUpdate).not.toHaveProperty('scheduled_date');
+      expect(passedUpdate).not.toHaveProperty('reschedule_reason');
+      expect(passedUpdate).not.toHaveProperty('cancelled_reason');
+    });
+
+    it('returns 404 when the service reports the visit was not found', async () => {
+      vi.mocked(ApplicationService.updateHomeVisit).mockResolvedValue(null);
+
+      const res = await request(buildApp())
+        .put(`/api/v1/applications/${applicationId}/home-visits/${visitId}`)
+        .send({ status: 'cancelled', cancelled_reason: 'duplicate' });
+
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -1042,7 +1042,37 @@ export class ApplicationController extends BaseController {
 
   updateHomeVisit = async (req: AuthenticatedRequest, res: Response) => {
     const { applicationId, visitId } = req.params;
-    const updateData = req.body;
+    const {
+      scheduled_date,
+      scheduled_time,
+      assigned_staff,
+      notes,
+      outcome,
+      outcome_notes,
+      reschedule_reason,
+      cancelled_reason,
+      status,
+      started_at,
+      rescheduled_at,
+      cancelled_at,
+      conditions,
+    } = req.body;
+
+    const updateData = {
+      ...(scheduled_date !== undefined && { scheduledDate: scheduled_date }),
+      ...(scheduled_time !== undefined && { scheduledTime: scheduled_time }),
+      ...(assigned_staff !== undefined && { assignedStaff: assigned_staff }),
+      ...(notes !== undefined && { notes }),
+      ...(outcome !== undefined && { outcome }),
+      ...(outcome_notes !== undefined && { outcomeNotes: outcome_notes }),
+      ...(reschedule_reason !== undefined && { rescheduleReason: reschedule_reason }),
+      ...(cancelled_reason !== undefined && { cancelledReason: cancelled_reason }),
+      ...(status !== undefined && { status }),
+      ...(started_at !== undefined && { startedAt: started_at }),
+      ...(rescheduled_at !== undefined && { rescheduledAt: rescheduled_at }),
+      ...(cancelled_at !== undefined && { cancelledAt: cancelled_at }),
+      ...(conditions !== undefined && { conditions }),
+    };
 
     const visit = await ApplicationService.updateHomeVisit(
       applicationId,


### PR DESCRIPTION
## Summary

- **Bug:** `updateHomeVisit` in `ApplicationController` was forwarding `req.body` directly to `ApplicationService.updateHomeVisit`, passing snake_case field names (e.g. `scheduled_date`, `outcome_notes`, `cancelled_reason`) that the service layer expects in camelCase. This meant updates were silently ignored because the service never saw the fields it was looking for.
- **Context:** The sibling method `scheduleHomeVisit` already performs this snake_case → camelCase translation correctly; `updateHomeVisit` was the only home-visit controller action missing it.
- **Fix:** Destructure the known snake_case fields from `req.body` and rebuild the update payload with their camelCase equivalents, only including fields that were actually provided (`!== undefined`). This matches the pattern used by `scheduleHomeVisit`.

## Changed files

- `service.backend/src/controllers/application.controller.ts` — translate snake_case request body fields to camelCase before passing to the service
- `service.backend/src/__tests__/routes/application.routes.test.ts` — add tests verifying the translation happens and that the service never receives snake_case keys

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_