### PR TITLE
refactor(types): replace remaining Sequelize string-array any casts (ADS-705)

### DIFF
--- a/service.backend/src/models/Content.ts
+++ b/service.backend/src/models/Content.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getArrayType, getUuidType } from '../sequelize';
+import { setStringArrayAttr } from '../utils/sequelize-jsonb';
 import { generateUuidV7 } from '../utils/uuid';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
@@ -190,13 +191,7 @@ Content.init(
         return raw || [];
       },
       set(value: string[]) {
-        if (process.env.NODE_ENV === 'test') {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('metaKeywords', JSON.stringify(value || []) as any);
-        } else {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('metaKeywords', value || ([] as any));
-        }
+        setStringArrayAttr(this, 'metaKeywords', value);
       },
     },
     featuredImageUrl: {

--- a/service.backend/src/models/EmailQueue.ts
+++ b/service.backend/src/models/EmailQueue.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { JsonObject } from '../types/common';
+import { setStringArrayAttr } from '../utils/sequelize-jsonb';
 import { generateUuidV7 } from '../utils/uuid';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
@@ -351,15 +352,7 @@ EmailQueue.init(
         return rawValue || [];
       },
       set(value: string[]) {
-        if (process.env.NODE_ENV === 'test') {
-          // In test mode (SQLite), store as JSON string
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('ccEmails', JSON.stringify(value || []) as any);
-        } else {
-          // In production (PostgreSQL), store as native array
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('ccEmails', value || ([] as any));
-        }
+        setStringArrayAttr(this, 'ccEmails', value);
       },
     },
     bccEmails: {
@@ -379,15 +372,7 @@ EmailQueue.init(
         return rawValue || [];
       },
       set(value: string[]) {
-        if (process.env.NODE_ENV === 'test') {
-          // In test mode (SQLite), store as JSON string
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('bccEmails', JSON.stringify(value || []) as any);
-        } else {
-          // In production (PostgreSQL), store as native array
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('bccEmails', value || ([] as any));
-        }
+        setStringArrayAttr(this, 'bccEmails', value);
       },
     },
     replyToEmail: {
@@ -534,15 +519,7 @@ EmailQueue.init(
         return rawValue || [];
       },
       set(value: string[]) {
-        if (process.env.NODE_ENV === 'test') {
-          // In test mode (SQLite), store as JSON string
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('tags', JSON.stringify(value || []) as any);
-        } else {
-          // In production (PostgreSQL), store as native array
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('tags', value || ([] as any));
-        }
+        setStringArrayAttr(this, 'tags', value);
       },
     },
     idempotencyKey: {

--- a/service.backend/src/models/EmailTemplate.ts
+++ b/service.backend/src/models/EmailTemplate.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Model, Optional } from 'sequelize';
 import sequelize, { getJsonType, getUuidType, getArrayType, getGeometryType } from '../sequelize';
 import { JsonObject } from '../types/common';
+import { setStringArrayAttr } from '../utils/sequelize-jsonb';
 import { generateUuidV7 } from '../utils/uuid';
 import { auditColumns, auditIndexes, withAuditHooks } from './audit-columns';
 
@@ -376,14 +377,7 @@ EmailTemplate.init(
         return rawValue || [];
       },
       set(value: string[]) {
-        // In SQLite, store as JSON string
-        if (process.env.NODE_ENV === 'test') {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('tags', JSON.stringify(value || []) as any);
-        } else {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this.setDataValue('tags', value || ([] as any));
-        }
+        setStringArrayAttr(this, 'tags', value);
       },
     },
     // createdBy column dropped — superseded by auditColumns.created_by.

--- a/service.backend/src/utils/sequelize-jsonb.ts
+++ b/service.backend/src/utils/sequelize-jsonb.ts
@@ -1,0 +1,28 @@
+import type { Model } from 'sequelize';
+
+/**
+ * Typed helper for writing a string-array attribute that is backed by a
+ * PostgreSQL ARRAY column in production and a JSON-encoded TEXT column in the
+ * test SQLite environment (see `getArrayType` in `../sequelize`).
+ *
+ * The dual storage means a setter on the model needs to call
+ * `setDataValue(key, stringifiedJson | rawArray)` depending on the dialect.
+ * Sequelize's `setDataValue` is strictly typed to the attribute's declared
+ * shape (`string[]`), which forces an `as any` at every call site for the
+ * test-mode string branch.
+ *
+ * This helper isolates the single justified cast — every model setter then
+ * stays cast-free.
+ */
+export const setStringArrayAttr = <M extends Model>(
+  instance: M,
+  key: keyof M & string,
+  value: readonly string[] | null | undefined
+): void => {
+  const arr = value ? [...value] : [];
+  const stored: string | string[] = process.env.NODE_ENV === 'test' ? JSON.stringify(arr) : arr;
+  // Sequelize types `setDataValue` against the model's attribute shape
+  // (`string[]`), but in test mode the column is TEXT and accepts a JSON
+  // string. The structural cast is necessary and isolated here.
+  (instance.setDataValue as (k: string, v: unknown) => void)(key, stored);
+};


### PR DESCRIPTION
Closes ADS-705 (residual after PR #824).

## Summary

Replaces the last 5 `as any` casts on string-array setters in `EmailQueue`, `EmailTemplate`, and `Content` models with a typed `setStringArrayAttr<M>(instance, key, value)` helper. The cast is now isolated to one well-commented location (the helper itself), where it's required because Sequelize's `setDataValue` is typed against the declared model attribute (`string[]`) and rejects the JSON-string branch used in test mode (SQLite, no native array type).

Note on naming: the columns are Postgres `TEXT[]` (not JSONB) — same dual-storage pattern though. Named the helper `setStringArrayAttr` accordingly.

## Changes

- `service.backend/src/utils/sequelize-jsonb.ts` — new typed helper.
- `service.backend/src/models/EmailQueue.ts` — `ccEmails`, `bccEmails`, `tags` setters refactored.
- `service.backend/src/models/EmailTemplate.ts` — `tags` setter refactored.
- `service.backend/src/models/Content.ts` — `metaKeywords` setter refactored.

5 `as any` casts removed (plus 5 paired `eslint-disable` directives). Zero `as any` remaining anywhere under `service.backend/src/models/`.

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/service-backend` — 2996 pass, 221 skipped, 0 failed.
- [x] `tsc --noEmit` clean.
- [ ] Reviewer sanity-checks the helper's lone cast and its inline comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bf3T5HEmsGUUswNZ4wq4ek)_