### PR TITLE
feat(ci): add Renovate config for automated dependency updates

### DIFF
--- a/docs/operations/dependency-updates.md
+++ b/docs/operations/dependency-updates.md
@@ -1,0 +1,29 @@
+# Dependency Updates — Renovate [ADS-706]
+
+Automated dependency updates are managed by [Renovate](https://docs.renovatebot.com/),
+configured via `renovate.json` at the repo root. The config extends
+`config:recommended` and runs on the `schedule:earlyMondays` schedule so PRs
+land in a predictable window. Semantic-commit messages use the `chore` type
+across all updates so they stay out of the release notes.
+
+## How updates are grouped
+
+To avoid PR fatigue across this monorepo, related packages are grouped into
+single PRs:
+
+- **`devDependencies (non-major)`** — all minor/patch dev-dep updates batched.
+- **`typescript-eslint`** — `@typescript-eslint/*` packages move together.
+- **`vitest`** — `vitest` and `@vitest/*` packages move together.
+- **`react`** — `react`, `react-dom`, and their `@types/*` packages move together.
+
+## Automerge & limits
+
+Minor/patch updates to `devDependencies` automerge (squash) once CI is green;
+all other updates require manual review. Renovate is capped at **5 concurrent
+PRs** and **2 PRs per hour** to keep CI load predictable. `lockFileMaintenance`
+runs weekly (before 6am Monday) to refresh `package-lock.json`. GitHub Actions
+are pinned to commit SHAs (`pinDigests`), and vulnerability alerts are labelled
+`security` + `DevEx` with elevated priority and never automerge.
+
+The Renovate Dependency Dashboard issue tracks pending and rate-limited
+updates — check it if you expect a PR that hasn't appeared.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    "schedule:earlyMondays",
+    ":dependencyDashboard"
+  ],
+  "labels": ["dependencies", "DevEx"],
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "description": "Group all non-major devDependency updates",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "devDependencies (non-major)"
+    },
+    {
+      "description": "Group TypeScript ESLint packages",
+      "matchPackagePatterns": ["^@typescript-eslint/"],
+      "groupName": "typescript-eslint"
+    },
+    {
+      "description": "Group Vitest packages",
+      "matchPackagePatterns": ["^vitest$", "^@vitest/"],
+      "groupName": "vitest"
+    },
+    {
+      "description": "Group React types",
+      "matchPackageNames": ["@types/react", "@types/react-dom", "react", "react-dom"],
+      "groupName": "react"
+    },
+    {
+      "description": "Automerge minor/patch devDeps when CI is green",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Pin GitHub Action SHAs",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security", "DevEx"],
+    "automerge": false,
+    "prPriority": 10
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on Monday"]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `renovate.json` at the repo root to enable automated dependency updates across this Turborepo monorepo (Node 22, Turbo, Vitest, React 19, Express, Sequelize).

Linear: https://linear.app/ideasquared/issue/ADS-706

### Configuration highlights

- **Extends** `config:recommended`, `:semanticCommits` with `chore` type for all updates, `schedule:earlyMondays`, and `:dependencyDashboard` so all in-flight/rate-limited work is visible on a single tracker issue.
- **Grouping** keeps PR volume manageable in a 27-package monorepo:
  - `devDependencies (non-major)` — all minor/patch dev-dep updates batched.
  - `typescript-eslint` — `@typescript-eslint/*` packages move together.
  - `vitest` — `vitest` + `@vitest/*` move together.
  - `react` — `react`, `react-dom`, and their `@types/*` move together.
- **Automerge** is enabled (squash) for minor/patch `devDependencies` once CI is green; everything else requires manual review.
- **Limits**: 5 concurrent PRs, 2 PRs/hour to keep CI load predictable.
- **Schedule**: opens PRs Monday mornings (`schedule:earlyMondays`); `lockFileMaintenance` runs before 6am Monday.
- **Security**: vulnerability alerts get `security` + `DevEx` labels, elevated `prPriority: 10`, and never automerge.
- **GitHub Actions** are pinned to commit SHAs via `pinDigests`.
- **rangeStrategy: bump** so workspace `package.json` ranges update alongside the lockfile.

Also adds `docs/operations/dependency-updates.md` summarising the policy for the team.

## Test plan

- [ ] JSON parses cleanly (verified locally with `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8'))"`)
- [ ] Renovate app is installed on the repo (org admin step)
- [ ] On first run, confirm the Dependency Dashboard issue is created
- [ ] Confirm grouped PRs appear (e.g. a single `chore(deps): update vitest` PR rather than one per `@vitest/*` package)
- [ ] Confirm semantic commit prefix is `chore(deps): ...`
- [ ] Confirm automerge fires on a green minor/patch dev-dep PR before merging anything manually

https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj

---
_Generated by [Claude Code](https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj)_