### PR TITLE
fix: align copy with Voice & Tone guide

### DIFF
--- a/app.admin/src/components/ErrorBoundary.tsx
+++ b/app.admin/src/components/ErrorBoundary.tsx
@@ -72,10 +72,10 @@ class ErrorBoundary extends Component<Props, State> {
               </svg>
             </div>
 
-            <h1 className={styles.errorTitle}>Oops! Something went wrong</h1>
+            <h1 className={styles.errorTitle}>Something went wrong</h1>
 
             <p className={styles.errorMessage}>
-              We're sorry, but something unexpected happened. Don't worry, your data is safe.
+              Something unexpected happened. Try again or reload the page.
             </p>
 
             <div className={styles.buttonContainer}>

--- a/app.admin/src/pages/LoginPage.tsx
+++ b/app.admin/src/pages/LoginPage.tsx
@@ -41,8 +41,8 @@ export const LoginPage = () => {
           <div className={styles.helperText}>
             <strong>Administrators Only:</strong> This app is for system administrators and
             moderators. <br />
-            Pet adopters should use the <strong>Client App</strong> (port 3000) <br />
-            Rescue staff should use the <strong>Rescue App</strong> (port 3002)
+            Pet adopters should use the <strong>Client App</strong>. <br />
+            Rescue staff should use the <strong>Rescue App</strong>.
           </div>
         }
       />

--- a/app.client/src/components/application/QuickApplicationPrompt.tsx
+++ b/app.client/src/components/application/QuickApplicationPrompt.tsx
@@ -31,14 +31,14 @@ export const QuickApplicationPrompt: React.FC<QuickApplicationPromptProps> = ({
 
       <div className={styles.promptContent}>
         <p className={styles.promptContentP}>
-          Great news! Your profile is {completionPercentage}% complete, so you can apply for{' '}
-          {petName} with just a few clicks using your saved information.
+          Your profile is {completionPercentage}% complete, so you can apply for {petName} in a
+          few clicks using your saved information.
         </p>
 
         <div className={styles.benefits}>
           <span className={styles.benefit}>✨ Pre-filled forms</span>
           <span className={styles.benefit}>⏱️ 2-minute application</span>
-          <span className={styles.benefit}>🎯 Higher approval rate</span>
+          <span className={styles.benefit}>🎯 Faster to submit</span>
         </div>
 
         <div className={styles.buttonGroup}>

--- a/app.client/src/components/application/QuickApplicationPrompt.tsx
+++ b/app.client/src/components/application/QuickApplicationPrompt.tsx
@@ -31,8 +31,8 @@ export const QuickApplicationPrompt: React.FC<QuickApplicationPromptProps> = ({
 
       <div className={styles.promptContent}>
         <p className={styles.promptContentP}>
-          Your profile is {completionPercentage}% complete, so you can apply for {petName} in a
-          few clicks using your saved information.
+          Your profile is {completionPercentage}% complete, so you can apply for {petName} in a few
+          clicks using your saved information.
         </p>
 
         <div className={styles.benefits}>

--- a/app.client/src/components/application/SubmissionSuccess.tsx
+++ b/app.client/src/components/application/SubmissionSuccess.tsx
@@ -28,7 +28,7 @@ export const SubmissionSuccess: React.FC<SubmissionSuccessProps> = ({
     <ul className={styles.nextSteps}>
       <li className={styles.nextStepItem}>
         We&apos;ve emailed a confirmation to <strong>{email}</strong> — keep an eye on your inbox
-        (and the spam folder, just in case).
+        (and the spam folder too).
       </li>
       <li className={styles.nextStepItem}>
         {rescueName} typically responds within a few days. If they need more information

--- a/app.client/src/components/common/ErrorBoundary.tsx
+++ b/app.client/src/components/common/ErrorBoundary.tsx
@@ -49,8 +49,7 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className={styles.errorContainer} role='alert'>
           <h2 className={styles.errorTitle}>Something went wrong</h2>
           <p className={styles.errorMessage}>
-            We&apos;re sorry, but something unexpected happened. Please try again or contact support
-            if the problem persists.
+            Something unexpected happened. Try again or contact support if the problem persists.
           </p>
           {import.meta.env.DEV && this.state.error && (
             <details className={styles.errorDetails}>

--- a/app.client/src/components/hero/SwipeHero.tsx
+++ b/app.client/src/components/hero/SwipeHero.tsx
@@ -26,19 +26,18 @@ export const SwipeHero: React.FC = () => {
       <div className={styles.heroContent}>
         <div className={styles.swipeBadge}>
           <MdAutoFixHigh className={styles.sparkle} />
-          New: AI-Powered Pet Matching
+          New: Smart Pet Matching
         </div>
 
         <h1 className={styles.mainHeading}>
-          Find Your Perfect
+          Find Your Next
           <br />
           Companion with a Swipe
         </h1>
 
         <p className={styles.subtitle}>
-          Discover amazing pets waiting for their forever home. Our innovative swipe feature uses
-          smart matching to help you find the perfect companion based on your preferences and
-          lifestyle.
+          Swipe through adoptable pets matched to your preferences and lifestyle. Like the ones that
+          catch your eye — we'll connect you with their rescue.
         </p>
 
         <div className={styles.ctaContainer}>
@@ -66,19 +65,19 @@ export const SwipeHero: React.FC = () => {
           <div className={styles.featureCard}>
             <MdSwipe className='icon' />
             <h3>Smart Swiping</h3>
-            <p>Swipe right to like, left to pass. Our algorithm learns your preferences!</p>
+            <p>Swipe right to like, left to pass. Matches improve as you set more preferences.</p>
           </div>
 
           <div className={styles.featureCard}>
             <MdTrendingUp className='icon' />
-            <h3>Instant Matching</h3>
-            <p>Get matched with pets that fit your lifestyle and preferences in real-time.</p>
+            <h3>Preference Matching</h3>
+            <p>See pets that fit your home, lifestyle, and experience level first.</p>
           </div>
 
           <div className={styles.featureCard}>
             <MdFlashOn className='icon' />
             <h3>Quick & Fun</h3>
-            <p>Finding your new best friend has never been this easy and entertaining!</p>
+            <p>A faster way to browse adoptable pets — no endless scrolling required.</p>
           </div>
         </div>
       </div>

--- a/app.client/src/components/modals/LoginPromptModal.tsx
+++ b/app.client/src/components/modals/LoginPromptModal.tsx
@@ -68,7 +68,7 @@ export const LoginPromptModal: React.FC<LoginPromptModalProps> = ({
 
         <p className={styles.message}>
           To {getActionMessage()}, you&apos;ll need to create an account or sign in. It&apos;s free
-          and helps us find you the perfect pet match!
+          and helps us match you with the right pet.
         </p>
 
         <div className={styles.buttonGroup}>

--- a/app.client/src/pages/ApplicationPage.tsx
+++ b/app.client/src/pages/ApplicationPage.tsx
@@ -60,7 +60,7 @@ const MACRO_STEPS: readonly MacroStepDef[] = [
     id: 'this_pet',
     title: 'About {petName} ❤️',
     description: petName =>
-      `Last bit! Just a few questions about ${petName ?? 'this pet'} and we're done.`,
+      `Last bit — a few questions about ${petName ?? 'this pet'} and we're done.`,
     categories: ['final_acknowledgments'],
   },
 ];

--- a/app.client/src/pages/HomePage.tsx
+++ b/app.client/src/pages/HomePage.tsx
@@ -153,11 +153,11 @@ export const HomePage: React.FC = () => {
         <section className={styles.heroSection}>
           <div className={styles.heroGlow} aria-hidden />
           <div className={`${styles.container} ${styles.heroInner}`}>
-            <span className={styles.heroEyebrow}>10,000+ adopted · 500+ rescue partners</span>
-            <h1 className={styles.heroTitle}>Find Your Perfect Companion</h1>
+            <span className={styles.heroEyebrow}>Rescue pets, matched to you</span>
+            <h1 className={styles.heroTitle}>Find Your Next Companion</h1>
             <p className={styles.heroSubtitle}>
-              Every pet deserves a loving home. Browse thousands of adoptable pets and find your new
-              best friend today.
+              Every pet deserves a loving home. Browse adoptable pets from verified rescues and start
+              your adoption journey.
             </p>
             <div className={styles.heroActions}>
               <Link to='/search' onClick={() => handleCTAClick('browse_pets')}>
@@ -211,38 +211,14 @@ export const HomePage: React.FC = () => {
         </div>
       </section>
 
-      {/* Statistics Section */}
-      <section className={styles.statsSection}>
-        <div className={styles.container}>
-          <div className='stats-grid'>
-            <div className='stat-item'>
-              <h3>10,000+</h3>
-              <p>Pets Adopted</p>
-            </div>
-            <div className='stat-item'>
-              <h3>500+</h3>
-              <p>Rescue Partners</p>
-            </div>
-            <div className='stat-item'>
-              <h3>50+</h3>
-              <p>States Covered</p>
-            </div>
-            <div className='stat-item'>
-              <h3>24/7</h3>
-              <p>Support Available</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {/* Call to Action Section */}
       <section className={styles.ctaSection}>
         <div className={styles.container}>
           <h2>Ready to Make a Difference?</h2>
           <p>
             {isAuthenticated
-              ? 'Browse our available pets and find your new best friend today!'
-              : 'Create your account and start your adoption journey today!'}
+              ? 'Browse our available pets and find your next companion.'
+              : 'Create your account and start your adoption journey.'}
           </p>
           {isAuthenticated ? (
             <Link to='/search' onClick={() => handleCTAClick('browse_pets')}>

--- a/app.client/src/pages/HomePage.tsx
+++ b/app.client/src/pages/HomePage.tsx
@@ -156,8 +156,8 @@ export const HomePage: React.FC = () => {
             <span className={styles.heroEyebrow}>Rescue pets, matched to you</span>
             <h1 className={styles.heroTitle}>Find Your Next Companion</h1>
             <p className={styles.heroSubtitle}>
-              Every pet deserves a loving home. Browse adoptable pets from verified rescues and start
-              your adoption journey.
+              Every pet deserves a loving home. Browse adoptable pets from verified rescues and
+              start your adoption journey.
             </p>
             <div className={styles.heroActions}>
               <Link to='/search' onClick={() => handleCTAClick('browse_pets')}>

--- a/app.client/src/pages/RegisterPage.tsx
+++ b/app.client/src/pages/RegisterPage.tsx
@@ -13,7 +13,7 @@ export const RegisterPage: React.FC = () => {
   return (
     <AuthLayout
       title='Create Your Account'
-      subtitle='Join thousands of people who have found their perfect pet companion'
+      subtitle='Find your next companion through adoption'
       footer={
         <div className={styles.loginPrompt}>
           <p>Already have an account?</p>

--- a/app.client/src/pages/ResetPasswordPage.tsx
+++ b/app.client/src/pages/ResetPasswordPage.tsx
@@ -133,9 +133,9 @@ export const ResetPasswordPage: React.FC = () => {
       <div className={styles.container}>
         <Card className={styles.resetPasswordCard}>
           <div className={styles.successContainer}>
-            <h2>Password Reset Successful!</h2>
-            <p>Your password has been successfully updated.</p>
-            <p>You can now log in with your new password.</p>
+            <h2>Password updated</h2>
+            <p>Your password has been updated.</p>
+            <p>You can now sign in with your new password.</p>
             <p className='redirect-message'>
               Redirecting to login in {redirectCountdown} seconds...
             </p>

--- a/app.client/src/pages/VerifyEmailPage.tsx
+++ b/app.client/src/pages/VerifyEmailPage.tsx
@@ -116,8 +116,7 @@ export const VerifyEmailPage: React.FC = () => {
             <div className={styles.header}>
               <h1>Email Verified!</h1>
               <p>
-                Your email has been successfully verified. You can now access all features of Adopt
-                Don't Shop.
+                Email verified. You can now access all features of Adopt Don't Shop.
               </p>
             </div>
             <Alert variant='success'>Verification successful! Redirecting to login...</Alert>

--- a/app.client/src/pages/VerifyEmailPage.tsx
+++ b/app.client/src/pages/VerifyEmailPage.tsx
@@ -115,9 +115,7 @@ export const VerifyEmailPage: React.FC = () => {
             <div className={styles.iconContainer}>✅</div>
             <div className={styles.header}>
               <h1>Email Verified!</h1>
-              <p>
-                Email verified. You can now access all features of Adopt Don't Shop.
-              </p>
+              <p>Email verified. You can now access all features of Adopt Don't Shop.</p>
             </div>
             <Alert variant='success'>Verification successful! Redirecting to login...</Alert>
             <div className={styles.buttonGroup}>

--- a/app.rescue/src/pages/LoginPage.tsx
+++ b/app.rescue/src/pages/LoginPage.tsx
@@ -33,8 +33,8 @@ const LoginPage = () => {
         helperText={
           <div className={styles.helperText}>
             <strong>Rescue Staff Only:</strong> This app is for rescue organization staff. <br />
-            Pet adopters should use the <strong>Client App</strong> (port 3000) <br />
-            System admins should use the <strong>Admin App</strong> (port 3001)
+            Pet adopters should use the <strong>Client App</strong>. <br />
+            System admins should use the <strong>Admin App</strong>.
           </div>
         }
       />

--- a/lib.components/src/components/ui/SanctionBanner/SanctionBanner.test.tsx
+++ b/lib.components/src/components/ui/SanctionBanner/SanctionBanner.test.tsx
@@ -37,7 +37,7 @@ describe('SanctionBanner', () => {
       expect(screen.getAllByTestId('sanction-banner-item')).toHaveLength(2);
     });
     expect(screen.getByText('A moderator issued you a warning')).toBeInTheDocument();
-    expect(screen.getByText('Your account has been suspended')).toBeInTheDocument();
+    expect(screen.getByText('We suspended your account')).toBeInTheDocument();
     expect(screen.getByText('Repeated harassment')).toBeInTheDocument();
   });
 
@@ -72,7 +72,7 @@ describe('SanctionBanner', () => {
     await waitFor(() => {
       expect(screen.queryByText('A moderator issued you a warning')).not.toBeInTheDocument();
     });
-    expect(screen.getByText('Your account has been suspended')).toBeInTheDocument();
+    expect(screen.getByText('We suspended your account')).toBeInTheDocument();
   });
 
   it('refetches when the refreshKey prop changes', async () => {

--- a/lib.components/src/components/ui/SanctionBanner/SanctionBanner.tsx
+++ b/lib.components/src/components/ui/SanctionBanner/SanctionBanner.tsx
@@ -37,9 +37,9 @@ export type SanctionBannerProps = {
 
 const TITLES: Record<string, string> = {
   warning_issued: 'A moderator issued you a warning',
-  user_suspended: 'Your account has been suspended',
-  user_banned: 'Your account has been banned',
-  account_restricted: 'Your account has been restricted',
+  user_suspended: 'We suspended your account',
+  user_banned: 'We banned your account',
+  account_restricted: 'We restricted your account',
 };
 
 const titleFor = (type: string): string =>

--- a/service.backend/src/seeders/reference/email-templates.ts
+++ b/service.backend/src/seeders/reference/email-templates.ts
@@ -17,7 +17,7 @@ const emailTemplateData = [
         </div>
         <div style="padding: 30px;">
           <p>Dear {{firstName}},</p>
-          <p>Thank you for joining our community of animal lovers! We're excited to help you find your perfect companion.</p>
+          <p>Thank you for joining our community of animal lovers. We're here to help you find a companion.</p>
           <p>Here's what you can do next:</p>
           <ul>
             <li>Browse available pets in your area</li>
@@ -28,8 +28,8 @@ const emailTemplateData = [
           <div style="text-align: center; margin: 30px 0;">
             <a href="{{baseUrl}}/pets" style="background-color: #4CAF50; color: white; padding: 15px 30px; text-decoration: none; border-radius: 5px;">Start Browsing Pets</a>
           </div>
-          <p>If you have any questions, our support team is here to help!</p>
-          <p>Happy pet hunting! 🐕🐱</p>
+          <p>If you have any questions, our support team is here to help.</p>
+          <p>Happy browsing! 🐕🐱</p>
           <p>The Adopt Don't Shop Team</p>
         </div>
       </div>
@@ -39,7 +39,7 @@ const emailTemplateData = [
       
       Dear {{firstName}},
       
-      Thank you for joining our community of animal lovers! We're excited to help you find your perfect companion.
+      Thank you for joining our community of animal lovers. We're here to help you find a companion.
       
       Here's what you can do next:
       - Browse available pets in your area
@@ -49,9 +49,9 @@ const emailTemplateData = [
       
       Visit {{baseUrl}}/pets to start browsing pets.
       
-      If you have any questions, our support team is here to help!
-      
-      Happy pet hunting!
+      If you have any questions, our support team is here to help.
+
+      Happy browsing!
       The Adopt Don't Shop Team
     `,
     category: TemplateCategory.WELCOME,
@@ -146,17 +146,17 @@ const emailTemplateData = [
     templateId: '597a7fb1-18b3-418f-a067-29042288d737',
     name: 'Application Approved',
     type: TemplateType.NOTIFICATION,
-    subject: '🎉 Great News! Your Application for {{petName}} is Approved!',
+    subject: '🎉 Your Application for {{petName}} is Approved',
     htmlContent: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <div style="background-color: #4CAF50; color: white; padding: 20px; text-align: center;">
           <h1>🎉 Congratulations!</h1>
-          <h2>Your application has been approved!</h2>
+          <h2>We approved your application.</h2>
         </div>
         <div style="padding: 30px;">
           <p>Dear {{applicantName}},</p>
-          <p>We are thrilled to let you know that your application to adopt <strong>{{petName}}</strong> has been approved!</p>
-          <p>{{petName}} is excited to meet you and potentially become part of your family. Here are the next steps:</p>
+          <p>Good news — we approved your application to adopt <strong>{{petName}}</strong>.</p>
+          <p>{{petName}} is waiting to meet you. Here are the next steps:</p>
           <ol>
             <li><strong>Schedule a Meet & Greet</strong> - Contact us to arrange a meeting with {{petName}}</li>
             <li><strong>Bring Required Items</strong> - We'll provide you with a list of what to bring</li>
@@ -171,20 +171,20 @@ const emailTemplateData = [
           <div style="text-align: center; margin: 30px 0;">
             <a href="{{baseUrl}}/applications/{{applicationId}}" style="background-color: #4CAF50; color: white; padding: 15px 30px; text-decoration: none; border-radius: 5px;">View Application Details</a>
           </div>
-          <p>We can't wait to see {{petName}} find their forever home with you!</p>
-          <p>Congratulations and thank you for choosing to adopt!</p>
+          <p>We look forward to seeing {{petName}} settle in with you.</p>
+          <p>Congratulations, and thank you for choosing to adopt.</p>
           <p>{{rescueName}} Team</p>
         </div>
       </div>
     `,
     textContent: `
-      🎉 Congratulations! Your application has been approved!
-      
+      🎉 Congratulations! We approved your application.
+
       Dear {{applicantName}},
-      
-      We are thrilled to let you know that your application to adopt {{petName}} has been approved!
-      
-      {{petName}} is excited to meet you and potentially become part of your family.
+
+      Good news — we approved your application to adopt {{petName}}.
+
+      {{petName}} is waiting to meet you.
       
       Next steps:
       1. Schedule a Meet & Greet - Contact us to arrange a meeting with {{petName}}
@@ -198,9 +198,9 @@ const emailTemplateData = [
       
       View application details: {{baseUrl}}/applications/{{applicationId}}
       
-      We can't wait to see {{petName}} find their forever home with you!
-      
-      Congratulations and thank you for choosing to adopt!
+      We look forward to seeing {{petName}} settle in with you.
+
+      Congratulations, and thank you for choosing to adopt.
       {{rescueName}} Team
     `,
     category: TemplateCategory.APPLICATION_UPDATE,
@@ -235,8 +235,8 @@ const emailTemplateData = [
             <p><strong>Reason:</strong> {{rejectionReason}}</p>
           </div>
           {{/if}}
-          <p>Please don't be discouraged! This decision is not a reflection of you as a person, but rather our commitment to finding the perfect match for each pet's unique needs.</p>
-          <p>We encourage you to:</p>
+          <p>This decision reflects our matching process, not you as a person. Every pet has specific needs, and the right fit matters.</p>
+          <p>What to do next:</p>
           <ul>
             <li>Browse our other available pets who might be a better fit</li>
             <li>Consider visiting us to meet pets in person</li>
@@ -246,7 +246,7 @@ const emailTemplateData = [
           <div style="text-align: center; margin: 30px 0;">
             <a href="{{baseUrl}}/pets" style="background-color: #FF9800; color: white; padding: 15px 30px; text-decoration: none; border-radius: 5px;">Browse Other Pets</a>
           </div>
-          <p>Thank you for choosing to adopt, and we hope to help you find your perfect companion soon!</p>
+          <p>Thank you for choosing to adopt. We hope to help you find the right companion.</p>
           <p>{{rescueName}} Team</p>
         </div>
       </div>
@@ -262,9 +262,9 @@ const emailTemplateData = [
       Reason: {{rejectionReason}}
       {{/if}}
       
-      Please don't be discouraged! This decision is not a reflection of you as a person, but rather our commitment to finding the perfect match for each pet's unique needs.
-      
-      We encourage you to:
+      This decision reflects our matching process, not you as a person. Every pet has specific needs, and the right fit matters.
+
+      What to do next:
       - Browse our other available pets who might be a better fit
       - Consider visiting us to meet pets in person
       - Stay connected for future pet arrivals
@@ -272,7 +272,7 @@ const emailTemplateData = [
       
       Browse other pets: {{baseUrl}}/pets
       
-      Thank you for choosing to adopt, and we hope to help you find your perfect companion soon!
+      Thank you for choosing to adopt. We hope to help you find the right companion.
       
       {{rescueName}} Team
     `,
@@ -309,7 +309,7 @@ const emailTemplateData = [
           <div style="text-align: center; margin: 30px 0;">
             <a href="{{baseUrl}}/chat/{{chatId}}" style="background-color: #9C27B0; color: white; padding: 15px 30px; text-decoration: none; border-radius: 5px;">Read Full Message</a>
           </div>
-          <p>Stay connected and don't miss any important updates about your adoption journey!</p>
+          <p>Stay connected and don't miss any important updates about your adoption journey.</p>
           <p>The Adopt Don't Shop Team</p>
         </div>
       </div>
@@ -325,7 +325,7 @@ const emailTemplateData = [
       
       Read the full message: {{baseUrl}}/chat/{{chatId}}
       
-      Stay connected and don't miss any important updates about your adoption journey!
+      Stay connected and don't miss any important updates about your adoption journey.
       
       The Adopt Don't Shop Team
     `,
@@ -355,7 +355,7 @@ const emailTemplateData = [
         </div>
         <div style="padding: 30px;">
           <p>Dear {{rescueName}},</p>
-          <p>Thank you for joining our platform! We're thrilled to have you as part of our community dedicated to finding loving homes for rescue animals.</p>
+          <p>Thank you for joining our platform. We're glad to have you as part of our community dedicated to finding loving homes for rescue animals.</p>
           <h3 style="color: #4CAF50;">What You Can Do Now:</h3>
           <ul style="line-height: 1.8;">
             <li><strong>Add Your Pets</strong> - List available animals for adoption</li>
@@ -365,7 +365,7 @@ const emailTemplateData = [
           <div style="text-align: center; margin: 30px 0;">
             <a href="{{baseUrl}}/rescue/dashboard" style="background-color: #4CAF50; color: white; padding: 15px 30px; text-decoration: none; border-radius: 8px;">Go to Dashboard</a>
           </div>
-          <p>Together, we're making a difference!</p>
+          <p>Together, we're making a difference.</p>
           <p>The Adopt Don't Shop Team</p>
         </div>
       </div>
@@ -393,7 +393,7 @@ Thank you for joining!`,
     templateId: '9f766dcb-3d50-44f4-ae97-deef82b66f91',
     name: 'Rescue Verification Approved',
     type: TemplateType.TRANSACTIONAL,
-    subject: '🎉 {{rescueName}} Has Been Verified!',
+    subject: '🎉 {{rescueName}} is now verified',
     htmlContent: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <div style="background-color: #4CAF50; color: white; padding: 30px; text-align: center;">
@@ -401,7 +401,7 @@ Thank you for joining!`,
         </div>
         <div style="padding: 30px;">
           <p>Dear {{rescueName}},</p>
-          <p><strong>Great news!</strong> Your rescue has been verified on Adopt Don't Shop.</p>
+          <p><strong>Good news</strong> — we verified your rescue on Adopt Don't Shop.</p>
           <div style="text-align: center; margin: 30px 0;">
             <a href="{{baseUrl}}/rescue/pets/new" style="background-color: #4CAF50; color: white; padding: 15px 30px; text-decoration: none; border-radius: 8px;">Add Your First Pet</a>
           </div>
@@ -409,7 +409,7 @@ Thank you for joining!`,
         </div>
       </div>
     `,
-    textContent: `Congratulations! Your rescue has been verified.`,
+    textContent: `Congratulations — we verified your rescue.`,
     category: TemplateCategory.RESCUE_VERIFICATION,
     status: TemplateStatus.ACTIVE,
     variables: [],
@@ -472,7 +472,7 @@ Thank you for joining!`,
         <div style="background-color: white; padding: 40px; margin: 20px 0;">
           <p style="font-size: 16px; line-height: 1.6; color: #333;">Dear {{firstName}},</p>
           <p style="font-size: 16px; line-height: 1.6; color: #333;">
-            Thank you for joining Adopt Don't Shop! To complete your registration and start your journey to find the perfect companion, please verify your email address.
+            Thank you for joining Adopt Don't Shop. To complete your registration and start your adoption journey, please verify your email address.
           </p>
           <div style="background-color: #fff3cd; border-left: 4px solid #ffc107; padding: 15px; margin: 25px 0;">
             <p style="margin: 0; font-size: 14px; color: #856404;">
@@ -506,7 +506,7 @@ Thank you for joining!`,
             <li>Connect with rescue organizations</li>
           </ul>
           <p style="font-size: 16px; line-height: 1.6; color: #333; margin-top: 30px;">
-            We're excited to help you find your perfect companion! 🐕🐱
+            We're here to help you find a companion. 🐕🐱
           </p>
           <p style="font-size: 16px; line-height: 1.6; color: #333;">
             Best regards,<br>
@@ -528,7 +528,7 @@ Thank you for joining!`,
 
       Dear {{firstName}},
 
-      Thank you for joining Adopt Don't Shop! To complete your registration and start your journey to find the perfect companion, please verify your email address.
+      Thank you for joining Adopt Don't Shop. To complete your registration and start your adoption journey, please verify your email address.
 
       ⏰ IMPORTANT: This verification link will expire in 24 hours.
 
@@ -544,7 +544,7 @@ Thank you for joining!`,
       Didn't create an account?
       If you didn't sign up for Adopt Don't Shop, you can safely ignore this email. No account will be created without verification.
 
-      We're excited to help you find your perfect companion!
+      We're here to help you find a companion.
 
       Best regards,
       The Adopt Don't Shop Team
@@ -588,7 +588,7 @@ Thank you for joining!`,
           </p>
           <div style="background-color: #fff3cd; border-left: 4px solid #ffc107; padding: 15px; margin: 25px 0;">
             <p style="margin: 0; font-size: 14px; color: #856404;">
-              <strong>Your verification link will expire soon!</strong> Click the button below to verify your email now.
+              <strong>Your verification link will expire soon.</strong> Click the button below to verify your email now.
             </p>
           </div>
           <div style="text-align: center; margin: 35px 0;">
@@ -624,7 +624,7 @@ Thank you for joining!`,
 
       We noticed you haven't verified your email address yet. Verification is required to access all features and start your adoption journey.
 
-      ⚠️ Your verification link will expire soon! Click the link below to verify your email now.
+      ⚠️ Your verification link will expire soon. Click the link below to verify your email now.
 
       {{verificationUrl}}
 

--- a/service.backend/src/services/applicationTimeline.service.ts
+++ b/service.backend/src/services/applicationTimeline.service.ts
@@ -272,10 +272,10 @@ export class ApplicationTimelineService {
     const descriptions: Record<ApplicationStage, string> = {
       [ApplicationStage.PENDING]: 'Application is now pending initial review',
       [ApplicationStage.REVIEWING]: 'Application is under active review',
-      [ApplicationStage.VISITING]: 'Home visit has been scheduled',
-      [ApplicationStage.DECIDING]: 'Application is in final decision phase',
-      [ApplicationStage.RESOLVED]: 'Application has been completed',
-      [ApplicationStage.WITHDRAWN]: 'Application has been withdrawn',
+      [ApplicationStage.VISITING]: 'Home visit scheduled',
+      [ApplicationStage.DECIDING]: 'Application moved to final decision',
+      [ApplicationStage.RESOLVED]: 'Application completed',
+      [ApplicationStage.WITHDRAWN]: 'Application withdrawn',
     };
 
     return descriptions[new_stage] || `Application moved to ${new_stage} stage`;

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -1067,9 +1067,9 @@ class ModerationService {
       escalated: 'Your report was escalated',
     };
     const messages: Record<typeof resolution, string> = {
-      resolved: 'A moderator has resolved a report you submitted.',
+      resolved: 'A moderator resolved your report.',
       dismissed: 'A moderator reviewed your report and took no further action.',
-      escalated: 'Your report has been escalated for further review.',
+      escalated: 'We escalated your report for further review.',
     };
     try {
       await NotificationService.createNotification({
@@ -1114,9 +1114,9 @@ class ModerationService {
     const { userId, actionId, actionType, reason, description, expiresAt } = params;
     const titles: Record<string, string> = {
       [ActionType.WARNING_ISSUED]: 'A moderator issued you a warning',
-      [ActionType.USER_SUSPENDED]: 'Your account has been suspended',
-      [ActionType.USER_BANNED]: 'Your account has been banned',
-      [ActionType.ACCOUNT_RESTRICTED]: 'Your account has been restricted',
+      [ActionType.USER_SUSPENDED]: 'We suspended your account',
+      [ActionType.USER_BANNED]: 'We banned your account',
+      [ActionType.ACCOUNT_RESTRICTED]: 'We restricted your account',
     };
     try {
       await NotificationService.createNotification({


### PR DESCRIPTION
## Summary

Audited all user-facing copy across the monorepo against the [Voice & Tone guide](https://www.notion.so/idea-squared/Voice-Tone-9d06184f394e429aa5d5e6642cb812c9) and fixed every violation found.

- **Removed unsubstantiated claims**: placeholder stats (10,000+, 500+, 50+, 24/7), "AI-Powered Pet Matching" (preference-based filtering, not ML), "Higher approval rate", "Join thousands of people"
- **Removed banned filler words**: "just" from 3 user-facing strings (kept idiomatic "just now" timestamps)
- **Rewrote SwipeHero**: replaced adjective-stacked oversell ("amazing", "innovative", "smart", exclamation marks) with confident, direct copy
- **Active voice**: rewrote passive moderation notifications ("Your account has been suspended" → "We suspended your account"), timeline descriptions, and email templates
- **Tightened email templates**: removed "excited"/"thrilled", "Happy pet hunting!" → "Happy browsing!", made rejection email direct and honest per the guide's difficult-news tone
- **Fixed admin ErrorBoundary**: "Oops!" → "Something went wrong", removed unsubstantiated "your data is safe"
- **Stripped dev port numbers** from rescue and admin login helper text (end users don't know what "port 3000" means)

16 files changed across app.client, app.admin, app.rescue, service.backend, and email templates.

## Test plan

- [ ] Verify SwipeHero renders correctly with updated copy
- [ ] Verify HomePage renders without stats section, CTA copy updated
- [ ] Verify admin and rescue login pages no longer show port numbers
- [ ] Verify error boundaries display updated messages
- [ ] Check email templates render correctly (welcome, approved, not approved, verification)
- [ ] Confirm no TypeScript errors introduced (type-check passes)

https://claude.ai/code/session_015HdyCCGh7kJW5PTjmZBd1L

---
_Generated by [Claude Code](https://claude.ai/code/session_015HdyCCGh7kJW5PTjmZBd1L)_