### PR TITLE
feat(email): resolve link destination per role + email type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,6 +152,10 @@ VITE_WS_BASE_URL=ws://localhost:5000
 # to localhost and every email link will be broken.
 FRONTEND_URL=http://localhost:3000
 RESCUE_FRONTEND_URL=http://localhost:3002
+# ADMIN_FRONTEND_URL is used by the per-role email link resolver to send
+# admin/moderator/support recipients to the admin dashboard. Optional in
+# all environments: if unset, admin recipients fall back to FRONTEND_URL.
+ADMIN_FRONTEND_URL=http://localhost:3001
 
 # Backend self-URL (used in email/webhook callbacks). Required in production.
 API_URL=http://localhost:5000

--- a/service.backend/src/__tests__/services/invitation.service.test.ts
+++ b/service.backend/src/__tests__/services/invitation.service.test.ts
@@ -234,6 +234,36 @@ describe('InvitationService', () => {
           })
         );
       });
+
+      it('should build the invitation URL from the rescue app origin (per-role resolver)', async () => {
+        // Rescue invitations are a typed email — the resolver must pin
+        // them to RESCUE_FRONTEND_URL regardless of the recipient's role.
+        const originalRescueUrl = process.env.RESCUE_FRONTEND_URL;
+        const originalClientUrl = process.env.FRONTEND_URL;
+        process.env.FRONTEND_URL = 'http://localhost:3000';
+        process.env.RESCUE_FRONTEND_URL = 'http://localhost:3002';
+
+        try {
+          MockedRescue.findByPk = vi.fn().mockResolvedValue(buildRescue());
+          MockedStaffMember.findOne = vi.fn().mockResolvedValue(null);
+          MockedInvitation.findOne = vi.fn().mockResolvedValue(null);
+          MockedInvitation.create = vi.fn().mockResolvedValue(buildInvitation());
+
+          await InvitationService.inviteStaffMember(
+            'rescue-001',
+            'staff@example.com',
+            'Volunteer',
+            'admin-user-id'
+          );
+
+          const call = (MockedEmailTemplateService.sendStaffInvitation as vi.Mock).mock.calls[0][0];
+          expect(call.invitationUrl).toMatch(/^http:\/\/localhost:3002\/accept-invitation\?token=/);
+          expect(call.invitationUrl).not.toContain('localhost:3000');
+        } finally {
+          process.env.RESCUE_FRONTEND_URL = originalRescueUrl;
+          process.env.FRONTEND_URL = originalClientUrl;
+        }
+      });
     });
 
     describe('when the email send fails', () => {

--- a/service.backend/src/__tests__/services/legal-reminder.test.ts
+++ b/service.backend/src/__tests__/services/legal-reminder.test.ts
@@ -19,9 +19,10 @@ vi.mock('../../models/AuditLog', () => ({
   withAuditMutationAllowed: vi.fn(),
 }));
 
-vi.mock('../../models/User', () => ({
-  default: { findByPk: vi.fn() },
-}));
+vi.mock('../../models/User', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('../../models/User');
+  return { ...actual, default: { findByPk: vi.fn() } };
+});
 
 vi.mock('../../services/email.service', () => ({
   default: { sendEmail: vi.fn().mockResolvedValue('email-id-123') },

--- a/service.backend/src/services/auth.service.ts
+++ b/service.backend/src/services/auth.service.ts
@@ -13,7 +13,7 @@ import TwoFactorRecovery from '../models/TwoFactorRecovery';
 import EmailQueue, { EmailStatus, EmailType, EmailPriority } from '../models/EmailQueue';
 import { logger, loggerHelpers } from '../utils/logger';
 import { decryptSecret, encryptSecret, hashToken, verifyBackupCode } from '../utils/secrets';
-import { getValidatedFrontendOrigin } from '../utils/url-allowlist';
+import { EmailLinkType, resolveEmailLinkBase } from '../utils/email-url';
 import { AuditLogService } from './auditLog.service';
 import { redactEmail } from './redact';
 import { env } from '../config/env';
@@ -94,7 +94,7 @@ export class AuthService {
       // Send verification email
       try {
         const emailService = (await import('./email.service')).default;
-        const frontendUrl = getValidatedFrontendOrigin();
+        const frontendUrl = resolveEmailLinkBase(EmailLinkType.EMAIL_VERIFICATION);
         const verificationUrl = `${frontendUrl}/verify-email?token=${verificationToken}`;
 
         const template = await emailService.getTemplateByName('Email Verification');
@@ -126,7 +126,7 @@ export class AuthService {
             fromEmail: process.env.EMAIL_FROM_ADDRESS || 'noreply@adoptdontshop.com',
             toEmail: user.email,
             subject: 'Verify Your Email',
-            htmlContent: `<p>Hello ${user.firstName},</p><p>Please verify your email by clicking <a href="${getValidatedFrontendOrigin()}/verify-email?token=${verificationToken}">here</a></p>`,
+            htmlContent: `<p>Hello ${user.firstName},</p><p>Please verify your email by clicking <a href="${resolveEmailLinkBase(EmailLinkType.EMAIL_VERIFICATION)}/verify-email?token=${verificationToken}">here</a></p>`,
             type: EmailType.TRANSACTIONAL,
             priority: EmailPriority.HIGH,
             status: EmailStatus.QUEUED,
@@ -140,7 +140,7 @@ export class AuthService {
             templateData: {
               firstName: user.firstName,
               verificationToken,
-              verificationUrl: `${getValidatedFrontendOrigin()}/verify-email?token=${verificationToken}`,
+              verificationUrl: `${resolveEmailLinkBase(EmailLinkType.EMAIL_VERIFICATION)}/verify-email?token=${verificationToken}`,
               expiresAt: verificationExpires.toISOString(),
             },
           });
@@ -164,7 +164,7 @@ export class AuthService {
   }
 
   private static async sendAccountExistsEmail(email: string): Promise<void> {
-    const frontendUrl = getValidatedFrontendOrigin();
+    const frontendUrl = resolveEmailLinkBase(EmailLinkType.ACCOUNT_EXISTS);
     const resetUrl = `${frontendUrl}/forgot-password`;
     try {
       const emailService = (await import('./email.service')).default;
@@ -574,7 +574,8 @@ export class AuthService {
         const emailService = (await import('./email.service')).default;
         // ADS-438: validate FRONTEND_URL origin before building the link so a
         // misconfigured env var cannot redirect users to an attacker domain.
-        const resetUrl = `${getValidatedFrontendOrigin()}/reset-password?token=${resetToken}`;
+        // Password reset is a typed-adopter email — pins to the client app.
+        const resetUrl = `${resolveEmailLinkBase(EmailLinkType.PASSWORD_RESET)}/reset-password?token=${resetToken}`;
 
         await emailService.sendEmail({
           toEmail: user.email,
@@ -881,7 +882,7 @@ Need help? Contact us at support@adoptdontshop.com
       try {
         const emailService = (await import('./email.service')).default;
         // ADS-438: validate FRONTEND_URL origin before building the link.
-        const recoveryUrl = `${getValidatedFrontendOrigin()}/auth/2fa/recover?token=${plaintextToken}`;
+        const recoveryUrl = `${resolveEmailLinkBase(EmailLinkType.TWO_FACTOR_RECOVERY)}/auth/2fa/recover?token=${plaintextToken}`;
 
         await emailService.sendEmail({
           toEmail: user.email,
@@ -1114,7 +1115,7 @@ Need help? Contact us at support@adoptdontshop.com
         const user = await User.findByPk(userId);
         if (user) {
           const emailService = (await import('./email.service')).default;
-          const loginUrl = `${getValidatedFrontendOrigin()}/login`;
+          const loginUrl = `${resolveEmailLinkBase(EmailLinkType.TWO_FACTOR_RECOVERY)}/login`;
 
           await emailService.sendEmail({
             toEmail: user.email,
@@ -1382,7 +1383,7 @@ If this wasn't you, your account may be compromised. Reset your password immedia
           templateData: {
             firstName: user.firstName,
             verificationToken: verificationToken,
-            verificationUrl: `${getValidatedFrontendOrigin()}/verify-email?token=${verificationToken}`,
+            verificationUrl: `${resolveEmailLinkBase(EmailLinkType.EMAIL_VERIFICATION)}/verify-email?token=${verificationToken}`,
             expiresAt: verificationExpires.toISOString(),
           },
           type: 'transactional',
@@ -1836,7 +1837,7 @@ If this wasn't you, your account may be compromised. Reset your password immedia
 
       const emailService = (await import('./email.service')).default;
       // ADS-438: origin is validated against the configured allowlist.
-      const frontendUrl = getValidatedFrontendOrigin();
+      const frontendUrl = resolveEmailLinkBase(EmailLinkType.EMAIL_VERIFICATION);
 
       for (const user of unverifiedUsers) {
         try {

--- a/service.backend/src/services/invitation.service.ts
+++ b/service.backend/src/services/invitation.service.ts
@@ -10,6 +10,7 @@ import EmailTemplateService from './email-template.service';
 import { invalidateAuthCache } from '../lib/auth-cache';
 import { logger } from '../utils/logger';
 import { hashToken } from '../utils/secrets';
+import { EmailLinkType, resolveEmailLinkBase } from '../utils/email-url';
 
 export class InvitationService {
   /**
@@ -111,7 +112,7 @@ export class InvitationService {
 
       // Send invitation email
       try {
-        const invitationUrl = `${process.env.RESCUE_FRONTEND_URL || 'http://localhost:3002'}/accept-invitation?token=${token}`;
+        const invitationUrl = `${resolveEmailLinkBase(EmailLinkType.RESCUE_INVITATION)}/accept-invitation?token=${token}`;
 
         await EmailTemplateService.sendStaffInvitation({
           recipientEmail: email,

--- a/service.backend/src/services/legal-reminder.service.ts
+++ b/service.backend/src/services/legal-reminder.service.ts
@@ -1,11 +1,12 @@
 import { Op } from 'sequelize';
 import { z } from 'zod';
 import AuditLog from '../models/AuditLog';
-import User from '../models/User';
+import User, { UserType } from '../models/User';
 import { AuditLogService } from './auditLog.service';
 import emailService from './email.service';
 import { PendingReacceptanceItem, getPendingReacceptance } from './legal-content.service';
 import { logger } from '../utils/logger';
+import { EmailLinkType, resolveEmailLinkBase } from '../utils/email-url';
 
 /**
  * ADS-497 (slice 3): admin-triggered re-acceptance reminder email.
@@ -146,9 +147,10 @@ const documentLabel = (documentType: 'terms' | 'privacy'): string =>
 
 const renderReminderHtml = (
   firstName: string | null,
-  pending: ReadonlyArray<ReminderableDocument>
+  pending: ReadonlyArray<ReminderableDocument>,
+  recipientPrimaryRole: UserType | undefined
 ): string => {
-  const baseUrl = process.env.FRONTEND_URL || 'https://adoptdontshop.com';
+  const baseUrl = resolveEmailLinkBase(EmailLinkType.LEGAL_REACCEPTANCE, recipientPrimaryRole);
   const supportEmail = process.env.SUPPORT_EMAIL || 'support@adoptdontshop.com';
   const greeting = firstName ? `Hi ${firstName},` : 'Hi there,';
   const items = pending
@@ -181,9 +183,10 @@ const renderReminderHtml = (
 
 const renderReminderText = (
   firstName: string | null,
-  pending: ReadonlyArray<ReminderableDocument>
+  pending: ReadonlyArray<ReminderableDocument>,
+  recipientPrimaryRole: UserType | undefined
 ): string => {
-  const baseUrl = process.env.FRONTEND_URL || 'https://adoptdontshop.com';
+  const baseUrl = resolveEmailLinkBase(EmailLinkType.LEGAL_REACCEPTANCE, recipientPrimaryRole);
   const supportEmail = process.env.SUPPORT_EMAIL || 'support@adoptdontshop.com';
   const greeting = firstName ? `Hi ${firstName},` : 'Hi there,';
   const items = pending
@@ -232,7 +235,7 @@ export const sendReacceptanceReminder = async (
   const { userId, triggeredBy = null } = options;
 
   const user = await User.findByPk(userId, {
-    attributes: ['userId', 'email', 'firstName'],
+    attributes: ['userId', 'email', 'firstName', 'userType'],
   });
   if (!user) {
     throw new Error('User not found');
@@ -270,8 +273,8 @@ export const sendReacceptanceReminder = async (
     toName: user.firstName ?? undefined,
     userId,
     subject: buildSubject(pending),
-    htmlContent: renderReminderHtml(user.firstName ?? null, pending),
-    textContent: renderReminderText(user.firstName ?? null, pending),
+    htmlContent: renderReminderHtml(user.firstName ?? null, pending, user.userType),
+    textContent: renderReminderText(user.firstName ?? null, pending, user.userType),
     type: 'transactional',
     priority: 'normal',
     metadata: {

--- a/service.backend/src/utils/email-url.test.ts
+++ b/service.backend/src/utils/email-url.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('./logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { EmailLinkType, resolveEmailLinkBase } from './email-url';
+import { UserType } from '../models/User';
+
+describe('resolveEmailLinkBase', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.NODE_ENV = 'development';
+    delete process.env.FRONTEND_URL;
+    delete process.env.RESCUE_FRONTEND_URL;
+    delete process.env.ADMIN_FRONTEND_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('typed emails — destination is pinned regardless of recipient role', () => {
+    it('routes RESCUE_INVITATION to the rescue app even for an adopter recipient', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.RESCUE_INVITATION, UserType.ADOPTER);
+      expect(base).toBe('http://localhost:3002');
+    });
+
+    it('routes RESCUE_VERIFICATION to the rescue app even for an admin recipient', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.RESCUE_VERIFICATION, UserType.ADMIN);
+      expect(base).toBe('http://localhost:3002');
+    });
+
+    it('routes PASSWORD_RESET to the client app even for rescue staff', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.PASSWORD_RESET, UserType.RESCUE_STAFF);
+      expect(base).toBe('http://localhost:3000');
+    });
+
+    it('routes EMAIL_VERIFICATION to the client app even for rescue staff', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.EMAIL_VERIFICATION, UserType.RESCUE_STAFF);
+      expect(base).toBe('http://localhost:3000');
+    });
+
+    it('routes TWO_FACTOR_RECOVERY to the client app even for admins', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.TWO_FACTOR_RECOVERY, UserType.ADMIN);
+      expect(base).toBe('http://localhost:3000');
+    });
+
+    it('routes APPLICATION_STATUS_CHANGE to the client app even for rescue staff', () => {
+      const base = resolveEmailLinkBase(
+        EmailLinkType.APPLICATION_STATUS_CHANGE,
+        UserType.RESCUE_STAFF
+      );
+      expect(base).toBe('http://localhost:3000');
+    });
+  });
+
+  describe('role-driven emails — destination follows recipient primary role', () => {
+    it('routes a GENERIC email for an adopter to the client app', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.GENERIC, UserType.ADOPTER);
+      expect(base).toBe('http://localhost:3000');
+    });
+
+    it('routes a GENERIC email for rescue staff to the rescue app', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.GENERIC, UserType.RESCUE_STAFF);
+      expect(base).toBe('http://localhost:3002');
+    });
+
+    it('routes a GENERIC email for an admin to the admin app', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.GENERIC, UserType.ADMIN);
+      expect(base).toBe('http://localhost:3001');
+    });
+
+    it('routes a moderation-outcome email for a moderator to the admin app', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.MODERATION_OUTCOME, UserType.MODERATOR);
+      expect(base).toBe('http://localhost:3001');
+    });
+
+    it('routes a legal-reacceptance email for rescue staff to the rescue app', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.LEGAL_REACCEPTANCE, UserType.RESCUE_STAFF);
+      expect(base).toBe('http://localhost:3002');
+    });
+  });
+
+  describe('fallback when recipient primary role is unknown', () => {
+    it('routes a GENERIC email with no role to the client app (safe default)', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.GENERIC);
+      expect(base).toBe('http://localhost:3000');
+    });
+
+    it('routes a LEGAL_REACCEPTANCE email with no role to the client app', () => {
+      const base = resolveEmailLinkBase(EmailLinkType.LEGAL_REACCEPTANCE);
+      expect(base).toBe('http://localhost:3000');
+    });
+  });
+
+  describe('honours configured environment URLs', () => {
+    it('uses ADMIN_FRONTEND_URL when configured', () => {
+      process.env.ADMIN_FRONTEND_URL = 'http://localhost:3001';
+      const base = resolveEmailLinkBase(EmailLinkType.GENERIC, UserType.ADMIN);
+      expect(base).toBe('http://localhost:3001');
+    });
+
+    it('uses RESCUE_FRONTEND_URL when configured', () => {
+      process.env.RESCUE_FRONTEND_URL = 'http://localhost:3002';
+      const base = resolveEmailLinkBase(EmailLinkType.RESCUE_INVITATION);
+      expect(base).toBe('http://localhost:3002');
+    });
+
+    it('strips trailing slash from configured URL', () => {
+      process.env.RESCUE_FRONTEND_URL = 'http://localhost:3002/';
+      const base = resolveEmailLinkBase(EmailLinkType.RESCUE_INVITATION);
+      expect(base).toBe('http://localhost:3002');
+    });
+  });
+});

--- a/service.backend/src/utils/email-url.ts
+++ b/service.backend/src/utils/email-url.ts
@@ -1,0 +1,164 @@
+/**
+ * Per-role / per-email-type link destination resolver.
+ *
+ * Background: notification emails previously linked to a single fixed
+ * frontend (FRONTEND_URL). For multi-role users (an adopter who is also
+ * verified rescue staff, or an admin who also adopts) that link drops
+ * them in the wrong app — they have to manually navigate to the right
+ * surface to complete the action.
+ *
+ * Strategy:
+ *   1. Strongly-typed emails (rescue invitation, password reset, etc.)
+ *      pin the destination to a fixed app regardless of who the
+ *      recipient is. This is the dominant case and the safest mapping:
+ *      a rescue invitation is meaningless outside the rescue app.
+ *   2. Untyped / role-driven emails (legal re-acceptance, generic
+ *      notifications) use the recipient's primary role to pick the app.
+ *   3. Missing primary role falls back to the client app — the safe
+ *      default, since every account can use the adopter surface.
+ *
+ * The returned origin is the same value `getValidatedFrontendOrigin`
+ * would return (validated against the allowlist, scheme-checked for
+ * production) — this helper picks WHICH origin to validate, not how.
+ */
+import { UserType } from '../models/User';
+import { assertAllowedFrontendUrl } from './url-allowlist';
+
+/**
+ * Known typed-email contexts. Add a new value here when a new email
+ * has a fixed-app destination; the compiler will then force the
+ * mapping table below to be updated.
+ */
+export enum EmailLinkType {
+  // Adopter-facing (client app)
+  PASSWORD_RESET = 'password_reset',
+  EMAIL_VERIFICATION = 'email_verification',
+  TWO_FACTOR_RECOVERY = 'two_factor_recovery',
+  ACCOUNT_EXISTS = 'account_exists',
+  APPLICATION_STATUS_CHANGE = 'application_status_change',
+
+  // Rescue-facing (rescue app)
+  RESCUE_INVITATION = 'rescue_invitation',
+  RESCUE_VERIFICATION = 'rescue_verification',
+
+  // Role-driven (no fixed app — resolve via recipient role)
+  MODERATION_OUTCOME = 'moderation_outcome',
+  LEGAL_REACCEPTANCE = 'legal_reacceptance',
+  GENERIC = 'generic',
+}
+
+const DEFAULT_CLIENT_URL = 'http://localhost:3000';
+const DEFAULT_RESCUE_URL = 'http://localhost:3002';
+const DEFAULT_ADMIN_URL = 'http://localhost:3001';
+
+const isProduction = (): boolean => process.env.NODE_ENV === 'production';
+
+const readClientUrl = (): string => {
+  const raw = process.env.FRONTEND_URL;
+  if (!raw) {
+    if (isProduction()) {
+      throw new Error('FRONTEND_URL is not set in production');
+    }
+    return DEFAULT_CLIENT_URL;
+  }
+  return assertAllowedFrontendUrl(raw).replace(/\/$/, '');
+};
+
+const readRescueUrl = (): string => {
+  const raw = process.env.RESCUE_FRONTEND_URL;
+  if (!raw) {
+    if (isProduction()) {
+      throw new Error('RESCUE_FRONTEND_URL is not set in production');
+    }
+    return DEFAULT_RESCUE_URL;
+  }
+  return assertAllowedFrontendUrl(raw).replace(/\/$/, '');
+};
+
+const readAdminUrl = (): string => {
+  // ADMIN_FRONTEND_URL is optional even in production — admin-only emails
+  // are rare, and falling back to the client URL keeps links functional
+  // (the admin can navigate from there) rather than throwing.
+  const raw = process.env.ADMIN_FRONTEND_URL;
+  if (!raw) {
+    if (isProduction()) {
+      return readClientUrl();
+    }
+    return DEFAULT_ADMIN_URL;
+  }
+  return assertAllowedFrontendUrl(raw).replace(/\/$/, '');
+};
+
+/**
+ * Maps a recipient's primary role to the app they primarily live in.
+ * Used as a fallback when the email type doesn't pin a destination.
+ */
+const primaryRoleToApp = (role: UserType | undefined): 'client' | 'rescue' | 'admin' => {
+  switch (role) {
+    case UserType.RESCUE_STAFF:
+      return 'rescue';
+    case UserType.ADMIN:
+    case UserType.SUPER_ADMIN:
+    case UserType.MODERATOR:
+    case UserType.SUPPORT_AGENT:
+      return 'admin';
+    case UserType.ADOPTER:
+    default:
+      // Safe default: every account can use the adopter surface, so
+      // a missing/unknown primaryRole lands in the client app.
+      return 'client';
+  }
+};
+
+/**
+ * Maps a typed email to its fixed destination app. Returns `null` for
+ * email types that defer to the recipient's primary role.
+ */
+const emailTypeToApp = (type: EmailLinkType): 'client' | 'rescue' | 'admin' | null => {
+  switch (type) {
+    case EmailLinkType.PASSWORD_RESET:
+    case EmailLinkType.EMAIL_VERIFICATION:
+    case EmailLinkType.TWO_FACTOR_RECOVERY:
+    case EmailLinkType.ACCOUNT_EXISTS:
+    case EmailLinkType.APPLICATION_STATUS_CHANGE:
+      return 'client';
+    case EmailLinkType.RESCUE_INVITATION:
+    case EmailLinkType.RESCUE_VERIFICATION:
+      return 'rescue';
+    case EmailLinkType.MODERATION_OUTCOME:
+    case EmailLinkType.LEGAL_REACCEPTANCE:
+    case EmailLinkType.GENERIC:
+      return null;
+  }
+};
+
+const readAppOrigin = (app: 'client' | 'rescue' | 'admin'): string => {
+  switch (app) {
+    case 'client':
+      return readClientUrl();
+    case 'rescue':
+      return readRescueUrl();
+    case 'admin':
+      return readAdminUrl();
+  }
+};
+
+/**
+ * Resolve the validated origin (no trailing slash) to use as the link
+ * base for an email. Pass the recipient's `userType` so role-driven
+ * emails can route correctly; omit it for emails sent to addresses
+ * with no associated account.
+ *
+ * Typed emails (rescue invitation, password reset, etc.) always go to
+ * their fixed app and ignore `recipientPrimaryRole`. Role-driven types
+ * (legal reminders, moderation outcomes, generic notifications) use
+ * the primary role; absent role → client app.
+ */
+export const resolveEmailLinkBase = (
+  emailType: EmailLinkType,
+  recipientPrimaryRole?: UserType
+): string => {
+  const typedApp = emailTypeToApp(emailType);
+  const app = typedApp ?? primaryRoleToApp(recipientPrimaryRole);
+  return readAppOrigin(app);
+};

--- a/service.backend/src/utils/url-allowlist.ts
+++ b/service.backend/src/utils/url-allowlist.ts
@@ -30,7 +30,7 @@ const parseOrUndefined = (raw: string | undefined): URL | undefined => {
 
 const collectAllowedOrigins = (): Set<string> => {
   const allowed = new Set<string>();
-  for (const key of ['FRONTEND_URL', 'RESCUE_FRONTEND_URL']) {
+  for (const key of ['FRONTEND_URL', 'RESCUE_FRONTEND_URL', 'ADMIN_FRONTEND_URL']) {
     const url = parseOrUndefined(process.env[key]);
     if (url) {
       allowed.add(url.origin);

--- a/service.backend/src/utils/validate-env.ts
+++ b/service.backend/src/utils/validate-env.ts
@@ -115,6 +115,7 @@ const baseSchema = z.object({
   CORS_ORIGIN: z.string().optional(),
   FRONTEND_URL: z.string().optional(),
   RESCUE_FRONTEND_URL: z.string().optional(),
+  ADMIN_FRONTEND_URL: z.string().optional(),
   STATSIG_SERVER_SECRET_KEY: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary

- Adds a `resolveEmailLinkBase` helper (`service.backend/src/utils/email-url.ts`) that picks the correct frontend origin for email links based on a two-tier strategy:
  1. **Email-type-first**: strongly-typed emails (e.g. `RESCUE_INVITATION`, `PASSWORD_RESET`) are pinned to a fixed app regardless of the recipient's role — a rescue invitation always links to the rescue app, password reset always links to the client app.
  2. **Primary-role fallback**: role-driven emails (`LEGAL_REACCEPTANCE`, `MODERATION_OUTCOME`, `GENERIC`) resolve via the recipient's `UserType` — rescue staff go to the rescue app, admins/moderators to the admin app, adopters (and unknown roles) to the client app.
- Updates `auth.service`, `invitation.service`, and `legal-reminder.service` to use `resolveEmailLinkBase` instead of reading `FRONTEND_URL` directly.
- Adds `RESCUE_FRONTEND_URL` and `ADMIN_FRONTEND_URL` to `.env.example` and `validate-env.ts`.
- Includes comprehensive behavioural tests for the resolver covering typed emails, role-driven emails, unknown-role fallback, and configured environment URLs.

## Test plan

- [ ] Verify `resolveEmailLinkBase` tests pass (`npx turbo test --filter=@adopt-dont-shop/service-backend`)
- [ ] Verify existing invitation and auth service tests still pass
- [ ] Confirm `.env.example` documents the new `RESCUE_FRONTEND_URL` and `ADMIN_FRONTEND_URL` vars
- [ ] Manual: send a rescue invitation email and confirm the link points to the rescue app origin
- [ ] Manual: trigger a password reset and confirm the link points to the client app origin

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_