### PR TITLE
fix: add rootDir to lib.components tsconfig.build.json

### DIFF
--- a/lib.components/package.json
+++ b/lib.components/package.json
@@ -4,13 +4,13 @@
   "description": "Shared component library for Adopt Don't Shop applications",
   "main": "dist/adopt-dont-shop-components.umd.js",
   "module": "dist/adopt-dont-shop-components.es.js",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "type": "module",
   "style": "dist/adopt-dont-shop-components.css",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/adopt-dont-shop-components.es.js",
       "require": "./dist/adopt-dont-shop-components.umd.js"
     },
@@ -95,7 +95,7 @@
     "rimraf": "^6.1.3",
     "storybook": "^10.3.6",
     "ts-dedent": "^2.2.0",
-"typescript": "^6.0.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4",
     "use-sync-external-store": "^1.6.0",
     "vite": "^8.0.14",

--- a/lib.components/tsconfig.build.json
+++ b/lib.components/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "declaration": true,
+    "rootDir": "./src",
     "declarationDir": "./dist",
     "emitDeclarationOnly": true,
     "allowImportingTsExtensions": false


### PR DESCRIPTION
## Summary
- Adds `rootDir: "./src"` to `lib.components/tsconfig.build.json` to fix TS5011 build error
- TypeScript 6 requires `rootDir` to be explicitly set when the computed common source directory differs from the project root
- The `tsc -p tsconfig.build.json` declaration emit step was failing without this, breaking `npm run build:libs` and all downstream Docker builds

## Test plan
- [ ] `npm run build:libs` completes successfully (lib.components no longer fails)
- [ ] Docker build for app.admin/app.client/app.rescue succeeds

https://claude.ai/code/session_015Yju6oLgmLZ89BYM7ceiNb

---
_Generated by [Claude Code](https://claude.ai/code/session_015Yju6oLgmLZ89BYM7ceiNb)_