### PR TITLE
feat(microservices): auth gRPC server boot + adapter (Phase 2.3c)

### DIFF
--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -84,15 +84,27 @@ for adopt-dont-shop's domain.
   (`['BEGIN', '…', 'COMMIT', 'NATS_PUBLISH']`), idempotency on
   already-revoked tokens, and `super_admin` bypass.
 
-## What's NOT here yet
+**Phase 2.3c** — gRPC server boot + adapter:
+- `src/grpc/adapter.ts` — `adapt` (principal-required) and
+  `adaptUnauth` (principal-optional, for Login/RefreshToken/
+  ValidateToken). Both map `HandlerError.code → grpc.status` and
+  scrub unknown errors to `INTERNAL` (logged via `logger.error`).
+- `src/grpc/principal.ts` — `extractPrincipal` from the
+  `x-user-id` / `x-user-roles` / `x-user-permissions` / `x-rescue-id`
+  metadata headers (same shape as services/notifications).
+- `src/grpc/password-hasher.ts` — `createBcryptPasswordHasher`
+  wrapping the same `bcryptjs` the monolith uses (existing hashes
+  validate without a re-hash on first login).
+- `src/grpc/token-issuer.ts` — `createJwtTokenIssuer` wrapping
+  `jsonwebtoken`. Access tokens 15m, refresh tokens 30d. Separate
+  secrets — a leaked access secret doesn't compromise refresh.
+- `src/grpc/server.ts` — `createGrpcServer` + `startGrpcServer`.
+  Same shape as services/notifications. Binds all six
+  AuthService RPCs on `AUTH_GRPC_PORT` (default 6002).
+- `src/index.ts` wires `pool` + `nats` + hasher + issuer into the
+  gRPC server and runs it alongside the HTTP /health surface.
 
-- **Phase 2.3c** — gRPC server boot + adapter:
-  - the `(call, callback)` adapter that wraps each handler and maps
-    `HandlerError.code → grpc.status` (port of
-    `services/notifications/src/grpc/adapter.ts`)
-  - production `passwordHasher` (bcryptjs) + `tokenIssuer`
-    (jsonwebtoken) implementations
-  - gRPC server boot inside `createServer` on `AUTH_GRPC_PORT` 6002
+## What's NOT here yet
 - **Phase 2.4** — NATS publishers: `auth.userCreated`,
   `auth.roleAssigned`, `auth.tokenRevoked`. Downstream services
   (notifications, applications) consume these.

--- a/services/auth/src/grpc/adapter.test.ts
+++ b/services/auth/src/grpc/adapter.test.ts
@@ -1,0 +1,173 @@
+import { Metadata, status, type ServerUnaryCall, type sendUnaryData } from '@grpc/grpc-js';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from 'winston';
+
+import { adapt, adaptUnauth } from './adapter.js';
+import { HandlerError, type HandlerDeps } from './handlers.js';
+
+function makeLogger() {
+  const calls: Array<{ level: string; msg: string; meta?: unknown }> = [];
+  const logger = {
+    info: (msg: string, meta?: unknown) => calls.push({ level: 'info', msg, meta }),
+    error: (msg: string, meta?: unknown) => calls.push({ level: 'error', msg, meta }),
+    warn: (msg: string, meta?: unknown) => calls.push({ level: 'warn', msg, meta }),
+    debug: (msg: string, meta?: unknown) => calls.push({ level: 'debug', msg, meta }),
+    silly: (msg: string, meta?: unknown) => calls.push({ level: 'silly', msg, meta }),
+  } as unknown as Logger;
+  return { logger, calls };
+}
+
+function buildMetadata(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+const VALID_PRINCIPAL_HEADERS = {
+  'x-user-id': 'usr-1',
+  'x-user-roles': 'adopter',
+  'x-user-permissions': 'notifications.read',
+};
+
+// Minimal deps stub — handlers under adapter don't touch pg/nats in
+// these tests because we hand-roll the handler function.
+const deps = {
+  pool: {},
+  nats: {},
+  passwordHasher: { compare: vi.fn() },
+  tokenIssuer: { mint: vi.fn(), verifyAccess: vi.fn(), verifyRefresh: vi.fn() },
+} as unknown as HandlerDeps;
+
+function makeCall<Req>(request: Req, metadata: Metadata): ServerUnaryCall<Req, unknown> {
+  return { request, metadata } as ServerUnaryCall<Req, unknown>;
+}
+
+describe('adapt (principal-required) — happy path', () => {
+  it('passes the request and extracted principal to the handler', async () => {
+    const handler = vi.fn(async (_deps, principal, req: { ping: string }) => ({
+      pong: req.ping,
+      asUser: principal.userId,
+    }));
+
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({ ping: 'hi' }, buildMetadata(VALID_PRINCIPAL_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ pong: 'hi', asUser: 'usr-1' });
+  });
+});
+
+describe('adapt — error code mapping', () => {
+  it('UNAUTHENTICATED when principal headers are missing', async () => {
+    const handler = vi.fn();
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata({})), callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(handler).not.toHaveBeenCalled();
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.UNAUTHENTICATED });
+  });
+
+  it.each([
+    ['INVALID_ARGUMENT', status.INVALID_ARGUMENT],
+    ['UNAUTHENTICATED', status.UNAUTHENTICATED],
+    ['PERMISSION_DENIED', status.PERMISSION_DENIED],
+    ['NOT_FOUND', status.NOT_FOUND],
+    ['INTERNAL', status.INTERNAL],
+  ] as const)('HandlerError("%s") → %i', async (code, grpcCode) => {
+    const handler = vi.fn(async () => {
+      throw new HandlerError(code, 'oops');
+    });
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_PRINCIPAL_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: grpcCode, details: 'oops' });
+  });
+
+  it('unknown errors → INTERNAL with scrubbed message AND logger.error', async () => {
+    const handler = vi.fn(async () => {
+      throw new Error('pg: connection lost');
+    });
+    const { logger, calls } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_PRINCIPAL_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.INTERNAL, details: 'internal error' });
+    expect((err as Error).message).toBe('internal error');
+    const errorCall = calls.find(c => c.level === 'error');
+    expect(errorCall?.msg).toContain('unhandled');
+  });
+});
+
+describe('adaptUnauth (principal-optional) — Login/Refresh/Validate', () => {
+  it('invokes the handler with principal=null when metadata is missing', async () => {
+    const handler = vi.fn(async (_deps, principal, _req: unknown) => ({
+      gotNull: principal === null,
+    }));
+    const { logger } = makeLogger();
+    const wrapped = adaptUnauth(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata({})), callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ gotNull: true });
+  });
+
+  it('passes the principal through when metadata IS present', async () => {
+    const handler = vi.fn(async (_deps, principal, _req: unknown) => ({
+      userId: principal?.userId,
+    }));
+    const { logger } = makeLogger();
+    const wrapped = adaptUnauth(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_PRINCIPAL_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ userId: 'usr-1' });
+  });
+
+  it('still maps HandlerError codes to gRPC status', async () => {
+    const handler = vi.fn(async () => {
+      throw new HandlerError('UNAUTHENTICATED', 'invalid credentials');
+    });
+    const { logger } = makeLogger();
+    const wrapped = adaptUnauth(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata({})), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({
+      code: status.UNAUTHENTICATED,
+      details: 'invalid credentials',
+    });
+  });
+});

--- a/services/auth/src/grpc/adapter.ts
+++ b/services/auth/src/grpc/adapter.ts
@@ -1,0 +1,120 @@
+// Adapter — wraps the plain async handler functions in handlers.ts
+// in the grpc-js `(call, callback)` signature ts-proto generates.
+//
+// Two variants:
+//   - `adapt`        — for handlers that REQUIRE a principal
+//                      (Logout, GetMe, AssignRole). Throws
+//                      UNAUTHENTICATED when metadata is missing.
+//   - `adaptUnauth`  — for handlers that DON'T (Login, RefreshToken,
+//                      ValidateToken — these mint or verify the
+//                      principal). Passes `null` through to the
+//                      handler; the handler's signature is typed
+//                      `Principal | null`.
+//
+// HandlerError code mapping mirrors the table in
+// services/notifications/src/grpc/adapter.ts so the same gateway
+// REST→gRPC code-to-status translation works for every extracted
+// service.
+
+import {
+  status,
+  type Metadata,
+  type ServerUnaryCall,
+  type ServiceError,
+  type sendUnaryData,
+} from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Logger } from 'winston';
+
+import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
+  INVALID_ARGUMENT: status.INVALID_ARGUMENT,
+  UNAUTHENTICATED: status.UNAUTHENTICATED,
+  PERMISSION_DENIED: status.PERMISSION_DENIED,
+  NOT_FOUND: status.NOT_FOUND,
+  INTERNAL: status.INTERNAL,
+};
+
+export type UnaryHandler<Req, Res> = (
+  deps: HandlerDeps,
+  principal: Principal,
+  req: Req
+) => Promise<Res>;
+
+export type UnaryHandlerUnauth<Req, Res> = (
+  deps: HandlerDeps,
+  principal: Principal | null,
+  req: Req
+) => Promise<Res>;
+
+export type AdaptOptions = {
+  deps: HandlerDeps;
+  logger: Logger;
+};
+
+export function adapt<Req, Res>(
+  handler: UnaryHandler<Req, Res>,
+  { deps, logger }: AdaptOptions
+): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
+  return (call, callback) => {
+    void (async () => {
+      try {
+        const principal = extractPrincipal(call.metadata);
+        const response = await handler(deps, principal, call.request);
+        callback(null, response);
+      } catch (err) {
+        callback(toServiceError(err, call.metadata, logger), null);
+      }
+    })();
+  };
+}
+
+// `adaptUnauth` skips principal extraction — used by Login,
+// RefreshToken, ValidateToken which can be called without one.
+export function adaptUnauth<Req, Res>(
+  handler: UnaryHandlerUnauth<Req, Res>,
+  { deps, logger }: AdaptOptions
+): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
+  return (call, callback) => {
+    void (async () => {
+      try {
+        // Best-effort principal extraction — pass it through when
+        // present (gateway middleware may already have validated a
+        // request the caller could have made authenticated), but
+        // never block on its absence.
+        let principal: Principal | null = null;
+        try {
+          principal = extractPrincipal(call.metadata);
+        } catch {
+          principal = null;
+        }
+        const response = await handler(deps, principal, call.request);
+        callback(null, response);
+      } catch (err) {
+        callback(toServiceError(err, call.metadata, logger), null);
+      }
+    })();
+  };
+}
+
+function toServiceError(err: unknown, metadata: Metadata, logger: Logger): ServiceError {
+  if (err instanceof MissingPrincipalError) {
+    return makeServiceError(status.UNAUTHENTICATED, err.message, metadata);
+  }
+  if (err instanceof HandlerError) {
+    return makeServiceError(CODE_TO_GRPC[err.code], err.message, metadata);
+  }
+  logger.error('unhandled handler error', { err });
+  return makeServiceError(status.INTERNAL, 'internal error', metadata);
+}
+
+function makeServiceError(code: number, message: string, metadata: Metadata): ServiceError {
+  const err = new Error(message) as ServiceError;
+  err.code = code;
+  err.details = message;
+  err.metadata = metadata;
+  return err;
+}

--- a/services/auth/src/grpc/password-hasher.test.ts
+++ b/services/auth/src/grpc/password-hasher.test.ts
@@ -1,0 +1,23 @@
+import bcrypt from 'bcryptjs';
+import { describe, expect, it } from 'vitest';
+
+import { createBcryptPasswordHasher } from './password-hasher.js';
+
+// Use cost 4 (the lowest bcrypt allows) so the test stays under ~30ms
+// per hash. Production hashes are written by the monolith at cost 10+
+// and this hasher only ever READS them.
+const fastHash = (s: string) => bcrypt.hash(s, 4);
+
+describe('createBcryptPasswordHasher', () => {
+  it('returns true when the password matches the hash', async () => {
+    const hasher = createBcryptPasswordHasher();
+    const hash = await fastHash('hunter2');
+    expect(await hasher.compare('hunter2', hash)).toBe(true);
+  });
+
+  it('returns false when the password does not match', async () => {
+    const hasher = createBcryptPasswordHasher();
+    const hash = await fastHash('hunter2');
+    expect(await hasher.compare('wrong', hash)).toBe(false);
+  });
+});

--- a/services/auth/src/grpc/password-hasher.ts
+++ b/services/auth/src/grpc/password-hasher.ts
@@ -1,0 +1,19 @@
+// Production PasswordHasher implementation backed by bcryptjs.
+//
+// Same library the monolith uses (service.backend/services/auth.service.ts
+// imports `bcryptjs` directly). Keeping the package identical means the
+// auth schema's existing `password` column values keep validating
+// against this hasher without a re-hash on first login.
+//
+// Tests pass a vi.fn() stub — see handlers.test.ts. This file is only
+// touched at boot when wiring real deps in src/index.ts.
+
+import bcrypt from 'bcryptjs';
+
+import type { PasswordHasher } from './handlers.js';
+
+export function createBcryptPasswordHasher(): PasswordHasher {
+  return {
+    compare: (password, hash) => bcrypt.compare(password, hash),
+  };
+}

--- a/services/auth/src/grpc/principal.test.ts
+++ b/services/auth/src/grpc/principal.test.ts
@@ -1,0 +1,53 @@
+import { Metadata } from '@grpc/grpc-js';
+import { describe, expect, it } from 'vitest';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+function build(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+describe('extractPrincipal', () => {
+  it('throws MissingPrincipalError when x-user-id is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-roles': 'adopter' }))).toThrowError(
+      MissingPrincipalError
+    );
+  });
+
+  it('throws MissingPrincipalError when x-user-roles is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-id': 'u' }))).toThrowError(MissingPrincipalError);
+  });
+
+  it('parses comma-separated roles + permissions', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'rescue_staff, admin',
+        'x-user-permissions': 'pets.read , pets.update',
+      })
+    );
+    expect(p.userId).toBe('usr-1');
+    expect(p.roles).toEqual(['rescue_staff', 'admin']);
+    expect(p.permissions).toEqual(['pets.read', 'pets.update']);
+  });
+
+  it('accepts an empty permissions header (role-only authz)', () => {
+    const p = extractPrincipal(
+      build({ 'x-user-id': 'u', 'x-user-roles': 'adopter', 'x-user-permissions': '' })
+    );
+    expect(p.permissions).toEqual([]);
+  });
+
+  it('carries x-rescue-id when present', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'u',
+        'x-user-roles': 'rescue_staff',
+        'x-rescue-id': 'rsc-42',
+      })
+    );
+    expect(p.rescueId).toBe('rsc-42');
+  });
+});

--- a/services/auth/src/grpc/principal.ts
+++ b/services/auth/src/grpc/principal.ts
@@ -1,0 +1,72 @@
+// Principal extractor for gRPC handlers that REQUIRE a principal.
+//
+// Every extracted service receives identity context as gRPC metadata
+// headers from the gateway:
+//
+//   x-user-id           UUID of the calling user
+//   x-user-roles        comma-separated UserRole list
+//   x-user-permissions  comma-separated Permission list
+//   x-rescue-id         (optional) rescueId for rescue-scoped roles
+//
+// Direct port of services/notifications/src/grpc/principal.ts — the
+// gateway populates the same headers regardless of which service the
+// call lands on.
+//
+// AuthService.{Login, RefreshToken, ValidateToken} are the only RPCs
+// that DON'T require the principal (they mint/verify it). The adapter
+// distinguishes them via `adaptUnauth` and never calls extractPrincipal
+// for those RPCs.
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export class MissingPrincipalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingPrincipalError';
+  }
+}
+
+export function extractPrincipal(metadata: Metadata): Principal {
+  const userId = headerOne(metadata, 'x-user-id');
+  if (!userId) {
+    throw new MissingPrincipalError('missing x-user-id metadata');
+  }
+
+  const rolesRaw = headerOne(metadata, 'x-user-roles');
+  if (!rolesRaw) {
+    throw new MissingPrincipalError('missing x-user-roles metadata');
+  }
+
+  const roles = rolesRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as UserRole[];
+
+  const permissionsRaw = headerOne(metadata, 'x-user-permissions') ?? '';
+  const permissions = permissionsRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as Permission[];
+
+  const rescueIdRaw = headerOne(metadata, 'x-rescue-id')?.trim();
+  const rescueId = rescueIdRaw ? (rescueIdRaw as RescueId) : undefined;
+
+  return {
+    userId: userId as UserId,
+    roles,
+    permissions,
+    rescueId,
+  };
+}
+
+function headerOne(metadata: Metadata, key: string): string | undefined {
+  const values = metadata.get(key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}

--- a/services/auth/src/grpc/server.test.ts
+++ b/services/auth/src/grpc/server.test.ts
@@ -1,0 +1,80 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AuthV1 } from '@adopt-dont-shop/proto';
+
+import type { AuthConfig } from '../config.js';
+
+import type { HandlerDeps } from './handlers.js';
+import { createGrpcServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const config: AuthConfig = {
+  port: 5002,
+  grpcPort: 6002,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'auth',
+  natsUrl: 'nats://localhost:4222',
+  jwtSecret: 'access-secret',
+  jwtRefreshSecret: 'refresh-secret',
+};
+
+const pool = {} as unknown as Pool;
+const nats = {} as unknown as NatsConnection;
+const passwordHasher: HandlerDeps['passwordHasher'] = { compare: vi.fn() };
+const tokenIssuer: HandlerDeps['tokenIssuer'] = {
+  mint: vi.fn(),
+  verifyAccess: vi.fn(),
+  verifyRefresh: vi.fn(),
+};
+
+describe('createGrpcServer', () => {
+  it('registers all six AuthService methods on the grpc.Server', () => {
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      passwordHasher,
+      tokenIssuer,
+      logger: quietLogger,
+    });
+
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    expect(handlers.has('/adopt_dont_shop.auth.v1.AuthService/Login')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.auth.v1.AuthService/Logout')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.auth.v1.AuthService/RefreshToken')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.auth.v1.AuthService/ValidateToken')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.auth.v1.AuthService/GetMe')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.auth.v1.AuthService/AssignRole')).toBe(true);
+  });
+
+  it('matches every path from the canonical AuthServiceService Definition table', () => {
+    const definition = AuthV1.AuthServiceService;
+    const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
+
+    const server = createGrpcServer({
+      config,
+      pool,
+      nats,
+      passwordHasher,
+      tokenIssuer,
+      logger: quietLogger,
+    });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    for (const p of expectedPaths) {
+      expect(handlers.has(p)).toBe(true);
+    }
+  });
+});

--- a/services/auth/src/grpc/server.ts
+++ b/services/auth/src/grpc/server.ts
@@ -1,0 +1,98 @@
+// gRPC server boot — binds AuthServiceService to the six adapter-
+// wrapped handlers and starts listening on AUTH_GRPC_PORT.
+//
+// Same shape as services/notifications/src/grpc/server.ts. Dev uses
+// insecure credentials (TLS terminates at nginx in front); production
+// keeps gRPC HTTP/2 cleartext on the cluster network until a future
+// deploy wants mTLS.
+
+import { promisify } from 'node:util';
+
+import { Server, ServerCredentials } from '@grpc/grpc-js';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { AuthV1 } from '@adopt-dont-shop/proto';
+
+import type { AuthConfig } from '../config.js';
+
+import { adapt, adaptUnauth } from './adapter.js';
+import {
+  assignRole,
+  getMe,
+  login,
+  logout,
+  refreshToken,
+  validateToken,
+  type HandlerDeps,
+} from './handlers.js';
+
+export type CreateGrpcServerOptions = {
+  config: AuthConfig;
+  pool: Pool;
+  nats: NatsConnection;
+  passwordHasher: HandlerDeps['passwordHasher'];
+  tokenIssuer: HandlerDeps['tokenIssuer'];
+  logger: Logger;
+};
+
+export type RunningGrpcServer = {
+  server: Server;
+  port: number;
+  shutdown: () => Promise<void>;
+};
+
+export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
+  const { config, pool, nats, passwordHasher, tokenIssuer, logger } = opts;
+  const deps: HandlerDeps = { pool, nats, passwordHasher, tokenIssuer };
+  const server = new Server();
+
+  server.addService(AuthV1.AuthServiceService, {
+    // Token-minting / verification RPCs — no caller principal required.
+    login: adaptUnauth(login, { deps, logger }),
+    refreshToken: adaptUnauth(refreshToken, { deps, logger }),
+    validateToken: adaptUnauth(validateToken, { deps, logger }),
+    // Principal-required RPCs.
+    logout: adapt(logout, { deps, logger }),
+    getMe: adapt(getMe, { deps, logger }),
+    assignRole: adapt(assignRole, { deps, logger }),
+  });
+
+  logger.info('gRPC AuthService registered', {
+    methods: ['login', 'logout', 'refreshToken', 'validateToken', 'getMe', 'assignRole'],
+    grpcPort: config.grpcPort,
+  });
+
+  return server;
+};
+
+export const startGrpcServer = async (
+  opts: CreateGrpcServerOptions
+): Promise<RunningGrpcServer> => {
+  const { config, logger } = opts;
+  const server = createGrpcServer(opts);
+
+  const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
+  const port = await bindAsync(
+    `${opts.config.host}:${config.grpcPort}`,
+    ServerCredentials.createInsecure()
+  );
+
+  logger.info('gRPC server listening', { port, host: opts.config.host });
+
+  return {
+    server,
+    port,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          resolve();
+        });
+      }),
+  };
+};

--- a/services/auth/src/grpc/token-issuer.test.ts
+++ b/services/auth/src/grpc/token-issuer.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { createJwtTokenIssuer } from './token-issuer.js';
+
+const cfg = {
+  accessSecret: 'access-secret-' + 'x'.repeat(32),
+  refreshSecret: 'refresh-secret-' + 'x'.repeat(32),
+};
+
+describe('createJwtTokenIssuer', () => {
+  it('mints a pair with non-empty access + refresh tokens', async () => {
+    const issuer = createJwtTokenIssuer(cfg);
+    const minted = await issuer.mint('usr-1');
+    expect(minted.pair.accessToken).toMatch(/^eyJ/);
+    expect(minted.pair.refreshToken).toMatch(/^eyJ/);
+    expect(minted.accessJti).toMatch(/^[0-9a-f-]{36}$/);
+    expect(minted.refreshJti).toMatch(/^[0-9a-f-]{36}$/);
+    expect(minted.accessExpiresAt.getTime()).toBeGreaterThan(Date.now());
+    expect(minted.refreshExpiresAt.getTime()).toBeGreaterThan(minted.accessExpiresAt.getTime());
+  });
+
+  it('verifyAccess round-trips the claims it minted', async () => {
+    const issuer = createJwtTokenIssuer(cfg);
+    const minted = await issuer.mint('usr-1');
+    const claims = await issuer.verifyAccess(minted.pair.accessToken);
+    expect(claims.sub).toBe('usr-1');
+    expect(claims.jti).toBe(minted.accessJti);
+  });
+
+  it('verifyRefresh round-trips the claims it minted', async () => {
+    const issuer = createJwtTokenIssuer(cfg);
+    const minted = await issuer.mint('usr-1');
+    const claims = await issuer.verifyRefresh(minted.pair.refreshToken);
+    expect(claims.sub).toBe('usr-1');
+    expect(claims.jti).toBe(minted.refreshJti);
+  });
+
+  it('verifyAccess REJECTS a refresh token (distinct secrets)', async () => {
+    const issuer = createJwtTokenIssuer(cfg);
+    const minted = await issuer.mint('usr-1');
+    await expect(issuer.verifyAccess(minted.pair.refreshToken)).rejects.toThrowError();
+  });
+
+  it('verifyRefresh REJECTS an access token (distinct secrets)', async () => {
+    const issuer = createJwtTokenIssuer(cfg);
+    const minted = await issuer.mint('usr-1');
+    await expect(issuer.verifyRefresh(minted.pair.accessToken)).rejects.toThrowError();
+  });
+
+  it('verifyAccess rejects a tampered token', async () => {
+    const issuer = createJwtTokenIssuer(cfg);
+    const minted = await issuer.mint('usr-1');
+    const tampered = minted.pair.accessToken.slice(0, -3) + 'AAA';
+    await expect(issuer.verifyAccess(tampered)).rejects.toThrowError();
+  });
+});

--- a/services/auth/src/grpc/token-issuer.ts
+++ b/services/auth/src/grpc/token-issuer.ts
@@ -1,0 +1,100 @@
+// Production TokenIssuer implementation backed by jsonwebtoken.
+//
+// Mint short-lived access tokens + longer-lived refresh tokens, signed
+// with separate secrets (config.jwtSecret + config.jwtRefreshSecret) so
+// a leaked access secret doesn't compromise refresh.
+//
+// Token lifetimes match the monolith:
+//   - access:  15m
+//   - refresh: 30d
+//
+// `jti` is a random UUID per token — used by the Logout / RefreshToken
+// denylist (auth.revoked_tokens.jti) so revoking a token doesn't
+// require keeping the full token text around.
+
+import { randomUUID } from 'node:crypto';
+
+import jwt from 'jsonwebtoken';
+
+import type {
+  AccessTokenClaims,
+  MintedTokens,
+  RefreshTokenClaims,
+  TokenIssuer,
+} from './handlers.js';
+
+const ACCESS_TTL_SECONDS = 15 * 60;
+const REFRESH_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+export type TokenIssuerConfig = {
+  accessSecret: string;
+  refreshSecret: string;
+};
+
+export function createJwtTokenIssuer(cfg: TokenIssuerConfig): TokenIssuer {
+  return {
+    mint: async userId => {
+      const now = Math.floor(Date.now() / 1000);
+      const accessJti = randomUUID();
+      const refreshJti = randomUUID();
+
+      const accessExp = now + ACCESS_TTL_SECONDS;
+      const refreshExp = now + REFRESH_TTL_SECONDS;
+
+      const accessToken = jwt.sign(
+        { sub: userId, jti: accessJti, iat: now, exp: accessExp },
+        cfg.accessSecret
+      );
+      const refreshToken = jwt.sign(
+        { sub: userId, jti: refreshJti, iat: now, exp: refreshExp },
+        cfg.refreshSecret
+      );
+
+      const minted: MintedTokens = {
+        pair: {
+          accessToken,
+          refreshToken,
+          accessExpiresAt: new Date(accessExp * 1000).toISOString(),
+          refreshExpiresAt: new Date(refreshExp * 1000).toISOString(),
+        },
+        accessJti,
+        accessExpiresAt: new Date(accessExp * 1000),
+        refreshJti,
+        refreshExpiresAt: new Date(refreshExp * 1000),
+      };
+      return minted;
+    },
+
+    verifyAccess: async token => {
+      const decoded = jwt.verify(token, cfg.accessSecret) as Record<string, unknown>;
+      return toAccessClaims(decoded);
+    },
+
+    verifyRefresh: async token => {
+      const decoded = jwt.verify(token, cfg.refreshSecret) as Record<string, unknown>;
+      return toRefreshClaims(decoded);
+    },
+  };
+}
+
+function toAccessClaims(raw: Record<string, unknown>): AccessTokenClaims {
+  const sub = typeof raw.sub === 'string' ? raw.sub : undefined;
+  const jti = typeof raw.jti === 'string' ? raw.jti : undefined;
+  const iat = typeof raw.iat === 'number' ? raw.iat : undefined;
+  const exp = typeof raw.exp === 'number' ? raw.exp : undefined;
+  if (!sub || !jti || iat === undefined || exp === undefined) {
+    throw new Error('access token missing required claims');
+  }
+  return { sub, jti, iat, exp };
+}
+
+function toRefreshClaims(raw: Record<string, unknown>): RefreshTokenClaims {
+  const sub = typeof raw.sub === 'string' ? raw.sub : undefined;
+  const jti = typeof raw.jti === 'string' ? raw.jti : undefined;
+  const iat = typeof raw.iat === 'number' ? raw.iat : undefined;
+  const exp = typeof raw.exp === 'number' ? raw.exp : undefined;
+  if (!sub || !jti || iat === undefined || exp === undefined) {
+    throw new Error('refresh token missing required claims');
+  }
+  return { sub, jti, iat, exp };
+}

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -1,21 +1,54 @@
+import { connect, type NatsConnection } from 'nats';
+
+import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { createBcryptPasswordHasher } from './grpc/password-hasher.js';
+import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
+import { createJwtTokenIssuer } from './grpc/token-issuer.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.auth' });
 
+  let nats: NatsConnection | undefined;
+  let pool: ReturnType<typeof createDbClient> | undefined;
+  let grpc: RunningGrpcServer | undefined;
+  let httpClosed = false;
+
   try {
     const config = loadConfig();
-    const server = createServer({ config, logger });
 
-    await server.listen({ port: config.port, host: config.host });
+    // Connect deps FIRST so we crash here rather than after starting
+    // to accept traffic. Same boot order as services/notifications.
+    pool = createDbClient({
+      connectionString: config.databaseUrl,
+      schema: config.schema,
+    });
+    nats = await connect({ servers: config.natsUrl });
 
-    logger.info('service.auth listening', {
-      port: config.port,
-      host: config.host,
-      grpcPort: config.grpcPort,
+    const passwordHasher = createBcryptPasswordHasher();
+    const tokenIssuer = createJwtTokenIssuer({
+      accessSecret: config.jwtSecret,
+      refreshSecret: config.jwtRefreshSecret,
+    });
+
+    grpc = await startGrpcServer({
+      config,
+      pool,
+      nats,
+      passwordHasher,
+      tokenIssuer,
+      logger,
+    });
+
+    const httpServer = createServer({ config, logger });
+    await httpServer.listen({ port: config.port, host: config.host });
+
+    logger.info('service.auth running', {
+      http: { port: config.port, host: config.host },
+      grpc: { port: grpc.port, host: config.host },
       schema: config.schema,
       natsUrl: config.natsUrl,
       environment: config.environment,
@@ -24,9 +57,27 @@ const main = async (): Promise<void> => {
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.auth shutting down', { signal });
       try {
-        await server.close();
+        if (!httpClosed) {
+          await httpServer.close();
+          httpClosed = true;
+        }
       } catch (err) {
-        logger.error('error during shutdown', { err });
+        logger.error('http close error', { err });
+      }
+      try {
+        await grpc?.shutdown();
+      } catch (err) {
+        logger.error('grpc shutdown error', { err });
+      }
+      try {
+        await nats?.drain();
+      } catch (err) {
+        logger.error('nats drain error', { err });
+      }
+      try {
+        await pool?.end();
+      } catch (err) {
+        logger.error('pool end error', { err });
       }
       process.exit(0);
     };
@@ -35,6 +86,21 @@ const main = async (): Promise<void> => {
     process.once('SIGINT', () => void shutdown('SIGINT'));
   } catch (err) {
     logger.error('service.auth failed to start', { err });
+    try {
+      await grpc?.shutdown();
+    } catch {
+      // Swallow — we're already on the failure path.
+    }
+    try {
+      await nats?.drain();
+    } catch {
+      // Same.
+    }
+    try {
+      await pool?.end();
+    } catch {
+      // Same.
+    }
     process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

Phase 2.3c of the microservices migration — wires the six `AuthService` handlers from Phase 2.3b into a running gRPC server on `AUTH_GRPC_PORT` (default 6002), alongside the existing Fastify `/health/simple` surface. Mirrors `services/notifications` to the line.

## What's in

**`src/grpc/adapter.ts`** — two variants:
- `adapt` for principal-required RPCs (`Logout`, `GetMe`, `AssignRole`). Throws `UNAUTHENTICATED` when metadata is missing.
- `adaptUnauth` for token-minting/verifying RPCs (`Login`, `RefreshToken`, `ValidateToken`). Best-effort principal extraction; passes through `null` to the handler when absent.

Both map `HandlerError.code → grpc.status` and scrub unknown errors to `INTERNAL` (logged via `logger.error`).

**`src/grpc/principal.ts`** — direct port of `services/notifications/src/grpc/principal.ts`. Extracts the `Principal` shape `@adopt-dont-shop/authz` expects from the `x-user-{id,roles,permissions,rescue-id}` metadata headers the gateway populates.

**`src/grpc/password-hasher.ts`** — `createBcryptPasswordHasher()` wrapping the same `bcryptjs` the monolith uses, so existing password column values validate without a re-hash on first login.

**`src/grpc/token-issuer.ts`** — `createJwtTokenIssuer()` wrapping `jsonwebtoken`. Access tokens 15m, refresh tokens 30d. Separate secrets — a leaked access secret doesn't compromise refresh.

**`src/grpc/server.ts`** — `createGrpcServer` + `startGrpcServer`. Binds all six `AuthService` methods to adapter-wrapped handlers and runs on `AUTH_GRPC_PORT` with insecure credentials (TLS terminates at nginx in front).

**`src/index.ts`** — wires `pool` + `nats` + hasher + issuer into the gRPC server and runs it alongside the HTTP `/health` surface, with the same boot-then-listen ordering as `services/notifications` (deps connect FIRST, then start serving).

## Test plan

- [x] `npm test` in `services/auth` — **92/92** green (26 new across adapter, principal, server, password-hasher, token-issuer)
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.auth'` — green
- [x] Lint clean

**Coverage of business behaviour:**
- full table of `HandlerError → grpc.status` mappings via `it.each`
- `adapt` vs `adaptUnauth` branch behaviour (principal required vs nullable)
- principal metadata parsing (comma-split roles + permissions, empty permissions, optional rescue-id)
- JWT issuer separate-secret enforcement (access secret rejects refresh tokens and vice versa)
- bcrypt match / no-match
- server handler-table registration asserted against `AuthV1.AuthServiceService.path[]`

## What's NOT in

- **Phase 2.4** — downstream NATS subscribers for `auth.userCreated` / `auth.roleAssigned` / `auth.tokenRevoked` (handlers already emit them via the events package).
- **Phase 2.5** — Gateway middleware calling `ValidateToken` to populate metadata for every non-auth request.
- **Phase 2.6** — Cutover from monolith `/api/auth/*`.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_