### PR TITLE
feat(lib.components): add PetImage component with no-image fallback (ADS-14)

### DIFF
--- a/app.client/src/components/PetCard.css.ts
+++ b/app.client/src/components/PetCard.css.ts
@@ -33,40 +33,6 @@ globalStyle(`${imageContainer}:hover img`, {
   transform: 'scale(1.05)',
 });
 
-export const placeholderImage = style({
-  width: '100%',
-  height: '100%',
-  background: 'linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  position: 'relative',
-  overflow: 'hidden',
-  '::before': {
-    content: '""',
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    width: '60px',
-    height: '60px',
-    backgroundImage:
-      "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23a0a0a0'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z'/%3E%3C/svg%3E\")",
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'center',
-    backgroundSize: 'contain',
-    opacity: 0.3,
-  },
-  '::after': {
-    content: '"No Photo Available"',
-    position: 'absolute',
-    bottom: '20px',
-    fontSize: '0.9rem',
-    opacity: 0.8,
-    color: '#666',
-  },
-});
-
 export const favoriteButton = style({
   position: 'absolute',
   top: '12px',

--- a/app.client/src/components/PetCard.tsx
+++ b/app.client/src/components/PetCard.tsx
@@ -2,7 +2,7 @@ import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { useFavorites } from '@/contexts/FavoritesContext';
 import { useStatsig } from '@/hooks/useStatsig';
 import { Pet } from '@/services';
-import { Badge, Button, Card, ProgressiveImage } from '@adopt-dont-shop/lib.components';
+import { Badge, Button, Card, PetImage } from '@adopt-dont-shop/lib.components';
 import React, { useState } from 'react';
 import { MdFavorite, MdFavoriteBorder, MdLocationOn } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
@@ -192,16 +192,7 @@ export const PetCard: React.FC<PetCardProps> = ({
       onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && handleCardClick()}
     >
       <div className={styles.imageContainer}>
-        {resolvedImageUrl ? (
-          <ProgressiveImage
-            src={resolvedImageUrl}
-            alt={pet.name}
-            errorFallback={<div className={styles.placeholderImage} />}
-            placeholder={<div className={styles.placeholderImage} />}
-          />
-        ) : (
-          <div className={styles.placeholderImage} />
-        )}
+        <PetImage src={resolvedImageUrl} alt={pet.name} />
 
         <Badge variant={getStatusColor(pet.status)} className={styles.statusBadge}>
           {getStatusLabel(pet.status)}

--- a/app.client/src/setup-tests.ts
+++ b/app.client/src/setup-tests.ts
@@ -304,6 +304,8 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
       errored ? errorFallback : null
     );
   },
+  PetImage: ({ src, alt }: { src?: string; alt: string }) =>
+    React.createElement('img', { src, alt }),
   toast: Object.assign(vi.fn(), {
     success: vi.fn(),
     error: vi.fn(),

--- a/app.rescue/src/components/pets/PetCard.css.ts
+++ b/app.rescue/src/components/pets/PetCard.css.ts
@@ -26,17 +26,6 @@ export const petImage = style({
   objectFit: 'cover',
 });
 
-export const placeholderImage = style({
-  width: '100%',
-  height: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  fontSize: '3rem',
-  color: '#9ca3af',
-  background: 'linear-gradient(135deg, #f9fafb, #f3f4f6)',
-});
-
 export const statusBadgeContainer = style({
   position: 'absolute',
   top: '0.75rem',

--- a/app.rescue/src/components/pets/PetCard.tsx
+++ b/app.rescue/src/components/pets/PetCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Card, Button, ProgressiveImage } from '@adopt-dont-shop/lib.components';
+import { Card, Button, PetImage } from '@adopt-dont-shop/lib.components';
 import { Pet, PetStatus } from '@adopt-dont-shop/lib.pets';
 import { formatRelativeDate } from '@adopt-dont-shop/lib.utils';
 import * as styles from './PetCard.css';
@@ -145,15 +145,7 @@ const PetCard: React.FC<PetCardProps> = ({
           </label>
         )}
         <div className={styles.petImageContainer}>
-          {primaryImage ? (
-            <ProgressiveImage
-              src={primaryImage.url}
-              alt={pet.name}
-              errorFallback={<div className={styles.placeholderImage}>🐾</div>}
-            />
-          ) : (
-            <div className={styles.placeholderImage}>🐾</div>
-          )}
+          <PetImage src={primaryImage?.url} alt={pet.name} />
           <div className={styles.statusBadgeContainer}>
             {pet.status === 'foster' ? (
               // ADS-644: link the foster badge to the foster page filtered to

--- a/app.rescue/src/setup-tests.ts
+++ b/app.rescue/src/setup-tests.ts
@@ -244,4 +244,6 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
     dismiss: vi.fn(),
   }),
   Toaster: () => null,
+  PetImage: ({ src, alt }: { src?: string; alt: string }) =>
+    React.createElement('img', { src, alt }),
 }));

--- a/lib.components/src/components/ui/PetImage/PetImage.test.tsx
+++ b/lib.components/src/components/ui/PetImage/PetImage.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { PetImage } from './PetImage';
+
+describe('PetImage', () => {
+  describe('when no src is provided', () => {
+    it('renders an image with the correct alt text immediately', () => {
+      render(<PetImage alt='A cat' />);
+      expect(screen.getByRole('img', { name: 'A cat' })).toBeInTheDocument();
+    });
+
+    it('passes className to the fallback image', () => {
+      render(<PetImage alt='A cat' className='custom-class' />);
+      expect(screen.getByRole('img', { name: 'A cat' })).toHaveClass('custom-class');
+    });
+
+    it('shows a no-image asset (src ends with no-image.png)', () => {
+      render(<PetImage alt='A cat' />);
+      const img = screen.getByRole('img', { name: 'A cat' });
+      expect(img.getAttribute('src')).toMatch(/no-image\.png/);
+    });
+  });
+
+  describe('when src is provided', () => {
+    it('renders the image with the given src', () => {
+      render(<PetImage src='https://cdn.example/pet.jpg' alt='Buddy' eager />);
+      expect(screen.getByRole('img', { name: 'Buddy' })).toHaveAttribute(
+        'src',
+        'https://cdn.example/pet.jpg'
+      );
+    });
+
+    it('shows a no-image fallback when the image fails to load', () => {
+      render(<PetImage src='https://cdn.example/broken.jpg' alt='Buddy' eager />);
+
+      // The original img is in the DOM — fire error on it
+      fireEvent.error(screen.getByRole('img', { name: 'Buddy' }));
+
+      // After error, a second img (the no-image fallback) should be present
+      const images = screen.getAllByRole('img', { name: 'Buddy' });
+      const fallback = images.find(img => img.getAttribute('src')?.match(/no-image\.png/));
+      expect(fallback).toBeInTheDocument();
+    });
+  });
+});

--- a/lib.components/src/components/ui/PetImage/PetImage.tsx
+++ b/lib.components/src/components/ui/PetImage/PetImage.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ProgressiveImage } from '../ProgressiveImage';
+import noImage from '../ImageGallery/no-image.png';
+
+export type PetImageProps = {
+  src?: string;
+  alt: string;
+  className?: string;
+  eager?: boolean;
+};
+
+export const PetImage: React.FC<PetImageProps> = ({ src, alt, className, eager = false }) => {
+  if (!src) {
+    return <img src={noImage} alt={alt} className={className} />;
+  }
+
+  return (
+    <ProgressiveImage
+      src={src}
+      alt={alt}
+      className={className}
+      eager={eager}
+      errorFallback={<img src={noImage} alt={alt} />}
+    />
+  );
+};

--- a/lib.components/src/components/ui/PetImage/index.ts
+++ b/lib.components/src/components/ui/PetImage/index.ts
@@ -1,0 +1,2 @@
+export { PetImage } from './PetImage';
+export type { PetImageProps } from './PetImage';

--- a/lib.components/src/index.ts
+++ b/lib.components/src/index.ts
@@ -146,9 +146,11 @@ export type { WidgetPickerProps, WidgetPreset } from './components/reports/Widge
 export { DrillDownModal } from './components/reports/DrillDownModal';
 export type { DrillDownModalProps } from './components/reports/DrillDownModal';
 
-// ADS-14: Shared image component
+// ADS-14: Shared image components
 export { ProgressiveImage } from './components/ui/ProgressiveImage';
 export type { ProgressiveImageProps } from './components/ui/ProgressiveImage';
+export { PetImage } from './components/ui/PetImage';
+export type { PetImageProps } from './components/ui/PetImage';
 
 // PWA install prompt
 export { InstallPwaBanner } from './components/ui/InstallPwaBanner';


### PR DESCRIPTION
## Summary

- Adds a `PetImage` component to `lib.components` that wraps `ProgressiveImage` with a standard `no-image.png` fallback — shown immediately when `src` is absent, and on image load errors
- Migrates `app.client/PetCard` and `app.rescue/PetCard` to use `PetImage`, removing the inconsistent inline conditional rendering and per-app placeholder divs
- Removes the now-orphaned `placeholderImage` CSS exports from both PetCard CSS files

Closes ADS-14. `fileUploadsPath` was already 0 matches; this completes the remaining acceptance criteria (shared component + migrated call sites).

## What was not migrated

`TopPicksPage`, `TopPicksHomeModule`, and `SwipeCard` use pet-type emoji fallbacks (🐕, 🐈, etc.) as deliberate UI design — not the same as "no image". Replacing those with `no-image.png` would regress the UX, so they are left as-is.

## Test plan

- [x] 5 new unit tests for `PetImage` — all pass (531/531 in lib.components)
- [x] `lib.components` type-check clean (`tsc --noEmit` exit 0)
- [x] No remaining `ProgressiveImage` imports in `app.rescue`

## Notes

URL resolution (`resolveFileUrl`) stays in the app layer — it uses `import.meta.env.VITE_API_BASE_URL` and will change with the ADS-13 S3 migration. `PetImage` accepts an already-resolved optional `src`.

https://claude.ai/code/session_01VXAfUkEEWmyogi3pcPV4aP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXAfUkEEWmyogi3pcPV4aP)_