### PR TITLE
docs(claude): add 15 backend, frontend, UX, testing, and workflow skills

### DIFF
--- a/.claude/skills/accessibility/SKILL.md
+++ b/.claude/skills/accessibility/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: accessibility
+description: >
+  Accessibility rules for React components, pages, and form UI. Apply when writing
+  or modifying any JSX, custom component, modal, dropdown, form input, navigation,
+  or page-level layout.
+---
+
+# Accessibility Rules
+
+The platform targets WCAG AA across all three themes (`light`, `normal`, `dark`).
+See `docs/ACCESSIBILITY.md` for the architectural notes. This skill captures the
+authoring rules that prevent regressions.
+
+## Semantic HTML first
+
+Use the right element for the job before reaching for ARIA. Most a11y bugs come
+from `<div>` doing the job of something else.
+
+| Job | Use | Not |
+|-----|-----|-----|
+| Click target that submits / navigates | `<button>` or `<a>` | `<div onClick>` |
+| Heading hierarchy | `<h1>`–`<h6>` (one `<h1>` per page) | `<div class="heading-1">` |
+| Form fields | `<input>` with `<label>` | `<div>` with placeholder only |
+| Lists | `<ul>` / `<ol>` / `<li>` | flex `<div>`s |
+| Tabular data | `<table>` | grid of `<div>`s |
+| Region landmarks | `<main>`, `<nav>`, `<aside>`, `<header>`, `<footer>` | unlabeled `<div>` |
+
+**Rule of thumb:** every interactive element should be reachable via Tab and
+operable via Enter/Space without extra code on your part. If you're adding
+keydown handlers to a `<div>`, you've picked the wrong element.
+
+## Names — every interactive element must have one
+
+Buttons, links, inputs, and icon-only controls need an accessible name. In order
+of preference:
+
+1. **Visible text content** — `<button>Save changes</button>`
+2. **`aria-label`** — for icon-only buttons (`<IconButton aria-label="Close menu">`)
+3. **`aria-labelledby`** — when the name is rendered elsewhere on the page
+4. **`<label htmlFor>`** — for every form input (or wrap the input)
+
+```typescript
+// GOOD
+<button aria-label="Close dialog" onClick={onClose}>
+  <X aria-hidden />
+</button>
+
+<label htmlFor="email">Email</label>
+<input id="email" type="email" />
+
+// BAD — screen reader announces "button" with no name
+<button onClick={onClose}><X /></button>
+
+// BAD — placeholder is not a label
+<input type="email" placeholder="Email" />
+```
+
+For icons inside labelled buttons, mark the icon `aria-hidden` so it doesn't
+double up the announcement.
+
+## Form fields — required for forms
+
+Every input, textarea, and select must:
+
+1. Have an associated `<label>` (use `<FormField>` from `lib.components` which
+   handles this — see the `forms` skill)
+2. Surface validation errors via `aria-describedby` pointing at the error text
+3. Set `aria-invalid="true"` while in an error state
+4. Be focusable in tab order
+
+The `FormField` component in `lib.components/src/components/form/FormField` wires
+all of this up — use it rather than building from scratch.
+
+## Focus management
+
+- **Modals/dialogs**: focus the first interactive element on open, restore focus
+  to the trigger on close. Trap focus inside while open.
+- **Route changes**: scroll to top and move focus to the new page's `<h1>` or
+  `<main>`.
+- **Inline state updates** (banners, errors): use `aria-live="polite"` (or
+  `assertive` for critical) so screen readers announce them.
+- **Never** set `tabIndex={-1}` on a control unless you're managing focus
+  programmatically. Never set `tabIndex` > 0 — it breaks natural order.
+
+## Keyboard support
+
+Standard interactions must work without a mouse:
+
+| Element | Keys |
+|---------|------|
+| Button | Enter, Space activates |
+| Link | Enter activates |
+| Checkbox | Space toggles |
+| Radio group | Arrow keys move within group, Tab leaves |
+| Select / combobox | Up/Down arrows, Enter selects, Escape closes |
+| Dialog | Escape closes |
+| Tabs | Left/Right arrows move, Home/End jump |
+
+If you're building a custom widget, refer to the WAI-ARIA Authoring Practices for
+the keyboard pattern — don't invent your own.
+
+## Color and contrast
+
+- All text must hit WCAG AA contrast (4.5:1 normal, 3:1 large) against its
+  background. Theme tokens are already verified; **use `vars.*` not hex literals**
+  (see the `design-tokens` skill).
+- Never convey state by colour alone. Pair red/green with an icon, text, or
+  underline.
+- Focus indicators must be visible — don't `outline: none` without an explicit
+  alternative.
+
+```typescript
+// BAD — only colour tells the user this is an error
+<span style={{ color: 'red' }}>Invalid postcode</span>
+
+// GOOD — icon + colour + assistive text
+<span role="alert">
+  <AlertIcon aria-hidden /> Invalid postcode
+</span>
+```
+
+## Reduced motion
+
+Respect `prefers-reduced-motion` on any transition/animation:
+
+```typescript
+// In a *.css.ts file
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../styles/theme.css';
+
+export const card = style({
+  transition: `transform ${vars.transitions.fast}`,
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      transition: 'none',
+    },
+  },
+});
+```
+
+The new-component skill includes this pattern by default — keep it.
+
+## Images and icons
+
+- Meaningful images: `<img alt="A border collie puppy sitting on a sofa">`
+- Decorative images: `<img alt="">` (empty string, not omitted)
+- Icons that duplicate visible text: `aria-hidden` so they don't double-announce
+- SVG icons used as the only label: wrap in a button with `aria-label`
+
+## Page structure
+
+Every page should have:
+
+- One `<h1>` describing the page
+- Heading hierarchy that doesn't skip levels (no `<h3>` directly after `<h1>`)
+- A `<main>` landmark wrapping the primary content
+- Skip-to-content link (provided by the app shell — don't remove it)
+
+## Testing accessibility
+
+In React Testing Library, query by accessibility metadata — this exercises a11y
+as a side effect:
+
+```typescript
+screen.getByRole('button', { name: /save/i });  // exercises accessible name
+screen.getByLabelText(/email/i);                 // exercises input label
+```
+
+If `getByRole` can't find your control, it's probably not accessible.
+
+For automated audits, run axe via `@axe-core/react` in dev or `vitest-axe` in
+tests. The Playwright e2e suite runs axe on key pages — don't add regressions.
+
+## Common mistakes
+
+- `<div onClick>` for clickable things — use `<button>`
+- Icon-only buttons with no `aria-label` — screen readers announce "button"
+- Placeholder used as the only label — disappears on input, fails screen readers
+- `outline: none` on focus — invisible focus state, keyboard users get lost
+- Skipped heading levels (`<h1>` then `<h3>`) — breaks navigation by heading
+- `tabIndex={0}` on every clickable div — symptom of using the wrong element
+- Colour-only state indication (red invalid, green valid) — fails colour-blind users
+- Auto-playing animation/video without controls — vestibular and attention issues
+- Hidden text fields used as state (e.g. `<input type="hidden">` carrying meaning
+  for sighted users) — invisible to assistive tech

--- a/.claude/skills/audit-logging/SKILL.md
+++ b/.claude/skills/audit-logging/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: audit-logging
+description: >
+  When and how to emit audit events in service.backend. Apply when working on any
+  service or route that creates, updates, or deletes user data, performs an
+  authentication action, or otherwise changes state that needs forensic record.
+---
+
+# Audit Logging
+
+The backend separates **operational logs** (Layer 1 — `logger.*`) from **audit
+events** (Layer 2 — durable `audit_logs` table). This skill is about Layer 2.
+
+| | Layer 1 — `logger.*` | Layer 2 — audit |
+|---|---|---|
+| Purpose | Debugging, ops | Forensics: who did what to what |
+| Storage | console + files + Loki | `audit_logs` table + Loki |
+| Mutable | Yes | No (immutable, append-only) |
+| How | `logger.info/warn/error` | `AuditLogService.log()` or `auditRoute()` |
+
+## When to audit (Layer 2)
+
+Emit an audit row for any action a security/compliance reviewer would want to
+reconstruct months later:
+
+- Create / update / delete of business entities (users, pets, applications, rescues,
+  invitations, etc.)
+- Authentication events (login, logout, password reset, MFA changes)
+- Authorisation changes (role grant, permission change, suspension)
+- Sensitive reads (admin viewing a user's PII record) — use `audit: true` on `fieldMask`
+- Bulk operations, exports, data deletions
+
+Don't audit pure read-only endpoints unless they expose sensitive data. Don't audit
+health checks, static assets, or anything a system user couldn't act on.
+
+## Decision rule: pick exactly ONE path
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Service runs the write inside a Sequelize transaction?                 │
+│  ──────────────────────────────────────────────────────────────────────│
+│   Yes  →  AuditLogService.log({..., transaction: t}) INSIDE the service │
+│   No   →  Background job / cron / consumer?                             │
+│             Yes →  AuditLogService.log(...) — no transaction needed     │
+│             No  →  Route-level CRUD?                                    │
+│                     Yes → auditRoute({...}) middleware                  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Never combine both.** `auditRoute()` fires AFTER `res.finish`, which is OUTSIDE
+the service transaction — combining produces duplicate rows and breaks atomicity.
+
+## Path A — Inside a service transaction (preferred for writes)
+
+```typescript
+import sequelize from '../sequelize';
+import { AuditLogService } from './auditLog.service';
+
+return sequelize.transaction(async t => {
+  const pet = await Pet.create(payload, { transaction: t });
+
+  await AuditLogService.log({
+    userId: actorUserId,
+    action: 'CREATE',
+    entity: 'Pet',
+    entityId: pet.petId,
+    details: { name: pet.name, rescueId: pet.rescueId },
+    transaction: t,                     // ← critical — commits with the write
+  });
+
+  return pet;
+});
+```
+
+`pet.service.ts:174`, `application.service.ts:524`, `invitation.service.ts`,
+`foster.service.ts`, `field-permission.service.ts` follow this pattern.
+
+## Path B — Route-level middleware (route does the write directly)
+
+For lightweight CRUD routes whose controllers don't open a service-level transaction.
+The middleware registers `res.on('finish')` and writes the audit row only on 2xx
+responses.
+
+```typescript
+import { auditRoute } from '../middleware/audit-route';
+
+router.put('/:petId',
+  petIdParam,
+  auditRoute({
+    action: 'APPLICATION_DRAFT_UPSERTED',
+    entity: 'ApplicationDraft',
+    entityIdFrom: 'params.petId',
+    metadataFrom: ['body.status'],          // optional extra details
+  }),
+  (req, res) => ApplicationDraftController.upsertDraft(req, res)
+);
+```
+
+`application-draft.routes.ts`, `cms.routes.ts`, `reports.routes.ts` use this.
+
+Trade-off: cannot share a transaction with the handler. Acceptable when the audit row
+is best-effort observation rather than transactional invariant.
+
+## Path C — Background job / cron / consumer
+
+No transaction needed because there's no HTTP request to scope to. Just call:
+
+```typescript
+await AuditLogService.log({
+  userId: 'system',
+  action: 'DATA_RETENTION_PURGE',
+  entity: 'User',
+  entityId: user.userId,
+  details: { reason: 'gdpr-retention-window-elapsed' },
+});
+```
+
+## Capturing before/after for UPDATEs
+
+For sensitive entity updates, record the diff so the audit row tells the full story.
+
+### Option 1 — Read previous row in the same transaction
+
+```typescript
+const before = await FieldPermission.findOne({ where: {...}, transaction: t });
+await record.update(changes, { transaction: t });
+
+await AuditLogService.log({
+  userId: actorUserId,
+  action: 'UPDATE',
+  entity: 'FieldPermission',
+  entityId: record.id,
+  details: { before: before?.toJSON(), after: record.toJSON() },
+  transaction: t,
+});
+```
+
+See `field-permission.service.ts upsert()`.
+
+### Option 2 — diffSequelize helper
+
+For models you mutate with `instance.set()` before `instance.save()`:
+
+```typescript
+import { diffSequelize } from '../utils/audit-diff';
+
+pet.set(changes);
+const delta = diffSequelize(pet, ['name', 'description', 'rescueId']);
+await pet.save({ transaction: t });
+
+await AuditLogService.log({
+  userId: actorUserId,
+  action: 'UPDATE',
+  entity: 'Pet',
+  entityId: pet.petId,
+  details: delta,
+  transaction: t,
+});
+```
+
+The allowlist prevents accidentally auditing internal fields.
+
+## Action and entity naming
+
+`action` is an UPPER_SNAKE_CASE verb phrase. Common values are in the
+`AuditLogAction` enum in `auditLog.service.ts`. Prefer the enum value; only add a new
+one with a clear domain reason.
+
+| Pattern | Example |
+|---------|---------|
+| Generic CRUD | `CREATE`, `UPDATE`, `DELETE` |
+| Auth | `LOGIN`, `LOGOUT`, `PASSWORD_RESET`, `EMAIL_VERIFICATION` |
+| Domain event | `RESCUE_VERIFIED`, `APPLICATION_APPROVED`, `STAFF_INVITED` |
+
+`entity` is PascalCase singular matching the model name: `User`, `Pet`, `Application`.
+
+`entityId` is the primary key as a string.
+
+## PII and secrets
+
+`details` is redacted by the Winston logger config, but treat the column as durable
+storage. Never put:
+
+- Plain-text passwords, reset tokens, MFA secrets
+- Full credit card or bank account numbers
+- Unredacted government IDs
+
+Capture identifiers (userId, email, last4) instead.
+
+## Why not just `logger.info()`?
+
+`logger.info` writes to a rotated file + Loki. Logs are queryable for ops but:
+- Get compacted away
+- Have no schema
+- Aren't a system-of-record for compliance
+
+`audit_logs` is the durable record. Use both layers — log for ops noise, audit for
+forensics.
+
+## Common mistakes
+
+- Forgetting `transaction: t` inside a service transaction → audit row commits even
+  if the business write rolls back
+- Using `auditRoute()` on a route whose service runs a transaction → duplicate rows,
+  one of them outside the tx
+- Auditing reads that aren't sensitive → noisy table, no value
+- Putting secrets in `details` → durable leak
+- Inventing new `action` values that overlap with existing ones (e.g. `USER_CREATED`
+  when `CREATE` + `entity: 'User'` already conveys it)
+- Skipping the `await` — fire-and-forget audit calls are silently dropped on error

--- a/.claude/skills/backend-endpoint/SKILL.md
+++ b/.claude/skills/backend-endpoint/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: backend-endpoint
+description: >
+  Add a new REST endpoint to service.backend. Use when the user asks to create a new
+  API route, expose a controller action, or add CRUD endpoints. Walks through routes,
+  controllers, services, validation, RBAC, and audit hookup.
+disable-model-invocation: true
+---
+
+# Adding a Backend REST Endpoint
+
+The backend follows a strict layering: **Route → Controller → Service → Model**. Each
+layer has one job. Skipping or merging layers fights the codebase.
+
+| Layer | Responsibility | Lives in |
+|-------|---------------|----------|
+| Route | Wire middleware (auth, RBAC, validation, audit), forward to controller | `src/routes/` |
+| Controller | Parse req, call service, return response. **No business logic.** | `src/controllers/` |
+| Service | Business rules, DB writes, audit, transactions | `src/services/` |
+| Model | Sequelize schema, associations, hooks | `src/models/` |
+
+## Step 1 — Define the request/response schema (Zod first)
+
+Schemas live in `lib.validation` so frontends and backend share one source of truth.
+
+```typescript
+// lib.validation/src/<feature>.ts
+import { z } from 'zod';
+
+export const CreateThingRequestSchema = z.object({
+  name: z.string().min(1).max(120),
+  description: z.string().max(2000).optional(),
+});
+
+export type CreateThingRequest = z.infer<typeof CreateThingRequestSchema>;
+```
+
+Re-export from `lib.validation/src/index.ts`. Rebuild lib.validation
+(`cd lib.validation && npm run build`) so service.backend resolves the new export.
+
+## Step 2 — Add validation in the controller
+
+Use `validateBody` / `validateParams` / `validateQuery` from `middleware/zod-validate`,
+**not** express-validator. (Existing routes still use express-validator; new code
+should prefer Zod.)
+
+```typescript
+// src/controllers/thing.controller.ts
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { CreateThingRequestSchema } from '@adopt-dont-shop/lib.validation';
+import { validateBody, validateParams } from '../middleware/zod-validate';
+import { BaseController } from './base.controller';
+import { ThingService } from '../services/thing.service';
+import { AuthenticatedRequest } from '../types';
+
+const ThingIdParamSchema = z.object({
+  thingId: z.string().uuid('Valid thing ID is required'),
+});
+
+export class ThingController extends BaseController {
+  static validateCreate = [validateBody(CreateThingRequestSchema)];
+  static validateById = [validateParams(ThingIdParamSchema)];
+
+  static async create(req: AuthenticatedRequest, res: Response) {
+    const userId = req.user!.userId;
+    const thing = await ThingService.create(req.body, userId);
+    return res.status(201).json({ data: thing });
+  }
+
+  static async getById(req: AuthenticatedRequest, res: Response) {
+    const thing = await ThingService.getById(req.params.thingId);
+    return res.status(200).json({ data: thing });
+  }
+}
+```
+
+**Controllers must not contain business rules.** They only:
+- Pull values off the request (already validated)
+- Call a service method
+- Choose the success status code
+- Return `{ data: ... }` (or `{ data, pagination }` for lists)
+
+Errors propagate to the error-handler middleware automatically — never write
+`try/catch` in a controller just to translate to HTTP. See the `error-handling` skill.
+
+## Step 3 — Implement the service
+
+```typescript
+// src/services/thing.service.ts
+import sequelize from '../sequelize';
+import Thing from '../models/Thing';
+import { NotFoundError } from '../middleware/error-handler';
+import { AuditLogService } from './auditLog.service';
+import { CreateThingRequest } from '@adopt-dont-shop/lib.validation';
+
+export class ThingService {
+  static async create(payload: CreateThingRequest, actorUserId: string): Promise<Thing> {
+    return sequelize.transaction(async t => {
+      const thing = await Thing.create({ ...payload, createdBy: actorUserId }, { transaction: t });
+
+      // Audit inside the transaction — commits atomically with the write.
+      await AuditLogService.log({
+        userId: actorUserId,
+        action: 'CREATE',
+        entity: 'Thing',
+        entityId: thing.thingId,
+        details: { name: thing.name },
+        transaction: t,
+      });
+
+      return thing;
+    });
+  }
+
+  static async getById(thingId: string): Promise<Thing> {
+    const thing = await Thing.findByPk(thingId);
+    if (!thing) {
+      throw new NotFoundError('Thing not found');
+    }
+    return thing;
+  }
+}
+```
+
+See the `audit-logging` skill for when to use `AuditLogService.log()` inside a
+transaction vs the route-level `auditRoute()` middleware. Don't combine both.
+
+## Step 4 — Wire the route
+
+```typescript
+// src/routes/thing.routes.ts
+import express from 'express';
+import { authenticateToken } from '../middleware/auth';
+import { requirePermission } from '../middleware/rbac';
+import { fieldMask, fieldWriteGuard } from '../middleware/field-permissions';
+import { ThingController } from '../controllers/thing.controller';
+import { PERMISSIONS } from '../types';
+
+const router = express.Router();
+
+router.use(authenticateToken);
+
+router.post('/',
+  requirePermission(PERMISSIONS.THING_CREATE),
+  ...ThingController.validateCreate,
+  // fieldWriteGuard('things', { audit: true }),    // only if 'things' is a field-permissioned resource
+  ThingController.create
+);
+
+router.get('/:thingId',
+  requirePermission(PERMISSIONS.THING_READ),
+  ...ThingController.validateById,
+  // fieldMask('things', { audit: true, resourceIdParam: 'thingId' }),
+  ThingController.getById
+);
+
+export default router;
+```
+
+**Middleware order matters** — see the `field-permissions` skill:
+
+```
+authenticateToken → requirePermission → validate* → fieldMask/fieldWriteGuard → controller
+```
+
+## Step 5 — Mount the router
+
+In `src/index.ts` (or wherever routes are mounted):
+
+```typescript
+import thingRoutes from './routes/thing.routes';
+app.use('/api/v1/things', thingRoutes);
+```
+
+## Step 6 — Write tests (TDD)
+
+Tests come BEFORE implementation per CLAUDE.md. See the `backend-test` skill for the
+mock setup and behaviour-focused patterns.
+
+- Service tests: `src/__tests__/services/thing.service.test.ts`
+- Controller tests: `src/__tests__/controllers/thing.controller.test.ts` (sparingly —
+  most logic should be covered at the service layer)
+- Route tests: `src/__tests__/routes/thing.routes.test.ts` (integration-style with
+  supertest)
+
+## Step 7 — Field permissions (if applicable)
+
+If the resource is one of `users`, `rescues`, `pets`, `applications` — or you're adding
+a new one — read the `field-permissions` skill. You must:
+
+1. Add field defaults in `lib.types/src/config/field-permission-defaults.ts` (all 4 roles)
+2. Apply `fieldMask()` to GET routes and `fieldWriteGuard()` to write routes
+3. Add sensitive fields to `SENSITIVE_FIELD_DENYLIST`
+
+## Step 8 — Swagger / OpenAPI
+
+Existing routes document each endpoint with JSDoc `@swagger` blocks above the route
+handler. Match that pattern so the generated docs stay complete. See
+`application.routes.ts` for a comprehensive example.
+
+## Conventions checklist
+
+- [ ] Schema-first: Zod schema in `lib.validation`, type derived via `z.infer`
+- [ ] Validation in the controller via `validateBody/Params/Query` (Zod) for new code
+- [ ] Controller has no `try/catch`, no business logic — just request/response shape
+- [ ] Service holds all business rules, runs DB writes in a transaction when multiple
+      tables change
+- [ ] Audit hookup: inside the transaction (`AuditLogService.log({ transaction: t })`)
+      OR via `auditRoute()` middleware — never both
+- [ ] RBAC via `requirePermission` / `requireRole` / `requirePermissionOrOwnership`
+- [ ] Field permissions on routes for users/rescues/pets/applications
+- [ ] Response shape: `{ data: ... }` on success, errors handled by error middleware
+- [ ] Swagger JSDoc on each route
+- [ ] Tests first, behaviour-focused
+
+## Common mistakes
+
+- Putting business logic in the controller (validation, DB queries, audit calls)
+- `try/catch` in the controller that swallows the error or returns a custom shape —
+  let it bubble to the error handler
+- Skipping `requirePermission` because "auth is enough" — auth is identity, RBAC is
+  what they can do
+- Forgetting `await` on `AuditLogService.log()` inside a transaction — the audit row
+  won't be in the tx
+- Mixing express-validator and Zod on the same route (pick one — prefer Zod for new code)
+- Forgetting to re-export the new Zod schema from `lib.validation/src/index.ts` and
+  rebuild the lib

--- a/.claude/skills/backend-test/SKILL.md
+++ b/.claude/skills/backend-test/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: backend-test
+description: >
+  Patterns for writing tests in service.backend. Apply when adding or modifying any
+  service, controller, route, or middleware test. Covers Vitest setup, mock patterns,
+  behaviour-focused assertions, and TDD.
+---
+
+# Backend Testing Patterns
+
+The backend uses **Vitest** (not Jest) with the setup in
+`service.backend/src/setup-tests.ts`. Tests favour behaviour over implementation.
+
+## Test layout
+
+```
+service.backend/src/__tests__/
+  services/<name>.service.test.ts        # Most logic lives here
+  controllers/<name>.controller.test.ts  # Sparingly — HTTP shape only
+  routes/<name>.routes.test.ts           # Integration via supertest
+  middleware/<name>.test.ts              # For new middleware
+  integration/                           # Cross-layer scenarios
+  models/                                # Validation/hooks only — not CRUD
+```
+
+Run all backend tests:
+```bash
+cd service.backend && npm test
+```
+
+Run a single file (fast feedback loop):
+```bash
+cd service.backend && npm test -- src/__tests__/services/thing.service.test.ts
+```
+
+## TDD loop (per CLAUDE.md)
+
+1. **Red** — write a failing test describing the desired behaviour
+2. **Green** — minimum code to pass
+3. **Refactor** — clean up with tests green
+
+State the success criteria before you start:
+> "Create returns the new Thing and writes one audit row with action=CREATE"
+
+## What to test
+
+**Test behaviour through public APIs only.** Internals must be invisible.
+
+| Good | Bad |
+|------|-----|
+| "Suspending a user blocks future logins" | "calls userRepo.update with status=suspended" |
+| "POST /things 201s and returns the new id" | "Controller calls ThingService.create" |
+| "Rejecting an application emits a notification" | "spy was called with NotificationType.REJECTED" |
+
+A test that breaks every time you refactor is testing implementation, not behaviour.
+
+## Vitest imports
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+```
+
+Use `vi.fn()`, `vi.mock()`, `vi.spyOn()`. **Never** `jest.*` — this project does not
+use Jest.
+
+## Mock setup pattern (services)
+
+`setup-tests.ts` already mocks the logger, encryption keys, and JWT/CSRF secrets.
+Mock anything external your service touches:
+
+```typescript
+import { vi } from 'vitest';
+
+// External services — mock at the top of the file before importing the SUT.
+vi.mock('../../services/notification.service', () => ({
+  NotificationService: {
+    createNotification: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../services/email.service', () => ({
+  default: {
+    sendEmail: vi.fn().mockResolvedValue('email-id-1'),
+    queueEmail: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Socket emits — capture without a live IO server.
+vi.mock('../../socket/socket-registry', () => ({
+  emitToUser: vi.fn(),
+  emitToRescue: vi.fn(),
+}));
+
+import { ThingService } from '../../services/thing.service';
+import { NotificationService } from '../../services/notification.service';
+
+describe('ThingService — Business Logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a thing and notifies the owner', async () => {
+    const thing = await ThingService.create({ name: 'Buddy' }, 'user-1');
+
+    expect(thing.thingId).toBeDefined();
+    expect(NotificationService.createNotification).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+## Database in tests
+
+Tests run against a real in-memory SQLite (configured in `setup-tests.ts`), so model
+behaviour is tested accurately. You don't mock Sequelize models — you let them write
+to the in-memory DB and assert the resulting state.
+
+If a test needs a clean DB, truncate inside `beforeEach`:
+
+```typescript
+beforeEach(async () => {
+  await Thing.destroy({ where: {}, truncate: true });
+});
+```
+
+Avoid `sequelize.sync({ force: true })` per-test — slow and unnecessary.
+
+## Controller tests
+
+Use `supertest` for route/controller integration. Spin up an Express app with just the
+router under test rather than booting the whole `index.ts`:
+
+```typescript
+import express from 'express';
+import request from 'supertest';
+import thingRoutes from '../../routes/thing.routes';
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/things', thingRoutes);
+
+it('rejects unauthenticated requests', async () => {
+  const res = await request(app).post('/api/v1/things').send({ name: 'X' });
+  expect(res.status).toBe(401);
+});
+```
+
+## Auditing assertions
+
+Don't assert on `AuditLogService.log` call args by mocking it — that tests
+implementation. Instead, query the `audit_logs` table after the operation:
+
+```typescript
+import { AuditLog } from '../../models/AuditLog';
+
+it('records an audit row on create', async () => {
+  await ThingService.create({ name: 'Buddy' }, 'user-1');
+
+  const rows = await AuditLog.findAll({ where: { entity: 'Thing' } });
+  expect(rows).toHaveLength(1);
+  expect(rows[0].action).toBe('CREATE');
+});
+```
+
+## Error path coverage
+
+Each `throw` in a service is a branch. Cover it:
+
+```typescript
+it('throws NotFoundError when the thing is missing', async () => {
+  await expect(ThingService.getById('missing-id')).rejects.toThrow('Thing not found');
+});
+```
+
+Test the error TYPE, not the message string, when downstream code branches on it:
+
+```typescript
+import { NotFoundError } from '../../middleware/error-handler';
+
+await expect(ThingService.getById('x')).rejects.toBeInstanceOf(NotFoundError);
+```
+
+## What to skip
+
+- Don't snapshot test JSON responses — they break on every field add. Assert on specific fields.
+- Don't test that the logger was called. Logger output is operational, not behaviour.
+- Don't test Sequelize internals (e.g. `findByPk` was called). Test the OBSERVABLE result.
+
+## Coverage
+
+CLAUDE.md targets 100% coverage but ONLY of meaningful business behaviour. Don't
+add tests to lift coverage on lines that don't matter. If a line can't be reached by
+realistic input, the line is dead code — delete it instead.
+
+## TypeScript rules (apply to tests too)
+
+- No `any` — use `unknown` or `vi.MockedFunction<typeof fn>`
+- No `as` assertions without a comment explaining why
+- No `@ts-ignore`/`@ts-expect-error` — fix the type
+- Tests are first-class TypeScript code
+
+## Common mistakes
+
+- `jest.fn()` instead of `vi.fn()` — wrong test framework
+- Mocking `AuditLogService` to assert log calls — test the resulting audit row instead
+- Snapshotting full responses — brittle, doesn't describe behaviour
+- Testing private methods via casting — refactor so the behaviour is visible publicly
+- `sequelize.sync({ force: true })` in every test — slow; truncate the tables you touch
+- Asserting against the mocked logger — operational signal, not behaviour
+- Skipping the `beforeEach(() => vi.clearAllMocks())` reset — call-count assertions
+  leak across tests

--- a/.claude/skills/commit-conventions/SKILL.md
+++ b/.claude/skills/commit-conventions/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: commit-conventions
+description: >
+  Conventional Commits rules used by this repo's commitlint + release-please
+  pipeline. Apply when writing any commit message, PR title, or release-relevant
+  changelog entry.
+---
+
+# Commit & PR Conventions
+
+This repo enforces **Conventional Commits** via `@commitlint/config-conventional`
+(see `commitlint.config.js`). The release pipeline (release-please) reads commit
+messages to:
+
+1. Decide the next version (major / minor / patch)
+2. Generate the changelog automatically
+3. Group commits by section
+
+A commit that doesn't follow the convention is rejected by the husky pre-commit
+hook, and even if force-pushed, lands in the changelog as "Other" — invisible
+to reviewers.
+
+## The format
+
+```
+<type>(<optional scope>): <short summary>
+
+<optional longer body, wrapped at ~72 cols>
+
+<optional footer(s) — BREAKING CHANGE, Refs:, Closes:>
+```
+
+Examples from the repo's history:
+
+```
+feat(audit): system audit row for scheduled report execution
+fix(email): reap stuck SENDING rows so crashed-worker sends aren't lost
+fix: file-upload size + orphans, CMS publishedAt enforcement
+fix: plan-limit TOCTOU on pet create, drop activity_level data loss
+docs(claude): add backend-focused skills for endpoints, migrations, tests, audit, errors
+```
+
+## Types
+
+| Type | Use for | Triggers release? |
+|------|---------|-------------------|
+| `feat` | New user-facing feature or capability | minor bump |
+| `fix` | Bug fix visible to users or callers | patch bump |
+| `docs` | Docs only (READMEs, CLAUDE.md, ADRs, skill files) | no bump |
+| `refactor` | Code restructure with no behaviour change | no bump |
+| `test` | Test-only changes (new tests, refactored tests) | no bump |
+| `chore` | Build, deps, tooling, internal housekeeping | no bump |
+| `perf` | Performance improvement | patch bump |
+| `style` | Whitespace, formatting (rare — Prettier handles most) | no bump |
+| `ci` | CI config (GitHub Actions, etc.) | no bump |
+| `build` | Build system / external deps (Webpack, npm scripts) | no bump |
+| `revert` | Reverting a previous commit | matches reverted |
+
+**Use `feat` only for things a user can observe.** Internal additions that don't
+change behaviour are usually `refactor` or `chore`.
+
+## Scopes
+
+Scope is the area of the codebase affected. Use sparingly and consistently.
+Common scopes from this repo:
+
+- App / lib package short names: `audit`, `email`, `pet`, `application`, `auth`,
+  `claude`, `chat`, `gdpr`, `field-permissions`, `inbox`
+- Cross-cutting: `deps`, `ci`, `docker`
+
+Skip the scope if the change spans many areas (`fix: ...`) — it's better than
+inventing a misleading one.
+
+## Subject line rules
+
+- Max ~72 chars (commitlint enforces 100, but aim shorter for changelog readability)
+- Imperative mood: "add", "fix", "remove" — NOT "added", "fixes", "removing"
+- Lowercase first letter (after the type prefix)
+- No trailing full stop
+- Describe the WHAT and WHY-in-a-nutshell, not the HOW
+
+```
+GOOD: fix(email): reap stuck SENDING rows so crashed-worker sends aren't lost
+BAD:  Fix email service (the SENDING rows in the queue were getting stuck).
+BAD:  fixed email bug
+BAD:  fix: I added a thing that reaps stuck rows in the queue
+```
+
+## Body
+
+Use the body when the change deserves explanation. It survives in `git log` and
+in the changelog (release-please includes it).
+
+- Wrap around 72 cols
+- Explain WHY, not WHAT (the diff shows the what)
+- Reference tickets in the footer, not the subject
+
+```
+fix(application): prevent duplicate audit rows on bulk approve
+
+Bulk approval was calling AuditLogService.log inside the transaction
+AND auditRoute() on the route, producing two rows per record. Switched
+to the in-transaction path only to preserve atomicity with the status
+write.
+
+Refs: ADS-712
+```
+
+## Breaking changes
+
+Two ways to mark a breaking change — pick one:
+
+1. **`!` after type/scope:**
+   ```
+   feat(api)!: remove /api/v1/legacy-pets endpoint
+   ```
+
+2. **`BREAKING CHANGE:` footer:**
+   ```
+   feat(api): rename pet status enum values
+
+   BREAKING CHANGE: PetStatus.AVAILABLE renamed to PetStatus.ADOPTABLE.
+   Frontend callers must update their imports and conditionals.
+   ```
+
+Either form triggers a **major** version bump. Use one, not both.
+
+## Footers
+
+Standard footers release-please recognises:
+
+- `Refs: ADS-123` or `Closes: #456` — links to ticket / issue
+- `BREAKING CHANGE: <description>` — see above
+- `Co-authored-by: Name <email>` — multi-person commit
+
+`Refs:` is preferred for in-flight work; `Closes:` for completing the ticket.
+
+## PR titles
+
+PR titles follow the same convention — they end up as squash-merge commits when
+release-please runs, so they ARE the changelog entry. Match the format used by
+recent merges on `main`.
+
+## What about WIP / multi-step work?
+
+Within a feature branch you can commit anything you like locally. Before PR /
+squash-merge, the squashed commit (or the rebased commits if you're rebasing)
+must conform.
+
+If a single PR contains multiple atomic changes worth separate changelog
+entries, keep them as separate commits and don't squash. The release pipeline
+handles a multi-commit PR fine.
+
+## Common mistakes
+
+- Past-tense subject: `feat: added pet search` → use `feat: add pet search`
+- Capitalised subject: `feat: Add pet search` → use `feat: add pet search`
+- Trailing period: `feat: add pet search.` → drop the period
+- Misusing `feat` for refactors → causes spurious minor bumps in releases
+- Unscoped sprawling commits (`feat: lots of stuff`) → split or summarise honestly
+- Forgetting `BREAKING CHANGE:` → users get bitten by a silent major-shape change
+- Ticket reference in the subject (`feat: ADS-712 add foo`) → put it in the
+  footer (`Refs: ADS-712`)
+- Skipping the type → commitlint rejects the commit at pre-commit
+
+## Quick reference
+
+```
+feat(scope): short imperative summary
+
+[Optional body explaining WHY, wrapped at 72 cols.]
+
+Refs: ADS-XXX
+```
+
+That's it. Match the existing log style (`git log --oneline -20`) when in
+doubt.

--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: db-migration
+description: >
+  Create a Sequelize migration for service.backend. Use when the user asks to add a
+  column, table, index, enum value, or any schema change. Covers numbering,
+  idempotency, transactions, and up/down symmetry.
+disable-model-invocation: true
+---
+
+# Adding a Database Migration
+
+Migrations live in `service.backend/src/migrations/` and run sequentially by filename.
+NEVER modify an existing migration — create a new one.
+
+## Current latest migration
+!`ls /home/user/adopt-dont-shop/service.backend/src/migrations/ 2>/dev/null | grep -v "^_" | sort | tail -5`
+
+## Step 1 — Pick the filename
+
+Format: `<NN>-<kebab-case-summary>.ts` where `NN` is the next integer in the existing
+series.
+
+- Baseline migrations (`00-baseline-*`) are the per-model bootstrap — never add to
+  this series.
+- Increment from the highest numeric prefix. If the last is `10-migrate-quiz-data`,
+  yours becomes `11-<your-change>`.
+- Keep the summary short and descriptive: `09-add-allergies-to-adopter-match-profile.ts`,
+  `06-add-audit-logs-login-failures-index.ts`.
+
+## Step 2 — Use the helpers
+
+`src/migrations/_helpers.ts` provides:
+
+| Helper | Purpose |
+|--------|---------|
+| `runInTransaction(queryInterface, fn)` | Wraps the body in a transaction — required for multi-step DDL |
+| `columnExists(queryInterface, table, col)` | Idempotency guard before `addColumn` |
+| `dropEnumTypeIfExists(queryInterface, name)` | Cleanly drop a Postgres ENUM in `down` |
+| `assertDestructiveDownAcknowledged()` | Guard for destructive `down` (data-loss) |
+
+Idempotency matters because `00-baseline-*` migrations create the schema via
+`sequelize.sync()` on a fresh DB, and the model definitions already include columns
+declared in later migrations. Without an `if (columnExists)` guard, a fresh install
+re-tries to add a column that's already there → migration failure.
+
+## Step 3 — Write the migration
+
+### Add a column
+
+```typescript
+// 11-add-favourite-colour-to-pets.ts
+import { DataTypes, type QueryInterface } from 'sequelize';
+import { columnExists, runInTransaction } from './_helpers';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    if (await columnExists(queryInterface, 'pets', 'favourite_colour')) {
+      return;
+    }
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.addColumn(
+        'pets',
+        'favourite_colour',
+        { type: DataTypes.STRING(50), allowNull: true, defaultValue: null },
+        { transaction }
+      );
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.removeColumn('pets', 'favourite_colour', { transaction });
+    });
+  },
+};
+```
+
+### Add an index
+
+```typescript
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.addIndex('audit_logs', ['user_id', 'action'], {
+        name: 'idx_audit_logs_user_action',
+        transaction,
+      });
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await runInTransaction(queryInterface, async transaction => {
+      await queryInterface.removeIndex('audit_logs', 'idx_audit_logs_user_action', {
+        transaction,
+      });
+    });
+  },
+};
+```
+
+### Add an ENUM value
+
+Postgres ENUMs require a special path — `ALTER TYPE ... ADD VALUE` cannot run inside
+a transaction.
+
+```typescript
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.sequelize.query(
+      `ALTER TYPE "enum_notifications_type" ADD VALUE IF NOT EXISTS 'NEW_VALUE'`
+    );
+  },
+
+  down: async () => {
+    // Postgres can't remove enum values cleanly.
+    // Leave as a no-op or assertDestructiveDownAcknowledged().
+  },
+};
+```
+
+## Step 4 — Update the Sequelize model
+
+If you added a column, the model in `src/models/<Model>.ts` must declare it too. Two
+places to update:
+
+1. The `XxxAttributes` interface
+2. The `Xxx.init({...})` call
+
+The model is the source of truth for `sequelize.sync()` (clean-DB bootstrap), so a
+missing model declaration means a freshly synced dev DB won't have the new column.
+
+## Step 5 — `down` symmetry
+
+Every `up` must have a matching `down` that returns the schema to its prior state.
+This is enforced by the migration runner in CI for non-destructive changes.
+
+For destructive `down` (drops a column with data, drops a table) — use
+`assertDestructiveDownAcknowledged()` so it only runs when explicitly approved via the
+documented env var.
+
+## Step 6 — Run and verify
+
+```bash
+# Inside the backend container
+docker exec adopt-dont-shop-service-backend-1 npm run db:migrate
+
+# Inspect the result
+docker exec adopt-dont-shop-database-1 \
+  psql -U adopt_user -d adopt_dont_shop_dev \
+  -c "\d+ pets"
+
+# Roll back to verify down
+docker exec adopt-dont-shop-service-backend-1 npm run db:migrate:undo
+```
+
+For the local (non-Docker) path: `npm run db:migrate` from `service.backend/`.
+
+## Step 7 — Add a migration test
+
+`src/__tests__/migrations/` contains per-migration tests that exercise up + down
+against a fresh DB. Match the style of an existing test for the same change shape.
+
+## Conventions checklist
+
+- [ ] Filename uses next integer prefix, kebab-case summary
+- [ ] `columnExists()` guard on every `addColumn` (or equivalent for other ops)
+- [ ] Body wrapped in `runInTransaction` (except ENUM ADD VALUE)
+- [ ] `down` reverses `up` (or is acknowledged-destructive)
+- [ ] Model file updated to match
+- [ ] Brief JSDoc header explaining WHY the change (ticket ref, motivation)
+- [ ] Migration test added
+
+## Common mistakes
+
+- Modifying an existing migration — never. Migrations are append-only history
+- Skipping `columnExists` → migration fails on fresh DBs where `sync()` already added it
+- Running ENUM `ADD VALUE` inside `runInTransaction` → Postgres rejects it
+- Forgetting to update the model → fresh `sync()` skips the column
+- `down` that destroys data without `assertDestructiveDownAcknowledged()`
+- Adding a NOT NULL column without a default → fails on tables with existing rows.
+  Use nullable + default in step 1, backfill in step 2, then tighten if needed.

--- a/.claude/skills/design-tokens/SKILL.md
+++ b/.claude/skills/design-tokens/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: design-tokens
+description: >
+  Design token rules for styling React components with vanilla-extract. Apply when
+  writing or modifying any .css.ts file, component style, theme reference, or visual
+  property like color, spacing, typography, border, or shadow.
+---
+
+# Design Tokens
+
+The platform uses **vanilla-extract** (`*.css.ts`) for all component styling. Theme
+values come from `vars` exported by `lib.components/src/styles/theme.css.ts`. See
+`DESIGN_TOKENS.md` for the canonical token list.
+
+**Core rule:** never hardcode visual values. Always reference `vars.*`. This is
+how the three themes (`light`, `normal`, `dark`) stay consistent and WCAG AA.
+
+## Import once, use everywhere
+
+```typescript
+// At the top of every *.css.ts file
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../styles/theme.css';      // adjust path per directory depth
+```
+
+For variant-driven styles, also import `recipe`:
+
+```typescript
+import { recipe } from '@vanilla-extract/recipes';
+```
+
+## Available token categories
+
+| Category | Path | Examples |
+|----------|------|----------|
+| Brand colours | `vars.colors.*` | `primary`, `primaryHover`, `secondary`, `danger`, `success`, `warning`, `info` |
+| Color states | `vars.colors.{name}Hover`, `{name}Active` | `vars.colors.primaryHover` |
+| Color subtle | `vars.colors.{name}BgSubtle`, `{name}BorderSubtle` | `vars.colors.primaryBgSubtle` |
+| Text | `vars.text.*` | `primary`, `secondary`, `tertiary`, `inverse`, `disabled` |
+| Background | `vars.background.*` | `primary`, `secondary`, `tertiary`, `subtle` |
+| Border | `vars.border.*` | `radius.{none,sm,base,md,lg,xl,full}`, `color.{primary,subtle,strong}`, `width.{thin,base,thick}` |
+| Spacing | `vars.spacing['{0,1,2,3,...}']` | **string keys**, e.g. `vars.spacing['4']` |
+| Typography | `vars.typography.*` | `size.{xs,sm,base,lg,xl,2xl,...}`, `weight.{normal,medium,semibold,bold}`, `family.{sans,mono}`, `lineHeight.*` |
+| Shadows | `vars.shadows.*` | `sm`, `base`, `md`, `lg`, `xl` |
+| Transitions | `vars.transitions.*` | `fast`, `base`, `slow` |
+| Z-index | `vars.zIndex.*` | `dropdown`, `modal`, `tooltip` |
+
+The full list lives in `lib.components/src/styles/theme.css.ts`. If you need a
+token that doesn't exist, add it there rather than hardcoding.
+
+## What this looks like
+
+```typescript
+// MyCard.css.ts
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../styles/theme.css';
+
+export const card = style({
+  backgroundColor: vars.background.primary,
+  color: vars.text.primary,
+  padding: vars.spacing['4'],
+  borderRadius: vars.border.radius.base,
+  border: `${vars.border.width.thin} solid ${vars.border.color.subtle}`,
+  boxShadow: vars.shadows.sm,
+  transition: `box-shadow ${vars.transitions.fast}`,
+  selectors: {
+    '&:hover': {
+      boxShadow: vars.shadows.md,
+    },
+  },
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      transition: 'none',
+    },
+  },
+});
+```
+
+## What NOT to write
+
+```typescript
+// BAD — hex literal. Breaks dark theme, fails contrast audits
+backgroundColor: '#FFFFFF',
+
+// BAD — magic spacing value
+padding: '16px',
+
+// BAD — named colour
+color: 'red',
+
+// BAD — rgba with embedded values
+border: '1px solid rgba(0, 0, 0, 0.1)',
+
+// BAD — inline style attribute with literal
+<div style={{ color: '#333', marginTop: 12 }} />
+```
+
+Any of these in a PR is a regression. The themes only work if every paint goes
+through `vars`.
+
+## Spacing keys are strings
+
+Spacing keys are quoted strings, not numbers — this is a vanilla-extract gotcha:
+
+```typescript
+padding: vars.spacing['4'],       // ✓
+padding: vars.spacing[4],         // ✗  TypeScript error
+padding: `${vars.spacing['2']} ${vars.spacing['4']}`,  // ✓ for shorthand
+```
+
+## Variants — use `recipe`
+
+For components with discrete states (variant, size, tone), use
+`@vanilla-extract/recipes`:
+
+```typescript
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '../../styles/theme.css';
+
+export const button = recipe({
+  base: {
+    fontFamily: vars.typography.family.sans,
+    borderRadius: vars.border.radius.base,
+    border: 'none',
+    cursor: 'pointer',
+    transition: `background-color ${vars.transitions.fast}`,
+  },
+  variants: {
+    variant: {
+      primary: { backgroundColor: vars.colors.primary, color: vars.text.inverse },
+      secondary: { backgroundColor: vars.colors.secondary, color: vars.text.inverse },
+      danger: { backgroundColor: vars.colors.danger, color: vars.text.inverse },
+    },
+    size: {
+      sm: { padding: `${vars.spacing['1']} ${vars.spacing['2']}`, fontSize: vars.typography.size.sm },
+      md: { padding: `${vars.spacing['2']} ${vars.spacing['4']}`, fontSize: vars.typography.size.base },
+      lg: { padding: `${vars.spacing['3']} ${vars.spacing['6']}`, fontSize: vars.typography.size.lg },
+    },
+  },
+  defaultVariants: { variant: 'primary', size: 'md' },
+});
+```
+
+In the component:
+
+```typescript
+import { clsx } from 'clsx';
+import * as styles from './Button.css';
+
+<button className={clsx(styles.button({ variant, size }), className)}>
+```
+
+## Pseudo-selectors and media queries
+
+```typescript
+export const link = style({
+  color: vars.colors.primary,
+  textDecoration: 'underline',
+  selectors: {
+    '&:hover': { color: vars.colors.primaryHover },
+    '&:focus-visible': {
+      outline: `${vars.border.width.thick} solid ${vars.colors.primary}`,
+      outlineOffset: vars.spacing['1'],
+    },
+  },
+  '@media': {
+    '(prefers-reduced-motion: reduce)': { transition: 'none' },
+  },
+});
+```
+
+## Dark mode
+
+`vars` already resolves to the correct theme via the `data-theme` attribute on
+`<html>`. You don't need to write `@media (prefers-color-scheme: dark)` blocks —
+the theme tokens themselves swap. If a token looks wrong in dark mode, fix the
+token definition in `theme.css.ts`, not the component.
+
+## When you genuinely need a literal
+
+Sometimes you need a literal for a non-themed thing (a fixed-size SVG dimension,
+an `0` line-height for an inline icon). That's fine — but ask first whether a
+token would fit. Literals creep into a codebase one at a time and rot the theme.
+
+## Inline styles
+
+Avoid `style={...}` props for visual properties. Use vanilla-extract. The one
+exception: dynamic values that genuinely come from data at runtime (e.g. a
+percentage-width progress bar):
+
+```typescript
+<div style={{ width: `${percent}%` }} className={styles.progressFill} />
+```
+
+The colour, padding, and border on that progress bar still come from the
+`.css.ts` file.
+
+## Common mistakes
+
+- Hardcoding hex/rgb/named colours instead of `vars.colors.*`
+- Magic `px` values (`padding: '16px'`) instead of `vars.spacing[...]`
+- Using a number key for spacing (`vars.spacing[4]`) instead of `vars.spacing['4']`
+- Importing from `../styles/theme` instead of `../../styles/theme.css` — the
+  `.css` suffix is required for vanilla-extract to resolve correctly
+- `styled-components` patterns or `className={'btn btn-primary'}` — this project
+  uses vanilla-extract exclusively
+- Forgetting `prefers-reduced-motion` on transitions — fails the a11y skill
+- `outline: none` on focus — replace with a visible outline using token values
+- Re-declaring theme values locally instead of adding them to `theme.css.ts`

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: e2e-test
+description: >
+  Playwright end-to-end testing patterns for the cross-app suite in /e2e. Apply
+  when adding, modifying, or debugging spec files in e2e/tests/, fixtures, or
+  helpers; or when the user asks about Playwright, role-based browser contexts,
+  or full-stack journey tests.
+---
+
+# End-to-End Testing (Playwright)
+
+The e2e suite lives in `/e2e/` and runs against the full stack (all three apps +
+backend + Postgres). It complements per-package Vitest tests by exercising real
+cross-app journeys ("rescue publishes pet → adopter sees it").
+
+## Layout
+
+```
+e2e/
+├── playwright.config.ts          # baseURLs, browser projects, timeouts
+├── global-setup.ts               # builds .auth/<role>.json storage states
+├── global-teardown.ts
+├── fixtures/                     # shared `test` extensions
+│   ├── index.ts                  # `apiAs`, `asRole`
+│   ├── api.ts                    # ApiClient + loginViaApi
+│   └── roles.ts                  # ROLES map → email, app URL, auth file
+├── helpers/
+│   └── seeds.ts                  # postWithCsrf, seed helpers
+└── tests/
+    ├── admin/                    # uses .auth/admin.json by default
+    ├── client/
+    └── rescue/
+```
+
+## Running
+
+```bash
+# From repo root (all three apps + backend must be running)
+cd e2e
+npm test                          # full suite
+npm test -- admin/                # one app
+npm test -- 2fa-enrollment        # one spec
+npm run test:headed               # see the browser
+npm run test:debug                # pause on failure
+npm run report                    # open HTML report
+```
+
+The suite expects the full stack to be running. `docker compose up -d` first.
+
+## The fixture system
+
+Tests import `test` and `expect` from `../../fixtures`, NOT directly from
+`@playwright/test`. The custom fixtures provide:
+
+| Fixture | Purpose |
+|---------|---------|
+| `apiAs(role)` | Returns an `ApiClient` already authenticated as that role. Use for API contract tests and seed setup. |
+| `asRole(role)` | Opens a fresh browser context authenticated as `role`. Use for cross-role journeys. |
+
+```typescript
+import { test, expect } from '../../fixtures';
+
+test.describe('admin pet management', () => {
+  test('admin can view all pets', async ({ apiAs, page }) => {
+    const adminApi = await apiAs('admin');
+    const res = await adminApi.context.get('/api/v1/pets');
+    expect(res.ok()).toBe(true);
+
+    await page.goto('/pets');
+    await expect(page.getByRole('heading', { name: /pets/i })).toBeVisible();
+  });
+});
+```
+
+For tests in `tests/admin/`, the `page` fixture is already authenticated as
+`admin` (via `storageState: AUTH_FILES.admin` in the project config). The
+`apiAs`/`asRole` fixtures are for stepping outside that default.
+
+## Roles
+
+Defined in `fixtures/roles.ts`. Each role has:
+- `email` + `password` for login
+- `appUrl` — which app to navigate to
+- `authFile` — the storage state path
+
+Tests in `tests/<role>/` automatically use that role's storage state. Don't
+log in manually inside a test — use the fixture.
+
+## Selectors — by role, not by CSS
+
+Playwright's `getByRole`, `getByLabel`, `getByText` mirror React Testing Library's
+priority order. Use them for the same reason: tests survive styling changes and
+exercise accessibility.
+
+```typescript
+// GOOD
+await page.getByRole('button', { name: /save/i }).click();
+await page.getByLabel(/email/i).fill('user@example.com');
+await expect(page.getByText(/saved successfully/i)).toBeVisible();
+
+// BAD — brittle
+await page.locator('.save-btn-primary').click();
+await page.locator('#email-input').fill('user@example.com');
+```
+
+Use `data-testid` only when there's no good semantic selector.
+
+## API setup before UI assertions
+
+Many journeys need pre-existing data (a published pet, a submitted application).
+Seed via the API rather than driving the UI through setup:
+
+```typescript
+import { postWithCsrf } from '../../helpers/seeds';
+
+test('adopter sees newly published pet', async ({ apiAs, page }) => {
+  const rescueApi = await apiAs('rescue');
+  const created = await postWithCsrf(rescueApi.context, '/api/v1/pets', {
+    name: 'Buddy',
+    species: 'dog',
+    status: 'available',
+  });
+  const { data: pet } = await created.json();
+
+  await page.goto('/search');
+  await expect(page.getByText(pet.name)).toBeVisible();
+});
+```
+
+`postWithCsrf` handles the CSRF token dance automatically — see the `api-fetch`
+skill for why that matters.
+
+## Timeouts
+
+Defaults from `playwright.config.ts`:
+- Test timeout: 60s
+- `expect` timeout: 10s
+- Action timeout: 10s
+- Navigation timeout: 30s
+
+Don't lower these per-test. If a test is flaky on timing, the right fix is
+usually to wait for a specific UI state (`expect(...).toBeVisible()`), not a
+raw `page.waitForTimeout()`.
+
+```typescript
+// BAD — fragile and slow
+await page.waitForTimeout(2000);
+
+// GOOD — waits for the actual state you care about
+await expect(page.getByText(/loaded/i)).toBeVisible();
+```
+
+## Traces, screenshots, video
+
+`playwright.config.ts` already enables:
+- `trace: 'on-first-retry'` — full trace on retry
+- `screenshot: 'only-on-failure'`
+- `video: 'retain-on-failure'`
+
+When a CI failure is unclear, download the artefact and open the trace viewer:
+```bash
+npx playwright show-trace path/to/trace.zip
+```
+
+## Best-effort assertions
+
+Some tests guard against environmental drift (a previous run leaving state, a
+flaky downstream service). The `2fa-enrollment.spec.ts` pattern shows the
+acceptable approach: assert the load-bearing contract strictly, downgrade
+optional round-trip steps to best-effort with a clear comment:
+
+```typescript
+// Best-effort enable + disable. If the server rejects (e.g. the
+// code rolled, or some downstream step like AuditLogService.log
+// fails internally), don't fail the whole test — the setup
+// contract is the load-bearing assertion here.
+```
+
+Don't use this to paper over real flakes. If a test fails intermittently for a
+fixable reason, fix the reason.
+
+## Stability rules
+
+- **Atomic tests** — each `test()` must work in isolation. No reliance on
+  ordering between tests within a describe.
+- **No shared mutable state** — if a test creates data, give it a unique
+  identifier (`pet-${Date.now()}`) or clean up in `afterEach`.
+- **No real-world dependencies** — never hit production APIs, Stripe live, real
+  email providers. The local stack is the contract.
+- **`fullyParallel: true`** is set — tests in the same file run sequentially but
+  files run in parallel. Plan seed data accordingly.
+
+## When NOT to write an e2e
+
+E2E tests are expensive — slow, flaky-prone, hard to debug. Prefer:
+
+| Pre-flight | Type |
+|------------|------|
+| Service business logic | Backend Vitest (`backend-test` skill) |
+| Component rendering / interaction | Frontend Vitest + RTL (`frontend-test` skill) |
+| API contract | Backend route test + supertest |
+| Cross-app or auth-state journey | E2E |
+| Real CSRF / cookie / proxy flow | E2E |
+
+A failing e2e should usually indicate a missing cheaper test, not the only test.
+
+## Common mistakes
+
+- Importing `test` from `@playwright/test` instead of `../../fixtures` → loses
+  the auth fixtures and CSRF helpers
+- Logging in by driving the login form → slow, flaky. Use `apiAs` / role-based
+  storage states
+- CSS / data-testid selectors when a role/label would work
+- `page.waitForTimeout()` instead of waiting on a UI state
+- Test relies on a record created in a previous test → atomic test rule violated
+- Hitting live external services
+- Snapshotting full pages — every minor copy change breaks the test
+- Forgetting to seed via API before driving UI — slow setup
+- Writing an e2e for logic that a backend service test would cover

--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: error-handling
+description: >
+  Backend error class hierarchy and how errors propagate through routes. Apply when
+  throwing errors from services, writing controllers, or implementing middleware
+  that needs to signal HTTP status codes.
+---
+
+# Backend Error Handling
+
+The backend has a single error-handler middleware (`src/middleware/error-handler.ts`)
+that translates thrown errors into HTTP responses. Services and controllers throw —
+they never write status codes themselves.
+
+## The error class hierarchy
+
+```
+Error
+└── ApiError(statusCode, message)
+    ├── BadRequestError       400
+    ├── UnauthorizedError     401
+    ├── ForbiddenError        403
+    ├── NotFoundError         404
+    ├── ConflictError         409
+    └── UnprocessableError    422
+```
+
+All defined in `src/middleware/error-handler.ts`. Import from there:
+
+```typescript
+import {
+  BadRequestError,
+  NotFoundError,
+  ConflictError,
+  ForbiddenError,
+  UnprocessableError,
+} from '../middleware/error-handler';
+```
+
+## When to use each
+
+| Class | Status | Meaning |
+|-------|--------|---------|
+| `BadRequestError` | 400 | Request is malformed in a way the client can fix (other than schema validation — Zod handles 422 for that) |
+| `UnauthorizedError` | 401 | Caller is not authenticated. Usually emitted by auth middleware, rarely by services |
+| `ForbiddenError` | 403 | Caller is authenticated but not allowed (RBAC denial, ownership mismatch) |
+| `NotFoundError` | 404 | Resource doesn't exist or is hidden from this caller |
+| `ConflictError` | 409 | Operation conflicts with current state (duplicate key, already-approved application) |
+| `UnprocessableError` | 422 | Well-formed request, semantically invalid (failed business rule). Also the status the Zod validator emits for schema failures |
+
+When in doubt: 404 for "missing", 403 for "forbidden", 409 for "already exists", 422
+for "rule violated", 400 for "garbled input".
+
+## Pattern: throw from the service
+
+```typescript
+import { NotFoundError, ConflictError } from '../middleware/error-handler';
+
+export class PetService {
+  static async getById(petId: string): Promise<Pet> {
+    const pet = await Pet.findByPk(petId);
+    if (!pet) {
+      throw new NotFoundError('Pet not found');
+    }
+    return pet;
+  }
+
+  static async create(payload: CreatePetRequest): Promise<Pet> {
+    const existing = await Pet.findOne({ where: { microchipId: payload.microchipId } });
+    if (existing) {
+      throw new ConflictError('A pet with this microchip is already registered');
+    }
+    return Pet.create(payload);
+  }
+}
+```
+
+## Pattern: no try/catch in controllers
+
+Controllers are thin. Express forwards thrown errors to the error middleware
+automatically (Express 5 catches async rejections; Express 4 needs `express-async-errors`
+which is already wired here).
+
+```typescript
+// GOOD — let it propagate
+static async getById(req: Request, res: Response) {
+  const pet = await PetService.getById(req.params.petId);
+  return res.status(200).json({ data: pet });
+}
+
+// BAD — translation belongs in middleware
+static async getById(req: Request, res: Response) {
+  try {
+    const pet = await PetService.getById(req.params.petId);
+    return res.status(200).json({ data: pet });
+  } catch (err) {
+    if (err.message === 'Pet not found') {
+      return res.status(404).json({ error: err.message });   // ← duplicates middleware
+    }
+    return res.status(500).json({ error: 'Server error' });   // ← swallows the stack
+  }
+}
+```
+
+The only time a controller catches is to **enrich** before re-throwing:
+
+```typescript
+try {
+  return await PetService.transfer(...);
+} catch (err) {
+  if (err instanceof ConflictError) {
+    throw new ConflictError(`Transfer failed: ${err.message} (petId: ${petId})`);
+  }
+  throw err;
+}
+```
+
+## Response shape the middleware emits
+
+```json
+{
+  "status": "error",
+  "message": "Pet not found",
+  "code": 404
+}
+```
+
+(`stack` is included when `NODE_ENV=development`.)
+
+Frontend consumers should read `message` and `code`. The api-fetch skill describes
+how `apiService` surfaces these.
+
+## Sequelize errors
+
+The error handler unwraps a few common Sequelize errors automatically:
+
+- `UniqueConstraintError` → 409 with the field name
+- `ValidationError` → 422 with the field details
+- Other `BaseError` → 500 (treat as a bug)
+
+This means services usually don't need to translate Sequelize errors — let them
+propagate. Only catch when you want to swap the message for something user-friendly.
+
+## Auth middleware errors
+
+`authenticateToken` throws `UnauthorizedError`. `requirePermission`,
+`requireRole`, `requirePermissionOrOwnership` respond with 403 directly (they don't
+throw because they need to log the denial with request context first). Don't
+re-implement that pattern — call the existing middleware.
+
+## Logging vs throwing
+
+Always do both for serious errors — log with context, then throw:
+
+```typescript
+import { logger } from '../utils/logger';
+
+if (!staff || staff.rescueId !== pet.rescueId) {
+  logger.warn('Unauthorized pet access attempt', {
+    callerUserId,
+    callerRescueId: staff?.rescueId,
+    petRescueId: pet.rescueId,
+  });
+  throw new ForbiddenError('Access denied: pet belongs to another rescue');
+}
+```
+
+For audit-worthy authorisation denials, also write an audit row — see the
+`audit-logging` skill.
+
+## Tests
+
+Assert on the error TYPE (so call sites can branch reliably), not on the message
+string (messages change with copy edits):
+
+```typescript
+import { NotFoundError } from '../../middleware/error-handler';
+
+await expect(PetService.getById('missing'))
+  .rejects.toBeInstanceOf(NotFoundError);
+```
+
+## Common mistakes
+
+- `throw new Error('Not found')` — loses the 404, middleware returns 500
+- `res.status(400).json(...)` inside a service — services have no `res`. Throw instead.
+- `try/catch` in a controller that returns `{ error }` — duplicates the middleware
+  and breaks the consistent response shape
+- Throwing `BadRequestError` for schema validation failures — Zod's `validateBody`
+  already emits 422. Use `BadRequestError` for semantic-but-not-schema problems
+- Throwing `ForbiddenError` from a service when you meant `UnauthorizedError` —
+  401 = "who are you?", 403 = "I know you, you can't do this"
+- Swallowing errors with `catch { /* ignore */ }` — every catch should either
+  re-throw, throw a new typed error, or do meaningful recovery

--- a/.claude/skills/feature-flags/SKILL.md
+++ b/.claude/skills/feature-flags/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: feature-flags
+description: >
+  How to gate code with Statsig feature flags via lib.feature-flags. Apply when
+  introducing a new feature toggle, A/B test, reading a dynamic config value,
+  or working with useFeatureGate / useDynamicConfig / useConfigValue.
+---
+
+# Feature Flags (Statsig via lib.feature-flags)
+
+Feature flags are managed through **Statsig**, accessed via
+`@adopt-dont-shop/lib.feature-flags`. The library wraps Statsig's SDK with typed
+hooks and a list of known gates/configs.
+
+The backend-managed feature flag system was removed — Statsig is the only path.
+
+## The three hooks
+
+| Hook | Returns | Use when |
+|------|---------|----------|
+| `useFeatureGate(name)` | boolean | Simple on/off toggle |
+| `useDynamicConfig(name)` | full config object | You need multiple values from one config |
+| `useConfigValue(name, key, fallback)` | a single value | You only need one value from a config |
+
+```typescript
+import {
+  useFeatureGate,
+  useConfigValue,
+  KNOWN_GATES,
+  KNOWN_CONFIGS,
+} from '@adopt-dont-shop/lib.feature-flags';
+
+const NewPetSearch = () => {
+  const isEnabled = useFeatureGate(KNOWN_GATES.NEW_PET_SEARCH);
+  const maxResults = useConfigValue(
+    KNOWN_CONFIGS.PET_SEARCH_CONFIG,
+    'maxResults',
+    20
+  );
+
+  if (!isEnabled) return <LegacyPetSearch />;
+  return <PetSearchV2 maxResults={maxResults} />;
+};
+```
+
+## Use the constants, not string literals
+
+`KNOWN_GATES` and `KNOWN_CONFIGS` are the source of truth for what's currently
+deployed. Using them gives type safety + autocomplete:
+
+```typescript
+// GOOD — typo here is a compile error
+useFeatureGate(KNOWN_GATES.NEW_PET_SEARCH);
+
+// BAD — silently returns false if the gate name is misspelled
+useFeatureGate('new-pet-serach');
+```
+
+When adding a new gate or config:
+
+1. Define it in Statsig first
+2. Add it to `KNOWN_GATES` / `KNOWN_CONFIGS` in
+   `lib.feature-flags/src/types/index.ts`
+3. Rebuild: `cd lib.feature-flags && npm run build` (or rely on the Vite alias
+   in dev — see the `new-lib` skill)
+
+## Flag patterns
+
+### Simple toggle
+
+```typescript
+const showNewBanner = useFeatureGate(KNOWN_GATES.NEW_DASHBOARD_BANNER);
+return showNewBanner ? <NewBanner /> : null;
+```
+
+### A/B variant
+
+```typescript
+const variant = useConfigValue(KNOWN_CONFIGS.SIGNUP_FLOW, 'variant', 'control');
+
+switch (variant) {
+  case 'control': return <SignupControl />;
+  case 'simplified': return <SignupSimplified />;
+  case 'with-onboarding': return <SignupOnboarding />;
+  default: return <SignupControl />;
+}
+```
+
+The fallback is critical — if Statsig is unreachable, the user sees the safe
+default, not a blank screen.
+
+### Gated route
+
+```typescript
+import { Navigate } from 'react-router-dom';
+
+const ReportsRoute = () => {
+  const enabled = useFeatureGate(KNOWN_GATES.REPORTS_V2);
+  if (!enabled) return <Navigate to="/dashboard" replace />;
+  return <ReportsV2Page />;
+};
+```
+
+### Gated server call
+
+Don't roll your own backend gate — pass the flag to the API and let the backend
+decide:
+
+```typescript
+const includeBeta = useFeatureGate(KNOWN_GATES.PET_SEARCH_BETA_FILTERS);
+const { data } = usePets({ ...filters, beta: includeBeta });
+```
+
+The backend should accept the parameter and act on it. Backend code MUST NOT
+re-check Statsig — only the frontend evaluates user-targeted gates.
+
+## Loading state
+
+Statsig evaluates client-side after a roundtrip. Until the SDK is ready, every
+gate returns `false`. For most UI this is fine — the safe default renders, then
+flips when the SDK loads.
+
+If you need to wait for SDK readiness, the provider exposes a `useStatsigReady`
+hook (or similar — check the lib API). Use it sparingly; gating the whole app
+on Statsig readiness adds a perceptible delay.
+
+## Fallback safety
+
+Every flag check needs a safe default. Ask: "if Statsig is down, what should
+the user see?" — usually the existing behaviour, not the new one.
+
+```typescript
+// GOOD — feature is off when SDK is down or slow
+const showExperimental = useFeatureGate(KNOWN_GATES.EXPERIMENTAL_FEATURE);
+return showExperimental ? <Experimental /> : <Stable />;
+
+// BAD — defaulting to "on" means a Statsig outage shows experimental UI to all
+const hideExperimental = useFeatureGate(KNOWN_GATES.HIDE_EXPERIMENTAL_FEATURE);
+return hideExperimental ? <Stable /> : <Experimental />;
+```
+
+Frame gates as "show the new thing" not "hide the new thing" — the false default
+is safer.
+
+## Don't gate forever
+
+Feature flags are temporary. Once a feature is fully rolled out:
+
+1. Remove the gate from the code
+2. Delete the entry from `KNOWN_GATES`
+3. Archive the gate in Statsig
+
+Leaving flags around indefinitely creates dead code paths, confuses developers,
+and the underlying code drifts from the gated branch.
+
+## What NOT to flag
+
+- Permission/auth decisions — those are RBAC, not feature flags
+- Schema/validation rules — those are versioned, not flagged
+- Hotfix toggles — those should be config, not flags
+- Anything that needs server-side enforcement — flags are advisory, not security
+
+If a user shouldn't be able to do something, the backend RBAC must enforce it
+(see the `permissions-frontend` and field-permissions skills). A frontend flag
+is bypassable.
+
+## Testing flagged code
+
+Mock the hook in tests:
+
+```typescript
+vi.mock('@adopt-dont-shop/lib.feature-flags', () => ({
+  useFeatureGate: vi.fn(),
+  KNOWN_GATES: { NEW_PET_SEARCH: 'new_pet_search' },
+}));
+
+import { useFeatureGate } from '@adopt-dont-shop/lib.feature-flags';
+
+it('renders legacy when flag off', () => {
+  vi.mocked(useFeatureGate).mockReturnValue(false);
+  renderWithProviders(<PetSearchEntry />);
+  expect(screen.getByTestId('legacy-search')).toBeInTheDocument();
+});
+
+it('renders v2 when flag on', () => {
+  vi.mocked(useFeatureGate).mockReturnValue(true);
+  renderWithProviders(<PetSearchEntry />);
+  expect(screen.getByTestId('search-v2')).toBeInTheDocument();
+});
+```
+
+Test both branches — that's the entire point of the flag.
+
+## Common mistakes
+
+- String-literal flag names (`useFeatureGate('foo')`) → typo silently returns false
+- No fallback value on `useConfigValue` → undefined breaks downstream consumers
+- Defaulting to the new behaviour when Statsig is down → outage = experimental
+  UI for everyone
+- Backend re-evaluating the same gate → either source-of-truth ambiguity or a
+  redundant SDK call. Frontend evaluates, server accepts a parameter.
+- Flag left in code after full rollout → dead code, confused readers
+- Using flags for permission gates → bypassable, use RBAC instead
+- Testing only the "flag on" branch — the off branch is the rollback path, test it

--- a/.claude/skills/forms/SKILL.md
+++ b/.claude/skills/forms/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: forms
+description: >
+  Patterns for building forms in the React apps. Apply when adding form inputs,
+  validation, submission handlers, error display, or multi-step flows. Covers Zod
+  schemas, FormField from lib.components, apiService submission, and accessibility.
+---
+
+# Forms
+
+Forms in this project follow a consistent stack:
+
+- **Schema** — Zod (shared with the backend via `lib.validation` where possible)
+- **Inputs** — components from `lib.components/src/components/form/` (`TextInput`,
+  `SelectInput`, `CheckboxInput`, `DateInput`, `TextArea`, `FileUpload`, etc.) wrapped
+  in `<FormField>` for label + error wiring
+- **Submission** — through `apiService` (see `api-fetch` skill)
+- **Server state** — via React Query `useMutation` (see `react-query` skill)
+
+## The full pattern
+
+```typescript
+import { z } from 'zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  FormField,
+  TextInput,
+  SelectInput,
+  CheckboxInput,
+  Button,
+  toast,
+} from '@adopt-dont-shop/lib.components';
+import { useState } from 'react';
+import { petService } from '../services/petService';
+
+const CreatePetFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(120),
+  species: z.enum(['dog', 'cat', 'rabbit']),
+  ageYears: z.coerce.number().int().min(0).max(30),
+  fostered: z.boolean().default(false),
+});
+
+type CreatePetForm = z.infer<typeof CreatePetFormSchema>;
+
+export const CreatePetForm = ({ onSuccess }: { onSuccess: () => void }) => {
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<Partial<CreatePetForm>>({});
+  const [errors, setErrors] = useState<Partial<Record<keyof CreatePetForm, string>>>({});
+
+  const mutation = useMutation({
+    mutationFn: (payload: CreatePetForm) => petService.create(payload),
+    onSuccess: () => {
+      toast.success('Pet created');
+      queryClient.invalidateQueries({ queryKey: ['pets'] });
+      onSuccess();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message ?? 'Failed to create pet');
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const parsed = CreatePetFormSchema.safeParse(values);
+    if (!parsed.success) {
+      setErrors(formatZodErrors(parsed.error));
+      return;
+    }
+    setErrors({});
+    mutation.mutate(parsed.data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      <FormField label="Name" htmlFor="pet-name" required error={errors.name}>
+        <TextInput
+          id="pet-name"
+          value={values.name ?? ''}
+          onChange={e => setValues(v => ({ ...v, name: e.target.value }))}
+          aria-invalid={!!errors.name}
+        />
+      </FormField>
+
+      <FormField label="Species" htmlFor="pet-species" required error={errors.species}>
+        <SelectInput
+          id="pet-species"
+          value={values.species ?? ''}
+          onChange={e => setValues(v => ({ ...v, species: e.target.value as CreatePetForm['species'] }))}
+          options={[
+            { value: 'dog', label: 'Dog' },
+            { value: 'cat', label: 'Cat' },
+            { value: 'rabbit', label: 'Rabbit' },
+          ]}
+        />
+      </FormField>
+
+      <Button type="submit" disabled={mutation.isPending}>
+        {mutation.isPending ? 'Saving…' : 'Create pet'}
+      </Button>
+    </form>
+  );
+};
+```
+
+## Step-by-step
+
+### 1. Define the schema (Zod)
+
+Keep the schema next to the form, or import from `lib.validation` if the backend
+uses the same shape. Schema-first means the type is derived (`z.infer`) so the
+form and the API contract can't drift.
+
+```typescript
+const FormSchema = z.object({
+  email: z.string().email(),
+  phone: z.string().regex(/^0\d{4} \d{3} \d{4}$/, 'Use UK format: 0XXXX XXX XXX'),
+});
+
+type FormValues = z.infer<typeof FormSchema>;
+```
+
+### 2. Validate on submit, not on every keystroke
+
+Per-keystroke validation creates jittery error messages. Validate on submit and
+clear an individual error when the user edits that field:
+
+```typescript
+const handleChange = (field: keyof FormValues) => (e: React.ChangeEvent<HTMLInputElement>) => {
+  setValues(v => ({ ...v, [field]: e.target.value }));
+  if (errors[field]) {
+    setErrors(prev => ({ ...prev, [field]: undefined }));
+  }
+};
+```
+
+Onblur validation per field is acceptable for fields with expensive checks
+(postcode lookup, email-exists). Keep it consistent within a form.
+
+### 3. Use `FormField` for label + error + required marker
+
+`FormField` from `lib.components` handles:
+
+- Rendering the `<label htmlFor>` correctly
+- Showing the `required` asterisk
+- Slotting an error message with `aria-describedby` wired up
+- Spacing between fields
+
+Don't reproduce its scaffolding manually — you'll miss an a11y detail.
+
+### 4. Submit via apiService through a service module
+
+Forms call a service method (`petService.create`), never `fetch`/`axios` directly.
+Server state changes flow through React Query mutations:
+
+```typescript
+const mutation = useMutation({
+  mutationFn: petService.create,
+  onSuccess: data => {
+    queryClient.invalidateQueries({ queryKey: ['pets'] });
+    onClose();
+  },
+});
+```
+
+See the `api-fetch` and `react-query` skills.
+
+### 5. Surface errors accessibly
+
+Per the `accessibility` skill, every error must:
+- Be linked to its input via `aria-describedby`
+- Set `aria-invalid="true"` on the input
+- Be announced — `FormField` handles this via `role="alert"` on the error slot
+
+Top-of-form summary errors (network failures, server-side validation) live in
+an `aria-live="polite"` region or a toast. The project uses `toast` from
+`lib.components`:
+
+```typescript
+import { toast } from '@adopt-dont-shop/lib.components';
+toast.error('Submission failed — please try again');
+```
+
+### 6. Disable submit while pending
+
+```typescript
+<Button type="submit" disabled={mutation.isPending}>
+  {mutation.isPending ? 'Saving…' : 'Save'}
+</Button>
+```
+
+Prevents double-submits. Don't `setDisabled(true)` manually — derive from the
+mutation state.
+
+## UK-locale fields
+
+For UK-specific inputs (postcode, phone, address), use the formatters and
+validators from `lib.utils`. See the `uk-localization` skill for the full list.
+
+```typescript
+import { validatePostcode, formatPhoneNumber } from '@adopt-dont-shop/lib.utils';
+
+const PostcodeSchema = z.string().refine(validatePostcode, 'Invalid UK postcode');
+```
+
+## File uploads
+
+Use `FileUpload` from `lib.components/src/components/form/FileUpload`. It handles:
+- Drag-and-drop
+- File type filtering
+- Size limits
+- Multi-file accumulation
+
+```typescript
+<FormField label="Documents" htmlFor="docs">
+  <FileUpload
+    id="docs"
+    accept="application/pdf,image/*"
+    maxSizeBytes={5 * 1024 * 1024}
+    onFilesAdded={files => setValues(v => ({ ...v, docs: files }))}
+  />
+</FormField>
+```
+
+The backend upload guard checks MIME types again — see `enforceUploadMime`
+middleware. Don't rely on frontend filtering alone for security.
+
+## Multi-step forms
+
+For long flows (rescue onboarding, adoption applications), break the form into
+steps with `<FormSection>` and a wizard wrapper that:
+
+1. Keeps all answers in a single state object
+2. Validates each step's slice of the schema on "Next"
+3. Submits the full payload only on the final step
+4. Persists draft state via the relevant draft service if the user might leave
+
+Example: `app.client/src/pages/AdoptionApplicationFlow.tsx` uses
+`ApplicationDraftService` to save progress.
+
+## Testing forms
+
+See the `frontend-test` skill. Key points:
+
+- Use `userEvent.setup()` for typing, not `fireEvent`
+- Query inputs by label: `screen.getByLabelText(/email/i)`
+- Submit by clicking the named button: `screen.getByRole('button', { name: /save/i })`
+- Assert errors appear: `await screen.findByText(/required/i)`
+
+```typescript
+import { renderWithProviders, screen } from '../test-utils';
+import userEvent from '@testing-library/user-event';
+
+it('rejects an empty submission', async () => {
+  const user = userEvent.setup();
+  renderWithProviders(<CreatePetForm onSuccess={vi.fn()} />);
+
+  await user.click(screen.getByRole('button', { name: /create pet/i }));
+  expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
+});
+```
+
+## Helpers
+
+A `formatZodErrors` utility flattens a `ZodError` into `{ [field]: message }`:
+
+```typescript
+const formatZodErrors = (error: z.ZodError) =>
+  Object.fromEntries(
+    error.errors.map(e => [e.path.join('.'), e.message])
+  );
+```
+
+Some apps already export this from `src/utils/`; check before redefining.
+
+## Common mistakes
+
+- Using `<input>` without a `<label>` (or `<FormField>`) — fails a11y
+- Validating on every keystroke — jittery UX, hostile to slow typers
+- Storing each field in its own `useState` — leads to stale-closure bugs.
+  One `values` object is simpler.
+- Submitting via raw `fetch` instead of through a service module
+- Manually disabling submit and forgetting to re-enable on failure — use
+  `mutation.isPending`
+- Putting validation errors as inline `<span style={{ color: 'red' }}>` — bypasses
+  the a11y wiring in `FormField` (see the `accessibility` and `design-tokens` skills)
+- Toasting on every keystroke validation error — only toast on submission failure
+- Not handling the loading state on submit → double-submits
+- Skipping the postcode/phone formatter for UK fields → inconsistent display
+  (see the `uk-localization` skill)

--- a/.claude/skills/frontend-test/SKILL.md
+++ b/.claude/skills/frontend-test/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: frontend-test
+description: >
+  Patterns for testing React apps (app.admin, app.client, app.rescue) with Vitest,
+  React Testing Library, and MSW. Apply when adding or modifying component, page,
+  hook, or context tests in any app.* package.
+---
+
+# Frontend Testing Patterns
+
+The frontend apps use **Vitest** (not Jest) + **React Testing Library** + **MSW** for
+API mocking. Each app has a `src/test-utils/` directory with the shared render helper.
+
+## The shared render helper
+
+Every test should use `renderWithProviders` from `src/test-utils/render.tsx`, never
+the raw `render` from `@testing-library/react`. It wires up:
+
+- `QueryClientProvider` with retries disabled
+- `MemoryRouter` (configurable `initialRoute`)
+- `ThemeProvider` from `lib.components`
+
+```typescript
+import { renderWithProviders, screen, fireEvent } from '../test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import { MyPage } from './MyPage';
+
+describe('MyPage', () => {
+  it('renders the heading', () => {
+    renderWithProviders(<MyPage />, { initialRoute: '/things' });
+    expect(screen.getByRole('heading', { name: /things/i })).toBeInTheDocument();
+  });
+});
+```
+
+Without this wrapper, components using `useQuery`, `useNavigate`, or theme tokens
+will throw at render. Bare `render(<MyPage />)` is wrong.
+
+## Query selectors — by accessibility, not by DOM
+
+Prefer queries in this order (matches the React Testing Library priority):
+
+1. `getByRole('button', { name: /save/i })` — semantic role + accessible name
+2. `getByLabelText(/email/i)` — for form inputs
+3. `getByPlaceholderText(...)` — when label isn't present
+4. `getByText(...)` — visible static text
+5. `getByDisplayValue(...)` — for input current value
+6. `getByTestId(...)` — last resort
+
+Don't query by class name, CSS selector, or DOM structure — these are implementation
+details and tests break on every refactor.
+
+```typescript
+// GOOD — survives styling changes
+fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+// BAD — coupled to implementation
+fireEvent.click(container.querySelector('.submit-btn'));
+```
+
+## Mocking `apiService`
+
+Frontend services wrap `apiService` (see the `api-fetch` skill). Mock the service
+module, not `apiService` itself:
+
+```typescript
+import { vi } from 'vitest';
+
+vi.mock('../services/petService', () => ({
+  petService: {
+    getAll: vi.fn().mockResolvedValue({ data: [] }),
+    create: vi.fn().mockResolvedValue({ data: { petId: 'p1' } }),
+  },
+}));
+
+import { petService } from '../services/petService';
+import { PetsPage } from './PetsPage';
+
+it('lists pets returned by the API', async () => {
+  vi.mocked(petService.getAll).mockResolvedValueOnce({
+    data: [{ petId: 'p1', name: 'Buddy', status: 'available' }],
+  });
+
+  renderWithProviders(<PetsPage />);
+  expect(await screen.findByText('Buddy')).toBeInTheDocument();
+});
+```
+
+`findBy*` queries wait for the element to appear (async); `getBy*` is synchronous.
+Use `findBy*` after any data-fetching trigger.
+
+## Mocking custom hooks
+
+When testing a page that uses a custom hook (e.g. `useInbox`), mock the hook
+module so you can drive its return value per test:
+
+```typescript
+const mockUseInbox = vi.fn();
+vi.mock('../hooks/useInbox', () => ({
+  useInbox: () => mockUseInbox(),
+}));
+
+beforeEach(() => {
+  mockUseInbox.mockReturnValue({ items: [], isLoading: false, error: null });
+});
+
+it('shows loading state', () => {
+  mockUseInbox.mockReturnValueOnce({ items: [], isLoading: true, error: null });
+  renderWithProviders(<InboxPage />);
+  expect(screen.getByRole('status')).toBeInTheDocument();
+});
+```
+
+## Testing hooks directly
+
+For hooks with real logic (not just data fetching), use `renderHook`:
+
+```typescript
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { usePets } from './usePets';
+
+const wrapper = ({ children }) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+it('returns pets from the service', async () => {
+  const { result } = renderHook(() => usePets(), { wrapper });
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  expect(result.current.data?.data).toHaveLength(2);
+});
+```
+
+## MSW for network-layer mocks
+
+For integration tests that exercise multiple components fetching real network
+calls, use MSW handlers from `src/test-utils/msw-handlers.ts` instead of mocking
+each service. MSW intercepts `fetch`/`axios` at the network boundary:
+
+```typescript
+import { http, HttpResponse } from 'msw';
+import { server } from '../test-utils/msw-server';
+
+it('handles a 500 from the API', async () => {
+  server.use(
+    http.get('/api/v1/pets', () => HttpResponse.json({ error: 'Server error' }, { status: 500 }))
+  );
+  renderWithProviders(<PetsPage />);
+  expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+});
+```
+
+Use service mocks for unit-style tests, MSW for integration tests.
+
+## User events
+
+`fireEvent` is fine for simple clicks. For realistic user input (typing, tabbing,
+keyboard nav), use `@testing-library/user-event`:
+
+```typescript
+import userEvent from '@testing-library/user-event';
+
+it('submits when Enter is pressed', async () => {
+  const user = userEvent.setup();
+  renderWithProviders(<SearchForm />);
+  await user.type(screen.getByLabelText(/search/i), 'border collie{Enter}');
+  expect(screen.getByText('Results for "border collie"')).toBeInTheDocument();
+});
+```
+
+## Async expectations
+
+Always `await` async assertions:
+
+```typescript
+// GOOD
+expect(await screen.findByText('Saved')).toBeInTheDocument();
+
+// BAD — flaky, the element may not have appeared yet
+expect(screen.getByText('Saved')).toBeInTheDocument();
+```
+
+For absence: use `waitForElementToBeRemoved` or `queryBy*` + `waitFor`:
+
+```typescript
+await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+```
+
+## TypeScript rules apply
+
+- No `any` — use `vi.MockedFunction<typeof fn>` for typed mocks
+- No `as` assertions on test data — declare it with the real type
+- Strict mode is on; tests must compile cleanly
+
+## What NOT to test
+
+- CSS class names or vanilla-extract output — that's a snapshot of styling
+- Internal component state (`useState` values) — observable behaviour only
+- That `apiService.get` was called — test the resulting UI
+
+## Common mistakes
+
+- Using raw `render` instead of `renderWithProviders` → missing context/router
+- `jest.fn()` / `jest.mock()` → wrong framework, use `vi.fn()` / `vi.mock()`
+- `getByText` for an async element → use `findByText`
+- Asserting on class names (`.submit-button`) → coupled to implementation
+- Forgetting to mock the network → tests hit real endpoints, fail in CI
+- Not awaiting `userEvent` actions — they're async since v14
+- Sharing a `QueryClient` across tests → cached responses leak between cases

--- a/.claude/skills/permissions-frontend/SKILL.md
+++ b/.claude/skills/permissions-frontend/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: permissions-frontend
+description: >
+  How to gate UI by user role, permission, or field-level access in React apps.
+  Apply when conditionally rendering admin-only controls, role-gated routes,
+  rescue staff features, or fields hidden by the field-permissions system.
+---
+
+# Frontend Permissions
+
+The frontend has three permission layers, each with a clear job:
+
+| Layer | Purpose | Source |
+|-------|---------|--------|
+| **Role gates** | Coarse: is this user an admin / rescue staff / adopter? | `useAuth()` → `user.userType` |
+| **Permission gates** | Fine: does this user have permission X? | `lib.permissions` `PermissionsService` |
+| **Field gates** | Per-field read/write access by role + resource | `lib.permissions` `FieldPermissionsService` (see `field-permissions` skill) |
+
+**Critical rule:** frontend permission checks are UX, not security. The backend
+enforces every permission on every request. Never use a frontend check as the
+only barrier to a sensitive action.
+
+## Role gates (the simplest case)
+
+```typescript
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+
+const Settings = () => {
+  const { user } = useAuth();
+
+  if (user?.userType !== 'admin') {
+    return <Unauthorized />;
+  }
+
+  return <AdminSettings />;
+};
+```
+
+For route-level role guards, use the route wrapper (e.g.
+`<ProtectedRoute roles={['admin']}>`) defined in each app's router config rather
+than inlining the check on every page.
+
+## Permission gates
+
+`lib.permissions` exports `PermissionsService` with check helpers. The user's
+permission set is loaded once on auth and cached. Use it from a hook:
+
+```typescript
+import { useAuth } from '@adopt-dont-shop/lib.auth';
+import { PermissionsService } from '@adopt-dont-shop/lib.permissions';
+
+const usePermission = (permission: string) => {
+  const { user } = useAuth();
+  if (!user) return false;
+  return PermissionsService.userHasPermission(user, permission);
+};
+
+// In a component
+const canSuspend = usePermission('user.suspend');
+
+{canSuspend && <SuspendButton userId={userId} />}
+```
+
+Use constants for permission strings, not inline literals — `lib.permissions`
+exports `PERMISSIONS.USER_SUSPEND` etc. so typos don't slip through.
+
+## Field gates
+
+Use `FieldPermissionsService` when rendering a form or a profile view that
+exposes fields whose access depends on role. The service merges defaults +
+DB overrides + the sensitive denylist (see `field-permissions` skill).
+
+```typescript
+import { FieldPermissionsService } from '@adopt-dont-shop/lib.permissions';
+
+const PetForm = ({ pet }: { pet: Pet }) => {
+  const { user } = useAuth();
+  const access = FieldPermissionsService.getEffectiveAccessMap('pets', user!.userType);
+
+  return (
+    <form>
+      {access.name === 'write' && <TextInput name="name" defaultValue={pet.name} />}
+      {access.name === 'read' && <ReadOnlyField label="Name" value={pet.name} />}
+
+      {access.medical_notes === 'write' && (
+        <TextArea name="medical_notes" defaultValue={pet.medical_notes} />
+      )}
+      {/* access.medical_notes === 'none' → don't render at all */}
+    </form>
+  );
+};
+```
+
+The service caches the access map for 60s. Don't recompute it inside a render
+loop — pull it once at the top of the component.
+
+## What the access levels mean
+
+| Level | UI behaviour |
+|-------|--------------|
+| `write` | Render as an editable input |
+| `read` | Render as read-only (label + value) |
+| `none` | Don't render the field at all (not even disabled — hide entirely) |
+
+`none` means the backend will strip the field from the response too (see the
+`field-permissions` skill), so the value won't be present even if you tried to
+render it.
+
+## Combining gates
+
+Order from cheapest to most expensive:
+
+```typescript
+if (!isAuthenticated) return <SignIn />;
+if (user.userType !== 'admin') return <Unauthorized />;
+if (!usePermission('reports.export')) return <Unauthorized />;
+// ... render the admin reports page
+```
+
+Don't chain unrelated checks — if a check returns false, render the appropriate
+state and stop. Don't blank-screen because two flags don't align.
+
+## Gating actions, not just views
+
+Hide controls the user can't invoke. If a user lacks `pet.delete`, don't render
+the delete button. Disabled-but-visible is acceptable when:
+- The button is part of a primary toolbar that would feel broken if missing
+- The disabled state communicates *why* via tooltip / aria-describedby
+
+```typescript
+{canDelete ? (
+  <DangerButton onClick={onDelete}>Delete</DangerButton>
+) : (
+  <DangerButton disabled aria-describedby="delete-disabled-reason">Delete</DangerButton>
+)}
+<span id="delete-disabled-reason" className="sr-only">
+  You don't have permission to delete pets.
+</span>
+```
+
+Most of the time, just hide.
+
+## Empty states for restricted users
+
+If a whole page or section has zero permitted content, show an explanation, not
+a blank screen:
+
+```typescript
+const { data: pets } = usePets();
+const visiblePets = pets?.data.filter(p => canRead(p)) ?? [];
+
+if (visiblePets.length === 0) {
+  return <EmptyState title="No pets" message="You don't have access to any pets in this rescue." />;
+}
+```
+
+## Always assume the backend will reject
+
+Frontend gates are UX hints. The backend re-checks:
+
+- Auth on every request (`authenticateToken`)
+- RBAC on every route (`requirePermission`)
+- Field-level read masking (`fieldMask`) and write rejection (`fieldWriteGuard`)
+
+So a malicious user bypassing the frontend can't escalate. **Your job is making
+the UI not show them buttons that would 403.**
+
+## Testing permission gates
+
+In Vitest tests, mock `useAuth` to drive different roles:
+
+```typescript
+vi.mock('@adopt-dont-shop/lib.auth', () => ({
+  useAuth: () => ({
+    user: { userId: 'u1', userType: 'admin' },
+    isAuthenticated: true,
+  }),
+}));
+```
+
+Test the matrix that matters: admin sees the control, adopter doesn't. Don't
+write 10 permutations — one positive and one negative per gate is enough.
+
+For field permissions, `lib.permissions/src/test-utils/` provides helpers for
+building synthetic access maps in tests.
+
+## Common mistakes
+
+- Treating frontend gates as security — they're UX. Backend is the gate.
+- Hardcoding role strings (`'admin'`) instead of using `UserType.ADMIN` exports
+- Re-computing the field access map on every render → 60s cache helps but still
+  unnecessary work. Lift it to the top of the component
+- Showing a disabled "Delete" button to a user who can't see deletion exists at
+  all — that's noise, just hide
+- Forgetting that field access `none` means the value is also stripped on the
+  wire → don't try to fall back to it
+- Inconsistent gates between list view and detail view — user sees the row but
+  can't open it. Decide once and apply everywhere.
+- Adding new permission strings without checking `PERMISSIONS.*` constants

--- a/.claude/skills/react-query/SKILL.md
+++ b/.claude/skills/react-query/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: react-query
+description: >
+  TanStack Query (React Query) patterns for server state. Apply when adding or
+  modifying custom hooks that fetch, mutate, or cache data; when wiring optimistic
+  updates; or when working with query keys, invalidation, or stale times.
+---
+
+# React Query (TanStack Query) Patterns
+
+The apps use React Query for ALL server state. Local UI state is `useState`,
+shared UI state is React Context, server state is React Query. Don't mix them.
+
+`QueryClient` is set up in each app's `main.tsx`. Custom hooks wrap `useQuery` /
+`useMutation` and live in `app.*/src/hooks/`.
+
+## Query keys
+
+Keys are arrays. Convention: `[entity, filters?]`.
+
+```typescript
+['pets']                          // list of pets
+['pets', filters]                 // filtered list
+['pets', { id: petId }]           // single pet
+['pets', petId, 'comments']       // nested resource
+```
+
+Identical keys share a cache entry. Use plain objects/arrays — React Query does
+structural equality, so `{ status: 'active' }` and `{ status: 'active' }` match.
+
+## Basic query hook
+
+```typescript
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { petService, type PetFilters } from '../services/petService';
+
+export const usePets = (filters: PetFilters = {}) =>
+  useQuery({
+    queryKey: ['pets', filters],
+    queryFn: () => petService.getAll(filters),
+    placeholderData: keepPreviousData,    // avoid blank flash on filter change
+    staleTime: 30_000,                    // 30s before refetch
+  });
+```
+
+| Option | When to use |
+|--------|-------------|
+| `staleTime` | How long data is "fresh". Set per-query based on volatility. Default 0 (always stale). |
+| `gcTime` | How long to keep unused data cached (was `cacheTime` in v4). Default 5min. |
+| `placeholderData: keepPreviousData` | For paginated/filtered lists — keeps the old data visible while the new query loads |
+| `enabled: boolean` | Conditionally run the query. E.g. `enabled: !!userId` skips until userId exists |
+| `select` | Transform/narrow data before returning — derived data without recomputing |
+| `refetchInterval` | Polling. Use sparingly — prefer WebSocket or invalidation. |
+
+## Service module pattern
+
+The hook calls a service module (which uses `apiService` — see `api-fetch`):
+
+```typescript
+// services/petService.ts
+import { apiService } from './libraryServices';
+import type { Pet, PetFilters } from '../types/pet';
+
+export const petService = {
+  getAll: (filters: PetFilters) =>
+    apiService.get<{ data: Pet[] }>('/api/v1/pets', { params: filters }),
+  getById: (petId: string) =>
+    apiService.get<{ data: Pet }>(`/api/v1/pets/${petId}`),
+  create: (payload: CreatePetPayload) =>
+    apiService.post<{ data: Pet }>('/api/v1/pets', payload),
+};
+```
+
+Don't call `useQuery` from a component directly — wrap in a hook so the key
+naming and service binding stay consistent.
+
+## Mutations
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useCreatePet = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreatePetPayload) => petService.create(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pets'] });
+    },
+  });
+};
+```
+
+In the component:
+
+```typescript
+const createPet = useCreatePet();
+
+const handleSubmit = (data: CreatePetPayload) => {
+  createPet.mutate(data, {
+    onSuccess: () => navigate('/pets'),
+    onError: err => toast.error(err.message),
+  });
+};
+
+<Button disabled={createPet.isPending}>...</Button>
+```
+
+## Invalidation
+
+After a mutation, invalidate the queries that depend on the changed data.
+`invalidateQueries` with a prefix invalidates all matching keys:
+
+```typescript
+// Invalidates ['pets'], ['pets', filters], ['pets', petId, ...]
+queryClient.invalidateQueries({ queryKey: ['pets'] });
+
+// More targeted — only the single-pet query
+queryClient.invalidateQueries({ queryKey: ['pets', petId] });
+```
+
+Be precise when you can. Invalidating `['pets']` after editing a single pet's
+description re-fetches every paginated page — wasteful.
+
+## Optimistic updates
+
+For instant UI feedback on mutations:
+
+```typescript
+export const useTogglePetFavourite = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ petId, favourite }: { petId: string; favourite: boolean }) =>
+      petService.setFavourite(petId, favourite),
+
+    onMutate: async ({ petId, favourite }) => {
+      await queryClient.cancelQueries({ queryKey: ['pets', petId] });
+      const previous = queryClient.getQueryData<{ data: Pet }>(['pets', petId]);
+
+      queryClient.setQueryData<{ data: Pet }>(['pets', petId], old =>
+        old ? { ...old, data: { ...old.data, favourite } } : old
+      );
+
+      return { previous };
+    },
+
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['pets', context!.previous]);
+      }
+    },
+
+    onSettled: (_data, _err, { petId }) => {
+      queryClient.invalidateQueries({ queryKey: ['pets', petId] });
+    },
+  });
+};
+```
+
+The four hooks:
+- `onMutate` — snapshot + apply optimistic value
+- `onError` — roll back to snapshot
+- `onSuccess` — usually empty (server already confirmed)
+- `onSettled` — invalidate to reconcile with the server
+
+## Pagination
+
+For paginated lists, use `keepPreviousData` so the old page stays visible while
+the new one loads:
+
+```typescript
+const filters = { page, limit: 20, status: 'available' };
+const { data, isFetching } = useQuery({
+  queryKey: ['pets', filters],
+  queryFn: () => petService.getAll(filters),
+  placeholderData: keepPreviousData,
+});
+```
+
+For "load more" lists, use `useInfiniteQuery` instead.
+
+## Auth-gated queries
+
+Queries that need an authenticated user should be conditional on auth state:
+
+```typescript
+const { user, isAuthenticated } = useAuth();
+const { data } = useQuery({
+  queryKey: ['profile', user?.userId],
+  queryFn: () => userService.getProfile(user!.userId),
+  enabled: isAuthenticated && !!user?.userId,
+});
+```
+
+The `enabled` flag prevents an unauthenticated request firing before the auth
+context is ready, which would cause a 401 retry storm.
+
+## Testing
+
+Per the `frontend-test` skill: use `renderWithProviders` (which provides a fresh
+`QueryClient` per test with retries disabled). For testing hooks directly,
+construct a wrapper:
+
+```typescript
+const wrapper = ({ children }) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+const { result } = renderHook(() => usePets(), { wrapper });
+await waitFor(() => expect(result.current.isSuccess).toBe(true));
+```
+
+Mock the service module, not React Query itself. Don't `vi.mock('@tanstack/react-query')`.
+
+## What NOT to do
+
+- **Don't store server data in `useState`/Redux/Context** — that's React Query's
+  job. Storing it elsewhere creates two sources of truth.
+- **Don't `useEffect` + `setState` to fetch** — duplicates what React Query gives
+  you (loading, error, caching, dedupe, refetch on focus).
+- **Don't manually set `data` after a mutation** unless it's an optimistic update.
+  Invalidate instead.
+- **Don't put non-serializable values in query keys** (Dates, class instances).
+  Use ISO strings or primitives.
+- **Don't share a `QueryClient` across tests** — cached responses leak.
+
+## Common mistakes
+
+- Forgetting to `enabled: !!userId` on a query that depends on auth → 401 spam
+- Invalidating `['pets']` after a single-pet edit → re-fetches every page
+- Storing query data in component state with `useState(data)` → defeats caching
+- `useEffect` to refetch on prop change → React Query already does this via key
+- Mutation `onSuccess` doesn't invalidate → stale list after a create
+- Not handling `isPending`/`isError` in the UI → blank screens, no error messages
+- Calling `mutate` instead of `mutateAsync` and trying to `await` it → mutate
+  returns void, use mutateAsync if you need the promise
+- Forgetting `placeholderData: keepPreviousData` on paginated queries → flicker
+  on page change

--- a/.claude/skills/uk-localization/SKILL.md
+++ b/.claude/skills/uk-localization/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: uk-localization
+description: >
+  UK-locale formatting and validation conventions — dates, phone numbers,
+  postcodes, currency, addresses. Apply when displaying dates/times/money,
+  validating user input, or rendering address fields anywhere in the apps.
+---
+
+# UK Localization
+
+The platform is UK-only. All user-facing dates, times, phone numbers, postcodes,
+and currency follow UK conventions via helpers in `@adopt-dont-shop/lib.utils`.
+
+See `docs/UK_LOCALIZATION.md` and `docs/UK_LOCALIZATION_QUICK_REFERENCE.md` for
+the canonical reference.
+
+## Formats at a glance
+
+| Type | Format | Example |
+|------|--------|---------|
+| Date | DD/MM/YYYY | `19/01/2025` |
+| Time | HH:mm (24-hour) | `14:30` |
+| Phone | 0XXX XXX XXXX | `020 1234 5678` |
+| Postcode | AA9A 9AA | `SW1A 1AA` |
+| Currency | £X,XXX.XX | `£150.00` |
+
+## Helpers
+
+All from `@adopt-dont-shop/lib.utils`:
+
+```typescript
+import {
+  // Dates
+  formatDate,
+  formatDateTime,
+  formatTime,
+  formatRelativeDate,
+
+  // Currency
+  formatCurrency,
+  formatCurrencyWhole,
+  formatNumber,
+
+  // Phone
+  formatPhoneNumber,
+  validatePhoneNumber,
+  getPhonePlaceholder,
+
+  // Address
+  validatePostcode,
+  formatPostcode,
+  getPostcodePlaceholder,
+  UK_COUNTIES,
+
+  // Config
+  LOCALE_CONFIG,
+} from '@adopt-dont-shop/lib.utils';
+```
+
+## Dates and times
+
+```typescript
+formatDate(application.createdAt)        // "19/01/2025"
+formatDateTime(message.sentAt)           // "19/01/2025 14:30"
+formatTime(slot.startsAt)                // "14:30"
+formatRelativeDate(notification.createdAt)  // "2 days ago"
+```
+
+**Never** use `toLocaleDateString()` without an explicit locale — the result
+depends on the user's browser config and produces inconsistent display
+("1/19/2025" vs "19/1/2025"). Always use the helpers.
+
+Database timestamps are stored as ISO UTC strings. The formatters convert to
+UK local time + DD/MM/YYYY at the display boundary. Don't convert in services or
+in the schema — only at render.
+
+## Currency
+
+```typescript
+formatCurrency(150)        // "£150.00"
+formatCurrency(1500.5)     // "£1,500.50"
+formatCurrencyWhole(150)   // "£150"      — for round numbers
+formatNumber(1234567)      // "1,234,567"
+```
+
+Currency is always GBP. There's no multi-currency support — don't introduce one
+without a product conversation. Store amounts in pence (integer) at the schema
+boundary if precision matters, format at display.
+
+## Phone numbers
+
+```typescript
+formatPhoneNumber('02012345678')          // "020 1234 5678"
+formatPhoneNumber('+44 20 1234 5678')     // "020 1234 5678"  — normalises +44
+validatePhoneNumber('not a phone')        // false
+getPhonePlaceholder()                     // "0XXX XXX XXXX"
+```
+
+For form fields, set `placeholder={getPhonePlaceholder()}` and validate on
+submit:
+
+```typescript
+const PhoneFieldSchema = z.string().refine(
+  validatePhoneNumber,
+  'Enter a valid UK phone number'
+);
+```
+
+## Postcodes
+
+```typescript
+validatePostcode('sw1a 1aa')   // true   — case-insensitive, space-tolerant
+formatPostcode('sw1a1aa')      // "SW1A 1AA"
+getPostcodePlaceholder()       // "AA9A 9AA"
+```
+
+Store the canonical formatted form (`"SW1A 1AA"`) at the schema boundary, not
+the user's raw input. Format on submit before sending to the API:
+
+```typescript
+const cleaned = formatPostcode(values.postcode);  // normalise before submit
+```
+
+The backend uses the same validator (shared from `lib.utils`) so a postcode that
+passes the frontend will pass the backend.
+
+## Addresses
+
+UK addresses use the structured fields (`address_line_1`, `address_line_2`,
+`town_city`, `county`, `postcode`, `country`). See `UK_LOCALIZATION.md` for the
+canonical schema. **Don't** use a generic single-line address field — postcode
+lookups and validation depend on the structured form.
+
+The `UK_COUNTIES` constant exports the canonical list for SelectInput options.
+
+```typescript
+import { UK_COUNTIES } from '@adopt-dont-shop/lib.utils';
+
+<SelectInput
+  options={UK_COUNTIES.map(c => ({ value: c, label: c }))}
+  value={values.county}
+/>
+```
+
+## When NOT to format
+
+- **API payloads** — send ISO dates (`2025-01-19T14:30:00Z`), pence-precise
+  currency, canonical postcodes. Format ONLY at display.
+- **Database columns** — store ISO dates, integer pence, canonical postcodes.
+- **Log lines** — keep machine-readable formats so they're greppable.
+
+The rule: format at the very last step before the user sees the value. Internal
+boundaries (function calls, API requests, DB rows) use the canonical machine
+form.
+
+## i18n future
+
+The platform is not currently i18n-ready. The helpers wrap `Intl.NumberFormat`
+and `Intl.DateTimeFormat` with `en-GB` baked in. If/when the platform expands,
+the helpers are the swap point — don't scatter locale-specific code outside
+`lib.utils`.
+
+## Common mistakes
+
+- `new Date(x).toLocaleDateString()` without a locale → US format on US
+  browsers, breaks consistency
+- Hardcoded "GBP" / "£" symbols → use `formatCurrency`
+- Storing display strings in the DB (`"19/01/2025"`) — opaque to queries,
+  drifts with format changes. Store ISO.
+- Validating postcode with a hand-rolled regex → use `validatePostcode`
+- Sending the raw user-input postcode to the API → use `formatPostcode` first
+- A generic single-line address `<input>` → use the structured fields
+- Hardcoded county lists → use `UK_COUNTIES`
+- US-style dollar amounts in any user-facing string


### PR DESCRIPTION
## Summary

The pre-existing `.claude/skills/` set covered Docker, scaffolding (`new-app`, `new-component`, `new-lib`), the api-fetch rule, and field-permissions — leaving most of the codebase uncovered by skill-level guidance. This PR adds **15 new skills** across two batches.

### Batch 1 — Backend (5 skills)
- **`backend-endpoint`** — full Route → Controller → Service → Model flow with Zod, RBAC, audit, field-perms, Swagger
- **`db-migration`** — `_helpers.ts` patterns, idempotency guards, ENUM caveats, model-sync pairing, up/down symmetry
- **`backend-test`** — Vitest mock patterns, behaviour-not-implementation rules, real in-memory SQLite, supertest
- **`audit-logging`** — three-path decision tree (in-tx / `auditRoute` / background), diff capture, action naming
- **`error-handling`** — `ApiError` hierarchy, "no try/catch in controllers", response shape, Sequelize auto-translation

### Batch 2 — Frontend, UX, testing, workflow (10 skills)
- **`frontend-test`** — Vitest + RTL + MSW, `renderWithProviders`, query-by-role, mocking `apiService`
- **`accessibility`** — semantic HTML, accessible names, focus, keyboard, contrast, reduced motion
- **`design-tokens`** — vanilla-extract + `vars.*`, recipes, spacing string keys, dark mode
- **`forms`** — Zod schemas + `FormField` + `apiService` + `useMutation` + a11y, UK fields, multi-step
- **`e2e-test`** — Playwright fixtures (`apiAs`, `asRole`), role-based contexts, accessibility selectors, when NOT to write e2e
- **`react-query`** — keys, mutations, invalidation, optimistic updates, `enabled` for auth-gated queries
- **`permissions-frontend`** — role / permission / field gates; "frontend is UX, backend is security"
- **`feature-flags`** — Statsig via `lib.feature-flags`, `KNOWN_GATES` constants, safe defaults, testing both branches
- **`uk-localization`** — date/phone/postcode/currency formatters, "format only at display"
- **`commit-conventions`** — Conventional Commits + release-please, types, scopes, breaking changes

### Conventions used
- Scaffolding recipes (`backend-endpoint`, `db-migration`) carry `disable-model-invocation: true` — user-invocable only, matching the existing `new-app` / `new-component` / `new-lib` pattern
- Rule/architecture skills (everything else) are model-invocable so they trigger automatically when relevant
- All skills cross-reference each other (`forms` → `react-query` → `api-fetch`; `accessibility` → `design-tokens`; etc.)
- Grounded against the real codebase (no invented paths) — patterns sampled from `application.routes.ts`, `pet.service.ts`, `Inbox.test.tsx`, `usePets.ts`, `2fa-enrollment.spec.ts`, `_helpers.ts`, `test-utils/render.tsx`, etc.

## Test plan

- [ ] Skim each `SKILL.md` in the GitHub diff for accuracy against the referenced files
- [ ] Confirm cross-references between skills resolve (e.g. `forms` → `react-query`, `api-fetch`, `accessibility`, `design-tokens`, `uk-localization`)
- [ ] Verify the scaffolding skills (`backend-endpoint`, `db-migration`) render correctly when invoked as `/backend-endpoint` and `/db-migration`
- [ ] Trigger a model-invocable skill in a follow-up session — e.g. ask Claude to "write a service test" and confirm `backend-test` is applied
- [ ] Confirm the existing skills are unchanged (only new files in this PR)

https://claude.ai/code/session_017r8K5LXuWoM1w1GsRrNjRS