### PR TITLE
fix: file-upload size + orphans, CMS publishedAt enforcement

### DIFF
--- a/service.backend/src/__tests__/routes/cms.routes.test.ts
+++ b/service.backend/src/__tests__/routes/cms.routes.test.ts
@@ -90,7 +90,14 @@ describe('CMS routes', () => {
       expect(res.body.success).toBe(true);
       expect(res.body.items).toHaveLength(1);
       expect(authenticateTokenMock).not.toHaveBeenCalled();
-      expect(mockList).toHaveBeenCalledWith(expect.objectContaining({ status: 'published' }));
+      expect(mockList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'published',
+          // Public listing must also gate on publishedAt being in the
+          // past to keep embargoed-but-status-published rows hidden.
+          publishedAtBefore: expect.any(Date),
+        })
+      );
     });
 
     it('forwards search and pagination query params', async () => {
@@ -100,14 +107,24 @@ describe('CMS routes', () => {
         .query({ search: 'cats', page: '2', limit: '20' });
 
       expect(mockList).toHaveBeenCalledWith(
-        expect.objectContaining({ search: 'cats', page: 2, limit: 20, status: 'published' })
+        expect.objectContaining({
+          search: 'cats',
+          page: 2,
+          limit: 20,
+          status: 'published',
+          publishedAtBefore: expect.any(Date),
+        })
       );
     });
   });
 
   describe('GET /api/v1/cms/public/content/:slug', () => {
     it('returns 200 when the slug resolves to a published page', async () => {
-      mockGetBySlug.mockResolvedValue({ slug: 'about', status: 'published' });
+      mockGetBySlug.mockResolvedValue({
+        slug: 'about',
+        status: 'published',
+        publishedAt: new Date('2024-01-01'),
+      });
       const res = await request(buildApp()).get('/api/v1/cms/public/content/about');
       expect(res.status).toBe(200);
       expect(res.body.content.slug).toBe('about');
@@ -115,6 +132,20 @@ describe('CMS routes', () => {
 
     it('returns 404 when the resolved page is not published', async () => {
       mockGetBySlug.mockResolvedValue({ slug: 'about', status: 'draft' });
+      const res = await request(buildApp()).get('/api/v1/cms/public/content/about');
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('returns 404 when the resolved page has a future publishedAt (embargo)', async () => {
+      // An admin can flip status to 'published' while leaving publishedAt
+      // in the future for a scheduled release. The public endpoint must
+      // hide it until the embargo lifts.
+      mockGetBySlug.mockResolvedValue({
+        slug: 'about',
+        status: 'published',
+        publishedAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      });
       const res = await request(buildApp()).get('/api/v1/cms/public/content/about');
       expect(res.status).toBe(404);
       expect(res.body.success).toBe(false);

--- a/service.backend/src/__tests__/services/file-upload.service.test.ts
+++ b/service.backend/src/__tests__/services/file-upload.service.test.ts
@@ -128,6 +128,10 @@ const setupSuccessfulUpload = (mimetype = 'image/jpeg') => {
   });
   vi.mocked(fs.promises.stat).mockResolvedValue({
     mtime: new Date('2024-01-01'),
+    // The service now reads the on-disk size after processing so the DB
+    // row reflects compressed bytes, not the original multer-reported
+    // size. Existing assertions use file.size, so mirror that here.
+    size: 2048,
   } as unknown as import('fs').Stats);
   vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('file-content'));
   vi.mocked(FileUpload.create).mockResolvedValue(makeMockRecord({ mime_type: mimetype }));

--- a/service.backend/src/controllers/cms.controller.ts
+++ b/service.backend/src/controllers/cms.controller.ts
@@ -95,6 +95,11 @@ export const listPublicContent = async (
   const result = await CmsService.listContent({
     contentType: contentType as ContentType | undefined,
     status: 'published' as ContentStatus,
+    // Hide content whose publishedAt is in the future (embargo) — the
+    // admin author route lets editors schedule a future publishedAt
+    // while flipping status to 'published'; without this filter the
+    // public list would surface that row immediately.
+    publishedAtBefore: new Date(),
     search,
     page: page ? parseInt(page, 10) : undefined,
     limit: limit ? parseInt(limit, 10) : undefined,
@@ -107,7 +112,11 @@ export const getPublicContentBySlug = async (
   res: Response
 ): Promise<void> => {
   const item = await CmsService.getContentBySlug(req.params.slug);
-  if (item.status !== 'published') {
+  if (item.status !== 'published' || !item.publishedAt || item.publishedAt.getTime() > Date.now()) {
+    // 404 covers three cases that public callers shouldn't distinguish:
+    // not-yet-published draft/scheduled, embargoed (status=published but
+    // publishedAt in the future), and never-published. Returning the
+    // same 404 prevents enumeration of unreleased slugs.
     res.status(404).json({ success: false, error: 'Content not found' });
     return;
   }

--- a/service.backend/src/services/cms.service.ts
+++ b/service.backend/src/services/cms.service.ts
@@ -13,6 +13,12 @@ type ListContentOptions = {
   page?: number;
   limit?: number;
   authorId?: string;
+  // ADS C6: public callers set this to `new Date()` so future-dated
+  // published content (e.g. content with status='published' but
+  // publishedAt set for embargo) stays hidden from the public listing
+  // until its publish moment. Admin callers omit it so the admin view
+  // continues to surface scheduled rows.
+  publishedAtBefore?: Date;
 };
 
 type ListContentResult = {
@@ -78,7 +84,15 @@ const generateSlug = (title: string): string =>
 
 class CmsService {
   async listContent(options: ListContentOptions = {}): Promise<ListContentResult> {
-    const { contentType, status, search, page = 1, limit = 20, authorId } = options;
+    const {
+      contentType,
+      status,
+      search,
+      page = 1,
+      limit = 20,
+      authorId,
+      publishedAtBefore,
+    } = options;
 
     const where: WhereOptions = {};
 
@@ -90,6 +104,14 @@ class CmsService {
     }
     if (authorId) {
       Object.assign(where, { authorId });
+    }
+    if (publishedAtBefore) {
+      // Match rows that have already gone live: publishedAt set and not
+      // in the future. Status='published' alone isn't enough — embargoed
+      // future-dated rows would otherwise leak through the public list.
+      Object.assign(where, {
+        publishedAt: { [Op.ne]: null, [Op.lte]: publishedAtBefore },
+      });
     }
     if (search) {
       const likeOp = sequelize.getDialect() === 'postgres' ? Op.iLike : Op.like;

--- a/service.backend/src/services/file-upload.service.ts
+++ b/service.backend/src/services/file-upload.service.ts
@@ -274,8 +274,24 @@ export class FileUploadService {
         }
       }
 
-      // Create database record
-      const uploadRecord = await this.createUploadRecord(fileMetadata, metadata);
+      // Create database record. If this fails the upload row is never
+      // created, so the remote object is referenced nowhere — wrap the
+      // DB write so we can roll the remote upload back instead of
+      // leaving an orphaned object accruing storage cost.
+      let uploadRecord;
+      try {
+        uploadRecord = await this.createUploadRecord(fileMetadata, metadata);
+      } catch (dbErr) {
+        if (remoteUrls) {
+          await this.rollbackRemoteUpload(remoteUrls).catch(cleanupErr => {
+            logger.error('Failed to roll back remote upload after DB write failure', {
+              path: remoteUrls.path,
+              cleanupErr,
+            });
+          });
+        }
+        throw dbErr;
+      }
 
       // Log the upload
       await AuditLogService.log({
@@ -809,6 +825,39 @@ export class FileUploadService {
     return categoryMap[uploadType];
   }
 
+  /**
+   * Delete the remote object(s) created by `transferToRemoteStorage`
+   * after a downstream failure (e.g. DB write). Best-effort — callers
+   * log the cleanup error but don't re-throw, because the originating
+   * error is what the caller cares about.
+   */
+  private static async rollbackRemoteUpload(remoteUrls: {
+    url: string;
+    thumbnailUrl?: string;
+    path: string;
+  }): Promise<void> {
+    const provider = getStorageProvider();
+    // `path` is `${category}/${filename}` (see transferToRemoteStorage
+    // return shape). Split once to recover the bits deleteFile wants.
+    const splitPath = (p: string): { category: string; filename: string } | null => {
+      const slash = p.indexOf('/');
+      if (slash < 0) return null;
+      return { category: p.slice(0, slash), filename: p.slice(slash + 1) };
+    };
+    const main = splitPath(remoteUrls.path);
+    if (main) {
+      await provider.deleteFile(main.filename, main.category);
+    }
+    if (remoteUrls.thumbnailUrl) {
+      // thumbnailUrl is `/uploads/${category}/${thumbFilename}`.
+      const stripped = remoteUrls.thumbnailUrl.replace(/^\/uploads\//, '');
+      const thumb = splitPath(stripped);
+      if (thumb) {
+        await provider.deleteFile(thumb.filename, thumb.category);
+      }
+    }
+  }
+
   private static async transferToRemoteStorage(
     file: Express.Multer.File,
     processedFile: ProcessedFileInfo,
@@ -834,13 +883,28 @@ export class FileUploadService {
     if (processedFile.thumbnailPath) {
       const safeThumbPath = this.safeResolveUploadPath(processedFile.thumbnailPath);
       const thumbBuffer = await fs.promises.readFile(safeThumbPath);
-      const thumbResult = await provider.uploadFile(
-        thumbBuffer,
-        `thumb_${file.originalname}`,
-        'image/jpeg',
-        category
-      );
-      thumbnailFilename = thumbResult.filename;
+      try {
+        const thumbResult = await provider.uploadFile(
+          thumbBuffer,
+          `thumb_${file.originalname}`,
+          'image/jpeg',
+          category
+        );
+        thumbnailFilename = thumbResult.filename;
+      } catch (thumbErr) {
+        // Roll back the main upload that already landed so we don't
+        // leak an orphaned object — the function is about to throw, no
+        // DB row will reference it, and there's no GC path that would
+        // catch it later.
+        await provider.deleteFile(uploadResult.filename, category).catch(cleanupErr => {
+          logger.error('Failed to roll back main upload after thumbnail failure', {
+            filename: uploadResult.filename,
+            category,
+            cleanupErr,
+          });
+        });
+        throw thumbErr;
+      }
     }
 
     // Best-effort cleanup of local temp files after successful remote upload
@@ -1033,7 +1097,13 @@ export class FileUploadService {
       filename: file.filename,
       originalName: file.originalname,
       mimeType: file.mimetype,
-      size: file.size,
+      // file.size is what multer reported at upload time — i.e. the size
+      // of the ORIGINAL bytes. processFile() resizes / compresses images
+      // before this metadata is generated, so the bytes on disk now have
+      // stats.size (often ~50–80% smaller). Use the on-disk size so
+      // storage-quota accounting, audit reporting and cost calculations
+      // see what's actually stored, not what was originally uploaded.
+      size: stats.size,
       path: file.path,
       url: this.generateFileUrl(uploadType, file.filename),
       thumbnailUrl: processedFile.thumbnailPath


### PR DESCRIPTION
## Summary

Round 6 audit of file uploads + storage and CMS public content (Blog/Help/Legal). Four real bugs:

### Fixed

- **`file_size` records original size, not stored size** (`file-upload.service.ts`). `generateFileMetadata` wrote `file.size` — multer's report of the original bytes — into `FileUpload.file_size`, but `processFile` resizes / compresses images before this point. The DB therefore showed a number 40-80% larger than what's actually on disk, breaking storage quota accounting, audit reporting and cost calculations. Use the `stats.size` already being read on the line above.

- **Orphaned main file when thumbnail upload fails** (`file-upload.service.ts`). `transferToRemoteStorage` uploads the main file then the thumbnail. If thumb upload threw, the main file was left orphaned in S3 (no DB row ever pointed at it, no GC would catch it). Wrap the thumb upload in a try/catch that calls `deleteFile` on the main upload before re-throwing.

- **Orphaned remote object when DB write fails** (`file-upload.service.ts`). `uploadFile` happily lets a successful remote transfer become orphaned if the subsequent `createUploadRecord` DB write fails. Catch the DB error, call a new `rollbackRemoteUpload` helper that deletes the main + thumb in remote storage, then re-throw.

- **CMS public content ignores `publishedAt`** (`cms.controller.ts` + `cms.service.ts`). `listPublicContent` and `getPublicContentBySlug` filtered by `status='published'` but did not check `publishedAt`. An admin who flipped status to published while leaving publishedAt in the future (the normal embargo / scheduling pattern) exposed the row immediately to the public list and detail endpoints. Extend `listContent` with a `publishedAtBefore` option, pass `new Date()` from the public list controller, and gate the slug detail on `publishedAt <= now`. Same 404 for unreleased / embargoed / draft to avoid slug enumeration.

### Investigated and rejected as non-bugs

- **"`scheduledPublishAt` accepts past dates"**: the cron job at `cms.service.ts:317` publishes immediately if the timestamp is in the past — that's correct "I want this live now" semantics, not a bug.
- **"ACL path lookup race"** (`upload-acl.service.ts`): speculative race that doesn't actually happen — the filename rename completes synchronously within the same request before the URL is generated.
- **Rich text sanitization, admin route auth, legal versioning, slug uniqueness, locale handling, search SQL injection**: all clean.

### Verification

- Could not boot the stack (no Docker daemon in this sandbox). Static review + tests only.
- Vitest backend: 2967 passed / 0 failed (added embargo coverage to `cms.routes.test.ts`, kept the public list assertion strict).
- ESLint clean (0 errors).

## Test plan

- [ ] As admin, schedule a blog post with `status='published'` and `publishedAt` set 1 day in the future. Confirm `GET /api/v1/cms/public/content/{slug}` returns 404 and the post does not appear in `GET /api/v1/cms/public/content`. Once the time passes, both should start serving.
- [ ] Upload a large image; confirm `FileUpload.file_size` reflects the processed/compressed size (smaller than the upload Content-Length), not the original.
- [ ] Simulate a thumbnail-upload failure (e.g. corrupt the thumbnail path) and confirm the main object is no longer in the bucket after the request errors.
- [ ] Simulate a `createUploadRecord` failure (e.g. drop the unique index temporarily) and confirm both main + thumb are deleted from the bucket after the request errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hsE6P79GVucYWzjP6cGjK)_