### PR TITLE
fix(turbo): include vitest config files in test task inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,15 @@
     "test": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
-      "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
+      "inputs": [
+        "src/**/*.tsx",
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "test/**/*.tsx",
+        "vitest.config.ts",
+        "package.json",
+        "$TURBO_ROOT$/vitest.shared.config.ts"
+      ]
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
## Summary

Linear: [ADS-712](https://linear.app/ideasquared/issue/ADS-712)

The Turbo `test` task `inputs` only listed `src/**/*.ts(x)` and `test/**`, so changes to a package's `vitest.config.ts`, the shared root `vitest.shared.config.ts`, or `package.json` would not invalidate the test cache. This meant edits to test configuration silently reused stale cached results.

This change expands `test.inputs` in `turbo.json` to also include:

- `vitest.config.ts` (per-package)
- `package.json` (per-package — covers test script and dep changes)
- `$TURBO_ROOT$/vitest.shared.config.ts` (root shared config, using Turbo 2's root-relative syntax)

## Test plan

- [x] `npx turbo run test --dry-run=json` parses without errors
- [x] Dry-run output confirms each package's task inputs now include `vitest.config.ts`, `package.json`, and `../vitest.shared.config.ts`
- [ ] CI test job runs successfully on this branch
- [ ] Editing `vitest.shared.config.ts` on a follow-up change produces a cache miss for `test` tasks

https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj

---
_Generated by [Claude Code](https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj)_