### PR TITLE
feat(microservices): services/moderation boot skeleton (Phase 8.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4850,6 +4850,10 @@
       "resolved": "services/gateway",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/service.moderation": {
+      "resolved": "services/moderation",
+      "link": true
+    },
     "node_modules/@adopt-dont-shop/service.notifications": {
       "resolved": "services/notifications",
       "link": true
@@ -32665,6 +32669,14 @@
         "fastify": "^5.8.5",
         "nats": "^2.29.3",
         "socket.io": "^4.8.3"
+      }
+    },
+    "services/moderation": {
+      "name": "@adopt-dont-shop/service.moderation",
+      "version": "0.1.0",
+      "dependencies": {
+        "@adopt-dont-shop/observability": "*",
+        "fastify": "^5.8.5"
       }
     },
     "services/notifications": {

--- a/services/moderation/README.md
+++ b/services/moderation/README.md
@@ -1,0 +1,36 @@
+# service.moderation
+
+Moderation vertical — Phase 8 of the microservices migration.
+
+Owns the `moderation.*` schema (Report, ModeratorAction,
+ModerationEvidence, UserSanction, SupportTicket, SupportTicketResponse)
+and exposes `ModerationService` over gRPC. Cross-cutting reads via
+gRPC; consumes events (`chat.messageCreated`, `pets.created`,
+`applications.submitted`) for content scanning + auto-report triggers.
+
+## What's shipped so far
+
+**Phase 8.1** — boot skeleton: `/health/simple` on `MODERATION_PORT`
+(default 5007), OpenTelemetry boot, env-validated config.
+
+## What's NOT here yet
+
+- **Phase 8.2** — `moderation.*` schema + migrations.
+- **Phase 8.3** — gRPC `ModerationService` (file-report, moderator
+  action, evidence upload, user sanction, support ticket).
+- **Phase 8.4** — NATS subscribers on `chat.messageCreated`,
+  `pets.created`, `applications.submitted`.
+- **Phase 8.5** — Gateway routes `/api/moderation/*`.
+- **Phase 8.6** — Cutover.
+
+## Configuration
+
+| Env var                | Default            | Required | Purpose                         |
+| ---------------------- | ------------------ | -------- | ------------------------------- |
+| `MODERATION_PORT`      | `5007`             |          | HTTP port for `/health/simple`. |
+| `MODERATION_GRPC_PORT` | `6007`             |          | gRPC port (Phase 8.3c).         |
+| `MODERATION_HOST`      | `0.0.0.0`          |          | Bind interface.                 |
+| `MODERATION_SCHEMA`    | `moderation`       |          | Postgres schema.                |
+| `DATABASE_URL`         | —                  | ✅       | Postgres connection string.     |
+| `NATS_URL`             | `nats://nats:4222` |          | NATS bus URL.                   |
+| `NODE_ENV`             | `development`      |          | Surfaces in health + logs.      |

--- a/services/moderation/package.json
+++ b/services/moderation/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@adopt-dont-shop/service.moderation",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Moderation service — Phase 8 extraction. Owns the moderation.* schema (Report, ModeratorAction, ModerationEvidence, UserSanction, SupportTicket, SupportTicketResponse) and exposes gRPC ModerationService. Cross-cutting reads via gRPC; consumes events (chat.messageCreated, pets.created, applications.submitted) for content scanning + auto-report triggers. Polymorphic evidence model preserved (parent_type enum). Phase 8.1 commit is just the boot skeleton; schema/gRPC/NATS/gateway land in later phases.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
+    "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adopt-dont-shop/observability": "*",
+    "fastify": "^5.8.5"
+  }
+}

--- a/services/moderation/src/config.test.ts
+++ b/services/moderation/src/config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from './config.js';
+
+const REQUIRED = {
+  DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+};
+
+describe('loadConfig', () => {
+  it('uses the documented defaults when only the required env vars are set', () => {
+    const config = loadConfig({ ...REQUIRED });
+    expect(config.port).toBe(5007);
+    expect(config.grpcPort).toBe(6007);
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.schema).toBe('moderation');
+  });
+
+  it('honours all env overrides when set', () => {
+    const config = loadConfig({
+      MODERATION_PORT: '5500',
+      MODERATION_GRPC_PORT: '6500',
+      MODERATION_HOST: '127.0.0.1',
+      MODERATION_SCHEMA: 'moderation_test',
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/moderation',
+      NATS_URL: 'nats://nats.internal:4222',
+    });
+    expect(config.port).toBe(5500);
+    expect(config.grpcPort).toBe(6500);
+    expect(config.schema).toBe('moderation_test');
+  });
+
+  it('rejects a non-numeric MODERATION_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, MODERATION_PORT: 'x' })).toThrow(
+      /MODERATION_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-numeric MODERATION_GRPC_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, MODERATION_GRPC_PORT: 'x' })).toThrow(
+      /MODERATION_GRPC_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-positive MODERATION_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, MODERATION_PORT: '0' })).toThrow(
+      /MODERATION_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects an unset DATABASE_URL', () => {
+    expect(() => loadConfig({})).toThrow(/DATABASE_URL is required/);
+  });
+});

--- a/services/moderation/src/config.ts
+++ b/services/moderation/src/config.ts
@@ -1,0 +1,60 @@
+export type ModerationConfig = {
+  // HTTP port for the boot-readiness surface (/health/simple). Distinct
+  // from every other service in the stack (5000 backend, 4000 gateway,
+  // 5001 notifications, 5002 auth, 5003 pets, 5004 rescue,
+  // 5005 applications, 5006 chat).
+  port: number;
+  host: string;
+  // gRPC server port. ModerationService.{FileReport, ResolveReport,
+  // SanctionUser, ListReports, OpenTicket, RespondToTicket} bind here
+  // once Phase 8.3c brings the server online. Convention: HTTP + 1000.
+  grpcPort: number;
+  // Environment label, surfaced in health responses and on log lines.
+  environment: string;
+  // Postgres connection string. Required for migrations + the runtime
+  // database client. Same physical Postgres as service.backend; this
+  // service owns the `moderation` schema (CAD-style schema-per-service).
+  databaseUrl: string;
+  // Schema name. Defaults to `moderation`.
+  schema: string;
+  // NATS bus. Phase 8.3 onwards publishes moderation.reportFiled,
+  // moderation.actionTaken, moderation.userSanctioned. Subscribes to
+  // chat.messageCreated, pets.created, applications.submitted etc.
+  // for content scanning + auto-report triggers.
+  natsUrl: string;
+};
+
+const DEFAULT_PORT = 5007;
+const DEFAULT_GRPC_PORT = 6007;
+const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_SCHEMA = 'moderation';
+const DEFAULT_NATS_URL = 'nats://nats:4222';
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ModerationConfig => {
+  const port = parsePort(env.MODERATION_PORT, DEFAULT_PORT, 'MODERATION_PORT');
+  const grpcPort = parsePort(env.MODERATION_GRPC_PORT, DEFAULT_GRPC_PORT, 'MODERATION_GRPC_PORT');
+
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required (Postgres connection string)');
+  }
+
+  return {
+    port,
+    grpcPort,
+    host: env.MODERATION_HOST?.trim() || DEFAULT_HOST,
+    environment: env.NODE_ENV?.trim() || 'development',
+    databaseUrl,
+    schema: env.MODERATION_SCHEMA?.trim() || DEFAULT_SCHEMA,
+    natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+  };
+};
+
+function parsePort(raw: string | undefined, fallback: number, name: string): number {
+  const trimmed = raw?.trim();
+  const value = trimmed ? Number.parseInt(trimmed, 10) : fallback;
+  if (Number.isNaN(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${trimmed}"`);
+  }
+  return value;
+}

--- a/services/moderation/src/index.ts
+++ b/services/moderation/src/index.ts
@@ -1,0 +1,42 @@
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from './config.js';
+import { createServer } from './server.js';
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.moderation' });
+
+  try {
+    const config = loadConfig();
+    const server = createServer({ config, logger });
+
+    await server.listen({ port: config.port, host: config.host });
+
+    logger.info('service.moderation listening', {
+      port: config.port,
+      host: config.host,
+      grpcPort: config.grpcPort,
+      schema: config.schema,
+      natsUrl: config.natsUrl,
+      environment: config.environment,
+    });
+
+    const shutdown = async (signal: string): Promise<void> => {
+      logger.info('service.moderation shutting down', { signal });
+      try {
+        await server.close();
+      } catch (err) {
+        logger.error('error during shutdown', { err });
+      }
+      process.exit(0);
+    };
+
+    process.once('SIGTERM', () => void shutdown('SIGTERM'));
+    process.once('SIGINT', () => void shutdown('SIGINT'));
+  } catch (err) {
+    logger.error('service.moderation failed to start', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/moderation/src/instrumentation.ts
+++ b/services/moderation/src/instrumentation.ts
@@ -1,0 +1,6 @@
+// OpenTelemetry SDK bootstrap for service.moderation. Same pattern as
+// the rest of the extracted services. See @adopt-dont-shop/observability.
+
+import { initializeOpenTelemetry } from '@adopt-dont-shop/observability';
+
+initializeOpenTelemetry({ serviceName: 'service.moderation' });

--- a/services/moderation/src/server.test.ts
+++ b/services/moderation/src/server.test.ts
@@ -1,0 +1,66 @@
+import { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { ModerationConfig } from './config.js';
+import { createServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const baseConfig: ModerationConfig = {
+  port: 0,
+  grpcPort: 0,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'moderation',
+  natsUrl: 'nats://localhost:4222',
+};
+
+describe('createServer — health endpoint', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = createServer({ config: baseConfig, logger: quietLogger });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('responds to GET /health/simple with status ok', async () => {
+    const res = await server.inject({ method: 'GET', url: '/health/simple' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      status: 'ok',
+      service: 'service.moderation',
+      environment: 'test',
+    });
+  });
+
+  it('surfaces the configured environment in the health payload', async () => {
+    const stagingServer = createServer({
+      config: { ...baseConfig, environment: 'staging' },
+      logger: quietLogger,
+    });
+    try {
+      const res = await stagingServer.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.json()).toMatchObject({ environment: 'staging' });
+    } finally {
+      await stagingServer.close();
+    }
+  });
+
+  it('returns a 500 when a route handler throws (custom error handler)', async () => {
+    server.get('/boom', async () => {
+      throw new Error('boom');
+    });
+    const res = await server.inject({ method: 'GET', url: '/boom' });
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/services/moderation/src/server.ts
+++ b/services/moderation/src/server.ts
@@ -1,0 +1,44 @@
+// services/moderation — Phase 8 extraction. Owns the moderation.*
+// schema and exposes ModerationService over gRPC. Cross-cutting reads
+// via gRPC; consumes events (chat.messageCreated, pets.created,
+// applications.submitted) for content scanning + auto-report triggers.
+//
+// Phase 8.1 (this commit) is just the boot skeleton; schema (8.2),
+// gRPC (8.3), NATS subscribers (8.4), gateway routing (8.5), and
+// cutover (8.6) arrive in subsequent commits.
+
+import { createLogger } from '@adopt-dont-shop/observability';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+import type { ModerationConfig } from './config.js';
+
+export type CreateServerOptions = {
+  config: ModerationConfig;
+  logger?: ReturnType<typeof createLogger>;
+};
+
+export const createServer = (opts: CreateServerOptions): FastifyInstance => {
+  const { config } = opts;
+  const logger = opts.logger ?? createLogger({ serviceName: 'service.moderation' });
+
+  const server = Fastify({ logger: false, trustProxy: true });
+
+  server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
+    logger.error('request failed', {
+      method: req.method,
+      url: req.url,
+      message: err.message,
+    });
+    void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
+  });
+
+  server.get('/health/simple', async () => ({
+    status: 'ok',
+    service: 'service.moderation',
+    environment: config.environment,
+  }));
+
+  return server;
+};
+
+export type { ModerationConfig };

--- a/services/moderation/tsconfig.json
+++ b/services/moderation/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/services/moderation/vitest.config.ts
+++ b/services/moderation/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 8 — moderation vertical. Cross-cutting reads via gRPC; consumes events (`chat.messageCreated`, `pets.created`, `applications.submitted`) for content scanning + auto-report triggers. Polymorphic evidence model preserved when 8.2 ports the schema.

**Opened in parallel** with #875, #877, #879, #880 + sibling boot skeletons. New files only in `services/moderation/` — zero overlap with anything else open.

`MODERATION_PORT` 5007 / `MODERATION_GRPC_PORT` 6007.

## Test plan

- [x] **9/9** green
- [x] Lint clean, type-check clean, workflow-paths clean

## What's NOT in

Phases 8.2 schema → 8.6 cutover.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_