### PR TITLE
fix(security): cap unbounded pagination and sanitise getCurrentUser response

### DIFF
--- a/service.backend/src/__tests__/security/pagination-bounds.test.ts
+++ b/service.backend/src/__tests__/security/pagination-bounds.test.ts
@@ -38,11 +38,21 @@ vi.mock('../../models/AdopterMatchProfile', () => ({
   default: { findByPk: vi.fn() },
 }));
 
+vi.mock('../../services/security.service', () => ({
+  default: {
+    listSessions: vi.fn(),
+    getLoginHistory: vi.fn(),
+    getSuspiciousActivity: vi.fn(),
+  },
+}));
+
 import { MatchController } from '../../controllers/match.controller';
 import { NotificationController } from '../../controllers/notification.controller';
+import { SecurityController } from '../../controllers/security.controller';
 import { NotificationService } from '../../services/notification.service';
+import SecurityService from '../../services/security.service';
 import Pet from '../../models/Pet';
-import { DEFAULT_PAGE_SIZE } from '../../constants/pagination';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../constants/pagination';
 import { AuthenticatedRequest } from '../../types/auth';
 
 const mockUser = { userId: 'user-1' } as AuthenticatedRequest['user'];
@@ -154,6 +164,164 @@ describe('Pagination bounds — defense-in-depth', () => {
 
       const [, options] = vi.mocked(NotificationService.getUserNotifications).mock.calls[0];
       expect(options?.limit).toBe(DEFAULT_PAGE_SIZE);
+    });
+  });
+
+  describe('SecurityController.listSessions', () => {
+    const buildReq = (limit?: string) =>
+      ({
+        user: mockUser,
+        query: limit === undefined ? {} : { limit },
+      }) as unknown as AuthenticatedRequest;
+
+    beforeEach(() => {
+      vi.mocked(SecurityService.listSessions).mockResolvedValue({
+        sessions: [],
+        total: 0,
+        page: 1,
+        totalPages: 1,
+      });
+    });
+
+    it('caps an oversized limit at MAX_PAGE_SIZE', async () => {
+      const req = buildReq('999999');
+      const res = mockRes();
+
+      await SecurityController.listSessions(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.listSessions).mock.calls[0];
+      expect(args?.limit).toBe(MAX_PAGE_SIZE);
+    });
+
+    it('honours a valid in-range limit', async () => {
+      const req = buildReq('25');
+      const res = mockRes();
+
+      await SecurityController.listSessions(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.listSessions).mock.calls[0];
+      expect(args?.limit).toBe(25);
+    });
+
+    it('passes undefined limit when none is provided, letting the service use its default', async () => {
+      const req = buildReq();
+      const res = mockRes();
+
+      await SecurityController.listSessions(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.listSessions).mock.calls[0];
+      expect(args?.limit).toBeUndefined();
+    });
+
+    it('clamps a limit of zero up to 1', async () => {
+      const req = buildReq('0');
+      const res = mockRes();
+
+      await SecurityController.listSessions(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.listSessions).mock.calls[0];
+      expect(args?.limit).toBe(1);
+    });
+  });
+
+  describe('SecurityController.getLoginHistory', () => {
+    const buildReq = (limit?: string) =>
+      ({
+        user: mockUser,
+        query: limit === undefined ? {} : { limit },
+      }) as unknown as AuthenticatedRequest;
+
+    beforeEach(() => {
+      vi.mocked(SecurityService.getLoginHistory).mockResolvedValue({
+        entries: [],
+        total: 0,
+        page: 1,
+        totalPages: 1,
+      });
+    });
+
+    it('caps an oversized limit at MAX_PAGE_SIZE', async () => {
+      const req = buildReq('999999');
+      const res = mockRes();
+
+      await SecurityController.getLoginHistory(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.getLoginHistory).mock.calls[0];
+      expect(args?.limit).toBe(MAX_PAGE_SIZE);
+    });
+
+    it('honours a valid in-range limit', async () => {
+      const req = buildReq('20');
+      const res = mockRes();
+
+      await SecurityController.getLoginHistory(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.getLoginHistory).mock.calls[0];
+      expect(args?.limit).toBe(20);
+    });
+
+    it('passes undefined limit when none is provided, letting the service use its default', async () => {
+      const req = buildReq();
+      const res = mockRes();
+
+      await SecurityController.getLoginHistory(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.getLoginHistory).mock.calls[0];
+      expect(args?.limit).toBeUndefined();
+    });
+  });
+
+  describe('SecurityController.getSuspiciousActivity', () => {
+    const buildReq = (query: { failureThreshold?: string; windowHours?: string } = {}) =>
+      ({
+        user: mockUser,
+        query,
+      }) as unknown as AuthenticatedRequest;
+
+    beforeEach(() => {
+      vi.mocked(SecurityService.getSuspiciousActivity).mockResolvedValue([]);
+    });
+
+    it('clamps windowHours at the 720-hour ceiling', async () => {
+      const req = buildReq({ windowHours: '99999' });
+      const res = mockRes();
+
+      await SecurityController.getSuspiciousActivity(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.getSuspiciousActivity).mock.calls[0];
+      expect(args?.windowHours).toBe(720);
+    });
+
+    it('clamps failureThreshold up to minimum 1', async () => {
+      const req = buildReq({ failureThreshold: '0' });
+      const res = mockRes();
+
+      await SecurityController.getSuspiciousActivity(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.getSuspiciousActivity).mock.calls[0];
+      expect(args?.failureThreshold).toBe(1);
+    });
+
+    it('honours valid in-range params', async () => {
+      const req = buildReq({ failureThreshold: '5', windowHours: '48' });
+      const res = mockRes();
+
+      await SecurityController.getSuspiciousActivity(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.getSuspiciousActivity).mock.calls[0];
+      expect(args?.failureThreshold).toBe(5);
+      expect(args?.windowHours).toBe(48);
+    });
+
+    it('passes undefined params when none are provided', async () => {
+      const req = buildReq();
+      const res = mockRes();
+
+      await SecurityController.getSuspiciousActivity(req, res as Response);
+
+      const [args] = vi.mocked(SecurityService.getSuspiciousActivity).mock.calls[0];
+      expect(args?.failureThreshold).toBeUndefined();
+      expect(args?.windowHours).toBeUndefined();
     });
   });
 });

--- a/service.backend/src/controllers/auth.controller.ts
+++ b/service.backend/src/controllers/auth.controller.ts
@@ -201,8 +201,38 @@ export class AuthController {
    * Get current user profile
    */
   async getCurrentUser(req: AuthenticatedRequest, res: Response): Promise<void> {
-    // Simply return the authenticated user from the request
-    res.json(req.user);
+    const u = req.user!;
+    res.json({
+      userId: u.userId,
+      email: u.email,
+      firstName: u.firstName,
+      lastName: u.lastName,
+      phoneNumber: u.phoneNumber,
+      emailVerified: u.emailVerified,
+      userType: u.userType,
+      status: u.status,
+      profileImageUrl: u.profileImageUrl,
+      bio: u.bio,
+      dateOfBirth: u.dateOfBirth,
+      country: u.country,
+      city: u.city,
+      addressLine1: u.addressLine1,
+      addressLine2: u.addressLine2,
+      postalCode: u.postalCode,
+      location: u.location,
+      timezone: u.timezone,
+      language: u.language,
+      twoFactorEnabled: u.twoFactorEnabled,
+      lastLoginAt: u.lastLoginAt,
+      termsAcceptedAt: u.termsAcceptedAt,
+      privacyPolicyAcceptedAt: u.privacyPolicyAcceptedAt,
+      applicationDefaults: u.applicationDefaults,
+      profileCompletionStatus: u.profileCompletionStatus,
+      createdAt: u.createdAt,
+      updatedAt: u.updatedAt,
+      Roles: u.Roles,
+      rescueId: u.rescueId,
+    });
   }
 
   /**

--- a/service.backend/src/controllers/security.controller.ts
+++ b/service.backend/src/controllers/security.controller.ts
@@ -2,21 +2,27 @@ import { Response } from 'express';
 import SecurityService from '../services/security.service';
 import { IpRuleType } from '../models/IpRule';
 import { AuthenticatedRequest } from '../types/auth';
+import { MAX_PAGE_SIZE } from '../constants/pagination';
+
+const SESSION_DEFAULT_LIMIT = 50;
 
 export class SecurityController {
   static async listSessions(req: AuthenticatedRequest, res: Response) {
     const { userId, page, limit } = req.query;
+    const parsedLimit = limit ? parseInt(limit as string, 10) : undefined;
+    const clampedLimit =
+      parsedLimit !== undefined ? Math.min(Math.max(1, parsedLimit), MAX_PAGE_SIZE) : undefined;
     const result = await SecurityService.listSessions({
       userId: userId as string | undefined,
       page: page ? parseInt(page as string, 10) : undefined,
-      limit: limit ? parseInt(limit as string, 10) : undefined,
+      limit: clampedLimit,
     });
     return res.json({
       success: true,
       data: result.sessions,
       pagination: {
         page: result.page,
-        limit: parseInt((limit as string) || '50', 10),
+        limit: clampedLimit ?? SESSION_DEFAULT_LIMIT,
         total: result.total,
         pages: result.totalPages,
       },
@@ -103,20 +109,23 @@ export class SecurityController {
 
   static async getLoginHistory(req: AuthenticatedRequest, res: Response) {
     const { userId, status, startDate, endDate, page, limit } = req.query;
+    const parsedLimit = limit ? parseInt(limit as string, 10) : undefined;
+    const clampedLimit =
+      parsedLimit !== undefined ? Math.min(Math.max(1, parsedLimit), MAX_PAGE_SIZE) : undefined;
     const result = await SecurityService.getLoginHistory({
       userId: userId as string | undefined,
       status: status as 'success' | 'failure' | undefined,
       startDate: startDate ? new Date(startDate as string) : undefined,
       endDate: endDate ? new Date(endDate as string) : undefined,
       page: page ? parseInt(page as string, 10) : undefined,
-      limit: limit ? parseInt(limit as string, 10) : undefined,
+      limit: clampedLimit,
     });
     return res.json({
       success: true,
       data: result.entries,
       pagination: {
         page: result.page,
-        limit: parseInt((limit as string) || '50', 10),
+        limit: clampedLimit ?? SESSION_DEFAULT_LIMIT,
         total: result.total,
         pages: result.totalPages,
       },
@@ -125,9 +134,11 @@ export class SecurityController {
 
   static async getSuspiciousActivity(req: AuthenticatedRequest, res: Response) {
     const { failureThreshold, windowHours } = req.query;
+    const parsedThreshold = failureThreshold ? parseInt(failureThreshold as string, 10) : undefined;
+    const parsedWindowHours = windowHours ? parseInt(windowHours as string, 10) : undefined;
     const data = await SecurityService.getSuspiciousActivity({
-      failureThreshold: failureThreshold ? parseInt(failureThreshold as string, 10) : undefined,
-      windowHours: windowHours ? parseInt(windowHours as string, 10) : undefined,
+      failureThreshold: parsedThreshold !== undefined ? Math.max(1, parsedThreshold) : undefined,
+      windowHours: parsedWindowHours !== undefined ? Math.min(parsedWindowHours, 720) : undefined,
     });
     return res.json({ success: true, data });
   }


### PR DESCRIPTION
## Summary

Fixes ADS-700: three admin-only endpoints accepted user-supplied `limit`/threshold params with no upper bound, allowing a compromised admin to exhaust database resources. Additionally, `GET /auth/me` leaked internal user model fields to the client.

- **`SecurityController.listSessions`** — clamp `limit` to `MAX_PAGE_SIZE` (100) using `Math.min(Math.max(1, limit), MAX_PAGE_SIZE)`
- **`SecurityController.getLoginHistory`** — same limit clamping
- **`SecurityController.getSuspiciousActivity`** — clamp `windowHours` ≤ 720 (30 days) and `failureThreshold` ≥ 1
- **`AuthController.getCurrentUser`** — replace `res.json(req.user)` with an explicit field allowlist, preventing internal fields (`loginAttempts`, `lockedUntil`, `tokensInvalidBefore`, `pendingAnonymizationAt`, `resetTokenExpiration`, etc.) from reaching the client

## Test plan

- [ ] All 17 tests in `pagination-bounds.test.ts` pass (11 new for the three SecurityController methods)
- [ ] All 30 tests in `auth.routes.test.ts` pass — `GET /auth/me` still returns 200
- [ ] Requesting `?limit=999999` on sessions/login-history now sends at most 100 rows
- [ ] `GET /auth/me` response no longer contains `loginAttempts`, `lockedUntil`, `tokensInvalidBefore` etc.

Closes ADS-700

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvkMsWhJ7Qc4ZWeeLPBzvZ)_