### PR TITLE
feat(setup): add .gitmessage commit template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,19 @@
+# <type>(<scope>): <subject>
+#
+# Types: feat | fix | refactor | test | docs | chore | ci | perf | style | build
+# Scope (optional): package name without @adopt-dont-shop/ prefix.
+#                   Examples: lib.auth, app.admin, service.backend, ci, deps
+#
+# Subject: imperative, <= 72 chars, no trailing period.
+#
+# Examples:
+#   feat(lib.auth): add two-factor authentication support
+#   fix(service.backend): correct date format in rescue profile
+#   chore(deps): bump vitest to 4.0.9
+#
+# --- Body (optional) ---
+# Explain WHY, not WHAT. Wrap at 72 cols.
+#
+# --- Footer (optional) ---
+# BREAKING CHANGE: <description>
+# Closes #123 / Refs ADS-456

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ docs: update API reference
 
 A Husky `commit-msg` hook runs [commitlint](https://commitlint.js.org/) with `@commitlint/config-conventional` to enforce this locally — non-conforming messages will be rejected before the commit is created. In an emergency you can bypass the hook with `git commit --no-verify`, but the CI commit-message check will still fail the PR.
 
+A `.gitmessage` template at the repo root prefills `git commit` with the conventional-commit format and a list of allowed types/scopes. `npm run setup` wires it in automatically via `git config commit.template .gitmessage`; if you skipped setup, run that command yourself to enable it.
+
 ### TDD loop
 
 This project follows strict Test-Driven Development — **no new behaviour without a test first**:

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -223,6 +223,22 @@ async function setup() {
       log('', RESET);
     }
 
+    // Step 7: Configure git commit message template (idempotent — git config overwrites)
+    logStep('7', 'Configuring git commit message template...');
+    try {
+      execSync('git config commit.template .gitmessage', {
+        stdio: 'ignore',
+        cwd: ROOT,
+      });
+      logSuccess('Git commit template set to .gitmessage');
+    } catch {
+      logError(
+        'Failed to set git commit template — run `git config commit.template .gitmessage` manually.'
+      );
+      // Non-fatal: not every contributor environment has git configured (e.g. some CI sandboxes).
+    }
+    log('', RESET);
+
     // Success message
     logHeader('Setup Complete! 🎉');
     log('', GREEN);


### PR DESCRIPTION
Linear: https://linear.app/ideasquared/issue/ADS-719

## Summary

Adds a `.gitmessage` template at the repo root that prefills `git commit` with the project's Conventional Commits format (allowed types, scope conventions, subject rules, body/footer hints). The `npm run setup` bootstrap now wires the template into the local repo via `git config commit.template .gitmessage`, so new contributors get the helper without any extra step.

### Changes

- `.gitmessage` — new template at repo root with type/scope/subject guidance and worked examples (`lib.auth`, `service.backend`, `deps` scopes).
- `scripts/bootstrap.mjs` — adds Step 7 that runs `git config commit.template .gitmessage`. Idempotent (git config overwrites the same key) and wrapped in try/catch so a git failure logs a warning but doesn't fail the whole bootstrap.
- `CONTRIBUTING.md` — short note in the Commits section pointing at the template and the manual fallback (`git config commit.template .gitmessage`) for anyone who skipped `npm run setup`.

## Test plan

- [ ] `git config commit.template` returns `.gitmessage` after running `npm run setup` on a fresh clone.
- [ ] Re-running `npm run setup` does not error and leaves the config unchanged (idempotency).
- [ ] `git commit` (no `-m`) opens the editor prefilled from `.gitmessage`.
- [ ] Force a `git config` failure (e.g. read-only git dir) and confirm bootstrap reports the warning but still exits 0 from Step 7 onward.
- [ ] CONTRIBUTING.md renders cleanly on GitHub with the new paragraph in the Commits section.

---
_Generated by [Claude Code](https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj)_