### PR TITLE
fix(application): broadcast socket events when applicant withdraws

### DIFF
--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1565,6 +1565,21 @@ export class ApplicationService {
       logger.info('Application withdrawn', { applicationId, userId });
 
       await application.reload();
+
+      // Mirror the broadcast pattern in updateApplicationStatus: the rescue
+      // dashboard needs to know the application moved to WITHDRAWN so staff
+      // don't keep reviewing it, and the adopter's own connected sessions
+      // need the state change to flow to other tabs / devices.
+      emitToUser(application.userId, 'application_status_changed', {
+        applicationId,
+        status: application.status,
+        stage: application.stage,
+        updatedAt: application.updatedAt,
+      });
+      emitToRescue(application.rescueId, 'application_updated', {
+        applicationId,
+      });
+
       return {
         ...(application.toJSON() as ApplicationData),
         answers: await loadAnswersJson(applicationId),


### PR DESCRIPTION
## Summary

Round 2 deeper pass over the four key flows after #790 merged. Most of the things round 1 flagged as speculative either turned out to be non-issues on closer inspection or are policy/design decisions, not bugs. One concrete bug fell out.

### Fixed

- **Withdraw application emits no socket events** (`service.backend/src/services/application.service.ts`). `ApplicationService.withdrawApplication` transitions the row to `WITHDRAWN` but never emits `application_updated` to the rescue room or `application_status_changed` to the user room. Rescue staff keep seeing the application in their queue with no signal it was withdrawn; the adopter's other tabs / devices stay stuck on the old state. Mirrored the broadcast pattern already in place in `updateApplicationStatus`.

### Investigated and confirmed clean

- **Login gate against unverified email** — `auth.service.ts:336` throws `ForbiddenError` before issuing tokens. ✅
- **Email verification race** — atomic conditional UPDATE with `affectedCount` check (`auth.service.ts:1222`). ✅
- **Socket chat room IDOR** — `socket-handlers.ts:512` calls `requireChatAccess` before `socket.join` (per ADS-708). ✅
- **Chat service IDOR more broadly** — `requireChatParticipant` is consistently called on every read/write path. ✅
- **Pet update / delete IDOR** — `assertCallerOwnsPet` gates all writes. ✅
- **401 refresh recursion** — `api-service.ts:283-287` explicitly excludes `/auth/refresh-token`, `/auth/login`, `/auth/logout` from refresh-retry; single-flight refresh promise prevents thundering herd. ✅
- **Featured / recent pet queries** — both filter `archived: false` and `status IN (AVAILABLE, FOSTER)`. ✅

### Deferred — policy calls, not bugs

- Unverified rescues can still list pets and have them appear in public search (`pet.service.ts`). Whether to gate creation/visibility on `rescue.status === 'verified'` is a product decision.
- Duplicate rescue org names aren't enforced unique. Same — product decision.
- ApplicationDashboard manual fetch (no socket subscription) is a polish/UX gap, not a regression.

### Verification

- **Could not** boot the stack in this remote sandbox (no Docker daemon). Static review only.
- Vitest: 111/0 on `application.service.test.ts` + `application-workflow.test.ts` (the integration suite exercises `withdrawApplication` directly).
- `tsc --noEmit` clean on `service.backend`.

## Test plan

- [ ] As an adopter on `app.client`, submit then withdraw an application; have a second browser open as rescue staff on `app.rescue` viewing the applications list — confirm the list refreshes / the entry moves out of the active queue when the withdraw fires (was previously stuck until manual refresh).
- [ ] Confirm a second tab logged in as the same adopter receives the `application_status_changed` event and reflects the WITHDRAWN status without refresh.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hsE6P79GVucYWzjP6cGjK)_