### PR TITLE
feat(moderation): phase 8.3b-prep — gRPC principal extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32736,9 +32736,12 @@
       "name": "@adopt-dont-shop/service.moderation",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/authz": "*",
         "@adopt-dont-shop/db": "*",
+        "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
         "@adopt-dont-shop/proto": "*",
+        "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"

--- a/services/moderation/package.json
+++ b/services/moderation/package.json
@@ -33,9 +33,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/authz": "*",
     "@adopt-dont-shop/db": "*",
+    "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
     "@adopt-dont-shop/proto": "*",
+    "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.21.0"

--- a/services/moderation/src/grpc/principal.test.ts
+++ b/services/moderation/src/grpc/principal.test.ts
@@ -1,0 +1,57 @@
+import { Metadata } from '@grpc/grpc-js';
+import { describe, expect, it } from 'vitest';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+function build(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+describe('extractPrincipal', () => {
+  it('throws MissingPrincipalError when x-user-id is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-roles': 'adopter' }))).toThrowError(
+      MissingPrincipalError
+    );
+  });
+
+  it('throws MissingPrincipalError when x-user-roles is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-id': 'u' }))).toThrowError(MissingPrincipalError);
+  });
+
+  it('parses comma-separated roles + permissions for an adopter filing a report', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+        'x-user-permissions': 'reports.create , reports.read',
+      })
+    );
+    expect(p.userId).toBe('usr-1');
+    expect(p.roles).toEqual(['adopter']);
+    expect(p.permissions).toEqual(['reports.create', 'reports.read']);
+  });
+
+  it('parses moderator with action permissions', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'mod-1',
+        'x-user-roles': 'moderator, admin',
+        'x-user-permissions': 'reports.resolve, sanctions.issue',
+      })
+    );
+    expect(p.roles).toEqual(['moderator', 'admin']);
+    expect(p.permissions).toEqual(['reports.resolve', 'sanctions.issue']);
+  });
+
+  it('omits rescueId when x-rescue-id is absent', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-3',
+        'x-user-roles': 'moderator',
+      })
+    );
+    expect(p.rescueId).toBeUndefined();
+  });
+});

--- a/services/moderation/src/grpc/principal.ts
+++ b/services/moderation/src/grpc/principal.ts
@@ -1,0 +1,61 @@
+// Principal extractor for gRPC handlers that REQUIRE a principal.
+//
+// Direct port of services/rescue/src/grpc/principal.ts. All
+// ModerationService RPCs require a principal — moderators / admins
+// for the action surface (assign, resolve, log moderator action,
+// issue sanction), and any authenticated user for file-report /
+// open-support-ticket.
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export class MissingPrincipalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingPrincipalError';
+  }
+}
+
+export function extractPrincipal(metadata: Metadata): Principal {
+  const userId = headerOne(metadata, 'x-user-id');
+  if (!userId) {
+    throw new MissingPrincipalError('missing x-user-id metadata');
+  }
+
+  const rolesRaw = headerOne(metadata, 'x-user-roles');
+  if (!rolesRaw) {
+    throw new MissingPrincipalError('missing x-user-roles metadata');
+  }
+
+  const roles = rolesRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as UserRole[];
+
+  const permissionsRaw = headerOne(metadata, 'x-user-permissions') ?? '';
+  const permissions = permissionsRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as Permission[];
+
+  const rescueIdRaw = headerOne(metadata, 'x-rescue-id')?.trim();
+  const rescueId = rescueIdRaw ? (rescueIdRaw as RescueId) : undefined;
+
+  return {
+    userId: userId as UserId,
+    roles,
+    permissions,
+    rescueId,
+  };
+}
+
+function headerOne(metadata: Metadata, key: string): string | undefined {
+  const values = metadata.get(key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}


### PR DESCRIPTION
## Summary

Phase 8.3b-prep — `services/moderation/src/grpc/principal.ts` + tests. Direct port of the rescue / pets / auth principal pattern.

All `ModerationService` RPCs require a principal — moderators / admins for the action surface (`AssignReport`, `ResolveReport`, `LogModeratorAction`, `IssueSanction`), and any authenticated user for `FileReport` / `OpenSupportTicket`.

Foundation for the gRPC handler logic in Phase 8.3b proper.

## Parallel-PR context

Only touches `services/moderation/src/grpc/principal.{ts,test.ts}` (new file alongside the merged `enum-map.{ts,test.ts}`) plus the package.json deps for `@adopt-dont-shop/authz`, `lib.types`, `@grpc/grpc-js`. Sits in its own service dir — zero overlap with #895 (audit enum-map) or #896 (applications principal).

## Test plan

- [x] `npm test` in services/moderation — 128/128 green (9 boot + 10 migrations + 114 enum-map + 5 principal)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_