### PR TITLE
fix(ci): align test-backend Postgres image with docker-compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,8 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        # Match docker-compose.yml database image to avoid version drift (ADS-710)
+        image: postgis/postgis:16-3.4
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: ${{ env.TEST_DB_PASSWORD }}


### PR DESCRIPTION
## Summary

Aligns the CI `test-backend` job's Postgres service image with the one used by the dev Docker stack (`docker-compose.yml`), eliminating a version drift between CI and local development.

- Before: `postgres:15`
- After: `postgis/postgis:16-3.4` (matches `docker-compose.yml`)

This addresses [ADS-710](https://linear.app/ideasquared/issue/ADS-710). A comment was added above the `image:` line referencing `docker-compose.yml` so the rationale is visible to future readers.

## Test plan

- [ ] CI test-backend job runs successfully on the new image


---
_Generated by [Claude Code](https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj)_