### PR TITLE
feat(matching): phase 9.3b-prep — keyset cursor helpers

### DIFF
--- a/services/matching/src/grpc/cursor.test.ts
+++ b/services/matching/src/grpc/cursor.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decodeSearchPetsCursor,
+  decodeSwipeHistoryCursor,
+  encodeSearchPetsCursor,
+  encodeSwipeHistoryCursor,
+  InvalidCursorError,
+} from './cursor.js';
+
+describe('SwipeHistoryCursor', () => {
+  it('round-trips a (timestamp, swipeActionId) tuple', () => {
+    const original = {
+      timestamp: '2026-06-01T00:00:00.000Z',
+      swipeActionId: '11111111-1111-1111-1111-111111111111',
+    };
+    expect(decodeSwipeHistoryCursor(encodeSwipeHistoryCursor(original))).toEqual(original);
+  });
+
+  it('rejects malformed base64', () => {
+    expect(() => decodeSwipeHistoryCursor('!!!')).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects valid base64 that is not JSON', () => {
+    const garbage = Buffer.from('not-json', 'utf8').toString('base64url');
+    expect(() => decodeSwipeHistoryCursor(garbage)).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects JSON missing required fields', () => {
+    const partial = Buffer.from(JSON.stringify({ timestamp: 'x' }), 'utf8').toString('base64url');
+    expect(() => decodeSwipeHistoryCursor(partial)).toThrowError(InvalidCursorError);
+  });
+});
+
+describe('SearchPetsCursor', () => {
+  it('round-trips a (score, petId) tuple', () => {
+    const original = {
+      score: 0.87,
+      petId: '22222222-2222-2222-2222-222222222222',
+    };
+    expect(decodeSearchPetsCursor(encodeSearchPetsCursor(original))).toEqual(original);
+  });
+
+  it('rejects JSON with wrong field types', () => {
+    const wrong = Buffer.from(JSON.stringify({ score: '0.5', petId: 1 }), 'utf8').toString(
+      'base64url'
+    );
+    expect(() => decodeSearchPetsCursor(wrong)).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects JSON missing required fields', () => {
+    const partial = Buffer.from(JSON.stringify({ score: 0.5 }), 'utf8').toString('base64url');
+    expect(() => decodeSearchPetsCursor(partial)).toThrowError(InvalidCursorError);
+  });
+});

--- a/services/matching/src/grpc/cursor.ts
+++ b/services/matching/src/grpc/cursor.ts
@@ -1,0 +1,85 @@
+// Base64-JSON keyset cursor helper for MatchingService's list RPCs.
+//
+// Two cursor shapes — the listing surface mixes pagination shapes:
+//
+//   - ListSwipeHistory uses (timestamp, swipe_action_id). Stable
+//     across new inserts because swipe_actions is append-only.
+//
+//   - SearchPets uses (score, pet_id). The score is the recommender
+//     ranking value on [0.0, 1.0]; ties break on pet_id. Less stable
+//     than the timestamp cursor (a recommender rerank between pages
+//     could shift the order) but acceptable for a search UX.
+//
+// Both encode as base64-JSON. Same shape as services/audit and
+// services/moderation cursor helpers.
+
+import { Buffer } from 'node:buffer';
+
+export type SwipeHistoryCursor = {
+  timestamp: string;
+  swipeActionId: string;
+};
+
+export type SearchPetsCursor = {
+  // Score on [0.0, 1.0]; ranking value the recommender attached.
+  score: number;
+  petId: string;
+};
+
+export class InvalidCursorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidCursorError';
+  }
+}
+
+export function encodeSwipeHistoryCursor(cursor: SwipeHistoryCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeSwipeHistoryCursor(raw: string): SwipeHistoryCursor {
+  const parsed = parseBase64Json(raw);
+  if (
+    typeof (parsed as { timestamp?: unknown }).timestamp !== 'string' ||
+    typeof (parsed as { swipeActionId?: unknown }).swipeActionId !== 'string'
+  ) {
+    throw new InvalidCursorError('cursor missing timestamp or swipeActionId');
+  }
+  return parsed as SwipeHistoryCursor;
+}
+
+export function encodeSearchPetsCursor(cursor: SearchPetsCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeSearchPetsCursor(raw: string): SearchPetsCursor {
+  const parsed = parseBase64Json(raw);
+  if (
+    typeof (parsed as { score?: unknown }).score !== 'number' ||
+    typeof (parsed as { petId?: unknown }).petId !== 'string'
+  ) {
+    throw new InvalidCursorError('cursor missing score or petId');
+  }
+  return parsed as SearchPetsCursor;
+}
+
+function parseBase64Json(raw: string): object {
+  let json: string;
+  try {
+    json = Buffer.from(raw, 'base64url').toString('utf8');
+  } catch {
+    throw new InvalidCursorError('cursor is not valid base64url');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new InvalidCursorError('cursor does not decode to JSON');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new InvalidCursorError('cursor is not an object');
+  }
+  return parsed;
+}


### PR DESCRIPTION
## Summary

Phase 9.3b-prep — `services/matching/src/grpc/cursor.ts` + tests. Two cursor shapes because matching's list surface mixes pagination strategies:

- **SwipeHistoryCursor**: `(timestamp, swipeActionId)` — stable across new inserts (`swipe_actions` is append-only).
- **SearchPetsCursor**: `(score, petId)` — recommender ranking value on [0.0, 1.0]; ties break on petId. Less stable than the timestamp cursor (a rerank between pages could shift order) but acceptable for a search UX.

Same base64-JSON encoding + strict shape validation as `services/audit` (#904) and `services/moderation` (#905) cursor helpers.

## Parallel-PR context

Only touches `services/matching/src/grpc/cursor.{ts,test.ts}` (new file). Concurrent with #904 / #905 / the upcoming applications cursor — disjoint paths.

## Test plan

- [x] `npm test` in services/matching — 45/45 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_