### PR TITLE
feat: mobile responsiveness pass across all three apps

### DIFF
--- a/app.admin/src/components/layout/AdminHeader.css.ts
+++ b/app.admin/src/components/layout/AdminHeader.css.ts
@@ -16,13 +16,51 @@ export const headerContainer = recipe({
     right: 0,
     zIndex: 90,
     transition: 'left 0.3s ease',
+    gap: '1rem',
+    // On phones the sidebar is off-canvas, so the header spans the full
+    // width and the hamburger trigger replaces the desktop offset.
+    '@media': {
+      '(max-width: 768px)': {
+        left: 0,
+        padding: '0 1rem',
+      },
+    },
   },
   variants: {
     sidebarCollapsed: {
-      true: { left: '80px' },
-      false: { left: '280px' },
+      true: { left: '80px', '@media': { '(max-width: 768px)': { left: 0 } } },
+      false: { left: '280px', '@media': { '(max-width: 768px)': { left: 0 } } },
     },
   },
+});
+
+// Hamburger trigger for the off-canvas sidebar drawer. Hidden on desktop,
+// where the sidebar is always visible.
+export const mobileMenuButton = style({
+  background: 'transparent',
+  border: '1px solid #d1d5db',
+  padding: '0.625rem',
+  borderRadius: '8px',
+  cursor: 'pointer',
+  color: '#6b7280',
+  alignItems: 'center',
+  justifyContent: 'center',
+  transition: 'all 0.2s ease',
+  display: 'none',
+  ':hover': {
+    background: '#f9fafb',
+    borderColor: vars.colors.primary,
+    color: vars.colors.primaryHover,
+  },
+  '@media': {
+    '(max-width: 768px)': {
+      display: 'flex',
+    },
+  },
+});
+
+globalStyle(`${mobileMenuButton} svg`, {
+  fontSize: '1.25rem',
 });
 
 export const searchContainer = style({
@@ -149,6 +187,12 @@ export const userInfo = style({
   flexDirection: 'column',
   alignItems: 'flex-start',
   textAlign: 'left',
+  // The name/role labels are dropped on phones; the avatar alone is enough.
+  '@media': {
+    '(max-width: 480px)': {
+      display: 'none',
+    },
+  },
 });
 
 export const userName = style({

--- a/app.admin/src/components/layout/AdminHeader.tsx
+++ b/app.admin/src/components/layout/AdminHeader.tsx
@@ -1,14 +1,25 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
-import { FiSearch, FiBell, FiUser, FiLogOut, FiSettings, FiChevronDown } from 'react-icons/fi';
+import {
+  FiSearch,
+  FiBell,
+  FiUser,
+  FiLogOut,
+  FiSettings,
+  FiChevronDown,
+  FiMenu,
+} from 'react-icons/fi';
 import * as styles from './AdminHeader.css';
 
 interface AdminHeaderProps {
   sidebarCollapsed: boolean;
+  // Opens the off-canvas sidebar drawer on narrow viewports. The trigger is
+  // hidden on desktop where the sidebar is always visible.
+  onMobileMenuOpen?: () => void;
 }
 
-export const AdminHeader: React.FC<AdminHeaderProps> = ({ sidebarCollapsed }) => {
+export const AdminHeader: React.FC<AdminHeaderProps> = ({ sidebarCollapsed, onMobileMenuOpen }) => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const [userMenuOpen, setUserMenuOpen] = useState(false);
@@ -35,6 +46,13 @@ export const AdminHeader: React.FC<AdminHeaderProps> = ({ sidebarCollapsed }) =>
 
   return (
     <header className={styles.headerContainer({ sidebarCollapsed })}>
+      <button
+        className={styles.mobileMenuButton}
+        onClick={onMobileMenuOpen}
+        aria-label='Open navigation menu'
+      >
+        <FiMenu />
+      </button>
       <div className={styles.searchContainer}>
         <FiSearch className={styles.searchIcon} />
         <input

--- a/app.admin/src/components/layout/AdminLayout.css.ts
+++ b/app.admin/src/components/layout/AdminLayout.css.ts
@@ -13,11 +13,36 @@ export const mainContent = recipe({
     marginTop: '80px',
     transition: 'margin-left 0.3s ease',
     minHeight: 'calc(100vh - 80px)',
+    // Constrain the main column so wide children (tables, charts) scroll
+    // within their own containers rather than overflowing the viewport.
+    minWidth: 0,
+    '@media': {
+      // On phones the sidebar becomes an off-canvas drawer, so the main
+      // column spans the full width regardless of the collapsed state.
+      '(max-width: 768px)': {
+        marginLeft: 0,
+      },
+    },
   },
   variants: {
     sidebarCollapsed: {
       true: { marginLeft: '80px' },
       false: { marginLeft: '280px' },
+    },
+  },
+});
+
+// Backdrop shown behind the off-canvas sidebar drawer on small screens.
+// Rendered only when the drawer is open; tapping it closes the drawer.
+export const mobileBackdrop = style({
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0, 0, 0, 0.5)',
+  zIndex: 99,
+  display: 'none',
+  '@media': {
+    '(max-width: 768px)': {
+      display: 'block',
     },
   },
 });

--- a/app.admin/src/components/layout/AdminLayout.tsx
+++ b/app.admin/src/components/layout/AdminLayout.tsx
@@ -12,17 +12,41 @@ interface AdminLayoutProps {
 
 export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  // Off-canvas drawer state for narrow viewports. On desktop the sidebar is
+  // always visible and this has no effect (see AdminSidebar.css media query).
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   const toggleSidebar = () => {
     setSidebarCollapsed(!sidebarCollapsed);
   };
 
+  const openMobileSidebar = () => {
+    setMobileOpen(true);
+  };
+
+  const closeMobileSidebar = () => {
+    setMobileOpen(false);
+  };
+
   return (
     <div className={styles.layoutContainer}>
       <SkipLink />
-      <AdminSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
+      <AdminSidebar
+        collapsed={sidebarCollapsed}
+        onToggle={toggleSidebar}
+        mobileOpen={mobileOpen}
+        onMobileClose={closeMobileSidebar}
+      />
+      {mobileOpen && (
+        <div
+          className={styles.mobileBackdrop}
+          onClick={closeMobileSidebar}
+          aria-hidden='true'
+          data-testid='sidebar-backdrop'
+        />
+      )}
       <main className={styles.mainContent({ sidebarCollapsed })}>
-        <AdminHeader sidebarCollapsed={sidebarCollapsed} />
+        <AdminHeader sidebarCollapsed={sidebarCollapsed} onMobileMenuOpen={openMobileSidebar} />
         {/* ADS C4-5: dismissible sanction banner sits above the main-content
             target so the SkipLink still bypasses it to '#main-content'. */}
         <SanctionBannerHost />

--- a/app.admin/src/components/layout/AdminSidebar.css.ts
+++ b/app.admin/src/components/layout/AdminSidebar.css.ts
@@ -15,7 +15,7 @@ export const sidebarContainer = recipe({
     zIndex: 100,
     borderRight: '1px solid #374151',
     overflowY: 'auto',
-    transition: 'width 0.3s ease',
+    transition: 'width 0.3s ease, transform 0.3s ease',
     selectors: {
       '&::-webkit-scrollbar': {
         width: '6px',
@@ -28,11 +28,32 @@ export const sidebarContainer = recipe({
         borderRadius: '3px',
       },
     },
+    // On phones the sidebar is a full-width drawer that slides off-canvas
+    // by default; the `mobileOpen` variant slides it back into view.
+    '@media': {
+      '(max-width: 768px)': {
+        width: '280px',
+        maxWidth: '85vw',
+        transform: 'translateX(-100%)',
+      },
+    },
   },
   variants: {
     collapsed: {
-      true: { width: '80px' },
+      // The collapsed (icon-only) rail is a desktop affordance; on phones
+      // the drawer always opens at full width regardless of this state.
+      true: { width: '80px', '@media': { '(max-width: 768px)': { width: '280px' } } },
       false: { width: '280px' },
+    },
+    mobileOpen: {
+      true: {
+        '@media': {
+          '(max-width: 768px)': {
+            transform: 'translateX(0)',
+          },
+        },
+      },
+      false: {},
     },
   },
 });
@@ -84,6 +105,35 @@ export const toggleButton = style({
     background: '#374151',
     borderColor: vars.colors.primary,
   },
+  // The collapse/expand rail is a desktop-only affordance.
+  '@media': {
+    '(max-width: 768px)': {
+      display: 'none',
+    },
+  },
+});
+
+// Drawer-close button, shown only on phones where the sidebar is off-canvas.
+export const mobileCloseButton = style({
+  background: 'transparent',
+  border: '1px solid #4b5563',
+  color: '#f9fafb',
+  padding: '0.5rem',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  display: 'none',
+  alignItems: 'center',
+  justifyContent: 'center',
+  transition: 'all 0.2s ease',
+  ':hover': {
+    background: '#374151',
+    borderColor: vars.colors.primary,
+  },
+  '@media': {
+    '(max-width: 768px)': {
+      display: 'flex',
+    },
+  },
 });
 
 export const nav = style({
@@ -108,7 +158,7 @@ export const navSectionPadding = recipe({
   base: {},
   variants: {
     collapsed: {
-      true: { padding: '0' },
+      true: { padding: '0', '@media': { '(max-width: 768px)': { padding: '0 1rem' } } },
       false: { padding: '0 1rem' },
     },
   },
@@ -126,7 +176,7 @@ export const navSectionTitle = recipe({
   },
   variants: {
     collapsed: {
-      true: { display: 'none' },
+      true: { display: 'none', '@media': { '(max-width: 768px)': { display: 'block' } } },
       false: { display: 'block' },
     },
   },
@@ -192,6 +242,12 @@ export const styledNavLink = recipe({
       true: {
         padding: '0.75rem',
         justifyContent: 'center',
+        '@media': {
+          '(max-width: 768px)': {
+            padding: '0.75rem 1rem',
+            justifyContent: 'flex-start',
+          },
+        },
       },
       false: {
         padding: '0.75rem 1rem',
@@ -209,7 +265,7 @@ export const navLinkSpan = recipe({
   },
   variants: {
     collapsed: {
-      true: { display: 'none' },
+      true: { display: 'none', '@media': { '(max-width: 768px)': { display: 'block' } } },
       false: { display: 'block' },
     },
   },

--- a/app.admin/src/components/layout/AdminSidebar.test.tsx
+++ b/app.admin/src/components/layout/AdminSidebar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // The global setup-tests.ts mock of @adopt-dont-shop/lib.components doesn't
 // export Logo (which AdminSidebar pulls in for the header). The previous
@@ -99,5 +100,49 @@ describe('AdminSidebar Inbox assigned-to-me badge', () => {
     renderSidebar();
 
     expect(screen.queryByTestId('inbox-my-queue-badge')).not.toBeInTheDocument();
+  });
+});
+
+describe('AdminSidebar mobile off-canvas drawer', () => {
+  it('closes the drawer when the close button is clicked', async () => {
+    mockCount.mockReturnValue(0);
+    const onMobileClose = vi.fn();
+    render(
+      <MemoryRouter>
+        <AdminSidebar
+          collapsed={false}
+          onToggle={() => undefined}
+          mobileOpen
+          onMobileClose={onMobileClose}
+        />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close navigation menu' }));
+
+    expect(onMobileClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the drawer after navigating to a new route', async () => {
+    mockCount.mockReturnValue(0);
+    const onMobileClose = vi.fn();
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AdminSidebar
+          collapsed={false}
+          onToggle={() => undefined}
+          mobileOpen
+          onMobileClose={onMobileClose}
+        />
+      </MemoryRouter>
+    );
+
+    // Navigating away from the current route closes the drawer; the initial
+    // mount does not, so the drawer can be opened on the current page.
+    expect(onMobileClose).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('link', { name: 'Users' }));
+
+    expect(onMobileClose).toHaveBeenCalled();
   });
 });

--- a/app.admin/src/components/layout/AdminSidebar.tsx
+++ b/app.admin/src/components/layout/AdminSidebar.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { NavLink } from 'react-router-dom';
+import React, { useEffect, useRef } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 import { Logo } from '@adopt-dont-shop/lib.components';
 import * as styles from './AdminSidebar.css';
 import { useMyInboxCount } from '../../hooks/useMyInboxCount';
@@ -23,18 +23,39 @@ import {
   FiHeart,
   FiFile,
   FiInbox,
+  FiX,
 } from 'react-icons/fi';
 
 interface SidebarProps {
   collapsed: boolean;
   onToggle: () => void;
+  // Off-canvas drawer state for narrow viewports. Ignored on desktop, where
+  // the sidebar is always visible (see AdminSidebar.css media queries).
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
 }
 
-export const AdminSidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) => {
+export const AdminSidebar: React.FC<SidebarProps> = ({
+  collapsed,
+  onToggle,
+  mobileOpen = false,
+  onMobileClose,
+}) => {
   const { count: myInboxCount } = useMyInboxCount();
+  const { pathname } = useLocation();
+  // Auto-close the off-canvas drawer after navigating to a new route on
+  // mobile. Skips the initial mount so the drawer can be opened freely.
+  const didMount = useRef(false);
+  useEffect(() => {
+    if (!didMount.current) {
+      didMount.current = true;
+      return;
+    }
+    onMobileClose?.();
+  }, [pathname, onMobileClose]);
 
   return (
-    <aside className={styles.sidebarContainer({ collapsed })}>
+    <aside className={styles.sidebarContainer({ collapsed, mobileOpen })}>
       <div className={styles.sidebarHeader({ collapsed })}>
         <div className={styles.logo({ collapsed })}>
           <Logo size={32} showWordmark={!collapsed} darkBg />
@@ -44,6 +65,13 @@ export const AdminSidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) =>
             <FiChevronLeft size={16} />
           </button>
         )}
+        <button
+          className={styles.mobileCloseButton}
+          onClick={onMobileClose}
+          aria-label='Close navigation menu'
+        >
+          <FiX size={18} />
+        </button>
       </div>
 
       {collapsed && (

--- a/app.admin/src/components/moderation/ReportDetailModal.css.ts
+++ b/app.admin/src/components/moderation/ReportDetailModal.css.ts
@@ -104,6 +104,11 @@ export const infoGrid = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(2, 1fr)',
   gap: '1rem',
+  '@media': {
+    '(max-width: 480px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
 });
 
 export const infoItem = style({

--- a/app.admin/src/pages/Analytics.css.ts
+++ b/app.admin/src/pages/Analytics.css.ts
@@ -11,6 +11,12 @@ export const analyticsGrid = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(auto-fit, minmax(500px, 1fr))',
   gap: '1.5rem',
+  // The 500px minimum overflows phones; drop to a single full-width column.
+  '@media': {
+    '(max-width: 768px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
 });
 
 export const chartCard = style({

--- a/app.admin/src/pages/Configuration.css.ts
+++ b/app.admin/src/pages/Configuration.css.ts
@@ -11,6 +11,12 @@ export const configGrid = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(auto-fit, minmax(500px, 1fr))',
   gap: '1.5rem',
+  // The 500px minimum overflows phones; drop to a single full-width column.
+  '@media': {
+    '(max-width: 768px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
 });
 
 export const sectionCard = style({

--- a/app.client/src/components/chat/ChatPage.css.ts
+++ b/app.client/src/components/chat/ChatPage.css.ts
@@ -11,7 +11,10 @@ export const chatContainer = style({
   overflow: 'hidden',
   '@media': {
     '(max-width: 768px)': {
-      height: '100vh',
+      // Subtract the 56px sticky navbar and the 56px space the shell reserves
+      // for the fixed BottomTabBar so the message composer stays on-screen and
+      // isn't hidden behind the bottom nav.
+      height: 'calc(100vh - 112px)',
     },
   },
 });

--- a/app.client/src/components/layout/AppShell.css.ts
+++ b/app.client/src/components/layout/AppShell.css.ts
@@ -9,3 +9,14 @@ export const shell = style({
 export const main = style({
   flex: '1',
 });
+
+// The BottomTabBar is position:fixed and renders on mobile for both anonymous
+// (Discover/Search) and authenticated visitors. Reserve space at the bottom of
+// the shell so the fixed bar never covers the footer or the end of page content.
+export const shellWithBottomNav = style({
+  '@media': {
+    '(max-width: 768px)': {
+      paddingBottom: 'calc(56px + env(safe-area-inset-bottom, 0px))',
+    },
+  },
+});

--- a/app.client/src/components/layout/AppShell.tsx
+++ b/app.client/src/components/layout/AppShell.tsx
@@ -13,7 +13,7 @@ export const AppShell: React.FC = () => {
   const [showOnboarding, setShowOnboarding] = useState(true);
 
   return (
-    <div className={styles.shell}>
+    <div className={`${styles.shell} ${styles.shellWithBottomNav}`}>
       <SkipLink />
       <header>
         <AppNavbar />

--- a/app.client/src/components/navigation/BottomTabBar.test.tsx
+++ b/app.client/src/components/navigation/BottomTabBar.test.tsx
@@ -56,9 +56,17 @@ describe('BottomTabBar', () => {
     matchPreferencesState.isLoading = false;
   });
 
-  it('does not render when the user is unauthenticated', () => {
-    const { container } = renderWithProviders(<BottomTabBar />);
-    expect(container).toBeEmptyDOMElement();
+  it('exposes only the public browse tabs when the user is unauthenticated', () => {
+    renderWithProviders(<BottomTabBar />);
+    const nav = screen.getByRole('navigation', { name: /primary/i });
+    expect(within(nav).getByRole('link', { name: /discover/i })).toHaveAttribute(
+      'href',
+      '/discover'
+    );
+    expect(within(nav).getByRole('link', { name: /search/i })).toHaveAttribute('href', '/search');
+    expect(within(nav).queryByRole('link', { name: /favorites/i })).not.toBeInTheDocument();
+    expect(within(nav).queryByRole('link', { name: /messages/i })).not.toBeInTheDocument();
+    expect(within(nav).queryByRole('button', { name: /user menu/i })).not.toBeInTheDocument();
   });
 
   it('renders a navigation region with the primary tabs when authenticated', () => {

--- a/app.client/src/components/navigation/BottomTabBar.tsx
+++ b/app.client/src/components/navigation/BottomTabBar.tsx
@@ -21,26 +21,31 @@ export const BottomTabBar: React.FC = () => {
   const { hasPreferences } = useMatchPreferences();
   const location = useLocation();
 
-  if (!isAuthenticated) {
-    return null;
-  }
-
-  const tabs: TabDef[] = [
-    { to: '/discover', label: 'Discover', icon: <MdSwipe aria-hidden='true' /> },
-    { to: '/search', label: 'Search', icon: <MdOutlineSearch aria-hidden='true' /> },
-    {
-      to: hasPreferences ? '/match/top-picks' : '/onboarding',
-      label: 'Top Picks',
-      icon: <MdStarBorder aria-hidden='true' />,
-    },
-    { to: '/favorites', label: 'Favorites', icon: <MdFavoriteBorder aria-hidden='true' /> },
-    {
-      to: '/chat',
-      label: 'Messages',
-      icon: <MdChat aria-hidden='true' />,
-      badge: unreadMessageCount,
-    },
-  ];
+  // Anonymous visitors can still browse the public /discover and /search
+  // surfaces, so the mobile bottom bar exposes those entry points. The
+  // personalised tabs (Top Picks, Favorites, Messages, account menu) only
+  // appear once authenticated.
+  const tabs: TabDef[] = isAuthenticated
+    ? [
+        { to: '/discover', label: 'Discover', icon: <MdSwipe aria-hidden='true' /> },
+        { to: '/search', label: 'Search', icon: <MdOutlineSearch aria-hidden='true' /> },
+        {
+          to: hasPreferences ? '/match/top-picks' : '/onboarding',
+          label: 'Top Picks',
+          icon: <MdStarBorder aria-hidden='true' />,
+        },
+        { to: '/favorites', label: 'Favorites', icon: <MdFavoriteBorder aria-hidden='true' /> },
+        {
+          to: '/chat',
+          label: 'Messages',
+          icon: <MdChat aria-hidden='true' />,
+          badge: unreadMessageCount,
+        },
+      ]
+    : [
+        { to: '/discover', label: 'Discover', icon: <MdSwipe aria-hidden='true' /> },
+        { to: '/search', label: 'Search', icon: <MdOutlineSearch aria-hidden='true' /> },
+      ];
 
   const isActive = (to: string) =>
     location.pathname === to || location.pathname.startsWith(`${to}/`);
@@ -73,9 +78,11 @@ export const BottomTabBar: React.FC = () => {
             </li>
           );
         })}
-        <li className={styles.meTab}>
-          <NavUserMenu />
-        </li>
+        {isAuthenticated && (
+          <li className={styles.meTab}>
+            <NavUserMenu />
+          </li>
+        )}
       </ul>
     </nav>
   );

--- a/app.client/src/pages/ApplicationPage.css.ts
+++ b/app.client/src/pages/ApplicationPage.css.ts
@@ -6,6 +6,11 @@ export const container = style({
   maxWidth: '800px',
   margin: '0 auto',
   padding: '2rem',
+  '@media': {
+    '(max-width: 768px)': {
+      padding: '1rem',
+    },
+  },
 });
 
 export const header = style({

--- a/app.client/src/pages/PetDetailsPage.css.ts
+++ b/app.client/src/pages/PetDetailsPage.css.ts
@@ -5,6 +5,11 @@ export const pageContainer = style({
   maxWidth: '1200px',
   margin: '0 auto',
   padding: '2rem',
+  '@media': {
+    '(max-width: 768px)': {
+      padding: '1rem',
+    },
+  },
 });
 
 export const backLink = style({

--- a/app.client/src/pages/ProfilePage.css.ts
+++ b/app.client/src/pages/ProfilePage.css.ts
@@ -133,6 +133,13 @@ export const applicationCard = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
+  gap: '1rem',
+  '@media': {
+    '(max-width: 768px)': {
+      flexDirection: 'column',
+      alignItems: 'stretch',
+    },
+  },
 });
 
 export const applicationInfo = style({});

--- a/app.rescue/src/components/applications/ApplicationReview.css.ts
+++ b/app.rescue/src/components/applications/ApplicationReview.css.ts
@@ -91,6 +91,15 @@ export const headerContent = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
+  gap: '1rem',
+  '@media': {
+    // On narrow screens the title block and the action cluster no longer fit
+    // side by side, so stack them to avoid horizontal overflow inside the modal.
+    '(max-width: 768px)': {
+      flexDirection: 'column',
+      alignItems: 'stretch',
+    },
+  },
 });
 
 export const headerLeft = style({
@@ -115,6 +124,9 @@ export const headerRight = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.75rem',
+  // Allow the badges and action buttons to wrap onto multiple lines rather
+  // than overflowing the modal width on small screens.
+  flexWrap: 'wrap',
 });
 
 export const statusBadge = recipe({
@@ -194,6 +206,18 @@ export const tabContainer = style({
 export const tabList = style({
   display: 'flex',
   padding: '0 1.5rem',
+  // The four tabs don't fit across a phone-width modal; allow horizontal
+  // scrolling so every tab stays reachable instead of overflowing/clipping.
+  overflowX: 'auto',
+  '@media': {
+    '(max-width: 768px)': {
+      padding: '0 0.5rem',
+    },
+  },
+});
+
+globalStyle(`${tabList} > button`, {
+  whiteSpace: 'nowrap',
 });
 
 export const tab = recipe({

--- a/app.rescue/src/components/shared/Layout.css.ts
+++ b/app.rescue/src/components/shared/Layout.css.ts
@@ -5,6 +5,13 @@ export const appLayout = style({
   display: 'flex',
   minHeight: '100vh',
   background: vars.background.body,
+  '@media': {
+    // On mobile the sidebar is an off-canvas drawer, so the shell stacks
+    // vertically: the mobile bar sits on top of the main column.
+    '(max-width: 768px)': {
+      flexDirection: 'column',
+    },
+  },
 });
 
 export const mainColumn = style({
@@ -18,6 +25,11 @@ export const mainContent = style({
   flex: 1,
   overflow: 'auto',
   padding: '2rem',
+  '@media': {
+    '(max-width: 768px)': {
+      padding: '1rem',
+    },
+  },
 });
 
 // ADS-497 (slice 5b): minimal footer strip carrying the "Manage cookies"

--- a/app.rescue/src/components/shared/Navigation.css.ts
+++ b/app.rescue/src/components/shared/Navigation.css.ts
@@ -13,11 +13,115 @@ export const mainNavigation = style({
   position: 'sticky',
   top: 0,
   overflowY: 'auto',
+  '@media': {
+    // Below the md breakpoint the sidebar becomes an off-canvas drawer so it
+    // no longer eats most of the viewport. It slides in from the left when
+    // opened via the hamburger button in the mobile bar.
+    '(max-width: 768px)': {
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      zIndex: 1001,
+      maxWidth: '85vw',
+      transform: 'translateX(-100%)',
+      transition: 'transform 0.25s ease',
+      boxShadow: '2px 0 12px rgba(0, 0, 0, 0.3)',
+    },
+  },
+});
+
+export const mainNavigationOpen = style({
+  '@media': {
+    '(max-width: 768px)': {
+      transform: 'translateX(0)',
+    },
+  },
+});
+
+// Slim top bar with the hamburger trigger. Only visible on mobile; the
+// drawer itself carries the branding/footer on desktop.
+export const mobileBar = style({
+  display: 'none',
+  '@media': {
+    '(max-width: 768px)': {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.75rem',
+      padding: '0.5rem 1rem',
+      position: 'sticky',
+      top: 0,
+      zIndex: 1000,
+      background: vars.colors.primaryTextEmphasis,
+      color: 'white',
+    },
+  },
+});
+
+export const mobileMenuButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '44px',
+  height: '44px',
+  background: 'transparent',
+  border: 'none',
+  color: 'white',
+  fontSize: '1.5rem',
+  lineHeight: 1,
+  cursor: 'pointer',
+  borderRadius: '6px',
+  ':hover': {
+    background: 'rgba(255, 255, 255, 0.1)',
+  },
+});
+
+export const mobileCloseButton = style({
+  display: 'none',
+  '@media': {
+    '(max-width: 768px)': {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '44px',
+      height: '44px',
+      background: 'transparent',
+      border: 'none',
+      color: 'white',
+      fontSize: '1.25rem',
+      lineHeight: 1,
+      cursor: 'pointer',
+      borderRadius: '6px',
+      ':hover': {
+        background: 'rgba(255, 255, 255, 0.1)',
+      },
+    },
+  },
+});
+
+export const mobileOverlay = style({
+  display: 'none',
+  '@media': {
+    '(max-width: 768px)': {
+      display: 'block',
+      position: 'fixed',
+      inset: 0,
+      zIndex: 1000,
+      background: 'rgba(0, 0, 0, 0.5)',
+    },
+  },
 });
 
 export const navHeader = style({
   padding: '2rem 1.5rem',
   borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  '@media': {
+    '(max-width: 768px)': {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: '1rem 1.5rem',
+    },
+  },
 });
 
 globalStyle(`${navHeader} h2`, {

--- a/app.rescue/src/components/shared/Navigation.tsx
+++ b/app.rescue/src/components/shared/Navigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { RescueRole, useAuth } from '@adopt-dont-shop/lib.auth';
 import { Logo } from '@adopt-dont-shop/lib.components';
@@ -29,6 +29,13 @@ const Navigation: React.FC = () => {
   const location = useLocation();
   const { user, logout, isLoading } = useAuth();
   const { unreadMessageCount } = useChat();
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
+
+  // Close the mobile drawer whenever the route changes so navigating to a
+  // page doesn't leave the drawer covering the content.
+  useEffect(() => {
+    setIsMobileOpen(false);
+  }, [location.pathname]);
 
   // Group order is intentional: day-to-day Operations first, then
   // Communication (high-frequency but distinct context), then Admin
@@ -117,76 +124,107 @@ const Navigation: React.FC = () => {
   };
 
   return (
-    <nav className={styles.mainNavigation}>
-      <div className={styles.navHeader}>
-        <Logo size={32} showWordmark darkBg />
-      </div>
-
-      <div className={styles.navList}>
-        {visibleGroups.map(group => {
-          const headingId = `nav-group-${group.id}`;
-          return (
-            <section
-              key={group.id}
-              role="group"
-              aria-labelledby={headingId}
-              className={styles.navGroup}
-            >
-              <h2 id={headingId} className={styles.navGroupLabel}>
-                {group.label}
-              </h2>
-              <ul className={styles.navGroupList}>
-                {group.items.map(item => {
-                  const isActive = location.pathname === item.path;
-                  const hasUnread = typeof item.badge === 'number' && item.badge > 0;
-                  return (
-                    <li key={item.path} className={styles.navItem}>
-                      <Link
-                        to={item.path}
-                        className={clsx(
-                          styles.navLink({
-                            active: isActive,
-                            hasUnread: hasUnread && !isActive,
-                          })
-                        )}
-                      >
-                        <span className={styles.navIcon}>{item.icon}</span>
-                        <span className={styles.navLabel}>{item.label}</span>
-                        {hasUnread && (
-                          <span
-                            className={styles.navBadge}
-                            aria-label={`${item.badge} unread message${item.badge === 1 ? '' : 's'}`}
-                          >
-                            {item.badge! > 99 ? '99+' : item.badge}
-                          </span>
-                        )}
-                      </Link>
-                    </li>
-                  );
-                })}
-              </ul>
-            </section>
-          );
-        })}
-      </div>
-
-      <div className={styles.navFooter}>
-        <div className={styles.userInfo}>
-          <div className={styles.userAvatar}>
-            {getUserInitials(user?.firstName, user?.lastName)}
-          </div>
-          <div className={styles.userDetails}>
-            <span className={styles.userName}>
-              {user?.firstName} {user?.lastName}
-            </span>
-            <span className={styles.userRole}>{formatUserRole(user?.userType)}</span>
-          </div>
-        </div>
-        <button className={styles.logoutButton} onClick={handleLogout} disabled={isLoading}>
-          {isLoading ? 'Signing Out...' : 'Sign Out'}
+    <>
+      <div className={styles.mobileBar}>
+        <button
+          type="button"
+          className={styles.mobileMenuButton}
+          aria-label="Open navigation menu"
+          aria-expanded={isMobileOpen}
+          onClick={() => setIsMobileOpen(true)}
+        >
+          ☰
         </button>
+        <Logo size={28} showWordmark darkBg />
       </div>
-    </nav>
+
+      {isMobileOpen && (
+        <div
+          className={styles.mobileOverlay}
+          aria-hidden="true"
+          onClick={() => setIsMobileOpen(false)}
+        />
+      )}
+
+      <nav className={clsx(styles.mainNavigation, isMobileOpen && styles.mainNavigationOpen)}>
+        <div className={styles.navHeader}>
+          <Logo size={32} showWordmark darkBg />
+          <button
+            type="button"
+            className={styles.mobileCloseButton}
+            aria-label="Close navigation menu"
+            onClick={() => setIsMobileOpen(false)}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className={styles.navList}>
+          {visibleGroups.map(group => {
+            const headingId = `nav-group-${group.id}`;
+            return (
+              <section
+                key={group.id}
+                role="group"
+                aria-labelledby={headingId}
+                className={styles.navGroup}
+              >
+                <h2 id={headingId} className={styles.navGroupLabel}>
+                  {group.label}
+                </h2>
+                <ul className={styles.navGroupList}>
+                  {group.items.map(item => {
+                    const isActive = location.pathname === item.path;
+                    const hasUnread = typeof item.badge === 'number' && item.badge > 0;
+                    return (
+                      <li key={item.path} className={styles.navItem}>
+                        <Link
+                          to={item.path}
+                          className={clsx(
+                            styles.navLink({
+                              active: isActive,
+                              hasUnread: hasUnread && !isActive,
+                            })
+                          )}
+                        >
+                          <span className={styles.navIcon}>{item.icon}</span>
+                          <span className={styles.navLabel}>{item.label}</span>
+                          {hasUnread && (
+                            <span
+                              className={styles.navBadge}
+                              aria-label={`${item.badge} unread message${item.badge === 1 ? '' : 's'}`}
+                            >
+                              {item.badge! > 99 ? '99+' : item.badge}
+                            </span>
+                          )}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+
+        <div className={styles.navFooter}>
+          <div className={styles.userInfo}>
+            <div className={styles.userAvatar}>
+              {getUserInitials(user?.firstName, user?.lastName)}
+            </div>
+            <div className={styles.userDetails}>
+              <span className={styles.userName}>
+                {user?.firstName} {user?.lastName}
+              </span>
+              <span className={styles.userRole}>{formatUserRole(user?.userType)}</span>
+            </div>
+          </div>
+          <button className={styles.logoutButton} onClick={handleLogout} disabled={isLoading}>
+            {isLoading ? 'Signing Out...' : 'Sign Out'}
+          </button>
+        </div>
+      </nav>
+    </>
   );
 };
 

--- a/app.rescue/src/pages/StaffManagement.css.ts
+++ b/app.rescue/src/pages/StaffManagement.css.ts
@@ -39,6 +39,14 @@ export const headerActions = style({
   display: 'flex',
   gap: '1rem',
   alignItems: 'center',
+  '@media': {
+    // The header stacks vertically on mobile; let the action buttons stack and
+    // fill the width too rather than crowding onto one cramped row.
+    'screen and (max-width: 768px)': {
+      flexDirection: 'column',
+      alignItems: 'stretch',
+    },
+  },
 });
 
 export const actionButtonPrimary = style({


### PR DESCRIPTION
## Summary

Improves the mobile experience across all three frontend apps. Three parallel agents each audited one app against the existing vanilla-extract / design-system breakpoint conventions (`768px` / `480px`) and applied **surgical** fixes to the genuine mobile gaps — no redesigns.

All apps already had a viewport meta tag and varying amounts of responsive CSS; this fills the gaps where layouts overflowed, navigation was unreachable, or content was cramped on phones.

## Changes by app

### app.client (consumer-facing — highest mobile priority)
- **Fixes an anonymous mobile dead-end:** the bottom tab bar returned `null` when logged out, leaving phone visitors with no way to reach the public `/discover` and `/search` routes. It now shows Discover/Search for anonymous users; personalised tabs + account menu remain auth-gated.
- Bottom-nav space is now always reserved on mobile, and the chat composer height accounts for it (no longer hidden behind the bar).
- Reduced page padding on Application, PetDetails, and Profile pages (`2rem` → `1rem`); profile application cards reflow to a column on small screens.

### app.rescue
- Added an **off-canvas hamburger drawer** for the sidebar on small screens (overlay, 44px tap targets, auto-close on route change); shell stacks vertically.
- Fixed horizontal overflow in the `ApplicationReview` modal header/tabs and `StaffManagement` header actions.

### app.admin (was weakest — fixed sidebar, ~9/60 responsive files)
- Completed the **off-canvas drawer** wiring (CSS scaffolding existed but components weren't wired — also fixed a resulting type error): hamburger trigger in the header, close button in the sidebar, auto-close on route change.
- Fixed the fixed-position header overflowing on phones (full-width on mobile, hide user text on small phones).
- Collapsed the `Analytics` / `Configuration` 500px-min grids and a moderation modal grid to a single column on mobile.

## Verification
- `type-check`: 27/27 tasks pass across the three apps.
- `test`: 1,362 tests pass (client 414, admin 630, rescue 318), including new behaviour tests for the admin sidebar drawer and the anonymous bottom-tab-bar.
- `lint`: no new errors introduced (pre-existing `no-explicit-any` warnings in unrelated source files remain).

## Notes / follow-ups (not in scope here)
Shared modal/dialog chrome (overlay, max-width, scroll) lives in `lib.components`, not the apps. If admin/rescue modals still feel cramped on very small screens, a bottom-sheet / full-width treatment belongs in the shared `Modal` component. Flagged by the agents but intentionally not touched to keep this change app-scoped.

https://claude.ai/code/session_01Nf4zrL7ZM6Cbo438PFEwde

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf4zrL7ZM6Cbo438PFEwde)_