### PR TITLE
feat(microservices): services/applications boot skeleton (Phase 5.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4842,6 +4842,10 @@
       "resolved": "service.backend",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/service.applications": {
+      "resolved": "services/applications",
+      "link": true
+    },
     "node_modules/@adopt-dont-shop/service.auth": {
       "resolved": "services/auth",
       "link": true
@@ -32629,6 +32633,14 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "services/applications": {
+      "name": "@adopt-dont-shop/service.applications",
+      "version": "0.1.0",
+      "dependencies": {
+        "@adopt-dont-shop/observability": "*",
+        "fastify": "^5.8.5"
       }
     },
     "services/auth": {

--- a/services/applications/README.md
+++ b/services/applications/README.md
@@ -1,0 +1,70 @@
+# service.applications
+
+Applications vertical — Phase 5 of the microservices migration.
+
+**The deepest extraction — CAD Phase 2 equivalent.** Owns the
+`applications.*` schema (Application, ApplicationDraft, ApplicationAnswer,
+ApplicationTimelineEntry, HomeVisit, Reference) and exposes
+`ApplicationService` over gRPC.
+
+Event-sourced — the application state machine
+(`draft → submitted → under_review → home_visit_scheduled →
+home_visit_completed → approved | rejected | withdrawn → adopted`)
+drives multiple downstream consumers (notifications, moderation,
+audit), and "how did we get here?" is a real product question for
+adopters and rescue staff. Pure `apply`/`fold` domain + Postgres event
+store + publish-after-commit on `applications.*` events.
+
+## What's shipped so far
+
+**Phase 5.1** — boot skeleton:
+- `src/index.ts` starts a Fastify server on `APPLICATIONS_PORT`
+  (default 5005), wires `/health/simple`.
+- `src/instrumentation.ts` boots OpenTelemetry via
+  `@adopt-dont-shop/observability` with
+  `serviceName: 'service.applications'`.
+- `src/config.ts` env validation. Hard-requires `DATABASE_URL` so
+  misconfiguration fails fast at boot rather than at first request.
+- `src/server.ts` `createServer({ config, logger? })`.
+
+## What's NOT here yet
+
+The CAD Phase 2 cadence — six PRs:
+- **Phase 5.2** — pure event-sourced application domain
+  (`apply`/`fold`, commands, invariants). I/O-free, fully unit-tested.
+- **Phase 5.3** — `applications.*` schema + migrations, persisted gRPC
+  service (Postgres event store + read model with optimistic
+  concurrency on `(aggregate_id, version)`, NATS publish post-commit,
+  gRPC handlers).
+- **Phase 5.4** — `services/notifications` consumes `applications.*`
+  events and fans to involved users (adopter + rescue staff).
+- **Phase 5.5** — Gateway `/api/applications/*` REST routes proxying
+  to applications gRPC.
+- **Phase 5.6** — Cutover: monolith's applications code becomes dead,
+  removal bundled into Phase 11.
+
+## Configuration
+
+| Env var                  | Default            | Required | Purpose                                                                  |
+| ------------------------ | ------------------ | -------- | ------------------------------------------------------------------------ |
+| `APPLICATIONS_PORT`      | `5005`             |          | HTTP port for `/health/simple`.                                          |
+| `APPLICATIONS_GRPC_PORT` | `6005`             |          | gRPC port `ApplicationService` will bind (Phase 5.3c).                   |
+| `APPLICATIONS_HOST`      | `0.0.0.0`          |          | Bind interface (both HTTP + gRPC).                                       |
+| `APPLICATIONS_SCHEMA`    | `applications`     |          | Postgres schema. Override for parallel test DBs.                         |
+| `DATABASE_URL`           | —                  | ✅       | Postgres connection string. Same physical Postgres as `service.backend`. |
+| `NATS_URL`               | `nats://nats:4222` |          | NATS bus URL.                                                            |
+| `NODE_ENV`               | `development`      |          | Surfaces in health + logs.                                               |
+
+Plus the standard observability env vars consumed by
+`@adopt-dont-shop/observability`.
+
+## Running
+
+```bash
+# Dev — hot reload, OTel SDK loaded via --import
+npm run dev
+
+# Production build
+npm run build
+npm run start
+```

--- a/services/applications/package.json
+++ b/services/applications/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@adopt-dont-shop/service.applications",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Applications service — Phase 5 extraction. Owns the applications.* schema (Application, ApplicationDraft, ApplicationAnswer, ApplicationTimelineEntry, HomeVisit, Reference) and exposes gRPC ApplicationService over a status state machine (draft → submitted → under_review → home_visit_scheduled → home_visit_completed → approved | rejected | withdrawn → adopted). This is the EVENT-SOURCED vertical — clear state machine + multi-consumer audit needs; pure apply/fold domain + Postgres event store + publish-after-commit on applications.* events. CAD Phase 2 equivalent (deepest extraction). Phase 5.1 commit is just the boot skeleton; the event-sourced domain, persistence, gRPC, NATS, and gateway land in later phases.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
+    "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adopt-dont-shop/observability": "*",
+    "fastify": "^5.8.5"
+  }
+}

--- a/services/applications/src/config.test.ts
+++ b/services/applications/src/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from './config.js';
+
+const REQUIRED = {
+  DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+};
+
+describe('loadConfig', () => {
+  it('uses the documented defaults when only the required env vars are set', () => {
+    const config = loadConfig({ ...REQUIRED });
+    expect(config.port).toBe(5005);
+    expect(config.grpcPort).toBe(6005);
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.environment).toBe('development');
+    expect(config.databaseUrl).toBe(REQUIRED.DATABASE_URL);
+    expect(config.schema).toBe('applications');
+    expect(config.natsUrl).toBe('nats://nats:4222');
+  });
+
+  it('honours all env overrides when set', () => {
+    const config = loadConfig({
+      APPLICATIONS_PORT: '5500',
+      APPLICATIONS_GRPC_PORT: '6500',
+      APPLICATIONS_HOST: '127.0.0.1',
+      APPLICATIONS_SCHEMA: 'applications_test',
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/applications',
+      NATS_URL: 'nats://nats.internal:4222',
+    });
+
+    expect(config.port).toBe(5500);
+    expect(config.grpcPort).toBe(6500);
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.environment).toBe('production');
+    expect(config.schema).toBe('applications_test');
+    expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/applications');
+    expect(config.natsUrl).toBe('nats://nats.internal:4222');
+  });
+
+  it('rejects a non-numeric APPLICATIONS_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, APPLICATIONS_PORT: 'five-thousand' })).toThrow(
+      /APPLICATIONS_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-numeric APPLICATIONS_GRPC_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, APPLICATIONS_GRPC_PORT: 'six-thousand' })).toThrow(
+      /APPLICATIONS_GRPC_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-positive APPLICATIONS_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, APPLICATIONS_PORT: '0' })).toThrow(
+      /APPLICATIONS_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects an unset DATABASE_URL', () => {
+    expect(() => loadConfig({})).toThrow(/DATABASE_URL is required/);
+  });
+});

--- a/services/applications/src/config.ts
+++ b/services/applications/src/config.ts
@@ -1,0 +1,68 @@
+export type ApplicationsConfig = {
+  // HTTP port for the boot-readiness surface (/health/simple). Distinct
+  // from service.backend's 5000, service.gateway's 4000,
+  // service.notifications' 5001, service.auth's 5002, service.pets's
+  // 5003, service.rescue's 5004.
+  port: number;
+  host: string;
+  // gRPC server port. ApplicationService.{StartDraft, SubmitDraft,
+  // Get, List, ScheduleHomeVisit, CompleteHomeVisit, Approve, Reject,
+  // Withdraw, ...} bind here once Phase 5.3c brings the server online.
+  // Convention: HTTP + 1000.
+  grpcPort: number;
+  // Environment label, surfaced in health responses and on log lines.
+  environment: string;
+  // Postgres connection string. Required for migrations + the runtime
+  // database client. Same physical Postgres as service.backend; this
+  // service owns the `applications` schema (CAD-style schema-per-service).
+  databaseUrl: string;
+  // Schema name. Defaults to `applications` — every table in this
+  // service lives here and other services don't read it directly.
+  schema: string;
+  // NATS bus. Phase 5.3 onwards publishes applications.created,
+  // applications.submitted, applications.approved, applications.rejected,
+  // applications.homeVisitScheduled etc. for downstream services
+  // (notifications, moderation, audit, matching) to consume. This
+  // is the multi-consumer event firehose that justifies the
+  // event-sourced design.
+  natsUrl: string;
+};
+
+const DEFAULT_PORT = 5005;
+const DEFAULT_GRPC_PORT = 6005;
+const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_SCHEMA = 'applications';
+const DEFAULT_NATS_URL = 'nats://nats:4222';
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ApplicationsConfig => {
+  const port = parsePort(env.APPLICATIONS_PORT, DEFAULT_PORT, 'APPLICATIONS_PORT');
+  const grpcPort = parsePort(
+    env.APPLICATIONS_GRPC_PORT,
+    DEFAULT_GRPC_PORT,
+    'APPLICATIONS_GRPC_PORT'
+  );
+
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required (Postgres connection string)');
+  }
+
+  return {
+    port,
+    grpcPort,
+    host: env.APPLICATIONS_HOST?.trim() || DEFAULT_HOST,
+    environment: env.NODE_ENV?.trim() || 'development',
+    databaseUrl,
+    schema: env.APPLICATIONS_SCHEMA?.trim() || DEFAULT_SCHEMA,
+    natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+  };
+};
+
+function parsePort(raw: string | undefined, fallback: number, name: string): number {
+  const trimmed = raw?.trim();
+  const value = trimmed ? Number.parseInt(trimmed, 10) : fallback;
+  if (Number.isNaN(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${trimmed}"`);
+  }
+  return value;
+}

--- a/services/applications/src/index.ts
+++ b/services/applications/src/index.ts
@@ -1,0 +1,42 @@
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from './config.js';
+import { createServer } from './server.js';
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.applications' });
+
+  try {
+    const config = loadConfig();
+    const server = createServer({ config, logger });
+
+    await server.listen({ port: config.port, host: config.host });
+
+    logger.info('service.applications listening', {
+      port: config.port,
+      host: config.host,
+      grpcPort: config.grpcPort,
+      schema: config.schema,
+      natsUrl: config.natsUrl,
+      environment: config.environment,
+    });
+
+    const shutdown = async (signal: string): Promise<void> => {
+      logger.info('service.applications shutting down', { signal });
+      try {
+        await server.close();
+      } catch (err) {
+        logger.error('error during shutdown', { err });
+      }
+      process.exit(0);
+    };
+
+    process.once('SIGTERM', () => void shutdown('SIGTERM'));
+    process.once('SIGINT', () => void shutdown('SIGINT'));
+  } catch (err) {
+    logger.error('service.applications failed to start', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/applications/src/instrumentation.ts
+++ b/services/applications/src/instrumentation.ts
@@ -1,0 +1,15 @@
+// OpenTelemetry SDK bootstrap for service.applications.
+//
+// Same --import-flag pattern as the rest of the stack: tsx / node
+// loads this BEFORE the rest of the service so the auto-
+// instrumentations can hook http, fastify, pg, undici BEFORE those
+// modules are first imported.
+//
+// Behaviour matches the rest of the stack (see @adopt-dont-shop/observability):
+//   - Silent no-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+//   - OTEL_SERVICE_NAME env var overrides the value below.
+//   - No-throw contract.
+
+import { initializeOpenTelemetry } from '@adopt-dont-shop/observability';
+
+initializeOpenTelemetry({ serviceName: 'service.applications' });

--- a/services/applications/src/server.test.ts
+++ b/services/applications/src/server.test.ts
@@ -1,0 +1,67 @@
+import { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { ApplicationsConfig } from './config.js';
+import { createServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const baseConfig: ApplicationsConfig = {
+  port: 0,
+  grpcPort: 0,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'applications',
+  natsUrl: 'nats://localhost:4222',
+};
+
+describe('createServer — health endpoint', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = createServer({ config: baseConfig, logger: quietLogger });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('responds to GET /health/simple with status ok', async () => {
+    const res = await server.inject({ method: 'GET', url: '/health/simple' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      status: 'ok',
+      service: 'service.applications',
+      environment: 'test',
+    });
+  });
+
+  it('surfaces the configured environment in the health payload', async () => {
+    const stagingServer = createServer({
+      config: { ...baseConfig, environment: 'staging' },
+      logger: quietLogger,
+    });
+    try {
+      const res = await stagingServer.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.json()).toMatchObject({ environment: 'staging' });
+    } finally {
+      await stagingServer.close();
+    }
+  });
+
+  it('returns a 500 when a route handler throws (custom error handler)', async () => {
+    server.get('/boom', async () => {
+      throw new Error('boom');
+    });
+    const res = await server.inject({ method: 'GET', url: '/boom' });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ error: 'internal_error' });
+  });
+});

--- a/services/applications/src/server.ts
+++ b/services/applications/src/server.ts
@@ -1,0 +1,65 @@
+// services/applications — Phase 5 extraction. Owns the applications.*
+// schema and exposes ApplicationService over gRPC.
+//
+// This is the EVENT-SOURCED vertical — CAD Phase 2 equivalent. The
+// state machine (draft → submitted → under_review → home_visit_scheduled
+// → home_visit_completed → approved | rejected | withdrawn → adopted)
+// drives multiple downstream consumers (notifications, moderation,
+// audit), and "how did we get here?" is a real product question for
+// adopters and rescue staff. Pure apply/fold domain + Postgres event
+// store + publish-after-commit.
+//
+// Phase 5.1 (this commit) is just the boot skeleton; the event-sourced
+// domain (5.2), persistence + gRPC (5.3), notification subscribers
+// (5.4), gateway routing (5.5), and cutover (5.6) arrive in subsequent
+// commits.
+
+import { createLogger } from '@adopt-dont-shop/observability';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+import type { ApplicationsConfig } from './config.js';
+
+export type CreateServerOptions = {
+  config: ApplicationsConfig;
+  // Optional logger injection — tests pass a quiet logger so the
+  // suite output stays readable. Real boot uses createLogger so the
+  // service emits structured lines through the same pipeline as the
+  // rest of the stack.
+  logger?: ReturnType<typeof createLogger>;
+};
+
+export const createServer = (opts: CreateServerOptions): FastifyInstance => {
+  const { config } = opts;
+  const logger = opts.logger ?? createLogger({ serviceName: 'service.applications' });
+
+  // Disable Fastify's built-in pino — winston handles service-level
+  // lines (boot, shutdown, error handler), and OTel's HTTP
+  // auto-instrumentation already covers per-request spans. Same
+  // shape as the other extracted services.
+  const server = Fastify({
+    logger: false,
+    trustProxy: true,
+  });
+
+  server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
+    logger.error('request failed', {
+      method: req.method,
+      url: req.url,
+      message: err.message,
+    });
+    void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
+  });
+
+  // Health endpoint — matches the rest of the stack's
+  // `/health/simple` path so the existing Docker compose healthcheck
+  // pattern picks this service up unchanged.
+  server.get('/health/simple', async () => ({
+    status: 'ok',
+    service: 'service.applications',
+    environment: config.environment,
+  }));
+
+  return server;
+};
+
+export type { ApplicationsConfig };

--- a/services/applications/tsconfig.json
+++ b/services/applications/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/services/applications/vitest.config.ts
+++ b/services/applications/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 5 of the migration — **the deepest extraction, CAD Phase 2 equivalent**. This is the **event-sourced** vertical: the application state machine (`draft → submitted → under_review → home_visit_scheduled → home_visit_completed → approved | rejected | withdrawn → adopted`) drives multiple downstream consumers (notifications, moderation, audit), and "how did we get here?" is a real product question for adopters and rescue staff. Pure `apply`/`fold` domain + Postgres event store + publish-after-commit.

This commit is just the boot skeleton; the event-sourced domain (5.2), persistence + gRPC (5.3), notification subscribers (5.4), gateway routing (5.5), and cutover (5.6) arrive in subsequent commits.

**Cross-vertical parallel work**: opened from `origin/main` while the Phase 4.5 PR ([#874](https://github.com/ideaSquared/adopt-dont-shop/pull/874), gateway `/api/rescue/*`) is still in CI. Boot skeletons of different services never share files, so the two branches won't conflict.

## What's in

- **`services/applications/package.json`** — same scripts + scoped deps shape as `services/rescue` / `services/pets`. `APPLICATIONS_PORT` defaults to 5005, `APPLICATIONS_GRPC_PORT` to 6005 (HTTP+1000 convention).
- **`src/config.ts`** — env loader. `DATABASE_URL` is the only hard requirement; misconfiguration fails fast at boot rather than at first request.
- **`src/server.ts`** — `createServer` with `/health/simple`. Mirror of `service.rescue`'s `createServer`.
- **`src/instrumentation.ts`** — boots OpenTelemetry via `@adopt-dont-shop/observability` with `serviceName: 'service.applications'`.
- **`src/index.ts`** — wires HTTP listen + SIGTERM/SIGINT shutdown.
- **`README.md`** documents the Phase 5.1 surface and outlines the CAD Phase 2 6-PR cadence for 5.2-5.6.

## Test plan

- [x] `npm test` in `services/applications` — **9/9** green
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.applications'` — green
- [x] Lint clean

## What's NOT in

The CAD Phase 2 cadence — six PRs:
- **Phase 5.2** — pure event-sourced application domain (`apply`/`fold`, commands, invariants). I/O-free, fully unit-tested.
- **Phase 5.3** — `applications.*` schema + migrations, persisted gRPC service (Postgres event store + read model with optimistic concurrency on `(aggregate_id, version)`, NATS publish post-commit, gRPC handlers).
- **Phase 5.4** — `services/notifications` consumes `applications.*` events and fans to involved users (adopter + rescue staff).
- **Phase 5.5** — Gateway `/api/applications/*` REST routes proxying to applications gRPC.
- **Phase 5.6** — Cutover.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_