### PR TITLE
refactor(testing): migrate app.client tests to lib.dev-tools createMockUser (ADS-718)

### DIFF
--- a/app.client/src/components/profile/ProfileCompletionMeter.test.tsx
+++ b/app.client/src/components/profile/ProfileCompletionMeter.test.tsx
@@ -7,6 +7,7 @@ import {
   PROFILE_METER_CELEBRATED_STORAGE_KEY,
   PROFILE_METER_DISMISSED_STORAGE_KEY,
 } from '@/utils/profileCompletion';
+import { createMockUser } from '@adopt-dont-shop/lib.dev-tools';
 
 const mockLogEvent = vi.fn();
 
@@ -19,17 +20,14 @@ vi.mock('@adopt-dont-shop/lib.auth', () => ({
   useAuth: () => useAuthMock(),
 }));
 
-const incompleteUser = {
+const incompleteUser = createMockUser({
   userId: 'u-1',
   email: 'jane@example.org',
   firstName: 'Jane',
   lastName: 'Doe',
-  emailVerified: true,
-  userType: 'adopter' as const,
-  status: 'active' as const,
   createdAt: '2026-01-01',
   updatedAt: '2026-01-01',
-};
+});
 
 const completeUser = {
   ...incompleteUser,

--- a/app.client/src/pages/ProfilePage.test.tsx
+++ b/app.client/src/pages/ProfilePage.test.tsx
@@ -3,21 +3,21 @@ import { MemoryRouter } from 'react-router-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@adopt-dont-shop/lib.components';
+import { createMockUser } from '@adopt-dont-shop/lib.dev-tools';
 
 const updateProfileMock = vi.fn();
 const updatePreferencesMock = vi.fn();
 const getPreferencesMock = vi.fn();
 
 const mockUser = {
-  userId: 'user-1',
-  email: 'adopter@example.com',
-  firstName: 'Ada',
-  lastName: 'Lovelace',
-  emailVerified: true,
-  userType: 'adopter' as const,
-  status: 'active' as const,
-  createdAt: '2024-01-01T00:00:00.000Z',
-  updatedAt: '2024-01-01T00:00:00.000Z',
+  ...createMockUser({
+    userId: 'user-1',
+    email: 'adopter@example.com',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  }),
   notificationPreferences: {
     emailNotifications: true,
     pushNotifications: false,


### PR DESCRIPTION
Closes ADS-718 (partially — see "Follow-ups" below).

## Summary

Migrates app.client tests that defined inline `mockUser` objects to use the shared `createMockUser` factory scaffolded in PR #822. Scope is narrower than the original ticket implied — investigation found that the other apps don't have a clean migration path without a separate refactor.

## Changes

- `app.client/src/pages/ProfilePage.test.tsx` — `mockUser` → `createMockUser({...})` spread with app-specific fields preserved.
- `app.client/src/components/profile/ProfileCompletionMeter.test.tsx` — `incompleteUser` → `createMockUser({...})`.

## What was NOT migrated (deliberate)

- **`setup-tests.ts` files** in all three apps contain no entity mocks — only jsdom polyfills and `vi.mock(...)` shims for `lib.components`. Nothing to migrate.
- **app.admin** — inline mocks are typed as `AdminUser` (`app.admin/src/types/admin.ts:8`), which has 17 required fields different from `MockUser` and a different `status` union (`'active' | 'suspended' | 'pending' | 'pending_verification'`, no `'inactive'`). Substituting would break typing — out of scope per the "hyper-specific, leave alone" guardrail.
- **app.rescue** — only minimal partials like `{ userId: 'u1', userType: 'rescue_staff' }` in `App.test.tsx` / `Navigation.test.tsx`. One-off mocks that don't fit a baseline factory.
- **Pet / Application factories** not added — only one consumer in app.client; would be speculative to add factories before a second consumer exists.

## Follow-ups (recommend separate tickets)

1. `createMockAdminUser` factory keyed to `AdminUser`, OR unify `AdminUser` with the lib.auth `User` shape. Larger refactor; not part of this rollout.
2. Pet / Rescue / Application factories — wait until at least two apps share the same mock shape.

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/app.client` — 72 files, 455 tests passing.
- [x] `tsc --noEmit` clean on migrated files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bf3T5HEmsGUUswNZ4wq4ek)_