### PR TITLE
feat(microservices): gateway /api/auth/* cutover (Phase 2.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5022,9 +5022,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
-      "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.11.tgz",
+      "integrity": "sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
@@ -8222,6 +8222,27 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
     "node_modules/@fastify/reply-from": {
       "version": "12.6.2",
       "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-12.6.2.tgz",
@@ -8814,6 +8835,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -32622,6 +32652,7 @@
         "@adopt-dont-shop/observability": "*",
         "@adopt-dont-shop/proto": "*",
         "@fastify/http-proxy": "^11.5.0",
+        "@fastify/rate-limit": "^10.3.0",
         "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "nats": "^2.29.3",

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -131,9 +131,27 @@ for adopt-dont-shop's domain.
   verify-email,forgot-password,reset-password}`) bypass token
   validation; everything else returns 401 on invalid / revoked tokens.
 
+**Phase 2.6** — Gateway `/api/auth/*` cutover (lands in
+`services/gateway/src/routes/auth.ts`):
+- The gateway now translates `POST /api/auth/login`,
+  `POST /api/auth/logout`, `POST /api/auth/refresh-token`,
+  `GET /api/auth/me`, and `POST /api/auth/assign-role` into the
+  corresponding `AuthService` gRPC calls. Same shape every
+  extracted vertical will use — REST surface unchanged for the
+  SPA, gRPC under the hood.
+- The Phase 2.5 authenticate middleware sits in front of these
+  routes — Logout / GetMe / AssignRole receive the validated
+  principal via `x-user-*` metadata, Login / RefreshToken don't
+  need it.
+- The monolith's `/api/auth/*` endpoints become dead code; their
+  removal is bundled into Phase 11 (decommission residual
+  monolith) so this PR stays small and reversible.
+
 ## What's NOT here yet
-- **Phase 2.6** — Cutover: gateway routes `/api/auth/*` here; the
-  monolith's auth code deletes.
+- **Phase 3+** — pets, rescue, applications, chat, moderation,
+  matching, audit verticals.
+- **Phase 11** — delete the monolith's now-dead `/api/auth/*`
+  surface.
 
 ## Configuration
 

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -36,6 +36,7 @@
     "@adopt-dont-shop/observability": "*",
     "@adopt-dont-shop/proto": "*",
     "@fastify/http-proxy": "^11.5.0",
+    "@fastify/rate-limit": "^10.3.0",
     "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "nats": "^2.29.3",

--- a/services/gateway/src/grpc-clients/auth-client.ts
+++ b/services/gateway/src/grpc-clients/auth-client.ts
@@ -1,23 +1,39 @@
 // Promise-wrapped client for service.auth.
 //
-// Phase 2.5 surface — only ValidateToken is callable from the gateway.
-// Login / Logout / RefreshToken / GetMe / AssignRole arrive when the
-// gateway routes /api/auth/* through here (Phase 2.6).
+// Phase 2.5 wired only ValidateToken (the per-request hot path).
+// Phase 2.6 adds Login / Logout / RefreshToken / GetMe / AssignRole
+// so the gateway can route /api/auth/* through here instead of the
+// catch-all proxy.
 //
 // Same shape as services/gateway/src/grpc-clients/notifications-client.ts:
 // the interface is exported so tests can substitute a mock; the
-// middleware depends on the shape, not the @grpc/grpc-js client.
+// middleware + routes depend on the shape, not the @grpc/grpc-js client.
 
 import { credentials, Metadata } from '@grpc/grpc-js';
 
 import {
   AuthV1,
+  type AssignRoleRequest,
+  type AssignRoleResponse,
+  type GetMeRequest,
+  type GetMeResponse,
+  type LoginRequest,
+  type LoginResponse,
+  type LogoutRequest,
+  type LogoutResponse,
+  type RefreshTokenRequest,
+  type RefreshTokenResponse,
   type ValidateTokenRequest,
   type ValidateTokenResponse,
 } from '@adopt-dont-shop/proto';
 
 export type AuthClient = {
+  login(req: LoginRequest, metadata: Metadata): Promise<LoginResponse>;
+  logout(req: LogoutRequest, metadata: Metadata): Promise<LogoutResponse>;
+  refreshToken(req: RefreshTokenRequest, metadata: Metadata): Promise<RefreshTokenResponse>;
   validateToken(req: ValidateTokenRequest, metadata: Metadata): Promise<ValidateTokenResponse>;
+  getMe(req: GetMeRequest, metadata: Metadata): Promise<GetMeResponse>;
+  assignRole(req: AssignRoleRequest, metadata: Metadata): Promise<AssignRoleResponse>;
   close(): void;
 };
 
@@ -44,7 +60,12 @@ export const createAuthClient = (opts: CreateAuthClientOptions): AuthClient => {
     });
 
   return {
+    login: (req, metadata) => callUnary(stub.login, req, metadata),
+    logout: (req, metadata) => callUnary(stub.logout, req, metadata),
+    refreshToken: (req, metadata) => callUnary(stub.refreshToken, req, metadata),
     validateToken: (req, metadata) => callUnary(stub.validateToken, req, metadata),
+    getMe: (req, metadata) => callUnary(stub.getMe, req, metadata),
+    assignRole: (req, metadata) => callUnary(stub.assignRole, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -1,0 +1,322 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AuthV1,
+  type AssignRoleResponse,
+  type GetMeResponse,
+  type LoginResponse,
+  type LogoutResponse,
+  type RefreshTokenResponse,
+} from '@adopt-dont-shop/proto';
+
+import type { AuthClient } from '../grpc-clients/auth-client.js';
+
+import { registerAuthRoutes } from './auth.js';
+
+function makeClient(): {
+  client: AuthClient;
+  loginMock: ReturnType<typeof vi.fn>;
+  logoutMock: ReturnType<typeof vi.fn>;
+  refreshMock: ReturnType<typeof vi.fn>;
+  validateMock: ReturnType<typeof vi.fn>;
+  getMeMock: ReturnType<typeof vi.fn>;
+  assignMock: ReturnType<typeof vi.fn>;
+} {
+  const loginMock = vi.fn();
+  const logoutMock = vi.fn();
+  const refreshMock = vi.fn();
+  const validateMock = vi.fn();
+  const getMeMock = vi.fn();
+  const assignMock = vi.fn();
+  const client: AuthClient = {
+    login: loginMock,
+    logout: logoutMock,
+    refreshToken: refreshMock,
+    validateToken: validateMock,
+    getMe: getMeMock,
+    assignRole: assignMock,
+    close: vi.fn(),
+  };
+  return { client, loginMock, logoutMock, refreshMock, validateMock, getMeMock, assignMock };
+}
+
+async function makeApp(client: AuthClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerAuthRoutes(app, { client });
+  return app;
+}
+
+const LOGIN_RES: LoginResponse = {
+  user: {
+    userId: 'usr-1',
+    email: 'alex@example.com',
+    userType: AuthV1.UserRole.USER_ROLE_ADOPTER,
+    status: AuthV1.UserStatus.USER_STATUS_ACTIVE,
+    emailVerified: true,
+    phoneVerified: false,
+    twoFactorEnabled: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  },
+  tokens: {
+    accessToken: 'a.jwt',
+    refreshToken: 'r.jwt',
+    accessExpiresAt: '2026-06-05T18:30:00Z',
+    refreshExpiresAt: '2026-07-05T18:00:00Z',
+  },
+  permissions: ['pets.read'],
+};
+
+describe('POST /api/auth/login', () => {
+  let app: FastifyInstance;
+  let loginMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    loginMock = m.loginMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards email/password to AuthService.Login + threads ipAddress + userAgent', async () => {
+    loginMock.mockResolvedValueOnce(LOGIN_RES);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      headers: { 'user-agent': 'vitest' },
+      payload: { email: 'alex@example.com', password: 'hunter2' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { user: { email: string }; tokens: { accessToken: string } };
+    expect(body.user.email).toBe('alex@example.com');
+    expect(body.tokens.accessToken).toBe('a.jwt');
+
+    const [req] = loginMock.mock.calls[0];
+    expect(req.email).toBe('alex@example.com');
+    expect(req.password).toBe('hunter2');
+    expect(req.userAgent).toBe('vitest');
+    expect(req.ipAddress).toBeDefined();
+  });
+
+  it('maps UNAUTHENTICATED → 401', async () => {
+    loginMock.mockRejectedValueOnce(
+      Object.assign(new Error('invalid credentials'), {
+        code: grpcStatus.UNAUTHENTICATED,
+        details: 'invalid credentials',
+      })
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { email: 'alex@example.com', password: 'wrong' },
+    });
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toEqual({ error: 'invalid credentials' });
+  });
+
+  it('maps INVALID_ARGUMENT → 400 on missing email', async () => {
+    loginMock.mockRejectedValueOnce(
+      Object.assign(new Error('email is required'), {
+        code: grpcStatus.INVALID_ARGUMENT,
+        details: 'email is required',
+      })
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { password: 'x' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /api/auth/logout', () => {
+  let app: FastifyInstance;
+  let logoutMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    logoutMock = m.logoutMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards the refreshToken body field + x-user-* metadata', async () => {
+    const logoutRes: LogoutResponse = { revoked: true };
+    logoutMock.mockResolvedValueOnce(logoutRes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/logout',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: { refreshToken: 'r.jwt' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ revoked: true });
+    const [req, metadata] = logoutMock.mock.calls[0];
+    expect(req.refreshToken).toBe('r.jwt');
+    expect(metadata.get('x-user-id')[0]).toBe('usr-1');
+  });
+});
+
+describe('POST /api/auth/refresh-token', () => {
+  it('forwards the refreshToken and returns the rotated TokenPair', async () => {
+    const { client, refreshMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const refreshRes: RefreshTokenResponse = {
+        tokens: {
+          accessToken: 'a2.jwt',
+          refreshToken: 'r2.jwt',
+          accessExpiresAt: '2026-06-05T19:00:00Z',
+          refreshExpiresAt: '2026-07-05T19:00:00Z',
+        },
+      };
+      refreshMock.mockResolvedValueOnce(refreshRes);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/auth/refresh-token',
+        payload: { refreshToken: 'r.jwt' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { tokens: { accessToken: string } };
+      expect(body.tokens.accessToken).toBe('a2.jwt');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('GET /api/auth/me', () => {
+  it('threads x-user-* metadata to GetMe and returns the user + roles + permissions', async () => {
+    const { client, getMeMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const getMeRes: GetMeResponse = {
+        user: LOGIN_RES.user!,
+        roles: [AuthV1.UserRole.USER_ROLE_ADOPTER],
+        permissions: ['pets.read'],
+      };
+      getMeMock.mockResolvedValueOnce(getMeRes);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/auth/me',
+        headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { user: { userId: string }; permissions: string[] };
+      expect(body.user.userId).toBe('usr-1');
+      expect(body.permissions).toEqual(['pets.read']);
+      const [, metadata] = getMeMock.mock.calls[0];
+      expect(metadata.get('x-user-id')[0]).toBe('usr-1');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('POST /api/auth/assign-role', () => {
+  let app: FastifyInstance;
+  let assignMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    assignMock = m.assignMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('parses the canonical DB role string and forwards the proto enum value', async () => {
+    const assignRes: AssignRoleResponse = {
+      roles: [AuthV1.UserRole.USER_ROLE_RESCUE_STAFF],
+    };
+    assignMock.mockResolvedValueOnce(assignRes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/assign-role',
+      headers: { 'x-user-id': 'usr-admin', 'x-user-roles': 'admin' },
+      payload: { targetUserId: 'usr-1', role: 'rescue_staff', reason: 'onboarding' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [req] = assignMock.mock.calls[0];
+    expect(req.targetUserId).toBe('usr-1');
+    expect(req.role).toBe(AuthV1.UserRole.USER_ROLE_RESCUE_STAFF);
+    expect(req.reason).toBe('onboarding');
+  });
+
+  it('accepts the SCREAMING proto form as well', async () => {
+    assignMock.mockResolvedValueOnce({ roles: [] });
+    await app.inject({
+      method: 'POST',
+      url: '/api/auth/assign-role',
+      payload: { targetUserId: 'usr-1', role: 'USER_ROLE_MODERATOR' },
+    });
+    const [req] = assignMock.mock.calls[0];
+    expect(req.role).toBe(AuthV1.UserRole.USER_ROLE_MODERATOR);
+  });
+
+  it('coerces an unknown role to UNSPECIFIED so the service returns INVALID_ARGUMENT', async () => {
+    assignMock.mockResolvedValueOnce({ roles: [] });
+    await app.inject({
+      method: 'POST',
+      url: '/api/auth/assign-role',
+      payload: { targetUserId: 'usr-1', role: 'not_a_role' },
+    });
+    const [req] = assignMock.mock.calls[0];
+    expect(req.role).toBe(AuthV1.UserRole.USER_ROLE_UNSPECIFIED);
+  });
+
+  it('maps PERMISSION_DENIED → 403', async () => {
+    assignMock.mockRejectedValueOnce(
+      Object.assign(new Error('forbidden'), {
+        code: grpcStatus.PERMISSION_DENIED,
+        details: 'admin.security.manage required',
+      })
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/assign-role',
+      payload: { targetUserId: 'usr-1', role: 'admin' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({ error: 'admin.security.manage required' });
+  });
+});
+
+describe('error mapping fallback', () => {
+  it('maps an unknown gRPC code → 500', async () => {
+    const { client, loginMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      loginMock.mockRejectedValueOnce(new Error('connection refused'));
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/auth/login',
+        payload: { email: 'a@b', password: 'c' },
+      });
+      expect(res.statusCode).toBe(500);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -20,6 +20,7 @@
 // need them (they mint a fresh principal); the middleware passes
 // requests with no Authorization header through to the route.
 
+import rateLimit from '@fastify/rate-limit';
 import { Metadata, status } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
@@ -71,54 +72,85 @@ type AssignRoleBody = {
   reason?: string;
 };
 
+// Per-route rate limits guard the credential-stuffing surface
+// (CodeQL #281). Limits are conservative — login + refresh are the
+// hot brute-force targets so they take the tightest cap; assign-role
+// is admin-only and gets a wider window. All keyed on req.ip via
+// the default key generator. Production deploys can swap in a Redis
+// store via the plugin's `redis` option without touching this file.
+const AUTH_RATE_LIMITS = {
+  login: { max: 10, timeWindow: '1 minute' },
+  logout: { max: 30, timeWindow: '1 minute' },
+  refreshToken: { max: 30, timeWindow: '1 minute' },
+  getMe: { max: 60, timeWindow: '1 minute' },
+  assignRole: { max: 30, timeWindow: '1 minute' },
+} as const;
+
 export const registerAuthRoutes = async (
   app: FastifyInstance,
   opts: AuthRoutesOptions
 ): Promise<void> => {
   const { client } = opts;
 
-  app.post('/api/auth/login', async (req, reply) => {
-    const body = (req.body ?? {}) as LoginBody;
-    const grpcReq: LoginRequest = {
-      email: body.email ?? '',
-      password: body.password ?? '',
-      ipAddress: req.ip,
-      userAgent: req.headers['user-agent'],
-    };
+  // Register the rate-limit plugin scoped to THIS plugin's routes
+  // only. Encapsulated registration means the limits don't bleed
+  // into the notifications routes / catch-all proxy / health check.
+  await app.register(rateLimit, { global: false });
 
-    try {
-      const res = await client.login(grpcReq, buildMetadata(req));
-      return reply.send(AuthV1.LoginResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.post(
+    '/api/auth/login',
+    { config: { rateLimit: AUTH_RATE_LIMITS.login } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as LoginBody;
+      const grpcReq: LoginRequest = {
+        email: body.email ?? '',
+        password: body.password ?? '',
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      };
+
+      try {
+        const res = await client.login(grpcReq, buildMetadata(req));
+        return reply.send(AuthV1.LoginResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.post('/api/auth/logout', async (req, reply) => {
-    const body = (req.body ?? {}) as LogoutBody;
-    const grpcReq: LogoutRequest = { refreshToken: body.refreshToken ?? '' };
+  app.post(
+    '/api/auth/logout',
+    { config: { rateLimit: AUTH_RATE_LIMITS.logout } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as LogoutBody;
+      const grpcReq: LogoutRequest = { refreshToken: body.refreshToken ?? '' };
 
-    try {
-      const res = await client.logout(grpcReq, buildMetadata(req));
-      return reply.send(AuthV1.LogoutResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.logout(grpcReq, buildMetadata(req));
+        return reply.send(AuthV1.LogoutResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.post('/api/auth/refresh-token', async (req, reply) => {
-    const body = (req.body ?? {}) as RefreshTokenBody;
-    const grpcReq: RefreshTokenRequest = { refreshToken: body.refreshToken ?? '' };
+  app.post(
+    '/api/auth/refresh-token',
+    { config: { rateLimit: AUTH_RATE_LIMITS.refreshToken } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as RefreshTokenBody;
+      const grpcReq: RefreshTokenRequest = { refreshToken: body.refreshToken ?? '' };
 
-    try {
-      const res = await client.refreshToken(grpcReq, buildMetadata(req));
-      return reply.send(AuthV1.RefreshTokenResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.refreshToken(grpcReq, buildMetadata(req));
+        return reply.send(AuthV1.RefreshTokenResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.get('/api/auth/me', async (req, reply) => {
+  app.get('/api/auth/me', { config: { rateLimit: AUTH_RATE_LIMITS.getMe } }, async (req, reply) => {
     try {
       const res = await client.getMe({}, buildMetadata(req));
       return reply.send(AuthV1.GetMeResponse.toJSON(res));
@@ -127,21 +159,25 @@ export const registerAuthRoutes = async (
     }
   });
 
-  app.post('/api/auth/assign-role', async (req, reply) => {
-    const body = (req.body ?? {}) as AssignRoleBody;
-    const grpcReq: AssignRoleRequest = {
-      targetUserId: body.targetUserId ?? '',
-      role: parseRole(body.role),
-      reason: body.reason,
-    };
+  app.post(
+    '/api/auth/assign-role',
+    { config: { rateLimit: AUTH_RATE_LIMITS.assignRole } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as AssignRoleBody;
+      const grpcReq: AssignRoleRequest = {
+        targetUserId: body.targetUserId ?? '',
+        role: parseRole(body.role),
+        reason: body.reason,
+      };
 
-    try {
-      const res = await client.assignRole(grpcReq, buildMetadata(req));
-      return reply.send(AuthV1.AssignRoleResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+      try {
+        const res = await client.assignRole(grpcReq, buildMetadata(req));
+        return reply.send(AuthV1.AssignRoleResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 };
 
 // --- Helpers ---------------------------------------------------------

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -1,0 +1,186 @@
+// REST → gRPC translation for /api/auth/*.
+//
+// Phase 2.6 cutover: this Fastify plugin registers BEFORE the
+// strangler-fig http-proxy catch-all, so Fastify's first-registered-
+// wins prefix routing picks it for /api/auth/* requests before the
+// catch-all sees them. Same shape as routes/notifications.ts.
+//
+// Route map (matches the monolith's existing /api/auth/* surface so
+// the SPA + lib.auth React contexts don't have to change):
+//
+//   POST /api/auth/login           → AuthService.Login
+//   POST /api/auth/logout          → AuthService.Logout
+//   POST /api/auth/refresh-token   → AuthService.RefreshToken
+//   GET  /api/auth/me              → AuthService.GetMe
+//   POST /api/auth/assign-role     → AuthService.AssignRole  (admin-only)
+//
+// The authenticate middleware (Phase 2.5) already populates the
+// x-user-* metadata headers for routes whose handler relies on the
+// principal — Logout, GetMe, AssignRole. Login + RefreshToken don't
+// need them (they mint a fresh principal); the middleware passes
+// requests with no Authorization header through to the route.
+
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  AuthV1,
+  type AssignRoleRequest,
+  type LoginRequest,
+  type LogoutRequest,
+  type RefreshTokenRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { AuthClient } from '../grpc-clients/auth-client.js';
+
+export type AuthRoutesOptions = {
+  client: AuthClient;
+};
+
+// Same gRPC-status → HTTP-status table the notifications routes use.
+// UNAUTHENTICATED maps to 401 here so a wrong-password login returns
+// 401, not 500.
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.INTERNAL]: 500,
+};
+
+// Body shapes accepted by the REST surface. Kept narrow + explicit
+// so a client typo doesn't get silently forwarded as `undefined` to
+// the proto encoder, where it would land as the empty string.
+type LoginBody = {
+  email?: string;
+  password?: string;
+};
+
+type LogoutBody = {
+  refreshToken?: string;
+};
+
+type RefreshTokenBody = {
+  refreshToken?: string;
+};
+
+type AssignRoleBody = {
+  targetUserId?: string;
+  role?: string;
+  reason?: string;
+};
+
+export const registerAuthRoutes = async (
+  app: FastifyInstance,
+  opts: AuthRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  app.post('/api/auth/login', async (req, reply) => {
+    const body = (req.body ?? {}) as LoginBody;
+    const grpcReq: LoginRequest = {
+      email: body.email ?? '',
+      password: body.password ?? '',
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'],
+    };
+
+    try {
+      const res = await client.login(grpcReq, buildMetadata(req));
+      return reply.send(AuthV1.LoginResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.post('/api/auth/logout', async (req, reply) => {
+    const body = (req.body ?? {}) as LogoutBody;
+    const grpcReq: LogoutRequest = { refreshToken: body.refreshToken ?? '' };
+
+    try {
+      const res = await client.logout(grpcReq, buildMetadata(req));
+      return reply.send(AuthV1.LogoutResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.post('/api/auth/refresh-token', async (req, reply) => {
+    const body = (req.body ?? {}) as RefreshTokenBody;
+    const grpcReq: RefreshTokenRequest = { refreshToken: body.refreshToken ?? '' };
+
+    try {
+      const res = await client.refreshToken(grpcReq, buildMetadata(req));
+      return reply.send(AuthV1.RefreshTokenResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get('/api/auth/me', async (req, reply) => {
+    try {
+      const res = await client.getMe({}, buildMetadata(req));
+      return reply.send(AuthV1.GetMeResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.post('/api/auth/assign-role', async (req, reply) => {
+    const body = (req.body ?? {}) as AssignRoleBody;
+    const grpcReq: AssignRoleRequest = {
+      targetUserId: body.targetUserId ?? '',
+      role: parseRole(body.role),
+      reason: body.reason,
+    };
+
+    try {
+      const res = await client.assignRole(grpcReq, buildMetadata(req));
+      return reply.send(AuthV1.AssignRoleResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  // Same set the notifications routes forward — the authenticate
+  // middleware already stripped any spoofs and (when there's a valid
+  // Bearer) stamped the validated principal.
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}
+
+// Accept the canonical DB role string (`adopter`, `rescue_staff`, …)
+// OR the SCREAMING proto form (`USER_ROLE_ADOPTER`). The handler's
+// own INVALID_ARGUMENT guard fires when the value resolves to
+// UNSPECIFIED, so an unknown role still produces the right 400.
+function parseRole(raw: string | undefined): AuthV1.UserRole {
+  if (!raw) {
+    return AuthV1.UserRole.USER_ROLE_UNSPECIFIED;
+  }
+  const upper = `USER_ROLE_${raw.toUpperCase()}`;
+  const candidate = Object.values(AuthV1.UserRole).includes(upper as never) ? upper : raw;
+  const out = AuthV1.userRoleFromJSON(candidate);
+  return out === AuthV1.UserRole.UNRECOGNIZED ? AuthV1.UserRole.USER_ROLE_UNSPECIFIED : out;
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -23,6 +23,7 @@ import type { GatewayConfig } from './config.js';
 import type { AuthClient } from './grpc-clients/auth-client.js';
 import type { NotificationsClient } from './grpc-clients/notifications-client.js';
 import { registerAuthenticate } from './middleware/authenticate.js';
+import { registerAuthRoutes } from './routes/auth.js';
 import { registerNotificationsRoutes } from './routes/notifications.js';
 
 export type CreateServerOptions = {
@@ -97,6 +98,13 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   // Service-specific routes register BEFORE the catch-all proxy.
   // Fastify's first-registered-wins prefix routing picks them off
   // before the catch-all sees the request.
+  //
+  // Phase 2.6: /api/auth/* now lands here instead of the monolith.
+  // The authClient is re-used from the authenticate middleware so
+  // we don't open a second gRPC channel for the same upstream.
+  if (opts.authClient) {
+    await registerAuthRoutes(server, { client: opts.authClient });
+  }
   if (opts.notificationsClient) {
     await registerNotificationsRoutes(server, { client: opts.notificationsClient });
   }


### PR DESCRIPTION
## Summary

Strangler-fig final step for the auth vertical — the gateway now translates the five public `/api/auth/*` endpoints into `AuthService` gRPC calls instead of proxying them through to the monolith. Same shape as the Phase 1.6 `/api/notifications/*` cutover.

## What's in

**`services/gateway/src/grpc-clients/auth-client.ts`** extended from the Phase 2.5 `ValidateToken`-only surface to the full six-method client (`Login`, `Logout`, `RefreshToken`, `ValidateToken`, `GetMe`, `AssignRole`). One stub, one TCP connection — re-used by both the authenticate middleware and the new routes.

**`services/gateway/src/routes/auth.ts`** — REST → gRPC translation for:

| HTTP | gRPC | Notes |
|---|---|---|
| `POST /api/auth/login` | `AuthService.Login` | Threads `ipAddress` (from `req.ip`) + `userAgent` (from request header) into the gRPC request. |
| `POST /api/auth/logout` | `AuthService.Logout` | Forwards refresh token from body + `x-user-*` metadata. |
| `POST /api/auth/refresh-token` | `AuthService.RefreshToken` | Rotated `TokenPair` returned to the client. |
| `GET  /api/auth/me` | `AuthService.GetMe` | Pure metadata-driven; principal lifted from the authenticate middleware. |
| `POST /api/auth/assign-role` | `AuthService.AssignRole` | `parseRole()` accepts the canonical DB string (`rescue_staff`) and the SCREAMING proto form (`USER_ROLE_RESCUE_STAFF`); unknown coerces to `UNSPECIFIED` so the service's own INVALID_ARGUMENT guard produces a clean 400. |

Same `GRPC_TO_HTTP` table the notifications routes use: `UNAUTHENTICATED → 401`, `INVALID_ARGUMENT → 400`, `PERMISSION_DENIED → 403`, `NOT_FOUND → 404`, anything else → 500.

**`services/gateway/src/server.ts`** registers the auth routes BEFORE the catch-all proxy, sharing `opts.authClient` with the Phase 2.5 authenticate middleware so we don't open two gRPC channels for the same upstream.

The monolith's `/api/auth/*` endpoints become dead code — their removal is bundled into Phase 11 (decommission residual monolith) so this PR stays small and reversible.

## Test plan

- [x] `npm test` in `services/gateway` — **57/57** green (11 new across `auth.test.ts`)
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.gateway'` — green
- [x] Lint clean

**Coverage of business behaviour:** happy path for all 5 endpoints, `x-user-*` metadata forwarding (logout/me/assign-role), role-string parsing (canonical + SCREAMING + unknown), and the full table of error code mappings (UNAUTHENTICATED, INVALID_ARGUMENT, PERMISSION_DENIED, INTERNAL fallback).

## What's NOT in

- **Phase 3+** — pets, rescue, applications, chat, moderation, matching, audit verticals.
- **Phase 11** — deletion of the monolith's now-dead `/api/auth/*` surface.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_