### PR TITLE
feat: add skeleton loading states across all apps

### DIFF
--- a/app.admin/src/components/data/DataTable.tsx
+++ b/app.admin/src/components/data/DataTable.tsx
@@ -9,7 +9,7 @@ import {
   FiChevronLeft,
   FiChevronRight,
 } from 'react-icons/fi';
-import { SkeletonTableRow } from '../ui/Skeleton';
+import { SkeletonTableRow } from '@adopt-dont-shop/lib.components';
 
 export interface Column<T> {
   id: string;

--- a/app.admin/src/components/modals/RescueDetailModal/ListingsTab.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal/ListingsTab.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { DateTime } from '@adopt-dont-shop/lib.components';
-import { Skeleton } from '../../ui/Skeleton';
+import { DateTime, Skeleton } from '@adopt-dont-shop/lib.components';
 import * as styles from '../RescueDetailModal.css';
 import { petService, type AdminPet } from '@/services/petService';
 

--- a/app.admin/src/components/modals/RescueDetailModal/StaffTab.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal/StaffTab.tsx
@@ -1,7 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import * as styles from '../RescueDetailModal.css';
-import { Button, DateTime, ConfirmDialog, useConfirm } from '@adopt-dont-shop/lib.components';
-import { Skeleton, SkeletonText } from '../../ui/Skeleton';
+import {
+  Button,
+  DateTime,
+  ConfirmDialog,
+  useConfirm,
+  Skeleton,
+  SkeletonText,
+} from '@adopt-dont-shop/lib.components';
 import { FiUserPlus, FiUserMinus, FiCheck, FiClock, FiX } from 'react-icons/fi';
 import type { StaffMember, StaffInvitation, InviteStaffPayload } from '@/types/rescue';
 import { rescueService } from '@/services/rescueService';

--- a/app.admin/src/components/modals/RescueDetailModal/index.tsx
+++ b/app.admin/src/components/modals/RescueDetailModal/index.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import clsx from 'clsx';
-import { Heading, Text, Button } from '@adopt-dont-shop/lib.components';
+import { Heading, Text, Button, Skeleton, SkeletonText } from '@adopt-dont-shop/lib.components';
 import { rescueStatusLabel, type RescueStatus } from '@adopt-dont-shop/lib.types';
-import { Skeleton, SkeletonText } from '../../ui/Skeleton';
 import { FiX, FiCheckCircle, FiXCircle } from 'react-icons/fi';
 import type { AdminRescue, RescueStatistics } from '@/types/rescue';
 import { rescueService } from '@/services/rescueService';

--- a/app.admin/src/components/ui/SharedComponents.tsx
+++ b/app.admin/src/components/ui/SharedComponents.tsx
@@ -129,7 +129,3 @@ export const EmptyState = ({ className, ...props }: React.HTMLAttributes<HTMLDiv
 export const EmptyStateIcon = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={`${styles.emptyStateIcon}${className ? ` ${className}` : ''}`} {...props} />
 );
-
-export const LoadingSpinner = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={`${styles.loadingSpinner}${className ? ` ${className}` : ''}`} {...props} />
-);

--- a/app.admin/src/components/ui/index.ts
+++ b/app.admin/src/components/ui/index.ts
@@ -10,7 +10,12 @@ export { ActionMenu } from './ActionMenu';
 export type { ActionMenuItem } from './ActionMenu';
 
 export { ExportButton } from './ExportButton';
-export { Skeleton, SkeletonText, SkeletonTableRow, SkeletonCard } from './Skeleton';
+export {
+  Skeleton,
+  SkeletonText,
+  SkeletonTableRow,
+  SkeletonCard,
+} from '@adopt-dont-shop/lib.components';
 
 export * from './SharedComponents';
 

--- a/app.admin/src/pages/FieldPermissions.tsx
+++ b/app.admin/src/pages/FieldPermissions.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import clsx from 'clsx';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
-import { Heading, Text, Button } from '@adopt-dont-shop/lib.components';
+import { Heading, Text, Button, Skeleton } from '@adopt-dont-shop/lib.components';
 import type {
   FieldAccessLevel,
   FieldAccessMap,
@@ -20,7 +20,6 @@ import {
   CardTitle,
   CardContent,
 } from '../components/ui';
-import { Skeleton } from '../components/ui/Skeleton';
 import * as styles from './FieldPermissions.css';
 
 const RESOURCES: ReadonlyArray<FieldPermissionResource> = [

--- a/app.admin/src/setup-tests.ts
+++ b/app.admin/src/setup-tests.ts
@@ -118,6 +118,44 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   Modal: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', props, children),
   Spinner: () => React.createElement('div', { 'aria-label': 'loading' }),
+  Skeleton: ({ width, height, radius, className, style, ...props }: Record<string, unknown>) =>
+    React.createElement('div', {
+      'aria-hidden': 'true',
+      style: { width, height, borderRadius: radius, ...((style as React.CSSProperties) ?? {}) },
+      ...props,
+    }),
+  SkeletonText: ({ lines = 3 }: { lines?: number }) =>
+    React.createElement(
+      'div',
+      { 'aria-hidden': 'true' },
+      ...Array.from({ length: lines as number }, (_, i) => React.createElement('div', { key: i }))
+    ),
+  SkeletonTableRow: ({
+    columnCount,
+    hasCheckbox,
+  }: {
+    columnCount: number;
+    hasCheckbox?: boolean;
+  }) =>
+    React.createElement(
+      'tr',
+      { 'aria-hidden': 'true', 'data-testid': 'skeleton-row' },
+      hasCheckbox ? React.createElement('td', { key: 'cb' }) : null,
+      ...Array.from({ length: columnCount as number }, (_, i) =>
+        React.createElement('td', { key: i })
+      )
+    ),
+  SkeletonCard: ({ lines = 3, showAvatar }: { lines?: number; showAvatar?: boolean }) =>
+    React.createElement(
+      'div',
+      { 'aria-hidden': 'true' },
+      showAvatar ? React.createElement('div', { key: 'avatar' }) : null,
+      React.createElement(
+        'div',
+        { key: 'text' },
+        ...Array.from({ length: lines as number }, (_, i) => React.createElement('div', { key: i }))
+      )
+    ),
   DateTime: ({ value }: { value: string }) => React.createElement('span', null, value),
   ConfirmDialog: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', props, children),

--- a/app.client/src/components/home/TopPicksHomeModule.tsx
+++ b/app.client/src/components/home/TopPicksHomeModule.tsx
@@ -5,8 +5,8 @@ import {
   Container,
   MatchReasonChips,
   ProgressiveImage,
-  Spinner,
 } from '@adopt-dont-shop/lib.components';
+import { PetCardSkeletonGrid } from '@/components/skeletons';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import type { MatchTopPick } from '@adopt-dont-shop/lib.matching';
 import { useMatchPreferences } from '@/hooks/useMatchPreferences';
@@ -94,7 +94,9 @@ export const TopPicksHomeModule: React.FC = () => {
           </Link>
         </div>
         {loading ? (
-          <Spinner />
+          <div className={styles.grid}>
+            <PetCardSkeletonGrid count={3} />
+          </div>
         ) : (
           <div className={styles.grid}>
             {picks.map(pick => {

--- a/app.client/src/components/skeletons/ApplicationCardSkeleton.css.ts
+++ b/app.client/src/components/skeletons/ApplicationCardSkeleton.css.ts
@@ -1,0 +1,31 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const card = style({
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.lg,
+  padding: vars.spacing[3],
+  display: 'flex',
+  gap: vars.spacing[3],
+});
+
+export const imageBlock = style({
+  width: '80px',
+  height: '80px',
+  borderRadius: vars.border.radius.base,
+  flexShrink: 0,
+});
+
+export const content = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});
+
+export const statusRow = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});

--- a/app.client/src/components/skeletons/ApplicationCardSkeleton.tsx
+++ b/app.client/src/components/skeletons/ApplicationCardSkeleton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Skeleton } from '@adopt-dont-shop/lib.components';
+import * as styles from './ApplicationCardSkeleton.css';
+
+export const ApplicationCardSkeleton: React.FC = () => (
+  <div className={styles.card} aria-hidden='true'>
+    <Skeleton className={styles.imageBlock} height='auto' />
+    <div className={styles.content}>
+      <Skeleton height='1rem' width='50%' />
+      <Skeleton height='0.75rem' width='70%' />
+      <div className={styles.statusRow}>
+        <Skeleton height='1.5rem' width='80px' radius='9999px' />
+        <Skeleton height='0.75rem' width='100px' />
+      </div>
+    </div>
+  </div>
+);
+
+type ApplicationCardSkeletonListProps = {
+  count?: number;
+};
+
+export const ApplicationCardSkeletonList: React.FC<ApplicationCardSkeletonListProps> = ({
+  count = 3,
+}) => (
+  <>
+    {Array.from({ length: count }, (_, i) => (
+      <ApplicationCardSkeleton key={i} />
+    ))}
+  </>
+);

--- a/app.client/src/components/skeletons/ApplicationDetailSkeleton.css.ts
+++ b/app.client/src/components/skeletons/ApplicationDetailSkeleton.css.ts
@@ -1,0 +1,35 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  maxWidth: '800px',
+  margin: '0 auto',
+  padding: vars.spacing[4],
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[4],
+});
+
+export const headerRow = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
+  gap: vars.spacing[3],
+  flexWrap: 'wrap',
+});
+
+export const headerText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});
+
+export const section = style({
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.lg,
+  padding: vars.spacing[3],
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});

--- a/app.client/src/components/skeletons/ApplicationDetailSkeleton.tsx
+++ b/app.client/src/components/skeletons/ApplicationDetailSkeleton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Skeleton, SkeletonText } from '@adopt-dont-shop/lib.components';
+import * as styles from './ApplicationDetailSkeleton.css';
+
+export const ApplicationDetailSkeleton: React.FC = () => (
+  <div className={styles.container} aria-hidden='true'>
+    <Skeleton height='1rem' width='4rem' />
+
+    <div className={styles.headerRow}>
+      <div className={styles.headerText}>
+        <Skeleton height='1.75rem' width='250px' />
+        <Skeleton height='0.875rem' width='180px' />
+      </div>
+      <Skeleton height='2rem' width='100px' radius='9999px' />
+    </div>
+
+    <div className={styles.section}>
+      <Skeleton height='1rem' width='120px' />
+      <SkeletonText lines={3} />
+    </div>
+
+    <div className={styles.section}>
+      <Skeleton height='1rem' width='140px' />
+      <SkeletonText lines={4} />
+    </div>
+  </div>
+);

--- a/app.client/src/components/skeletons/PetCardSkeleton.css.ts
+++ b/app.client/src/components/skeletons/PetCardSkeleton.css.ts
@@ -1,0 +1,27 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const card = style({
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.lg,
+  overflow: 'hidden',
+  height: '100%',
+});
+
+export const imagePlaceholder = style({
+  width: '100%',
+  aspectRatio: '4/3',
+});
+
+export const content = style({
+  padding: vars.spacing[3],
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});
+
+export const detailRow = style({
+  display: 'flex',
+  gap: vars.spacing[2],
+});

--- a/app.client/src/components/skeletons/PetCardSkeleton.tsx
+++ b/app.client/src/components/skeletons/PetCardSkeleton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Skeleton } from '@adopt-dont-shop/lib.components';
+import * as styles from './PetCardSkeleton.css';
+
+export const PetCardSkeleton: React.FC = () => (
+  <div className={styles.card} aria-hidden='true'>
+    <Skeleton className={styles.imagePlaceholder} height='auto' radius='0' />
+    <div className={styles.content}>
+      <Skeleton height='1.25rem' width='60%' />
+      <div className={styles.detailRow}>
+        <Skeleton height='0.75rem' width='30%' />
+        <Skeleton height='0.75rem' width='40%' />
+      </div>
+      <div className={styles.detailRow}>
+        <Skeleton height='0.75rem' width='25%' />
+        <Skeleton height='0.75rem' width='35%' />
+      </div>
+      <div className={styles.detailRow}>
+        <Skeleton height='0.75rem' width='28%' />
+        <Skeleton height='0.75rem' width='30%' />
+      </div>
+      <Skeleton height='0.75rem' width='90%' />
+      <Skeleton height='0.75rem' width='70%' />
+    </div>
+  </div>
+);
+
+type PetCardSkeletonGridProps = {
+  count?: number;
+};
+
+export const PetCardSkeletonGrid: React.FC<PetCardSkeletonGridProps> = ({ count = 6 }) => (
+  <>
+    {Array.from({ length: count }, (_, i) => (
+      <PetCardSkeleton key={i} />
+    ))}
+  </>
+);

--- a/app.client/src/components/skeletons/PetDetailSkeleton.css.ts
+++ b/app.client/src/components/skeletons/PetDetailSkeleton.css.ts
@@ -1,0 +1,55 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  maxWidth: '1200px',
+  margin: '0 auto',
+  padding: vars.spacing[4],
+});
+
+export const header = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
+  marginBottom: vars.spacing[4],
+  gap: vars.spacing[3],
+  flexWrap: 'wrap',
+});
+
+export const titleGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});
+
+export const subtitleRow = style({
+  display: 'flex',
+  gap: vars.spacing[2],
+});
+
+export const imagePlaceholder = style({
+  width: '100%',
+  aspectRatio: '16/9',
+  maxHeight: '500px',
+  borderRadius: vars.border.radius.lg,
+  marginBottom: vars.spacing[4],
+});
+
+export const infoGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+  gap: vars.spacing[3],
+  marginBottom: vars.spacing[4],
+});
+
+export const infoItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[1],
+});
+
+export const descriptionBlock = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});

--- a/app.client/src/components/skeletons/PetDetailSkeleton.tsx
+++ b/app.client/src/components/skeletons/PetDetailSkeleton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Skeleton } from '@adopt-dont-shop/lib.components';
+import * as styles from './PetDetailSkeleton.css';
+
+export const PetDetailSkeleton: React.FC = () => (
+  <div className={styles.container} aria-hidden='true'>
+    <Skeleton height='1rem' width='4rem' radius='4px' />
+
+    <div className={styles.header}>
+      <div className={styles.titleGroup}>
+        <Skeleton height='2rem' width='200px' />
+        <div className={styles.subtitleRow}>
+          <Skeleton height='0.875rem' width='60px' />
+          <Skeleton height='0.875rem' width='80px' />
+          <Skeleton height='0.875rem' width='50px' />
+          <Skeleton height='0.875rem' width='60px' />
+        </div>
+      </div>
+      <Skeleton height='2rem' width='120px' radius='9999px' />
+    </div>
+
+    <Skeleton className={styles.imagePlaceholder} height='auto' />
+
+    <div className={styles.infoGrid}>
+      {Array.from({ length: 6 }, (_, i) => (
+        <div key={i} className={styles.infoItem}>
+          <Skeleton height='0.75rem' width='40%' />
+          <Skeleton height='1rem' width='70%' />
+        </div>
+      ))}
+    </div>
+
+    <div className={styles.descriptionBlock}>
+      <Skeleton height='1.25rem' width='120px' />
+      <Skeleton height='0.875rem' width='100%' />
+      <Skeleton height='0.875rem' width='100%' />
+      <Skeleton height='0.875rem' width='75%' />
+    </div>
+  </div>
+);

--- a/app.client/src/components/skeletons/RescueDetailSkeleton.css.ts
+++ b/app.client/src/components/skeletons/RescueDetailSkeleton.css.ts
@@ -1,0 +1,35 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  maxWidth: '1200px',
+  margin: '0 auto',
+  padding: vars.spacing[4],
+});
+
+export const header = style({
+  display: 'flex',
+  gap: vars.spacing[3],
+  alignItems: 'center',
+  marginBottom: vars.spacing[4],
+});
+
+export const headerText = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});
+
+export const infoSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+  marginBottom: vars.spacing[4],
+});
+
+export const petGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+  gap: vars.spacing[3],
+});

--- a/app.client/src/components/skeletons/RescueDetailSkeleton.tsx
+++ b/app.client/src/components/skeletons/RescueDetailSkeleton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Skeleton, SkeletonText } from '@adopt-dont-shop/lib.components';
+import { PetCardSkeleton } from './PetCardSkeleton';
+import * as styles from './RescueDetailSkeleton.css';
+
+export const RescueDetailSkeleton: React.FC = () => (
+  <div className={styles.container} aria-hidden='true'>
+    <div className={styles.header}>
+      <Skeleton width='5rem' height='5rem' radius='50%' />
+      <div className={styles.headerText}>
+        <Skeleton height='1.75rem' width='200px' />
+        <Skeleton height='0.875rem' width='300px' />
+      </div>
+    </div>
+
+    <div className={styles.infoSection}>
+      <Skeleton height='1.25rem' width='140px' />
+      <SkeletonText lines={3} />
+    </div>
+
+    <div className={styles.infoSection}>
+      <Skeleton height='1.25rem' width='180px' />
+      <div className={styles.petGrid}>
+        {Array.from({ length: 3 }, (_, i) => (
+          <PetCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  </div>
+);

--- a/app.client/src/components/skeletons/index.ts
+++ b/app.client/src/components/skeletons/index.ts
@@ -1,4 +1,5 @@
 export { PetCardSkeleton, PetCardSkeletonGrid } from './PetCardSkeleton';
 export { PetDetailSkeleton } from './PetDetailSkeleton';
 export { ApplicationCardSkeleton, ApplicationCardSkeletonList } from './ApplicationCardSkeleton';
+export { ApplicationDetailSkeleton } from './ApplicationDetailSkeleton';
 export { RescueDetailSkeleton } from './RescueDetailSkeleton';

--- a/app.client/src/components/skeletons/index.ts
+++ b/app.client/src/components/skeletons/index.ts
@@ -1,0 +1,4 @@
+export { PetCardSkeleton, PetCardSkeletonGrid } from './PetCardSkeleton';
+export { PetDetailSkeleton } from './PetDetailSkeleton';
+export { ApplicationCardSkeleton, ApplicationCardSkeletonList } from './ApplicationCardSkeleton';
+export { RescueDetailSkeleton } from './RescueDetailSkeleton';

--- a/app.client/src/pages/ApplicationDashboard.tsx
+++ b/app.client/src/pages/ApplicationDashboard.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button, Card } from '@adopt-dont-shop/lib.components';
+import { ApplicationCardSkeletonList } from '@/components/skeletons';
 import { applicationStatusLabel } from '@adopt-dont-shop/lib.types';
 import { formatDisplayDate } from '@adopt-dont-shop/lib.utils';
 import { useChat } from '@/contexts/ChatContext';
@@ -125,9 +126,10 @@ export const ApplicationDashboard: React.FC = () => {
   if (loading) {
     return (
       <div className={styles.container}>
-        <div className={styles.loadingState}>
-          <div>Loading your applications...</div>
+        <div className={styles.header}>
+          <h1 className={styles.title}>My Applications</h1>
         </div>
+        <ApplicationCardSkeletonList count={3} />
       </div>
     );
   }

--- a/app.client/src/pages/ApplicationDetailsPage.tsx
+++ b/app.client/src/pages/ApplicationDetailsPage.tsx
@@ -1,5 +1,6 @@
 import { applicationService, Application } from '@/services';
-import { Alert, Button, Spinner } from '@adopt-dont-shop/lib.components';
+import { Alert, Button } from '@adopt-dont-shop/lib.components';
+import { ApplicationDetailSkeleton } from '@/components/skeletons';
 import { applicationStatusLabel } from '@adopt-dont-shop/lib.types';
 import { formatDisplayDate } from '@adopt-dont-shop/lib.utils';
 import { useChat } from '@/contexts/ChatContext';
@@ -111,9 +112,7 @@ export const ApplicationDetailsPage: React.FC = () => {
   if (isLoading) {
     return (
       <div className={styles.container}>
-        <div className={styles.loadingContainer}>
-          <Spinner />
-        </div>
+        <ApplicationDetailSkeleton />
       </div>
     );
   }

--- a/app.client/src/pages/FavoritesPage.tsx
+++ b/app.client/src/pages/FavoritesPage.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { petService, Pet } from '@/services';
-import { Alert, Container, Spinner } from '@adopt-dont-shop/lib.components';
+import { Alert, Container } from '@adopt-dont-shop/lib.components';
+import { PetCardSkeletonGrid } from '@/components/skeletons';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { PetCard } from '../components/PetCard';
@@ -115,8 +116,8 @@ export const FavoritesPage: React.FC = () => {
 
       {/* Loading state */}
       {loading && (
-        <div className={styles.loadingContainer}>
-          <Spinner size='lg' />
+        <div className={styles.petGrid}>
+          <PetCardSkeletonGrid count={6} />
         </div>
       )}
 

--- a/app.client/src/pages/HomePage.tsx
+++ b/app.client/src/pages/HomePage.tsx
@@ -6,7 +6,8 @@ import { useAnalytics } from '@/contexts/AnalyticsContext';
 import { useStatsig } from '@/hooks/useStatsig';
 import { useFeatureGate } from '@adopt-dont-shop/lib.feature-flags';
 import { petService, Pet } from '@/services';
-import { Button, Spinner } from '@adopt-dont-shop/lib.components';
+import { Button } from '@adopt-dont-shop/lib.components';
+import { PetCardSkeletonGrid } from '@/components/skeletons';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import * as styles from './HomePage.css';
@@ -185,8 +186,8 @@ export const HomePage: React.FC = () => {
           <h2>Featured Pets</h2>
 
           {isLoading && (
-            <div className={styles.loadingContainer}>
-              <Spinner />
+            <div className={styles.petGrid}>
+              <PetCardSkeletonGrid count={8} />
             </div>
           )}
 

--- a/app.client/src/pages/PetDetailsPage.tsx
+++ b/app.client/src/pages/PetDetailsPage.tsx
@@ -4,6 +4,7 @@ import { useChat } from '@/contexts/ChatContext';
 import { useStatsig } from '@/hooks/useStatsig';
 import { petService, Pet } from '@/services';
 import { Badge, Button, Card, toast } from '@adopt-dont-shop/lib.components';
+import { PetDetailSkeleton } from '@/components/skeletons';
 import React, { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { resolveFileUrl } from '../utils/fileUtils';
@@ -477,7 +478,7 @@ export const PetDetailsPage: React.FC<PetDetailsPageProps> = () => {
   if (loading) {
     return (
       <div className={styles.pageContainer}>
-        <div className={styles.loadingContainer}>Loading pet details...</div>
+        <PetDetailSkeleton />
       </div>
     );
   }

--- a/app.client/src/pages/ProfilePage.tsx
+++ b/app.client/src/pages/ProfilePage.tsx
@@ -12,10 +12,10 @@ import {
   ConfirmDialog,
   Input,
   Modal,
-  Spinner,
   toast,
   useConfirm,
 } from '@adopt-dont-shop/lib.components';
+import { ApplicationCardSkeletonList } from '@/components/skeletons';
 import { applicationStatusLabel } from '@adopt-dont-shop/lib.types';
 import { formatDisplayDate } from '@adopt-dont-shop/lib.utils';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -370,9 +370,7 @@ export const ProfilePage: React.FC = () => {
           <p>As a {user?.userType}, you don&apos;t submit adoption applications.</p>
         </div>
       ) : isLoading ? (
-        <div className={styles.loadingContainer}>
-          <Spinner />
-        </div>
+        <ApplicationCardSkeletonList count={3} />
       ) : applications.length === 0 ? (
         <div className={styles.centeredEmpty}>
           <p>You haven&apos;t submitted any adoption applications yet.</p>

--- a/app.client/src/pages/RescueDetailsPage.tsx
+++ b/app.client/src/pages/RescueDetailsPage.tsx
@@ -1,6 +1,7 @@
 import { PetCard } from '@/components/PetCard';
 import { rescueService, petService, Rescue, Pet } from '@/services';
 import { Badge, Button, Card } from '@adopt-dont-shop/lib.components';
+import { RescueDetailSkeleton } from '@/components/skeletons';
 import { rescueStatusLabel } from '@adopt-dont-shop/lib.types';
 import { safeHref } from '@adopt-dont-shop/lib.utils';
 import React, { useEffect, useState } from 'react';
@@ -93,7 +94,7 @@ export const RescueDetailsPage: React.FC<RescueDetailsPageProps> = () => {
   if (loading) {
     return (
       <div className={styles.pageContainer}>
-        <div className={styles.loadingContainer}>Loading rescue details...</div>
+        <RescueDetailSkeleton />
       </div>
     );
   }

--- a/app.client/src/pages/SearchPage.tsx
+++ b/app.client/src/pages/SearchPage.tsx
@@ -5,7 +5,8 @@ import { useSearchFilters } from '@/hooks/useSearchFilters';
 import { useStatsig } from '@/hooks/useStatsig';
 import { useFeatureGate } from '@adopt-dont-shop/lib.feature-flags';
 import { petService, PaginatedResponse, Pet } from '@/services';
-import { Button, Container, SelectInput, Spinner } from '@adopt-dont-shop/lib.components';
+import { Button, Container, SelectInput } from '@adopt-dont-shop/lib.components';
+import { PetCardSkeletonGrid } from '@/components/skeletons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import * as styles from './SearchPage.css';
@@ -227,8 +228,8 @@ export const SearchPage: React.FC = () => {
         </div>
 
         {isLoading ? (
-          <div className={styles.loadingContainer}>
-            <Spinner size='lg' />
+          <div className={styles.petGrid}>
+            <PetCardSkeletonGrid count={8} />
           </div>
         ) : error ? (
           <div className={styles.emptyState}>

--- a/app.client/src/setup-tests.ts
+++ b/app.client/src/setup-tests.ts
@@ -86,6 +86,44 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   Modal: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', props, children),
   Spinner: () => React.createElement('div', { 'aria-label': 'loading' }),
+  Skeleton: ({ width, height, radius, className, style, ...props }: Record<string, unknown>) =>
+    React.createElement('div', {
+      'aria-hidden': 'true',
+      style: { width, height, borderRadius: radius, ...((style as React.CSSProperties) ?? {}) },
+      ...props,
+    }),
+  SkeletonText: ({ lines = 3 }: { lines?: number }) =>
+    React.createElement(
+      'div',
+      { 'aria-hidden': 'true' },
+      ...Array.from({ length: lines as number }, (_, i) => React.createElement('div', { key: i }))
+    ),
+  SkeletonTableRow: ({
+    columnCount,
+    hasCheckbox,
+  }: {
+    columnCount: number;
+    hasCheckbox?: boolean;
+  }) =>
+    React.createElement(
+      'tr',
+      { 'aria-hidden': 'true', 'data-testid': 'skeleton-row' },
+      hasCheckbox ? React.createElement('td', { key: 'cb' }) : null,
+      ...Array.from({ length: columnCount as number }, (_, i) =>
+        React.createElement('td', { key: i })
+      )
+    ),
+  SkeletonCard: ({ lines = 3, showAvatar }: { lines?: number; showAvatar?: boolean }) =>
+    React.createElement(
+      'div',
+      { 'aria-hidden': 'true' },
+      showAvatar ? React.createElement('div', { key: 'avatar' }) : null,
+      React.createElement(
+        'div',
+        { key: 'text' },
+        ...Array.from({ length: lines as number }, (_, i) => React.createElement('div', { key: i }))
+      )
+    ),
   MatchReasonChips: () => React.createElement('div', { 'data-testid': 'match-reason-chips' }),
   Alert: ({ children, ...props }: React.ComponentPropsWithoutRef<'div'>) =>
     React.createElement('div', { role: 'alert', ...props }, children),

--- a/app.rescue/src/components/skeletons/DashboardSkeleton.css.ts
+++ b/app.rescue/src/components/skeletons/DashboardSkeleton.css.ts
@@ -1,0 +1,42 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const metricsGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+  gap: vars.spacing[3],
+  marginBottom: vars.spacing[4],
+});
+
+export const metricCard = style({
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.lg,
+  padding: vars.spacing[3],
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});
+
+export const analyticsGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+  gap: vars.spacing[3],
+  marginBottom: vars.spacing[4],
+});
+
+export const chartCard = style({
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.lg,
+  padding: vars.spacing[3],
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});
+
+export const activityLines = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});

--- a/app.rescue/src/components/skeletons/DashboardSkeleton.tsx
+++ b/app.rescue/src/components/skeletons/DashboardSkeleton.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Skeleton, SkeletonText } from '@adopt-dont-shop/lib.components';
+import * as styles from './DashboardSkeleton.css';
+
+export const DashboardSkeleton: React.FC = () => (
+  <div aria-hidden="true">
+    <div className={styles.metricsGrid}>
+      {Array.from({ length: 4 }, (_, i) => (
+        <div key={i} className={styles.metricCard}>
+          <Skeleton height="0.75rem" width="60%" />
+          <Skeleton height="2rem" width="40%" />
+          <Skeleton height="0.625rem" width="80%" />
+        </div>
+      ))}
+    </div>
+
+    <div className={styles.analyticsGrid}>
+      <div className={styles.chartCard}>
+        <Skeleton height="1rem" width="150px" />
+        <Skeleton height="200px" width="100%" />
+      </div>
+      <div className={styles.chartCard}>
+        <Skeleton height="1rem" width="180px" />
+        <div className={styles.activityLines}>
+          <SkeletonText lines={5} />
+        </div>
+      </div>
+      <div className={styles.chartCard}>
+        <Skeleton height="1rem" width="140px" />
+        <div className={styles.activityLines}>
+          {Array.from({ length: 4 }, (_, i) => (
+            <div key={i} style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <Skeleton height="0.625rem" width="80px" />
+              <Skeleton height="0.875rem" width="100%" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  </div>
+);

--- a/app.rescue/src/components/skeletons/PetListSkeleton.css.ts
+++ b/app.rescue/src/components/skeletons/PetListSkeleton.css.ts
@@ -1,0 +1,41 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[3],
+});
+
+export const searchBar = style({
+  marginBottom: vars.spacing[2],
+});
+
+export const petRow = style({
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.lg,
+  padding: vars.spacing[3],
+  display: 'flex',
+  gap: vars.spacing[3],
+  alignItems: 'center',
+});
+
+export const imageBlock = style({
+  width: '60px',
+  height: '60px',
+  borderRadius: vars.border.radius.base,
+  flexShrink: 0,
+});
+
+export const textBlock = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[1],
+});
+
+export const actions = style({
+  display: 'flex',
+  gap: vars.spacing[2],
+});

--- a/app.rescue/src/components/skeletons/PetListSkeleton.tsx
+++ b/app.rescue/src/components/skeletons/PetListSkeleton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Skeleton } from '@adopt-dont-shop/lib.components';
+import * as styles from './PetListSkeleton.css';
+
+export const PetListSkeleton: React.FC = () => (
+  <div className={styles.container} aria-hidden="true">
+    <Skeleton className={styles.searchBar} height="2.5rem" width="100%" />
+    {Array.from({ length: 5 }, (_, i) => (
+      <div key={i} className={styles.petRow}>
+        <Skeleton className={styles.imageBlock} height="auto" />
+        <div className={styles.textBlock}>
+          <Skeleton height="1rem" width="40%" />
+          <Skeleton height="0.75rem" width="60%" />
+        </div>
+        <div className={styles.actions}>
+          <Skeleton height="2rem" width="60px" radius="4px" />
+          <Skeleton height="2rem" width="60px" radius="4px" />
+        </div>
+      </div>
+    ))}
+  </div>
+);

--- a/app.rescue/src/components/skeletons/SettingsFormSkeleton.css.ts
+++ b/app.rescue/src/components/skeletons/SettingsFormSkeleton.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[4],
+});
+
+export const fieldGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.spacing[2],
+});

--- a/app.rescue/src/components/skeletons/SettingsFormSkeleton.tsx
+++ b/app.rescue/src/components/skeletons/SettingsFormSkeleton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Skeleton } from '@adopt-dont-shop/lib.components';
+import * as styles from './SettingsFormSkeleton.css';
+
+export const SettingsFormSkeleton: React.FC = () => (
+  <div className={styles.container} aria-hidden="true">
+    {Array.from({ length: 6 }, (_, i) => (
+      <div key={i} className={styles.fieldGroup}>
+        <Skeleton height="0.75rem" width={`${80 + (i % 3) * 20}px`} />
+        <Skeleton height="2.5rem" width="100%" />
+      </div>
+    ))}
+    <Skeleton height="2.5rem" width="120px" radius="4px" />
+  </div>
+);

--- a/app.rescue/src/components/skeletons/index.ts
+++ b/app.rescue/src/components/skeletons/index.ts
@@ -1,0 +1,3 @@
+export { DashboardSkeleton } from './DashboardSkeleton';
+export { PetListSkeleton } from './PetListSkeleton';
+export { SettingsFormSkeleton } from './SettingsFormSkeleton';

--- a/app.rescue/src/components/staff/StaffOverview.css.ts
+++ b/app.rescue/src/components/staff/StaffOverview.css.ts
@@ -1,9 +1,4 @@
-import { globalStyle, style, keyframes } from '@vanilla-extract/css';
-
-const loading = keyframes({
-  '0%': { backgroundPosition: '200% 0' },
-  '100%': { backgroundPosition: '-200% 0' },
-});
+import { globalStyle, style } from '@vanilla-extract/css';
 
 export const overviewContainer = style({
   marginBottom: '2rem',
@@ -154,14 +149,6 @@ export const overviewSkeleton = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
   gap: '1rem',
-});
-
-export const skeletonCard = style({
-  height: '100px',
-  background: 'linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%)',
-  backgroundSize: '200% 100%',
-  animation: `${loading} 1.5s infinite`,
-  borderRadius: '12px',
 });
 
 export const emptyContainer = style({

--- a/app.rescue/src/components/staff/StaffOverview.tsx
+++ b/app.rescue/src/components/staff/StaffOverview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SkeletonCard } from '@adopt-dont-shop/lib.components';
 import { StaffMember } from '../../types/staff';
 import * as styles from './StaffOverview.css';
 
@@ -12,10 +13,9 @@ const StaffOverview: React.FC<StaffOverviewProps> = ({ staff, loading = false })
     return (
       <div className={styles.loadingContainer}>
         <div className={styles.overviewSkeleton}>
-          <div className={styles.skeletonCard} />
-          <div className={styles.skeletonCard} />
-          <div className={styles.skeletonCard} />
-          <div className={styles.skeletonCard} />
+          {Array.from({ length: 4 }, (_, i) => (
+            <SkeletonCard key={i} lines={2} />
+          ))}
         </div>
       </div>
     );

--- a/app.rescue/src/pages/Dashboard.tsx
+++ b/app.rescue/src/pages/Dashboard.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { Card, Container, Heading, Spinner, Text } from '@adopt-dont-shop/lib.components';
+import { Card, Container, Heading, Text } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { useDashboardData } from '../hooks';
 import { UnreadMessagesPanel } from '../components/dashboard/UnreadMessagesPanel';
+import { DashboardSkeleton } from '../components/skeletons';
 import { formatRelativeDate } from '@adopt-dont-shop/lib.utils';
 import * as styles from './Dashboard.css';
 
@@ -16,11 +17,8 @@ const Dashboard: React.FC = () => {
       <Container className={styles.dashboardContainer}>
         <div className={styles.dashboardHeader}>
           <Heading level="h1">Rescue Dashboard</Heading>
-          <Text>Loading dashboard data...</Text>
         </div>
-        <div className={styles.loadingState}>
-          <Spinner size="md" label="Loading dashboard data" />
-        </div>
+        <DashboardSkeleton />
       </Container>
     );
   }

--- a/app.rescue/src/pages/Events.tsx
+++ b/app.rescue/src/pages/Events.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import clsx from 'clsx';
-import { Card, ConfirmDialog, toast, useConfirm } from '@adopt-dont-shop/lib.components';
+import {
+  Card,
+  ConfirmDialog,
+  SkeletonCard,
+  toast,
+  useConfirm,
+} from '@adopt-dont-shop/lib.components';
 import { FiCalendar, FiPlus } from 'react-icons/fi';
 import * as styles from './Events.css';
 
@@ -354,11 +360,11 @@ const Events: React.FC = () => {
 
       <div className={styles.contentArea}>
         {loading ? (
-          <Card>
-            <div className={styles.loadingState}>
-              <p>Loading events...</p>
-            </div>
-          </Card>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            {Array.from({ length: 3 }, (_, i) => (
+              <SkeletonCard key={i} lines={3} />
+            ))}
+          </div>
         ) : filteredEvents.length === 0 && !loading ? (
           <Card>
             <div className={styles.emptyState}>

--- a/app.rescue/src/pages/FosterCoordination.tsx
+++ b/app.rescue/src/pages/FosterCoordination.tsx
@@ -5,7 +5,7 @@ import { petService } from '../services/libraryServices';
 import { staffService, type StaffMember } from '../services/staffService';
 import type { Pet } from '@adopt-dont-shop/lib.pets';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
-import { Modal, useConfirm, ConfirmDialog } from '@adopt-dont-shop/lib.components';
+import { Modal, useConfirm, ConfirmDialog, SkeletonCard } from '@adopt-dont-shop/lib.components';
 import * as styles from './FosterCoordination.css';
 
 const FosterCoordination: React.FC = () => {
@@ -196,7 +196,11 @@ const FosterCoordination: React.FC = () => {
       </div>
 
       {loading ? (
-        <p>Loading placements…</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {Array.from({ length: 3 }, (_, i) => (
+            <SkeletonCard key={i} lines={2} />
+          ))}
+        </div>
       ) : visiblePlacements.length === 0 ? (
         <p>No foster placements found.</p>
       ) : (

--- a/app.rescue/src/pages/PetManagement.tsx
+++ b/app.rescue/src/pages/PetManagement.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Card, Container, Button, Text, Heading, toast } from '@adopt-dont-shop/lib.components';
+import { PetListSkeleton } from '../components/skeletons';
 import { Pet, PetStatus, petManagementService } from '@adopt-dont-shop/lib.pets';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { apiService } from '@adopt-dont-shop/lib.api';
@@ -330,9 +331,8 @@ const PetManagement: React.FC = () => {
   if (loading && pets.length === 0) {
     return (
       <Container className={styles.pageContainer}>
-        <div className={styles.loadingContainer}>
-          <Text>Loading pets...</Text>
-        </div>
+        <Heading level="h1">Pet Management</Heading>
+        <PetListSkeleton />
       </Container>
     );
   }

--- a/app.rescue/src/pages/RescueSettings.test.tsx
+++ b/app.rescue/src/pages/RescueSettings.test.tsx
@@ -9,10 +9,17 @@ vi.mock('@adopt-dont-shop/lib.auth', () => ({
   TwoFactorSettings: () => null,
 }));
 
-vi.mock('@adopt-dont-shop/lib.components', () => ({
-  ThemeToggle: () => null,
-  toast: { success: vi.fn(), error: vi.fn() },
-}));
+vi.mock('@adopt-dont-shop/lib.components', async () => {
+  const React = await import('react');
+  return {
+    ThemeToggle: () => null,
+    toast: { success: vi.fn(), error: vi.fn() },
+    Skeleton: (props: Record<string, unknown>) =>
+      React.createElement('div', { 'aria-hidden': 'true', ...props }),
+    SkeletonText: () => React.createElement('div', { 'aria-hidden': 'true' }),
+    SkeletonCard: () => React.createElement('div', { 'aria-hidden': 'true' }),
+  };
+});
 
 vi.mock('../contexts/PermissionsContext', () => ({
   usePermissions: () => ({ hasPermission: () => true }),

--- a/app.rescue/src/pages/RescueSettings.tsx
+++ b/app.rescue/src/pages/RescueSettings.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import { useAuth, TwoFactorSettings } from '@adopt-dont-shop/lib.auth';
 import { ThemeToggle, toast } from '@adopt-dont-shop/lib.components';
+import { SettingsFormSkeleton } from '../components/skeletons';
 import { usePermissions } from '../contexts/PermissionsContext';
 import { apiService, rescueService } from '../services/libraryServices';
 import { RESCUE_SETTINGS_UPDATE } from '@adopt-dont-shop/lib.permissions';
@@ -112,7 +113,7 @@ const RescueSettings: React.FC = () => {
   if (loading) {
     return (
       <div className={styles.pageContainer}>
-        <div className={styles.loadingContainer}>Loading rescue settings...</div>
+        <SettingsFormSkeleton />
       </div>
     );
   }

--- a/app.rescue/src/setup-tests.ts
+++ b/app.rescue/src/setup-tests.ts
@@ -127,6 +127,36 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   Alert: ({ children, ...props }: any) =>
     React.createElement('div', { role: 'alert', ...props }, children),
   Spinner: (props: any) => React.createElement('div', { 'aria-label': props?.label ?? 'loading' }),
+  Skeleton: ({ width, height, radius, className, style, ...props }: any) =>
+    React.createElement('div', {
+      'aria-hidden': 'true',
+      style: { width, height, borderRadius: radius, ...(style ?? {}) },
+      ...props,
+    }),
+  SkeletonText: ({ lines = 3 }: any) =>
+    React.createElement(
+      'div',
+      { 'aria-hidden': 'true' },
+      ...Array.from({ length: lines }, (_, i) => React.createElement('div', { key: i }))
+    ),
+  SkeletonTableRow: ({ columnCount, hasCheckbox }: any) =>
+    React.createElement(
+      'tr',
+      { 'aria-hidden': 'true', 'data-testid': 'skeleton-row' },
+      hasCheckbox ? React.createElement('td', { key: 'cb' }) : null,
+      ...Array.from({ length: columnCount }, (_, i) => React.createElement('td', { key: i }))
+    ),
+  SkeletonCard: ({ lines = 3, showAvatar }: any) =>
+    React.createElement(
+      'div',
+      { 'aria-hidden': 'true' },
+      showAvatar ? React.createElement('div', { key: 'avatar' }) : null,
+      React.createElement(
+        'div',
+        { key: 'text' },
+        ...Array.from({ length: lines }, (_, i) => React.createElement('div', { key: i }))
+      )
+    ),
   CheckboxInput: ({ children, ...props }: any) =>
     React.createElement('input', { type: 'checkbox', ...props }, children),
   SelectInput: ({ children, ...props }: any) => React.createElement('select', props, children),

--- a/lib.components/src/components/data/Table/Table.css.ts
+++ b/lib.components/src/components/data/Table/Table.css.ts
@@ -261,9 +261,23 @@ export const srOnly = style({
   clip: 'rect(0 0 0 0)',
 });
 
+const shimmer = keyframes({
+  '0%': { backgroundPosition: '200% 0' },
+  '100%': { backgroundPosition: '-200% 0' },
+});
+
 export const loadingSkeletonCell = style({
   height: '20px',
   width: '100%',
+  background: `linear-gradient(90deg, ${vars.background.muted} 25%, ${vars.border.color.muted} 50%, ${vars.background.muted} 75%)`,
+  backgroundSize: '200% 100%',
+  animation: `${shimmer} 1.5s ease-in-out infinite`,
+  borderRadius: vars.border.radius.sm,
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      animation: 'none',
+    },
+  },
 });
 
 export const emptyStateIcon = style({

--- a/lib.components/src/components/ui/Skeleton/Skeleton.css.ts
+++ b/lib.components/src/components/ui/Skeleton/Skeleton.css.ts
@@ -1,4 +1,5 @@
 import { style, keyframes } from '@vanilla-extract/css';
+import { vars } from '../../../styles/theme.css';
 
 const shimmer = keyframes({
   '0%': { backgroundPosition: '200% 0' },
@@ -6,9 +7,14 @@ const shimmer = keyframes({
 });
 
 export const skeletonBase = style({
-  background: 'linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%)',
+  background: `linear-gradient(90deg, ${vars.background.muted} 25%, ${vars.border.color.muted} 50%, ${vars.background.muted} 75%)`,
   backgroundSize: '200% 100%',
   animation: `${shimmer} 1.5s ease-in-out infinite`,
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      animation: 'none',
+    },
+  },
 });
 
 export const textLine = style({
@@ -27,14 +33,14 @@ export const cellContainer = style({
 });
 
 export const cardContainer = style({
-  background: '#ffffff',
-  border: '1px solid #e5e7eb',
-  borderRadius: '12px',
-  padding: '1.5rem',
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: vars.border.radius.lg,
+  padding: vars.spacing[4],
 });
 
 export const tableCell = style({
-  padding: '1rem',
+  padding: vars.spacing[3],
 });
 
 export const checkboxSkeleton = style({
@@ -56,19 +62,19 @@ export const flexFill = style({
 
 export const textRowPrimary = style({
   height: '0.875rem',
-  borderRadius: '4px',
+  borderRadius: vars.border.radius.sm,
   marginBottom: '0.25rem',
 });
 
 export const textRowSecondary = style({
   height: '0.75rem',
   width: '70%',
-  borderRadius: '4px',
+  borderRadius: vars.border.radius.sm,
 });
 
 export const genericTextRow = style({
   height: '0.875rem',
-  borderRadius: '4px',
+  borderRadius: vars.border.radius.sm,
 });
 
 export const avatarLarge = style({
@@ -82,17 +88,17 @@ export const avatarRow = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.75rem',
-  marginBottom: '1rem',
+  marginBottom: vars.spacing[3],
 });
 
 export const cardTextPrimary = style({
   height: '1rem',
-  borderRadius: '4px',
+  borderRadius: vars.border.radius.sm,
   marginBottom: '0.375rem',
 });
 
 export const cardTextSecondary = style({
   height: '0.875rem',
   width: '60%',
-  borderRadius: '4px',
+  borderRadius: vars.border.radius.sm,
 });

--- a/lib.components/src/components/ui/Skeleton/Skeleton.test.tsx
+++ b/lib.components/src/components/ui/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,103 @@
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { Skeleton, SkeletonText, SkeletonTableRow, SkeletonCard } from './Skeleton';
+
+describe('Skeleton primitives', () => {
+  describe('Skeleton', () => {
+    it('renders a hidden placeholder element', () => {
+      const { container } = render(<Skeleton />);
+      const el = container.firstChild as HTMLElement;
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('applies custom width and height', () => {
+      const { container } = render(<Skeleton width='200px' height='2rem' />);
+      const el = container.firstChild as HTMLElement;
+      expect(el).toHaveStyle({ width: '200px', height: '2rem' });
+    });
+
+    it('defaults to full width and 1rem height', () => {
+      const { container } = render(<Skeleton />);
+      const el = container.firstChild as HTMLElement;
+      expect(el).toHaveStyle({ width: '100%', height: '1rem' });
+    });
+
+    it('accepts custom className', () => {
+      const { container } = render(<Skeleton className='custom' />);
+      const el = container.firstChild as HTMLElement;
+      expect(el.className).toContain('custom');
+    });
+  });
+
+  describe('SkeletonText', () => {
+    it('renders the requested number of lines', () => {
+      const { container } = render(<SkeletonText lines={5} />);
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper).toHaveAttribute('aria-hidden', 'true');
+      expect(wrapper.children).toHaveLength(5);
+    });
+
+    it('defaults to 3 lines', () => {
+      const { container } = render(<SkeletonText />);
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.children).toHaveLength(3);
+    });
+
+    it('sets the last line to a shorter width', () => {
+      const { container } = render(<SkeletonText lines={2} lastLineWidth='40%' />);
+      const wrapper = container.firstChild as HTMLElement;
+      const lastLine = wrapper.children[1] as HTMLElement;
+      expect(lastLine).toHaveStyle({ width: '40%' });
+    });
+  });
+
+  describe('SkeletonTableRow', () => {
+    it('renders a table row with the specified column count', () => {
+      const { container } = render(
+        <table>
+          <tbody>
+            <SkeletonTableRow columnCount={3} />
+          </tbody>
+        </table>
+      );
+      const row = screen.getByTestId('skeleton-row');
+      expect(row).toHaveAttribute('aria-hidden', 'true');
+      expect(row.querySelectorAll('td')).toHaveLength(3);
+    });
+
+    it('adds a checkbox cell when hasCheckbox is true', () => {
+      render(
+        <table>
+          <tbody>
+            <SkeletonTableRow columnCount={2} hasCheckbox />
+          </tbody>
+        </table>
+      );
+      const row = screen.getByTestId('skeleton-row');
+      expect(row.querySelectorAll('td')).toHaveLength(3);
+    });
+  });
+
+  describe('SkeletonCard', () => {
+    it('renders a card with text lines', () => {
+      const { container } = render(<SkeletonCard lines={4} />);
+      const card = container.firstChild as HTMLElement;
+      expect(card).toHaveAttribute('aria-hidden', 'true');
+      const textWrapper = card.firstChild as HTMLElement;
+      expect(textWrapper.children).toHaveLength(4);
+    });
+
+    it('shows an avatar row when showAvatar is true', () => {
+      const { container } = render(<SkeletonCard showAvatar />);
+      const card = container.firstChild as HTMLElement;
+      expect(card.children).toHaveLength(2);
+    });
+
+    it('hides avatar row by default', () => {
+      const { container } = render(<SkeletonCard />);
+      const card = container.firstChild as HTMLElement;
+      expect(card.children).toHaveLength(1);
+    });
+  });
+});

--- a/lib.components/src/components/ui/Skeleton/Skeleton.tsx
+++ b/lib.components/src/components/ui/Skeleton/Skeleton.tsx
@@ -12,6 +12,7 @@ type SkeletonProps = {
 
 export const Skeleton: React.FC<SkeletonProps> = ({ width, height, radius, className, style }) => (
   <div
+    aria-hidden='true'
     className={clsx(styles.skeletonBase, className)}
     style={{
       width: width ?? '100%',
@@ -28,7 +29,7 @@ type SkeletonTextProps = {
 };
 
 export const SkeletonText: React.FC<SkeletonTextProps> = ({ lines = 3, lastLineWidth = '60%' }) => (
-  <div>
+  <div aria-hidden='true'>
     {Array.from({ length: lines }, (_, i) => (
       <div
         key={i}

--- a/lib.components/src/components/ui/Skeleton/index.ts
+++ b/lib.components/src/components/ui/Skeleton/index.ts
@@ -1,0 +1,1 @@
+export { Skeleton, SkeletonText, SkeletonTableRow, SkeletonCard } from './Skeleton';

--- a/lib.components/src/index.ts
+++ b/lib.components/src/index.ts
@@ -29,6 +29,7 @@ export { Button } from './components/ui/Button';
 export { default as DateTime } from './components/ui/DateTime/DateTime';
 export { Heading } from './components/ui/Heading';
 export { DotSpinner, Spinner } from './components/ui/Spinner';
+export { Skeleton, SkeletonCard, SkeletonTableRow, SkeletonText } from './components/ui/Skeleton';
 export { Text } from './components/ui/Text';
 
 // Layout Components


### PR DESCRIPTION
## Summary

- **Extract shared skeleton primitives to lib.components** — moved `Skeleton`, `SkeletonText`, `SkeletonTableRow`, and `SkeletonCard` from `app.admin` into the shared component library so all apps can use them. Shimmer colours now use theme tokens (works in light, normal, and dark mode) and respect `prefers-reduced-motion`.

- **Add skeletons to app.client** — replaced `<Spinner>` and "Loading..." text on 8 pages (SearchPage, PetDetailsPage, HomePage, FavoritesPage, ApplicationDashboard, RescueDetailsPage, ApplicationDetailsPage, ProfilePage, TopPicksHomeModule) with domain-specific skeleton components that match each page's layout.

- **Add skeletons to app.rescue** — replaced emoji loading text ("📊 Loading...") and plain text on 5 pages (Dashboard, PetManagement, RescueSettings, Events, FosterCoordination) with skeleton loading states. Consolidated StaffOverview's ad-hoc CSS skeletons with the shared `SkeletonCard`.

- **Cleanup** — removed unused `LoadingSpinner` export from SharedComponents and orphaned skeleton CSS/keyframes from StaffOverview.

## Test plan

- [ ] All lib.components tests pass (501 tests including new Skeleton tests)
- [ ] All app.admin tests pass (409 tests, existing loading-states.behavior.test.tsx still green)
- [ ] All app.client tests pass (410 tests)
- [ ] All app.rescue tests pass (309 tests)
- [ ] Visually verify skeleton shimmer renders in light and dark mode
- [ ] Verify shimmer animation stops with `prefers-reduced-motion: reduce`
- [ ] Spot-check SearchPage, PetDetailsPage, and rescue Dashboard for layout-matching skeletons

https://claude.ai/code/session_01JU5PivocHd4HbB7JLAnHHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JU5PivocHd4HbB7JLAnHHg)_