### PR TITLE
feat(audit): phase 10.3b-prep — gRPC principal extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32670,9 +32670,12 @@
       "name": "@adopt-dont-shop/service.audit",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/authz": "*",
         "@adopt-dont-shop/db": "*",
+        "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
         "@adopt-dont-shop/proto": "*",
+        "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -33,9 +33,12 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/authz": "*",
     "@adopt-dont-shop/db": "*",
+    "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
     "@adopt-dont-shop/proto": "*",
+    "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.21.0"

--- a/services/audit/src/grpc/principal.test.ts
+++ b/services/audit/src/grpc/principal.test.ts
@@ -1,0 +1,56 @@
+import { Metadata } from '@grpc/grpc-js';
+import { describe, expect, it } from 'vitest';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+function build(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+describe('extractPrincipal', () => {
+  it('throws MissingPrincipalError when x-user-id is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-roles': 'admin' }))).toThrowError(
+      MissingPrincipalError
+    );
+  });
+
+  it('throws MissingPrincipalError when x-user-roles is absent', () => {
+    expect(() => extractPrincipal(build({ 'x-user-id': 'u' }))).toThrowError(MissingPrincipalError);
+  });
+
+  it('parses an admin with view Audit permission', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'admin-1',
+        'x-user-roles': 'admin, super_admin',
+        'x-user-permissions': 'audit.view , audit.read',
+      })
+    );
+    expect(p.userId).toBe('admin-1');
+    expect(p.roles).toEqual(['admin', 'super_admin']);
+    expect(p.permissions).toEqual(['audit.view', 'audit.read']);
+  });
+
+  it('omits rescueId when x-rescue-id is absent (audit is admin-only, no rescue scope)', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'admin-2',
+        'x-user-roles': 'admin',
+      })
+    );
+    expect(p.rescueId).toBeUndefined();
+  });
+
+  it('drops empty permission slots from a trailing comma', () => {
+    const p = extractPrincipal(
+      build({
+        'x-user-id': 'admin-3',
+        'x-user-roles': 'admin',
+        'x-user-permissions': 'audit.view,, ',
+      })
+    );
+    expect(p.permissions).toEqual(['audit.view']);
+  });
+});

--- a/services/audit/src/grpc/principal.ts
+++ b/services/audit/src/grpc/principal.ts
@@ -1,0 +1,61 @@
+// Principal extractor for gRPC handlers that REQUIRE a principal.
+//
+// Direct port of services/rescue/src/grpc/principal.ts. Both
+// AuditQueryService RPCs (Query, GetByTarget) require a principal —
+// the gateway only forwards these calls after gating on the
+// `view Audit` ability (admin+). The handler re-checks the ability
+// against the metadata principal (defence in depth, CAD pattern).
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export class MissingPrincipalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingPrincipalError';
+  }
+}
+
+export function extractPrincipal(metadata: Metadata): Principal {
+  const userId = headerOne(metadata, 'x-user-id');
+  if (!userId) {
+    throw new MissingPrincipalError('missing x-user-id metadata');
+  }
+
+  const rolesRaw = headerOne(metadata, 'x-user-roles');
+  if (!rolesRaw) {
+    throw new MissingPrincipalError('missing x-user-roles metadata');
+  }
+
+  const roles = rolesRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as UserRole[];
+
+  const permissionsRaw = headerOne(metadata, 'x-user-permissions') ?? '';
+  const permissions = permissionsRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as Permission[];
+
+  const rescueIdRaw = headerOne(metadata, 'x-rescue-id')?.trim();
+  const rescueId = rescueIdRaw ? (rescueIdRaw as RescueId) : undefined;
+
+  return {
+    userId: userId as UserId,
+    roles,
+    permissions,
+    rescueId,
+  };
+}
+
+function headerOne(metadata: Metadata, key: string): string | undefined {
+  const values = metadata.get(key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}


### PR DESCRIPTION
## Summary

Phase 10.3b-prep — `services/audit/src/grpc/principal.ts` + tests. Direct port of the rescue / pets / auth / moderation / matching / applications principal pattern.

Both `AuditQueryService` RPCs (`Query`, `GetByTarget`) require a principal — the gateway only forwards these calls after gating on the `view Audit` ability (admin+). The handler re-checks the ability against the metadata principal (defence in depth, CAD pattern).

Foundation for the gRPC handler logic in Phase 10.3b proper.

## Parallel-PR context

Only touches `services/audit/src/grpc/principal.{ts,test.ts}` (new file) plus package.json deps for `authz`, `lib.types`, `proto`, `@grpc/grpc-js`. Builds on #884 (audit schema, merged) + #894 (audit proto, merged). Concurrent with #895 (audit enum-map, in flight) — both add new files under `services/audit/src/grpc/` so no conflict.

## Test plan

- [x] `npm test` in services/audit — 17/17 green (9 boot + 3 migrations + 5 principal)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_