### PR TITLE
feat(microservices): services/rescue boot skeleton (Phase 4.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4858,6 +4858,10 @@
       "resolved": "services/pets",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/service.rescue": {
+      "resolved": "services/rescue",
+      "link": true
+    },
     "node_modules/@apideck/better-ajv-errors": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
@@ -32693,6 +32697,14 @@
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"
+      }
+    },
+    "services/rescue": {
+      "name": "@adopt-dont-shop/service.rescue",
+      "version": "0.1.0",
+      "dependencies": {
+        "@adopt-dont-shop/observability": "*",
+        "fastify": "^5.8.5"
       }
     }
   }

--- a/services/rescue/README.md
+++ b/services/rescue/README.md
@@ -1,0 +1,63 @@
+# service.rescue
+
+Rescue vertical — Phase 4 of the microservices migration.
+
+Owns the `rescue.*` schema (Rescue, RescueSettings, StaffMember,
+Invitation, FosterPlacement, ApplicationQuestion) and exposes
+`RescueService` over gRPC.
+
+Classical (no event sourcing — mostly CRUD with a few status
+transitions). Subscribes to `auth.userCreated` to maintain
+staff-member denormalisation (CAD-style cross-service maintained
+read model).
+
+## What's shipped so far
+
+**Phase 4.1** — boot skeleton:
+- `src/index.ts` starts a Fastify server on `RESCUE_PORT` (default
+  5004), wires `/health/simple`.
+- `src/instrumentation.ts` boots OpenTelemetry via
+  `@adopt-dont-shop/observability` with `serviceName: 'service.rescue'`.
+- `src/config.ts` env validation. Hard-requires `DATABASE_URL` so
+  misconfiguration fails fast at boot rather than at first request.
+- `src/server.ts` `createServer({ config, logger? })`.
+
+## What's NOT here yet
+
+- **Phase 4.2** — `rescue.*` schema + migrations.
+- **Phase 4.3** — gRPC `RescueService`:
+  - proto + grpc-js stubs in `@adopt-dont-shop/proto`
+  - handler logic (CRUD + verify / invite-staff transitions)
+  - gRPC server boot + adapter (same pattern as service.pets)
+- **Phase 4.4** — NATS publishers (`rescue.created`,
+  `rescue.verified`, `rescue.staffInvited`, etc.) + subscriber for
+  `auth.userCreated` to denormalise staff_member rows.
+- **Phase 4.5** — Gateway routes `/api/rescue/*` here.
+- **Phase 4.6** — Cutover: monolith's rescue code becomes dead,
+  removal bundled into Phase 11.
+
+## Configuration
+
+| Env var            | Default            | Required | Purpose                                                                  |
+| ------------------ | ------------------ | -------- | ------------------------------------------------------------------------ |
+| `RESCUE_PORT`      | `5004`             |          | HTTP port for `/health/simple`.                                          |
+| `RESCUE_GRPC_PORT` | `6004`             |          | gRPC port `RescueService` will bind (Phase 4.3c).                        |
+| `RESCUE_HOST`      | `0.0.0.0`          |          | Bind interface (both HTTP + gRPC).                                       |
+| `RESCUE_SCHEMA`    | `rescue`           |          | Postgres schema. Override for parallel test DBs.                         |
+| `DATABASE_URL`     | —                  | ✅       | Postgres connection string. Same physical Postgres as `service.backend`. |
+| `NATS_URL`         | `nats://nats:4222` |          | NATS bus URL.                                                            |
+| `NODE_ENV`         | `development`      |          | Surfaces in health + logs.                                               |
+
+Plus the standard observability env vars consumed by
+`@adopt-dont-shop/observability`.
+
+## Running
+
+```bash
+# Dev — hot reload, OTel SDK loaded via --import
+npm run dev
+
+# Production build
+npm run build
+npm run start
+```

--- a/services/rescue/package.json
+++ b/services/rescue/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@adopt-dont-shop/service.rescue",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Rescue service — Phase 4 extraction. Owns the rescue.* schema (Rescue, RescueSettings, StaffMember, Invitation, FosterPlacement, ApplicationQuestion) and exposes gRPC RescueService over classical CRUD + a few status transitions. Subscribes to auth.userCreated to maintain staff-member denormalisation. Phase 4.1 commit is just the boot skeleton; schema/gRPC/NATS/gateway land in later phases.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
+    "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adopt-dont-shop/observability": "*",
+    "fastify": "^5.8.5"
+  }
+}

--- a/services/rescue/src/config.test.ts
+++ b/services/rescue/src/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from './config.js';
+
+const REQUIRED = {
+  DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+};
+
+describe('loadConfig', () => {
+  it('uses the documented defaults when only the required env vars are set', () => {
+    const config = loadConfig({ ...REQUIRED });
+    expect(config.port).toBe(5004);
+    expect(config.grpcPort).toBe(6004);
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.environment).toBe('development');
+    expect(config.databaseUrl).toBe(REQUIRED.DATABASE_URL);
+    expect(config.schema).toBe('rescue');
+    expect(config.natsUrl).toBe('nats://nats:4222');
+  });
+
+  it('honours all env overrides when set', () => {
+    const config = loadConfig({
+      RESCUE_PORT: '5500',
+      RESCUE_GRPC_PORT: '6500',
+      RESCUE_HOST: '127.0.0.1',
+      RESCUE_SCHEMA: 'rescue_test',
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/rescue',
+      NATS_URL: 'nats://nats.internal:4222',
+    });
+
+    expect(config.port).toBe(5500);
+    expect(config.grpcPort).toBe(6500);
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.environment).toBe('production');
+    expect(config.schema).toBe('rescue_test');
+    expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/rescue');
+    expect(config.natsUrl).toBe('nats://nats.internal:4222');
+  });
+
+  it('rejects a non-numeric RESCUE_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, RESCUE_PORT: 'five-thousand' })).toThrow(
+      /RESCUE_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-numeric RESCUE_GRPC_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, RESCUE_GRPC_PORT: 'six-thousand' })).toThrow(
+      /RESCUE_GRPC_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-positive RESCUE_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, RESCUE_PORT: '0' })).toThrow(
+      /RESCUE_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects an unset DATABASE_URL', () => {
+    expect(() => loadConfig({})).toThrow(/DATABASE_URL is required/);
+  });
+});

--- a/services/rescue/src/config.ts
+++ b/services/rescue/src/config.ts
@@ -1,0 +1,61 @@
+export type RescueConfig = {
+  // HTTP port for the boot-readiness surface (/health/simple). Distinct
+  // from service.backend's 5000, service.gateway's 4000,
+  // service.notifications' 5001, service.auth's 5002, service.pets's 5003.
+  port: number;
+  host: string;
+  // gRPC server port. RescueService.{Create, Get, List, Update,
+  // Verify, InviteStaff, ...} bind here once Phase 4.3c brings the
+  // server online. Convention: HTTP + 1000.
+  grpcPort: number;
+  // Environment label, surfaced in health responses and on log lines.
+  environment: string;
+  // Postgres connection string. Required for migrations + the runtime
+  // database client. Same physical Postgres as service.backend; this
+  // service owns the `rescue` schema (CAD-style schema-per-service).
+  databaseUrl: string;
+  // Schema name. Defaults to `rescue` — every table in this service
+  // lives here and other services don't read it directly.
+  schema: string;
+  // NATS bus. Phase 4.3 onwards publishes rescue.created,
+  // rescue.verified, rescue.staffInvited etc. for downstream services
+  // to consume. The service also SUBSCRIBES to auth.userCreated so
+  // it can denormalise newly-registered users into staff_member rows
+  // (CAD-style cross-service maintained read model).
+  natsUrl: string;
+};
+
+const DEFAULT_PORT = 5004;
+const DEFAULT_GRPC_PORT = 6004;
+const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_SCHEMA = 'rescue';
+const DEFAULT_NATS_URL = 'nats://nats:4222';
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): RescueConfig => {
+  const port = parsePort(env.RESCUE_PORT, DEFAULT_PORT, 'RESCUE_PORT');
+  const grpcPort = parsePort(env.RESCUE_GRPC_PORT, DEFAULT_GRPC_PORT, 'RESCUE_GRPC_PORT');
+
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required (Postgres connection string)');
+  }
+
+  return {
+    port,
+    grpcPort,
+    host: env.RESCUE_HOST?.trim() || DEFAULT_HOST,
+    environment: env.NODE_ENV?.trim() || 'development',
+    databaseUrl,
+    schema: env.RESCUE_SCHEMA?.trim() || DEFAULT_SCHEMA,
+    natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+  };
+};
+
+function parsePort(raw: string | undefined, fallback: number, name: string): number {
+  const trimmed = raw?.trim();
+  const value = trimmed ? Number.parseInt(trimmed, 10) : fallback;
+  if (Number.isNaN(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${trimmed}"`);
+  }
+  return value;
+}

--- a/services/rescue/src/index.ts
+++ b/services/rescue/src/index.ts
@@ -1,0 +1,42 @@
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from './config.js';
+import { createServer } from './server.js';
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.rescue' });
+
+  try {
+    const config = loadConfig();
+    const server = createServer({ config, logger });
+
+    await server.listen({ port: config.port, host: config.host });
+
+    logger.info('service.rescue listening', {
+      port: config.port,
+      host: config.host,
+      grpcPort: config.grpcPort,
+      schema: config.schema,
+      natsUrl: config.natsUrl,
+      environment: config.environment,
+    });
+
+    const shutdown = async (signal: string): Promise<void> => {
+      logger.info('service.rescue shutting down', { signal });
+      try {
+        await server.close();
+      } catch (err) {
+        logger.error('error during shutdown', { err });
+      }
+      process.exit(0);
+    };
+
+    process.once('SIGTERM', () => void shutdown('SIGTERM'));
+    process.once('SIGINT', () => void shutdown('SIGINT'));
+  } catch (err) {
+    logger.error('service.rescue failed to start', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/rescue/src/instrumentation.ts
+++ b/services/rescue/src/instrumentation.ts
@@ -1,0 +1,16 @@
+// OpenTelemetry SDK bootstrap for service.rescue.
+//
+// Same --import-flag pattern as service.pets / service.auth /
+// service.notifications / service.gateway: tsx / node loads this
+// BEFORE the rest of the service so the auto-instrumentations can
+// hook http, fastify, pg, undici BEFORE those modules are first
+// imported.
+//
+// Behaviour matches the rest of the stack (see @adopt-dont-shop/observability):
+//   - Silent no-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+//   - OTEL_SERVICE_NAME env var overrides the value below.
+//   - No-throw contract.
+
+import { initializeOpenTelemetry } from '@adopt-dont-shop/observability';
+
+initializeOpenTelemetry({ serviceName: 'service.rescue' });

--- a/services/rescue/src/server.test.ts
+++ b/services/rescue/src/server.test.ts
@@ -1,0 +1,67 @@
+import { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { RescueConfig } from './config.js';
+import { createServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const baseConfig: RescueConfig = {
+  port: 0,
+  grpcPort: 0,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'rescue',
+  natsUrl: 'nats://localhost:4222',
+};
+
+describe('createServer — health endpoint', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = createServer({ config: baseConfig, logger: quietLogger });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('responds to GET /health/simple with status ok', async () => {
+    const res = await server.inject({ method: 'GET', url: '/health/simple' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      status: 'ok',
+      service: 'service.rescue',
+      environment: 'test',
+    });
+  });
+
+  it('surfaces the configured environment in the health payload', async () => {
+    const stagingServer = createServer({
+      config: { ...baseConfig, environment: 'staging' },
+      logger: quietLogger,
+    });
+    try {
+      const res = await stagingServer.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.json()).toMatchObject({ environment: 'staging' });
+    } finally {
+      await stagingServer.close();
+    }
+  });
+
+  it('returns a 500 when a route handler throws (custom error handler)', async () => {
+    server.get('/boom', async () => {
+      throw new Error('boom');
+    });
+    const res = await server.inject({ method: 'GET', url: '/boom' });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ error: 'internal_error' });
+  });
+});

--- a/services/rescue/src/server.ts
+++ b/services/rescue/src/server.ts
@@ -1,0 +1,57 @@
+// services/rescue — Phase 4 extraction. Owns the rescue.* schema and
+// exposes RescueService over gRPC. Phase 4.1 (this commit) is just the
+// boot skeleton; everything else arrives in subsequent commits.
+//
+// Mirror of services/pets/src/server.ts structure: Fastify for
+// /health/simple, gRPC server attached in Phase 4.3c, NATS publishers
+// in Phase 4.4, gateway routing in Phase 4.5, cutover in Phase 4.6.
+
+import { createLogger } from '@adopt-dont-shop/observability';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+import type { RescueConfig } from './config.js';
+
+export type CreateServerOptions = {
+  config: RescueConfig;
+  // Optional logger injection — tests pass a quiet logger so the
+  // suite output stays readable. Real boot uses createLogger so the
+  // service emits structured lines through the same pipeline as the
+  // rest of the stack.
+  logger?: ReturnType<typeof createLogger>;
+};
+
+export const createServer = (opts: CreateServerOptions): FastifyInstance => {
+  const { config } = opts;
+  const logger = opts.logger ?? createLogger({ serviceName: 'service.rescue' });
+
+  // Disable Fastify's built-in pino — winston handles service-level
+  // lines (boot, shutdown, error handler), and OTel's HTTP
+  // auto-instrumentation already covers per-request spans. Same
+  // shape as the other extracted services.
+  const server = Fastify({
+    logger: false,
+    trustProxy: true,
+  });
+
+  server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
+    logger.error('request failed', {
+      method: req.method,
+      url: req.url,
+      message: err.message,
+    });
+    void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
+  });
+
+  // Health endpoint — matches the rest of the stack's
+  // `/health/simple` path so the existing Docker compose healthcheck
+  // pattern picks this service up unchanged.
+  server.get('/health/simple', async () => ({
+    status: 'ok',
+    service: 'service.rescue',
+    environment: config.environment,
+  }));
+
+  return server;
+};
+
+export type { RescueConfig };

--- a/services/rescue/tsconfig.json
+++ b/services/rescue/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/services/rescue/vitest.config.ts
+++ b/services/rescue/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 4 of the microservices migration — classical vertical (no event sourcing, mostly CRUD with a few status transitions). Subscribes to `auth.userCreated` to maintain a denormalised `staff_member` projection (CAD-style cross-service maintained read model). This commit is just the boot skeleton; the schema, gRPC, NATS, and gateway routing arrive in 4.2-4.6.

## What's in

- **`services/rescue/package.json`** — same scripts + scoped deps shape as `services/pets` / `services/auth`. `RESCUE_PORT` defaults to 5004, `RESCUE_GRPC_PORT` to 6004 (HTTP+1000 convention).
- **`src/config.ts`** — env loader. `DATABASE_URL` is the only hard requirement; misconfiguration fails fast at boot rather than at first request.
- **`src/server.ts`** — `createServer` with `/health/simple`. Mirror of `service.pets`'s `createServer` to the line.
- **`src/instrumentation.ts`** — boots OpenTelemetry via `@adopt-dont-shop/observability` with `serviceName: 'service.rescue'`.
- **`src/index.ts`** — wires HTTP listen + SIGTERM/SIGINT shutdown.
- **`README.md`** documents the Phase 4.1 surface and what's coming in 4.2-4.6.

## Test plan

- [x] `npm test` in `services/rescue` — **9/9** green
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.rescue'` — green
- [x] Lint clean

## What's NOT in

- **Phase 4.2** — `rescue.*` schema + migrations (Rescue, RescueSettings, StaffMember, Invitation, FosterPlacement, ApplicationQuestion).
- **Phase 4.3** — proto + handlers + adapter (classical CRUD + verify / invite-staff transitions).
- **Phase 4.4** — NATS publishers (`rescue.created`, `rescue.verified`, `rescue.staffInvited`) + subscriber for `auth.userCreated` to denormalise staff_member rows.
- **Phase 4.5** — Gateway routes `/api/rescue/*` here.
- **Phase 4.6** — Cutover.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_