### PR TITLE
feat(applications): phase 5.3b-prep — gRPC principal extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32655,8 +32655,12 @@
       "name": "@adopt-dont-shop/service.applications",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/authz": "*",
         "@adopt-dont-shop/db": "*",
+        "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
+        "@adopt-dont-shop/proto": "*",
+        "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"

--- a/services/applications/package.json
+++ b/services/applications/package.json
@@ -33,8 +33,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/authz": "*",
     "@adopt-dont-shop/db": "*",
+    "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
+    "@adopt-dont-shop/proto": "*",
+    "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.21.0"

--- a/services/applications/src/grpc/principal.test.ts
+++ b/services/applications/src/grpc/principal.test.ts
@@ -1,0 +1,70 @@
+import { Metadata } from '@grpc/grpc-js';
+import { describe, expect, it } from 'vitest';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+function build(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+describe('extractPrincipal', () => {
+  it('throws MissingPrincipalError when x-user-id is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-roles': 'adopter' }))).toThrowError(
+      MissingPrincipalError
+    );
+  });
+
+  it('throws MissingPrincipalError when x-user-roles is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-id': 'u' }))).toThrowError(MissingPrincipalError);
+  });
+
+  it('parses comma-separated roles + permissions for an adopter', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+        'x-user-permissions': 'applications.create , applications.read',
+      })
+    );
+    expect(p.userId).toBe('usr-1');
+    expect(p.roles).toEqual(['adopter']);
+    expect(p.permissions).toEqual(['applications.create', 'applications.read']);
+  });
+
+  it('parses rescue staff with x-rescue-id scope', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-2',
+        'x-user-roles': 'rescue_staff, admin',
+        'x-rescue-id': 'rsc-42',
+        'x-user-permissions': 'applications.update, applications.approve',
+      })
+    );
+    expect(p.roles).toEqual(['rescue_staff', 'admin']);
+    expect(p.rescueId).toBe('rsc-42');
+    expect(p.permissions).toEqual(['applications.update', 'applications.approve']);
+  });
+
+  it('omits rescueId when x-rescue-id is absent (adopter case)', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-3',
+        'x-user-roles': 'adopter',
+      })
+    );
+    expect(p.rescueId).toBeUndefined();
+  });
+
+  it('drops empty permission slots from a trailing comma', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-4',
+        'x-user-roles': 'adopter',
+        'x-user-permissions': 'applications.read,, ',
+      })
+    );
+    expect(p.permissions).toEqual(['applications.read']);
+  });
+});

--- a/services/applications/src/grpc/principal.ts
+++ b/services/applications/src/grpc/principal.ts
@@ -1,0 +1,68 @@
+// Principal extractor for gRPC handlers that REQUIRE a principal.
+//
+// Every extracted service receives identity context as gRPC metadata
+// headers from the gateway:
+//
+//   x-user-id           UUID of the calling user
+//   x-user-roles        comma-separated UserRole list
+//   x-user-permissions  comma-separated Permission list
+//   x-rescue-id         (optional) rescueId for rescue-scoped roles
+//
+// Direct port of services/rescue/src/grpc/principal.ts. All
+// ApplicationService RPCs require a principal — there's no
+// token-minting flow on this surface (auth handles that). Even
+// `StartDraft` requires a principal because drafts are user-scoped.
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export class MissingPrincipalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingPrincipalError';
+  }
+}
+
+export function extractPrincipal(metadata: Metadata): Principal {
+  const userId = headerOne(metadata, 'x-user-id');
+  if (!userId) {
+    throw new MissingPrincipalError('missing x-user-id metadata');
+  }
+
+  const rolesRaw = headerOne(metadata, 'x-user-roles');
+  if (!rolesRaw) {
+    throw new MissingPrincipalError('missing x-user-roles metadata');
+  }
+
+  const roles = rolesRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as UserRole[];
+
+  const permissionsRaw = headerOne(metadata, 'x-user-permissions') ?? '';
+  const permissions = permissionsRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as Permission[];
+
+  const rescueIdRaw = headerOne(metadata, 'x-rescue-id')?.trim();
+  const rescueId = rescueIdRaw ? (rescueIdRaw as RescueId) : undefined;
+
+  return {
+    userId: userId as UserId,
+    roles,
+    permissions,
+    rescueId,
+  };
+}
+
+function headerOne(metadata: Metadata, key: string): string | undefined {
+  const values = metadata.get(key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}


### PR DESCRIPTION
## Summary

Phase 5.3b-prep — `services/applications/src/grpc/principal.ts` + tests. Direct port of `services/rescue/src/grpc/principal.ts` (and the identical pattern in services/pets / services/auth).

Pulls identity context from gateway-stamped gRPC metadata headers:
- `x-user-id` — UUID of the calling user (required)
- `x-user-roles` — comma-separated `UserRole` list (required)
- `x-user-permissions` — comma-separated `Permission` list
- `x-rescue-id` — optional rescueId for rescue-scoped roles

Every `ApplicationService` RPC requires a principal — there's no token-minting flow on this surface (auth handles that). Even `StartDraft` requires a principal because drafts are user-scoped.

Foundation for the gRPC handler logic in Phase 5.3b proper.

## Parallel-PR context

Only touches `services/applications/src/grpc/` (new dir) plus the package.json deps for `@adopt-dont-shop/authz`, `lib.types`, `proto`, `@grpc/grpc-js`. Builds on already-merged proto + schema PRs.

## Test plan

- [x] `npm test` in services/applications — 62/62 green (9 boot + 40 Phase 5.2 domain + 7 migrations + 6 principal)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_