### PR TITLE
fix(app.admin): correct in-app navigation from moderation report to entity

### DIFF
--- a/app.admin/src/components/moderation/ReportDetailModal.test.tsx
+++ b/app.admin/src/components/moderation/ReportDetailModal.test.tsx
@@ -5,11 +5,18 @@
  *   prior report history and active sanctions inline so a moderator has full
  *   context before acting on the current report.
  * - When the reported entity has no reportedUserId, neither section is rendered.
+ * - The "View <entity>" action navigates to the correct in-app admin route for
+ *   the reported entity type (and never opens externally for known types).
+ * - Clicking the "View <entity>" action closes the modal before navigating so
+ *   the moderator lands on the entity page, not behind the overlay.
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { ReportDetailModal } from './ReportDetailModal';
+import { openExternal } from '../../utils/openExternal';
 import type {
   Report,
   ModeratorAction,
@@ -19,6 +26,7 @@ import type {
 
 const mockUseReports = vi.fn();
 const mockUseActiveActions = vi.fn();
+const mockNavigate = vi.fn();
 
 vi.mock('@adopt-dont-shop/lib.moderation', () => ({
   useReports: (...args: unknown[]) => mockUseReports(...args),
@@ -34,6 +42,16 @@ vi.mock('@adopt-dont-shop/lib.moderation', () => ({
 vi.mock('../../utils/openExternal', () => ({
   openExternal: vi.fn(),
 }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const renderWithRouter = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
 
 const makeReport = (overrides: Partial<Report> = {}): Report => ({
   reportId: 'report-current',
@@ -81,10 +99,26 @@ const makeAction = (overrides: Partial<ModeratorAction> = {}): ModeratorAction =
   ...overrides,
 });
 
+const stubHooks = () => {
+  mockUseReports.mockReturnValue({
+    data: { data: [], pagination: { page: 1, limit: 10, total: 0, totalPages: 0 } },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  mockUseActiveActions.mockReturnValue({
+    data: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+};
+
 describe('ReportDetailModal — prior history and active sanctions', () => {
   beforeEach(() => {
     mockUseReports.mockReset();
     mockUseActiveActions.mockReset();
+    mockNavigate.mockReset();
   });
 
   it('renders prior reports excluding the current one when reportedUserId is set', async () => {
@@ -105,14 +139,13 @@ describe('ReportDetailModal — prior history and active sanctions', () => {
       refetch: vi.fn(),
     });
 
-    render(<ReportDetailModal isOpen onClose={() => undefined} report={current} />);
+    renderWithRouter(<ReportDetailModal isOpen onClose={() => undefined} report={current} />);
 
     await waitFor(() => {
       expect(screen.getByTestId('prior-history-list')).toBeInTheDocument();
     });
     expect(screen.getByText('Prior offence A')).toBeInTheDocument();
-    // Current report should not appear in history.
-    expect(screen.queryByText(/Repeated harassment of other adopters/)).toBeInTheDocument(); // title is in modal header
+    expect(screen.queryByText(/Repeated harassment of other adopters/)).toBeInTheDocument();
     expect(screen.getByTestId('no-active-sanctions')).toBeInTheDocument();
   });
 
@@ -131,7 +164,7 @@ describe('ReportDetailModal — prior history and active sanctions', () => {
       refetch: vi.fn(),
     });
 
-    render(<ReportDetailModal isOpen onClose={() => undefined} report={current} />);
+    renderWithRouter(<ReportDetailModal isOpen onClose={() => undefined} report={current} />);
 
     expect(screen.getByTestId('active-sanctions-list')).toBeInTheDocument();
     expect(screen.getByText(/repeated rule violations/i)).toBeInTheDocument();
@@ -153,11 +186,100 @@ describe('ReportDetailModal — prior history and active sanctions', () => {
       refetch: vi.fn(),
     });
 
-    render(<ReportDetailModal isOpen onClose={() => undefined} report={current} />);
+    renderWithRouter(<ReportDetailModal isOpen onClose={() => undefined} report={current} />);
 
     expect(screen.queryByTestId('prior-history-list')).not.toBeInTheDocument();
     expect(screen.queryByTestId('no-prior-history')).not.toBeInTheDocument();
     expect(screen.queryByTestId('active-sanctions-list')).not.toBeInTheDocument();
     expect(screen.queryByTestId('no-active-sanctions')).not.toBeInTheDocument();
+  });
+});
+
+describe('ReportDetailModal — view-in-context navigation', () => {
+  beforeEach(() => {
+    mockUseReports.mockReset();
+    mockUseActiveActions.mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(openExternal).mockReset();
+    stubHooks();
+  });
+
+  it.each([
+    ['user', '/users/target-user-1'],
+    ['rescue', '/rescues/target-user-1'],
+    ['pet', '/pets/target-user-1'],
+    ['application', '/applications/target-user-1'],
+    ['message', '/messages?chatId=target-user-1'],
+    ['conversation', '/messages?chatId=target-user-1'],
+  ])('targets the correct in-app route for %s reports', (entityType, expectedRoute) => {
+    const report = makeReport({
+      reportedEntityType: entityType,
+      reportedEntityId: 'target-user-1',
+      reportedUserId: null,
+    });
+
+    renderWithRouter(<ReportDetailModal isOpen onClose={() => undefined} report={report} />);
+
+    const button = screen.getByTestId('view-entity-button');
+    expect(button.getAttribute('data-view-url')).toBe(expectedRoute);
+  });
+
+  it('does not render a view-entity button for unknown entity types', () => {
+    const report = makeReport({
+      reportedEntityType: 'something-else',
+      reportedEntityId: 'x',
+      reportedUserId: null,
+    });
+
+    renderWithRouter(<ReportDetailModal isOpen onClose={() => undefined} report={report} />);
+
+    expect(screen.queryByTestId('view-entity-button')).not.toBeInTheDocument();
+  });
+
+  it('closes the modal and navigates in-app when the view-entity button is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const report = makeReport({
+      reportedEntityType: 'conversation',
+      reportedEntityId: 'chat-42',
+      reportedUserId: null,
+    });
+
+    renderWithRouter(<ReportDetailModal isOpen onClose={onClose} report={report} />);
+
+    await user.click(screen.getByTestId('view-entity-button'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/messages?chatId=chat-42');
+  });
+
+  it('does not call openExternal when viewing an in-app entity', async () => {
+    const user = userEvent.setup();
+    const report = makeReport({
+      reportedEntityType: 'message',
+      reportedEntityId: 'chat-99',
+      reportedUserId: null,
+    });
+
+    renderWithRouter(<ReportDetailModal isOpen onClose={() => undefined} report={report} />);
+
+    await user.click(screen.getByTestId('view-entity-button'));
+
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('renders the reported-entity section so the user can find the view button by label', () => {
+    const report = makeReport({
+      reportedEntityType: 'message',
+      reportedEntityId: 'chat-1',
+      reportedUserId: null,
+    });
+
+    renderWithRouter(<ReportDetailModal isOpen onClose={() => undefined} report={report} />);
+
+    // Sanity: the button is labelled by entity type so moderators understand the action.
+    const button = screen.getByTestId('view-entity-button');
+    expect(within(button).getByText(/View Message/)).toBeInTheDocument();
   });
 });

--- a/app.admin/src/components/moderation/ReportDetailModal.tsx
+++ b/app.admin/src/components/moderation/ReportDetailModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   FiX,
   FiAlertTriangle,
@@ -64,7 +65,8 @@ const getSeverityBadgeClass = (
   }
 };
 
-// Helper to generate URLs to view reported content
+// Helper to generate in-app routes to view reported content. Returns null when
+// the entity type has no corresponding admin detail route.
 const getEntityViewUrl = (entityType: string, entityId: string): string | null => {
   switch (entityType) {
     case 'user':
@@ -77,7 +79,9 @@ const getEntityViewUrl = (entityType: string, entityId: string): string | null =
       return `/applications/${entityId}`;
     case 'message':
     case 'conversation':
-      return `/chats?messageId=${entityId}`;
+      // The chat list lives at /messages. The reported entityId is the
+      // conversation id for both message and conversation reports.
+      return `/messages?chatId=${entityId}`;
     default:
       return null;
   }
@@ -204,6 +208,8 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
   onClose,
   report,
 }) => {
+  const navigate = useNavigate();
+
   if (!report) {
     return null;
   }
@@ -231,7 +237,10 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
 
   const handleViewContent = () => {
     if (viewUrl) {
-      openExternal(viewUrl);
+      // Close the modal first so the moderator lands on the entity page
+      // instead of being trapped behind the still-open overlay.
+      onClose();
+      navigate(viewUrl);
     }
   };
 
@@ -351,7 +360,12 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
 
               {viewUrl && (
                 <>
-                  <button className={styles.viewContentButton} onClick={handleViewContent}>
+                  <button
+                    className={styles.viewContentButton}
+                    onClick={handleViewContent}
+                    data-testid='view-entity-button'
+                    data-view-url={viewUrl}
+                  >
                     <FiExternalLink size={16} />
                     View {getEntityTypeLabel(report.reportedEntityType)}
                   </button>


### PR DESCRIPTION
## Summary

- `ReportDetailModal` "View <entity>" button now uses in-app `useNavigate` instead of `openExternal`
- Message/conversation reports route to `/messages?chatId=<id>` (was broken `/chats?messageId=<id>`)
- Modal closes before navigating so moderator does not land behind overlay

## Trade-off

`app.admin/src/pages/Messages.tsx` reads `selectedChatId` from local state, not query string — so `?chatId=<id>` lands on messages list but won't auto-open the chat detail modal until a follow-up wires that up. Out of scope here; covered by parallel inbox deep-link PR.

## Test plan

- [x] `npx vitest run src/components/moderation/ReportDetailModal.test.tsx` — 13/13 pass
- [x] `npx tsc --noEmit` — no new errors
- [ ] Manual: open a message report in admin, click "View Conversation", confirm in-app navigation

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>