### PR TITLE
fix: add missing ApiError import in rescue controller

### DIFF
--- a/service.backend/src/controllers/rescue.controller.ts
+++ b/service.backend/src/controllers/rescue.controller.ts
@@ -5,6 +5,7 @@ import { RescueService, BulkRescueAction } from '../services/rescue.service';
 import { InvitationService } from '../services/invitation.service';
 import { RichTextProcessingService } from '../services/rich-text-processing.service';
 import { AuthenticatedRequest } from '../types/auth';
+import { ApiError } from '../middleware/error-handler';
 import { logger } from '../utils/logger';
 import { AdoptionPolicy } from '../types/rescue';
 import EmailService from '../services/email.service';


### PR DESCRIPTION
## Summary

- Adds the missing `ApiError` import from `../middleware/error-handler` in `rescue.controller.ts`, fixing the TypeScript compilation failure in the production Docker build.

## Test plan

- [ ] Verify `npm run build` succeeds in `service.backend`
- [ ] Verify Docker production build completes without errors

https://claude.ai/code/session_017T2b6QUPLh1hK1QURDd1jB

---
_Generated by [Claude Code](https://claude.ai/code/session_017T2b6QUPLh1hK1QURDd1jB)_