### PR TITLE
feat(audit): phase 10.2 — audit.audit_events schema + immutable trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32659,8 +32659,11 @@
       "name": "@adopt-dont-shop/service.audit",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/observability": "*",
-        "fastify": "^5.8.5"
+        "fastify": "^5.8.5",
+        "node-pg-migrate": "^8.0.4",
+        "pg": "^8.21.0"
       }
     },
     "services/auth": {

--- a/services/audit/README.md
+++ b/services/audit/README.md
@@ -13,11 +13,27 @@ pattern). Owns the `audit.*` schema. Replaces the monolith's
 **Phase 10.1** — boot skeleton: `/health/simple` on `AUDIT_PORT`
 (default 5009), OpenTelemetry boot, env-validated config.
 
+**Phase 10.2** — `audit.*` schema + migrations:
+- `001_create_audit_events.ts` — single `audit_events` table.
+  Idempotent on `event_id` (producer's NATS message id is the PK).
+  Columns capture both the actor (`actor_user_id`,
+  `actor_email_snapshot`) and the target (`aggregate_type`,
+  `aggregate_id`) so the gateway's `Query` and `GetByTarget` RPCs
+  can serve admin forensic queries directly.
+- Row-level trigger `audit_events_immutable` rejects UPDATE/DELETE
+  (CAD PR #49 pattern, bundled with the table create so there's no
+  install-time race). Per-transaction escape hatch via
+  `SET LOCAL audit.allow_mutation = 'on'` for retention cleanups,
+  mirroring the monolith's `audit_logs.allow_mutation` GUC.
+- Indexes for forensic query patterns: `(aggregate_type,
+  aggregate_id)`, `actor_user_id` (partial, NOT NULL),
+  `occurred_at`, `service`, `subject`, `outcome`.
+- Run via `npm run db:migrate` (uses `@adopt-dont-shop/db` —
+  inherits all four CAD-lesson fixes: `createSchema`,
+  `ignorePattern`, `search_path`, advisory-lock retry).
+
 ## What's NOT here yet
 
-- **Phase 10.2** — `audit.*` schema + migrations (single
-  `audit_events` table with row-level trigger rejecting
-  UPDATE/DELETE).
 - **Phase 10.3** — gRPC `AuditQueryService.{Query, GetByTarget}`
   with base64-JSON keyset cursors.
 - **Phase 10.4** — NATS subscribers on every `*.actionTaken` topic

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "db:migrate": "tsx ./src/db/migrate.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
@@ -32,7 +33,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/observability": "*",
-    "fastify": "^5.8.5"
+    "fastify": "^5.8.5",
+    "node-pg-migrate": "^8.0.4",
+    "pg": "^8.21.0"
   }
 }

--- a/services/audit/src/db/migrate.ts
+++ b/services/audit/src/db/migrate.ts
@@ -1,0 +1,42 @@
+// Migration entry point — runs the audit.* schema migrations via
+// @adopt-dont-shop/db (which wraps node-pg-migrate with the four
+// CAD-lesson fixes: createSchema, ignorePattern, search_path,
+// advisory-lock retry).
+//
+// Invoked by `npm run db:migrate`. Production deploys run a compiled
+// version against dist/migrations/.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runMigrations } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+
+// CAD lesson #2: this path MUST resolve identically in dev (tsx) and
+// prod (bundled). In dev, import.meta.url points at .../src/db/migrate.ts
+// and the migrations sit under ../migrations/.
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.audit.migrate' });
+  try {
+    const config = loadConfig();
+    logger.info('running migrations', {
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    await runMigrations({
+      databaseUrl: config.databaseUrl,
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    logger.info('migrations complete');
+  } catch (err) {
+    logger.error('migrations failed', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/audit/src/migrations/001_create_audit_events.ts
+++ b/services/audit/src/migrations/001_create_audit_events.ts
@@ -1,0 +1,128 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — audit_events.
+//
+// Forensic record-of-record consuming *.actionTaken NATS events from
+// every service. Idempotent on event_id (the producer's NATS message
+// id is the PK — replays from JetStream redelivery are clean skips).
+//
+// Append-only by design — the row-level trigger installed below
+// rejects UPDATE/DELETE so a compromised connection or buggy code
+// path can't rewrite history. INSERT remains permitted so this
+// service keeps appending; SELECT remains permitted so the gateway's
+// `view Audit`-gated GET /api/audit/* can read. A maintenance flag
+// (`SET LOCAL audit.allow_mutation = 'on'`) opens a per-transaction
+// escape hatch for retention cleanups, matching the monolith's
+// `audit_logs.allow_mutation` pattern in
+// service.backend/src/models/audit-logs-immutable.ts.
+//
+// CAD PR #49 pattern — the trigger ships with the table, not
+// separately. The monolith installed it post-sync; that race window
+// (rows could be UPDATE-able between table create and trigger
+// install) is closed here by bundling both into one migration.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('audit_events', {
+    // Producer's NATS message id (uuid). Idempotency key — a
+    // redelivered message INSERTs with ON CONFLICT DO NOTHING.
+    event_id: { type: 'uuid', primaryKey: true },
+    // Source service that emitted the event: 'service.auth',
+    // 'service.pets', 'service.applications', etc. Indexed for
+    // per-service forensic queries.
+    service: { type: 'varchar(64)', notNull: true },
+    // Full NATS subject — 'auth.userLoggedIn', 'pets.statusChanged',
+    // 'applications.submitted'. Indexed for topic-scoped queries.
+    subject: { type: 'varchar(128)', notNull: true },
+    // Domain aggregate type ('application', 'pet', 'user', etc.) +
+    // its id. (aggregate_type, aggregate_id) is the composite key the
+    // gateway's GetByTarget RPC will index — admins answering "show
+    // me everything that happened to pet X" hit this directly.
+    aggregate_type: { type: 'varchar(64)', notNull: true },
+    aggregate_id: { type: 'uuid', notNull: true },
+    // The user who triggered the action. NULL for system events
+    // (cron jobs, NATS replay backfills). user_id is a SOFT pointer
+    // to auth.users — cross-schema FKs aren't enforced (CAD-style),
+    // and the user may be deleted long after the audit row is
+    // written. user_email_snapshot keeps the trail readable when the
+    // user is gone.
+    actor_user_id: { type: 'uuid' },
+    actor_email_snapshot: { type: 'varchar(320)' },
+    // The action name within the aggregate's domain — 'submit',
+    // 'approve', 'login', 'updateStatus', etc. Combined with
+    // (aggregate_type, subject) for human-readable timeline rendering.
+    action: { type: 'varchar(64)', notNull: true },
+    // Did the action succeed, get denied (authz failure), or fail
+    // (server error)? Denied actions go through the audit log too —
+    // that IS the forensic value. Indexed for "show me all denied
+    // attempts" queries.
+    outcome: { type: 'varchar(16)', notNull: true },
+    // When the action happened in the producer's clock. Distinct
+    // from recorded_at (this row's INSERT time) — NATS redeliveries
+    // and processing lag mean recorded_at >= occurred_at, sometimes
+    // by minutes. Indexed for time-window queries; this is the
+    // primary forensic ordering.
+    occurred_at: { type: 'timestamptz', notNull: true },
+    recorded_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+    // Full event body. Schema-less by design — every service's events
+    // have different shapes. The gateway's query handlers render
+    // relevant fields per (service, subject) tuple. Capped soft-side
+    // by the NATS max message size.
+    payload: { type: 'jsonb', notNull: true },
+    // Optional request context — captured when the producing
+    // service has it (gateway-originated events do; cron-originated
+    // ones don't). Indexed only if forensic patterns later demand.
+    ip_address: { type: 'varchar(45)' },
+    user_agent: { type: 'text' },
+  });
+
+  // Forensic query indexes. The two most-likely queries are
+  // "what happened to aggregate X" and "what did user Y do":
+  pgm.createIndex('audit_events', ['aggregate_type', 'aggregate_id'], {
+    name: 'audit_events_aggregate_idx',
+  });
+  pgm.createIndex('audit_events', 'actor_user_id', {
+    name: 'audit_events_actor_user_id_idx',
+    where: 'actor_user_id IS NOT NULL',
+  });
+  pgm.createIndex('audit_events', 'occurred_at', {
+    name: 'audit_events_occurred_at_idx',
+  });
+  pgm.createIndex('audit_events', 'service', { name: 'audit_events_service_idx' });
+  pgm.createIndex('audit_events', 'subject', { name: 'audit_events_subject_idx' });
+  pgm.createIndex('audit_events', 'outcome', { name: 'audit_events_outcome_idx' });
+
+  // Row-level tamper-resistance trigger. The function lives in this
+  // service's schema (not public) so a schema drop cleans up the
+  // function too. The `audit.allow_mutation` GUC is the per-tx
+  // escape hatch for retention cleanups — `SET LOCAL` scopes it to
+  // the current transaction, so it can never leak across requests
+  // or be set persistently from a misconfigured client.
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION audit_events_reject_mutation() RETURNS TRIGGER AS $$
+    BEGIN
+      IF current_setting('audit.allow_mutation', true) = 'on' THEN
+        RETURN COALESCE(NEW, OLD);
+      END IF;
+      RAISE EXCEPTION 'audit_events is append-only; UPDATE/DELETE rejected';
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  pgm.sql(`
+    CREATE TRIGGER audit_events_immutable
+    BEFORE UPDATE OR DELETE ON audit_events
+    FOR EACH ROW
+    EXECUTE FUNCTION audit_events_reject_mutation();
+  `);
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  // pgm.dropTable() cascades indexes + triggers; the function is
+  // dropped explicitly because it survives the table drop otherwise.
+  pgm.sql('DROP TRIGGER IF EXISTS audit_events_immutable ON audit_events;');
+  pgm.dropTable('audit_events');
+  pgm.sql('DROP FUNCTION IF EXISTS audit_events_reject_mutation();');
+};

--- a/services/audit/src/migrations/migrations.test.ts
+++ b/services/audit/src/migrations/migrations.test.ts
@@ -1,0 +1,52 @@
+import { readdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Smoke tests for the migration files in this directory. We don't run
+// them against a real Postgres here — @adopt-dont-shop/db is already
+// tested for the runner contract, and the migrations get exercised
+// end-to-end by the docker-compose stack smoke (Phase 10.6).
+//
+// This file guards the things that break silently:
+//   - every migration exports `up` and `down` functions
+//   - the file naming convention stays consistent (lexicographic =
+//     execution order; node-pg-migrate sorts the dir scan by filename)
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_FILENAME_PATTERN = /^\d{3}_[a-z0-9_]+\.ts$/;
+
+async function listMigrationFiles(): Promise<string[]> {
+  const entries = await readdir(MIGRATIONS_DIR);
+  return entries.filter(f => MIGRATION_FILENAME_PATTERN.test(f)).sort((a, b) => a.localeCompare(b));
+}
+
+describe('audit migrations', () => {
+  it('has migration files following the NNN_snake_case.ts naming convention', async () => {
+    const files = await listMigrationFiles();
+    expect(files.length).toBeGreaterThanOrEqual(1);
+    for (const f of files) {
+      expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
+    }
+  });
+
+  it('numbers migrations sequentially without gaps', async () => {
+    const files = await listMigrationFiles();
+    const numbers = files.map(f => Number.parseInt(f.slice(0, 3), 10));
+    for (let i = 0; i < numbers.length; i++) {
+      expect(numbers[i]).toBe(i + 1);
+    }
+  });
+
+  it.each(['001_create_audit_events.ts'])(
+    '%s exports `up` and `down` functions',
+    async filename => {
+      const mod = (await import(`./${filename}`)) as {
+        up: unknown;
+        down: unknown;
+      };
+      expect(typeof mod.up).toBe('function');
+      expect(typeof mod.down).toBe('function');
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Phase 10.2 — `audit.audit_events` schema + tamper-resistance trigger.

- **Single append-only table** at `audit.audit_events`. PK is the producer's NATS message id (`event_id` uuid) so JetStream redelivery becomes an idempotent `ON CONFLICT DO NOTHING` insert.
- **Actor + target columns** capture both who did the action (`actor_user_id`, `actor_email_snapshot`) and what was acted on (`aggregate_type`, `aggregate_id`). Lets the gateway's forthcoming `Query` and `GetByTarget` RPCs serve admin forensic questions directly without joining cross-schema.
- **Row-level immutability trigger** (CAD PR #49 pattern) — `audit_events_immutable BEFORE UPDATE OR DELETE` raises `audit_events is append-only; UPDATE/DELETE rejected` unless the per-transaction GUC `SET LOCAL audit.allow_mutation = 'on'` is set. Mirrors the monolith's `audit_logs.allow_mutation` escape hatch, scoped tight enough that it can't leak across connections.
- **Trigger bundled with the create** — unlike the monolith which installed it post-sync (race window between table create and trigger install). One migration, no gap.
- **Forensic indexes**: `(aggregate_type, aggregate_id)`, `actor_user_id` partial NOT NULL, `occurred_at`, `service`, `subject`, `outcome`.
- **`npm run db:migrate`** entry point uses `@adopt-dont-shop/db` — inherits all four CAD-lesson fixes (`createSchema`, `ignorePattern`, `search_path`, advisory-lock retry).

## Parallel-PR context

Phase 10.2 only touches `services/audit/` plus a transitive `package-lock.json` bump. Zero overlap with Phase 6.2 / 8.2 / 9.2 (chat / moderation / matching schemas — each in their own `services/<name>/`) or any in-flight applications-vertical work. Builds on Phase 10.1 (PR #883, merged).

## Test plan

- [x] `npm test` in services/audit — 12/12 green (9 boot + 3 migrations smoke)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_