### PR TITLE
feat(microservices): downstream rescue.* event subscribers (Phase 4.4)

### DIFF
--- a/services/notifications/src/nats/event-types.ts
+++ b/services/notifications/src/nats/event-types.ts
@@ -95,3 +95,41 @@ export type PetDeletedEvent = {
   petId: string;
   rescueId: string | null;
 };
+
+// rescue.verified — service.rescue publishes after an admin verifies
+// a rescue (Phase 4.3b). Payload carries the from/to status pair so
+// downstream subscribers can pick out the verified-from-pending case
+// vs the reinstate-from-suspended case.
+//
+// Phase 4.4: log-only on the consumer side. Surfacing a user-facing
+// notification needs recipient discovery (the rescue's contact_person /
+// created_by) — same recipient-discovery deferral as pets.statusChanged.
+export type RescueVerifiedEvent = {
+  rescueId: string;
+  fromStatus: string;
+  toStatus: string;
+  reason: string | null;
+};
+
+// rescue.rejected — service.rescue publishes when an admin rejects a
+// pending application. Payload mirrors RescueVerifiedEvent (same
+// emit shape on the rescue side).
+export type RescueRejectedEvent = {
+  rescueId: string;
+  fromStatus: string;
+  toStatus: string;
+  reason: string | null;
+};
+
+// rescue.staffInvited — service.rescue publishes when InviteStaff
+// mints + persists an invitation row (Phase 4.3b). Includes the
+// invitee email so an email worker can dispatch the invite token.
+// The plain-text token itself is NOT in the payload (it's returned
+// in the InviteStaffResponse and never persisted in NATS).
+export type RescueStaffInvitedEvent = {
+  invitationId: string;
+  rescueId: string;
+  email: string;
+  invitedBy: string;
+  expiration: string;
+};

--- a/services/notifications/src/nats/subscribers.test.ts
+++ b/services/notifications/src/nats/subscribers.test.ts
@@ -192,7 +192,7 @@ describe('registerSubscribers', () => {
 
     const subs = registerSubscribers({ nats, deps, logger });
 
-    expect(subs).toHaveLength(7);
+    expect(subs).toHaveLength(10);
     // Subscribed subjects (raw nats.subscribe receives the subject as
     // first arg, then an options object containing `queue`).
     const subjects = subscribeFn.mock.calls.map(call => call[0]);
@@ -204,6 +204,9 @@ describe('registerSubscribers', () => {
       'auth.roleAssigned',
       'pets.statusChanged',
       'pets.deleted',
+      'rescue.verified',
+      'rescue.rejected',
+      'rescue.staffInvited',
     ]);
   });
 

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -41,6 +41,9 @@ import type {
   AuthUserLoggedInEvent,
   PetDeletedEvent,
   PetStatusChangedEvent,
+  RescueRejectedEvent,
+  RescueStaffInvitedEvent,
+  RescueVerifiedEvent,
 } from './event-types.js';
 import { SYSTEM_PRINCIPAL } from './system-principal.js';
 
@@ -148,6 +151,51 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
         logger.info('pets.deleted received', {
           petId: payload.petId,
           rescueId: payload.rescueId,
+        });
+      }
+    )
+  );
+
+  // rescue.verified / rescue.rejected / rescue.staffInvited (Phase 4.4):
+  // log-only on the consumer side, same pattern as the pets.* events.
+  // Recipient-discovery (rescue.contact_person, invitee email worker)
+  // lands when those upstream lookups exist.
+  subscriptions.push(
+    subscribe<RescueVerifiedEvent>(
+      nats,
+      { subject: 'rescue.verified', queue: QUEUE_GROUP, onError },
+      async payload => {
+        logger.info('rescue.verified received', {
+          rescueId: payload.rescueId,
+          fromStatus: payload.fromStatus,
+          toStatus: payload.toStatus,
+        });
+      }
+    )
+  );
+
+  subscriptions.push(
+    subscribe<RescueRejectedEvent>(
+      nats,
+      { subject: 'rescue.rejected', queue: QUEUE_GROUP, onError },
+      async payload => {
+        logger.info('rescue.rejected received', {
+          rescueId: payload.rescueId,
+          reason: payload.reason,
+        });
+      }
+    )
+  );
+
+  subscriptions.push(
+    subscribe<RescueStaffInvitedEvent>(
+      nats,
+      { subject: 'rescue.staffInvited', queue: QUEUE_GROUP, onError },
+      async payload => {
+        logger.info('rescue.staffInvited received', {
+          invitationId: payload.invitationId,
+          rescueId: payload.rescueId,
+          email: payload.email,
         });
       }
     )

--- a/services/rescue/README.md
+++ b/services/rescue/README.md
@@ -103,11 +103,23 @@ read model).
   runs it alongside the HTTP `/health` surface; deps connect FIRST,
   then start serving.
 
+**Phase 4.4** — downstream NATS event flow:
+- The Phase 4.3b handlers already publish `rescue.created`,
+  `rescue.updated`, `rescue.verified`, `rescue.rejected`, and
+  `rescue.staffInvited` via `withTransaction` (publish-after-commit).
+- `services/notifications` subscribes to the three terminal subjects
+  (`rescue.verified`, `rescue.rejected`, `rescue.staffInvited`),
+  joining the existing `notifications-workers` queue group. Log-only
+  for now — surfacing user-facing rows needs recipient discovery
+  (the rescue's `contact_person` for status changes, the invitee's
+  email worker for invitations) that lands with later phases.
+- The `auth.userCreated → staff_member` denormalisation flagged in
+  the Phase 4 plan stays unwired here until `service.auth` ships a
+  Register endpoint that emits the subject. The subscriber slot is
+  reserved for that PR.
+
 ## What's NOT here yet
 
-- **Phase 4.4** — NATS publishers (`rescue.created`,
-  `rescue.verified`, `rescue.staffInvited`, etc.) + subscriber for
-  `auth.userCreated` to denormalise staff_member rows.
 - **Phase 4.5** — Gateway routes `/api/rescue/*` here.
 - **Phase 4.6** — Cutover: monolith's rescue code becomes dead,
   removal bundled into Phase 11.


### PR DESCRIPTION
## Summary

Wires the consumer side of the rescue event flow. The Phase 4.3b handlers already publish `rescue.created` / `rescue.updated` / `rescue.verified` / `rescue.rejected` / `rescue.staffInvited` via `withTransaction` (publish-after-commit). This commit subscribes `service.notifications` to the three terminal subjects.

## What's in

**`services/notifications/src/nats/event-types.ts`** gains three consumer-side event shapes:

| Type | Payload |
|---|---|
| `RescueVerifiedEvent` | `{ rescueId, fromStatus, toStatus, reason }` |
| `RescueRejectedEvent` | `{ rescueId, fromStatus, toStatus, reason }` |
| `RescueStaffInvitedEvent` | `{ invitationId, rescueId, email, invitedBy, expiration }` (no token — that's returned in the gRPC response and never persisted in NATS) |

**`services/notifications/src/nats/subscribers.ts`** adds three log-only subscriptions joining the existing `notifications-workers` queue group. Same Phase 3.4 pattern: subjects are wired so the wire path is exercised end-to-end, but user-facing notification rows wait on recipient discovery (the rescue's `contact_person` for status changes; an invitee email worker for invitations) that lands with later phases. The contract sits on the consumer side so future translator changes only fill in the message body, not the registration.

`registerSubscribers` now reports **10 subjects** (3 `applications.*` + 2 `auth.*` + 2 `pets.*` + 3 `rescue.*`) all on the `notifications-workers` queue group.

## Test plan

- [x] `npm test` in `services/notifications` — **70/70** green
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.notifications'` — green
- [x] Lint clean

## What's NOT in

- The `auth.userCreated → staff_member` denormalisation in `service.rescue` flagged in the Phase 4 plan. `service.auth` doesn't ship a Register endpoint yet (Phase 2.3b is Login + the 6 standard RPCs only); the subscriber slot is reserved for the PR that adds it.
- **Phase 4.5** — Gateway routes `/api/rescue/*` through here.
- **Phase 4.6** — Cutover from monolith `/api/rescue/*`.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_