### PR TITLE
feat(microservices): services/pets boot skeleton (Phase 3.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4854,6 +4854,10 @@
       "resolved": "services/notifications",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/service.pets": {
+      "resolved": "services/pets",
+      "link": true
+    },
     "node_modules/@apideck/better-ajv-errors": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
@@ -32673,6 +32677,14 @@
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"
+      }
+    },
+    "services/pets": {
+      "name": "@adopt-dont-shop/service.pets",
+      "version": "0.1.0",
+      "dependencies": {
+        "@adopt-dont-shop/observability": "*",
+        "fastify": "^5.8.5"
       }
     }
   }

--- a/services/pets/README.md
+++ b/services/pets/README.md
@@ -1,0 +1,65 @@
+# service.pets
+
+Pets vertical — Phase 3 of the microservices migration.
+
+Owns the `pets.*` schema (Pet, PetMedia, Breed, UserFavorite, Rating,
+PetStatusTransition) and exposes `PetService` over gRPC.
+
+CAD Phase 3 equivalent — first service in the migration where event
+sourcing pays off. Pet status transitions
+(`available → reserved → adopted → unavailable`, plus `deceased`,
+`returned`) form a real state machine with multi-consumer audit needs
+(matching, notifications, moderation, applications). Pure `apply`/`fold`
+domain + publish-after-commit on `pets.statusChanged`.
+
+## What's shipped so far
+
+**Phase 3.1** — boot skeleton:
+- `src/index.ts` starts a Fastify server on `PETS_PORT` (default
+  5003), wires `/health/simple`.
+- `src/instrumentation.ts` boots OpenTelemetry via
+  `@adopt-dont-shop/observability` with `serviceName: 'service.pets'`.
+- `src/config.ts` env validation. Hard-requires `DATABASE_URL` so
+  misconfiguration fails fast at boot rather than at first request.
+- `src/server.ts` `createServer({ config, logger? })`.
+
+## What's NOT here yet
+
+- **Phase 3.2** — `pets.*` schema + migrations.
+- **Phase 3.3** — gRPC `PetService`:
+  - proto + grpc-js stubs in `@adopt-dont-shop/proto`
+  - handler logic (event-sourced status machine + standard CRUD)
+  - gRPC server boot + adapter (same pattern as service.auth)
+- **Phase 3.4** — NATS publishers: `pets.created`,
+  `pets.statusChanged`, `pets.deleted` etc. Downstream services
+  (notifications, matching, moderation, applications) consume these.
+- **Phase 3.5** — Gateway routes `/api/pets/*` here (the Phase 2.5
+  authenticate middleware already handles auth gating).
+- **Phase 3.6** — Cutover: monolith's pets code becomes dead, removal
+  bundled into Phase 11.
+
+## Configuration
+
+| Env var          | Default            | Required | Purpose                                                                  |
+| ---------------- | ------------------ | -------- | ------------------------------------------------------------------------ |
+| `PETS_PORT`      | `5003`             |          | HTTP port for `/health/simple`.                                          |
+| `PETS_GRPC_PORT` | `6003`             |          | gRPC port `PetService` will bind (Phase 3.3c).                           |
+| `PETS_HOST`      | `0.0.0.0`          |          | Bind interface (both HTTP + gRPC).                                       |
+| `PETS_SCHEMA`    | `pets`             |          | Postgres schema. Override for parallel test DBs.                         |
+| `DATABASE_URL`   | —                  | ✅       | Postgres connection string. Same physical Postgres as `service.backend`. |
+| `NATS_URL`       | `nats://nats:4222` |          | NATS bus URL.                                                            |
+| `NODE_ENV`       | `development`      |          | Surfaces in health + logs.                                               |
+
+Plus the standard observability env vars consumed by
+`@adopt-dont-shop/observability`.
+
+## Running
+
+```bash
+# Dev — hot reload, OTel SDK loaded via --import
+npm run dev
+
+# Production build
+npm run build
+npm run start
+```

--- a/services/pets/package.json
+++ b/services/pets/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@adopt-dont-shop/service.pets",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Pets service — Phase 3 extraction. Owns the pets.* schema (Pet, PetMedia, Breed, UserFavorite, Rating, PetStatusTransition) and exposes gRPC PetService over a status state machine (available → reserved → adopted → unavailable, plus deceased / returned). Pet state transitions are event-sourced — pure apply/fold domain + publish-after-commit on pets.statusChanged. Phase 3.1 commit is just the boot skeleton; schema/gRPC/NATS/gateway land in later phases.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
+    "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adopt-dont-shop/observability": "*",
+    "fastify": "^5.8.5"
+  }
+}

--- a/services/pets/src/config.test.ts
+++ b/services/pets/src/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from './config.js';
+
+const REQUIRED = {
+  DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+};
+
+describe('loadConfig', () => {
+  it('uses the documented defaults when only the required env vars are set', () => {
+    const config = loadConfig({ ...REQUIRED });
+    expect(config.port).toBe(5003);
+    expect(config.grpcPort).toBe(6003);
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.environment).toBe('development');
+    expect(config.databaseUrl).toBe(REQUIRED.DATABASE_URL);
+    expect(config.schema).toBe('pets');
+    expect(config.natsUrl).toBe('nats://nats:4222');
+  });
+
+  it('honours all env overrides when set', () => {
+    const config = loadConfig({
+      PETS_PORT: '5500',
+      PETS_GRPC_PORT: '6500',
+      PETS_HOST: '127.0.0.1',
+      PETS_SCHEMA: 'pets_test',
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/pets',
+      NATS_URL: 'nats://nats.internal:4222',
+    });
+
+    expect(config.port).toBe(5500);
+    expect(config.grpcPort).toBe(6500);
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.environment).toBe('production');
+    expect(config.schema).toBe('pets_test');
+    expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/pets');
+    expect(config.natsUrl).toBe('nats://nats.internal:4222');
+  });
+
+  it('rejects a non-numeric PETS_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, PETS_PORT: 'five-thousand' })).toThrow(
+      /PETS_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-numeric PETS_GRPC_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, PETS_GRPC_PORT: 'six-thousand' })).toThrow(
+      /PETS_GRPC_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-positive PETS_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, PETS_PORT: '0' })).toThrow(
+      /PETS_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects an unset DATABASE_URL', () => {
+    expect(() => loadConfig({})).toThrow(/DATABASE_URL is required/);
+  });
+});

--- a/services/pets/src/config.ts
+++ b/services/pets/src/config.ts
@@ -1,0 +1,59 @@
+export type PetsConfig = {
+  // HTTP port for the boot-readiness surface (/health/simple). Distinct
+  // from service.backend's 5000, service.gateway's 4000,
+  // service.notifications' 5001, service.auth's 5002.
+  port: number;
+  host: string;
+  // gRPC server port. PetService.{Create, Get, List, UpdateStatus,
+  // Delete, ...} bind here once Phase 3.3c brings the server online.
+  // Convention: HTTP + 1000.
+  grpcPort: number;
+  // Environment label, surfaced in health responses and on log lines.
+  environment: string;
+  // Postgres connection string. Required for migrations + the runtime
+  // database client. Same physical Postgres as service.backend; this
+  // service owns the `pets` schema (CAD-style schema-per-service).
+  databaseUrl: string;
+  // Schema name. Defaults to `pets` — every table in this service
+  // lives here and other services don't read it directly.
+  schema: string;
+  // NATS bus. Phase 3.3 onwards publishes pets.created,
+  // pets.statusChanged, pets.deleted etc. for downstream services
+  // (notifications, matching, moderation, applications) to consume.
+  natsUrl: string;
+};
+
+const DEFAULT_PORT = 5003;
+const DEFAULT_GRPC_PORT = 6003;
+const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_SCHEMA = 'pets';
+const DEFAULT_NATS_URL = 'nats://nats:4222';
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): PetsConfig => {
+  const port = parsePort(env.PETS_PORT, DEFAULT_PORT, 'PETS_PORT');
+  const grpcPort = parsePort(env.PETS_GRPC_PORT, DEFAULT_GRPC_PORT, 'PETS_GRPC_PORT');
+
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required (Postgres connection string)');
+  }
+
+  return {
+    port,
+    grpcPort,
+    host: env.PETS_HOST?.trim() || DEFAULT_HOST,
+    environment: env.NODE_ENV?.trim() || 'development',
+    databaseUrl,
+    schema: env.PETS_SCHEMA?.trim() || DEFAULT_SCHEMA,
+    natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+  };
+};
+
+function parsePort(raw: string | undefined, fallback: number, name: string): number {
+  const trimmed = raw?.trim();
+  const value = trimmed ? Number.parseInt(trimmed, 10) : fallback;
+  if (Number.isNaN(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${trimmed}"`);
+  }
+  return value;
+}

--- a/services/pets/src/index.ts
+++ b/services/pets/src/index.ts
@@ -1,0 +1,42 @@
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from './config.js';
+import { createServer } from './server.js';
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.pets' });
+
+  try {
+    const config = loadConfig();
+    const server = createServer({ config, logger });
+
+    await server.listen({ port: config.port, host: config.host });
+
+    logger.info('service.pets listening', {
+      port: config.port,
+      host: config.host,
+      grpcPort: config.grpcPort,
+      schema: config.schema,
+      natsUrl: config.natsUrl,
+      environment: config.environment,
+    });
+
+    const shutdown = async (signal: string): Promise<void> => {
+      logger.info('service.pets shutting down', { signal });
+      try {
+        await server.close();
+      } catch (err) {
+        logger.error('error during shutdown', { err });
+      }
+      process.exit(0);
+    };
+
+    process.once('SIGTERM', () => void shutdown('SIGTERM'));
+    process.once('SIGINT', () => void shutdown('SIGINT'));
+  } catch (err) {
+    logger.error('service.pets failed to start', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/pets/src/instrumentation.ts
+++ b/services/pets/src/instrumentation.ts
@@ -1,0 +1,15 @@
+// OpenTelemetry SDK bootstrap for service.pets.
+//
+// Same --import-flag pattern as service.notifications, service.auth and
+// service.gateway: tsx / node loads this BEFORE the rest of the service
+// so the auto-instrumentations can hook http, fastify, pg, undici BEFORE
+// those modules are first imported.
+//
+// Behaviour matches the rest of the stack (see @adopt-dont-shop/observability):
+//   - Silent no-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+//   - OTEL_SERVICE_NAME env var overrides the value below.
+//   - No-throw contract.
+
+import { initializeOpenTelemetry } from '@adopt-dont-shop/observability';
+
+initializeOpenTelemetry({ serviceName: 'service.pets' });

--- a/services/pets/src/server.test.ts
+++ b/services/pets/src/server.test.ts
@@ -1,0 +1,67 @@
+import { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { PetsConfig } from './config.js';
+import { createServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const baseConfig: PetsConfig = {
+  port: 0,
+  grpcPort: 0,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'pets',
+  natsUrl: 'nats://localhost:4222',
+};
+
+describe('createServer — health endpoint', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = createServer({ config: baseConfig, logger: quietLogger });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('responds to GET /health/simple with status ok', async () => {
+    const res = await server.inject({ method: 'GET', url: '/health/simple' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      status: 'ok',
+      service: 'service.pets',
+      environment: 'test',
+    });
+  });
+
+  it('surfaces the configured environment in the health payload', async () => {
+    const stagingServer = createServer({
+      config: { ...baseConfig, environment: 'staging' },
+      logger: quietLogger,
+    });
+    try {
+      const res = await stagingServer.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.json()).toMatchObject({ environment: 'staging' });
+    } finally {
+      await stagingServer.close();
+    }
+  });
+
+  it('returns a 500 when a route handler throws (custom error handler)', async () => {
+    server.get('/boom', async () => {
+      throw new Error('boom');
+    });
+    const res = await server.inject({ method: 'GET', url: '/boom' });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ error: 'internal_error' });
+  });
+});

--- a/services/pets/src/server.ts
+++ b/services/pets/src/server.ts
@@ -1,0 +1,57 @@
+// services/pets — Phase 3 extraction. Owns the pets.* schema and
+// exposes PetService over gRPC. Phase 3.1 (this commit) is just the
+// boot skeleton; everything else arrives in subsequent commits.
+//
+// Mirror of services/auth/src/server.ts structure: Fastify for
+// /health/simple, gRPC server attached in Phase 3.3c, NATS publishers
+// in Phase 3.4, gateway routing in Phase 3.5, cutover in Phase 3.6.
+
+import { createLogger } from '@adopt-dont-shop/observability';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+import type { PetsConfig } from './config.js';
+
+export type CreateServerOptions = {
+  config: PetsConfig;
+  // Optional logger injection — tests pass a quiet logger so the
+  // suite output stays readable. Real boot uses createLogger so the
+  // service emits structured lines through the same pipeline as the
+  // rest of the stack.
+  logger?: ReturnType<typeof createLogger>;
+};
+
+export const createServer = (opts: CreateServerOptions): FastifyInstance => {
+  const { config } = opts;
+  const logger = opts.logger ?? createLogger({ serviceName: 'service.pets' });
+
+  // Disable Fastify's built-in pino — winston handles service-level
+  // lines (boot, shutdown, error handler), and OTel's HTTP
+  // auto-instrumentation already covers per-request spans. Same
+  // shape as services/auth + services/notifications + services/gateway.
+  const server = Fastify({
+    logger: false,
+    trustProxy: true,
+  });
+
+  server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
+    logger.error('request failed', {
+      method: req.method,
+      url: req.url,
+      message: err.message,
+    });
+    void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
+  });
+
+  // Health endpoint — matches the rest of the stack's
+  // `/health/simple` path so the existing Docker compose healthcheck
+  // pattern picks this service up unchanged.
+  server.get('/health/simple', async () => ({
+    status: 'ok',
+    service: 'service.pets',
+    environment: config.environment,
+  }));
+
+  return server;
+};
+
+export type { PetsConfig };

--- a/services/pets/tsconfig.json
+++ b/services/pets/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/services/pets/vitest.config.ts
+++ b/services/pets/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 3 of the microservices migration — first vertical where event sourcing pays off (pet status state machine: `available → reserved → adopted → unavailable`, plus `deceased` / `returned`). This commit is just the boot skeleton; the schema, gRPC, NATS, and gateway routing arrive in 3.2-3.6.

## What's in

- **`services/pets/package.json`** — same scripts + scoped deps shape as `services/auth`. `PETS_PORT` defaults to 5003, `PETS_GRPC_PORT` to 6003 (HTTP+1000 convention).
- **`src/config.ts`** — env loader. `DATABASE_URL` is the only hard requirement; misconfiguration fails fast at boot rather than at first request.
- **`src/server.ts`** — `createServer` with `/health/simple`. Mirror of `service.auth`'s `createServer` to the line.
- **`src/instrumentation.ts`** — boots OpenTelemetry via `@adopt-dont-shop/observability` with `serviceName: 'service.pets'`.
- **`src/index.ts`** — wires HTTP listen + SIGTERM/SIGINT shutdown.
- **`README.md`** documents the Phase 3.1 surface and what's coming in 3.2-3.6.

## Test plan

- [x] `npm test` in `services/pets` — **9/9** green
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.pets'` — green
- [x] Lint clean

## What's NOT in

- **Phase 3.2** — `pets.*` schema + migrations (Pet, PetMedia, Breed, UserFavorite, Rating, PetStatusTransition).
- **Phase 3.3** — proto + handlers + adapter (event-sourced status machine).
- **Phase 3.4** — NATS publishers (`pets.created`, `pets.statusChanged`, `pets.deleted`) + downstream subscribers in `services/notifications`.
- **Phase 3.5** — Gateway routes `/api/pets/*` here.
- **Phase 3.6** — Cutover.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_