### PR TITLE
docs(ops): pre-launch secret rotation runbook + staging-reuse CI gate (ADS-659)

### DIFF
--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -24,6 +24,80 @@ the operator-side steps that the compose file alone doesn't capture.
    `api.${PROD_HOSTNAME}`, `admin.${PROD_HOSTNAME}`, `rescue.${PROD_HOSTNAME}`
    pointing at the host.
 
+## Pre-launch secret rotation
+
+Run this section **before the first production deploy** and whenever a secret may
+have been compromised.
+
+### 1. Generate fresh production secrets
+
+```bash
+npm run secrets:generate
+```
+
+Copy the output into your production `.env` (or secrets manager). Each run produces
+cryptographically random values — **do not re-use values from staging or development**.
+
+The six application secrets that must be rotated for every new environment:
+
+| Variable | Purpose |
+|---|---|
+| `JWT_SECRET` | Signs short-lived access tokens |
+| `JWT_REFRESH_SECRET` | Signs long-lived refresh tokens |
+| `SESSION_SECRET` | Encrypts server-side sessions |
+| `CSRF_SECRET` | Signs CSRF tokens |
+| `ENCRYPTION_KEY` | AES-256-GCM key for PII fields (must be 64 hex chars / 32 bytes) |
+| `UPLOAD_SIGNING_SECRET` | Signs upload URLs |
+
+Regenerate `POSTGRES_PASSWORD` and `REDIS_PASSWORD` too if they carried over from a
+development or staging environment.
+
+### 2. Verify secrets are valid and distinct
+
+`validate-env.mjs` enforces that all six secrets are present, at least 32 characters
+long, not a placeholder (`CHANGE_THIS…`), and distinct from each other. Run it against
+your production env file before deploying:
+
+```bash
+# Validate a named file
+NODE_ENV=production npm run validate:env -- --env-file=.env.prod
+
+# Or with secrets already in the environment (CI)
+NODE_ENV=production npm run validate:env
+```
+
+A non-zero exit means at least one secret is missing, too short, uses a placeholder
+value, or is duplicated across secrets — fix it before proceeding.
+
+### 3. Confirm staging values are not reused
+
+`validate-env.mjs` already rejects known placeholder patterns. For an extra check,
+verify that no production secret shares a value with your staging env file:
+
+```bash
+# Any output here means a secret is shared between staging and prod — must fix.
+comm -12 \
+  <(grep -E '^(JWT_SECRET|JWT_REFRESH_SECRET|SESSION_SECRET|CSRF_SECRET|ENCRYPTION_KEY|UPLOAD_SIGNING_SECRET)=' .env.staging | sort) \
+  <(grep -E '^(JWT_SECRET|JWT_REFRESH_SECRET|SESSION_SECRET|CSRF_SECRET|ENCRYPTION_KEY|UPLOAD_SIGNING_SECRET)=' .env.prod    | sort)
+```
+
+Expected output: (empty — no shared values).
+
+### 4. Log the rotation
+
+Record the rotation date, who performed it, and the reason in your secrets manager
+or secured ops log. At minimum: `date`, `rotated_by`, `reason`.
+
+### Rotation cadence
+
+| Trigger | Action |
+|---|---|
+| Initial production launch | Full rotation of all six application secrets |
+| Quarterly (~every 90 days) | Full rotation of all six application secrets |
+| Suspected compromise | Immediate rotation of affected secret(s); full rotation if scope is unclear |
+| Team member off-boarding | Rotate any secret the person had access to |
+| Staging value detected in prod | Immediate full rotation |
+
 ## Release deploy
 
 The `service-backend-migrate` init container runs `npm run db:migrate`

--- a/scripts/validate-env.mjs
+++ b/scripts/validate-env.mjs
@@ -10,6 +10,9 @@
  *  3. Diffs the active env against root /.env.example so missing or stale
  *     keys surface before deploy.
  *  4. Exits non-zero on any error so it can run as a CI gate.
+ *  5. Optional --staging-env=PATH: fails if any of the six application secrets
+ *     share a value with the staging env (prevents staging→prod secret reuse,
+ *     ADS-659).
  *
  * Keep the rule set in sync with service.backend/src/utils/validate-env.ts.
  * The two implementations validate the same secrets so operators get the same
@@ -306,13 +309,44 @@ function diffAgainstExample(env, examplePath) {
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
+// Staging-reuse check (ADS-659)
+// Fails if any of the six application secrets share a value with a staging env.
+// ---------------------------------------------------------------------------
+const SECRET_VARS = [
+  'JWT_SECRET',
+  'JWT_REFRESH_SECRET',
+  'SESSION_SECRET',
+  'CSRF_SECRET',
+  'ENCRYPTION_KEY',
+  'UPLOAD_SIGNING_SECRET',
+];
+
+function checkStagingReuse(prodEnv, stagingPath, errors) {
+  const stagingEnv = loadEnvFile(stagingPath);
+  if (!stagingEnv) {
+    log.warn(`--staging-env file not found at ${stagingPath}; skipping reuse check`);
+    return;
+  }
+  for (const key of SECRET_VARS) {
+    const prodVal = prodEnv[key];
+    const stagingVal = stagingEnv[key];
+    if (prodVal && stagingVal && prodVal === stagingVal) {
+      errors.push(
+        `${key} is identical in production and staging — rotate before deploying`
+      );
+    }
+  }
+}
+
 function parseArgs(argv) {
-  const args = { envFile: null, examplePath: null, json: false };
+  const args = { envFile: null, examplePath: null, stagingEnv: null, json: false };
   for (const arg of argv.slice(2)) {
     if (arg.startsWith('--env-file=')) {
       args.envFile = arg.slice('--env-file='.length);
     } else if (arg.startsWith('--example=')) {
       args.examplePath = arg.slice('--example='.length);
+    } else if (arg.startsWith('--staging-env=')) {
+      args.stagingEnv = arg.slice('--staging-env='.length);
     } else if (arg === '--json') {
       args.json = true;
     }
@@ -326,10 +360,12 @@ function main() {
   const examplePath = args.examplePath
     ? path.resolve(args.examplePath)
     : path.join(rootDir, '.env.example');
-
   log.title('Environment / secret validation');
   log.info(`env file:    ${envFile}`);
   log.info(`example:     ${examplePath}`);
+  if (args.stagingEnv) {
+    log.info(`staging env: ${path.resolve(args.stagingEnv)}`);
+  }
 
   const fileEnv = loadEnvFile(envFile);
   // Merge file env on top of process.env so `STATSIG_SERVER_SECRET_KEY=foo
@@ -342,6 +378,10 @@ function main() {
   }
 
   const { errors, warnings } = validate(env);
+
+  if (args.stagingEnv) {
+    checkStagingReuse(env, path.resolve(args.stagingEnv), errors);
+  }
   const { missing, examplePath: foundExample } = diffAgainstExample(env, examplePath);
 
   if (foundExample && missing.length > 0) {


### PR DESCRIPTION
## Summary

- Adds a **Pre-launch secret rotation** section to `docs/operations/deploy.md` covering: generating fresh secrets, validating with `validate-env.mjs`, cross-checking no staging values were reused, logging the rotation, and rotation cadence
- Adds `--staging-env=PATH` flag to `scripts/validate-env.mjs` as an optional CI gate — fails with a clear error if any of the six application secrets share a value with a staging env file

## Motivation

Closes ADS-659. The existing `deploy.md` documented image promotion but had no guidance on secret hygiene before first deploy. Operators could silently carry staging values into production. `validate-env.mjs` already enforced format/distinctness; this PR closes the staging-reuse gap and documents the rotation process end-to-end.

## Changes

**`docs/operations/deploy.md`** — new `## Pre-launch secret rotation` section (placed before `## Release deploy`):
- Step-by-step: generate → validate → staging-reuse check → log
- Rotation cadence table (launch, quarterly, post-incident, off-boarding)

**`scripts/validate-env.mjs`** — `--staging-env=PATH` flag:
- Loads the staging env file and errors if any of `JWT_SECRET`, `JWT_REFRESH_SECRET`, `SESSION_SECRET`, `CSRF_SECRET`, `ENCRYPTION_KEY`, `UPLOAD_SIGNING_SECRET` match the active env
- Gracefully skips with a warning if the file doesn't exist
- Logs the staging env path when supplied

## Test plan

- [ ] `node scripts/validate-env.mjs --help` (check no crash)
- [ ] Create two `.env` files with identical secrets; confirm `--staging-env=` reports all six as identical
- [ ] Create two `.env` files with distinct secrets; confirm `--staging-env=` passes cleanly
- [ ] Read through `docs/operations/deploy.md` pre-launch section for accuracy

https://claude.ai/code/session_01ExCTWKZiMorm3552jyqD9H

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExCTWKZiMorm3552jyqD9H)_