### PR TITLE
fix(docker): switch app build from Alpine to Debian-slim

### DIFF
--- a/Dockerfile.app.optimized
+++ b/Dockerfile.app.optimized
@@ -9,20 +9,20 @@
 # Usage: docker build --build-arg APP_NAME=app.client -f Dockerfile.app.optimized .
 
 ARG NODE_VERSION=22.15.1
-FROM node:${NODE_VERSION}-alpine AS base
+FROM node:${NODE_VERSION}-slim AS base
 
 WORKDIR /app
 
 # Install necessary packages including wget for health checks
-# hadolint ignore=DL3018
-RUN apk add --no-cache \
-    git=~2 \
-    wget=~1 \
-    dumb-init=~1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    wget \
+    dumb-init \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S viteuser -u 1001
+RUN groupadd -g 1001 nodejs && \
+    useradd -m -u 1001 -g nodejs viteuser
 
 # Development stage
 FROM base AS development


### PR DESCRIPTION
## Summary

- Switches the `base` stage in `Dockerfile.app.optimized` from `node:22-alpine` to `node:22-slim` (Debian) to fix the `app.admin` production build failure
- Rolldown's napi-rs musl binding has a bug where the `onLog` callback returns `undefined` instead of an object, causing `"The function returned 'undefined', but expected 'object'"` during `vite build`
- The nginx production stage remains on Alpine since it only serves static files and doesn't use native bindings

## Test plan

- [ ] Docker CI workflow (`docker.yml`) passes for all three apps (app.admin, app.client, app.rescue)
- [ ] `docker compose up --build` starts successfully for local development
- [ ] Production image builds complete without the rolldown error

https://claude.ai/code/session_01XPMdPrKNG5eBxMiM2SQPN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPMdPrKNG5eBxMiM2SQPN1)_