### PR TITLE
fix(app.admin): show all user statuses in edit panel, prevent silent status corruption

### DIFF
--- a/app.admin/src/__tests__/user-management.behavior.test.tsx
+++ b/app.admin/src/__tests__/user-management.behavior.test.tsx
@@ -21,6 +21,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
 import Users from '../pages/Users';
 import type { AdminUser } from '../types/user';
+import { apiService } from '../services/libraryServices';
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -145,6 +146,30 @@ const mockAdminUsers: AdminUser[] = [
     lastLogin: null,
     createdAt: '2024-01-03T00:00:00Z',
     updatedAt: '2024-01-03T00:00:00Z',
+  },
+  {
+    userId: 'user-4',
+    email: 'alice.pending@example.com',
+    firstName: 'Alice',
+    lastName: 'Pending',
+    userType: 'adopter',
+    status: 'pending_verification',
+    emailVerified: false,
+    phoneNumber: null,
+    phoneVerified: false,
+    profileImageUrl: null,
+    bio: null,
+    country: null,
+    city: null,
+    addressLine1: null,
+    addressLine2: null,
+    postalCode: null,
+    rescueId: null,
+    rescueName: null,
+    lastLoginAt: null,
+    lastLogin: null,
+    createdAt: '2024-01-04T00:00:00Z',
+    updatedAt: '2024-01-04T00:00:00Z',
   },
 ];
 
@@ -579,6 +604,31 @@ describe('User Management page', () => {
       await user.click(screen.getByRole('tab', { name: 'Activity' }));
 
       expect(screen.getByText('No activity recorded for this user.')).toBeInTheDocument();
+    });
+
+    it('shows Pending Verification in status dropdown for a pending_verification user', async () => {
+      const user = userEvent.setup();
+      setupSuccessfulLoad(mockAdminUsers);
+      renderUsersPage('/users/user-4');
+
+      await user.click(screen.getByRole('tab', { name: 'Edit' }));
+
+      expect(screen.getByDisplayValue('Pending Verification')).toBeInTheDocument();
+    });
+
+    it('does not call the API when saving the edit form without changing any fields for a pending_verification user', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiService.patch).mockClear();
+      setupSuccessfulLoad(mockAdminUsers);
+      renderUsersPage('/users/user-4');
+
+      await user.click(screen.getByRole('tab', { name: 'Edit' }));
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Saved')).toBeInTheDocument();
+      });
+      expect(apiService.patch).not.toHaveBeenCalled();
     });
   });
 });

--- a/app.admin/src/components/detail/UserDetailPanel.tsx
+++ b/app.admin/src/components/detail/UserDetailPanel.tsx
@@ -289,11 +289,14 @@ const EditTab: React.FC<{
           <select
             className={styles.formSelect}
             id='edit-status'
-            value={formData.status === 'active' ? 'active' : 'suspended'}
+            value={formData.status}
             onChange={e => setFormData({ ...formData, status: e.target.value as UserStatus })}
           >
             <option value='active'>Active</option>
+            <option value='inactive'>Inactive</option>
             <option value='suspended'>Suspended</option>
+            <option value='pending_verification'>Pending Verification</option>
+            <option value='deactivated'>Deactivated</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Fixes data corruption bug in `UserDetailPanel` Edit tab where the status dropdown collapsed `inactive`, `pending_verification`, and `deactivated` statuses to `suspended` via a hardcoded ternary on the controlled `value` prop
- An admin editing any other field (e.g. first name) on a `pending_verification` user would see "Suspended" in the dropdown; if they interacted with it and confirmed "Suspended", the user's status would be silently changed
- Fix: use `formData.status` directly as the controlled value and expose all five valid `UserStatus` options (`active`, `inactive`, `suspended`, `pending_verification`, `deactivated`)

Closes ADS-689

## Test plan

- [x] Opening Edit tab for a `pending_verification` user shows "Pending Verification" in the status dropdown (not "Suspended")
- [x] Saving the form without changing status does not call `apiService.patch` at all (no status mutation)
- [x] All 38 existing user-management behaviour tests continue to pass

https://claude.ai/code/session_011m3gVcfXE4E4KRYHNmYVK6

---
_Generated by [Claude Code](https://claude.ai/code/session_011m3gVcfXE4E4KRYHNmYVK6)_