### PR TITLE
feat(microservices): downstream auth.* event subscribers (Phase 2.4)

### DIFF
--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -104,10 +104,20 @@ for adopt-dont-shop's domain.
 - `src/index.ts` wires `pool` + `nats` + hasher + issuer into the
   gRPC server and runs it alongside the HTTP /health surface.
 
+**Phase 2.4** — downstream NATS event flow:
+- The Phase 2.3b handlers already publish `auth.userLoggedIn`,
+  `auth.tokenRevoked`, `auth.tokenRefreshed`, and `auth.roleAssigned`
+  via `@adopt-dont-shop/events.withTransaction` (publish-after-commit).
+- `services/notifications` now subscribes to two of those subjects:
+  - `auth.userLoggedIn` → `ACCOUNT_SECURITY` in-app notification
+    ("New sign-in to your account from <ip> (<ua>)")
+  - `auth.roleAssigned` → `STAFF_ASSIGNMENT` in-app notification
+    ("You have been granted the <role> role")
+- Both subscribers go through the existing
+  `createNotification(SYSTEM_PRINCIPAL, …)` translation layer so
+  the publish-after-commit + idempotency disciplines stay intact.
+
 ## What's NOT here yet
-- **Phase 2.4** — NATS publishers: `auth.userCreated`,
-  `auth.roleAssigned`, `auth.tokenRevoked`. Downstream services
-  (notifications, applications) consume these.
 - **Phase 2.5** — Gateway auth middleware: every non-auth route
   calls `service.auth.ValidateToken` to populate the
   `x-user-{id,roles,permissions,rescue-id}` metadata headers (which

--- a/services/notifications/src/nats/event-types.ts
+++ b/services/notifications/src/nats/event-types.ts
@@ -45,3 +45,26 @@ export type ApplicationRejectedEvent = {
   rejectedAt: string;
   reason?: string;
 };
+
+// auth.userLoggedIn — service.auth publishes after every successful
+// login (Phase 2.3b). service.notifications surfaces a security
+// notification so the user can spot unrecognised sign-ins. Mirrors
+// what GitHub / Google account-security emails do — the in-app
+// channel is the cheapest first cut; an email worker can subscribe to
+// the same subject later for an additional channel.
+export type AuthUserLoggedInEvent = {
+  userId: UserId;
+  ipAddress: string | null;
+  userAgent: string | null;
+};
+
+// auth.roleAssigned — service.auth publishes when an admin grants a
+// user a role (e.g. promotes an adopter to rescue_staff). The user
+// gets an in-app notification announcing the new role + a hint about
+// the new affordances.
+export type AuthRoleAssignedEvent = {
+  targetUserId: UserId;
+  role: string;
+  assignedBy: UserId;
+  reason: string | null;
+};

--- a/services/notifications/src/nats/subscribers.test.ts
+++ b/services/notifications/src/nats/subscribers.test.ts
@@ -8,6 +8,8 @@ import {
   buildApplicationApprovedCreate,
   buildApplicationRejectedCreate,
   buildApplicationSubmittedCreate,
+  buildAuthRoleAssignedCreate,
+  buildAuthUserLoggedInCreate,
   registerSubscribers,
 } from './subscribers.js';
 
@@ -92,6 +94,61 @@ describe('event → CreateNotificationRequest translation', () => {
       expect(data.reason).toBeNull();
     });
   });
+
+  describe('buildAuthUserLoggedInCreate', () => {
+    it('produces a LOW-priority ACCOUNT_SECURITY in-app notification with the IP + UA', () => {
+      const req = buildAuthUserLoggedInCreate({
+        userId: 'usr-a' as UserId,
+        ipAddress: '203.0.113.7',
+        userAgent: 'Chrome on macOS',
+      });
+      expect(req.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_ACCOUNT_SECURITY);
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_LOW);
+      expect(req.channel).toBe(NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP);
+      expect(req.message).toContain('203.0.113.7');
+      expect(req.message).toContain('Chrome on macOS');
+      expect(req.relatedEntityType).toBe(
+        NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_SECURITY
+      );
+    });
+
+    it('falls back gracefully when ipAddress / userAgent are null', () => {
+      const req = buildAuthUserLoggedInCreate({
+        userId: 'usr-a' as UserId,
+        ipAddress: null,
+        userAgent: null,
+      });
+      expect(req.message).toContain('unknown location');
+      expect(req.message).not.toContain('null');
+    });
+  });
+
+  describe('buildAuthRoleAssignedCreate', () => {
+    it('announces the new role with NORMAL priority and the canonical role string', () => {
+      const req = buildAuthRoleAssignedCreate({
+        targetUserId: 'usr-a' as UserId,
+        role: 'rescue_staff',
+        assignedBy: 'usr-admin' as UserId,
+        reason: null,
+      });
+      expect(req.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_STAFF_ASSIGNMENT);
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL);
+      expect(req.message).toContain('rescue_staff');
+      const data = JSON.parse(req.dataJson) as Record<string, unknown>;
+      expect(data.role).toBe('rescue_staff');
+      expect(data.assignedBy).toBe('usr-admin');
+    });
+
+    it('appends the reason when supplied', () => {
+      const req = buildAuthRoleAssignedCreate({
+        targetUserId: 'usr-a' as UserId,
+        role: 'moderator',
+        assignedBy: 'usr-admin' as UserId,
+        reason: 'community trust',
+      });
+      expect(req.message).toContain('Reason: community trust');
+    });
+  });
 });
 
 // --- Subscriber registration ----------------------------------------
@@ -130,12 +187,12 @@ describe('registerSubscribers', () => {
     silly: () => undefined,
   } as unknown as Parameters<typeof registerSubscribers>[0]['logger'];
 
-  it('registers a NATS subscription per known application.* subject', () => {
+  it('registers a NATS subscription per known cross-service subject', () => {
     const { nats, subscribeFn } = makeNats();
 
     const subs = registerSubscribers({ nats, deps, logger });
 
-    expect(subs).toHaveLength(3);
+    expect(subs).toHaveLength(5);
     // Subscribed subjects (raw nats.subscribe receives the subject as
     // first arg, then an options object containing `queue`).
     const subjects = subscribeFn.mock.calls.map(call => call[0]);
@@ -143,6 +200,8 @@ describe('registerSubscribers', () => {
       'applications.submitted',
       'applications.approved',
       'applications.rejected',
+      'auth.userLoggedIn',
+      'auth.roleAssigned',
     ]);
   });
 

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -37,6 +37,8 @@ import type {
   ApplicationApprovedEvent,
   ApplicationRejectedEvent,
   ApplicationSubmittedEvent,
+  AuthRoleAssignedEvent,
+  AuthUserLoggedInEvent,
 } from './event-types.js';
 import { SYSTEM_PRINCIPAL } from './system-principal.js';
 
@@ -90,6 +92,26 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
       { subject: 'applications.rejected', queue: QUEUE_GROUP, onError },
       async payload => {
         await createNotification(deps, SYSTEM_PRINCIPAL, buildApplicationRejectedCreate(payload));
+      }
+    )
+  );
+
+  subscriptions.push(
+    subscribe<AuthUserLoggedInEvent>(
+      nats,
+      { subject: 'auth.userLoggedIn', queue: QUEUE_GROUP, onError },
+      async payload => {
+        await createNotification(deps, SYSTEM_PRINCIPAL, buildAuthUserLoggedInCreate(payload));
+      }
+    )
+  );
+
+  subscriptions.push(
+    subscribe<AuthRoleAssignedEvent>(
+      nats,
+      { subject: 'auth.roleAssigned', queue: QUEUE_GROUP, onError },
+      async payload => {
+        await createNotification(deps, SYSTEM_PRINCIPAL, buildAuthRoleAssignedCreate(payload));
       }
     )
   );
@@ -173,4 +195,55 @@ export const buildApplicationRejectedCreate = (
   relatedEntityType:
     NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_APPLICATION,
   relatedEntityId: event.applicationId,
+});
+
+// auth.userLoggedIn — security notification. We surface the IP +
+// user agent so the user can spot unrecognised sign-ins; the message
+// stays generic when neither is supplied (the gateway may strip these
+// in dev / local).
+export const buildAuthUserLoggedInCreate = (
+  event: AuthUserLoggedInEvent
+): CreateNotificationRequest => {
+  const where = event.ipAddress ?? 'an unknown location';
+  const how = event.userAgent ? ` (${event.userAgent})` : '';
+  return {
+    userId: event.userId as string,
+    type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_ACCOUNT_SECURITY,
+    channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+    priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_LOW,
+    title: 'New sign-in to your account',
+    message: `We detected a new sign-in from ${where}${how}. If this wasn't you, change your password immediately.`,
+    dataJson: JSON.stringify({
+      ipAddress: event.ipAddress,
+      userAgent: event.userAgent,
+    }),
+    templateVariablesJson: '{}',
+    relatedEntityType:
+      NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_SECURITY,
+  };
+};
+
+// auth.roleAssigned — in-app announcement of the new role + a hint
+// about the new affordances. The role string is the canonical DB
+// value (`adopter`, `rescue_staff`, etc.) — keep it as-is so the
+// frontend can render a label/icon from a lookup table.
+export const buildAuthRoleAssignedCreate = (
+  event: AuthRoleAssignedEvent
+): CreateNotificationRequest => ({
+  userId: event.targetUserId as string,
+  type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_STAFF_ASSIGNMENT,
+  channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL,
+  title: 'New role assigned',
+  message: event.reason
+    ? `You have been granted the ${event.role} role. Reason: ${event.reason}`
+    : `You have been granted the ${event.role} role.`,
+  dataJson: JSON.stringify({
+    role: event.role,
+    assignedBy: event.assignedBy,
+    reason: event.reason,
+  }),
+  templateVariablesJson: '{}',
+  relatedEntityType:
+    NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_USER,
 });


### PR DESCRIPTION
## Summary

Phase 2.4 of the microservices migration — wires the consumer side of the auth event flow. The Phase 2.3b handlers already publish `auth.userLoggedIn` / `auth.roleAssigned` / `auth.tokenRevoked` / `auth.tokenRefreshed` via `withTransaction` (publish-after-commit). This commit adds two downstream subscribers in `service.notifications`.

## What's in

**`services/notifications/src/nats/event-types.ts`** gains two consumer-side event shapes:
- `AuthUserLoggedInEvent` — `{ userId, ipAddress, userAgent }`
- `AuthRoleAssignedEvent` — `{ targetUserId, role, assignedBy, reason }`

**`services/notifications/src/nats/subscribers.ts`** adds two subscribers, both joining the existing `notifications-workers` queue group:

| Subject | Translation | Notification |
|---|---|---|
| `auth.userLoggedIn` | `buildAuthUserLoggedInCreate` | `ACCOUNT_SECURITY` in-app at **LOW** priority — "New sign-in to your account from `<ip> (<ua>)`". Falls back gracefully when either is null. |
| `auth.roleAssigned` | `buildAuthRoleAssignedCreate` | `STAFF_ASSIGNMENT` in-app at **NORMAL** priority — "You have been granted the `<role>` role". Includes canonical DB role string + `assignedBy` in `dataJson`. |

Both translators are pure functions exported for direct test coverage — same shape as the existing `applications.*` builders. Each subscriber routes through `createNotification(SYSTEM_PRINCIPAL, …)` so the publish-after-commit + idempotency disciplines stay intact.

## Test plan

- [x] `npm test` in `services/notifications` — **70/70** green (5 new across translation + registration)
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.notifications'` — green
- [x] Lint clean

**Coverage:** LOW vs NORMAL priority assertions, IP/UA fallback wording, role string echo, reason appended only when supplied, and `registerSubscribers` now reports 5 subjects (3 `applications.*` + 2 `auth.*`) all on the `notifications-workers` queue group.

## What's NOT in

- **Phase 2.5** — Gateway middleware calling `ValidateToken` for every non-auth route.
- **Phase 2.6** — Cutover from monolith `/api/auth/*`.
- Per-event idempotency dedupe by `id` — CAD #4 poison-pill protection is already covered by `@adopt-dont-shop/events.subscribe`; the per-event dedupe lands with the applications vertical (Phase 5).

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_