### PR TITLE
feat(entity-inspector): foundation for cross-entity admin detail panels

### DIFF
--- a/app.admin/src/__tests__/bulk-operations.behavior.test.tsx
+++ b/app.admin/src/__tests__/bulk-operations.behavior.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../hooks', () => ({
   useBulkUpdateUsers: () => mockUseBulkUpdateUsers(),
   useBulkUpdateRescues: () => mockUseBulkUpdateRescues(),
   useCreateUser: () => mockUseCreateUser(),
-  useUserActivity: () => ({ data: [], isLoading: false, error: null }),
+  useEntityActivity: () => ({ data: [], isLoading: false, error: null }),
 }));
 
 const mockGetAll = vi.fn();

--- a/app.admin/src/__tests__/export.behavior.test.tsx
+++ b/app.admin/src/__tests__/export.behavior.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../hooks', () => ({
   useDeleteUser: () => mockUseDeleteUser(),
   useBulkUpdateUsers: () => defaultMutation,
   useCreateUser: () => defaultMutation,
-  useUserActivity: () => ({ data: [], isLoading: false, error: null }),
+  useEntityActivity: () => ({ data: [], isLoading: false, error: null }),
 }));
 
 vi.mock('../services/libraryServices', () => ({

--- a/app.admin/src/__tests__/list-page-url-filters.behavior.test.tsx
+++ b/app.admin/src/__tests__/list-page-url-filters.behavior.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../hooks', () => ({
   useDeleteUser: () => ({ mutateAsync: vi.fn() }),
   useBulkUpdateUsers: () => mockUseBulkUpdateUsers(),
   useCreateUser: () => ({ mutateAsync: vi.fn() }),
-  useUserActivity: () => ({ data: [], isLoading: false, error: null }),
+  useEntityActivity: () => ({ data: [], isLoading: false, error: null }),
   usePets: (filters: unknown) => mockUsePets(filters),
   useBulkUpdatePets: () => mockUseBulkUpdatePets(),
 }));

--- a/app.admin/src/__tests__/user-management.behavior.test.tsx
+++ b/app.admin/src/__tests__/user-management.behavior.test.tsx
@@ -31,7 +31,7 @@ const mockUseVerifyUser = vi.fn();
 const mockUseDeleteUser = vi.fn();
 const mockUseBulkUpdateUsers = vi.fn();
 const mockUseCreateUser = vi.fn();
-const mockUseUserActivity = vi.fn();
+const mockUseEntityActivity = vi.fn();
 
 vi.mock('../hooks', () => ({
   useUsers: (...args: unknown[]) => mockUseUsers(...args),
@@ -41,7 +41,7 @@ vi.mock('../hooks', () => ({
   useDeleteUser: () => mockUseDeleteUser(),
   useBulkUpdateUsers: () => mockUseBulkUpdateUsers(),
   useCreateUser: () => mockUseCreateUser(),
-  useUserActivity: (...args: unknown[]) => mockUseUserActivity(...args),
+  useEntityActivity: (...args: unknown[]) => mockUseEntityActivity(...args),
 }));
 
 vi.mock('../services/libraryServices', () => ({
@@ -220,7 +220,7 @@ describe('User Management page', () => {
     mockUseDeleteUser.mockReturnValue(mockMutationResult);
     mockUseBulkUpdateUsers.mockReturnValue(mockMutationResult);
     mockUseCreateUser.mockReturnValue(mockMutationResult);
-    mockUseUserActivity.mockReturnValue({
+    mockUseEntityActivity.mockReturnValue({
       data: [],
       isLoading: false,
       error: null,

--- a/app.admin/src/components/detail/UserDetailPanel.css.ts
+++ b/app.admin/src/components/detail/UserDetailPanel.css.ts
@@ -2,24 +2,6 @@ import { globalStyle, style } from '@vanilla-extract/css';
 
 import { vars } from '@adopt-dont-shop/lib.components/theme';
 
-export const panel = style({
-  display: 'flex',
-  flexDirection: 'column',
-  height: '100%',
-  background: vars.background.surface,
-  border: `1px solid ${vars.border.color.default}`,
-  borderRadius: '12px',
-  overflow: 'hidden',
-});
-
-export const panelHeader = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '0.75rem',
-  padding: '1rem 1.25rem',
-  borderBottom: `1px solid ${vars.border.color.default}`,
-});
-
 export const avatar = style({
   width: '48px',
   height: '48px',
@@ -62,57 +44,6 @@ export const headerBadges = style({
   display: 'flex',
   gap: '0.375rem',
   flexShrink: 0,
-});
-
-export const closeButton = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '28px',
-  height: '28px',
-  border: 'none',
-  borderRadius: '6px',
-  background: 'transparent',
-  color: vars.text.tertiary,
-  cursor: 'pointer',
-  flexShrink: 0,
-  ':hover': {
-    background: vars.background.muted,
-    color: vars.text.primary,
-  },
-});
-
-export const tabBar = style({
-  display: 'flex',
-  gap: 0,
-  borderBottom: `1px solid ${vars.border.color.default}`,
-  padding: '0 1.25rem',
-});
-
-export const tab = style({
-  padding: '0.625rem 1rem',
-  border: 'none',
-  borderBottom: '2px solid transparent',
-  background: 'transparent',
-  color: vars.text.tertiary,
-  fontSize: '0.8125rem',
-  fontWeight: '500',
-  cursor: 'pointer',
-  transition: 'all 0.15s ease',
-  ':hover': {
-    color: vars.text.primary,
-  },
-});
-
-export const tabActive = style({
-  color: vars.colors.primary,
-  borderBottomColor: vars.colors.primary,
-});
-
-export const tabContent = style({
-  flex: 1,
-  overflowY: 'auto',
-  padding: '1.25rem',
 });
 
 // ── Overview tab ──────────────────────────────────────────────────

--- a/app.admin/src/components/detail/UserDetailPanel.tsx
+++ b/app.admin/src/components/detail/UserDetailPanel.tsx
@@ -1,5 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { Button, Input, Spinner } from '@adopt-dont-shop/lib.components';
+import {
+  Button,
+  EntityInspector,
+  type EntityInspectorTab,
+  Input,
+  Spinner,
+} from '@adopt-dont-shop/lib.components';
 import { formatDisplayDate } from '@adopt-dont-shop/lib.utils';
 import {
   FiMail,
@@ -8,7 +14,6 @@ import {
   FiClock,
   FiUser,
   FiShield,
-  FiX,
   FiPause,
   FiPlay,
   FiCheckCircle,
@@ -17,10 +22,8 @@ import {
 } from 'react-icons/fi';
 import clsx from 'clsx';
 import type { AdminUser, UserType, UserStatus } from '@/types';
-import { useUserActivity } from '../../hooks';
+import { useEntityActivity } from '../../hooks';
 import * as styles from './UserDetailPanel.css';
-
-type TabId = 'overview' | 'edit' | 'actions' | 'activity';
 
 type UserDetailPanelProps = {
   user: AdminUser;
@@ -33,13 +36,6 @@ type UserDetailPanelProps = {
   onResetPassword: (userId: string) => Promise<void>;
   onMessage: (user: AdminUser) => void;
 };
-
-const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
-  { id: 'overview', label: 'Overview' },
-  { id: 'edit', label: 'Edit' },
-  { id: 'actions', label: 'Actions' },
-  { id: 'activity', label: 'Activity' },
-];
 
 const getUserInitials = (
   firstName: string | null | undefined,
@@ -380,7 +376,7 @@ const ActionsTab: React.FC<{
 // ── Activity Tab ──────────────────────────────────────────────────
 
 const ActivityTab: React.FC<{ userId: string }> = ({ userId }) => {
-  const { data, isLoading, error } = useUserActivity(userId);
+  const { data, isLoading, error } = useEntityActivity('user', userId);
 
   if (isLoading) {
     return (
@@ -431,67 +427,49 @@ export const UserDetailPanel: React.FC<UserDetailPanelProps> = ({
   onResetPassword,
   onMessage,
 }) => {
-  const [activeTab, setActiveTab] = useState<TabId>('overview');
-
-  useEffect(() => {
-    setActiveTab('overview');
-  }, [user.userId]);
+  const tabs: EntityInspectorTab[] = [
+    { id: 'overview', label: 'Overview', content: <OverviewTab user={user} /> },
+    { id: 'edit', label: 'Edit', content: <EditTab user={user} onSave={onSave} /> },
+    {
+      id: 'actions',
+      label: 'Actions',
+      content: (
+        <ActionsTab
+          user={user}
+          onSuspend={onSuspend}
+          onUnsuspend={onUnsuspend}
+          onVerify={onVerify}
+          onDelete={onDelete}
+          onResetPassword={onResetPassword}
+          onMessage={onMessage}
+        />
+      ),
+    },
+    { id: 'activity', label: 'Activity', content: <ActivityTab userId={user.userId} /> },
+  ];
 
   return (
-    <div className={styles.panel} data-testid='user-detail-panel'>
-      <div className={styles.panelHeader}>
-        <div className={styles.avatar}>{getUserInitials(user.firstName, user.lastName)}</div>
-        <div className={styles.headerInfo}>
-          <h3 className={styles.headerName}>
-            {user.firstName} {user.lastName}
-          </h3>
-          <p className={styles.headerEmail}>{user.email}</p>
-        </div>
-        <div className={styles.headerBadges}>
-          {getUserTypeBadge(user.userType)}
-          {getStatusBadge(user.status, user.emailVerified ?? false)}
-        </div>
-        <button
-          type='button'
-          className={styles.closeButton}
-          onClick={onClose}
-          aria-label='Close detail panel'
-        >
-          <FiX />
-        </button>
-      </div>
-
-      <div className={styles.tabBar} role='tablist'>
-        {TABS.map(tab => (
-          <button
-            key={tab.id}
-            type='button'
-            role='tab'
-            aria-selected={activeTab === tab.id}
-            className={clsx(styles.tab, activeTab === tab.id && styles.tabActive)}
-            onClick={() => setActiveTab(tab.id)}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      <div className={styles.tabContent} role='tabpanel'>
-        {activeTab === 'overview' && <OverviewTab user={user} />}
-        {activeTab === 'edit' && <EditTab user={user} onSave={onSave} />}
-        {activeTab === 'actions' && (
-          <ActionsTab
-            user={user}
-            onSuspend={onSuspend}
-            onUnsuspend={onUnsuspend}
-            onVerify={onVerify}
-            onDelete={onDelete}
-            onResetPassword={onResetPassword}
-            onMessage={onMessage}
-          />
-        )}
-        {activeTab === 'activity' && <ActivityTab userId={user.userId} />}
-      </div>
-    </div>
+    <EntityInspector
+      data-testid='user-detail-panel'
+      resetTabsOnKeyChange={user.userId}
+      onClose={onClose}
+      closeLabel='Close detail panel'
+      tabs={tabs}
+      header={
+        <>
+          <div className={styles.avatar}>{getUserInitials(user.firstName, user.lastName)}</div>
+          <div className={styles.headerInfo}>
+            <h3 className={styles.headerName}>
+              {user.firstName} {user.lastName}
+            </h3>
+            <p className={styles.headerEmail}>{user.email}</p>
+          </div>
+          <div className={styles.headerBadges}>
+            {getUserTypeBadge(user.userType)}
+            {getStatusBadge(user.status, user.emailVerified ?? false)}
+          </div>
+        </>
+      }
+    />
   );
 };

--- a/app.admin/src/hooks/index.ts
+++ b/app.admin/src/hooks/index.ts
@@ -19,3 +19,6 @@ export * from './useAnalytics';
 
 // Inbox hooks
 export * from './useInbox';
+
+// Generic entity activity (used by EntityInspector across all entity types)
+export * from './useEntityActivity';

--- a/app.admin/src/hooks/useEntityActivity.ts
+++ b/app.admin/src/hooks/useEntityActivity.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import type { EntityActivityFilters, EntityType } from '@adopt-dont-shop/lib.types';
+
+import { entityActivityService } from '../services/entityActivityService';
+
+/**
+ * Fetch the chronological activity log for a single entity instance.
+ *
+ * Used by the EntityInspector "Activity" tab across users, rescues,
+ * applications, pets, reports, etc. The route prefix per entity type is
+ * resolved inside `entityActivityService`; this hook stays uniform.
+ */
+export const useEntityActivity = (
+  entityType: EntityType,
+  entityId: string,
+  filters: EntityActivityFilters = {}
+) => {
+  return useQuery({
+    queryKey: ['entity-activity', entityType, entityId, filters],
+    queryFn: () => entityActivityService.getActivity(entityType, entityId, filters),
+    enabled: !!entityId,
+  });
+};

--- a/app.admin/src/hooks/useUsers.ts
+++ b/app.admin/src/hooks/useUsers.ts
@@ -92,20 +92,6 @@ export const useResetUserPassword = () => {
 };
 
 /**
- * Hook to fetch user activity
- */
-export const useUserActivity = (
-  userId: string,
-  filters: Parameters<typeof userManagementService.getUserActivity>[1] = {}
-) => {
-  return useQuery({
-    queryKey: ['user-activity', userId, filters],
-    queryFn: () => userManagementService.getUserActivity(userId, filters),
-    enabled: !!userId,
-  });
-};
-
-/**
  * Hook to search users
  */
 export const useSearchUsers = (

--- a/app.admin/src/services/entityActivityService.test.ts
+++ b/app.admin/src/services/entityActivityService.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn();
+
+vi.mock('./libraryServices', () => ({
+  apiService: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+import { entityActivityService, EntityActivityNotSupportedError } from './entityActivityService';
+
+const sampleActivity = [
+  {
+    activityId: 1,
+    activityType: 'login' as const,
+    action: 'USER_LOGIN',
+    description: 'Logged into account',
+    category: 'AUTH',
+    ipAddress: null,
+    userAgent: null,
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+];
+
+describe('entityActivityService.getActivity', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('hits the user route for entityType=user', async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: sampleActivity });
+
+    const result = await entityActivityService.getActivity('user', 'u1', { limit: 10 });
+
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/users/u1/activity', { limit: 10 });
+    expect(result).toEqual(sampleActivity);
+  });
+
+  it('unwraps the {success, data} envelope', async () => {
+    mockGet.mockResolvedValueOnce({ success: true, data: sampleActivity });
+    const result = await entityActivityService.getActivity('user', 'u1');
+    expect(result).toBe(sampleActivity);
+  });
+
+  it('throws EntityActivityNotSupportedError for entity types not yet wired', async () => {
+    await expect(entityActivityService.getActivity('rescue', 'r1')).rejects.toBeInstanceOf(
+      EntityActivityNotSupportedError
+    );
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/app.admin/src/services/entityActivityService.ts
+++ b/app.admin/src/services/entityActivityService.ts
@@ -1,0 +1,51 @@
+import type { EntityActivity, EntityActivityFilters, EntityType } from '@adopt-dont-shop/lib.types';
+
+import { apiService } from './libraryServices';
+
+/**
+ * Map a logical entity type to the backend route prefix that serves its
+ * activity log. Phase 1 wires `user` only; Phase 2 PRs add the remaining
+ * prefixes as the per-entity routes land.
+ *
+ * Keeping this lookup explicit (rather than pluralising the EntityType
+ * string) means a typo here fails loudly via TypeScript instead of
+ * silently 404ing at runtime.
+ */
+const ENTITY_ROUTE_PREFIX: Partial<Record<EntityType, string>> = {
+  user: '/api/v1/users',
+  // Phase 2 will add:
+  // rescue: '/api/v1/rescues',
+  // application: '/api/v1/applications',
+  // pet: '/api/v1/pets',
+  // report: '/api/v1/moderation/reports',
+  // chat: '/api/v1/chats',
+  // support_ticket: '/api/v1/support/tickets',
+};
+
+export class EntityActivityNotSupportedError extends Error {
+  constructor(entityType: EntityType) {
+    super(`Activity feed is not yet supported for entity type: ${entityType}`);
+    this.name = 'EntityActivityNotSupportedError';
+  }
+}
+
+class EntityActivityService {
+  async getActivity(
+    entityType: EntityType,
+    entityId: string,
+    filters: EntityActivityFilters = {}
+  ): Promise<EntityActivity[]> {
+    const prefix = ENTITY_ROUTE_PREFIX[entityType];
+    if (!prefix) {
+      throw new EntityActivityNotSupportedError(entityType);
+    }
+
+    const response = await apiService.get<{ success: boolean; data: EntityActivity[] }>(
+      `${prefix}/${entityId}/activity`,
+      filters
+    );
+    return response.data;
+  }
+}
+
+export const entityActivityService = new EntityActivityService();

--- a/app.admin/src/services/userManagementService.test.ts
+++ b/app.admin/src/services/userManagementService.test.ts
@@ -220,29 +220,6 @@ describe('UserManagementService', () => {
     });
   });
 
-  describe('getUserActivity', () => {
-    it('fetches activity with filters', async () => {
-      const activities = [
-        {
-          activityId: 1,
-          activityType: 'login',
-          action: 'USER_LOGIN',
-          description: 'Logged into account',
-          category: 'AUTH',
-          ipAddress: null,
-          userAgent: null,
-          createdAt: '2024-01-01T00:00:00Z',
-        },
-      ];
-      mockGet.mockResolvedValueOnce({ success: true, data: activities });
-
-      const result = await userManagementService.getUserActivity('u1', { limit: 10 });
-
-      expect(mockGet).toHaveBeenCalledWith('/api/v1/users/u1/activity', { limit: 10 });
-      expect(result).toEqual(activities);
-    });
-  });
-
   describe('searchUsers', () => {
     it('passes query and filters to the search endpoint', async () => {
       mockGet.mockResolvedValueOnce(paginatedUsers);

--- a/app.admin/src/services/userManagementService.ts
+++ b/app.admin/src/services/userManagementService.ts
@@ -1,5 +1,4 @@
 import type { BulkUserUpdateData } from '@adopt-dont-shop/lib.validation';
-import type { UserActivity, UserActivityFilters } from '@adopt-dont-shop/lib.types';
 import { apiService } from './libraryServices';
 import { User, PaginatedResponse } from '@/types';
 
@@ -169,25 +168,6 @@ class UserManagementService {
       );
     } catch (error) {
       console.error('❌ UserManagementService: Failed to reset user password:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Get user activity log
-   */
-  async getUserActivity(
-    userId: string,
-    filters: UserActivityFilters = {}
-  ): Promise<UserActivity[]> {
-    try {
-      const response = await apiService.get<{ success: boolean; data: UserActivity[] }>(
-        `/api/v1/users/${userId}/activity`,
-        filters
-      );
-      return response.data;
-    } catch (error) {
-      console.error('❌ UserManagementService: Failed to fetch user activity:', error);
       throw error;
     }
   }

--- a/app.admin/src/setup-tests.ts
+++ b/app.admin/src/setup-tests.ts
@@ -216,4 +216,63 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
   }) => React.createElement('div', { role: 'status', ...props }, message),
   ToastContainer: ({ children }: { children: React.ReactNode }) =>
     React.createElement('div', { 'data-testid': 'toast-container' }, children),
+  // EntityInspector — minimal mock that renders the header, every tab as a
+  // role="tab" button, the close button (if onClose provided), and the
+  // active tab body. Mirrors the real component's a11y surface so tests
+  // that find tabs by role/name keep working.
+  EntityInspector: ({
+    header,
+    tabs,
+    defaultTabId,
+    onClose,
+    closeLabel,
+    'data-testid': testId,
+  }: {
+    header: React.ReactNode;
+    tabs: ReadonlyArray<{ id: string; label: string; content: React.ReactNode }>;
+    defaultTabId?: string;
+    onClose?: () => void;
+    closeLabel?: string;
+    'data-testid'?: string;
+  }) => {
+    const initialId =
+      defaultTabId && tabs.some(t => t.id === defaultTabId) ? defaultTabId : (tabs[0]?.id ?? null);
+    const [activeId, setActiveId] = React.useState<string | null>(initialId);
+    const active = tabs.find(t => t.id === activeId) ?? null;
+    return React.createElement(
+      'div',
+      { 'data-testid': testId },
+      React.createElement('div', { key: 'header' }, header),
+      onClose
+        ? React.createElement(
+            'button',
+            {
+              key: 'close',
+              type: 'button',
+              onClick: onClose,
+              'aria-label': closeLabel ?? 'Close inspector',
+            },
+            '✕'
+          )
+        : null,
+      React.createElement(
+        'div',
+        { key: 'tabs', role: 'tablist' },
+        ...tabs.map(t =>
+          React.createElement(
+            'button',
+            {
+              key: t.id,
+              type: 'button',
+              role: 'tab',
+              'aria-selected': t.id === activeId,
+              onClick: () => setActiveId(t.id),
+            },
+            t.label
+          )
+        )
+      ),
+      React.createElement('div', { key: 'panel', role: 'tabpanel' }, active?.content ?? null)
+    );
+  },
 }));

--- a/lib.components/src/components/data/EntityInspector/EntityInspector.css.ts
+++ b/lib.components/src/components/data/EntityInspector/EntityInspector.css.ts
@@ -1,0 +1,82 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../../styles/theme.css';
+
+export const panel = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  background: vars.background.surface,
+  border: `1px solid ${vars.border.color.default}`,
+  borderRadius: '12px',
+  overflow: 'hidden',
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  padding: '1rem 1.25rem',
+  borderBottom: `1px solid ${vars.border.color.default}`,
+});
+
+export const headerSlot = style({
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+});
+
+export const closeButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '28px',
+  height: '28px',
+  border: 'none',
+  borderRadius: '6px',
+  background: 'transparent',
+  color: vars.text.tertiary,
+  cursor: 'pointer',
+  flexShrink: 0,
+  fontSize: '1rem',
+  ':hover': {
+    background: vars.background.muted,
+    color: vars.text.primary,
+  },
+});
+
+export const tabBar = style({
+  display: 'flex',
+  gap: 0,
+  borderBottom: `1px solid ${vars.border.color.default}`,
+  padding: '0 1.25rem',
+  overflowX: 'auto',
+});
+
+export const tab = style({
+  padding: '0.625rem 1rem',
+  border: 'none',
+  borderBottom: '2px solid transparent',
+  background: 'transparent',
+  color: vars.text.tertiary,
+  fontSize: '0.8125rem',
+  fontWeight: '500',
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+  transition: 'all 0.15s ease',
+  ':hover': {
+    color: vars.text.primary,
+  },
+});
+
+export const tabActive = style({
+  color: vars.colors.primary,
+  borderBottomColor: vars.colors.primary,
+});
+
+export const tabContent = style({
+  flex: 1,
+  overflowY: 'auto',
+  padding: '1.25rem',
+});

--- a/lib.components/src/components/data/EntityInspector/EntityInspector.test.tsx
+++ b/lib.components/src/components/data/EntityInspector/EntityInspector.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityInspector } from './EntityInspector';
+
+const baseTabs = [
+  { id: 'overview', label: 'Overview', content: <div>Overview body</div> },
+  { id: 'edit', label: 'Edit', content: <div>Edit body</div> },
+  { id: 'activity', label: 'Activity', content: <div>Activity body</div> },
+];
+
+describe('EntityInspector', () => {
+  it('renders the header slot and every tab label', () => {
+    render(
+      <EntityInspector header={<h3>Jessica Wilson</h3>} tabs={baseTabs} data-testid='inspector' />
+    );
+
+    expect(screen.getByText('Jessica Wilson')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Activity' })).toBeInTheDocument();
+  });
+
+  it('shows the first tab body by default', () => {
+    render(<EntityInspector header={<h3>X</h3>} tabs={baseTabs} />);
+
+    expect(screen.getByText('Overview body')).toBeInTheDocument();
+    expect(screen.queryByText('Edit body')).not.toBeInTheDocument();
+    expect(screen.queryByText('Activity body')).not.toBeInTheDocument();
+  });
+
+  it('honours defaultTabId', () => {
+    render(<EntityInspector header={<h3>X</h3>} tabs={baseTabs} defaultTabId='activity' />);
+
+    expect(screen.getByText('Activity body')).toBeInTheDocument();
+    expect(screen.queryByText('Overview body')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the first tab when defaultTabId does not match any tab', () => {
+    render(<EntityInspector header={<h3>X</h3>} tabs={baseTabs} defaultTabId='nope' />);
+
+    expect(screen.getByText('Overview body')).toBeInTheDocument();
+  });
+
+  it('switches the body when a tab is clicked', async () => {
+    const user = userEvent.setup();
+    render(<EntityInspector header={<h3>X</h3>} tabs={baseTabs} />);
+
+    await user.click(screen.getByRole('tab', { name: 'Edit' }));
+
+    expect(screen.getByText('Edit body')).toBeInTheDocument();
+    expect(screen.queryByText('Overview body')).not.toBeInTheDocument();
+  });
+
+  it('marks the active tab as aria-selected', async () => {
+    const user = userEvent.setup();
+    render(<EntityInspector header={<h3>X</h3>} tabs={baseTabs} />);
+
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true');
+
+    await user.click(screen.getByRole('tab', { name: 'Activity' }));
+
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tab', { name: 'Activity' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('renders a close button when onClose is provided and calls it', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<EntityInspector header={<h3>X</h3>} tabs={baseTabs} onClose={onClose} />);
+
+    const close = screen.getByRole('button', { name: 'Close inspector' });
+    await user.click(close);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the close button when onClose is not provided', () => {
+    render(<EntityInspector header={<h3>X</h3>} tabs={baseTabs} />);
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+  });
+
+  it('resets the active tab when resetTabsOnKeyChange changes', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <EntityInspector header={<h3>X</h3>} tabs={baseTabs} resetTabsOnKeyChange='user-1' />
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Activity' }));
+    expect(screen.getByText('Activity body')).toBeInTheDocument();
+
+    rerender(<EntityInspector header={<h3>X</h3>} tabs={baseTabs} resetTabsOnKeyChange='user-2' />);
+
+    expect(screen.getByText('Overview body')).toBeInTheDocument();
+  });
+
+  it('handles an empty tab list without crashing', () => {
+    render(<EntityInspector header={<h3>X</h3>} tabs={[]} data-testid='inspector' />);
+    expect(screen.getByTestId('inspector')).toBeInTheDocument();
+    expect(screen.queryAllByRole('tab')).toHaveLength(0);
+  });
+});

--- a/lib.components/src/components/data/EntityInspector/EntityInspector.tsx
+++ b/lib.components/src/components/data/EntityInspector/EntityInspector.tsx
@@ -1,0 +1,118 @@
+import clsx from 'clsx';
+import React, { useEffect, useState } from 'react';
+
+import * as styles from './EntityInspector.css';
+
+export type EntityInspectorTab = {
+  /** Stable identifier for the tab — used as React key and for default selection. */
+  id: string;
+  /** Visible label. */
+  label: string;
+  /** Tab body. Rendered when the tab is active; pre-mounted tabs are an explicit opt-in. */
+  content: React.ReactNode;
+};
+
+export type EntityInspectorProps = {
+  /**
+   * Slot rendered on the left of the header — avatar, name, badges, etc.
+   * Pure presentation; the inspector imposes no shape on the entity.
+   */
+  header: React.ReactNode;
+  /**
+   * Ordered list of tabs. The first tab is selected by default unless
+   * `defaultTabId` is supplied.
+   */
+  tabs: ReadonlyArray<EntityInspectorTab>;
+  /** Tab to select when the inspector first renders. Falls back to `tabs[0]`. */
+  defaultTabId?: string;
+  /** Resets the active tab back to `defaultTabId` (or `tabs[0]`) when this value changes. */
+  resetTabsOnKeyChange?: string | number;
+  /** Called when the user clicks the close button. Omit to hide the close button. */
+  onClose?: () => void;
+  /** Accessible label for the close button. */
+  closeLabel?: string;
+  className?: string;
+  'data-testid'?: string;
+};
+
+const resolveDefaultTabId = (
+  tabs: ReadonlyArray<EntityInspectorTab>,
+  preferred?: string
+): string | null => {
+  if (preferred && tabs.some(tab => tab.id === preferred)) {
+    return preferred;
+  }
+  return tabs[0]?.id ?? null;
+};
+
+export const EntityInspector: React.FC<EntityInspectorProps> = ({
+  header,
+  tabs,
+  defaultTabId,
+  resetTabsOnKeyChange,
+  onClose,
+  closeLabel = 'Close inspector',
+  className,
+  'data-testid': testId,
+}) => {
+  const [activeTabId, setActiveTabId] = useState<string | null>(() =>
+    resolveDefaultTabId(tabs, defaultTabId)
+  );
+
+  // Reset selection when the inspected entity changes. Callers pass the
+  // entity id via resetTabsOnKeyChange so switching rows in a split-pane
+  // list doesn't leave a stale tab open.
+  useEffect(() => {
+    setActiveTabId(resolveDefaultTabId(tabs, defaultTabId));
+  }, [resetTabsOnKeyChange, defaultTabId, tabs]);
+
+  const activeTab = tabs.find(tab => tab.id === activeTabId) ?? null;
+
+  return (
+    <div className={clsx(styles.panel, className)} data-testid={testId}>
+      <div className={styles.header}>
+        <div className={styles.headerSlot}>{header}</div>
+        {onClose && (
+          <button
+            type='button'
+            className={styles.closeButton}
+            onClick={onClose}
+            aria-label={closeLabel}
+          >
+            {/* Plain unicode times — keeps lib.components free of icon deps */}
+            &#x2715;
+          </button>
+        )}
+      </div>
+
+      <div className={styles.tabBar} role='tablist'>
+        {tabs.map(tab => {
+          const isActive = tab.id === activeTabId;
+          return (
+            <button
+              key={tab.id}
+              type='button'
+              role='tab'
+              aria-selected={isActive}
+              aria-controls={`entity-inspector-panel-${tab.id}`}
+              id={`entity-inspector-tab-${tab.id}`}
+              className={clsx(styles.tab, isActive && styles.tabActive)}
+              onClick={() => setActiveTabId(tab.id)}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        className={styles.tabContent}
+        role='tabpanel'
+        id={activeTab ? `entity-inspector-panel-${activeTab.id}` : undefined}
+        aria-labelledby={activeTab ? `entity-inspector-tab-${activeTab.id}` : undefined}
+      >
+        {activeTab?.content ?? null}
+      </div>
+    </div>
+  );
+};

--- a/lib.components/src/components/data/EntityInspector/index.ts
+++ b/lib.components/src/components/data/EntityInspector/index.ts
@@ -1,0 +1,2 @@
+export { EntityInspector } from './EntityInspector';
+export type { EntityInspectorProps, EntityInspectorTab } from './EntityInspector';

--- a/lib.components/src/index.ts
+++ b/lib.components/src/index.ts
@@ -39,6 +39,10 @@ export type {
 } from './components/layout/SplitPaneDetail';
 export { Card, CardContent, CardFooter, CardHeader } from './components/ui/Card';
 
+// Data Components
+export { EntityInspector } from './components/data/EntityInspector';
+export type { EntityInspectorProps, EntityInspectorTab } from './components/data/EntityInspector';
+
 // Form Components
 export { CheckboxInput } from './components/form/CheckboxInput';
 export { SelectInput } from './components/form/SelectInput/';

--- a/lib.types/src/index.ts
+++ b/lib.types/src/index.ts
@@ -32,5 +32,8 @@ export * from './types/domain-status';
 // Common utility types (sort, date range, service config)
 export * from './types/common';
 
-// User activity (admin user detail panel — activity log + summary)
+// Generic entity activity (admin EntityInspector — works across all entity types)
+export * from './types/entity-activity';
+
+// User activity (admin user detail panel — activity log + summary; aliases to entity-activity)
 export * from './types/user-activity';

--- a/lib.types/src/types/entity-activity.ts
+++ b/lib.types/src/types/entity-activity.ts
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// Entity activity — shared API contract for the admin EntityInspector
+// ---------------------------------------------------------------------------
+//
+// The admin app surfaces an "Activity" tab on every entity detail view
+// (users, rescues, applications, pets, reports). All of those endpoints
+// return the same shape; only the route prefix differs:
+//
+//   GET /api/v1/users/:id/activity         → EntityActivity[]
+//   GET /api/v1/rescues/:id/activity       → EntityActivity[]
+//   GET /api/v1/applications/:id/activity  → EntityActivity[]
+//   ...
+//
+// Dates are wire-format ISO 8601 strings (not Date) because these types
+// describe JSON responses. Convert at the edge if you need Date objects.
+
+export type EntityType =
+  | 'user'
+  | 'rescue'
+  | 'application'
+  | 'pet'
+  | 'report'
+  | 'chat'
+  | 'support_ticket';
+
+export type EntityActivityType =
+  | 'application'
+  | 'chat'
+  | 'favorite'
+  | 'profile_update'
+  | 'login'
+  | 'other';
+
+export type EntityActivity = {
+  activityId: number;
+  activityType: EntityActivityType;
+  action: string;
+  description: string;
+  category: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+};
+
+export type EntityActivityFilters = {
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+};

--- a/lib.types/src/types/user-activity.ts
+++ b/lib.types/src/types/user-activity.ts
@@ -2,38 +2,21 @@
 // User activity — shared API contract between service.backend and admin app
 // ---------------------------------------------------------------------------
 //
-// Two distinct endpoints share these types:
-//   GET /api/v1/users/:userId/activity          → UserActivity[]
-//   GET /api/v1/users/:userId/activity-summary  → UserActivitySummary
+// The activity-log shape was generalised into EntityActivity (see
+// entity-activity.ts) so the admin EntityInspector can drive every
+// entity tab from one type. UserActivity / UserActivityFilters /
+// UserActivityType are kept as aliases so existing consumers keep
+// compiling — prefer the Entity* names in new code.
 //
-// Dates are wire-format ISO 8601 strings (not Date) because these types
-// describe JSON responses. Convert at the edge if you need Date objects.
+// UserActivitySummary stays user-specific because aggregate-stats shapes
+// differ per entity (a rescue summary, for example, would expose verified
+// staff count rather than messages exchanged).
 
-export type UserActivityType =
-  | 'application'
-  | 'chat'
-  | 'favorite'
-  | 'profile_update'
-  | 'login'
-  | 'other';
+import type { EntityActivity, EntityActivityFilters, EntityActivityType } from './entity-activity';
 
-export type UserActivity = {
-  activityId: number;
-  activityType: UserActivityType;
-  action: string;
-  description: string;
-  category: string;
-  ipAddress: string | null;
-  userAgent: string | null;
-  createdAt: string;
-};
-
-export type UserActivityFilters = {
-  from?: string;
-  to?: string;
-  limit?: number;
-  offset?: number;
-};
+export type UserActivityType = EntityActivityType;
+export type UserActivity = EntityActivity;
+export type UserActivityFilters = EntityActivityFilters;
 
 export type UserActivityRecentItem = {
   action: string;

--- a/service.backend/src/services/audit-log-formatting.ts
+++ b/service.backend/src/services/audit-log-formatting.ts
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------------------
+// Shared audit-log → activity formatting helpers
+// ---------------------------------------------------------------------------
+//
+// The admin EntityInspector renders an Activity tab on every entity type
+// (users, rescues, pets, applications, ...). All of those tabs need the
+// same translation from raw audit_log rows to the EntityActivity wire
+// shape — so the action→verb mapping, description composition, and
+// metadata label extraction live here rather than being duplicated per
+// entity service.
+
+import type { EntityActivity, EntityActivityType } from '@adopt-dont-shop/lib.types';
+import type { JsonObject } from '../types/common';
+import type { AuditLog } from '../models/AuditLog';
+
+/** Map an UPPER_SNAKE audit action to a coarse activity type bucket. */
+export const mapActionToActivityType = (action: string): EntityActivityType => {
+  if (action.includes('APPLICATION')) {
+    return 'application';
+  }
+  if (action.includes('CHAT') || action.includes('MESSAGE')) {
+    return 'chat';
+  }
+  if (action.includes('FAVORITE')) {
+    return 'favorite';
+  }
+  if (action.includes('PROFILE') || action.includes('USER_UPDATE')) {
+    return 'profile_update';
+  }
+  if (action.includes('LOGIN')) {
+    return 'login';
+  }
+  return 'other';
+};
+
+/**
+ * Pull a display-friendly entity label out of metadata. Audit writers
+ * stash human-readable context under metadata.details (petName, title,
+ * name, email, ...); fall back to metadata.entityId so something
+ * recognisable surfaces even when the writer didn't include a name.
+ */
+export const extractEntityLabel = (metadata?: JsonObject | null): string | undefined => {
+  if (!metadata) {
+    return undefined;
+  }
+  const details =
+    typeof metadata.details === 'object' && metadata.details !== null
+      ? (metadata.details as JsonObject)
+      : undefined;
+  const candidateKeys = ['petName', 'title', 'name', 'rescueName', 'subject', 'email'];
+  for (const key of candidateKeys) {
+    const fromDetails = details?.[key];
+    if (typeof fromDetails === 'string' && fromDetails.length > 0) {
+      return fromDetails;
+    }
+    const fromMetadata = metadata[key];
+    if (typeof fromMetadata === 'string' && fromMetadata.length > 0) {
+      return fromMetadata;
+    }
+  }
+  const entityId = metadata.entityId;
+  if (typeof entityId === 'string' && entityId.length > 0) {
+    return entityId;
+  }
+  return undefined;
+};
+
+/** Convert an UPPER_SNAKE action name to a past-tense verb phrase. */
+export const actionToVerb = (action: string): string => {
+  const verbMap: Record<string, string> = {
+    CREATE: 'Created',
+    UPDATE: 'Updated',
+    DELETE: 'Deleted',
+    VIEW: 'Viewed',
+    UPDATE_STATUS: 'Updated status of',
+    ADD_IMAGES: 'Added images to',
+    UPDATE_IMAGES: 'Updated images on',
+    REMOVE_IMAGE: 'Removed image from',
+    BULK_OPERATION: 'Performed bulk operation on',
+    BULK_UPDATE: 'Bulk-updated',
+    SUSPEND: 'Suspended',
+    UNSUSPEND: 'Unsuspended',
+    DEACTIVATE: 'Deactivated',
+    REACTIVATE: 'Reactivated',
+  };
+  if (verbMap[action]) {
+    return verbMap[action];
+  }
+  return action
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/^./, c => c.toUpperCase());
+};
+
+/**
+ * Format activity description from action, entity category, and metadata.
+ *
+ * Audit rows are emitted as (action, category, metadata) where category is
+ * the entity name (PET, APPLICATION, USER, ...) and metadata.details holds
+ * arbitrary context — often a human-readable name. We compose all three so
+ * bare verbs like CREATE/UPDATE/DELETE surface their entity instead of
+ * appearing as a one-word "create" / "update" in the UI.
+ */
+export const formatActivityDescription = (
+  action: string,
+  category: string,
+  metadata?: JsonObject | null
+): string => {
+  const knownPhrasings: Record<string, (entity: string | undefined) => string> = {
+    APPLICATION_SUBMITTED: entity => `Submitted application for ${entity ?? 'a pet'}`,
+    APPLICATION_UPDATED: entity => `Updated application${entity ? ` for ${entity}` : ''}`,
+    APPLICATION_STATUS_UPDATED: entity =>
+      `Application status changed${entity ? ` for ${entity}` : ''}`,
+    WITHDRAW: () => 'Withdrew application',
+    USER_LOGIN: () => 'Logged into account',
+    LOGIN: () => 'Logged in',
+    LOGOUT: () => 'Logged out',
+    LOGIN_FAILED: () => 'Failed login attempt',
+    PROFILE_UPDATED: () => 'Updated profile',
+    USER_CREATED: () => 'Account created',
+    PASSWORD_RESET: () => 'Password reset',
+    PASSWORD_RESET_REQUEST: () => 'Requested password reset',
+    EMAIL_VERIFICATION: () => 'Verified email address',
+    PET_FAVORITED: entity => `Added ${entity ?? 'a pet'} to favorites`,
+    MESSAGE_SENT: () => 'Sent a message',
+    MESSAGE_READ: () => 'Read a message',
+    CHAT_CREATED: () => 'Started a new conversation',
+    FILE_UPLOAD: entity => `Uploaded ${entity ?? 'a file'}`,
+    FILE_DELETE: entity => `Deleted ${entity ?? 'a file'}`,
+    VIEW: entity => `Viewed ${entity ?? category.toLowerCase()}`,
+    TWO_FACTOR_ENABLED: () => 'Enabled two-factor authentication',
+    TWO_FACTOR_DISABLED: () => 'Disabled two-factor authentication',
+  };
+
+  const entityLabel = extractEntityLabel(metadata);
+  const phrasing = knownPhrasings[action];
+  if (phrasing) {
+    return phrasing(entityLabel);
+  }
+
+  const verb = actionToVerb(action);
+  const entityName = category ? category.toLowerCase().replace(/_/g, ' ') : '';
+  const base = entityName ? `${verb} ${entityName}` : verb;
+  return entityLabel ? `${base}: ${entityLabel}` : base;
+};
+
+/** Map a raw AuditLog row to the shared EntityActivity wire shape. */
+export const auditLogToActivity = (row: AuditLog): EntityActivity => ({
+  activityId: row.id,
+  activityType: mapActionToActivityType(row.action),
+  action: row.action,
+  description: formatActivityDescription(row.action, row.category, row.metadata),
+  category: row.category,
+  ipAddress: row.ip_address,
+  userAgent: row.user_agent,
+  createdAt: row.timestamp.toISOString(),
+});

--- a/service.backend/src/services/auditLog.service.ts
+++ b/service.backend/src/services/auditLog.service.ts
@@ -147,6 +147,80 @@ export class AuditLogService {
   }
 
   /**
+   * Get target-based activity for a single entity instance.
+   *
+   * Audit rows store the affected entity as `category` (entity type, e.g.
+   * 'PET') and stash its primary key inside the JSON `metadata.entityId`
+   * field. This query returns the chronological list of actions taken
+   * AGAINST a given entity instance — distinct from
+   * `getLogsByUser` (which asks "what did this user do?").
+   *
+   * JSON extraction is dialect-specific:
+   *   Postgres: `metadata->>'entityId' = :entityId`
+   *   SQLite:   `json_extract(metadata, '$.entityId') = :entityId`
+   *
+   * Used by the admin EntityInspector Activity tab across rescues, pets,
+   * applications, reports, chats, support_tickets.
+   */
+  static async getEntityActivityLog(
+    entityType: string,
+    entityId: string,
+    options: {
+      from?: Date;
+      to?: Date;
+      limit?: number;
+      offset?: number;
+    } = {}
+  ): Promise<AuditLog[]> {
+    const limit = Math.min(Math.max(options.limit ?? 50, 1), 200);
+    const offset = Math.max(options.offset ?? 0, 0);
+
+    const dialect = sequelize.getDialect();
+    const jsonExtract =
+      dialect === 'postgres' ? `metadata->>'entityId'` : `json_extract(metadata, '$.entityId')`;
+
+    const where: WhereOptions = {
+      category: entityType,
+      [Op.and]: [sequelize.where(sequelize.literal(jsonExtract), entityId)],
+    };
+    if (options.from || options.to) {
+      const range: { [Op.gte]?: Date; [Op.lte]?: Date } = {};
+      if (options.from) {
+        range[Op.gte] = options.from;
+      }
+      if (options.to) {
+        range[Op.lte] = options.to;
+      }
+      (where as { timestamp?: typeof range }).timestamp = range;
+    }
+
+    try {
+      return await AuditLog.findAll({
+        where,
+        order: [['timestamp', 'DESC']],
+        limit,
+        offset,
+        attributes: [
+          'id',
+          'action',
+          'category',
+          'metadata',
+          'ip_address',
+          'user_agent',
+          'timestamp',
+        ],
+      });
+    } catch (error) {
+      logger.error('Failed to get entity activity log:', {
+        error: error instanceof Error ? error.message : String(error),
+        entityType,
+        entityId,
+      });
+      throw error;
+    }
+  }
+
+  /**
    * Clean up old logs (data retention).
    *
    * ADS-508: audit_logs is append-only at both the database and Sequelize

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -3,9 +3,13 @@ import { normalizeEmail } from '@adopt-dont-shop/lib.validation';
 import type {
   UserActivity as SharedUserActivity,
   UserActivityFilters,
-  UserActivityType,
 } from '@adopt-dont-shop/lib.types';
 import { JsonObject } from '../types/common';
+import {
+  auditLogToActivity,
+  formatActivityDescription,
+  mapActionToActivityType,
+} from './audit-log-formatting';
 import { Op, QueryTypes, WhereOptions } from 'sequelize';
 import { validateSortField } from '../utils/sort-validation';
 import { escapeLikePattern } from '../utils/escape-like';
@@ -711,8 +715,8 @@ export class UserService {
         activeChatsCount,
         petsFavoritedCount,
         recentActivity: (recentActivity || []).map(log => ({
-          type: this.mapActionToActivityType(log.action),
-          description: this.formatActivityDescription(log.action, log.category, log.metadata),
+          type: mapActionToActivityType(log.action),
+          description: formatActivityDescription(log.action, log.category, log.metadata),
           timestamp: log.timestamp,
           metadata: log.metadata || {},
         })),
@@ -878,28 +882,6 @@ export class UserService {
   }
 
   /**
-   * Map audit log action to activity type
-   */
-  private static mapActionToActivityType(action: string): UserActivityType {
-    if (action.includes('APPLICATION')) {
-      return 'application';
-    }
-    if (action.includes('CHAT') || action.includes('MESSAGE')) {
-      return 'chat';
-    }
-    if (action.includes('FAVORITE')) {
-      return 'favorite';
-    }
-    if (action.includes('PROFILE') || action.includes('USER_UPDATE')) {
-      return 'profile_update';
-    }
-    if (action.includes('LOGIN')) {
-      return 'login';
-    }
-    return 'other';
-  }
-
-  /**
    * Get paginated user activity log from audit_logs.
    */
   static async getUserActivityLog(
@@ -944,16 +926,7 @@ export class UserService {
         ],
       });
 
-      const activities: SharedUserActivity[] = rows.map(row => ({
-        activityId: row.id,
-        activityType: this.mapActionToActivityType(row.action),
-        action: row.action,
-        description: this.formatActivityDescription(row.action, row.category, row.metadata),
-        category: row.category,
-        ipAddress: row.ip_address,
-        userAgent: row.user_agent,
-        createdAt: row.timestamp.toISOString(),
-      }));
+      const activities: SharedUserActivity[] = rows.map(auditLogToActivity);
 
       loggerHelpers.logPerformance('User Activity Log', {
         duration: Date.now() - startTime,
@@ -970,122 +943,6 @@ export class UserService {
       });
       throw error;
     }
-  }
-
-  /**
-   * Format activity description from action, entity category, and metadata.
-   *
-   * Audit rows are emitted as (action, category, metadata) where category is
-   * the entity name (PET, APPLICATION, USER, ...) and metadata.details holds
-   * arbitrary context — often a human-readable name. We compose all three so
-   * bare verbs like CREATE/UPDATE/DELETE surface their entity instead of
-   * appearing as a one-word "create" / "update" in the UI.
-   */
-  private static formatActivityDescription(
-    action: string,
-    category: string,
-    metadata?: JsonObject | null
-  ): string {
-    // High-frequency actions get bespoke phrasing.
-    const knownPhrasings: Record<string, (entity: string | undefined) => string> = {
-      APPLICATION_SUBMITTED: entity => `Submitted application for ${entity ?? 'a pet'}`,
-      APPLICATION_UPDATED: entity => `Updated application${entity ? ` for ${entity}` : ''}`,
-      APPLICATION_STATUS_UPDATED: entity =>
-        `Application status changed${entity ? ` for ${entity}` : ''}`,
-      WITHDRAW: () => 'Withdrew application',
-      USER_LOGIN: () => 'Logged into account',
-      LOGIN: () => 'Logged in',
-      LOGOUT: () => 'Logged out',
-      LOGIN_FAILED: () => 'Failed login attempt',
-      PROFILE_UPDATED: () => 'Updated profile',
-      USER_CREATED: () => 'Account created',
-      PASSWORD_RESET: () => 'Password reset',
-      PASSWORD_RESET_REQUEST: () => 'Requested password reset',
-      EMAIL_VERIFICATION: () => 'Verified email address',
-      PET_FAVORITED: entity => `Added ${entity ?? 'a pet'} to favorites`,
-      MESSAGE_SENT: () => 'Sent a message',
-      MESSAGE_READ: () => 'Read a message',
-      CHAT_CREATED: () => 'Started a new conversation',
-      FILE_UPLOAD: entity => `Uploaded ${entity ?? 'a file'}`,
-      FILE_DELETE: entity => `Deleted ${entity ?? 'a file'}`,
-      VIEW: entity => `Viewed ${entity ?? category.toLowerCase()}`,
-      TWO_FACTOR_ENABLED: () => 'Enabled two-factor authentication',
-      TWO_FACTOR_DISABLED: () => 'Disabled two-factor authentication',
-    };
-
-    const entityLabel = this.extractEntityLabel(metadata);
-    const phrasing = knownPhrasings[action];
-    if (phrasing) {
-      return phrasing(entityLabel);
-    }
-
-    // Generic fallback: combine verb + entity. Example:
-    //   action="CREATE",  category="PET",         entity="Buddy"  → "Created pet: Buddy"
-    //   action="UPDATE",  category="APPLICATION", entity=undefined → "Updated application"
-    //   action="DELETE",  category="CHAT",         entity=undefined → "Deleted chat"
-    const verb = this.actionToVerb(action);
-    const entityName = category ? category.toLowerCase().replace(/_/g, ' ') : '';
-    const base = entityName ? `${verb} ${entityName}` : verb;
-    return entityLabel ? `${base}: ${entityLabel}` : base;
-  }
-
-  /**
-   * Pull a display-friendly entity label out of metadata. Audit writers
-   * stash human-readable context under metadata.details (petName, title,
-   * name, email, ...); fall back to metadata.entityId so something
-   * recognisable surfaces even when the writer didn't include a name.
-   */
-  private static extractEntityLabel(metadata?: JsonObject | null): string | undefined {
-    if (!metadata) {
-      return undefined;
-    }
-    const details =
-      typeof metadata.details === 'object' && metadata.details !== null
-        ? (metadata.details as JsonObject)
-        : undefined;
-    const candidateKeys = ['petName', 'title', 'name', 'rescueName', 'subject', 'email'];
-    for (const key of candidateKeys) {
-      const fromDetails = details?.[key];
-      if (typeof fromDetails === 'string' && fromDetails.length > 0) {
-        return fromDetails;
-      }
-      const fromMetadata = metadata[key];
-      if (typeof fromMetadata === 'string' && fromMetadata.length > 0) {
-        return fromMetadata;
-      }
-    }
-    const entityId = metadata.entityId;
-    if (typeof entityId === 'string' && entityId.length > 0) {
-      return entityId;
-    }
-    return undefined;
-  }
-
-  /** Convert an UPPER_SNAKE action name to a past-tense verb phrase. */
-  private static actionToVerb(action: string): string {
-    const verbMap: Record<string, string> = {
-      CREATE: 'Created',
-      UPDATE: 'Updated',
-      DELETE: 'Deleted',
-      VIEW: 'Viewed',
-      UPDATE_STATUS: 'Updated status of',
-      ADD_IMAGES: 'Added images to',
-      UPDATE_IMAGES: 'Updated images on',
-      REMOVE_IMAGE: 'Removed image from',
-      BULK_OPERATION: 'Performed bulk operation on',
-      BULK_UPDATE: 'Bulk-updated',
-      SUSPEND: 'Suspended',
-      UNSUSPEND: 'Unsuspended',
-      DEACTIVATE: 'Deactivated',
-      REACTIVATE: 'Reactivated',
-    };
-    if (verbMap[action]) {
-      return verbMap[action];
-    }
-    return action
-      .toLowerCase()
-      .replace(/_/g, ' ')
-      .replace(/^./, c => c.toUpperCase());
   }
 
   /**

--- a/service.backend/src/types/user.ts
+++ b/service.backend/src/types/user.ts
@@ -145,7 +145,7 @@ export interface UserActivity {
 }
 
 export interface ActivityItem {
-  type: 'application' | 'chat' | 'favorite' | 'profile_update' | 'login';
+  type: 'application' | 'chat' | 'favorite' | 'profile_update' | 'login' | 'other';
   description: string;
   timestamp: Date;
   metadata?: JsonObject;


### PR DESCRIPTION
## Summary

Phase 1 of the EntityInspector rollout. Lays the reusable foundation that subsequent per-entity PRs (rescues, applications, pets, reports, chats, support tickets) will hang off. The user detail panel is migrated as the first consumer so the abstraction is exercised by a real surface rather than only by unit tests.

**Wait for this PR to merge before Phase 2 PRs land** — they all depend on the shared types and the `EntityInspector` component this introduces.

## What's included

### Shared types (`lib.types`)
- New `EntityActivity`, `EntityActivityType`, `EntityActivityFilters`, `EntityType` — generic activity-log shape used by every admin entity tab.
- Re-export `UserActivity` / `UserActivityFilters` / `UserActivityType` as aliases of the new types so existing consumers keep compiling.

### Backend (`service.backend`)
- New `service/audit-log-formatting.ts` owns the action→verb, metadata→label, and `AuditLog → EntityActivity` mapping so every entity service formats activity rows identically.
- New `AuditLogService.getEntityActivityLog(entityType, entityId, ...)` queries `audit_logs` by `category + metadata.entityId` with cross-dialect JSON extraction (PG `metadata->>'entityId'`, SQLite `json_extract`).
- `UserService` refactored to consume the shared helpers; ~120 lines of duplicated description-formatting code removed.

### Shared component (`lib.components`)
- New `EntityInspector` — entity-agnostic shell with header slot, tabs, optional close button, automatic tab reset on entity change. Pure presentation; no data fetching or domain knowledge baked in.

### Admin (`app.admin`)
- New `useEntityActivity` hook + `entityActivityService` that resolves the per-entity route prefix. Only `user` is wired for now; Phase 2 PRs will add `rescue` / `application` / `pet` / `report` / `chat` / `support_ticket` prefixes.
- `UserDetailPanel` migrated to compose `EntityInspector` + per-tab content components. Drops the bespoke shell, tab bar, close-button code, and the now-unused CSS rules.

## Test plan

- [x] `lib.types` build clean
- [x] `lib.components` build + tests: **512/512 pass** (incl. 10 new `EntityInspector` tests)
- [x] `service.backend` type-check + build clean
- [x] `service.backend` user route + service tests: **52/52 pass**
- [x] `app.admin` type-check + build clean
- [x] `app.admin` tests: **611/611 pass**
- [ ] Manual: open admin user detail panel, switch between Overview/Edit/Actions/Activity tabs, confirm visual parity with the previous bespoke implementation
- [ ] Manual: confirm activity tab renders entries with entity context (e.g. `Created pet: Buddy`)

## Phase 2 (after merge)

Parallel PRs, one per entity:
- Rescues — heaviest, includes verification workflow + staff list
- Applications — status timeline, references, documents
- Pets — image gallery + applications received
- Reports / Moderation
- Chats
- Support tickets

Each Phase 2 PR will:
1. Add the per-entity activity route + controller wrapper around `AuditLogService.getEntityActivityLog`.
2. Add the entity's route prefix to `ENTITY_ROUTE_PREFIX` in `entityActivityService.ts`.
3. Replace the existing modal/detail with a `EntityInspector`-based panel.
4. Ship its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)