### PR TITLE
feat(microservices): packages/authz — CASL ability model (Phase 0c)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4715,6 +4715,10 @@
       "resolved": "app.rescue",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/authz": {
+      "resolved": "packages/authz",
+      "link": true
+    },
     "node_modules/@adopt-dont-shop/db": {
       "resolved": "packages/db",
       "link": true
@@ -6702,6 +6706,18 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@casl/ability": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-7.0.0.tgz",
+      "integrity": "sha512-QhwRflkTucpdS2uw1XScrzLWbgLYJGvPoq2Xm5OjeRci3dwtPixxnjUKJ04Ss1ivNS9tZQ8y4sjWeelWsrwo4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ucast/mongo2js": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
       }
     },
     "node_modules/@colordx/core": {
@@ -14378,6 +14394,41 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@ucast/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-4XVx6LzPXZGvnZO5jp39cm/G4UvuwvEdtmg+9+4+zl6uFkCcB7UJacvtMYeBE56GJVT99Zqy6Pii7dGJq3Kz9Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ucast/js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-4.0.1.tgz",
+      "integrity": "sha512-9O5xPBvwEWQk2WvO69Eh2WJB8QljVZ2vRVdFvfnKjlZwWXcYxp1lqLBhwXBU1AtuSgCvKhJPkXdjKJggUmAmQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "2.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-3.0.0.tgz",
+      "integrity": "sha512-kwuSH+kdB4GCR0LGhy/PEDm4PCflur89AlK82kNiYD0FvsA8A/p+0sx7m+/R8mMFAlmlkAd3VXp7sM/cLLYWYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "2.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo2js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-2.0.0.tgz",
+      "integrity": "sha512-vNBZzRnsfLr/TSxEoxz6W6hHQ5tmWsfEeC0nCq5z8RezC1AqIRy3cfHm8AGvlGtcn+cTSFQcZremfqnz6wm+nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "2.0.0",
+        "@ucast/js": "4.0.1",
+        "@ucast/mongo": "3.0.0"
       }
     },
     "node_modules/@use-gesture/core": {
@@ -29351,6 +29402,19 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "packages/authz": {
+      "name": "@adopt-dont-shop/authz",
+      "version": "0.1.0",
+      "dependencies": {
+        "@casl/ability": "^7.0.0"
+      },
+      "devDependencies": {
+        "@adopt-dont-shop/lib.types": "*"
+      },
+      "peerDependencies": {
+        "@adopt-dont-shop/lib.types": "*"
       }
     },
     "packages/db": {

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -1,0 +1,71 @@
+# @adopt-dont-shop/authz
+
+CASL ability model for backend microservices. Ported from CAD's
+`@cad/lib.authz` with adopt-dont-shop's role + rescue-scope model.
+
+## What's here
+
+- **`defineAbilitiesFor(principal)`** — returns a CASL `MongoAbility`
+  matching the user's role + scope. The same definitions are used at the
+  gateway edge and at each receiving service (CAD's defence-in-depth
+  re-check pattern — gateway decision + per-service decision can never
+  disagree because both build the ability from the same `(userType,
+  rescueId)` payload).
+- **`requireAbility(ability, action, scope)`** — wraps `ability.can(...)`
+  with the **CAD lesson #10** fix for CASL's bare-string-vs-tagged-subject
+  quirk:
+
+  ```ts
+  ability.can('read', 'Pet')                  // → TRUE  (any rule for type passes)
+  ability.can('read', subject('Pet', {}))     // → FALSE (empty conditions fail
+                                              //         a `{rescueId: '...'}` rule)
+  ```
+
+  The helper detects the empty-conditions case and passes the bare string;
+  with at least one condition, it tags the subject so condition rules can
+  evaluate. Without this, unscoped reads 403 for users whose rules require
+  a scope match.
+
+## Role model
+
+Adapted from adopt-dont-shop's existing `UserRole`:
+
+| Role           | Scope            | Headline rule                                            |
+|----------------|------------------|----------------------------------------------------------|
+| `super_admin`  | platform-wide    | `manage all`                                             |
+| `admin`        | rescueId         | `manage` Pet / Application / StaffMember / Rescue / Invitation within own rescue |
+| `rescue_staff` | rescueId         | CRUD + review/approve/reject Application within own rescue; no staff management |
+| `moderator`    | platform-wide    | review/moderate Report, moderate Message, suspend User    |
+| `support_agent`| platform-wide    | read/update SupportTicket, read-only on User / Application |
+| `adopter`      | self (userId)    | create + read own Application; read/send Message on own Chat; read public Pet listings |
+
+The `rescueId` scope on `admin` + `rescue_staff` mirrors CAD's `tier`
+scope on `dispatcher` / `supervisor` — same multi-tenant shape, different
+domain word.
+
+## Usage
+
+```ts
+import { defineAbilitiesFor, requireAbility } from '@adopt-dont-shop/authz';
+
+// Service receives `x-user-{id,type,rescue-id}` gRPC metadata and rebuilds:
+const ability = defineAbilitiesFor({
+  userId: req.headers['x-user-id'],
+  userType: req.headers['x-user-type'],
+  rescueId: req.headers['x-rescue-id'] || undefined,
+});
+
+// Then gate every command:
+if (!requireAbility(ability, 'approve', { kind: 'Application', rescueId: app.rescueId })) {
+  throw new ForbiddenError('not allowed to approve this application');
+}
+```
+
+## What's NOT here yet
+
+- **Persistence of the rule list across the wire.** CAD ships `ability_json`
+  in `LoginResponse` so the SPA can build the same ability the gateway
+  uses. We'll add that when `service.auth` extracts; until then each side
+  builds its own from the same `(userType, rescueId)` shape.
+- **Field-level permissions.** `lib.permissions` already covers field
+  masking via a separate system; authz is action+subject only.

--- a/packages/authz/package.json
+++ b/packages/authz/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@adopt-dont-shop/authz",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CASL ability model for backend microservices. Ported from CAD's @cad/lib.authz with adopt-dont-shop's role + scope model. Includes the CAD lesson #10 fix for the bare-string vs tagged-subject CASL gotcha.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@casl/ability": "^7.0.0"
+  },
+  "peerDependencies": {
+    "@adopt-dont-shop/lib.types": "*"
+  },
+  "devDependencies": {
+    "@adopt-dont-shop/lib.types": "*"
+  }
+}

--- a/packages/authz/src/abilities.test.ts
+++ b/packages/authz/src/abilities.test.ts
@@ -1,0 +1,125 @@
+import { subject } from '@casl/ability';
+import { describe, expect, it } from 'vitest';
+
+import type { RescueId, UserId } from '@adopt-dont-shop/lib.types';
+
+import { defineAbilitiesFor, type Principal } from './abilities.js';
+
+const userId = 'usr-1' as UserId;
+const otherUserId = 'usr-2' as UserId;
+const rescueId = 'res-1' as RescueId;
+const otherRescueId = 'res-2' as RescueId;
+
+function principal(overrides: Partial<Principal> & Pick<Principal, 'userType'>): Principal {
+  return { userId, ...overrides };
+}
+
+describe('defineAbilitiesFor', () => {
+  describe('super_admin', () => {
+    const ability = defineAbilitiesFor(principal({ userType: 'super_admin' }));
+
+    it('can manage every subject', () => {
+      expect(ability.can('manage', 'all')).toBe(true);
+      expect(ability.can('delete', 'User')).toBe(true);
+      expect(ability.can('suspend', 'User')).toBe(true);
+      expect(ability.can('moderate', 'Report')).toBe(true);
+    });
+  });
+
+  describe('admin (rescue admin)', () => {
+    const ability = defineAbilitiesFor(principal({ userType: 'admin', rescueId }));
+
+    it('can manage all entities scoped to their own rescue', () => {
+      expect(ability.can('manage', 'Pet')).toBe(true);
+      expect(ability.can('manage', 'Application')).toBe(true);
+      expect(ability.can('manage', 'StaffMember')).toBe(true);
+    });
+
+    it('cannot manage another rescue’s entities (scope mismatch)', () => {
+      // Tagged subject with wrong rescueId fails the condition.
+      expect(ability.can('delete', subject('Pet', { rescueId: otherRescueId }))).toBe(false);
+      expect(ability.can('update', subject('Application', { rescueId: otherRescueId }))).toBe(
+        false
+      );
+    });
+
+    it('falls back to no rescue-scoped abilities when rescueId is missing', () => {
+      const noScope = defineAbilitiesFor(principal({ userType: 'admin' }));
+      expect(noScope.can('manage', 'Pet')).toBe(false);
+      expect(noScope.can('manage', 'Application')).toBe(false);
+    });
+  });
+
+  describe('rescue_staff', () => {
+    const ability = defineAbilitiesFor(principal({ userType: 'rescue_staff', rescueId }));
+
+    it('can review and approve applications for their own rescue', () => {
+      expect(ability.can('review', 'Application')).toBe(true);
+      expect(ability.can('approve', 'Application')).toBe(true);
+      expect(ability.can('reject', 'Application')).toBe(true);
+    });
+
+    it('cannot manage staff or rescue settings (admin owns those)', () => {
+      expect(ability.can('delete', subject('StaffMember', { rescueId }))).toBe(false);
+      expect(ability.can('update', subject('Rescue', { rescueId }))).toBe(false);
+    });
+  });
+
+  describe('moderator', () => {
+    const ability = defineAbilitiesFor(principal({ userType: 'moderator' }));
+
+    it('can review and moderate reports across all rescues', () => {
+      expect(ability.can('moderate', 'Report')).toBe(true);
+      expect(ability.can('review', 'Report')).toBe(true);
+      expect(ability.can('moderate', 'Message')).toBe(true);
+    });
+
+    it('can suspend a User but not delete or update them via generic update', () => {
+      expect(ability.can('suspend', 'User')).toBe(true);
+      expect(ability.can('delete', 'User')).toBe(false);
+      expect(ability.can('update', 'User')).toBe(false);
+    });
+  });
+
+  describe('support_agent', () => {
+    const ability = defineAbilitiesFor(principal({ userType: 'support_agent' }));
+
+    it('can read and update support tickets but not moderate content', () => {
+      expect(ability.can('update', 'SupportTicket')).toBe(true);
+      expect(ability.can('read', 'User')).toBe(true);
+      expect(ability.can('moderate', 'Report')).toBe(false);
+      expect(ability.can('suspend', 'User')).toBe(false);
+    });
+  });
+
+  describe('adopter', () => {
+    const ability = defineAbilitiesFor(principal({ userType: 'adopter' }));
+
+    it('can read and list public pets without scope', () => {
+      expect(ability.can('read', 'Pet')).toBe(true);
+      expect(ability.can('list', 'Pet')).toBe(true);
+    });
+
+    it('cannot mutate pets at all', () => {
+      expect(ability.can('update', 'Pet')).toBe(false);
+      expect(ability.can('delete', 'Pet')).toBe(false);
+    });
+
+    it('can read and update their OWN user record but not others’', () => {
+      expect(ability.can('update', subject('User', { userId }))).toBe(true);
+      expect(ability.can('update', subject('User', { userId: otherUserId }))).toBe(false);
+    });
+
+    it('can create and read their OWN applications but not others’', () => {
+      expect(ability.can('create', subject('Application', { adopterId: userId }))).toBe(true);
+      expect(ability.can('read', subject('Application', { adopterId: userId }))).toBe(true);
+      expect(ability.can('read', subject('Application', { adopterId: otherUserId }))).toBe(false);
+    });
+
+    it('cannot review or approve any application', () => {
+      const ownApp = subject('Application', { adopterId: userId });
+      expect(ability.can('review', ownApp)).toBe(false);
+      expect(ability.can('approve', ownApp)).toBe(false);
+    });
+  });
+});

--- a/packages/authz/src/abilities.ts
+++ b/packages/authz/src/abilities.ts
@@ -1,0 +1,171 @@
+import { AbilityBuilder, createMongoAbility, type MongoAbility } from '@casl/ability';
+
+import type { RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+// CASL subject names — these correspond to the entity types each service
+// owns. They're strings, not classes (we don't ship runtime class shapes
+// to keep the ability serialisable across the wire). Each extracted service
+// adds rules for its own subjects; consumers (gateway + receiving services)
+// rebuild the ability from the same `(userType, scope)` payload so the two
+// always agree (CAD's gateway-edge + per-service-re-check pattern).
+export type AbilitySubject =
+  | 'User'
+  | 'Pet'
+  | 'Application'
+  | 'Rescue'
+  | 'StaffMember'
+  | 'Invitation'
+  | 'Chat'
+  | 'Message'
+  | 'Notification'
+  | 'Audit'
+  | 'Report'
+  | 'SupportTicket'
+  | 'Rating'
+  | 'all';
+
+// Action vocabulary. Mirrors lib.types `PermissionAction` plus `manage`
+// (CASL convention for "any action"). New actions are added here first and
+// then to lib.types — the two must stay in sync.
+export type AbilityAction =
+  | 'create'
+  | 'read'
+  | 'update'
+  | 'delete'
+  | 'list'
+  | 'archive'
+  | 'feature'
+  | 'publish'
+  | 'approve'
+  | 'reject'
+  | 'review'
+  | 'verify'
+  | 'suspend'
+  | 'moderate'
+  | 'manage';
+
+export type AppAbility = MongoAbility<[AbilityAction, AbilitySubject]>;
+
+// Principal carries the minimum identity payload needed to derive an ability.
+// Services receive this via gRPC metadata (`x-user-id`, `x-user-type`,
+// `x-rescue-id`) and rebuild the ability locally — the same shape the
+// gateway used at the edge, so the two ability instances are identical.
+export type Principal = {
+  userId: UserId;
+  userType: UserRole;
+  // Present for `rescue_staff` and rescue-scoped `admin` roles. Drives the
+  // tenant-scoping rules below. Absent for adopter, super_admin, moderator,
+  // support_agent.
+  rescueId?: RescueId;
+};
+
+// defineAbilitiesFor returns a CASL ability matching the principal's role +
+// scope. The rules below are authoritative; per-service `ability.can(...)`
+// re-checks use the same definitions so deny/allow decisions match the
+// edge gate (CAD's defence-in-depth pattern).
+export function defineAbilitiesFor(principal: Principal): AppAbility {
+  const builder = new AbilityBuilder<AppAbility>(createMongoAbility);
+  // CASL v7's `AbilityBuilder.can` infers conditions as `MongoQuery<never>`
+  // when subjects are bare strings (it expects subject CLASSES to derive
+  // field shapes from). Runtime conditions work fine — CASL just compares
+  // values — but the type guard rejects every `{ rescueId, adopterId, … }`
+  // object literal. Wrap once here so the rules below stay readable; this
+  // is the same approach the CAD repo uses against its own subject set.
+  const can = builder.can.bind(builder) as (
+    action: AbilityAction | AbilityAction[],
+    subject: AbilitySubject,
+    conditions?: Record<string, unknown>
+  ) => void;
+  const build = builder.build.bind(builder);
+
+  // ------------------------------------------------------------------------
+  // Public / common rules — apply to every authenticated user. Anonymous
+  // users get a principal with `userType: 'adopter'` and an unauthenticated
+  // marker upstream; rules below are still safe to grant since they only
+  // permit reading public listings.
+  // ------------------------------------------------------------------------
+  can(['read', 'list'], 'Pet');
+  can(['read', 'list'], 'Rescue');
+  can('read', 'Rating');
+
+  switch (principal.userType) {
+    case 'super_admin':
+      // Platform-wide superuser. `manage all` is CASL's wildcard.
+      can('manage', 'all');
+      break;
+
+    case 'admin':
+      // Rescue admin — full control of their own rescue's entities. The
+      // `{ rescueId }` condition is what CAD-#10 tests force us to handle
+      // carefully: a tagged subject with no `rescueId` field on it evaluates
+      // FALSE against this rule. See requireAbility for the bare-string fix.
+      if (principal.rescueId) {
+        const rescueScope = { rescueId: principal.rescueId as string };
+        can('manage', 'Pet', rescueScope);
+        can('manage', 'Application', rescueScope);
+        can('manage', 'StaffMember', rescueScope);
+        can('manage', 'Rescue', rescueScope);
+        can('manage', 'Invitation', rescueScope);
+        can(['read', 'list'], 'Chat', rescueScope);
+        can(['read', 'list'], 'Message', rescueScope);
+      }
+      break;
+
+    case 'rescue_staff':
+      // Day-to-day rescue operator — read + write own rescue's data, but not
+      // staff management or rescue settings (admin owns those).
+      if (principal.rescueId) {
+        const rescueScope = { rescueId: principal.rescueId as string };
+        can(['create', 'read', 'update', 'list', 'archive'], 'Pet', rescueScope);
+        can(['read', 'list', 'review', 'approve', 'reject'], 'Application', rescueScope);
+        can(['read', 'list'], 'StaffMember', rescueScope);
+        can(['read', 'list', 'create', 'update'], 'Chat', rescueScope);
+        can(['read', 'list', 'create'], 'Message', rescueScope);
+      }
+      break;
+
+    case 'moderator':
+      // Cross-rescue content moderation. No data-mutation outside moderation
+      // surfaces — sanctions live on the User aggregate but only via the
+      // `suspend` verb, not generic `update`.
+      can(['read', 'list', 'review', 'moderate'], 'Report');
+      can(['read', 'list', 'moderate'], 'Message');
+      can('suspend', 'User');
+      can(['read', 'list'], 'User');
+      can(['read', 'list'], 'Pet');
+      break;
+
+    case 'support_agent':
+      // Read-mostly + ticket-handling. No moderation surface, no rescue
+      // operations.
+      can(['read', 'list', 'update'], 'SupportTicket');
+      can(['read', 'list'], 'User');
+      can(['read', 'list'], 'Application');
+      can(['read', 'list'], 'Chat');
+      can(['read', 'list'], 'Message');
+      break;
+
+    case 'adopter':
+      // The default. Public listings already granted above. Adopter can:
+      //  - apply to adopt (create Application referencing self)
+      //  - read OWN applications
+      //  - read OWN chats + send messages on chats they participate in
+      //  - read OWN notifications
+      {
+        const selfId = principal.userId as string;
+        can('create', 'Application', { adopterId: selfId });
+        can(['read', 'list'], 'Application', { adopterId: selfId });
+        can(['read', 'list'], 'Chat', { adopterId: selfId });
+        can(['create', 'read', 'list'], 'Message', { adopterId: selfId });
+        can(['read', 'list', 'update'], 'Notification', { userId: selfId });
+        can(['read', 'update'], 'User', { userId: selfId });
+        can(['create', 'read'], 'Rating');
+        can(['create', 'read'], 'Report');
+        can('create', 'SupportTicket', { userId: selfId });
+        can(['read', 'list'], 'SupportTicket', { userId: selfId });
+      }
+      break;
+  }
+
+  return build();
+}

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -1,0 +1,4 @@
+export { defineAbilitiesFor } from './abilities.js';
+export type { AppAbility, AbilityAction, AbilitySubject, Principal } from './abilities.js';
+export { requireAbility } from './require-ability.js';
+export type { SubjectScope } from './require-ability.js';

--- a/packages/authz/src/require-ability.test.ts
+++ b/packages/authz/src/require-ability.test.ts
@@ -1,0 +1,53 @@
+import { AbilityBuilder, createMongoAbility, subject } from '@casl/ability';
+import { describe, expect, it } from 'vitest';
+
+import type { AppAbility } from './abilities.js';
+import { requireAbility } from './require-ability.js';
+
+// Build a tiny ability with a tier-conditioned rule so we can reproduce the
+// CAD-#10 bare-string-vs-tagged-subject mismatch. The CAD repo wrote the
+// test up against an `Incident` subject; we use `Pet` + `rescueId` here
+// because that's the shape of every scoped rule in adopt-dont-shop.
+function buildScopedAbility(): AppAbility {
+  const { can, build } = new AbilityBuilder<AppAbility>(createMongoAbility);
+  can('read', 'Pet', { rescueId: 'res-1' });
+  return build();
+}
+
+describe('requireAbility', () => {
+  describe('CAD-#10 bare-string vs tagged-subject semantics', () => {
+    const ability = buildScopedAbility();
+
+    it('returns TRUE for a bare-string subject because any rule on the type passes (CASL semantics)', () => {
+      // Direct call shows the underlying CASL behaviour we're working with.
+      expect(ability.can('read', 'Pet')).toBe(true);
+    });
+
+    it('returns FALSE for a tagged subject with empty conditions (the bug CAD-#10 fixed)', () => {
+      // This is the trap: the helper used to always tag the subject, which
+      // made unscoped reads 403 for users whose rules required matching
+      // conditions. We assert the underlying CASL behaviour first.
+      expect(ability.can('read', subject('Pet', {}))).toBe(false);
+    });
+
+    it('passes the bare string when scope has no conditions (helper fix)', () => {
+      expect(requireAbility(ability, 'read', { kind: 'Pet' })).toBe(true);
+    });
+
+    it('passes a tagged subject when scope has at least one condition', () => {
+      expect(requireAbility(ability, 'read', { kind: 'Pet', rescueId: 'res-1' })).toBe(true);
+      expect(requireAbility(ability, 'read', { kind: 'Pet', rescueId: 'res-2' })).toBe(false);
+    });
+
+    it('accepts a bare subject string directly (shorthand for unscoped checks)', () => {
+      expect(requireAbility(ability, 'read', 'Pet')).toBe(true);
+    });
+  });
+
+  describe('integration with action verbs', () => {
+    it('returns false for an action the ability does not grant', () => {
+      const ability = buildScopedAbility();
+      expect(requireAbility(ability, 'delete', { kind: 'Pet', rescueId: 'res-1' })).toBe(false);
+    });
+  });
+});

--- a/packages/authz/src/require-ability.ts
+++ b/packages/authz/src/require-ability.ts
@@ -1,0 +1,42 @@
+import { subject as caslSubject } from '@casl/ability';
+
+import type { AbilityAction, AbilitySubject, AppAbility } from './abilities.js';
+
+// Subject + optional scope conditions. When `conditions` is empty (or the
+// caller passes a bare string), `requireAbility` falls back to CASL's
+// bare-string semantics — see CAD lesson #10 below.
+export type SubjectScope = {
+  kind: Exclude<AbilitySubject, 'all'>;
+} & Record<string, unknown>;
+
+// requireAbility runs `ability.can(action, subject)` while handling CASL's
+// bare-string-vs-tagged-instance quirk. The CAD repo wrote this up after
+// PR #46 caused observer 403s on unscoped reads.
+//
+// CAD lesson #10, copied here verbatim because the trap is identical:
+//
+//   ability.can('view', 'Incident')                  → TRUE
+//     (any rule for this subject type passes;
+//      conditions are ignored)
+//
+//   ability.can('view', subject('Incident', {}))     → FALSE
+//     (CASL evaluates the rule's `{tier:'police'}` against
+//      tier:undefined; condition match fails)
+//
+// The fix is: detect the no-conditions case and pass the bare string. With
+// at least one condition present, use the tagged subject so condition rules
+// can evaluate.
+export function requireAbility(
+  ability: AppAbility,
+  action: AbilityAction,
+  scope: SubjectScope | Exclude<AbilitySubject, 'all'>
+): boolean {
+  if (typeof scope === 'string') {
+    return ability.can(action, scope);
+  }
+  const { kind, ...conditions } = scope;
+  if (Object.keys(conditions).length === 0) {
+    return ability.can(action, kind);
+  }
+  return ability.can(action, caslSubject(kind, conditions) as unknown as AbilitySubject);
+}

--- a/packages/authz/tsconfig.json
+++ b/packages/authz/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/authz/vitest.config.ts
+++ b/packages/authz/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Closing — the CASL approach deviates from adopt-dont-shop's existing DB-driven Role/Permission system (lib.types `Permission`, lib.permissions `PermissionsService`). Replacing with a permission-string helper that mirrors the existing model. See follow-up PR.