### PR TITLE
fix(security): sanitize bio field in updateUser to prevent stored XSS

### DIFF
--- a/service.backend/src/__tests__/security/xss-sanitization.test.ts
+++ b/service.backend/src/__tests__/security/xss-sanitization.test.ts
@@ -19,6 +19,11 @@ vi.mock('../../services/supportTicket.service', () => ({
   },
 }));
 vi.mock('../../services/notification.service');
+vi.mock('../../services/user.service', () => ({
+  default: {
+    updateUserProfile: vi.fn(),
+  },
+}));
 vi.mock('../../services/email.service', () => ({
   default: {
     sendEmail: vi.fn(),
@@ -47,6 +52,8 @@ vi.mock('../../utils/logger', () => ({
   },
 }));
 
+import { UserController } from '../../controllers/user.controller';
+import UserService from '../../services/user.service';
 import { ApplicationController } from '../../controllers/application.controller';
 import { ApplicationService } from '../../services/application.service';
 import { RescueController } from '../../controllers/rescue.controller';
@@ -398,6 +405,54 @@ describe('NotificationController - XSS sanitization', () => {
       const [, notifData] = vi.mocked(NotificationService.createBulkNotifications).mock.calls[0];
       expect((notifData as Record<string, string>).message).not.toContain('<script>');
       expect((notifData as Record<string, string>).message).toContain('Important content');
+    });
+  });
+});
+
+// ============================================================
+// UserController
+// ============================================================
+
+describe('UserController - XSS sanitization', () => {
+  let controller: UserController;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new UserController();
+    res = mockRes();
+    vi.mocked(UserService.updateUserProfile).mockResolvedValue({
+      userId: 'user-123',
+    } as unknown as Awaited<ReturnType<typeof UserService.updateUserProfile>>);
+  });
+
+  describe('updateUser', () => {
+    it('sanitizes XSS from bio before calling service', async () => {
+      const req = {
+        user: mockUser,
+        body: { bio: XSS_WITH_TEXT },
+        params: { userId: 'user-123' },
+      } as unknown as AuthenticatedRequest;
+
+      await controller.updateUser(req, res as Response);
+
+      const [, updateData] = vi.mocked(UserService.updateUserProfile).mock.calls[0];
+      expect((updateData as Record<string, string>).bio).not.toContain('<script>');
+      expect((updateData as Record<string, string>).bio).toContain('Important content');
+    });
+
+    it('passes plain text bio through unchanged', async () => {
+      const plainBio = 'I love animals and have a big yard';
+      const req = {
+        user: mockUser,
+        body: { bio: plainBio },
+        params: { userId: 'user-123' },
+      } as unknown as AuthenticatedRequest;
+
+      await controller.updateUser(req, res as Response);
+
+      const [, updateData] = vi.mocked(UserService.updateUserProfile).mock.calls[0];
+      expect((updateData as Record<string, string>).bio).toBe(plainBio);
     });
   });
 });

--- a/service.backend/src/controllers/user.controller.ts
+++ b/service.backend/src/controllers/user.controller.ts
@@ -13,6 +13,7 @@ import {
 import { AuthenticatedRequest } from '../types';
 import { logger, loggerHelpers } from '../utils/logger';
 import { validateBody } from '../middleware/zod-validate';
+import { RichTextProcessingService } from '../services/rich-text-processing.service';
 
 // Validation rules
 export const userValidation = {
@@ -110,17 +111,19 @@ export class UserController {
    */
   async updateUser(req: AuthenticatedRequest, res: Response): Promise<void> {
     const { userId } = req.params;
-    const updateData = req.body;
     const requestingUserId = req.user!.userId;
     const requestingUserType = req.user!.userType as UserType;
 
-    // Check permissions
     if (requestingUserId !== userId && requestingUserType !== UserType.ADMIN) {
       res.status(403).json({ error: "Cannot update another user's profile" });
       return;
     }
 
-    const updatedUser = await UserService.updateUserProfile(userId, updateData);
+    if (typeof req.body.bio === 'string') {
+      req.body.bio = RichTextProcessingService.sanitize(req.body.bio);
+    }
+
+    const updatedUser = await UserService.updateUserProfile(userId, req.body);
     res.json(updatedUser);
   }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **ADS-703**: `UserController.updateUser` was passing `req.body` directly to `UserService.updateUserProfile` without sanitizing the `bio` field, enabling stored XSS.
- A user-supplied HTML/script payload in `bio` would be stored verbatim and executed in the admin panel when it renders user bios.
- Applies `RichTextProcessingService.sanitize()` to `bio` before the service call — identical to the pattern already used in `rescue`, `application`, `notification`, and `supportTicket` controllers.
- Adds two test cases to `xss-sanitization.test.ts`: one verifying `<script>` tags are stripped, one verifying plain text passes through unchanged.

## Changes

| File | Change |
|------|--------|
| `service.backend/src/controllers/user.controller.ts` | Import `RichTextProcessingService`; sanitize `req.body.bio` before passing to service |
| `service.backend/src/__tests__/security/xss-sanitization.test.ts` | Add `UserController - XSS sanitization` describe block with 2 tests |

## Test plan

- [x] `UserController - XSS sanitization > updateUser > sanitizes XSS from bio before calling service` — passes
- [x] `UserController - XSS sanitization > updateUser > passes plain text bio through unchanged` — passes
- [x] All existing user route tests continue to pass (11/11)
- [x] All XSS sanitization tests pass (17/17)

## Notes on AC#2 (updateNotificationPreferences)

The `updateNotificationPreferences` endpoint already validates input via the `validatePreferences` express-validator chain at the route level, and the controller calls `sendValidationErrors` to enforce it. Notification preferences contain only boolean and HH:MM-format string fields — no rich text — so sanitization is not applicable. The existing validation satisfies the "validates input with a schema" criterion.

https://claude.ai/code/session_015Dxfatnp6b7BLgTABTZgr9
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Dxfatnp6b7BLgTABTZgr9)_