### PR TITLE
fix(audit): close transactional drift in notification/chat/moderation

### DIFF
--- a/service.backend/src/services/chat.service.ts
+++ b/service.backend/src/services/chat.service.ts
@@ -881,6 +881,28 @@ export class ChatService {
         { where: { chat_id: data.chatId }, transaction }
       );
 
+      // Determine the actual message type for the audit row. We resolve it
+      // here (rather than after commit) so the audit write can be paired
+      // with the message + chat-touch inside the same transaction.
+      const auditMessageType = this.inferMessageType(data.attachments);
+
+      // Log the action inside the transaction so the audit row commits
+      // (or rolls back) atomically with the message write. Previously
+      // this fired AFTER commit, so a thrown audit error left the message
+      // committed but propagated as if the send failed, and the catch's
+      // transaction.rollback() then no-op'd on an already-committed tx.
+      await AuditLogService.log({
+        userId: data.senderId,
+        action: 'MESSAGE_SENT',
+        entity: 'Message',
+        entityId: messageWithSender.message_id,
+        details: {
+          chatId: data.chatId,
+          messageType: auditMessageType,
+        },
+        transaction,
+      });
+
       await transaction.commit();
 
       // Auto-report HIGH/CRITICAL violations after commit
@@ -950,21 +972,8 @@ export class ChatService {
         // Don't fail the message send if notifications fail
       }
 
-      // Determine the actual message type for logging
-      const actualMessageType = this.inferMessageType(data.attachments);
-
-      // Log the action
-      await AuditLogService.log({
-        userId: data.senderId,
-        action: 'MESSAGE_SENT',
-        entity: 'Message',
-        entityId: messageWithSender.message_id,
-        details: {
-          chatId: data.chatId,
-          messageType: actualMessageType,
-        },
-      });
-
+      // Audit row was written inside the transaction above; nothing
+      // to do post-commit beyond returning the resolved message.
       return messageWithSender;
     } catch (error) {
       await transaction.rollback();

--- a/service.backend/src/services/moderation.service.ts
+++ b/service.backend/src/services/moderation.service.ts
@@ -174,9 +174,12 @@ class ModerationService {
         await this.autoAssignReport(report.reportId, transaction);
       }
 
-      await transaction.commit();
-
-      // Log the submission
+      // Log the submission inside the transaction so the audit row commits
+      // (or rolls back) atomically with the report + status-transition
+      // writes. Previously this fired AFTER commit, so an audit failure
+      // propagated as a submitReport error even though the report had
+      // already been persisted — the catch then attempted to rollback an
+      // already-committed transaction.
       await AuditLogService.log({
         userId: reporterId,
         action: 'REPORT_SUBMITTED',
@@ -189,7 +192,10 @@ class ModerationService {
         },
         ipAddress: requestContext?.ip,
         userAgent: requestContext?.userAgent,
+        transaction,
       });
+
+      await transaction.commit();
 
       logger.info(`Report submitted: ${report.reportId} by user ${reporterId}`);
       return report;

--- a/service.backend/src/services/notification.service.ts
+++ b/service.backend/src/services/notification.service.ts
@@ -572,7 +572,8 @@ export class NotificationService {
       });
       await prefs.update(apiPatchToPrefsRow(preferences), { transaction });
 
-      // Log the action
+      // Log the action — paired with the prefs.update via `transaction`
+      // so the audit row commits atomically with the preference change.
       await AuditLogService.log({
         userId,
         action: 'UPDATE_NOTIFICATION_PREFERENCES',
@@ -581,6 +582,7 @@ export class NotificationService {
         details: {
           updatedPreferences: preferences,
         },
+        transaction,
       });
 
       loggerHelpers.logBusiness(


### PR DESCRIPTION
## Why

Third-pass sweep over services not touched by #794 / #800 / #801 surfaced three more instances of the same transactional-drift pattern. Pinpoint fixes only.

## Bugs fixed

### `notification.service.updateNotificationPreferences` — audit missing `transaction:` param
The audit call sat inside the transaction's `try` block (between `prefs.update({...}, { transaction })` and `transaction.commit()`), but was not actually bound to the transaction. Audit row could commit standalone while the preferences update rolled back. **Fix:** add `transaction:` parameter.

### `chat.service.sendMessage` — audit fired AFTER `transaction.commit()`
Worse than drift: if the post-commit audit write threw, the `catch` block called `transaction.rollback()` on an already-committed tx (no-op) and the caller saw a misleading "send failed" error even though the message was persisted in the DB. **Fix:** moved the audit call inside the transaction, before commit, with `transaction:` param. Inlined `inferMessageType` resolution earlier so the value is available in tx scope.

### `moderation.service.submitReport` — same post-commit anti-pattern
Identical to chat.service.sendMessage. Compliance-sensitive — moderation trails need atomic audit/state pairing. **Fix:** moved audit inside tx, before commit, with `transaction:` param.

## Test plan
- [x] All 2965 backend tests pass — no regressions
- [x] `tsc --noEmit` clean

## Out of scope

The sweep also flagged some "potential" findings I verified and rejected:
- `application.service.updateApplicationStatus` — already captures from/to status; diff implicit in action name
- `notification.service.updateNotificationPreferences` diff capture — preferences payload is the full diff already
- Various silent-catch flags — all turned out to have intentional `logger.warn` + comment ("graceful degradation")


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKQYeGZJXLxx6aKpnmRULX)_