### PR TITLE
fix(app.admin): deep-link inbox message rows to chat thread

### DIFF
--- a/app.admin/src/pages/Inbox.css.ts
+++ b/app.admin/src/pages/Inbox.css.ts
@@ -218,6 +218,14 @@ export const itemMeta = style({
   marginTop: '0.25rem',
 });
 
+export const relatedUserEmailLink = style({
+  color: vars.colors.primary,
+  textDecoration: 'none',
+  ':hover': {
+    textDecoration: 'underline',
+  },
+});
+
 export const timestamp = style({
   fontSize: '0.875rem',
   color: vars.text.tertiary,

--- a/app.admin/src/pages/Inbox.test.tsx
+++ b/app.admin/src/pages/Inbox.test.tsx
@@ -72,7 +72,7 @@ vi.mock('@adopt-dont-shop/lib.auth', () => ({
 }));
 
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {
     ...actual,
     useNavigate: () => mockNavigate,
@@ -145,5 +145,45 @@ describe('Inbox page', () => {
     fireEvent.change(sourceSelect, { target: { value: 'moderation' } });
 
     expect(sourceSelect).toHaveValue('moderation');
+  });
+
+  it('navigates message-source rows to the chat deep-link, not the list view', () => {
+    renderWithProviders(<Inbox />);
+
+    fireEvent.click(screen.getByText('Chat #abc123'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/messages?chatId=chat-1');
+  });
+
+  it('navigates moderation rows to the moderation page', () => {
+    renderWithProviders(<Inbox />);
+
+    fireEvent.click(screen.getByText('Spam report on pet listing'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/moderation');
+  });
+
+  it('navigates support rows to the specific ticket page', () => {
+    renderWithProviders(<Inbox />);
+
+    fireEvent.click(screen.getByText('Cannot access my account'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/support/ticket-1');
+  });
+
+  it('renders the related user email as a link to the user detail page', () => {
+    renderWithProviders(<Inbox />);
+
+    const emailLink = screen.getByRole('link', { name: 'spammer@test.com' });
+    expect(emailLink).toHaveAttribute('href', '/users/user-1');
+  });
+
+  it('clicking the email link does not trigger the row navigation', () => {
+    renderWithProviders(<Inbox />);
+
+    const emailLink = screen.getByRole('link', { name: 'user3@test.com' });
+    fireEvent.click(emailLink);
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('/messages?chatId=chat-1');
   });
 });

--- a/app.admin/src/pages/Inbox.tsx
+++ b/app.admin/src/pages/Inbox.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { Input } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { FiSearch, FiUserPlus } from 'react-icons/fi';
@@ -99,7 +99,7 @@ const getDetailPath = (item: InboxItem): string => {
     case 'support':
       return `/support/${item.id}`;
     case 'message':
-      return '/messages';
+      return `/messages?chatId=${item.id}`;
   }
 };
 
@@ -199,7 +199,21 @@ const Inbox: React.FC = () => {
             {item.title}
           </div>
           <div className={styles.itemSummary}>{item.summary}</div>
-          {item.relatedUserEmail && <div className={styles.itemMeta}>{item.relatedUserEmail}</div>}
+          {item.relatedUserEmail && (
+            <div className={styles.itemMeta}>
+              {item.relatedUserId ? (
+                <Link
+                  to={`/users/${item.relatedUserId}`}
+                  className={styles.relatedUserEmailLink}
+                  onClick={e => e.stopPropagation()}
+                >
+                  {item.relatedUserEmail}
+                </Link>
+              ) : (
+                item.relatedUserEmail
+              )}
+            </div>
+          )}
         </div>
       ),
       width: '350px',

--- a/app.admin/src/pages/Messages.test.tsx
+++ b/app.admin/src/pages/Messages.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+
+vi.mock('@adopt-dont-shop/lib.chat', () => ({
+  useAdminChats: () => ({
+    data: { data: [] },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useAdminChatStats: () => ({
+    data: {
+      totalChats: 0,
+      activeChats: 0,
+      totalMessages: 0,
+      averageMessagesPerChat: 0,
+    },
+  }),
+  useAdminChatMutations: () => ({
+    deleteChat: { mutateAsync: vi.fn() },
+    updateChatStatus: { mutateAsync: vi.fn() },
+  }),
+}));
+
+const chatDetailModalCalls: Array<{ isOpen: boolean; chatId: string | null }> = [];
+
+vi.mock('../components/modals', () => ({
+  ChatDetailModal: (props: { isOpen: boolean; chatId: string | null; onClose: () => void }) => {
+    chatDetailModalCalls.push({ isOpen: props.isOpen, chatId: props.chatId });
+    return props.isOpen ? (
+      <div data-testid='chat-detail-modal' data-chat-id={props.chatId ?? ''}>
+        chat-detail-modal-open
+      </div>
+    ) : null;
+  },
+}));
+
+import Messages from './Messages';
+
+describe('Messages page deep-link', () => {
+  beforeEach(() => {
+    chatDetailModalCalls.length = 0;
+  });
+
+  it('opens the chat detail modal when ?chatId= is present in the URL', () => {
+    renderWithProviders(<Messages />, { initialRoute: '/messages?chatId=chat-abc' });
+
+    const modal = screen.getByTestId('chat-detail-modal');
+    expect(modal).toBeInTheDocument();
+    expect(modal).toHaveAttribute('data-chat-id', 'chat-abc');
+  });
+
+  it('does not open the chat detail modal without a chatId param', () => {
+    renderWithProviders(<Messages />, { initialRoute: '/messages' });
+
+    expect(screen.queryByTestId('chat-detail-modal')).not.toBeInTheDocument();
+  });
+});

--- a/app.admin/src/pages/Messages.tsx
+++ b/app.admin/src/pages/Messages.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   Heading,
   Text,
@@ -57,10 +58,29 @@ const getStatusDotClass = (status: string): string => {
 };
 
 const Messages: React.FC = () => {
+  // ADS: deep-link support — initialise from ?chatId= so the triage inbox
+  // can navigate users straight to a specific chat thread.
+  const [searchParams, setSearchParams] = useSearchParams();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
-  const [selectedChatId, setSelectedChatId] = useState<string | null>(null);
+  const [selectedChatId, setSelectedChatId] = useState<string | null>(() =>
+    searchParams.get('chatId')
+  );
   const { confirm, confirmProps } = useConfirm();
+
+  const handleCloseChatModal = () => {
+    setSelectedChatId(null);
+    if (searchParams.has('chatId')) {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          next.delete('chatId');
+          return next;
+        },
+        { replace: true }
+      );
+    }
+  };
 
   const filters = useMemo(() => {
     const apiFilters: {
@@ -386,7 +406,7 @@ const Messages: React.FC = () => {
 
       <ChatDetailModal
         isOpen={!!selectedChatId}
-        onClose={() => setSelectedChatId(null)}
+        onClose={handleCloseChatModal}
         chatId={selectedChatId}
         onUpdate={refetch}
       />


### PR DESCRIPTION
## Summary

- Inbox rows with `source === 'message'` navigate to `/messages?chatId=<id>` instead of bare list view — preserves admin context after a chat is assigned.
- `Messages` page reads `?chatId=` on mount and opens `ChatDetailModal` directly; closing modal clears query param.
- `relatedUserEmail` column is now a `<Link>` to `/users/<relatedUserId>` with `stopPropagation` so it doesn't trigger row navigation.

## Test plan

- [x] `npx vitest run src/pages/Inbox.test.tsx src/pages/Messages.test.tsx` — 13 pass
- [x] `npx tsc --noEmit` — no new errors in changed files
- [ ] Manual: from `/inbox`, click message row → lands on `/messages?chatId=<id>` with modal open
- [ ] Manual: click email cell → lands on `/users/<id>` without firing row click

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>