### PR TITLE
perf(ci): cache node_modules via composite setup action

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,26 @@
+name: 'Setup Workspace'
+description: 'Checkout, install Node, cache and install workspace dependencies'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'npm'
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+      with:
+        path: |
+          node_modules
+          */node_modules
+          lib.*/node_modules
+          app.*/node_modules
+          service.backend/node_modules
+          eslint-config-*/node_modules
+          e2e/node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    - name: Install workspace dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install workspace dependencies
-        run: npm ci
+      - uses: ./.github/actions/setup-workspace
 
       # ADS-390: Cache compiled lib.*/dist across CI runs.
       # Key covers all lib source files, package manifests, tsconfig files and
@@ -179,14 +172,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install workspace dependencies
-        run: npm ci
+      - uses: ./.github/actions/setup-workspace
 
       - name: Generate per-run test secrets
         # Avoid hard-coded placeholder secrets in the workflow file.
@@ -269,14 +255,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install workspace dependencies
-        run: npm ci
+      - uses: ./.github/actions/setup-workspace
 
       - name: Download pre-built libraries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -325,14 +304,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install workspace dependencies
-        run: npm ci
+      - uses: ./.github/actions/setup-workspace
 
       - name: Download pre-built libraries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -386,19 +358,13 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY"
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+      - uses: ./.github/actions/setup-workspace
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
         with:
           driver-opts: |
             image=moby/buildkit:latest
             network=host
-
-      - name: Install workspace dependencies
-        run: npm ci
 
       - name: Resolve Playwright version
         id: pw


### PR DESCRIPTION
## Summary

Linear: [ADS-711](https://linear.app/ideasquared/issue/ADS-711)

Introduces `.github/actions/setup-workspace/` composite action that runs setup-node, caches all workspace `node_modules` keyed on `package-lock.json` hash, and only runs `npm ci --prefer-offline --no-audit --no-fund` on cache miss. Replaces the repeated setup-node + install step pairs across the build-libs, test-backend, test-frontend, test-libs, dev-auth-guard, and test-e2e jobs in `ci.yml`.

Expected ~50% reduction in install time across a CI run after the first cache populates.

## Test plan

- [ ] First CI run populates the node_modules cache
- [ ] Subsequent runs skip `npm ci` entirely (cache hit)
- [ ] All affected jobs still succeed with cached node_modules
- [ ] Cache invalidates when `package-lock.json` changes


---
_Generated by [Claude Code](https://claude.ai/code/session_016BGBmCNLB4o9F7MdzK5WZj)_