### PR TITLE
fix: admin UX polish (7 findings)

### DIFF
--- a/app.admin/src/App.tsx
+++ b/app.admin/src/App.tsx
@@ -161,7 +161,7 @@ const AdminApp: React.FC = () => {
               <Route path='/configuration/questions' element={<Configuration />} />
 
               {/* Content Management */}
-              <Route path='/content' element={<ContentManagement />} />
+              <Route path='/content-management' element={<ContentManagement />} />
 
               {/* Field-Level Permissions */}
               <Route path='/field-permissions' element={<FieldPermissions />} />

--- a/app.admin/src/__tests__/moderation.behavior.test.tsx
+++ b/app.admin/src/__tests__/moderation.behavior.test.tsx
@@ -280,7 +280,11 @@ describe('Content Moderation page', () => {
       });
 
       renderWithProviders(<Moderation />);
-      expect(screen.getByText('No data available')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'No reports found matching your criteria. Try adjusting your filters or search query.'
+        )
+      ).toBeInTheDocument();
     });
   });
 

--- a/app.admin/src/__tests__/rescues.behavior.test.tsx
+++ b/app.admin/src/__tests__/rescues.behavior.test.tsx
@@ -284,7 +284,9 @@ describe('Rescue Management page', () => {
       renderWithProviders(<Rescues />);
       await waitFor(() => {
         expect(
-          screen.getByText('No rescue organizations found matching your criteria')
+          screen.getByText(
+            'No rescue organizations found matching your criteria. Try adjusting your search or filters.'
+          )
         ).toBeInTheDocument();
       });
     });

--- a/app.admin/src/__tests__/user-management.behavior.test.tsx
+++ b/app.admin/src/__tests__/user-management.behavior.test.tsx
@@ -378,7 +378,11 @@ describe('User Management page', () => {
     it('shows an empty message when no users match', () => {
       setupSuccessfulLoad([]);
       renderWithProviders(<Users />);
-      expect(screen.getByText('No users found matching your criteria')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'No users found matching your criteria. Try adjusting your search or filters.'
+        )
+      ).toBeInTheDocument();
     });
   });
 

--- a/app.admin/src/components/layout/AdminSidebar.tsx
+++ b/app.admin/src/components/layout/AdminSidebar.tsx
@@ -216,7 +216,7 @@ export const AdminSidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) =>
               styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
             }
           >
-            <FiShield />
+            <FiLock />
             <span className={styles.navLinkSpan({ collapsed })}>Privacy Tools</span>
           </NavLink>
           <NavLink

--- a/app.admin/src/components/layout/AdminSidebar.tsx
+++ b/app.admin/src/components/layout/AdminSidebar.tsx
@@ -175,7 +175,7 @@ export const AdminSidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) =>
         >
           <div className={styles.navSectionTitle({ collapsed })}>Content</div>
           <NavLink
-            to='/content'
+            to='/content-management'
             className={({ isActive }) =>
               styles.styledNavLink({ collapsed }) + (isActive ? ' active' : '')
             }

--- a/app.admin/src/components/modals/BulkConfirmationModal.css.ts
+++ b/app.admin/src/components/modals/BulkConfirmationModal.css.ts
@@ -187,3 +187,41 @@ export const failureGuidance = style({
   color: '#6b7280',
   lineHeight: '1.5',
 });
+
+export const failedIdsSection = style({
+  marginTop: '0.75rem',
+});
+
+export const failedIdsToggle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.375rem',
+  background: 'none',
+  border: 'none',
+  padding: '0.25rem 0',
+  fontSize: '0.8125rem',
+  fontWeight: '600',
+  color: '#374151',
+  cursor: 'pointer',
+  ':hover': {
+    color: '#111827',
+  },
+});
+
+export const failedIdsList = style({
+  listStyle: 'none',
+  margin: '0.5rem 0 0',
+  padding: '0.5rem 0.75rem',
+  background: '#f9fafb',
+  border: '1px solid #e5e7eb',
+  borderRadius: '6px',
+  maxHeight: '120px',
+  overflowY: 'auto',
+  fontSize: '0.8125rem',
+  fontFamily: 'monospace',
+  color: '#374151',
+});
+
+export const failedIdItem = style({
+  padding: '0.125rem 0',
+});

--- a/app.admin/src/components/modals/BulkConfirmationModal.test.tsx
+++ b/app.admin/src/components/modals/BulkConfirmationModal.test.tsx
@@ -111,3 +111,81 @@ describe('BulkConfirmationModal — partial-failure retry (UX P2 D)', () => {
     expect(screen.queryByText(/Some items couldn't be updated/i)).not.toBeInTheDocument();
   });
 });
+
+/**
+ * Failed IDs display + retry-failed-only
+ *
+ * When the backend returns per-item failedIds, the modal shows a collapsible
+ * list and an optional "Retry failed only" button.
+ */
+describe('BulkConfirmationModal — failedIds display', () => {
+  it('renders a collapsible toggle showing the count of failed IDs', () => {
+    render(
+      <BulkConfirmationModal
+        {...defaultProps}
+        resultSummary={{ succeeded: 2, failed: 2 }}
+        failedIds={['user-1', 'user-2']}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /2 failed items/i })).toBeInTheDocument();
+  });
+
+  it('expands to show individual failed IDs when toggled', () => {
+    render(
+      <BulkConfirmationModal
+        {...defaultProps}
+        resultSummary={{ succeeded: 1, failed: 2 }}
+        failedIds={['user-abc', 'user-def']}
+      />
+    );
+
+    expect(screen.queryByText('user-abc')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /2 failed items/i }));
+
+    expect(screen.getByText('user-abc')).toBeInTheDocument();
+    expect(screen.getByText('user-def')).toBeInTheDocument();
+  });
+
+  it('does not show failed IDs section when failedIds is empty', () => {
+    render(
+      <BulkConfirmationModal
+        {...defaultProps}
+        resultSummary={{ succeeded: 3, failed: 0 }}
+        failedIds={[]}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /failed item/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a Retry failed only button when onRetryFailed and failedIds are provided', () => {
+    const onRetryFailed = vi.fn();
+    render(
+      <BulkConfirmationModal
+        {...defaultProps}
+        resultSummary={{ succeeded: 1, failed: 1 }}
+        failedIds={['user-1']}
+        onRetryFailed={onRetryFailed}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /retry failed only/i })).toBeInTheDocument();
+  });
+
+  it('invokes onRetryFailed when Retry failed only is clicked', () => {
+    const onRetryFailed = vi.fn();
+    render(
+      <BulkConfirmationModal
+        {...defaultProps}
+        resultSummary={{ succeeded: 1, failed: 1 }}
+        failedIds={['user-1']}
+        onRetryFailed={onRetryFailed}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /retry failed only/i }));
+    expect(onRetryFailed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app.admin/src/components/modals/BulkConfirmationModal.tsx
+++ b/app.admin/src/components/modals/BulkConfirmationModal.tsx
@@ -1,7 +1,14 @@
 import React, { useId, useRef, useEffect, useState } from 'react';
 import * as styles from './BulkConfirmationModal.css';
 import { Button } from '@adopt-dont-shop/lib.components';
-import { FiAlertTriangle, FiCheckCircle, FiInfo, FiX } from 'react-icons/fi';
+import {
+  FiAlertTriangle,
+  FiCheckCircle,
+  FiChevronDown,
+  FiChevronRight,
+  FiInfo,
+  FiX,
+} from 'react-icons/fi';
 
 export type BulkConfirmationVariant = 'danger' | 'warning' | 'info';
 
@@ -19,12 +26,8 @@ type BulkConfirmationModalProps = {
   reasonPlaceholder?: string;
   isLoading?: boolean;
   resultSummary?: { succeeded: number; failed: number } | null;
-  // UX P2 D: when the bulk action partially failed, give the operator a way
-  // to re-run the action without rebuilding the selection. The backend bulk
-  // endpoints (POST /api/v1/users/bulk-update, etc.) only return aggregate
-  // {success, failed} counts today — there is no per-item failed-IDs payload
-  // — so retry must re-attempt the same userIds the parent originally
-  // submitted. A backend follow-up is required to enable retry-failed-only.
+  failedIds?: ReadonlyArray<string>;
+  onRetryFailed?: () => void | Promise<void>;
   onRetry?: () => void | Promise<void>;
 };
 
@@ -48,9 +51,12 @@ export const BulkConfirmationModal: React.FC<BulkConfirmationModalProps> = ({
   reasonPlaceholder = 'Enter reason...',
   isLoading = false,
   resultSummary,
+  failedIds,
+  onRetryFailed,
   onRetry,
 }) => {
   const [reason, setReason] = useState('');
+  const [failedIdsExpanded, setFailedIdsExpanded] = useState(false);
   const titleId = useId();
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -134,6 +140,28 @@ export const BulkConfirmationModal: React.FC<BulkConfirmationModalProps> = ({
                   per-row status, or try the action again.
                 </p>
               )}
+              {failedIds && failedIds.length > 0 && (
+                <div className={styles.failedIdsSection}>
+                  <button
+                    type='button'
+                    className={styles.failedIdsToggle}
+                    onClick={() => setFailedIdsExpanded(prev => !prev)}
+                    aria-expanded={failedIdsExpanded}
+                  >
+                    {failedIdsExpanded ? <FiChevronDown /> : <FiChevronRight />}
+                    {failedIds.length} failed item{failedIds.length !== 1 ? 's' : ''}
+                  </button>
+                  {failedIdsExpanded && (
+                    <ul className={styles.failedIdsList}>
+                      {failedIds.map(id => (
+                        <li key={id} className={styles.failedIdItem}>
+                          {id}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
             </>
           ) : (
             <>
@@ -164,6 +192,11 @@ export const BulkConfirmationModal: React.FC<BulkConfirmationModalProps> = ({
         <div className={styles.modalFooter}>
           {resultSummary ? (
             <>
+              {resultSummary.failed > 0 && onRetryFailed && failedIds && failedIds.length > 0 && (
+                <Button variant='outline' onClick={onRetryFailed} disabled={isLoading}>
+                  {isLoading ? 'Retrying...' : 'Retry failed only'}
+                </Button>
+              )}
               {resultSummary.failed > 0 && onRetry && (
                 <Button variant='outline' onClick={onRetry} disabled={isLoading}>
                   {isLoading ? 'Retrying...' : 'Try again'}

--- a/app.admin/src/components/modals/RescueDetailModal.css.ts
+++ b/app.admin/src/components/modals/RescueDetailModal.css.ts
@@ -498,6 +498,14 @@ export const skeletonName = style({
   marginBottom: '0.5rem',
 });
 
+export const modalFooter = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '0.75rem',
+  padding: '1.25rem 1.5rem',
+  borderTop: '1px solid #e5e7eb',
+});
+
 export const successMessage = style({
   padding: '0.75rem',
   marginBottom: '1rem',

--- a/app.admin/src/components/modals/RescueDetailModal/index.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal/index.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import clsx from 'clsx';
-import { Heading, Text } from '@adopt-dont-shop/lib.components';
+import { Heading, Text, Button } from '@adopt-dont-shop/lib.components';
 import { rescueStatusLabel, type RescueStatusValue } from '@adopt-dont-shop/lib.types';
 import { Skeleton, SkeletonText } from '../../ui/Skeleton';
-import { FiX } from 'react-icons/fi';
+import { FiX, FiCheckCircle, FiXCircle } from 'react-icons/fi';
 import type { AdminRescue, RescueStatistics } from '@/types/rescue';
 import { rescueService } from '@/services/rescueService';
 import * as styles from '../RescueDetailModal.css';
@@ -18,6 +18,8 @@ type RescueDetailModalProps = {
   rescueId: string;
   onClose: () => void;
   onUpdate?: () => void;
+  onApprove?: (rescue: AdminRescue) => void;
+  onReject?: (rescue: AdminRescue) => void;
 };
 
 type ActiveTab = 'overview' | 'contact' | 'policies' | 'staff' | 'listings' | 'plan';
@@ -49,6 +51,8 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
   rescueId,
   onClose,
   onUpdate,
+  onApprove,
+  onReject,
 }) => {
   const [rescue, setRescue] = useState<AdminRescue | null>(null);
   const [, setStatistics] = useState<RescueStatistics | null>(null);
@@ -162,6 +166,23 @@ export const RescueDetailModal: React.FC<RescueDetailModalProps> = ({
             </>
           )}
         </div>
+
+        {!loading && rescue && rescue.status === 'pending' && (onApprove || onReject) && (
+          <div className={styles.modalFooter}>
+            {onReject && (
+              <Button variant='danger' onClick={() => onReject(rescue)}>
+                <FiXCircle style={{ marginRight: '0.5rem' }} />
+                Reject
+              </Button>
+            )}
+            {onApprove && (
+              <Button variant='primary' onClick={() => onApprove(rescue)}>
+                <FiCheckCircle style={{ marginRight: '0.5rem' }} />
+                Approve
+              </Button>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app.admin/src/components/moderation/ActionSelectionModal.css.ts
+++ b/app.admin/src/components/moderation/ActionSelectionModal.css.ts
@@ -84,6 +84,16 @@ export const reportText = style({
   color: '#111827',
 });
 
+export const inlineError = style({
+  background: '#fee2e2',
+  border: '1px solid #fecaca',
+  borderRadius: '8px',
+  padding: '0.75rem 1rem',
+  color: '#991b1b',
+  fontSize: '0.875rem',
+  marginBottom: '1.5rem',
+});
+
 export const formGroup = style({
   marginBottom: '1.5rem',
 });

--- a/app.admin/src/components/moderation/ActionSelectionModal.tsx
+++ b/app.admin/src/components/moderation/ActionSelectionModal.tsx
@@ -26,6 +26,7 @@ interface ActionSelectionModalProps {
   onSubmit: (data: ActionSelectionData) => void;
   reportTitle: string;
   isLoading?: boolean;
+  error?: string | null;
 }
 
 const actionTypeLabels: Record<ActionType, string> = {
@@ -54,6 +55,7 @@ export const ActionSelectionModal: React.FC<ActionSelectionModalProps> = ({
   onSubmit,
   reportTitle,
   isLoading = false,
+  error = null,
 }) => {
   const [actionType, setActionType] = useState<ActionType>('no_action');
   const [reason, setReason] = useState('');
@@ -113,6 +115,12 @@ export const ActionSelectionModal: React.FC<ActionSelectionModalProps> = ({
               <div className={styles.reportTitle}>Report:</div>
               <div className={styles.reportText}>{reportTitle}</div>
             </div>
+
+            {error && (
+              <div className={styles.inlineError} role='alert'>
+                {error}
+              </div>
+            )}
 
             <div className={styles.formGroup}>
               <label className={styles.label} htmlFor='actionType'>

--- a/app.admin/src/pages/Dashboard.css.ts
+++ b/app.admin/src/pages/Dashboard.css.ts
@@ -69,6 +69,12 @@ export const metricChangeNegative = style({
   fontWeight: '500',
 });
 
+export const metricChangeNeutral = style({
+  fontSize: '0.875rem',
+  color: vars.text.tertiary,
+  fontWeight: '500',
+});
+
 const shimmerAnim = keyframes({
   '0%': { backgroundPosition: '-200px 0' },
   '100%': { backgroundPosition: 'calc(200px + 100%) 0' },

--- a/app.admin/src/pages/Dashboard.tsx
+++ b/app.admin/src/pages/Dashboard.tsx
@@ -18,12 +18,14 @@ const formatGrowthLabel = (current: number, previous: number, label: string): st
   return `${sign}${pct}% from last month`;
 };
 
+type MetricTone = 'positive' | 'neutral' | 'negative';
+
 type MetricDefinition = {
   icon: string;
   label: string;
   value: string;
   change: string;
-  positive: boolean;
+  tone: MetricTone;
   href: string;
 };
 
@@ -74,7 +76,7 @@ const Dashboard: React.FC = () => {
             0,
             `${formatNumber(data.users.newThisMonth)} new this month`
           ),
-          positive: data.users.newThisMonth >= 0,
+          tone: data.users.newThisMonth >= 0 ? 'positive' : 'negative',
           href: '/users',
         },
         {
@@ -82,7 +84,7 @@ const Dashboard: React.FC = () => {
           label: 'Active Rescues',
           value: formatNumber(data.rescues.verified),
           change: `${formatNumber(data.rescues.pending)} pending verification`,
-          positive: data.rescues.pending === 0,
+          tone: 'neutral',
           href: '/rescues?status=verified',
         },
         {
@@ -90,7 +92,7 @@ const Dashboard: React.FC = () => {
           label: 'Pets Listed',
           value: formatNumber(data.pets.available),
           change: `${formatNumber(data.pets.total)} total pets`,
-          positive: true,
+          tone: 'positive',
           href: '/pets?status=available',
         },
         {
@@ -98,7 +100,7 @@ const Dashboard: React.FC = () => {
           label: 'Adoptions (30d)',
           value: formatNumber(data.pets.adopted),
           change: `${formatNumber(data.applications.approved)} applications approved`,
-          positive: data.pets.adopted > 0,
+          tone: data.pets.adopted > 0 ? 'positive' : 'neutral',
           href: '/pets?status=adopted',
         },
         {
@@ -106,7 +108,7 @@ const Dashboard: React.FC = () => {
           label: 'Pending Applications',
           value: formatNumber(data.applications.pending),
           change: `${formatNumber(data.applications.total)} total this month`,
-          positive: data.applications.pending === 0,
+          tone: 'neutral',
           href: '/applications?status=submitted',
         },
         {
@@ -114,7 +116,7 @@ const Dashboard: React.FC = () => {
           label: 'New Users (30d)',
           value: formatNumber(data.users.newThisMonth),
           change: `${formatNumber(data.users.active)} active users`,
-          positive: data.users.newThisMonth > 0,
+          tone: data.users.newThisMonth > 0 ? 'positive' : 'neutral',
           href: '/users',
         },
       ]
@@ -164,7 +166,11 @@ const Dashboard: React.FC = () => {
                 <div className={styles.metricValue}>{metric.value}</div>
                 <div
                   className={
-                    metric.positive ? styles.metricChangePositive : styles.metricChangeNegative
+                    metric.tone === 'positive'
+                      ? styles.metricChangePositive
+                      : metric.tone === 'negative'
+                        ? styles.metricChangeNegative
+                        : styles.metricChangeNeutral
                   }
                 >
                   {metric.change}

--- a/app.admin/src/pages/Moderation.test.tsx
+++ b/app.admin/src/pages/Moderation.test.tsx
@@ -1,31 +1,16 @@
 /**
  * UX P0/P1 #8: when a moderation action submission fails, the page
- * previously only console.error'd the failure — the modal stayed open
- * with no feedback. The handler now surfaces the failure via the
- * app-admin `toast.error` pattern so the user can retry or close.
+ * surfaces the failure as a persistent inline error in the action modal
+ * so the user can see the error, retry, or close.
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils';
 
-const toastErrorMock = vi.fn();
 const resolveReportMock = vi.fn();
 const dismissReportMock = vi.fn();
 const refetchMock = vi.fn().mockResolvedValue(undefined);
-
-vi.mock('@adopt-dont-shop/lib.components', async () => {
-  const actual = await vi.importActual<Record<string, unknown>>('@adopt-dont-shop/lib.components');
-  return {
-    ...actual,
-    toast: Object.assign(vi.fn(), {
-      error: (...args: unknown[]) => toastErrorMock(...args),
-      success: vi.fn(),
-      info: vi.fn(),
-      warning: vi.fn(),
-    }),
-  };
-});
 
 const sampleReport = {
   reportId: 'rep-1',
@@ -66,27 +51,32 @@ vi.mock('@adopt-dont-shop/lib.moderation', () => ({
 }));
 
 // Replace ActionSelectionModal with a stub that exposes a "submit" button
-// firing onSubmit with a deterministic payload — that's all we need to
-// observe the error-handling branch.
+// firing onSubmit with a deterministic payload, and renders the error prop
+// inline so we can assert on it.
 vi.mock('../components/moderation/ActionSelectionModal', () => ({
   ActionSelectionModal: ({
     isOpen,
     onSubmit,
+    error,
   }: {
     isOpen: boolean;
     onSubmit: (data: { actionType: string; reason: string }) => void;
+    error?: string | null;
   }) => {
     if (!isOpen) {
       return null;
     }
     return (
-      <button
-        type='button'
-        onClick={() => onSubmit({ actionType: 'no_action', reason: 'looked fine' })}
-        data-testid='stub-action-submit'
-      >
-        Submit Action
-      </button>
+      <div>
+        {error && <div role='alert'>{error}</div>}
+        <button
+          type='button'
+          onClick={() => onSubmit({ actionType: 'no_action', reason: 'looked fine' })}
+          data-testid='stub-action-submit'
+        >
+          Submit Action
+        </button>
+      </div>
     );
   },
 }));
@@ -112,7 +102,7 @@ describe('Moderation handleActionSubmit error feedback', () => {
     vi.clearAllMocks();
   });
 
-  it('surfaces a toast.error when the dismiss mutation throws', async () => {
+  it('surfaces an inline error in the modal when the dismiss mutation throws', async () => {
     dismissReportMock.mockRejectedValueOnce(new Error('Server exploded'));
 
     renderWithProviders(<Moderation />);
@@ -121,14 +111,13 @@ describe('Moderation handleActionSubmit error feedback', () => {
     fireEvent.click(screen.getByTestId('stub-action-submit'));
 
     await waitFor(() => {
-      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveTextContent(/failed to take moderation action/i);
+      expect(alert).toHaveTextContent(/server exploded/i);
     });
-    const [message] = toastErrorMock.mock.calls[0];
-    expect(message).toMatch(/failed to take moderation action/i);
-    expect(message).toMatch(/server exploded/i);
   });
 
-  it('does not show a toast.error when the mutation succeeds', async () => {
+  it('does not show an inline error when the mutation succeeds', async () => {
     dismissReportMock.mockResolvedValueOnce(undefined);
 
     renderWithProviders(<Moderation />);
@@ -139,6 +128,6 @@ describe('Moderation handleActionSubmit error feedback', () => {
     await waitFor(() => {
       expect(dismissReportMock).toHaveBeenCalled();
     });
-    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/app.admin/src/pages/Moderation.tsx
+++ b/app.admin/src/pages/Moderation.tsx
@@ -512,6 +512,7 @@ const Moderation: React.FC = () => {
         data={reports}
         columns={columns}
         loading={isLoading}
+        emptyMessage='No reports found matching your criteria. Try adjusting your filters or search query.'
         onRowClick={handleOpenDetailModal}
         currentPage={pagination?.page || 1}
         totalPages={pagination?.totalPages || 1}

--- a/app.admin/src/pages/Moderation.tsx
+++ b/app.admin/src/pages/Moderation.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Heading, Text, Button, Input, toast } from '@adopt-dont-shop/lib.components';
+import { Heading, Text, Button, Input } from '@adopt-dont-shop/lib.components';
 import {
   FiSearch,
   FiAlertTriangle,
@@ -127,6 +127,7 @@ const Moderation: React.FC = () => {
   const [isActionModalOpen, setIsActionModalOpen] = useState(false);
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [selectedReport, setSelectedReport] = useState<Report | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // Bulk selection state
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
@@ -183,12 +184,14 @@ const Moderation: React.FC = () => {
 
   const handleOpenActionModal = (report: Report) => {
     setSelectedReport(report);
+    setActionError(null);
     setIsActionModalOpen(true);
   };
 
   const handleCloseActionModal = () => {
     setIsActionModalOpen(false);
     setSelectedReport(null);
+    setActionError(null);
   };
 
   const handleActionSubmit = async (actionData: ActionSelectionData) => {
@@ -206,13 +209,9 @@ const Moderation: React.FC = () => {
       handleCloseActionModal();
       await refetch();
     } catch (err) {
-      // UX P0/P1 #8: previously the catch only console.error'd, which left
-      // the modal open in limbo with no signal to the user. Keep the modal
-      // open so they can retry / close, and surface the failure via the
-      // app-admin toast pattern.
       console.error('Failed to take moderation action:', err);
       const message = err instanceof Error ? err.message : 'Unknown error';
-      toast.error(`Failed to take moderation action: ${message}`, { duration: 6000 });
+      setActionError(`Failed to take moderation action: ${message}`);
     }
   };
 
@@ -535,6 +534,7 @@ const Moderation: React.FC = () => {
         onSubmit={handleActionSubmit}
         reportTitle={selectedReport?.title || ''}
         isLoading={isActionLoading}
+        error={actionError}
       />
 
       <BulkModerationModal

--- a/app.admin/src/pages/Rescues.tsx
+++ b/app.admin/src/pages/Rescues.tsx
@@ -365,7 +365,7 @@ const Rescues: React.FC = () => {
         data={rescues}
         loading={loading}
         error={error}
-        emptyMessage='No rescue organizations found matching your criteria'
+        emptyMessage='No rescue organizations found matching your criteria. Try adjusting your search or filters.'
         onRowClick={rescue => handleViewDetails(rescue.rescueId)}
         currentPage={currentPage}
         totalPages={totalPages}

--- a/app.admin/src/pages/Rescues.tsx
+++ b/app.admin/src/pages/Rescues.tsx
@@ -381,6 +381,8 @@ const Rescues: React.FC = () => {
           rescueId={selectedRescue.rescueId}
           onClose={handleModalClose}
           onUpdate={fetchRescues}
+          onApprove={handleApprove}
+          onReject={handleReject}
         />
       )}
 

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -604,7 +604,7 @@ const Users: React.FC = () => {
         columns={columns}
         data={users}
         loading={isLoading}
-        emptyMessage='No users found matching your criteria'
+        emptyMessage='No users found matching your criteria. Try adjusting your search or filters.'
         onRowClick={handleRowClick}
         currentPage={page}
         totalPages={totalPages}

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -117,6 +117,7 @@ const Users: React.FC = () => {
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<BulkActionType | null>(null);
   const [bulkResult, setBulkResult] = useState<{ succeeded: number; failed: number } | null>(null);
+  const [bulkFailedIds, setBulkFailedIds] = useState<string[]>([]);
   // UX P2 D: keep the last submitted batch around so the "Try again" button on
   // the result view can re-run the same userIds + reason without the operator
   // rebuilding the selection. Cleared on close.
@@ -275,8 +276,14 @@ const Users: React.FC = () => {
     action: BulkActionType,
     userIds: string[],
     reason?: string
-  ): Promise<{ succeeded: number; failed: number }> => {
-    let result: { successCount?: number; failedCount?: number; success?: number; failed?: number };
+  ): Promise<{ succeeded: number; failed: number; failedIds: string[] }> => {
+    let result: {
+      successCount?: number;
+      failedCount?: number;
+      success?: number;
+      failed?: number;
+      failedIds?: string[];
+    };
 
     if (action === 'activate') {
       result = await bulkUpdateUsers.mutateAsync({
@@ -291,17 +298,26 @@ const Users: React.FC = () => {
         reason,
       });
     } else {
-      result = await Promise.all(
-        userIds.map(id => deleteUser.mutateAsync({ userId: id, reason }).catch(() => null))
-      ).then(results => ({
-        successCount: results.filter(r => r !== null).length,
-        failedCount: results.filter(r => r === null).length,
-      }));
+      const outcomes = await Promise.all(
+        userIds.map(id =>
+          deleteUser
+            .mutateAsync({ userId: id, reason })
+            .then(() => id)
+            .catch(() => null)
+        )
+      );
+      const deletedFailedIds = userIds.filter((_, i) => outcomes[i] === null);
+      result = {
+        successCount: outcomes.filter(r => r !== null).length,
+        failedCount: deletedFailedIds.length,
+        failedIds: deletedFailedIds,
+      };
     }
 
     return {
       succeeded: result.successCount ?? result.success ?? 0,
       failed: result.failedCount ?? result.failed ?? 0,
+      failedIds: result.failedIds ?? [],
     };
   };
 
@@ -311,15 +327,12 @@ const Users: React.FC = () => {
     }
     const userIds = Array.from(selectedRows);
     const summary = await runBulkAction(bulkAction, userIds, reason);
-    setBulkResult(summary);
+    setBulkResult({ succeeded: summary.succeeded, failed: summary.failed });
+    setBulkFailedIds(summary.failedIds);
     setLastBulkSubmission({ userIds, reason });
     setSelectedRows(new Set());
   };
 
-  // UX P2 D: re-run the entire batch with the same userIds + reason. The backend
-  // bulk endpoints return only aggregate counts, so we cannot retry just the
-  // failed subset without a per-item failed-IDs response shape — that's a
-  // follow-up.
   const handleBulkRetry = async () => {
     if (!bulkAction || !lastBulkSubmission) {
       return;
@@ -329,12 +342,24 @@ const Users: React.FC = () => {
       lastBulkSubmission.userIds,
       lastBulkSubmission.reason
     );
-    setBulkResult(summary);
+    setBulkResult({ succeeded: summary.succeeded, failed: summary.failed });
+    setBulkFailedIds(summary.failedIds);
+  };
+
+  const handleBulkRetryFailed = async () => {
+    if (!bulkAction || bulkFailedIds.length === 0) {
+      return;
+    }
+    const reason = lastBulkSubmission?.reason;
+    const summary = await runBulkAction(bulkAction, bulkFailedIds, reason);
+    setBulkResult({ succeeded: summary.succeeded, failed: summary.failed });
+    setBulkFailedIds(summary.failedIds);
   };
 
   const handleBulkModalClose = () => {
     setBulkAction(null);
     setBulkResult(null);
+    setBulkFailedIds([]);
     setLastBulkSubmission(null);
   };
 
@@ -675,6 +700,8 @@ const Users: React.FC = () => {
         }
         isLoading={bulkUpdateUsers.isPending || deleteUser.isPending}
         resultSummary={bulkResult}
+        failedIds={bulkFailedIds}
+        onRetryFailed={handleBulkRetryFailed}
         onRetry={handleBulkRetry}
       />
 


### PR DESCRIPTION
## Summary

Ships seven admin UX polish fixes:

- **Dead sidebar link** -- `/content` sidebar link updated to `/content-management` with matching route
- **Detail modal actions** -- Approve/Reject buttons added to RescueDetailModal footer for pending rescues
- **Metric card colours** -- Count-based dashboard metrics (pending applications, pending rescues) use neutral text instead of red
- **Bulk result failedIds** -- BulkConfirmationModal now shows a collapsible list of failed item IDs and a "Retry failed only" button; wired into Users.tsx
- **Duplicate icon** -- Privacy Tools sidebar icon changed from FiShield to FiLock (Security Center already uses FiShield)
- **Moderation error persistence** -- Failed moderation actions show a persistent inline error in the modal instead of a 6-second toast
- **Empty state guidance** -- DataTable empty messages in Users, Rescues, and Moderation now include next-action copy ("Try adjusting your search or filters")

## Test plan

- [x] All 405 app.admin tests pass (excluding 1 pre-existing failure in `ModerationTab.test.tsx`)
- [x] Lint passes with 0 errors
- [x] 5 new tests added for failedIds display and retry-failed-only behaviour
- [x] Updated existing tests for empty state messages and moderation error feedback
- [x] One commit per finding

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_