### PR TITLE
ci: add CI Required aggregator and ruleset for required checks

### DIFF
--- a/.github/rulesets/main-required-checks.json
+++ b/.github/rulesets/main-required-checks.json
@@ -1,0 +1,41 @@
+{
+  "name": "main-required-checks",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "CI Required" },
+          { "context": "Verify every lib.* package has tests" },
+          { "context": "Schema Equivalence (migrate vs sync)" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -161,20 +161,58 @@ GHCR_TOKEN=read-only-personal-access-token         # scope: read:packages
 
 ### Branch Protection
 
-Recommended branch protection rules for `main`:
+We use the **aggregator (merge-gate) pattern**: branch protection points at a
+single `CI Required` job in `ci.yml` that fans-in to every regression-blocking
+job. Renaming or adding a job under that fan-in doesn't require touching the
+ruleset.
 
-- ✅ Require status checks to pass before merging
-- ✅ Require branches to be up to date before merging
-- ✅ Required status checks (names taken directly from the workflow files):
-  - `Verify Workspace ↔ Filesystem Alignment` (from `ci.yml`)
-  - `Detect Changes` (from `ci.yml`)
-  - `Backend Tests` (from `ci.yml`, gated by path filter)
-  - `Frontend Tests (app.client)` (from `ci.yml`, gated by path filter)
-  - `Frontend Tests (app.admin)` (from `ci.yml`, gated by path filter)
-  - `Frontend Tests (app.rescue)` (from `ci.yml`, gated by path filter)
-  - `Library Tests` (from `ci.yml`, gated by path filter)
-  - `E2E Tests (Playwright)` (from `ci.yml`, ADS-419 blocking signal)
-  - `Verify every lib.* package has tests` (from `lib-test-guard.yml`)
+The ruleset itself lives in the repo at
+`.github/rulesets/main-required-checks.json` and is imported via
+**Settings → Rules → Rulesets → New ruleset → Import a ruleset**.
+
+Three required status checks on `main`:
+
+| Check                                       | Source workflow            | Why required                                                                                                       |
+| ------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `CI Required`                               | `ci.yml`                   | Aggregates workspace-drift, build-libs, backend/frontend/library tests (with coverage gates), dev-auth-guard, E2E. |
+| `Verify every lib.* package has tests`      | `lib-test-guard.yml`       | Deterministic script; always runs; prevents `--passWithNoTests` regressions (ADS-186 / ADS-328).                   |
+| `Schema Equivalence (migrate vs sync)`      | `schema-equivalence.yml`   | Deterministic pg_dump diff; path-filtered to migrations/models. Required to block schema drift on relevant PRs.    |
+
+#### Why these three (and not the others)
+
+The set is filtered to **HIGH-accuracy, no-regression-allowed** signals:
+- **Workspace drift, dev-auth-guard, lib-test-guard, schema-equivalence** —
+  deterministic checks. No flake, no false positives.
+- **Backend / Frontend / Library Tests** — coverage-thresholded in
+  `vitest.config.ts`, so a behaviour regression fails the build directly.
+- **E2E (Playwright)** — designed as the integration blocking signal under
+  ADS-419. Retries are set to `2` in `e2e/playwright.config.ts` to absorb
+  browser/timing flake without hiding real breakage.
+
+Intentionally **not** required:
+- `Detect Changes` — pure metadata helper, not a regression signal.
+- `Quality` (dependency check) — advisory only (`continue-on-error: true`).
+- `Security` (npm audit) — fails on new external CVEs unrelated to the PR.
+- `CodeQL` — possible false positives; runs weekly anyway for drift detection.
+- `Docker` — covered by E2E's `docker compose up --build`; prod images run
+  only on push to `main`/`develop` ahead of `deploy.yml`.
+- `Storybook`, `Release`, `Release Please`, `Deploy`, `Rollback`, `Labeler`,
+  `Sync Labels` — publishing or housekeeping; not PR gates.
+
+#### How `CI Required` handles path-filtered jobs
+
+The aggregator runs with `if: always()` and only fails when a needed job's
+`result` is `failure` or `cancelled`. A job that is `skipped` because its
+path filter didn't match is treated as success — so a PR touching only
+`app.admin/` doesn't get blocked by a skipped backend job.
+
+#### Updating the ruleset
+
+If you add a new HIGH-accuracy regression-blocking job, the preferred path is
+to add it as a `needs:` entry on `ci-required` in `ci.yml` so it rolls up into
+the existing required check. Only add a new entry to the ruleset JSON if the
+job lives in a *separate* workflow file (as `lib-test-guard` and
+`schema-equivalence` do).
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,3 +571,44 @@ jobs:
       - name: Tear down stack
         if: always()
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
+
+  # ============================================================================
+  # CI REQUIRED — single aggregator gate for branch protection.
+  #
+  # Branch protection / Rulesets reference this one job name. It fans-in to
+  # every regression-blocking job above so adding/renaming a job below does
+  # not require touching the ruleset.
+  #
+  # Path-filtered jobs (test-backend, test-frontend, test-libs, dev-auth-guard,
+  # test-e2e) report `skipped` on PRs that do not touch their paths; classic
+  # branch protection treats `skipped` as a failure, which is why a plain list
+  # of required checks is fragile. This aggregator only fails on `failure`
+  # or `cancelled`, treating `skipped` as success — the standard "merge gate"
+  # pattern.
+  # ============================================================================
+  ci-required:
+    name: CI Required
+    if: always()
+    needs:
+      - workspace-drift
+      - build-libs
+      - test-backend
+      - test-frontend
+      - test-libs
+      - dev-auth-guard
+      - test-e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify required jobs succeeded or skipped
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | jq .
+          failed=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key')
+          if [ -n "$failed" ]; then
+            echo "::error::Required jobs failed or were cancelled:"
+            echo "$failed"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped (path filter)."

--- a/.github/workflows/schema-equivalence.yml
+++ b/.github/workflows/schema-equivalence.yml
@@ -14,26 +14,52 @@ name: Schema Equivalence
 # after normalisation. As per-domain baselines land, DB-A's bootstrap shifts
 # to explicit createTable calls; the gate then has teeth.
 #
-# Expensive (Postgres + 2x bootstrap + dump). Therefore PR-only and
-# path-filtered to migrations/models. Add as a separate required check in
-# branch protection settings rather than embedding it in `ci.yml`.
+# Expensive (Postgres + 2x bootstrap + dump). Therefore the heavy job is
+# gated by an in-workflow path-detection job rather than the workflow-level
+# `paths:` filter — the latter would prevent the required check name from
+# reporting on PRs that don't touch migrations, blocking those PRs forever
+# under GitHub Rulesets.
 
 on:
   pull_request:
-    paths:
-      - 'service.backend/src/migrations/**'
-      - 'service.backend/src/models/**'
-      - 'service.backend/scripts/normalise-pg-dump.sh'
-      - 'service.backend/scripts/schema-equivalence.sh'
-      - '.github/workflows/schema-equivalence.yml'
 
 concurrency:
   group: schema-equivalence-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  schema-equivalence:
-    name: Schema Equivalence (migrate vs sync)
+  # ============================================================================
+  # PATH DETECTION — always runs, fast (~10s). Outputs whether any schema-
+  # relevant files changed; downstream jobs gate on this.
+  # ============================================================================
+  detect-changes:
+    name: Detect schema-relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'service.backend/src/migrations/**'
+              - 'service.backend/src/models/**'
+              - 'service.backend/scripts/normalise-pg-dump.sh'
+              - 'service.backend/scripts/schema-equivalence.sh'
+              - '.github/workflows/schema-equivalence.yml'
+
+  # ============================================================================
+  # COMPUTE — the expensive bootstrap-and-diff job. Conditional on the path
+  # detection above. Renamed from `schema-equivalence` so the aggregator below
+  # owns the required-check name.
+  # ============================================================================
+  schema-equivalence-compute:
+    name: Schema Equivalence (compute)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -219,3 +245,40 @@ jobs:
           path: schema-equivalence-out/
           retention-days: 14
           if-no-files-found: warn
+
+  # ============================================================================
+  # AGGREGATOR — owns the `Schema Equivalence (migrate vs sync)` status check
+  # name that branch-protection / the ruleset depends on. Always runs, so the
+  # check always reports. Passes when the compute job succeeded OR was skipped
+  # (no relevant changes); fails when the compute job failed or was cancelled.
+  # ============================================================================
+  schema-equivalence:
+    name: Schema Equivalence (migrate vs sync)
+    needs: [detect-changes, schema-equivalence-compute]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify compute job result
+        env:
+          COMPUTE_RESULT: ${{ needs.schema-equivalence-compute.result }}
+          RELEVANT: ${{ needs.detect-changes.outputs.relevant }}
+        run: |
+          echo "compute result: $COMPUTE_RESULT"
+          echo "schema-relevant change detected: $RELEVANT"
+          case "$COMPUTE_RESULT" in
+            failure|cancelled)
+              echo "::error::Schema equivalence check failed."
+              exit 1
+              ;;
+            skipped)
+              echo "No schema-relevant changes — no-op pass."
+              ;;
+            success)
+              echo "Schema equivalence check passed."
+              ;;
+            *)
+              echo "::error::Unexpected compute result: $COMPUTE_RESULT"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Summary

Locks down a HIGH-accuracy, regression-blocking set of CI checks as required on `main`, using the industry-standard **aggregator (merge-gate) pattern + GitHub Rulesets**.

### What's required after this lands

| Required check                              | Source                       | Why required                                                                |
| ------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------- |
| `CI Required`                               | `ci.yml` (new aggregator)    | Workspace drift, build-libs, backend/frontend/lib tests + coverage, dev-auth guard, E2E |
| `Verify every lib.* package has tests`      | `lib-test-guard.yml`         | Deterministic; blocks `--passWithNoTests` regressions (ADS-186/ADS-328)     |
| `Schema Equivalence (migrate vs sync)`      | `schema-equivalence.yml`     | Deterministic pg_dump diff; blocks schema drift                              |

### What's deliberately NOT required

- `Quality` (dependency check) — advisory only (`continue-on-error: true`)
- `Security` (npm audit) — fails on external CVEs unrelated to the PR
- `CodeQL` — possible false positives; weekly scan handles drift
- `Docker` — covered by E2E's `docker compose up --build`
- `Detect Changes` — pure metadata, not a regression signal
- Storybook / Release / Deploy / Rollback / Labelers — publishing or housekeeping

### How it works

The `CI Required` aggregator runs with `if: always()` and `needs:` every regression-blocking job. It only fails when a needed job's `result` is `failure` or `cancelled` — `skipped` (path filter didn't match) is treated as success. This sidesteps the classic branch-protection bug where a skipped check blocks merging.

### Changes

- `.github/workflows/ci.yml` — new `ci-required` job at end of file
- `.github/rulesets/main-required-checks.json` — importable Ruleset (Settings → Rules → Rulesets → New ruleset → Import)
- `.github/workflows/README.md` — replaces the per-job required-check list with the aggregator pattern + rationale

## Test plan

- [ ] CI runs green on this PR (the new `CI Required` job appears in the checks list)
- [ ] Confirm `CI Required` reports green when all needed jobs are skipped (e.g. a docs-only follow-up PR)
- [ ] Confirm `CI Required` reports red if any needed job fails (sanity-check via a deliberately failing local branch, or trust the JSON-result check semantics)
- [ ] Import `.github/rulesets/main-required-checks.json` via repo Settings → Rules → Rulesets → New ruleset → Import a ruleset
- [ ] Verify the three required checks block merges on a follow-up test PR

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_013d3rMraAgMaNnULd5kKTma)_