### PR TITLE
fix(inbox): escape LIKE wildcards in search filter and remove type assertions

### DIFF
--- a/service.backend/src/__tests__/services/inbox.service.test.ts
+++ b/service.backend/src/__tests__/services/inbox.service.test.ts
@@ -1,0 +1,169 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { Op } from 'sequelize';
+
+vi.mock('../../models/Report', () => ({
+  __esModule: true,
+  default: { findAll: vi.fn() },
+  ReportStatus: {},
+  ReportSeverity: {},
+}));
+
+vi.mock('../../models/SupportTicket', () => ({
+  __esModule: true,
+  default: { findAll: vi.fn() },
+  TicketStatus: {},
+  TicketPriority: {},
+}));
+
+vi.mock('../../models/Chat', () => ({
+  __esModule: true,
+  Chat: { findAll: vi.fn() },
+}));
+
+vi.mock('../../models/ChatParticipant', () => ({
+  __esModule: true,
+  ChatParticipant: {},
+  default: {},
+}));
+
+vi.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+vi.mock('../../types/chat', () => ({
+  ChatStatus: { ACTIVE: 'active', LOCKED: 'locked', ARCHIVED: 'archived' },
+}));
+
+import Report from '../../models/Report';
+import SupportTicket from '../../models/SupportTicket';
+import { getInboxItems } from '../../services/inbox.service';
+
+describe('getInboxItems search escaping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('moderation report search', () => {
+    it('passes a plain search term as-is in the LIKE pattern', async () => {
+      vi.mocked(Report.findAll).mockResolvedValue([]);
+
+      await getInboxItems({ source: 'moderation', search: 'spam' });
+
+      expect(Report.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            [Op.or]: [
+              { title: { [Op.iLike]: '%spam%' } },
+              { description: { [Op.iLike]: '%spam%' } },
+            ],
+          }),
+        })
+      );
+    });
+
+    it('escapes % so it matches literally rather than acting as a wildcard', async () => {
+      vi.mocked(Report.findAll).mockResolvedValue([]);
+
+      await getInboxItems({ source: 'moderation', search: '%' });
+
+      expect(Report.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            [Op.or]: [{ title: { [Op.iLike]: '%\\%%' } }, { description: { [Op.iLike]: '%\\%%' } }],
+          }),
+        })
+      );
+    });
+
+    it('escapes _ so it matches literally rather than acting as a wildcard', async () => {
+      vi.mocked(Report.findAll).mockResolvedValue([]);
+
+      await getInboxItems({ source: 'moderation', search: 'a_b' });
+
+      expect(Report.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            [Op.or]: [
+              { title: { [Op.iLike]: '%a\\_b%' } },
+              { description: { [Op.iLike]: '%a\\_b%' } },
+            ],
+          }),
+        })
+      );
+    });
+
+    it('does not add Op.or when no search term is given', async () => {
+      vi.mocked(Report.findAll).mockResolvedValue([]);
+
+      await getInboxItems({ source: 'moderation' });
+
+      const call = vi.mocked(Report.findAll).mock.calls[0][0] as { where: Record<symbol, unknown> };
+      expect(call.where[Op.or]).toBeUndefined();
+    });
+  });
+
+  describe('support ticket search', () => {
+    it('passes a plain search term as-is in the LIKE pattern', async () => {
+      vi.mocked(SupportTicket.findAll).mockResolvedValue([]);
+
+      await getInboxItems({ source: 'support', search: 'login' });
+
+      expect(SupportTicket.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            [Op.or]: [
+              { subject: { [Op.iLike]: '%login%' } },
+              { description: { [Op.iLike]: '%login%' } },
+            ],
+          }),
+        })
+      );
+    });
+
+    it('escapes % so it matches literally rather than acting as a wildcard', async () => {
+      vi.mocked(SupportTicket.findAll).mockResolvedValue([]);
+
+      await getInboxItems({ source: 'support', search: '%' });
+
+      expect(SupportTicket.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            [Op.or]: [
+              { subject: { [Op.iLike]: '%\\%%' } },
+              { description: { [Op.iLike]: '%\\%%' } },
+            ],
+          }),
+        })
+      );
+    });
+
+    it('escapes _ so it matches literally rather than acting as a wildcard', async () => {
+      vi.mocked(SupportTicket.findAll).mockResolvedValue([]);
+
+      await getInboxItems({ source: 'support', search: 'foo_bar' });
+
+      expect(SupportTicket.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            [Op.or]: [
+              { subject: { [Op.iLike]: '%foo\\_bar%' } },
+              { description: { [Op.iLike]: '%foo\\_bar%' } },
+            ],
+          }),
+        })
+      );
+    });
+
+    it('does not add Op.or when no search term is given', async () => {
+      vi.mocked(SupportTicket.findAll).mockResolvedValue([]);
+
+      await getInboxItems({ source: 'support' });
+
+      const call = vi.mocked(SupportTicket.findAll).mock.calls[0][0] as {
+        where: Record<symbol, unknown>;
+      };
+      expect(call.where[Op.or]).toBeUndefined();
+    });
+  });
+});

--- a/service.backend/src/services/inbox.service.ts
+++ b/service.backend/src/services/inbox.service.ts
@@ -1,5 +1,6 @@
 import { Op } from 'sequelize';
 import { z } from 'zod';
+import { escapeLikePattern } from '../utils/escape-like';
 import Report, { ReportSeverity, ReportStatus } from '../models/Report';
 import SupportTicket, { TicketPriority, TicketStatus } from '../models/SupportTicket';
 import { Chat } from '../models/Chat';
@@ -119,10 +120,12 @@ const fetchReports = async (filters: InboxFilters): Promise<ReadonlyArray<InboxI
     where.assignedModerator = filters.assignedTo;
   }
   if (filters.search) {
-    where[Op.or as unknown as string] = [
-      { title: { [Op.iLike]: `%${filters.search}%` } },
-      { description: { [Op.iLike]: `%${filters.search}%` } },
-    ];
+    Object.assign(where, {
+      [Op.or]: [
+        { title: { [Op.iLike]: `%${escapeLikePattern(filters.search)}%` } },
+        { description: { [Op.iLike]: `%${escapeLikePattern(filters.search)}%` } },
+      ],
+    });
   }
 
   const reports = await Report.findAll({
@@ -151,10 +154,12 @@ const fetchTickets = async (filters: InboxFilters): Promise<ReadonlyArray<InboxI
     where.assignedTo = filters.assignedTo;
   }
   if (filters.search) {
-    where[Op.or as unknown as string] = [
-      { subject: { [Op.iLike]: `%${filters.search}%` } },
-      { description: { [Op.iLike]: `%${filters.search}%` } },
-    ];
+    Object.assign(where, {
+      [Op.or]: [
+        { subject: { [Op.iLike]: `%${escapeLikePattern(filters.search)}%` } },
+        { description: { [Op.iLike]: `%${escapeLikePattern(filters.search)}%` } },
+      ],
+    });
   }
 
   const tickets = await SupportTicket.findAll({


### PR DESCRIPTION
## Summary

- Fixes ADS-691: searching for `%` or `_` in the triage inbox previously returned all records instead of matching the literal characters
- Replaces `Op.or as unknown as string` double type assertion with the `Object.assign` spread pattern used across other services
- Adds `inbox.service.test.ts` with 8 tests covering escaping behaviour for both moderation reports and support tickets

## Changes

**`service.backend/src/services/inbox.service.ts`**
- Import `escapeLikePattern` from `../utils/escape-like` (already used by `admin.service.ts`, `chat.service.ts`, `supportTicket.service.ts`, and others)
- `fetchReports`: wrap `filters.search` with `escapeLikePattern()` and replace the `as unknown as string` cast with `Object.assign`
- `fetchTickets`: same fix

**`service.backend/src/__tests__/services/inbox.service.test.ts`** *(new)*
- 8 behaviour tests verifying `%` and `_` are escaped in both report and ticket search paths, plain terms pass through unchanged, and no `Op.or` is added when search is absent

## Test plan

- [x] All 8 new service tests pass
- [x] All 7 existing inbox route tests pass
- [x] No type assertions remain in the search filter paths

Closes ADS-691

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgYHxkyqpbBiFdL1qeB1N9)_