### PR TITLE
feat(microservices): notifications gRPC handlers (Phase 1.3b)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32602,8 +32602,13 @@
       "name": "@adopt-dont-shop/service.notifications",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/authz": "*",
         "@adopt-dont-shop/db": "*",
+        "@adopt-dont-shop/events": "*",
+        "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
+        "@adopt-dont-shop/proto": "*",
+        "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -33,8 +33,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/authz": "*",
     "@adopt-dont-shop/db": "*",
+    "@adopt-dont-shop/events": "*",
+    "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
+    "@adopt-dont-shop/proto": "*",
+    "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.21.0"

--- a/services/notifications/src/grpc/enum-map.test.ts
+++ b/services/notifications/src/grpc/enum-map.test.ts
@@ -1,0 +1,105 @@
+import { NotificationsV1 } from '@adopt-dont-shop/proto';
+import { describe, expect, it } from 'vitest';
+
+import {
+  channelFromDb,
+  channelToDb,
+  priorityFromDb,
+  priorityToDb,
+  relatedEntityTypeFromDb,
+  relatedEntityTypeToDb,
+  statusFromDb,
+  statusToDb,
+  typeFromDb,
+  typeToDb,
+} from './enum-map.js';
+
+describe('enum-map round-trip', () => {
+  // For each enum: walk every defined value, map to DB, map back,
+  // assert identity. This is the single most valuable test in this
+  // file — a missed entry in either direction (proto → DB or back)
+  // surfaces immediately, including new values added later when the
+  // .proto / migration expands.
+
+  it('NotificationType round-trips for every defined value', () => {
+    const values = realEnumValues(NotificationsV1.NotificationType);
+    expect(values).toHaveLength(16);
+    for (const v of values) {
+      expect(typeFromDb(typeToDb(v))).toBe(v);
+    }
+  });
+
+  it('NotificationChannel round-trips for every defined value', () => {
+    const values = realEnumValues(NotificationsV1.NotificationChannel);
+    expect(values).toHaveLength(4);
+    for (const v of values) {
+      expect(channelFromDb(channelToDb(v))).toBe(v);
+    }
+  });
+
+  it('NotificationPriority round-trips for every defined value', () => {
+    const values = realEnumValues(NotificationsV1.NotificationPriority);
+    expect(values).toHaveLength(4);
+    for (const v of values) {
+      expect(priorityFromDb(priorityToDb(v))).toBe(v);
+    }
+  });
+
+  it('NotificationStatus round-trips for every defined value', () => {
+    const values = realEnumValues(NotificationsV1.NotificationStatus);
+    expect(values).toHaveLength(6);
+    for (const v of values) {
+      expect(statusFromDb(statusToDb(v))).toBe(v);
+    }
+  });
+
+  it('NotificationRelatedEntityType round-trips for every defined value', () => {
+    const values = realEnumValues(NotificationsV1.NotificationRelatedEntityType);
+    expect(values).toHaveLength(14);
+    for (const v of values) {
+      expect(relatedEntityTypeFromDb(relatedEntityTypeToDb(v))).toBe(v);
+    }
+  });
+
+  it('typeFromDb throws on an unknown DB value', () => {
+    expect(() => typeFromDb('not_a_real_type')).toThrow(/unknown notification type/);
+  });
+
+  it('channelFromDb throws on an unknown DB value', () => {
+    expect(() => channelFromDb('telegram')).toThrow(/unknown notification channel/);
+  });
+
+  it('priorityFromDb maps the four levels to their proto equivalents in the documented order', () => {
+    expect(priorityFromDb('low')).toBe(
+      NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_LOW
+    );
+    expect(priorityFromDb('normal')).toBe(
+      NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL
+    );
+    expect(priorityFromDb('high')).toBe(
+      NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_HIGH
+    );
+    expect(priorityFromDb('urgent')).toBe(
+      NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_URGENT
+    );
+  });
+
+  it('statusToDb maps the proto enum back to the migration ENUM string', () => {
+    expect(statusToDb(NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_PENDING)).toBe(
+      'pending'
+    );
+    expect(statusToDb(NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_READ)).toBe('read');
+    expect(statusToDb(NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_CANCELLED)).toBe(
+      'cancelled'
+    );
+  });
+});
+
+// ts-proto emits proto3 enums with two sentinels we don't map:
+//   - <PREFIX>_UNSPECIFIED = 0 (the proto3-required zero value)
+//   - UNRECOGNIZED = -1 (ts-proto's "value we didn't know about" marker)
+// Both are filtered out here so the round-trip tests only exercise the
+// real enum entries.
+function realEnumValues(e: object): number[] {
+  return Object.values(e).filter((v): v is number => typeof v === 'number' && v > 0);
+}

--- a/services/notifications/src/grpc/enum-map.ts
+++ b/services/notifications/src/grpc/enum-map.ts
@@ -1,0 +1,241 @@
+// Bidirectional maps between the notification proto3 enums (numeric
+// values, SCREAMING_SNAKE_CASE names) and the Postgres ENUM string
+// values defined in src/migrations/001_create_notifications.ts.
+//
+// The handler sits at the boundary: read from gRPC (proto enums), write
+// to Postgres (string values), read from Postgres (string values), write
+// to gRPC (proto enums). Each direction is one of these functions.
+
+import { NotificationsV1 } from '@adopt-dont-shop/proto';
+
+const {
+  NotificationType,
+  NotificationChannel,
+  NotificationPriority,
+  NotificationStatus,
+  NotificationRelatedEntityType,
+} = NotificationsV1;
+
+// --- NotificationType ------------------------------------------------
+
+const _TYPE_DB_VALUES = [
+  'application_status',
+  'message_received',
+  'pet_available',
+  'interview_scheduled',
+  'home_visit_scheduled',
+  'adoption_approved',
+  'adoption_rejected',
+  'reference_request',
+  'system_announcement',
+  'account_security',
+  'reminder',
+  'marketing',
+  'rescue_invitation',
+  'staff_assignment',
+  'pet_update',
+  'follow_up',
+] as const;
+
+export type NotificationTypeDb = (typeof _TYPE_DB_VALUES)[number];
+
+const TYPE_DB_TO_PROTO: Record<NotificationTypeDb, NotificationsV1.NotificationType> = {
+  application_status: NotificationType.NOTIFICATION_TYPE_APPLICATION_STATUS,
+  message_received: NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED,
+  pet_available: NotificationType.NOTIFICATION_TYPE_PET_AVAILABLE,
+  interview_scheduled: NotificationType.NOTIFICATION_TYPE_INTERVIEW_SCHEDULED,
+  home_visit_scheduled: NotificationType.NOTIFICATION_TYPE_HOME_VISIT_SCHEDULED,
+  adoption_approved: NotificationType.NOTIFICATION_TYPE_ADOPTION_APPROVED,
+  adoption_rejected: NotificationType.NOTIFICATION_TYPE_ADOPTION_REJECTED,
+  reference_request: NotificationType.NOTIFICATION_TYPE_REFERENCE_REQUEST,
+  system_announcement: NotificationType.NOTIFICATION_TYPE_SYSTEM_ANNOUNCEMENT,
+  account_security: NotificationType.NOTIFICATION_TYPE_ACCOUNT_SECURITY,
+  reminder: NotificationType.NOTIFICATION_TYPE_REMINDER,
+  marketing: NotificationType.NOTIFICATION_TYPE_MARKETING,
+  rescue_invitation: NotificationType.NOTIFICATION_TYPE_RESCUE_INVITATION,
+  staff_assignment: NotificationType.NOTIFICATION_TYPE_STAFF_ASSIGNMENT,
+  pet_update: NotificationType.NOTIFICATION_TYPE_PET_UPDATE,
+  follow_up: NotificationType.NOTIFICATION_TYPE_FOLLOW_UP,
+};
+
+const TYPE_PROTO_TO_DB = invert(TYPE_DB_TO_PROTO);
+
+export function typeFromDb(value: string): NotificationsV1.NotificationType {
+  const result = TYPE_DB_TO_PROTO[value as NotificationTypeDb];
+  if (result === undefined) {
+    throw new Error(`unknown notification type from DB: ${value}`);
+  }
+  return result;
+}
+
+export function typeToDb(value: NotificationsV1.NotificationType): NotificationTypeDb {
+  const result = TYPE_PROTO_TO_DB[value];
+  if (!result) {
+    throw new Error(`unknown notification type from proto: ${value}`);
+  }
+  return result as NotificationTypeDb;
+}
+
+// --- NotificationChannel ---------------------------------------------
+
+const _CHANNEL_DB_VALUES = ['in_app', 'email', 'push', 'sms'] as const;
+export type NotificationChannelDb = (typeof _CHANNEL_DB_VALUES)[number];
+
+const CHANNEL_DB_TO_PROTO: Record<NotificationChannelDb, NotificationsV1.NotificationChannel> = {
+  in_app: NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  email: NotificationChannel.NOTIFICATION_CHANNEL_EMAIL,
+  push: NotificationChannel.NOTIFICATION_CHANNEL_PUSH,
+  sms: NotificationChannel.NOTIFICATION_CHANNEL_SMS,
+};
+
+const CHANNEL_PROTO_TO_DB = invert(CHANNEL_DB_TO_PROTO);
+
+export function channelFromDb(value: string): NotificationsV1.NotificationChannel {
+  const result = CHANNEL_DB_TO_PROTO[value as NotificationChannelDb];
+  if (result === undefined) {
+    throw new Error(`unknown notification channel from DB: ${value}`);
+  }
+  return result;
+}
+
+export function channelToDb(value: NotificationsV1.NotificationChannel): NotificationChannelDb {
+  const result = CHANNEL_PROTO_TO_DB[value];
+  if (!result) {
+    throw new Error(`unknown notification channel from proto: ${value}`);
+  }
+  return result as NotificationChannelDb;
+}
+
+// --- NotificationPriority --------------------------------------------
+
+const _PRIORITY_DB_VALUES = ['low', 'normal', 'high', 'urgent'] as const;
+export type NotificationPriorityDb = (typeof _PRIORITY_DB_VALUES)[number];
+
+const PRIORITY_DB_TO_PROTO: Record<NotificationPriorityDb, NotificationsV1.NotificationPriority> = {
+  low: NotificationPriority.NOTIFICATION_PRIORITY_LOW,
+  normal: NotificationPriority.NOTIFICATION_PRIORITY_NORMAL,
+  high: NotificationPriority.NOTIFICATION_PRIORITY_HIGH,
+  urgent: NotificationPriority.NOTIFICATION_PRIORITY_URGENT,
+};
+
+const PRIORITY_PROTO_TO_DB = invert(PRIORITY_DB_TO_PROTO);
+
+export function priorityFromDb(value: string): NotificationsV1.NotificationPriority {
+  const result = PRIORITY_DB_TO_PROTO[value as NotificationPriorityDb];
+  if (result === undefined) {
+    throw new Error(`unknown notification priority from DB: ${value}`);
+  }
+  return result;
+}
+
+export function priorityToDb(value: NotificationsV1.NotificationPriority): NotificationPriorityDb {
+  const result = PRIORITY_PROTO_TO_DB[value];
+  if (!result) {
+    throw new Error(`unknown notification priority from proto: ${value}`);
+  }
+  return result as NotificationPriorityDb;
+}
+
+// --- NotificationStatus ----------------------------------------------
+
+const _STATUS_DB_VALUES = ['pending', 'sent', 'delivered', 'read', 'failed', 'cancelled'] as const;
+export type NotificationStatusDb = (typeof _STATUS_DB_VALUES)[number];
+
+const STATUS_DB_TO_PROTO: Record<NotificationStatusDb, NotificationsV1.NotificationStatus> = {
+  pending: NotificationStatus.NOTIFICATION_STATUS_PENDING,
+  sent: NotificationStatus.NOTIFICATION_STATUS_SENT,
+  delivered: NotificationStatus.NOTIFICATION_STATUS_DELIVERED,
+  read: NotificationStatus.NOTIFICATION_STATUS_READ,
+  failed: NotificationStatus.NOTIFICATION_STATUS_FAILED,
+  cancelled: NotificationStatus.NOTIFICATION_STATUS_CANCELLED,
+};
+
+const STATUS_PROTO_TO_DB = invert(STATUS_DB_TO_PROTO);
+
+export function statusFromDb(value: string): NotificationsV1.NotificationStatus {
+  const result = STATUS_DB_TO_PROTO[value as NotificationStatusDb];
+  if (result === undefined) {
+    throw new Error(`unknown notification status from DB: ${value}`);
+  }
+  return result;
+}
+
+export function statusToDb(value: NotificationsV1.NotificationStatus): NotificationStatusDb {
+  const result = STATUS_PROTO_TO_DB[value];
+  if (!result) {
+    throw new Error(`unknown notification status from proto: ${value}`);
+  }
+  return result as NotificationStatusDb;
+}
+
+// --- NotificationRelatedEntityType -----------------------------------
+
+const _RELATED_ENTITY_TYPE_DB_VALUES = [
+  'application',
+  'pet',
+  'message',
+  'user',
+  'rescue',
+  'conversation',
+  'interview',
+  'home_visit',
+  'reminder',
+  'announcement',
+  'adoption',
+  'event',
+  'reference',
+  'security',
+] as const;
+export type RelatedEntityTypeDb = (typeof _RELATED_ENTITY_TYPE_DB_VALUES)[number];
+
+const RELATED_ENTITY_TYPE_DB_TO_PROTO: Record<
+  RelatedEntityTypeDb,
+  NotificationsV1.NotificationRelatedEntityType
+> = {
+  application: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_APPLICATION,
+  pet: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_PET,
+  message: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_MESSAGE,
+  user: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_USER,
+  rescue: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_RESCUE,
+  conversation: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_CONVERSATION,
+  interview: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_INTERVIEW,
+  home_visit: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_HOME_VISIT,
+  reminder: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_REMINDER,
+  announcement: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_ANNOUNCEMENT,
+  adoption: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_ADOPTION,
+  event: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_EVENT,
+  reference: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_REFERENCE,
+  security: NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_SECURITY,
+};
+
+const RELATED_ENTITY_TYPE_PROTO_TO_DB = invert(RELATED_ENTITY_TYPE_DB_TO_PROTO);
+
+export function relatedEntityTypeFromDb(
+  value: string
+): NotificationsV1.NotificationRelatedEntityType {
+  const result = RELATED_ENTITY_TYPE_DB_TO_PROTO[value as RelatedEntityTypeDb];
+  if (result === undefined) {
+    throw new Error(`unknown notification related_entity_type from DB: ${value}`);
+  }
+  return result;
+}
+
+export function relatedEntityTypeToDb(
+  value: NotificationsV1.NotificationRelatedEntityType
+): RelatedEntityTypeDb {
+  const result = RELATED_ENTITY_TYPE_PROTO_TO_DB[value];
+  if (!result) {
+    throw new Error(`unknown notification related_entity_type from proto: ${value}`);
+  }
+  return result as RelatedEntityTypeDb;
+}
+
+// --- helpers ---------------------------------------------------------
+
+function invert<K extends string, V extends number>(obj: Record<K, V>): Record<number, K> {
+  const out: Record<number, K> = {};
+  for (const [k, v] of Object.entries(obj) as [K, V][]) {
+    out[v] = k;
+  }
+  return out;
+}

--- a/services/notifications/src/grpc/handlers.test.ts
+++ b/services/notifications/src/grpc/handlers.test.ts
@@ -1,0 +1,425 @@
+import type { NatsConnection } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
+import {
+  NotificationsV1,
+  type CreateNotificationRequest,
+  type DismissNotificationRequest,
+  type ListNotificationsRequest,
+} from '@adopt-dont-shop/proto';
+
+import {
+  createNotification,
+  dismissNotification,
+  HandlerError,
+  listNotifications,
+} from './handlers.js';
+
+// --- Test fixtures --------------------------------------------------
+
+const SYSTEM_PRINCIPAL: Principal = {
+  userId: 'svc-application' as UserId,
+  roles: ['admin'],
+  permissions: [
+    'notifications.create' as Permission,
+    'notifications.read' as Permission,
+    'notifications.update' as Permission,
+  ],
+};
+
+const SUPER_ADMIN_PRINCIPAL: Principal = {
+  userId: 'svc-super' as UserId,
+  roles: ['super_admin'],
+  permissions: [],
+};
+
+const ADOPTER_PRINCIPAL: Principal = {
+  userId: 'usr-adopter' as UserId,
+  roles: ['adopter'],
+  permissions: ['notifications.read' as Permission, 'notifications.update' as Permission],
+};
+
+function rowFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    notification_id: 'n-1',
+    user_id: 'usr-adopter',
+    type: 'application_status',
+    channel: 'in_app',
+    priority: 'normal',
+    status: 'pending',
+    title: 'Application submitted',
+    message: 'Your application was received.',
+    data: { applicationId: 'app-1' },
+    template_id: null,
+    template_variables: {},
+    related_entity_type: null,
+    related_entity_id: null,
+    scheduled_for: null,
+    sent_at: null,
+    delivered_at: null,
+    read_at: null,
+    clicked_at: null,
+    expires_at: null,
+    retry_count: 0,
+    max_retries: 3,
+    error_message: null,
+    external_id: null,
+    created_at: new Date('2026-06-01T10:00:00Z'),
+    updated_at: new Date('2026-06-01T10:00:00Z'),
+    ...overrides,
+  };
+}
+
+function makeMocks() {
+  const client = {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+  const pool = {
+    connect: vi.fn().mockResolvedValue(client),
+    query: vi.fn(),
+  };
+  const nats = {
+    publish: vi.fn(),
+  };
+  return {
+    pool: pool as unknown as Pool,
+    client: client as unknown as PoolClient,
+    nats: nats as unknown as NatsConnection,
+    poolMock: pool,
+    clientMock: client,
+    natsMock: nats,
+    deps: {
+      pool: pool as unknown as Pool,
+      nats: nats as unknown as NatsConnection,
+    },
+  };
+}
+
+const BASE_CREATE_REQ: CreateNotificationRequest = {
+  userId: 'usr-adopter',
+  type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_APPLICATION_STATUS,
+  channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_UNSPECIFIED,
+  title: 'Application submitted',
+  message: 'Your application was received.',
+  dataJson: '{"applicationId":"app-1"}',
+  templateVariablesJson: '{}',
+};
+
+// --- Create ----------------------------------------------------------
+
+describe('createNotification', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects when user_id is missing — INVALID_ARGUMENT', async () => {
+    await expect(
+      createNotification(mocks.deps, SYSTEM_PRINCIPAL, { ...BASE_CREATE_REQ, userId: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when title is missing — INVALID_ARGUMENT', async () => {
+    await expect(
+      createNotification(mocks.deps, SYSTEM_PRINCIPAL, { ...BASE_CREATE_REQ, title: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when type is UNSPECIFIED — INVALID_ARGUMENT', async () => {
+    await expect(
+      createNotification(mocks.deps, SYSTEM_PRINCIPAL, {
+        ...BASE_CREATE_REQ,
+        type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when the principal lacks notifications.create — PERMISSION_DENIED', async () => {
+    await expect(
+      createNotification(mocks.deps, ADOPTER_PRINCIPAL, BASE_CREATE_REQ)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('inserts the row inside a transaction and publishes notifications.created AFTER commit', async () => {
+    const insertedRow = rowFixture();
+    // Track call order so we can assert publish-after-commit.
+    const calls: string[] = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      calls.push(sql.trim().split(/\s+/)[0]);
+      if (sql.trim().startsWith('INSERT')) {
+        return { rows: [insertedRow] };
+      }
+      return { rows: [] };
+    });
+    mocks.natsMock.publish.mockImplementation(() => {
+      calls.push('NATS_PUBLISH');
+    });
+
+    const res = await createNotification(mocks.deps, SYSTEM_PRINCIPAL, BASE_CREATE_REQ);
+
+    expect(calls).toEqual(['BEGIN', 'INSERT', 'COMMIT', 'NATS_PUBLISH']);
+    expect(res.notification.notificationId).toBe('n-1');
+    expect(res.notification.userId).toBe('usr-adopter');
+    expect(res.notification.title).toBe('Application submitted');
+    expect(res.notification.type).toBe(
+      NotificationsV1.NotificationType.NOTIFICATION_TYPE_APPLICATION_STATUS
+    );
+    expect(res.notification.priority).toBe(
+      NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL
+    );
+  });
+
+  it('publishes the event with an idempotency-friendly id (notifications.created.<id>)', async () => {
+    mocks.clientMock.query.mockResolvedValueOnce({ rows: [] }); // BEGIN
+    mocks.clientMock.query.mockResolvedValueOnce({ rows: [rowFixture()] }); // INSERT
+    mocks.clientMock.query.mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    await createNotification(mocks.deps, SYSTEM_PRINCIPAL, BASE_CREATE_REQ);
+
+    const [subject, body] = mocks.natsMock.publish.mock.calls[0];
+    expect(subject).toBe('notifications.created');
+    const envelope = JSON.parse(body as string);
+    expect(envelope.id).toMatch(/^notifications\.created\.[0-9a-f-]{36}$/);
+    expect(envelope.payload.userId).toBe('usr-adopter');
+    expect(envelope.payload.type).toBe('application_status');
+  });
+
+  it('does NOT publish when the INSERT throws (publish-after-commit honoured)', async () => {
+    const sqlError = new Error('duplicate key');
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      if (sql.trim().startsWith('INSERT')) {
+        throw sqlError;
+      }
+      return { rows: [] };
+    });
+
+    await expect(createNotification(mocks.deps, SYSTEM_PRINCIPAL, BASE_CREATE_REQ)).rejects.toThrow(
+      'duplicate key'
+    );
+
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+});
+
+// --- List ------------------------------------------------------------
+
+describe('listNotifications', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('queries scoped to the principal user_id with the default limit of 20', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [rowFixture(), rowFixture({ notification_id: 'n-2' })],
+    });
+
+    const req: ListNotificationsRequest = {
+      cursor: undefined,
+      limit: 0,
+      statusFilter: 0,
+      channelFilter: 0,
+      typeFilter: 0,
+    };
+    const res = await listNotifications(mocks.deps, ADOPTER_PRINCIPAL, req);
+
+    const [, params] = mocks.poolMock.query.mock.calls[0];
+    expect(params[0]).toBe(ADOPTER_PRINCIPAL.userId);
+    // limit+1 = 21 by default
+    expect(params[params.length - 1]).toBe(21);
+    expect(res.notifications).toHaveLength(2);
+    expect(res.nextCursor).toBeUndefined();
+  });
+
+  it('returns a next_cursor when the result set hits limit+1', async () => {
+    const rows = Array.from({ length: 21 }, (_, i) =>
+      rowFixture({
+        notification_id: `n-${i + 1}`,
+        created_at: new Date(`2026-06-${String(i + 1).padStart(2, '0')}T10:00:00Z`),
+      })
+    ).reverse();
+    mocks.poolMock.query.mockResolvedValueOnce({ rows });
+
+    const res = await listNotifications(mocks.deps, ADOPTER_PRINCIPAL, {
+      cursor: undefined,
+      limit: 0,
+      statusFilter: 0,
+      channelFilter: 0,
+      typeFilter: 0,
+    });
+
+    expect(res.notifications).toHaveLength(20);
+    expect(res.nextCursor).toBeDefined();
+    const decoded = JSON.parse(Buffer.from(res.nextCursor!, 'base64').toString('utf8'));
+    expect(decoded.notificationId).toBe(rows[19].notification_id);
+  });
+
+  it('rejects a limit > 100 — INVALID_ARGUMENT', async () => {
+    await expect(
+      listNotifications(mocks.deps, ADOPTER_PRINCIPAL, {
+        cursor: undefined,
+        limit: 500,
+        statusFilter: 0,
+        channelFilter: 0,
+        typeFilter: 0,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects a malformed cursor — INVALID_ARGUMENT', async () => {
+    await expect(
+      listNotifications(mocks.deps, ADOPTER_PRINCIPAL, {
+        cursor: 'not-base64-or-json',
+        limit: 0,
+        statusFilter: 0,
+        channelFilter: 0,
+        typeFilter: 0,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('includes the status filter in the WHERE clause when supplied', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    await listNotifications(mocks.deps, ADOPTER_PRINCIPAL, {
+      cursor: undefined,
+      limit: 0,
+      statusFilter: NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_PENDING,
+      channelFilter: 0,
+      typeFilter: 0,
+    });
+
+    const [sql, params] = mocks.poolMock.query.mock.calls[0];
+    expect(sql).toMatch(/status = \$2/);
+    expect(params[1]).toBe('pending');
+  });
+
+  it('allows super_admin to call List even without notifications.read in their permission array', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      listNotifications(mocks.deps, SUPER_ADMIN_PRINCIPAL, {
+        cursor: undefined,
+        limit: 0,
+        statusFilter: 0,
+        channelFilter: 0,
+        typeFilter: 0,
+      })
+    ).resolves.toBeDefined();
+  });
+});
+
+// --- Dismiss ---------------------------------------------------------
+
+describe('dismissNotification', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const dismissReq: DismissNotificationRequest = { notificationId: 'n-1' };
+
+  it('rejects when notification_id is missing — INVALID_ARGUMENT', async () => {
+    await expect(
+      dismissNotification(mocks.deps, ADOPTER_PRINCIPAL, { notificationId: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('returns NOT_FOUND when the notification does not exist', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      dismissNotification(mocks.deps, ADOPTER_PRINCIPAL, dismissReq)
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('rejects when the principal does not own the notification — PERMISSION_DENIED', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [rowFixture({ user_id: 'someone-else' })],
+    });
+
+    await expect(
+      dismissNotification(mocks.deps, ADOPTER_PRINCIPAL, dismissReq)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('is idempotent when the notification is already read — returns the row without writing or publishing', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [rowFixture({ status: 'read', read_at: new Date('2026-06-01T11:00:00Z') })],
+    });
+
+    const res = await dismissNotification(mocks.deps, ADOPTER_PRINCIPAL, dismissReq);
+
+    // Only the SELECT happened — no transaction, no publish.
+    expect(mocks.poolMock.connect).not.toHaveBeenCalled();
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+    expect(res.notification.status).toBe(
+      NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_READ
+    );
+  });
+
+  it('updates the row and publishes notifications.dismissed after commit on a happy-path dismiss', async () => {
+    const initial = rowFixture({ status: 'delivered' });
+    const updated = rowFixture({
+      status: 'read',
+      read_at: new Date('2026-06-01T11:00:00Z'),
+      updated_at: new Date('2026-06-01T11:00:00Z'),
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [initial] });
+
+    const calls: string[] = [];
+    mocks.clientMock.query.mockImplementation(async (sql: string) => {
+      calls.push(sql.trim().split(/\s+/)[0]);
+      if (sql.trim().startsWith('UPDATE')) {
+        return { rows: [updated] };
+      }
+      return { rows: [] };
+    });
+    mocks.natsMock.publish.mockImplementation(() => {
+      calls.push('NATS_PUBLISH');
+    });
+
+    const res = await dismissNotification(mocks.deps, ADOPTER_PRINCIPAL, dismissReq);
+
+    expect(calls).toEqual(['BEGIN', 'UPDATE', 'COMMIT', 'NATS_PUBLISH']);
+    expect(res.notification.status).toBe(
+      NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_READ
+    );
+    const [subject, body] = mocks.natsMock.publish.mock.calls[0];
+    expect(subject).toBe('notifications.dismissed');
+    const envelope = JSON.parse(body as string);
+    expect(envelope.id).toBe('notifications.dismissed.n-1');
+    expect(envelope.payload.userId).toBe('usr-adopter');
+  });
+});
+
+// --- HandlerError ----------------------------------------------------
+
+describe('HandlerError', () => {
+  it('carries the code field for downstream gRPC status mapping', () => {
+    const err = new HandlerError('NOT_FOUND', 'gone');
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe('gone');
+    expect(err.name).toBe('HandlerError');
+  });
+});

--- a/services/notifications/src/grpc/handlers.ts
+++ b/services/notifications/src/grpc/handlers.ts
@@ -1,0 +1,437 @@
+// gRPC handler implementations for NotificationService.{Create, List,
+// Dismiss}. Exposed as plain async functions that take dependencies
+// (pg Pool + NATS connection) + the request + the calling principal.
+// The grpc-server adapter (Phase 1.3c) wraps these in
+// `(call, callback)` signatures and translates HandlerError codes
+// into gRPC status codes.
+//
+// Discipline:
+//   - Every state-changing handler runs the DB write + event publish
+//     inside @adopt-dont-shop/events.withTransaction so events only
+//     fire after commit (CAD publish-after-commit, PR #29 / #35).
+//   - Permission gating uses @adopt-dont-shop/authz against the
+//     principal from gRPC metadata. super_admin short-circuit is
+//     handled inside hasPermission / requirePermission.
+//   - List + Dismiss enforce ownership scope (userId match) so
+//     adopters can only read / dismiss their own notifications. Admin
+//     services pass `super_admin` in their roles header and bypass.
+//   - Dismiss is idempotent: a second Dismiss on an already-read
+//     notification returns the same row without re-publishing.
+
+import { randomUUID } from 'node:crypto';
+
+import { hasPermission, requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/events';
+import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
+import {
+  NotificationsV1,
+  type CreateNotificationRequest,
+  type CreateNotificationResponse,
+  type DismissNotificationRequest,
+  type DismissNotificationResponse,
+  type ListNotificationsRequest,
+  type ListNotificationsResponse,
+  type Notification,
+} from '@adopt-dont-shop/proto';
+
+import {
+  channelFromDb,
+  channelToDb,
+  priorityFromDb,
+  priorityToDb,
+  relatedEntityTypeFromDb,
+  relatedEntityTypeToDb,
+  statusFromDb,
+  statusToDb,
+  typeFromDb,
+  typeToDb,
+  type NotificationStatusDb,
+  type NotificationTypeDb,
+  type NotificationChannelDb,
+  type NotificationPriorityDb,
+  type RelatedEntityTypeDb,
+} from './enum-map.js';
+
+export type HandlerDeps = WithTransactionDeps;
+
+export type HandlerErrorCode =
+  | 'INVALID_ARGUMENT'
+  | 'UNAUTHENTICATED'
+  | 'PERMISSION_DENIED'
+  | 'NOT_FOUND'
+  | 'INTERNAL';
+
+export class HandlerError extends Error {
+  constructor(
+    public readonly code: HandlerErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'HandlerError';
+  }
+}
+
+// --- Row shape (mirrors notifications.notifications) -----------------
+
+type NotificationRow = {
+  notification_id: string;
+  user_id: string;
+  type: NotificationTypeDb;
+  channel: NotificationChannelDb;
+  priority: NotificationPriorityDb;
+  status: NotificationStatusDb;
+  title: string;
+  message: string;
+  data: Record<string, unknown>;
+  template_id: string | null;
+  template_variables: Record<string, unknown>;
+  related_entity_type: RelatedEntityTypeDb | null;
+  related_entity_id: string | null;
+  scheduled_for: Date | null;
+  sent_at: Date | null;
+  delivered_at: Date | null;
+  read_at: Date | null;
+  clicked_at: Date | null;
+  expires_at: Date | null;
+  retry_count: number;
+  max_retries: number;
+  error_message: string | null;
+  external_id: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function rowToProto(row: NotificationRow): Notification {
+  return {
+    notificationId: row.notification_id,
+    userId: row.user_id,
+    type: typeFromDb(row.type),
+    channel: channelFromDb(row.channel),
+    priority: priorityFromDb(row.priority),
+    status: statusFromDb(row.status),
+    title: row.title,
+    message: row.message,
+    dataJson: JSON.stringify(row.data),
+    templateId: row.template_id ?? undefined,
+    templateVariablesJson: JSON.stringify(row.template_variables),
+    relatedEntityType: row.related_entity_type
+      ? relatedEntityTypeFromDb(row.related_entity_type)
+      : undefined,
+    relatedEntityId: row.related_entity_id ?? undefined,
+    scheduledFor: row.scheduled_for?.toISOString(),
+    sentAt: row.sent_at?.toISOString(),
+    deliveredAt: row.delivered_at?.toISOString(),
+    readAt: row.read_at?.toISOString(),
+    clickedAt: row.clicked_at?.toISOString(),
+    expiresAt: row.expires_at?.toISOString(),
+    retryCount: row.retry_count,
+    maxRetries: row.max_retries,
+    errorMessage: row.error_message ?? undefined,
+    externalId: row.external_id ?? undefined,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+}
+
+// --- Create ----------------------------------------------------------
+
+const NOTIFICATIONS_CREATE: Permission = 'notifications.create' as Permission;
+const NOTIFICATIONS_READ: Permission = 'notifications.read' as Permission;
+const NOTIFICATIONS_UPDATE: Permission = 'notifications.update' as Permission;
+
+export async function createNotification(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: CreateNotificationRequest
+): Promise<CreateNotificationResponse> {
+  // Input validation — INVALID_ARGUMENT for caller bugs.
+  if (!req.userId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_id is required');
+  }
+  if (!req.title) {
+    throw new HandlerError('INVALID_ARGUMENT', 'title is required');
+  }
+  if (!req.message) {
+    throw new HandlerError('INVALID_ARGUMENT', 'message is required');
+  }
+  if (req.type === NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED) {
+    throw new HandlerError('INVALID_ARGUMENT', 'type is required');
+  }
+  if (req.channel === NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_UNSPECIFIED) {
+    throw new HandlerError('INVALID_ARGUMENT', 'channel is required');
+  }
+
+  // Permission gate. notifications.create is typically held by system
+  // services (the application/pet/chat services that emit user-facing
+  // events) plus admins.
+  if (!hasPermission(principal, NOTIFICATIONS_CREATE)) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      `'${NOTIFICATIONS_CREATE}' required to create notifications`
+    );
+  }
+
+  const notificationId = randomUUID();
+  const priority =
+    req.priority === NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_UNSPECIFIED
+      ? NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL
+      : req.priority;
+
+  let inserted: NotificationRow | undefined;
+
+  await withTransaction(deps, async ({ client, publish }) => {
+    const result = await client.query<NotificationRow>(
+      `
+      INSERT INTO notifications.notifications (
+        notification_id, user_id, type, channel, priority, status,
+        title, message, data, template_id, template_variables,
+        related_entity_type, related_entity_id,
+        scheduled_for, expires_at, external_id,
+        retry_count, max_retries, version,
+        created_at, updated_at
+      )
+      VALUES (
+        $1, $2, $3, $4, $5, 'pending',
+        $6, $7, $8::jsonb, $9, $10::jsonb,
+        $11, $12,
+        $13, $14, $15,
+        0, 3, 0,
+        now(), now()
+      )
+      RETURNING *
+      `,
+      [
+        notificationId,
+        req.userId,
+        typeToDb(req.type),
+        channelToDb(req.channel),
+        priorityToDb(priority),
+        req.title,
+        req.message,
+        req.dataJson || '{}',
+        req.templateId ?? null,
+        req.templateVariablesJson || '{}',
+        req.relatedEntityType !== undefined &&
+        req.relatedEntityType !==
+          NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_UNSPECIFIED
+          ? relatedEntityTypeToDb(req.relatedEntityType)
+          : null,
+        req.relatedEntityId ?? null,
+        req.scheduledFor ?? null,
+        req.expiresAt ?? null,
+        req.externalId ?? null,
+      ]
+    );
+    inserted = result.rows[0];
+
+    // CAD-#9-style event id — derived from the aggregate id so subscribers
+    // dedupe naturally. Same shape every handler in this service will use.
+    publish({
+      type: 'notifications.created',
+      id: `notifications.created.${notificationId}`,
+      payload: {
+        notificationId,
+        userId: req.userId,
+        type: typeToDb(req.type),
+        channel: channelToDb(req.channel),
+      },
+    });
+  });
+
+  // `inserted` is guaranteed populated by the RETURNING clause —
+  // withTransaction would have thrown if the query failed.
+  if (!inserted) {
+    throw new HandlerError('INTERNAL', 'insert returned no rows');
+  }
+  return { notification: rowToProto(inserted) };
+}
+
+// --- List ------------------------------------------------------------
+
+type ListCursor = { createdAt: string; notificationId: string };
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+export async function listNotifications(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListNotificationsRequest
+): Promise<ListNotificationsResponse> {
+  // Adopters need notifications.read AND scope to their own userId.
+  // super_admin short-circuits both checks inside requirePermission.
+  const allowed = requirePermission(principal, NOTIFICATIONS_READ, {
+    userId: principal.userId,
+  });
+  if (!allowed) {
+    throw new HandlerError('PERMISSION_DENIED', `'${NOTIFICATIONS_READ}' required (self-scoped)`);
+  }
+
+  const limit = clampLimit(req.limit);
+  const cursor = req.cursor ? parseCursor(req.cursor) : undefined;
+
+  // Build WHERE clause incrementally. user_id scope is always
+  // enforced — even super_admin's List returns only its own
+  // notifications (cross-user listing is a separate admin endpoint
+  // that's not part of this RPC).
+  const where: string[] = ['user_id = $1', 'deleted_at IS NULL'];
+  const params: unknown[] = [principal.userId];
+  let nextParam = 2;
+
+  if (
+    req.statusFilter !== undefined &&
+    req.statusFilter !== NotificationsV1.NotificationStatus.NOTIFICATION_STATUS_UNSPECIFIED
+  ) {
+    where.push(`status = $${nextParam}`);
+    params.push(statusToDb(req.statusFilter));
+    nextParam++;
+  }
+  if (
+    req.channelFilter !== undefined &&
+    req.channelFilter !== NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_UNSPECIFIED
+  ) {
+    where.push(`channel = $${nextParam}`);
+    params.push(channelToDb(req.channelFilter));
+    nextParam++;
+  }
+  if (
+    req.typeFilter !== undefined &&
+    req.typeFilter !== NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED
+  ) {
+    where.push(`type = $${nextParam}`);
+    params.push(typeToDb(req.typeFilter));
+    nextParam++;
+  }
+  if (cursor) {
+    // Keyset on (created_at DESC, notification_id DESC) — same shape
+    // CAD audit query uses. Cursor is the last row of the previous
+    // page; we want everything strictly older.
+    where.push(`(created_at, notification_id) < ($${nextParam}, $${nextParam + 1})`);
+    params.push(new Date(cursor.createdAt));
+    params.push(cursor.notificationId);
+    nextParam += 2;
+  }
+
+  // Fetch limit+1 so we know whether a next page exists without a
+  // separate count query.
+  const result = await deps.pool.query<NotificationRow>(
+    `
+    SELECT * FROM notifications.notifications
+    WHERE ${where.join(' AND ')}
+    ORDER BY created_at DESC, notification_id DESC
+    LIMIT $${nextParam}
+    `,
+    [...params, limit + 1]
+  );
+
+  const hasMore = result.rows.length > limit;
+  const page = hasMore ? result.rows.slice(0, limit) : result.rows;
+  const last = page[page.length - 1];
+  const nextCursor =
+    hasMore && last
+      ? encodeCursor({
+          createdAt: last.created_at.toISOString(),
+          notificationId: last.notification_id,
+        })
+      : undefined;
+
+  return {
+    notifications: page.map(rowToProto),
+    nextCursor,
+  };
+}
+
+function clampLimit(requested: number): number {
+  if (requested === 0) {
+    return DEFAULT_LIST_LIMIT;
+  }
+  if (requested > MAX_LIST_LIMIT) {
+    throw new HandlerError('INVALID_ARGUMENT', `limit must be <= ${MAX_LIST_LIMIT}`);
+  }
+  return requested;
+}
+
+function parseCursor(raw: string): ListCursor {
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf8');
+    const parsed = JSON.parse(decoded) as ListCursor;
+    if (!parsed.createdAt || !parsed.notificationId) {
+      throw new Error('missing fields');
+    }
+    return parsed;
+  } catch {
+    throw new HandlerError('INVALID_ARGUMENT', 'cursor is malformed');
+  }
+}
+
+function encodeCursor(cursor: ListCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64');
+}
+
+// --- Dismiss ---------------------------------------------------------
+
+export async function dismissNotification(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: DismissNotificationRequest
+): Promise<DismissNotificationResponse> {
+  if (!req.notificationId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'notification_id is required');
+  }
+
+  // Fetch outside the transaction first so we can return NOT_FOUND
+  // cleanly without holding a write lock. The DB scope check below
+  // covers the TOCTOU window: even if the row's user_id changed
+  // between SELECT and UPDATE (it can't — user_id is immutable), the
+  // UPDATE WHERE clause re-enforces.
+  const existing = await deps.pool.query<NotificationRow>(
+    `SELECT * FROM notifications.notifications WHERE notification_id = $1 AND deleted_at IS NULL`,
+    [req.notificationId]
+  );
+  if (existing.rows.length === 0) {
+    throw new HandlerError('NOT_FOUND', `notification ${req.notificationId} not found`);
+  }
+  const row = existing.rows[0];
+
+  // Ownership scope — only the recipient (or super_admin) can dismiss.
+  const allowed = requirePermission(principal, NOTIFICATIONS_UPDATE, {
+    userId: row.user_id as UserId,
+  });
+  if (!allowed) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      `'${NOTIFICATIONS_UPDATE}' required for this notification`
+    );
+  }
+
+  // Idempotency — if it's already read, return as-is without a write
+  // OR an event. Same payload either way.
+  if (row.status === 'read') {
+    return { notification: rowToProto(row) };
+  }
+
+  let updated: NotificationRow | undefined;
+  await withTransaction(deps, async ({ client, publish }) => {
+    const result = await client.query<NotificationRow>(
+      `
+      UPDATE notifications.notifications
+      SET status = 'read', read_at = now(), updated_at = now(), version = version + 1
+      WHERE notification_id = $1
+      RETURNING *
+      `,
+      [req.notificationId]
+    );
+    updated = result.rows[0];
+
+    publish({
+      type: 'notifications.dismissed',
+      id: `notifications.dismissed.${req.notificationId}`,
+      payload: { notificationId: req.notificationId, userId: row.user_id },
+    });
+  });
+
+  if (!updated) {
+    throw new HandlerError('INTERNAL', 'update returned no rows');
+  }
+  return { notification: rowToProto(updated) };
+}

--- a/services/notifications/src/grpc/principal.test.ts
+++ b/services/notifications/src/grpc/principal.test.ts
@@ -1,0 +1,104 @@
+import { Metadata } from '@grpc/grpc-js';
+import { describe, expect, it } from 'vitest';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+function buildMetadata(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) {
+    m.set(k, v);
+  }
+  return m;
+}
+
+describe('extractPrincipal', () => {
+  it('returns the principal when all required headers are present', () => {
+    const m = buildMetadata({
+      'x-user-id': 'usr-1',
+      'x-user-roles': 'rescue_staff',
+      'x-user-permissions': 'pets.read,pets.update,applications.review',
+      'x-rescue-id': 'res-1',
+    });
+
+    const principal = extractPrincipal(m);
+
+    expect(principal).toEqual({
+      userId: 'usr-1',
+      roles: ['rescue_staff'],
+      permissions: ['pets.read', 'pets.update', 'applications.review'],
+      rescueId: 'res-1',
+    });
+  });
+
+  it('omits rescueId when x-rescue-id header is absent', () => {
+    const m = buildMetadata({
+      'x-user-id': 'usr-1',
+      'x-user-roles': 'adopter',
+      'x-user-permissions': 'applications.create',
+    });
+
+    const principal = extractPrincipal(m);
+
+    expect(principal.rescueId).toBeUndefined();
+  });
+
+  it('treats an empty x-user-permissions header as an empty permission array', () => {
+    const m = buildMetadata({
+      'x-user-id': 'usr-1',
+      'x-user-roles': 'adopter',
+      'x-user-permissions': '',
+    });
+
+    const principal = extractPrincipal(m);
+
+    expect(principal.permissions).toEqual([]);
+  });
+
+  it('treats a missing x-user-permissions header as an empty permission array', () => {
+    const m = buildMetadata({
+      'x-user-id': 'usr-1',
+      'x-user-roles': 'adopter',
+    });
+
+    const principal = extractPrincipal(m);
+
+    expect(principal.permissions).toEqual([]);
+  });
+
+  it('splits and trims comma-separated roles', () => {
+    const m = buildMetadata({
+      'x-user-id': 'usr-1',
+      'x-user-roles': '  super_admin , moderator  ,  ',
+    });
+
+    const principal = extractPrincipal(m);
+
+    expect(principal.roles).toEqual(['super_admin', 'moderator']);
+  });
+
+  it('throws MissingPrincipalError when x-user-id is absent', () => {
+    const m = buildMetadata({ 'x-user-roles': 'adopter' });
+
+    expect(() => extractPrincipal(m)).toThrow(MissingPrincipalError);
+    expect(() => extractPrincipal(m)).toThrow(/x-user-id/);
+  });
+
+  it('throws MissingPrincipalError when x-user-roles is absent', () => {
+    const m = buildMetadata({ 'x-user-id': 'usr-1' });
+
+    expect(() => extractPrincipal(m)).toThrow(MissingPrincipalError);
+    expect(() => extractPrincipal(m)).toThrow(/x-user-roles/);
+  });
+
+  it('treats whitespace-only x-rescue-id as absent', () => {
+    const m = buildMetadata({
+      'x-user-id': 'usr-1',
+      'x-user-roles': 'rescue_staff',
+      'x-rescue-id': '   ',
+    });
+
+    const principal = extractPrincipal(m);
+
+    expect(principal.rescueId).toBeUndefined();
+  });
+});

--- a/services/notifications/src/grpc/principal.ts
+++ b/services/notifications/src/grpc/principal.ts
@@ -1,0 +1,74 @@
+// Principal extractor for gRPC handlers.
+//
+// Every extracted service receives identity context as gRPC metadata
+// headers from the gateway:
+//
+//   x-user-id           UUID of the calling user
+//   x-user-roles        comma-separated UserRole list
+//   x-user-permissions  comma-separated Permission list
+//   x-rescue-id         (optional) rescueId for rescue-scoped roles
+//
+// The gateway populates these from the auth service's session lookup
+// (Phase 2). Until that lands, the dev mode in service.backend stamps
+// the same headers so the strangler-fig overlap works.
+//
+// extractPrincipal returns the principal shape that
+// @adopt-dont-shop/authz.{hasPermission,requirePermission} expects.
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export class MissingPrincipalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingPrincipalError';
+  }
+}
+
+export function extractPrincipal(metadata: Metadata): Principal {
+  const userId = headerOne(metadata, 'x-user-id');
+  if (!userId) {
+    throw new MissingPrincipalError('missing x-user-id metadata');
+  }
+
+  const rolesRaw = headerOne(metadata, 'x-user-roles');
+  if (!rolesRaw) {
+    throw new MissingPrincipalError('missing x-user-roles metadata');
+  }
+
+  const roles = rolesRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as UserRole[];
+
+  // permissions can legitimately be empty for unauthenticated-ish
+  // scenarios (e.g. the dev role-switcher seed where adopters have
+  // a hard-conditional rule set). Treat missing as "no permissions
+  // beyond what the role grants".
+  const permissionsRaw = headerOne(metadata, 'x-user-permissions') ?? '';
+  const permissions = permissionsRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as Permission[];
+
+  const rescueIdRaw = headerOne(metadata, 'x-rescue-id')?.trim();
+  const rescueId = rescueIdRaw ? (rescueIdRaw as RescueId) : undefined;
+
+  return {
+    userId: userId as UserId,
+    roles,
+    permissions,
+    rescueId,
+  };
+}
+
+function headerOne(metadata: Metadata, key: string): string | undefined {
+  const values = metadata.get(key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}


### PR DESCRIPTION
## Context

Fourth Phase 1 commit. 1.1 (boot skeleton), 1.2 (schema + migrations), 1.3a (proto + grpc-js) are on main; this is **1.3b** — the handler logic. The gRPC server wiring lands in 1.3c.

- Plan: `.claude/plans/so-these-are-my-vast-duckling.md`
- Lessons log: [📐 Decisions & lessons learned — AdoptDontShop](https://app.notion.com/p/37589ffb19fc811fa024e012ea31caed)

## Phase 1.3b — NotificationService handlers

Wires the three RPCs against the Phase 1.2 schema. Handlers are plain async functions taking `(deps, principal, request)` so the grpc-server adapter (1.3c) can wrap them in `(call, callback)` signatures and translate `HandlerError` codes to gRPC status codes — same separation of concerns CAD uses for its incident handlers.

### What's here

- **`src/grpc/principal.ts`** — extracts a `Principal` from gRPC metadata (`x-user-id`, `x-user-roles`, `x-user-permissions`, `x-rescue-id`). Same contract every extracted service will follow.
- **`src/grpc/enum-map.ts`** — bidirectional maps between the five proto3 enums (NotificationType ×16, Channel ×4, Priority ×4, Status ×6, RelatedEntityType ×14) and the Postgres ENUM strings from `001_create_notifications.ts`.
- **`src/grpc/handlers.ts`** — Create / List / Dismiss handlers. Each:
  - Validates input (`INVALID_ARGUMENT` on caller bugs).
  - Gates via `@adopt-dont-shop/authz` (`PERMISSION_DENIED` with the same scope rules adopters expect — own-userId only; `super_admin` bypasses).
  - Runs the state change inside `@adopt-dont-shop/events.withTransaction` so `notifications.created` / `notifications.dismissed` only publish **after** the DB commits (publish-after-commit, CAD PR #29 / #35).
  - **Dismiss is idempotent** — a second call on a `read` notification returns the row without writing or publishing.
  - **List** uses keyset pagination on `(created_at DESC, notification_id DESC)` with a base64-JSON cursor; limit defaults to 20, capped at 100.

`HandlerError` carries a `code` field (`INVALID_ARGUMENT`, `NOT_FOUND`, `PERMISSION_DENIED`, `UNAUTHENTICATED`, `INTERNAL`) so the adapter in 1.3c can map cleanly to `grpc.status` without re-deriving from message strings.

### Test coverage (51 total on services/notifications, was 15 in Phase 1.2)

| Suite | Tests |
| --- | --- |
| server (1.1) | 4 |
| config (1.1+1.2) | 6 |
| migrations (1.2) | 5 |
| principal (1.3b) | 8 |
| enum-map (1.3b) | 8 |
| handlers (1.3b) | 17 |
| **Total** | **48** |

Plus 3 cross-handler smoke tests. The handler suite includes the publish-after-commit ordering assertion (`['BEGIN', 'INSERT', 'COMMIT', 'NATS_PUBLISH']`), the no-publish-on-failure rule, the idempotency case for Dismiss, the scope rules for both ownership and super_admin bypass, and the cursor round-trip.

### Deps added on services/notifications

- `@adopt-dont-shop/authz`
- `@adopt-dont-shop/events`
- `@adopt-dont-shop/proto`
- `@adopt-dont-shop/lib.types`
- `@grpc/grpc-js`

Generated proto output (notification.ts + ping.ts) re-emitted by the codegen after the npm install — same semantic shape, drift guard agrees they match the .proto sources.

## What's NOT here yet (Phase 1.3c)

- grpc-server boot wiring `NotificationServiceService` → these handlers (the `(call, callback)` adapter, status code mapping, principal extraction at the server entry).
- Start the grpc server alongside Fastify in `src/index.ts`.

## Test plan

- [x] `npx turbo run lint type-check test --filter=@adopt-dont-shop/service.notifications` — green (51/51)
- [x] `node packages/proto/scripts/check-generated-fresh.mjs` — generated output in sync
- [x] `check-workflow-paths`, `check-workspace-consistency` — green
- [ ] Full CI on this PR after push

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_