### PR TITLE
feat(microservices): gateway WebSocket fan-out for notifications (Phase 1.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32593,9 +32593,12 @@
       "name": "@adopt-dont-shop/service.gateway",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/observability": "*",
         "@fastify/http-proxy": "^11.5.0",
-        "fastify": "^5.8.5"
+        "fastify": "^5.8.5",
+        "nats": "^2.29.3",
+        "socket.io": "^4.8.3"
       }
     },
     "services/notifications": {

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -32,8 +32,11 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/observability": "*",
     "@fastify/http-proxy": "^11.5.0",
-    "fastify": "^5.8.5"
+    "fastify": "^5.8.5",
+    "nats": "^2.29.3",
+    "socket.io": "^4.8.3"
   }
 }

--- a/services/gateway/src/config.test.ts
+++ b/services/gateway/src/config.test.ts
@@ -9,20 +9,23 @@ describe('loadConfig', () => {
     expect(config.host).toBe('0.0.0.0');
     expect(config.upstreamBackendUrl).toBe('http://service-backend:5000');
     expect(config.environment).toBe('development');
+    expect(config.natsUrl).toBe('nats://nats:4222');
   });
 
-  it('honours GATEWAY_PORT / GATEWAY_HOST / UPSTREAM_BACKEND_URL / NODE_ENV when set', () => {
+  it('honours GATEWAY_PORT / GATEWAY_HOST / UPSTREAM_BACKEND_URL / NODE_ENV / NATS_URL when set', () => {
     const config = loadConfig({
       GATEWAY_PORT: '4321',
       GATEWAY_HOST: '127.0.0.1',
       UPSTREAM_BACKEND_URL: 'http://backend.internal:8080',
       NODE_ENV: 'production',
+      NATS_URL: 'nats://nats.internal:4222',
     });
 
     expect(config.port).toBe(4321);
     expect(config.host).toBe('127.0.0.1');
     expect(config.upstreamBackendUrl).toBe('http://backend.internal:8080');
     expect(config.environment).toBe('production');
+    expect(config.natsUrl).toBe('nats://nats.internal:4222');
   });
 
   it('rejects a non-numeric GATEWAY_PORT', () => {

--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -12,11 +12,16 @@ export type GatewayConfig = {
   // Environment label, surfaced in health responses and on log lines.
   // Falls back to NODE_ENV.
   environment: string;
+  // NATS bus. Phase 1.5 onwards: gateway subscribes to notifications.*
+  // (and chat.*, applications.* etc. as services extract) and fans the
+  // events to connected Socket.IO clients.
+  natsUrl: string;
 };
 
 const DEFAULT_PORT = 4000;
 const DEFAULT_HOST = '0.0.0.0';
 const DEFAULT_UPSTREAM = 'http://service-backend:5000';
+const DEFAULT_NATS_URL = 'nats://nats:4222';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig => {
   const portRaw = env.GATEWAY_PORT?.trim();
@@ -30,5 +35,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     host: env.GATEWAY_HOST?.trim() || DEFAULT_HOST,
     upstreamBackendUrl: env.UPSTREAM_BACKEND_URL?.trim() || DEFAULT_UPSTREAM,
     environment: env.NODE_ENV?.trim() || 'development',
+    natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
   };
 };

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1,10 +1,19 @@
+import { connect, type NatsConnection } from 'nats';
+import type { Server as IOServer } from 'socket.io';
+
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
 import { createServer } from './server.js';
+import { registerNotificationSubscribers } from './ws/notifications-subscriber.js';
+import { SocketRegistry } from './ws/socket-registry.js';
+import { attachSocketServer } from './ws/socket-server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.gateway' });
+
+  let nats: NatsConnection | undefined;
+  let io: IOServer | undefined;
 
   try {
     const config = loadConfig();
@@ -12,19 +21,39 @@ const main = async (): Promise<void> => {
 
     await server.listen({ port: config.port, host: config.host });
 
+    // NATS + Socket.IO get wired AFTER the HTTP server binds so the
+    // underlying node http.Server exists for socket.io to attach to.
+    nats = await connect({ servers: config.natsUrl });
+    const registry = new SocketRegistry();
+    io = attachSocketServer({ httpServer: server.server, registry, logger });
+    registerNotificationSubscribers({ nats, registry, logger });
+
     logger.info('service.gateway listening', {
       port: config.port,
       host: config.host,
       upstream: config.upstreamBackendUrl,
+      natsUrl: config.natsUrl,
       environment: config.environment,
     });
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.gateway shutting down', { signal });
       try {
+        if (io) {
+          await new Promise<void>(resolve => io!.close(() => resolve()));
+        }
+      } catch (err) {
+        logger.error('socket.io close error', { err });
+      }
+      try {
         await server.close();
       } catch (err) {
-        logger.error('error during shutdown', { err });
+        logger.error('http close error', { err });
+      }
+      try {
+        await nats?.drain();
+      } catch (err) {
+        logger.error('nats drain error', { err });
       }
       process.exit(0);
     };
@@ -33,6 +62,11 @@ const main = async (): Promise<void> => {
     process.once('SIGINT', () => void shutdown('SIGINT'));
   } catch (err) {
     logger.error('service.gateway failed to start', { err });
+    try {
+      await nats?.drain();
+    } catch {
+      // Swallow — already on the failure path.
+    }
     process.exit(1);
   }
 };

--- a/services/gateway/src/ws/notifications-subscriber.test.ts
+++ b/services/gateway/src/ws/notifications-subscriber.test.ts
@@ -1,0 +1,194 @@
+import type { NatsConnection, Subscription } from 'nats';
+import type { Socket } from 'socket.io';
+import type { Logger } from 'winston';
+import { describe, expect, it, vi } from 'vitest';
+
+import { registerNotificationSubscribers } from './notifications-subscriber.js';
+import { SocketRegistry } from './socket-registry.js';
+
+function fakeSocket(): Socket & { emit: ReturnType<typeof vi.fn> } {
+  return { emit: vi.fn() } as unknown as Socket & { emit: ReturnType<typeof vi.fn> };
+}
+
+function quietLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    silly: vi.fn(),
+  } as unknown as Logger;
+}
+
+// Fake NatsConnection that captures subscriptions and exposes a way to
+// inject messages back through them. The @adopt-dont-shop/events
+// `subscribe` helper calls `nats.subscribe(subject, opts?)` then
+// runs a for-await loop on the returned Subscription; we hand it a
+// fresh async iterable per subject so the test can push test events
+// in deterministically.
+function makeNats(): {
+  nats: NatsConnection;
+  subscribeFn: ReturnType<typeof vi.fn>;
+  push: (subject: string, payload: unknown, id?: string) => Promise<void>;
+} {
+  const queues = new Map<
+    string,
+    { resolve: (msg: { subject: string; data: Uint8Array } | typeof DONE) => void }[]
+  >();
+  const DONE = Symbol('done');
+
+  const subscribeFn = vi.fn((subject: string) => {
+    const sub = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: (): Promise<{ value: { subject: string; data: Uint8Array }; done: boolean }> => {
+            return new Promise(resolve => {
+              const waiters = queues.get(subject) ?? [];
+              waiters.push({
+                resolve: msg => {
+                  if (msg === DONE) {
+                    resolve({ value: undefined as never, done: true });
+                  } else {
+                    resolve({ value: msg, done: false });
+                  }
+                },
+              });
+              queues.set(subject, waiters);
+            });
+          },
+        };
+      },
+    };
+    return sub as unknown as Subscription;
+  });
+
+  const nats = { subscribe: subscribeFn } as unknown as NatsConnection;
+
+  const push = async (subject: string, payload: unknown, id = 'evt-1'): Promise<void> => {
+    const waiters = queues.get(subject);
+    const waiter = waiters?.shift();
+    if (!waiter) {
+      throw new Error(`no waiter on ${subject}`);
+    }
+    const envelope = { id, occurredAt: '2026-06-01T10:00:00Z', payload };
+    waiter.resolve({
+      subject,
+      data: new TextEncoder().encode(JSON.stringify(envelope)),
+    });
+    // Yield so the subscribe loop's microtask consumes the message
+    // before the caller asserts on the side effects.
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  return { nats, subscribeFn, push };
+}
+
+describe('registerNotificationSubscribers — wiring', () => {
+  it('subscribes to notifications.created AND notifications.dismissed', () => {
+    const { nats, subscribeFn } = makeNats();
+    registerNotificationSubscribers({
+      nats,
+      registry: new SocketRegistry(),
+      logger: quietLogger(),
+    });
+
+    expect(subscribeFn).toHaveBeenCalledTimes(2);
+    const subjects = subscribeFn.mock.calls.map(c => c[0]);
+    expect(subjects).toEqual(['notifications.created', 'notifications.dismissed']);
+  });
+
+  it('does NOT use a queue group — every gateway replica sees every event', () => {
+    const { nats, subscribeFn } = makeNats();
+    registerNotificationSubscribers({
+      nats,
+      registry: new SocketRegistry(),
+      logger: quietLogger(),
+    });
+
+    // Second arg is the subscribe-options object @adopt-dont-shop/events
+    // hands the underlying client. queue absent → no queue grouping.
+    for (const call of subscribeFn.mock.calls) {
+      expect(call[1]).toBeUndefined();
+    }
+  });
+});
+
+describe('registerNotificationSubscribers — fan-out behaviour', () => {
+  it('emits notification:created to every socket the recipient has on THIS replica', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const s1 = fakeSocket();
+    const s2 = fakeSocket();
+    const otherUserSocket = fakeSocket();
+    registry.add('usr-recipient', s1);
+    registry.add('usr-recipient', s2);
+    registry.add('usr-other', otherUserSocket);
+
+    registerNotificationSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('notifications.created', {
+      notificationId: 'n-1',
+      userId: 'usr-recipient',
+      type: 'application_status',
+      channel: 'in_app',
+    });
+
+    expect(s1.emit).toHaveBeenCalledWith(
+      'notification:created',
+      expect.objectContaining({
+        notificationId: 'n-1',
+        userId: 'usr-recipient',
+      })
+    );
+    expect(s2.emit).toHaveBeenCalledWith(
+      'notification:created',
+      expect.objectContaining({
+        notificationId: 'n-1',
+      })
+    );
+    expect(otherUserSocket.emit).not.toHaveBeenCalled();
+  });
+
+  it('emits notification:dismissed only to the recipient', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const target = fakeSocket();
+    registry.add('usr-1', target);
+
+    registerNotificationSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('notifications.dismissed', {
+      notificationId: 'n-9',
+      userId: 'usr-1',
+    });
+
+    expect(target.emit).toHaveBeenCalledWith(
+      'notification:dismissed',
+      expect.objectContaining({
+        notificationId: 'n-9',
+      })
+    );
+  });
+
+  it('no-ops when the recipient has no connected sockets on this replica', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const otherUserSocket = fakeSocket();
+    registry.add('usr-other', otherUserSocket);
+
+    registerNotificationSubscribers({ nats, registry, logger: quietLogger() });
+
+    // No throw — the subscriber's poison-pill protection treats the
+    // event as a clean fan-out to zero sockets.
+    await push('notifications.created', {
+      notificationId: 'n-2',
+      userId: 'usr-not-here',
+      type: 'application_status',
+      channel: 'in_app',
+    });
+
+    expect(otherUserSocket.emit).not.toHaveBeenCalled();
+  });
+});

--- a/services/gateway/src/ws/notifications-subscriber.ts
+++ b/services/gateway/src/ws/notifications-subscriber.ts
@@ -1,0 +1,90 @@
+// NATS → Socket.IO fan-out for notifications.* domain events.
+//
+// service.notifications publishes notifications.created /
+// notifications.dismissed on the bus after every committed write. This
+// subscriber sits at the gateway edge, looks up which sockets on THIS
+// replica belong to the event's recipient, and emits the SPA-facing
+// event shape:
+//
+//   socket.emit('notification:created',  { notificationId, type, channel })
+//   socket.emit('notification:dismissed', { notificationId })
+//
+// No queue group: each gateway replica subscribes independently so
+// every replica sees every event. The replica that holds the user's
+// socket emits; the rest no-op via the empty registry lookup. See
+// socket-registry.ts for the trade-off discussion.
+
+import type { NatsConnection, Subscription } from 'nats';
+import type { Logger } from 'winston';
+
+import { subscribe } from '@adopt-dont-shop/events';
+
+import type { SocketRegistry } from './socket-registry.js';
+
+export type RegisterNotificationSubscribersOptions = {
+  nats: NatsConnection;
+  registry: SocketRegistry;
+  logger: Logger;
+};
+
+// Payload shapes mirror what service.notifications publishes (handlers.ts).
+// Lives consumer-side until the producing service ships a typed event
+// namespace via @adopt-dont-shop/proto.
+type NotificationCreatedPayload = {
+  notificationId: string;
+  userId: string;
+  type: string;
+  channel: string;
+};
+
+type NotificationDismissedPayload = {
+  notificationId: string;
+  userId: string;
+};
+
+export const registerNotificationSubscribers = (
+  opts: RegisterNotificationSubscribersOptions
+): Subscription[] => {
+  const { nats, registry, logger } = opts;
+
+  const onError = (err: unknown, ctx: { subject: string }): void => {
+    logger.error('ws subscriber failed', {
+      subject: ctx.subject,
+      err: (err as Error)?.message ?? String(err),
+    });
+  };
+
+  const subs: Subscription[] = [];
+
+  subs.push(
+    subscribe<NotificationCreatedPayload>(
+      nats,
+      { subject: 'notifications.created', onError },
+      payload => {
+        const sockets = registry.socketsFor(payload.userId);
+        for (const socket of sockets) {
+          socket.emit('notification:created', payload);
+        }
+      }
+    )
+  );
+
+  subs.push(
+    subscribe<NotificationDismissedPayload>(
+      nats,
+      { subject: 'notifications.dismissed', onError },
+      payload => {
+        const sockets = registry.socketsFor(payload.userId);
+        for (const socket of sockets) {
+          socket.emit('notification:dismissed', payload);
+        }
+      }
+    )
+  );
+
+  logger.info('gateway WS subscribers registered', {
+    subjects: ['notifications.created', 'notifications.dismissed'],
+  });
+
+  return subs;
+};

--- a/services/gateway/src/ws/socket-registry.test.ts
+++ b/services/gateway/src/ws/socket-registry.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { Socket } from 'socket.io';
+
+import { SocketRegistry } from './socket-registry.js';
+
+// Sockets aren't materially used by the registry — it just holds them.
+// Empty objects are enough to assert membership + identity.
+function fakeSocket(): Socket {
+  return {} as Socket;
+}
+
+describe('SocketRegistry', () => {
+  it('returns an empty array for a user with no connected sockets', () => {
+    const reg = new SocketRegistry();
+    expect(reg.socketsFor('usr-1')).toEqual([]);
+    expect(reg.size()).toBe(0);
+  });
+
+  it('stores a single socket under the user and returns it on lookup', () => {
+    const reg = new SocketRegistry();
+    const s = fakeSocket();
+    reg.add('usr-1', s);
+
+    expect(reg.socketsFor('usr-1')).toEqual([s]);
+    expect(reg.size()).toBe(1);
+  });
+
+  it('supports multiple sockets per user (e.g. two browser tabs)', () => {
+    const reg = new SocketRegistry();
+    const s1 = fakeSocket();
+    const s2 = fakeSocket();
+    reg.add('usr-1', s1);
+    reg.add('usr-1', s2);
+
+    const sockets = reg.socketsFor('usr-1');
+    expect(sockets).toHaveLength(2);
+    expect(sockets).toContain(s1);
+    expect(sockets).toContain(s2);
+    expect(reg.size()).toBe(1);
+  });
+
+  it('removes a single socket without affecting siblings under the same user', () => {
+    const reg = new SocketRegistry();
+    const s1 = fakeSocket();
+    const s2 = fakeSocket();
+    reg.add('usr-1', s1);
+    reg.add('usr-1', s2);
+
+    reg.remove('usr-1', s1);
+
+    expect(reg.socketsFor('usr-1')).toEqual([s2]);
+    expect(reg.size()).toBe(1);
+  });
+
+  it('removes the user bucket entirely once the last socket disconnects', () => {
+    const reg = new SocketRegistry();
+    const s = fakeSocket();
+    reg.add('usr-1', s);
+    reg.remove('usr-1', s);
+
+    expect(reg.socketsFor('usr-1')).toEqual([]);
+    expect(reg.size()).toBe(0);
+  });
+
+  it('is a no-op when removing a socket the registry never saw', () => {
+    const reg = new SocketRegistry();
+    expect(() => reg.remove('usr-1', fakeSocket())).not.toThrow();
+    expect(reg.size()).toBe(0);
+  });
+
+  it('returns a snapshot — mutating the returned array does not change the registry', () => {
+    const reg = new SocketRegistry();
+    const s = fakeSocket();
+    reg.add('usr-1', s);
+
+    const snapshot = reg.socketsFor('usr-1');
+    snapshot.pop();
+
+    expect(reg.socketsFor('usr-1')).toEqual([s]);
+  });
+});

--- a/services/gateway/src/ws/socket-registry.ts
+++ b/services/gateway/src/ws/socket-registry.ts
@@ -1,0 +1,58 @@
+// Per-replica userId → Set<Socket> map. Tracks which Socket.IO
+// connections belong to which user on THIS gateway replica.
+//
+// Multi-replica fan-out architecture (Phase 1.5):
+//
+//   - Each gateway replica subscribes to `notifications.*` on NATS
+//     WITHOUT a queue group, so every replica receives every event.
+//   - On an event, each replica looks up the recipient's sockets in
+//     its own registry. The replica that holds the socket emits; the
+//     other replicas no-op.
+//   - Cost: event amplification (each event hits N replicas). Benefit:
+//     no Redis-pub-sub-between-gateways glue is needed. For the
+//     notification volume adopt-dont-shop expects, the trade-off is
+//     correct. Revisit if event rate climbs.
+//
+// CAD's gateway uses an equivalent registry. Same name, same shape.
+
+import type { Socket } from 'socket.io';
+
+export class SocketRegistry {
+  private readonly bucketsByUser = new Map<string, Set<Socket>>();
+
+  add(userId: string, socket: Socket): void {
+    const existing = this.bucketsByUser.get(userId);
+    if (existing) {
+      existing.add(socket);
+      return;
+    }
+    this.bucketsByUser.set(userId, new Set([socket]));
+  }
+
+  remove(userId: string, socket: Socket): void {
+    const bucket = this.bucketsByUser.get(userId);
+    if (!bucket) {
+      return;
+    }
+    bucket.delete(socket);
+    if (bucket.size === 0) {
+      this.bucketsByUser.delete(userId);
+    }
+  }
+
+  // Returns a snapshot array so the caller can iterate safely even if
+  // a socket disconnects mid-loop (which would mutate the underlying
+  // Set).
+  socketsFor(userId: string): Socket[] {
+    const bucket = this.bucketsByUser.get(userId);
+    if (!bucket) {
+      return [];
+    }
+    return Array.from(bucket);
+  }
+
+  // For ops + smoke tests. Don't depend on this in production logic.
+  size(): number {
+    return this.bucketsByUser.size;
+  }
+}

--- a/services/gateway/src/ws/socket-server.ts
+++ b/services/gateway/src/ws/socket-server.ts
@@ -1,0 +1,83 @@
+// Socket.IO server attached to the gateway's underlying HTTP server.
+//
+// Auth (Phase 1.5 dev-mode): the client supplies `?userId=<id>` on the
+// handshake query string. No real authentication — the gateway trusts
+// the value. Phase 2 replaces this with token verification via
+// service.auth.ValidateToken, after which the principal carried in
+// gRPC metadata for HTTP requests will also drive socket identity.
+//
+// Lifecycle:
+//   - On connect: extract userId, register the socket in the per-
+//     replica SocketRegistry.
+//   - On disconnect: unregister.
+//   - On message from client: ignored for now (Phase 1.5 is server-
+//     to-client only). Phase 6 (chat) adds typing indicators, presence,
+//     and outbound messages from the client.
+
+import type { Server as HttpServer } from 'node:http';
+
+import { Server as IOServer, type Socket } from 'socket.io';
+import type { Logger } from 'winston';
+
+import type { SocketRegistry } from './socket-registry.js';
+
+export type AttachSocketServerOptions = {
+  httpServer: HttpServer;
+  registry: SocketRegistry;
+  logger: Logger;
+};
+
+export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer => {
+  const { httpServer, registry, logger } = opts;
+
+  const io = new IOServer(httpServer, {
+    // Permissive CORS in dev — nginx is the real terminator in prod
+    // and applies its own CSP / origin checks before any traffic
+    // reaches this socket layer.
+    cors: { origin: true, credentials: true },
+    // The same /socket.io path the existing app uses, so the React
+    // clients don't need to rebind during the strangler overlap.
+    path: '/socket.io',
+  });
+
+  io.on('connection', (socket: Socket) => {
+    const userId = extractUserId(socket);
+    if (!userId) {
+      logger.warn('socket connection rejected — missing userId', {
+        socketId: socket.id,
+      });
+      socket.disconnect(true);
+      return;
+    }
+
+    registry.add(userId, socket);
+    logger.info('socket connected', {
+      socketId: socket.id,
+      userId,
+      bucketSize: registry.socketsFor(userId).length,
+    });
+
+    socket.on('disconnect', reason => {
+      registry.remove(userId, socket);
+      logger.info('socket disconnected', { socketId: socket.id, userId, reason });
+    });
+  });
+
+  return io;
+};
+
+// userId can land on either the handshake auth object (Socket.IO v3+
+// preferred — `io({ auth: { userId } })`) or the query string (legacy
+// clients). Accept both during the migration so we don't have to
+// version-gate the connect call across all three React apps.
+function extractUserId(socket: Socket): string | undefined {
+  const fromAuth = socket.handshake.auth?.userId;
+  if (typeof fromAuth === 'string' && fromAuth.length > 0) {
+    return fromAuth;
+  }
+  const fromQuery = socket.handshake.query?.userId;
+  if (typeof fromQuery === 'string' && fromQuery.length > 0) {
+    return fromQuery;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Context

Seventh Phase 1 commit. Phase 1.4 (NATS subscribers in `service.notifications`) is on main; this is **Phase 1.5** — the gateway side of the WebSocket spine.

- Plan: `.claude/plans/so-these-are-my-vast-duckling.md`
- Lessons log: [📐 Decisions & lessons learned — AdoptDontShop](https://app.notion.com/p/37589ffb19fc811fa024e012ea31caed)

## Phase 1.5 — gateway WebSocket fan-out

Attaches Socket.IO to the gateway's HTTP server and wires a NATS subscriber that fans `notifications.created` / `notifications.dismissed` events out to the right connected sockets. End-to-end:

```
service.notifications.handlers.createNotification
  → INSERT + COMMIT in notifications.notifications
  → @adopt-dont-shop/events.withTransaction publishes
    notifications.created on NATS (publish-after-commit, CAD #29)
  → gateway's NATS subscriber consumes
  → registry.socketsFor(payload.userId).forEach(s => s.emit(...))
```

After this lands, the SPA receives notifications live without any new monolith path — the only thing still on `service.backend` for this domain is the REST route, which Phase 1.6 cuts over.

### What's here

- **`src/ws/socket-registry.ts`** — per-replica `userId → Set<Socket>` map. Returns snapshot arrays so callers can iterate safely while sockets disconnect mid-loop. Multi-replica architecture documented inline: no queue group on the NATS sub, each replica fans to its own local sockets, no Redis-pub-sub-between-gateways glue needed.
- **`src/ws/socket-server.ts`** — attaches Socket.IO to the underlying `http.Server`. Connection handler extracts userId from `handshake.auth.userId` OR `handshake.query.userId` (legacy fallback). **No real auth in this phase** — Phase 2 plugs in `service.auth.ValidateToken`.
- **`src/ws/notifications-subscriber.ts`** — `@adopt-dont-shop/events.subscribe` on `notifications.created` + `notifications.dismissed`. No queue group (every replica sees every event). Per-event lookup + emit. Poison-pill protection inherited from `packages/events.subscribe`.
- **`src/index.ts`** — connect NATS, attach Socket.IO to `server.server` AFTER Fastify listen so the `http.Server` is real, register subscribers. Shutdown closes io first (stops accepting), then HTTP, then drains NATS.
- **`src/config.ts`** — adds `NATS_URL` (default `nats://nats:4222`).

### Test coverage (24 total on service.gateway, was 12)

12 new tests:

- **SocketRegistry (7)** — empty lookup, single + multi-socket per user, remove keeps siblings, last-removal cleans bucket, no-op on unknown socket, snapshot semantics.
- **registerNotificationSubscribers (5)** — correct subjects subscribed, no queue group (asserts every gateway replica sees every event), fan-out to multiple sockets per user, scoped to recipient, no-op when recipient absent on this replica.

### Why no queue group, no Redis adapter

For adopt-dont-shop's notification volume the "every replica sees every event, only the holder of the socket emits" trade-off is correct. Avoids Redis-pub-sub-between-gateways glue. Documented inline so the next reader doesn't reach for the typical Socket.IO Redis adapter unnecessarily. Revisit if event rate climbs.

## What's NOT here yet (Phase 1.6)

- **Cutover**: gateway routes `/api/notifications/*` to `service.notifications` (over gRPC, via a Fastify plugin that translates REST → gRPC); the monolith's notification routes delete.

## Test plan

- [x] `npx turbo run lint type-check test --filter=@adopt-dont-shop/service.gateway` — green (24/24)
- [x] `check-workflow-paths`, `check-workspace-consistency` — green
- [ ] Full CI on this PR after push

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_