### PR TITLE
feat(app.admin): deep-link pets via /pets/:petId

### DIFF
--- a/app.admin/src/pages/Pets.test.tsx
+++ b/app.admin/src/pages/Pets.test.tsx
@@ -3,17 +3,33 @@
  * the inline error row (introduced by UX #5) in addition to whatever top-of-page
  * error treatment already existed. This pins down the wiring so future
  * refactors don't silently drop the inline affordance.
+ *
+ * Deep-link behaviour (feat/admin-pets-deep-link):
+ * - Visiting /pets/:petId with that pet in the list opens the detail modal.
+ * - Clicking a row updates the URL to /pets/:petId.
+ * - Closing the modal navigates back to /pets, preserving filter query params.
+ * - An unknown petId redirects to /pets without crashing and surfaces a toast.
  */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { ThemeProvider, toast } from '@adopt-dont-shop/lib.components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderWithProviders } from '../test-utils';
+import type { AdminPet } from '../services/petService';
+
+// Mutable state used by the mocked `usePets` hook below.
+let mockPetsResponse: { data: AdminPet[]; pagination?: { pages: number } } | undefined;
+let mockIsLoading = false;
+let mockError: Error | null = null;
 
 vi.mock('../hooks', () => ({
   usePets: () => ({
-    data: undefined,
-    isLoading: false,
-    error: new Error('Failed to fetch pets from server'),
+    data: mockPetsResponse,
+    isLoading: mockIsLoading,
+    error: mockError,
   }),
   useBulkUpdatePets: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useRescuesList: () => ({ data: { data: [] } }),
@@ -21,16 +37,155 @@ vi.mock('../hooks', () => ({
 
 vi.mock('../components/modals', () => ({
   BulkConfirmationModal: () => null,
-  PetDetailModal: () => null,
+  PetDetailModal: ({
+    isOpen,
+    pet,
+    onClose,
+  }: {
+    isOpen: boolean;
+    pet: AdminPet | null;
+    onClose: () => void;
+  }) =>
+    isOpen && pet ? (
+      <div data-testid='pet-detail-modal'>
+        <span>Detail for: {pet.petId}</span>
+        <span>Name: {pet.name}</span>
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null,
 }));
 
 import Pets from './Pets';
 
+const buildPet = (overrides: Partial<AdminPet> = {}): AdminPet => ({
+  petId: 'pet-1',
+  name: 'Buddy',
+  type: 'dog',
+  breed: 'Labrador',
+  status: 'available',
+  archived: false,
+  featured: false,
+  rescueId: 'rescue-1',
+  rescueName: 'Happy Tails',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const setPetsState = (pets: AdminPet[]): void => {
+  mockPetsResponse = { data: pets, pagination: { pages: 1 } };
+  mockIsLoading = false;
+  mockError = null;
+};
+
+const LocationProbe: React.FC = () => {
+  const location = useLocation();
+  return (
+    <div data-testid='location'>
+      {location.pathname}
+      {location.search}
+    </div>
+  );
+};
+
+const renderPetsRoute = (initialRoute: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <ThemeProvider>
+          <Routes>
+            <Route path='/pets' element={<Pets />} />
+            <Route path='/pets/:petId' element={<Pets />} />
+          </Routes>
+          <LocationProbe />
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+beforeEach(() => {
+  mockPetsResponse = undefined;
+  mockIsLoading = false;
+  mockError = null;
+  vi.mocked(toast.error).mockClear();
+});
+
 describe('Pets page error wiring (UX P2 H)', () => {
   it('renders the inline DataTable error row when the pets query fails', () => {
+    mockPetsResponse = undefined;
+    mockIsLoading = false;
+    mockError = new Error('Failed to fetch pets from server');
+
     renderWithProviders(<Pets />);
 
     const alert = screen.getByRole('alert');
     expect(alert).toHaveTextContent(/failed to fetch pets/i);
+  });
+});
+
+describe('Pets page deep-linking', () => {
+  it('opens the detail modal when /pets/:petId matches a pet in the list', async () => {
+    const buddy = buildPet({ petId: 'pet-1', name: 'Buddy' });
+    const luna = buildPet({ petId: 'pet-2', name: 'Luna' });
+    setPetsState([buddy, luna]);
+
+    renderPetsRoute('/pets/pet-2');
+
+    const modal = await screen.findByTestId('pet-detail-modal');
+    expect(modal).toHaveTextContent('Detail for: pet-2');
+    expect(modal).toHaveTextContent('Name: Luna');
+  });
+
+  it('navigates to /pets/:petId when a row is clicked', async () => {
+    const buddy = buildPet({ petId: 'pet-1', name: 'Buddy' });
+    setPetsState([buddy]);
+
+    renderPetsRoute('/pets');
+
+    expect(screen.queryByTestId('pet-detail-modal')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Buddy'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/pets/pet-1');
+    });
+    expect(await screen.findByTestId('pet-detail-modal')).toHaveTextContent('Detail for: pet-1');
+  });
+
+  it('navigates back to /pets when the modal is closed, preserving filter params', async () => {
+    const buddy = buildPet({ petId: 'pet-1', name: 'Buddy' });
+    setPetsState([buddy]);
+
+    renderPetsRoute('/pets/pet-1?status=available');
+
+    const closeButton = await screen.findByRole('button', { name: /close/i });
+    await userEvent.click(closeButton);
+
+    await waitFor(() => {
+      const probe = screen.getByTestId('location');
+      expect(probe).toHaveTextContent('/pets');
+      expect(probe).toHaveTextContent('status=available');
+    });
+    expect(screen.queryByTestId('pet-detail-modal')).not.toBeInTheDocument();
+  });
+
+  it('redirects to /pets when the petId is unknown and surfaces a toast', async () => {
+    const buddy = buildPet({ petId: 'pet-1', name: 'Buddy' });
+    setPetsState([buddy]);
+
+    renderPetsRoute('/pets/does-not-exist');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/pets');
+    });
+    expect(toast.error).toHaveBeenCalledWith('Pet not found');
+    expect(screen.queryByTestId('pet-detail-modal')).not.toBeInTheDocument();
   });
 });

--- a/app.admin/src/pages/Pets.tsx
+++ b/app.admin/src/pages/Pets.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { Heading, Text, Input } from '@adopt-dont-shop/lib.components';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { Heading, Text, Input, toast } from '@adopt-dont-shop/lib.components';
 import { FiSearch, FiPackage } from 'react-icons/fi';
 import { DataTable, type Column } from '../components/data';
 import { usePets, useBulkUpdatePets, useRescuesList } from '../hooks';
@@ -42,6 +42,8 @@ const VALID_PET_STATUS_FILTERS: ReadonlySet<string> = new Set([
 ]);
 
 const Pets: React.FC = () => {
+  const { petId } = useParams<{ petId?: string }>();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const statusParam = searchParams.get('status');
@@ -71,7 +73,6 @@ const Pets: React.FC = () => {
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<BulkPetActionType | null>(null);
   const [bulkResult, setBulkResult] = useState<{ succeeded: number; failed: number } | null>(null);
-  const [selectedPet, setSelectedPet] = useState<AdminPet | null>(null);
 
   useEffect(() => {
     setPage(1);
@@ -94,6 +95,31 @@ const Pets: React.FC = () => {
   const bulkUpdatePets = useBulkUpdatePets();
 
   const pets: AdminPet[] = data?.data ?? [];
+
+  // ADS: Deep-link pets via /pets/:petId. Look up the active pet from the loaded
+  // list and surface a toast + redirect when an unknown id appears in the URL.
+  const selectedPet: AdminPet | null = petId ? (pets.find(p => p.petId === petId) ?? null) : null;
+
+  useEffect(() => {
+    if (!petId || isLoading) {
+      return;
+    }
+    if (pets.length === 0) {
+      return;
+    }
+    if (!pets.some(p => p.petId === petId)) {
+      toast.error('Pet not found');
+      navigate({ pathname: '/pets', search: searchParams.toString() }, { replace: true });
+    }
+  }, [petId, isLoading, pets, navigate, searchParams]);
+
+  const handleRowClick = (pet: AdminPet): void => {
+    navigate({ pathname: `/pets/${pet.petId}`, search: searchParams.toString() });
+  };
+
+  const handleDetailClose = (): void => {
+    navigate({ pathname: '/pets', search: searchParams.toString() });
+  };
 
   const handleBulkConfirm = async (reason?: string): Promise<void> => {
     if (!bulkAction) {
@@ -304,14 +330,10 @@ const Pets: React.FC = () => {
         selectedRows={selectedRows}
         onSelectionChange={setSelectedRows}
         getRowId={pet => pet.petId}
-        onRowClick={pet => setSelectedPet(pet)}
+        onRowClick={handleRowClick}
       />
 
-      <PetDetailModal
-        isOpen={selectedPet !== null}
-        onClose={() => setSelectedPet(null)}
-        pet={selectedPet}
-      />
+      <PetDetailModal isOpen={selectedPet !== null} onClose={handleDetailClose} pet={selectedPet} />
 
       <BulkConfirmationModal
         isOpen={bulkAction !== null}


### PR DESCRIPTION
## Summary

- `Pets` page now derives `selectedPet` from `useParams<{ petId?: string }>()` — no local state for modal selection
- Row click navigates to `/pets/<petId>` (preserves active search params)
- Modal close navigates back to `/pets` (preserves search params)
- Unknown `petId` after pets load → toast + redirect to `/pets`

## Test plan

- [x] 5/5 tests pass — open from URL, row-click updates URL, close preserves filters, unknown id redirects + toasts
- [x] `npx tsc --noEmit` — clean on changed files
- [ ] Manual: visit `/pets/<id>` directly → modal opens
- [ ] Manual: row click → URL becomes `/pets/<id>`, back button closes modal

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>