### PR TITLE
feat(moderation): phase 8.2 — moderation.* schema + migrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32711,8 +32711,11 @@
       "name": "@adopt-dont-shop/service.moderation",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/observability": "*",
-        "fastify": "^5.8.5"
+        "fastify": "^5.8.5",
+        "node-pg-migrate": "^8.0.4",
+        "pg": "^8.21.0"
       }
     },
     "services/notifications": {

--- a/services/moderation/README.md
+++ b/services/moderation/README.md
@@ -13,9 +13,32 @@ gRPC; consumes events (`chat.messageCreated`, `pets.created`,
 **Phase 8.1** — boot skeleton: `/health/simple` on `MODERATION_PORT`
 (default 5007), OpenTelemetry boot, env-validated config.
 
+**Phase 8.2** — `moderation.*` schema + migrations:
+- `001_create_reports.ts` — reports with polymorphic
+  (reported_entity_type, reported_entity_id).
+- `002_create_report_status_transitions.ts` — append-only history
+  feeding back into `reports.status`.
+- `003_install_report_status_propagation_trigger.ts` — AFTER
+  INSERT trigger that updates `reports.status` from
+  `to_status`; DB owns the invariant.
+- `004_create_moderator_actions.ts` — append-only history with
+  `acknowledged_at` folded in from monolith migration 08.
+- `005_create_moderation_evidence.ts` — polymorphic via
+  (parent_type, parent_id) where parent_type is the enum
+  discriminator.
+- `006_create_user_sanctions.ts` — append-only sanction history
+  with appeal + revocation columns and the
+  `(user_id, is_active, end_date)` hot-path compound idx.
+- `007_create_support_tickets.ts` — text[] tags with GIN idx,
+  status/priority/category enums.
+- `008_create_support_ticket_responses.ts` — paranoid with
+  `deleted_at` idx, intra-schema FK to support_tickets with
+  CASCADE.
+- Run via `npm run db:migrate` (uses `@adopt-dont-shop/db` —
+  inherits all four CAD-lesson fixes).
+
 ## What's NOT here yet
 
-- **Phase 8.2** — `moderation.*` schema + migrations.
 - **Phase 8.3** — gRPC `ModerationService` (file-report, moderator
   action, evidence upload, user sanction, support ticket).
 - **Phase 8.4** — NATS subscribers on `chat.messageCreated`,

--- a/services/moderation/package.json
+++ b/services/moderation/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "db:migrate": "tsx ./src/db/migrate.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
@@ -32,7 +33,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/observability": "*",
-    "fastify": "^5.8.5"
+    "fastify": "^5.8.5",
+    "node-pg-migrate": "^8.0.4",
+    "pg": "^8.21.0"
   }
 }

--- a/services/moderation/src/db/migrate.ts
+++ b/services/moderation/src/db/migrate.ts
@@ -1,0 +1,42 @@
+// Migration entry point — runs the moderation.* schema migrations via
+// @adopt-dont-shop/db (which wraps node-pg-migrate with the four
+// CAD-lesson fixes: createSchema, ignorePattern, search_path,
+// advisory-lock retry).
+//
+// Invoked by `npm run db:migrate`. Production deploys run a compiled
+// version against dist/migrations/.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runMigrations } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+
+// CAD lesson #2: this path MUST resolve identically in dev (tsx) and
+// prod (bundled). In dev, import.meta.url points at .../src/db/migrate.ts
+// and the migrations sit under ../migrations/.
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.moderation.migrate' });
+  try {
+    const config = loadConfig();
+    logger.info('running migrations', {
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    await runMigrations({
+      databaseUrl: config.databaseUrl,
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    logger.info('migrations complete');
+  } catch (err) {
+    logger.error('migrations failed', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/moderation/src/migrations/001_create_reports.ts
+++ b/services/moderation/src/migrations/001_create_reports.ts
@@ -1,0 +1,95 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — reports.
+//
+// Direct port of service.backend's 00-baseline-041-reports.ts INTO the
+// `moderation` schema. Cross-schema FK targets (reporter_id /
+// reported_user_id / assigned_moderator / resolved_by / escalated_to /
+// created_by / updated_by reference auth.users) are declared as plain
+// uuid — no DB REFERENCES, schema-per-service rule keeps integrity
+// application-side via gRPC. evidence lives in moderation_evidence
+// (polymorphic).
+//
+// reported_entity_id is a STRING in the monolith because the polymorphic
+// target can be a uuid (user, rescue, etc.) or any other id shape.
+// Carrying that fidelity here.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('report_entity_type', [
+    'user',
+    'rescue',
+    'pet',
+    'application',
+    'message',
+    'conversation',
+  ]);
+  pgm.createType('report_category', [
+    'inappropriate_content',
+    'spam',
+    'harassment',
+    'false_information',
+    'scam',
+    'animal_welfare',
+    'identity_theft',
+    'other',
+  ]);
+  pgm.createType('report_severity', ['low', 'medium', 'high', 'critical']);
+  pgm.createType('report_status', [
+    'pending',
+    'under_review',
+    'resolved',
+    'dismissed',
+    'escalated',
+  ]);
+
+  pgm.createTable('reports', {
+    report_id: { type: 'uuid', primaryKey: true },
+    reporter_id: { type: 'uuid', notNull: true },
+    reported_entity_type: { type: 'report_entity_type', notNull: true },
+    reported_entity_id: { type: 'varchar(255)', notNull: true },
+    reported_user_id: { type: 'uuid' },
+    category: { type: 'report_category', notNull: true },
+    severity: { type: 'report_severity', notNull: true, default: 'medium' },
+    status: { type: 'report_status', notNull: true, default: 'pending' },
+    title: { type: 'varchar(255)', notNull: true },
+    description: { type: 'text', notNull: true },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func(`'{}'::jsonb`) },
+    assigned_moderator: { type: 'uuid' },
+    assigned_at: { type: 'timestamptz' },
+    resolved_by: { type: 'uuid' },
+    resolved_at: { type: 'timestamptz' },
+    resolution: { type: 'varchar(100)' },
+    resolution_notes: { type: 'text' },
+    escalated_to: { type: 'uuid' },
+    escalated_at: { type: 'timestamptz' },
+    escalation_reason: { type: 'text' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.createIndex('reports', 'reporter_id', { name: 'reports_reporter_id_idx' });
+  pgm.createIndex('reports', ['reported_entity_type', 'reported_entity_id'], {
+    name: 'reports_reported_entity_idx',
+  });
+  pgm.createIndex('reports', 'reported_user_id', { name: 'reports_reported_user_id_idx' });
+  pgm.createIndex('reports', 'category', { name: 'reports_category_idx' });
+  pgm.createIndex('reports', 'status', { name: 'reports_status_idx' });
+  pgm.createIndex('reports', 'severity', { name: 'reports_severity_idx' });
+  pgm.createIndex('reports', 'assigned_moderator', { name: 'reports_assigned_moderator_idx' });
+  pgm.createIndex('reports', 'resolved_by', { name: 'reports_resolved_by_idx' });
+  pgm.createIndex('reports', 'escalated_to', { name: 'reports_escalated_to_idx' });
+  pgm.createIndex('reports', 'created_at', { name: 'reports_created_at_idx' });
+  pgm.createIndex('reports', 'created_by', { name: 'reports_created_by_idx' });
+  pgm.createIndex('reports', 'updated_by', { name: 'reports_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('reports');
+  pgm.dropType('report_entity_type');
+  pgm.dropType('report_category');
+  pgm.dropType('report_severity');
+  pgm.dropType('report_status');
+};

--- a/services/moderation/src/migrations/002_create_report_status_transitions.ts
+++ b/services/moderation/src/migrations/002_create_report_status_transitions.ts
@@ -1,0 +1,41 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — report_status_transitions.
+//
+// Direct port of service.backend's 00-baseline-042-report-status-transitions.ts.
+// No created_at/updated_at/deleted_at — only `transitioned_at` tracks the
+// event time. report_id FK is intra-schema with CASCADE; transitioned_by
+// is a soft pointer to auth.users.
+//
+// The monolith's AFTER INSERT trigger that propagates to_status to
+// reports.status ships in migration 003 here so the DB owns the
+// invariant.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('report_status_transitions', {
+    transition_id: { type: 'uuid', primaryKey: true },
+    report_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'reports(report_id)',
+      onDelete: 'CASCADE',
+    },
+    from_status: { type: 'report_status' },
+    to_status: { type: 'report_status', notNull: true },
+    transitioned_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    transitioned_by: { type: 'uuid' },
+    reason: { type: 'text' },
+    metadata: { type: 'jsonb' },
+  });
+
+  pgm.createIndex('report_status_transitions', ['report_id', 'transitioned_at'], {
+    name: 'report_status_transitions_report_id_at_idx',
+  });
+  pgm.createIndex('report_status_transitions', 'transitioned_by', {
+    name: 'report_status_transitions_transitioned_by_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('report_status_transitions');
+};

--- a/services/moderation/src/migrations/003_install_report_status_propagation_trigger.ts
+++ b/services/moderation/src/migrations/003_install_report_status_propagation_trigger.ts
@@ -1,0 +1,35 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// AFTER INSERT trigger that propagates report_status_transitions.to_status
+// back to reports.status, replacing the monolith's
+// installStatusTransitionTrigger afterSync hook. The DB owns the
+// invariant — raw INSERT into report_status_transitions automatically
+// updates the parent report's status (and updated_at), eliminating the
+// service-side two-write coordination the monolith required.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION reports_propagate_status_transition() RETURNS TRIGGER AS $$
+    BEGIN
+      UPDATE reports
+      SET status = NEW.to_status,
+          updated_at = now()
+      WHERE report_id = NEW.report_id;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  pgm.sql(`
+    CREATE TRIGGER report_status_transitions_propagate
+    AFTER INSERT ON report_status_transitions
+    FOR EACH ROW
+    EXECUTE FUNCTION reports_propagate_status_transition();
+  `);
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(
+    'DROP TRIGGER IF EXISTS report_status_transitions_propagate ON report_status_transitions;'
+  );
+  pgm.sql('DROP FUNCTION IF EXISTS reports_propagate_status_transition();');
+};

--- a/services/moderation/src/migrations/004_create_moderator_actions.ts
+++ b/services/moderation/src/migrations/004_create_moderator_actions.ts
@@ -1,0 +1,94 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — moderator_actions.
+//
+// Direct port of service.backend's 00-baseline-047-moderator-actions.ts,
+// with 08-add-moderator-actions-acknowledged-at.ts folded in (the
+// monolith's current state). Append-only (paranoid: false) — no
+// deleted_at. Cross-schema FKs (moderator_id, target_user_id,
+// reversed_by, created_by, updated_by reference auth.users) are
+// declared as plain uuid. report_id is intra-schema and can FK to
+// reports — keeping it soft because moderator_actions exist
+// without an originating report (auto-flag, content scan, etc.).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('moderator_action_target_entity_type', [
+    'user',
+    'rescue',
+    'pet',
+    'application',
+    'message',
+    'conversation',
+  ]);
+  pgm.createType('moderator_action_type', [
+    'warning_issued',
+    'content_removed',
+    'user_suspended',
+    'user_banned',
+    'account_restricted',
+    'content_flagged',
+    'report_dismissed',
+    'escalation',
+    'appeal_reviewed',
+    'no_action',
+  ]);
+  pgm.createType('moderator_action_severity', ['low', 'medium', 'high', 'critical']);
+
+  pgm.createTable('moderator_actions', {
+    action_id: { type: 'uuid', primaryKey: true },
+    moderator_id: { type: 'uuid', notNull: true },
+    report_id: { type: 'uuid' },
+    target_entity_type: { type: 'moderator_action_target_entity_type', notNull: true },
+    target_entity_id: { type: 'varchar(255)', notNull: true },
+    target_user_id: { type: 'uuid' },
+    action_type: { type: 'moderator_action_type', notNull: true },
+    severity: { type: 'moderator_action_severity', notNull: true },
+    reason: { type: 'varchar(500)', notNull: true },
+    description: { type: 'text' },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func(`'{}'::jsonb`) },
+    duration: { type: 'integer' },
+    expires_at: { type: 'timestamptz' },
+    is_active: { type: 'boolean', notNull: true, default: true },
+    reversed_by: { type: 'uuid' },
+    reversed_at: { type: 'timestamptz' },
+    reversal_reason: { type: 'text' },
+    notification_sent: { type: 'boolean', notNull: true, default: false },
+    internal_notes: { type: 'text' },
+    acknowledged_at: { type: 'timestamptz' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.createIndex('moderator_actions', 'moderator_id', {
+    name: 'moderator_actions_moderator_id_idx',
+  });
+  pgm.createIndex('moderator_actions', 'report_id', { name: 'moderator_actions_report_id_idx' });
+  pgm.createIndex('moderator_actions', ['target_entity_type', 'target_entity_id'], {
+    name: 'moderator_actions_target_entity_idx',
+  });
+  pgm.createIndex('moderator_actions', 'target_user_id', {
+    name: 'moderator_actions_target_user_id_idx',
+  });
+  pgm.createIndex('moderator_actions', 'action_type', {
+    name: 'moderator_actions_action_type_idx',
+  });
+  pgm.createIndex('moderator_actions', 'severity', { name: 'moderator_actions_severity_idx' });
+  pgm.createIndex('moderator_actions', 'is_active', { name: 'moderator_actions_is_active_idx' });
+  pgm.createIndex('moderator_actions', 'expires_at', { name: 'moderator_actions_expires_at_idx' });
+  pgm.createIndex('moderator_actions', 'reversed_by', {
+    name: 'moderator_actions_reversed_by_idx',
+  });
+  pgm.createIndex('moderator_actions', 'created_at', { name: 'moderator_actions_created_at_idx' });
+  pgm.createIndex('moderator_actions', 'created_by', { name: 'moderator_actions_created_by_idx' });
+  pgm.createIndex('moderator_actions', 'updated_by', { name: 'moderator_actions_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('moderator_actions');
+  pgm.dropType('moderator_action_target_entity_type');
+  pgm.dropType('moderator_action_type');
+  pgm.dropType('moderator_action_severity');
+};

--- a/services/moderation/src/migrations/005_create_moderation_evidence.ts
+++ b/services/moderation/src/migrations/005_create_moderation_evidence.ts
@@ -1,0 +1,48 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — moderation_evidence.
+//
+// Direct port of service.backend's 00-baseline-048-moderation-evidence.ts.
+// Polymorphic via (parent_type, parent_id) — no DB-level FK to a single
+// parent table by design. parent_id is uuid because both report_id and
+// action_id are uuids. (Distinct from reports.reported_entity_id which
+// is varchar because it points across schemas where ids can be other
+// shapes.)
+//
+// `paranoid: false` — no deleted_at column.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('moderation_evidence_parent_type', ['report', 'moderator_action']);
+  pgm.createType('moderation_evidence_type', ['screenshot', 'url', 'text', 'file']);
+
+  pgm.createTable('moderation_evidence', {
+    evidence_id: { type: 'uuid', primaryKey: true },
+    parent_type: { type: 'moderation_evidence_parent_type', notNull: true },
+    parent_id: { type: 'uuid', notNull: true },
+    type: { type: 'moderation_evidence_type', notNull: true },
+    content: { type: 'text', notNull: true },
+    description: { type: 'text' },
+    uploaded_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('moderation_evidence', ['parent_type', 'parent_id'], {
+    name: 'moderation_evidence_parent_idx',
+  });
+  pgm.createIndex('moderation_evidence', 'created_by', {
+    name: 'moderation_evidence_created_by_idx',
+  });
+  pgm.createIndex('moderation_evidence', 'updated_by', {
+    name: 'moderation_evidence_updated_by_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('moderation_evidence');
+  pgm.dropType('moderation_evidence_parent_type');
+  pgm.dropType('moderation_evidence_type');
+};

--- a/services/moderation/src/migrations/006_create_user_sanctions.ts
+++ b/services/moderation/src/migrations/006_create_user_sanctions.ts
@@ -1,0 +1,103 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — user_sanctions.
+//
+// Direct port of service.backend's 00-baseline-049-user-sanctions.ts.
+// Append-only sanction history (paranoid: false) — lifting a sanction
+// is a new row, not a soft-delete on the original. Cross-schema FKs
+// (user_id, issued_by, appeal_resolved_by, revoked_by, created_by,
+// updated_by reference auth.users) declared as plain uuid.
+// report_id / moderator_action_id are intra-schema soft pointers
+// (sanctions exist with or without an originating report or action).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('user_sanction_type', [
+    'warning',
+    'restriction',
+    'temporary_ban',
+    'permanent_ban',
+    'messaging_restriction',
+    'posting_restriction',
+    'application_restriction',
+  ]);
+  pgm.createType('user_sanction_reason', [
+    'harassment',
+    'spam',
+    'inappropriate_content',
+    'terms_violation',
+    'scam_attempt',
+    'false_information',
+    'animal_welfare_concern',
+    'repeated_violations',
+    'other',
+  ]);
+  pgm.createType('user_sanction_issued_by_role', ['ADMIN', 'MODERATOR', 'SUPER_ADMIN']);
+  pgm.createType('user_sanction_appeal_status', ['pending', 'approved', 'rejected']);
+
+  pgm.createTable('user_sanctions', {
+    sanction_id: { type: 'uuid', primaryKey: true },
+    user_id: { type: 'uuid', notNull: true },
+    sanction_type: { type: 'user_sanction_type', notNull: true },
+    reason: { type: 'user_sanction_reason', notNull: true },
+    description: { type: 'text', notNull: true },
+    is_active: { type: 'boolean', notNull: true, default: true },
+    start_date: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    end_date: { type: 'timestamptz' },
+    duration: { type: 'integer' },
+    issued_by: { type: 'uuid', notNull: true },
+    issued_by_role: { type: 'user_sanction_issued_by_role', notNull: true },
+    report_id: { type: 'uuid' },
+    moderator_action_id: { type: 'uuid' },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func(`'{}'::jsonb`) },
+    appealed_at: { type: 'timestamptz' },
+    appeal_reason: { type: 'text' },
+    appeal_status: { type: 'user_sanction_appeal_status' },
+    appeal_resolved_by: { type: 'uuid' },
+    appeal_resolved_at: { type: 'timestamptz' },
+    appeal_resolution: { type: 'text' },
+    revoked_by: { type: 'uuid' },
+    revoked_at: { type: 'timestamptz' },
+    revocation_reason: { type: 'text' },
+    notification_sent: { type: 'boolean', notNull: true, default: false },
+    internal_notes: { type: 'text' },
+    warning_count: { type: 'integer', default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.createIndex('user_sanctions', 'user_id', { name: 'user_sanctions_user_id_idx' });
+  pgm.createIndex('user_sanctions', 'sanction_type', { name: 'user_sanctions_sanction_type_idx' });
+  pgm.createIndex('user_sanctions', 'reason', { name: 'user_sanctions_reason_idx' });
+  pgm.createIndex('user_sanctions', 'is_active', { name: 'user_sanctions_is_active_idx' });
+  pgm.createIndex('user_sanctions', 'start_date', { name: 'user_sanctions_start_date_idx' });
+  pgm.createIndex('user_sanctions', 'end_date', { name: 'user_sanctions_end_date_idx' });
+  pgm.createIndex('user_sanctions', 'issued_by', { name: 'user_sanctions_issued_by_idx' });
+  pgm.createIndex('user_sanctions', 'report_id', { name: 'user_sanctions_report_id_idx' });
+  pgm.createIndex('user_sanctions', 'moderator_action_id', {
+    name: 'user_sanctions_moderator_action_id_idx',
+  });
+  pgm.createIndex('user_sanctions', 'appeal_resolved_by', {
+    name: 'user_sanctions_appeal_resolved_by_idx',
+  });
+  pgm.createIndex('user_sanctions', 'revoked_by', { name: 'user_sanctions_revoked_by_idx' });
+  pgm.createIndex('user_sanctions', 'appeal_status', { name: 'user_sanctions_appeal_status_idx' });
+  pgm.createIndex('user_sanctions', 'created_at', { name: 'user_sanctions_created_at_idx' });
+  // Compound idx for the active-sanctions-by-user hot path
+  // (GET /api/v1/auth/sanctions/active equivalent).
+  pgm.createIndex('user_sanctions', ['user_id', 'is_active', 'end_date'], {
+    name: 'user_sanctions_user_active_end_idx',
+  });
+  pgm.createIndex('user_sanctions', 'created_by', { name: 'user_sanctions_created_by_idx' });
+  pgm.createIndex('user_sanctions', 'updated_by', { name: 'user_sanctions_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('user_sanctions');
+  pgm.dropType('user_sanction_type');
+  pgm.dropType('user_sanction_reason');
+  pgm.dropType('user_sanction_issued_by_role');
+  pgm.dropType('user_sanction_appeal_status');
+};

--- a/services/moderation/src/migrations/007_create_support_tickets.ts
+++ b/services/moderation/src/migrations/007_create_support_tickets.ts
@@ -1,0 +1,90 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — support_tickets.
+//
+// Direct port of service.backend's 00-baseline-050-support-tickets.ts.
+// Cross-schema FKs (user_id, assigned_to, escalated_to, created_by,
+// updated_by reference auth.users) declared as plain uuid. tags is
+// text[] with GIN index for tag-array search. attachments + metadata
+// are JSONB. No paranoid (deleted_at).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('support_ticket_status', [
+    'open',
+    'in_progress',
+    'waiting_for_user',
+    'resolved',
+    'closed',
+    'escalated',
+  ]);
+  pgm.createType('support_ticket_priority', ['low', 'normal', 'high', 'urgent', 'critical']);
+  pgm.createType('support_ticket_category', [
+    'technical_issue',
+    'account_problem',
+    'adoption_inquiry',
+    'payment_issue',
+    'feature_request',
+    'report_bug',
+    'general_question',
+    'compliance_concern',
+    'data_request',
+    'other',
+  ]);
+
+  pgm.createTable('support_tickets', {
+    ticket_id: { type: 'uuid', primaryKey: true },
+    user_id: { type: 'uuid' },
+    user_email: { type: 'varchar(320)', notNull: true },
+    user_name: { type: 'varchar(255)' },
+    assigned_to: { type: 'uuid' },
+    status: { type: 'support_ticket_status', notNull: true, default: 'open' },
+    priority: { type: 'support_ticket_priority', notNull: true, default: 'normal' },
+    category: { type: 'support_ticket_category', notNull: true },
+    subject: { type: 'varchar(255)', notNull: true },
+    description: { type: 'text', notNull: true },
+    tags: { type: 'text[]', notNull: true },
+    attachments: { type: 'jsonb', notNull: true, default: pgm.func(`'[]'::jsonb`) },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func(`'{}'::jsonb`) },
+    first_response_at: { type: 'timestamptz' },
+    last_response_at: { type: 'timestamptz' },
+    resolved_at: { type: 'timestamptz' },
+    closed_at: { type: 'timestamptz' },
+    escalated_at: { type: 'timestamptz' },
+    escalated_to: { type: 'uuid' },
+    escalation_reason: { type: 'text' },
+    satisfaction_rating: { type: 'integer' },
+    satisfaction_feedback: { type: 'text' },
+    internal_notes: { type: 'text' },
+    due_date: { type: 'timestamptz' },
+    estimated_resolution_time: { type: 'integer' },
+    actual_resolution_time: { type: 'integer' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.createIndex('support_tickets', 'user_id', { name: 'support_tickets_user_id_idx' });
+  pgm.createIndex('support_tickets', 'user_email', { name: 'support_tickets_user_email_idx' });
+  pgm.createIndex('support_tickets', 'assigned_to', { name: 'support_tickets_assigned_to_idx' });
+  pgm.createIndex('support_tickets', 'escalated_to', { name: 'support_tickets_escalated_to_idx' });
+  pgm.createIndex('support_tickets', 'status', { name: 'support_tickets_status_idx' });
+  pgm.createIndex('support_tickets', 'priority', { name: 'support_tickets_priority_idx' });
+  pgm.createIndex('support_tickets', 'category', { name: 'support_tickets_category_idx' });
+  pgm.createIndex('support_tickets', 'created_at', { name: 'support_tickets_created_at_idx' });
+  pgm.createIndex('support_tickets', 'due_date', { name: 'support_tickets_due_date_idx' });
+  pgm.createIndex('support_tickets', 'tags', {
+    method: 'gin',
+    name: 'support_tickets_tags_gin_idx',
+  });
+  pgm.createIndex('support_tickets', 'created_by', { name: 'support_tickets_created_by_idx' });
+  pgm.createIndex('support_tickets', 'updated_by', { name: 'support_tickets_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('support_tickets');
+  pgm.dropType('support_ticket_status');
+  pgm.dropType('support_ticket_priority');
+  pgm.dropType('support_ticket_category');
+};

--- a/services/moderation/src/migrations/008_create_support_ticket_responses.ts
+++ b/services/moderation/src/migrations/008_create_support_ticket_responses.ts
@@ -1,0 +1,69 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — support_ticket_responses.
+//
+// Direct port of service.backend's 00-baseline-051-support-ticket-responses.ts.
+// ticket_id FK is intra-schema with CASCADE. responder_id is a soft
+// pointer (cross-schema to auth.users for staff, same for user
+// responders — the responder_type discriminator distinguishes).
+// Paranoid: deleted_at column with dedicated idx. attachments JSONB is
+// nullable here (the only nullable JSON in the moderation domain).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('support_ticket_response_responder_type', ['staff', 'user']);
+
+  pgm.createTable('support_ticket_responses', {
+    response_id: { type: 'uuid', primaryKey: true },
+    ticket_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'support_tickets(ticket_id)',
+      onDelete: 'CASCADE',
+    },
+    responder_id: { type: 'uuid', notNull: true },
+    responder_type: { type: 'support_ticket_response_responder_type', notNull: true },
+    content: { type: 'text', notNull: true },
+    attachments: { type: 'jsonb' },
+    is_internal: { type: 'boolean', notNull: true, default: false },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.createIndex('support_ticket_responses', 'ticket_id', {
+    name: 'support_ticket_responses_ticket_id_idx',
+  });
+  pgm.createIndex('support_ticket_responses', 'responder_id', {
+    name: 'support_ticket_responses_responder_id_idx',
+  });
+  pgm.createIndex('support_ticket_responses', 'created_at', {
+    name: 'support_ticket_responses_created_at_idx',
+  });
+  pgm.createIndex('support_ticket_responses', 'responder_type', {
+    name: 'support_ticket_responses_responder_type_idx',
+  });
+  pgm.createIndex('support_ticket_responses', 'is_internal', {
+    name: 'support_ticket_responses_is_internal_idx',
+  });
+  // Compound idx for the ticket-window pagination hot path.
+  pgm.createIndex('support_ticket_responses', ['ticket_id', 'created_at'], {
+    name: 'support_ticket_responses_ticket_created_idx',
+  });
+  pgm.createIndex('support_ticket_responses', 'deleted_at', {
+    name: 'support_ticket_responses_deleted_at_idx',
+  });
+  pgm.createIndex('support_ticket_responses', 'created_by', {
+    name: 'support_ticket_responses_created_by_idx',
+  });
+  pgm.createIndex('support_ticket_responses', 'updated_by', {
+    name: 'support_ticket_responses_updated_by_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('support_ticket_responses');
+  pgm.dropType('support_ticket_response_responder_type');
+};

--- a/services/moderation/src/migrations/migrations.test.ts
+++ b/services/moderation/src/migrations/migrations.test.ts
@@ -1,0 +1,58 @@
+import { readdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Smoke tests for the migration files in this directory. We don't run
+// them against a real Postgres here — @adopt-dont-shop/db is already
+// tested for the runner contract, and the migrations get exercised
+// end-to-end by the docker-compose stack smoke (Phase 8.6).
+//
+// This file guards the things that break silently:
+//   - every migration exports `up` and `down` functions
+//   - the file naming convention stays consistent (lexicographic =
+//     execution order; node-pg-migrate sorts the dir scan by filename)
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_FILENAME_PATTERN = /^\d{3}_[a-z0-9_]+\.ts$/;
+
+async function listMigrationFiles(): Promise<string[]> {
+  const entries = await readdir(MIGRATIONS_DIR);
+  return entries.filter(f => MIGRATION_FILENAME_PATTERN.test(f)).sort((a, b) => a.localeCompare(b));
+}
+
+describe('moderation migrations', () => {
+  it('has migration files following the NNN_snake_case.ts naming convention', async () => {
+    const files = await listMigrationFiles();
+    expect(files.length).toBeGreaterThanOrEqual(8);
+    for (const f of files) {
+      expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
+    }
+  });
+
+  it('numbers migrations sequentially without gaps', async () => {
+    const files = await listMigrationFiles();
+    const numbers = files.map(f => Number.parseInt(f.slice(0, 3), 10));
+    for (let i = 0; i < numbers.length; i++) {
+      expect(numbers[i]).toBe(i + 1);
+    }
+  });
+
+  it.each([
+    '001_create_reports.ts',
+    '002_create_report_status_transitions.ts',
+    '003_install_report_status_propagation_trigger.ts',
+    '004_create_moderator_actions.ts',
+    '005_create_moderation_evidence.ts',
+    '006_create_user_sanctions.ts',
+    '007_create_support_tickets.ts',
+    '008_create_support_ticket_responses.ts',
+  ])('%s exports `up` and `down` functions', async filename => {
+    const mod = (await import(`./${filename}`)) as {
+      up: unknown;
+      down: unknown;
+    };
+    expect(typeof mod.up).toBe('function');
+    expect(typeof mod.down).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 8.2 — `moderation.*` schema + migrations. Eight migrations port the monolith's seven moderation tables into the new schema, plus one trigger migration that moves a status invariant from the service layer into the DB.

- **001 reports** — polymorphic `(reported_entity_type, reported_entity_id)`. `reported_entity_id` is `varchar` to absorb whatever id shape the target schema uses. Status / category / severity enums verbatim. Cross-schema FK targets declared as plain uuid.
- **002 report_status_transitions** — append-only history. `report_id` FK intra-schema CASCADE; `from_status` / `to_status` share the `report_status` enum from 001.
- **003 report_status_propagation trigger** — AFTER INSERT trigger on report_status_transitions propagates `to_status` back into `reports.status` (+ `updated_at`). Replaces the monolith's `installStatusTransitionTrigger` afterSync hook so the DB owns the invariant.
- **004 moderator_actions** — append-only history with `acknowledged_at` folded in from monolith migration 08 (banner dismissal).
- **005 moderation_evidence** — polymorphic via `(parent_type, parent_id)` with `parent_type` enum as the discriminator. No DB FK to a single parent by design.
- **006 user_sanctions** — append-only sanction history with appeal + revocation columns. `(user_id, is_active, end_date)` compound idx for the active-sanctions banner hot path.
- **007 support_tickets** — `text[]` tags with GIN idx, status / priority / category enums. attachments + metadata JSONB.
- **008 support_ticket_responses** — paranoid with `deleted_at` idx, intra-schema FK to support_tickets CASCADEs on delete.

Run via `npm run db:migrate`. Inherits all four CAD-lesson fixes from `@adopt-dont-shop/db`.

## Parallel-PR context

Only touches `services/moderation/` plus a transitive `package-lock.json` bump. Zero overlap with #884 (Phase 10.2 audit schema), #885 (Phase 6.2 chat schema), or #882 (Phase 9.1 matching boot). Builds on Phase 8.1 (PR #881, merged).

## Test plan

- [x] `npm test` in services/moderation — 19/19 green (9 boot + 10 migrations smoke)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_