### PR TITLE
feat(microservices): pets.* schema + migrations (Phase 3.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32683,8 +32683,11 @@
       "name": "@adopt-dont-shop/service.pets",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/observability": "*",
-        "fastify": "^5.8.5"
+        "fastify": "^5.8.5",
+        "node-pg-migrate": "^8.0.4",
+        "pg": "^8.21.0"
       }
     }
   }

--- a/services/pets/README.md
+++ b/services/pets/README.md
@@ -23,9 +23,30 @@ domain + publish-after-commit on `pets.statusChanged`.
   misconfiguration fails fast at boot rather than at first request.
 - `src/server.ts` `createServer({ config, logger? })`.
 
+**Phase 3.2** — `pets.*` schema + migrations:
+- `001_create_breeds.ts` — lookup table (no soft-delete; `(species,
+  name)` unique). Creates the `postgis` extension in `public` for the
+  pet `location` column.
+- `002_create_pets.ts` — the full pet listing row (ported verbatim
+  from the monolith's `00-baseline-016-pets.ts`): 8 enums (status,
+  type, gender, size, age_group, energy_level, vaccination_status,
+  spay_neuter_status), PostGIS `location`, `tsvector` search_vector,
+  partial-unique microchip index, GIN/GiST indexes. `breed_id` /
+  `secondary_breed_id` keep their intra-schema FK to `breeds`;
+  `rescue_id` / `created_by` / `updated_by` are cross-schema, FK-free.
+- `003_create_pet_media.ts` — media rows, `pet_id` FK (CASCADE),
+  partial-unique one-primary-per-pet.
+- `004_create_pet_status_transitions.ts` — append-only status event
+  log behind the state machine; reuses the shared `pet_status` enum.
+- `005_create_ratings.ts` — polymorphic reviews; only `pet_id` keeps
+  an intra-schema FK.
+- `006_create_user_favorites.ts` — adopter↔pet join; partial-unique
+  one-active-favourite-per-user+pet.
+- `src/db/migrate.ts` runs them via `@adopt-dont-shop/db.runMigrations`.
+  Run with `npm run db:migrate`.
+
 ## What's NOT here yet
 
-- **Phase 3.2** — `pets.*` schema + migrations.
 - **Phase 3.3** — gRPC `PetService`:
   - proto + grpc-js stubs in `@adopt-dont-shop/proto`
   - handler logic (event-sourced status machine + standard CRUD)

--- a/services/pets/package.json
+++ b/services/pets/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "db:migrate": "tsx ./src/db/migrate.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
@@ -32,7 +33,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/observability": "*",
-    "fastify": "^5.8.5"
+    "fastify": "^5.8.5",
+    "node-pg-migrate": "^8.0.4",
+    "pg": "^8.21.0"
   }
 }

--- a/services/pets/src/db/migrate.ts
+++ b/services/pets/src/db/migrate.ts
@@ -1,0 +1,42 @@
+// Migration entry point — runs the pets.* schema migrations via
+// @adopt-dont-shop/db (which wraps node-pg-migrate with the four
+// CAD-lesson fixes: createSchema, ignorePattern, search_path,
+// advisory-lock retry).
+//
+// Invoked by `npm run db:migrate`. Production deploys run a compiled
+// version against dist/migrations/.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runMigrations } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+
+// CAD lesson #2: this path MUST resolve identically in dev (tsx) and
+// prod (bundled). In dev, import.meta.url points at .../src/db/migrate.ts
+// and the migrations sit under ../migrations/.
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.pets.migrate' });
+  try {
+    const config = loadConfig();
+    logger.info('running migrations', {
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    await runMigrations({
+      databaseUrl: config.databaseUrl,
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    logger.info('migrations complete');
+  } catch (err) {
+    logger.error('migrations failed', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/pets/src/migrations/001_create_breeds.ts
+++ b/services/pets/src/migrations/001_create_breeds.ts
@@ -1,0 +1,59 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — breeds (lookup table).
+//
+// Direct port of service.backend's 00-baseline-019-breeds.ts INTO the
+// `pets` schema. Reference data — the Breed model opts out of the global
+// paranoid default, so there's NO deleted_at column. Cross-schema FKs
+// (created_by / updated_by → auth.users) are deliberately omitted —
+// they're audit pointers the schema-per-service rule keeps
+// application-side.
+//
+// Extensions: citext / postgis live in `public` (the postgis Docker
+// image + the @adopt-dont-shop/db search_path make them resolvable).
+// pets needs postgis for the `location` POINT column added in 002.
+// CREATE EXTENSION IF NOT EXISTS keeps the service self-contained.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql('CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;');
+
+  // species mirrors the monolith's enum_breeds_species (same labels as
+  // the pet `type` enum, but a distinct Postgres type — Sequelize derived
+  // the name from (table, column), so we keep them separate here too).
+  pgm.createType('breed_species', [
+    'dog',
+    'cat',
+    'rabbit',
+    'bird',
+    'reptile',
+    'small_mammal',
+    'fish',
+    'other',
+  ]);
+
+  pgm.createTable('breeds', {
+    breed_id: { type: 'uuid', primaryKey: true },
+    species: { type: 'breed_species', notNull: true },
+    name: { type: 'varchar(128)', notNull: true },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  // Composite unique on (species, name): one canonical breed per name per
+  // species. Allows the same name across species (Persian cat vs rabbit).
+  pgm.createIndex('breeds', ['species', 'name'], {
+    name: 'breeds_species_name_unique',
+    unique: true,
+  });
+  pgm.createIndex('breeds', 'name', { name: 'breeds_name_idx' });
+  pgm.createIndex('breeds', 'created_by', { name: 'breeds_created_by_idx' });
+  pgm.createIndex('breeds', 'updated_by', { name: 'breeds_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('breeds');
+  pgm.dropType('breed_species');
+};

--- a/services/pets/src/migrations/002_create_pets.ts
+++ b/services/pets/src/migrations/002_create_pets.ts
@@ -1,0 +1,164 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — pets.
+//
+// Direct port of service.backend's 00-baseline-016-pets.ts INTO the
+// `pets` schema. The big one — the full pet listing row.
+//
+// FK decisions:
+//   - breed_id / secondary_breed_id → breeds: INTRA-schema, so the FK
+//     stays enforced (both tables live in `pets`). ON DELETE SET NULL
+//     matches the monolith's nullable belongsTo.
+//   - rescue_id → rescue schema, created_by / updated_by → auth.users:
+//     CROSS-schema, so no DB-level FK — the no-cross-schema-joins rule
+//     keeps these application-side.
+//
+// search_vector is a plain TSVECTOR column (the maintaining trigger lives
+// with the model's afterSync hook in the monolith — not part of the
+// baseline schema, so not ported here). location is public.geometry(Point)
+// — PostGIS lives in public (extension created in 001).
+
+const PET_STATUS = [
+  'available',
+  'pending',
+  'adopted',
+  'foster',
+  'medical_hold',
+  'behavioral_hold',
+  'not_available',
+  'deceased',
+];
+
+const PET_TYPE = ['dog', 'cat', 'rabbit', 'bird', 'reptile', 'small_mammal', 'fish', 'other'];
+const GENDER = ['male', 'female', 'unknown'];
+const SIZE = ['extra_small', 'small', 'medium', 'large', 'extra_large'];
+const AGE_GROUP = ['baby', 'young', 'adult', 'senior'];
+const ENERGY_LEVEL = ['low', 'medium', 'high', 'very_high'];
+const VACCINATION_STATUS = ['up_to_date', 'partial', 'not_vaccinated', 'unknown'];
+const SPAY_NEUTER_STATUS = ['spayed', 'neutered', 'not_altered', 'unknown'];
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('pet_status', PET_STATUS);
+  pgm.createType('pet_type', PET_TYPE);
+  pgm.createType('pet_gender', GENDER);
+  pgm.createType('pet_size', SIZE);
+  pgm.createType('pet_age_group', AGE_GROUP);
+  pgm.createType('pet_energy_level', ENERGY_LEVEL);
+  pgm.createType('pet_vaccination_status', VACCINATION_STATUS);
+  pgm.createType('pet_spay_neuter_status', SPAY_NEUTER_STATUS);
+
+  pgm.createTable('pets', {
+    pet_id: { type: 'uuid', primaryKey: true },
+    name: { type: 'varchar(100)', notNull: true },
+    // Nullable cross-schema pointer to the owning rescue (no DB FK).
+    rescue_id: { type: 'uuid' },
+    short_description: { type: 'text' },
+    long_description: { type: 'text' },
+    age_years: { type: 'integer' },
+    age_months: { type: 'integer' },
+    birth_date: { type: 'date' },
+    is_birth_date_estimate: { type: 'boolean', notNull: true, default: false },
+    age_group: { type: 'pet_age_group', notNull: true, default: 'adult' },
+    gender: { type: 'pet_gender', notNull: true, default: 'unknown' },
+    status: { type: 'pet_status', notNull: true, default: 'available' },
+    type: { type: 'pet_type', notNull: true },
+    breed_id: {
+      type: 'uuid',
+      references: 'breeds(breed_id)',
+      onDelete: 'SET NULL',
+    },
+    secondary_breed_id: {
+      type: 'uuid',
+      references: 'breeds(breed_id)',
+      onDelete: 'SET NULL',
+    },
+    weight_kg: { type: 'decimal(5,2)' },
+    size: { type: 'pet_size', notNull: true, default: 'medium' },
+    color: { type: 'varchar(100)' },
+    markings: { type: 'varchar(255)' },
+    microchip_id: { type: 'varchar(50)', unique: true },
+    archived: { type: 'boolean', notNull: true, default: false },
+    featured: { type: 'boolean', notNull: true, default: false },
+    priority_listing: { type: 'boolean', notNull: true, default: false },
+    adoption_fee_minor: { type: 'integer' },
+    adoption_fee_currency: { type: 'char(3)', default: 'GBP' },
+    special_needs: { type: 'boolean', notNull: true, default: false },
+    special_needs_description: { type: 'text' },
+    house_trained: { type: 'boolean', notNull: true, default: false },
+    good_with_children: { type: 'boolean' },
+    good_with_dogs: { type: 'boolean' },
+    good_with_cats: { type: 'boolean' },
+    good_with_small_animals: { type: 'boolean' },
+    energy_level: { type: 'pet_energy_level', notNull: true, default: 'medium' },
+    exercise_needs: { type: 'text' },
+    grooming_needs: { type: 'text' },
+    training_notes: { type: 'text' },
+    temperament: { type: 'text[]' },
+    medical_notes: { type: 'text' },
+    behavioral_notes: { type: 'text' },
+    surrender_reason: { type: 'text' },
+    intake_date: { type: 'timestamptz' },
+    vaccination_status: { type: 'pet_vaccination_status', notNull: true, default: 'unknown' },
+    vaccination_date: { type: 'timestamptz' },
+    spay_neuter_status: { type: 'pet_spay_neuter_status', notNull: true, default: 'unknown' },
+    spay_neuter_date: { type: 'timestamptz' },
+    last_vet_checkup: { type: 'timestamptz' },
+    location: { type: 'public.geometry(Point)' },
+    available_since: { type: 'timestamptz' },
+    adopted_date: { type: 'timestamptz' },
+    foster_start_date: { type: 'timestamptz' },
+    foster_end_date: { type: 'timestamptz' },
+    view_count: { type: 'integer', notNull: true, default: 0 },
+    favorite_count: { type: 'integer', notNull: true, default: 0 },
+    application_count: { type: 'integer', notNull: true, default: 0 },
+    search_vector: { type: 'tsvector' },
+    tags: { type: 'text[]' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  // Index names mirror the monolith so dual-stack debugging stays legible.
+  pgm.createIndex('pets', 'rescue_id', { name: 'pets_rescue_id_idx' });
+  pgm.createIndex('pets', 'status', { name: 'pets_status_idx' });
+  pgm.createIndex('pets', 'type', { name: 'pets_type_idx' });
+  pgm.createIndex('pets', 'size', { name: 'pets_size_idx' });
+  pgm.createIndex('pets', 'age_group', { name: 'pets_age_group_idx' });
+  pgm.createIndex('pets', 'gender', { name: 'pets_gender_idx' });
+  pgm.createIndex('pets', 'breed_id', { name: 'pets_breed_id_idx' });
+  pgm.createIndex('pets', 'secondary_breed_id', { name: 'pets_secondary_breed_id_idx' });
+  pgm.createIndex('pets', 'featured', { name: 'pets_featured_idx' });
+  pgm.createIndex('pets', 'priority_listing', { name: 'pets_priority_idx' });
+  pgm.createIndex('pets', 'created_at', { name: 'pets_created_at_idx' });
+  pgm.createIndex('pets', 'available_since', { name: 'pets_available_since_idx' });
+  // Partial unique — only one non-null microchip_id per row (the
+  // redundant looser pets_microchip_id_key constraint comes from the
+  // column-level unique above; both shapes appear in the monolith).
+  pgm.createIndex('pets', 'microchip_id', {
+    name: 'pets_microchip_unique',
+    unique: true,
+    where: 'microchip_id IS NOT NULL',
+  });
+  pgm.createIndex('pets', 'search_vector', { name: 'pets_search_vector_gin_idx', method: 'gin' });
+  pgm.createIndex('pets', 'location', { name: 'pets_location_gist_idx', method: 'gist' });
+  pgm.createIndex('pets', ['status', 'rescue_id'], { name: 'pets_status_rescue_idx' });
+  pgm.createIndex('pets', ['status', 'type', 'size'], { name: 'pets_status_type_size_idx' });
+  pgm.createIndex('pets', 'deleted_at', { name: 'pets_deleted_at_idx' });
+  pgm.createIndex('pets', 'created_by', { name: 'pets_created_by_idx' });
+  pgm.createIndex('pets', 'updated_by', { name: 'pets_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('pets');
+  pgm.dropType('pet_status');
+  pgm.dropType('pet_type');
+  pgm.dropType('pet_gender');
+  pgm.dropType('pet_size');
+  pgm.dropType('pet_age_group');
+  pgm.dropType('pet_energy_level');
+  pgm.dropType('pet_vaccination_status');
+  pgm.dropType('pet_spay_neuter_status');
+};

--- a/services/pets/src/migrations/003_create_pet_media.ts
+++ b/services/pets/src/migrations/003_create_pet_media.ts
@@ -1,0 +1,52 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — pet_media.
+//
+// Direct port of service.backend's 00-baseline-017-pet-media.ts INTO the
+// `pets` schema. pet_id is an INTRA-schema FK to pets.pet_id (ON DELETE
+// CASCADE — media dies with its pet). created_by / updated_by are
+// cross-schema audit pointers, left FK-free.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('pet_media_type', ['image', 'video']);
+
+  pgm.createTable('pet_media', {
+    media_id: { type: 'uuid', primaryKey: true },
+    pet_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'pets(pet_id)',
+      onDelete: 'CASCADE',
+    },
+    type: { type: 'pet_media_type', notNull: true },
+    url: { type: 'text', notNull: true },
+    thumbnail_url: { type: 'text' },
+    caption: { type: 'text' },
+    order_index: { type: 'integer', notNull: true, default: 0 },
+    is_primary: { type: 'boolean', notNull: true, default: false },
+    duration_seconds: { type: 'integer' },
+    uploaded_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.createIndex('pet_media', ['pet_id', 'order_index'], { name: 'pet_media_pet_order_idx' });
+  pgm.createIndex('pet_media', ['pet_id', 'type'], { name: 'pet_media_pet_type_idx' });
+  // Partial unique: at most one is_primary=true media row per pet.
+  pgm.createIndex('pet_media', 'pet_id', {
+    name: 'pet_media_one_primary_per_pet',
+    unique: true,
+    where: 'is_primary = true',
+  });
+  pgm.createIndex('pet_media', 'created_by', { name: 'pet_media_created_by_idx' });
+  pgm.createIndex('pet_media', 'updated_by', { name: 'pet_media_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('pet_media');
+  pgm.dropType('pet_media_type');
+};

--- a/services/pets/src/migrations/004_create_pet_status_transitions.ts
+++ b/services/pets/src/migrations/004_create_pet_status_transitions.ts
@@ -1,0 +1,46 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — pet_status_transitions.
+//
+// Direct port of service.backend's 00-baseline-018-pet-status-transitions.ts
+// INTO the `pets` schema. Append-only event log behind the pet status
+// state machine — the row-level audit trail Phase 3's event sourcing
+// reads/writes. pet_id is an INTRA-schema FK to pets.pet_id (ON DELETE
+// CASCADE matches the monolith's nullable belongsTo + SET NULL... but the
+// monolith keeps pet_id nullable; we CASCADE here so a deleted pet takes
+// its transition log with it, which is the cleaner lifecycle for an
+// extracted service that owns both tables). transitioned_by is forensic
+// metadata with no FK (survives user deletion).
+//
+// from_status / to_status reuse the pet_status enum created in 002 —
+// unlike the monolith (which derived a distinct type per column), the
+// extracted schema shares one canonical enum.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('pet_status_transitions', {
+    transition_id: { type: 'uuid', primaryKey: true },
+    pet_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'pets(pet_id)',
+      onDelete: 'CASCADE',
+    },
+    from_status: { type: 'pet_status' },
+    to_status: { type: 'pet_status', notNull: true },
+    transitioned_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    transitioned_by: { type: 'uuid' },
+    reason: { type: 'text' },
+    metadata: { type: 'jsonb' },
+  });
+
+  pgm.createIndex('pet_status_transitions', ['pet_id', 'transitioned_at'], {
+    name: 'pet_status_transitions_pet_id_at_idx',
+  });
+  pgm.createIndex('pet_status_transitions', 'transitioned_by', {
+    name: 'pet_status_transitions_transitioned_by_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('pet_status_transitions');
+};

--- a/services/pets/src/migrations/005_create_ratings.ts
+++ b/services/pets/src/migrations/005_create_ratings.ts
@@ -1,0 +1,80 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — ratings.
+//
+// Direct port of service.backend's 00-baseline-015-ratings.ts INTO the
+// `pets` schema. Polymorphic review row (pet / rescue / user / application
+// / experience). pet_id is the only INTRA-schema FK kept (→ pets.pet_id,
+// ON DELETE SET NULL — a deleted pet shouldn't erase the reviewer's
+// rating history). reviewer_id / reviewee_id → auth.users, rescue_id →
+// rescue schema, application_id → applications schema: all CROSS-schema,
+// left FK-free.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('rating_type', ['pet', 'rescue', 'user', 'application', 'experience']);
+  pgm.createType('rating_category', [
+    'overall',
+    'communication',
+    'process',
+    'care',
+    'follow_up',
+    'value',
+    'recommendation',
+  ]);
+
+  pgm.createTable('ratings', {
+    rating_id: { type: 'uuid', primaryKey: true },
+    reviewer_id: { type: 'uuid', notNull: true },
+    reviewee_id: { type: 'uuid' },
+    pet_id: {
+      type: 'uuid',
+      references: 'pets(pet_id)',
+      onDelete: 'SET NULL',
+    },
+    rescue_id: { type: 'uuid' },
+    application_id: { type: 'uuid' },
+    rating_type: { type: 'rating_type', notNull: true },
+    category: { type: 'rating_category', notNull: true },
+    score: { type: 'integer', notNull: true },
+    title: { type: 'varchar(200)' },
+    review_text: { type: 'text' },
+    pros: { type: 'jsonb' },
+    cons: { type: 'jsonb' },
+    helpful_count: { type: 'integer', notNull: true, default: 0 },
+    reported_count: { type: 'integer', notNull: true, default: 0 },
+    is_verified: { type: 'boolean', notNull: true, default: false },
+    is_anonymous: { type: 'boolean', notNull: true, default: false },
+    is_featured: { type: 'boolean', notNull: true, default: false },
+    is_moderated: { type: 'boolean', notNull: true, default: false },
+    moderation_notes: { type: 'text' },
+    response_text: { type: 'text' },
+    response_date: { type: 'timestamptz' },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('ratings', ['rating_type', 'category'], {
+    name: 'ratings_rating_type_category',
+  });
+  pgm.createIndex('ratings', 'pet_id', { name: 'ratings_pet_id_idx' });
+  pgm.createIndex('ratings', 'rescue_id', { name: 'ratings_rescue_id_idx' });
+  pgm.createIndex('ratings', 'reviewer_id', { name: 'ratings_reviewer_id_idx' });
+  pgm.createIndex('ratings', 'reviewee_id', { name: 'ratings_reviewee_id_idx' });
+  pgm.createIndex('ratings', 'application_id', { name: 'ratings_application_id_idx' });
+  pgm.createIndex('ratings', 'score', { name: 'ratings_score' });
+  pgm.createIndex('ratings', 'is_featured', { name: 'ratings_is_featured' });
+  pgm.createIndex('ratings', 'is_moderated', { name: 'ratings_is_moderated' });
+  pgm.createIndex('ratings', 'created_at', { name: 'ratings_created_at' });
+  pgm.createIndex('ratings', 'created_by', { name: 'ratings_created_by_idx' });
+  pgm.createIndex('ratings', 'updated_by', { name: 'ratings_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('ratings');
+  pgm.dropType('rating_type');
+  pgm.dropType('rating_category');
+};

--- a/services/pets/src/migrations/006_create_user_favorites.ts
+++ b/services/pets/src/migrations/006_create_user_favorites.ts
@@ -1,0 +1,47 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — user_favorites.
+//
+// Direct port of service.backend's 00-baseline-054-user-favorites.ts INTO
+// the `pets` schema. Join row between an adopter and a pet they've
+// favourited. pet_id is the INTRA-schema FK (→ pets.pet_id, ON DELETE
+// CASCADE — a deleted pet drops its favourite rows). user_id /
+// created_by / updated_by → auth.users are CROSS-schema, left FK-free.
+//
+// The partial unique index unique_user_pet_favorite enforces "one active
+// favourite per user+pet" while permitting historical soft-deleted rows.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('user_favorites', {
+    id: { type: 'uuid', primaryKey: true },
+    user_id: { type: 'uuid', notNull: true },
+    pet_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'pets(pet_id)',
+      onDelete: 'CASCADE',
+    },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('user_favorites', ['user_id', 'pet_id'], {
+    name: 'unique_user_pet_favorite',
+    unique: true,
+    where: 'deleted_at IS NULL',
+  });
+  pgm.createIndex('user_favorites', 'user_id', { name: 'idx_user_favorites_user_id' });
+  pgm.createIndex('user_favorites', 'pet_id', { name: 'idx_user_favorites_pet_id' });
+  pgm.createIndex('user_favorites', 'created_at', { name: 'idx_user_favorites_created_at' });
+  pgm.createIndex('user_favorites', 'deleted_at', { name: 'user_favorites_deleted_at_idx' });
+  pgm.createIndex('user_favorites', 'created_by', { name: 'user_favorites_created_by_idx' });
+  pgm.createIndex('user_favorites', 'updated_by', { name: 'user_favorites_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('user_favorites');
+};

--- a/services/pets/src/migrations/migrations.test.ts
+++ b/services/pets/src/migrations/migrations.test.ts
@@ -1,0 +1,56 @@
+import { readdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Smoke tests for the migration files in this directory. We don't run
+// them against a real Postgres here — @adopt-dont-shop/db is already
+// tested for the runner contract, and the migrations get exercised
+// end-to-end by the docker-compose stack smoke.
+//
+// This file guards the things that break silently:
+//   - every migration exports `up` and `down` functions
+//   - the file naming convention stays consistent (lexicographic =
+//     execution order; node-pg-migrate sorts the dir scan by filename)
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_FILENAME_PATTERN = /^\d{3}_[a-z0-9_]+\.ts$/;
+
+async function listMigrationFiles(): Promise<string[]> {
+  const entries = await readdir(MIGRATIONS_DIR);
+  return entries.filter(f => MIGRATION_FILENAME_PATTERN.test(f)).sort((a, b) => a.localeCompare(b));
+}
+
+describe('pets migrations', () => {
+  it('has migration files following the NNN_snake_case.ts naming convention', async () => {
+    const files = await listMigrationFiles();
+    expect(files.length).toBeGreaterThanOrEqual(6);
+    for (const f of files) {
+      expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
+    }
+  });
+
+  it('numbers migrations sequentially without gaps', async () => {
+    const files = await listMigrationFiles();
+    const numbers = files.map(f => Number.parseInt(f.slice(0, 3), 10));
+    for (let i = 0; i < numbers.length; i++) {
+      expect(numbers[i]).toBe(i + 1);
+    }
+  });
+
+  it.each([
+    '001_create_breeds.ts',
+    '002_create_pets.ts',
+    '003_create_pet_media.ts',
+    '004_create_pet_status_transitions.ts',
+    '005_create_ratings.ts',
+    '006_create_user_favorites.ts',
+  ])('%s exports `up` and `down` functions', async filename => {
+    const mod = (await import(`./${filename}`)) as {
+      up: unknown;
+      down: unknown;
+    };
+    expect(typeof mod.up).toBe('function');
+    expect(typeof mod.down).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Ports the six pet-domain tables from the monolith's per-model rebaseline migrations into the `pets` schema, using `node-pg-migrate` (same shape as the auth service's Phase 2.2 migrations).

## Tables (in dependency order)

| # | Table | Notes |
|---|---|---|
| 001 | `breeds` | Lookup table, `(species, name)` unique, no soft-delete. Creates the `postgis` extension in `public` for the pet `location` column. |
| 002 | `pets` | The full listing row, ported verbatim from `00-baseline-016-pets.ts`. 8 enums, PostGIS `location`, `tsvector` search_vector (plain column — the maintaining trigger lives with the model afterSync hook in the monolith and isn't baseline schema), partial-unique microchip, GIN/GiST indexes. |
| 003 | `pet_media` | Media rows, partial-unique one-primary-per-pet. |
| 004 | `pet_status_transitions` | Append-only status event log behind the state machine; reuses the shared `pet_status` enum (the monolith derived a distinct type per column; the extracted schema shares one). |
| 005 | `ratings` | Polymorphic reviews (pet/rescue/user/application/experience). |
| 006 | `user_favorites` | Adopter↔pet join, partial-unique one-active-favourite-per-user+pet. |

## FK decisions (schema-per-service rule)

- **INTRA-schema FKs stay enforced:** `pets.breed_id`/`secondary_breed_id` → `breeds` (SET NULL); `pet_media`/`pet_status_transitions`/`user_favorites.pet_id` → `pets` (CASCADE); `ratings.pet_id` → `pets` (SET NULL).
- **CROSS-schema pointers stay FK-free** (application-side): `rescue_id` → rescue schema; `user_id`/`reviewer_id`/`reviewee_id`/`created_by`/`updated_by` → `auth.users`; `application_id` → applications schema.

## Test plan

- [x] `npm test` in `services/pets` — **17/17** green (added migrations smoke: naming convention, sequential numbering, up/down exports)
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.pets'` — green
- [x] Lint clean

Adds `@adopt-dont-shop/db` + `node-pg-migrate` + `pg` deps, the `db:migrate` script, and `src/db/migrate.ts` entrypoint.

## What's NOT in

- **Phase 3.3** — proto + handlers + adapter (event-sourced status machine over `pet_status_transitions` + standard CRUD).
- **Phase 3.4** — NATS publishers (`pets.created`, `pets.statusChanged`, `pets.deleted`).
- **Phase 3.5** — Gateway routes `/api/pets/*` here.
- **Phase 3.6** — Cutover.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_