### PR TITLE
docs(security): document GHCR_TOKEN read:packages-only scope requirement

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -29,7 +29,9 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
     steps:
       # ADS-670: pin SSH host fingerprint to prevent MitM.
-      # ADS-671: GHCR_TOKEN and SHA passed via envs (not interpolated into script).
+      # ADS-671: GHCR_TOKEN must be scoped `read:packages` only — it is used
+      # exclusively for `docker pull` during rollback. Passed via envs (not
+      # interpolated into script) to prevent token exposure in process listings.
       # SHA is validated server-side to prevent shell injection.
       - name: Rollback on server
         env:

--- a/docs/SECRETS-MANAGEMENT.md
+++ b/docs/SECRETS-MANAGEMENT.md
@@ -316,6 +316,21 @@ npm run validate:env
 
 ### CI/CD Integration
 
+#### GitHub Actions repository secrets
+
+The deploy and rollback workflows require the following secret stored under **Settings → Secrets and variables → Actions**:
+
+| Secret | Required scope | Purpose |
+|--------|----------------|---------|
+| `GHCR_TOKEN` | `read:packages` **only** | `docker pull` images from GHCR on the deploy server |
+
+`GHCR_TOKEN` must be a Personal Access Token (classic or fine-grained) with **only** `read:packages` permission. Never grant `write:packages` or `repo` scope — a compromised token with those scopes would allow an attacker to push malicious container images or read/modify source code (supply-chain attack). See [ADS-671](https://linear.app/ideasquared/issue/ADS-671).
+
+To rotate this token:
+1. Create a new PAT at **GitHub → Settings → Developer settings → Personal access tokens** with `read:packages` only.
+2. Update the `GHCR_TOKEN` repository secret under **Settings → Secrets and variables → Actions**.
+3. Trigger a staging deploy or rollback to verify the new token works.
+
 **GitHub Actions:**
 
 ```yaml

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -9,6 +9,7 @@ the operator-side steps that the compose file alone doesn't capture.
 - TLS cert + key mounted at `nginx/ssl/fullchain.pem` and `nginx/ssl/privkey.pem`,
   or a working letsencrypt volume populated by certbot.
 - All `${VAR:?}` env vars in `docker-compose.prod.yml` set in `.env`.
+- `GHCR_TOKEN` repository secret set to a PAT scoped **`read:packages` only** — used by the deploy and rollback workflows to `docker pull` images on the server. See [`docs/SECRETS-MANAGEMENT.md`](../SECRETS-MANAGEMENT.md#github-actions-repository-secrets). [ADS-671]
 
 ## One-time setup
 


### PR DESCRIPTION
## Summary

- Aligns `rollback.yml` comment with `deploy.yml` by explicitly stating that `GHCR_TOKEN` must be scoped `read:packages` only (used exclusively for `docker pull` during rollback)
- Adds a dedicated **GitHub Actions repository secrets** section to `SECRETS-MANAGEMENT.md` documenting the PAT scope requirement, the supply-chain risk of over-scoped tokens, and step-by-step rotation instructions
- Adds a `GHCR_TOKEN` prerequisite note to `docs/operations/deploy.md` linking to the new secrets doc

## What still needs a human action

The `GHCR_TOKEN` secret itself must be rotated to a `read:packages`-only PAT via **GitHub → Settings → Secrets and variables → Actions**. That is a GitHub UI action and cannot be done in code. Once rotated, the remaining acceptance criteria in ADS-671 (verify deploy and rollback still work) should be confirmed with a staging deploy.

Closes / progresses: https://linear.app/ideasquared/issue/ADS-671

## Test plan

- [ ] Confirm `rollback.yml` comment is consistent with `deploy.yml` (no functional change)
- [ ] Review `SECRETS-MANAGEMENT.md` new section for accuracy
- [ ] Human: rotate `GHCR_TOKEN` to `read:packages`-only PAT in GitHub Settings
- [ ] Human: trigger a staging deploy to verify the scoped token works

---
_Generated by [Claude Code](https://claude.ai/code/session_014hXp7kqfGab3Z5Rkpd9apC)_