### PR TITLE
fix(audit): close transactional drift in application + gdpr services

### DIFF
--- a/service.backend/src/services/application.service.ts
+++ b/service.backend/src/services/application.service.ts
@@ -520,7 +520,12 @@ export class ApplicationService {
           },
         });
 
-        // Log creation
+        // Log creation — paired with the application + status-transition
+        // writes via `transaction: t` so the audit row commits atomically
+        // with the create. Previously the call sat inside the tx callback
+        // but wasn't bound to it, so an audit succeeding then tx
+        // committing could still leave the trail drifted if the tx itself
+        // rolled back after the audit row was written.
         await AuditLogService.log({
           action: 'CREATE',
           entity: 'Application',
@@ -531,6 +536,7 @@ export class ApplicationService {
             priority: application.priority,
           },
           userId,
+          transaction: t,
         });
 
         loggerHelpers.logBusiness(

--- a/service.backend/src/services/gdpr.service.ts
+++ b/service.backend/src/services/gdpr.service.ts
@@ -197,6 +197,7 @@ export const GdprService = {
           actorUserId: actorUserId ?? null,
           graceDays: GDPR_ANONYMIZATION_GRACE_DAYS,
         },
+        transaction: tx,
       });
 
       logger.info('User erasure requested (GDPR phase 1)', {
@@ -346,6 +347,7 @@ export const GdprService = {
             phase: 'phase-2-anonymise',
             attachmentsScheduledForDeletion: attachmentIds.length,
           },
+          transaction: tx,
         });
 
         logger.info('User anonymised (GDPR phase 2)', {
@@ -417,6 +419,7 @@ export const GdprService = {
         details: {
           actorUserId: actor.userId,
         },
+        transaction: tx,
       });
 
       logger.info('User erasure cancelled within grace window', {
@@ -714,6 +717,7 @@ export const GdprService = {
           staffDowngraded,
           actorUserId: actorUserId ?? null,
         },
+        transaction: tx,
       });
 
       logger.info('Rescue anonymised for GDPR erasure', {


### PR DESCRIPTION
## Why

Fourth-pass sweep over services not previously scanned for the same transactional-drift pattern fixed in #801 (rescue) and #802 (notification/chat/moderation). Five more sites found in two compliance-critical services.

## Bugs fixed

### `application.service.createApplication` (L524)
Audit call inside the `sequelize.transaction(async t => ...)` callback was missing `transaction: t`. Added.

### `gdpr.service` — four sites
All four audit calls inside their respective `sequelize.transaction(async tx => ...)` callbacks were missing `transaction: tx`:
- `requestErasure` (phase 1 erasure request)
- `executeAnonymization` (phase 2 anonymisation)
- `cancelErasure` (grace-window cancel)
- `eraseRescue` (full rescue erasure)

These are GDPR Article 17 paths — a drifted forensic trail on an erasure request would be hard to defend in an audit. One-line fix per site; no behaviour change in the happy path, but the bad path (tx rollback after audit succeeded) no longer leaks orphan audit rows.

## What I'm NOT fixing (verified, false alarms)

The fourth-pass agent flagged four other items; I rejected each after verifying:

- **`auth.service.refreshToken` missing audit** — high-volume token rotation (every API cycle). Same category as failed-login attempts which we deliberately skip to avoid log-flood attacks. Security-relevant events (reuse detection, family revocation) ARE already audited via `loggerHelpers.logSecurity`.
- **`email.service` BULK_EMAIL_SEND missing entityId** — no such action exists in the codebase.
- **`email-template.service.deleteTemplate` missing audit** — no such method exists.
- **`invitation.service.acceptInvitation` per-StaffMember/UserRole audit** — wrapping `INVITATION_ACCEPTED` event is the right granularity; per-row audits would add noise without forensic value.

## Test plan

- [x] All 2966 backend tests pass — no regressions
- [x] `tsc --noEmit` clean

## Diminishing returns note

Each pass has found fewer real bugs (5 → 4 → 2 → 3 → 5 → ...). This pass found 5 because gdpr.service was an entire service that had never been scanned for the drift pattern. After this lands, the remaining services likely have ≤2 drift bugs total. One more pass would probably be the last useful one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKQYeGZJXLxx6aKpnmRULX)_