### PR TITLE
feat(microservices): gateway /api/rescue/* cutover (Phase 4.5)

### DIFF
--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -27,6 +27,9 @@ export type GatewayConfig = {
   // service.pets gRPC URL — Phase 3.5 cuts /api/pets/* over to this
   // address.
   petsGrpcUrl: string;
+  // service.rescue gRPC URL — Phase 4.5 cuts /api/rescue/* over to
+  // this address.
+  rescueGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 4000;
@@ -36,6 +39,7 @@ const DEFAULT_NATS_URL = 'nats://nats:4222';
 const DEFAULT_NOTIFICATIONS_GRPC_URL = 'service-notifications:6001';
 const DEFAULT_AUTH_GRPC_URL = 'service-auth:6002';
 const DEFAULT_PETS_GRPC_URL = 'service-pets:6003';
+const DEFAULT_RESCUE_GRPC_URL = 'service-rescue:6004';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig => {
   const portRaw = env.GATEWAY_PORT?.trim();
@@ -53,5 +57,6 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     notificationsGrpcUrl: env.NOTIFICATIONS_GRPC_URL?.trim() || DEFAULT_NOTIFICATIONS_GRPC_URL,
     authGrpcUrl: env.AUTH_GRPC_URL?.trim() || DEFAULT_AUTH_GRPC_URL,
     petsGrpcUrl: env.PETS_GRPC_URL?.trim() || DEFAULT_PETS_GRPC_URL,
+    rescueGrpcUrl: env.RESCUE_GRPC_URL?.trim() || DEFAULT_RESCUE_GRPC_URL,
   };
 };

--- a/services/gateway/src/grpc-clients/rescue-client.test.ts
+++ b/services/gateway/src/grpc-clients/rescue-client.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { createRescueClient } from './rescue-client.js';
+
+describe('createRescueClient', () => {
+  it('returns an object exposing the six RescueService methods + close', () => {
+    const client = createRescueClient({ address: '127.0.0.1:65532' });
+    try {
+      expect(typeof client.create).toBe('function');
+      expect(typeof client.get).toBe('function');
+      expect(typeof client.list).toBe('function');
+      expect(typeof client.update).toBe('function');
+      expect(typeof client.verify).toBe('function');
+      expect(typeof client.inviteStaff).toBe('function');
+      expect(typeof client.close).toBe('function');
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/gateway/src/grpc-clients/rescue-client.ts
+++ b/services/gateway/src/grpc-clients/rescue-client.ts
@@ -1,0 +1,71 @@
+// Promise-wrapped client for service.rescue.
+//
+// Phase 4.5 surface — full RescueService.{Create, Get, List, Update,
+// Verify, InviteStaff}. The Phase 2.5 authenticate middleware already
+// populates the x-user-* metadata for every authenticated request, so
+// the routes that consume this client thread the same gRPC Metadata
+// pattern as services/gateway/src/grpc-clients/pets-client.ts.
+//
+// The interface is exported so tests can substitute a mock; the
+// routes depend on the shape, not the @grpc/grpc-js client.
+
+import { credentials, Metadata } from '@grpc/grpc-js';
+
+import {
+  RescueV1,
+  type CreateRescueRequest,
+  type CreateRescueResponse,
+  type GetRescueRequest,
+  type GetRescueResponse,
+  type InviteStaffRequest,
+  type InviteStaffResponse,
+  type ListRescuesRequest,
+  type ListRescuesResponse,
+  type UpdateRescueRequest,
+  type UpdateRescueResponse,
+  type VerifyRescueRequest,
+  type VerifyRescueResponse,
+} from '@adopt-dont-shop/proto';
+
+export type RescueClient = {
+  create(req: CreateRescueRequest, metadata: Metadata): Promise<CreateRescueResponse>;
+  get(req: GetRescueRequest, metadata: Metadata): Promise<GetRescueResponse>;
+  list(req: ListRescuesRequest, metadata: Metadata): Promise<ListRescuesResponse>;
+  update(req: UpdateRescueRequest, metadata: Metadata): Promise<UpdateRescueResponse>;
+  verify(req: VerifyRescueRequest, metadata: Metadata): Promise<VerifyRescueResponse>;
+  inviteStaff(req: InviteStaffRequest, metadata: Metadata): Promise<InviteStaffResponse>;
+  close(): void;
+};
+
+export type CreateRescueClientOptions = {
+  address: string;
+};
+
+export const createRescueClient = (opts: CreateRescueClientOptions): RescueClient => {
+  const stub = new RescueV1.RescueServiceClient(opts.address, credentials.createInsecure());
+
+  const callUnary = <Req, Res>(
+    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> =>
+    new Promise<Res>((resolve, reject) => {
+      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(res);
+      });
+    });
+
+  return {
+    create: (req, metadata) => callUnary(stub.create, req, metadata),
+    get: (req, metadata) => callUnary(stub.get, req, metadata),
+    list: (req, metadata) => callUnary(stub.list, req, metadata),
+    update: (req, metadata) => callUnary(stub.update, req, metadata),
+    verify: (req, metadata) => callUnary(stub.verify, req, metadata),
+    inviteStaff: (req, metadata) => callUnary(stub.inviteStaff, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -7,6 +7,7 @@ import { loadConfig } from './config.js';
 import { createAuthClient } from './grpc-clients/auth-client.js';
 import { createNotificationsClient } from './grpc-clients/notifications-client.js';
 import { createPetsClient } from './grpc-clients/pets-client.js';
+import { createRescueClient } from './grpc-clients/rescue-client.js';
 import { createServer } from './server.js';
 import { registerNotificationSubscribers } from './ws/notifications-subscriber.js';
 import { SocketRegistry } from './ws/socket-registry.js';
@@ -20,6 +21,7 @@ const main = async (): Promise<void> => {
   let notificationsClient: ReturnType<typeof createNotificationsClient> | undefined;
   let authClient: ReturnType<typeof createAuthClient> | undefined;
   let petsClient: ReturnType<typeof createPetsClient> | undefined;
+  let rescueClient: ReturnType<typeof createRescueClient> | undefined;
 
   try {
     const config = loadConfig();
@@ -29,6 +31,7 @@ const main = async (): Promise<void> => {
     notificationsClient = createNotificationsClient({ address: config.notificationsGrpcUrl });
     authClient = createAuthClient({ address: config.authGrpcUrl });
     petsClient = createPetsClient({ address: config.petsGrpcUrl });
+    rescueClient = createRescueClient({ address: config.rescueGrpcUrl });
 
     const server = await createServer({
       config,
@@ -36,6 +39,7 @@ const main = async (): Promise<void> => {
       notificationsClient,
       authClient,
       petsClient,
+      rescueClient,
     });
 
     await server.listen({ port: config.port, host: config.host });
@@ -55,6 +59,7 @@ const main = async (): Promise<void> => {
       notificationsGrpcUrl: config.notificationsGrpcUrl,
       authGrpcUrl: config.authGrpcUrl,
       petsGrpcUrl: config.petsGrpcUrl,
+      rescueGrpcUrl: config.rescueGrpcUrl,
       environment: config.environment,
     });
 
@@ -92,6 +97,11 @@ const main = async (): Promise<void> => {
       } catch (err) {
         logger.error('pets client close error', { err });
       }
+      try {
+        rescueClient?.close();
+      } catch (err) {
+        logger.error('rescue client close error', { err });
+      }
       process.exit(0);
     };
 
@@ -116,6 +126,11 @@ const main = async (): Promise<void> => {
     }
     try {
       petsClient?.close();
+    } catch {
+      // Same.
+    }
+    try {
+      rescueClient?.close();
     } catch {
       // Same.
     }

--- a/services/gateway/src/routes/rescue.test.ts
+++ b/services/gateway/src/routes/rescue.test.ts
@@ -1,0 +1,347 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  RescueV1,
+  type CreateRescueResponse,
+  type GetRescueResponse,
+  type InviteStaffResponse,
+  type ListRescuesResponse,
+  type Rescue,
+  type UpdateRescueResponse,
+  type VerifyRescueResponse,
+} from '@adopt-dont-shop/proto';
+
+import type { RescueClient } from '../grpc-clients/rescue-client.js';
+
+import { registerRescueRoutes } from './rescue.js';
+
+function makeClient(): {
+  client: RescueClient;
+  createMock: ReturnType<typeof vi.fn>;
+  getMock: ReturnType<typeof vi.fn>;
+  listMock: ReturnType<typeof vi.fn>;
+  updateMock: ReturnType<typeof vi.fn>;
+  verifyMock: ReturnType<typeof vi.fn>;
+  inviteStaffMock: ReturnType<typeof vi.fn>;
+} {
+  const createMock = vi.fn();
+  const getMock = vi.fn();
+  const listMock = vi.fn();
+  const updateMock = vi.fn();
+  const verifyMock = vi.fn();
+  const inviteStaffMock = vi.fn();
+  const client: RescueClient = {
+    create: createMock,
+    get: getMock,
+    list: listMock,
+    update: updateMock,
+    verify: verifyMock,
+    inviteStaff: inviteStaffMock,
+    close: vi.fn(),
+  };
+  return { client, createMock, getMock, listMock, updateMock, verifyMock, inviteStaffMock };
+}
+
+async function makeApp(client: RescueClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerRescueRoutes(app, { client });
+  return app;
+}
+
+const RESCUE_FIXTURE: Rescue = {
+  rescueId: 'rsc-1',
+  name: 'Pawsome',
+  email: 'hi@p.example',
+  address: '1 High St',
+  city: 'London',
+  postcode: 'SW1A 1AA',
+  country: 'GB',
+  contactPerson: 'Alex',
+  status: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED,
+  settingsJson: '{}',
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+describe('GET /api/rescue', () => {
+  let app: FastifyInstance;
+  let listMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    listMock = m.listMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('lists rescues and parses the canonical status filter', async () => {
+    const listRes: ListRescuesResponse = { rescues: [RESCUE_FIXTURE], nextCursor: 'cur' };
+    listMock.mockResolvedValueOnce(listRes);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/rescue?status=verified&limit=10',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { rescues: unknown[]; nextCursor?: string };
+    expect(body.rescues).toHaveLength(1);
+    expect(body.nextCursor).toBe('cur');
+    const [req] = listMock.mock.calls[0];
+    expect(req.statusFilter).toBe(RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED);
+    expect(req.limit).toBe(10);
+  });
+
+  it('coerces an unknown status to UNSPECIFIED', async () => {
+    listMock.mockResolvedValueOnce({ rescues: [] });
+    await app.inject({ method: 'GET', url: '/api/rescue?status=not_a_status' });
+    const [req] = listMock.mock.calls[0];
+    expect(req.statusFilter).toBe(RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED);
+  });
+
+  it('maps INVALID_ARGUMENT → 400', async () => {
+    listMock.mockRejectedValueOnce(
+      Object.assign(new Error('limit too big'), {
+        code: grpcStatus.INVALID_ARGUMENT,
+        details: 'limit must be <= 100',
+      })
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/rescue?limit=200' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /api/rescue/:id', () => {
+  it('threads the path param and returns the rescue', async () => {
+    const { client, getMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const getRes: GetRescueResponse = { rescue: RESCUE_FIXTURE };
+      getMock.mockResolvedValueOnce(getRes);
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/rescue/rsc-1',
+        headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { rescue: { rescueId: string } };
+      expect(body.rescue.rescueId).toBe('rsc-1');
+      const [req, metadata] = getMock.mock.calls[0];
+      expect(req.rescueId).toBe('rsc-1');
+      expect(metadata.get('x-user-id')[0]).toBe('usr-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps NOT_FOUND → 404', async () => {
+    const { client, getMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      getMock.mockRejectedValueOnce(
+        Object.assign(new Error('gone'), {
+          code: grpcStatus.NOT_FOUND,
+          details: 'rescue ghost not found',
+        })
+      );
+      const res = await app.inject({ method: 'GET', url: '/api/rescue/ghost' });
+      expect(res.statusCode).toBe(404);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('POST /api/rescue', () => {
+  it('returns 201 + threads body fields into the gRPC request', async () => {
+    const { client, createMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const createRes: CreateRescueResponse = { rescue: RESCUE_FIXTURE };
+      createMock.mockResolvedValueOnce(createRes);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/rescue',
+        headers: { 'x-user-id': 'usr-admin', 'x-user-roles': 'admin' },
+        payload: {
+          name: 'Pawsome',
+          email: 'hi@p.example',
+          address: '1 High St',
+          city: 'London',
+          postcode: 'SW1A 1AA',
+          contactPerson: 'Alex',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const [req] = createMock.mock.calls[0];
+      expect(req.name).toBe('Pawsome');
+      expect(req.email).toBe('hi@p.example');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps PERMISSION_DENIED → 403', async () => {
+    const { client, createMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      createMock.mockRejectedValueOnce(
+        Object.assign(new Error('nope'), {
+          code: grpcStatus.PERMISSION_DENIED,
+          details: 'rescues.create required',
+        })
+      );
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/rescue',
+        payload: { name: 'Pawsome', email: 'hi@p.example' },
+      });
+      expect(res.statusCode).toBe(403);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('PATCH /api/rescue/:id', () => {
+  it('threads path param + body fields', async () => {
+    const { client, updateMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const updateRes: UpdateRescueResponse = { rescue: { ...RESCUE_FIXTURE, name: 'Pawsome 2' } };
+      updateMock.mockResolvedValueOnce(updateRes);
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/rescue/rsc-1',
+        payload: { name: 'Pawsome 2' },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { rescue: { name: string } };
+      expect(body.rescue.name).toBe('Pawsome 2');
+      const [req] = updateMock.mock.calls[0];
+      expect(req.rescueId).toBe('rsc-1');
+      expect(req.name).toBe('Pawsome 2');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('POST /api/rescue/:id/verify', () => {
+  let app: FastifyInstance;
+  let verifyMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    verifyMock = m.verifyMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('parses the canonical status string and verification source', async () => {
+    const verifyRes: VerifyRescueResponse = {
+      rescue: { ...RESCUE_FIXTURE, status: RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED },
+    };
+    verifyMock.mockResolvedValueOnce(verifyRes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/rescue/rsc-1/verify',
+      payload: { toStatus: 'verified', verificationSource: 'companies_house' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [req] = verifyMock.mock.calls[0];
+    expect(req.rescueId).toBe('rsc-1');
+    expect(req.toStatus).toBe(RescueV1.RescueStatus.RESCUE_STATUS_VERIFIED);
+    expect(req.verificationSource).toBe(
+      RescueV1.RescueVerificationSource.RESCUE_VERIFICATION_SOURCE_COMPANIES_HOUSE
+    );
+  });
+
+  it('accepts the SCREAMING proto form too', async () => {
+    verifyMock.mockResolvedValueOnce({ rescue: RESCUE_FIXTURE });
+    await app.inject({
+      method: 'POST',
+      url: '/api/rescue/rsc-1/verify',
+      payload: { toStatus: 'RESCUE_STATUS_REJECTED', failureReason: 'no docs' },
+    });
+    const [req] = verifyMock.mock.calls[0];
+    expect(req.toStatus).toBe(RescueV1.RescueStatus.RESCUE_STATUS_REJECTED);
+    expect(req.failureReason).toBe('no docs');
+  });
+
+  it('maps INVALID_ARGUMENT → 400 on illegal transition', async () => {
+    verifyMock.mockRejectedValueOnce(
+      Object.assign(new Error('illegal'), {
+        code: grpcStatus.INVALID_ARGUMENT,
+        details: 'illegal status transition verified → rejected',
+      })
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/rescue/rsc-1/verify',
+      payload: { toStatus: 'rejected' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /api/rescue/:id/invitations', () => {
+  it('returns 201 + the token alongside the invitation', async () => {
+    const { client, inviteStaffMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      const inviteRes: InviteStaffResponse = {
+        invitation: {
+          invitationId: 'inv-1',
+          email: 'new@p.example',
+          rescueId: 'rsc-1',
+          expiration: '2026-06-08T00:00:00Z',
+          used: false,
+          createdAt: '2026-06-01T00:00:00Z',
+        },
+        token: 'a'.repeat(64),
+      };
+      inviteStaffMock.mockResolvedValueOnce(inviteRes);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/rescue/rsc-1/invitations',
+        payload: { email: 'new@p.example', title: 'Volunteer' },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json() as { invitation: { invitationId: string }; token: string };
+      expect(body.invitation.invitationId).toBe('inv-1');
+      expect(body.token).toMatch(/^a{64}$/);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('error mapping fallback', () => {
+  it('unknown gRPC code → 500', async () => {
+    const { client, getMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      getMock.mockRejectedValueOnce(new Error('connection refused'));
+      const res = await app.inject({ method: 'GET', url: '/api/rescue/rsc-1' });
+      expect(res.statusCode).toBe(500);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/gateway/src/routes/rescue.ts
+++ b/services/gateway/src/routes/rescue.ts
@@ -1,0 +1,253 @@
+// REST → gRPC translation for /api/rescue/*.
+//
+// Phase 4.5 cutover: this Fastify plugin registers BEFORE the
+// strangler-fig http-proxy catch-all, so Fastify's first-registered-
+// wins prefix routing picks it for /api/rescue/* requests before the
+// catch-all sees them. Same shape as routes/pets.ts / routes/auth.ts.
+//
+// Route map (mirrors the monolith's existing /api/rescue/* surface):
+//
+//   GET    /api/rescue                    → RescueService.List
+//   GET    /api/rescue/:id                → RescueService.Get
+//   POST   /api/rescue                    → RescueService.Create
+//   PATCH  /api/rescue/:id                → RescueService.Update
+//   POST   /api/rescue/:id/verify         → RescueService.Verify
+//   POST   /api/rescue/:id/invitations    → RescueService.InviteStaff
+//
+// The Phase 2.5 authenticate middleware already populates x-user-*
+// metadata; every RescueService RPC requires a principal.
+
+import rateLimit from '@fastify/rate-limit';
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  RescueV1,
+  type CreateRescueRequest,
+  type InviteStaffRequest,
+  type ListRescuesRequest,
+  type UpdateRescueRequest,
+  type VerifyRescueRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { RescueClient } from '../grpc-clients/rescue-client.js';
+
+export type RescueRoutesOptions = {
+  client: RescueClient;
+};
+
+// Same gRPC-status → HTTP-status table the other routes use.
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.INTERNAL]: 500,
+};
+
+// Per-route rate limits. Reads are public-ish (adopters browse rescues
+// + pet listings render rescue details); writes / status transitions
+// are admin/staff only.
+const RESCUE_RATE_LIMITS = {
+  list: { max: 60, timeWindow: '1 minute' },
+  get: { max: 120, timeWindow: '1 minute' },
+  create: { max: 10, timeWindow: '1 minute' },
+  update: { max: 30, timeWindow: '1 minute' },
+  verify: { max: 30, timeWindow: '1 minute' },
+  inviteStaff: { max: 30, timeWindow: '1 minute' },
+} as const;
+
+type CreateRescueBody = Partial<CreateRescueRequest>;
+type UpdateRescueBody = Partial<Omit<UpdateRescueRequest, 'rescueId'>>;
+type VerifyBody = {
+  toStatus?: string;
+  verificationSource?: string;
+  failureReason?: string;
+};
+type InviteStaffBody = {
+  email?: string;
+  title?: string;
+  expiresInSeconds?: number;
+};
+
+export const registerRescueRoutes = async (
+  app: FastifyInstance,
+  opts: RescueRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  await app.register(rateLimit, { global: false });
+
+  app.get('/api/rescue', { config: { rateLimit: RESCUE_RATE_LIMITS.list } }, async (req, reply) => {
+    const query = req.query as Record<string, string | undefined>;
+    const grpcReq: ListRescuesRequest = {
+      cursor: query.cursor,
+      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      statusFilter: parseStatus(query.status),
+    };
+    try {
+      const res = await client.list(grpcReq, buildMetadata(req));
+      return reply.send(RescueV1.ListRescuesResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get<{ Params: { id: string } }>(
+    '/api/rescue/:id',
+    { config: { rateLimit: RESCUE_RATE_LIMITS.get } },
+    async (req, reply) => {
+      try {
+        const res = await client.get({ rescueId: req.params.id }, buildMetadata(req));
+        return reply.send(RescueV1.GetRescueResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post(
+    '/api/rescue',
+    { config: { rateLimit: RESCUE_RATE_LIMITS.create } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as CreateRescueBody;
+      const grpcReq: CreateRescueRequest = {
+        name: body.name ?? '',
+        email: body.email ?? '',
+        phone: body.phone,
+        address: body.address ?? '',
+        city: body.city ?? '',
+        county: body.county,
+        postcode: body.postcode ?? '',
+        country: body.country,
+        website: body.website,
+        description: body.description,
+        mission: body.mission,
+        companiesHouseNumber: body.companiesHouseNumber,
+        charityRegistrationNumber: body.charityRegistrationNumber,
+        contactPerson: body.contactPerson ?? '',
+        contactTitle: body.contactTitle,
+        contactEmail: body.contactEmail,
+        contactPhone: body.contactPhone,
+      };
+      try {
+        const res = await client.create(grpcReq, buildMetadata(req));
+        return reply.code(201).send(RescueV1.CreateRescueResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.patch<{ Params: { id: string } }>(
+    '/api/rescue/:id',
+    { config: { rateLimit: RESCUE_RATE_LIMITS.update } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as UpdateRescueBody;
+      const grpcReq: UpdateRescueRequest = { rescueId: req.params.id, ...body };
+      try {
+        const res = await client.update(grpcReq, buildMetadata(req));
+        return reply.send(RescueV1.UpdateRescueResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/rescue/:id/verify',
+    { config: { rateLimit: RESCUE_RATE_LIMITS.verify } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as VerifyBody;
+      const grpcReq: VerifyRescueRequest = {
+        rescueId: req.params.id,
+        toStatus: parseStatus(body.toStatus),
+        verificationSource: parseVerificationSource(body.verificationSource),
+        failureReason: body.failureReason,
+      };
+      try {
+        const res = await client.verify(grpcReq, buildMetadata(req));
+        return reply.send(RescueV1.VerifyRescueResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/rescue/:id/invitations',
+    { config: { rateLimit: RESCUE_RATE_LIMITS.inviteStaff } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as InviteStaffBody;
+      const grpcReq: InviteStaffRequest = {
+        rescueId: req.params.id,
+        email: body.email ?? '',
+        title: body.title,
+        expiresInSeconds: body.expiresInSeconds,
+      };
+      try {
+        const res = await client.inviteStaff(grpcReq, buildMetadata(req));
+        return reply.code(201).send(RescueV1.InviteStaffResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}
+
+// parseStatus accepts the canonical DB string ('verified', 'pending')
+// AND the SCREAMING proto form ('RESCUE_STATUS_VERIFIED'). Unknown
+// coerces to UNSPECIFIED so the service's own INVALID_ARGUMENT guard
+// produces a clean 400.
+function parseStatus(raw: string | undefined): RescueV1.RescueStatus {
+  if (!raw) {
+    return RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED;
+  }
+  const upper = `RESCUE_STATUS_${raw.toUpperCase()}`;
+  const candidate = Object.values(RescueV1.RescueStatus).includes(upper as never) ? upper : raw;
+  const out = RescueV1.rescueStatusFromJSON(candidate);
+  return out === RescueV1.RescueStatus.UNRECOGNIZED
+    ? RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED
+    : out;
+}
+
+function parseVerificationSource(
+  raw: string | undefined
+): RescueV1.RescueVerificationSource | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const upper = `RESCUE_VERIFICATION_SOURCE_${raw.toUpperCase()}`;
+  const candidate = Object.values(RescueV1.RescueVerificationSource).includes(upper as never)
+    ? upper
+    : raw;
+  const out = RescueV1.rescueVerificationSourceFromJSON(candidate);
+  return out === RescueV1.RescueVerificationSource.UNRECOGNIZED
+    ? RescueV1.RescueVerificationSource.RESCUE_VERIFICATION_SOURCE_UNSPECIFIED
+    : out;
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -23,10 +23,12 @@ import type { GatewayConfig } from './config.js';
 import type { AuthClient } from './grpc-clients/auth-client.js';
 import type { NotificationsClient } from './grpc-clients/notifications-client.js';
 import type { PetsClient } from './grpc-clients/pets-client.js';
+import type { RescueClient } from './grpc-clients/rescue-client.js';
 import { registerAuthenticate } from './middleware/authenticate.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerNotificationsRoutes } from './routes/notifications.js';
 import { registerPetsRoutes } from './routes/pets.js';
+import { registerRescueRoutes } from './routes/rescue.js';
 
 export type CreateServerOptions = {
   config: GatewayConfig;
@@ -51,6 +53,9 @@ export type CreateServerOptions = {
   // gRPC client to service.pets — Phase 3.5 cuts /api/pets/* over to
   // this address. Same optional shape as the other clients.
   petsClient?: PetsClient;
+  // gRPC client to service.rescue — Phase 4.5 cuts /api/rescue/* over
+  // to this address. Same optional shape as the other clients.
+  rescueClient?: RescueClient;
 };
 
 export const createServer = async (opts: CreateServerOptions): Promise<FastifyInstance> => {
@@ -115,6 +120,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   if (opts.petsClient) {
     await registerPetsRoutes(server, { client: opts.petsClient });
+  }
+  if (opts.rescueClient) {
+    await registerRescueRoutes(server, { client: opts.rescueClient });
   }
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in


### PR DESCRIPTION
## Summary

Strangler-fig step for the rescue vertical — the gateway now translates the six public `/api/rescue/*` endpoints into `RescueService` gRPC calls instead of proxying them through to the monolith. Same shape as the Phase 3.5 `/api/pets/*` and Phase 2.6 `/api/auth/*` cutovers.

## What's in

**`services/gateway/src/grpc-clients/rescue-client.ts`** — Promise-wrapped `RescueV1.RescueServiceClient` with the full six-method surface.

**`services/gateway/src/routes/rescue.ts`** — REST → gRPC translation:

| HTTP | gRPC |
|---|---|
| `GET    /api/rescue` | `RescueService.List` |
| `GET    /api/rescue/:id` | `RescueService.Get` |
| `POST   /api/rescue` | `RescueService.Create` |
| `PATCH  /api/rescue/:id` | `RescueService.Update` |
| `POST   /api/rescue/:id/verify` | `RescueService.Verify` |
| `POST   /api/rescue/:id/invitations` | `RescueService.InviteStaff` (returns 201 with the token alongside the invitation row — monolith contract) |

Same `GRPC_TO_HTTP` table. `parseStatus` / `parseVerificationSource` accept the canonical DB string (`'verified'`, `'companies_house'`) AND the SCREAMING proto form (`'RESCUE_STATUS_VERIFIED'`); unknown values coerce to UNSPECIFIED.

`@fastify/rate-limit` scoped to this plugin (`global: false`): reads chatty (list 60/min, get 120/min), writes tight (create 10/min, update/verify/inviteStaff 30/min).

**Wiring:**
- `services/gateway/src/config.ts` gains `RESCUE_GRPC_URL` (defaults to `service-rescue:6004` — matches Phase 4.3c default).
- `services/gateway/src/server.ts` registers the rescue routes BEFORE the catch-all proxy. `rescueClient` is optional on `CreateServerOptions`.
- `services/gateway/src/index.ts` creates + closes the `rescueClient` alongside the other clients.

## Test plan

- [x] `npm test` in `services/gateway` — **85/85** green (14 new across `rescue.test.ts` + `rescue-client.test.ts`)
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.gateway'` — green
- [x] Lint clean

## What's NOT in

- **Phase 4.6** — deletion of the monolith's now-dead `/api/rescue/*` surface (bundled into Phase 11).

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_