### PR TITLE
fix: replace vite-plugin-dts with tsc for lib.components build

### DIFF
--- a/lib.components/package.json
+++ b/lib.components/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "dev:server": "vite --port 3010 --mode development",
-    "build": "rimraf dist && vite build && vite build --config vite.theme.config.ts",
+    "build": "rimraf dist && vite build && tsc -p tsconfig.build.json && vite build --config vite.theme.config.ts",
     "build:types": "tsc --emitDeclarationOnly",
     "type-check": "tsc --noEmit",
     "preview": "vite preview",

--- a/lib.components/tsconfig.build.json
+++ b/lib.components/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "emitDeclarationOnly": true,
+    "allowImportingTsExtensions": false
+  }
+}

--- a/lib.components/vite.config.ts
+++ b/lib.components/vite.config.ts
@@ -2,7 +2,6 @@ import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
-import dts from 'vite-plugin-dts';
 
 export default defineConfig(({ mode }) => ({
   plugins: [
@@ -12,7 +11,6 @@ export default defineConfig(({ mode }) => ({
       },
     }),
     vanillaExtractPlugin(),
-    dts(),
   ],
 
   // Development server setup for standalone component development


### PR DESCRIPTION
## Summary\n\n- **Removed `vite-plugin-dts`** from the Vite build — it uses unplugin with a `rollup>=3` peer dep and is incompatible with Vite 8's rolldown bundler. Its `onLog` hook returns `undefined` where rolldown expects an object, causing the build to crash.\n- **Added `tsconfig.build.json`** with `emitDeclarationOnly: true` for separate declaration generation via `tsc`.\n- **Updated build script** to run `tsc -p tsconfig.build.json` between the main vite build and the theme build.\n\n## Test plan\n\n- [ ] `lib.components` builds successfully in CI (Docker workflow)\n- [ ] Declaration files are generated in `dist/` correctly\n- [ ] Downstream apps (`app.admin`, `app.client`, `app.rescue`) that consume `lib.components` build and type-check successfully\n\nhttps://claude.ai/code/session_01JPpox5qpVN44vQotJpgSFq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpox5qpVN44vQotJpgSFq)_