### PR TITLE
fix: staff lifecycle cache invalidation, reference IDOR, withdraw cascade

### DIFF
--- a/service.backend/src/__tests__/integration/application-workflow.test.ts
+++ b/service.backend/src/__tests__/integration/application-workflow.test.ts
@@ -88,6 +88,17 @@ describe('Application Submission Workflow Integration Tests', () => {
       status: 'verified',
     } as never);
 
+    // Default: the rescue-staff fixture is verified staff at the rescue
+    // that owns the test applications. The createMockApplication factory
+    // defaults rescueId to 'rescue-123' (see bottom of file), so we mock
+    // staff to the same id. Specific tests override this for wrong-rescue
+    // / no-membership scenarios.
+    MockedStaffMember.findOne = vi.fn().mockResolvedValue({
+      userId: rescueStaffId,
+      rescueId: 'rescue-123',
+      isVerified: true,
+    } as never);
+
     // Setup default timeline mocks
     MockedApplicationTimelineService.createEvent = vi.fn().mockResolvedValue(undefined as never);
 
@@ -768,7 +779,12 @@ describe('Application Submission Workflow Integration Tests', () => {
           status: 'contacted',
         };
 
-        await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
+        await ApplicationService.updateReference(
+          applicationId,
+          referenceUpdate,
+          rescueStaffId,
+          UserType.RESCUE_STAFF
+        );
 
         expect(refRow.update).toHaveBeenCalledWith(
           expect.objectContaining({ status: 'contacted' })
@@ -789,7 +805,12 @@ describe('Application Submission Workflow Integration Tests', () => {
           notes: 'Confirmed excellent pet owner',
         };
 
-        await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
+        await ApplicationService.updateReference(
+          applicationId,
+          referenceUpdate,
+          rescueStaffId,
+          UserType.RESCUE_STAFF
+        );
 
         expect(refRow.update).toHaveBeenCalledWith(
           expect.objectContaining({ status: 'verified', notes: 'Confirmed excellent pet owner' })
@@ -810,7 +831,12 @@ describe('Application Submission Workflow Integration Tests', () => {
           notes: 'Phone number disconnected',
         };
 
-        await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
+        await ApplicationService.updateReference(
+          applicationId,
+          referenceUpdate,
+          rescueStaffId,
+          UserType.RESCUE_STAFF
+        );
 
         expect(refRow.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
       });
@@ -830,7 +856,12 @@ describe('Application Submission Workflow Integration Tests', () => {
           contactedAt,
         };
 
-        await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
+        await ApplicationService.updateReference(
+          applicationId,
+          referenceUpdate,
+          rescueStaffId,
+          UserType.RESCUE_STAFF
+        );
 
         expect(refRow.update).toHaveBeenCalledWith(
           expect.objectContaining({ status: 'contacted', contacted_at: contactedAt })
@@ -851,11 +882,43 @@ describe('Application Submission Workflow Integration Tests', () => {
           notes: 'Very positive reference - highly recommended',
         };
 
-        await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
+        await ApplicationService.updateReference(
+          applicationId,
+          referenceUpdate,
+          rescueStaffId,
+          UserType.RESCUE_STAFF
+        );
 
         expect(refRow.update).toHaveBeenCalledWith(
           expect.objectContaining({ notes: 'Very positive reference - highly recommended' })
         );
+      });
+
+      it('rejects reference update when staff is from a different rescue', async () => {
+        // The application belongs to rescue-123 (factory default); the caller
+        // is staff at a different rescue. Even though they have the
+        // RESCUE_STAFF role, they must not be able to touch this application.
+        const mockApplication = createMockApplication({ applicationId: applicationId });
+        MockedApplication.findByPk = vi.fn().mockResolvedValue(mockApplication as never);
+        MockedStaffMember.findOne = vi.fn().mockResolvedValue({
+          userId: rescueStaffId,
+          rescueId: 'other-rescue',
+          isVerified: true,
+        } as never);
+
+        const referenceUpdate: ReferenceUpdateRequest = {
+          referenceId: 'ref-0',
+          status: 'verified',
+        };
+
+        await expect(
+          ApplicationService.updateReference(
+            applicationId,
+            referenceUpdate,
+            rescueStaffId,
+            UserType.RESCUE_STAFF
+          )
+        ).rejects.toThrow(/Access denied/);
       });
     });
   });
@@ -1486,7 +1549,12 @@ describe('Application Submission Workflow Integration Tests', () => {
           status: 'verified',
         };
 
-        await ApplicationService.updateReference(applicationId, referenceUpdate, rescueStaffId);
+        await ApplicationService.updateReference(
+          applicationId,
+          referenceUpdate,
+          rescueStaffId,
+          UserType.RESCUE_STAFF
+        );
 
         // Step 3: Home visit
         await ApplicationService.updateApplication(

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -538,7 +538,8 @@ export class ApplicationController extends BaseController {
     const application = await ApplicationService.updateReference(
       applicationId,
       req.body,
-      req.user!.userId
+      req.user!.userId,
+      req.user!.userType as UserType
     );
 
     res.status(200).json({

--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -1562,6 +1562,21 @@ export class ApplicationService {
         userId,
       });
 
+      // Cancel any non-terminal home visits scheduled for this application.
+      // Without this, withdrawing leaves SCHEDULED / IN_PROGRESS HomeVisit
+      // rows pointing at a withdrawn application — rescue staff see a zombie
+      // visit on a deal that's already off the table. COMPLETED / CANCELLED
+      // rows are historical and left alone.
+      await HomeVisit.update(
+        { status: HomeVisitStatus.CANCELLED, cancelled_reason: 'Application withdrawn' },
+        {
+          where: {
+            application_id: applicationId,
+            status: { [Op.notIn]: [HomeVisitStatus.COMPLETED, HomeVisitStatus.CANCELLED] },
+          },
+        }
+      );
+
       logger.info('Application withdrawn', { applicationId, userId });
 
       await application.reload();
@@ -1727,12 +1742,24 @@ export class ApplicationService {
   static async updateReference(
     applicationId: string,
     referenceUpdate: ReferenceUpdateRequest,
-    userId: string
+    userId: string,
+    userType: UserType
   ): Promise<ApplicationData> {
     try {
       const application = await Application.findByPk(applicationId);
       if (!application) {
         throw new NotFoundError('Application not found');
+      }
+
+      // Authorize: rescue staff may only act on their own rescue's
+      // applications. The route's requireRole only checks the role —
+      // without this, a staff member at rescue A could PATCH references
+      // on rescue B's application. Admins / moderators are allowed.
+      if (userType !== UserType.ADMIN && userType !== UserType.MODERATOR) {
+        const staffRescueId = await ApplicationService.getStaffRescueIdForUser(userId);
+        if (!staffRescueId || staffRescueId !== application.rescueId) {
+          throw new ForbiddenError('Access denied');
+        }
       }
 
       // Determine the reference index to update

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -1432,6 +1432,13 @@ export class RescueService {
 
       await transaction.commit();
 
+      // ADS-253 mirror: bust the auth cache so requireRescueTenant /
+      // permission checks on the removed user's next request re-read the
+      // (now soft-deleted) StaffMember row instead of serving the stale
+      // verified-staff entry. Without this, a removed user keeps their
+      // rescue access for the full cache TTL.
+      invalidateAuthCache(userId);
+
       logger.info(`Soft deleted staff member ${userId} from rescue ${rescueId}`);
       return { success: true, message: 'Staff member removed successfully' };
     } catch (error) {


### PR DESCRIPTION
## Summary

Round 3 audit of the four un-covered flow groups (discovery/search/match, home-visits/references/profile, invitations/roles, moderation/support/admin). Most audit findings turned out to be design choices or non-issues on closer inspection. Three real bugs:

### Fixed

- **Removed staff retain access until cache TTL** (`service.backend/src/services/rescue.service.ts`). `removeStaffMember` paranoid-deletes the StaffMember row but doesn't bust the auth cache, so `requireRescueTenant` / permission middleware keep serving the cached verified-staff entry until the TTL expires. Mirrors the `invalidateAuthCache(userId)` call invitation acceptance already does (ADS-253).

- **Cross-rescue IDOR on reference update** (`service.backend/src/services/application.service.ts` + controller). `PATCH /applications/:id/references` is gated to role `RESCUE_STAFF | ADMIN` but the service did not verify the caller's rescue matches the application's. Rescue A staff could update references on rescue B's application. Added an inline membership check (uses the already-loaded application to keep existing test mocks intact) and threaded `userType` through the controller. Integration test added for the cross-rescue rejection path.

- **Withdraw leaves zombie home visits** (`service.backend/src/services/application.service.ts`). `withdrawApplication` flips status to `WITHDRAWN` but never touches the linked `HomeVisit` rows, so `SCHEDULED` / `IN_PROGRESS` visits stay on the rescue's calendar pointing at a dead application. Cancel non-terminal visits with reason `Application withdrawn` inside the withdraw path.

### Investigated and rejected as non-bugs

- **Invitation email-mismatch check** (raised as CRITICAL by the audit agent). The token IS the bearer credential. Re-checking email from the request body adds no security because the acceptance page already displays the invited email — anyone with the link sees it.
- **Support ticket `createTicket` trusts `req.body.userId`**. The route is permission-gated to `SUPPORT_TICKET_CREATE` (admin/agent). `userId` is the *subject* of the ticket (whom it's filed on behalf of), not the caller's identity.
- **Pet controller `parseInt` NaN bypass**. `validateQuery` middleware runs before the controller and `sendValidationErrors` returns 4xx — NaN inputs never reach `parseInt`.
- **`updateUserProfile` missing cache invalidation**. The current `UpdateProfileSchema` whitelist excludes any field that affects auth/role.
- **Home visit timezone storage**, **breed multi-value URL parsing**, **`maxDistance=0`** — design preferences, not bugs.

### Verification

- Could not boot the stack (no Docker daemon in this remote sandbox). Static review + tests only.
- Vitest backend: 2945 passed / 0 failed (1 new test added for the cross-rescue IDOR rejection).
- `tsc --noEmit` clean; ESLint 0 errors.

## Test plan

- [ ] As verified rescue admin, remove a staff member from a rescue. With a fresh JWT issued before the removal, confirm subsequent `/api/v1/rescues/.../staff` (or any `requireRescueTenant`-gated) request now 403s instead of waiting for the cache TTL.
- [ ] As rescue A staff, attempt `PATCH /api/v1/applications/{rescue-B-application-id}/references` — should 403/access-denied. As rescue A staff against rescue A's own application, should succeed.
- [ ] As adopter, schedule a home visit on a submitted application, then withdraw the application. Confirm the rescue calendar no longer shows the visit as SCHEDULED — it shows CANCELLED with the 'Application withdrawn' reason.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hsE6P79GVucYWzjP6cGjK)_