### PR TITLE
feat(audit): rescue transactional drift + structured diff capture on Pet/User updates

### DIFF
--- a/service.backend/src/__tests__/services/pet-business-logic.test.ts
+++ b/service.backend/src/__tests__/services/pet-business-logic.test.ts
@@ -71,6 +71,14 @@ const createMockPet = (overrides = {}) => ({
   created_at: new Date(),
   updated_at: new Date(),
   update: vi.fn().mockResolvedValue(undefined),
+  // PetService.updatePet now uses set() + save() so the audit-diff helper
+  // can read changed()/_previousDataValues. Stub these so the mock pet
+  // satisfies the updated call sequence without changing test intent.
+  set: vi.fn(),
+  save: vi.fn().mockResolvedValue(undefined),
+  changed: vi.fn().mockReturnValue(false),
+  _previousDataValues: {},
+  dataValues: {},
   reload: vi.fn(),
   destroy: vi.fn().mockResolvedValue(undefined),
   increment: vi.fn().mockResolvedValue(undefined),
@@ -536,12 +544,15 @@ describe('PetService - Business Logic', () => {
       // When: Updating pet information
       await PetService.updatePet(mockPetId, updateData, mockUserId);
 
-      // Then: Fields are updated with correct snake_case conversion
-      expect(mockPet.update).toHaveBeenCalledWith({
+      // Then: Fields are passed to the model via set() + save() so the
+      // audit-diff helper can read changed()/_previousDataValues. The net
+      // persisted update is identical to the previous .update() call shape.
+      expect(mockPet.set).toHaveBeenCalledWith({
         name: 'Max',
         shortDescription: 'Friendly and energetic',
         longDescription: 'A wonderful companion who loves to play and cuddle.',
       });
+      expect(mockPet.save).toHaveBeenCalled();
     });
 
     it('should update medical information', async () => {
@@ -561,8 +572,9 @@ describe('PetService - Business Logic', () => {
       // When: Updating medical info
       await PetService.updatePet(mockPetId, updateData, mockUserId);
 
-      // Then: Medical fields are updated
-      expect(mockPet.update).toHaveBeenCalledWith(
+      // Then: Medical fields are passed to set() before save() — see the
+      // first updatePet test for the rationale on set/save vs update.
+      expect(mockPet.set).toHaveBeenCalledWith(
         expect.objectContaining({
           vaccinationStatus: VaccinationStatus.UP_TO_DATE,
           vaccinationDate: expect.any(Date),
@@ -592,8 +604,8 @@ describe('PetService - Business Logic', () => {
       // When: Updating behavioral info
       await PetService.updatePet(mockPetId, updateData, mockUserId);
 
-      // Then: Behavioral fields are updated
-      expect(mockPet.update).toHaveBeenCalledWith(
+      // Then: Behavioral fields are passed to set() before save().
+      expect(mockPet.set).toHaveBeenCalledWith(
         expect.objectContaining({
           goodWithChildren: true,
           goodWithDogs: true,
@@ -630,7 +642,7 @@ describe('PetService - Business Logic', () => {
       const result = await PetService.updatePet(mockPetId, updateData, mockUserId);
 
       // Then: Update succeeds (service allows this)
-      expect(mockPet.update).toHaveBeenCalledWith({ name: 'Updated Name' });
+      expect(mockPet.set).toHaveBeenCalledWith({ name: 'Updated Name' });
       expect(result).toBeDefined();
     });
 
@@ -646,7 +658,7 @@ describe('PetService - Business Logic', () => {
       const result = await PetService.updatePet(mockPetId, updateData, mockUserId);
 
       // Then: Update succeeds (service allows this for administrative purposes)
-      expect(mockPet.update).toHaveBeenCalledWith({ name: 'Updated Name' });
+      expect(mockPet.set).toHaveBeenCalledWith({ name: 'Updated Name' });
       expect(result).toBeDefined();
     });
   });
@@ -862,8 +874,8 @@ describe('PetService - Business Logic', () => {
       // When: Updating pet
       await PetService.updatePet(mockPetId, updateData, mockUserId);
 
-      // Then: rescueId is not in the update call (immutable)
-      expect(mockPet.update).toHaveBeenCalledWith({ name: 'Updated Name' });
+      // Then: rescueId is not in the persisted payload (immutable).
+      expect(mockPet.set).toHaveBeenCalledWith({ name: 'Updated Name' });
     });
 
     it('should maintain image order_index integrity when adding images', async () => {
@@ -913,9 +925,10 @@ describe('PetService - Business Logic', () => {
     });
 
     it('should handle database errors during pet update', async () => {
-      // Given: Pet exists but update fails
+      // Given: Pet exists but save fails. updatePet now uses set() + save()
+      // rather than update(), so the rejection has to happen on save.
       const mockPet = createMockPet();
-      mockPet.update.mockRejectedValue(new Error('Database error'));
+      mockPet.save.mockRejectedValue(new Error('Database error'));
       MockedPet.findByPk = vi.fn().mockResolvedValue(mockPet);
 
       const updateData: PetUpdateData = { name: 'Updated Name' };

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -36,9 +36,26 @@ import {
 import { BadRequestError, NotFoundError, ConflictError } from '../middleware/error-handler';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
+import { diffSequelize } from '../utils/audit-diff';
 import User, { UserType } from '../models/User';
 import StaffMember from '../models/StaffMember';
 import { PLAN_LIMITS, type RescuePlan } from '../config/plans';
+
+/**
+ * Sensitive fields tracked with structured before/after in the audit row.
+ * Anything outside this list is omitted from the diff (the full list of
+ * updated field NAMES is still captured under `updatedFields`). Restricting
+ * to an allowlist keeps audit rows compact and prevents an accidental dump
+ * of bulky description fields into forensic storage.
+ */
+const PET_AUDIT_DIFF_ALLOWLIST = [
+  'status',
+  'adoptionFeeMinor',
+  'adoptionFeeCurrency',
+  'microchipId',
+  'specialNeeds',
+  'specialNeedsDescription',
+] as const;
 
 const PET_SEARCH_SORT_FIELDS = [
   'createdAt',
@@ -848,8 +865,14 @@ export class PetService {
         }
       });
 
-      // Update pet
-      await pet.update(dbUpdateData);
+      // Update pet using set() + save() (instead of .update()) so the diff
+      // helper can read instance.changed() + _previousDataValues to produce
+      // a structured before/after for the sensitive-field allowlist. The
+      // previous approach dumped the entire pet object into the audit row,
+      // which was bulky and leaked unrelated fields into forensic storage.
+      pet.set(dbUpdateData);
+      const diff = diffSequelize(pet, PET_AUDIT_DIFF_ALLOWLIST);
+      await pet.save();
 
       // Log the update with performance metrics
       await AuditLogService.log({
@@ -857,8 +880,8 @@ export class PetService {
         entity: 'Pet',
         entityId: petId,
         details: {
-          originalData: JSON.parse(JSON.stringify(originalData)),
-          updateData: JSON.parse(JSON.stringify(dbUpdateData)),
+          ...(diff ? { diff } : {}),
+          updatedFields: Object.keys(dbUpdateData),
           updatedBy,
         },
         userId: updatedBy,

--- a/service.backend/src/services/rescue.service.ts
+++ b/service.backend/src/services/rescue.service.ts
@@ -794,7 +794,10 @@ export class RescueService {
       const oldData = rescue.toJSON();
       await rescue.update(updateData, { transaction });
 
-      // Log the action
+      // Log the action — paired with the business writes by passing
+      // `transaction` so the audit row commits atomically with the rescue
+      // update. Without it the audit could commit standalone while the
+      // business update rolled back, leaving the trail drifted.
       await AuditLogService.log({
         userId: updatedBy,
         action: 'update',
@@ -809,6 +812,7 @@ export class RescueService {
             status: oldData.status,
           },
         },
+        transaction,
       });
 
       loggerHelpers.logBusiness(
@@ -888,6 +892,8 @@ export class RescueService {
 
       // Log the action — `auditAction` lets bulk callers preserve their
       // original verb ('approve' vs 'verify') rather than collapsing them.
+      // `transaction` pairs the audit write with the verification update so
+      // they commit (or rollback) atomically.
       await AuditLogService.log({
         userId: verifiedBy,
         action: auditAction,
@@ -898,6 +904,7 @@ export class RescueService {
           name: rescue.name,
           verificationNotes: notes || null,
         },
+        transaction,
       });
 
       loggerHelpers.logBusiness(
@@ -1009,6 +1016,7 @@ export class RescueService {
           rejectionReason: reason || null,
           rejectionNotes: notes || null,
         },
+        transaction,
       });
 
       loggerHelpers.logBusiness(
@@ -1075,6 +1083,7 @@ export class RescueService {
           name: rescue.name,
           reason: reason ?? null,
         },
+        transaction,
       });
 
       loggerHelpers.logBusiness(
@@ -1355,7 +1364,9 @@ export class RescueService {
         logger.warn('rescue_staff role not found in database');
       }
 
-      // Log the action
+      // Log the action — `transaction` pairs the audit row with the
+      // StaffMember.create + UserRole.create writes above so the
+      // permission-grant audit row can never drift from the actual grant.
       await AuditLogService.log({
         userId: addedBy,
         action: 'addStaff',
@@ -1368,6 +1379,7 @@ export class RescueService {
           staffName: `${user.firstName} ${user.lastName}`,
           roleAssigned: rescueStaffRole ? 'rescue_staff' : 'none',
         },
+        transaction,
       });
 
       await transaction.commit();
@@ -1416,7 +1428,9 @@ export class RescueService {
       // This allows them to be re-added easily and maintains their capability level
       // Roles represent what they CAN do, not what they ARE currently doing
 
-      // Log the action
+      // Log the action — `transaction` pairs the audit row with the
+      // staffMember.destroy() so the permission-revoke audit row commits
+      // (or rolls back) atomically with the actual revoke.
       await AuditLogService.log({
         userId: removedBy,
         action: 'removeStaff',
@@ -1428,6 +1442,7 @@ export class RescueService {
           staffName: `${user.firstName} ${user.lastName}`,
           method: 'soft_delete',
         },
+        transaction,
       });
 
       await transaction.commit();
@@ -1495,6 +1510,7 @@ export class RescueService {
           staffName: `${staffMember.user.firstName} ${staffMember.user.lastName}`,
           updates,
         },
+        transaction,
       });
 
       await transaction.commit();
@@ -1676,7 +1692,8 @@ export class RescueService {
       // paranoid soft-delete sets deletedAt; the audit log captures who.
       await rescue.destroy({ transaction });
 
-      // Log the action
+      // Log the action — `transaction` pairs the audit row with the
+      // rescue deletion so they commit (or rollback) atomically.
       await AuditLogService.log({
         userId: deletedBy,
         action: 'delete',
@@ -1687,6 +1704,7 @@ export class RescueService {
           name: rescue.name,
           reason: reason || null,
         },
+        transaction,
       });
 
       await transaction.commit();

--- a/service.backend/src/services/user.service.ts
+++ b/service.backend/src/services/user.service.ts
@@ -33,6 +33,25 @@ import {
 import { UserActivity } from '../types/user';
 import { logger, loggerHelpers } from '../utils/logger';
 import { AuditLogService } from './auditLog.service';
+import { diffSequelize } from '../utils/audit-diff';
+
+/**
+ * Sensitive User fields tracked with structured before/after in audit rows.
+ * Restricted allowlist keeps audit rows compact and prevents bulky
+ * `location` GeoJSON / preference JSON from bloating forensic storage.
+ * The full list of mutated field NAMES is still captured under
+ * `updatedFields` so a forensic query can answer "what changed?" even when
+ * the value falls outside the diff allowlist.
+ */
+const USER_AUDIT_DIFF_ALLOWLIST = [
+  'email',
+  'phoneNumber',
+  'firstName',
+  'lastName',
+  'status',
+  'userType',
+  'emailVerified',
+] as const;
 import {
   BadRequestError,
   NotFoundError,
@@ -40,7 +59,6 @@ import {
   ConflictError,
 } from '../middleware/error-handler';
 import { isAdminRole } from '../utils/is-admin-role';
-import { redactSensitiveFields } from '../utils/redact';
 import RefreshToken from '../models/RefreshToken';
 import { invalidateAuthCache } from '../lib/auth-cache';
 import { emitAuthRoleChanged } from '../socket/socket-registry';
@@ -251,9 +269,6 @@ export class UserService {
         throw new NotFoundError('User not found');
       }
 
-      // Store original data for audit
-      const originalData = user.toJSON();
-
       // Validate and whitelist allowed fields to prevent mass assignment
       const safeData = UpdateProfileSchema.parse(updateData);
 
@@ -293,8 +308,16 @@ export class UserService {
         }
       }
 
-      // Update user
-      await user.update(processedUpdateData);
+      // Update user via set() + save() so the diff helper can read
+      // instance.changed() + _previousDataValues to produce a structured
+      // before/after for the sensitive-field allowlist. The previous
+      // approach dumped a redacted snapshot of the entire user object into
+      // the audit row, which was bulky and only marginally useful for
+      // forensics — a structured diff of the fields that actually changed
+      // is both smaller and easier to query.
+      user.set(processedUpdateData);
+      const diff = diffSequelize(user, USER_AUDIT_DIFF_ALLOWLIST);
+      await user.save();
 
       // Log the update
       await AuditLogService.log({
@@ -302,12 +325,8 @@ export class UserService {
         entity: 'User',
         entityId: userId,
         details: {
-          originalData: redactSensitiveFields(
-            JSON.parse(JSON.stringify(originalData))
-          ) as JsonObject,
-          updateData: redactSensitiveFields(
-            JSON.parse(JSON.stringify(processedUpdateData))
-          ) as JsonObject,
+          ...(diff ? { diff } : {}),
+          updatedFields: Object.keys(processedUpdateData),
         },
         userId,
       });

--- a/service.backend/src/utils/audit-diff.ts
+++ b/service.backend/src/utils/audit-diff.ts
@@ -1,4 +1,3 @@
-import type { Model } from 'sequelize';
 import type { JsonObject, JsonValue } from '../types/common';
 
 /**
@@ -27,7 +26,22 @@ import type { JsonObject, JsonValue } from '../types/common';
  * leaks of bulky / sensitive fields that weren't intended to be tracked.
  */
 
-type AnyModel = Model<Record<string, unknown>>;
+/**
+ * Runtime shape we need. We accept `unknown` at the boundary because
+ * Sequelize models do not publicly expose `_previousDataValues`, but it
+ * exists at runtime — narrowing it ourselves keeps the call sites free of
+ * `as` casts while still being type-safe inside the helper.
+ */
+type DiffableModel = {
+  changed: () => string[] | false;
+  _previousDataValues: Record<string, unknown>;
+  dataValues: Record<string, unknown>;
+};
+
+const isDiffable = (instance: unknown): instance is DiffableModel =>
+  typeof instance === 'object' &&
+  instance !== null &&
+  typeof (instance as { changed?: unknown }).changed === 'function';
 
 const toJsonSafe = (value: unknown): JsonValue => {
   if (value === null || value === undefined) {
@@ -46,11 +60,11 @@ const toJsonSafe = (value: unknown): JsonValue => {
   }
 };
 
-export const diffSequelize = <T extends AnyModel>(
-  instance: T,
+export const diffSequelize = (
+  instance: unknown,
   allowlist: ReadonlyArray<string>
 ): JsonObject | null => {
-  if (!instance || typeof instance.changed !== 'function') {
+  if (!isDiffable(instance)) {
     return null;
   }
   const changed = instance.changed();
@@ -64,11 +78,8 @@ export const diffSequelize = <T extends AnyModel>(
     if (!allowed.has(field)) {
       continue;
     }
-    const previous = (instance as unknown as { _previousDataValues: Record<string, unknown> })
-      ._previousDataValues?.[field];
-    const next = (instance as unknown as { dataValues: Record<string, unknown> }).dataValues?.[
-      field
-    ];
+    const previous = instance._previousDataValues?.[field];
+    const next = instance.dataValues?.[field];
     diff[field] = {
       before: toJsonSafe(previous),
       after: toJsonSafe(next),


### PR DESCRIPTION
## Why

Second-pass audit sweep across services NOT touched by #794 / #800 surfaced two categories of real forensic gaps. Both are closed here.

## Fix 1 — `rescue.service` transactional drift (8 sites)

Every mutating method in `rescue.service` opened a Sequelize transaction, did the business writes inside it, then called `AuditLogService.log(...)` **without passing the `transaction`**. The audit row sat outside the transaction it was logically paired with.

**The drift scenario:** the audit write succeeds → `transaction.commit()` fails (serialization conflict, network blip) → business writes roll back → audit row stays committed standalone → forensic trail diverges from reality.

Fixed by threading `transaction` through every audit call in:
- `updateRescue`, `verifyRescue`, `rejectRescue`, `suspendRescue`
- `addStaffMember`, `removeStaffMember`, `updateStaffMember`
- `deleteRescue`

Intentionally left alone: `registerRescue` and `createRescue` — these audit AFTER `await transaction.commit()` as post-commit record-keeping (registration is already complete by then; sequence is correct).

## Fix 2 — Diff capture on Pet/User UPDATEs

Replaced the "dump entire model snapshot + update payload into `details`" pattern in `pet.service.updatePet` and `user.service.updateUserProfile` with structured before/after diffs for a curated allowlist of sensitive fields, plus a flat list of changed field names.

Before:
```ts
details: {
  originalData: redactSensitiveFields(JSON.parse(JSON.stringify(originalData))),
  updateData: redactSensitiveFields(JSON.parse(JSON.stringify(processedUpdateData))),
}
```

After:
```ts
details: {
  diff: { email: { before: 'old@x', after: 'new@x' } },  // only allowlisted fields
  updatedFields: ['email', 'firstName', 'location'],     // names of everything that changed
}
```

Smaller audit rows, no accidental PII leakage of unrelated fields, and a forensic query can answer "what was the adoptionFee before this change?" directly from `details.diff.adoptionFeeMinor` without parsing a whole snapshot.

Allowlists:
- **Pet**: `status`, `adoptionFeeMinor`, `adoptionFeeCurrency`, `microchipId`, `specialNeeds`, `specialNeedsDescription`
- **User**: `email`, `phoneNumber`, `firstName`, `lastName`, `status`, `userType`, `emailVerified`

Uses `set()` + `diffSequelize()` + `save()` instead of `update()` so the helper can read `instance.changed()` + `_previousDataValues` before save resets them.

## `audit-diff` helper signature relaxation

`diffSequelize` previously required a tightly-bound `Model<Record<string, unknown>>` generic, which the strictly typed model subclasses in this codebase don't satisfy without adding a string index signature to every `*Attributes` type. Relaxed to `unknown` parameter + runtime `isDiffable` narrowing. Net effect: same runtime behaviour, callable from any service that already holds a Sequelize instance, no `as` casts at call sites.

## Test plan

- [x] All 2965 backend tests pass — no regressions
- [x] 49 rescue tests, 38 pet-business-logic tests, full backend suite
- [x] `tsc --noEmit` clean
- [x] Lint clean on changed files (warnings all pre-existing)

## What I'm intentionally NOT fixing (pushback)

- **admin.service transactional drift** flagged by the sweep at 8 sites. The sweep didn't cite specific commit/rollback line numbers and each admin op has a different transaction shape. Blindly refactoring 8 sites risks regressions; will revisit individually if/when a specific drift is observed in practice.
- **Action-name standardisation across `rescue.service`** (`'update'`, `'addStaff'` lowercase vs SCREAMING_SNAKE_CASE elsewhere). Cosmetic refactor touching many call sites + downstream Loki dashboards/queries; separate cleanup if we want to normalise.
- **swipe.service per-event audit, per-failed-login audit, ReportStatusTransition audit** — already addressed in #800's "skip with rationale" section. Still skipped for the same reasons (high volume, low forensic value, or auditing-the-audit).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKQYeGZJXLxx6aKpnmRULX)_