### PR TITLE
fix(app.client): client UX polish fixes

### DIFF
--- a/app.client/src/__tests__/search-page-error-state.behavior.test.tsx
+++ b/app.client/src/__tests__/search-page-error-state.behavior.test.tsx
@@ -1,6 +1,6 @@
 /**
  * UX P0/P1 #5: when the pet-search API fails, SearchPage must render a
- * recoverable error state with a "Try Again" button rather than dropping
+ * recoverable error state with a "Retry" button rather than dropping
  * the user into an empty-state look-alike.
  */
 import { http, HttpResponse } from 'msw';
@@ -91,26 +91,26 @@ afterEach(() => {
 afterAll(() => server.close());
 
 describe('SearchPage error state', () => {
-  it('renders a Try Again button when the initial pet search fails', async () => {
+  it('renders a Retry button when the initial pet search fails', async () => {
     renderWithProviders(<SearchPage />);
 
-    const retry = await screen.findByRole('button', { name: /try again/i }, { timeout: 10_000 });
+    const retry = await screen.findByRole('button', { name: /retry/i }, { timeout: 10_000 });
     expect(retry).toBeInTheDocument();
-    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText(/unable to load results/i)).toBeInTheDocument();
     // Empty-state copy must not be shown on a load failure.
-    expect(screen.queryByText(/no pets found/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/no pets match/i)).not.toBeInTheDocument();
   });
 
-  it('refetches when the user clicks Try Again', async () => {
+  it('refetches when the user clicks Retry', async () => {
     const user = userEvent.setup();
     renderWithProviders(<SearchPage />);
 
-    const retry = await screen.findByRole('button', { name: /try again/i }, { timeout: 10_000 });
+    const retry = await screen.findByRole('button', { name: /retry/i }, { timeout: 10_000 });
     await user.click(retry);
 
     // Second call returns 200 with an empty data array — empty state appears.
     await waitFor(() => {
-      expect(screen.getByText(/no pets found/i)).toBeInTheDocument();
+      expect(screen.getByText(/no pets match/i)).toBeInTheDocument();
     });
   });
 });

--- a/app.client/src/components/PetCard.tsx
+++ b/app.client/src/components/PetCard.tsx
@@ -24,7 +24,6 @@ export const PetCard: React.FC<PetCardProps> = ({
   isFavorite: propIsFavorite,
 }) => {
   'use memo';
-  const [isLoadingFavorite, setIsLoadingFavorite] = useState(false);
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
   const { isAuthenticated } = useAuth();
   const favorites = useFavorites();
@@ -66,12 +65,15 @@ export const PetCard: React.FC<PetCardProps> = ({
       return;
     }
 
-    setIsLoadingFavorite(true);
+    // Optimistic: flip immediately via the context (which already does
+    // its own optimistic update) and notify parent right away so the UI
+    // feels instant. Revert the parent callback on error.
+    const newFavorite = !isFavorite;
+    onFavoriteToggle?.(pet.pet_id, newFavorite);
 
     try {
       if (isFavorite) {
         await favorites.removeFromFavorites(pet.pet_id);
-        onFavoriteToggle?.(pet.pet_id, false);
 
         // Log favorite removal
         logEvent('pet_unfavorited', 1, {
@@ -82,7 +84,6 @@ export const PetCard: React.FC<PetCardProps> = ({
         });
       } else {
         await favorites.addToFavorites(pet.pet_id);
-        onFavoriteToggle?.(pet.pet_id, true);
 
         // Log favorite addition
         logEvent('pet_favorited', 1, {
@@ -93,6 +94,9 @@ export const PetCard: React.FC<PetCardProps> = ({
         });
       }
     } catch (error) {
+      // Revert the optimistic parent callback
+      onFavoriteToggle?.(pet.pet_id, isFavorite);
+
       console.error('Failed to toggle favorite:', error);
 
       // Log favorite error
@@ -101,8 +105,6 @@ export const PetCard: React.FC<PetCardProps> = ({
         action: isFavorite ? 'remove' : 'add',
         error_message: error instanceof Error ? error.message : 'Unknown error',
       });
-    } finally {
-      setIsLoadingFavorite(false);
     }
   };
 
@@ -216,7 +218,6 @@ export const PetCard: React.FC<PetCardProps> = ({
           <button
             className={styles.favoriteButton}
             onClick={handleFavoriteClick}
-            disabled={isLoadingFavorite}
             style={{ color: isFavorite ? '#ff6b6b' : '#ccc' }}
           >
             {isFavorite ? <MdFavorite size={24} /> : <MdFavoriteBorder size={24} />}

--- a/app.client/src/components/PetCard.tsx
+++ b/app.client/src/components/PetCard.tsx
@@ -254,7 +254,7 @@ export const PetCard: React.FC<PetCardProps> = ({
 
         {pet.short_description && <p className={styles.description}>{pet.short_description}</p>}
 
-        {pet.rescue_id && <div className={styles.rescueInfo}>Rescue ID: {pet.rescue_id}</div>}
+        {pet.rescue?.name && <div className={styles.rescueInfo}>From {pet.rescue.name}</div>}
 
         <div className={styles.cardActions}>
           <Button size='sm' variant='primary' className={styles.actionButton}>

--- a/app.client/src/components/chat/ChatPage.tsx
+++ b/app.client/src/components/chat/ChatPage.tsx
@@ -33,7 +33,7 @@ export function ChatPage() {
     return (
       <div className={styles.chatContainer}>
         <div className={styles.loginPrompt}>
-          <h2>🔐 Login Required</h2>
+          <h2>Login Required</h2>
           <p>
             Please log in to access your messages. Connect with rescue organizations and stay
             updated on your adoption applications.

--- a/app.client/src/pages/FavoritesPage.tsx
+++ b/app.client/src/pages/FavoritesPage.tsx
@@ -68,7 +68,7 @@ export const FavoritesPage: React.FC = () => {
     return (
       <Container className={styles.pageContainer}>
         <div className={styles.loginPrompt}>
-          <h2>🔐 Login Required</h2>
+          <h2>Login Required</h2>
           <p>
             Please log in to view your favorite pets. Your favorites will be saved across all your
             devices.
@@ -84,7 +84,7 @@ export const FavoritesPage: React.FC = () => {
   return (
     <Container className={styles.pageContainer}>
       <div className={styles.header}>
-        <h1>❤️ Your Favorite Pets</h1>
+        <h1>Your Favorite Pets</h1>
         <p>
           Keep track of the pets that caught your heart. Your favorites are saved and synced across
           all your devices.
@@ -152,7 +152,6 @@ export const FavoritesPage: React.FC = () => {
       {/* Empty state */}
       {!loading && !error && favorites.length === 0 && (
         <div className={styles.emptyState}>
-          <span className='emoji'>💔</span>
           <h2>No favorites yet</h2>
           <p>
             You haven&apos;t saved any pets to your favorites yet. Start exploring to find pets that
@@ -160,10 +159,10 @@ export const FavoritesPage: React.FC = () => {
           </p>
           <div className={styles.ctaButtonRow}>
             <Link to='/discover' className={styles.ctaButton}>
-              🔍 Start Swiping
+              Start Swiping
             </Link>
             <Link to='/search' className={`${styles.ctaButton} ${styles.ctaButtonGreen}`}>
-              📋 Browse All Pets
+              Browse All Pets
             </Link>
           </div>
         </div>

--- a/app.client/src/pages/PetDetailsPage.tsx
+++ b/app.client/src/pages/PetDetailsPage.tsx
@@ -619,14 +619,10 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
                 <span className='label'>Gender</span>
                 <span className='value'>{pet.gender}</span>
               </div>
-              {pet.location && (
+              {pet.rescue?.location && (
                 <div className='info-item'>
                   <span className='label'>Location</span>
-                  <span className='value'>
-                    {pet.location.coordinates
-                      ? `${pet.location.coordinates[1]}, ${pet.location.coordinates[0]}`
-                      : 'Not specified'}
-                  </span>
+                  <span className='value'>{pet.rescue.location}</span>
                 </div>
               )}
             </div>

--- a/app.client/src/pages/ProfilePage.tsx
+++ b/app.client/src/pages/ProfilePage.tsx
@@ -319,7 +319,7 @@ export const ProfilePage: React.FC = () => {
                 <div className={styles.infoItem}>
                   <span className={styles.infoLabel}>Preferred Contact</span>
                   <span className={styles.infoValue}>
-                    {user.preferredContactMethod || 'Not specified'}
+                    {user.preferredContactMethod || 'Not provided'}
                   </span>
                 </div>
                 <div className={styles.infoItem}>

--- a/app.client/src/pages/SearchPage.tsx
+++ b/app.client/src/pages/SearchPage.tsx
@@ -142,7 +142,7 @@ export const SearchPage: React.FC = () => {
       });
     } catch (err) {
       console.error('Search error details:', err);
-      setError('Failed to load pets. Please try again.');
+      setError('Something went wrong loading results. Please check your connection and try again.');
       setPets([]);
       setPagination(null);
 
@@ -232,14 +232,14 @@ export const SearchPage: React.FC = () => {
           </div>
         ) : error ? (
           <div className={styles.emptyState}>
-            <h3>Oops! Something went wrong</h3>
+            <h3>Unable to load results</h3>
             <p>{error}</p>
-            <Button onClick={loadPets}>Try Again</Button>
+            <Button onClick={loadPets}>Retry</Button>
           </div>
         ) : !pets || pets.length === 0 ? (
           <div className={styles.emptyState}>
-            <h3>No pets found</h3>
-            <p>Try adjusting your search criteria or clearing some filters to see more results.</p>
+            <h3>No pets match your filters</h3>
+            <p>Try broadening your search by removing some filters or using different keywords.</p>
             {hasActiveFilters && <Button onClick={handleClearAll}>Clear All Filters</Button>}
           </div>
         ) : (

--- a/app.client/src/pages/SearchPage.tsx
+++ b/app.client/src/pages/SearchPage.tsx
@@ -258,7 +258,8 @@ export const SearchPage: React.FC = () => {
         {pagination && pagination.totalPages > 1 && (
           <div className={styles.pagination}>
             <div className='page-info'>
-              Page {pagination.page} of {pagination.totalPages}({pagination.total} total pets)
+              Showing page {pagination.page} of {pagination.totalPages} &mdash; {pagination.total}{' '}
+              pets
             </div>
 
             <div className='page-controls'>


### PR DESCRIPTION
## Summary

Seven small UX polish fixes for the client app:

- **Pet card rescue info**: Show rescue name ("From Happy Tails") instead of raw UUID
- **Pet details location**: Show rescue location name instead of raw lat/lng coordinates
- **Favorite toggle**: Optimistic update -- heart icon flips immediately on click, reverts on API error
- **Profile empty fields**: Standardize "Not specified" to "Not provided" for consistency
- **Emoji removal**: Remove emoji from FavoritesPage and ChatPage headers/CTAs
- **Pagination text**: Reformat "Page N of M(X total pets)" to "Showing page N of M -- X pets"
- **Search error messages**: Differentiate network errors ("Unable to load results" + Retry) from empty results ("No pets match your filters" + suggest broadening)

## Test plan

- [x] `npx turbo lint test --filter=@adopt-dont-shop/app.client` passes (410 tests, 66 files)
- [x] Updated search-page-error-state tests to match new copy
- [ ] Visual check: pet cards show rescue name, not UUID
- [ ] Visual check: pet details show location name, not coordinates
- [ ] Visual check: heart icon toggles instantly on click
- [ ] Visual check: profile page uses consistent "Not provided" labels
- [ ] Visual check: no emoji in FavoritesPage or ChatPage headers

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_