### PR TITLE
feat(app.admin): replace modal stack with split-pane user detail

### DIFF
--- a/app.admin/src/__tests__/bulk-operations.behavior.test.tsx
+++ b/app.admin/src/__tests__/bulk-operations.behavior.test.tsx
@@ -42,6 +42,7 @@ vi.mock('../hooks', () => ({
   useBulkUpdateUsers: () => mockUseBulkUpdateUsers(),
   useBulkUpdateRescues: () => mockUseBulkUpdateRescues(),
   useCreateUser: () => mockUseCreateUser(),
+  useUserActivity: () => ({ data: [], isLoading: false, error: null }),
 }));
 
 const mockGetAll = vi.fn();
@@ -622,12 +623,11 @@ describe('ADS-651 — bulk-action reasons are required and captured', () => {
     });
   });
 
-  describe('Single-row actions are unchanged', () => {
-    it('still renders the per-row actions menu and edit/email buttons', () => {
+  describe('Single-row actions are available via the detail panel', () => {
+    it('renders the table without per-row action menus (actions moved to detail panel)', () => {
       renderWithProviders(<Users />);
-      // Per-row UserActionsMenu (mocked) is present for every row.
-      expect(screen.getByTestId('actions-user-1')).toBeInTheDocument();
-      expect(screen.getByTestId('actions-user-2')).toBeInTheDocument();
+      // Per-row UserActionsMenu is no longer rendered; actions live in the detail panel.
+      expect(screen.queryByTestId('actions-user-1')).not.toBeInTheDocument();
     });
   });
 });

--- a/app.admin/src/__tests__/export.behavior.test.tsx
+++ b/app.admin/src/__tests__/export.behavior.test.tsx
@@ -42,6 +42,7 @@ vi.mock('../hooks', () => ({
   useDeleteUser: () => mockUseDeleteUser(),
   useBulkUpdateUsers: () => defaultMutation,
   useCreateUser: () => defaultMutation,
+  useUserActivity: () => ({ data: [], isLoading: false, error: null }),
 }));
 
 vi.mock('../services/libraryServices', () => ({

--- a/app.admin/src/__tests__/list-page-url-filters.behavior.test.tsx
+++ b/app.admin/src/__tests__/list-page-url-filters.behavior.test.tsx
@@ -33,6 +33,7 @@ vi.mock('../hooks', () => ({
   useDeleteUser: () => ({ mutateAsync: vi.fn() }),
   useBulkUpdateUsers: () => mockUseBulkUpdateUsers(),
   useCreateUser: () => ({ mutateAsync: vi.fn() }),
+  useUserActivity: () => ({ data: [], isLoading: false, error: null }),
   usePets: (filters: unknown) => mockUsePets(filters),
   useBulkUpdatePets: () => mockUseBulkUpdatePets(),
 }));

--- a/app.admin/src/__tests__/user-management.behavior.test.tsx
+++ b/app.admin/src/__tests__/user-management.behavior.test.tsx
@@ -8,13 +8,16 @@
  * - Error state shown when the API fails
  * - Admin can filter users by type and status
  * - Admin can search for users
- * - Admin can open user detail by clicking a row
- * - Admin can open edit modal and send message modal
- * - Admin can perform actions: suspend, unsuspend, verify, delete
+ * - Admin can open user detail panel by clicking a row
+ * - Admin can perform actions from the detail panel: suspend, unsuspend
  */
 
+import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { renderWithProviders, screen, waitFor } from '../test-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
 import Users from '../pages/Users';
 import type { AdminUser } from '../types/user';
@@ -28,6 +31,7 @@ const mockUseVerifyUser = vi.fn();
 const mockUseDeleteUser = vi.fn();
 const mockUseBulkUpdateUsers = vi.fn();
 const mockUseCreateUser = vi.fn();
+const mockUseUserActivity = vi.fn();
 
 vi.mock('../hooks', () => ({
   useUsers: (...args: unknown[]) => mockUseUsers(...args),
@@ -37,6 +41,7 @@ vi.mock('../hooks', () => ({
   useDeleteUser: () => mockUseDeleteUser(),
   useBulkUpdateUsers: () => mockUseBulkUpdateUsers(),
   useCreateUser: () => mockUseCreateUser(),
+  useUserActivity: (...args: unknown[]) => mockUseUserActivity(...args),
 }));
 
 vi.mock('../services/libraryServices', () => ({
@@ -50,33 +55,6 @@ vi.mock('../services/libraryServices', () => ({
 vi.mock('../components/modals', () => ({
   AddUserModal: () => null,
   BulkConfirmationModal: () => null,
-  UserDetailModal: ({
-    isOpen,
-    user,
-  }: {
-    isOpen: boolean;
-    onClose: () => void;
-    user: AdminUser | null;
-  }) =>
-    isOpen && user ? (
-      <div data-testid='user-detail-modal'>
-        <span>Detail: {user.email}</span>
-      </div>
-    ) : null,
-  EditUserModal: ({
-    isOpen,
-    user,
-  }: {
-    isOpen: boolean;
-    onClose: () => void;
-    user: AdminUser | null;
-    onSave: () => void;
-  }) =>
-    isOpen && user ? (
-      <div data-testid='edit-user-modal'>
-        <span>Edit: {user.email}</span>
-      </div>
-    ) : null,
   CreateSupportTicketModal: ({
     isOpen,
     user,
@@ -91,30 +69,6 @@ vi.mock('../components/modals', () => ({
         <span>Ticket for: {user.email}</span>
       </div>
     ) : null,
-  UserActionsMenu: ({
-    user,
-    onSuspend,
-    onUnsuspend,
-  }: {
-    user: AdminUser;
-    onSuspend: (userId: string, reason?: string) => Promise<void>;
-    onUnsuspend: (userId: string) => Promise<void>;
-    onVerify: (userId: string) => Promise<void>;
-    onDelete: (userId: string, reason?: string) => Promise<void>;
-  }) => (
-    <div>
-      <button data-testid={`actions-${user.userId}`}>Actions</button>
-      <button
-        data-testid={`suspend-${user.userId}`}
-        onClick={() => onSuspend(user.userId, 'test reason')}
-      >
-        Suspend
-      </button>
-      <button data-testid={`unsuspend-${user.userId}`} onClick={() => onUnsuspend(user.userId)}>
-        Unsuspend
-      </button>
-    </div>
-  ),
 }));
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -198,6 +152,7 @@ const mockMutationResult = {
   mutateAsync: vi.fn().mockResolvedValue({}),
   mutate: vi.fn(),
   isLoading: false,
+  isPending: false,
   isError: false,
   isSuccess: false,
   reset: vi.fn(),
@@ -232,6 +187,28 @@ const setupErrorState = (message = 'Network error') => {
   });
 };
 
+const renderUsersPage = (initialRoute = '/users') => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <ThemeProvider>
+          <Routes>
+            <Route path='/users' element={<Users />} />
+            <Route path='/users/:userId' element={<Users />} />
+          </Routes>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('User Management page', () => {
@@ -243,43 +220,47 @@ describe('User Management page', () => {
     mockUseDeleteUser.mockReturnValue(mockMutationResult);
     mockUseBulkUpdateUsers.mockReturnValue(mockMutationResult);
     mockUseCreateUser.mockReturnValue(mockMutationResult);
+    mockUseUserActivity.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
   });
 
   describe('page structure', () => {
     it('shows the User Management heading', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByText('User Management')).toBeInTheDocument();
     });
 
     it('shows the page description', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByText('Manage all platform users and permissions')).toBeInTheDocument();
     });
 
     it('shows the Export button', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByRole('button', { name: /export/i })).toBeInTheDocument();
     });
 
     it('shows the Add User button', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByRole('button', { name: /add user/i })).toBeInTheDocument();
     });
 
     it('shows the search input', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByPlaceholderText(/search by name or email/i)).toBeInTheDocument();
     });
 
     it('shows the User Type filter', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByText('User Type')).toBeInTheDocument();
       expect(screen.getByDisplayValue('All Types')).toBeInTheDocument();
     });
 
     it('shows the Status filter', () => {
-      renderWithProviders(<Users />);
-      // "Status" appears as both a filter label and a column header
+      renderUsersPage();
       const statusLabels = screen.getAllByText('Status');
       expect(statusLabels.length).toBeGreaterThan(0);
       expect(screen.getByDisplayValue('All Statuses')).toBeInTheDocument();
@@ -289,14 +270,14 @@ describe('User Management page', () => {
   describe('loading state', () => {
     it('shows skeleton rows while fetching users', () => {
       setupLoadingState();
-      const { container } = renderWithProviders(<Users />);
+      const { container } = renderUsersPage();
       const skeletonRows = container.querySelectorAll('[data-testid="skeleton-row"]');
       expect(skeletonRows.length).toBeGreaterThan(0);
     });
 
     it('does not show user data while loading', () => {
       setupLoadingState();
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.queryByText('john.doe@example.com')).not.toBeInTheDocument();
     });
   });
@@ -304,80 +285,75 @@ describe('User Management page', () => {
   describe('error state', () => {
     it('shows a failure message when the API returns an error', () => {
       setupErrorState('Failed to connect to server');
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByText('Failed to load users')).toBeInTheDocument();
     });
 
     it('shows the specific error message', () => {
       setupErrorState('Failed to connect to server');
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByText('Failed to connect to server')).toBeInTheDocument();
     });
   });
 
   describe('displaying users', () => {
     it('renders user names in the table', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByText('John Doe')).toBeInTheDocument();
       expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     });
 
     it('renders user emails in the table', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByText('john.doe@example.com')).toBeInTheDocument();
       expect(screen.getByText('jane.smith@example.com')).toBeInTheDocument();
     });
 
     it('shows the Adopter badge for adopter users', () => {
-      renderWithProviders(<Users />);
-      // "Adopter" appears as badge and also in the filter dropdown
+      renderUsersPage();
       const adopterLabels = screen.getAllByText('Adopter');
       expect(adopterLabels.length).toBeGreaterThan(0);
     });
 
     it('shows the Rescue Staff badge for rescue staff users', () => {
-      renderWithProviders(<Users />);
-      // "Rescue Staff" appears as badge and also in the filter dropdown
+      renderUsersPage();
       const rescueStaffLabels = screen.getAllByText('Rescue Staff');
       expect(rescueStaffLabels.length).toBeGreaterThan(0);
     });
 
     it('shows the Active status badge for active users', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       const activeBadges = screen.getAllByText('Active');
       expect(activeBadges.length).toBeGreaterThan(0);
     });
 
     it('shows the Suspended status badge for suspended users', () => {
-      renderWithProviders(<Users />);
-      // "Suspended" appears as badge and also in the status filter dropdown
+      renderUsersPage();
       const suspendedLabels = screen.getAllByText('Suspended');
       expect(suspendedLabels.length).toBeGreaterThan(0);
     });
 
     it('shows the rescue name for rescue staff', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(screen.getByText('Happy Paws')).toBeInTheDocument();
     });
 
     it('shows a dash when user has no rescue', () => {
-      renderWithProviders(<Users />);
+      renderUsersPage();
       const dashCells = screen.getAllByText('-');
       expect(dashCells.length).toBeGreaterThan(0);
     });
 
     it('shows the table column headers', () => {
-      renderWithProviders(<Users />);
-      // Column headers are among the visible text elements
+      renderUsersPage();
       expect(screen.getAllByText('User').length).toBeGreaterThan(0);
       expect(screen.getByText('Type')).toBeInTheDocument();
-      // "Status" appears as both column header and filter label
       expect(screen.getAllByText('Status').length).toBeGreaterThan(0);
     });
 
     it('shows an empty message when no users match', () => {
       setupSuccessfulLoad([]);
-      renderWithProviders(<Users />);
+      renderUsersPage();
       expect(
         screen.getByText(
           'No users found matching your criteria. Try adjusting your search or filters.'
@@ -401,7 +377,7 @@ describe('User Management page', () => {
         refetch: vi.fn(),
       }));
 
-      renderWithProviders(<Users />);
+      renderUsersPage();
 
       await user.selectOptions(screen.getByDisplayValue('All Types'), 'adopter');
 
@@ -425,7 +401,7 @@ describe('User Management page', () => {
         refetch: vi.fn(),
       }));
 
-      renderWithProviders(<Users />);
+      renderUsersPage();
 
       await user.selectOptions(screen.getByDisplayValue('All Statuses'), 'suspended');
 
@@ -436,59 +412,40 @@ describe('User Management page', () => {
     });
   });
 
-  describe('user detail modal', () => {
-    it('opens the detail modal when admin clicks on a user row', async () => {
-      const user = userEvent.setup();
-      renderWithProviders(<Users />);
-
-      await user.click(screen.getByText('john.doe@example.com'));
-
-      expect(screen.getByTestId('user-detail-modal')).toBeInTheDocument();
-      expect(screen.getByText('Detail: john.doe@example.com')).toBeInTheDocument();
-    });
-  });
-
-  describe('user action buttons', () => {
-    it('renders action buttons for each user row', () => {
-      renderWithProviders(<Users />);
-      // Each user row has its own edit/message buttons
-      const editButtons = screen.getAllByTitle('Edit user');
-      expect(editButtons.length).toBe(mockAdminUsers.length);
-      const messageButtons = screen.getAllByTitle('Send message');
-      expect(messageButtons.length).toBe(mockAdminUsers.length);
+  describe('split-pane detail panel', () => {
+    it('does not show the detail panel when no user is selected', () => {
+      renderUsersPage();
+      expect(screen.queryByTestId('user-detail-panel')).not.toBeInTheDocument();
     });
 
-    it('opens edit modal when admin clicks Edit on a user', async () => {
-      const user = userEvent.setup();
-      renderWithProviders(<Users />);
+    it('shows the detail panel when navigated to a user URL', () => {
+      renderUsersPage('/users/user-1');
 
-      const editButtons = screen.getAllByTitle('Edit user');
-      await user.click(editButtons[0]);
-
-      expect(screen.getByTestId('edit-user-modal')).toBeInTheDocument();
+      const panel = screen.getByTestId('user-detail-panel');
+      expect(panel).toBeInTheDocument();
+      // Panel header shows the user name
+      expect(panel).toHaveTextContent('John Doe');
     });
 
-    it('opens support ticket modal when admin clicks Send message', async () => {
-      const user = userEvent.setup();
-      renderWithProviders(<Users />);
+    it('shows the close button on the detail panel', () => {
+      renderUsersPage('/users/user-1');
 
-      const messageButtons = screen.getAllByTitle('Send message');
-      await user.click(messageButtons[0]);
-
-      expect(screen.getByTestId('support-ticket-modal')).toBeInTheDocument();
+      expect(screen.getByLabelText('Close detail panel')).toBeInTheDocument();
     });
   });
 
   describe('suspension feedback messages', () => {
-    it('shows a success message when a user is suspended successfully', async () => {
+    it('shows a success message when a user is suspended via the panel', async () => {
       const user = userEvent.setup();
       mockUseSuspendUser.mockReturnValue({
         ...mockMutationResult,
         mutateAsync: vi.fn().mockResolvedValue({}),
       });
-      renderWithProviders(<Users />);
 
-      await user.click(screen.getByTestId('suspend-user-1'));
+      renderUsersPage('/users/user-1');
+
+      await user.click(screen.getByRole('tab', { name: 'Actions' }));
+      await user.click(screen.getByText('Suspend User'));
 
       await waitFor(() => {
         expect(screen.getByText('User suspended successfully')).toBeInTheDocument();
@@ -501,9 +458,11 @@ describe('User Management page', () => {
         ...mockMutationResult,
         mutateAsync: vi.fn().mockRejectedValue(new Error('Permission denied')),
       });
-      renderWithProviders(<Users />);
 
-      await user.click(screen.getByTestId('suspend-user-1'));
+      renderUsersPage('/users/user-1');
+
+      await user.click(screen.getByRole('tab', { name: 'Actions' }));
+      await user.click(screen.getByText('Suspend User'));
 
       await waitFor(() => {
         expect(screen.getByText('Failed to suspend user — Permission denied')).toBeInTheDocument();
@@ -516,24 +475,28 @@ describe('User Management page', () => {
         ...mockMutationResult,
         mutateAsync: vi.fn().mockRejectedValue('unknown error'),
       });
-      renderWithProviders(<Users />);
 
-      await user.click(screen.getByTestId('suspend-user-1'));
+      renderUsersPage('/users/user-1');
+
+      await user.click(screen.getByRole('tab', { name: 'Actions' }));
+      await user.click(screen.getByText('Suspend User'));
 
       await waitFor(() => {
         expect(screen.getByText('Failed to suspend user — please try again')).toBeInTheDocument();
       });
     });
 
-    it('shows a success message when a user is unsuspended successfully', async () => {
+    it('shows a success message when a user is unsuspended via the panel', async () => {
       const user = userEvent.setup();
       mockUseUnsuspendUser.mockReturnValue({
         ...mockMutationResult,
         mutateAsync: vi.fn().mockResolvedValue({}),
       });
-      renderWithProviders(<Users />);
 
-      await user.click(screen.getByTestId('unsuspend-user-3'));
+      renderUsersPage('/users/user-3');
+
+      await user.click(screen.getByRole('tab', { name: 'Actions' }));
+      await user.click(screen.getByText('Unsuspend User'));
 
       await waitFor(() => {
         expect(screen.getByText('User unsuspended successfully')).toBeInTheDocument();
@@ -546,9 +509,11 @@ describe('User Management page', () => {
         ...mockMutationResult,
         mutateAsync: vi.fn().mockRejectedValue(new Error('Server unavailable')),
       });
-      renderWithProviders(<Users />);
 
-      await user.click(screen.getByTestId('unsuspend-user-3'));
+      renderUsersPage('/users/user-3');
+
+      await user.click(screen.getByRole('tab', { name: 'Actions' }));
+      await user.click(screen.getByText('Unsuspend User'));
 
       await waitFor(() => {
         expect(
@@ -563,13 +528,57 @@ describe('User Management page', () => {
         ...mockMutationResult,
         mutateAsync: vi.fn().mockRejectedValue('unknown error'),
       });
-      renderWithProviders(<Users />);
 
-      await user.click(screen.getByTestId('unsuspend-user-3'));
+      renderUsersPage('/users/user-3');
+
+      await user.click(screen.getByRole('tab', { name: 'Actions' }));
+      await user.click(screen.getByText('Unsuspend User'));
 
       await waitFor(() => {
         expect(screen.getByText('Failed to unsuspend user — please try again')).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('detail panel tabs', () => {
+    it('shows Overview tab by default with user details', () => {
+      renderUsersPage('/users/user-1');
+
+      expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('shows Edit tab with form fields when clicked', async () => {
+      const user = userEvent.setup();
+      renderUsersPage('/users/user-1');
+
+      await user.click(screen.getByRole('tab', { name: 'Edit' }));
+
+      expect(screen.getByLabelText('First Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Last Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    });
+
+    it('shows Actions tab with action buttons when clicked', async () => {
+      const user = userEvent.setup();
+      renderUsersPage('/users/user-1');
+
+      await user.click(screen.getByRole('tab', { name: 'Actions' }));
+
+      expect(screen.getByText('Suspend User')).toBeInTheDocument();
+      expect(screen.getByText('Reset Password')).toBeInTheDocument();
+      expect(screen.getByText('Delete User')).toBeInTheDocument();
+    });
+
+    it('shows Activity tab when clicked', async () => {
+      const user = userEvent.setup();
+      renderUsersPage('/users/user-1');
+
+      await user.click(screen.getByRole('tab', { name: 'Activity' }));
+
+      expect(screen.getByText('No activity recorded for this user.')).toBeInTheDocument();
     });
   });
 });

--- a/app.admin/src/components/detail/UserDetailPanel.css.ts
+++ b/app.admin/src/components/detail/UserDetailPanel.css.ts
@@ -1,0 +1,385 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { vars } from '@adopt-dont-shop/lib.components/theme';
+
+export const panel = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: '12px',
+  overflow: 'hidden',
+});
+
+export const panelHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  padding: '1rem 1.25rem',
+  borderBottom: `1px solid ${vars.border.color.default}`,
+});
+
+export const avatar = style({
+  width: '48px',
+  height: '48px',
+  borderRadius: '50%',
+  background: vars.colors.gradientPrimary,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: vars.background.surface,
+  fontWeight: '600',
+  fontSize: '1.125rem',
+  flexShrink: 0,
+});
+
+export const headerInfo = style({
+  flex: 1,
+  minWidth: 0,
+});
+
+export const headerName = style({
+  margin: 0,
+  fontSize: '1.125rem',
+  fontWeight: '600',
+  color: vars.text.primary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const headerEmail = style({
+  margin: 0,
+  fontSize: '0.8125rem',
+  color: vars.text.tertiary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const headerBadges = style({
+  display: 'flex',
+  gap: '0.375rem',
+  flexShrink: 0,
+});
+
+export const closeButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '28px',
+  height: '28px',
+  border: 'none',
+  borderRadius: '6px',
+  background: 'transparent',
+  color: vars.text.tertiary,
+  cursor: 'pointer',
+  flexShrink: 0,
+  ':hover': {
+    background: vars.background.muted,
+    color: vars.text.primary,
+  },
+});
+
+export const tabBar = style({
+  display: 'flex',
+  gap: 0,
+  borderBottom: `1px solid ${vars.border.color.default}`,
+  padding: '0 1.25rem',
+});
+
+export const tab = style({
+  padding: '0.625rem 1rem',
+  border: 'none',
+  borderBottom: '2px solid transparent',
+  background: 'transparent',
+  color: vars.text.tertiary,
+  fontSize: '0.8125rem',
+  fontWeight: '500',
+  cursor: 'pointer',
+  transition: 'all 0.15s ease',
+  ':hover': {
+    color: vars.text.primary,
+  },
+});
+
+export const tabActive = style({
+  color: vars.colors.primary,
+  borderBottomColor: vars.colors.primary,
+});
+
+export const tabContent = style({
+  flex: 1,
+  overflowY: 'auto',
+  padding: '1.25rem',
+});
+
+// ── Overview tab ──────────────────────────────────────────────────
+
+export const detailGrid = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr',
+  gap: '1rem',
+});
+
+export const detailItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+});
+
+export const detailLabel = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.375rem',
+  fontSize: '0.6875rem',
+  fontWeight: '600',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  color: vars.text.muted,
+});
+
+export const detailValue = style({
+  fontSize: '0.875rem',
+  color: vars.text.primary,
+  fontWeight: '500',
+});
+
+export const emptyValue = style({
+  color: vars.text.muted,
+  fontStyle: 'italic',
+});
+
+// ── Edit tab ──────────────────────────────────────────────────────
+
+export const form = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+export const formGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.375rem',
+});
+
+export const formLabel = style({
+  fontSize: '0.8125rem',
+  fontWeight: '600',
+  color: vars.text.secondary,
+});
+
+export const formSelect = style({
+  padding: '0.5rem 0.75rem',
+  border: `1px solid ${vars.border.color.muted}`,
+  borderRadius: '8px',
+  fontSize: '0.875rem',
+  color: vars.text.primary,
+  background: vars.background.surface,
+  cursor: 'pointer',
+  ':focus-visible': {
+    outline: 'none',
+    borderColor: vars.colors.primary,
+    boxShadow: '0 0 0 3px rgba(102, 126, 234, 0.1)',
+  },
+});
+
+export const formRow = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '0.75rem',
+});
+
+export const formActions = style({
+  display: 'flex',
+  gap: '0.5rem',
+  justifyContent: 'flex-end',
+  paddingTop: '0.75rem',
+  borderTop: `1px solid ${vars.border.color.default}`,
+});
+
+export const formError = style({
+  padding: '0.5rem 0.75rem',
+  background: vars.colors.dangerBgSubtle,
+  border: `1px solid ${vars.colors.dangerBgSubtle}`,
+  borderRadius: '8px',
+  color: vars.colors.dangerTextEmphasis,
+  fontSize: '0.8125rem',
+});
+
+// ── Actions tab ──────────────────────────────────────────────────
+
+export const actionsSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+export const actionGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+});
+
+export const actionGroupLabel = style({
+  fontSize: '0.6875rem',
+  fontWeight: '600',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  color: vars.text.muted,
+});
+
+export const actionButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  width: '100%',
+  padding: '0.625rem 0.875rem',
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: '8px',
+  background: vars.background.surface,
+  color: vars.text.primary,
+  fontSize: '0.8125rem',
+  fontWeight: '500',
+  cursor: 'pointer',
+  textAlign: 'left',
+  transition: 'all 0.15s ease',
+  ':hover': {
+    background: vars.background.muted,
+    borderColor: vars.border.color.muted,
+  },
+});
+
+export const actionButtonDanger = style({
+  color: vars.colors.dangerTextEmphasis,
+  ':hover': {
+    background: vars.colors.dangerBgSubtle,
+    borderColor: vars.colors.dangerBgSubtle,
+  },
+});
+
+// ── Activity tab ──────────────────────────────────────────────────
+
+export const activityList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+});
+
+export const activityItem = style({
+  display: 'flex',
+  gap: '0.75rem',
+  padding: '0.625rem 0',
+  borderBottom: `1px solid ${vars.border.color.default}`,
+  ':last-child': {
+    borderBottom: 'none',
+  },
+});
+
+export const activityDot = style({
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+  background: vars.colors.primary,
+  marginTop: '0.375rem',
+  flexShrink: 0,
+});
+
+export const activityContent = style({
+  flex: 1,
+  minWidth: 0,
+});
+
+export const activityDescription = style({
+  fontSize: '0.8125rem',
+  color: vars.text.primary,
+  margin: 0,
+});
+
+export const activityMeta = style({
+  fontSize: '0.75rem',
+  color: vars.text.muted,
+  margin: '0.125rem 0 0 0',
+});
+
+export const activityEmpty = style({
+  padding: '2rem 1rem',
+  textAlign: 'center',
+  color: vars.text.muted,
+  fontSize: '0.875rem',
+});
+
+// ── Badge styles (shared) ──────────────────────────────────────
+
+export const badgeSuccess = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '0.125rem 0.5rem',
+  borderRadius: '9999px',
+  fontSize: '0.6875rem',
+  fontWeight: '600',
+  background: vars.colors.successBgSubtle,
+  color: vars.colors.successTextEmphasis,
+});
+
+export const badgeWarning = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '0.125rem 0.5rem',
+  borderRadius: '9999px',
+  fontSize: '0.6875rem',
+  fontWeight: '600',
+  background: vars.colors.warningBgSubtle,
+  color: vars.colors.warningTextEmphasis,
+});
+
+export const badgeDanger = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '0.125rem 0.5rem',
+  borderRadius: '9999px',
+  fontSize: '0.6875rem',
+  fontWeight: '600',
+  background: vars.colors.dangerBgSubtle,
+  color: vars.colors.dangerTextEmphasis,
+});
+
+export const badgeInfo = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '0.125rem 0.5rem',
+  borderRadius: '9999px',
+  fontSize: '0.6875rem',
+  fontWeight: '600',
+  background: vars.colors.infoBgSubtle,
+  color: vars.colors.infoTextEmphasis,
+});
+
+export const badgeNeutral = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '0.125rem 0.5rem',
+  borderRadius: '9999px',
+  fontSize: '0.6875rem',
+  fontWeight: '600',
+  background: vars.background.muted,
+  color: vars.text.secondary,
+});
+
+// ── Admin notes tab ──────────────────────────────────────────────
+
+export const notesPlaceholder = style({
+  padding: '2rem 1rem',
+  textAlign: 'center',
+  color: vars.text.muted,
+  fontSize: '0.875rem',
+});
+
+globalStyle(`${notesPlaceholder} code`, {
+  fontSize: '0.75rem',
+  background: vars.background.muted,
+  padding: '0.125rem 0.375rem',
+  borderRadius: '4px',
+});

--- a/app.admin/src/components/detail/UserDetailPanel.tsx
+++ b/app.admin/src/components/detail/UserDetailPanel.tsx
@@ -1,0 +1,497 @@
+import React, { useState, useEffect } from 'react';
+import { Button, Input, Spinner } from '@adopt-dont-shop/lib.components';
+import { formatDisplayDate } from '@adopt-dont-shop/lib.utils';
+import {
+  FiMail,
+  FiPhone,
+  FiCalendar,
+  FiClock,
+  FiUser,
+  FiShield,
+  FiX,
+  FiPause,
+  FiPlay,
+  FiCheckCircle,
+  FiTrash2,
+  FiKey,
+} from 'react-icons/fi';
+import clsx from 'clsx';
+import type { AdminUser, UserType, UserStatus } from '@/types';
+import { useUserActivity } from '../../hooks';
+import * as styles from './UserDetailPanel.css';
+
+type TabId = 'overview' | 'edit' | 'actions' | 'activity';
+
+type UserDetailPanelProps = {
+  user: AdminUser;
+  onClose: () => void;
+  onSave: (userId: string, updates: Partial<AdminUser>) => Promise<void>;
+  onSuspend: (userId: string, reason?: string) => Promise<void>;
+  onUnsuspend: (userId: string) => Promise<void>;
+  onVerify: (userId: string) => Promise<void>;
+  onDelete: (userId: string, reason?: string) => Promise<void>;
+  onResetPassword: (userId: string) => Promise<void>;
+  onMessage: (user: AdminUser) => void;
+};
+
+const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'edit', label: 'Edit' },
+  { id: 'actions', label: 'Actions' },
+  { id: 'activity', label: 'Activity' },
+];
+
+const getUserInitials = (
+  firstName: string | null | undefined,
+  lastName: string | null | undefined
+): string => {
+  const first = firstName?.charAt(0) ?? '';
+  const last = lastName?.charAt(0) ?? '';
+  return `${first}${last}`.toUpperCase() || '??';
+};
+
+const getUserTypeBadge = (userType: string): React.ReactElement => {
+  switch (userType) {
+    case 'admin':
+    case 'super_admin':
+      return <span className={styles.badgeDanger}>Admin</span>;
+    case 'moderator':
+      return <span className={styles.badgeWarning}>Moderator</span>;
+    case 'rescue_staff':
+      return <span className={styles.badgeInfo}>Rescue Staff</span>;
+    default:
+      return <span className={styles.badgeNeutral}>Adopter</span>;
+  }
+};
+
+const getStatusBadge = (status: string, emailVerified: boolean): React.ReactElement => {
+  if (status === 'suspended') {
+    return <span className={styles.badgeDanger}>Suspended</span>;
+  }
+  if (status === 'pending' || !emailVerified) {
+    return <span className={styles.badgeWarning}>Pending</span>;
+  }
+  return <span className={styles.badgeSuccess}>Active</span>;
+};
+
+// ── Overview Tab ──────────────────────────────────────────────────
+
+const OverviewTab: React.FC<{ user: AdminUser }> = ({ user }) => (
+  <div className={styles.detailGrid}>
+    <DetailField icon={<FiMail />} label='Email' value={user.email} />
+    <DetailField
+      icon={<FiPhone />}
+      label='Phone'
+      value={user.phoneNumber}
+      emptyText='Not provided'
+    />
+    <DetailField
+      icon={<FiUser />}
+      label='User Type'
+      value={user.userType.replace('_', ' ').toUpperCase()}
+    />
+    <DetailField icon={<FiShield />} label='Status' value={user.status.toUpperCase()} />
+    <DetailField
+      icon={<FiShield />}
+      label='Email Verified'
+      value={(user.emailVerified ?? false) ? 'Yes' : 'No'}
+    />
+    {(user.rescueName ?? '') !== '' && (
+      <DetailField icon={<FiUser />} label='Rescue Organization' value={user.rescueName ?? ''} />
+    )}
+    <DetailField icon={<FiCalendar />} label='Joined' value={formatDisplayDate(user.createdAt)} />
+    <DetailField
+      icon={<FiClock />}
+      label='Last Login'
+      value={user.lastLogin ? formatDisplayDate(user.lastLogin) : null}
+      emptyText='Never'
+    />
+    {user.updatedAt && (
+      <DetailField
+        icon={<FiClock />}
+        label='Last Updated'
+        value={formatDisplayDate(user.updatedAt)}
+      />
+    )}
+  </div>
+);
+
+const DetailField: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  value: string | null | undefined;
+  emptyText?: string;
+}> = ({ icon, label, value, emptyText = 'Not provided' }) => (
+  <div className={styles.detailItem}>
+    <div className={styles.detailLabel}>
+      {icon}
+      {label}
+    </div>
+    <div className={styles.detailValue}>
+      {value ? value : <span className={styles.emptyValue}>{emptyText}</span>}
+    </div>
+  </div>
+);
+
+// ── Edit Tab ──────────────────────────────────────────────────────
+
+const EditTab: React.FC<{
+  user: AdminUser;
+  onSave: (userId: string, updates: Partial<AdminUser>) => Promise<void>;
+}> = ({ user, onSave }) => {
+  const [formData, setFormData] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phoneNumber: '',
+    userType: 'adopter' as UserType,
+    status: 'active' as UserStatus,
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setFormData({
+      firstName: user.firstName ?? '',
+      lastName: user.lastName ?? '',
+      email: user.email,
+      phoneNumber: user.phoneNumber ?? '',
+      userType: user.userType,
+      status: user.status,
+    });
+    setError(null);
+    setSaved(false);
+  }, [
+    user.userId,
+    user.firstName,
+    user.lastName,
+    user.email,
+    user.phoneNumber,
+    user.userType,
+    user.status,
+  ]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+    setSaved(false);
+
+    try {
+      const updates: Partial<AdminUser> = {};
+      if (formData.firstName !== (user.firstName ?? '')) {
+        updates.firstName = formData.firstName;
+      }
+      if (formData.lastName !== (user.lastName ?? '')) {
+        updates.lastName = formData.lastName;
+      }
+      if (formData.email !== user.email) {
+        updates.email = formData.email;
+      }
+      if (formData.phoneNumber !== (user.phoneNumber ?? '')) {
+        updates.phoneNumber = formData.phoneNumber;
+      }
+      if (formData.userType !== user.userType) {
+        updates.userType = formData.userType;
+      }
+      if (formData.status !== user.status) {
+        updates.status = formData.status;
+      }
+
+      if (Object.keys(updates).length === 0) {
+        setSaved(true);
+        return;
+      }
+
+      await onSave(user.userId, updates);
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update user');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      {error && <div className={styles.formError}>{error}</div>}
+
+      <div className={styles.formRow}>
+        <div className={styles.formGroup}>
+          <label className={styles.formLabel} htmlFor='edit-first-name'>
+            First Name
+          </label>
+          <Input
+            id='edit-first-name'
+            type='text'
+            value={formData.firstName}
+            onChange={e => setFormData({ ...formData, firstName: e.target.value })}
+            required
+          />
+        </div>
+        <div className={styles.formGroup}>
+          <label className={styles.formLabel} htmlFor='edit-last-name'>
+            Last Name
+          </label>
+          <Input
+            id='edit-last-name'
+            type='text'
+            value={formData.lastName}
+            onChange={e => setFormData({ ...formData, lastName: e.target.value })}
+            required
+          />
+        </div>
+      </div>
+
+      <div className={styles.formGroup}>
+        <label className={styles.formLabel} htmlFor='edit-email'>
+          Email
+        </label>
+        <Input
+          id='edit-email'
+          type='email'
+          value={formData.email}
+          onChange={e => setFormData({ ...formData, email: e.target.value })}
+          required
+        />
+      </div>
+
+      <div className={styles.formGroup}>
+        <label className={styles.formLabel} htmlFor='edit-phone'>
+          Phone Number
+        </label>
+        <Input
+          id='edit-phone'
+          type='tel'
+          value={formData.phoneNumber}
+          onChange={e => setFormData({ ...formData, phoneNumber: e.target.value })}
+        />
+      </div>
+
+      <div className={styles.formRow}>
+        <div className={styles.formGroup}>
+          <label className={styles.formLabel} htmlFor='edit-role'>
+            Role
+          </label>
+          <select
+            className={styles.formSelect}
+            id='edit-role'
+            value={formData.userType}
+            onChange={e => setFormData({ ...formData, userType: e.target.value as UserType })}
+          >
+            <option value='adopter'>Adopter</option>
+            <option value='admin'>Admin</option>
+            <option value='moderator'>Moderator</option>
+            <option value='super_admin'>Super Admin</option>
+          </select>
+        </div>
+        <div className={styles.formGroup}>
+          <label className={styles.formLabel} htmlFor='edit-status'>
+            Status
+          </label>
+          <select
+            className={styles.formSelect}
+            id='edit-status'
+            value={formData.status === 'active' ? 'active' : 'suspended'}
+            onChange={e => setFormData({ ...formData, status: e.target.value as UserStatus })}
+          >
+            <option value='active'>Active</option>
+            <option value='suspended'>Suspended</option>
+          </select>
+        </div>
+      </div>
+
+      <div className={styles.formActions}>
+        {saved && <span className={styles.badgeSuccess}>Saved</span>}
+        <Button type='submit' variant='primary' size='sm' disabled={isSubmitting}>
+          {isSubmitting ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+// ── Actions Tab ──────────────────────────────────────────────────
+
+const ActionsTab: React.FC<{
+  user: AdminUser;
+  onSuspend: (userId: string, reason?: string) => Promise<void>;
+  onUnsuspend: (userId: string) => Promise<void>;
+  onVerify: (userId: string) => Promise<void>;
+  onDelete: (userId: string, reason?: string) => Promise<void>;
+  onResetPassword: (userId: string) => Promise<void>;
+  onMessage: (user: AdminUser) => void;
+}> = ({ user, onSuspend, onUnsuspend, onVerify, onDelete, onResetPassword, onMessage }) => (
+  <div className={styles.actionsSection}>
+    <div className={styles.actionGroup}>
+      <span className={styles.actionGroupLabel}>Communication</span>
+      <button type='button' className={styles.actionButton} onClick={() => onMessage(user)}>
+        <FiMail /> Send Message
+      </button>
+    </div>
+
+    <div className={styles.actionGroup}>
+      <span className={styles.actionGroupLabel}>Account</span>
+      {user.status === 'suspended' ? (
+        <button
+          type='button'
+          className={styles.actionButton}
+          onClick={() => onUnsuspend(user.userId)}
+        >
+          <FiPlay /> Unsuspend User
+        </button>
+      ) : (
+        <button
+          type='button'
+          className={styles.actionButton}
+          onClick={() => onSuspend(user.userId)}
+        >
+          <FiPause /> Suspend User
+        </button>
+      )}
+      {!user.emailVerified && (
+        <button type='button' className={styles.actionButton} onClick={() => onVerify(user.userId)}>
+          <FiCheckCircle /> Verify Email
+        </button>
+      )}
+      <button
+        type='button'
+        className={styles.actionButton}
+        onClick={() => onResetPassword(user.userId)}
+      >
+        <FiKey /> Reset Password
+      </button>
+    </div>
+
+    <div className={styles.actionGroup}>
+      <span className={styles.actionGroupLabel}>Danger Zone</span>
+      <button
+        type='button'
+        className={clsx(styles.actionButton, styles.actionButtonDanger)}
+        onClick={() => onDelete(user.userId)}
+      >
+        <FiTrash2 /> Delete User
+      </button>
+    </div>
+  </div>
+);
+
+// ── Activity Tab ──────────────────────────────────────────────────
+
+const ActivityTab: React.FC<{ userId: string }> = ({ userId }) => {
+  const { data, isLoading, error } = useUserActivity(userId);
+
+  if (isLoading) {
+    return (
+      <div className={styles.activityEmpty}>
+        <Spinner size='sm' label='Loading activity' />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className={styles.activityEmpty}>Failed to load activity history.</div>;
+  }
+
+  const activities = data ?? [];
+
+  if (activities.length === 0) {
+    return <div className={styles.activityEmpty}>No activity recorded for this user.</div>;
+  }
+
+  return (
+    <div className={styles.activityList}>
+      {activities.map(activity => (
+        <div key={activity.activity_id} className={styles.activityItem}>
+          <div className={styles.activityDot} />
+          <div className={styles.activityContent}>
+            <p className={styles.activityDescription}>{activity.description}</p>
+            <p className={styles.activityMeta}>
+              {activity.activity_type} &middot;{' '}
+              {new Date(activity.created_at).toLocaleString('en-GB')}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ── Main Panel ──────────────────────────────────────────────────
+
+export const UserDetailPanel: React.FC<UserDetailPanelProps> = ({
+  user,
+  onClose,
+  onSave,
+  onSuspend,
+  onUnsuspend,
+  onVerify,
+  onDelete,
+  onResetPassword,
+  onMessage,
+}) => {
+  const [activeTab, setActiveTab] = useState<TabId>('overview');
+
+  useEffect(() => {
+    setActiveTab('overview');
+  }, [user.userId]);
+
+  return (
+    <div className={styles.panel} data-testid='user-detail-panel'>
+      <div className={styles.panelHeader}>
+        <div className={styles.avatar}>{getUserInitials(user.firstName, user.lastName)}</div>
+        <div className={styles.headerInfo}>
+          <h3 className={styles.headerName}>
+            {user.firstName} {user.lastName}
+          </h3>
+          <p className={styles.headerEmail}>{user.email}</p>
+        </div>
+        <div className={styles.headerBadges}>
+          {getUserTypeBadge(user.userType)}
+          {getStatusBadge(user.status, user.emailVerified ?? false)}
+        </div>
+        <button
+          type='button'
+          className={styles.closeButton}
+          onClick={onClose}
+          aria-label='Close detail panel'
+        >
+          <FiX />
+        </button>
+      </div>
+
+      <div className={styles.tabBar} role='tablist'>
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            type='button'
+            role='tab'
+            aria-selected={activeTab === tab.id}
+            className={clsx(styles.tab, activeTab === tab.id && styles.tabActive)}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.tabContent} role='tabpanel'>
+        {activeTab === 'overview' && <OverviewTab user={user} />}
+        {activeTab === 'edit' && <EditTab user={user} onSave={onSave} />}
+        {activeTab === 'actions' && (
+          <ActionsTab
+            user={user}
+            onSuspend={onSuspend}
+            onUnsuspend={onUnsuspend}
+            onVerify={onVerify}
+            onDelete={onDelete}
+            onResetPassword={onResetPassword}
+            onMessage={onMessage}
+          />
+        )}
+        {activeTab === 'activity' && <ActivityTab userId={user.userId} />}
+      </div>
+    </div>
+  );
+};

--- a/app.admin/src/components/detail/index.ts
+++ b/app.admin/src/components/detail/index.ts
@@ -1,0 +1,1 @@
+export { UserDetailPanel } from './UserDetailPanel';

--- a/app.admin/src/pages/Users.css.ts
+++ b/app.admin/src/pages/Users.css.ts
@@ -238,3 +238,63 @@ export const errorMessage = style({
 export const addUserIcon = style({
   marginRight: '0.5rem',
 });
+
+// ── Split-pane layout ──────────────────────────────────────────
+
+export const splitLayout = style({
+  display: 'flex',
+  gap: '1.5rem',
+  minHeight: 0,
+  flex: 1,
+});
+
+export const listPane = style({
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  transition: 'flex 0.2s ease',
+});
+
+export const listPaneNarrow = style({
+  flex: '1 1 55%',
+  '@media': {
+    '(max-width: 1024px)': {
+      display: 'none',
+    },
+  },
+});
+
+export const detailPane = style({
+  flex: '0 0 440px',
+  minWidth: '360px',
+  maxWidth: '500px',
+  '@media': {
+    '(max-width: 1024px)': {
+      flex: '1 1 auto',
+      maxWidth: 'none',
+      minWidth: 0,
+    },
+  },
+});
+
+export const backToList = style({
+  display: 'none',
+  '@media': {
+    '(max-width: 1024px)': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '0.375rem',
+      background: 'transparent',
+      border: `1px solid ${vars.border.color.default}`,
+      borderRadius: '8px',
+      padding: '0.375rem 0.75rem',
+      marginBottom: '0.5rem',
+      cursor: 'pointer',
+      color: vars.text.secondary,
+      fontSize: '0.8125rem',
+      fontWeight: '500',
+    },
+  },
+});

--- a/app.admin/src/pages/Users.tsx
+++ b/app.admin/src/pages/Users.tsx
@@ -10,7 +10,8 @@ import {
   ToastContainer,
   type ToastMessage,
 } from '@adopt-dont-shop/lib.components';
-import { FiSearch, FiUserPlus, FiEdit2, FiMail } from 'react-icons/fi';
+import { FiSearch, FiUserPlus, FiArrowLeft } from 'react-icons/fi';
+import clsx from 'clsx';
 import { DataTable, type Column } from '../components/data';
 import {
   useUsers,
@@ -26,13 +27,11 @@ import { exportData, type ExportColumn } from '../services/exportService';
 import { userManagementService } from '../services/userManagementService';
 import { ExportButton, BulkActionToolbar } from '../components/ui';
 import {
-  UserDetailModal,
-  EditUserModal,
   AddUserModal,
   CreateSupportTicketModal,
-  UserActionsMenu,
   BulkConfirmationModal,
 } from '../components/modals';
+import { UserDetailPanel } from '../components/detail';
 import * as styles from './Users.css';
 
 type BulkActionType = 'activate' | 'deactivate' | 'delete';
@@ -106,21 +105,16 @@ const Users: React.FC = () => {
     setPage(1);
   }, [searchQuery, userTypeFilter, statusFilter]);
 
-  // Modal state
-  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
-  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  // Modal state (only for add user and support ticket - detail/edit moved to panel)
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isMessageModalOpen, setIsMessageModalOpen] = useState(false);
+  const [messageUser, setMessageUser] = useState<AdminUser | null>(null);
 
   // Bulk selection state
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<BulkActionType | null>(null);
   const [bulkResult, setBulkResult] = useState<{ succeeded: number; failed: number } | null>(null);
   const [bulkFailedIds, setBulkFailedIds] = useState<string[]>([]);
-  // UX P2 D: keep the last submitted batch around so the "Try again" button on
-  // the result view can re-run the same userIds + reason without the operator
-  // rebuilding the selection. Cleared on close.
   const [lastBulkSubmission, setLastBulkSubmission] = useState<{
     userIds: string[];
     reason?: string;
@@ -144,41 +138,21 @@ const Users: React.FC = () => {
   const createUser = useCreateUser();
   const { toasts, showToast, hideToast } = useToast();
 
-  // Load user from URL parameter
-  useEffect(() => {
-    if (userId && data?.data) {
-      const user = data.data.find((u: AdminUser) => u.userId === userId);
-      if (user) {
-        setSelectedUser(user);
-        setIsDetailModalOpen(true);
-      }
-    }
-  }, [userId, data?.data]);
+  // Derive selected user from URL param + data
+  const selectedUser: AdminUser | null =
+    userId && data?.data ? (data.data.find((u: AdminUser) => u.userId === userId) ?? null) : null;
 
-  // Handler functions
   const handleRowClick = (user: AdminUser) => {
-    setSelectedUser(user);
-    setIsDetailModalOpen(true);
-    // Update URL to reflect selected user
     navigate(`/users/${user.userId}`, { replace: true });
   };
 
-  const handleCloseDetailModal = () => {
-    setIsDetailModalOpen(false);
-    // Clear URL parameter when closing modal
-    if (userId) {
-      navigate('/users', { replace: true });
-    }
+  const handleCloseDetail = () => {
+    navigate('/users', { replace: true });
   };
 
-  const handleEditUser = (user: AdminUser) => {
-    setSelectedUser(user);
-    setIsEditModalOpen(true);
-  };
-
-  const handleSaveUser = async (userId: string, updates: Partial<AdminUser>) => {
+  const handleSaveUser = async (id: string, updates: Partial<AdminUser>) => {
     try {
-      await apiService.patch(`/api/v1/admin/users/${userId}`, updates);
+      await apiService.patch(`/api/v1/admin/users/${id}`, updates);
       await refetch();
     } catch (err) {
       throw new Error(err instanceof Error ? err.message : 'Failed to update user');
@@ -186,7 +160,7 @@ const Users: React.FC = () => {
   };
 
   const handleMessageUser = (user: AdminUser) => {
-    setSelectedUser(user);
+    setMessageUser(user);
     setIsMessageModalOpen(true);
   };
 
@@ -200,7 +174,6 @@ const Users: React.FC = () => {
     priority: string;
   }) => {
     try {
-      // Transform field names from frontend to backend
       const backendTicketData = {
         userId: ticketData.customerId,
         userEmail: ticketData.customerEmail,
@@ -217,9 +190,9 @@ const Users: React.FC = () => {
     }
   };
 
-  const handleSuspendUser = async (userId: string, reason?: string) => {
+  const handleSuspendUser = async (id: string, reason?: string) => {
     try {
-      await suspendUser.mutateAsync({ userId, reason });
+      await suspendUser.mutateAsync({ userId: id, reason });
       showToast('User suspended successfully', 'success');
     } catch (err) {
       const errorReason = err instanceof Error ? err.message : undefined;
@@ -232,9 +205,9 @@ const Users: React.FC = () => {
     }
   };
 
-  const handleUnsuspendUser = async (userId: string) => {
+  const handleUnsuspendUser = async (id: string) => {
     try {
-      await unsuspendUser.mutateAsync(userId);
+      await unsuspendUser.mutateAsync(id);
       showToast('User unsuspended successfully', 'success');
     } catch (err) {
       const errorReason = err instanceof Error ? err.message : undefined;
@@ -247,25 +220,28 @@ const Users: React.FC = () => {
     }
   };
 
-  const handleVerifyUser = async (userId: string) => {
+  const handleVerifyUser = async (id: string) => {
     try {
-      await verifyUser.mutateAsync(userId);
+      await verifyUser.mutateAsync(id);
+      showToast('User verified successfully', 'success');
     } catch (err) {
       throw new Error(err instanceof Error ? err.message : 'Failed to verify user');
     }
   };
 
-  const handleDeleteUser = async (userId: string, reason?: string) => {
+  const handleDeleteUser = async (id: string, reason?: string) => {
     try {
-      await deleteUser.mutateAsync({ userId, reason });
+      await deleteUser.mutateAsync({ userId: id, reason });
+      showToast('User deleted', 'success');
+      handleCloseDetail();
     } catch (err) {
       throw new Error(err instanceof Error ? err.message : 'Failed to delete user');
     }
   };
 
-  const handleResetPassword = async (userId: string) => {
+  const handleResetPassword = async (id: string) => {
     try {
-      await userManagementService.resetUserPassword(userId);
+      await userManagementService.resetUserPassword(id);
       showToast('Password reset triggered', 'success');
     } catch (err) {
       throw new Error(err instanceof Error ? err.message : 'Failed to reset password');
@@ -474,44 +450,9 @@ const Users: React.FC = () => {
       width: '120px',
       sortable: true,
     },
-    {
-      id: 'actions',
-      header: 'Actions',
-      accessor: row => (
-        <div
-          className={styles.actionButtons}
-          onClick={e => e.stopPropagation()}
-          onKeyDown={e => e.stopPropagation()}
-          role='presentation'
-        >
-          <button
-            className={styles.iconButton}
-            title='Edit user'
-            onClick={() => handleEditUser(row)}
-          >
-            <FiEdit2 />
-          </button>
-          <button
-            className={styles.iconButton}
-            title='Send message'
-            onClick={() => handleMessageUser(row)}
-          >
-            <FiMail />
-          </button>
-          <UserActionsMenu
-            user={row}
-            onSuspend={handleSuspendUser}
-            onUnsuspend={handleUnsuspendUser}
-            onVerify={handleVerifyUser}
-            onDelete={handleDeleteUser}
-            onResetPassword={handleResetPassword}
-          />
-        </div>
-      ),
-      width: '140px',
-      align: 'center',
-    },
   ];
+
+  const detailOpen = selectedUser !== null;
 
   return (
     <div className={styles.pageContainer}>
@@ -529,106 +470,118 @@ const Users: React.FC = () => {
         </div>
       </div>
 
-      <div className={styles.filterBar}>
-        <div className={styles.searchInputWrapper}>
-          <FiSearch />
-          <Input
-            type='text'
-            placeholder='Search by name or email...'
-            value={searchQuery}
-            onChange={e => setSearchQuery(e.target.value)}
+      <div className={styles.splitLayout}>
+        {/* List pane: table with filters and bulk actions */}
+        <div className={clsx(styles.listPane, detailOpen && styles.listPaneNarrow)}>
+          <div className={styles.filterBar}>
+            <div className={styles.searchInputWrapper}>
+              <FiSearch />
+              <Input
+                type='text'
+                placeholder='Search by name or email...'
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+              />
+            </div>
+
+            <div className={styles.filterGroup}>
+              <label className={styles.filterLabel} htmlFor='users-type-filter'>
+                User Type
+              </label>
+              <select
+                id='users-type-filter'
+                className={styles.select}
+                value={userTypeFilter}
+                onChange={e => setUserTypeFilter(e.target.value)}
+              >
+                <option value='all'>All Types</option>
+                <option value='admin'>Admin</option>
+                <option value='moderator'>Moderator</option>
+                <option value='rescue_staff'>Rescue Staff</option>
+                <option value='adopter'>Adopter</option>
+              </select>
+            </div>
+
+            <div className={styles.filterGroup}>
+              <label className={styles.filterLabel} htmlFor='users-status-filter'>
+                Status
+              </label>
+              <select
+                id='users-status-filter'
+                className={styles.select}
+                value={statusFilter}
+                onChange={e => setStatusFilter(e.target.value)}
+              >
+                <option value='all'>All Statuses</option>
+                <option value='active'>Active</option>
+                <option value='pending'>Pending</option>
+                <option value='suspended'>Suspended</option>
+              </select>
+            </div>
+          </div>
+
+          <BulkActionToolbar
+            selectedCount={selectedRows.size}
+            totalCount={users.length}
+            onSelectAll={() => setSelectedRows(new Set(users.map((u: AdminUser) => u.userId)))}
+            onClearSelection={() => setSelectedRows(new Set())}
+            actions={[
+              {
+                label: 'Activate',
+                variant: 'primary',
+                onClick: () => setBulkAction('activate'),
+              },
+              {
+                label: 'Deactivate',
+                variant: 'warning',
+                onClick: () => setBulkAction('deactivate'),
+              },
+              {
+                label: 'Delete',
+                variant: 'danger',
+                onClick: () => setBulkAction('delete'),
+              },
+            ]}
+          />
+
+          <DataTable
+            columns={columns}
+            data={users}
+            loading={isLoading}
+            emptyMessage='No users found matching your criteria. Try adjusting your search or filters.'
+            onRowClick={handleRowClick}
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+            selectable
+            selectedRows={selectedRows}
+            onSelectionChange={setSelectedRows}
+            getRowId={user => user.userId}
           />
         </div>
 
-        <div className={styles.filterGroup}>
-          <label className={styles.filterLabel} htmlFor='users-type-filter'>
-            User Type
-          </label>
-          <select
-            id='users-type-filter'
-            className={styles.select}
-            value={userTypeFilter}
-            onChange={e => setUserTypeFilter(e.target.value)}
-          >
-            <option value='all'>All Types</option>
-            <option value='admin'>Admin</option>
-            <option value='moderator'>Moderator</option>
-            <option value='rescue_staff'>Rescue Staff</option>
-            <option value='adopter'>Adopter</option>
-          </select>
-        </div>
-
-        <div className={styles.filterGroup}>
-          <label className={styles.filterLabel} htmlFor='users-status-filter'>
-            Status
-          </label>
-          <select
-            id='users-status-filter'
-            className={styles.select}
-            value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value)}
-          >
-            <option value='all'>All Statuses</option>
-            <option value='active'>Active</option>
-            <option value='pending'>Pending</option>
-            <option value='suspended'>Suspended</option>
-          </select>
-        </div>
+        {/* Detail pane: shown when a user is selected */}
+        {detailOpen && (
+          <div className={styles.detailPane}>
+            <button type='button' className={styles.backToList} onClick={handleCloseDetail}>
+              <FiArrowLeft /> Back to list
+            </button>
+            <UserDetailPanel
+              user={selectedUser}
+              onClose={handleCloseDetail}
+              onSave={handleSaveUser}
+              onSuspend={handleSuspendUser}
+              onUnsuspend={handleUnsuspendUser}
+              onVerify={handleVerifyUser}
+              onDelete={handleDeleteUser}
+              onResetPassword={handleResetPassword}
+              onMessage={handleMessageUser}
+            />
+          </div>
+        )}
       </div>
 
-      <BulkActionToolbar
-        selectedCount={selectedRows.size}
-        totalCount={users.length}
-        onSelectAll={() => setSelectedRows(new Set(users.map((u: AdminUser) => u.userId)))}
-        onClearSelection={() => setSelectedRows(new Set())}
-        actions={[
-          {
-            label: 'Activate',
-            variant: 'primary',
-            onClick: () => setBulkAction('activate'),
-          },
-          {
-            label: 'Deactivate',
-            variant: 'warning',
-            onClick: () => setBulkAction('deactivate'),
-          },
-          {
-            label: 'Delete',
-            variant: 'danger',
-            onClick: () => setBulkAction('delete'),
-          },
-        ]}
-      />
-
-      <DataTable
-        columns={columns}
-        data={users}
-        loading={isLoading}
-        emptyMessage='No users found matching your criteria. Try adjusting your search or filters.'
-        onRowClick={handleRowClick}
-        currentPage={page}
-        totalPages={totalPages}
-        onPageChange={setPage}
-        selectable
-        selectedRows={selectedRows}
-        onSelectionChange={setSelectedRows}
-        getRowId={user => user.userId}
-      />
-
-      {/* Modals */}
-      <UserDetailModal
-        isOpen={isDetailModalOpen}
-        onClose={handleCloseDetailModal}
-        user={selectedUser}
-      />
-
-      <EditUserModal
-        isOpen={isEditModalOpen}
-        onClose={() => setIsEditModalOpen(false)}
-        user={selectedUser}
-        onSave={handleSaveUser}
-      />
-
+      {/* Modals (only add user, support ticket, and bulk operations remain as modals) */}
       <AddUserModal
         isOpen={isAddModalOpen}
         onClose={() => setIsAddModalOpen(false)}
@@ -641,7 +594,7 @@ const Users: React.FC = () => {
       <CreateSupportTicketModal
         isOpen={isMessageModalOpen}
         onClose={() => setIsMessageModalOpen(false)}
-        user={selectedUser}
+        user={messageUser}
         onCreate={handleCreateSupportTicket}
       />
 
@@ -682,7 +635,6 @@ const Users: React.FC = () => {
         variant={
           bulkAction === 'delete' ? 'danger' : bulkAction === 'deactivate' ? 'warning' : 'info'
         }
-        // ADS-651: every bulk state-change records a reason in the audit log.
         requireReason
         reasonLabel={
           bulkAction === 'delete'


### PR DESCRIPTION
## Summary

- Replaces the UserDetailModal / EditUserModal / UserActionsMenu modal chain on the Users page with an inline split-pane detail panel (ADS-650)
- Detail panel appears on the right side when a user row is clicked, with four tabs: **Overview** (read-only fields), **Edit** (inline form), **Actions** (suspend/unsuspend/verify/delete/reset password/message), and **Activity** (timeline from getUserActivity API)
- Browser back/forward navigates between `/users` and `/users/:userId` without losing filter state — filters are preserved in component state while the URL param controls which user is selected
- Old modal components (UserDetailModal, EditUserModal, UserActionsMenu) are preserved in the modals barrel export for other consumers but are no longer imported by the Users page

### Pattern for follow-up adoption

The split-pane pattern used here can be replicated on Rescues, Pets, and Applications pages:

1. Remove per-row action buttons and detail/edit modals from the table
2. Derive selected entity from `useParams()` URL param + query data
3. Create an `EntityDetailPanel` component with tabs for overview/edit/actions
4. Wrap the DataTable and detail panel in a flex split layout
5. Navigate via `replace: true` to preserve browser history behavior

## Test plan

- [x] All 36 user-management behavior tests pass (rewritten for panel-based flow)
- [x] All 92 tests across affected files pass (user-management, export, bulk-operations, list-page-url-filters)
- [x] Pre-existing test failures (AdminLayout, ChatDetailModal/ModerationTab) confirmed unrelated
- [ ] Manual: click user row → detail panel opens on right side
- [ ] Manual: browser back from detail → returns to list with filters preserved
- [ ] Manual: Edit tab → modify fields → Save → changes persisted
- [ ] Manual: Actions tab → suspend/unsuspend/delete work with toast feedback
- [ ] Manual: Activity tab → shows user activity timeline
- [ ] Manual: narrow viewport → list hides, back-to-list button appears

https://claude.ai/code/session_01HPBt1saVyemSELpmi9coyG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPBt1saVyemSELpmi9coyG)_