### PR TITLE
fix(ci): add missing test:coverage task to turbo pipeline

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,11 @@
       "outputs": ["coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },
+    "test:coverage": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"],
+      "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
+    },
     "lint": {
       "outputs": []
     },


### PR DESCRIPTION
## Summary

Fixes the broken **Library Tests** CI job on `main`. The job runs:

```bash
npx turbo run lint test:coverage type-check --filter='@adopt-dont-shop/lib.*'
```

but `test:coverage` was never declared in `turbo.json`'s `tasks`. Turbo aborts the **entire** run with `Could not find task 'test:coverage' in project`, so the job has been failing since #762 (ADS-708) switched CI from `test` to `test:coverage` without adding the corresponding pipeline task.

## Root cause

- #762 added a `test:coverage` script to all 24 `lib.*` packages and changed CI to invoke it via turbo.
- `turbo.json` only defined `test`, not `test:coverage`. Turbo refuses to run any task absent from its pipeline.
- Backend and frontend jobs invoke `npm run test:coverage` directly with a `working-directory`, so they were unaffected — only the libs job goes through turbo.

## Fix

Add a `test:coverage` task to `turbo.json`, mirroring the existing `test` task (`dependsOn: ^build`, caches `coverage/**`, same source inputs).

## Verification (local, on latest `main`)

- ✅ `npx turbo run lint test:coverage type-check --filter='@adopt-dont-shop/lib.*'` → **78/78 tasks succeed** (previously aborted immediately)
- ✅ Backend `lint` + `test:coverage` (2888 tests) + `build`
- ✅ All three frontend apps `test:coverage` + `lint` + `type-check` + `build`
- ✅ `node scripts/check-workspace-consistency.mjs`
- ✅ Confirmed every turbo task referenced across CI workflows (`lint`, `test`, `test:coverage`, `type-check`) now exists in the pipeline

https://claude.ai/code/session_01L7mcsE3MX8ecCB254bv7aw

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7mcsE3MX8ecCB254bv7aw)_