### PR TITLE
fix(app.admin): debounce inbox search and surface assign errors (ADS-697)

### DIFF
--- a/app.admin/src/hooks/index.ts
+++ b/app.admin/src/hooks/index.ts
@@ -22,3 +22,6 @@ export * from './useInbox';
 
 // Generic entity activity (used by EntityInspector across all entity types)
 export * from './useEntityActivity';
+
+// Generic utility hooks
+export * from './useDebouncedValue';

--- a/app.admin/src/hooks/useDebouncedValue.ts
+++ b/app.admin/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs` has
+ * elapsed without further changes. Useful for keeping fast-changing inputs
+ * (e.g. search boxes) decoupled from expensive consumers like API queries.
+ */
+export const useDebouncedValue = <T>(value: T, delayMs: number = 300): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debouncedValue;
+};

--- a/app.admin/src/pages/Inbox.test.tsx
+++ b/app.admin/src/pages/Inbox.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen, act } from '@testing-library/react';
+import { toast } from '@adopt-dont-shop/lib.components';
 import { renderWithProviders } from '../test-utils';
 import type { InboxFilters } from '../hooks/useInbox';
 
@@ -134,11 +135,17 @@ describe('Inbox page', () => {
     const assignButtons = screen.getAllByTitle('Assign to me');
     fireEvent.click(assignButtons[0]);
 
-    expect(mockAssignMutate).toHaveBeenCalledWith({
-      itemId: 'report-1',
-      source: 'moderation',
-      assignedTo: 'admin-user-1',
-    });
+    expect(mockAssignMutate).toHaveBeenCalledWith(
+      {
+        itemId: 'report-1',
+        source: 'moderation',
+        assignedTo: 'admin-user-1',
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    );
   });
 
   it('allows filtering by source', () => {
@@ -230,6 +237,66 @@ describe('Inbox page', () => {
       expect(chip).toHaveAttribute('aria-pressed', 'false');
       const lastCall = mockUseInbox.mock.calls.at(-1);
       expect(lastCall?.[0]?.assignedTo).toBeUndefined();
+    });
+  });
+
+  // ADS-697: search input must not fire an API call on every keystroke and
+  // assign failures must surface to the user rather than fail silently.
+  describe('search debouncing', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does not pass the search term to useInbox until the user stops typing', () => {
+      renderWithProviders(<Inbox />);
+
+      const searchInput = screen.getByPlaceholderText('Search across all items...');
+
+      act(() => {
+        fireEvent.change(searchInput, { target: { value: 'spam' } });
+      });
+
+      // Immediately after typing, the query must still be running against the
+      // previous (empty) search term — no API hit per keystroke.
+      const immediateCall = mockUseInbox.mock.calls.at(-1);
+      expect(immediateCall?.[0]?.search).toBeUndefined();
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      const debouncedCall = mockUseInbox.mock.calls.at(-1);
+      expect(debouncedCall?.[0]?.search).toBe('spam');
+    });
+  });
+
+  describe('assign mutation feedback', () => {
+    it('shows a success toast when the assign mutation succeeds', () => {
+      renderWithProviders(<Inbox />);
+
+      const assignButtons = screen.getAllByTitle('Assign to me');
+      fireEvent.click(assignButtons[0]);
+
+      const options = mockAssignMutate.mock.calls.at(-1)?.[1];
+      options?.onSuccess?.();
+
+      expect(toast.success).toHaveBeenCalledWith('Item assigned to you');
+    });
+
+    it('shows an error toast when the assign mutation fails', () => {
+      renderWithProviders(<Inbox />);
+
+      const assignButtons = screen.getAllByTitle('Assign to me');
+      fireEvent.click(assignButtons[0]);
+
+      const options = mockAssignMutate.mock.calls.at(-1)?.[1];
+      options?.onError?.(new Error('boom'));
+
+      expect(toast.error).toHaveBeenCalledWith('Failed to assign item. Please try again.');
     });
   });
 });

--- a/app.admin/src/pages/Inbox.tsx
+++ b/app.admin/src/pages/Inbox.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import { Input } from '@adopt-dont-shop/lib.components';
+import { Input, toast } from '@adopt-dont-shop/lib.components';
 import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { FiSearch, FiUserPlus, FiUser } from 'react-icons/fi';
 import { DataTable, type Column } from '../components/data';
@@ -11,6 +11,7 @@ import {
   type InboxFilters,
   type InboxSource,
 } from '../hooks/useInbox';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import * as styles from './Inbox.css';
 
 const formatRelativeTime = (iso: string): string => {
@@ -142,9 +143,13 @@ const Inbox: React.FC = () => {
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [page, setPage] = useState(1);
 
+  // ADS-697: debounce the search input so we don't fire an API call on every
+  // keystroke — only the settled value participates in the query key.
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, 300);
+
   useEffect(() => {
     setPage(1);
-  }, [searchQuery, sourceFilter, severityFilter, statusFilter, myQueueActive]);
+  }, [debouncedSearchQuery, sourceFilter, severityFilter, statusFilter, myQueueActive]);
 
   const filters = useMemo((): InboxFilters => {
     const f: InboxFilters = {
@@ -162,14 +167,14 @@ const Inbox: React.FC = () => {
     if (statusFilter !== 'all') {
       f.status = statusFilter;
     }
-    if (searchQuery) {
-      f.search = searchQuery;
+    if (debouncedSearchQuery) {
+      f.search = debouncedSearchQuery;
     }
     if (myQueueActive && user) {
       f.assignedTo = user.userId;
     }
     return f;
-  }, [sourceFilter, severityFilter, statusFilter, searchQuery, page, myQueueActive, user]);
+  }, [sourceFilter, severityFilter, statusFilter, debouncedSearchQuery, page, myQueueActive, user]);
 
   const { data: inboxData, isLoading, error } = useInbox(filters);
   const items = inboxData?.data ?? [];
@@ -180,11 +185,23 @@ const Inbox: React.FC = () => {
     if (!user) {
       return;
     }
-    assignMutation.mutate({
-      itemId: item.id,
-      source: item.source,
-      assignedTo: user.userId,
-    });
+    assignMutation.mutate(
+      {
+        itemId: item.id,
+        source: item.source,
+        assignedTo: user.userId,
+      },
+      {
+        // ADS-697: surface assign success/failure so users get explicit feedback
+        // instead of relying on the optimistic table update alone.
+        onSuccess: () => {
+          toast.success('Item assigned to you');
+        },
+        onError: () => {
+          toast.error('Failed to assign item. Please try again.');
+        },
+      }
+    );
   };
 
   const handleRowClick = (item: InboxItem) => {


### PR DESCRIPTION
## Summary

Fixes [ADS-697](https://linear.app/ideasquared/issue/ADS-697).

The Triage Inbox search input previously updated `searchQuery` on every keystroke, which flowed straight into the `useInbox` query key and triggered an API call per character. The "Assign to me" button also fired its mutation without any `onError` handler, so failures were silently swallowed by the global mutation handler and successes gave no positive feedback at all.

- Add a small reusable `useDebouncedValue` hook in `app.admin/src/hooks/` (300ms default) and use it for the inbox search term — only the settled value participates in the `useInbox` query key now.
- Pass per-mutation `onSuccess` / `onError` handlers to `assignMutation.mutate(...)` that fire success and failure toasts via the existing `toast` API from `@adopt-dont-shop/lib.components`.

Changes are scoped to `app.admin` only.

## Test plan

- [x] `npx turbo lint type-check test --filter=@adopt-dont-shop/app.admin` (lint, type-check, 633 tests across 55 files all passing)
- [x] New behaviour-level tests in `Inbox.test.tsx`:
  - Search term is not passed to `useInbox` until 300ms after the last keystroke
  - Successful assign mutation shows "Item assigned to you" toast
  - Failed assign mutation shows "Failed to assign item. Please try again." toast
  - Existing assign-mutation test updated to assert the options object is now passed alongside the payload
- [ ] Manual smoke test: type quickly in the inbox search box and confirm only one network request fires once typing stops; trigger an assign failure and confirm the error toast appears

https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBB9WuHHB2o8HYbYCygJV2)_