### PR TITLE
feat(moderation): phase 8.3b-prep — gRPC adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32749,6 +32749,7 @@
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
         "@adopt-dont-shop/db": "*",
+        "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
         "@adopt-dont-shop/proto": "*",

--- a/services/moderation/package.json
+++ b/services/moderation/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
     "@adopt-dont-shop/db": "*",
+    "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
     "@adopt-dont-shop/proto": "*",

--- a/services/moderation/src/grpc/adapter.test.ts
+++ b/services/moderation/src/grpc/adapter.test.ts
@@ -1,0 +1,108 @@
+import { Metadata, status, type ServerUnaryCall, type sendUnaryData } from '@grpc/grpc-js';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from 'winston';
+
+import { adapt, HandlerError, type HandlerDeps } from './adapter.js';
+
+function makeLogger() {
+  const calls: Array<{ level: string; msg: string; meta?: unknown }> = [];
+  const logger = {
+    info: (msg: string, meta?: unknown) => calls.push({ level: 'info', msg, meta }),
+    error: (msg: string, meta?: unknown) => calls.push({ level: 'error', msg, meta }),
+    warn: (msg: string, meta?: unknown) => calls.push({ level: 'warn', msg, meta }),
+    debug: (msg: string, meta?: unknown) => calls.push({ level: 'debug', msg, meta }),
+    silly: (msg: string, meta?: unknown) => calls.push({ level: 'silly', msg, meta }),
+  } as unknown as Logger;
+  return { logger, calls };
+}
+
+function buildMetadata(headers: Record<string, string>): Metadata {
+  const m = new Metadata();
+  for (const [k, v] of Object.entries(headers)) m.set(k, v);
+  return m;
+}
+
+const VALID_HEADERS = {
+  'x-user-id': 'mod-1',
+  'x-user-roles': 'moderator',
+  'x-user-permissions': 'reports.resolve',
+};
+
+const deps = { pool: {}, nats: {} } as unknown as HandlerDeps;
+
+function makeCall<Req>(request: Req, metadata: Metadata): ServerUnaryCall<Req, unknown> {
+  return { request, metadata } as ServerUnaryCall<Req, unknown>;
+}
+
+describe('adapt — happy path', () => {
+  it('passes the request and extracted principal to the handler', async () => {
+    const handler = vi.fn(async (_d, principal, req: { ping: string }) => ({
+      pong: req.ping,
+      asUser: principal.userId,
+    }));
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({ ping: 'hi' }, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err, res] = vi.mocked(callback).mock.calls[0];
+    expect(err).toBeNull();
+    expect(res).toEqual({ pong: 'hi', asUser: 'mod-1' });
+  });
+});
+
+describe('adapt — error code mapping', () => {
+  it('UNAUTHENTICATED when principal headers are missing', async () => {
+    const handler = vi.fn();
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata({})), callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(handler).not.toHaveBeenCalled();
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.UNAUTHENTICATED });
+  });
+
+  it.each([
+    ['INVALID_ARGUMENT', status.INVALID_ARGUMENT],
+    ['UNAUTHENTICATED', status.UNAUTHENTICATED],
+    ['PERMISSION_DENIED', status.PERMISSION_DENIED],
+    ['NOT_FOUND', status.NOT_FOUND],
+    ['INTERNAL', status.INTERNAL],
+  ] as const)('HandlerError("%s") → %i', async (code, grpcCode) => {
+    const handler = vi.fn(async () => {
+      throw new HandlerError(code, `${code} test`);
+    });
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: grpcCode });
+  });
+
+  it('unknown errors → INTERNAL and log', async () => {
+    const handler = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const { logger, calls } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(makeCall({}, buildMetadata(VALID_HEADERS)), callback);
+    await new Promise(r => setImmediate(r));
+
+    const [err] = vi.mocked(callback).mock.calls[0];
+    expect(err).toMatchObject({ code: status.INTERNAL });
+    expect(calls.some(c => c.level === 'error')).toBe(true);
+  });
+});

--- a/services/moderation/src/grpc/adapter.ts
+++ b/services/moderation/src/grpc/adapter.ts
@@ -1,0 +1,99 @@
+// Adapter — wraps the plain async handler functions (Phase 8.3b)
+// in the grpc-js `(call, callback)` signature ts-proto generates.
+//
+// All 14 ModerationService RPCs require a principal — moderators /
+// admins for the action surface (AssignReport, ResolveReport,
+// LogModeratorAction, IssueSanction), and any authenticated user
+// for FileReport / OpenSupportTicket. No anonymous surface, so the
+// single `adapt` variant covers the entire RPC set.
+//
+// HandlerError + HandlerErrorCode + HandlerDeps live HERE rather
+// than in a separate handlers.ts so this PR can land standalone.
+
+import {
+  status,
+  type Metadata,
+  type ServerUnaryCall,
+  type ServiceError,
+  type sendUnaryData,
+} from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+import type { Logger } from 'winston';
+
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+export type HandlerDeps = WithTransactionDeps;
+
+export type HandlerErrorCode =
+  | 'INVALID_ARGUMENT'
+  | 'UNAUTHENTICATED'
+  | 'PERMISSION_DENIED'
+  | 'NOT_FOUND'
+  | 'INTERNAL';
+
+export class HandlerError extends Error {
+  constructor(
+    public readonly code: HandlerErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'HandlerError';
+  }
+}
+
+const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
+  INVALID_ARGUMENT: status.INVALID_ARGUMENT,
+  UNAUTHENTICATED: status.UNAUTHENTICATED,
+  PERMISSION_DENIED: status.PERMISSION_DENIED,
+  NOT_FOUND: status.NOT_FOUND,
+  INTERNAL: status.INTERNAL,
+};
+
+export type UnaryHandler<Req, Res> = (
+  deps: HandlerDeps,
+  principal: Principal,
+  req: Req
+) => Promise<Res>;
+
+export type AdaptOptions = {
+  deps: HandlerDeps;
+  logger: Logger;
+};
+
+export function adapt<Req, Res>(
+  handler: UnaryHandler<Req, Res>,
+  { deps, logger }: AdaptOptions
+): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
+  return (call, callback) => {
+    void (async () => {
+      try {
+        const principal = extractPrincipal(call.metadata);
+        const response = await handler(deps, principal, call.request);
+        callback(null, response);
+      } catch (err) {
+        callback(toServiceError(err, call.metadata, logger), null);
+      }
+    })();
+  };
+}
+
+function toServiceError(err: unknown, metadata: Metadata, logger: Logger): ServiceError {
+  if (err instanceof MissingPrincipalError) {
+    return makeServiceError(status.UNAUTHENTICATED, err.message, metadata);
+  }
+  if (err instanceof HandlerError) {
+    return makeServiceError(CODE_TO_GRPC[err.code], err.message, metadata);
+  }
+  logger.error('unhandled handler error', { err });
+  return makeServiceError(status.INTERNAL, 'internal error', metadata);
+}
+
+function makeServiceError(code: number, message: string, metadata: Metadata): ServiceError {
+  const err = new Error(message) as ServiceError;
+  err.code = code;
+  err.details = message;
+  err.metadata = metadata;
+  return err;
+}


### PR DESCRIPTION
## Summary

Phase 8.3b-prep — `services/moderation/src/grpc/adapter.ts` + tests. Direct port of `services/audit/src/grpc/adapter.ts` (#900).

All 14 ModerationService RPCs require a principal — moderators / admins for the action surface (AssignReport, ResolveReport, LogModeratorAction, IssueSanction), and any authenticated user for FileReport / OpenSupportTicket. No anonymous surface, so the single `adapt` variant covers the entire RPC set.

## Parallel-PR context

Only touches `services/moderation/src/grpc/adapter.{ts,test.ts}` + `@adopt-dont-shop/events` dep. Sits in its own service dir — concurrent with #900 (audit adapter), #901 (matching adapter), all identical shape.

## Test plan

- [x] `npm test` in services/moderation — 136/136 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_