### PR TITLE
fix: admin session invalidation, self-action guards, reports IDOR

### DIFF
--- a/service.backend/src/__tests__/services/admin.service.test.ts
+++ b/service.backend/src/__tests__/services/admin.service.test.ts
@@ -232,6 +232,55 @@ describe('AdminService', () => {
     });
   });
 
+  describe('Session invalidation on user state changes', () => {
+    // ADS C4-pass4: suspending or deleting a user must invalidate their
+    // JWTs by bumping tokens_invalid_before — without it the user keeps
+    // accessing the API for the full JWT TTL even though the per-request
+    // status check would (eventually) catch a SUSPENDED user.
+    it('suspendUser bumps tokens_invalid_before so existing JWTs are rejected', async () => {
+      const before = new Date('2026-01-01T00:00:00Z');
+      const user = await User.create({
+        userId: 'user-suspend',
+        firstName: 'To',
+        lastName: 'Suspend',
+        email: 'tosuspend@example.com',
+        password: 'hashedPassword123!',
+        status: UserStatus.ACTIVE,
+        userType: UserType.ADOPTER,
+        emailVerified: true,
+        tokensInvalidBefore: before,
+      });
+
+      await AdminService.suspendUser(user.userId, 'admin-1', 'spam');
+
+      const reloaded = await User.findByPk(user.userId);
+      expect(reloaded?.status).toBe(UserStatus.SUSPENDED);
+      expect(reloaded?.tokensInvalidBefore?.getTime()).toBeGreaterThan(before.getTime());
+    });
+
+    it('deleteUser bumps tokens_invalid_before so a deleted user cannot keep using their JWT', async () => {
+      const before = new Date('2026-01-01T00:00:00Z');
+      const user = await User.create({
+        userId: 'user-delete',
+        firstName: 'To',
+        lastName: 'Delete',
+        email: 'todelete@example.com',
+        password: 'hashedPassword123!',
+        status: UserStatus.ACTIVE,
+        userType: UserType.ADOPTER,
+        emailVerified: true,
+        tokensInvalidBefore: before,
+      });
+
+      await AdminService.deleteUser(user.userId, 'admin-1', 'gdpr');
+
+      // paranoid soft-delete keeps the row, so we can still read it back
+      // with paranoid:false. tokens_invalid_before must have been bumped.
+      const reloaded = await User.findByPk(user.userId, { paranoid: false });
+      expect(reloaded?.tokensInvalidBefore?.getTime()).toBeGreaterThan(before.getTime());
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle errors in getUsers gracefully', async () => {
       await expect(AdminService.getUsers({ page: -1, limit: 0 })).resolves.toBeDefined();

--- a/service.backend/src/controllers/admin.controller.ts
+++ b/service.backend/src/controllers/admin.controller.ts
@@ -3,6 +3,7 @@ import { DEFAULT_PAGE_SIZE, LARGE_PAGE_SIZE } from '../constants/pagination';
 import User, { UserStatus, UserType } from '../models/User';
 import Rescue from '../models/Rescue';
 import AdminService from '../services/admin.service';
+import { UserService } from '../services/user.service';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from '../services/auditLog.service';
 import type { RescuePlan } from '../config/plans';
@@ -97,6 +98,11 @@ export class AdminController {
         error: 'Action is required',
       });
     }
+
+    // Block self-actions: an admin must not be able to suspend, delete
+    // or otherwise act on their own account through the admin API
+    // surface (would lock themselves out / drift role state).
+    UserService.validateUserOperation(adminId, userId, action);
 
     let result;
     switch (action) {
@@ -703,6 +709,16 @@ export class AdminController {
     const { userId } = req.params;
     const { firstName, lastName, email, phoneNumber, userType } = req.body;
     const adminId = req.user!.userId;
+
+    // Self-action guard: an admin must not be able to change their own
+    // userType via the admin API — that's a lock-out / role-drift hazard
+    // (e.g. demoting yourself out of ADMIN with no other admin around).
+    // Editing your own name/email/phone here is still allowed.
+    if (userId === adminId && userType !== undefined && userType !== null) {
+      return res.status(403).json({
+        error: 'Cannot change your own userType',
+      });
+    }
 
     const user = await User.findByPk(userId);
     if (!user) {

--- a/service.backend/src/controllers/reports.controller.ts
+++ b/service.backend/src/controllers/reports.controller.ts
@@ -294,8 +294,18 @@ class ReportsControllerImpl extends BaseController {
       return this.sendUnauthorized(res);
     }
     try {
-      const schedule = await ReportsService.deleteSchedule(req.params.scheduleId);
-      await removeScheduleRepeat(schedule);
+      // Mirror upsertSchedule's gating: only callers with edit access on
+      // the parent report may delete its schedule. Without this any
+      // authenticated user could enumerate scheduleId and drop other
+      // rescues' or other staff members' schedules.
+      const schedule = await ReportsService.getSchedule(req.params.scheduleId);
+      const report = await ReportsService.getReport(schedule.saved_report_id);
+      const canEdit = await ReportsService.canEdit(report, { userId: req.user.userId });
+      if (!canEdit) {
+        return this.sendForbidden(res);
+      }
+      const deleted = await ReportsService.deleteSchedule(req.params.scheduleId);
+      await removeScheduleRepeat(deleted);
       return this.sendSuccess(res, { deleted: true }, 'Schedule deleted');
     } catch (err) {
       if (err instanceof ApiError) {
@@ -347,8 +357,18 @@ class ReportsControllerImpl extends BaseController {
       return this.sendUnauthorized(res);
     }
     try {
-      const share = await ReportsService.revokeShare(req.params.shareId);
-      return this.sendSuccess(res, share, 'Share revoked');
+      // Mirror createShare's gating: only callers with edit access on
+      // the parent report may revoke its share. Without this any
+      // authenticated user could enumerate shareId and pull the rug
+      // out from under other rescues' / staff members' shared links.
+      const share = await ReportsService.getShare(req.params.shareId);
+      const report = await ReportsService.getReport(share.saved_report_id);
+      const canEdit = await ReportsService.canEdit(report, { userId: req.user.userId });
+      if (!canEdit) {
+        return this.sendForbidden(res);
+      }
+      const revoked = await ReportsService.revokeShare(req.params.shareId);
+      return this.sendSuccess(res, revoked, 'Share revoked');
     } catch (err) {
       if (err instanceof ApiError) {
         return this.sendError(res, err.message, err.statusCode);

--- a/service.backend/src/services/admin.service.ts
+++ b/service.backend/src/services/admin.service.ts
@@ -14,7 +14,7 @@ import { logger, loggerHelpers } from '../utils/logger';
 import { escapeLikePattern } from '../utils/escape-like';
 import { safeCsvCell } from '../utils/safe-csv-cell';
 import { AuditLogService } from './auditLog.service';
-import { disconnectAllSockets } from '../socket/socket-registry';
+import { invalidateUserTokens } from '../lib/invalidate-user-tokens';
 
 export type ExportType = 'users' | 'rescues' | 'pets' | 'applications' | 'audit_logs';
 export type ExportFormat = 'json' | 'jsonl' | 'csv';
@@ -299,9 +299,13 @@ class AdminService {
       await user.save();
 
       // ADS-597: tear down any live Socket.IO connections so a
-      // suspended user can't continue receiving events. The HTTP path
-      // is already blocked by authenticateRequest's status check.
-      disconnectAllSockets(userId);
+      // suspended user can't continue receiving events. Pair the socket
+      // disconnect with full token invalidation — without it the JWT
+      // stays valid until natural expiry (the per-request status check
+      // is served from the auth cache and lags behind). invalidateUserTokens
+      // sets tokens_invalid_before, revokes refresh tokens, busts the
+      // auth cache, and disconnects sockets in one call.
+      await invalidateUserTokens(userId);
 
       await AuditLogService.log({
         action: 'SUSPEND',
@@ -395,6 +399,13 @@ class AdminService {
       if (!user) {
         throw new NotFoundError('User not found');
       }
+
+      // Kill sessions BEFORE the destroy so the paranoid-scoped UPDATE
+      // inside invalidateUserTokens actually reaches the row (a
+      // soft-deleted user would otherwise slip past the default
+      // deleted_at IS NULL filter and the JWT would stay valid until
+      // natural expiry).
+      await invalidateUserTokens(userId);
 
       await user.destroy();
 

--- a/service.backend/src/services/reports.service.ts
+++ b/service.backend/src/services/reports.service.ts
@@ -325,6 +325,22 @@ export const ReportsService = {
     });
   },
 
+  async getSchedule(scheduleId: string): Promise<ScheduledReport> {
+    const schedule = await ScheduledReport.findByPk(scheduleId);
+    if (!schedule) {
+      throw new NotFoundError('Schedule not found');
+    }
+    return schedule;
+  },
+
+  async getShare(shareId: string): Promise<ReportShare> {
+    const share = await ReportShare.findByPk(shareId);
+    if (!share) {
+      throw new NotFoundError('Share not found');
+    }
+    return share;
+  },
+
   async deleteSchedule(scheduleId: string): Promise<ScheduledReport> {
     const schedule = await ScheduledReport.findByPk(scheduleId);
     if (!schedule) {


### PR DESCRIPTION
## Summary

Round 4 audit of un-touched areas (reports/analytics, foster+events, admin actions, backend infra). Most audit findings were design choices or non-issues on closer reading. Five real bugs:

### Fixed

- **`suspendUser` left JWTs valid until natural expiry** (`admin.service.ts`). `disconnectAllSockets` killed live sockets but didn't touch `tokens_invalid_before` / refresh tokens / auth cache, so a suspended user kept making HTTP requests for the full JWT TTL even though the per-request status check would (eventually) catch it. Swap for `invalidateUserTokens`, the canonical kick-the-user helper that already exists for credential-change flows.

- **`deleteUser` had the same gap** (`admin.service.ts`). Same fix, with a subtle ordering twist: `invalidateUserTokens` must run BEFORE `user.destroy()` — the paranoid-scoped `User.update` inside it would otherwise miss the soft-deleted row and the JWT would stay valid until expiry. Caught by a regression test.

- **`performUserAction` had no self-action guard** (`admin.controller.ts`). An admin could suspend / delete / unsuspend their own account via the admin API (lock-out / role-drift hazard). Call the existing `UserService.validateUserOperation` helper.

- **`updateUserProfile` let an admin demote themselves** (`admin.controller.ts`). Self-userType change is a hard lock-out (demote out of ADMIN with no one else around). Block self-userType edits; still allow self name/email/phone edits.

- **`deleteSchedule` + `revokeShare` IDOR** (`reports.controller.ts`). Both only checked authentication, not edit access on the parent report. Any authenticated user could enumerate schedule/share IDs and drop another rescue's schedule or revoke their share link. Mirror `upsertSchedule` / `createShare`'s `canEdit` gate. Added thin `getSchedule` / `getShare` service helpers.

### Investigated and rejected as non-bugs

- **`/legal/send-reacceptance-reminder` "missing auth"** — covered by `router.use(requireAdmin)` at the top of `admin.routes.ts`.
- **`rejectRescueVerification` "no pet cascade"** — policy question (should rejected rescues' pets stay visible?), not a bug.
- **`moderateRescue` "no existence check"** — global error middleware maps the service-layer `NotFoundError` to a 404.
- **`updateUserProfile` "missing auth cache invalidation"** — `UpdateProfileSchema` whitelist excludes any field that affects auth.
- **File-upload orphan order, email queue retry, in-memory rate limiters, CSRF token after logout** — deeper refactors / depend on deployment model. Worth their own tickets, not safe drive-bys.
- **Events backend missing entirely** — structural feature gap, not a bug.
- **Foster IDOR silent failure** — low confidence on closer reading; relies on auth middleware failing in a specific way that may not happen in practice.

### Verification

- Could not boot the stack (no Docker daemon in this remote sandbox). Static review + tests only.
- Vitest backend: 2947 passed / 0 failed (+2 new tests for the suspend/delete token-invalidation behaviour).
- `tsc --noEmit` clean; ESLint 0 errors.

## Test plan

- [ ] As admin, suspend a user who has an active session; confirm their JWT is rejected on the next request (don't need to wait for TTL).
- [ ] As admin, delete a user; confirm same — JWT rejected immediately.
- [ ] As admin, attempt `POST /admin/users/{your-own-id}/action {action:'suspend'}` — should 403.
- [ ] As admin, attempt `PATCH /admin/users/{your-own-id}/profile {userType:'adopter'}` — should 403. `{firstName:'X'}` should still succeed.
- [ ] As rescue-A admin, attempt `DELETE /reports/schedules/{rescue-B-schedule-id}` and `DELETE /reports/shares/{rescue-B-share-id}` — both should 403.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hsE6P79GVucYWzjP6cGjK)_