### PR TITLE
fix: plan-limit TOCTOU on pet create, drop activity_level data loss

### DIFF
--- a/app.client/src/pages/OnboardingWizardPage.tsx
+++ b/app.client/src/pages/OnboardingWizardPage.tsx
@@ -308,11 +308,24 @@ export const OnboardingWizardPage: React.FC = () => {
       yard: form.yard,
     };
 
+    // Step 1 collects household activity_level (low/medium/high) but the
+    // backend profile only has preferred_energy. If the adopter answered
+    // Step 1 but skipped the Step 2 energy chips, the activity_level
+    // answer would otherwise be silently dropped — mirror the legacy
+    // quiz migration (10-migrate-quiz-data-to-match-profile.ts) and
+    // derive preferred_energy from activity_level when chips are empty.
+    const preferredEnergy =
+      form.preferred_energy.length > 0
+        ? form.preferred_energy
+        : form.activity_level
+          ? [form.activity_level]
+          : [];
+
     return {
       preferred_types: form.preferred_types,
       preferred_sizes: form.preferred_sizes,
       preferred_age_groups: form.preferred_age_groups,
-      preferred_energy: form.preferred_energy,
+      preferred_energy: preferredEnergy,
       lifestyle,
       max_distance_km: form.max_distance_km === '' ? null : form.max_distance_km,
       open_to_special_needs: form.open_to_special_needs,

--- a/service.backend/src/__tests__/services/pet-business-logic.test.ts
+++ b/service.backend/src/__tests__/services/pet-business-logic.test.ts
@@ -409,12 +409,15 @@ describe('PetService - Business Logic', () => {
       // When: Creating a new pet
       const result = await PetService.createPet(petData, mockRescueId, mockUserId);
 
-      // Then: Pet is created with correct rescueId
+      // Then: Pet is created with correct rescueId (now inside a
+      // transaction — the second arg is the transaction options
+      // wrapper, which we don't care about here).
       expect(MockedPet.create).toHaveBeenCalledWith(
         expect.objectContaining({
           ...petData,
           rescueId: mockRescueId,
-        })
+        }),
+        expect.objectContaining({ transaction: expect.anything() })
       );
       expect(result).toEqual(mockCreatedPet);
     });
@@ -842,11 +845,14 @@ describe('PetService - Business Logic', () => {
       // When: Creating pet
       await PetService.createPet(petData, mockRescueId, mockUserId);
 
-      // Then: rescueId is set from parameter, not data
+      // Then: rescueId is set from parameter, not data (the second
+      // arg is the transaction wrapper from the plan-limit critical
+      // section).
       expect(MockedPet.create).toHaveBeenCalledWith(
         expect.objectContaining({
           rescueId: mockRescueId, // From parameter
-        })
+        }),
+        expect.objectContaining({ transaction: expect.anything() })
       );
     });
 

--- a/service.backend/src/__tests__/services/plan-limits.service.test.ts
+++ b/service.backend/src/__tests__/services/plan-limits.service.test.ts
@@ -100,7 +100,15 @@ vi.mock('../../models', () => ({
 }));
 vi.mock('../../sequelize', () => ({
   __esModule: true,
-  default: { getDialect: vi.fn().mockReturnValue('sqlite') },
+  default: {
+    getDialect: vi.fn().mockReturnValue('sqlite'),
+    // PetService.createPet now wraps the plan-limit check + Pet.create
+    // in a sequelize.transaction() so concurrent creates serialise on
+    // a SELECT FOR UPDATE of the rescue row. The transaction body is
+    // executed as a callback receiving a fake tx; passing it through
+    // to the model mocks is enough for the tests in this file.
+    transaction: (fn: (tx: unknown) => Promise<unknown>) => fn(shared.fakeTx),
+  },
 }));
 vi.mock('../../cache/redis-cache', () => ({
   cached: vi.fn((_, fn: () => unknown) => fn()),
@@ -153,6 +161,23 @@ describe('Plan limit enforcement', () => {
       await expect(
         PetService.createPet({ name: 'Buddy', type: 'dog' } as never, 'rescue-1', 'user-1')
       ).resolves.toBeDefined();
+    });
+
+    it('locks the rescue row when checking the plan limit so concurrent creates serialise', async () => {
+      // The TOCTOU fix takes a SELECT FOR UPDATE on the rescue inside
+      // the createPet transaction. Without that lock, two parallel
+      // createPet calls can both pass the count check below the limit
+      // and both INSERT, putting the rescue over its plan ceiling.
+      mockRescue.findByPk.mockResolvedValue({ plan: 'free' });
+      mockPet.count.mockResolvedValue(10);
+      mockPet.create.mockResolvedValue({ petId: 'pet-1', status: PetStatus.AVAILABLE });
+
+      const { PetService } = await import('../../services/pet.service');
+      await PetService.createPet({ name: 'Buddy', type: 'dog' } as never, 'rescue-1', 'user-1');
+
+      const callOpts = mockRescue.findByPk.mock.calls[0]?.[1] as { lock?: unknown } | undefined;
+      expect(callOpts).toBeDefined();
+      expect(callOpts!.lock).toBeDefined();
     });
 
     it('throws PLAN_LIMIT_EXCEEDED when free tier limit is reached', async () => {

--- a/service.backend/src/services/pet.service.ts
+++ b/service.backend/src/services/pet.service.ts
@@ -533,8 +533,19 @@ export class PetService {
     }
   }
 
-  private static async assertActivePetLimit(rescueId: string): Promise<void> {
-    const rescue = await Rescue.findByPk(rescueId, { attributes: ['plan'] });
+  private static async assertActivePetLimit(
+    rescueId: string,
+    transaction?: Transaction
+  ): Promise<void> {
+    // When a transaction is supplied, lock the rescue row so concurrent
+    // createPet calls serialize on the plan-limit check. Without the
+    // lock, two parallel requests can both pass the count check and
+    // both INSERT, putting the rescue over its plan ceiling.
+    const rescue = await Rescue.findByPk(rescueId, {
+      attributes: ['plan'],
+      transaction,
+      ...(transaction ? { lock: transaction.LOCK.UPDATE } : {}),
+    });
     if (!rescue) return;
     const plan: RescuePlan = (rescue.plan as RescuePlan) ?? 'free';
     const limit = PLAN_LIMITS[plan].maxActivePets;
@@ -552,6 +563,7 @@ export class PetService {
           ],
         },
       },
+      transaction,
     });
     if (active >= limit) {
       const err = new Error('Active pet listing limit reached for current plan') as Error & {
@@ -579,14 +591,17 @@ export class PetService {
     const startTime = Date.now();
 
     try {
-      await PetService.assertActivePetLimit(rescueId);
-
       const { initialImages, initialVideos, ...petAttributes } = petData;
 
-      // Create pet first; media rows reference the new pet_id (plan 2.1).
-      const pet = await Pet.create({
-        ...petAttributes,
-        rescueId,
+      // Plan-limit check + create run atomically against a SELECT FOR
+      // UPDATE on the rescue row so concurrent createPet calls
+      // serialize. Without this, two parallel requests can both pass
+      // the count check and both INSERT, exceeding the plan ceiling.
+      // The follow-on writes (media, transition log, audit) are
+      // independent of the limit and stay outside the critical section.
+      const pet = await sequelize.transaction(async tx => {
+        await PetService.assertActivePetLimit(rescueId, tx);
+        return Pet.create({ ...petAttributes, rescueId }, { transaction: tx });
       });
 
       // Initial gallery — images and videos are rows in pet_media now,


### PR DESCRIPTION
## Summary

Round 5 audit focused on areas we've consistently deferred: drafts / idempotency / plan-limits and onboarding / match / adopter preferences. Two real bugs surfaced.

### Fixed

- **Plan-limit TOCTOU on pet creation** (`service.backend/src/services/pet.service.ts`). `assertActivePetLimit` ran a SELECT COUNT outside any transaction, then `Pet.create` ran outside any transaction. Two concurrent requests could both observe `count < limit` and both INSERT, putting the rescue past its plan ceiling. Wrap the check + create in `sequelize.transaction()` and take `SELECT FOR UPDATE` on the rescue row inside `assertActivePetLimit` so concurrent createPet calls per rescue serialise. Follow-on writes (media, status transitions, audit log) don't affect the limit and stay outside the critical section.

- **Onboarding `activity_level` silently dropped** (`app.client/src/pages/OnboardingWizardPage.tsx`). Step 1 collects household activity_level (low/medium/high), the step 4 review screen displays it, but `buildPayload` dropped it from the PUT to `/match/profile`. If the adopter answered step 1 but skipped step 2's energy chips, their activity_level answer was lost — the resulting `AdopterMatchProfile.preferred_energy` came back empty and matching degraded silently. Mirror the legacy quiz migration (`10-migrate-quiz-data-to-match-profile.ts`) and derive preferred_energy from activity_level when chips are empty.

### Investigated and rejected as non-bugs

- **Idempotency PK collision across users**: the middleware's catch block (`idempotency.ts:93-100`) explicitly swallows `UniqueConstraintError`, the comment at lines 28-31 documents this as intended ("the losing INSERT gets a PK conflict which we swallow"), and the probability of two users generating the same Idempotency-Key value is vanishingly small (random per-request UUID). Real-world impact is one user loses a cache entry on collision — the handler still runs. A migration to `(key_hash, user_id, endpoint)` is correct long-term but not a drive-by.
- **Application drafts**: clearDraft fires on submit success, backend has a 30-day TTL reaping stragglers, draft is correctly scoped by (userId, petId).
- **Match scoring**: divide-by-zero guards in `blendScores` (`totalWeight === 0` check), clamping in rule scorer (`Math.min(100, Math.max(0, score))`).
- **Top-picks scoping, max_distance_km units, route authorization**: all clean.

### Verification

- Could not boot the stack (no Docker daemon in this sandbox). Static review + tests only.
- Vitest backend: 2966 passed / 0 failed (+1 new test asserting the SELECT FOR UPDATE).
- Vitest app.client: 451 passed / 0 failed.
- ESLint clean (0 errors).

## Test plan

- [ ] On a rescue currently at `n-1` of `n` plan-limit pets, fire two concurrent `POST /pets` requests. With the lock: one succeeds, the other gets `PLAN_LIMIT_EXCEEDED`. Without the lock: both used to succeed.
- [ ] In the onboarding wizard, on a fresh adopter account, fill only step 1 (pick "Pretty relaxed" for household activity level) and step 2's pet-type chips. Leave the step 2 energy chips empty. Submit. Confirm the resulting match profile has `preferred_energy = ['low']` (was previously `[]`).
- [ ] In the onboarding wizard, fill BOTH step 1 activity_level and step 2 energy chips. The explicit chip selection should win — `preferred_energy` matches what was selected in step 2, not derived from step 1.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hsE6P79GVucYWzjP6cGjK)_