### PR TITLE
feat(chat): phase 6.2 — chat.* schema + migrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32688,8 +32688,11 @@
       "name": "@adopt-dont-shop/service.chat",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/observability": "*",
-        "fastify": "^5.8.5"
+        "fastify": "^5.8.5",
+        "node-pg-migrate": "^8.0.4",
+        "pg": "^8.21.0"
       }
     },
     "services/gateway": {

--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -22,10 +22,27 @@ on NATS for fan-out via the existing Phase 1.5 WS subscriber.
   misconfiguration fails fast at boot rather than at first request.
 - `src/server.ts` `createServer({ config, logger? })`.
 
+**Phase 6.2** — `chat.*` schema + migrations:
+- `001_create_chats.ts` — chats (+ assigned_to from monolith's
+  migration 09 folded in; `chat_status` enum).
+- `002_create_chat_participants.ts` — chat_participants with the
+  `(chat_id, participant_id)` UNIQUE; `chat_participant_role` enum.
+- `003_create_messages.ts` — messages with moderation columns
+  (`is_flagged`, `flag_reason`, `flag_severity`, `moderation_status`,
+  `flagged_at`), TSVECTOR `search_vector` + GIN index, the
+  `(chat_id, created_at DESC)` paging idx, and JSONB `attachments`.
+- `004_install_messages_search_vector_trigger.ts` — BEFORE
+  INSERT/UPDATE trigger replacing the monolith's afterSync hook;
+  DB owns the invariant.
+- `005_create_message_reactions.ts` — message_reactions with
+  `(message_id, user_id, emoji)` UNIQUE.
+- `006_create_message_reads.ts` — message_reads with
+  `(message_id, user_id)` UNIQUE.
+- Run via `npm run db:migrate` (uses `@adopt-dont-shop/db` —
+  inherits all four CAD-lesson fixes).
+
 ## What's NOT here yet
 
-- **Phase 6.2** — `chat.*` schema + migrations (Chat,
-  ChatParticipant, Message, MessageReaction, MessageRead).
 - **Phase 6.3** — gRPC `ChatService`:
   - proto + grpc-js stubs in `@adopt-dont-shop/proto`
   - handler logic (send / list / mark-read / react)

--- a/services/chat/package.json
+++ b/services/chat/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "db:migrate": "tsx ./src/db/migrate.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
@@ -32,7 +33,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/observability": "*",
-    "fastify": "^5.8.5"
+    "fastify": "^5.8.5",
+    "node-pg-migrate": "^8.0.4",
+    "pg": "^8.21.0"
   }
 }

--- a/services/chat/src/db/migrate.ts
+++ b/services/chat/src/db/migrate.ts
@@ -1,0 +1,42 @@
+// Migration entry point — runs the chat.* schema migrations via
+// @adopt-dont-shop/db (which wraps node-pg-migrate with the four
+// CAD-lesson fixes: createSchema, ignorePattern, search_path,
+// advisory-lock retry).
+//
+// Invoked by `npm run db:migrate`. Production deploys run a compiled
+// version against dist/migrations/.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runMigrations } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+
+// CAD lesson #2: this path MUST resolve identically in dev (tsx) and
+// prod (bundled). In dev, import.meta.url points at .../src/db/migrate.ts
+// and the migrations sit under ../migrations/.
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.chat.migrate' });
+  try {
+    const config = loadConfig();
+    logger.info('running migrations', {
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    await runMigrations({
+      databaseUrl: config.databaseUrl,
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    logger.info('migrations complete');
+  } catch (err) {
+    logger.error('migrations failed', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/chat/src/migrations/001_create_chats.ts
+++ b/services/chat/src/migrations/001_create_chats.ts
@@ -1,0 +1,44 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — chats.
+//
+// Direct port of service.backend's 00-baseline-029-chats.ts INTO the
+// `chat` schema, with 09-add-chats-assigned-to.ts folded in (the
+// `assigned_to` column ships in the baseline now, matching the
+// monolith's CURRENT state). Cross-schema FK targets (application_id
+// in applications.*, rescue_id in rescue.*, pet_id in pets.*,
+// assigned_to / created_by / updated_by in auth.users) are
+// deliberately omitted — schema-per-service rule keeps them
+// application-side over gRPC, no DB REFERENCES.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('chat_status', ['active', 'locked', 'archived']);
+
+  pgm.createTable('chats', {
+    chat_id: { type: 'uuid', primaryKey: true },
+    application_id: { type: 'uuid' },
+    rescue_id: { type: 'uuid', notNull: true },
+    pet_id: { type: 'uuid' },
+    status: { type: 'chat_status', notNull: true, default: 'active' },
+    assigned_to: { type: 'uuid' },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('chats', 'application_id', { name: 'chats_application_id_idx' });
+  pgm.createIndex('chats', 'rescue_id', { name: 'chats_rescue_id_idx' });
+  pgm.createIndex('chats', 'pet_id', { name: 'chats_pet_id_idx' });
+  pgm.createIndex('chats', 'status', { name: 'chats_status_idx' });
+  pgm.createIndex('chats', 'assigned_to', { name: 'chats_assigned_to_idx' });
+  pgm.createIndex('chats', 'created_by', { name: 'chats_created_by_idx' });
+  pgm.createIndex('chats', 'updated_by', { name: 'chats_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('chats');
+  pgm.dropType('chat_status');
+};

--- a/services/chat/src/migrations/002_create_chat_participants.ts
+++ b/services/chat/src/migrations/002_create_chat_participants.ts
@@ -1,0 +1,52 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — chat_participants.
+//
+// Direct port of service.backend's 00-baseline-030-chat-participants.ts.
+// participant_id, rescue_id, created_by, updated_by reference auth.users
+// / rescue.rescues — cross-schema, no DB FK. chat_id is intra-schema
+// so the FK is enforced with CASCADE on chat deletion.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('chat_participant_role', ['rescue', 'user', 'admin', 'member']);
+
+  pgm.createTable('chat_participants', {
+    chat_participant_id: { type: 'uuid', primaryKey: true },
+    chat_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'chats(chat_id)',
+      onDelete: 'CASCADE',
+    },
+    participant_id: { type: 'uuid', notNull: true },
+    role: { type: 'chat_participant_role', notNull: true },
+    rescue_id: { type: 'uuid' },
+    last_read_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('chat_participants', ['chat_id', 'participant_id'], {
+    unique: true,
+    name: 'chat_participants_chat_id_participant_id_unique',
+  });
+  pgm.createIndex('chat_participants', 'participant_id', {
+    name: 'chat_participants_participant_id_idx',
+  });
+  pgm.createIndex('chat_participants', 'role', { name: 'chat_participants_role_idx' });
+  pgm.createIndex('chat_participants', 'created_by', {
+    name: 'chat_participants_created_by_idx',
+  });
+  pgm.createIndex('chat_participants', 'updated_by', {
+    name: 'chat_participants_updated_by_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('chat_participants');
+  pgm.dropType('chat_participant_role');
+};

--- a/services/chat/src/migrations/003_create_messages.ts
+++ b/services/chat/src/migrations/003_create_messages.ts
@@ -1,0 +1,73 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — messages.
+//
+// Direct port of service.backend's 00-baseline-031-messages.ts. Moderation
+// columns (is_flagged / flag_reason / flag_severity / moderation_status /
+// flagged_at) are carried verbatim — the monolith ships them on Message
+// and services/moderation (Phase 8) reads them via gRPC. chat_id FK is
+// intra-schema and CASCADEs on chat deletion; sender_id is a soft pointer
+// into auth.users.
+//
+// Full-text search: the search_vector column is TSVECTOR + GIN index here.
+// The BEFORE INSERT/UPDATE trigger that maintains it ships in the next
+// migration (004_install_messages_search_vector_trigger.ts) so the
+// model's afterSync hook (`installGeneratedSearchVector`) becomes
+// unnecessary for this service — the DB owns the invariant.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('message_content_format', ['plain', 'markdown', 'html']);
+  pgm.createType('message_flag_severity', ['low', 'medium', 'high', 'critical']);
+  pgm.createType('message_moderation_status', ['pending_review', 'approved', 'rejected']);
+
+  pgm.createTable('messages', {
+    message_id: { type: 'uuid', primaryKey: true },
+    chat_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'chats(chat_id)',
+      onDelete: 'CASCADE',
+    },
+    sender_id: { type: 'uuid', notNull: true },
+    content: { type: 'text', notNull: true },
+    content_format: {
+      type: 'message_content_format',
+      notNull: true,
+      default: 'plain',
+    },
+    attachments: { type: 'jsonb', notNull: true, default: pgm.func(`'[]'::jsonb`) },
+    search_vector: { type: 'tsvector' },
+    is_flagged: { type: 'boolean', notNull: true, default: false },
+    flag_reason: { type: 'varchar(255)' },
+    flag_severity: { type: 'message_flag_severity' },
+    moderation_status: { type: 'message_moderation_status' },
+    flagged_at: { type: 'timestamptz' },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('messages', 'chat_id', { name: 'messages_chat_id_idx' });
+  pgm.createIndex('messages', 'sender_id', { name: 'messages_sender_id_idx' });
+  pgm.createIndex('messages', 'created_at', { name: 'messages_created_at_idx' });
+  pgm.createIndex('messages', 'search_vector', {
+    method: 'gin',
+    name: 'messages_search_vector_gin_idx',
+  });
+  // Compound idx for chat-window pagination: load latest N messages for
+  // a chat ordered by recency. Mirrors the monolith's
+  // messages_chat_created_idx.
+  pgm.sql('CREATE INDEX messages_chat_created_idx ON messages (chat_id, created_at DESC);');
+  pgm.createIndex('messages', 'created_by', { name: 'messages_created_by_idx' });
+  pgm.createIndex('messages', 'updated_by', { name: 'messages_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('messages');
+  pgm.dropType('message_content_format');
+  pgm.dropType('message_flag_severity');
+  pgm.dropType('message_moderation_status');
+};

--- a/services/chat/src/migrations/004_install_messages_search_vector_trigger.ts
+++ b/services/chat/src/migrations/004_install_messages_search_vector_trigger.ts
@@ -1,0 +1,40 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// BEFORE INSERT/UPDATE trigger that keeps messages.search_vector in
+// lockstep with the row's content column. Replaces the monolith's
+// afterSync hook (`installGeneratedSearchVector` in
+// service.backend/src/models/generated-search-vector.ts) — the DB owns
+// the invariant here so there's no JS hook to bypass on raw INSERT /
+// UPDATE / COPY paths.
+//
+// Why a trigger instead of a stored generated column: to_tsvector is
+// STABLE (not IMMUTABLE) because the result depends on the active
+// text-search configuration. Postgres rejects non-IMMUTABLE
+// expressions in `GENERATED ALWAYS AS (...) STORED`. The BEFORE
+// trigger sidesteps that constraint and produces the same end-state.
+//
+// The 'english' config matches the monolith's expression exactly (see
+// service.backend/src/models/Message.ts:328) so search behaviour ports
+// without surprise.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION messages_search_vector_update() RETURNS TRIGGER AS $$
+    BEGIN
+      NEW.search_vector := to_tsvector('english', coalesce(NEW.content, ''));
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  pgm.sql(`
+    CREATE TRIGGER messages_search_vector_trigger
+    BEFORE INSERT OR UPDATE OF content ON messages
+    FOR EACH ROW
+    EXECUTE FUNCTION messages_search_vector_update();
+  `);
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql('DROP TRIGGER IF EXISTS messages_search_vector_trigger ON messages;');
+  pgm.sql('DROP FUNCTION IF EXISTS messages_search_vector_update();');
+};

--- a/services/chat/src/migrations/005_create_message_reactions.ts
+++ b/services/chat/src/migrations/005_create_message_reactions.ts
@@ -1,0 +1,44 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — message_reactions.
+//
+// Direct port of service.backend's 00-baseline-032-message-reactions.ts.
+// No deleted_at — reactions are hard-deleted in the monolith
+// (paranoid: false on the model). message_id FK is intra-schema and
+// CASCADEs on message deletion; user_id is a soft pointer to
+// auth.users.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('message_reactions', {
+    reaction_id: { type: 'uuid', primaryKey: true },
+    message_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'messages(message_id)',
+      onDelete: 'CASCADE',
+    },
+    user_id: { type: 'uuid', notNull: true },
+    emoji: { type: 'varchar(32)', notNull: true },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('message_reactions', ['message_id', 'user_id', 'emoji'], {
+    unique: true,
+    name: 'message_reactions_message_user_emoji_unique',
+  });
+  pgm.createIndex('message_reactions', 'user_id', { name: 'message_reactions_user_id_idx' });
+  pgm.createIndex('message_reactions', 'created_by', {
+    name: 'message_reactions_created_by_idx',
+  });
+  pgm.createIndex('message_reactions', 'updated_by', {
+    name: 'message_reactions_updated_by_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('message_reactions');
+};

--- a/services/chat/src/migrations/006_create_message_reads.ts
+++ b/services/chat/src/migrations/006_create_message_reads.ts
@@ -1,0 +1,40 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — message_reads.
+//
+// Direct port of service.backend's 00-baseline-033-message-reads.ts.
+// (message_id, user_id) UNIQUE — at most one read receipt per
+// (message, user). message_id FK is intra-schema and CASCADEs on
+// message deletion; user_id is a soft pointer to auth.users.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('message_reads', {
+    read_id: { type: 'uuid', primaryKey: true },
+    message_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'messages(message_id)',
+      onDelete: 'CASCADE',
+    },
+    user_id: { type: 'uuid', notNull: true },
+    read_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('message_reads', ['message_id', 'user_id'], {
+    unique: true,
+    name: 'message_reads_message_user_unique',
+  });
+  pgm.createIndex('message_reads', 'user_id', { name: 'message_reads_user_id_idx' });
+  pgm.createIndex('message_reads', 'created_by', { name: 'message_reads_created_by_idx' });
+  pgm.createIndex('message_reads', 'updated_by', { name: 'message_reads_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('message_reads');
+};

--- a/services/chat/src/migrations/migrations.test.ts
+++ b/services/chat/src/migrations/migrations.test.ts
@@ -1,0 +1,56 @@
+import { readdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Smoke tests for the migration files in this directory. We don't run
+// them against a real Postgres here — @adopt-dont-shop/db is already
+// tested for the runner contract, and the migrations get exercised
+// end-to-end by the docker-compose stack smoke (Phase 6.6).
+//
+// This file guards the things that break silently:
+//   - every migration exports `up` and `down` functions
+//   - the file naming convention stays consistent (lexicographic =
+//     execution order; node-pg-migrate sorts the dir scan by filename)
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_FILENAME_PATTERN = /^\d{3}_[a-z0-9_]+\.ts$/;
+
+async function listMigrationFiles(): Promise<string[]> {
+  const entries = await readdir(MIGRATIONS_DIR);
+  return entries.filter(f => MIGRATION_FILENAME_PATTERN.test(f)).sort((a, b) => a.localeCompare(b));
+}
+
+describe('chat migrations', () => {
+  it('has migration files following the NNN_snake_case.ts naming convention', async () => {
+    const files = await listMigrationFiles();
+    expect(files.length).toBeGreaterThanOrEqual(6);
+    for (const f of files) {
+      expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
+    }
+  });
+
+  it('numbers migrations sequentially without gaps', async () => {
+    const files = await listMigrationFiles();
+    const numbers = files.map(f => Number.parseInt(f.slice(0, 3), 10));
+    for (let i = 0; i < numbers.length; i++) {
+      expect(numbers[i]).toBe(i + 1);
+    }
+  });
+
+  it.each([
+    '001_create_chats.ts',
+    '002_create_chat_participants.ts',
+    '003_create_messages.ts',
+    '004_install_messages_search_vector_trigger.ts',
+    '005_create_message_reactions.ts',
+    '006_create_message_reads.ts',
+  ])('%s exports `up` and `down` functions', async filename => {
+    const mod = (await import(`./${filename}`)) as {
+      up: unknown;
+      down: unknown;
+    };
+    expect(typeof mod.up).toBe('function');
+    expect(typeof mod.down).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 6.2 — `chat.*` schema + migrations. Six tables ported from the monolith's `baseline-029` through `baseline-033`, with migration 09's `chats.assigned_to` folded into the chats baseline (monolith's current state).

- **001 chats** — `chat_status` enum (`active` / `locked` / `archived`), `assigned_to` from monolith migration 09 folded in. Cross-schema FK targets (application_id, rescue_id, pet_id, assigned_to, created_by, updated_by) declared as plain uuid — no DB REFERENCES; application gates integrity over gRPC.
- **002 chat_participants** — `chat_participant_role` enum (rescue / user / admin / member), `(chat_id, participant_id)` UNIQUE. `chat_id` FK is intra-schema with CASCADE.
- **003 messages** — moderation columns (`is_flagged`, `flag_reason`, `flag_severity`, `moderation_status`, `flagged_at`) carried verbatim so `service.moderation` can read them via gRPC. TSVECTOR `search_vector` + GIN index. Compound `(chat_id, created_at DESC)` idx for the chat-window pagination hot path. JSONB `attachments`. `chat_id` FK CASCADEs on chat delete.
- **004 messages_search_vector_trigger** — BEFORE INSERT/UPDATE OF content trigger maintaining `search_vector` with `to_tsvector('english', coalesce(content, ''))`. Replaces the monolith's afterSync hook so the DB owns the invariant — raw INSERT / UPDATE / COPY can't bypass it.
- **005 message_reactions** — `(message_id, user_id, emoji)` UNIQUE. No `deleted_at` (paranoid:false on monolith). `message_id` FK CASCADEs.
- **006 message_reads** — `(message_id, user_id)` UNIQUE. `message_id` FK CASCADEs.

Run via `npm run db:migrate`. Inherits all four CAD-lesson fixes from `@adopt-dont-shop/db` (createSchema, ignorePattern, search_path, advisory-lock retry).

## Parallel-PR context

Only touches `services/chat/` plus a transitive `package-lock.json` bump. Zero overlap with #884 (Phase 10.2 audit schema, `services/audit/`) or #882 (Phase 9.1 matching boot, `services/matching/`). Builds on Phase 6.1 (PR #877, merged).

## Test plan

- [x] `npm test` in services/chat — 17/17 green (9 boot + 8 migrations smoke)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_