### PR TITLE
feat(app.admin): deep-link applications via /applications/:applicationId

### DIFF
--- a/app.admin/src/pages/Applications.test.tsx
+++ b/app.admin/src/pages/Applications.test.tsx
@@ -3,34 +3,218 @@
  * renders the inline error row (introduced by UX #5) in addition to whatever
  * top-of-page error treatment already existed. This pins down the wiring so
  * future refactors don't silently drop the inline affordance.
+ *
+ * Deep-link wiring (ADS): the Applications page is driven by the
+ * `/applications/:applicationId` route param. Row clicks navigate, the
+ * detail modal opens off the URL, close returns to `/applications` (with
+ * filter query params preserved), and unknown ids redirect with a toast.
  */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderWithProviders } from '../test-utils';
+import type { AdminApplication } from '../services/applicationService';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+const mockUseApplications = vi.fn();
 
 vi.mock('../hooks', () => ({
-  useApplications: () => ({
-    data: undefined,
-    isLoading: false,
-    error: new Error('Failed to fetch applications from server'),
-  }),
+  useApplications: (...args: unknown[]) => mockUseApplications(...args),
   useBulkUpdateApplications: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useRescuesList: () => ({ data: { data: [] } }),
 }));
 
 vi.mock('../components/modals', () => ({
   BulkConfirmationModal: () => null,
-  ApplicationDetailModal: () => null,
+  ApplicationDetailModal: ({
+    isOpen,
+    application,
+    onClose,
+  }: {
+    isOpen: boolean;
+    application: AdminApplication | null;
+    onClose: () => void;
+  }) =>
+    isOpen && application ? (
+      <div role='dialog' aria-label='Application detail'>
+        <span data-testid='detail-application-id'>{application.applicationId}</span>
+        <span>{application.applicantName}</span>
+        <button type='button' onClick={onClose}>
+          Close detail
+        </button>
+      </div>
+    ) : null,
 }));
 
 import Applications from './Applications';
 
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const buildApplication = (overrides: Partial<AdminApplication> = {}): AdminApplication => ({
+  applicationId: 'app-1',
+  applicantName: 'Alice Applicant',
+  applicantEmail: 'alice@example.com',
+  petName: 'Rex',
+  rescueName: 'Happy Tails',
+  status: 'submitted',
+  createdAt: new Date('2026-05-01T00:00:00Z').toISOString(),
+  ...overrides,
+});
+
+const setApplicationsResult = (
+  overrides: Partial<{
+    data: AdminApplication[];
+    isLoading: boolean;
+    error: Error | null;
+  }> = {}
+) => {
+  const data = overrides.data ?? [buildApplication()];
+  mockUseApplications.mockReturnValue({
+    data: {
+      data,
+      pagination: { pages: 1, total: data.length, page: 1, limit: 20 },
+    },
+    isLoading: overrides.isLoading ?? false,
+    error: overrides.error ?? null,
+  });
+};
+
+// ── Test harness with full routing ────────────────────────────────────────────
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return (
+    <div data-testid='location-probe'>
+      {location.pathname}
+      {location.search}
+    </div>
+  );
+};
+
+const renderApplicationsAt = (initialRoute: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <ThemeProvider>
+          <Routes>
+            <Route path='/applications' element={<Applications />} />
+            <Route path='/applications/:applicationId' element={<Applications />} />
+          </Routes>
+          <LocationProbe />
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+beforeEach(() => {
+  mockUseApplications.mockReset();
+});
+
+// ── Pre-existing behaviour ───────────────────────────────────────────────────
+
 describe('Applications page error wiring (UX P2 H)', () => {
   it('renders the inline DataTable error row when the applications query fails', () => {
+    mockUseApplications.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Failed to fetch applications from server'),
+    });
+
     renderWithProviders(<Applications />);
 
     const alert = screen.getByRole('alert');
     expect(alert).toHaveTextContent(/failed to fetch applications/i);
+  });
+});
+
+// ── Deep-link behaviour ──────────────────────────────────────────────────────
+
+describe('Applications page deep-link wiring', () => {
+  it('opens the detail modal for the application matching the URL param', async () => {
+    setApplicationsResult({
+      data: [
+        buildApplication({ applicationId: 'app-1', applicantName: 'Alice Applicant' }),
+        buildApplication({ applicationId: 'app-2', applicantName: 'Bob Builder' }),
+      ],
+    });
+
+    renderApplicationsAt('/applications/app-2');
+
+    const dialog = await screen.findByRole('dialog', { name: /application detail/i });
+    expect(dialog).toHaveTextContent('Bob Builder');
+    expect(screen.getByTestId('detail-application-id')).toHaveTextContent('app-2');
+  });
+
+  it('navigates to the detail URL when a row is clicked', async () => {
+    setApplicationsResult({
+      data: [buildApplication({ applicationId: 'app-7', applicantName: 'Cara Clicker' })],
+    });
+
+    const user = userEvent.setup();
+    renderApplicationsAt('/applications');
+
+    // Click the row matching the applicant.
+    const row = await screen.findByText('Cara Clicker');
+    await user.click(row);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-probe')).toHaveTextContent('/applications/app-7');
+    });
+  });
+
+  it('returns to /applications and preserves filter query params on close', async () => {
+    setApplicationsResult({
+      data: [buildApplication({ applicationId: 'app-9' })],
+    });
+
+    const user = userEvent.setup();
+    renderApplicationsAt('/applications/app-9?status=submitted');
+
+    const close = await screen.findByRole('button', { name: /close detail/i });
+    await user.click(close);
+
+    await waitFor(() => {
+      const probe = screen.getByTestId('location-probe');
+      expect(probe).toHaveTextContent('/applications');
+      expect(probe).toHaveTextContent('status=submitted');
+    });
+  });
+
+  it('redirects to /applications without crashing when the URL id is unknown', async () => {
+    setApplicationsResult({
+      data: [buildApplication({ applicationId: 'app-real' })],
+    });
+
+    renderApplicationsAt('/applications/does-not-exist');
+
+    await waitFor(() => {
+      const probe = screen.getByTestId('location-probe');
+      expect(probe.textContent).toBe('/applications');
+    });
+
+    // No detail modal should be open.
+    expect(screen.queryByRole('dialog', { name: /application detail/i })).toBeNull();
+  });
+
+  it('defers redirect while the applications query is still loading', () => {
+    setApplicationsResult({ data: [], isLoading: true });
+
+    renderApplicationsAt('/applications/app-loading');
+
+    // We should still be at the deep-link URL — no redirect yet.
+    expect(screen.getByTestId('location-probe')).toHaveTextContent('/applications/app-loading');
   });
 });

--- a/app.admin/src/pages/Applications.tsx
+++ b/app.admin/src/pages/Applications.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { Heading, Text, Input } from '@adopt-dont-shop/lib.components';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import {
+  Heading,
+  Text,
+  Input,
+  useToast,
+  Toast,
+  ToastContainer,
+  type ToastMessage,
+} from '@adopt-dont-shop/lib.components';
 import { FiSearch } from 'react-icons/fi';
 import { DataTable, type Column } from '../components/data';
 import { useApplications, useBulkUpdateApplications, useRescuesList } from '../hooks';
@@ -40,6 +48,9 @@ const VALID_STATUS_FILTERS: ReadonlySet<string> = new Set([
 
 const Applications: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { applicationId } = useParams<{ applicationId?: string }>();
+  const navigate = useNavigate();
+  const { toasts, showToast, hideToast } = useToast();
 
   const statusParam = searchParams.get('status');
   const statusFilter = statusParam && VALID_STATUS_FILTERS.has(statusParam) ? statusParam : 'all';
@@ -66,7 +77,6 @@ const Applications: React.FC = () => {
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [bulkAction, setBulkAction] = useState<BulkApplicationActionType | null>(null);
   const [bulkResult, setBulkResult] = useState<{ succeeded: number; failed: number } | null>(null);
-  const [selectedApplication, setSelectedApplication] = useState<AdminApplication | null>(null);
 
   useEffect(() => {
     setPage(1);
@@ -88,6 +98,37 @@ const Applications: React.FC = () => {
   const bulkUpdateApplications = useBulkUpdateApplications();
 
   const applications: AdminApplication[] = data?.data ?? [];
+
+  // Derive selected application from URL param + loaded list.
+  const selectedApplication: AdminApplication | null = applicationId
+    ? (applications.find(app => app.applicationId === applicationId) ?? null)
+    : null;
+
+  // If the param resolves to no application after loading completes,
+  // redirect back to the list and surface a toast.
+  useEffect(() => {
+    if (!applicationId || isLoading) {
+      return;
+    }
+    if (applications.find(app => app.applicationId === applicationId)) {
+      return;
+    }
+    const search = searchParams.toString();
+    navigate(search ? `/applications?${search}` : '/applications', { replace: true });
+    showToast('Application not found', 'error');
+  }, [applicationId, applications, isLoading, navigate, searchParams, showToast]);
+
+  const handleRowClick = (app: AdminApplication): void => {
+    const search = searchParams.toString();
+    navigate(
+      search ? `/applications/${app.applicationId}?${search}` : `/applications/${app.applicationId}`
+    );
+  };
+
+  const handleCloseDetail = (): void => {
+    const search = searchParams.toString();
+    navigate(search ? `/applications?${search}` : '/applications');
+  };
 
   const handleBulkConfirm = async (reason?: string): Promise<void> => {
     if (!bulkAction) {
@@ -269,12 +310,12 @@ const Applications: React.FC = () => {
         selectedRows={selectedRows}
         onSelectionChange={setSelectedRows}
         getRowId={app => app.applicationId}
-        onRowClick={app => setSelectedApplication(app)}
+        onRowClick={handleRowClick}
       />
 
       <ApplicationDetailModal
         isOpen={selectedApplication !== null}
-        onClose={() => setSelectedApplication(null)}
+        onClose={handleCloseDetail}
         application={selectedApplication}
       />
 
@@ -309,6 +350,12 @@ const Applications: React.FC = () => {
         isLoading={bulkUpdateApplications.isPending}
         resultSummary={bulkResult}
       />
+
+      <ToastContainer position='top-right'>
+        {toasts.map((toast: ToastMessage) => (
+          <Toast key={toast.id} {...toast} onClose={hideToast} position='top-right' />
+        ))}
+      </ToastContainer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- `Applications` page derives `selectedApplication` from `useParams<{ applicationId?: string }>()` — no local state for selection
- Row click navigates to `/applications/<applicationId>` (preserves search params)
- Modal close navigates back to `/applications` (preserves search params)
- Unknown `applicationId` after load → toast + replace-redirect to `/applications`
- Loading state defers redirect so deep-link URL stays during fetch

## Test plan

- [x] 6/6 tests pass — visit URL opens modal, row click updates URL, close preserves `?status=`, unknown id redirects, loading defers redirect
- [x] `npx tsc --noEmit` — clean on changed files
- [ ] Manual: visit `/applications/<id>` directly → modal opens
- [ ] Manual: row click → URL becomes `/applications/<id>`, back button closes modal

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>