### PR TITLE
feat(microservices): Phase 0 — CAD-style backend microservices migration

### DIFF
--- a/.github/workflow-source-paths.yml
+++ b/.github/workflow-source-paths.yml
@@ -14,6 +14,8 @@ paths:
   - 'app.admin/**'
   - 'app.rescue/**'
   - 'lib.*/**'
+  - 'packages/**'
+  - 'services/**'
   - 'package.json'
   - 'package-lock.json'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,8 @@ on:
       - 'app.admin/**'
       - 'app.rescue/**'
       - 'lib.*/**'
+      - 'packages/**'
+      - 'services/**'
       - 'package.json'
       - 'package-lock.json'
       - '**/Dockerfile*'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,6 +12,8 @@ on:
       - 'app.admin/**'
       - 'app.rescue/**'
       - 'lib.*/**'
+      - 'packages/**'
+      - 'services/**'
       - 'package.json'
       - 'package-lock.json'
   pull_request:
@@ -22,6 +24,8 @@ on:
       - 'app.admin/**'
       - 'app.rescue/**'
       - 'lib.*/**'
+      - 'packages/**'
+      - 'services/**'
       - 'package.json'
       - 'package-lock.json'
   workflow_dispatch:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,8 @@ on:
       - 'app.admin/**'
       - 'app.rescue/**'
       - 'lib.*/**'
+      - 'packages/**'
+      - 'services/**'
       - 'package.json'
       - 'package-lock.json'
   pull_request:
@@ -22,6 +24,8 @@ on:
       - 'app.admin/**'
       - 'app.rescue/**'
       - 'lib.*/**'
+      - 'packages/**'
+      - 'services/**'
       - 'package.json'
       - 'package-lock.json'
   schedule:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,28 @@ services:
       timeout: 5s
       retries: 5
 
+  # NATS JetStream — async event bus between backend microservices.
+  # Phase 0 foundation (ADS-microservices migration). Mirrors the CAD pattern:
+  # publish-after-commit from each service, idempotent subscribers fan out to
+  # consumers. JetStream enables durable consumers + replay; without `-js`
+  # NATS is core pub/sub only (lost on disconnect). Monitoring port 8222 is
+  # used by the healthcheck and by `nats-top` / curl probes for ops.
+  nats:
+    image: nats:2.10-alpine
+    restart: always
+    ports:
+      - '127.0.0.1:4222:4222'  # client protocol
+      - '127.0.0.1:8222:8222'  # monitoring + healthz
+    command: '-js -sd /data -m 8222'
+    volumes:
+      - nats_data:/data
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:8222/healthz | grep -q ok || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   # Redis for caching and sessions
   redis:
     image: redis:7-alpine
@@ -365,6 +387,7 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  nats_data:
   lib_types_node_modules:
   loki_data:
   grafana_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,9 @@
         "lib.utils",
         "lib.validation",
         "service.backend",
-        "e2e"
+        "e2e",
+        "packages/*",
+        "services/*"
       ],
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
@@ -4711,6 +4713,10 @@
     },
     "node_modules/@adopt-dont-shop/app.rescue": {
       "resolved": "app.rescue",
+      "link": true
+    },
+    "node_modules/@adopt-dont-shop/db": {
+      "resolved": "packages/db",
       "link": true
     },
     "node_modules/@adopt-dont-shop/e2e": {
@@ -22612,6 +22618,194 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/node-pg-migrate": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/node-pg-migrate/-/node-pg-migrate-8.0.4.tgz",
+      "integrity": "sha512-HTlJ6fOT/2xHhAUtsqSN85PGMAqSbfGJNRwQF8+ZwQ1+sVGNUTl/ZGEshPsOI3yV22tPIyHXrKXr3S0JxeYLrg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "~11.1.0",
+        "yargs": "~17.7.0"
+      },
+      "bin": {
+        "node-pg-migrate": "bin/node-pg-migrate.js"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "peerDependencies": {
+        "@types/pg": ">=6.0.0 <9.0.0",
+        "pg": ">=4.3.0 <9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/pg": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/node-pg-migrate/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/node-pg-migrate/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
@@ -23300,6 +23494,46 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
     "node_modules/pg-hstore": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.4.tgz",
@@ -23319,6 +23553,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
@@ -29075,6 +29318,17 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "packages/db": {
+      "name": "@adopt-dont-shop/db",
+      "version": "0.1.0",
+      "dependencies": {
+        "node-pg-migrate": "^8.0.4",
+        "pg": "^8.21.0"
+      },
+      "devDependencies": {
+        "@types/pg": "^8.15.5"
+      }
+    },
     "service.backend": {
       "name": "@adopt-dont-shop/service-backend",
       "version": "1.0.0",
@@ -30856,55 +31110,6 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "service.backend/node_modules/pg": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
-      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-connection-string": "^2.13.0",
-        "pg-pool": "^3.14.0",
-        "pg-protocol": "^1.14.0",
-        "pg-types": "2.2.0",
-        "pgpass": "1.0.5"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "optionalDependencies": {
-        "pg-cloudflare": "^1.4.0"
-      },
-      "peerDependencies": {
-        "pg-native": ">=3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "pg-native": {
-          "optional": true
-        }
-      }
-    },
-    "service.backend/node_modules/pg-cloudflare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
-      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "service.backend/node_modules/pg-connection-string": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
-      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
-      "license": "MIT"
-    },
-    "service.backend/node_modules/pg-pool": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
-      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "pg": ">=8.0"
       }
     },
     "service.backend/node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4735,6 +4735,10 @@
       "resolved": "eslint-config-react",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/events": {
+      "resolved": "packages/events",
+      "link": true
+    },
     "node_modules/@adopt-dont-shop/lib.analytics": {
       "resolved": "lib.analytics",
       "link": true
@@ -22402,6 +22406,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nats": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/nats/-/nats-2.29.3.tgz",
+      "integrity": "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==",
+      "deprecated": "Package moved. Use @nats-io/transport-node from https://github.com/nats-io/nats.js",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "nkeys.js": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -22415,6 +22432,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nkeys.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nkeys.js/-/nkeys.js-1.1.0.tgz",
+      "integrity": "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tweetnacl": "1.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/node-abi": {
@@ -27501,6 +27530,12 @@
         "@turbo/windows-arm64": "2.9.16"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -29327,6 +29362,20 @@
       },
       "devDependencies": {
         "@types/pg": "^8.15.5"
+      }
+    },
+    "packages/events": {
+      "name": "@adopt-dont-shop/events",
+      "version": "0.1.0",
+      "dependencies": {
+        "nats": "^2.29.3"
+      },
+      "devDependencies": {
+        "@types/pg": "^8.15.5",
+        "pg": "^8.21.0"
+      },
+      "peerDependencies": {
+        "pg": "^8.21.0"
       }
     },
     "service.backend": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "lib.utils",
     "lib.validation",
     "service.backend",
-    "e2e"
+    "e2e",
+    "packages/*",
+    "services/*"
   ],
   "scripts": {
     "setup": "node scripts/bootstrap.mjs",

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,51 @@
+# @adopt-dont-shop/db
+
+Postgres client + migration runner for backend microservices.
+
+Bakes in the four CAD-lesson fixes so every service that adds Postgres
+gets the working setup from day one:
+
+1. **`createSchema: true`** (CAD lesson #1) — the runner creates its
+   `pgmigrations` bookkeeping table inside the service schema; without
+   this, services crash-loop on first boot with
+   `schema "<x>" does not exist`.
+2. **Output-path discipline** (CAD lesson #2) — callers must point
+   `migrationsDir` at a path that resolves identically in dev (`tsx`)
+   and prod (bundled). The CAD fix was a `tsup` `entry:` remap to
+   `dist/migrations/<name>.js`; mirror that in any service that bundles.
+3. **`ignorePattern: '(\\..*|.*\\.map)'`** (CAD lesson #3) — without
+   this the runner's directory scan picks up `.js.map` sidecars and
+   tries to `import()` them, dying with `ERR_UNKNOWN_FILE_EXTENSION`.
+4. **Retry-with-linear-backoff** (CAD lesson #9) — `node-pg-migrate`
+   takes a database-wide advisory lock around `pgmigrations`. When N
+   services boot together, losers throw
+   _"Another migration is already running"_ and crash. The runner
+   doesn't expose a wait-for-lock option, so we retry up to 12 attempts
+   with a 250 ms × attempt backoff.
+
+Plus the schema/public `search_path` for PostGIS compatibility
+(CAD lesson from PR #48 — without `public` on the path, `geography`
+types and the `<->` KNN operator are invisible).
+
+## Usage
+
+```ts
+import { createDbClient, runMigrations } from '@adopt-dont-shop/db';
+
+// On boot:
+await runMigrations({
+  databaseUrl: process.env.DATABASE_URL!,
+  schema: 'pets',
+  migrationsDir: new URL('./migrations/', import.meta.url).pathname,
+});
+
+// In handlers:
+const db = createDbClient({
+  connectionString: process.env.DATABASE_URL,
+  schema: 'pets',
+});
+const result = await db.query('SELECT id FROM pets WHERE status = $1', ['available']);
+```
+
+`search_path` is set automatically on every new connection — unqualified
+table refs resolve service-locally; PostGIS types stay reachable in `public`.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@adopt-dont-shop/db",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Postgres client + node-pg-migrate runner for backend microservices. Bakes in the four CAD-lesson fixes (createSchema, output-path remap, ignorePattern, advisory-lock retry) plus the schema/public search_path so PostGIS works.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "node-pg-migrate": "^8.0.4",
+    "pg": "^8.21.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.15.5"
+  }
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,21 @@
+import { Pool, type PoolConfig } from 'pg';
+
+export type DbClientOptions = PoolConfig & {
+  // Postgres schema this service owns. Every connection's search_path is set
+  // to `<schema>, public` so unqualified table refs resolve service-locally
+  // while PostGIS types/operators (installed into `public` by the postgis
+  // Docker image) remain resolvable. CAD lesson from PR #48 — without
+  // `public` on the path, `geography(Point,4326)` and `<->` blow up.
+  schema: string;
+};
+
+export function createDbClient(opts: DbClientOptions): Pool {
+  const { schema, ...config } = opts;
+  const pool = new Pool(config);
+
+  pool.on('connect', client => {
+    void client.query(`SET search_path TO "${schema}", public`);
+  });
+
+  return pool;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,4 @@
+export { createDbClient } from './client.js';
+export type { DbClientOptions } from './client.js';
+export { runMigrations } from './migrate.js';
+export type { MigrationOptions } from './migrate.js';

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-pg-migrate', () => ({
+  runner: vi.fn(),
+}));
+
+import { runner } from 'node-pg-migrate';
+
+import { runMigrations } from './migrate.js';
+
+const mockRunner = vi.mocked(runner);
+
+const baseOpts = {
+  databaseUrl: 'postgres://test',
+  schema: 'test_schema',
+  migrationsDir: '/tmp/migrations',
+  retryBackoffMs: 0,
+};
+
+describe('runMigrations', () => {
+  beforeEach(() => {
+    mockRunner.mockReset();
+  });
+
+  it('runs the runner once when the first attempt succeeds', async () => {
+    mockRunner.mockResolvedValueOnce(undefined as unknown as Awaited<ReturnType<typeof runner>>);
+
+    await runMigrations(baseOpts);
+
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the four CAD-lesson safety options through to the runner', async () => {
+    mockRunner.mockResolvedValueOnce(undefined as unknown as Awaited<ReturnType<typeof runner>>);
+
+    await runMigrations({ ...baseOpts, schema: 'pets' });
+
+    expect(mockRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema: 'pets',
+        // CAD lesson #1
+        createSchema: true,
+        // CAD lesson #3
+        ignorePattern: '(\\..*|.*\\.map)',
+        // Set by the helper, not the caller
+        migrationsTable: 'pgmigrations',
+        direction: 'up',
+      })
+    );
+  });
+
+  it('retries on the advisory-lock contention message and eventually succeeds (CAD-#9)', async () => {
+    const lockErr = new Error('Another migration is already running');
+    mockRunner
+      .mockRejectedValueOnce(lockErr)
+      .mockRejectedValueOnce(lockErr)
+      .mockResolvedValueOnce(undefined as unknown as Awaited<ReturnType<typeof runner>>);
+
+    await runMigrations(baseOpts);
+
+    expect(mockRunner).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry non-lock errors — they propagate immediately', async () => {
+    const sqlErr = new Error('relation "x" does not exist');
+    mockRunner.mockRejectedValueOnce(sqlErr);
+
+    await expect(runMigrations(baseOpts)).rejects.toThrow('relation "x" does not exist');
+    expect(mockRunner).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after maxRetries lock errors and re-throws the last error', async () => {
+    const lockErr = new Error('Another migration is already running');
+    mockRunner.mockRejectedValue(lockErr);
+
+    await expect(runMigrations({ ...baseOpts, maxRetries: 3 })).rejects.toThrow(
+      'Another migration is already running'
+    );
+    expect(mockRunner).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,0 +1,69 @@
+import { runner, type RunnerOption } from 'node-pg-migrate';
+
+export type MigrationOptions = {
+  databaseUrl: string;
+  // Postgres schema this service owns. node-pg-migrate creates it if missing.
+  schema: string;
+  // Absolute path to the migrations directory. Use a path that resolves
+  // identically in dev (tsx) and prod (bundled) — see CAD lesson on tsup
+  // `entry:` remap to `dist/migrations/<name>.js`.
+  migrationsDir: string;
+  // Max retry attempts on the database-wide advisory-lock contention error
+  // that node-pg-migrate raises when multiple services boot together.
+  maxRetries?: number;
+  // Linear backoff base (ms). Attempt N waits `retryBackoffMs * N`.
+  retryBackoffMs?: number;
+};
+
+// node-pg-migrate raises this message when another instance holds the
+// database-wide advisory lock around `pgmigrations`. We don't get a typed
+// error class, so substring match is the only signal available.
+const ADVISORY_LOCK_MESSAGE = 'Another migration is already running';
+
+export async function runMigrations(opts: MigrationOptions): Promise<void> {
+  const { databaseUrl, schema, migrationsDir, maxRetries = 12, retryBackoffMs = 250 } = opts;
+
+  const runnerOpts: RunnerOption = {
+    databaseUrl,
+    schema,
+    // CAD lesson #1: without this the runner tries to create the
+    // bookkeeping table inside a schema that doesn't yet exist.
+    createSchema: true,
+    dir: migrationsDir,
+    migrationsTable: 'pgmigrations',
+    direction: 'up',
+    // CAD lesson #3: directory scan picks up `.js.map` sidecars and tries
+    // to `import()` them — dies with ERR_UNKNOWN_FILE_EXTENSION. Also skips
+    // dotfiles.
+    ignorePattern: '(\\..*|.*\\.map)',
+    log: () => {
+      /* silent — callers wrap in their own observability layer */
+    },
+  };
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await runner(runnerOpts);
+      return;
+    } catch (err) {
+      lastError = err;
+      // CAD lesson #9: with N services migrating against the same physical
+      // Postgres, simultaneous boots race for the advisory lock — losers
+      // crash on startup. Retry-with-linear-backoff queues them.
+      const msg = (err as Error | null)?.message ?? '';
+      if (!msg.includes(ADVISORY_LOCK_MESSAGE)) {
+        throw err;
+      }
+      if (attempt === maxRetries) {
+        break;
+      }
+      await sleep(retryBackoffMs * attempt);
+    }
+  }
+  throw lastError;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -1,0 +1,62 @@
+# @adopt-dont-shop/events
+
+NATS publish-after-commit + idempotent-subscriber helpers for backend
+microservices. Encodes two CAD-lesson disciplines that pay off most:
+
+## Publish after commit
+
+Domain events go on NATS **only after** the Postgres transaction commits.
+No phantom events on rollback, ever.
+
+```ts
+import { withTransaction } from '@adopt-dont-shop/events';
+
+await withTransaction({ pool, nats }, async ({ client, publish }) => {
+  await client.query('INSERT INTO pets (...) VALUES (...) RETURNING id', [...]);
+  publish({
+    type: 'pets.created',
+    id: 'pet-created-' + petId,  // event id is what subscribers dedupe on
+    payload: { petId, status: 'available' },
+  });
+});
+```
+
+If the `INSERT` throws, `publish(...)` was a no-op — no event reaches NATS.
+If `COMMIT` throws, same — staged events stay buffered and die with the
+client. Subscribers see only events from transactions that actually
+committed (CAD's PR #29 / #35 codified pattern).
+
+## Idempotent subscribers
+
+Every consumer wraps its handler in poison-pill protection: one bad
+message can never tear down the subscription loop (CAD lesson #4).
+
+```ts
+import { subscribe } from '@adopt-dont-shop/events';
+
+subscribe<{ petId: string }>(
+  nats,
+  { subject: 'pets.created', queue: 'notification-workers', onError: logger.warn },
+  async (payload, { id }) => {
+    // De-dupe on the event id — every handler should be idempotent.
+    if (await alreadyProcessed(id)) return;
+    await sendWelcomeNotification(payload.petId);
+    await markProcessed(id);
+  },
+);
+```
+
+Errors thrown from the handler are reported via `onError` and the loop
+keeps draining. Malformed JSON is also a clean skip. Unknown id / wrong
+state / concurrency failures (the CAD list) are caller-side concerns —
+the handler should treat them as skip-not-throw.
+
+## What's NOT here yet
+
+- **Durable consumers / replay-on-reconnect.** Current helpers use core
+  NATS (best-effort delivery). When a service ships JetStream durable
+  consumers, the API adds an `opts.durable` flag and the subscribe loop
+  switches to `JetStreamClient.consume(...)`. CAD's Phase 5+ backlog
+  item; not yet a blocker.
+- **Connection management.** Callers own the `NatsConnection` lifecycle
+  (`connect()` / `drain()`). The helpers expect a live connection.

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@adopt-dont-shop/events",
+  "version": "0.1.0",
+  "private": true,
+  "description": "NATS publish-after-commit + idempotent subscriber helpers for backend microservices. Encodes the CAD-lesson discipline that no domain event ever fires on a rolled-back transaction and no single bad message tears down a subscription loop.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "nats": "^2.29.3"
+  },
+  "peerDependencies": {
+    "pg": "^8.21.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.15.5",
+    "pg": "^8.21.0"
+  }
+}

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,0 +1,4 @@
+export { withTransaction } from './publish.js';
+export type { DomainEvent, TransactionalScope, WithTransactionDeps } from './publish.js';
+export { subscribe } from './subscribe.js';
+export type { MessageHandler, SubscribeOptions } from './subscribe.js';

--- a/packages/events/src/publish.test.ts
+++ b/packages/events/src/publish.test.ts
@@ -1,0 +1,136 @@
+import type { NatsConnection } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { withTransaction } from './publish.js';
+
+function makeMocks() {
+  const client = {
+    query: vi.fn().mockResolvedValue({ rows: [] }),
+    release: vi.fn(),
+  };
+  const pool = {
+    connect: vi.fn().mockResolvedValue(client),
+  };
+  const nats = {
+    publish: vi.fn(),
+  };
+  return {
+    pool: pool as unknown as Pool,
+    client: client as unknown as PoolClient & {
+      query: ReturnType<typeof vi.fn>;
+      release: ReturnType<typeof vi.fn>;
+    },
+    nats: nats as unknown as NatsConnection,
+    natsMock: nats,
+    poolMock: pool,
+    clientMock: client,
+  };
+}
+
+describe('withTransaction', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('runs BEGIN, the work function, and COMMIT in order on success', async () => {
+    const order: string[] = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      order.push(sql);
+      return { rows: [] };
+    });
+
+    await withTransaction({ pool: mocks.pool, nats: mocks.nats }, async () => {
+      order.push('fn');
+      return 'result';
+    });
+
+    expect(order).toEqual(['BEGIN', 'fn', 'COMMIT']);
+    expect(mocks.clientMock.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes staged events ONLY after the commit succeeds (CAD publish-after-commit)', async () => {
+    await withTransaction({ pool: mocks.pool, nats: mocks.nats }, async ({ publish }) => {
+      publish({ type: 'pets.created', id: 'evt-1', payload: { petId: 'p1' } });
+      publish({ type: 'pets.created', id: 'evt-2', payload: { petId: 'p2' } });
+      // No publish should have happened yet — we're pre-commit.
+      expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+    });
+
+    expect(mocks.natsMock.publish).toHaveBeenCalledTimes(2);
+    expect(mocks.natsMock.publish).toHaveBeenNthCalledWith(
+      1,
+      'pets.created',
+      expect.stringContaining('"id":"evt-1"')
+    );
+    expect(mocks.natsMock.publish).toHaveBeenNthCalledWith(
+      2,
+      'pets.created',
+      expect.stringContaining('"id":"evt-2"')
+    );
+  });
+
+  it('does NOT publish staged events when the work function throws (no phantom events on rollback)', async () => {
+    const boom = new Error('work blew up');
+
+    await expect(
+      withTransaction({ pool: mocks.pool, nats: mocks.nats }, async ({ publish }) => {
+        publish({ type: 'pets.created', id: 'evt-1', payload: {} });
+        throw boom;
+      })
+    ).rejects.toThrow('work blew up');
+
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+    expect(mocks.clientMock.query).toHaveBeenCalledWith('ROLLBACK');
+    expect(mocks.clientMock.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT publish staged events when COMMIT itself fails', async () => {
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      if (sql === 'COMMIT') {
+        throw new Error('serialization failure');
+      }
+      return { rows: [] };
+    });
+
+    await expect(
+      withTransaction({ pool: mocks.pool, nats: mocks.nats }, async ({ publish }) => {
+        publish({ type: 'pets.created', id: 'evt-1', payload: {} });
+      })
+    ).rejects.toThrow('serialization failure');
+
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+    expect(mocks.clientMock.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the client even when ROLLBACK also fails', async () => {
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      if (sql === 'ROLLBACK') {
+        throw new Error('connection already gone');
+      }
+      return { rows: [] };
+    });
+
+    await expect(
+      withTransaction({ pool: mocks.pool, nats: mocks.nats }, async () => {
+        throw new Error('original error');
+      })
+    ).rejects.toThrow('original error');
+
+    expect(mocks.clientMock.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('stamps occurredAt with the provided value when set', async () => {
+    const occurredAt = new Date('2026-01-15T10:30:00Z');
+
+    await withTransaction({ pool: mocks.pool, nats: mocks.nats }, async ({ publish }) => {
+      publish({ type: 'pets.created', id: 'evt-1', occurredAt, payload: {} });
+    });
+
+    const [, body] = mocks.natsMock.publish.mock.calls[0];
+    const envelope = JSON.parse(body as string);
+    expect(envelope.occurredAt).toBe('2026-01-15T10:30:00.000Z');
+  });
+});

--- a/packages/events/src/publish.ts
+++ b/packages/events/src/publish.ts
@@ -1,0 +1,88 @@
+import type { NatsConnection } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+
+export type DomainEvent<T = unknown> = {
+  // NATS subject the event publishes on. Convention: `<service>.<entity>.<verb>`,
+  // e.g. `pets.unit.statusChanged`. Subscribers wildcard the prefix.
+  type: string;
+  payload: T;
+  // Event id used for idempotency on the subscriber side. Callers MUST set
+  // this to a value that uniquely identifies the business action — typically
+  // the aggregate id + version, or a ULID minted at command time. Falls back
+  // to a generated value but that defeats idempotency.
+  id?: string;
+  // When the event happened in the domain (not when it was published). Defaults
+  // to now if omitted, but explicit is better — clock skew between services is
+  // a real source of bugs.
+  occurredAt?: Date;
+};
+
+export type TransactionalScope = {
+  // The Postgres client inside the BEGIN/COMMIT span. Pass to repository code.
+  client: PoolClient;
+  // Stage a domain event to publish AFTER the transaction commits. If the
+  // transaction rolls back, no staged event will ever leave the process —
+  // CAD's publish-after-commit rule.
+  publish<T>(event: DomainEvent<T>): void;
+};
+
+export type WithTransactionDeps = {
+  pool: Pool;
+  nats: NatsConnection;
+};
+
+// withTransaction runs `fn` inside a Postgres transaction and publishes any
+// events staged via `scope.publish(...)` only after the commit succeeds.
+//
+// Failure modes:
+//  - `fn` throws → ROLLBACK, no events fire, error re-thrown.
+//  - COMMIT throws → no events fire (we never reach the publish loop), error
+//    re-thrown. Transaction is effectively rolled back.
+//  - publish throws → does NOT roll back (commit already happened) but the
+//    error bubbles. Callers should treat this as a transient infra issue;
+//    consumers will re-derive state from the next event.
+//
+// This is the CAD pattern that PR #29 / #35 codified: no phantom events on
+// rollback, ever.
+export async function withTransaction<R>(
+  { pool, nats }: WithTransactionDeps,
+  fn: (scope: TransactionalScope) => Promise<R>
+): Promise<R> {
+  const client = await pool.connect();
+  const staged: DomainEvent[] = [];
+  try {
+    await client.query('BEGIN');
+    const result = await fn({
+      client,
+      publish: event => {
+        staged.push(event);
+      },
+    });
+    await client.query('COMMIT');
+    publishStaged(nats, staged);
+    return result;
+  } catch (err) {
+    try {
+      await client.query('ROLLBACK');
+    } catch {
+      // Swallow rollback failures — the original error is the one the caller
+      // needs to see. A failed rollback typically means the connection is
+      // already gone (the most common case), and `client.release()` below
+      // handles cleanup.
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+function publishStaged(nats: NatsConnection, staged: readonly DomainEvent[]): void {
+  for (const event of staged) {
+    const envelope = {
+      id: event.id,
+      occurredAt: event.occurredAt ?? new Date(),
+      payload: event.payload,
+    };
+    nats.publish(event.type, JSON.stringify(envelope));
+  }
+}

--- a/packages/events/src/subscribe.test.ts
+++ b/packages/events/src/subscribe.test.ts
@@ -1,0 +1,150 @@
+import type { NatsConnection, Subscription } from 'nats';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { subscribe } from './subscribe.js';
+
+// A tiny replayable Subscription stand-in. NATS' real Subscription is an
+// async iterable that yields `Msg` objects; we provide our own queue and
+// resolve the iterator once the queue is drained.
+function makeSubscription(messages: Array<{ subject: string; data: Uint8Array }>): Subscription {
+  let index = 0;
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => {
+          if (index >= messages.length) {
+            return { value: undefined, done: true };
+          }
+          return { value: messages[index++], done: false };
+        },
+      };
+    },
+  } as unknown as Subscription;
+}
+
+function makeNats(messages: Array<{ subject: string; data: Uint8Array }>) {
+  const subscription = makeSubscription(messages);
+  const subscribeFn = vi.fn().mockReturnValue(subscription);
+  return {
+    nats: { subscribe: subscribeFn } as unknown as NatsConnection,
+    subscribeFn,
+  };
+}
+
+function encode(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(obj));
+}
+
+// Spin until all queued microtasks settle. Used because subscribe() drives
+// the for-await loop in a fire-and-forget IIFE.
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('subscribe', () => {
+  let calls: Array<{ payload: unknown; meta: { subject: string; id?: string } }>;
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  it('invokes the handler once per message with the decoded payload + envelope metadata', async () => {
+    const { nats } = makeNats([
+      {
+        subject: 'pets.created',
+        data: encode({ id: 'evt-1', occurredAt: '2026-01-01T00:00:00Z', payload: { petId: 'p1' } }),
+      },
+      {
+        subject: 'pets.created',
+        data: encode({ id: 'evt-2', occurredAt: '2026-01-01T00:00:01Z', payload: { petId: 'p2' } }),
+      },
+    ]);
+
+    subscribe<{ petId: string }>(nats, { subject: 'pets.created' }, async (payload, meta) => {
+      calls.push({ payload, meta: { subject: meta.subject, id: meta.id } });
+    });
+
+    await flushMicrotasks();
+
+    expect(calls).toEqual([
+      { payload: { petId: 'p1' }, meta: { subject: 'pets.created', id: 'evt-1' } },
+      { payload: { petId: 'p2' }, meta: { subject: 'pets.created', id: 'evt-2' } },
+    ]);
+  });
+
+  it('continues processing after a handler throws (CAD #4 — no poison-pill crash)', async () => {
+    const errors: unknown[] = [];
+    const { nats } = makeNats([
+      { subject: 's', data: encode({ id: '1', payload: { ok: true } }) },
+      { subject: 's', data: encode({ id: '2', payload: { ok: false } }) },
+      { subject: 's', data: encode({ id: '3', payload: { ok: true } }) },
+    ]);
+
+    subscribe<{ ok: boolean }>(
+      nats,
+      {
+        subject: 's',
+        onError: err => {
+          errors.push(err);
+        },
+      },
+      async payload => {
+        if (!payload.ok) {
+          throw new Error('handler crashed');
+        }
+        calls.push({ payload, meta: { subject: 's' } });
+      }
+    );
+
+    await flushMicrotasks();
+
+    expect(calls.map(c => c.payload)).toEqual([{ ok: true }, { ok: true }]);
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe('handler crashed');
+  });
+
+  it('treats a malformed (non-JSON) message as a clean skip', async () => {
+    const errors: unknown[] = [];
+    const { nats } = makeNats([
+      { subject: 's', data: new TextEncoder().encode('not-valid-json{{') },
+      { subject: 's', data: encode({ id: '2', payload: { ok: true } }) },
+    ]);
+
+    subscribe<{ ok: boolean }>(
+      nats,
+      {
+        subject: 's',
+        onError: err => {
+          errors.push(err);
+        },
+      },
+      async payload => {
+        calls.push({ payload, meta: { subject: 's' } });
+      }
+    );
+
+    await flushMicrotasks();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].payload).toEqual({ ok: true });
+    expect(errors).toHaveLength(1);
+  });
+
+  it('passes the queue option through when supplied (load-shared consumers)', async () => {
+    const { nats, subscribeFn } = makeNats([]);
+
+    subscribe(nats, { subject: 'pets.>', queue: 'pets-workers' }, async () => undefined);
+
+    expect(subscribeFn).toHaveBeenCalledWith('pets.>', { queue: 'pets-workers' });
+  });
+
+  it('does not pass a queue option when omitted', async () => {
+    const { nats, subscribeFn } = makeNats([]);
+
+    subscribe(nats, { subject: 'pets.>' }, async () => undefined);
+
+    expect(subscribeFn).toHaveBeenCalledWith('pets.>', undefined);
+  });
+});

--- a/packages/events/src/subscribe.ts
+++ b/packages/events/src/subscribe.ts
@@ -1,0 +1,63 @@
+import type { NatsConnection, Subscription } from 'nats';
+
+export type SubscribeOptions = {
+  // NATS subject pattern (e.g. `pets.unit.statusChanged`). Wildcards (`*`,
+  // `>`) are supported by NATS — callers pass whatever subject string makes
+  // sense for their consumer.
+  subject: string;
+  // Optional queue group. NATS will load-share messages across replicas
+  // sharing the same queue name — use this for horizontally-scaled consumers.
+  queue?: string;
+  // Called for every error raised inside a message handler. The subscription
+  // loop continues regardless — CAD lesson #4: one bad message must never
+  // tear down the drain.
+  onError?: (err: unknown, ctx: { subject: string; raw: string }) => void;
+};
+
+export type EventEnvelope<T> = {
+  id?: string;
+  occurredAt?: string;
+  payload: T;
+};
+
+export type MessageHandler<T = unknown> = (
+  payload: T,
+  meta: { subject: string; id?: string; occurredAt?: Date }
+) => Promise<void> | void;
+
+// subscribe wraps NATS subscription with CAD-style poison-pill protection:
+//
+//  * Each message handler runs in its own try/catch. An exception from the
+//    handler does NOT crash the for-await loop; it's reported via `onError`
+//    and the next message is processed.
+//  * Handlers are expected to be idempotent on the event id. The id is
+//    surfaced in the `meta` argument so handlers can dedupe via their own
+//    storage (e.g. a `processed_events(event_id PK)` table).
+//  * JSON parse failures are also caught and reported — a malformed message
+//    is a clean skip, not a crash.
+//
+// The returned Subscription can be `.drain()`'d for graceful shutdown.
+export function subscribe<T = unknown>(
+  nc: NatsConnection,
+  opts: SubscribeOptions,
+  handler: MessageHandler<T>
+): Subscription {
+  const sub = nc.subscribe(opts.subject, opts.queue ? { queue: opts.queue } : undefined);
+
+  void (async () => {
+    const decoder = new TextDecoder();
+    for await (const msg of sub) {
+      const raw = decoder.decode(msg.data);
+      try {
+        const envelope = JSON.parse(raw) as EventEnvelope<T>;
+        const occurredAt = envelope.occurredAt ? new Date(envelope.occurredAt) : undefined;
+        await handler(envelope.payload, { subject: msg.subject, id: envelope.id, occurredAt });
+      } catch (err) {
+        opts.onError?.(err, { subject: msg.subject, raw });
+        // Continue the loop — CAD lesson #4.
+      }
+    }
+  })();
+
+  return sub;
+}

--- a/packages/events/tsconfig.json
+++ b/packages/events/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/events/vitest.config.ts
+++ b/packages/events/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Context

P0 architectural migration: decompose `service.backend` into ~10 CAD-style backend microservices (shared physical Postgres with schema-per-service, gRPC + NATS, strangler-fig via gateway). M7-M10 launch work is paused until this lands.

**Reference docs:**
- Plan: `.claude/plans/so-these-are-my-vast-duckling.md` (in-repo, untracked)
- Lessons log: [📐 Decisions & lessons learned — AdoptDontShop](https://app.notion.com/p/37589ffb19fc811fa024e012ea31caed) (mirrors the [CAD equivalent](https://app.notion.com/p/37389ffb19fc819580c8c2e873ea5581))
- Parent project page: [🐾 AdoptDontShop](https://app.notion.com/p/40990807659f4df7bc5b460d5782e9f6)

This PR is the running collection of Phase 0 sub-commits. Each commit is independently verified.

## Phase 0a (this commit) — foundation, additive only

No existing directories moved or renamed. Adds:

- **`packages/db/`** — `@adopt-dont-shop/db` wrapping `pg` + `node-pg-migrate` with **all four CAD-lesson fixes baked in**:
  - `createSchema: true` (CAD #1 — runner creates the bookkeeping table inside the service schema, no boot-time crash)
  - `ignorePattern: '(\\..*|.*\\.map)'` (CAD #3 — runner doesn't try to `import()` `.js.map` sidecars)
  - `search_path` set to `<schema>, public` on every connection (CAD lesson from PR #48 — PostGIS types stay reachable)
  - Retry-with-linear-backoff on the advisory-lock contention message (CAD #9 — N services booting together queue rather than crash)
  - 5 behaviour tests lock the retry semantics, the option pass-through, and the don't-retry-non-lock-errors rule.
- **NATS JetStream** added to `docker-compose.yml` with healthcheck + persistent volume. Foundation for the publish-after-commit event bus all extracted services will share.
- **`packages/*` and `services/*`** added to npm workspaces so future foundation packages and extracted services land alongside without further workspace edits.
- **Workflow path filters** (`quality.yml`, `security.yml`, `docker.yml`) and the canonical `.github/workflow-source-paths.yml` updated to include `packages/**` and `services/**` (CAD lesson #13 — audit every glob when new file shapes arrive).

## What's next on this PR

- Phase 0b: `packages/events/` (NATS publish-after-commit + idempotent-subscriber helpers)
- Phase 0c: `packages/authz/` (CASL ability model ported from `@cad/lib.authz`)
- Phase 0d: `packages/proto/` (hermetic ts-proto codegen)
- Phase 0e: `packages/observability/`
- Phase 0f: `services/gateway/` (Fastify pass-through proxy to residual `service.backend`)

Then phase 1+ extracts each service per the plan.

## Test plan

- [x] `npx turbo run lint type-check test --filter=@adopt-dont-shop/db` — green (5/5 tests)
- [x] `node scripts/check-workflow-paths.mjs` — green
- [x] `node scripts/check-workspace-consistency.mjs` — green
- [x] `node scripts/check-lib-tests.mjs` — green
- [x] `docker compose config` — valid (env interpolation errors expected without `.env`)
- [ ] Full CI on this PR after push
- [ ] `npm run docker:dev:build` cold boot (deferred to local verification)

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_