### PR TITLE
feat(app.admin): deep-link support tickets via /support/:ticketId

### DIFF
--- a/app.admin/src/pages/Support.test.tsx
+++ b/app.admin/src/pages/Support.test.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const refetchMock = vi.fn().mockResolvedValue(undefined);
+const addResponseMock = vi.fn();
+
+const sampleTickets = [
+  {
+    ticketId: 'ticket-1',
+    subject: 'Cannot reset password',
+    description: 'I forgot my password and the reset link is broken',
+    status: 'open',
+    priority: 'high',
+    category: 'account_problem',
+    userId: 'user-1',
+    userName: 'Alice Tester',
+    userEmail: 'alice@test.com',
+    responses: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    ticketId: 'ticket-2',
+    subject: 'Adoption application stuck',
+    description: 'My application has been pending for weeks',
+    status: 'in_progress',
+    priority: 'normal',
+    category: 'adoption_inquiry',
+    userId: 'user-2',
+    userName: 'Bob Tester',
+    userEmail: 'bob@test.com',
+    responses: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+vi.mock('@adopt-dont-shop/lib.support-tickets', () => ({
+  useTickets: () => ({
+    data: {
+      data: sampleTickets,
+      pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+    },
+    isLoading: false,
+    error: null,
+    refetch: refetchMock,
+  }),
+  useTicketStats: () => ({
+    data: { open: 1, inProgress: 1, waitingForUser: 0, resolved: 0 },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useTicketMutations: () => ({
+    addResponse: addResponseMock,
+    isLoading: false,
+    error: null,
+  }),
+  getStatusLabel: (s: string) => s,
+  getPriorityLabel: (p: string) => p,
+  getCategoryLabel: (c: string) => c,
+  formatRelativeTime: () => 'just now',
+}));
+
+// Stub the modal so we can observe its open state and trigger close
+// without rendering the heavy real implementation.
+vi.mock('../components/modals/TicketDetailModal', () => ({
+  TicketDetailModal: ({
+    isOpen,
+    onClose,
+    ticket,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    ticket: { ticketId: string; subject: string } | null;
+  }) => {
+    if (!isOpen || !ticket) {
+      return null;
+    }
+    return (
+      <div data-testid='ticket-detail-modal'>
+        <div data-testid='ticket-detail-id'>{ticket.ticketId}</div>
+        <div data-testid='ticket-detail-subject'>{ticket.subject}</div>
+        <button type='button' onClick={onClose} data-testid='ticket-detail-close'>
+          Close
+        </button>
+      </div>
+    );
+  },
+}));
+
+import Support from './Support';
+
+const renderSupportAt = (initialRoute: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <ThemeProvider>
+          <Routes>
+            <Route path='/support' element={<Support />} />
+            <Route path='/support/:ticketId' element={<Support />} />
+          </Routes>
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+// The ticket subject in the list is rendered alongside an id prefix
+// ("#cket-1 - Cannot reset password") which splits across text nodes,
+// so we look up rows by the customer email column which is intact.
+const findTicketRow = (email: string): HTMLElement => {
+  const emailCell = screen.getByText(new RegExp(email.replace(/\./g, '\\.'), 'i'));
+  const row = emailCell.closest('tr');
+  if (!row) {
+    throw new Error(`Could not find row for ${email}`);
+  }
+  return row;
+};
+
+describe('Support deep-linking via /support/:ticketId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the detail modal for the ticket in the URL', async () => {
+    renderSupportAt('/support/ticket-1');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-detail-modal')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('ticket-detail-id')).toHaveTextContent('ticket-1');
+    expect(screen.getByTestId('ticket-detail-subject')).toHaveTextContent('Cannot reset password');
+  });
+
+  it('does not open the modal when visiting /support without a ticketId', () => {
+    renderSupportAt('/support');
+
+    expect(screen.queryByTestId('ticket-detail-modal')).not.toBeInTheDocument();
+  });
+
+  it('clicking a row navigates to /support/<ticketId> and opens the modal', async () => {
+    renderSupportAt('/support');
+
+    expect(screen.queryByTestId('ticket-detail-modal')).not.toBeInTheDocument();
+
+    fireEvent.click(findTicketRow('bob@test.com'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-detail-modal')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('ticket-detail-id')).toHaveTextContent('ticket-2');
+  });
+
+  it('closing the modal navigates back to /support and unmounts the modal', async () => {
+    renderSupportAt('/support/ticket-1');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ticket-detail-modal')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('ticket-detail-close'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('ticket-detail-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('redirects to /support without crashing when the ticketId is unknown', async () => {
+    renderSupportAt('/support/does-not-exist');
+
+    // List still renders, modal never opens, and a toast surfaces the error.
+    await waitFor(() => {
+      expect(screen.getByText(/ticket not found/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('ticket-detail-modal')).not.toBeInTheDocument();
+    // Both ticket rows remain visible by their (intact) email cells.
+    expect(screen.getByText(/alice@test\.com/)).toBeInTheDocument();
+    expect(screen.getByText(/bob@test\.com/)).toBeInTheDocument();
+  });
+});

--- a/app.admin/src/pages/Support.tsx
+++ b/app.admin/src/pages/Support.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { Heading, Text, Input } from '@adopt-dont-shop/lib.components';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  Heading,
+  Text,
+  Input,
+  useToast,
+  Toast,
+  ToastContainer,
+  type ToastMessage,
+} from '@adopt-dont-shop/lib.components';
 import { FiSearch, FiMessageSquare, FiClock, FiCheckCircle, FiAlertCircle } from 'react-icons/fi';
 import { DataTable, type Column } from '../components/data';
 import {
@@ -63,6 +71,8 @@ const VALID_TICKET_STATUSES: ReadonlySet<string> = new Set([
 ]);
 
 const Support: React.FC = () => {
+  const { ticketId } = useParams<{ ticketId?: string }>();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const statusParam = searchParams.get('status');
@@ -89,6 +99,7 @@ const Support: React.FC = () => {
   const [categoryFilter, setCategoryFilter] = useState<TicketCategory | 'all'>('all');
   const [page, setPage] = useState(1);
   const [selectedTicket, setSelectedTicket] = useState<SupportTicket | null>(null);
+  const { toasts, showToast, hideToast } = useToast();
 
   useEffect(() => {
     setPage(1);
@@ -144,11 +155,41 @@ const Support: React.FC = () => {
 
   const ticketSiblingIds = useMemo(() => tickets.map(t => t.ticketId), [tickets]);
 
-  const handleNavigateTicket = (ticketId: string) => {
-    const nextTicket = tickets.find(t => t.ticketId === ticketId);
-    if (nextTicket) {
-      setSelectedTicket(nextTicket);
+  // Preserve current filter query params (e.g. ?status=open) when navigating
+  // between the list and a ticket detail.
+  const searchSuffix = searchParams.toString() ? `?${searchParams.toString()}` : '';
+
+  // Sync the URL :ticketId param with the modal's selected ticket.
+  // When the list has loaded and the id is unknown, redirect to /support
+  // with a toast so the user understands why nothing opened.
+  useEffect(() => {
+    if (!ticketId) {
+      setSelectedTicket(null);
+      return;
     }
+    if (ticketsLoading) {
+      return;
+    }
+    const match = tickets.find(t => t.ticketId === ticketId);
+    if (match) {
+      setSelectedTicket(match);
+      return;
+    }
+    showToast('Ticket not found', 'error');
+    navigate(`/support${searchSuffix}`, { replace: true });
+  }, [ticketId, ticketsLoading, tickets, navigate, searchSuffix, showToast]);
+
+  const handleRowClick = (ticket: SupportTicket) => {
+    navigate(`/support/${ticket.ticketId}${searchSuffix}`);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedTicket(null);
+    navigate(`/support${searchSuffix}`);
+  };
+
+  const handleNavigateTicket = (nextTicketId: string) => {
+    navigate(`/support/${nextTicketId}${searchSuffix}`);
   };
 
   // Stats from API
@@ -394,7 +435,7 @@ const Support: React.FC = () => {
         data={tickets}
         loading={loading}
         emptyMessage='No support tickets found matching your criteria'
-        onRowClick={ticket => setSelectedTicket(ticket)}
+        onRowClick={handleRowClick}
         currentPage={page}
         totalPages={totalPages}
         onPageChange={setPage}
@@ -403,12 +444,18 @@ const Support: React.FC = () => {
 
       <TicketDetailModal
         isOpen={!!selectedTicket}
-        onClose={() => setSelectedTicket(null)}
+        onClose={handleCloseModal}
         ticket={selectedTicket}
         onReply={handleReply}
         siblingIds={ticketSiblingIds}
         onNavigate={handleNavigateTicket}
       />
+
+      <ToastContainer position='top-right'>
+        {toasts.map((toast: ToastMessage) => (
+          <Toast key={toast.id} {...toast} onClose={hideToast} position='top-right' />
+        ))}
+      </ToastContainer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- `TicketDetailModal` driven by `:ticketId` URL param so `/support/<id>` (e.g. from Triage Inbox) actually opens the ticket instead of dropping admin on list
- Row click navigates to `/support/<id>` — URLs canonical + shareable
- Modal close, prev/next, unknown-id redirect all preserve filter query params (`?status=`, etc)
- Unknown ticket id → toast (`useToast`) + redirect back to `/support`

No changes to `Inbox.tsx` — its `getDetailPath()` for support rows already returns `/support/<id>` and now lands correctly.

## Test plan

- [x] 5/5 tests pass — deep-link opens, no-id stays closed, row click updates URL, close returns to `/support`, unknown id redirects + toasts
- [x] `npx tsc --noEmit` — zero new errors (same 64 pre-existing as main)
- [ ] Manual: load `/support/<id>` directly, click row, close, prev/next — `?status=` survives each transition

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>