### PR TITLE
fix(email): reap stuck SENDING rows so crashed-worker sends aren't lost

### DIFF
--- a/service.backend/src/__tests__/services/email-queue-concurrency.test.ts
+++ b/service.backend/src/__tests__/services/email-queue-concurrency.test.ts
@@ -92,6 +92,71 @@ describe('EmailService.processEmailQueue concurrency [ADS-477]', () => {
     }
   };
 
+  it('reclaims SENDING rows whose worker crashed mid-send (older than the threshold)', async () => {
+    // Worker dies after markAsSending+save but before markAsSent.
+    // Without the reaper the row would stay SENDING forever and the
+    // email would silently be lost — processEmailQueue only ever pulls
+    // QUEUED rows.
+    const tracker = { peak: 0, current: 0 };
+    const provider = makeSlowProvider(0, tracker);
+
+    const service = new EmailService() as EmailServiceInternals;
+    await new Promise(resolve => setImmediate(resolve));
+    service.setProvider(provider);
+
+    // Stale SENDING row — lastAttemptAt 10 minutes ago (well past the
+    // 5-minute floor).
+    await EmailQueue.create({
+      toEmail: 'stuck@test.com',
+      fromEmail: 'noreply@test.com',
+      subject: 'stuck',
+      htmlContent: '<p>x</p>',
+      textContent: 'x',
+      type: EmailType.TRANSACTIONAL,
+      status: EmailStatus.SENDING,
+      priority: EmailPriority.NORMAL,
+      createdBy: 'admin',
+      ccEmails: [],
+      bccEmails: [],
+      attachments: [],
+      templateData: {},
+      attempts: 0,
+      maxAttempts: 3,
+      lastAttemptAt: new Date(Date.now() - 10 * 60 * 1000),
+    } as any);
+
+    // Fresh SENDING row — only 30s old, must NOT be reclaimed (a real
+    // worker may still be talking to the provider).
+    await EmailQueue.create({
+      toEmail: 'fresh@test.com',
+      fromEmail: 'noreply@test.com',
+      subject: 'fresh',
+      htmlContent: '<p>x</p>',
+      textContent: 'x',
+      type: EmailType.TRANSACTIONAL,
+      status: EmailStatus.SENDING,
+      priority: EmailPriority.NORMAL,
+      createdBy: 'admin',
+      ccEmails: [],
+      bccEmails: [],
+      attachments: [],
+      templateData: {},
+      attempts: 0,
+      maxAttempts: 3,
+      lastAttemptAt: new Date(Date.now() - 30 * 1000),
+    } as any);
+
+    await service.processEmailQueue();
+
+    // Stuck row was reclaimed (QUEUED) then sent on the same loop tick.
+    const stuck = await EmailQueue.findOne({ where: { toEmail: 'stuck@test.com' } });
+    expect(stuck?.status).toBe(EmailStatus.SENT);
+
+    // Fresh row was left alone.
+    const fresh = await EmailQueue.findOne({ where: { toEmail: 'fresh@test.com' } });
+    expect(fresh?.status).toBe(EmailStatus.SENDING);
+  });
+
   it('processes a batch in parallel up to EMAIL_QUEUE_CONCURRENCY', async () => {
     process.env.EMAIL_QUEUE_CONCURRENCY = '4';
     const tracker = { peak: 0, current: 0 };

--- a/service.backend/src/services/email.service.ts
+++ b/service.backend/src/services/email.service.ts
@@ -772,6 +772,15 @@ class EmailService {
     this.isProcessing = true;
 
     try {
+      // Reclaim stuck SENDING rows before pulling the next batch. If a
+      // worker / container crashed mid-send after `markAsSending` but
+      // before `markAsSent` or `markAsFailed`, the row would otherwise
+      // sit pinned in SENDING forever — nothing else queries that
+      // state, so the email is silently lost. A 5-minute floor on
+      // lastAttemptAt is well beyond any legitimate provider call so
+      // it won't race a real in-flight send.
+      await this.reclaimStuckSendingRows();
+
       const concurrency = this.getQueueConcurrency();
       // Pull a batch sized to the concurrency window so we don't
       // hold rows in QUEUED state any longer than necessary.
@@ -816,6 +825,36 @@ class EmailService {
       logger.error('Error processing email queue:', error);
     } finally {
       this.isProcessing = false;
+    }
+  }
+
+  // Rows stuck in SENDING for this long are assumed to be from a
+  // crashed worker. 5 minutes is well beyond any legitimate provider
+  // send call (Resend / SES finish in under a second under normal
+  // conditions) so a real in-flight row won't be reclaimed mid-send.
+  private static readonly STUCK_SENDING_THRESHOLD_MS = 5 * 60 * 1000;
+
+  private async reclaimStuckSendingRows(): Promise<void> {
+    try {
+      const cutoff = new Date(Date.now() - EmailService.STUCK_SENDING_THRESHOLD_MS);
+      const [reclaimed] = await EmailQueue.update(
+        { status: EmailStatus.QUEUED },
+        {
+          where: {
+            status: EmailStatus.SENDING,
+            lastAttemptAt: { [Op.lt]: cutoff },
+          } as WhereOptions,
+        }
+      );
+      if (reclaimed > 0) {
+        logger.warn(
+          `Reclaimed ${reclaimed} stuck SENDING email row(s) older than ${EmailService.STUCK_SENDING_THRESHOLD_MS}ms`
+        );
+      }
+    } catch (error) {
+      // Reclaim failure must not block the main processor loop — the
+      // worst case is the stuck rows wait another cycle.
+      logger.error('Failed to reclaim stuck SENDING email rows', { error });
     }
   }
 


### PR DESCRIPTION
## Summary

Round 7 audit of email queue / scheduled jobs and 2FA / push / device tokens. One confirmed data-loss bug; the rest of the agent findings were investigated and rejected.

### Fixed

- **Stuck `SENDING` email rows silently lost** (`email.service.ts`). `processEmail` calls `markAsSending() + save()` before invoking `provider.send()`. If the worker / container dies (SIGKILL, OOM, deploy restart, hard crash that skips the catch block) between those two writes, the row sits in `SENDING` forever — `processEmailQueue` only ever queries `QUEUED`, `retryFailedEmails` only acts on `FAILED`, and nothing else touches `SENDING` apart from a metrics `count()`. Real consequence: password resets, verification links, application status emails enqueue successfully, the caller is told "queued", and the recipient never gets the message — with no operator signal.

  Fix: reclaim `SENDING` rows whose `lastAttemptAt` is older than 5 minutes back to `QUEUED` at the top of every processor tick. 5 minutes is well beyond any legitimate provider send (Resend / SES finish in well under a second under normal load) so a real in-flight call won't race the reaper. The reclaim itself is wrapped in try/catch so its own failure doesn't block the main loop.

### Investigated and rejected as non-bugs

- **"Retry counter off-by-one (`maxRetries=3` should mean 4 total attempts)"**: existing `EmailQueue.model.test.ts:231` enforces the current semantic where `maxRetries=3` means 3 total attempts. This is a naming question, not a behavioural bug. Changing it would silently break the documented contract.
- **"Device token uniqueness only on `deleted_at IS NULL`"**: the paranoid soft-delete pattern intentionally allows re-registration after deletion. Changing the index would break legitimate re-use.
- **"2FA disable doesn't require password"**: security policy choice. The step-up-auth path (`verifyStepUpCredentials`) exists for genuinely destructive operations; disable-2FA from an authenticated session is consistent with the rest of the codebase.
- **"Push notification preference bypass in `deliverNotification` fallback"**: the fallback at `notification.service.ts:234` is a deliberate "if prefs returned no channels, honour the caller's explicit channel" path. Removing it would require product clarity on opt-out semantics that's beyond a drive-by.

### Verification

- Could not boot the stack (no Docker daemon in this sandbox). Static review + tests only.
- Vitest backend: 2968 passed / 0 failed (+1 new test covering both reclaim branches).
- ESLint clean (0 errors).

## Test plan

- [ ] Manually corrupt a row in the `email_queue` table so `status='sending'` and `last_attempt_at = NOW() - INTERVAL '10 minutes'`. Wait for the next processor tick (or trigger it). Confirm the row gets reset to `queued`, delivered on the same tick, and ends up `sent`.
- [ ] Set `status='sending'` and `last_attempt_at = NOW() - INTERVAL '30 seconds'` (a row a real worker may still be holding). Confirm it is NOT reclaimed.
- [ ] Verify no spurious `Reclaimed N stuck SENDING email row(s)` warnings under normal load.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hsE6P79GVucYWzjP6cGjK)_