### PR TITLE
feat(matching): phase 9.3b-prep — gRPC principal extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32724,9 +32724,12 @@
       "name": "@adopt-dont-shop/service.matching",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/authz": "*",
         "@adopt-dont-shop/db": "*",
+        "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
         "@adopt-dont-shop/proto": "*",
+        "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"

--- a/services/matching/package.json
+++ b/services/matching/package.json
@@ -33,9 +33,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/authz": "*",
     "@adopt-dont-shop/db": "*",
+    "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
     "@adopt-dont-shop/proto": "*",
+    "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.21.0"

--- a/services/matching/src/grpc/principal.test.ts
+++ b/services/matching/src/grpc/principal.test.ts
@@ -1,0 +1,56 @@
+import { Metadata } from '@grpc/grpc-js';
+import { describe, expect, it } from 'vitest';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+function build(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+describe('extractPrincipal', () => {
+  it('throws MissingPrincipalError when x-user-id is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-roles': 'adopter' }))).toThrowError(
+      MissingPrincipalError
+    );
+  });
+
+  it('throws MissingPrincipalError when x-user-roles is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-id': 'u' }))).toThrowError(MissingPrincipalError);
+  });
+
+  it('parses an adopter browsing for pets', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+        'x-user-permissions': 'pets.read , matching.swipe',
+      })
+    );
+    expect(p.userId).toBe('usr-1');
+    expect(p.roles).toEqual(['adopter']);
+    expect(p.permissions).toEqual(['pets.read', 'matching.swipe']);
+  });
+
+  it('omits rescueId when x-rescue-id is absent (adopters never have a rescue scope)', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-2',
+        'x-user-roles': 'adopter',
+      })
+    );
+    expect(p.rescueId).toBeUndefined();
+  });
+
+  it('drops empty permission slots from a trailing comma', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'usr-3',
+        'x-user-roles': 'adopter',
+        'x-user-permissions': 'pets.read,, ',
+      })
+    );
+    expect(p.permissions).toEqual(['pets.read']);
+  });
+});

--- a/services/matching/src/grpc/principal.ts
+++ b/services/matching/src/grpc/principal.ts
@@ -1,0 +1,62 @@
+// Principal extractor for gRPC handlers that REQUIRE a principal.
+//
+// Direct port of services/rescue/src/grpc/principal.ts. Note: most
+// MatchingService RPCs are session-scoped to the calling user, so a
+// principal is required for StartSession / EndSession / Recommend /
+// RecordSwipe / ListSwipeHistory. SearchPets is the one anonymous
+// surface (matches the monolith's public /api/search/*); the gateway
+// will route it through an unauth adapter variant in Phase 9.3c.
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export class MissingPrincipalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingPrincipalError';
+  }
+}
+
+export function extractPrincipal(metadata: Metadata): Principal {
+  const userId = headerOne(metadata, 'x-user-id');
+  if (!userId) {
+    throw new MissingPrincipalError('missing x-user-id metadata');
+  }
+
+  const rolesRaw = headerOne(metadata, 'x-user-roles');
+  if (!rolesRaw) {
+    throw new MissingPrincipalError('missing x-user-roles metadata');
+  }
+
+  const roles = rolesRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as UserRole[];
+
+  const permissionsRaw = headerOne(metadata, 'x-user-permissions') ?? '';
+  const permissions = permissionsRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as Permission[];
+
+  const rescueIdRaw = headerOne(metadata, 'x-rescue-id')?.trim();
+  const rescueId = rescueIdRaw ? (rescueIdRaw as RescueId) : undefined;
+
+  return {
+    userId: userId as UserId,
+    roles,
+    permissions,
+    rescueId,
+  };
+}
+
+function headerOne(metadata: Metadata, key: string): string | undefined {
+  const values = metadata.get(key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}


### PR DESCRIPTION
## Summary

Phase 9.3b-prep — `services/matching/src/grpc/principal.ts` + tests. Direct port of the rescue / pets / auth / moderation / applications principal pattern.

Most `MatchingService` RPCs are session-scoped to the calling user, so a principal is required for `StartSession` / `EndSession` / `Recommend` / `RecordSwipe` / `ListSwipeHistory`. `SearchPets` is the one anonymous surface (matches the monolith's public `/api/search/*`); the gateway will route it through an unauth adapter variant in Phase 9.3c.

Foundation for the gRPC handler logic in Phase 9.3b proper.

## Parallel-PR context

Only touches `services/matching/src/grpc/principal.{ts,test.ts}` (new file alongside the merged `enum-map.{ts,test.ts}`) plus package.json deps for `authz`, `lib.types`, `@grpc/grpc-js`. Sits in its own service dir — zero overlap with #895 / #896 / #897 / any in-flight work.

## Test plan

- [x] `npm test` in services/matching — 30/30 green (9 boot + 4 migrations + 14 enum-map + 5 principal)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_