### PR TITLE
fix(migrations): restore no-op down() in migration 10

### DIFF
--- a/service.backend/src/migrations/10-migrate-quiz-data-to-match-profile.ts
+++ b/service.backend/src/migrations/10-migrate-quiz-data-to-match-profile.ts
@@ -16,7 +16,7 @@
  */
 import { type QueryInterface } from 'sequelize';
 
-import { assertDestructiveDownAcknowledged, runInTransaction } from './_helpers';
+import { runInTransaction } from './_helpers';
 
 type QuizBlob = {
   homeType?: string;
@@ -185,9 +185,12 @@ export default {
   },
 
   down: async (): Promise<void> => {
-    // Data migration — no automatic rollback. The quiz blob data is still
-    // intact in user_preferences for manual recovery if needed. Operators
-    // must opt in explicitly before any future destructive down() is added.
-    assertDestructiveDownAcknowledged('10-migrate-quiz-data-to-match-profile');
+    // Intentional no-op. The source quiz data remains intact in
+    // user_preferences.preferences -> 'quiz', so rolling back this migration
+    // leaves no orphaned or unrecoverable state. The upserted rows in
+    // adopter_match_profile are safe to leave in place — they were written
+    // with ON CONFLICT DO NOTHING and can be re-derived from the quiz blobs.
+    // assertDestructiveDownAcknowledged does NOT belong here because this
+    // down() drops nothing; add it only if a future version deletes rows.
   },
 };


### PR DESCRIPTION
## Summary

- Removes the erroneous `assertDestructiveDownAcknowledged` call from the `down()` of migration 10 (`10-migrate-quiz-data-to-match-profile.ts`)
- The guard was incorrectly added — this `down()` performs no destructive work; source quiz data remains intact in `user_preferences.preferences -> 'quiz'`
- Replaces it with a clear explanatory comment matching the actual semantics: intentional no-op, safe to run without env vars

Fixes: [ADS-738](https://linear.app/ideasquared/issue/ADS-738)

## Test plan

- [ ] `db:undo` past migration 10 completes without requiring `MIGRATION_ALLOW_DESTRUCTIVE_DOWN=1` or `MIGRATION_DESTRUCTIVE_DOWN_KEY`
- [ ] `db:migrate` (up) still runs cleanly after the undo
- [ ] No TypeScript errors introduced (`tsc --noEmit`)
- [ ] Confirm `assertDestructiveDownAcknowledged` is no longer imported in this file

https://claude.ai/code/session_0153mHpUToRCR3LxjhCJBCRq

---
_Generated by [Claude Code](https://claude.ai/code/session_0153mHpUToRCR3LxjhCJBCRq)_