### PR TITLE
feat(matching): phase 9.2 — matching.* schema + migrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32724,8 +32724,11 @@
       "name": "@adopt-dont-shop/service.matching",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/observability": "*",
-        "fastify": "^5.8.5"
+        "fastify": "^5.8.5",
+        "node-pg-migrate": "^8.0.4",
+        "pg": "^8.21.0"
       }
     },
     "services/moderation": {

--- a/services/matching/README.md
+++ b/services/matching/README.md
@@ -13,9 +13,19 @@ discovery + search + swipe modules.
 **Phase 9.1** — boot skeleton: `/health/simple` on `MATCHING_PORT`
 (default 5008), OpenTelemetry boot, env-validated config.
 
+**Phase 9.2** — `matching.*` schema + migrations:
+- `001_create_swipe_sessions.ts` — behavioural session log;
+  `swipe_session_device_type` enum (desktop/mobile/tablet/unknown);
+  JSONB `filters` for schema-less filter evolution; non-paranoid,
+  no audit hooks.
+- `002_create_swipe_actions.ts` — high-volume action log;
+  `swipe_action_type` enum (like/pass/super_like/info);
+  `session_id` FK intra-schema CASCADE; `pet_id` / `user_id` soft
+  pointers; recommender hot-path idx `(user_id, action)`.
+- Run via `npm run db:migrate` (uses `@adopt-dont-shop/db`).
+
 ## What's NOT here yet
 
-- **Phase 9.2** — `matching.*` schema + migrations.
 - **Phase 9.3** — gRPC `MatchingService` (recommend, record-swipe,
   discover, search). Reads pets via gRPC from `service.pets`.
 - **Phase 9.4** — NATS publishers (`matching.swipeRecorded` etc.).

--- a/services/matching/package.json
+++ b/services/matching/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
+    "db:migrate": "tsx ./src/db/migrate.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
@@ -32,7 +33,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/observability": "*",
-    "fastify": "^5.8.5"
+    "fastify": "^5.8.5",
+    "node-pg-migrate": "^8.0.4",
+    "pg": "^8.21.0"
   }
 }

--- a/services/matching/src/db/migrate.ts
+++ b/services/matching/src/db/migrate.ts
@@ -1,0 +1,39 @@
+// Migration entry point — runs the matching.* schema migrations via
+// @adopt-dont-shop/db (which wraps node-pg-migrate with the four
+// CAD-lesson fixes: createSchema, ignorePattern, search_path,
+// advisory-lock retry).
+//
+// Invoked by `npm run db:migrate`. Production deploys run a compiled
+// version against dist/migrations/.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runMigrations } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.matching.migrate' });
+  try {
+    const config = loadConfig();
+    logger.info('running migrations', {
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    await runMigrations({
+      databaseUrl: config.databaseUrl,
+      schema: config.schema,
+      migrationsDir: MIGRATIONS_DIR,
+    });
+    logger.info('migrations complete');
+  } catch (err) {
+    logger.error('migrations failed', { err });
+    process.exit(1);
+  }
+};
+
+void main();

--- a/services/matching/src/migrations/001_create_swipe_sessions.ts
+++ b/services/matching/src/migrations/001_create_swipe_sessions.ts
@@ -1,0 +1,46 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — swipe_sessions.
+//
+// Direct port of service.backend's 00-baseline-053-swipe-sessions.ts INTO
+// the `matching` schema. Non-paranoid (no deleted_at), no audit hooks
+// (no created_by / updated_by / version) — this is a behavioural
+// session log, not domain state. user_id is a soft pointer to
+// auth.users (NULL allowed for anonymous browsing sessions).
+//
+// device_type carries the monolith's 4-value enum verbatim. filters
+// is JSONB so the matching service can evolve filter shape (species,
+// breed, size, age, etc.) without ALTER TABLE per addition.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('swipe_session_device_type', ['desktop', 'mobile', 'tablet', 'unknown']);
+
+  pgm.createTable('swipe_sessions', {
+    session_id: { type: 'uuid', primaryKey: true },
+    user_id: { type: 'uuid' },
+    start_time: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    end_time: { type: 'timestamptz' },
+    total_swipes: { type: 'integer', notNull: true, default: 0 },
+    likes: { type: 'integer', notNull: true, default: 0 },
+    passes: { type: 'integer', notNull: true, default: 0 },
+    super_likes: { type: 'integer', notNull: true, default: 0 },
+    filters: { type: 'jsonb', notNull: true, default: pgm.func(`'{}'::jsonb`) },
+    ip_address: { type: 'inet' },
+    user_agent: { type: 'text' },
+    device_type: { type: 'swipe_session_device_type', default: 'unknown' },
+    is_active: { type: 'boolean', notNull: true, default: true },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  // Hot-path: load a user's open session.
+  pgm.createIndex('swipe_sessions', ['user_id', 'is_active'], {
+    name: 'swipe_sessions_user_active_idx',
+  });
+  pgm.createIndex('swipe_sessions', 'start_time', { name: 'swipe_sessions_start_time_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('swipe_sessions');
+  pgm.dropType('swipe_session_device_type');
+};

--- a/services/matching/src/migrations/002_create_swipe_actions.ts
+++ b/services/matching/src/migrations/002_create_swipe_actions.ts
@@ -1,0 +1,55 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — swipe_actions.
+//
+// Direct port of service.backend's 00-baseline-052-swipe-actions.ts INTO
+// the `matching` schema. High-volume behavioural log — non-paranoid
+// (no deleted_at), no audit hooks. session_id FK is intra-schema with
+// CASCADE so closing a session drops its action history.
+// pet_id / user_id reference pets.* and auth.users — schema-per-service
+// rule keeps them application-side as soft pointers (no DB REFERENCES).
+//
+// action values: 'like' / 'pass' / 'super_like' / 'info'. The 'info'
+// action is the monolith's "user tapped the info button without
+// swiping" trace event, kept for the recommender's preference
+// modelling.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('swipe_action_type', ['like', 'pass', 'super_like', 'info']);
+
+  pgm.createTable('swipe_actions', {
+    swipe_action_id: { type: 'uuid', primaryKey: true },
+    session_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'swipe_sessions(session_id)',
+      onDelete: 'CASCADE',
+    },
+    pet_id: { type: 'uuid', notNull: true },
+    user_id: { type: 'uuid' },
+    action: { type: 'swipe_action_type', notNull: true },
+    timestamp: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    response_time: { type: 'integer' },
+    device_type: { type: 'varchar(50)' },
+    coordinates: { type: 'jsonb' },
+    gesture_data: { type: 'jsonb' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('swipe_actions', 'session_id', { name: 'swipe_actions_session_idx' });
+  pgm.createIndex('swipe_actions', 'pet_id', { name: 'swipe_actions_pet_idx' });
+  // Recommender hot-path: "what has user X liked / passed".
+  pgm.createIndex('swipe_actions', ['user_id', 'action'], {
+    name: 'swipe_actions_user_action_idx',
+  });
+  pgm.createIndex('swipe_actions', 'timestamp', { name: 'swipe_actions_timestamp_idx' });
+  pgm.createIndex('swipe_actions', ['action', 'timestamp'], {
+    name: 'swipe_actions_action_time_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('swipe_actions');
+  pgm.dropType('swipe_action_type');
+};

--- a/services/matching/src/migrations/migrations.test.ts
+++ b/services/matching/src/migrations/migrations.test.ts
@@ -1,0 +1,47 @@
+import { readdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Smoke tests for the migration files in this directory. We don't run
+// them against a real Postgres here — @adopt-dont-shop/db is already
+// tested for the runner contract, and the migrations get exercised
+// end-to-end by the docker-compose stack smoke (Phase 9.6).
+
+const MIGRATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+const MIGRATION_FILENAME_PATTERN = /^\d{3}_[a-z0-9_]+\.ts$/;
+
+async function listMigrationFiles(): Promise<string[]> {
+  const entries = await readdir(MIGRATIONS_DIR);
+  return entries.filter(f => MIGRATION_FILENAME_PATTERN.test(f)).sort((a, b) => a.localeCompare(b));
+}
+
+describe('matching migrations', () => {
+  it('has migration files following the NNN_snake_case.ts naming convention', async () => {
+    const files = await listMigrationFiles();
+    expect(files.length).toBeGreaterThanOrEqual(2);
+    for (const f of files) {
+      expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
+    }
+  });
+
+  it('numbers migrations sequentially without gaps', async () => {
+    const files = await listMigrationFiles();
+    const numbers = files.map(f => Number.parseInt(f.slice(0, 3), 10));
+    for (let i = 0; i < numbers.length; i++) {
+      expect(numbers[i]).toBe(i + 1);
+    }
+  });
+
+  it.each(['001_create_swipe_sessions.ts', '002_create_swipe_actions.ts'])(
+    '%s exports `up` and `down` functions',
+    async filename => {
+      const mod = (await import(`./${filename}`)) as {
+        up: unknown;
+        down: unknown;
+      };
+      expect(typeof mod.up).toBe('function');
+      expect(typeof mod.down).toBe('function');
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Phase 9.2 — `matching.*` schema + migrations. Two migrations port the monolith's `swipe_sessions` + `swipe_actions` into the matching schema.

- **001 swipe_sessions** — behavioural session log. Non-paranoid (no `deleted_at`), no audit hooks (no `created_by` / `updated_by` / `version`). `user_id` is a soft pointer to auth.users (NULL for anonymous browsing). `device_type` enum verbatim from monolith (desktop / mobile / tablet / unknown). `filters` is JSONB so filter shape evolves without ALTER TABLE. Hot-path idx `(user_id, is_active)` for "load this user's open session".

- **002 swipe_actions** — high-volume action log. `session_id` FK is intra-schema with CASCADE so closing a session drops its action trail. `pet_id` / `user_id` are soft pointers to `pets.*` / `auth.users` (schema-per-service rule). `action` enum verbatim (like / pass / super_like / info). `info` is the monolith's tap-info-without-swiping trace event, kept for the recommender's preference modelling. Recommender hot-path idx `(user_id, action)`.

Run via `npm run db:migrate`. Inherits all four CAD-lesson fixes from `@adopt-dont-shop/db`.

## Parallel-PR context

Only touches `services/matching/` plus a transitive `package-lock.json` bump. Built on Phase 9.1 (PR #882, merged). Sits in its own service dir — zero overlap with concurrent gRPC handler work.

## Test plan

- [x] `npm test` in services/matching — 13/13 green (9 boot + 4 migrations smoke)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_