### PR TITLE
fix(service.backend): wrap quiz data migration in transaction with idempotent insert (ADS-695)

### DIFF
--- a/service.backend/src/migrations/10-migrate-quiz-data-to-match-profile.ts
+++ b/service.backend/src/migrations/10-migrate-quiz-data-to-match-profile.ts
@@ -16,6 +16,8 @@
  */
 import { type QueryInterface } from 'sequelize';
 
+import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+
 type QuizBlob = {
   homeType?: string;
   kids?: string;
@@ -45,135 +47,147 @@ export default {
   up: async (queryInterface: QueryInterface) => {
     const sequelize = queryInterface.sequelize;
 
-    // Find users with quiz data in their preferences blob.
-    const [rows] = (await sequelize.query(`
-      SELECT u.user_id, up.preferences
-      FROM users u
-      JOIN user_preferences up ON up.user_id = u.user_id
-      WHERE up.preferences::text LIKE '%"quiz"%'
-    `)) as [Array<{ user_id: string; preferences: Record<string, unknown> }>, unknown];
-
-    for (const row of rows) {
-      const prefs =
-        typeof row.preferences === 'string'
-          ? (JSON.parse(row.preferences) as Record<string, unknown>)
-          : row.preferences;
-      const quiz = prefs.quiz as QuizBlob | undefined;
-      if (!quiz) continue;
-
-      // Check if match profile already exists
-      const [existing] = (await sequelize.query(
+    await runInTransaction(queryInterface, async transaction => {
+      // Find users with quiz data in their preferences blob.
+      const [rows] = (await sequelize.query(
         `
-        SELECT user_id, lifestyle, preferred_energy, preferred_sizes, allergies
-        FROM adopter_match_profile
-        WHERE user_id = :userId
+        SELECT u.user_id, up.preferences
+        FROM users u
+        JOIN user_preferences up ON up.user_id = u.user_id
+        WHERE up.preferences::text LIKE '%"quiz"%'
       `,
-        {
-          replacements: { userId: row.user_id },
-        }
-      )) as [
-        Array<{
-          user_id: string;
-          lifestyle: Record<string, unknown>;
-          preferred_energy: string[] | null;
-          preferred_sizes: string[] | null;
-          allergies: string | null;
-        }>,
-        unknown,
-      ];
+        { transaction }
+      )) as [Array<{ user_id: string; preferences: Record<string, unknown> }>, unknown];
 
-      const profile = existing[0];
+      for (const row of rows) {
+        const prefs =
+          typeof row.preferences === 'string'
+            ? (JSON.parse(row.preferences) as Record<string, unknown>)
+            : row.preferences;
+        const quiz = prefs.quiz as QuizBlob | undefined;
+        if (!quiz) continue;
 
-      if (profile) {
-        // Match profile exists — only fill in blanks (match profile data wins)
-        const lifestyle = (
-          typeof profile.lifestyle === 'string'
-            ? JSON.parse(profile.lifestyle)
-            : (profile.lifestyle ?? {})
-        ) as Record<string, unknown>;
-
-        const updates: string[] = [];
-        const replacements: Record<string, unknown> = { userId: row.user_id };
-
-        if (!lifestyle.housing_type && quiz.homeType) {
-          lifestyle.housing_type = mapHousingType(quiz.homeType);
-        }
-        if (lifestyle.has_children === undefined && quiz.kids) {
-          lifestyle.has_children = quiz.kids !== 'none';
-        }
-        if (lifestyle.has_other_pets === undefined && quiz.otherPets) {
-          lifestyle.has_other_pets = quiz.otherPets !== 'none';
-        }
-        if (quiz.homeType === 'house_with_yard' && lifestyle.yard === undefined) {
-          lifestyle.yard = true;
-        }
-
-        updates.push('lifestyle = :lifestyle');
-        replacements.lifestyle = JSON.stringify(lifestyle);
-
-        if (!profile.preferred_energy?.length && quiz.activityLevel) {
-          updates.push('preferred_energy = :energy');
-          replacements.energy = JSON.stringify(mapActivityToEnergy(quiz.activityLevel));
-        }
-        if (
-          !profile.preferred_sizes?.length &&
-          quiz.sizePreference &&
-          quiz.sizePreference !== 'any'
-        ) {
-          updates.push('preferred_sizes = :sizes');
-          replacements.sizes = JSON.stringify(mapSizePreference(quiz.sizePreference));
-        }
-        if (!profile.allergies && quiz.allergies && quiz.allergies !== 'none') {
-          updates.push('allergies = :allergies');
-          replacements.allergies = quiz.allergies;
-        }
-
-        if (updates.length > 0) {
-          await sequelize.query(
-            `UPDATE adopter_match_profile SET ${updates.join(', ')} WHERE user_id = :userId`,
-            { replacements }
-          );
-        }
-      } else {
-        // No match profile — create one from quiz data
-        const lifestyle: Record<string, unknown> = {};
-        if (quiz.homeType) lifestyle.housing_type = mapHousingType(quiz.homeType);
-        if (quiz.kids) lifestyle.has_children = quiz.kids !== 'none';
-        if (quiz.otherPets) lifestyle.has_other_pets = quiz.otherPets !== 'none';
-        if (quiz.homeType === 'house_with_yard') lifestyle.yard = true;
-
-        await sequelize.query(
+        // Check if match profile already exists
+        const [existing] = (await sequelize.query(
           `
-          INSERT INTO adopter_match_profile (
-            user_id, lifestyle, preferred_energy, preferred_sizes, allergies,
-            inferred_prefs, open_to_special_needs, notify_new_matches,
-            min_notification_score, created_at, updated_at
-          ) VALUES (
-            :userId, :lifestyle, :energy, :sizes, :allergies,
-            '{}', false, false, 75, NOW(), NOW()
-          )
+          SELECT user_id, lifestyle, preferred_energy, preferred_sizes, allergies
+          FROM adopter_match_profile
+          WHERE user_id = :userId
         `,
           {
-            replacements: {
-              userId: row.user_id,
-              lifestyle: JSON.stringify(lifestyle),
-              energy: quiz.activityLevel
-                ? JSON.stringify(mapActivityToEnergy(quiz.activityLevel))
-                : null,
-              sizes:
-                quiz.sizePreference && quiz.sizePreference !== 'any'
-                  ? JSON.stringify(mapSizePreference(quiz.sizePreference))
-                  : null,
-              allergies: quiz.allergies && quiz.allergies !== 'none' ? quiz.allergies : null,
-            },
+            replacements: { userId: row.user_id },
+            transaction,
           }
-        );
+        )) as [
+          Array<{
+            user_id: string;
+            lifestyle: Record<string, unknown>;
+            preferred_energy: string[] | null;
+            preferred_sizes: string[] | null;
+            allergies: string | null;
+          }>,
+          unknown,
+        ];
+
+        const profile = existing[0];
+
+        if (profile) {
+          // Match profile exists — only fill in blanks (match profile data wins)
+          const lifestyle = (
+            typeof profile.lifestyle === 'string'
+              ? JSON.parse(profile.lifestyle)
+              : (profile.lifestyle ?? {})
+          ) as Record<string, unknown>;
+
+          const updates: string[] = [];
+          const replacements: Record<string, unknown> = { userId: row.user_id };
+
+          if (!lifestyle.housing_type && quiz.homeType) {
+            lifestyle.housing_type = mapHousingType(quiz.homeType);
+          }
+          if (lifestyle.has_children === undefined && quiz.kids) {
+            lifestyle.has_children = quiz.kids !== 'none';
+          }
+          if (lifestyle.has_other_pets === undefined && quiz.otherPets) {
+            lifestyle.has_other_pets = quiz.otherPets !== 'none';
+          }
+          if (quiz.homeType === 'house_with_yard' && lifestyle.yard === undefined) {
+            lifestyle.yard = true;
+          }
+
+          updates.push('lifestyle = :lifestyle');
+          replacements.lifestyle = JSON.stringify(lifestyle);
+
+          if (!profile.preferred_energy?.length && quiz.activityLevel) {
+            updates.push('preferred_energy = :energy');
+            replacements.energy = JSON.stringify(mapActivityToEnergy(quiz.activityLevel));
+          }
+          if (
+            !profile.preferred_sizes?.length &&
+            quiz.sizePreference &&
+            quiz.sizePreference !== 'any'
+          ) {
+            updates.push('preferred_sizes = :sizes');
+            replacements.sizes = JSON.stringify(mapSizePreference(quiz.sizePreference));
+          }
+          if (!profile.allergies && quiz.allergies && quiz.allergies !== 'none') {
+            updates.push('allergies = :allergies');
+            replacements.allergies = quiz.allergies;
+          }
+
+          if (updates.length > 0) {
+            await sequelize.query(
+              `UPDATE adopter_match_profile SET ${updates.join(', ')} WHERE user_id = :userId`,
+              { replacements, transaction }
+            );
+          }
+        } else {
+          // No match profile — create one from quiz data. ON CONFLICT keeps
+          // this idempotent if a concurrent writer (or a retry of a partially
+          // applied migration) has inserted the row since the SELECT above.
+          const lifestyle: Record<string, unknown> = {};
+          if (quiz.homeType) lifestyle.housing_type = mapHousingType(quiz.homeType);
+          if (quiz.kids) lifestyle.has_children = quiz.kids !== 'none';
+          if (quiz.otherPets) lifestyle.has_other_pets = quiz.otherPets !== 'none';
+          if (quiz.homeType === 'house_with_yard') lifestyle.yard = true;
+
+          await sequelize.query(
+            `
+            INSERT INTO adopter_match_profile (
+              user_id, lifestyle, preferred_energy, preferred_sizes, allergies,
+              inferred_prefs, open_to_special_needs, notify_new_matches,
+              min_notification_score, created_at, updated_at
+            ) VALUES (
+              :userId, :lifestyle, :energy, :sizes, :allergies,
+              '{}', false, false, 75, NOW(), NOW()
+            )
+            ON CONFLICT (user_id) DO NOTHING
+          `,
+            {
+              replacements: {
+                userId: row.user_id,
+                lifestyle: JSON.stringify(lifestyle),
+                energy: quiz.activityLevel
+                  ? JSON.stringify(mapActivityToEnergy(quiz.activityLevel))
+                  : null,
+                sizes:
+                  quiz.sizePreference && quiz.sizePreference !== 'any'
+                    ? JSON.stringify(mapSizePreference(quiz.sizePreference))
+                    : null,
+                allergies: quiz.allergies && quiz.allergies !== 'none' ? quiz.allergies : null,
+              },
+              transaction,
+            }
+          );
+        }
       }
-    }
+    });
   },
 
   down: async (): Promise<void> => {
     // Data migration — no automatic rollback. The quiz blob data is still
-    // intact in user_preferences for manual recovery if needed.
+    // intact in user_preferences for manual recovery if needed. Operators
+    // must opt in explicitly before any future destructive down() is added.
+    assertDestructiveDownAcknowledged('10-migrate-quiz-data-to-match-profile');
   },
 };


### PR DESCRIPTION
## Summary

Closes [ADS-695](https://linear.app/ideasquared/issue/ADS-695).

Migration `10-migrate-quiz-data-to-match-profile` performed a SELECT followed by per-row UPDATE/INSERT writes without any transaction wrapper. A mid-loop failure left users in an inconsistent half-migrated state.

- Wrap the SELECT + per-row writes in `runInTransaction` so the whole pass either commits or rolls back atomically.
- Thread `{ transaction }` through every `sequelize.query()` inside the loop.
- Add `ON CONFLICT (user_id) DO NOTHING` to the `INSERT INTO adopter_match_profile` so a retry against a partially-applied database (or a row created by a concurrent writer between the SELECT and INSERT) does not fail with a unique-constraint violation.
- Replace the empty `down()` with `assertDestructiveDownAcknowledged('10-migrate-quiz-data-to-match-profile')` so any future destructive rollback requires explicit operator opt-in via `MIGRATION_ALLOW_DESTRUCTIVE_DOWN` + `MIGRATION_DESTRUCTIVE_DOWN_KEY` (matches the ADS-440 pattern).

## Safety for already-applied environments

This migration was merged recently (with the ADS-641/ADS-649/etc. batch) and may already be recorded in `SequelizeMeta` on some environments. Modifying it is safe here because:

- `SequelizeMeta` records the filename, so environments that have already run migration 10 will simply skip it on the next `db:migrate` — they will not re-execute the new body.
- The transaction wrapping has no retroactive effect on completed runs; it only protects future re-runs in fresh databases (CI, new envs, restored backups).
- The `ON CONFLICT DO NOTHING` change is idempotent and would be a no-op on environments where the migration already completed cleanly.
- The new `down()` guard only fires if an operator explicitly attempts to roll this migration back, which previously did nothing — the new behaviour is strictly safer (refuses by default, with a clear opt-in path).

## Test plan

- [x] `npx turbo lint type-check --filter=@adopt-dont-shop/service-backend` passes with 0 errors (pre-existing warnings unchanged).
- [ ] On a fresh database: `npm run db:migrate` completes migration 10 end-to-end.
- [ ] Simulate a mid-loop failure (e.g. inject a bad row) on a fresh database and confirm `adopter_match_profile` is left unchanged after rollback.
- [ ] Re-running the migration body against a database where a subset of rows is already present succeeds (ON CONFLICT path exercised).
- [ ] `down()` without the env opt-in throws the expected error message; with both env vars set it returns cleanly.

https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2)_