### PR TITLE
fix(app.admin): type entityContext and avoid hidden render in ReportDetailModal (ADS-698)

### DIFF
--- a/app.admin/src/components/moderation/ReportDetailModal.css.ts
+++ b/app.admin/src/components/moderation/ReportDetailModal.css.ts
@@ -14,10 +14,6 @@ export const overlay = style({
   padding: '1rem',
 });
 
-export const overlayHidden = style({
-  display: 'none',
-});
-
 export const modalContainer = style({
   background: '#ffffff',
   borderRadius: '12px',

--- a/app.admin/src/components/moderation/ReportDetailModal.tsx
+++ b/app.admin/src/components/moderation/ReportDetailModal.tsx
@@ -9,8 +9,8 @@ import {
   FiShield,
   FiClock,
 } from 'react-icons/fi';
-import { openExternal } from '../../utils/openExternal';
 import clsx from 'clsx';
+import { z } from 'zod';
 import { EntityInspector, type EntityInspectorTab, Spinner } from '@adopt-dont-shop/lib.components';
 import {
   Report,
@@ -113,16 +113,34 @@ const getEntityTypeLabel = (entityType: string): string => {
   }
 };
 
-type EntityContext = {
-  displayName?: string;
-  deleted?: boolean;
-  error?: boolean;
-  email?: string;
-  userType?: string;
-  petType?: string;
-  breed?: string;
-  city?: string;
-  country?: string;
+// The backend (moderation.service.ts#enrichReportsWithEntityContext) attaches
+// an `entityContext` field to each report at the top level. It isn't part of
+// the shared Report Zod schema, so we parse it locally to avoid a cross-package
+// schema change. Every field is optional because the backend may attach a
+// deleted/error fallback or omit fields per entity type.
+const EntityContextSchema = z
+  .object({
+    displayName: z.string().optional(),
+    deleted: z.boolean().optional(),
+    error: z.boolean().optional(),
+    email: z.string().optional(),
+    userType: z.string().optional(),
+    petType: z.string().optional(),
+    breed: z.string().optional(),
+    city: z.string().optional(),
+    country: z.string().optional(),
+  })
+  .passthrough();
+
+type EntityContext = z.infer<typeof EntityContextSchema>;
+
+const extractEntityContext = (report: Report): EntityContext | undefined => {
+  const candidate = (report as { entityContext?: unknown }).entityContext;
+  if (candidate === undefined) {
+    return undefined;
+  }
+  const parsed = EntityContextSchema.safeParse(candidate);
+  return parsed.success ? parsed.data : undefined;
 };
 
 // ── Overview Tab ──────────────────────────────────────────────────
@@ -289,7 +307,10 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ report, entityContext, onClos
         </div>
         <button
           className={clsx(styles.viewContentButton, styles.viewContentButtonSpacing)}
-          onClick={() => openExternal(`${window.location.origin}/users/${report.reporterId}`)}
+          onClick={() => {
+            onClose();
+            navigate(`/users/${report.reporterId}`);
+          }}
         >
           <FiExternalLink size={16} />
           View Reporter Profile
@@ -479,13 +500,15 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
   siblingIds,
   onNavigate,
 }) => {
+  if (!isOpen) {
+    return null;
+  }
+
   if (!report) {
     return null;
   }
 
-  const entityContext = (report as Record<string, unknown>).entityContext as
-    | EntityContext
-    | undefined;
+  const entityContext = extractEntityContext(report);
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
@@ -523,7 +546,7 @@ export const ReportDetailModal: React.FC<ReportDetailModalProps> = ({
 
   return (
     <div
-      className={clsx(styles.overlay, !isOpen && styles.overlayHidden)}
+      className={styles.overlay}
       onClick={handleOverlayClick}
       onKeyDown={e => e.key === 'Escape' && onClose()}
       role='presentation'


### PR DESCRIPTION
## Summary

Fixes three issues in `app.admin/src/components/moderation/ReportDetailModal.tsx` flagged in [ADS-698](https://linear.app/ideasquared/issue/ADS-698):

- **Typed `entityContext`** — The backend (`moderation.service.ts#enrichReportsWithEntityContext`) attaches an `entityContext` field at the top level of each enriched report, but it isn't part of the shared `Report` Zod schema. The component previously reached for it with a double type assertion (`(report as Record<string, unknown>).entityContext as { ... }`). Replaced this with a local `EntityContextSchema` (Zod) and a `safeParse`-based `extractEntityContext` helper. Schema lives in the component so we don't have to touch the shared `lib.moderation` package.
- **No hidden render** — Added `if (!isOpen) return null;` at the top of the component so it no longer renders DOM and fires child hooks (`useReports`, `useActiveActions`, `useEntityActivity`) while hidden. Dropped the now-unused `overlayHidden` class and its CSS export.
- **Same-app navigation** — Replaced `openExternal(`${window.location.origin}/users/${report.reporterId}`)` on the "View Reporter Profile" button with `onClose(); navigate(`/users/${report.reporterId}`)`, matching how the view-entity button already handles same-app nav.

## Follow-ups

- The component still uses a custom overlay (`styles.overlay` + `handleOverlayClick`) rather than the shared `<Modal>` component. The migration is a larger refactor that warrants its own ticket and was intentionally scoped out of this PR.

## Test plan

- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.admin` — 630 tests pass, lint and type-check clean.
- [ ] Manual: open a report detail modal, confirm reporter/profile/view-entity buttons navigate in-app and close the modal first.
- [ ] Manual: confirm closing the modal stops rendering (network panel: no more `/reports` / `/activity` requests fired by the hidden modal).

https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2)_