### PR TITLE
feat(microservices): downstream pets.* event subscribers (Phase 3.4)

### DIFF
--- a/services/notifications/src/nats/event-types.ts
+++ b/services/notifications/src/nats/event-types.ts
@@ -68,3 +68,30 @@ export type AuthRoleAssignedEvent = {
   assignedBy: UserId;
   reason: string | null;
 };
+
+// pets.statusChanged — service.pets publishes after every successful
+// status transition (Phase 3.3b). Payload carries the pet + rescue +
+// from/to status pair + optional reason; transitionedBy lives on the
+// pet_status_transitions row but is not yet in the NATS payload.
+//
+// Phase 3.4: this service subscribes to the subject but does NOT yet
+// create user-facing notifications — recipient discovery (rescue staff,
+// users who favourited the pet) requires gRPC lookups into the rescue
+// + pets verticals that don't exist yet (Phases 4 + 9). The subscriber
+// logs receipt so we can confirm the wire path end-to-end + the contract
+// stays anchored here.
+export type PetStatusChangedEvent = {
+  petId: string;
+  rescueId: string | null;
+  fromStatus: string;
+  toStatus: string;
+  reason: string | null;
+};
+
+// pets.deleted — service.pets publishes after soft-delete. Same
+// log-only treatment as pets.statusChanged for the same reason
+// (no recipient yet derivable in this service).
+export type PetDeletedEvent = {
+  petId: string;
+  rescueId: string | null;
+};

--- a/services/notifications/src/nats/subscribers.test.ts
+++ b/services/notifications/src/nats/subscribers.test.ts
@@ -192,7 +192,7 @@ describe('registerSubscribers', () => {
 
     const subs = registerSubscribers({ nats, deps, logger });
 
-    expect(subs).toHaveLength(5);
+    expect(subs).toHaveLength(7);
     // Subscribed subjects (raw nats.subscribe receives the subject as
     // first arg, then an options object containing `queue`).
     const subjects = subscribeFn.mock.calls.map(call => call[0]);
@@ -202,6 +202,8 @@ describe('registerSubscribers', () => {
       'applications.rejected',
       'auth.userLoggedIn',
       'auth.roleAssigned',
+      'pets.statusChanged',
+      'pets.deleted',
     ]);
   });
 

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -39,6 +39,8 @@ import type {
   ApplicationSubmittedEvent,
   AuthRoleAssignedEvent,
   AuthUserLoggedInEvent,
+  PetDeletedEvent,
+  PetStatusChangedEvent,
 } from './event-types.js';
 import { SYSTEM_PRINCIPAL } from './system-principal.js';
 
@@ -112,6 +114,41 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
       { subject: 'auth.roleAssigned', queue: QUEUE_GROUP, onError },
       async payload => {
         await createNotification(deps, SYSTEM_PRINCIPAL, buildAuthRoleAssignedCreate(payload));
+      }
+    )
+  );
+
+  // pets.statusChanged / pets.deleted (Phase 3.4): the subjects are
+  // wired here so the wire path is exercised end-to-end, but we do
+  // not yet create user-facing notification rows — see event-types.ts
+  // for the recipient-discovery deferral. Subscribing keeps the
+  // contract anchored on the consumer side and means upcoming changes
+  // (rescue staff lookup, favourite fan-out) only need to fill in the
+  // translator, not the registration.
+  subscriptions.push(
+    subscribe<PetStatusChangedEvent>(
+      nats,
+      { subject: 'pets.statusChanged', queue: QUEUE_GROUP, onError },
+      async payload => {
+        logger.info('pets.statusChanged received', {
+          petId: payload.petId,
+          rescueId: payload.rescueId,
+          fromStatus: payload.fromStatus,
+          toStatus: payload.toStatus,
+        });
+      }
+    )
+  );
+
+  subscriptions.push(
+    subscribe<PetDeletedEvent>(
+      nats,
+      { subject: 'pets.deleted', queue: QUEUE_GROUP, onError },
+      async payload => {
+        logger.info('pets.deleted received', {
+          petId: payload.petId,
+          rescueId: payload.rescueId,
+        });
       }
     )
   );

--- a/services/pets/README.md
+++ b/services/pets/README.md
@@ -89,11 +89,21 @@ domain + publish-after-commit on `pets.statusChanged`.
   runs it alongside the HTTP `/health` surface; deps connect FIRST,
   then start serving.
 
+**Phase 3.4** — downstream NATS event flow:
+- The Phase 3.3b handlers already publish `pets.created`,
+  `pets.updated`, `pets.statusChanged`, and `pets.deleted` via
+  `@adopt-dont-shop/events.withTransaction` (publish-after-commit).
+- `services/notifications` subscribes to `pets.statusChanged` and
+  `pets.deleted` (joins the existing `notifications-workers` queue
+  group). The subscribers currently log receipt only — actually
+  fanning out user-facing notification rows needs recipient
+  discovery (rescue staff, favourite holders) that lands with the
+  rescue + matching verticals (Phases 4 + 9). Wiring the
+  subscriptions now anchors the contract on the consumer side and
+  means upcoming changes only fill in the translator.
+
 ## What's NOT here yet
 
-- **Phase 3.4** — NATS publishers: `pets.created`,
-  `pets.statusChanged`, `pets.deleted` etc. Downstream services
-  (notifications, matching, moderation, applications) consume these.
 - **Phase 3.5** — Gateway routes `/api/pets/*` here (the Phase 2.5
   authenticate middleware already handles auth gating).
 - **Phase 3.6** — Cutover: monolith's pets code becomes dead, removal


### PR DESCRIPTION
## Summary

Phase 3.4 of the microservices migration — wires the consumer side of the pets event flow. The Phase 3.3b handlers already publish `pets.created` / `pets.updated` / `pets.statusChanged` / `pets.deleted` via `withTransaction` (publish-after-commit). This commit subscribes `service.notifications` to the two terminal subjects (`pets.statusChanged` + `pets.deleted`).

## What's in

**`services/notifications/src/nats/event-types.ts`** gains two consumer-side event shapes:
- `PetStatusChangedEvent` — `{ petId, rescueId, fromStatus, toStatus, reason }`
- `PetDeletedEvent` — `{ petId, rescueId }`

**`services/notifications/src/nats/subscribers.ts`** adds two subscriptions joining the existing `notifications-workers` queue group. They currently **log receipt only** — actually fanning out user-facing notification rows needs recipient discovery (rescue staff for the `rescueId`, favourite holders for the `petId`) that requires gRPC lookups into the rescue + matching verticals (Phases 4 + 9). Wiring the subscribers now anchors the contract on the consumer side and means the translator changes when those verticals land won't touch registration.

## Test plan

- [x] `npm test` in `services/notifications` — **70/70** green
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.notifications'` — green
- [x] Lint clean

`registerSubscribers` now reports **7 subjects** (3 `applications.*` + 2 `auth.*` + 2 `pets.*`) all on the `notifications-workers` queue group.

## What's NOT in

- **Phase 3.5** — Gateway routes `/api/pets/*` through here.
- **Phase 3.6** — Cutover from monolith `/api/pets/*`.
- The `pets.statusChanged` → user-facing notification translator — deferred until the rescue + matching verticals expose recipient lookups.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_