### PR TITLE
feat: add TextArea component for 'why_adopt' question key in Question…

### DIFF
--- a/app.client/src/components/application/QuestionField.tsx
+++ b/app.client/src/components/application/QuestionField.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TextArea } from '@adopt-dont-shop/lib.components';
 import { BooleanTiles } from './BooleanTiles';
 import * as styles from './QuestionField.css';
 import { CurrentPetsField } from './CurrentPetsField';
@@ -70,6 +71,26 @@ export const QuestionField: React.FC<QuestionFieldProps> = ({
 
     if (questionKey === 'current_pets') {
       return <CurrentPetsField value={value} onChange={onChange} hasError={!!error} />;
+    }
+
+    if (questionKey === 'why_adopt') {
+      return (
+        <TextArea
+          value={asString(value)}
+          placeholder={placeholder ?? undefined}
+          rows={6}
+          autoResize
+          minRows={6}
+          maxRows={20}
+          showCharacterCount
+          maxLength={2000}
+          required={isRequired}
+          error={error}
+          fullWidth
+          aria-label={ariaLabel}
+          onChange={e => onChange(e.target.value || undefined)}
+        />
+      );
     }
 
     switch (questionType) {


### PR DESCRIPTION
This pull request updates the `QuestionField` component to better support the "why_adopt" question by rendering it with a `TextArea` input and improves code modularity by importing the shared `TextArea` component from the library package.

**Component enhancements:**

* Added support for rendering the "why_adopt" question as a `TextArea` input, with features like auto-resize, character count, and validation, improving the user experience for long-form answers.

**Code modularity:**

* Imported the `TextArea` component from `@adopt-dont-shop/lib.components` to standardize input components across the application.