### PR TITLE
feat(audit): phase 10.3b-prep — gRPC enum-map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32668,6 +32668,7 @@
       "dependencies": {
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/observability": "*",
+        "@adopt-dont-shop/proto": "*",
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/observability": "*",
+    "@adopt-dont-shop/proto": "*",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.21.0"

--- a/services/audit/src/grpc/enum-map.test.ts
+++ b/services/audit/src/grpc/enum-map.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { AuditV1 } from '@adopt-dont-shop/proto';
+
+import { ALL_OUTCOMES, outcomeFromDb, outcomeToDb } from './enum-map.js';
+
+// Bite #10: ts-proto adds UNRECOGNIZED = -1; UNSPECIFIED = 0 is the
+// proto3 sentinel. Filter both with `v > 0`.
+function populatedCount(enumObj: Record<string, string | number>): number {
+  return Object.values(enumObj).filter(v => typeof v === 'number' && v > 0).length;
+}
+
+describe('AuditOutcome mapping', () => {
+  it.each(ALL_OUTCOMES)('round-trips %s', db => {
+    expect(outcomeToDb(outcomeFromDb(db))).toBe(db);
+  });
+
+  it('throws on UNSPECIFIED + unknown DB value', () => {
+    expect(() => outcomeToDb(AuditV1.AuditOutcome.AUDIT_OUTCOME_UNSPECIFIED)).toThrowError();
+    expect(() => outcomeFromDb('partial')).toThrowError();
+  });
+
+  it('proto-populated count matches DB variant count', () => {
+    expect(populatedCount(AuditV1.AuditOutcome)).toBe(ALL_OUTCOMES.length);
+  });
+
+  it('denied + failure are distinct (denied = authz block, failure = exception)', () => {
+    // Lesson from the audit proto comment: a DENIED row is forensically
+    // valuable because it captures the attempt; FAILURE is for server
+    // errors. Mapping must not collapse them.
+    expect(outcomeToDb(AuditV1.AuditOutcome.AUDIT_OUTCOME_DENIED)).toBe('denied');
+    expect(outcomeToDb(AuditV1.AuditOutcome.AUDIT_OUTCOME_FAILURE)).toBe('failure');
+    expect(outcomeToDb(AuditV1.AuditOutcome.AUDIT_OUTCOME_DENIED)).not.toBe(
+      outcomeToDb(AuditV1.AuditOutcome.AUDIT_OUTCOME_FAILURE)
+    );
+  });
+});

--- a/services/audit/src/grpc/enum-map.ts
+++ b/services/audit/src/grpc/enum-map.ts
@@ -1,0 +1,45 @@
+// Mappers between the audit.audit_events.outcome string values and the
+// AuditOutcome proto enum integers. Same shape as the moderation +
+// matching + rescue enum-maps. Single enum for this service (just
+// `outcome` — service / subject / action / aggregate_type are
+// free-form strings in the audit log).
+
+import { AuditV1 } from '@adopt-dont-shop/proto';
+
+// ===== AuditOutcome ==================================================
+
+export type AuditOutcomeDb = 'success' | 'denied' | 'failure';
+
+const OUTCOME_TO_DB: Record<AuditV1.AuditOutcome, AuditOutcomeDb | null> = {
+  [AuditV1.AuditOutcome.AUDIT_OUTCOME_UNSPECIFIED]: null,
+  [AuditV1.AuditOutcome.AUDIT_OUTCOME_SUCCESS]: 'success',
+  [AuditV1.AuditOutcome.AUDIT_OUTCOME_DENIED]: 'denied',
+  [AuditV1.AuditOutcome.AUDIT_OUTCOME_FAILURE]: 'failure',
+  [AuditV1.AuditOutcome.UNRECOGNIZED]: null,
+};
+
+const DB_TO_OUTCOME: Record<AuditOutcomeDb, AuditV1.AuditOutcome> = {
+  success: AuditV1.AuditOutcome.AUDIT_OUTCOME_SUCCESS,
+  denied: AuditV1.AuditOutcome.AUDIT_OUTCOME_DENIED,
+  failure: AuditV1.AuditOutcome.AUDIT_OUTCOME_FAILURE,
+};
+
+export function outcomeToDb(proto: AuditV1.AuditOutcome): AuditOutcomeDb {
+  const db = OUTCOME_TO_DB[proto];
+  if (!db) {
+    throw new Error(`invalid AuditOutcome proto value: ${proto}`);
+  }
+  return db;
+}
+
+export function outcomeFromDb(db: string): AuditV1.AuditOutcome {
+  const proto = DB_TO_OUTCOME[db as AuditOutcomeDb];
+  if (!proto) {
+    throw new Error(`unknown audit_events.outcome value: ${db}`);
+  }
+  return proto;
+}
+
+// ===== Exhaustiveness =================================================
+
+export const ALL_OUTCOMES: ReadonlyArray<AuditOutcomeDb> = ['success', 'denied', 'failure'];


### PR DESCRIPTION
## Summary

Phase 10.3b-prep — `services/audit/src/grpc/enum-map.ts` + tests. Single bidirectional mapper for `AuditOutcome` — the only typed enum in the `audit_events` schema (`service` / `subject` / `action` / `aggregate_type` are free-form strings).

Same shape as the moderation + matching enum-maps:
- `outcomeToDb(proto)` — throws on UNSPECIFIED / UNRECOGNIZED sentinels
- `outcomeFromDb(db)` — throws on unknown DB values
- `ALL_OUTCOMES` array for exhaustiveness tests

`AuditOutcome` (success / denied / failure) — the three semantics the #894 proto comment calls out:
- `SUCCESS`: action committed
- `DENIED`: authz blocked, but the audit row IS still written (forensic value)
- `FAILURE`: action raised an exception

Added a dedicated test asserting `denied` + `failure` round-trip to distinct DB values — guards against accidentally collapsing the two semantics under a single string.

## Parallel-PR context

Only touches `services/audit/src/grpc/` (new dir) plus the package.json proto dep + transitive package-lock.json bump. Builds on #884 (audit schema, merged) + #894 (audit proto, merged).

## Test plan

- [x] `npm test` in services/audit — 18/18 green (9 boot + 5 migrations + 4 enum-map)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_