### PR TITLE
feat(audit): phase 10.3b-prep — keyset cursor helper

### DIFF
--- a/services/audit/src/grpc/cursor.test.ts
+++ b/services/audit/src/grpc/cursor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
+
+describe('cursor', () => {
+  it('round-trips an (occurredAt, eventId) tuple', () => {
+    const original = {
+      occurredAt: '2026-06-01T00:00:00.000Z',
+      eventId: '11111111-1111-1111-1111-111111111111',
+    };
+    expect(decodeCursor(encodeCursor(original))).toEqual(original);
+  });
+
+  it('rejects malformed base64url', () => {
+    expect(() => decodeCursor('!!! not base64 !!!')).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects valid base64 that does not decode to JSON', () => {
+    const garbage = Buffer.from('not-json', 'utf8').toString('base64url');
+    expect(() => decodeCursor(garbage)).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects JSON missing required fields', () => {
+    const partial = Buffer.from(JSON.stringify({ occurredAt: '2026-06-01' }), 'utf8').toString(
+      'base64url'
+    );
+    expect(() => decodeCursor(partial)).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects JSON with wrong field types', () => {
+    const wrong = Buffer.from(JSON.stringify({ occurredAt: 1, eventId: 2 }), 'utf8').toString(
+      'base64url'
+    );
+    expect(() => decodeCursor(wrong)).toThrowError(InvalidCursorError);
+  });
+});

--- a/services/audit/src/grpc/cursor.ts
+++ b/services/audit/src/grpc/cursor.ts
@@ -1,0 +1,50 @@
+// Base64-JSON keyset cursor helper for AuditQueryService.{Query,
+// GetByTarget}. Cursor is the (occurred_at, event_id) tuple from the
+// last row of the previous page — stable across new inserts because
+// audit_events is append-only (CAD pattern, same as the monolith's
+// audit-log pagination).
+
+import { Buffer } from 'node:buffer';
+
+export type AuditCursor = {
+  occurredAt: string;
+  eventId: string;
+};
+
+export class InvalidCursorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidCursorError';
+  }
+}
+
+export function encodeCursor(cursor: AuditCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeCursor(raw: string): AuditCursor {
+  let json: string;
+  try {
+    json = Buffer.from(raw, 'base64url').toString('utf8');
+  } catch {
+    throw new InvalidCursorError('cursor is not valid base64url');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new InvalidCursorError('cursor does not decode to JSON');
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as { occurredAt?: unknown }).occurredAt !== 'string' ||
+    typeof (parsed as { eventId?: unknown }).eventId !== 'string'
+  ) {
+    throw new InvalidCursorError('cursor missing occurredAt or eventId');
+  }
+
+  return parsed as AuditCursor;
+}


### PR DESCRIPTION
## Summary

Phase 10.3b-prep — `services/audit/src/grpc/cursor.ts` + tests. Base64-JSON keyset cursor helper for `AuditQueryService.{Query, GetByTarget}`.

Cursor encodes the `(occurred_at, event_id)` tuple from the last row of the previous page — stable across new inserts because `audit_events` is append-only (CAD pattern, mirrors the monolith's audit-log pagination).

`encodeCursor` / `decodeCursor` pair with strict shape validation. Malformed base64, JSON parse failure, missing fields, and wrong field types all throw `InvalidCursorError` for the handler to translate to grpc `INVALID_ARGUMENT`.

## Parallel-PR context

Only touches `services/audit/src/grpc/cursor.{ts,test.ts}` (new file). Zero deps changes. Foundation for the audit handlers + server in a follow-up.

## Test plan

- [x] `npm test` in services/audit — 36/36 green (9 boot + 5 migrations + 4 enum-map + 5 principal + 8 adapter + 5 cursor)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_