### PR TITLE
feat(audit): phase 10.1 — service.audit boot skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4846,6 +4846,10 @@
       "resolved": "services/applications",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/service.audit": {
+      "resolved": "services/audit",
+      "link": true
+    },
     "node_modules/@adopt-dont-shop/service.auth": {
       "resolved": "services/auth",
       "link": true
@@ -32641,6 +32645,14 @@
     },
     "services/applications": {
       "name": "@adopt-dont-shop/service.applications",
+      "version": "0.1.0",
+      "dependencies": {
+        "@adopt-dont-shop/observability": "*",
+        "fastify": "^5.8.5"
+      }
+    },
+    "services/audit": {
+      "name": "@adopt-dont-shop/service.audit",
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/observability": "*",

--- a/services/audit/README.md
+++ b/services/audit/README.md
@@ -1,0 +1,43 @@
+# service.audit
+
+Audit vertical — Phase 10 of the microservices migration.
+
+Append-only event store consuming `*.actionTaken` NATS topics from
+every service. Idempotent on `event_id`. Row-level trigger rejects
+UPDATE/DELETE so audit history is tamper-evident (CAD PR #49
+pattern). Owns the `audit.*` schema. Replaces the monolith's
+`auditLog.service.ts` + audit middleware.
+
+## What's shipped so far
+
+**Phase 10.1** — boot skeleton: `/health/simple` on `AUDIT_PORT`
+(default 5009), OpenTelemetry boot, env-validated config.
+
+## What's NOT here yet
+
+- **Phase 10.2** — `audit.*` schema + migrations (single
+  `audit_events` table with row-level trigger rejecting
+  UPDATE/DELETE).
+- **Phase 10.3** — gRPC `AuditQueryService.{Query, GetByTarget}`
+  with base64-JSON keyset cursors.
+- **Phase 10.4** — NATS subscribers on every `*.actionTaken` topic
+  (auth, pets, rescue, applications, chat, notifications,
+  moderation, matching). Idempotent on `event_id`.
+- **Phase 10.5** — Gateway routes `GET /api/audit/*` gated on
+  `view Audit` ability (admin+).
+- **Phase 10.6** — Cutover: delete `auditLog.service.ts`,
+  `audit-log-formatting.ts`, and the audit middleware from the
+  residual monolith. This service is then the sole
+  producer/consumer.
+
+## Configuration
+
+| Env var           | Default            | Required | Purpose                         |
+| ----------------- | ------------------ | -------- | ------------------------------- |
+| `AUDIT_PORT`      | `5009`             |          | HTTP port for `/health/simple`. |
+| `AUDIT_GRPC_PORT` | `6009`             |          | gRPC port (Phase 10.3c).        |
+| `AUDIT_HOST`      | `0.0.0.0`          |          | Bind interface.                 |
+| `AUDIT_SCHEMA`    | `audit`            |          | Postgres schema.                |
+| `DATABASE_URL`    | —                  | ✅       | Postgres connection string.     |
+| `NATS_URL`        | `nats://nats:4222` |          | NATS bus URL.                   |
+| `NODE_ENV`        | `development`      |          | Surfaces in health + logs.      |

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@adopt-dont-shop/service.audit",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Audit service — Phase 10 extraction. Append-only event store consuming *.actionTaken NATS topics; idempotent on event_id; row-level trigger rejects UPDATE/DELETE. Owns the audit.* schema (AuditEvent). gRPC AuditQueryService.{Query, GetByTarget} with base64-JSON keyset cursors. Gateway gates GET /api/audit/* on the `view Audit` ability. Phase 10.1 commit is just the boot skeleton.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts",
+      "default": "./src/server.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
+    "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adopt-dont-shop/observability": "*",
+    "fastify": "^5.8.5"
+  }
+}

--- a/services/audit/src/config.test.ts
+++ b/services/audit/src/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig } from './config.js';
+
+const REQUIRED = {
+  DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+};
+
+describe('loadConfig', () => {
+  it('uses the documented defaults when only the required env vars are set', () => {
+    const config = loadConfig({ ...REQUIRED });
+    expect(config.port).toBe(5009);
+    expect(config.grpcPort).toBe(6009);
+    expect(config.host).toBe('0.0.0.0');
+    expect(config.environment).toBe('development');
+    expect(config.databaseUrl).toBe(REQUIRED.DATABASE_URL);
+    expect(config.schema).toBe('audit');
+    expect(config.natsUrl).toBe('nats://nats:4222');
+  });
+
+  it('honours all env overrides when set', () => {
+    const config = loadConfig({
+      AUDIT_PORT: '5500',
+      AUDIT_GRPC_PORT: '6500',
+      AUDIT_HOST: '127.0.0.1',
+      AUDIT_SCHEMA: 'audit_test',
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/audit',
+      NATS_URL: 'nats://nats.internal:4222',
+    });
+
+    expect(config.port).toBe(5500);
+    expect(config.grpcPort).toBe(6500);
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.environment).toBe('production');
+    expect(config.schema).toBe('audit_test');
+    expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/audit');
+    expect(config.natsUrl).toBe('nats://nats.internal:4222');
+  });
+
+  it('rejects a non-numeric AUDIT_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, AUDIT_PORT: 'five-thousand' })).toThrow(
+      /AUDIT_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-numeric AUDIT_GRPC_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, AUDIT_GRPC_PORT: 'six-thousand' })).toThrow(
+      /AUDIT_GRPC_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects a non-positive AUDIT_PORT', () => {
+    expect(() => loadConfig({ ...REQUIRED, AUDIT_PORT: '0' })).toThrow(
+      /AUDIT_PORT must be a positive integer/
+    );
+  });
+
+  it('rejects an unset DATABASE_URL', () => {
+    expect(() => loadConfig({})).toThrow(/DATABASE_URL is required/);
+  });
+});

--- a/services/audit/src/config.ts
+++ b/services/audit/src/config.ts
@@ -1,0 +1,62 @@
+export type AuditConfig = {
+  // HTTP port for the boot-readiness surface (/health/simple). Distinct
+  // from service.backend's 5000, service.gateway's 4000,
+  // service.notifications' 5001, service.auth's 5002, service.pets's
+  // 5003, service.rescue's 5004, service.applications' 5005,
+  // service.chat's 5006, service.moderation's 5007, service.matching's
+  // 5008.
+  port: number;
+  host: string;
+  // gRPC server port. AuditQueryService.{Query, GetByTarget} bind
+  // here once Phase 10.3c brings the server online. Convention:
+  // HTTP + 1000.
+  grpcPort: number;
+  // Environment label, surfaced in health responses and on log lines.
+  environment: string;
+  // Postgres connection string. Required for migrations + the runtime
+  // database client. Same physical Postgres as service.backend; this
+  // service owns the `audit` schema (CAD-style schema-per-service).
+  databaseUrl: string;
+  // Schema name. Defaults to `audit` — the audit_events table lives
+  // here. Row-level trigger rejects UPDATE/DELETE (CAD PR #49
+  // pattern); this service is the sole producer/consumer.
+  schema: string;
+  // NATS bus. Phase 10.3 onwards subscribes to *.actionTaken topics
+  // and persists each event idempotently by event_id.
+  natsUrl: string;
+};
+
+const DEFAULT_PORT = 5009;
+const DEFAULT_GRPC_PORT = 6009;
+const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_SCHEMA = 'audit';
+const DEFAULT_NATS_URL = 'nats://nats:4222';
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AuditConfig => {
+  const port = parsePort(env.AUDIT_PORT, DEFAULT_PORT, 'AUDIT_PORT');
+  const grpcPort = parsePort(env.AUDIT_GRPC_PORT, DEFAULT_GRPC_PORT, 'AUDIT_GRPC_PORT');
+
+  const databaseUrl = env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required (Postgres connection string)');
+  }
+
+  return {
+    port,
+    grpcPort,
+    host: env.AUDIT_HOST?.trim() || DEFAULT_HOST,
+    environment: env.NODE_ENV?.trim() || 'development',
+    databaseUrl,
+    schema: env.AUDIT_SCHEMA?.trim() || DEFAULT_SCHEMA,
+    natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+  };
+};
+
+function parsePort(raw: string | undefined, fallback: number, name: string): number {
+  const trimmed = raw?.trim();
+  const value = trimmed ? Number.parseInt(trimmed, 10) : fallback;
+  if (Number.isNaN(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${trimmed}"`);
+  }
+  return value;
+}

--- a/services/audit/src/index.ts
+++ b/services/audit/src/index.ts
@@ -1,0 +1,42 @@
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from './config.js';
+import { createServer } from './server.js';
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.audit' });
+
+  try {
+    const config = loadConfig();
+    const server = createServer({ config, logger });
+
+    await server.listen({ port: config.port, host: config.host });
+
+    logger.info('service.audit listening', {
+      port: config.port,
+      host: config.host,
+      grpcPort: config.grpcPort,
+      schema: config.schema,
+      natsUrl: config.natsUrl,
+      environment: config.environment,
+    });
+
+    const shutdown = async (signal: string): Promise<void> => {
+      logger.info('service.audit shutting down', { signal });
+      try {
+        await server.close();
+      } catch (err) {
+        logger.error('error during shutdown', { err });
+      }
+      process.exit(0);
+    };
+
+    process.once('SIGTERM', () => void shutdown('SIGTERM'));
+    process.once('SIGINT', () => void shutdown('SIGINT'));
+  } catch (err) {
+    logger.error('service.audit failed to start', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/audit/src/instrumentation.ts
+++ b/services/audit/src/instrumentation.ts
@@ -1,0 +1,15 @@
+// OpenTelemetry SDK bootstrap for service.audit.
+//
+// Same --import-flag pattern as the rest of the stack: tsx / node
+// loads this BEFORE the rest of the service so the auto-
+// instrumentations can hook http, fastify, pg, undici BEFORE those
+// modules are first imported.
+//
+// Behaviour matches the rest of the stack (see @adopt-dont-shop/observability):
+//   - Silent no-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
+//   - OTEL_SERVICE_NAME env var overrides the value below.
+//   - No-throw contract.
+
+import { initializeOpenTelemetry } from '@adopt-dont-shop/observability';
+
+initializeOpenTelemetry({ serviceName: 'service.audit' });

--- a/services/audit/src/server.test.ts
+++ b/services/audit/src/server.test.ts
@@ -1,0 +1,67 @@
+import { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { AuditConfig } from './config.js';
+import { createServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const baseConfig: AuditConfig = {
+  port: 0,
+  grpcPort: 0,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'audit',
+  natsUrl: 'nats://localhost:4222',
+};
+
+describe('createServer — health endpoint', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = createServer({ config: baseConfig, logger: quietLogger });
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('responds to GET /health/simple with status ok', async () => {
+    const res = await server.inject({ method: 'GET', url: '/health/simple' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      status: 'ok',
+      service: 'service.audit',
+      environment: 'test',
+    });
+  });
+
+  it('surfaces the configured environment in the health payload', async () => {
+    const stagingServer = createServer({
+      config: { ...baseConfig, environment: 'staging' },
+      logger: quietLogger,
+    });
+    try {
+      const res = await stagingServer.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.json()).toMatchObject({ environment: 'staging' });
+    } finally {
+      await stagingServer.close();
+    }
+  });
+
+  it('returns a 500 when a route handler throws (custom error handler)', async () => {
+    server.get('/boom', async () => {
+      throw new Error('boom');
+    });
+    const res = await server.inject({ method: 'GET', url: '/boom' });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ error: 'internal_error' });
+  });
+});

--- a/services/audit/src/server.ts
+++ b/services/audit/src/server.ts
@@ -1,0 +1,63 @@
+// services/audit — Phase 10 extraction. Append-only event store.
+//
+// Subscribes to *.actionTaken NATS topics from every service and
+// persists each event idempotently by event_id. Row-level trigger
+// rejects UPDATE/DELETE so audit history is tamper-evident (CAD PR
+// #49 pattern). gRPC AuditQueryService.{Query, GetByTarget} with
+// base64-JSON keyset cursors serves the gateway's
+// `view Audit`-gated GET /api/audit/* routes.
+//
+// Phase 10.1 (this commit) is just the boot skeleton; schema (10.2),
+// gRPC (10.3), NATS subscribers (10.4), gateway routing (10.5), and
+// monolith cutover (10.6 — deletes auditLog.service.ts + middleware)
+// arrive in subsequent commits.
+
+import { createLogger } from '@adopt-dont-shop/observability';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+import type { AuditConfig } from './config.js';
+
+export type CreateServerOptions = {
+  config: AuditConfig;
+  // Optional logger injection — tests pass a quiet logger so the
+  // suite output stays readable. Real boot uses createLogger so the
+  // service emits structured lines through the same pipeline as the
+  // rest of the stack.
+  logger?: ReturnType<typeof createLogger>;
+};
+
+export const createServer = (opts: CreateServerOptions): FastifyInstance => {
+  const { config } = opts;
+  const logger = opts.logger ?? createLogger({ serviceName: 'service.audit' });
+
+  // Disable Fastify's built-in pino — winston handles service-level
+  // lines (boot, shutdown, error handler), and OTel's HTTP
+  // auto-instrumentation already covers per-request spans. Same
+  // shape as the other extracted services.
+  const server = Fastify({
+    logger: false,
+    trustProxy: true,
+  });
+
+  server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
+    logger.error('request failed', {
+      method: req.method,
+      url: req.url,
+      message: err.message,
+    });
+    void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
+  });
+
+  // Health endpoint — matches the rest of the stack's
+  // `/health/simple` path so the existing Docker compose healthcheck
+  // pattern picks this service up unchanged.
+  server.get('/health/simple', async () => ({
+    status: 'ok',
+    service: 'service.audit',
+    environment: config.environment,
+  }));
+
+  return server;
+};
+
+export type { AuditConfig };

--- a/services/audit/tsconfig.json
+++ b/services/audit/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/services/audit/vitest.config.ts
+++ b/services/audit/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 10.1 boot skeleton for `services/audit/` — the append-only event-store vertical. CAD Phase 5 equivalent.

- New service at `services/audit/`, port 5009 / gRPC 6009 (next available after matching 5008/6008).
- Same boot-skeleton shape as service.chat / moderation / matching (Phase 6.1 / 8.1 / 9.1): `createServer` Fastify factory with `/health/simple`, custom 500 error handler, OTel via `--import ./src/instrumentation.ts`, env-validated config requiring `DATABASE_URL`.
- 9 tests passing — config defaults, env overrides, port validation, required `DATABASE_URL`, `/health/simple` payload + 500 error path.

## What's NOT here yet

- **Phase 10.2** — `audit.audit_events` table + row-level trigger rejecting UPDATE/DELETE (CAD PR #49 pattern — tamper-evident history).
- **Phase 10.3** — gRPC `AuditQueryService.{Query, GetByTarget}` with base64-JSON keyset cursors.
- **Phase 10.4** — NATS subscribers on every `*.actionTaken` topic, idempotent on `event_id`.
- **Phase 10.5** — Gateway `GET /api/audit/*` gated on `view Audit` ability.
- **Phase 10.6** — Cutover: delete `auditLog.service.ts`, `audit-log-formatting.ts`, and audit middleware from the residual monolith.

## Parallel-PR context

Last of the planned parallel boot skeletons. Touches only new files under `services/audit/` plus a transitive `package-lock.json` bump — zero overlap with #879 (applications domain), #881 (moderation boot), or #882 (matching boot).

## Test plan

- [x] `npm test` in services/audit — 9/9 green
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_