### PR TITLE
feat(ci): sign container images with cosign and verify on deploy (ADS-673)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,14 @@ on:
         required: false
         type: boolean
         default: false
+      # ADS-673: Bypass cosign signature verification. ONLY for documented
+      # emergency rollback scenarios where the signing infrastructure is
+      # broken — every use is logged loudly in the workflow output.
+      skip_cosign_verify:
+        description: 'Skip cosign signature verification (EMERGENCY ONLY — see docs/security/image-signing.md)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -36,6 +44,9 @@ jobs:
       contents: read
       packages: write
       checks: read
+      # ADS-673: id-token required for cosign keyless signing via the
+      # GitHub Actions OIDC token. No private key is provisioned.
+      id-token: write
     outputs:
       sha: ${{ github.sha }}
     steps:
@@ -91,6 +102,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # ADS-673: install cosign before any push so we can sign each image
+      # by digest after `docker push`. Keyless mode uses the job's OIDC
+      # token (id-token: write) — no secrets required. SHA-pinned to match
+      # the rest of this workflow's pinning strategy.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5  # v3.10.1
+
       - name: Build and push backend
         run: |
           # ADS-rollback: :latest is only updated for production deploys.
@@ -108,6 +126,13 @@ jobs:
             docker tag $IMAGE_PREFIX/backend:${{ github.sha }} $IMAGE_PREFIX/backend:latest
             docker push $IMAGE_PREFIX/backend:latest
           fi
+          # ADS-673: Sign the image by digest (immutable) via cosign keyless
+          # OIDC. RepoDigests is populated by `docker push` from the registry
+          # response. Sign only the SHA tag — :latest resolves to the same
+          # digest so a single signature covers both.
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_PREFIX/backend:${{ github.sha }}" | cut -d@ -f2)
+          echo "Signing $IMAGE_PREFIX/backend@$DIGEST"
+          cosign sign --yes "$IMAGE_PREFIX/backend@$DIGEST"
 
       - name: Build and push app.client
         run: |
@@ -131,6 +156,10 @@ jobs:
             docker tag $IMAGE_PREFIX/app-client:${{ github.sha }} $IMAGE_PREFIX/app-client:latest
             docker push $IMAGE_PREFIX/app-client:latest
           fi
+          # ADS-673: cosign keyless sign by digest. See backend step for rationale.
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_PREFIX/app-client:${{ github.sha }}" | cut -d@ -f2)
+          echo "Signing $IMAGE_PREFIX/app-client@$DIGEST"
+          cosign sign --yes "$IMAGE_PREFIX/app-client@$DIGEST"
 
       - name: Build and push app.admin
         run: |
@@ -154,6 +183,10 @@ jobs:
             docker tag $IMAGE_PREFIX/app-admin:${{ github.sha }} $IMAGE_PREFIX/app-admin:latest
             docker push $IMAGE_PREFIX/app-admin:latest
           fi
+          # ADS-673: cosign keyless sign by digest. See backend step for rationale.
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_PREFIX/app-admin:${{ github.sha }}" | cut -d@ -f2)
+          echo "Signing $IMAGE_PREFIX/app-admin@$DIGEST"
+          cosign sign --yes "$IMAGE_PREFIX/app-admin@$DIGEST"
 
       - name: Build and push app.rescue
         run: |
@@ -177,9 +210,70 @@ jobs:
             docker tag $IMAGE_PREFIX/app-rescue:${{ github.sha }} $IMAGE_PREFIX/app-rescue:latest
             docker push $IMAGE_PREFIX/app-rescue:latest
           fi
+          # ADS-673: cosign keyless sign by digest. See backend step for rationale.
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_PREFIX/app-rescue:${{ github.sha }}" | cut -d@ -f2)
+          echo "Signing $IMAGE_PREFIX/app-rescue@$DIGEST"
+          cosign sign --yes "$IMAGE_PREFIX/app-rescue@$DIGEST"
+
+  # ADS-673: Cosign signature verification gate. Runs BEFORE the deploy job
+  # so a tampered or unsigned image cannot reach the production host.
+  # Verification happens on the GitHub Actions runner (which has cosign and
+  # public internet egress to Rekor + Fulcio) rather than on the deploy host,
+  # which avoids installing cosign on every server.
+  verify-images:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5  # v3.10.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify image signatures
+        env:
+          SHA: ${{ github.sha }}
+          SKIP_VERIFY: ${{ github.event.inputs.skip_cosign_verify }}
+        run: |
+          set -euo pipefail
+          if [ "$SKIP_VERIFY" = "true" ]; then
+            echo "::warning title=Cosign verification skipped::skip_cosign_verify=true was passed to this deploy. This bypasses supply-chain integrity checks and must only be used for documented emergency rollback scenarios. See docs/security/image-signing.md."
+            echo "WARNING: cosign verification SKIPPED for $SHA"
+            exit 0
+          fi
+
+          # Identity expectation: signatures must be produced by THIS repo's
+          # workflows running on main. Any other source (forks, feature
+          # branches, manually-pushed images) will fail verification.
+          IDENTITY_REGEX='^https://github.com/ideaSquared/adopt-dont-shop/\.github/workflows/.+@refs/heads/main$'
+          ISSUER='https://token.actions.githubusercontent.com'
+
+          for image in backend app-client app-admin app-rescue; do
+            ref="$IMAGE_PREFIX/$image:$SHA"
+            # Resolve tag -> digest via the registry API so we verify the
+            # immutable artifact, not whatever the tag happens to point at
+            # right now. `docker buildx imagetools inspect` is pre-installed
+            # on ubuntu-latest runners and does not pull image layers.
+            digest=$(docker buildx imagetools inspect "$ref" --format '{{.Manifest.Digest}}')
+            target="$IMAGE_PREFIX/$image@$digest"
+            echo "Verifying $target"
+            cosign verify \
+              --certificate-identity-regexp "$IDENTITY_REGEX" \
+              --certificate-oidc-issuer "$ISSUER" \
+              "$target" > /dev/null
+            echo "OK: $image signature is valid and produced by main."
+          done
 
   deploy:
-    needs: build-and-push
+    needs: verify-images
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: ${{ github.event.inputs.environment }}

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -98,6 +98,16 @@ or secured ops log. At minimum: `date`, `rotated_by`, `reason`.
 | Team member off-boarding | Rotate any secret the person had access to |
 | Staging value detected in prod | Immediate full rotation |
 
+## Image signing & verification
+
+Images published by `.github/workflows/deploy.yml` are cosign-signed
+(keyless OIDC) and verified before the deploy job runs. A deploy whose
+images cannot be verified against this repo's `main`-branch identity
+will FAIL at the `verify-images` job, before any container reaches the
+host. See [`docs/security/image-signing.md`](../security/image-signing.md)
+for the trust model, the manual verification command, and the documented
+emergency-bypass procedure.
+
 ## Release deploy
 
 The `service-backend-migrate` init container runs `npm run db:migrate`

--- a/docs/security/image-signing.md
+++ b/docs/security/image-signing.md
@@ -1,0 +1,116 @@
+# Container Image Signing (Cosign + Sigstore)
+
+Container images published to GHCR by `.github/workflows/deploy.yml` are
+signed with [cosign](https://github.com/sigstore/cosign) using
+[Sigstore](https://www.sigstore.dev/) **keyless** OIDC signing. The deploy
+workflow refuses to roll out an image whose signature cannot be verified
+against this repository's identity.
+
+This document is the operator-facing reference for the system.
+
+## Why we sign
+
+Anyone with `packages: write` on the GHCR registry — humans, leaked tokens,
+a future compromised CI step — could push a malicious image to
+`ghcr.io/ideasquared/adopt-dont-shop/*`. Without verification, the deploy
+host would happily pull and run it. Cosign keyless signing closes that gap:
+
+- Each signature is bound to the **workflow identity** that produced it
+  (the workflow file path and the branch it ran on) via a Fulcio-issued
+  short-lived X.509 cert.
+- The signature is recorded in the **Rekor public transparency log**, so
+  retroactive tampering with signatures is detectable.
+- No long-lived private key exists for an attacker to steal.
+
+## How signing works
+
+`.github/workflows/deploy.yml` runs on `workflow_dispatch` against `main`.
+The `build-and-push` job:
+
+1. Has `permissions: id-token: write` so the runner can mint an OIDC token.
+2. After `docker push <image>:<sha>`, captures the registry digest from
+   `docker inspect ... .RepoDigests`.
+3. Runs `cosign sign --yes <image>@<digest>` — this:
+   - Mints an OIDC token from GitHub Actions.
+   - Exchanges it at Fulcio for a short-lived signing cert whose SAN
+     identifies the workflow + branch.
+   - Signs the image digest with the cert's ephemeral private key.
+   - Uploads the signature + cert + Rekor inclusion proof to GHCR (next
+     to the image, as a `sha256-<digest>.sig` tag).
+
+Each of the four images (backend, app-client, app-admin, app-rescue) is
+signed individually.
+
+## How verification works
+
+The `verify-images` job runs **after** `build-and-push` and **before**
+`deploy`. It:
+
+1. Resolves each `:<sha>` tag back to its registry digest via
+   `docker buildx imagetools inspect` (so we verify the immutable artifact,
+   not whatever the tag happens to point at).
+2. Runs `cosign verify` with:
+   - `--certificate-oidc-issuer https://token.actions.githubusercontent.com`
+   - `--certificate-identity-regexp '^https://github.com/ideaSquared/adopt-dont-shop/\.github/workflows/.+@refs/heads/main$'`
+3. Fails the job — and the deploy — if any image lacks a valid signature
+   produced by a workflow in this repo on `main`.
+
+## Manual verification
+
+To verify an image yourself (e.g. before bringing it up on a non-CI host):
+
+```bash
+# Install cosign — see https://docs.sigstore.dev/cosign/installation
+SHA=<git-sha-you-want-to-verify>
+for image in backend app-client app-admin app-rescue; do
+  cosign verify \
+    --certificate-identity-regexp '^https://github.com/ideaSquared/adopt-dont-shop/\.github/workflows/.+@refs/heads/main$' \
+    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+    "ghcr.io/ideasquared/adopt-dont-shop/${image}:${SHA}"
+done
+```
+
+A successful verification prints the signed payload and Rekor entry. A
+mismatch — wrong identity, wrong issuer, missing signature, Rekor entry
+absent — exits non-zero.
+
+## Emergency override
+
+If the signing infrastructure is broken (Fulcio down, Rekor down, OIDC
+broken on GitHub side) and you need to roll out **anyway**, the deploy
+workflow accepts a `skip_cosign_verify` input on `workflow_dispatch`.
+
+When to use it:
+
+- A production-critical fix must ship and Sigstore public-good
+  infrastructure is having a verified outage
+  ([sigstore status](https://status.sigstore.dev/)).
+- A rollback is required and Sigstore is unavailable.
+
+When **not** to use it:
+
+- "Verification failed and I don't know why." That is the signal working
+  as designed. Investigate the identity mismatch before bypassing it —
+  it usually means the image was built somewhere unexpected (a feature
+  branch, a re-tagged image, a manual push).
+- Routine deploys. There is no scenario where a normal deploy should
+  need this flag.
+
+Every use of `skip_cosign_verify=true` emits a `::warning::` annotation
+in the workflow run and prints a `WARNING: cosign verification SKIPPED`
+line in the job log, so the bypass is searchable in deploy history.
+
+## Known gaps
+
+- `.github/workflows/rollback.yml` pulls and runs previously-built images
+  without re-verifying their signatures. The images it pulls were signed
+  by `deploy.yml` at the time they were built, so the trust chain is
+  intact, but the rollback workflow does not enforce that on its own.
+  Adding a parallel verify step there is tracked separately.
+
+## References
+
+- [Sigstore keyless signing overview](https://docs.sigstore.dev/cosign/signing/overview/)
+- [`sigstore/cosign-installer` action](https://github.com/sigstore/cosign-installer)
+- [Fulcio certificate transparency](https://github.com/sigstore/fulcio)
+- [Rekor transparency log](https://github.com/sigstore/rekor)


### PR DESCRIPTION
Closes ADS-673.

## Summary

Adds Sigstore cosign keyless signing on every image push to GHCR, and a verify gate before deploy that aborts if signature/identity don't match. Closes the supply-chain hole where anyone with GHCR write could push a malicious image and the deploy would happily run it.

## Changes

**Publish side** (`build-and-push` job in `.github/workflows/deploy.yml`):
- `id-token: write` permission for OIDC keyless signing.
- `sigstore/cosign-installer` SHA-pinned to `7e8b541…` (v3.10.1) — matches the repo's existing SHA-pinning convention.
- For each of the 4 images (`backend`, `app-client`, `app-admin`, `app-rescue`), captures the digest from `docker inspect` and runs `cosign sign --yes <image>@<digest>`. Signing by digest covers both `:sha` and `:latest`.

**Deploy side** (new `verify-images` job; `deploy` now `needs: verify-images`):
- Installs same SHA-pinned cosign.
- Resolves each `:sha` tag to its digest via `docker buildx imagetools inspect` (no layer pull).
- `cosign verify` with:
  - `--certificate-identity-regexp '^https://github.com/ideaSquared/adopt-dont-shop/\.github/workflows/.+@refs/heads/main$'`
  - `--certificate-oidc-issuer 'https://token.actions.githubusercontent.com'`
- Verify failure aborts the deploy (no `continue-on-error`).

**Emergency override:** `skip_cosign_verify` `workflow_dispatch` boolean. When true, emits a `::warning::` annotation + loud log line, then proceeds. Mirrors the existing `skip_ci_check` pattern.

**Docs:**
- `docs/security/image-signing.md` — trust model, manual verify command, emergency bypass.
- `docs/operations/deploy.md` — short signing/verification section linking to the security doc.

## Test plan

- [ ] First merged deploy exercises the end-to-end signing flow (Fulcio cert issuance + Rekor upload).
- [ ] Verify the certificate-identity regex matches the actual Fulcio SAN — assumes canonical org case `ideaSquared`. If Sigstore lower-cases it, the regex needs tightening.
- [ ] Confirm `verify-images` job fails the deploy when a signature is missing (can simulate by pushing an unsigned image via `workflow_dispatch` with `skip_cosign_verify: false`).

## Known gap

`.github/workflows/rollback.yml` still pulls images without verification. The signatures exist on the rollback target (created at original deploy), so the trust chain isn't broken, but rollback doesn't enforce verification itself. Flagged in `docs/security/image-signing.md` "Known gaps" — left for a follow-up ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bf3T5HEmsGUUswNZ4wq4ek)_