### PR TITLE
feat(microservices): rescue.* schema + migrations (Phase 4.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32703,8 +32703,11 @@
       "name": "@adopt-dont-shop/service.rescue",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/observability": "*",
-        "fastify": "^5.8.5"
+        "fastify": "^5.8.5",
+        "node-pg-migrate": "^8.0.4",
+        "pg": "^8.21.0"
       }
     }
   }

--- a/services/rescue/README.md
+++ b/services/rescue/README.md
@@ -22,9 +22,36 @@ read model).
   misconfiguration fails fast at boot rather than at first request.
 - `src/server.ts` `createServer({ config, logger? })`.
 
+**Phase 4.2** — `rescue.*` schema + migrations:
+- `001_create_rescues.ts` — the headline organisation row (name,
+  contact, address, status / verification machinery, settings JSON).
+  Creates the `citext` extension in `public` for the case-insensitive
+  email column.
+- `002_create_rescue_settings.ts` — 1:1 typed-preference table keyed
+  on `rescue_id` (CASCADE FK to rescues).
+- `003_create_staff_members.ts` — user↔rescue join with verification +
+  onboarding trail. Phase 4.4 subscribes to `auth.userCreated` to
+  denormalise into here when invitees register.
+- `004_create_invitations.ts` — pending-staff invitation row
+  (signed token + expiry). Not paranoid — the monolith hard-deletes
+  on accept; we preserve that contract.
+- `005_create_foster_placements.ts` — active/completed/cancelled
+  foster runs per pet per rescue. Partial-unique on
+  `(pet_id, status='active', deleted_at IS NULL)` enforces "one active
+  placement at a time".
+- `006_create_application_questions.ts` — rescue-configurable
+  adoption questionnaire rows; 3 enums (scope / category /
+  question_type), two partial-unique indexes (per-rescue + global
+  core).
+- All `rescue_id` FKs are INTRA-schema (CASCADE). User pointers and
+  cross-vertical entity IDs (`pet_id`, `foster_user_id`, audit
+  `created_by`/`updated_by`) stay FK-free per the schema-per-service
+  rule.
+- `src/db/migrate.ts` runs them via `@adopt-dont-shop/db.runMigrations`.
+  Run with `npm run db:migrate`.
+
 ## What's NOT here yet
 
-- **Phase 4.2** — `rescue.*` schema + migrations.
 - **Phase 4.3** — gRPC `RescueService`:
   - proto + grpc-js stubs in `@adopt-dont-shop/proto`
   - handler logic (CRUD + verify / invite-staff transitions)

--- a/services/rescue/package.json
+++ b/services/rescue/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "db:migrate": "tsx ./src/db/migrate.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
@@ -32,7 +33,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/observability": "*",
-    "fastify": "^5.8.5"
+    "fastify": "^5.8.5",
+    "node-pg-migrate": "^8.0.4",
+    "pg": "^8.21.0"
   }
 }

--- a/services/rescue/src/db/migrate.ts
+++ b/services/rescue/src/db/migrate.ts
@@ -1,0 +1,39 @@
+// Migration entry point — runs the rescue.* schema migrations via
+// @adopt-dont-shop/db (which wraps node-pg-migrate with the four
+// CAD-lesson fixes: createSchema, ignorePattern, search_path,
+// advisory-lock retry).
+//
+// Invoked by `npm run db:migrate`. Production deploys run a compiled
+// version against dist/migrations/.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runMigrations } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.rescue.migrate' });
+  try {
+    const config = loadConfig();
+    logger.info('running migrations', {
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    await runMigrations({
+      databaseUrl: config.databaseUrl,
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    logger.info('migrations complete');
+  } catch (err) {
+    logger.error('migrations failed', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/rescue/src/migrations/001_create_rescues.ts
+++ b/services/rescue/src/migrations/001_create_rescues.ts
@@ -1,0 +1,65 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — rescues.
+//
+// Direct port of service.backend's 00-baseline-012-rescues.ts INTO the
+// `rescue` schema. The headline row for the vertical: organisation
+// identity, address, verification state, settings JSON blob.
+//
+// citext lives in `public` (extension created here, idempotent). FK
+// pointers verified_by / created_by / updated_by → auth.users are
+// CROSS-schema, left FK-free (audit-pointer convention).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql('CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;');
+
+  pgm.createType('rescue_status', ['pending', 'verified', 'suspended', 'inactive', 'rejected']);
+  pgm.createType('rescue_verification_source', ['companies_house', 'charity_commission', 'manual']);
+
+  pgm.createTable('rescues', {
+    rescue_id: { type: 'uuid', primaryKey: true },
+    name: { type: 'varchar(255)', notNull: true, unique: true },
+    email: { type: 'public.citext', notNull: true, unique: true },
+    phone: { type: 'varchar(255)' },
+    address: { type: 'text', notNull: true },
+    city: { type: 'varchar(255)', notNull: true },
+    // Model attribute `county` maps to legacy column `state`.
+    state: { type: 'varchar(255)' },
+    // Model attribute `postcode` maps to legacy column `zip_code`.
+    zip_code: { type: 'varchar(255)', notNull: true },
+    country: { type: 'char(2)', notNull: true, default: 'GB' },
+    website: { type: 'varchar(255)' },
+    description: { type: 'text' },
+    mission: { type: 'text' },
+    companies_house_number: { type: 'varchar(8)', unique: true },
+    charity_registration_number: { type: 'varchar(12)', unique: true },
+    contact_person: { type: 'varchar(255)', notNull: true },
+    contact_title: { type: 'varchar(255)' },
+    contact_email: { type: 'varchar(255)' },
+    contact_phone: { type: 'varchar(255)' },
+    status: { type: 'rescue_status', notNull: true, default: 'pending' },
+    verified_at: { type: 'timestamptz' },
+    verified_by: { type: 'uuid' },
+    verification_source: { type: 'rescue_verification_source' },
+    verification_failure_reason: { type: 'text' },
+    manual_verification_requested_at: { type: 'timestamptz' },
+    settings: { type: 'jsonb', default: pgm.func("'{}'::jsonb") },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('rescues', 'verified_by', { name: 'rescues_verified_by_idx' });
+  pgm.createIndex('rescues', 'deleted_at', { name: 'rescues_deleted_at_idx' });
+  pgm.createIndex('rescues', 'created_by', { name: 'rescues_created_by_idx' });
+  pgm.createIndex('rescues', 'updated_by', { name: 'rescues_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('rescues');
+  pgm.dropType('rescue_status');
+  pgm.dropType('rescue_verification_source');
+};

--- a/services/rescue/src/migrations/002_create_rescue_settings.ts
+++ b/services/rescue/src/migrations/002_create_rescue_settings.ts
@@ -1,0 +1,37 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — rescue_settings.
+//
+// Direct port of service.backend's 00-baseline-013-rescue-settings.ts.
+// 1:1 typed preference table for `rescues`. rescue_id is BOTH the PK
+// and the INTRA-schema FK → rescues.rescue_id (ON DELETE CASCADE —
+// settings die with their parent).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('rescue_settings', {
+    rescue_id: {
+      type: 'uuid',
+      primaryKey: true,
+      references: 'rescues(rescue_id)',
+      onDelete: 'CASCADE',
+    },
+    auto_approve_applications: { type: 'boolean', notNull: true, default: false },
+    require_home_visit: { type: 'boolean', notNull: true, default: true },
+    require_references: { type: 'boolean', notNull: true, default: true },
+    min_adopter_age: { type: 'integer', notNull: true, default: 18 },
+    allow_out_of_area_adoptions: { type: 'boolean', notNull: true, default: false },
+    application_expiry_days: { type: 'integer', notNull: true, default: 30 },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('rescue_settings', 'created_by', { name: 'rescue_settings_created_by_idx' });
+  pgm.createIndex('rescue_settings', 'updated_by', { name: 'rescue_settings_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('rescue_settings');
+};

--- a/services/rescue/src/migrations/003_create_staff_members.ts
+++ b/services/rescue/src/migrations/003_create_staff_members.ts
@@ -1,0 +1,51 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — staff_members.
+//
+// Direct port of service.backend's 00-baseline-010-staff-members.ts INTO
+// the `rescue` schema. The join row that links a user (auth.users) to a
+// rescue with a verification + onboarding trail.
+//
+// rescue_id is the INTRA-schema FK → rescues (ON DELETE CASCADE — when a
+// rescue is removed its staff rows go with it). user_id / verified_by /
+// added_by / created_by / updated_by are CROSS-schema pointers into
+// auth.users and stay FK-free (the no-cross-schema-joins rule). The
+// Phase 4.4 subscriber on `auth.userCreated` keeps this row denormalised
+// when a user signs up via an invitation.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('staff_members', {
+    staff_member_id: { type: 'uuid', primaryKey: true },
+    rescue_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'rescues(rescue_id)',
+      onDelete: 'CASCADE',
+    },
+    user_id: { type: 'uuid', notNull: true },
+    title: { type: 'varchar(255)' },
+    is_verified: { type: 'boolean', notNull: true, default: false },
+    verified_by: { type: 'uuid' },
+    verified_at: { type: 'timestamptz' },
+    added_by: { type: 'uuid', notNull: true },
+    added_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('staff_members', 'rescue_id', { name: 'staff_members_rescue_id_idx' });
+  pgm.createIndex('staff_members', 'user_id', { name: 'staff_members_user_id_idx' });
+  pgm.createIndex('staff_members', 'verified_by', { name: 'staff_members_verified_by_idx' });
+  pgm.createIndex('staff_members', 'added_by', { name: 'staff_members_added_by_idx' });
+  pgm.createIndex('staff_members', 'deleted_at', { name: 'staff_members_deleted_at_idx' });
+  pgm.createIndex('staff_members', 'created_by', { name: 'staff_members_created_by_idx' });
+  pgm.createIndex('staff_members', 'updated_by', { name: 'staff_members_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('staff_members');
+};

--- a/services/rescue/src/migrations/004_create_invitations.ts
+++ b/services/rescue/src/migrations/004_create_invitations.ts
@@ -1,0 +1,53 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — invitations.
+//
+// Direct port of service.backend's 00-baseline-011-invitations.ts INTO
+// the `rescue` schema. The pending-staff-invitation row — captures the
+// email + signed token until the invitee accepts and a real
+// `staff_members` row gets minted. NOT paranoid (no deleted_at) — the
+// monolith hard-deletes on accept; we preserve that contract.
+//
+// rescue_id is INTRA-schema FK → rescues (ON DELETE CASCADE). user_id /
+// invited_by / created_by / updated_by → auth.users are cross-schema,
+// FK-free.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('invitations', {
+    invitation_id: { type: 'uuid', primaryKey: true },
+    email: { type: 'varchar(255)', notNull: true },
+    token: { type: 'varchar(255)', notNull: true, unique: true },
+    rescue_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'rescues(rescue_id)',
+      onDelete: 'CASCADE',
+    },
+    user_id: { type: 'uuid' },
+    title: { type: 'varchar(100)' },
+    invited_by: { type: 'uuid' },
+    expiration: { type: 'timestamptz', notNull: true },
+    used: { type: 'boolean', default: false },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  // token already has the column-level unique constraint above; the
+  // explicit invitations_token_unique index mirrors the monolith's
+  // legacy migration that re-added the same thing (the monolith
+  // tracks it as a known duplicate; we keep just the index to keep
+  // the schema clean without losing the index name).
+  pgm.createIndex('invitations', 'rescue_id', { name: 'invitations_rescue_id_idx' });
+  pgm.createIndex('invitations', 'user_id', { name: 'invitations_user_id_idx' });
+  pgm.createIndex('invitations', 'email', { name: 'invitations_email_idx' });
+  pgm.createIndex('invitations', 'invited_by', { name: 'invitations_invited_by_idx' });
+  pgm.createIndex('invitations', 'created_by', { name: 'invitations_created_by_idx' });
+  pgm.createIndex('invitations', 'updated_by', { name: 'invitations_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('invitations');
+};

--- a/services/rescue/src/migrations/005_create_foster_placements.ts
+++ b/services/rescue/src/migrations/005_create_foster_placements.ts
@@ -1,0 +1,56 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — foster_placements.
+//
+// Direct port of service.backend's 03-create-foster-placements.ts INTO
+// the `rescue` schema. Tracks active/completed/cancelled foster runs
+// per pet per rescue. Partial-unique constraint enforces "one ACTIVE
+// placement per pet", soft-deletes excluded so historical rows don't
+// block a re-foster after cancel/complete.
+//
+// rescue_id is INTRA-schema FK → rescues (ON DELETE CASCADE).
+// foster_user_id → auth.users and pet_id → pets.pets are CROSS-schema
+// pointers, FK-free in this extracted shape — the application-side
+// invariants stay enforced via the gRPC handlers + the consuming
+// services' own FK shapes.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('foster_placement_status', ['active', 'completed', 'cancelled']);
+
+  pgm.createTable('foster_placements', {
+    placement_id: { type: 'uuid', primaryKey: true },
+    pet_id: { type: 'uuid', notNull: true },
+    foster_user_id: { type: 'uuid', notNull: true },
+    rescue_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'rescues(rescue_id)',
+      onDelete: 'CASCADE',
+    },
+    start_date: { type: 'timestamptz', notNull: true },
+    end_date: { type: 'timestamptz' },
+    status: { type: 'foster_placement_status', notNull: true, default: 'active' },
+    notes: { type: 'text' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('foster_placements', 'pet_id', { name: 'foster_placements_pet_id_idx' });
+  pgm.createIndex('foster_placements', 'foster_user_id', {
+    name: 'foster_placements_foster_user_id_idx',
+  });
+  pgm.createIndex('foster_placements', 'rescue_id', { name: 'foster_placements_rescue_id_idx' });
+  pgm.createIndex('foster_placements', 'status', { name: 'foster_placements_status_idx' });
+  // Partial unique — at most ONE active placement per pet at a time.
+  pgm.createIndex('foster_placements', 'pet_id', {
+    name: 'foster_placements_one_active_per_pet',
+    unique: true,
+    where: "status = 'active' AND deleted_at IS NULL",
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('foster_placements');
+  pgm.dropType('foster_placement_status');
+};

--- a/services/rescue/src/migrations/006_create_application_questions.ts
+++ b/services/rescue/src/migrations/006_create_application_questions.ts
@@ -1,0 +1,108 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — application_questions.
+//
+// Direct port of service.backend's 00-baseline-022-application-questions.ts
+// INTO the `rescue` schema. Rescue-configurable adoption questionnaire
+// rows — core questions (scope='core', rescue_id=NULL) form the shared
+// baseline; rescue_specific rows override or extend per rescue.
+//
+// Three ENUMs (scope, category, question_type). The DB-level partial
+// unique indexes enforce: (question_key, rescue_id) is unique among
+// non-deleted rows AND core questions have a globally unique
+// question_key (rescue_id IS NULL there).
+//
+// rescue_id is INTRA-schema FK → rescues (ON DELETE CASCADE — a deleted
+// rescue takes its custom questions with it; the core rows stay).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('application_question_scope', ['core', 'rescue_specific']);
+  pgm.createType('application_question_category', [
+    'personal_information',
+    'household_information',
+    'pet_ownership_experience',
+    'lifestyle_compatibility',
+    'pet_care_commitment',
+    'references_verification',
+    'final_acknowledgments',
+  ]);
+  pgm.createType('application_question_type', [
+    'text',
+    'email',
+    'phone',
+    'number',
+    'boolean',
+    'select',
+    'multi_select',
+    'address',
+    'date',
+    'file',
+  ]);
+
+  pgm.createTable('application_questions', {
+    question_id: { type: 'uuid', primaryKey: true },
+    rescue_id: {
+      type: 'uuid',
+      references: 'rescues(rescue_id)',
+      onDelete: 'CASCADE',
+    },
+    question_key: { type: 'varchar(100)', notNull: true },
+    scope: { type: 'application_question_scope', notNull: true },
+    category: { type: 'application_question_category', notNull: true },
+    question_type: { type: 'application_question_type', notNull: true },
+    question_text: { type: 'text', notNull: true },
+    help_text: { type: 'text' },
+    placeholder: { type: 'varchar(255)' },
+    options: { type: 'text[]' },
+    validation_rules: { type: 'jsonb' },
+    display_order: { type: 'integer', notNull: true, default: 0 },
+    is_enabled: { type: 'boolean', notNull: true, default: true },
+    is_required: { type: 'boolean', notNull: true, default: false },
+    conditional_logic: { type: 'jsonb' },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.createIndex('application_questions', 'rescue_id', {
+    name: 'application_questions_rescue_id_idx',
+  });
+  pgm.createIndex('application_questions', 'scope', {
+    name: 'application_questions_scope_idx',
+  });
+  pgm.createIndex('application_questions', 'category', {
+    name: 'application_questions_category_idx',
+  });
+  pgm.createIndex('application_questions', 'question_type', {
+    name: 'application_questions_type_idx',
+  });
+  pgm.createIndex('application_questions', 'is_enabled', {
+    name: 'application_questions_enabled_idx',
+  });
+  pgm.createIndex('application_questions', 'display_order', {
+    name: 'application_questions_order_idx',
+  });
+  // Per-rescue uniqueness on the question_key (excluding soft-deleted
+  // rows). Core rows (rescue_id IS NULL) get the looser uniqueness via
+  // the second partial-unique below.
+  pgm.createIndex('application_questions', ['question_key', 'rescue_id'], {
+    name: 'application_questions_key_rescue_unique',
+    unique: true,
+    where: 'deleted_at IS NULL',
+  });
+  pgm.createIndex('application_questions', 'question_key', {
+    name: 'application_questions_core_key_unique',
+    unique: true,
+    where: "scope = 'core' AND deleted_at IS NULL",
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('application_questions');
+  pgm.dropType('application_question_scope');
+  pgm.dropType('application_question_category');
+  pgm.dropType('application_question_type');
+};

--- a/services/rescue/src/migrations/migrations.test.ts
+++ b/services/rescue/src/migrations/migrations.test.ts
@@ -1,0 +1,56 @@
+import { readdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Smoke tests for the migration files in this directory. We don't run
+// them against a real Postgres here — @adopt-dont-shop/db is already
+// tested for the runner contract, and the migrations get exercised
+// end-to-end by the docker-compose stack smoke.
+//
+// This file guards the things that break silently:
+//   - every migration exports `up` and `down` functions
+//   - the file naming convention stays consistent (lexicographic =
+//     execution order; node-pg-migrate sorts the dir scan by filename)
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_FILENAME_PATTERN = /^\d{3}_[a-z0-9_]+\.ts$/;
+
+async function listMigrationFiles(): Promise<string[]> {
+  const entries = await readdir(MIGRATIONS_DIR);
+  return entries.filter(f => MIGRATION_FILENAME_PATTERN.test(f)).sort((a, b) => a.localeCompare(b));
+}
+
+describe('rescue migrations', () => {
+  it('has migration files following the NNN_snake_case.ts naming convention', async () => {
+    const files = await listMigrationFiles();
+    expect(files.length).toBeGreaterThanOrEqual(6);
+    for (const f of files) {
+      expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
+    }
+  });
+
+  it('numbers migrations sequentially without gaps', async () => {
+    const files = await listMigrationFiles();
+    const numbers = files.map(f => Number.parseInt(f.slice(0, 3), 10));
+    for (let i = 0; i < numbers.length; i++) {
+      expect(numbers[i]).toBe(i + 1);
+    }
+  });
+
+  it.each([
+    '001_create_rescues.ts',
+    '002_create_rescue_settings.ts',
+    '003_create_staff_members.ts',
+    '004_create_invitations.ts',
+    '005_create_foster_placements.ts',
+    '006_create_application_questions.ts',
+  ])('%s exports `up` and `down` functions', async filename => {
+    const mod = (await import(`./${filename}`)) as {
+      up: unknown;
+      down: unknown;
+    };
+    expect(typeof mod.up).toBe('function');
+    expect(typeof mod.down).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Ports the six rescue-domain tables from the monolith's per-model rebaseline migrations into the `rescue` schema. Same `node-pg-migrate` shape as Phase 3.2 / 2.2.

## Tables (in dependency order)

| # | Table | Notes |
|---|---|---|
| 001 | `rescues` | The headline organisation row. Two enums (`rescue_status`: pending/verified/suspended/inactive/rejected; `rescue_verification_source`: companies_house/charity_commission/manual). Creates `citext` in `public` for the case-insensitive email column. Unique on name, email, and the two registration numbers. |
| 002 | `rescue_settings` | 1:1 typed-preference table; `rescue_id` is both the PK and the CASCADE FK to rescues. |
| 003 | `staff_members` | user↔rescue join with verification + onboarding trail. Phase 4.4 will subscribe to `auth.userCreated` to denormalise into here when invitees register. |
| 004 | `invitations` | Pending-staff invitation row (token + expiry). **Not paranoid** — the monolith hard-deletes on accept; same contract preserved. |
| 005 | `foster_placements` | active/completed/cancelled foster runs. Partial-unique on `(pet_id, status='active', deleted_at IS NULL)` enforces "one active placement at a time". |
| 006 | `application_questions` | Rescue-configurable adoption questionnaire rows; 3 enums (scope / category / question_type), two partial-unique indexes (per-rescue + global core). |

## FK decisions (schema-per-service rule)

- **INTRA-schema FKs stay enforced** (all CASCADE): `rescue_settings`, `staff_members`, `invitations`, `foster_placements`, `application_questions` → `rescues`.
- **CROSS-schema pointers stay FK-free** (application-side): `user_id` / `verified_by` / `added_by` / `invited_by` / `created_by` / `updated_by` → `auth.users`; `pet_id` / `foster_user_id` → pets schema.

## Test plan

- [x] `npm test` in `services/rescue` — **17/17** green (migrations smoke: naming convention, sequential numbering, up/down exports)
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.rescue'` — green
- [x] Lint clean

Adds `@adopt-dont-shop/db` + `node-pg-migrate` + `pg` deps, the `db:migrate` script, and `src/db/migrate.ts` entrypoint.

## What's NOT in

- **Phase 4.3** — proto + handlers + adapter (`RescueService.{Create, Get, List, Update, Verify, InviteStaff, ...}`).
- **Phase 4.4** — NATS publishers (`rescue.created`, `rescue.verified`, `rescue.staffInvited`) + subscriber for `auth.userCreated` to denormalise staff_member rows.
- **Phase 4.5** — Gateway routes `/api/rescue/*` here.
- **Phase 4.6** — Cutover.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_