### PR TITLE
feat(microservices): pets gRPC server boot + adapter (Phase 3.3c)

### DIFF
--- a/services/pets/README.md
+++ b/services/pets/README.md
@@ -73,11 +73,24 @@ domain + publish-after-commit on `pets.statusChanged`.
   gating, super_admin bypass, publish-after-commit call ordering,
   illegal-transition rejection, keyset pagination).
 
+**Phase 3.3c** — gRPC server boot + adapter:
+- `src/grpc/principal.ts` — `extractPrincipal` from the
+  `x-user-{id,roles,permissions,rescue-id}` metadata headers (same
+  shape as `services/auth`).
+- `src/grpc/adapter.ts` — `adapt` wraps a pure handler in grpc-js's
+  `(call, callback)` signature, extracts the principal, maps
+  `HandlerError.code → grpc.status` and scrubs unknown errors to
+  `INTERNAL`. Single variant (no `adaptUnauth`) because every
+  `PetService` RPC requires a principal.
+- `src/grpc/server.ts` — `createGrpcServer` + `startGrpcServer`.
+  Binds all six methods on `PETS_GRPC_PORT` (default 6003) with
+  insecure credentials (TLS terminates at nginx).
+- `src/index.ts` wires `pool` + `nats` into the gRPC server and
+  runs it alongside the HTTP `/health` surface; deps connect FIRST,
+  then start serving.
+
 ## What's NOT here yet
 
-- **Phase 3.3c** — gRPC server boot + adapter (port of
-  `services/auth/src/grpc/{adapter,server}.ts`), wired into
-  `index.ts` on `PETS_GRPC_PORT`.
 - **Phase 3.4** — NATS publishers: `pets.created`,
   `pets.statusChanged`, `pets.deleted` etc. Downstream services
   (notifications, matching, moderation, applications) consume these.

--- a/services/pets/src/grpc/adapter.test.ts
+++ b/services/pets/src/grpc/adapter.test.ts
@@ -1,0 +1,110 @@
+import { Metadata, status, type ServerUnaryCall, type sendUnaryData } from '@grpc/grpc-js';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from 'winston';
+
+import { adapt } from './adapter.js';
+import { HandlerError, type HandlerDeps } from './handlers.js';
+
+function makeLogger() {
+  const calls: Array<{ level: string; msg: string; meta?: unknown }> = [];
+  const logger = {
+    info: (msg: string, meta?: unknown) => calls.push({ level: 'info', msg, meta }),
+    error: (msg: string, meta?: unknown) => calls.push({ level: 'error', msg, meta }),
+    warn: (msg: string, meta?: unknown) => calls.push({ level: 'warn', msg, meta }),
+    debug: (msg: string, meta?: unknown) => calls.push({ level: 'debug', msg, meta }),
+    silly: (msg: string, meta?: unknown) => calls.push({ level: 'silly', msg, meta }),
+  } as unknown as Logger;
+  return { logger, calls };
+}
+
+function buildMetadata(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+const VALID_HEADERS = {
+  'x-user-id': 'usr-1',
+  'x-user-roles': 'rescue_staff',
+  'x-user-permissions': 'pets.read',
+};
+
+const deps = { pool: {}, nats: {} } as unknown as HandlerDeps;
+
+function makeCall<Req>(request: Req, metadata: Metadata): ServerUnaryCall<Req, unknown> {
+  return { request, metadata } as ServerUnaryCall<Req, unknown>;
+}
+
+describe('adapt — happy path', () => {
+  it('passes the request and extracted principal to the handler', async () => {
+    const handler = vi.fn(async (_d, principal, req: { ping: string }) => ({
+      pong: req.ping,
+      asUser: principal.userId,
+    }));
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({ ping: 'hi' }, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ pong: 'hi', asUser: 'usr-1' });
+  });
+});
+
+describe('adapt — error code mapping', () => {
+  it('UNAUTHENTICATED when principal headers are missing', async () => {
+    const handler = vi.fn();
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata({})), callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(handler).not.toHaveBeenCalled();
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.UNAUTHENTICATED });
+  });
+
+  it.each([
+    ['INVALID_ARGUMENT', status.INVALID_ARGUMENT],
+    ['UNAUTHENTICATED', status.UNAUTHENTICATED],
+    ['PERMISSION_DENIED', status.PERMISSION_DENIED],
+    ['NOT_FOUND', status.NOT_FOUND],
+    ['INTERNAL', status.INTERNAL],
+  ] as const)('HandlerError("%s") → %i', async (code, grpcCode) => {
+    const handler = vi.fn(async () => {
+      throw new HandlerError(code, 'oops');
+    });
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: grpcCode, details: 'oops' });
+  });
+
+  it('unknown errors → INTERNAL with scrubbed message AND logger.error', async () => {
+    const handler = vi.fn(async () => {
+      throw new Error('pg: connection lost');
+    });
+    const { logger, calls } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.INTERNAL, details: 'internal error' });
+    expect((err as Error).message).toBe('internal error');
+    expect(calls.find(c => c.level === 'error')?.msg).toContain('unhandled');
+  });
+});

--- a/services/pets/src/grpc/adapter.ts
+++ b/services/pets/src/grpc/adapter.ts
@@ -1,0 +1,77 @@
+// Adapter — wraps the plain async handler functions in handlers.ts
+// in the grpc-js `(call, callback)` signature ts-proto generates.
+//
+// All six PetService RPCs require a principal (the gateway's Phase 2.5
+// authenticate middleware populates the x-user-* metadata for every
+// authenticated request), so unlike services/auth we only need a single
+// `adapt` variant. HandlerError → grpc.status mapping mirrors the table
+// in services/auth/src/grpc/adapter.ts.
+
+import {
+  status,
+  type Metadata,
+  type ServerUnaryCall,
+  type ServiceError,
+  type sendUnaryData,
+} from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Logger } from 'winston';
+
+import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
+  INVALID_ARGUMENT: status.INVALID_ARGUMENT,
+  UNAUTHENTICATED: status.UNAUTHENTICATED,
+  PERMISSION_DENIED: status.PERMISSION_DENIED,
+  NOT_FOUND: status.NOT_FOUND,
+  INTERNAL: status.INTERNAL,
+};
+
+export type UnaryHandler<Req, Res> = (
+  deps: HandlerDeps,
+  principal: Principal,
+  req: Req
+) => Promise<Res>;
+
+export type AdaptOptions = {
+  deps: HandlerDeps;
+  logger: Logger;
+};
+
+export function adapt<Req, Res>(
+  handler: UnaryHandler<Req, Res>,
+  { deps, logger }: AdaptOptions
+): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
+  return (call, callback) => {
+    void (async () => {
+      try {
+        const principal = extractPrincipal(call.metadata);
+        const response = await handler(deps, principal, call.request);
+        callback(null, response);
+      } catch (err) {
+        callback(toServiceError(err, call.metadata, logger), null);
+      }
+    })();
+  };
+}
+
+function toServiceError(err: unknown, metadata: Metadata, logger: Logger): ServiceError {
+  if (err instanceof MissingPrincipalError) {
+    return makeServiceError(status.UNAUTHENTICATED, err.message, metadata);
+  }
+  if (err instanceof HandlerError) {
+    return makeServiceError(CODE_TO_GRPC[err.code], err.message, metadata);
+  }
+  logger.error('unhandled handler error', { err });
+  return makeServiceError(status.INTERNAL, 'internal error', metadata);
+}
+
+function makeServiceError(code: number, message: string, metadata: Metadata): ServiceError {
+  const err = new Error(message) as ServiceError;
+  err.code = code;
+  err.details = message;
+  err.metadata = metadata;
+  return err;
+}

--- a/services/pets/src/grpc/principal.test.ts
+++ b/services/pets/src/grpc/principal.test.ts
@@ -1,0 +1,46 @@
+import { Metadata } from '@grpc/grpc-js';
+import { describe, expect, it } from 'vitest';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+function build(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+describe('extractPrincipal', () => {
+  it('throws MissingPrincipalError when x-user-id is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-roles': 'adopter' }))).toThrowError(
+      MissingPrincipalError
+    );
+  });
+
+  it('throws MissingPrincipalError when x-user-roles is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-id': 'u' }))).toThrowError(MissingPrincipalError);
+  });
+
+  it('parses comma-separated roles + permissions', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'rescue_staff, admin',
+        'x-user-permissions': 'pets.read , pets.update',
+      })
+    );
+    expect(p.userId).toBe('usr-1');
+    expect(p.roles).toEqual(['rescue_staff', 'admin']);
+    expect(p.permissions).toEqual(['pets.read', 'pets.update']);
+  });
+
+  it('carries x-rescue-id when present', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'u',
+        'x-user-roles': 'rescue_staff',
+        'x-rescue-id': 'rsc-42',
+      })
+    );
+    expect(p.rescueId).toBe('rsc-42');
+  });
+});

--- a/services/pets/src/grpc/principal.ts
+++ b/services/pets/src/grpc/principal.ts
@@ -1,0 +1,67 @@
+// Principal extractor for gRPC handlers that REQUIRE a principal.
+//
+// Every extracted service receives identity context as gRPC metadata
+// headers from the gateway:
+//
+//   x-user-id           UUID of the calling user
+//   x-user-roles        comma-separated UserRole list
+//   x-user-permissions  comma-separated Permission list
+//   x-rescue-id         (optional) rescueId for rescue-scoped roles
+//
+// Direct port of services/auth/src/grpc/principal.ts. All six
+// PetService RPCs require a principal — there's no token-minting
+// flow here, so we never call adaptUnauth for pets.
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export class MissingPrincipalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingPrincipalError';
+  }
+}
+
+export function extractPrincipal(metadata: Metadata): Principal {
+  const userId = headerOne(metadata, 'x-user-id');
+  if (!userId) {
+    throw new MissingPrincipalError('missing x-user-id metadata');
+  }
+
+  const rolesRaw = headerOne(metadata, 'x-user-roles');
+  if (!rolesRaw) {
+    throw new MissingPrincipalError('missing x-user-roles metadata');
+  }
+
+  const roles = rolesRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as UserRole[];
+
+  const permissionsRaw = headerOne(metadata, 'x-user-permissions') ?? '';
+  const permissions = permissionsRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as Permission[];
+
+  const rescueIdRaw = headerOne(metadata, 'x-rescue-id')?.trim();
+  const rescueId = rescueIdRaw ? (rescueIdRaw as RescueId) : undefined;
+
+  return {
+    userId: userId as UserId,
+    roles,
+    permissions,
+    rescueId,
+  };
+}
+
+function headerOne(metadata: Metadata, key: string): string | undefined {
+  const values = metadata.get(key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}

--- a/services/pets/src/grpc/server.test.ts
+++ b/services/pets/src/grpc/server.test.ts
@@ -1,0 +1,56 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+
+import { PetsV1 } from '@adopt-dont-shop/proto';
+
+import type { PetsConfig } from '../config.js';
+
+import { createGrpcServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const config: PetsConfig = {
+  port: 5003,
+  grpcPort: 6003,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'pets',
+  natsUrl: 'nats://localhost:4222',
+};
+
+const pool = {} as unknown as Pool;
+const nats = {} as unknown as NatsConnection;
+
+describe('createGrpcServer', () => {
+  it('registers all six PetService methods on the grpc.Server', () => {
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/Create')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/Get')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/List')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/Update')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/UpdateStatus')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.pets.v1.PetService/Delete')).toBe(true);
+  });
+
+  it('matches every path from the canonical PetServiceService Definition table', () => {
+    const definition = PetsV1.PetServiceService;
+    const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
+
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    for (const p of expectedPaths) {
+      expect(handlers.has(p)).toBe(true);
+    }
+  });
+});

--- a/services/pets/src/grpc/server.ts
+++ b/services/pets/src/grpc/server.ts
@@ -1,0 +1,86 @@
+// gRPC server boot — binds PetServiceService to the six adapter-
+// wrapped handlers and starts listening on PETS_GRPC_PORT.
+//
+// Same shape as services/auth/src/grpc/server.ts / services/notifications/
+// src/grpc/server.ts. Dev uses insecure credentials (TLS terminates at
+// nginx in front); production keeps gRPC HTTP/2 cleartext on the cluster
+// network until a future deploy wants mTLS.
+
+import { promisify } from 'node:util';
+
+import { Server, ServerCredentials } from '@grpc/grpc-js';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { PetsV1 } from '@adopt-dont-shop/proto';
+
+import type { PetsConfig } from '../config.js';
+
+import { adapt } from './adapter.js';
+import { createPet, deletePet, getPet, listPets, updatePet, updatePetStatus } from './handlers.js';
+
+export type CreateGrpcServerOptions = {
+  config: PetsConfig;
+  pool: Pool;
+  nats: NatsConnection;
+  logger: Logger;
+};
+
+export type RunningGrpcServer = {
+  server: Server;
+  port: number;
+  shutdown: () => Promise<void>;
+};
+
+export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
+  const { config, pool, nats, logger } = opts;
+  const deps = { pool, nats };
+  const server = new Server();
+
+  server.addService(PetsV1.PetServiceService, {
+    create: adapt(createPet, { deps, logger }),
+    get: adapt(getPet, { deps, logger }),
+    list: adapt(listPets, { deps, logger }),
+    update: adapt(updatePet, { deps, logger }),
+    updateStatus: adapt(updatePetStatus, { deps, logger }),
+    delete: adapt(deletePet, { deps, logger }),
+  });
+
+  logger.info('gRPC PetService registered', {
+    methods: ['create', 'get', 'list', 'update', 'updateStatus', 'delete'],
+    grpcPort: config.grpcPort,
+  });
+
+  return server;
+};
+
+export const startGrpcServer = async (
+  opts: CreateGrpcServerOptions
+): Promise<RunningGrpcServer> => {
+  const { config, logger } = opts;
+  const server = createGrpcServer(opts);
+
+  const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
+  const port = await bindAsync(
+    `${opts.config.host}:${config.grpcPort}`,
+    ServerCredentials.createInsecure()
+  );
+
+  logger.info('gRPC server listening', { port, host: opts.config.host });
+
+  return {
+    server,
+    port,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          resolve();
+        });
+      }),
+  };
+};

--- a/services/pets/src/index.ts
+++ b/services/pets/src/index.ts
@@ -1,21 +1,39 @@
+import { connect, type NatsConnection } from 'nats';
+
+import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.pets' });
 
+  let nats: NatsConnection | undefined;
+  let pool: ReturnType<typeof createDbClient> | undefined;
+  let grpc: RunningGrpcServer | undefined;
+  let httpClosed = false;
+
   try {
     const config = loadConfig();
-    const server = createServer({ config, logger });
 
-    await server.listen({ port: config.port, host: config.host });
+    // Connect deps FIRST so we crash here rather than after starting
+    // to accept traffic. Same boot order as services/auth.
+    pool = createDbClient({
+      connectionString: config.databaseUrl,
+      schema: config.schema,
+    });
+    nats = await connect({ servers: config.natsUrl });
 
-    logger.info('service.pets listening', {
-      port: config.port,
-      host: config.host,
-      grpcPort: config.grpcPort,
+    grpc = await startGrpcServer({ config, pool, nats, logger });
+
+    const httpServer = createServer({ config, logger });
+    await httpServer.listen({ port: config.port, host: config.host });
+
+    logger.info('service.pets running', {
+      http: { port: config.port, host: config.host },
+      grpc: { port: grpc.port, host: config.host },
       schema: config.schema,
       natsUrl: config.natsUrl,
       environment: config.environment,
@@ -24,9 +42,27 @@ const main = async (): Promise<void> => {
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.pets shutting down', { signal });
       try {
-        await server.close();
+        if (!httpClosed) {
+          await httpServer.close();
+          httpClosed = true;
+        }
       } catch (err) {
-        logger.error('error during shutdown', { err });
+        logger.error('http close error', { err });
+      }
+      try {
+        await grpc?.shutdown();
+      } catch (err) {
+        logger.error('grpc shutdown error', { err });
+      }
+      try {
+        await nats?.drain();
+      } catch (err) {
+        logger.error('nats drain error', { err });
+      }
+      try {
+        await pool?.end();
+      } catch (err) {
+        logger.error('pool end error', { err });
       }
       process.exit(0);
     };
@@ -35,6 +71,21 @@ const main = async (): Promise<void> => {
     process.once('SIGINT', () => void shutdown('SIGINT'));
   } catch (err) {
     logger.error('service.pets failed to start', { err });
+    try {
+      await grpc?.shutdown();
+    } catch {
+      // Swallow — already on the failure path.
+    }
+    try {
+      await nats?.drain();
+    } catch {
+      // Same.
+    }
+    try {
+      await pool?.end();
+    } catch {
+      // Same.
+    }
     process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

Wires the six `PetService` handlers from Phase 3.3b into a running gRPC server on `PETS_GRPC_PORT` (default 6003), alongside the existing Fastify `/health/simple` surface. Mirrors `services/auth`'s 2.3c shape.

## What's in

- **`src/grpc/principal.ts`** — `extractPrincipal` from the `x-user-{id,roles,permissions,rescue-id}` metadata headers (same shape as `service.auth` + `service.notifications`).
- **`src/grpc/adapter.ts`** — `adapt` wraps a pure handler in grpc-js's `(call, callback)` signature, extracts the principal, maps `HandlerError.code → grpc.status`, scrubs unknown errors to `INTERNAL` (logged via `logger.error`). **Single variant** — no `adaptUnauth` needed because every `PetService` RPC requires a principal.
- **`src/grpc/server.ts`** — `createGrpcServer` + `startGrpcServer`. Binds all six methods on `PETS_GRPC_PORT` with insecure credentials (TLS terminates at nginx).
- **`src/index.ts`** wires `pool` + `nats` into the gRPC server and runs it alongside the HTTP `/health` surface, with the same boot-then-listen ordering as `services/auth` (deps connect FIRST, then start serving).

## Test plan

- [x] `npm test` in `services/pets` — **87/87** green (14 new across principal, adapter, server)
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.pets'` — green
- [x] Lint clean

**Coverage:** metadata parsing edge cases, full table of `HandlerError → grpc.status` mappings via `it.each`, unknown-error scrubbing + `logger.error`, server handler-table registration asserted against `PetsV1.PetServiceService.path[]`.

## What's NOT in

- **Phase 3.4** — downstream NATS subscribers for `pets.*` events in `service.notifications`.
- **Phase 3.5** — Gateway routes `/api/pets/*` here.
- **Phase 3.6** — Cutover from monolith `/api/pets/*`.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_