### PR TITLE
feat(scripts): add ci:local preflight commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,17 @@ This project follows strict Test-Driven Development — **no new behaviour witho
 
 CI runs **ten** checks across `.github/workflows/ci.yml`, `lib-test-guard.yml`, `security.yml` and `quality.yml`. The four-command list previously documented here only covered a subset, so PRs that passed locally could still fail CI. Run the relevant tiers below before pushing.
 
+### One-shot preflight (recommended before pushing)
+
+Two aggregated scripts run the CI-equivalent checks for you:
+
+```bash
+npm run ci:local:quick   # fast preflight (~30s): format + lint + type-check
+npm run ci:local         # full preflight (~3-5min): format + lint + type-check + test + lib-test guard + workspace drift
+```
+
+`ci:local` covers everything in the fast and slow tiers below except E2E and the backend coverage thresholds — run those separately when relevant.
+
 ### Fast feedback (run every time, ~30s)
 
 These are the quickest signals and cover lint, unit tests, type-check and formatting across every workspace:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ npm run lint / lint:fix
 npm run type-check
 npm run format / format:check
 
+# Pre-push preflight (run CI-equivalent checks locally)
+npm run ci:local:quick           # fast preflight (~30s): format + lint + type-check
+npm run ci:local                 # full preflight (~3-5min): everything CI runs
+
 # Database (containers must be running)
 npm run db:migrate
 npm run db:seed

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "type-check": "turbo run type-check",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\" --ignore-path .prettierignore",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\" --ignore-path .prettierignore",
+    "ci:local": "npm run format:check && turbo run lint type-check test && npm run check:lib-tests && npm run check:workspaces",
+    "ci:local:quick": "npm run format:check && turbo run lint type-check",
     "clean": "turbo run clean && rm -rf node_modules",
     "db:migrate": "docker compose exec service-backend npm run migrate",
     "db:seed": "docker compose exec service-backend npm run seed",


### PR DESCRIPTION
## Summary

Linear: https://linear.app/ideasquared/issue/ADS-709

There was no single command to run CI-equivalent checks locally before pushing — contributors had to remember and chain four or more scripts. This PR adds two aggregated preflight scripts and documents them.

- `npm run ci:local:quick` — fast preflight (~30s): `format:check` + `lint` + `type-check`
- `npm run ci:local` — full preflight (~3-5min): `format:check` + `lint` + `type-check` + `test` + `check:lib-tests` + `check:workspaces`

`ci:local` covers everything in the fast and slow tiers documented in `CONTRIBUTING.md` except E2E and the backend coverage thresholds, which remain separate (they require Docker / the backend workspace context).

### Files changed

- `package.json` — adds the two scripts next to `format:check`
- `README.md` — documents both commands under "Common Commands"
- `CONTRIBUTING.md` — adds a "One-shot preflight" subsection above the existing fast/slow tiers in "Before opening a PR"

## Test plan

- [ ] `npm run ci:local:quick` parses and dispatches to `format:check` then `turbo run lint type-check`
- [ ] `npm run ci:local` parses and dispatches to `format:check`, the turbo lint/type-check/test pipeline, then `check:lib-tests` and `check:workspaces`
- [ ] README "Common Commands" lists both commands with the documented timings
- [ ] CONTRIBUTING "Before opening a PR" mentions `ci:local` as the recommended pre-push shortcut

https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj

---
_Generated by [Claude Code](https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj)_