### PR TITLE
feat(app.admin): add breadcrumb and prev/next navigation to detail modals

### DIFF
--- a/app.admin/src/components/modals/ChatDetailModal.test.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Smoke test for the ChatDetailModal breadcrumb header.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '../../test-utils';
+import { ChatDetailModal } from './ChatDetailModal/index';
+
+vi.mock('@adopt-dont-shop/lib.chat', () => ({
+  useAdminChatById: () => ({
+    data: {
+      id: 'chat-1234567890abcdef',
+      status: 'active',
+      participants: [],
+    },
+    isLoading: false,
+  }),
+  useAdminChatMessages: () => ({
+    data: { data: [], pagination: { page: 1, limit: 50, total: 0, totalPages: 0 } },
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+  useAdminChatMutations: () => ({
+    deleteChat: { mutateAsync: vi.fn() },
+    updateChatStatus: { mutateAsync: vi.fn() },
+    deleteMessage: { mutateAsync: vi.fn() },
+  }),
+}));
+
+describe('ChatDetailModal — breadcrumb header', () => {
+  it('renders Messages root link and the current chat label as the last segment', () => {
+    render(<ChatDetailModal isOpen onClose={vi.fn()} chatId='chat-1234567890abcdef' />);
+
+    const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i });
+
+    const messagesLink = within(breadcrumb).getByRole('link', { name: 'Messages' });
+    expect(messagesLink).toHaveAttribute('href', '/messages');
+
+    // Current segment includes the last 8 chars of the chat id, no link
+    expect(within(breadcrumb).queryByRole('link', { name: /Chat #/ })).toBeNull();
+    expect(within(breadcrumb).getByText(/Chat #90abcdef/)).toBeInTheDocument();
+  });
+});

--- a/app.admin/src/components/modals/ChatDetailModal/index.tsx
+++ b/app.admin/src/components/modals/ChatDetailModal/index.tsx
@@ -19,12 +19,17 @@ import { MessagesTab } from './MessagesTab';
 import { ParticipantsTab } from './ParticipantsTab';
 import { DetailsTab } from './DetailsTab';
 import { ModerationTab } from './ModerationTab';
+import { ModalBreadcrumbNav, type BreadcrumbSegment } from '../ModalBreadcrumbNav';
 
 type ChatDetailModalProps = {
   isOpen: boolean;
   onClose: () => void;
   chatId: string | null;
   onUpdate?: () => void;
+  /** Optional list of sibling chat IDs (in display order) to enable prev/next navigation. */
+  siblingIds?: ReadonlyArray<string>;
+  /** Called when prev/next is clicked, passes the target chat ID. */
+  onNavigate?: (chatId: string) => void;
 };
 
 type TabType = 'messages' | 'participants' | 'details' | 'moderation';
@@ -47,6 +52,8 @@ export const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
   onClose,
   chatId,
   onUpdate,
+  siblingIds,
+  onNavigate,
 }) => {
   const [activeTab, setActiveTab] = useState<TabType>('messages');
   const { confirm, confirmProps } = useConfirm();
@@ -118,9 +125,25 @@ export const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
     }
   };
 
+  const statusFilter = conversation?.status ?? 'active';
+  const breadcrumbSegments: ReadonlyArray<BreadcrumbSegment> = [
+    { label: 'Messages', to: '/messages' },
+    {
+      label: statusFilter.charAt(0).toUpperCase() + statusFilter.slice(1),
+      to: `/messages?status=${statusFilter}`,
+    },
+    { label: `Chat #${chatId.slice(-8)}` },
+  ];
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size='xl'>
       <div className={styles.modalContent}>
+        <ModalBreadcrumbNav
+          segments={breadcrumbSegments}
+          siblingIds={siblingIds}
+          currentId={chatId}
+          onNavigate={onNavigate}
+        />
         <div className={styles.chatHeader}>
           <div className={styles.chatTitle}>
             <FiMessageSquare />

--- a/app.admin/src/components/modals/ModalBreadcrumbNav.css.ts
+++ b/app.admin/src/components/modals/ModalBreadcrumbNav.css.ts
@@ -1,0 +1,81 @@
+import { style } from '@vanilla-extract/css';
+
+export const wrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '1rem',
+  padding: '0.5rem 0 1rem 0',
+  borderBottom: '1px solid #e5e7eb',
+  marginBottom: '1rem',
+});
+
+export const breadcrumb = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.375rem',
+  flexWrap: 'wrap',
+  fontSize: '0.8125rem',
+  color: '#6b7280',
+  minWidth: 0,
+});
+
+export const segmentLink = style({
+  color: '#4b5563',
+  textDecoration: 'none',
+  borderRadius: '4px',
+  padding: '0.125rem 0.25rem',
+  ':hover': {
+    color: '#111827',
+    textDecoration: 'underline',
+  },
+  ':focus-visible': {
+    outline: '2px solid #667eea',
+    outlineOffset: '2px',
+  },
+});
+
+export const segmentCurrent = style({
+  color: '#111827',
+  fontWeight: 600,
+});
+
+export const separator = style({
+  color: '#9ca3af',
+  userSelect: 'none',
+});
+
+export const navButtons = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.25rem',
+  flexShrink: 0,
+});
+
+export const navButton = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '2rem',
+  height: '2rem',
+  padding: 0,
+  background: '#ffffff',
+  border: '1px solid #d1d5db',
+  borderRadius: '6px',
+  color: '#374151',
+  cursor: 'pointer',
+  transition: 'all 0.15s ease',
+  ':hover': {
+    background: '#f3f4f6',
+    borderColor: '#9ca3af',
+  },
+  ':focus-visible': {
+    outline: '2px solid #667eea',
+    outlineOffset: '2px',
+  },
+  ':disabled': {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+    background: '#f9fafb',
+  },
+});

--- a/app.admin/src/components/modals/ModalBreadcrumbNav.test.tsx
+++ b/app.admin/src/components/modals/ModalBreadcrumbNav.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import { ModalBreadcrumbNav } from './ModalBreadcrumbNav';
+
+describe('ModalBreadcrumbNav', () => {
+  it('renders all segment labels in order', () => {
+    render(
+      <ModalBreadcrumbNav
+        segments={[
+          { label: 'Tickets', to: '/support' },
+          { label: 'Open', to: '/support?status=open' },
+          { label: 'Ticket #1234' },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Tickets')).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Ticket #1234')).toBeInTheDocument();
+  });
+
+  it('renders non-last segments with a `to` as links to that path', () => {
+    render(
+      <ModalBreadcrumbNav
+        segments={[
+          { label: 'Tickets', to: '/support' },
+          { label: 'Open', to: '/support?status=open' },
+          { label: 'Ticket #1234' },
+        ]}
+      />
+    );
+
+    const ticketsLink = screen.getByRole('link', { name: 'Tickets' });
+    expect(ticketsLink).toHaveAttribute('href', '/support');
+
+    const openLink = screen.getByRole('link', { name: 'Open' });
+    expect(openLink).toHaveAttribute('href', '/support?status=open');
+  });
+
+  it('renders the last segment as plain text (not a link) and marks it aria-current="page"', () => {
+    render(
+      <ModalBreadcrumbNav
+        segments={[{ label: 'Tickets', to: '/support' }, { label: 'Ticket #1234' }]}
+      />
+    );
+
+    expect(screen.queryByRole('link', { name: 'Ticket #1234' })).toBeNull();
+    const current = screen.getByText('Ticket #1234');
+    expect(current).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not render prev/next when siblingIds are not provided', () => {
+    render(<ModalBreadcrumbNav segments={[{ label: 'Tickets' }, { label: 'Ticket #1' }]} />);
+
+    expect(screen.queryByRole('button', { name: /previous item/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /next item/i })).toBeNull();
+  });
+
+  it('does not render prev/next when only a single sibling is provided', () => {
+    render(
+      <ModalBreadcrumbNav
+        segments={[{ label: 'Tickets' }, { label: 'Ticket #1' }]}
+        siblingIds={['only-id']}
+        currentId='only-id'
+        onNavigate={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /previous item/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /next item/i })).toBeNull();
+  });
+
+  it('invokes onNavigate with the previous sibling id when prev is clicked', async () => {
+    const onNavigate = vi.fn();
+    render(
+      <ModalBreadcrumbNav
+        segments={[{ label: 'Tickets' }, { label: 'Ticket #2' }]}
+        siblingIds={['t1', 't2', 't3']}
+        currentId='t2'
+        onNavigate={onNavigate}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /previous item/i }));
+    expect(onNavigate).toHaveBeenCalledWith('t1');
+  });
+
+  it('invokes onNavigate with the next sibling id when next is clicked', async () => {
+    const onNavigate = vi.fn();
+    render(
+      <ModalBreadcrumbNav
+        segments={[{ label: 'Tickets' }, { label: 'Ticket #2' }]}
+        siblingIds={['t1', 't2', 't3']}
+        currentId='t2'
+        onNavigate={onNavigate}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /next item/i }));
+    expect(onNavigate).toHaveBeenCalledWith('t3');
+  });
+
+  it('disables prev when on the first sibling', () => {
+    render(
+      <ModalBreadcrumbNav
+        segments={[{ label: 'Tickets' }, { label: 'Ticket #1' }]}
+        siblingIds={['t1', 't2', 't3']}
+        currentId='t1'
+        onNavigate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /previous item/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /next item/i })).not.toBeDisabled();
+  });
+
+  it('disables next when on the last sibling', () => {
+    render(
+      <ModalBreadcrumbNav
+        segments={[{ label: 'Tickets' }, { label: 'Ticket #3' }]}
+        siblingIds={['t1', 't2', 't3']}
+        currentId='t3'
+        onNavigate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /next item/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /previous item/i })).not.toBeDisabled();
+  });
+});

--- a/app.admin/src/components/modals/ModalBreadcrumbNav.tsx
+++ b/app.admin/src/components/modals/ModalBreadcrumbNav.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { FiChevronLeft, FiChevronRight } from 'react-icons/fi';
+import * as styles from './ModalBreadcrumbNav.css';
+
+export type BreadcrumbSegment = {
+  label: string;
+  /** When provided and this is not the last segment, the segment renders as a Link to this path. */
+  to?: string;
+};
+
+export type ModalBreadcrumbNavProps = {
+  segments: ReadonlyArray<BreadcrumbSegment>;
+  /** When provided alongside currentId and onNavigate, renders prev/next buttons. */
+  siblingIds?: ReadonlyArray<string>;
+  currentId?: string;
+  onNavigate?: (siblingId: string) => void;
+};
+
+export const ModalBreadcrumbNav: React.FC<ModalBreadcrumbNavProps> = ({
+  segments,
+  siblingIds,
+  currentId,
+  onNavigate,
+}) => {
+  const hasNav =
+    siblingIds !== undefined &&
+    currentId !== undefined &&
+    onNavigate !== undefined &&
+    siblingIds.length > 1;
+
+  const currentIndex = hasNav ? siblingIds.indexOf(currentId) : -1;
+  const prevId = hasNav && currentIndex > 0 ? siblingIds[currentIndex - 1] : undefined;
+  const nextId =
+    hasNav && currentIndex >= 0 && currentIndex < siblingIds.length - 1
+      ? siblingIds[currentIndex + 1]
+      : undefined;
+
+  const handlePrev = () => {
+    if (prevId !== undefined && onNavigate) {
+      onNavigate(prevId);
+    }
+  };
+
+  const handleNext = () => {
+    if (nextId !== undefined && onNavigate) {
+      onNavigate(nextId);
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <nav className={styles.breadcrumb} aria-label='Breadcrumb'>
+        {segments.map((segment, index) => {
+          const isLast = index === segments.length - 1;
+          const showLink = !isLast && segment.to !== undefined;
+          return (
+            <React.Fragment key={`${segment.label}-${index}`}>
+              {showLink && segment.to !== undefined ? (
+                <Link to={segment.to} className={styles.segmentLink}>
+                  {segment.label}
+                </Link>
+              ) : (
+                <span
+                  className={isLast ? styles.segmentCurrent : styles.segmentLink}
+                  aria-current={isLast ? 'page' : undefined}
+                >
+                  {segment.label}
+                </span>
+              )}
+              {!isLast && (
+                <span className={styles.separator} aria-hidden='true'>
+                  /
+                </span>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </nav>
+
+      {hasNav && (
+        <div className={styles.navButtons}>
+          <button
+            type='button'
+            className={styles.navButton}
+            onClick={handlePrev}
+            disabled={prevId === undefined}
+            aria-label='Previous item'
+          >
+            <FiChevronLeft />
+          </button>
+          <button
+            type='button'
+            className={styles.navButton}
+            onClick={handleNext}
+            disabled={nextId === undefined}
+            aria-label='Next item'
+          >
+            <FiChevronRight />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/app.admin/src/components/modals/TicketDetailModal.test.tsx
+++ b/app.admin/src/components/modals/TicketDetailModal.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Smoke tests covering the breadcrumb / prev-next navigation that the modal
+ * exposes on top of its existing ticket detail body.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import { TicketDetailModal } from './TicketDetailModal';
+import type { SupportTicket } from '@adopt-dont-shop/lib.support-tickets';
+
+const makeTicket = (overrides: Partial<SupportTicket> = {}): SupportTicket => ({
+  ticketId: 'ticket_1700000000_abcdef',
+  userId: 'user-1',
+  userEmail: 'user@example.com',
+  userName: 'Test User',
+  assignedTo: null,
+  status: 'open',
+  priority: 'normal',
+  category: 'general_question',
+  subject: 'Question about adoptions',
+  description: 'Hello, I have a question about how adoptions work on this platform.',
+  tags: [],
+  responses: [],
+  attachments: [],
+  metadata: {},
+  firstResponseAt: null,
+  lastResponseAt: null,
+  resolvedAt: null,
+  closedAt: null,
+  escalatedAt: null,
+  escalatedTo: null,
+  escalationReason: null,
+  satisfactionRating: null,
+  satisfactionFeedback: null,
+  internalNotes: null,
+  dueDate: null,
+  estimatedResolutionTime: null,
+  actualResolutionTime: null,
+  createdAt: new Date('2024-02-01T10:00:00Z'),
+  updatedAt: new Date('2024-02-01T10:00:00Z'),
+  ...overrides,
+});
+
+describe('TicketDetailModal — breadcrumb navigation', () => {
+  it('renders breadcrumb segments linking back to the support list and current status', () => {
+    const ticket = makeTicket();
+    render(
+      <TicketDetailModal
+        isOpen
+        onClose={vi.fn()}
+        ticket={ticket}
+        onReply={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    const ticketsLink = screen.getByRole('link', { name: 'Tickets' });
+    expect(ticketsLink).toHaveAttribute('href', '/support');
+
+    const statusLink = screen.getByRole('link', { name: 'Open' });
+    expect(statusLink).toHaveAttribute('href', '/support?status=open');
+  });
+
+  it('navigates to the next sibling when the next button is clicked', async () => {
+    const onNavigate = vi.fn();
+    const ticket = makeTicket({ ticketId: 'ticket_b' });
+    render(
+      <TicketDetailModal
+        isOpen
+        onClose={vi.fn()}
+        ticket={ticket}
+        onReply={vi.fn().mockResolvedValue(undefined)}
+        siblingIds={['ticket_a', 'ticket_b', 'ticket_c']}
+        onNavigate={onNavigate}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /next item/i }));
+    expect(onNavigate).toHaveBeenCalledWith('ticket_c');
+  });
+
+  it('disables next when the current ticket is the last sibling', () => {
+    const ticket = makeTicket({ ticketId: 'ticket_c' });
+    render(
+      <TicketDetailModal
+        isOpen
+        onClose={vi.fn()}
+        ticket={ticket}
+        onReply={vi.fn().mockResolvedValue(undefined)}
+        siblingIds={['ticket_a', 'ticket_b', 'ticket_c']}
+        onNavigate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /next item/i })).toBeDisabled();
+  });
+});

--- a/app.admin/src/components/modals/TicketDetailModal.tsx
+++ b/app.admin/src/components/modals/TicketDetailModal.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react-icons/fi';
 import clsx from 'clsx';
 import * as styles from './TicketDetailModal.css';
+import { ModalBreadcrumbNav, type BreadcrumbSegment } from './ModalBreadcrumbNav';
 
 type TicketDetailModalProps = {
   isOpen: boolean;
@@ -29,6 +30,10 @@ type TicketDetailModalProps = {
   onReply: (content: string, isInternal: boolean) => Promise<void>;
   onStatusChange?: (status: string) => Promise<void>;
   onPriorityChange?: (priority: string) => Promise<void>;
+  /** Optional list of sibling ticket IDs (in display order) to enable prev/next navigation. */
+  siblingIds?: ReadonlyArray<string>;
+  /** Called when prev/next is clicked, passes the target ticket ID. */
+  onNavigate?: (ticketId: string) => void;
 };
 
 export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
@@ -38,6 +43,8 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
   onReply,
   onStatusChange,
   onPriorityChange,
+  siblingIds,
+  onNavigate,
 }) => {
   const [replyContent, setReplyContent] = useState('');
   const [isInternal, setIsInternal] = useState(false);
@@ -86,6 +93,12 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
   const statusColors = statusColorMap[ticket.status] || statusColorMap.open;
   const priorityColors = priorityColorMap[ticket.priority] || priorityColorMap.normal;
 
+  const breadcrumbSegments: ReadonlyArray<BreadcrumbSegment> = [
+    { label: 'Tickets', to: '/support' },
+    { label: getStatusLabel(ticket.status), to: `/support?status=${ticket.status}` },
+    { label: formatTicketId(ticket.ticketId) },
+  ];
+
   return (
     <Modal
       isOpen={isOpen}
@@ -97,6 +110,12 @@ export const TicketDetailModal: React.FC<TicketDetailModalProps> = ({
       closeOnEscape={!isSubmitting}
     >
       <div className={styles.detailSection}>
+        <ModalBreadcrumbNav
+          segments={breadcrumbSegments}
+          siblingIds={siblingIds}
+          currentId={ticket.ticketId}
+          onNavigate={onNavigate}
+        />
         <div className={styles.ticketHeader}>
           <div>
             <div className={styles.ticketId}>{formatTicketId(ticket.ticketId)}</div>

--- a/app.admin/src/components/moderation/ReportDetailModal.test.tsx
+++ b/app.admin/src/components/moderation/ReportDetailModal.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '../../test-utils';
 import { ReportDetailModal } from './ReportDetailModal';
 import type {
   Report,
@@ -159,5 +159,27 @@ describe('ReportDetailModal — prior history and active sanctions', () => {
     expect(screen.queryByTestId('no-prior-history')).not.toBeInTheDocument();
     expect(screen.queryByTestId('active-sanctions-list')).not.toBeInTheDocument();
     expect(screen.queryByTestId('no-active-sanctions')).not.toBeInTheDocument();
+  });
+
+  it('renders the breadcrumb header with Moderation root link', () => {
+    const current = makeReport();
+    mockUseReports.mockReturnValue({
+      data: { data: [], pagination: { page: 1, limit: 10, total: 0, totalPages: 0 } },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockUseActiveActions.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<ReportDetailModal isOpen onClose={() => undefined} report={current} />);
+
+    const moderationLink = screen.getByRole('link', { name: 'Moderation' });
+    expect(moderationLink).toHaveAttribute('href', '/moderation');
+    expect(screen.getByText(/Report #report-c/)).toBeInTheDocument();
   });
 });

--- a/app.admin/src/components/moderation/ReportDetailModal.tsx
+++ b/app.admin/src/components/moderation/ReportDetailModal.tsx
@@ -21,11 +21,16 @@ import {
   useActiveActions,
 } from '@adopt-dont-shop/lib.moderation';
 import * as styles from './ReportDetailModal.css';
+import { ModalBreadcrumbNav, type BreadcrumbSegment } from '../modals/ModalBreadcrumbNav';
 
 export interface ReportDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   report: Report | null;
+  /** Optional list of sibling report IDs (in display order) to enable prev/next navigation. */
+  siblingIds?: ReadonlyArray<string>;
+  /** Called when prev/next is clicked, passes the target report ID. */
+  onNavigate?: (reportId: string) => void;
 }
 
 const getStatusBadgeClass = (
@@ -203,6 +208,8 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
   isOpen,
   onClose,
   report,
+  siblingIds,
+  onNavigate,
 }) => {
   if (!report) {
     return null;
@@ -235,6 +242,12 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
     }
   };
 
+  const breadcrumbSegments: ReadonlyArray<BreadcrumbSegment> = [
+    { label: 'Moderation', to: '/moderation' },
+    { label: getStatusLabel(report.status), to: `/moderation?status=${report.status}` },
+    { label: `Report #${report.reportId.substring(0, 8)}` },
+  ];
+
   return (
     <div
       className={clsx(styles.overlay, !isOpen && styles.overlayHidden)}
@@ -257,6 +270,12 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
         </div>
 
         <div className={styles.modalBody}>
+          <ModalBreadcrumbNav
+            segments={breadcrumbSegments}
+            siblingIds={siblingIds}
+            currentId={report.reportId}
+            onNavigate={onNavigate}
+          />
           <div className={styles.section}>
             <h3 className={styles.sectionTitle}>
               <FiAlertTriangle size={16} />

--- a/app.admin/src/pages/Support.tsx
+++ b/app.admin/src/pages/Support.tsx
@@ -142,6 +142,15 @@ const Support: React.FC = () => {
   const totalPages = ticketsData?.pagination?.totalPages ?? 1;
   const loading = ticketsLoading;
 
+  const ticketSiblingIds = useMemo(() => tickets.map(t => t.ticketId), [tickets]);
+
+  const handleNavigateTicket = (ticketId: string) => {
+    const nextTicket = tickets.find(t => t.ticketId === ticketId);
+    if (nextTicket) {
+      setSelectedTicket(nextTicket);
+    }
+  };
+
   // Stats from API
   const stats = {
     open: statsData?.open || 0,
@@ -397,6 +406,8 @@ const Support: React.FC = () => {
         onClose={() => setSelectedTicket(null)}
         ticket={selectedTicket}
         onReply={handleReply}
+        siblingIds={ticketSiblingIds}
+        onNavigate={handleNavigateTicket}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- New shared `ModalBreadcrumbNav` component rendered at top of `ChatDetailModal`, `TicketDetailModal`, `ReportDetailModal`
- Each breadcrumb segment except last is a `Link` back to relevant list page with `?status=` filter when known
- `TicketDetailModal` wires prev/next arrows via `siblingIds` + `onNavigate` props — `Support` page passes currently-loaded ticket IDs so admin can step through queue without closing modal
- Chat and Report modals expose same optional props but parents not wired up — breadcrumb only for those two (per task trade-off: avoid half-finished prev/next across all three)

## Test plan

- [x] 17 tests pass across 4 files (ModalBreadcrumbNav, TicketDetailModal, ChatDetailModal, ReportDetailModal)
- [x] `npx tsc --noEmit` — no new errors
- [ ] Manual: open ticket from `/support`, breadcrumb shows "Tickets / <Status> / TICK-…", prev/next steps through siblings + disables at boundaries
- [ ] Manual: open chat from `/messages` + report from `/moderation` — breadcrumb appears, close unchanged

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>