### PR TITLE
feat(audit): system audit row for scheduled report execution

### DIFF
--- a/service.backend/src/workers/reports.worker.ts
+++ b/service.backend/src/workers/reports.worker.ts
@@ -13,6 +13,7 @@ import ScheduledReport, {
 } from '../models/ScheduledReport';
 import User, { UserType } from '../models/User';
 import { logger } from '../utils/logger';
+import { AuditLogService } from '../services/auditLog.service';
 import type { ReportConfig } from '../schemas/reports.schema';
 
 /**
@@ -287,6 +288,30 @@ const handleRenderAndEmail = async (data: RenderAndEmailJob): Promise<void> => {
       schedule.last_status = ScheduledReportStatus.SUCCESS;
       schedule.last_error = null;
       await schedule.save();
+
+      // System-level audit so admins can answer "did the scheduled
+      // report run at 9am?" from audit_logs without trawling worker
+      // logs. Mirrors the pattern used by retention.job /
+      // weekly-digest.job. No transaction (background job, single op).
+      await AuditLogService.log({
+        userId: '',
+        action: 'SCHEDULED_REPORT_EXECUTED',
+        entity: 'ScheduledReport',
+        entityId: data.scheduleId,
+        service: 'reports-worker',
+        details: {
+          savedReportId: data.savedReportId,
+          format: data.format,
+          recipientCount: data.recipients?.length ?? 0,
+        },
+      }).catch(err => {
+        // Audit failure must not poison the worker's success path —
+        // the schedule's last_status is already SUCCESS in the DB.
+        logger.warn('Failed to write SCHEDULED_REPORT_EXECUTED audit row', {
+          scheduleId: data.scheduleId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
     }
   }
 };
@@ -346,6 +371,27 @@ export const startReportsWorker = (): Worker<ScheduledRunJob | RenderAndEmailJob
           schedule.last_status = ScheduledReportStatus.FAILED;
           schedule.last_error = err.message.slice(0, 1000);
           await schedule.save().catch(() => undefined);
+
+          // Audit the failure at WARNING level — same forensic
+          // story as the success path, just the bad branch.
+          await AuditLogService.log({
+            userId: '',
+            action: 'SCHEDULED_REPORT_FAILED',
+            entity: 'ScheduledReport',
+            entityId: parsed.data.scheduleId,
+            service: 'reports-worker',
+            level: 'WARNING',
+            status: 'failure',
+            details: {
+              savedReportId: parsed.data.savedReportId,
+              error: err.message.slice(0, 500),
+            },
+          }).catch(auditErr => {
+            logger.warn('Failed to write SCHEDULED_REPORT_FAILED audit row', {
+              scheduleId: parsed.data.scheduleId,
+              err: auditErr instanceof Error ? auditErr.message : String(auditErr),
+            });
+          });
         }
       }
     }


### PR DESCRIPTION
## Why

Fifth-pass sweep produced a complete coverage map of the audit system (see "Coverage state" below). The only real remaining gap was `reports.worker` — when a scheduled report job ran (success OR failure), the worker updated `ScheduledReport.last_status` but emitted no audit row.

## Fix

Added two system-level audit calls in the BullMQ worker:
- `SCHEDULED_REPORT_EXECUTED` on success (renderAndEmail completion)
- `SCHEDULED_REPORT_FAILED` on the worker's `failed` handler, level WARNING, status `failure`

Both fire-and-forget (`.catch` + `logger.warn`) because the schedule state has already been persisted by the time we audit — audit failure must not poison the worker outcome. Mirrors the pattern already used by `retention.job` / `weekly-digest.job` for system-level cron audit rows.

## Coverage state after this PR

Five PRs landed in total: #794, #800, #801, #802, #804, plus this one.

**Audited & verified clean (drift-pattern scanned + bugs fixed):**
admin, application, application-draft, auth, chat, cms, consent, field-permission, foster, gdpr, invitation, moderation, notification, pet, rescue, reports (routes), security, supportTicket, user

**No audit needed (read-only services):**
analytics, application-profile, applicationTimeline, audit-log-formatting, auditLog, companies-house, content-moderation, dashboard, data-retention, discovery, email-template, health-check, inbox, legal-content, messageBroker, messageSearch, notificationChannelService, question, redact, report-cache, report-renderer, rich-text-processing, simplifiedMessageBroker, swipe (intentional), upload-acl, weekly-digest, plus all provider abstractions (push, sms, storage, email-providers)

**Background jobs/workers — all audited:**
match-digest.job, retention.job, revoked-tokens-purge.job, weekly-digest.job, legal-reminder.worker, reports.worker (closed by THIS PR)

**Bugs the agent claimed but I verified as NOT real:**
- `broadcast.service.ts:262` — summary audit pattern for a fan-out, not drift. Acceptable.
- `file-upload.service.ts:426` — audit fires AFTER all deletes complete; ordering is correct.
- `auth.service` "17 calls, no tx threading" — most aren't in transaction contexts at all; the post-commit ones (login, 2FA recovery) are intentional design and would lose forensic signal if moved.

## Test plan

- [x] All 2967 backend tests pass
- [x] `tsc --noEmit` clean

## Final word on diminishing returns

This pass found 1 real bug across the entire backend. Coverage is functionally complete. Further passes would mostly produce false alarms (as this one's 4 false alarms demonstrate). Recommend treating the audit system as done unless a specific incident points to a new gap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKQYeGZJXLxx6aKpnmRULX)_