### PR TITLE
fix(docker): run frontend nginx as non-root and skip runtime npm install in production (ADS-701)

### DIFF
--- a/Dockerfile.app.optimized
+++ b/Dockerfile.app.optimized
@@ -216,8 +216,15 @@ RUN --mount=type=cache,target=/app/.turbo \
 # ============================================================================
 # PRODUCTION STAGE - Minimal Nginx image for static assets
 # ============================================================================
-FROM nginx:1.31-alpine AS production
+# Uses the unprivileged nginx image (runs as UID 101, listens on 8080) so the
+# container does not run as root. [ADS-701]
+FROM nginxinc/nginx-unprivileged:1.31-alpine AS production
 ARG APP_NAME
+
+# Privileged setup (package upgrade, suid strip, config write). The base image
+# drops back to the `nginx` user via the trailing USER directive below before
+# the runtime stage starts. [ADS-701]
+USER root
 
 # Install security updates
 # hadolint ignore=DL3018
@@ -260,7 +267,7 @@ http { \
                application/wasm; \
     \
     server { \
-        listen 80; \
+        listen 8080; \
         server_name _; \
         root /usr/share/nginx/html; \
         index index.html; \
@@ -298,12 +305,15 @@ http { \
     } \
 }' > /etc/nginx/nginx.conf
 
+# Drop back to the unprivileged nginx user (UID 101) for runtime. [ADS-701]
+USER nginx
+
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost/health || exit 1
+    CMD wget --quiet --tries=1 --spider http://localhost:8080/health || exit 1
 
-# Expose port
-EXPOSE 80
+# Expose port (unprivileged nginx listens on 8080, not 80) [ADS-701]
+EXPOSE 8080
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/deploy/gateway/nginx.conf
+++ b/deploy/gateway/nginx.conf
@@ -50,14 +50,15 @@ http {
     upstream prod_backend {
         server ads_prod_backend:5000;
     }
+    # Frontend containers run the unprivileged nginx image and listen on 8080. [ADS-701]
     upstream prod_client {
-        server ads_prod_client:80;
+        server ads_prod_client:8080;
     }
     upstream prod_admin {
-        server ads_prod_admin:80;
+        server ads_prod_admin:8080;
     }
     upstream prod_rescue {
-        server ads_prod_rescue:80;
+        server ads_prod_rescue:8080;
     }
 
     # Per-stack nginx — handles /uploads via auth_request to the backend
@@ -72,14 +73,15 @@ http {
     upstream staging_backend {
         server ads_staging_backend:5000;
     }
+    # Frontend containers run the unprivileged nginx image and listen on 8080. [ADS-701]
     upstream staging_client {
-        server ads_staging_client:80;
+        server ads_staging_client:8080;
     }
     upstream staging_admin {
-        server ads_staging_admin:80;
+        server ads_staging_admin:8080;
     }
     upstream staging_rescue {
-        server ads_staging_rescue:80;
+        server ads_staging_rescue:8080;
     }
 
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -230,12 +230,13 @@ services:
     container_name: ads_prod_admin
     restart: always
     volumes: []  # No volumes in production
+    # ADS-701: nginx runs unprivileged and listens on 8080.
     expose:
-      - "80"
+      - "8080"
     stdin_open: false
     tty: false
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:80']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -255,12 +256,13 @@ services:
     container_name: ads_prod_client
     restart: always
     volumes: []  # No volumes in production
+    # ADS-701: nginx runs unprivileged and listens on 8080.
     expose:
-      - "80"
+      - "8080"
     stdin_open: false
     tty: false
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:80']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -280,12 +282,13 @@ services:
     container_name: ads_prod_rescue
     restart: always
     volumes: []  # No volumes in production
+    # ADS-701: nginx runs unprivileged and listens on 8080.
     expose:
-      - "80"
+      - "8080"
     stdin_open: false
     tty: false
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:80']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080']
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -136,10 +136,11 @@ services:
     image: ghcr.io/ideasquared/adopt-dont-shop/app-client:${DEPLOY_SHA:-latest}
     container_name: ads_staging_client
     restart: always
+    # ADS-701: nginx runs unprivileged and listens on 8080.
     expose:
-      - "80"
+      - "8080"
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:80/']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -150,10 +151,11 @@ services:
     image: ghcr.io/ideasquared/adopt-dont-shop/app-admin:${DEPLOY_SHA:-latest}
     container_name: ads_staging_admin
     restart: always
+    # ADS-701: nginx runs unprivileged and listens on 8080.
     expose:
-      - "80"
+      - "8080"
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:80/']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -164,10 +166,11 @@ services:
     image: ghcr.io/ideasquared/adopt-dont-shop/app-rescue:${DEPLOY_SHA:-latest}
     container_name: ads_staging_rescue
     restart: always
+    # ADS-701: nginx runs unprivileged and listens on 8080.
     expose:
-      - "80"
+      - "8080"
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:80/']
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080/']
       interval: 30s
       timeout: 10s
       retries: 3

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -64,9 +64,10 @@ http {
     }
 
     upstream backend { server service-backend:5000; }
-    upstream client  { server app-client:3000; }
-    upstream admin   { server app-admin:3000; }
-    upstream rescue  { server app-rescue:3000; }
+    # Frontend containers run the unprivileged nginx image and listen on 8080. [ADS-701]
+    upstream client  { server app-client:8080; }
+    upstream admin   { server app-admin:8080; }
+    upstream rescue  { server app-rescue:8080; }
 
     # ------------------------------------------------------------------------
     # Shared SSL settings

--- a/service.backend/docker-entrypoint.sh
+++ b/service.backend/docker-entrypoint.sh
@@ -3,9 +3,14 @@ set -e
 
 cd /app/service.backend
 
-if [ ! -d "node_modules/pg" ]; then
-  echo "Installing dependencies (node_modules missing or stale)..."
-  npm install --prefer-offline 2>/dev/null || npm install
+# Skip runtime npm install in production — images bake dependencies in at
+# build time, and running npm install in a hardened (read-only) container
+# either fails or constitutes a supply-chain risk. [ADS-701]
+if [ "$NODE_ENV" != "production" ]; then
+  if [ ! -d "node_modules/pg" ]; then
+    echo "Installing dependencies (node_modules missing or stale)..."
+    npm install --prefer-offline 2>/dev/null || npm install
+  fi
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

Closes [ADS-701](https://linear.app/ideasquared/issue/ADS-701).

Two hardening fixes for the production container surface:

1. **Frontend nginx no longer runs as root.** The production stage of `Dockerfile.app.optimized` now bases on `nginxinc/nginx-unprivileged:1.31-alpine`, which ships a non-root `nginx` user (UID 101) and a writable `/var/cache/nginx` and `/var/run/nginx.pid`. The container listens on `8080` (the unprivileged image cannot bind 80). The privileged setup steps (`apk upgrade`, suid-bit strip, writing the inlined nginx config) run under an explicit `USER root` block, then drop back to `USER nginx` for runtime.
2. **Backend container no longer runs `npm install` at startup in production.** `service.backend/docker-entrypoint.sh` now wraps the install block in `if [ "$NODE_ENV" != "production" ]`. The dev workflow (which relies on the install-on-startup fallback when the bind-mounted `node_modules` is missing) is unchanged. The production image bakes dependencies in at build time, so the install was both unnecessary and incompatible with `read_only: true` from ADS-454.

### Port-mapping ripple

Because the container now listens on 8080 instead of 80, the following references were updated to match:

- `docker-compose.prod.yml` and `docker-compose.staging.yml`: `expose: ["80"]` -> `expose: ["8080"]`, healthchecks repointed at `:8080`.
- `nginx/nginx.prod.conf`: `upstream client/admin/rescue` repointed from `:3000` (also wrong previously) to `:8080`.
- `deploy/gateway/nginx.conf`: `ads_prod_client:80`, `ads_prod_admin:80`, `ads_prod_rescue:80` (and the matching staging upstreams) repointed to `:8080`. The per-stack `ads_prod_nginx:80` upstream is unchanged because it uses the regular `nginx:1.27-alpine` image, not the frontend Dockerfile.

The host-facing port mapping (`80:80` on the gateway in `deploy/gateway/docker-compose.gateway.yml`) is unchanged.

## Test plan

The change is config-only; the agent did not build images. Reviewer/maintainer should verify locally:

- [ ] `docker build -f Dockerfile.app.optimized --build-arg APP_NAME=app.client --target production -t ads-client-prod .` succeeds.
- [ ] `docker run --rm -p 8080:8080 ads-client-prod` starts without any `permission denied` / `bind: permission denied` errors in the logs.
- [ ] `docker exec <id> id` reports a non-root UID (101 / `nginx`).
- [ ] `curl http://localhost:8080/health` returns `healthy`.
- [ ] `curl http://localhost:8080/` returns the SPA `index.html`.
- [ ] `docker inspect <id> --format '{{.State.Health.Status}}'` becomes `healthy` within a minute.
- [ ] Spinning up the full prod stack (`docker compose -f docker-compose.prod.yml up`) shows the per-stack `nginx` reaching `app-client:8080` / `app-admin:8080` / `app-rescue:8080` successfully (no `502 Bad Gateway`).
- [ ] Backend container started with `NODE_ENV=production` does NOT print `Installing dependencies (node_modules missing or stale)...` and starts immediately. Dev container (no `NODE_ENV`) still runs the install fallback when needed.

https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2)_