### PR TITLE
feat(app.admin): deep-link moderation reports via /moderation/:reportId

### DIFF
--- a/app.admin/src/App.tsx
+++ b/app.admin/src/App.tsx
@@ -135,6 +135,15 @@ const AdminApp: React.FC = () => {
               <Route path='/moderation/queue' element={<Navigate to='/moderation' replace />} />
               <Route path='/moderation/reports' element={<Navigate to='/moderation' replace />} />
               <Route path='/moderation/sanctions' element={<Navigate to='/moderation' replace />} />
+              {/* Deep-link to a specific report — opens its detail modal */}
+              <Route
+                path='/moderation/:reportId'
+                element={
+                  <RouteBoundary name='moderation'>
+                    <Moderation />
+                  </RouteBoundary>
+                }
+              />
 
               {/* Support System */}
               <Route path='/support' element={<Support />} />

--- a/app.admin/src/__tests__/moderation.behavior.test.tsx
+++ b/app.admin/src/__tests__/moderation.behavior.test.tsx
@@ -18,8 +18,16 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { renderWithProviders, screen, waitFor } from '../test-utils';
 import userEvent from '@testing-library/user-event';
+import { Routes, Route } from 'react-router-dom';
 import Moderation from '../pages/Moderation';
 import type { Report, ReportSeverity, ReportStatus } from '@adopt-dont-shop/lib.moderation';
+
+const ModerationWithRoutes = () => (
+  <Routes>
+    <Route path='/moderation' element={<Moderation />} />
+    <Route path='/moderation/:reportId' element={<Moderation />} />
+  </Routes>
+);
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -339,23 +347,30 @@ describe('Content Moderation page', () => {
   describe('report detail modal', () => {
     it('opens the detail modal when admin clicks View Details', async () => {
       const user = userEvent.setup();
-      renderWithProviders(<Moderation />);
+      renderWithProviders(<ModerationWithRoutes />, { initialRoute: '/moderation' });
 
       const viewButtons = screen.getAllByTitle('View Details');
       await user.click(viewButtons[0]);
 
-      expect(screen.getByTestId('report-detail-modal')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId('report-detail-modal')).toBeInTheDocument();
+      });
       expect(screen.getByText('Report: Harassment Report')).toBeInTheDocument();
     });
 
     it('closes the detail modal when admin clicks Close', async () => {
       const user = userEvent.setup();
-      renderWithProviders(<Moderation />);
+      renderWithProviders(<ModerationWithRoutes />, { initialRoute: '/moderation' });
 
       await user.click(screen.getAllByTitle('View Details')[0]);
+      await waitFor(() => {
+        expect(screen.getByTestId('report-detail-modal')).toBeInTheDocument();
+      });
       await user.click(screen.getByRole('button', { name: /close/i }));
 
-      expect(screen.queryByTestId('report-detail-modal')).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId('report-detail-modal')).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/app.admin/src/pages/Inbox.test.tsx
+++ b/app.admin/src/pages/Inbox.test.tsx
@@ -158,12 +158,12 @@ describe('Inbox page', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/messages?chatId=chat-1');
   });
 
-  it('navigates moderation rows to the moderation page', () => {
+  it('navigates moderation rows to the specific report deep-link', () => {
     renderWithProviders(<Inbox />);
 
     fireEvent.click(screen.getByText('Spam report on pet listing'));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/moderation');
+    expect(mockNavigate).toHaveBeenCalledWith('/moderation/report-1');
   });
 
   it('navigates support rows to the specific ticket page', () => {

--- a/app.admin/src/pages/Inbox.tsx
+++ b/app.admin/src/pages/Inbox.tsx
@@ -95,7 +95,7 @@ const getSeverityDotClass = (severity: string): string => {
 const getDetailPath = (item: InboxItem): string => {
   switch (item.source) {
     case 'moderation':
-      return '/moderation';
+      return `/moderation/${item.id}`;
     case 'support':
       return `/support/${item.id}`;
     case 'message':

--- a/app.admin/src/pages/Moderation.test.tsx
+++ b/app.admin/src/pages/Moderation.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
 import { renderWithProviders } from '../test-utils';
 
 const resolveReportMock = vi.fn();
@@ -82,7 +83,27 @@ vi.mock('../components/moderation/ActionSelectionModal', () => ({
 }));
 
 vi.mock('../components/moderation/ReportDetailModal', () => ({
-  ReportDetailModal: () => null,
+  ReportDetailModal: ({
+    isOpen,
+    report,
+    onClose,
+  }: {
+    isOpen: boolean;
+    report: { reportId: string; title: string } | null;
+    onClose: () => void;
+  }) => {
+    if (!isOpen) {
+      return null;
+    }
+    return (
+      <div role='dialog' aria-label='Report Detail'>
+        <div data-testid='detail-report-id'>{report?.reportId}</div>
+        <button type='button' onClick={onClose} data-testid='stub-detail-close'>
+          Close
+        </button>
+      </div>
+    );
+  },
 }));
 
 vi.mock('../components/moderation/BulkModerationModal', () => ({
@@ -129,5 +150,96 @@ describe('Moderation handleActionSubmit error feedback', () => {
       expect(dismissReportMock).toHaveBeenCalled();
     });
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+const renderModerationAtRoute = (route: string) => {
+  return renderWithProviders(
+    <Routes>
+      <Route path='/moderation' element={<Moderation />} />
+      <Route path='/moderation/:reportId' element={<Moderation />} />
+    </Routes>,
+    { initialRoute: route }
+  );
+};
+
+describe('Moderation deep-link routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the detail modal for the report when visiting /moderation/:reportId', async () => {
+    renderModerationAtRoute('/moderation/rep-1');
+
+    const dialog = await screen.findByRole('dialog', { name: /report detail/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByTestId('detail-report-id')).toHaveTextContent('rep-1');
+  });
+
+  it('does not open the modal when no reportId is in the URL', () => {
+    renderModerationAtRoute('/moderation');
+
+    expect(screen.queryByRole('dialog', { name: /report detail/i })).not.toBeInTheDocument();
+  });
+
+  it('navigates to /moderation/:reportId when a report row is clicked', async () => {
+    renderModerationAtRoute('/moderation');
+
+    expect(screen.queryByRole('dialog', { name: /report detail/i })).not.toBeInTheDocument();
+
+    // Click the row body — title text is rendered inside the row
+    fireEvent.click(screen.getByText(/spammy listing/i));
+
+    const dialog = await screen.findByRole('dialog', { name: /report detail/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByTestId('detail-report-id')).toHaveTextContent('rep-1');
+  });
+
+  it('closes the modal and returns to /moderation when the close handler fires', async () => {
+    renderModerationAtRoute('/moderation/rep-1');
+
+    await screen.findByRole('dialog', { name: /report detail/i });
+
+    fireEvent.click(screen.getByTestId('stub-detail-close'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /report detail/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('preserves status filter query params when closing the modal', async () => {
+    renderModerationAtRoute('/moderation/rep-1?status=pending');
+
+    await screen.findByRole('dialog', { name: /report detail/i });
+
+    // status filter dropdown reflects the query param
+    const statusSelect = screen.getByLabelText(/status/i);
+    expect(statusSelect).toHaveValue('pending');
+
+    fireEvent.click(screen.getByTestId('stub-detail-close'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /report detail/i })).not.toBeInTheDocument();
+    });
+
+    // After close the filter is still applied
+    expect(screen.getByLabelText(/status/i)).toHaveValue('pending');
+  });
+
+  it('redirects to /moderation and surfaces a toast when the reportId is unknown', async () => {
+    const { toast } = await import('@adopt-dont-shop/lib.components');
+
+    renderModerationAtRoute('/moderation/does-not-exist');
+
+    // No detail dialog rendered
+    expect(screen.queryByRole('dialog', { name: /report detail/i })).not.toBeInTheDocument();
+
+    // Soft toast surfaces via the global sonner-backed toast singleton
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Report not found');
+    });
+
+    // Page itself still renders (header visible — no crash)
+    expect(screen.getByRole('heading', { name: /content moderation/i })).toBeInTheDocument();
   });
 });

--- a/app.admin/src/pages/Moderation.tsx
+++ b/app.admin/src/pages/Moderation.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { Input } from '@adopt-dont-shop/lib.components';
+import React, { useState, useMemo, useEffect } from 'react';
+import { useSearchParams, useParams, useNavigate } from 'react-router-dom';
+import { Input, toast } from '@adopt-dont-shop/lib.components';
 import { FiSearch, FiAlertTriangle, FiCheckCircle, FiEye, FiShield } from 'react-icons/fi';
 import { DataTable, type Column } from '../components/data';
 import { BulkActionToolbar } from '../components/ui';
@@ -125,12 +125,14 @@ const Moderation: React.FC = () => {
     );
   };
 
+  const { reportId } = useParams<{ reportId?: string }>();
+  const navigate = useNavigate();
+
   const [searchQuery, setSearchQuery] = useState('');
   const [entityTypeFilter, setEntityTypeFilter] = useState<string>('all');
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(20);
   const [isActionModalOpen, setIsActionModalOpen] = useState(false);
-  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [selectedReport, setSelectedReport] = useState<Report | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
@@ -177,14 +179,35 @@ const Moderation: React.FC = () => {
     );
   };
 
+  // ADS deep-link: the detail modal is driven by the URL :reportId param.
+  // Look up the report once the list has loaded; if the id doesn't match
+  // any loaded report (e.g. deleted/invalid), bounce back to /moderation
+  // and surface a soft toast. While reports are still loading we wait.
+  const detailReport = useMemo<Report | null>(
+    () => (reportId ? (reports.find((r: Report) => r.reportId === reportId) ?? null) : null),
+    [reportId, reports]
+  );
+  const isDetailModalOpen = Boolean(reportId) && detailReport !== null;
+
+  useEffect(() => {
+    if (!reportId || isLoading) {
+      return;
+    }
+    if (!reports.some((r: Report) => r.reportId === reportId)) {
+      toast.error('Report not found');
+      navigate({ pathname: '/moderation', search: searchParams.toString() }, { replace: true });
+    }
+  }, [reportId, isLoading, reports, navigate, searchParams]);
+
   const handleOpenDetailModal = (report: Report) => {
-    setSelectedReport(report);
-    setIsDetailModalOpen(true);
+    navigate({
+      pathname: `/moderation/${report.reportId}`,
+      search: searchParams.toString(),
+    });
   };
 
   const handleCloseDetailModal = () => {
-    setIsDetailModalOpen(false);
-    setSelectedReport(null);
+    navigate({ pathname: '/moderation', search: searchParams.toString() });
   };
 
   const handleOpenActionModal = (report: Report) => {
@@ -531,7 +554,7 @@ const Moderation: React.FC = () => {
       <ReportDetailModal
         isOpen={isDetailModalOpen}
         onClose={handleCloseDetailModal}
-        report={selectedReport}
+        report={detailReport}
       />
 
       <ActionSelectionModal


### PR DESCRIPTION
## Summary

- New `/moderation/:reportId` route in `App.tsx` (wrapped in same `RouteBoundary` as `/moderation`)
- `Moderation` page drives modal open state from `useParams<{ reportId?: string }>()` — no local state
- Row click navigates to `/moderation/<reportId>` (preserves query params like `?status=`, `?severity=`)
- Modal close navigates back to `/moderation` (preserves query params)
- Unknown `reportId` after load → sonner `toast.error('Report not found')` + replace-redirect to `/moderation`
- `Inbox.getDetailPath()` for moderation source now returns `/moderation/<id>` (was bare `/moderation`)

## Implementation note

Switched from local `useToast` to global sonner `toast.error` because local hook state is lost when React Router unmounts `Moderation` during redirect. Global `Toaster` already mounted in `main.tsx`, matching existing `Users.tsx` / `ChatDetailModal` usage.

## Test plan

- [x] `Moderation.test.tsx` — 8/8 pass (deep-link open, no-id, row click, close, filter preserved, unknown id)
- [x] `Inbox.test.tsx` — 15/15 pass (moderation row navigation updated)
- [x] `src/components/moderation` — 39/39 pass (no regressions)
- [x] `npx tsc --noEmit` — zero new errors
- [ ] Manual: from Inbox click a moderation row → lands on `/moderation/<id>` with report modal open
- [ ] Manual: refresh page on `/moderation/<id>` → modal stays open

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>