### PR TITLE
feat(app.admin): link entities in chat and ticket detail modals

### DIFF
--- a/app.admin/src/components/modals/ChatDetailModal.css.ts
+++ b/app.admin/src/components/modals/ChatDetailModal.css.ts
@@ -514,3 +514,12 @@ export const participantViewLink = style({
   fontSize: '0.875rem',
   color: '#2563eb',
 });
+
+export const entityLink = style({
+  color: '#2563eb',
+  textDecoration: 'none',
+  fontWeight: 'inherit',
+  ':hover': {
+    textDecoration: 'underline',
+  },
+});

--- a/app.admin/src/components/modals/ChatDetailModal/DetailsTab.test.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/DetailsTab.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '../../../test-utils';
+import { DetailsTab } from './DetailsTab';
+import type { Conversation } from '@adopt-dont-shop/lib.chat';
+
+const buildConversation = (overrides: Partial<Conversation> = {}): Conversation => ({
+  id: 'chat-1',
+  participants: [],
+  unreadCount: 0,
+  updatedAt: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  isActive: true,
+  status: 'active',
+  ...overrides,
+});
+
+const noopBadge = () => null;
+
+describe('DetailsTab', () => {
+  it('renders the rescue name as a link to the rescue detail route', () => {
+    render(
+      <DetailsTab
+        conversation={buildConversation({ rescueId: 'rescue-7', rescueName: 'Happy Paws' })}
+        getStatusBadge={noopBadge}
+        onClose={vi.fn()}
+      />
+    );
+    const link = screen.getByRole('link', { name: 'Happy Paws' });
+    expect(link).toHaveAttribute('href', '/rescues/rescue-7');
+  });
+
+  it('renders the pet id as a link to the pet detail route', () => {
+    render(
+      <DetailsTab
+        conversation={buildConversation({ petId: 'pet-9' })}
+        getStatusBadge={noopBadge}
+        onClose={vi.fn()}
+      />
+    );
+    const link = screen.getByRole('link', { name: 'pet-9' });
+    expect(link).toHaveAttribute('href', '/pets/pet-9');
+  });
+
+  it('calls onClose when the rescue link is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <DetailsTab
+        conversation={buildConversation({ rescueId: 'rescue-7', rescueName: 'Happy Paws' })}
+        getStatusBadge={noopBadge}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Happy Paws' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the pet link is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <DetailsTab
+        conversation={buildConversation({ petId: 'pet-9' })}
+        getStatusBadge={noopBadge}
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'pet-9' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the rescue name as plain text when rescueId is missing', () => {
+    render(
+      <DetailsTab
+        conversation={buildConversation({ rescueName: 'Orphan Rescue' })}
+        getStatusBadge={noopBadge}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('link', { name: 'Orphan Rescue' })).not.toBeInTheDocument();
+    expect(screen.getByText('Orphan Rescue')).toBeInTheDocument();
+  });
+});

--- a/app.admin/src/components/modals/ChatDetailModal/DetailsTab.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/DetailsTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import * as styles from '../ChatDetailModal.css';
 import { type Conversation } from '@adopt-dont-shop/lib.chat';
 import { FiInfo, FiClock, FiUsers, FiMessageSquare } from 'react-icons/fi';
@@ -6,6 +7,7 @@ import { FiInfo, FiClock, FiUsers, FiMessageSquare } from 'react-icons/fi';
 type DetailsTabProps = {
   conversation: Conversation;
   getStatusBadge: (status?: string) => React.ReactNode;
+  onClose: () => void;
 };
 
 const formatTimestamp = (timestamp: string) => {
@@ -31,7 +33,11 @@ const formatTimestamp = (timestamp: string) => {
   return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 };
 
-export const DetailsTab: React.FC<DetailsTabProps> = ({ conversation, getStatusBadge }) => (
+export const DetailsTab: React.FC<DetailsTabProps> = ({
+  conversation,
+  getStatusBadge,
+  onClose,
+}) => (
   <div className={styles.detailGrid}>
     <div className={styles.detailItem}>
       <div className={styles.detailLabel}>
@@ -49,14 +55,30 @@ export const DetailsTab: React.FC<DetailsTabProps> = ({ conversation, getStatusB
     {conversation.rescueName && (
       <div className={styles.detailItem}>
         <div className={styles.detailLabel}>Rescue</div>
-        <div className={styles.detailValue}>{conversation.rescueName}</div>
+        <div className={styles.detailValue}>
+          {conversation.rescueId ? (
+            <Link
+              to={`/rescues/${conversation.rescueId}`}
+              onClick={onClose}
+              className={styles.entityLink}
+            >
+              {conversation.rescueName}
+            </Link>
+          ) : (
+            conversation.rescueName
+          )}
+        </div>
       </div>
     )}
 
     {conversation.petId && (
       <div className={styles.detailItem}>
         <div className={styles.detailLabel}>Pet ID</div>
-        <div className={styles.detailValue}>{conversation.petId}</div>
+        <div className={styles.detailValue}>
+          <Link to={`/pets/${conversation.petId}`} onClick={onClose} className={styles.entityLink}>
+            {conversation.petId}
+          </Link>
+        </div>
       </div>
     )}
 

--- a/app.admin/src/components/modals/ChatDetailModal/ParticipantsTab.test.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/ParticipantsTab.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '../../../test-utils';
+import { ParticipantsTab } from './ParticipantsTab';
+import type { Participant } from '@adopt-dont-shop/lib.chat';
+
+const buildParticipant = (overrides: Partial<Participant> = {}): Participant => ({
+  id: 'user-1',
+  name: 'Alice Adopter',
+  type: 'user',
+  ...overrides,
+});
+
+describe('ParticipantsTab', () => {
+  it('renders the empty state when there are no participants', () => {
+    render(<ParticipantsTab participants={[]} onClose={vi.fn()} />);
+    expect(screen.getByText('No participants found')).toBeInTheDocument();
+  });
+
+  it('renders the participant name as a link to the user detail route', () => {
+    render(
+      <ParticipantsTab participants={[buildParticipant({ id: 'user-42' })]} onClose={vi.fn()} />
+    );
+    const link = screen.getByRole('link', { name: 'Alice Adopter' });
+    expect(link).toHaveAttribute('href', '/users/user-42');
+  });
+
+  it('calls onClose when a participant link is clicked so the modal closes before navigating', () => {
+    const onClose = vi.fn();
+    render(<ParticipantsTab participants={[buildParticipant()]} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Alice Adopter' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to plain text when the participant has no id', () => {
+    render(
+      <ParticipantsTab
+        participants={[buildParticipant({ id: '', name: 'Anonymous' })]}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('link', { name: 'Anonymous' })).not.toBeInTheDocument();
+    expect(screen.getByText('Anonymous')).toBeInTheDocument();
+  });
+});

--- a/app.admin/src/components/modals/ChatDetailModal/ParticipantsTab.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/ParticipantsTab.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import * as styles from '../ChatDetailModal.css';
 import { type Participant } from '@adopt-dont-shop/lib.chat';
 import { FiUsers } from 'react-icons/fi';
 
 type ParticipantsTabProps = {
   participants: Participant[];
+  onClose: () => void;
 };
 
 const getInitials = (name: string) =>
@@ -15,7 +17,7 @@ const getInitials = (name: string) =>
     .toUpperCase()
     .slice(0, 2);
 
-export const ParticipantsTab: React.FC<ParticipantsTabProps> = ({ participants }) => {
+export const ParticipantsTab: React.FC<ParticipantsTabProps> = ({ participants, onClose }) => {
   if (participants.length === 0) {
     return (
       <div className={styles.emptyState}>
@@ -31,7 +33,19 @@ export const ParticipantsTab: React.FC<ParticipantsTabProps> = ({ participants }
         <div key={participant.id} className={styles.participantCard}>
           <div className={styles.participantAvatar}>{getInitials(participant.name)}</div>
           <div className={styles.participantInfo}>
-            <div className={styles.participantName}>{participant.name}</div>
+            <div className={styles.participantName}>
+              {participant.id ? (
+                <Link
+                  to={`/users/${participant.id}`}
+                  onClick={onClose}
+                  className={styles.entityLink}
+                >
+                  {participant.name}
+                </Link>
+              ) : (
+                participant.name
+              )}
+            </div>
             <div className={styles.participantRole}>{participant.type}</div>
           </div>
         </div>

--- a/app.admin/src/components/modals/ChatDetailModal/index.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/index.tsx
@@ -174,10 +174,14 @@ export const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
                 <MessagesTab chatId={chatId} onMessageDeleted={onUpdate} />
               )}
               {activeTab === 'participants' && conversation && (
-                <ParticipantsTab participants={conversation.participants} />
+                <ParticipantsTab participants={conversation.participants} onClose={onClose} />
               )}
               {activeTab === 'details' && conversation && (
-                <DetailsTab conversation={conversation} getStatusBadge={getStatusBadge} />
+                <DetailsTab
+                  conversation={conversation}
+                  getStatusBadge={getStatusBadge}
+                  onClose={onClose}
+                />
               )}
               {activeTab === 'moderation' && conversation && (
                 <ModerationTab chat={conversation} chatId={chatId} />

--- a/app.admin/src/components/modals/TicketDetailModal.css.ts
+++ b/app.admin/src/components/modals/TicketDetailModal.css.ts
@@ -259,3 +259,12 @@ export const internalNotesLabel = style({
 export const internalBadgeSpacing = style({
   marginLeft: '0.5rem',
 });
+
+export const userLink = style({
+  color: '#2563eb',
+  textDecoration: 'none',
+  fontWeight: 'inherit',
+  ':hover': {
+    textDecoration: 'underline',
+  },
+});

--- a/app.admin/src/components/modals/TicketDetailModal.test.tsx
+++ b/app.admin/src/components/modals/TicketDetailModal.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '../../test-utils';
+import { TicketDetailModal } from './TicketDetailModal';
+import { SupportTicketSchema, type SupportTicket } from '@adopt-dont-shop/lib.support-tickets';
+
+const buildTicket = (overrides: Record<string, unknown> = {}): SupportTicket =>
+  SupportTicketSchema.parse({
+    ticketId: 'tkt-1',
+    userId: 'user-99',
+    userEmail: 'jane@example.com',
+    userName: 'Jane Doe',
+    subject: 'Help me please',
+    description: 'Something is wrong with my account',
+    category: 'general_question',
+    status: 'open',
+    priority: 'normal',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    responses: [],
+    ...overrides,
+  });
+
+describe('TicketDetailModal', () => {
+  it('renders the customer name as a link to the user detail route', () => {
+    render(<TicketDetailModal isOpen onClose={vi.fn()} ticket={buildTicket()} onReply={vi.fn()} />);
+    const link = screen.getByRole('link', { name: 'Jane Doe' });
+    expect(link).toHaveAttribute('href', '/users/user-99');
+  });
+
+  it('calls onClose when the customer link is clicked', () => {
+    const onClose = vi.fn();
+    render(<TicketDetailModal isOpen onClose={onClose} ticket={buildTicket()} onReply={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Jane Doe' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to plain text when the ticket has no userId', () => {
+    render(
+      <TicketDetailModal
+        isOpen
+        onClose={vi.fn()}
+        ticket={buildTicket({ userId: null })}
+        onReply={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('link', { name: 'Jane Doe' })).not.toBeInTheDocument();
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+  });
+});

--- a/app.admin/src/components/modals/TicketDetailModal.tsx
+++ b/app.admin/src/components/modals/TicketDetailModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Modal, Button } from '@adopt-dont-shop/lib.components';
 import {
   type SupportTicket,
@@ -86,6 +87,20 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
   const statusColors = statusColorMap[ticket.status] || statusColorMap.open;
   const priorityColors = priorityColorMap[ticket.priority] || priorityColorMap.normal;
 
+  const renderCustomer = () => {
+    if (!ticket.userName) {
+      return <span className={styles.emptyValue}>Not provided</span>;
+    }
+    if (ticket.userId) {
+      return (
+        <Link to={`/users/${ticket.userId}`} onClick={onClose} className={styles.userLink}>
+          {ticket.userName}
+        </Link>
+      );
+    }
+    return ticket.userName;
+  };
+
   return (
     <Modal
       isOpen={isOpen}
@@ -130,9 +145,7 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
               <FiUser />
               Customer
             </div>
-            <div className={styles.detailValue}>
-              {ticket.userName || <span className={styles.emptyValue}>Not provided</span>}
-            </div>
+            <div className={styles.detailValue}>{renderCustomer()}</div>
             <div className={clsx(styles.detailValue, styles.detailValueSecondary)}>
               {ticket.userEmail}
             </div>


### PR DESCRIPTION
## Summary

- Participant names in `ChatDetailModal/ParticipantsTab` link to `/users/<id>`, fall back to plain text when no id.
- `rescueName` in `DetailsTab` links to `/rescues/<rescueId>`; `petId` links to `/pets/<petId>`.
- `ticket.userName` in `TicketDetailModal` links to `/users/<userId>` when present.
- All links call modal `onClose` before navigating so admin doesn't land behind the overlay.

## Trade-offs

- Pet link uses raw id as text — pet name not present on `Conversation` schema. No new API call per scope constraint.
- Rescue participants currently linked via `/users/<id>` matching `ModerationTab` precedent. Underlying schema question (is `participant.id` actually a rescue id for type=rescue?) deferred.

## Test plan

- [x] 20 passing tests across 3 new test files
- [x] `npx tsc --noEmit` — clean on changed files
- [ ] Manual: open chat modal, click participant → user page
- [ ] Manual: open chat modal, click rescue → rescue page
- [ ] Manual: open ticket modal, click user → user page

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>