### PR TITLE
feat(security): add per-email and per-token rate limits to password reset (ADS-663)

### DIFF
--- a/service.backend/src/__tests__/middleware/auth-rate-limit.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/auth-rate-limit.middleware.test.ts
@@ -143,7 +143,9 @@ describe('auth-rate-limit: password reset limiters (ADS-663)', () => {
 
     let last = 200;
     for (let i = 0; i < 12; i++) {
-      const res = await request(app).post('/r').send({ email: `u${i}@ex.test` });
+      const res = await request(app)
+        .post('/r')
+        .send({ email: `u${i}@ex.test` });
       last = res.status;
     }
     expect(last).toBe(429);

--- a/service.backend/src/__tests__/middleware/auth-rate-limit.middleware.test.ts
+++ b/service.backend/src/__tests__/middleware/auth-rate-limit.middleware.test.ts
@@ -123,3 +123,102 @@ describe('auth-rate-limit (ADS-436, ADS-439)', () => {
     expect(last).toBe(429);
   }, 10000);
 });
+
+describe('auth-rate-limit: password reset limiters (ADS-663)', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('passwordResetIpLimiter blocks after 10 requests from the same IP', async () => {
+    process.env.NODE_ENV = 'production';
+    const { passwordResetIpLimiter } = await import('../../middleware/auth-rate-limit');
+    const app = buildApp(passwordResetIpLimiter);
+
+    let last = 200;
+    for (let i = 0; i < 12; i++) {
+      const res = await request(app).post('/r').send({ email: `u${i}@ex.test` });
+      last = res.status;
+    }
+    expect(last).toBe(429);
+  }, 15000);
+
+  it('passwordResetEmailLimiter blocks the same email after 3 requests regardless of IP', async () => {
+    process.env.NODE_ENV = 'production';
+    const { passwordResetEmailLimiter } = await import('../../middleware/auth-rate-limit');
+    const app = buildApp(passwordResetEmailLimiter);
+
+    let last = 200;
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app)
+        .post('/r')
+        .set('x-forwarded-for', `10.0.0.${i}`)
+        .send({ email: 'target@ex.test' });
+      last = res.status;
+    }
+    expect(last).toBe(429);
+  }, 10000);
+
+  it('passwordResetEmailLimiter does NOT block a different email', async () => {
+    process.env.NODE_ENV = 'production';
+    const { passwordResetEmailLimiter } = await import('../../middleware/auth-rate-limit');
+    const app = buildApp(passwordResetEmailLimiter);
+
+    // Exhaust the budget for one email
+    for (let i = 0; i < 4; i++) {
+      await request(app).post('/r').send({ email: 'victim@ex.test' });
+    }
+
+    // A different email must still go through
+    const res = await request(app).post('/r').send({ email: 'other@ex.test' });
+    expect(res.status).toBe(200);
+  }, 10000);
+
+  it('passwordResetTokenLimiter blocks the same token after 5 attempts', async () => {
+    process.env.NODE_ENV = 'production';
+    const { passwordResetTokenLimiter } = await import('../../middleware/auth-rate-limit');
+    const app = buildApp(passwordResetTokenLimiter);
+
+    let last = 200;
+    for (let i = 0; i < 7; i++) {
+      const res = await request(app).post('/r').send({ token: 'secret-reset-token-abc123' });
+      last = res.status;
+    }
+    expect(last).toBe(429);
+  }, 10000);
+
+  it('passwordResetTokenLimiter does NOT block a different token', async () => {
+    process.env.NODE_ENV = 'production';
+    const { passwordResetTokenLimiter } = await import('../../middleware/auth-rate-limit');
+    const app = buildApp(passwordResetTokenLimiter);
+
+    // Exhaust the budget for one token
+    for (let i = 0; i < 6; i++) {
+      await request(app).post('/r').send({ token: 'exhausted-token' });
+    }
+
+    // A different token must still go through
+    const res = await request(app).post('/r').send({ token: 'fresh-token' });
+    expect(res.status).toBe(200);
+  }, 10000);
+
+  it('passwordResetEmailLimiter honours RATE_LIMIT_DEV_BYPASS=true', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.RATE_LIMIT_DEV_BYPASS = 'true';
+    const { passwordResetEmailLimiter } = await import('../../middleware/auth-rate-limit');
+    const app = buildApp(passwordResetEmailLimiter);
+
+    let last = 200;
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app).post('/r').send({ email: 'bypass@ex.test' });
+      last = res.status;
+    }
+    expect(last).toBe(200);
+  }, 10000);
+});

--- a/service.backend/src/__tests__/routes/auth.routes.test.ts
+++ b/service.backend/src/__tests__/routes/auth.routes.test.ts
@@ -81,6 +81,11 @@ vi.mock('../../middleware/auth-rate-limit', () => ({
   registrationEmailLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>
     next(),
   loginIpLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  passwordResetIpLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  passwordResetEmailLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>
+    next(),
+  passwordResetTokenLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>
+    next(),
 }));
 
 vi.mock('../../middleware/turnstile', () => ({

--- a/service.backend/src/__tests__/routes/auth.routes.test.ts
+++ b/service.backend/src/__tests__/routes/auth.routes.test.ts
@@ -81,7 +81,8 @@ vi.mock('../../middleware/auth-rate-limit', () => ({
   registrationEmailLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>
     next(),
   loginIpLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
-  passwordResetIpLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) => next(),
+  passwordResetIpLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>
+    next(),
   passwordResetEmailLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>
     next(),
   passwordResetTokenLimiter: (_req: AuthenticatedRequest, _res: Response, next: NextFunction) =>

--- a/service.backend/src/middleware/auth-rate-limit.ts
+++ b/service.backend/src/middleware/auth-rate-limit.ts
@@ -117,6 +117,42 @@ export const loginIpLimiter = buildLimiter('login-ip', {
   skipSuccessfulRequests: true,
 });
 
+/**
+ * IP-keyed password reset request limiter — 10 per hour per IP.
+ * Defense in depth alongside the per-email limiter below.
+ */
+export const passwordResetIpLimiter = buildLimiter('reset-request-ip', {
+  windowMs: ONE_HOUR_MS,
+  max: 10,
+});
+
+/**
+ * Per-email password reset request limiter — 3 per hour per email.
+ * Prevents inbox DoS and email enumeration from rotating IPs.
+ * Response stays 200 regardless of whether the email exists (anti-enumeration
+ * is handled in the controller; this limiter only caps the send rate).
+ */
+export const passwordResetEmailLimiter = buildLimiter('reset-request-email', {
+  windowMs: ONE_HOUR_MS,
+  max: 3,
+  keyGenerator: emailKey,
+});
+
+/**
+ * Per-token password reset confirm limiter — 5 attempts per token per hour.
+ * Limits brute-force against short-lived reset tokens from rotating IPs.
+ * Keyed on the raw token value so each issued token has its own budget.
+ */
+export const passwordResetTokenLimiter = buildLimiter('reset-confirm-token', {
+  windowMs: ONE_HOUR_MS,
+  max: 5,
+  keyGenerator: (req: Request): string => {
+    const body = req.body as Record<string, unknown> | undefined;
+    const token = typeof body?.token === 'string' ? body.token : '';
+    return `token:${token}`;
+  },
+});
+
 if (!isProd() && !devBypass()) {
   // One-off boot warning: dev now blocks like prod (good for testing brute-
   // force protection); set RATE_LIMIT_DEV_BYPASS=true to bypass.

--- a/service.backend/src/routes/auth.routes.ts
+++ b/service.backend/src/routes/auth.routes.ts
@@ -4,6 +4,9 @@ import { authenticateToken } from '../middleware/auth';
 import { enforceIpRules } from '../middleware/ip-rules';
 import {
   loginIpLimiter,
+  passwordResetEmailLimiter,
+  passwordResetIpLimiter,
+  passwordResetTokenLimiter,
   registrationEmailLimiter,
   registrationIpLimiter,
 } from '../middleware/auth-rate-limit';
@@ -305,7 +308,8 @@ router.post('/refresh-token', authLimiter, AuthController.refreshToken);
  */
 router.post(
   '/forgot-password',
-  passwordResetLimiter,
+  passwordResetIpLimiter,
+  passwordResetEmailLimiter,
   authValidation.forgotPassword,
   AuthController.requestPasswordReset
 );
@@ -357,7 +361,7 @@ router.post(
  */
 router.post(
   '/reset-password',
-  passwordResetLimiter,
+  passwordResetTokenLimiter,
   authValidation.resetPassword,
   AuthController.confirmPasswordReset
 );


### PR DESCRIPTION
## Summary

Closes [ADS-663](https://linear.app/ideasquared/issue/ADS-663)

The `/forgot-password` endpoint was keyed only by IP (3 req/hour via the general `passwordResetLimiter`), leaving two attack vectors open:
- **Inbox DoS**: attacker sends unlimited reset emails to a target from rotating IPs
- **Email enumeration**: response timing/behaviour differences reveal whether an address is registered

### Changes

- **`auth-rate-limit.ts`**: adds three new Redis-backed limiters using the existing `buildLimiter` / `emailKey` infrastructure:
  - `passwordResetIpLimiter` — 10 req/hour/IP (defense in depth)
  - `passwordResetEmailLimiter` — 3 req/hour/email (caps sends to any one inbox regardless of source IP)
  - `passwordResetTokenLimiter` — 5 req/hour/token (limits brute-force of short-lived confirm tokens)
- **`auth.routes.ts`**: wires `passwordResetIpLimiter` + `passwordResetEmailLimiter` onto `/forgot-password` and `passwordResetTokenLimiter` onto `/reset-password`. The `2fa/recover*` routes keep `passwordResetLimiter` (out of scope for this ticket).
- **Tests**: 6 new behaviour tests covering block-on-limit, cross-email/token isolation, and `RATE_LIMIT_DEV_BYPASS` pass-through.

## Test plan

- [x] `passwordResetIpLimiter` blocks after 10 hits from same IP
- [x] `passwordResetEmailLimiter` blocks same email after 3 hits across different IPs
- [x] `passwordResetEmailLimiter` does not block a different email
- [x] `passwordResetTokenLimiter` blocks same token after 5 attempts
- [x] `passwordResetTokenLimiter` does not block a different token
- [x] `RATE_LIMIT_DEV_BYPASS=true` bypasses email limiter in dev
- [x] All 30 existing `auth.routes.test.ts` tests pass

https://linear.app/ideasquared/issue/ADS-663

---
_Generated by [Claude Code](https://claude.ai/code/session_016rNxhndLZ9yzJZZhBJN5NG)_