### PR TITLE
fix(service.backend): include reads in updateStaffMember transaction scope (ADS-692)

### DIFF
--- a/service.backend/src/__tests__/services/rescue.service.test.ts
+++ b/service.backend/src/__tests__/services/rescue.service.test.ts
@@ -665,6 +665,75 @@ describe('RescueService - Behavioral Testing', () => {
     });
   });
 
+  describe('updateStaffMember', () => {
+    it('should update staff member title successfully', async () => {
+      const rescue = await Rescue.create({
+        name: 'Test Rescue',
+        email: 'test@rescue.org',
+        phone: '555-0123',
+        address: '123 Main St',
+        city: 'London',
+        postcode: 'SW1A 1AA',
+        country: 'GB',
+        contactPerson: 'Jane Smith',
+        status: 'verified',
+      });
+
+      await StaffMember.create({
+        rescueId: rescue.rescueId,
+        userId: 'user-123',
+        title: 'Volunteer',
+        addedBy: 'admin-123',
+      });
+
+      await RescueService.updateStaffMember(
+        rescue.rescueId,
+        'user-123',
+        { title: 'Coordinator' },
+        'admin-123'
+      );
+
+      const updated = await StaffMember.findOne({
+        where: { rescueId: rescue.rescueId, userId: 'user-123' },
+      });
+      expect(updated?.title).toBe('Coordinator');
+    });
+
+    it('should throw error when rescue not found', async () => {
+      await expect(
+        RescueService.updateStaffMember(
+          'nonexistent-id',
+          'user-123',
+          { title: 'Coordinator' },
+          'admin-123'
+        )
+      ).rejects.toThrow('Rescue not found');
+    });
+
+    it('should throw error when staff member not found', async () => {
+      const rescue = await Rescue.create({
+        name: 'Test Rescue',
+        email: 'test@rescue.org',
+        phone: '555-0123',
+        address: '123 Main St',
+        city: 'London',
+        postcode: 'SW1A 1AA',
+        country: 'GB',
+        contactPerson: 'Jane Smith',
+        status: 'verified',
+      });
+
+      await expect(
+        RescueService.updateStaffMember(
+          rescue.rescueId,
+          'user-123',
+          { title: 'Coordinator' },
+          'admin-123'
+        )
+      ).rejects.toThrow('Staff member not found');
+    });
+  });
+
   describe('getRescueStatistics', () => {
     it('should get rescue statistics successfully', async () => {
       const rescue = await Rescue.create({

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -1178,7 +1178,7 @@ export class RescueService {
 
     try {
       // Verify rescue exists
-      const rescue = await Rescue.findByPk(rescueId);
+      const rescue = await Rescue.findByPk(rescueId, { transaction });
       if (!rescue) {
         throw new Error('Rescue not found');
       }
@@ -1187,6 +1187,7 @@ export class RescueService {
       const staffMember = await StaffMember.findOne({
         where: { rescueId, userId },
         include: [{ model: User, as: 'user' }],
+        transaction,
       });
 
       if (!staffMember) {


### PR DESCRIPTION
## Summary

Fixes [ADS-692](https://linear.app/ideasquared/issue/ADS-692). In `RescueService.updateStaffMember`, the method opened a transaction but its two reads (`Rescue.findByPk` and `StaffMember.findOne`) omitted `{ transaction }`. They executed on the default connection outside transaction scope, so a concurrent writer could change the rows between the existence checks and the subsequent `staffMember.update(..., { transaction })`. This is a classic read-outside-transaction race that can produce lost updates or misleading "not found" errors.

The fix passes `{ transaction }` to both reads so the whole flow operates on a single isolated snapshot.

## Changes

- `service.backend/src/services/rescue.service.ts`: add `{ transaction }` to the `Rescue.findByPk` and `StaffMember.findOne` calls inside `updateStaffMember`.
- `service.backend/src/__tests__/services/rescue.service.test.ts`: add a `describe('updateStaffMember', ...)` block with the happy-path update and both "not found" branches.

## Audit of sibling methods

I audited every other transaction-using method in `rescue.service.ts` for the same anti-pattern. **No further occurrences** — `createRescue`, `updateRescue`, `verifyRescue`, `rejectRescue`, `suspendRescue`, `addStaffMember`, `removeStaffMember`, `deleteRescue`, and `updateAdoptionPolicies` all correctly thread `{ transaction }` through their reads.

## Test plan

- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/service-backend` — all 4 tasks pass (2727 tests passed, 210 pre-existing skips).
- [x] New `updateStaffMember` tests pass against the fixed implementation.

https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2)_