### PR TITLE
docs(libs): fix incorrect API signatures and behavior claims in lib READMEs

### DIFF
--- a/lib.api/README.md
+++ b/lib.api/README.md
@@ -152,22 +152,34 @@ The library reads API URL from `VITE_API_BASE_URL` (canonical) or `VITE_API_URL`
 
 ## Error Handling
 
-Errors are thrown as `ApiError` subclasses with HTTP status attached. Import from the package and narrow with `instanceof`:
+The package exports several error classes that each extend the built-in `Error` directly — they are **not** subclasses of `ApiError`. `ApiError` itself is one of those classes and carries an HTTP status; the others are sibling classes for non-HTTP failure modes (network, timeout, validation) or HTTP-specific cases that arrive with their own shape (`NotFoundError`, `AuthenticationError`, `AuthorizationError`, `ConflictError`, `ValidationError`). Narrow with `instanceof` on the specific class you care about:
 
 ```typescript
-import { apiService, ApiError } from '@adopt-dont-shop/lib.api';
+import {
+  apiService,
+  ApiError,
+  NetworkError,
+  NotFoundError,
+  AuthenticationError,
+} from '@adopt-dont-shop/lib.api';
 
 try {
   await apiService.get('/api/v1/pets');
 } catch (err) {
-  if (err instanceof ApiError && err.status === 401) {
-    // handle unauthenticated
+  if (err instanceof AuthenticationError) {
+    // 401 — surface a sign-in prompt
+  } else if (err instanceof NotFoundError) {
+    // 404 — surface an empty state
+  } else if (err instanceof ApiError) {
+    // any other HTTP status — err.status, err.code, err.details
+  } else if (err instanceof NetworkError) {
+    // request never reached the server
   }
   throw err;
 }
 ```
 
-See `src/errors` for the concrete error classes.
+The `createHttpError(status, ...)` factory in `src/errors/index.ts` chooses the appropriate class based on status code. See that file for the authoritative list.
 
 ## Development
 

--- a/lib.auth/README.md
+++ b/lib.auth/README.md
@@ -79,7 +79,7 @@ await authService.logout();
 Session:
 
 - `login(credentials: LoginRequest): Promise<AuthResponse>`
-- `register(userData: RegisterRequest): Promise<AuthResponse>`
+- `register(userData: RegisterRequest): Promise<{ user: User; message: string }>` — registration requires email verification before login, so this returns just the user record and a server-supplied message; route the user to a "check your email" screen rather than treating the response as a successful session.
 - `logout(): Promise<void>`
 - `refreshToken(): Promise<string>`
 - `getCurrentUser(): User | null`
@@ -108,8 +108,8 @@ Two-factor:
 
 Token storage (local):
 
-- `getToken(): string | null`
-- `setToken(token: string | null | undefined): void`
+- `getToken(): null` — kept for compatibility; always returns `null`. The access token lives in an httpOnly cookie managed by the backend and is not readable from JavaScript. HTTP requests send it automatically via `credentials: 'include'`; Socket.IO uses the same cookie on the WebSocket upgrade.
+- `setToken(token: string | null | undefined): void` — no-op for the same reason.
 - `clearTokens(): void`
 
 ## useAuth hook

--- a/lib.dev-tools/README.md
+++ b/lib.dev-tools/README.md
@@ -35,7 +35,7 @@ See [src/index.ts](./src/index.ts) for the authoritative list.
 
 ### Environment guards
 
-- **`isDevelopmentMode()`** — true when running on `localhost`, `127.0.0.1`, a `*dev*` hostname, or `NODE_ENV === 'development'`.
+- **`isDevelopmentMode()`** — in the browser, true only when `window.location.hostname` is exactly `localhost` or `127.0.0.1`. The previous `*dev*` substring match was removed intentionally because it would have exposed dev tooling on production-adjacent hosts like `dev.example.com`. On the server it falls back to `NODE_ENV === 'development'`.
 
 ## Quick start
 

--- a/lib.utils/README.md
+++ b/lib.utils/README.md
@@ -173,7 +173,7 @@ Fully typed with comprehensive interfaces:
 
 - `DateFormatOptions`
 - `TruncateOptions`
-- `SlugifyOptions`
+- `SlugOptions`
 - `ValidationResult`
 - `CurrencyOptions`
 - `AddressData`


### PR DESCRIPTION
## Summary

Fourth and final batch of documentation accuracy fixes — library READMEs whose code examples would actively mislead a reader. Each correction verified against the implementation source.

### Fixes

**`lib.api/README.md`** — Error handling section
- Claimed errors are thrown as "`ApiError` subclasses". They're not: `NetworkError`, `TimeoutError`, `ValidationError`, `AuthenticationError`, `AuthorizationError`, `ConflictError`, `NotFoundError` all `extends Error` directly (see `lib.api/src/errors/index.ts:14-70`). The previous `instanceof ApiError` example would silently fail to catch 401/404/409/422 etc.
- Updated the example to use class-specific `instanceof` checks (`AuthenticationError`, `NotFoundError`, `ApiError`, `NetworkError`) and pointed at the `createHttpError(status, ...)` factory that picks the appropriate class.

**`lib.auth/README.md`** — AuthService method signatures
- `register()` was documented as returning `Promise<AuthResponse>`. Actual return type is `Promise<{ user: User; message: string }>` (auth-service.ts:76) because the backend forces email verification before login. Updated the signature and added the rationale.
- `getToken()` was documented as returning `string | null`. Actual return type is `null` (auth-service.ts:281) and the implementation always returns `null` because the access token is in an httpOnly cookie. Also clarified that `setToken` is a no-op for the same reason.

**`lib.utils/README.md`** — TypeScript Support list
- Listed `SlugifyOptions` as an exported type. The actual export is `SlugOptions` (src/types/index.ts:128); no `SlugifyOptions` exists.

**`lib.dev-tools/README.md`** — `isDevelopmentMode()` behavior
- Claimed the function returns true for "a `*dev*` hostname". That check was removed intentionally per the source comment because it would have exposed dev tooling on production-adjacent hosts like `dev.example.com`. The browser branch now only matches `localhost` or `127.0.0.1` exactly; the server branch falls back to `NODE_ENV === 'development'`. Updated the description.

### Notes

The audit also surveyed the other 20 lib READMEs (`lib.analytics`, `lib.applications`, `lib.audit-logs`, `lib.chat`, `lib.components`, `lib.discovery`, `lib.feature-flags`, `lib.invitations`, `lib.legal`, `lib.moderation`, `lib.notifications`, `lib.observability`, `lib.permissions`, `lib.pets`, `lib.rescue`, `lib.search`, `lib.support-tickets`, `lib.types`, `lib.validation`) — no falsifiable inaccuracies were found. `lib.matching` had no README at all; that's added in #798.

## Test plan
- [ ] CI green
- [ ] Manual review of the corrected `instanceof` example in lib.api

Closes the documentation accuracy audit. Companion PRs: #796 (root), #797 (service.backend), #798 (docs/ tree + lib.matching README).

---
_Generated by [Claude Code](https://claude.ai/code/session_018jPkvUwHvjwejiwZU7AFVG)_