### PR TITLE
feat(microservices): services/matching boot skeleton (Phase 9.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4862,6 +4862,10 @@
       "resolved": "services/gateway",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/service.matching": {
+      "resolved": "services/matching",
+      "link": true
+    },
     "node_modules/@adopt-dont-shop/service.moderation": {
       "resolved": "services/moderation",
       "link": true
@@ -32705,6 +32709,14 @@
         "fastify": "^5.8.5",
         "nats": "^2.29.3",
         "socket.io": "^4.8.3"
+      }
+    },
+    "services/matching": {
+      "name": "@adopt-dont-shop/service.matching",
+      "version": "0.1.0",
+      "dependencies": {
+        "@adopt-dont-shop/observability": "*",
+        "fastify": "^5.8.5"
       }
     },
     "services/moderation": {

--- a/services/matching/README.md
+++ b/services/matching/README.md
@@ -1,0 +1,36 @@
+# service.matching
+
+Matching vertical — Phase 9 of the microservices migration.
+
+Stateless recommender (CAD `service.dispatch` shape) — given a user,
+queries `service.pets` for candidates over gRPC, ranks by stored
+preferences + match-profile, returns top-K. Owns the `matching.*`
+schema (`SwipeSession`, `SwipeAction`). Absorbs the monolith's
+discovery + search + swipe modules.
+
+## What's shipped so far
+
+**Phase 9.1** — boot skeleton: `/health/simple` on `MATCHING_PORT`
+(default 5008), OpenTelemetry boot, env-validated config.
+
+## What's NOT here yet
+
+- **Phase 9.2** — `matching.*` schema + migrations.
+- **Phase 9.3** — gRPC `MatchingService` (recommend, record-swipe,
+  discover, search). Reads pets via gRPC from `service.pets`.
+- **Phase 9.4** — NATS publishers (`matching.swipeRecorded` etc.).
+- **Phase 9.5** — Gateway routes `/api/matching/*` (and the
+  legacy `/api/discovery/*`, `/api/search/*`).
+- **Phase 9.6** — Cutover.
+
+## Configuration
+
+| Env var              | Default            | Required | Purpose                         |
+| -------------------- | ------------------ | -------- | ------------------------------- |
+| `MATCHING_PORT`      | `5008`             |          | HTTP port for `/health/simple`. |
+| `MATCHING_GRPC_PORT` | `6008`             |          | gRPC port (Phase 9.3c).         |
+| `MATCHING_HOST`      | `0.0.0.0`          |          | Bind interface.                 |
+| `MATCHING_SCHEMA`    | `matching`         |          | Postgres schema.                |
+| `DATABASE_URL`       | —                  | ✅       | Postgres connection string.     |
+| `NATS_URL`           | `nats://nats:4222` |          | NATS bus URL.                   |
+| `NODE_ENV`           | `development`      |          | Surfaces in health + logs.      |

--- a/services/matching/package.json
+++ b/services/matching/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@adopt-dont-shop/service.matching",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Matching service — Phase 9 extraction. Stateless recommender — given a user, queries service.pets for candidates over gRPC, ranks by stored preferences + match-profile, returns top-K. Owns the matching.* schema (SwipeSession, SwipeAction). Absorbs the monolith's discovery + search + swipe modules. CAD service.dispatch shape. Phase 9.1 commit is just the boot skeleton.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
+    "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adopt-dont-shop/observability": "*",
+    "fastify": "^5.8.5"
+  }
+}

--- a/services/matching/src/config.test.ts
+++ b/services/matching/src/config.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from './config.js';
+
+const REQUIRED = { DATABASE_URL: 'postgres://test:test@localhost:5432/test' };
+
+describe('loadConfig', () => {
+  it('uses the documented defaults when only the required env vars are set', () => {
+    const config = loadConfig({ ...REQUIRED });
+    expect(config.port).toBe(5008);
+    expect(config.grpcPort).toBe(6008);
+    expect(config.schema).toBe('matching');
+  });
+
+  it('honours all env overrides when set', () => {
+    const config = loadConfig({
+      MATCHING_PORT: '5500',
+      MATCHING_GRPC_PORT: '6500',
+      MATCHING_HOST: '127.0.0.1',
+      MATCHING_SCHEMA: 'matching_test',
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgres://x',
+      NATS_URL: 'nats://nats.internal:4222',
+    });
+    expect(config.port).toBe(5500);
+    expect(config.grpcPort).toBe(6500);
+    expect(config.schema).toBe('matching_test');
+  });
+
+  it('rejects a non-numeric MATCHING_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, MATCHING_PORT: 'x' })).toThrow(
+      /MATCHING_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-numeric MATCHING_GRPC_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, MATCHING_GRPC_PORT: 'x' })).toThrow(
+      /MATCHING_GRPC_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-positive MATCHING_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, MATCHING_PORT: '0' })).toThrow(
+      /MATCHING_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects an unset DATABASE_URL', () => {
+    expect(() => loadConfig({})).toThrow(/DATABASE_URL is required/);
+  });
+});

--- a/services/matching/src/config.ts
+++ b/services/matching/src/config.ts
@@ -1,0 +1,58 @@
+export type MatchingConfig = {
+  // HTTP port for the boot-readiness surface (/health/simple). Distinct
+  // from every other service in the stack (5000 backend, 4000 gateway,
+  // 5001 notifications, 5002 auth, 5003 pets, 5004 rescue,
+  // 5005 applications, 5006 chat, 5007 moderation).
+  port: number;
+  host: string;
+  // gRPC server port. MatchingService.{Recommend, RecordSwipe,
+  // Discover, Search} bind here once Phase 9.3c brings the server
+  // online. Convention: HTTP + 1000.
+  grpcPort: number;
+  environment: string;
+  // Postgres connection string. Required for migrations + the runtime
+  // database client. Same physical Postgres as service.backend; this
+  // service owns the `matching` schema (CAD-style schema-per-service).
+  databaseUrl: string;
+  // Schema name. Defaults to `matching`.
+  schema: string;
+  // NATS bus. Phase 9.3 onwards publishes matching.swipeRecorded etc.
+  // The service consumes pet data via gRPC (not events) — it's
+  // stateless compute, not a denormalised projection.
+  natsUrl: string;
+};
+
+const DEFAULT_PORT = 5008;
+const DEFAULT_GRPC_PORT = 6008;
+const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_SCHEMA = 'matching';
+const DEFAULT_NATS_URL = 'nats://nats:4222';
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): MatchingConfig => {
+  const port = parsePort(env.MATCHING_PORT, DEFAULT_PORT, 'MATCHING_PORT');
+  const grpcPort = parsePort(env.MATCHING_GRPC_PORT, DEFAULT_GRPC_PORT, 'MATCHING_GRPC_PORT');
+
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required (Postgres connection string)');
+  }
+
+  return {
+    port,
+    grpcPort,
+    host: env.MATCHING_HOST?.trim() || DEFAULT_HOST,
+    environment: env.NODE_ENV?.trim() || 'development',
+    databaseUrl,
+    schema: env.MATCHING_SCHEMA?.trim() || DEFAULT_SCHEMA,
+    natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+  };
+};
+
+function parsePort(raw: string | undefined, fallback: number, name: string): number {
+  const trimmed = raw?.trim();
+  const value = trimmed ? Number.parseInt(trimmed, 10) : fallback;
+  if (Number.isNaN(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${trimmed}"`);
+  }
+  return value;
+}

--- a/services/matching/src/index.ts
+++ b/services/matching/src/index.ts
@@ -1,0 +1,42 @@
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from './config.js';
+import { createServer } from './server.js';
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.matching' });
+
+  try {
+    const config = loadConfig();
+    const server = createServer({ config, logger });
+
+    await server.listen({ port: config.port, host: config.host });
+
+    logger.info('service.matching listening', {
+      port: config.port,
+      host: config.host,
+      grpcPort: config.grpcPort,
+      schema: config.schema,
+      natsUrl: config.natsUrl,
+      environment: config.environment,
+    });
+
+    const shutdown = async (signal: string): Promise<void> => {
+      logger.info('service.matching shutting down', { signal });
+      try {
+        await server.close();
+      } catch (err) {
+        logger.error('error during shutdown', { err });
+      }
+      process.exit(0);
+    };
+
+    process.once('SIGTERM', () => void shutdown('SIGTERM'));
+    process.once('SIGINT', () => void shutdown('SIGINT'));
+  } catch (err) {
+    logger.error('service.matching failed to start', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/matching/src/instrumentation.ts
+++ b/services/matching/src/instrumentation.ts
@@ -1,0 +1,3 @@
+import { initializeOpenTelemetry } from '@adopt-dont-shop/observability';
+
+initializeOpenTelemetry({ serviceName: 'service.matching' });

--- a/services/matching/src/server.test.ts
+++ b/services/matching/src/server.test.ts
@@ -1,0 +1,66 @@
+import { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { MatchingConfig } from './config.js';
+import { createServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const baseConfig: MatchingConfig = {
+  port: 0,
+  grpcPort: 0,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'matching',
+  natsUrl: 'nats://localhost:4222',
+};
+
+describe('createServer — health endpoint', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = createServer({ config: baseConfig, logger: quietLogger });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('responds to GET /health/simple with status ok', async () => {
+    const res = await server.inject({ method: 'GET', url: '/health/simple' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      status: 'ok',
+      service: 'service.matching',
+      environment: 'test',
+    });
+  });
+
+  it('surfaces the configured environment in the health payload', async () => {
+    const stagingServer = createServer({
+      config: { ...baseConfig, environment: 'staging' },
+      logger: quietLogger,
+    });
+    try {
+      const res = await stagingServer.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.json()).toMatchObject({ environment: 'staging' });
+    } finally {
+      await stagingServer.close();
+    }
+  });
+
+  it('returns a 500 when a route handler throws (custom error handler)', async () => {
+    server.get('/boom', async () => {
+      throw new Error('boom');
+    });
+    const res = await server.inject({ method: 'GET', url: '/boom' });
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/services/matching/src/server.ts
+++ b/services/matching/src/server.ts
@@ -1,0 +1,39 @@
+// services/matching — Phase 9 extraction. Stateless recommender +
+// discovery + search + swipe absorption. Phase 9.1 (this commit) is
+// just the boot skeleton.
+
+import { createLogger } from '@adopt-dont-shop/observability';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+import type { MatchingConfig } from './config.js';
+
+export type CreateServerOptions = {
+  config: MatchingConfig;
+  logger?: ReturnType<typeof createLogger>;
+};
+
+export const createServer = (opts: CreateServerOptions): FastifyInstance => {
+  const { config } = opts;
+  const logger = opts.logger ?? createLogger({ serviceName: 'service.matching' });
+
+  const server = Fastify({ logger: false, trustProxy: true });
+
+  server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
+    logger.error('request failed', {
+      method: req.method,
+      url: req.url,
+      message: err.message,
+    });
+    void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
+  });
+
+  server.get('/health/simple', async () => ({
+    status: 'ok',
+    service: 'service.matching',
+    environment: config.environment,
+  }));
+
+  return server;
+};
+
+export type { MatchingConfig };

--- a/services/matching/tsconfig.json
+++ b/services/matching/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/services/matching/vitest.config.ts
+++ b/services/matching/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 9 — matching vertical. Stateless recommender (CAD `service.dispatch` shape) absorbing the monolith's discovery + search + swipe modules. Queries `service.pets` via gRPC, ranks by stored preferences + match-profile, returns top-K. Owns the `matching.*` schema (`SwipeSession`, `SwipeAction`).

**Opened in parallel** with the other open PRs — new files in `services/matching/` only, zero overlap.

`MATCHING_PORT` 5008 / `MATCHING_GRPC_PORT` 6008.

## Test plan

- [x] **9/9** green
- [x] Lint clean, type-check clean, workflow-paths clean

## What's NOT in

Phases 9.2 schema → 9.6 cutover.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_