### PR TITLE
feat(applications): phase 5.2.5b — home visits + drafts schema

### DIFF
--- a/services/applications/src/migrations/004_create_home_visits.ts
+++ b/services/applications/src/migrations/004_create_home_visits.ts
@@ -1,0 +1,56 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — home_visits.
+//
+// Direct port of service.backend's 00-baseline-027-home-visits.ts.
+// application_id FK is intra-schema with CASCADE — dropping an
+// application drops its visits. assigned_staff / created_by /
+// updated_by are cross-schema soft pointers to auth.users.
+//
+// Two enums: status (scheduled → in_progress → completed | cancelled)
+// and outcome (approved | rejected | conditional). The status state
+// machine is propagated from home_visit_status_transitions via the
+// trigger installed in migration 006.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('home_visit_status', ['scheduled', 'in_progress', 'completed', 'cancelled']);
+  pgm.createType('home_visit_outcome', ['approved', 'rejected', 'conditional']);
+
+  pgm.createTable('home_visits', {
+    visit_id: { type: 'uuid', primaryKey: true },
+    application_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'applications(application_id)',
+      onDelete: 'CASCADE',
+    },
+    scheduled_date: { type: 'date', notNull: true },
+    scheduled_time: { type: 'time', notNull: true },
+    assigned_staff: { type: 'uuid' },
+    status: { type: 'home_visit_status', notNull: true, default: 'scheduled' },
+    notes: { type: 'text' },
+    outcome: { type: 'home_visit_outcome' },
+    outcome_notes: { type: 'text' },
+    reschedule_reason: { type: 'text' },
+    cancelled_reason: { type: 'text' },
+    completed_at: { type: 'timestamptz' },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    version: { type: 'integer', notNull: true, default: 0 },
+  });
+
+  pgm.createIndex('home_visits', 'application_id', { name: 'home_visits_application_id_idx' });
+  pgm.createIndex('home_visits', 'status', { name: 'home_visits_status_idx' });
+  pgm.createIndex('home_visits', 'assigned_staff', { name: 'home_visits_assigned_staff_idx' });
+  pgm.createIndex('home_visits', 'scheduled_date', { name: 'home_visits_scheduled_date_idx' });
+  pgm.createIndex('home_visits', 'created_by', { name: 'home_visits_created_by_idx' });
+  pgm.createIndex('home_visits', 'updated_by', { name: 'home_visits_updated_by_idx' });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('home_visits');
+  pgm.dropType('home_visit_status');
+  pgm.dropType('home_visit_outcome');
+};

--- a/services/applications/src/migrations/005_create_home_visit_status_transitions.ts
+++ b/services/applications/src/migrations/005_create_home_visit_status_transitions.ts
@@ -1,0 +1,44 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — home_visit_status_transitions.
+//
+// Append-only event log of home-visit status changes. Mirrors the
+// monolith's 00-baseline-028 with the AFTER INSERT propagation
+// trigger moved INTO the migration set (migration 006) so the DB
+// owns the invariant — raw INSERT can't bypass the home_visits.status
+// update.
+//
+// visit_id FK is intra-schema with CASCADE.
+// transitioned_by is a soft pointer to auth.users; the monolith
+// explicitly used `constraints: false` on this association so the
+// actor reference survives user deletion. Same here.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('home_visit_status_transitions', {
+    transition_id: { type: 'uuid', primaryKey: true },
+    visit_id: {
+      type: 'uuid',
+      notNull: true,
+      references: 'home_visits(visit_id)',
+      onDelete: 'CASCADE',
+    },
+    from_status: { type: 'home_visit_status' },
+    to_status: { type: 'home_visit_status', notNull: true },
+    transitioned_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    transitioned_by: { type: 'uuid' },
+    reason: { type: 'text' },
+    metadata: { type: 'jsonb' },
+  });
+
+  pgm.createIndex('home_visit_status_transitions', ['visit_id', 'transitioned_at'], {
+    name: 'home_visit_status_transitions_visit_id_at_idx',
+  });
+  pgm.createIndex('home_visit_status_transitions', 'transitioned_by', {
+    name: 'home_visit_status_transitions_transitioned_by_idx',
+    where: 'transitioned_by IS NOT NULL',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('home_visit_status_transitions');
+};

--- a/services/applications/src/migrations/006_install_home_visit_status_propagation_trigger.ts
+++ b/services/applications/src/migrations/006_install_home_visit_status_propagation_trigger.ts
@@ -1,0 +1,39 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// AFTER INSERT trigger that propagates home_visit_status_transitions.to_status
+// back to home_visits.status, replacing the monolith's
+// installStatusTransitionTrigger afterSync hook for HomeVisitStatusTransition.
+// The DB owns the invariant — raw INSERT into the transitions table
+// automatically updates the parent visit's status (and updated_at),
+// eliminating the service-side two-write coordination the monolith
+// required.
+//
+// Same pattern as moderation's report_status_transitions trigger
+// (#886, migration 003) and the monolith's behaviour for both.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION home_visits_propagate_status_transition() RETURNS TRIGGER AS $$
+    BEGIN
+      UPDATE home_visits
+      SET status = NEW.to_status,
+          updated_at = now()
+      WHERE visit_id = NEW.visit_id;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  pgm.sql(`
+    CREATE TRIGGER home_visit_status_transitions_propagate
+    AFTER INSERT ON home_visit_status_transitions
+    FOR EACH ROW
+    EXECUTE FUNCTION home_visits_propagate_status_transition();
+  `);
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.sql(
+    'DROP TRIGGER IF EXISTS home_visit_status_transitions_propagate ON home_visit_status_transitions;'
+  );
+  pgm.sql('DROP FUNCTION IF EXISTS home_visits_propagate_status_transition();');
+};

--- a/services/applications/src/migrations/007_create_application_drafts.ts
+++ b/services/applications/src/migrations/007_create_application_drafts.ts
@@ -1,0 +1,45 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — application_drafts.
+//
+// Port of service.backend's 08-create-application-drafts.ts. Backend-
+// resident draft persistence — moves application drafts off localStorage
+// so users can resume from any device. Semantics: last-write-wins; each
+// (user_id, pet_id) pair has at most one draft (UNIQUE constraint).
+//
+// answers is JSONB free-form per-rescue question answers (same shape
+// the application read model carries at submit time).
+//
+// expires_at enforces a TTL — the service stamps now() + 30 days on
+// every upsert. A daily cron eventually deletes rows where
+// expires_at < now(). Idx on expires_at backs the purge query.
+//
+// user_id / pet_id are cross-schema soft pointers to auth.users /
+// pets.pets — no DB REFERENCES (schema-per-service rule). The
+// monolith DID enforce these as FKs with CASCADE; cross-schema
+// enforcement is application-side here. Service handler must reject
+// upserts for deleted users / pets.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('application_drafts', {
+    draft_id: { type: 'uuid', primaryKey: true },
+    user_id: { type: 'uuid', notNull: true },
+    pet_id: { type: 'uuid', notNull: true },
+    answers: { type: 'jsonb', notNull: true, default: pgm.func(`'{}'::jsonb`) },
+    expires_at: { type: 'timestamptz' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('application_drafts', ['user_id', 'pet_id'], {
+    unique: true,
+    name: 'application_drafts_user_pet_unique',
+  });
+  pgm.createIndex('application_drafts', 'expires_at', {
+    name: 'application_drafts_expires_at_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('application_drafts');
+};

--- a/services/applications/src/migrations/migrations.test.ts
+++ b/services/applications/src/migrations/migrations.test.ts
@@ -24,7 +24,7 @@ async function listMigrationFiles(): Promise<string[]> {
 describe('applications migrations', () => {
   it('has migration files following the NNN_snake_case.ts naming convention', async () => {
     const files = await listMigrationFiles();
-    expect(files.length).toBeGreaterThanOrEqual(3);
+    expect(files.length).toBeGreaterThanOrEqual(7);
     for (const f of files) {
       expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
     }
@@ -42,6 +42,10 @@ describe('applications migrations', () => {
     '001_create_application_events.ts',
     '002_create_applications.ts',
     '003_create_application_status_transitions.ts',
+    '004_create_home_visits.ts',
+    '005_create_home_visit_status_transitions.ts',
+    '006_install_home_visit_status_propagation_trigger.ts',
+    '007_create_application_drafts.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;


### PR DESCRIPTION
## Summary

Phase 5.2.5b — home-visit lifecycle tables + backend-resident draft store. Four more migrations on top of #887's core trio.

- **004 home_visits** — port of monolith baseline-027. `application_id` FK intra-schema CASCADE. Two enums: `home_visit_status` (scheduled / in_progress / completed / cancelled) and `home_visit_outcome` (approved / rejected / conditional). Cross-schema soft pointers for staff/audit columns.
- **005 home_visit_status_transitions** — append-only event log. `visit_id` FK intra-schema CASCADE. `transitioned_by` is a soft pointer to auth.users (monolith used `constraints:false` so the actor reference survives user deletion — preserved here).
- **006 home_visits propagation trigger** — AFTER INSERT on `home_visit_status_transitions` updates `home_visits.status` + `updated_at`. Replaces the monolith's afterSync hook so the DB owns the invariant. Same pattern as moderation's report status propagation (#886).
- **007 application_drafts** — port of monolith migration 08. Backend-resident draft persistence so users resume from any device. `(user_id, pet_id)` UNIQUE (last-write-wins per pair). `expires_at` TTL + idx for the purge cron. `user_id` / `pet_id` are cross-schema soft pointers (auth.users / pets.pets) — no DB REFERENCES per schema-per-service rule; the monolith DID enforce these as CASCADE FKs, but cross-schema enforcement moves to the handler.

## What's NOT in this PR

`application_questions`, `application_answers`, `application_references`, `user_application_prefs`. `application_timeline` is covered by the status transitions table from #887.

## Parallel-PR context

Only touches `services/applications/src/migrations/`. Zero overlap with #888 (matching schema, `services/matching/`) or #889 (moderation proto, `packages/proto/`). Builds on Phase 5.2.5 (#887, merged).

## Test plan

- [x] `npm test` in services/applications — 56/56 green (9 boot + 40 Phase 5.2 domain + 7 migrations smoke)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_