### PR TITLE
feat(testing): enable coverage thresholds infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,8 +287,8 @@ jobs:
         run: npm run lint
         working-directory: ${{ matrix.app }}
 
-      - name: Test
-        run: npm test
+      - name: Test (with coverage thresholds)
+        run: npm run test:coverage
         working-directory: ${{ matrix.app }}
 
       - name: Type check
@@ -340,7 +340,7 @@ jobs:
           name: lib-dist
 
       - name: Lint, test and type-check all libraries
-        run: npx turbo run lint test type-check --filter='@adopt-dont-shop/lib.*'
+        run: npx turbo run lint test:coverage type-check --filter='@adopt-dont-shop/lib.*'
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,23 @@ Every package uses **Vitest** (`vitest run`). The React apps and `lib.components
 
 Tests must cover **behaviour**, not implementation. 100% coverage is expected but tests must always be grounded in business requirements, not internal structure.
 
+### Coverage thresholds
+
+Since ADS-708, CI runs `test:coverage` (not plain `test`) across `lib.*` and `app.*` and enforces the thresholds declared in `vitest.shared.config.ts`. The baseline is **0%** so existing PRs are not blocked — the infrastructure is in place so individual packages can ratchet upward incrementally (tracked in ADS-717). To raise the bar for a single package, override the inherited thresholds in that package's `vitest.config.ts`:
+
+```typescript
+import { mergeConfig } from 'vitest/config';
+import shared from '../vitest.shared.config';
+
+export default mergeConfig(shared, {
+  test: {
+    coverage: {
+      thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
+    },
+  },
+});
+```
+
 ## Reporting bugs / proposing features
 
 Use the issue templates in [`.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE/):

--- a/vitest.shared.config.ts
+++ b/vitest.shared.config.ts
@@ -32,6 +32,17 @@ export default defineConfig({
         'src/**/*.spec.tsx',
         'src/index.ts',
       ],
+      // ADS-708: baseline coverage thresholds. Starts at 0% so today's PRs
+      // are not blocked — infrastructure is now in place for per-package
+      // ratcheting (ADS-717). Individual packages may override these in
+      // their own vitest.config.ts by setting test.coverage.thresholds.
+      thresholds: {
+        statements: 0,
+        branches: 0,
+        functions: 0,
+        lines: 0,
+        autoUpdate: false,
+      },
     },
   },
 });


### PR DESCRIPTION
Linear ticket: https://linear.app/ideasquared/issue/ADS-708

## Summary

Stand up coverage-threshold infrastructure across `lib.*` and `app.*` without blocking today's PRs. Per-package ratcheting follows in ADS-717.

- Add a `thresholds` block to `vitest.shared.config.ts` with all metrics at **0%** and `autoUpdate: false`. Every lib/app that extends the shared config now reports against coverage, but the gate cannot fail at the baseline.
- Update `.github/workflows/ci.yml` so the `test-libs` and `test-frontend` jobs run `test:coverage` instead of plain `test`. The infrastructure is now exercised on every CI run, so the day a package raises its thresholds the gate flips automatically.
- Document the ratchet workflow in `CONTRIBUTING.md` under "Test requirements" — packages opt into stricter thresholds by overriding the inherited values in their own `vitest.config.ts`.

`scripts/check-workspace-consistency.mjs` already lists `test:coverage` in both `REQUIRED_LIB_SCRIPTS` and `REQUIRED_APP_SCRIPTS`, so no change is needed there.

## Strategy: baseline = 0, ratchet later

A blanket non-zero threshold would block any PR that touches a low-coverage package on day one. Starting at 0% is intentional:

- No regression risk — existing builds keep passing.
- CI now runs the coverage reporter on every lib/app, so the wiring is proven before any team tightens the screws.
- ADS-717 will raise thresholds per-package as coverage improves, using the override pattern documented in `CONTRIBUTING.md`.

## Test plan

- [ ] `test-libs` job runs `npx turbo run lint test:coverage type-check --filter='@adopt-dont-shop/lib.*'` and stays green.
- [ ] `test-frontend` matrix runs `npm run test:coverage` per app and stays green.
- [ ] `test-backend` is unchanged (it was already on `test:coverage` since ADS-418).
- [ ] Confirm coverage reports surface in CI logs for at least one lib and one app.
- [ ] Temporarily set `statements: 100` in one package's `vitest.config.ts` locally to verify the override path fails as expected, then revert.

https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj

---
_Generated by [Claude Code](https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj)_