### PR TITLE
feat(microservices): gateway /api/pets/* cutover (Phase 3.5)

### DIFF
--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -24,6 +24,9 @@ export type GatewayConfig = {
   // x-user-* metadata is server-derived from a JWT instead of being
   // client-trusted (the Phase 1.5 dev mode).
   authGrpcUrl: string;
+  // service.pets gRPC URL — Phase 3.5 cuts /api/pets/* over to this
+  // address.
+  petsGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 4000;
@@ -32,6 +35,7 @@ const DEFAULT_UPSTREAM = 'http://service-backend:5000';
 const DEFAULT_NATS_URL = 'nats://nats:4222';
 const DEFAULT_NOTIFICATIONS_GRPC_URL = 'service-notifications:6001';
 const DEFAULT_AUTH_GRPC_URL = 'service-auth:6002';
+const DEFAULT_PETS_GRPC_URL = 'service-pets:6003';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig => {
   const portRaw = env.GATEWAY_PORT?.trim();
@@ -48,5 +52,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     notificationsGrpcUrl: env.NOTIFICATIONS_GRPC_URL?.trim() || DEFAULT_NOTIFICATIONS_GRPC_URL,
     authGrpcUrl: env.AUTH_GRPC_URL?.trim() || DEFAULT_AUTH_GRPC_URL,
+    petsGrpcUrl: env.PETS_GRPC_URL?.trim() || DEFAULT_PETS_GRPC_URL,
   };
 };

--- a/services/gateway/src/grpc-clients/pets-client.test.ts
+++ b/services/gateway/src/grpc-clients/pets-client.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { createPetsClient } from './pets-client.js';
+
+describe('createPetsClient', () => {
+  it('returns an object exposing the six PetService methods + close', () => {
+    const client = createPetsClient({ address: '127.0.0.1:65531' });
+    try {
+      expect(typeof client.create).toBe('function');
+      expect(typeof client.get).toBe('function');
+      expect(typeof client.list).toBe('function');
+      expect(typeof client.update).toBe('function');
+      expect(typeof client.updateStatus).toBe('function');
+      expect(typeof client.delete).toBe('function');
+      expect(typeof client.close).toBe('function');
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/gateway/src/grpc-clients/pets-client.ts
+++ b/services/gateway/src/grpc-clients/pets-client.ts
@@ -1,0 +1,72 @@
+// Promise-wrapped client for service.pets.
+//
+// Phase 3.5 surface — full PetService.{Create, Get, List, Update,
+// UpdateStatus, Delete}. The Phase 2.5 authenticate middleware
+// already populates the x-user-* metadata for every authenticated
+// request, so the routes that consume this client thread the same
+// gRPC Metadata pattern as services/gateway/src/grpc-clients/
+// auth-client.ts.
+//
+// The interface is exported so tests can substitute a mock; the
+// routes depend on the shape, not the @grpc/grpc-js client.
+
+import { credentials, Metadata } from '@grpc/grpc-js';
+
+import {
+  PetsV1,
+  type CreatePetRequest,
+  type CreatePetResponse,
+  type DeletePetRequest,
+  type DeletePetResponse,
+  type GetPetRequest,
+  type GetPetResponse,
+  type ListPetsRequest,
+  type ListPetsResponse,
+  type UpdatePetRequest,
+  type UpdatePetResponse,
+  type UpdatePetStatusRequest,
+  type UpdatePetStatusResponse,
+} from '@adopt-dont-shop/proto';
+
+export type PetsClient = {
+  create(req: CreatePetRequest, metadata: Metadata): Promise<CreatePetResponse>;
+  get(req: GetPetRequest, metadata: Metadata): Promise<GetPetResponse>;
+  list(req: ListPetsRequest, metadata: Metadata): Promise<ListPetsResponse>;
+  update(req: UpdatePetRequest, metadata: Metadata): Promise<UpdatePetResponse>;
+  updateStatus(req: UpdatePetStatusRequest, metadata: Metadata): Promise<UpdatePetStatusResponse>;
+  delete(req: DeletePetRequest, metadata: Metadata): Promise<DeletePetResponse>;
+  close(): void;
+};
+
+export type CreatePetsClientOptions = {
+  address: string;
+};
+
+export const createPetsClient = (opts: CreatePetsClientOptions): PetsClient => {
+  const stub = new PetsV1.PetServiceClient(opts.address, credentials.createInsecure());
+
+  const callUnary = <Req, Res>(
+    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> =>
+    new Promise<Res>((resolve, reject) => {
+      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(res);
+      });
+    });
+
+  return {
+    create: (req, metadata) => callUnary(stub.create, req, metadata),
+    get: (req, metadata) => callUnary(stub.get, req, metadata),
+    list: (req, metadata) => callUnary(stub.list, req, metadata),
+    update: (req, metadata) => callUnary(stub.update, req, metadata),
+    updateStatus: (req, metadata) => callUnary(stub.updateStatus, req, metadata),
+    delete: (req, metadata) => callUnary(stub.delete, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -6,6 +6,7 @@ import { createLogger } from '@adopt-dont-shop/observability';
 import { loadConfig } from './config.js';
 import { createAuthClient } from './grpc-clients/auth-client.js';
 import { createNotificationsClient } from './grpc-clients/notifications-client.js';
+import { createPetsClient } from './grpc-clients/pets-client.js';
 import { createServer } from './server.js';
 import { registerNotificationSubscribers } from './ws/notifications-subscriber.js';
 import { SocketRegistry } from './ws/socket-registry.js';
@@ -18,6 +19,7 @@ const main = async (): Promise<void> => {
   let io: IOServer | undefined;
   let notificationsClient: ReturnType<typeof createNotificationsClient> | undefined;
   let authClient: ReturnType<typeof createAuthClient> | undefined;
+  let petsClient: ReturnType<typeof createPetsClient> | undefined;
 
   try {
     const config = loadConfig();
@@ -26,8 +28,15 @@ const main = async (): Promise<void> => {
     // route plugins / middleware can close over them.
     notificationsClient = createNotificationsClient({ address: config.notificationsGrpcUrl });
     authClient = createAuthClient({ address: config.authGrpcUrl });
+    petsClient = createPetsClient({ address: config.petsGrpcUrl });
 
-    const server = await createServer({ config, logger, notificationsClient, authClient });
+    const server = await createServer({
+      config,
+      logger,
+      notificationsClient,
+      authClient,
+      petsClient,
+    });
 
     await server.listen({ port: config.port, host: config.host });
 
@@ -45,6 +54,7 @@ const main = async (): Promise<void> => {
       natsUrl: config.natsUrl,
       notificationsGrpcUrl: config.notificationsGrpcUrl,
       authGrpcUrl: config.authGrpcUrl,
+      petsGrpcUrl: config.petsGrpcUrl,
       environment: config.environment,
     });
 
@@ -77,6 +87,11 @@ const main = async (): Promise<void> => {
       } catch (err) {
         logger.error('auth client close error', { err });
       }
+      try {
+        petsClient?.close();
+      } catch (err) {
+        logger.error('pets client close error', { err });
+      }
       process.exit(0);
     };
 
@@ -96,6 +111,11 @@ const main = async (): Promise<void> => {
     }
     try {
       authClient?.close();
+    } catch {
+      // Same.
+    }
+    try {
+      petsClient?.close();
     } catch {
       // Same.
     }

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -1,0 +1,364 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  PetsV1,
+  type CreatePetResponse,
+  type DeletePetResponse,
+  type GetPetResponse,
+  type ListPetsResponse,
+  type Pet,
+  type UpdatePetResponse,
+  type UpdatePetStatusResponse,
+} from '@adopt-dont-shop/proto';
+
+import type { PetsClient } from '../grpc-clients/pets-client.js';
+
+import { registerPetsRoutes } from './pets.js';
+
+function makeClient(): {
+  client: PetsClient;
+  createMock: ReturnType<typeof vi.fn>;
+  getMock: ReturnType<typeof vi.fn>;
+  listMock: ReturnType<typeof vi.fn>;
+  updateMock: ReturnType<typeof vi.fn>;
+  updateStatusMock: ReturnType<typeof vi.fn>;
+  deleteMock: ReturnType<typeof vi.fn>;
+} {
+  const createMock = vi.fn();
+  const getMock = vi.fn();
+  const listMock = vi.fn();
+  const updateMock = vi.fn();
+  const updateStatusMock = vi.fn();
+  const deleteMock = vi.fn();
+  const client: PetsClient = {
+    create: createMock,
+    get: getMock,
+    list: listMock,
+    update: updateMock,
+    updateStatus: updateStatusMock,
+    delete: deleteMock,
+    close: vi.fn(),
+  };
+  return {
+    client,
+    createMock,
+    getMock,
+    listMock,
+    updateMock,
+    updateStatusMock,
+    deleteMock,
+  };
+}
+
+async function makeApp(client: PetsClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerPetsRoutes(app, { client });
+  return app;
+}
+
+const PET_FIXTURE: Pet = {
+  petId: 'pet-1',
+  name: 'Rex',
+  rescueId: 'rsc-1',
+  type: PetsV1.PetType.PET_TYPE_DOG,
+  status: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+  gender: PetsV1.PetGender.PET_GENDER_MALE,
+  size: PetsV1.PetSize.PET_SIZE_LARGE,
+  ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+  archived: false,
+  featured: false,
+  priorityListing: false,
+  specialNeeds: false,
+  houseTrained: true,
+  temperamentJson: '["friendly"]',
+  tagsJson: '[]',
+  extraJson: '{}',
+  viewCount: 0,
+  favoriteCount: 0,
+  applicationCount: 0,
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+describe('GET /api/pets', () => {
+  let app: FastifyInstance;
+  let listMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    listMock = m.listMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('lists pets and forwards filters', async () => {
+    const listRes: ListPetsResponse = { pets: [PET_FIXTURE], nextCursor: 'abc' };
+    listMock.mockResolvedValueOnce(listRes);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/pets?status=available&type=dog&size=large&limit=10&rescueId=rsc-1',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { pets: unknown[]; nextCursor?: string };
+    expect(body.pets).toHaveLength(1);
+    expect(body.nextCursor).toBe('abc');
+
+    const [req, metadata] = listMock.mock.calls[0];
+    expect(req.limit).toBe(10);
+    expect(req.statusFilter).toBe(PetsV1.PetStatus.PET_STATUS_AVAILABLE);
+    expect(req.typeFilter).toBe(PetsV1.PetType.PET_TYPE_DOG);
+    expect(req.sizeFilter).toBe(PetsV1.PetSize.PET_SIZE_LARGE);
+    expect(req.rescueIdFilter).toBe('rsc-1');
+    expect(metadata.get('x-user-id')[0]).toBe('usr-1');
+  });
+
+  it('coerces an unknown status to UNSPECIFIED (service returns 400)', async () => {
+    listMock.mockResolvedValueOnce({ pets: [] });
+    await app.inject({ method: 'GET', url: '/api/pets?status=not_a_status' });
+    const [req] = listMock.mock.calls[0];
+    expect(req.statusFilter).toBe(PetsV1.PetStatus.PET_STATUS_UNSPECIFIED);
+  });
+
+  it('maps INVALID_ARGUMENT → 400', async () => {
+    listMock.mockRejectedValueOnce(
+      Object.assign(new Error('bad limit'), {
+        code: grpcStatus.INVALID_ARGUMENT,
+        details: 'bad limit',
+      })
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/pets?limit=200' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /api/pets/:id', () => {
+  it('forwards the path param + x-user-* metadata and returns the pet', async () => {
+    const { client, getMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const getRes: GetPetResponse = { pet: PET_FIXTURE };
+      getMock.mockResolvedValueOnce(getRes);
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/pets/pet-1',
+        headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { pet: { petId: string } };
+      expect(body.pet.petId).toBe('pet-1');
+      const [req, metadata] = getMock.mock.calls[0];
+      expect(req.petId).toBe('pet-1');
+      expect(metadata.get('x-user-id')[0]).toBe('usr-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps NOT_FOUND → 404', async () => {
+    const { client, getMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      getMock.mockRejectedValueOnce(
+        Object.assign(new Error('gone'), {
+          code: grpcStatus.NOT_FOUND,
+          details: 'pet ghost not found',
+        })
+      );
+      const res = await app.inject({ method: 'GET', url: '/api/pets/ghost' });
+      expect(res.statusCode).toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('POST /api/pets', () => {
+  it('returns 201 on success and threads body fields into the gRPC request', async () => {
+    const { client, createMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const createRes: CreatePetResponse = { pet: PET_FIXTURE };
+      createMock.mockResolvedValueOnce(createRes);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/pets',
+        headers: { 'x-user-id': 'usr-staff', 'x-user-roles': 'rescue_staff' },
+        payload: {
+          name: 'Rex',
+          rescueId: 'rsc-1',
+          type: PetsV1.PetType.PET_TYPE_DOG,
+          gender: PetsV1.PetGender.PET_GENDER_MALE,
+          size: PetsV1.PetSize.PET_SIZE_LARGE,
+          ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+          specialNeeds: false,
+          houseTrained: true,
+          temperamentJson: '["friendly"]',
+          tagsJson: '[]',
+          extraJson: '{}',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const [req] = createMock.mock.calls[0];
+      expect(req.name).toBe('Rex');
+      expect(req.rescueId).toBe('rsc-1');
+      expect(req.type).toBe(PetsV1.PetType.PET_TYPE_DOG);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps PERMISSION_DENIED → 403', async () => {
+    const { client, createMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      createMock.mockRejectedValueOnce(
+        Object.assign(new Error('nope'), {
+          code: grpcStatus.PERMISSION_DENIED,
+          details: 'pets.create required for this rescue',
+        })
+      );
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/pets',
+        payload: { name: 'Rex', rescueId: 'rsc-other' },
+      });
+      expect(res.statusCode).toBe(403);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('PATCH /api/pets/:id', () => {
+  it('threads the path param + body fields', async () => {
+    const { client, updateMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const updateRes: UpdatePetResponse = { pet: { ...PET_FIXTURE, name: 'Rexy' } };
+      updateMock.mockResolvedValueOnce(updateRes);
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/pets/pet-1',
+        payload: { name: 'Rexy' },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { pet: { name: string } };
+      expect(body.pet.name).toBe('Rexy');
+      const [req] = updateMock.mock.calls[0];
+      expect(req.petId).toBe('pet-1');
+      expect(req.name).toBe('Rexy');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('POST /api/pets/:id/status', () => {
+  let app: FastifyInstance;
+  let updateStatusMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    updateStatusMock = m.updateStatusMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('parses the canonical DB status string and forwards the proto enum', async () => {
+    const updateStatusRes: UpdatePetStatusResponse = {
+      pet: { ...PET_FIXTURE, status: PetsV1.PetStatus.PET_STATUS_PENDING },
+      transition: {
+        transitionId: 't-1',
+        petId: 'pet-1',
+        fromStatus: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+        toStatus: PetsV1.PetStatus.PET_STATUS_PENDING,
+        transitionedAt: '2026-06-05T10:00:00Z',
+      },
+    };
+    updateStatusMock.mockResolvedValueOnce(updateStatusRes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pets/pet-1/status',
+      payload: { toStatus: 'pending', reason: 'application opened' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [req] = updateStatusMock.mock.calls[0];
+    expect(req.petId).toBe('pet-1');
+    expect(req.toStatus).toBe(PetsV1.PetStatus.PET_STATUS_PENDING);
+    expect(req.reason).toBe('application opened');
+  });
+
+  it('accepts the SCREAMING proto form too', async () => {
+    updateStatusMock.mockResolvedValueOnce({ pet: PET_FIXTURE });
+    await app.inject({
+      method: 'POST',
+      url: '/api/pets/pet-1/status',
+      payload: { toStatus: 'PET_STATUS_ADOPTED' },
+    });
+    const [req] = updateStatusMock.mock.calls[0];
+    expect(req.toStatus).toBe(PetsV1.PetStatus.PET_STATUS_ADOPTED);
+  });
+
+  it('maps INVALID_ARGUMENT → 400 on illegal transition', async () => {
+    updateStatusMock.mockRejectedValueOnce(
+      Object.assign(new Error('illegal'), {
+        code: grpcStatus.INVALID_ARGUMENT,
+        details: 'illegal status transition available → adopted',
+      })
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/pets/pet-1/status',
+      payload: { toStatus: 'adopted' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('DELETE /api/pets/:id', () => {
+  it('soft-deletes and returns { deleted: true }', async () => {
+    const { client, deleteMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const delRes: DeletePetResponse = { deleted: true };
+      deleteMock.mockResolvedValueOnce(delRes);
+
+      const res = await app.inject({ method: 'DELETE', url: '/api/pets/pet-1' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ deleted: true });
+      const [req] = deleteMock.mock.calls[0];
+      expect(req.petId).toBe('pet-1');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('error mapping fallback', () => {
+  it('unknown gRPC code → 500', async () => {
+    const { client, getMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      getMock.mockRejectedValueOnce(new Error('connection refused'));
+      const res = await app.inject({ method: 'GET', url: '/api/pets/pet-1' });
+      expect(res.statusCode).toBe(500);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -1,0 +1,247 @@
+// REST → gRPC translation for /api/pets/*.
+//
+// Phase 3.5 cutover: this Fastify plugin registers BEFORE the
+// strangler-fig http-proxy catch-all, so Fastify's first-registered-
+// wins prefix routing picks it for /api/pets/* requests before the
+// catch-all sees them. Same shape as routes/auth.ts.
+//
+// Route map (mirrors the surface the SPA + lib.pets React contexts
+// already use):
+//
+//   GET    /api/pets             → PetService.List
+//   GET    /api/pets/:id         → PetService.Get
+//   POST   /api/pets             → PetService.Create
+//   PATCH  /api/pets/:id         → PetService.Update
+//   POST   /api/pets/:id/status  → PetService.UpdateStatus
+//   DELETE /api/pets/:id         → PetService.Delete
+//
+// The authenticate middleware (Phase 2.5) already populates the
+// x-user-* metadata headers — every PetService RPC requires a
+// principal so we never pass anonymous traffic through.
+
+import rateLimit from '@fastify/rate-limit';
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  PetsV1,
+  type CreatePetRequest,
+  type ListPetsRequest,
+  type UpdatePetRequest,
+  type UpdatePetStatusRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { PetsClient } from '../grpc-clients/pets-client.js';
+
+export type PetsRoutesOptions = {
+  client: PetsClient;
+};
+
+// Same gRPC-status → HTTP-status table the auth + notifications
+// routes use.
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.INTERNAL]: 500,
+};
+
+// Per-route rate limits. Reads are chatty (SPA browse + per-pet view
+// counts); writes are far less frequent so the tighter caps apply
+// there. All keyed on req.ip via the plugin's default key generator.
+const PETS_RATE_LIMITS = {
+  list: { max: 120, timeWindow: '1 minute' },
+  get: { max: 240, timeWindow: '1 minute' },
+  create: { max: 30, timeWindow: '1 minute' },
+  update: { max: 30, timeWindow: '1 minute' },
+  updateStatus: { max: 30, timeWindow: '1 minute' },
+  delete: { max: 30, timeWindow: '1 minute' },
+} as const;
+
+// Body shapes — kept narrow so a client typo doesn't get silently
+// forwarded as undefined to the proto encoder.
+type CreatePetBody = Partial<CreatePetRequest>;
+type UpdatePetBody = Partial<Omit<UpdatePetRequest, 'petId'>>;
+type UpdateStatusBody = {
+  toStatus?: string;
+  reason?: string;
+};
+
+export const registerPetsRoutes = async (
+  app: FastifyInstance,
+  opts: PetsRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  await app.register(rateLimit, { global: false });
+
+  app.get('/api/pets', { config: { rateLimit: PETS_RATE_LIMITS.list } }, async (req, reply) => {
+    const query = req.query as Record<string, string | undefined>;
+    const grpcReq: ListPetsRequest = {
+      cursor: query.cursor,
+      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      statusFilter: parseStatus(query.status),
+      typeFilter: parseType(query.type),
+      sizeFilter: parseSize(query.size),
+      rescueIdFilter: query.rescueId,
+    };
+    try {
+      const res = await client.list(grpcReq, buildMetadata(req));
+      return reply.send(PetsV1.ListPetsResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get<{ Params: { id: string } }>(
+    '/api/pets/:id',
+    { config: { rateLimit: PETS_RATE_LIMITS.get } },
+    async (req, reply) => {
+      try {
+        const res = await client.get({ petId: req.params.id }, buildMetadata(req));
+        return reply.send(PetsV1.GetPetResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post('/api/pets', { config: { rateLimit: PETS_RATE_LIMITS.create } }, async (req, reply) => {
+    const body = (req.body ?? {}) as CreatePetBody;
+    const grpcReq: CreatePetRequest = {
+      name: body.name ?? '',
+      rescueId: body.rescueId ?? '',
+      type: body.type ?? PetsV1.PetType.PET_TYPE_UNSPECIFIED,
+      gender: body.gender ?? PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
+      size: body.size ?? PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
+      ageGroup: body.ageGroup ?? PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED,
+      breedId: body.breedId,
+      secondaryBreedId: body.secondaryBreedId,
+      shortDescription: body.shortDescription,
+      longDescription: body.longDescription,
+      ageYears: body.ageYears,
+      ageMonths: body.ageMonths,
+      adoptionFeeMinor: body.adoptionFeeMinor,
+      adoptionFeeCurrency: body.adoptionFeeCurrency,
+      specialNeeds: body.specialNeeds ?? false,
+      houseTrained: body.houseTrained ?? false,
+      temperamentJson: body.temperamentJson ?? '[]',
+      tagsJson: body.tagsJson ?? '[]',
+      extraJson: body.extraJson ?? '{}',
+    };
+    try {
+      const res = await client.create(grpcReq, buildMetadata(req));
+      return reply.code(201).send(PetsV1.CreatePetResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.patch<{ Params: { id: string } }>(
+    '/api/pets/:id',
+    { config: { rateLimit: PETS_RATE_LIMITS.update } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as UpdatePetBody;
+      const grpcReq: UpdatePetRequest = { petId: req.params.id, ...body };
+      try {
+        const res = await client.update(grpcReq, buildMetadata(req));
+        return reply.send(PetsV1.UpdatePetResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/pets/:id/status',
+    { config: { rateLimit: PETS_RATE_LIMITS.updateStatus } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as UpdateStatusBody;
+      const grpcReq: UpdatePetStatusRequest = {
+        petId: req.params.id,
+        toStatus: parseStatus(body.toStatus),
+        reason: body.reason,
+      };
+      try {
+        const res = await client.updateStatus(grpcReq, buildMetadata(req));
+        return reply.send(PetsV1.UpdatePetStatusResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.delete<{ Params: { id: string } }>(
+    '/api/pets/:id',
+    { config: { rateLimit: PETS_RATE_LIMITS.delete } },
+    async (req, reply) => {
+      try {
+        const res = await client.delete({ petId: req.params.id }, buildMetadata(req));
+        return reply.send(PetsV1.DeletePetResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}
+
+// Enum parsers — accept the canonical DB string (`available`, `dog`,
+// `large`) AND the SCREAMING proto form (`PET_STATUS_AVAILABLE`).
+// Unknown values coerce to UNSPECIFIED so the service's own
+// INVALID_ARGUMENT guard produces a clean 400.
+
+function parseStatus(raw: string | undefined): PetsV1.PetStatus {
+  if (!raw) {
+    return PetsV1.PetStatus.PET_STATUS_UNSPECIFIED;
+  }
+  const upper = `PET_STATUS_${raw.toUpperCase()}`;
+  const candidate = Object.values(PetsV1.PetStatus).includes(upper as never) ? upper : raw;
+  const out = PetsV1.petStatusFromJSON(candidate);
+  return out === PetsV1.PetStatus.UNRECOGNIZED ? PetsV1.PetStatus.PET_STATUS_UNSPECIFIED : out;
+}
+
+function parseType(raw: string | undefined): PetsV1.PetType {
+  if (!raw) {
+    return PetsV1.PetType.PET_TYPE_UNSPECIFIED;
+  }
+  const upper = `PET_TYPE_${raw.toUpperCase()}`;
+  const candidate = Object.values(PetsV1.PetType).includes(upper as never) ? upper : raw;
+  const out = PetsV1.petTypeFromJSON(candidate);
+  return out === PetsV1.PetType.UNRECOGNIZED ? PetsV1.PetType.PET_TYPE_UNSPECIFIED : out;
+}
+
+function parseSize(raw: string | undefined): PetsV1.PetSize {
+  if (!raw) {
+    return PetsV1.PetSize.PET_SIZE_UNSPECIFIED;
+  }
+  const upper = `PET_SIZE_${raw.toUpperCase()}`;
+  const candidate = Object.values(PetsV1.PetSize).includes(upper as never) ? upper : raw;
+  const out = PetsV1.petSizeFromJSON(candidate);
+  return out === PetsV1.PetSize.UNRECOGNIZED ? PetsV1.PetSize.PET_SIZE_UNSPECIFIED : out;
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -22,9 +22,11 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import type { GatewayConfig } from './config.js';
 import type { AuthClient } from './grpc-clients/auth-client.js';
 import type { NotificationsClient } from './grpc-clients/notifications-client.js';
+import type { PetsClient } from './grpc-clients/pets-client.js';
 import { registerAuthenticate } from './middleware/authenticate.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerNotificationsRoutes } from './routes/notifications.js';
+import { registerPetsRoutes } from './routes/pets.js';
 
 export type CreateServerOptions = {
   config: GatewayConfig;
@@ -46,6 +48,9 @@ export type CreateServerOptions = {
   // continues to trust client-supplied x-user-* headers (the Phase 1.5
   // dev-mode behaviour). Real boot ALWAYS supplies it from index.ts.
   authClient?: AuthClient;
+  // gRPC client to service.pets — Phase 3.5 cuts /api/pets/* over to
+  // this address. Same optional shape as the other clients.
+  petsClient?: PetsClient;
 };
 
 export const createServer = async (opts: CreateServerOptions): Promise<FastifyInstance> => {
@@ -107,6 +112,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   if (opts.notificationsClient) {
     await registerNotificationsRoutes(server, { client: opts.notificationsClient });
+  }
+  if (opts.petsClient) {
+    await registerPetsRoutes(server, { client: opts.petsClient });
   }
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in


### PR DESCRIPTION
## Summary

Strangler-fig step for the pets vertical — the gateway now translates the six public `/api/pets/*` endpoints into `PetService` gRPC calls instead of proxying them through to the monolith. Same shape as the Phase 2.6 `/api/auth/*` cutover.

## What's in

**`services/gateway/src/grpc-clients/pets-client.ts`** — Promise-wrapped `PetsV1.PetServiceClient` with the full six-method surface. Same promise-wrapping pattern as `auth-client` / `notifications-client`.

**`services/gateway/src/routes/pets.ts`** — REST → gRPC translation:

| HTTP | gRPC |
|---|---|
| `GET    /api/pets` | `PetService.List` |
| `GET    /api/pets/:id` | `PetService.Get` |
| `POST   /api/pets` | `PetService.Create` |
| `PATCH  /api/pets/:id` | `PetService.Update` |
| `POST   /api/pets/:id/status` | `PetService.UpdateStatus` |
| `DELETE /api/pets/:id` | `PetService.Delete` |

Same `GRPC_TO_HTTP` table the other routes use. `parseStatus` / `parseType` / `parseSize` accept the canonical DB string (`'available'`, `'dog'`, `'large'`) **or** the SCREAMING proto form (`'PET_STATUS_AVAILABLE'`); unknown values coerce to `UNSPECIFIED` so the service's own `INVALID_ARGUMENT` guard produces a clean 400.

`@fastify/rate-limit` registered with `global: false` scoped to the pets-routes plugin — reads chatty (list 120/min, get 240/min), writes tight (create / update / updateStatus / delete 30/min).

**Wiring:**
- `services/gateway/src/config.ts` gains `PETS_GRPC_URL` (defaults to `service-pets:6003` — matches the Phase 3.3c default).
- `services/gateway/src/server.ts` registers the pets routes BEFORE the catch-all proxy. `petsClient` is optional on `CreateServerOptions` so smoke tests against `/health/simple` don't have to spin a gRPC client.
- `services/gateway/src/index.ts` creates + closes the `petsClient` alongside `notificationsClient` and `authClient`.

## Test plan

- [x] `npm test` in `services/gateway` — **71/71** green (13 new across `pets.test.ts` + `pets-client.test.ts`)
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.gateway'` — green
- [x] Lint clean

**Coverage:** happy path for all six endpoints, `x-user-*` metadata forwarding, list filters (status / type / size / rescueId), unknown-status coercion to `UNSPECIFIED`, status-string parsing (canonical + SCREAMING), full table of error code mappings (`INVALID_ARGUMENT` → 400, `NOT_FOUND` → 404, `PERMISSION_DENIED` → 403, unknown → 500 fallback).

## What's NOT in

- **Phase 3.6** — deletion of the monolith's now-dead `/api/pets/*` surface (bundled into Phase 11).

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_