### PR TITLE
feat(microservices): services/chat boot skeleton (Phase 6.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4846,6 +4846,10 @@
       "resolved": "services/auth",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/service.chat": {
+      "resolved": "services/chat",
+      "link": true
+    },
     "node_modules/@adopt-dont-shop/service.gateway": {
       "resolved": "services/gateway",
       "link": true
@@ -32650,6 +32654,14 @@
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.7"
+      }
+    },
+    "services/chat": {
+      "name": "@adopt-dont-shop/service.chat",
+      "version": "0.1.0",
+      "dependencies": {
+        "@adopt-dont-shop/observability": "*",
+        "fastify": "^5.8.5"
       }
     },
     "services/gateway": {

--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -1,0 +1,66 @@
+# service.chat
+
+Chat vertical — Phase 6 of the microservices migration.
+
+Owns the `chat.*` schema (Chat, ChatParticipant, Message,
+MessageReaction, MessageRead) and exposes `ChatService` over gRPC.
+
+Classical (no event sourcing — chat messages are append-only by
+nature but they're not a state machine). WS-heavy: the gateway
+terminates Socket.IO and this service publishes
+`chat.messageCreated` / `chat.messageRead` / `chat.reactionAdded`
+on NATS for fan-out via the existing Phase 1.5 WS subscriber.
+
+## What's shipped so far
+
+**Phase 6.1** — boot skeleton:
+- `src/index.ts` starts a Fastify server on `CHAT_PORT` (default
+  5006), wires `/health/simple`.
+- `src/instrumentation.ts` boots OpenTelemetry via
+  `@adopt-dont-shop/observability` with `serviceName: 'service.chat'`.
+- `src/config.ts` env validation. Hard-requires `DATABASE_URL` so
+  misconfiguration fails fast at boot rather than at first request.
+- `src/server.ts` `createServer({ config, logger? })`.
+
+## What's NOT here yet
+
+- **Phase 6.2** — `chat.*` schema + migrations (Chat,
+  ChatParticipant, Message, MessageReaction, MessageRead).
+- **Phase 6.3** — gRPC `ChatService`:
+  - proto + grpc-js stubs in `@adopt-dont-shop/proto`
+  - handler logic (send / list / mark-read / react)
+  - gRPC server boot + adapter (same pattern as service.rescue)
+- **Phase 6.4** — NATS publishers (`chat.messageCreated`,
+  `chat.messageRead`, `chat.reactionAdded`). The gateway's existing
+  Phase 1.5 WS subscriber fans these to connected Socket.IO clients.
+  Moderation hook: `services/moderation` (Phase 8) consumes
+  `chat.messageCreated` for content scanning.
+- **Phase 6.5** — Gateway routes `/api/chat/*` here.
+- **Phase 6.6** — Cutover: monolith's chat code becomes dead,
+  removal bundled into Phase 11.
+
+## Configuration
+
+| Env var          | Default            | Required | Purpose                                                                  |
+| ---------------- | ------------------ | -------- | ------------------------------------------------------------------------ |
+| `CHAT_PORT`      | `5006`             |          | HTTP port for `/health/simple`.                                          |
+| `CHAT_GRPC_PORT` | `6006`             |          | gRPC port `ChatService` will bind (Phase 6.3c).                          |
+| `CHAT_HOST`      | `0.0.0.0`          |          | Bind interface (both HTTP + gRPC).                                       |
+| `CHAT_SCHEMA`    | `chat`             |          | Postgres schema. Override for parallel test DBs.                         |
+| `DATABASE_URL`   | —                  | ✅       | Postgres connection string. Same physical Postgres as `service.backend`. |
+| `NATS_URL`       | `nats://nats:4222` |          | NATS bus URL.                                                            |
+| `NODE_ENV`       | `development`      |          | Surfaces in health + logs.                                               |
+
+Plus the standard observability env vars consumed by
+`@adopt-dont-shop/observability`.
+
+## Running
+
+```bash
+# Dev — hot reload, OTel SDK loaded via --import
+npm run dev
+
+# Production build
+npm run build
+npm run start
+```

--- a/services/chat/package.json
+++ b/services/chat/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@adopt-dont-shop/service.chat",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Chat service — Phase 6 extraction. Owns the chat.* schema (Chat, ChatParticipant, Message, MessageReaction, MessageRead) and exposes gRPC ChatService for send/list/markRead. WS-heavy — the gateway terminates Socket.IO and this service publishes chat.messageCreated etc. on NATS for fan-out via the gateway's existing Phase 1.5 WS subscriber. Phase 6.1 commit is just the boot skeleton; schema/gRPC/NATS/gateway land in later phases.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
+    "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adopt-dont-shop/observability": "*",
+    "fastify": "^5.8.5"
+  }
+}

--- a/services/chat/src/config.test.ts
+++ b/services/chat/src/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from './config.js';
+
+const REQUIRED = {
+  DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+};
+
+describe('loadConfig', () => {
+  it('uses the documented defaults when only the required env vars are set', () => {
+    const config = loadConfig({ ...REQUIRED });
+    expect(config.port).toBe(5006);
+    expect(config.grpcPort).toBe(6006);
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.environment).toBe('development');
+    expect(config.databaseUrl).toBe(REQUIRED.DATABASE_URL);
+    expect(config.schema).toBe('chat');
+    expect(config.natsUrl).toBe('nats://nats:4222');
+  });
+
+  it('honours all env overrides when set', () => {
+    const config = loadConfig({
+      CHAT_PORT: '5500',
+      CHAT_GRPC_PORT: '6500',
+      CHAT_HOST: '127.0.0.1',
+      CHAT_SCHEMA: 'chat_test',
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/chat',
+      NATS_URL: 'nats://nats.internal:4222',
+    });
+
+    expect(config.port).toBe(5500);
+    expect(config.grpcPort).toBe(6500);
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.environment).toBe('production');
+    expect(config.schema).toBe('chat_test');
+    expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/chat');
+    expect(config.natsUrl).toBe('nats://nats.internal:4222');
+  });
+
+  it('rejects a non-numeric CHAT_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, CHAT_PORT: 'five-thousand' })).toThrow(
+      /CHAT_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-numeric CHAT_GRPC_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, CHAT_GRPC_PORT: 'six-thousand' })).toThrow(
+      /CHAT_GRPC_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-positive CHAT_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, CHAT_PORT: '0' })).toThrow(
+      /CHAT_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects an unset DATABASE_URL', () => {
+    expect(() => loadConfig({})).toThrow(/DATABASE_URL is required/);
+  });
+});

--- a/services/chat/src/config.ts
+++ b/services/chat/src/config.ts
@@ -1,0 +1,61 @@
+export type ChatConfig = {
+  // HTTP port for the boot-readiness surface (/health/simple). Distinct
+  // from service.backend's 5000, service.gateway's 4000,
+  // service.notifications' 5001, service.auth's 5002, service.pets's
+  // 5003, service.rescue's 5004, service.applications' 5005.
+  port: number;
+  host: string;
+  // gRPC server port. ChatService.{Send, ListMessages, ListChats,
+  // MarkRead, React} bind here once Phase 6.3c brings the server
+  // online. Convention: HTTP + 1000.
+  grpcPort: number;
+  // Environment label, surfaced in health responses and on log lines.
+  environment: string;
+  // Postgres connection string. Required for migrations + the runtime
+  // database client. Same physical Postgres as service.backend; this
+  // service owns the `chat` schema (CAD-style schema-per-service).
+  databaseUrl: string;
+  // Schema name. Defaults to `chat` — every table in this service
+  // lives here and other services don't read it directly.
+  schema: string;
+  // NATS bus. Phase 6.3 onwards publishes chat.messageCreated,
+  // chat.messageRead, chat.reactionAdded etc. The gateway's Phase 1.5
+  // WS subscriber fans these out to connected Socket.IO clients so
+  // open chats receive messages in real time.
+  natsUrl: string;
+};
+
+const DEFAULT_PORT = 5006;
+const DEFAULT_GRPC_PORT = 6006;
+const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_SCHEMA = 'chat';
+const DEFAULT_NATS_URL = 'nats://nats:4222';
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ChatConfig => {
+  const port = parsePort(env.CHAT_PORT, DEFAULT_PORT, 'CHAT_PORT');
+  const grpcPort = parsePort(env.CHAT_GRPC_PORT, DEFAULT_GRPC_PORT, 'CHAT_GRPC_PORT');
+
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required (Postgres connection string)');
+  }
+
+  return {
+    port,
+    grpcPort,
+    host: env.CHAT_HOST?.trim() || DEFAULT_HOST,
+    environment: env.NODE_ENV?.trim() || 'development',
+    databaseUrl,
+    schema: env.CHAT_SCHEMA?.trim() || DEFAULT_SCHEMA,
+    natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+  };
+};
+
+function parsePort(raw: string | undefined, fallback: number, name: string): number {
+  const trimmed = raw?.trim();
+  const value = trimmed ? Number.parseInt(trimmed, 10) : fallback;
+  if (Number.isNaN(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${trimmed}"`);
+  }
+  return value;
+}

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -1,0 +1,42 @@
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from './config.js';
+import { createServer } from './server.js';
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.chat' });
+
+  try {
+    const config = loadConfig();
+    const server = createServer({ config, logger });
+
+    await server.listen({ port: config.port, host: config.host });
+
+    logger.info('service.chat listening', {
+      port: config.port,
+      host: config.host,
+      grpcPort: config.grpcPort,
+      schema: config.schema,
+      natsUrl: config.natsUrl,
+      environment: config.environment,
+    });
+
+    const shutdown = async (signal: string): Promise<void> => {
+      logger.info('service.chat shutting down', { signal });
+      try {
+        await server.close();
+      } catch (err) {
+        logger.error('error during shutdown', { err });
+      }
+      process.exit(0);
+    };
+
+    process.once('SIGTERM', () => void shutdown('SIGTERM'));
+    process.once('SIGINT', () => void shutdown('SIGINT'));
+  } catch (err) {
+    logger.error('service.chat failed to start', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/chat/src/instrumentation.ts
+++ b/services/chat/src/instrumentation.ts
@@ -1,0 +1,15 @@
+// OpenTelemetry SDK bootstrap for service.chat.
+//
+// Same --import-flag pattern as the rest of the stack: tsx / node
+// loads this BEFORE the rest of the service so the auto-
+// instrumentations can hook http, fastify, pg, undici BEFORE those
+// modules are first imported.
+//
+// Behaviour matches the rest of the stack (see @adopt-dont-shop/observability):
+//   - Silent no-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+//   - OTEL_SERVICE_NAME env var overrides the value below.
+//   - No-throw contract.
+
+import { initializeOpenTelemetry } from '@adopt-dont-shop/observability';
+
+initializeOpenTelemetry({ serviceName: 'service.chat' });

--- a/services/chat/src/server.test.ts
+++ b/services/chat/src/server.test.ts
@@ -1,0 +1,67 @@
+import { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { ChatConfig } from './config.js';
+import { createServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const baseConfig: ChatConfig = {
+  port: 0,
+  grpcPort: 0,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'chat',
+  natsUrl: 'nats://localhost:4222',
+};
+
+describe('createServer — health endpoint', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = createServer({ config: baseConfig, logger: quietLogger });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('responds to GET /health/simple with status ok', async () => {
+    const res = await server.inject({ method: 'GET', url: '/health/simple' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      status: 'ok',
+      service: 'service.chat',
+      environment: 'test',
+    });
+  });
+
+  it('surfaces the configured environment in the health payload', async () => {
+    const stagingServer = createServer({
+      config: { ...baseConfig, environment: 'staging' },
+      logger: quietLogger,
+    });
+    try {
+      const res = await stagingServer.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.json()).toMatchObject({ environment: 'staging' });
+    } finally {
+      await stagingServer.close();
+    }
+  });
+
+  it('returns a 500 when a route handler throws (custom error handler)', async () => {
+    server.get('/boom', async () => {
+      throw new Error('boom');
+    });
+    const res = await server.inject({ method: 'GET', url: '/boom' });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ error: 'internal_error' });
+  });
+});

--- a/services/chat/src/server.ts
+++ b/services/chat/src/server.ts
@@ -1,0 +1,62 @@
+// services/chat — Phase 6 extraction. Owns the chat.* schema and
+// exposes ChatService over gRPC.
+//
+// Classical (no event sourcing — chat messages are append-only by
+// nature but they're not a state machine). WS-heavy: the gateway
+// terminates Socket.IO and this service publishes
+// chat.messageCreated / chat.messageRead / chat.reactionAdded on
+// NATS for fan-out via the existing Phase 1.5 WS subscriber.
+//
+// Phase 6.1 (this commit) is just the boot skeleton; schema (6.2),
+// gRPC (6.3), NATS publishers (6.4), gateway routing (6.5), and
+// cutover (6.6) arrive in subsequent commits.
+
+import { createLogger } from '@adopt-dont-shop/observability';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+import type { ChatConfig } from './config.js';
+
+export type CreateServerOptions = {
+  config: ChatConfig;
+  // Optional logger injection — tests pass a quiet logger so the
+  // suite output stays readable. Real boot uses createLogger so the
+  // service emits structured lines through the same pipeline as the
+  // rest of the stack.
+  logger?: ReturnType<typeof createLogger>;
+};
+
+export const createServer = (opts: CreateServerOptions): FastifyInstance => {
+  const { config } = opts;
+  const logger = opts.logger ?? createLogger({ serviceName: 'service.chat' });
+
+  // Disable Fastify's built-in pino — winston handles service-level
+  // lines (boot, shutdown, error handler), and OTel's HTTP
+  // auto-instrumentation already covers per-request spans. Same
+  // shape as the other extracted services.
+  const server = Fastify({
+    logger: false,
+    trustProxy: true,
+  });
+
+  server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
+    logger.error('request failed', {
+      method: req.method,
+      url: req.url,
+      message: err.message,
+    });
+    void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
+  });
+
+  // Health endpoint — matches the rest of the stack's
+  // `/health/simple` path so the existing Docker compose healthcheck
+  // pattern picks this service up unchanged.
+  server.get('/health/simple', async () => ({
+    status: 'ok',
+    service: 'service.chat',
+    environment: config.environment,
+  }));
+
+  return server;
+};
+
+export type { ChatConfig };

--- a/services/chat/tsconfig.json
+++ b/services/chat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/services/chat/vitest.config.ts
+++ b/services/chat/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 6 of the migration — chat vertical. Classical (no event sourcing — chat messages are append-only by nature but they're not a state machine). WS-heavy: the gateway terminates Socket.IO and this service publishes `chat.messageCreated` / `chat.messageRead` / `chat.reactionAdded` on NATS for fan-out via the existing Phase 1.5 WS subscriber.

**Opened in parallel** with [#875](https://github.com/ideaSquared/adopt-dont-shop/pull/875) (Phase 5.1 applications boot skeleton). Two different services, zero shared files — boot skeletons of independent verticals never conflict.

## What's in

- **`services/chat/package.json`** — same scripts + scoped deps shape as `services/applications` / `services/rescue`. `CHAT_PORT` defaults to 5006, `CHAT_GRPC_PORT` to 6006 (HTTP+1000 convention).
- **`src/config.ts`** — env loader. `DATABASE_URL` is the only hard requirement; misconfiguration fails fast at boot rather than at first request.
- **`src/server.ts`** — `createServer` with `/health/simple`. Mirror of `service.rescue`'s `createServer`.
- **`src/instrumentation.ts`** — boots OpenTelemetry via `@adopt-dont-shop/observability` with `serviceName: 'service.chat'`.
- **`src/index.ts`** — wires HTTP listen + SIGTERM/SIGINT shutdown.
- **`README.md`** documents the Phase 6.1 surface and what's coming in 6.2-6.6.

## Test plan

- [x] `npm test` in `services/chat` — **9/9** green
- [x] `npm run check:workflow-paths` — clean
- [x] `npx turbo type-check --filter='@adopt-dont-shop/service.chat'` — green
- [x] Lint clean

## What's NOT in

- **Phase 6.2** — `chat.*` schema + migrations (Chat, ChatParticipant, Message, MessageReaction, MessageRead).
- **Phase 6.3** — proto + handlers + adapter (send / list / mark-read / react).
- **Phase 6.4** — NATS publishers (`chat.messageCreated`, `chat.messageRead`, `chat.reactionAdded`) that feed the gateway's existing Phase 1.5 WS subscriber. Moderation hook: Phase 8 `service.moderation` consumes `chat.messageCreated` for content scanning.
- **Phase 6.5** — Gateway routes `/api/chat/*` here.
- **Phase 6.6** — Cutover.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_