### PR TITLE
fix: filter/sort URL persistence sweep (UX4)

### DIFF
--- a/app.admin/src/__tests__/list-page-url-filters.behavior.test.tsx
+++ b/app.admin/src/__tests__/list-page-url-filters.behavior.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { renderWithProviders, screen, waitFor } from '../test-utils';
+import { renderWithProviders, screen, waitFor, fireEvent } from '../test-utils';
 import Applications from '../pages/Applications';
 import Moderation from '../pages/Moderation';
 import Support from '../pages/Support';
@@ -172,6 +172,17 @@ describe('Applications list page reads ?status= from URL', () => {
     });
     expect(screen.getByDisplayValue('All Statuses')).toBeInTheDocument();
   });
+
+  it('persists status filter change to URL state', async () => {
+    renderWithProviders(<Applications />, { initialRoute: '/applications' });
+    const statusSelect = screen.getByLabelText('Status');
+    fireEvent.change(statusSelect, { target: { value: 'approved' } });
+    await waitFor(() => {
+      expect(mockUseApplications).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'approved' })
+      );
+    });
+  });
 });
 
 describe('Moderation list page reads ?status= and ?severity= from URL', () => {
@@ -192,6 +203,15 @@ describe('Moderation list page reads ?status= and ?severity= from URL', () => {
       );
     });
   });
+
+  it('persists severity filter change to URL state', async () => {
+    renderWithProviders(<Moderation />, { initialRoute: '/moderation' });
+    const severitySelect = screen.getByLabelText('Severity');
+    fireEvent.change(severitySelect, { target: { value: 'high' } });
+    await waitFor(() => {
+      expect(mockUseReports).toHaveBeenCalledWith(expect.objectContaining({ severity: 'high' }));
+    });
+  });
 });
 
 describe('Support list page reads ?status= from URL', () => {
@@ -199,6 +219,15 @@ describe('Support list page reads ?status= from URL', () => {
     renderWithProviders(<Support />, { initialRoute: '/support?status=escalated' });
     await waitFor(() => {
       expect(mockUseTickets).toHaveBeenCalledWith(expect.objectContaining({ status: 'escalated' }));
+    });
+  });
+
+  it('persists status filter change to URL state', async () => {
+    renderWithProviders(<Support />, { initialRoute: '/support' });
+    const statusSelect = screen.getByLabelText('Status');
+    fireEvent.change(statusSelect, { target: { value: 'open' } });
+    await waitFor(() => {
+      expect(mockUseTickets).toHaveBeenCalledWith(expect.objectContaining({ status: 'open' }));
     });
   });
 });
@@ -217,6 +246,15 @@ describe('Pets list page reads ?status= from URL', () => {
     renderWithProviders(<Pets />, { initialRoute: '/pets?status=available' });
     await waitFor(() => {
       expect(mockUsePets).toHaveBeenCalledWith(expect.objectContaining({ status: 'available' }));
+    });
+  });
+
+  it('persists status filter change to URL state', async () => {
+    renderWithProviders(<Pets />, { initialRoute: '/pets' });
+    const statusSelect = screen.getByLabelText('Status');
+    fireEvent.change(statusSelect, { target: { value: 'adopted' } });
+    await waitFor(() => {
+      expect(mockUsePets).toHaveBeenCalledWith(expect.objectContaining({ status: 'adopted' }));
     });
   });
 });

--- a/app.admin/src/components/data/DataTable.tsx
+++ b/app.admin/src/components/data/DataTable.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
 import * as styles from './DataTable.css';
 import {
   FiChevronUp,
@@ -67,21 +68,38 @@ export function DataTable<T extends object>({
   onSelectionChange,
   getRowId = (_row: T) => String(Math.random()),
 }: DataTableProps<T>) {
-  const [localSort, setLocalSort] = useState<{ column: string; direction: 'asc' | 'desc' } | null>(
-    null
-  );
+  // When no controlled onSort is provided, persist sort state in URL
+  // query params so it survives pagination and page refreshes.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlSortColumn = searchParams.get('sortBy') ?? undefined;
+  const urlSortDirection = (searchParams.get('sortOrder') === 'desc' ? 'desc' : 'asc') as
+    | 'asc'
+    | 'desc';
+
+  // Effective sort: controlled props take precedence, then URL params
+  const effectiveSortColumn = sortColumn ?? urlSortColumn;
+  const effectiveSortDirection = sortColumn
+    ? sortDirection
+    : urlSortColumn
+      ? urlSortDirection
+      : sortDirection;
 
   const handleSort = (columnId: string) => {
     const newDirection =
-      (sortColumn || localSort?.column) === columnId &&
-      (sortDirection || localSort?.direction) === 'asc'
-        ? 'desc'
-        : 'asc';
+      effectiveSortColumn === columnId && effectiveSortDirection === 'asc' ? 'desc' : 'asc';
 
     if (onSort) {
       onSort(columnId, newDirection);
     } else {
-      setLocalSort({ column: columnId, direction: newDirection });
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          next.set('sortBy', columnId);
+          next.set('sortOrder', newDirection);
+          return next;
+        },
+        { replace: true }
+      );
     }
   };
 
@@ -145,8 +163,8 @@ export function DataTable<T extends object>({
                 </th>
               )}
               {columns.map(column => {
-                const activeColumn = sortColumn || localSort?.column;
-                const activeDirection = sortDirection || localSort?.direction;
+                const activeColumn = effectiveSortColumn;
+                const activeDirection = effectiveSortDirection;
                 const isSortActive = activeColumn === column.id;
                 const ariaSort = column.sortable
                   ? isSortActive

--- a/app.admin/src/pages/Applications.tsx
+++ b/app.admin/src/pages/Applications.tsx
@@ -39,12 +39,27 @@ const VALID_STATUS_FILTERS: ReadonlySet<string> = new Set([
 ]);
 
 const Applications: React.FC = () => {
-  const [searchParams] = useSearchParams();
-  const initialStatus = searchParams.get('status');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const statusParam = searchParams.get('status');
+  const statusFilter = statusParam && VALID_STATUS_FILTERS.has(statusParam) ? statusParam : 'all';
+
+  const setFilterParam = (key: string, value: string) => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev);
+        if (value && value !== 'all') {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  };
+
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string>(
-    initialStatus && VALID_STATUS_FILTERS.has(initialStatus) ? initialStatus : 'all'
-  );
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [rescueFilter, setRescueFilter] = useState<string>('all');
   const [page, setPage] = useState(1);
@@ -170,7 +185,7 @@ const Applications: React.FC = () => {
             id='apps-status-filter'
             className={styles.select}
             value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value)}
+            onChange={e => setFilterParam('status', e.target.value)}
           >
             <option value='all'>All Statuses</option>
             <option value='submitted'>Submitted</option>

--- a/app.admin/src/pages/Moderation.tsx
+++ b/app.admin/src/pages/Moderation.tsx
@@ -106,21 +106,33 @@ const VALID_REPORT_STATUSES: ReadonlySet<string> = new Set([
 const VALID_REPORT_SEVERITIES: ReadonlySet<string> = new Set(['critical', 'high', 'medium', 'low']);
 
 const Moderation: React.FC = () => {
-  const [searchParams] = useSearchParams();
-  const initialStatusParam = searchParams.get('status');
-  const initialSeverityParam = searchParams.get('severity');
-  const initialStatus: ReportStatus | 'all' =
-    initialStatusParam && VALID_REPORT_STATUSES.has(initialStatusParam)
-      ? (initialStatusParam as ReportStatus)
-      : 'all';
-  const initialSeverity: ReportSeverity | 'all' =
-    initialSeverityParam && VALID_REPORT_SEVERITIES.has(initialSeverityParam)
-      ? (initialSeverityParam as ReportSeverity)
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const statusParam = searchParams.get('status');
+  const severityParam = searchParams.get('severity');
+  const statusFilter: ReportStatus | 'all' =
+    statusParam && VALID_REPORT_STATUSES.has(statusParam) ? (statusParam as ReportStatus) : 'all';
+  const severityFilter: ReportSeverity | 'all' =
+    severityParam && VALID_REPORT_SEVERITIES.has(severityParam)
+      ? (severityParam as ReportSeverity)
       : 'all';
 
+  const setFilterParam = (key: string, value: string) => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev);
+        if (value && value !== 'all') {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  };
+
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<ReportStatus | 'all'>(initialStatus);
-  const [severityFilter, setSeverityFilter] = useState<ReportSeverity | 'all'>(initialSeverity);
   const [entityTypeFilter, setEntityTypeFilter] = useState<string>('all');
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(20);
@@ -441,7 +453,7 @@ const Moderation: React.FC = () => {
             id='mod-status-filter'
             className={styles.select}
             value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value as any)}
+            onChange={e => setFilterParam('status', e.target.value)}
           >
             <option value='all'>All Statuses</option>
             <option value='pending'>Pending</option>
@@ -460,7 +472,7 @@ const Moderation: React.FC = () => {
             id='mod-severity-filter'
             className={styles.select}
             value={severityFilter}
-            onChange={e => setSeverityFilter(e.target.value as any)}
+            onChange={e => setFilterParam('severity', e.target.value)}
           >
             <option value='all'>All Severities</option>
             <option value='critical'>Critical</option>

--- a/app.admin/src/pages/Pets.tsx
+++ b/app.admin/src/pages/Pets.tsx
@@ -42,15 +42,28 @@ const VALID_PET_STATUS_FILTERS: ReadonlySet<string> = new Set([
 ]);
 
 const Pets: React.FC = () => {
-  const [searchParams] = useSearchParams();
-  const initialStatusParam = searchParams.get('status');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const statusParam = searchParams.get('status');
+  const statusFilter =
+    statusParam && VALID_PET_STATUS_FILTERS.has(statusParam) ? statusParam : 'all';
+
+  const setFilterParam = (key: string, value: string) => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev);
+        if (value && value !== 'all') {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  };
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string>(
-    initialStatusParam && VALID_PET_STATUS_FILTERS.has(initialStatusParam)
-      ? initialStatusParam
-      : 'all'
-  );
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [rescueFilter, setRescueFilter] = useState<string>('all');
   const [includeArchived, setIncludeArchived] = useState(false);
@@ -191,7 +204,7 @@ const Pets: React.FC = () => {
             id='pets-status-filter'
             className={styles.select}
             value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value)}
+            onChange={e => setFilterParam('status', e.target.value)}
           >
             <option value='all'>All Statuses</option>
             <option value='available'>Available</option>

--- a/app.admin/src/pages/Support.tsx
+++ b/app.admin/src/pages/Support.tsx
@@ -63,15 +63,28 @@ const VALID_TICKET_STATUSES: ReadonlySet<string> = new Set([
 ]);
 
 const Support: React.FC = () => {
-  const [searchParams] = useSearchParams();
-  const initialStatusParam = searchParams.get('status');
-  const initialStatus: TicketStatus | 'all' =
-    initialStatusParam && VALID_TICKET_STATUSES.has(initialStatusParam)
-      ? (initialStatusParam as TicketStatus)
-      : 'all';
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const statusParam = searchParams.get('status');
+  const statusFilter: TicketStatus | 'all' =
+    statusParam && VALID_TICKET_STATUSES.has(statusParam) ? (statusParam as TicketStatus) : 'all';
+
+  const setFilterParam = (key: string, value: string) => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev);
+        if (value && value !== 'all') {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  };
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<TicketStatus | 'all'>(initialStatus);
   const [priorityFilter, setPriorityFilter] = useState<TicketPriority | 'all'>('all');
   const [categoryFilter, setCategoryFilter] = useState<TicketCategory | 'all'>('all');
   const [page, setPage] = useState(1);
@@ -307,7 +320,7 @@ const Support: React.FC = () => {
             id='support-status-filter'
             className={styles.select}
             value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value as TicketStatus | 'all')}
+            onChange={e => setFilterParam('status', e.target.value)}
           >
             <option value='all'>All Statuses</option>
             <option value='open'>Open</option>

--- a/app.rescue/src/components/pets/PetFilters.test.tsx
+++ b/app.rescue/src/components/pets/PetFilters.test.tsx
@@ -1,0 +1,103 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderWithProviders, screen, fireEvent, waitFor } from '../../test-utils';
+import PetFilters from './PetFilters';
+
+const defaultFilters = {
+  search: '',
+  type: '',
+  status: '',
+  size: '',
+  breed: '',
+  ageGroup: '',
+  gender: '',
+};
+
+describe('PetFilters auto-apply behaviour', () => {
+  let onFilterChange: ReturnType<typeof vi.fn>;
+  let onClearFilters: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onFilterChange = vi.fn();
+    onClearFilters = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not render an Apply Filters button', () => {
+    renderWithProviders(
+      <PetFilters
+        filters={defaultFilters}
+        onFilterChange={onFilterChange}
+        onClearFilters={onClearFilters}
+      />
+    );
+    expect(screen.queryByRole('button', { name: /apply filters/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a Clear Filters button', () => {
+    renderWithProviders(
+      <PetFilters
+        filters={defaultFilters}
+        onFilterChange={onFilterChange}
+        onClearFilters={onClearFilters}
+      />
+    );
+    expect(screen.getByRole('button', { name: /clear filters/i })).toBeInTheDocument();
+  });
+
+  it('debounces search input and fires onFilterChange after 300ms', async () => {
+    renderWithProviders(
+      <PetFilters
+        filters={defaultFilters}
+        onFilterChange={onFilterChange}
+        onClearFilters={onClearFilters}
+      />
+    );
+
+    const searchInput = screen.getByLabelText('Search');
+    fireEvent.change(searchInput, { target: { value: 'labrador' } });
+
+    // Not called immediately
+    expect(onFilterChange).not.toHaveBeenCalledWith('search', 'labrador');
+
+    // Called after debounce
+    vi.advanceTimersByTime(300);
+    expect(onFilterChange).toHaveBeenCalledWith('search', 'labrador');
+  });
+
+  it('debounces breed input and fires onFilterChange after 300ms', async () => {
+    renderWithProviders(
+      <PetFilters
+        filters={defaultFilters}
+        onFilterChange={onFilterChange}
+        onClearFilters={onClearFilters}
+      />
+    );
+
+    const breedInput = screen.getByLabelText('Breed');
+    fireEvent.change(breedInput, { target: { value: 'golden' } });
+
+    expect(onFilterChange).not.toHaveBeenCalledWith('breed', 'golden');
+
+    vi.advanceTimersByTime(300);
+    expect(onFilterChange).toHaveBeenCalledWith('breed', 'golden');
+  });
+
+  it('applies select filter changes immediately without debounce', () => {
+    renderWithProviders(
+      <PetFilters
+        filters={defaultFilters}
+        onFilterChange={onFilterChange}
+        onClearFilters={onClearFilters}
+      />
+    );
+
+    const typeSelect = screen.getByLabelText('Pet Type');
+    fireEvent.change(typeSelect, { target: { value: 'dog' } });
+
+    expect(onFilterChange).toHaveBeenCalledWith('type', 'dog');
+  });
+});

--- a/app.rescue/src/components/pets/PetFilters.tsx
+++ b/app.rescue/src/components/pets/PetFilters.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@adopt-dont-shop/lib.components';
 import * as styles from './PetFilters.css';
 
@@ -14,15 +14,57 @@ interface PetFiltersProps {
   };
   onFilterChange: (key: string, value: string) => void;
   onClearFilters: () => void;
-  onApplyFilters: () => void;
 }
 
-const PetFilters: React.FC<PetFiltersProps> = ({
-  filters,
-  onFilterChange,
-  onClearFilters,
-  onApplyFilters,
-}) => {
+const DEBOUNCE_MS = 300;
+
+const PetFilters: React.FC<PetFiltersProps> = ({ filters, onFilterChange, onClearFilters }) => {
+  // Local state for text inputs so we can debounce them
+  const [localSearch, setLocalSearch] = useState(filters.search);
+  const [localBreed, setLocalBreed] = useState(filters.breed);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const breedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync local state when filters are cleared externally
+  useEffect(() => {
+    setLocalSearch(filters.search);
+  }, [filters.search]);
+
+  useEffect(() => {
+    setLocalBreed(filters.breed);
+  }, [filters.breed]);
+
+  const handleSearchChange = (value: string) => {
+    setLocalSearch(value);
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+    }
+    searchTimerRef.current = setTimeout(() => {
+      onFilterChange('search', value);
+    }, DEBOUNCE_MS);
+  };
+
+  const handleBreedChange = (value: string) => {
+    setLocalBreed(value);
+    if (breedTimerRef.current) {
+      clearTimeout(breedTimerRef.current);
+    }
+    breedTimerRef.current = setTimeout(() => {
+      onFilterChange('breed', value);
+    }, DEBOUNCE_MS);
+  };
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+      if (breedTimerRef.current) {
+        clearTimeout(breedTimerRef.current);
+      }
+    };
+  }, []);
   return (
     <div className={styles.filtersContainer}>
       <div className={styles.filtersHeader}>
@@ -38,8 +80,8 @@ const PetFilters: React.FC<PetFiltersProps> = ({
             id="search"
             type="text"
             placeholder="Pet name, breed, or ID..."
-            value={filters.search}
-            onChange={e => onFilterChange('search', e.target.value)}
+            value={localSearch}
+            onChange={e => handleSearchChange(e.target.value)}
           />
         </div>
 
@@ -106,8 +148,8 @@ const PetFilters: React.FC<PetFiltersProps> = ({
             id="breed"
             type="text"
             placeholder="Enter breed..."
-            value={filters.breed}
-            onChange={e => onFilterChange('breed', e.target.value)}
+            value={localBreed}
+            onChange={e => handleBreedChange(e.target.value)}
           />
         </div>
 
@@ -146,9 +188,6 @@ const PetFilters: React.FC<PetFiltersProps> = ({
       <div className={styles.filterActions}>
         <Button variant="outline" onClick={onClearFilters}>
           Clear Filters
-        </Button>
-        <Button variant="primary" onClick={onApplyFilters}>
-          Apply Filters
         </Button>
       </div>
     </div>

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -68,8 +68,34 @@ const PetManagement: React.FC = () => {
   const { user, refreshUser } = useAuth();
   // ADS-644: cross-linking. When deep-linked via /pets?petId=... we use the
   // petId as the search filter so the matching pet card surfaces immediately.
-  const [searchParams] = useSearchParams();
-  const initialPetId = searchParams.get('petId');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Filter state is driven by URL search params so refresh/back preserves it.
+  const statusFilter = (searchParams.get('status') ?? 'all') as PetStatus | 'all';
+  const searchFilter = searchParams.get('search') ?? searchParams.get('petId') ?? '';
+  const typeFilter = searchParams.get('type') ?? '';
+  const sizeFilter = searchParams.get('size') ?? '';
+  const breedFilter = searchParams.get('breed') ?? '';
+  const ageGroupFilter = searchParams.get('ageGroup') ?? '';
+  const genderFilter = searchParams.get('gender') ?? '';
+
+  const setFilterParam = (key: string, value: string) => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev);
+        if (value && value !== 'all') {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        // Reset to page 1 when filters change
+        next.delete('page');
+        return next;
+      },
+      { replace: true }
+    );
+  };
+
   const [pets, setPets] = useState<Pet[]>([]);
   const [stats, setStats] = useState<PetStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -78,17 +104,8 @@ const PetManagement: React.FC = () => {
   const [showCsvImport, setShowCsvImport] = useState(false);
   const [editingPet, setEditingPet] = useState<Pet | null>(null);
 
-  // Filter states
-  const [statusFilter, setStatusFilter] = useState<PetStatus | 'all'>('all');
-  const [searchFilter, setSearchFilter] = useState(initialPetId ?? '');
-  const [typeFilter, setTypeFilter] = useState<string>('');
-  const [sizeFilter, setSizeFilter] = useState<string>('');
-  const [breedFilter, setBreedFilter] = useState<string>('');
-  const [ageGroupFilter, setAgeGroupFilter] = useState<string>('');
-  const [genderFilter, setGenderFilter] = useState<string>('');
-
   // Pagination
-  const [currentPage, setCurrentPage] = useState(1);
+  const currentPage = Number(searchParams.get('page') ?? '1');
   const [totalPages, setTotalPages] = useState(1);
   const [hasNext, setHasNext] = useState(false);
   const [hasPrev, setHasPrev] = useState(false);
@@ -147,7 +164,6 @@ const PetManagement: React.FC = () => {
       const response = await petManagementService.getMyRescuePets(filters);
 
       setPets(response.pets);
-      setCurrentPage(response.pagination.page);
       setTotalPages(response.pagination.totalPages);
       setHasNext(response.pagination.hasNext);
       setHasPrev(response.pagination.hasPrev);
@@ -249,8 +265,7 @@ const PetManagement: React.FC = () => {
   };
 
   const handleSearch = (searchTerm: string) => {
-    setSearchFilter(searchTerm);
-    setCurrentPage(1); // Reset to first page
+    setFilterParam('search', searchTerm);
   };
 
   const handleToggleSelectPet = (petId: string) => {
@@ -302,7 +317,18 @@ const PetManagement: React.FC = () => {
   };
 
   const handlePageChange = (page: number) => {
-    setCurrentPage(page);
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev);
+        if (page > 1) {
+          next.set('page', String(page));
+        } else {
+          next.delete('page');
+        }
+        return next;
+      },
+      { replace: true }
+    );
   };
 
   if (loading && pets.length === 0) {
@@ -446,7 +472,7 @@ const PetManagement: React.FC = () => {
                   : {}
               }
               onStatusChange={status => {
-                setStatusFilter(status as any);
+                setFilterParam('status', status);
               }}
             />
           </div>
@@ -462,36 +488,23 @@ const PetManagement: React.FC = () => {
                 gender: genderFilter,
               }}
               onFilterChange={(key, value) => {
-                if (key === 'search') {
-                  handleSearch(value);
-                }
-                if (key === 'type') {
-                  setTypeFilter(value);
-                }
-                if (key === 'status') {
-                  setStatusFilter(value as any);
-                }
-                if (key === 'size') {
-                  setSizeFilter(value);
-                }
-                if (key === 'breed') {
-                  setBreedFilter(value);
-                }
-                if (key === 'ageGroup') {
-                  setAgeGroupFilter(value);
-                }
-                if (key === 'gender') {
-                  setGenderFilter(value);
-                }
+                setFilterParam(key, value);
               }}
               onClearFilters={() => {
-                setSearchFilter('');
-                setTypeFilter('');
-                setStatusFilter('all');
-                setSizeFilter('');
-                setBreedFilter('');
-                setAgeGroupFilter('');
-                setGenderFilter('');
+                setSearchParams(
+                  prev => {
+                    const next = new URLSearchParams(prev);
+                    // Keep petId if it was the original deep-link param
+                    const keepKeys = new Set(['petId']);
+                    for (const key of [...next.keys()]) {
+                      if (!keepKeys.has(key)) {
+                        next.delete(key);
+                      }
+                    }
+                    return next;
+                  },
+                  { replace: true }
+                );
               }}
             />
           </div>

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -493,9 +493,6 @@ const PetManagement: React.FC = () => {
                 setAgeGroupFilter('');
                 setGenderFilter('');
               }}
-              onApplyFilters={() => {
-                // Filters are applied immediately in this implementation
-              }}
             />
           </div>
         </div>

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -264,10 +264,6 @@ const PetManagement: React.FC = () => {
     }
   };
 
-  const handleSearch = (searchTerm: string) => {
-    setFilterParam('search', searchTerm);
-  };
-
   const handleToggleSelectPet = (petId: string) => {
     setSelectedPetIds(prev => {
       const next = new Set(prev);

--- a/app.rescue/src/pages/RescueSettings.test.tsx
+++ b/app.rescue/src/pages/RescueSettings.test.tsx
@@ -1,0 +1,104 @@
+import { vi, describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RescueSettings from './RescueSettings';
+
+// Mock all heavy dependencies to focus on tab/hash behaviour
+vi.mock('@adopt-dont-shop/lib.auth', () => ({
+  useAuth: () => ({ user: { userId: '1', rescueId: 'r1' } }),
+  TwoFactorSettings: () => null,
+}));
+
+vi.mock('@adopt-dont-shop/lib.components', () => ({
+  ThemeToggle: () => null,
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../contexts/PermissionsContext', () => ({
+  usePermissions: () => ({ hasPermission: () => true }),
+}));
+
+vi.mock('../services/libraryServices', () => ({
+  apiService: {
+    get: vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/staff/me')) {
+        return Promise.resolve({ data: { rescueId: 'r1' } });
+      }
+      return Promise.resolve({ data: { rescueId: 'r1', name: 'Test Rescue', settings: {} } });
+    }),
+    put: vi.fn().mockResolvedValue({}),
+  },
+  rescueService: { updateAdoptionPolicies: vi.fn().mockResolvedValue({}) },
+}));
+
+vi.mock('@adopt-dont-shop/lib.permissions', () => ({
+  RESCUE_SETTINGS_UPDATE: 'rescue:settings:update',
+}));
+
+vi.mock('../components/rescue/RescueProfileForm', () => ({
+  default: () => <div data-testid="profile-form">Profile Form</div>,
+}));
+
+vi.mock('../components/rescue/AdoptionPolicyForm', () => ({
+  default: () => <div data-testid="policy-form">Policy Form</div>,
+}));
+
+vi.mock('../components/rescue/NotificationPreferencesForm', () => ({
+  default: () => <div data-testid="notif-form">Notification Form</div>,
+}));
+
+vi.mock('../components/rescue/QuestionsBuilder', () => ({
+  default: () => <div data-testid="questions-builder">Questions</div>,
+}));
+
+const renderWithRoute = (initialRoute: string) =>
+  render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <RescueSettings />
+    </MemoryRouter>
+  );
+
+const waitForTabsToLoad = () =>
+  waitFor(() => {
+    expect(screen.getByRole('button', { name: /rescue profile/i })).toBeInTheDocument();
+  });
+
+describe('RescueSettings tab persistence via URL hash', () => {
+  it('defaults to profile tab when no hash is present', async () => {
+    renderWithRoute('/settings');
+    await waitForTabsToLoad();
+    const profileButton = screen.getByRole('button', { name: /rescue profile/i });
+    expect(profileButton.className).toContain('tabActive');
+  });
+
+  it('restores the security tab from #security hash', async () => {
+    renderWithRoute('/settings#security');
+    await waitForTabsToLoad();
+    const securityButton = screen.getByRole('button', { name: /^security$/i });
+    expect(securityButton.className).toContain('tabActive');
+  });
+
+  it('restores the appearance tab from #appearance hash', async () => {
+    renderWithRoute('/settings#appearance');
+    await waitForTabsToLoad();
+    const appearanceButton = screen.getByRole('button', { name: /appearance/i });
+    expect(appearanceButton.className).toContain('tabActive');
+  });
+
+  it('falls back to profile for invalid hash values', async () => {
+    renderWithRoute('/settings#nonexistent');
+    await waitForTabsToLoad();
+    const profileButton = screen.getByRole('button', { name: /rescue profile/i });
+    expect(profileButton.className).toContain('tabActive');
+  });
+
+  it('switches tab when a tab button is clicked', async () => {
+    renderWithRoute('/settings');
+    await waitForTabsToLoad();
+    fireEvent.click(screen.getByRole('button', { name: /adoption policies/i }));
+    // Navigate triggers re-render; wait for tabs to re-appear
+    await waitForTabsToLoad();
+    const policiesButton = screen.getByRole('button', { name: /adoption policies/i });
+    expect(policiesButton.className).toContain('tabActive');
+  });
+});

--- a/app.rescue/src/pages/RescueSettings.tsx
+++ b/app.rescue/src/pages/RescueSettings.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { useAuth, TwoFactorSettings } from '@adopt-dont-shop/lib.auth';
 import { ThemeToggle, toast } from '@adopt-dont-shop/lib.components';
@@ -14,10 +15,35 @@ import * as styles from './RescueSettings.css';
 
 type TabType = 'profile' | 'policies' | 'questions' | 'preferences' | 'security' | 'appearance';
 
+const VALID_TABS: ReadonlySet<string> = new Set<TabType>([
+  'profile',
+  'policies',
+  'questions',
+  'preferences',
+  'security',
+  'appearance',
+]);
+
+const parseTabFromHash = (hash: string): TabType => {
+  const value = hash.replace('#', '');
+  return VALID_TABS.has(value) ? (value as TabType) : 'profile';
+};
+
 const RescueSettings: React.FC = () => {
   const { user } = useAuth();
   const { hasPermission } = usePermissions();
-  const [activeTab, setActiveTab] = useState<TabType>('profile');
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const activeTab = parseTabFromHash(location.hash);
+
+  const setActiveTab = useCallback(
+    (tab: TabType) => {
+      const hash = tab === 'profile' ? '' : `#${tab}`;
+      navigate(`${location.pathname}${hash}`, { replace: true });
+    },
+    [navigate, location.pathname]
+  );
   const [rescue, setRescue] = useState<RescueProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

- **UX4-1**: Remove misleading "Apply Filters" button from `PetFilters`; add 300ms debounce on text inputs (search, breed) so filters auto-apply as the user types, matching the `ApplicationFilters` pattern.
- **UX4-2**: Move `PetManagement` filter state from local `useState` to `URLSearchParams` so refresh/back preserves the active search, status, type, size, breed, ageGroup, and gender filters.
- **UX4-3**: Make admin list pages (Moderation, Support, Applications, Pets) persist filter changes to URL. Previously these pages read initial `?status=` from the URL but never wrote changes back when the user changed dropdowns.
- **UX4-4**: Replace `DataTable`'s local `useState` sort with URL-backed state (`?sortBy=&sortOrder=`) so sorting survives pagination and browser refreshes.
- **UX4-5**: Use URL hash (`#profile`, `#security`, `#appearance`, etc.) in `RescueSettings` to restore the active tab on page reload.

## Test plan

- [x] `PetFilters` no longer renders an Apply button (5 tests)
- [x] Text inputs debounce at 300ms before firing `onFilterChange`
- [x] Select filters fire immediately
- [x] Admin list pages persist filter changes to URL state (4 new tests)
- [x] `RescueSettings` tab restored from URL hash on load (5 tests)
- [x] Gate: `npx turbo lint test --filter=@adopt-dont-shop/app.rescue --filter=@adopt-dont-shop/app.admin`
  - app.rescue: 36 files, 308 tests passing, lint clean
  - app.admin: 39 files, 408 tests passing, lint clean (1 pre-existing failure in ModerationTab.test.tsx unrelated to this PR)

https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT3WEnytPJ6QNajVSkqhwA)_