### PR TITLE
feat(moderation): phase 8.3b-prep — keyset cursor helper

### DIFF
--- a/services/moderation/src/grpc/cursor.test.ts
+++ b/services/moderation/src/grpc/cursor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
+
+describe('cursor', () => {
+  it('round-trips a (createdAt, id) tuple', () => {
+    const original = {
+      createdAt: '2026-06-01T00:00:00.000Z',
+      id: '11111111-1111-1111-1111-111111111111',
+    };
+    expect(decodeCursor(encodeCursor(original))).toEqual(original);
+  });
+
+  it('rejects malformed base64url', () => {
+    expect(() => decodeCursor('!!! not base64 !!!')).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects valid base64 that does not decode to JSON', () => {
+    const garbage = Buffer.from('not-json', 'utf8').toString('base64url');
+    expect(() => decodeCursor(garbage)).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects JSON missing required fields', () => {
+    const partial = Buffer.from(JSON.stringify({ createdAt: '2026-06-01' }), 'utf8').toString(
+      'base64url'
+    );
+    expect(() => decodeCursor(partial)).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects JSON with wrong field types', () => {
+    const wrong = Buffer.from(JSON.stringify({ createdAt: 1, id: 2 }), 'utf8').toString(
+      'base64url'
+    );
+    expect(() => decodeCursor(wrong)).toThrowError(InvalidCursorError);
+  });
+});

--- a/services/moderation/src/grpc/cursor.ts
+++ b/services/moderation/src/grpc/cursor.ts
@@ -1,0 +1,55 @@
+// Base64-JSON keyset cursor helper for ModerationService's list
+// RPCs (ListReports, ListModeratorActions, ListUserSanctions,
+// ListSupportTickets). Cursor encodes (created_at, id) from the last
+// row of the previous page — stable across new inserts because the
+// queries order by created_at DESC and ties break on a deterministic
+// uuid PK.
+//
+// Same shape as services/audit/src/grpc/cursor.ts. Per-list-RPC id
+// names vary (report_id, action_id, sanction_id, ticket_id) but the
+// cursor carries a generic `id` field; the handler dispatches.
+
+import { Buffer } from 'node:buffer';
+
+export type ModerationCursor = {
+  createdAt: string;
+  id: string;
+};
+
+export class InvalidCursorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidCursorError';
+  }
+}
+
+export function encodeCursor(cursor: ModerationCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeCursor(raw: string): ModerationCursor {
+  let json: string;
+  try {
+    json = Buffer.from(raw, 'base64url').toString('utf8');
+  } catch {
+    throw new InvalidCursorError('cursor is not valid base64url');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new InvalidCursorError('cursor does not decode to JSON');
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as { createdAt?: unknown }).createdAt !== 'string' ||
+    typeof (parsed as { id?: unknown }).id !== 'string'
+  ) {
+    throw new InvalidCursorError('cursor missing createdAt or id');
+  }
+
+  return parsed as ModerationCursor;
+}


### PR DESCRIPTION
## Summary

Phase 8.3b-prep — `services/moderation/src/grpc/cursor.ts` + tests. Same shape as `services/audit/src/grpc/cursor.ts` (#904).

Encodes `(created_at, id)` tuple from the last row of the previous page. `ListReports`, `ListModeratorActions`, `ListUserSanctions`, `ListSupportTickets` all paginate this way. Per-list-RPC id names vary (`report_id`, `action_id`, `sanction_id`, `ticket_id`) but the cursor carries a generic `id` field.

## Parallel-PR context

Only touches `services/moderation/src/grpc/cursor.{ts,test.ts}` (new file). Sits in own service dir — concurrent with #904 (audit cursor) and the upcoming matching / applications cursors.

## Test plan

- [x] `npm test` in services/moderation — 141/141 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_