### PR TITLE
fix: bugs across auth, application, chat, and notification flows

### DIFF
--- a/app.rescue/src/components/ApplicationCard.tsx
+++ b/app.rescue/src/components/ApplicationCard.tsx
@@ -70,7 +70,14 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({
       : `${totalEvents} events • Last: ${lastActivityText}`;
   };
 
-  const statusKey = application.status.toLowerCase() as
+  // The badge variants in ApplicationCard.css.ts are a mix of stage names
+  // (pending/reviewing/visiting/deciding) and terminal status names
+  // (approved/rejected). The backend `status` field is one of
+  // submitted/approved/rejected/withdrawn, while `stage` carries the
+  // finer-grained workflow position. Pick the variant accordingly so
+  // in-progress applications get a meaningful colour instead of falling
+  // through to the neutral default.
+  type BadgeVariant =
     | 'pending'
     | 'reviewing'
     | 'visiting'
@@ -78,8 +85,21 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({
     | 'approved'
     | 'rejected'
     | 'default';
-  const validStatuses = ['pending', 'reviewing', 'visiting', 'deciding', 'approved', 'rejected'];
-  const statusVariant = validStatuses.includes(statusKey) ? statusKey : 'default';
+  const validVariants: readonly BadgeVariant[] = [
+    'pending',
+    'reviewing',
+    'visiting',
+    'deciding',
+    'approved',
+    'rejected',
+  ];
+  const statusLower = application.status.toLowerCase();
+  const stageLower = (application.stage ?? '').toLowerCase();
+  const candidate =
+    statusLower === 'approved' || statusLower === 'rejected' ? statusLower : stageLower;
+  const statusVariant: BadgeVariant = (validVariants as readonly string[]).includes(candidate)
+    ? (candidate as BadgeVariant)
+    : 'default';
 
   const priorityKey = application.priority as 'high' | 'medium' | 'low';
 

--- a/lib.auth/src/contexts/AuthContext.tsx
+++ b/lib.auth/src/contexts/AuthContext.tsx
@@ -293,12 +293,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       // ADS-538: register no longer returns auth tokens — the user must
       // verify their email and log in normally before the session
       // becomes valid. Deliberately do NOT call setUser() here.
-      const response = await authService.register(registerData);
+      // The response is { message: string } only (no user object) to
+      // prevent account enumeration, so we use the submitted form data
+      // for the analytics event.
+      await authService.register(registerData);
 
       onAuthEvent?.('auth_registration_successful', {
-        user_id: response.user.userId,
-        email: response.user.email,
-        user_type: response.user.userType,
+        email: registerData.email,
+        user_type: registerData.userType,
       });
     } catch (error) {
       setUser(null);

--- a/service.backend/src/__tests__/services/application.service.test.ts
+++ b/service.backend/src/__tests__/services/application.service.test.ts
@@ -1135,10 +1135,26 @@ describe('ApplicationService - Business Logic', () => {
       expect(notifArgs.type).toBe('adoption_rejected');
     });
 
-    it('does not notify when application is approved (no symmetric send on approval here)', async () => {
+    it('notifies the applicant by email and in-app when application is approved', async () => {
+      // Symmetric with rejection: the adopter should hear about a positive
+      // decision through both channels instead of only seeing it on next
+      // dashboard refresh / socket push.
       const mockApplication = createMockApplication(ApplicationStatus.SUBMITTED);
       (mockApplication.canTransitionTo as vi.Mock).mockReturnValue(true);
       MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication);
+      MockedUser.findByPk = vi.fn().mockResolvedValue({
+        userId: mockUserId,
+        email: 'applicant@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+      MockedPet.findByPk = vi.fn().mockResolvedValue({
+        petId: mockPetId,
+        name: 'Buddy',
+      });
+      vi.mocked(emailService.getTemplateByName).mockResolvedValue({
+        templateId: 'tmpl-approved',
+      } as never);
 
       await ApplicationService.updateApplicationStatus(
         mockApplicationId,
@@ -1146,8 +1162,15 @@ describe('ApplicationService - Business Logic', () => {
         'rescue-staff-123'
       );
 
-      expect(mockEmailSend).not.toHaveBeenCalled();
-      expect(mockCreateNotification).not.toHaveBeenCalled();
+      expect(mockEmailSend).toHaveBeenCalledTimes(1);
+      const emailArgs = mockEmailSend.mock.calls[0][0];
+      expect(emailArgs.toEmail).toBe('applicant@example.com');
+      expect(emailArgs.templateId).toBe('tmpl-approved');
+
+      expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+      const notifArgs = mockCreateNotification.mock.calls[0][0];
+      expect(notifArgs.userId).toBe(mockUserId);
+      expect(notifArgs.type).toBe('adoption_approved');
     });
 
     it('does not fail the status update when the email send throws', async () => {

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1323,6 +1323,8 @@ export class ApplicationService {
       // change, but it must be logged so a human can chase it up.
       if (statusUpdate.status === ApplicationStatus.REJECTED) {
         await ApplicationService.notifyApplicantOfRejection(application, statusUpdate);
+      } else if (statusUpdate.status === ApplicationStatus.APPROVED) {
+        await ApplicationService.notifyApplicantOfApproval(application);
       }
 
       await application.reload();
@@ -1395,6 +1397,7 @@ export class ApplicationService {
           applicationId: application.applicationId,
           petId: application.petId,
           rejectionReason,
+          action_url: `/applications/${application.applicationId}`,
         },
       });
 
@@ -1425,6 +1428,71 @@ export class ApplicationService {
       }
     } catch (error) {
       logger.error('Rejection notification failed (non-fatal):', {
+        applicationId: application.applicationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Notify an applicant their adoption application was approved.
+   * Mirrors notifyApplicantOfRejection — best-effort, never throws,
+   * so a transient notification failure can't roll back the approval.
+   */
+  private static async notifyApplicantOfApproval(application: Application): Promise<void> {
+    try {
+      const [applicant, pet] = await Promise.all([
+        User.findByPk(application.userId),
+        Pet.findByPk(application.petId),
+      ]);
+
+      if (!applicant) {
+        logger.warn('Approval notification skipped: applicant not found', {
+          applicationId: application.applicationId,
+          userId: application.userId,
+        });
+        return;
+      }
+
+      const applicantName = [applicant.firstName, applicant.lastName].filter(Boolean).join(' ');
+      const petName = pet?.name ?? 'the pet';
+
+      await NotificationService.createNotification({
+        userId: application.userId,
+        type: NotificationType.ADOPTION_APPROVED,
+        title: `Your application for ${petName} was approved!`,
+        message: `Great news — your application to adopt ${petName} has been approved. Log in to see next steps.`,
+        data: {
+          applicationId: application.applicationId,
+          petId: application.petId,
+          action_url: `/applications/${application.applicationId}`,
+        },
+      });
+
+      if (applicant.email) {
+        const template = await emailService.getTemplateByName('Application Approved');
+        if (template) {
+          await emailService.sendEmail({
+            toEmail: applicant.email,
+            toName: applicantName || undefined,
+            templateId: template.templateId,
+            templateData: {
+              applicantName: applicantName || 'there',
+              petName,
+              applicationId: application.applicationId,
+            },
+            userId: application.userId,
+            type: 'transactional',
+            priority: 'normal',
+          });
+        } else {
+          logger.warn("Approval email template 'Application Approved' not found; skipping email", {
+            applicationId: application.applicationId,
+          });
+        }
+      }
+    } catch (error) {
+      logger.error('Approval notification failed (non-fatal):', {
         applicationId: application.applicationId,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/service.backend/src/services/chat.service.ts
+++ b/service.backend/src/services/chat.service.ts
@@ -936,6 +936,10 @@ export class ChatService {
                 chatId: data.chatId,
                 messageId: messageWithSender.message_id,
                 senderId: data.senderId,
+                // Deep-link for NotificationCenter / NotificationBell click
+                // handlers (currently surfaced in app.client). Other apps
+                // ignore action_url if their notification UI doesn't read it.
+                action_url: `/chat/${data.chatId}`,
               },
               priority: NotificationPriority.NORMAL,
             }))

--- a/service.backend/src/services/notification.service.ts
+++ b/service.backend/src/services/notification.service.ts
@@ -780,16 +780,34 @@ export class NotificationService {
     const startTime = Date.now();
 
     try {
+      // Resolve user_id -> email. Without this the EmailService gets a UUID
+      // as the toEmail and silently fails delivery while the notification row
+      // is marked as created.
+      const user = await User.findByPk(notification.user_id, {
+        attributes: ['email'],
+      });
+      if (!user?.email) {
+        logger.warn('Email notification skipped: user has no email', {
+          notificationId: notification.notification_id,
+          userId: notification.user_id,
+        });
+        return;
+      }
+
       const EmailService = (await import('./email.service')).default;
 
+      const actionUrl =
+        (notification.data?.action_url as string | undefined) ??
+        (notification.data?.actionUrl as string | undefined);
+
       await EmailService.sendEmail({
-        toEmail: notification.user_id, // This would need to be resolved to email
+        toEmail: user.email,
         subject: notification.title,
         htmlContent: `
           <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
             <h2>${notification.title}</h2>
             <p>${notification.message}</p>
-            ${notification.data?.actionUrl ? `<a href="${notification.data.actionUrl}" style="background-color: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View Details</a>` : ''}
+            ${actionUrl ? `<a href="${actionUrl}" style="background-color: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">View Details</a>` : ''}
           </div>
         `,
         type: 'notification',
@@ -804,7 +822,6 @@ export class NotificationService {
       loggerHelpers.logExternalService('Email Notification', 'Delivered', {
         notificationId: notification.notification_id,
         userId: notification.user_id,
-        email: notification.user_id,
         duration: Date.now() - startTime,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

End-to-end review of the four key flows (auth, adoption application, rescue + pet management, chat + notifications) with fixes for the real bugs that surfaced.

### Fixed

- **Auth — register success crash** (`lib.auth/.../AuthContext.tsx`). The `auth_registration_successful` analytics handler read `response.user.userId`, but the backend register endpoint returns `{ message }` only (ADS-538, to prevent enumeration). Every successful sign-up was throwing. Switched to the submitted form data.

- **Notifications — email sent to UUID** (`service.backend/.../notification.service.ts`). `sendEmailNotification` was passing `notification.user_id` (a UUID) as `toEmail` and silently failing delivery while marking the notification "created". Resolve `user_id → User.email` first; skip + log if no email on file.

- **Applications — no notification on approval** (`service.backend/.../application.service.ts`). Only `REJECTED` triggered `notifyApplicantOfRejection`; `APPROVED` only emitted a socket event, missed entirely if the adopter's dashboard wasn't open. Added the symmetric `notifyApplicantOfApproval` path (uses the seeded `Application Approved` email template + `NotificationType.ADOPTION_APPROVED`).

- **Notifications — missing deep-link `action_url`**. Both the new approval/rejection notifications and chat-message notifications now set `data.action_url` (`/applications/:id` and `/chat/:chatId` respectively) so the `NotificationCenter` / `NotificationBell` click handlers actually navigate instead of just marking-as-read.

- **Rescue ApplicationCard — wrong badge variant for submitted apps** (`app.rescue/.../ApplicationCard.tsx`). The badge variant was derived from `application.status` (`submitted | approved | rejected | withdrawn`), but the css variants are stage names (`pending | reviewing | visiting | deciding`) plus `approved | rejected`. Submitted (the most common) always fell through to the neutral `default` style. Now picks the variant from status when terminal and from `stage` otherwise.

### Investigated but not changed (false alarms / out of scope)

- `getFeaturedPets` / `getRecentPets` already filter `archived: false` (audit agent overstated).
- `RefreshToken.update()` destructuring is correct — `revokedCount[0]` is the affected-row count in Sequelize.
- Duplicate rescue org names and gating pet creation on `rescue.status === 'verified'` are business-policy calls, not bugs — left unchanged pending product confirmation.
- N+1 in `ApplicationDashboard` is `Promise.all`-parallel, not waterfall; not a regression to chase now.

### Verification

- **Could not** boot the full stack and click through flows — Docker daemon is unavailable in this remote-execution sandbox. Flagged at the start of the session.
- Static review across the four flows with file:line citations for each finding.
- Vitest: `service.backend` 2934 pass / 0 fail, `lib.auth` 43 / 0, `app.client` 451 / 0, `app.rescue` 344 / 0.
- TypeScript `type-check` clean across `lib.auth`, `service.backend`, `app.client`, `app.rescue`.
- ESLint clean (0 errors; pre-existing warnings untouched per surgical-changes rule).

## Test plan

- [ ] Sign-up a new adopter on `app.client`; confirm no console error and `auth_registration_successful` analytics event fires with the submitted email.
- [ ] As rescue staff, approve an application; confirm adopter receives both in-app notification + email (template `Application Approved`).
- [ ] Click the approval notification in `NotificationCenter` / `NotificationBell` — should navigate to `/applications/:id`.
- [ ] Send a chat message from rescue staff to an adopter; click the resulting message notification — should land on `/chat/:chatId`.
- [ ] On the rescue Applications list, confirm a submitted application now renders with a `pending`/`reviewing`/`visiting`/`deciding` (stage-derived) badge color instead of the neutral default.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hsE6P79GVucYWzjP6cGjK)_