### PR TITLE
fix(ci): scope labeler concurrency per-PR to stop cross-PR cancellations

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

The auto-label workflow (`.github/workflows/labeler.yml`) was being cancelled within ~3s whenever multiple PRs were active.

The concurrency group used `${{ github.ref }}`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

On a `pull_request_target` event, `github.ref` resolves to the **base branch** (`refs/heads/main`), not the PR's own ref. So every PR targeting `main` shared the single group `Labeler-refs/heads/main`. With `cancel-in-progress: true`, each new PR `opened`/`synchronize` event cancelled the still-running labeler from another PR — hence the near-instant cancellation.

## Fix

Use `github.head_ref` (the PR source branch, only set on PR events) with a `github.ref` fallback so each PR gets its own concurrency group:

```yaml
group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
```

## Scope

Checked all other workflows with the same `${{ github.ref }}` concurrency pattern (`ci`, `quality`, `security`, `storybook`, `docker`, `schema-equivalence`, `lib-test-guard`). They all trigger on regular `pull_request`, where `github.ref` is already PR-specific (`refs/pull/N/merge`), so they are **not** affected. Only `labeler.yml` runs on `pull_request_target`, so the fix is scoped to that file.

https://claude.ai/code/session_01Bj5iVS2muYeD4ETxes81k1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj5iVS2muYeD4ETxes81k1)_