### PR TITLE
ci: add workflow_dispatch triggers for manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -51,9 +52,9 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      libs: ${{ steps.filter.outputs.libs }}
+      backend: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.backend }}
+      frontend: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.frontend }}
+      libs: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.libs }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,7 @@ on:
     # Mondays at 06:00 UTC. Aligns with the Dependabot weekly schedule so
     # security review happens in the same window.
     - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,7 @@ on:
       - '**/Dockerfile*'
       - 'docker-compose*.yml'
       - '.dockerignore'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,7 +64,7 @@ jobs:
             network=host
 
       - name: Log in to GHCR (for Trivy DB pulls)
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
@@ -88,7 +89,7 @@ jobs:
       # Keeping them on push-to-main ensures we still catch prod-only
       # regressions (npm prune fallout, asset paths) before deploy.yml runs.
       - name: Build production image
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         id: build-prod
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
@@ -103,7 +104,7 @@ jobs:
           build-args: BUILDKIT_INLINE_CACHE=1
 
       - name: Run Trivy vulnerability scanner
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: |
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -118,7 +119,7 @@ jobs:
               paragonjenko/adoptdontshop:service-backend-prod-${{ github.sha }}
 
       - name: Upload Trivy results to GitHub Security tab
-        if: github.event_name == 'push' && always() && hashFiles('trivy-results.sarif') != ''
+        if: github.event_name != 'pull_request' && always() && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           sarif_file: 'trivy-results.sarif'
@@ -163,7 +164,7 @@ jobs:
       # which ci.yml's test-frontend matrix already runs natively. Keep it
       # on main pushes as a final pre-deploy gate.
       - name: Build production image
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .

--- a/.github/workflows/lib-test-guard.yml
+++ b/.github/workflows/lib-test-guard.yml
@@ -11,6 +11,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,6 +21,7 @@ on:
       - 'lib.*/**'
       - 'package.json'
       - 'package-lock.json'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,6 +23,7 @@ on:
       - 'package-lock.json'
   schedule:
     - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - 'lib.components/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to all CI workflows (ci, docker, quality, security, lib-test-guard, storybook, codeql) so they can be triggered manually from the Actions tab
- For `ci.yml`: `workflow_dispatch` bypasses the `dorny/paths-filter` change-detection gate and forces all jobs (backend, frontend, libs, e2e) to run
- For `docker.yml`: production image builds and Trivy scans now run on any non-PR event (push or dispatch), not just push

## Test plan

- [ ] After merge, verify each workflow appears in the Actions tab with a "Run workflow" button
- [ ] Manually trigger CI workflow on main and confirm all jobs run (not skipped)
- [ ] Manually trigger Docker workflow and confirm production builds + Trivy execute

https://claude.ai/code/session_014behDvjfWhbwesactvrCTA

---
_Generated by [Claude Code](https://claude.ai/code/session_014behDvjfWhbwesactvrCTA)_