### PR TITLE
docs: fix factual errors in root-level documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -2,11 +2,24 @@
 
 ## Workflow Files
 
+See [workflows/README.md](./workflows/README.md) for the full reference. The high-level picture:
+
 | File | Purpose |
 |---|---|
-| `ci.yml` | Main CI: lint, test, build for all packages + E2E |
+| `ci.yml` | Main CI: workspace drift, change detection, backend / frontend / library tests, Playwright E2E |
 | `quality.yml` | Dependency freshness check across all workspaces |
 | `security.yml` | `npm audit` vulnerability scan across all workspaces |
+| `codeql.yml` | CodeQL static analysis for JavaScript / TypeScript |
+| `docker.yml` | Build validation for backend and per-app Docker images |
+| `lib-test-guard.yml` | Fails when any `lib.*` package has zero test files |
+| `schema-equivalence.yml` | Diffs migrated vs synced schemas to detect drift |
+| `deploy.yml` | Manual deploy to staging or production via GHCR + SSH |
+| `rollback.yml` | Manual rollback to a previously published image SHA |
+| `release.yml` | Builds and pushes Docker images on tag / push to `main` |
+| `release-please.yml` | Generates release PRs, tags, and GitHub Releases from conventional commits |
+| `storybook.yml` | Builds and deploys `lib.components` Storybook |
+| `labeler.yml` | Auto-labels pull requests |
+| `sync-labels.yml` | Syncs `.github/labels.yml` to repository labels |
 
 ## Lib Build Artifact Caching (ADS-390)
 
@@ -30,6 +43,6 @@ This covers all workspace packages via the deduplicated `package-lock.json`.
 
 ## E2E Gate (ADS-386 / ADS-419)
 
-The `test-e2e` job in `ci.yml` is a blocking signal — a failure fails the PR check. The previous `continue-on-error: true` escape hatch was removed by ADS-419; see the comment block at `ci.yml:339`.
+The `test-e2e` job in `ci.yml` is a blocking signal — a failure fails the PR check. The previous `continue-on-error: true` escape hatch was removed by ADS-419; see the comment block at `ci.yml:398`.
 
 Playwright is configured with `retries: 2` in CI (see `e2e/playwright.config.ts`). Flaky-retry counts are surfaced in the "Report E2E retry counts" step after each run.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,8 @@ This directory contains GitHub Actions workflows for the Adopt Don't Shop platfo
 | `schema-equivalence.yml`   | Bootstraps DB-A (migrate) and DB-B (sync), diffs normalised `pg_dump` to detect schema drift.            |
 | `deploy.yml`               | Manual deploy to staging or production via GHCR + SSH.                                                  |
 | `rollback.yml`             | Manual rollback to a previously published GHCR image SHA.                                               |
-| `release.yml`              | Creates GitHub releases on tags and pushes images on successful CI runs to `main`.                      |
+| `release.yml`              | Builds and pushes production Docker images to Docker Hub on tag pushes (`v*`) and successful CI runs to `main`. |
+| `release-please.yml`       | Generates release PRs, version tags, and GitHub Releases with changelogs from conventional commits.     |
 | `storybook.yml`            | Builds and deploys `lib.components` Storybook to GitHub Pages.                                          |
 | `labeler.yml`              | Auto-labels pull requests using `.github/labeler.yml` rules.                                            |
 | `sync-labels.yml`          | Syncs `.github/labels.yml` to the repository's label set on changes to `main`.                          |
@@ -81,16 +82,17 @@ Tag a test with `@smoke` in its title to add it to the PR set. Keep the smoke se
 
 ### 🚀 **Release Workflow** (`release.yml`)
 
-**Purpose**: Automated releases and deployment pipeline.
+**Purpose**: Build and publish production Docker images.
 
 **What it does**:
 
-- 📝 Creates GitHub releases from tags
-- 🐳 Builds and pushes Docker images to registry
-- 🚀 Deploys to staging/production environments
-- 🏷️ Supports semantic versioning
+- 🐳 Builds and pushes the backend image to Docker Hub (`paragonjenko/adoptdontshop`)
+- 🐳 Builds and pushes per-app frontend images (`app.client`, `app.admin`, `app.rescue`) to Docker Hub
+- 🏷️ Tags images with semver (when triggered by a `v*` tag), branch name, and commit SHA
 
-**Triggers**: Tags starting with `v*`, pushes to `main`, manual dispatch
+GitHub Releases themselves are produced by `release-please.yml` from conventional commits — `release.yml` only handles image publishing. Deploys are driven separately by `deploy.yml`.
+
+**Triggers**: Tags starting with `v*`, completion of a successful CI run on `main`, manual dispatch.
 
 ---
 
@@ -141,18 +143,21 @@ Tag a test with `@smoke` in its title to add it to the PR set. Keep the smoke se
 
 ### Required Secrets
 
-For the release workflow to function fully, add these secrets to your repository:
+For release and deploy workflows to function fully, add these secrets to your repository:
 
 ```bash
-# Docker Hub (optional - for image publishing)
+# Docker Hub — release.yml pushes production images here
 DOCKER_USERNAME=your-docker-username
 DOCKER_PASSWORD=your-docker-password
 
-# Deployment (when ready)
-DEPLOY_HOST=your-server-hostname
-DEPLOY_USER=deployment-user
-DEPLOY_SSH_KEY=your-private-ssh-key
+# Deploy / rollback — Hetzner host accessed over SSH; backend image pulled from GHCR
+HETZNER_HOST=your-server-hostname
+HETZNER_SSH_KEY=your-private-ssh-key
+HETZNER_HOST_FINGERPRINT=ssh-host-key-fingerprint  # computed via `ssh-keyscan -t ed25519 $HOST | ssh-keygen -lf -`
+GHCR_TOKEN=read-only-personal-access-token         # scope: read:packages
 ```
+
+`deploy.yml` and `rollback.yml` also pass through application secrets (`SECRET_JWT_SECRET`, `SECRET_JWT_REFRESH_SECRET`, `SECRET_SESSION_SECRET`, `SECRET_CSRF_SECRET`, `SECRET_ENCRYPTION_KEY`, `SECRET_UPLOAD_SIGNING_SECRET`, `SECRET_DB_PASSWORD`, `SECRET_REDIS_PASSWORD`) — these must be configured per environment.
 
 ### Branch Protection
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ npm run test:e2e:report
 
 - Playwright runs with `retries: 2` in CI. A test must fail 3 times in a row before it counts as a failure.
 - Flaky retry counts are printed in the "Report E2E retry counts" CI step.
-- The `test-e2e` job is a blocking signal — a failure fails the PR check (see ADS-419 and the comment block at `.github/workflows/ci.yml:339`).
+- The `test-e2e` job is a blocking signal — a failure fails the PR check (see ADS-419 and the comment block at `.github/workflows/ci.yml:398`).
 
 ### Selector guidelines
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The Docker dev stack is configured for HMR on Windows/macOS/Linux:
 
 ## Tech Stack
 
-**Frontend:** React 19, TypeScript, Vite, styled-components, React Router, React Query, Socket.io
+**Frontend:** React 19, TypeScript, Vite, vanilla-extract, React Router, React Query, Socket.io
 **Backend:** Node.js 22, Express, TypeScript, Sequelize, PostgreSQL 16 + PostGIS, Redis 7, Socket.io, JWT
 **Tooling:** Turborepo, Docker (BuildKit), Nginx, GitHub Actions
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,14 @@ Utility scripts referenced from the root `package.json` or mounted into containe
 | `snapshot-postgres.sh` | cron on production host | Daily `pg_dump` of the prod database to S3. See `docs/operations/snapshot-policy.md`. Bash — Linux/macOS only. |
 | `snapshot-uploads.sh` | cron on production host | Daily rsync of the `uploads` Docker volume to S3. See `docs/operations/snapshot-policy.md`. Bash — Linux/macOS only. |
 | `check-workspace-consistency.mjs` | `npm run check:workspaces` | Workspace structural-drift guard (ADS-622). Verifies required scripts per `lib.*`/`app.*` package, `vitest.workspace.ts` coverage, `vite.shared.config.ts` `getLibraryAliases()` coverage, absence of nested `package-lock.json`, and absence of stale Jest references. Wired into the `workspace-drift` CI job. |
+| `check-docs-index.mjs` | invoked from CI / manually | Fails CI when a markdown file under `docs/` is not linked from `docs/README.md` (ADS-716). Allowlists `docs/README.md` itself and `docs/legal/**`. |
+| `ratchet-coverage.mjs` | `npm run ratchet:coverage` | Maintenance helper (ADS-717) — reads `service.backend/coverage/coverage-summary.json` and bumps the backend `vitest.config.ts` thresholds upward when actual coverage exceeds them. Never lowers thresholds. |
 | `init-postgis.sql` | mounted into `database` container at `/docker-entrypoint-initdb.d/` | Enables the PostGIS extension on first DB init. Runs automatically — do not invoke manually. |
+
+Helpers live in two subdirectories:
+
+- `scripts/lib/` — shared helpers (e.g. `template-engine.mjs`) consumed by the scaffolding scripts.
+- `scripts/templates/` — file templates used by `create-new-app.js` / `create-new-lib.js` to scaffold new workspaces.
 
 ## Adding a new script
 


### PR DESCRIPTION
## Summary

Audit pass over the root-level documentation. Each change was fact-checked against the corresponding source of truth (`package.json`, `.github/workflows/*.yml`, `docker-compose.yml`, the scripts themselves).

### Fixes

**`README.md`**
- Frontend styling stack listed as `styled-components`; the project actually uses `vanilla-extract` (`@vanilla-extract/css`, `@vanilla-extract/recipes`, `@vanilla-extract/vite-plugin` in every app + `lib.components`; `*.css.ts` files throughout `app.*/src/`). The only `styled-components` references in the repo are in `scripts/templates/` for scaffolding new apps.

**`CONTRIBUTING.md`, `.github/README.md`**
- Both referenced `ci.yml:339` for the ADS-419 comment block. The actual line is `ci.yml:398` (verified via `grep -n "ADS-419" .github/workflows/ci.yml`).

**`.github/README.md`**
- Workflow table only listed 3 of the 14 workflows in `.github/workflows/`. Expanded the table and pointed readers to `workflows/README.md` for the full reference.

**`.github/workflows/README.md`**
- Added `release-please.yml` entry (it owns version tags and GitHub Releases).
- Corrected the `release.yml` description: it builds and pushes Docker images to Docker Hub; it does not create GitHub Releases (release-please does) and does not deploy (deploy.yml does).
- Replaced the bogus `DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_SSH_KEY` secret names with the ones actually used by `deploy.yml` and `rollback.yml` (`HETZNER_HOST`, `HETZNER_SSH_KEY`, `HETZNER_HOST_FINGERPRINT`, `GHCR_TOKEN`) and listed the per-environment `SECRET_*` passthroughs.

**`scripts/README.md`**
- Added rows for `check-docs-index.mjs` and `ratchet-coverage.mjs`, both of which already exist in `scripts/` (and the latter is wired up via `npm run ratchet:coverage`).
- Documented the `scripts/lib/` and `scripts/templates/` subdirectories.

## Test plan
- [ ] Manual link / content review
- [ ] `npm run check:docs-index` if applicable

Part of a documentation accuracy audit. Companion PRs will follow for `service.backend`, the `docs/` tree, and library READMEs.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jPkvUwHvjwejiwZU7AFVG)_