### PR TITLE
feat(audit): phase 10.3b-prep — gRPC adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32672,6 +32672,7 @@
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
         "@adopt-dont-shop/db": "*",
+        "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
         "@adopt-dont-shop/proto": "*",

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
     "@adopt-dont-shop/db": "*",
+    "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
     "@adopt-dont-shop/proto": "*",

--- a/services/audit/src/grpc/adapter.test.ts
+++ b/services/audit/src/grpc/adapter.test.ts
@@ -1,0 +1,110 @@
+import { Metadata, status, type ServerUnaryCall, type sendUnaryData } from '@grpc/grpc-js';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from 'winston';
+
+import { adapt, HandlerError, type HandlerDeps } from './adapter.js';
+
+function makeLogger() {
+  const calls: Array<{ level: string; msg: string; meta?: unknown }> = [];
+  const logger = {
+    info: (msg: string, meta?: unknown) => calls.push({ level: 'info', msg, meta }),
+    error: (msg: string, meta?: unknown) => calls.push({ level: 'error', msg, meta }),
+    warn: (msg: string, meta?: unknown) => calls.push({ level: 'warn', msg, meta }),
+    debug: (msg: string, meta?: unknown) => calls.push({ level: 'debug', msg, meta }),
+    silly: (msg: string, meta?: unknown) => calls.push({ level: 'silly', msg, meta }),
+  } as unknown as Logger;
+  return { logger, calls };
+}
+
+function buildMetadata(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+const VALID_HEADERS = {
+  'x-user-id': 'admin-1',
+  'x-user-roles': 'admin',
+  'x-user-permissions': 'audit.view',
+};
+
+const deps = { pool: {}, nats: {} } as unknown as HandlerDeps;
+
+function makeCall<Req>(request: Req, metadata: Metadata): ServerUnaryCall<Req, unknown> {
+  return { request, metadata } as ServerUnaryCall<Req, unknown>;
+}
+
+describe('adapt — happy path', () => {
+  it('passes the request and extracted principal to the handler', async () => {
+    const handler = vi.fn(async (_d, principal, req: { ping: string }) => ({
+      pong: req.ping,
+      asUser: principal.userId,
+    }));
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({ ping: 'hi' }, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ pong: 'hi', asUser: 'admin-1' });
+  });
+});
+
+describe('adapt — error code mapping', () => {
+  it('UNAUTHENTICATED when principal headers are missing', async () => {
+    const handler = vi.fn();
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata({})), callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(handler).not.toHaveBeenCalled();
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.UNAUTHENTICATED });
+  });
+
+  it.each([
+    ['INVALID_ARGUMENT', status.INVALID_ARGUMENT],
+    ['UNAUTHENTICATED', status.UNAUTHENTICATED],
+    ['PERMISSION_DENIED', status.PERMISSION_DENIED],
+    ['NOT_FOUND', status.NOT_FOUND],
+    ['INTERNAL', status.INTERNAL],
+  ] as const)('HandlerError("%s") → %i', async (code, grpcCode) => {
+    const handler = vi.fn(async () => {
+      throw new HandlerError(code, `${code} test`);
+    });
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: grpcCode });
+  });
+
+  it('unknown errors → INTERNAL and log', async () => {
+    const handler = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const { logger, calls } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.INTERNAL });
+    // unknown errors get logged (don't surface internals to the
+    // caller, but DO log them).
+    expect(calls.some(c => c.level === 'error')).toBe(true);
+  });
+});

--- a/services/audit/src/grpc/adapter.ts
+++ b/services/audit/src/grpc/adapter.ts
@@ -1,0 +1,105 @@
+// Adapter — wraps the plain async handler functions (Phase 10.3b)
+// in the grpc-js `(call, callback)` signature ts-proto generates.
+//
+// Both AuditQueryService RPCs (Query, GetByTarget) require a
+// principal — the gateway only forwards these calls after gating on
+// the `view Audit` ability (admin+). HandlerError → grpc.status
+// mapping mirrors services/rescue/src/grpc/adapter.ts.
+//
+// HandlerError + HandlerErrorCode + HandlerDeps are defined here
+// rather than in a separate handlers.ts so this PR can land
+// standalone — the actual RPC handler functions arrive in Phase
+// 10.3b's handlers.ts and import HandlerError from this file.
+
+import {
+  status,
+  type Metadata,
+  type ServerUnaryCall,
+  type ServiceError,
+  type sendUnaryData,
+} from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+import type { Logger } from 'winston';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+// Per-handler dependencies — Postgres pool + NATS publisher etc.
+// Audit doesn't write through the gRPC surface (it's read-only), so
+// the deps are just the read side: a Postgres pool wrapped for query
+// + transaction semantics. Same shape as other services so the
+// adapter is identical.
+export type HandlerDeps = WithTransactionDeps;
+
+export type HandlerErrorCode =
+  | 'INVALID_ARGUMENT'
+  | 'UNAUTHENTICATED'
+  | 'PERMISSION_DENIED'
+  | 'NOT_FOUND'
+  | 'INTERNAL';
+
+export class HandlerError extends Error {
+  constructor(
+    public readonly code: HandlerErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'HandlerError';
+  }
+}
+
+const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
+  INVALID_ARGUMENT: status.INVALID_ARGUMENT,
+  UNAUTHENTICATED: status.UNAUTHENTICATED,
+  PERMISSION_DENIED: status.PERMISSION_DENIED,
+  NOT_FOUND: status.NOT_FOUND,
+  INTERNAL: status.INTERNAL,
+};
+
+export type UnaryHandler<Req, Res> = (
+  deps: HandlerDeps,
+  principal: Principal,
+  req: Req
+) => Promise<Res>;
+
+export type AdaptOptions = {
+  deps: HandlerDeps;
+  logger: Logger;
+};
+
+export function adapt<Req, Res>(
+  handler: UnaryHandler<Req, Res>,
+  { deps, logger }: AdaptOptions
+): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
+  return (call, callback) => {
+    void (async () => {
+      try {
+        const principal = extractPrincipal(call.metadata);
+        const response = await handler(deps, principal, call.request);
+        callback(null, response);
+      } catch (err) {
+        callback(toServiceError(err, call.metadata, logger), null);
+      }
+    })();
+  };
+}
+
+function toServiceError(err: unknown, metadata: Metadata, logger: Logger): ServiceError {
+  if (err instanceof MissingPrincipalError) {
+    return makeServiceError(status.UNAUTHENTICATED, err.message, metadata);
+  }
+  if (err instanceof HandlerError) {
+    return makeServiceError(CODE_TO_GRPC[err.code], err.message, metadata);
+  }
+  logger.error('unhandled handler error', { err });
+  return makeServiceError(status.INTERNAL, 'internal error', metadata);
+}
+
+function makeServiceError(code: number, message: string, metadata: Metadata): ServiceError {
+  const err = new Error(message) as ServiceError;
+  err.code = code;
+  err.details = message;
+  err.metadata = metadata;
+  return err;
+}


### PR DESCRIPTION
## Summary

Phase 10.3b-prep — `services/audit/src/grpc/adapter.ts` + tests. Direct port of `services/rescue/src/grpc/adapter.ts` shape.

Wraps plain async handlers in the grpc-js `(call, callback)` signature ts-proto generates:
- Extracts the principal from gateway-stamped metadata (delegates to `principal.ts` from #899)
- Maps `HandlerError` → `grpc.status` via a 5-row code table (INVALID_ARGUMENT, UNAUTHENTICATED, PERMISSION_DENIED, NOT_FOUND, INTERNAL)
- Surfaces unknown errors as INTERNAL with a log line (don't leak internals to caller; do log them server-side)

`HandlerError` + `HandlerErrorCode` + `HandlerDeps` live HERE rather than in a separate `handlers.ts` so this PR can land standalone — the actual RPC handler functions arrive in Phase 10.3b's `handlers.ts` and import `HandlerError` from this file.

Both `AuditQueryService` RPCs (Query, GetByTarget) require a principal (the gateway only forwards after gating on `view Audit`). Single `adapt()` variant — no token-minting flow here, no anonymous surface.

## Parallel-PR context

Only touches `services/audit/src/grpc/adapter.{ts,test.ts}` plus the `@adopt-dont-shop/events` dep + transitive package-lock.json bump. Builds on:
- #884 audit schema (merged)
- #894 audit proto (merged)
- #895 audit enum-map (merged)
- #899 audit principal (merged)

## Test plan

- [x] `npm test` in services/audit — 31/31 green (9 boot + 5 migrations + 4 enum-map + 5 principal + 8 adapter)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` — OK
- [x] `node scripts/check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_