### PR TITLE
fix(husky): add shebang and LF enforcement so hooks run on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,6 +23,7 @@
 
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
+.husky/* text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
+#!/usr/bin/env sh
 npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/usr/bin/env sh
 npx lint-staged


### PR DESCRIPTION
## Summary

- Adds `#!/usr/bin/env sh` to `.husky/pre-commit` and `.husky/commit-msg` so Windows-native git can spawn them
- Pins `.husky/*` to LF in `.gitattributes` to prevent CRLF re-conversion on Windows checkouts

## Why

Without the shebang, Windows git tries to exec the script as a binary and fails with `cannot spawn .husky/pre-commit: Exec format error`. Contributors on Windows have been bypassing with `--no-verify`, which defeats the point of the hooks. macOS/Linux happen to fall back to /bin/sh when there is no shebang, masking the bug.

## Test plan

- [x] Committed this PR through the hook itself — `lint-staged` and `commitlint` both ran successfully on Windows
- [ ] Reviewer on macOS/Linux: confirm hooks still trigger on commit
- [ ] No `.husky` re-conversion warning on fresh checkout

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>