### PR TITLE
docs(service.backend): align README and SECURITY with actual env requirements

### DIFF
--- a/service.backend/README.md
+++ b/service.backend/README.md
@@ -40,10 +40,11 @@ npm install
 # Run pending migrations (umzug runner — no sequelize-cli)
 npm run migrate
 
-# Seed initial data — pick the right safety profile (no "do everything" alias)
+# Seed initial data — pick the right safety profile
 npm run db:seed:reference   # idempotent reference data (RBAC, breeds, templates)
 npm run db:seed:demo        # Faker-generated demo data (dev/staging; ALLOW_DEMO_SEED=true)
 npm run db:seed:fixtures    # deterministic e2e fixtures
+npm run seed                # reference + demo in one go (ALLOW_DEMO_SEED forced on; dev only)
 ```
 
 ### 4. Development Server
@@ -113,7 +114,7 @@ User listing is admin-only and lives at `GET /api/v1/admin/users`. The `/api/v1/
 - GET `/api/v1/users/profile` - Get own profile
 - PUT `/api/v1/users/profile` - Update own profile
 - GET `/api/v1/users/preferences` - Get own preferences
-- GET `/api/v1/users/:userId` - Get another user's public profile
+- GET `/api/v1/users/:userId` - Get a user profile by ID. Gated by `requirePermissionOrOwnership(USER_READ, 'userId')` — accessible to the user themselves or to roles that hold the `USER_READ` permission (typically admin/support).
 
 ### Pets
 
@@ -222,30 +223,49 @@ npm run test:coverage  # Vitest with coverage
 
 ### Environment Variables
 
-**REQUIRED for production:**
+**REQUIRED for production** (enforced by `docker-compose.yml` `:?Error: ... required` guards — Compose refuses to start without them):
 
 ```bash
 # Application
 NODE_ENV=production
 PORT=5000
 
-# Database (REQUIRED)
+# Database — the backend selects ONE of DEV_DB_NAME / TEST_DB_NAME / PROD_DB_NAME
+# based on NODE_ENV. There is no generic DB_NAME variable (ADS-409/452/465).
 DB_HOST=your-db-host
 DB_PORT=5432
 DB_USERNAME=your-db-user
 DB_PASSWORD=your-secure-db-password
-DB_NAME=adopt_dont_shop
+PROD_DB_NAME=adopt_dont_shop_prod
+# Alternatively, set a single PROD_DATABASE_URL / DATABASE_URL to override the discrete vars.
 
-# Security (REQUIRED)
-JWT_SECRET=your-super-secret-jwt-key-minimum-32-characters-long
+# Database TLS (ADS-540) — production refuses `disable` unless ALLOW_INSECURE_DB=true
+DB_SSL_MODE=verify-full
+DB_SSL_ROOT_CERT=/etc/ssl/certs/rds-combined-ca-bundle.pem
+
+# Redis
+REDIS_HOST=your-redis-host
+REDIS_PORT=6379
+REDIS_PASSWORD=your-strong-redis-password
+
+# Auth secrets — minimum 32 characters each, generate with `npm run secrets:generate`
+JWT_SECRET=...
+JWT_REFRESH_SECRET=...
+SESSION_SECRET=...
+CSRF_SECRET=...
+ENCRYPTION_KEY=...
+UPLOAD_SIGNING_SECRET=...
+
+# CORS
 CORS_ORIGIN=https://yourdomain.com
-SESSION_SECRET=your-session-secret-minimum-32-characters-long
 
-# Optional but recommended
-BCRYPT_ROUNDS=12
+# Optional tuning
+JWT_EXPIRES_IN=1h            # default 1h; refresh tokens last 7 days
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
 ```
+
+See `.env.example` at the repo root for the authoritative list and per-variable notes.
 
 ### Docker Deployment
 

--- a/service.backend/SECURITY.md
+++ b/service.backend/SECURITY.md
@@ -14,14 +14,23 @@
 
 #### Required for Production
 
-```bash
-# CRITICAL: These MUST be set in production
-JWT_SECRET=your-super-secret-jwt-key-minimum-32-characters-long
-CORS_ORIGIN=https://yourdomain.com
-SESSION_SECRET=your-session-secret-minimum-32-characters-long
+These variables are enforced by `docker-compose.yml`'s `:?Error: ... required` guards — Compose refuses to start without them. See `.env.example` for the full list and per-variable notes; the authoritative source is the root `.env.example` and `scripts/validate-env.mjs`.
 
-# Database credentials
+```bash
+# CRITICAL secrets — generate strong values via `npm run secrets:generate`
+JWT_SECRET=your-super-secret-jwt-key-minimum-32-characters-long
+JWT_REFRESH_SECRET=different-strong-random-secret
+SESSION_SECRET=your-session-secret-minimum-32-characters-long
+CSRF_SECRET=your-csrf-secret-minimum-32-characters-long
+ENCRYPTION_KEY=your-encryption-key-minimum-32-characters-long
+UPLOAD_SIGNING_SECRET=your-upload-signing-secret-minimum-32-characters-long
+
+# Database / Redis credentials
 DB_PASSWORD=your-secure-database-password-here
+REDIS_PASSWORD=your-secure-redis-password-here
+
+# CORS — comma-separated allowed origins
+CORS_ORIGIN=https://yourdomain.com
 ```
 
 #### Security Requirements
@@ -42,9 +51,9 @@ DB_PASSWORD=your-secure-database-password-here
 
 #### Authentication Security
 
-- **JWT tokens**: Short-lived (15 minutes) access tokens
-- **Refresh tokens**: 7-day rotation
-- **Password hashing**: bcrypt with 12+ rounds
+- **JWT access tokens**: Short-lived. Default `JWT_EXPIRES_IN=1h` (see `.env.example` and `docker-compose.yml`). Override via the `JWT_EXPIRES_IN` env var to tighten in higher-risk environments (`15m`, `5m`, etc.).
+- **Refresh tokens**: 7-day rotation by default (`JWT_REFRESH_EXPIRES_IN`).
+- **Password hashing**: bcryptjs with 12+ rounds
 - **Account lockout**: Automatic protection against brute force
 
 #### Request Security


### PR DESCRIPTION
## Summary

Second batch of documentation accuracy fixes — backend service docs. Each fix verified against `docker-compose.yml`, `.env.example`, and the backend source.

### Fixes

**`service.backend/README.md`**
- Production env list referenced a non-existent `DB_NAME`. The backend selects one of `DEV_DB_NAME` / `TEST_DB_NAME` / `PROD_DB_NAME` based on `NODE_ENV` (ADS-409/452/465; explicitly called out in `.env.example`). Replaced with `PROD_DB_NAME` and added the missing required secrets enforced by Compose `:?Error: ... required` guards: `JWT_REFRESH_SECRET`, `CSRF_SECRET`, `ENCRYPTION_KEY`, `UPLOAD_SIGNING_SECRET`, `REDIS_PASSWORD`. Also added `DB_SSL_MODE` (ADS-540).
- Existing comment in Quick Start said there is "no do everything alias" for seeding — the `npm run seed` script (defined in `service.backend/package.json:25`) is exactly that. Added it to the list.
- `GET /api/v1/users/:userId` was described as "another user's public profile". It is actually gated by `requirePermissionOrOwnership(USER_READ, 'userId')` (user.routes.ts:1042-1047), so it is self-access or roles with `USER_READ` (admin/support). Rewrote the line.

**`service.backend/SECURITY.md`**
- Authentication section claimed JWT access tokens are "Short-lived (15 minutes)". Actual default is `1h` (`JWT_EXPIRES_IN=1h` in both `docker-compose.yml:111` and `.env.example:104`; `service.backend/src/config/index.ts` reads the env). Documented the real default and how to tighten it.
- "Required for Production" secret list was incomplete (missed `JWT_REFRESH_SECRET`, `CSRF_SECRET`, `ENCRYPTION_KEY`, `UPLOAD_SIGNING_SECRET`, `REDIS_PASSWORD`). Filled in to match what Compose enforces.

## Test plan
- [ ] Manual review against `.env.example` and `docker-compose.yml`
- [ ] CI green

Companion to #796 (root docs). More docs PRs to follow for the `docs/` tree and library READMEs.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jPkvUwHvjwejiwZU7AFVG)_