### PR TITLE
fix(ADS-736): add missing rescue_staff and support_agent options to Role dropdown

### DIFF
--- a/app.admin/src/__tests__/user-management.behavior.test.tsx
+++ b/app.admin/src/__tests__/user-management.behavior.test.tsx
@@ -171,6 +171,30 @@ const mockAdminUsers: AdminUser[] = [
     createdAt: '2024-01-04T00:00:00Z',
     updatedAt: '2024-01-04T00:00:00Z',
   },
+  {
+    userId: 'user-5',
+    email: 'sara.agent@example.com',
+    firstName: 'Sara',
+    lastName: 'Agent',
+    userType: 'support_agent',
+    status: 'active',
+    emailVerified: true,
+    phoneNumber: null,
+    phoneVerified: false,
+    profileImageUrl: null,
+    bio: null,
+    country: null,
+    city: null,
+    addressLine1: null,
+    addressLine2: null,
+    postalCode: null,
+    rescueId: null,
+    rescueName: null,
+    lastLoginAt: '2024-01-12T00:00:00Z',
+    lastLogin: '2024-01-12T00:00:00Z',
+    createdAt: '2024-01-05T00:00:00Z',
+    updatedAt: '2024-01-05T00:00:00Z',
+  },
 ];
 
 const mockMutationResult = {
@@ -621,6 +645,58 @@ describe('User Management page', () => {
       vi.mocked(apiService.patch).mockClear();
       setupSuccessfulLoad(mockAdminUsers);
       renderUsersPage('/users/user-4');
+
+      await user.click(screen.getByRole('tab', { name: 'Edit' }));
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Saved')).toBeInTheDocument();
+      });
+      expect(apiService.patch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('role dropdown for non-standard user types', () => {
+    it('shows Rescue Staff selected in the Role dropdown for a rescue_staff user', async () => {
+      const user = userEvent.setup();
+      setupSuccessfulLoad(mockAdminUsers);
+      renderUsersPage('/users/user-2');
+
+      await user.click(screen.getByRole('tab', { name: 'Edit' }));
+
+      expect(screen.getByDisplayValue('Rescue Staff')).toBeInTheDocument();
+    });
+
+    it('does not include userType in the API call when saving without changing the role for a rescue_staff user', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiService.patch).mockClear();
+      setupSuccessfulLoad(mockAdminUsers);
+      renderUsersPage('/users/user-2');
+
+      await user.click(screen.getByRole('tab', { name: 'Edit' }));
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Saved')).toBeInTheDocument();
+      });
+      expect(apiService.patch).not.toHaveBeenCalled();
+    });
+
+    it('shows Support Agent selected in the Role dropdown for a support_agent user', async () => {
+      const user = userEvent.setup();
+      setupSuccessfulLoad(mockAdminUsers);
+      renderUsersPage('/users/user-5');
+
+      await user.click(screen.getByRole('tab', { name: 'Edit' }));
+
+      expect(screen.getByDisplayValue('Support Agent')).toBeInTheDocument();
+    });
+
+    it('does not include userType in the API call when saving without changing the role for a support_agent user', async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiService.patch).mockClear();
+      setupSuccessfulLoad(mockAdminUsers);
+      renderUsersPage('/users/user-5');
 
       await user.click(screen.getByRole('tab', { name: 'Edit' }));
       await user.click(screen.getByRole('button', { name: /save changes/i }));

--- a/app.admin/src/components/detail/UserDetailPanel.tsx
+++ b/app.admin/src/components/detail/UserDetailPanel.tsx
@@ -277,8 +277,10 @@ const EditTab: React.FC<{
             onChange={e => setFormData({ ...formData, userType: e.target.value as UserType })}
           >
             <option value='adopter'>Adopter</option>
-            <option value='admin'>Admin</option>
+            <option value='rescue_staff'>Rescue Staff</option>
+            <option value='support_agent'>Support Agent</option>
             <option value='moderator'>Moderator</option>
+            <option value='admin'>Admin</option>
             <option value='super_admin'>Super Admin</option>
           </select>
         </div>

--- a/app.client/src/__tests__/search-page-error-state.behavior.test.tsx
+++ b/app.client/src/__tests__/search-page-error-state.behavior.test.tsx
@@ -10,13 +10,24 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 
 import { renderWithProviders, screen, userEvent, waitFor } from '../test-utils';
 
+// Stable function references shared across renders. The real useAnalytics /
+// useStatsig hooks memoise their returned callbacks, so the mocks must do the
+// same — otherwise SearchPage's loadPets useCallback (which depends on
+// trackEvent/logEvent) is recreated every render, re-firing its useEffect and
+// triggering an infinite update loop.
+const { mockTrackEvent, mockTrackPageView, mockLogEvent } = vi.hoisted(() => ({
+  mockTrackEvent: vi.fn(),
+  mockTrackPageView: vi.fn(),
+  mockLogEvent: vi.fn(),
+}));
+
 vi.mock('@/contexts/AnalyticsContext', () => ({
-  useAnalytics: () => ({ trackEvent: vi.fn(), trackPageView: vi.fn() }),
+  useAnalytics: () => ({ trackEvent: mockTrackEvent, trackPageView: mockTrackPageView }),
 }));
 
 vi.mock('@/hooks/useStatsig', () => ({
   useStatsig: () => ({
-    logEvent: vi.fn(),
+    logEvent: mockLogEvent,
     checkGate: () => false,
     client: null,
     getExperiment: () => null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10009,7 +10009,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.4",
@@ -10023,7 +10024,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rrweb/record": {
       "version": "2.0.0-alpha.17",


### PR DESCRIPTION
## Summary

- The `UserDetailPanel` Role `<select>` was missing `rescue_staff` and `support_agent` options — only 4 of 6 valid `UserType` values were listed
- Any admin who accidentally clicked the dropdown for a user with one of these roles would silently downgrade them to `adopter` on the next save, stripping rescue-tool and support-queue access
- Added both missing options (ordered to match `AddUserModal`), and locked in 4 behaviour tests covering correct option selection and no-op saves

## Test plan

- [ ] Open Edit tab for a `rescue_staff` user — Role dropdown shows **Rescue Staff** selected
- [ ] Open Edit tab for a `support_agent` user — Role dropdown shows **Support Agent** selected
- [ ] Save without changing anything for either role — no API call is made and no role change occurs
- [ ] All 42 tests in `user-management.behavior.test.tsx` pass
- [ ] Existing ADS-689 status dropdown behaviour is unaffected

Fixes: [ADS-736](https://linear.app/ideasquared/issue/ADS-736)

https://claude.ai/code/session_013JXsGctpYHqoprbrVQ4j9N

---
_Generated by [Claude Code](https://claude.ai/code/session_013JXsGctpYHqoprbrVQ4j9N)_