### PR TITLE
fix(security): tighten production nginx CSP headers [ADS-682]

### DIFF
--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -5,8 +5,9 @@
 #   * HTTP/80 server is a redirect-only block; HSTS is emitted only on 443
 #     so browsers never see HSTS over plain HTTP. [ADS-435]
 #   * Content-Security-Policy drops `unsafe-inline` / `unsafe-eval` from
-#     script-src and style-src (matches helmet config in service.backend).
-#     connect-src pins the prod hostname instead of wildcarding. [ADS-434]
+#     script-src and style-src; adds Google Fonts allowlist to style-src and
+#     font-src; pins connect-src to api.__PROD_HOSTNAME__ (matches helmet).
+#     [ADS-434, ADS-682]
 #   * Default-server returns 444 (no response) for unknown Host headers
 #     instead of catching `*.localhost`. [ADS-501]
 #
@@ -104,7 +105,8 @@ http {
     # ------------------------------------------------------------------------
     # Shared security-header snippet — applied inside every HTTPS server block.
     # HSTS lives only here so plain-HTTP responses never carry it. [ADS-435]
-    # CSP without unsafe-inline / unsafe-eval on script-src. [ADS-434]
+    # CSP: no unsafe-inline/unsafe-eval; Google Fonts allowlisted; connect-src
+    # pinned to api.__PROD_HOSTNAME__ for frontend blocks. [ADS-434, ADS-682]
     # ------------------------------------------------------------------------
     # nginx has no `include`-time variable expansion for add_header, so the
     # headers are repeated per server block. Keep them in sync.
@@ -123,7 +125,7 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://__PROD_HOSTNAME__ wss://__PROD_HOSTNAME__; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.__PROD_HOSTNAME__ wss://api.__PROD_HOSTNAME__; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
 
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             proxy_pass http://admin;
@@ -159,7 +161,7 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://__PROD_HOSTNAME__ wss://__PROD_HOSTNAME__; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.__PROD_HOSTNAME__ wss://api.__PROD_HOSTNAME__; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
 
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             proxy_pass http://rescue;
@@ -195,7 +197,7 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://__PROD_HOSTNAME__ wss://__PROD_HOSTNAME__; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
 
         location / {
             limit_req zone=api burst=20 nodelay;
@@ -246,7 +248,7 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://__PROD_HOSTNAME__ wss://__PROD_HOSTNAME__; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://api.__PROD_HOSTNAME__ wss://api.__PROD_HOSTNAME__; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" always;
 
         location /health {
             access_log off;


### PR DESCRIPTION
## Summary

Fixes three CSP gaps between `nginx/nginx.prod.conf` and the Helmet config it mirrors, identified in security audit ADS-682.

- **`style-src`**: added `https://fonts.googleapis.com` — all three frontend apps load Google Fonts via `<link>`, so the missing origin was actively blocking fonts in production
- **`font-src`**: added `https://fonts.gstatic.com` — the font files fetched by the Fonts stylesheet were also blocked
- **`connect-src`** (frontend blocks): changed `https://__PROD_HOSTNAME__` → `https://api.__PROD_HOSTNAME__` and same for WSS. `VITE_API_BASE_URL` and `VITE_WS_BASE_URL` point to the `api.*` subdomain in production, so API and WebSocket connections from admin, rescue, and client were being blocked by CSP
- **`connect-src`** (API block): simplified to `'self'` — the API server only serves JSON responses and doesn't initiate connections to the root domain

The `unsafe-inline` and wildcard `wss:`/`https:` issues mentioned in the ticket were already resolved by ADS-434; this PR closes the remaining consistency gap.

## Acceptance criteria status

- [x] `unsafe-inline` removed from `style-src` (already done, ADS-434)
- [x] `wss:` and `https:` wildcards in `connect-src` replaced with explicit hostnames (already done, ADS-434)
- [x] Google Fonts allowlisted in `style-src` and `font-src` so fonts load in production
- [x] `connect-src` pinned to `api.__PROD_HOSTNAME__` to match `VITE_API_BASE_URL`
- [x] CSP between nginx and Helmet is now consistent

## Test plan

- [ ] Deploy to a staging environment with `__PROD_HOSTNAME__` substituted and verify Google Fonts load in all three apps (admin, rescue, client)
- [ ] Confirm no CSP violations appear in browser console for normal app usage
- [ ] Confirm API calls from admin and rescue apps succeed (connect-src now correctly points to `api.*` subdomain)

Closes [ADS-682](https://linear.app/ideasquared/issue/ADS-682)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2Q1mHtH9Nc49g443xmrD9)_