### PR TITLE
feat(applications): phase 5.3b-prep — keyset cursor helper

### DIFF
--- a/services/applications/src/grpc/cursor.test.ts
+++ b/services/applications/src/grpc/cursor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
+
+describe('cursor', () => {
+  it('round-trips a (createdAt, applicationId) tuple', () => {
+    const original = {
+      createdAt: '2026-06-01T00:00:00.000Z',
+      applicationId: '11111111-1111-1111-1111-111111111111',
+    };
+    expect(decodeCursor(encodeCursor(original))).toEqual(original);
+  });
+
+  it('rejects malformed base64url', () => {
+    expect(() => decodeCursor('!!! not base64 !!!')).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects valid base64 that does not decode to JSON', () => {
+    const garbage = Buffer.from('not-json', 'utf8').toString('base64url');
+    expect(() => decodeCursor(garbage)).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects JSON missing required fields', () => {
+    const partial = Buffer.from(JSON.stringify({ createdAt: '2026-06-01' }), 'utf8').toString(
+      'base64url'
+    );
+    expect(() => decodeCursor(partial)).toThrowError(InvalidCursorError);
+  });
+
+  it('rejects JSON with wrong field types', () => {
+    const wrong = Buffer.from(JSON.stringify({ createdAt: 1, applicationId: 2 }), 'utf8').toString(
+      'base64url'
+    );
+    expect(() => decodeCursor(wrong)).toThrowError(InvalidCursorError);
+  });
+});

--- a/services/applications/src/grpc/cursor.ts
+++ b/services/applications/src/grpc/cursor.ts
@@ -1,0 +1,61 @@
+// Base64-JSON keyset cursor helper for ApplicationService's
+// ListApplications RPC. Cursor encodes (created_at, application_id)
+// from the last row of the previous page.
+//
+// Order is descending on created_at (newest first) — matches the
+// rescue inbox + adopter dashboard surfaces. Ties break on the
+// application_id PK so pagination stays deterministic when two
+// applications land in the same millisecond.
+//
+// Stable across new inserts because the projection's
+// applications.created_at is event-stamped at submit time, not at
+// projection time — backfilled events from a NATS replay land with
+// their original timestamps, not now().
+//
+// Same shape as services/audit (#904) and services/moderation (#905)
+// cursor helpers.
+
+import { Buffer } from 'node:buffer';
+
+export type ApplicationsCursor = {
+  createdAt: string;
+  applicationId: string;
+};
+
+export class InvalidCursorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidCursorError';
+  }
+}
+
+export function encodeCursor(cursor: ApplicationsCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeCursor(raw: string): ApplicationsCursor {
+  let json: string;
+  try {
+    json = Buffer.from(raw, 'base64url').toString('utf8');
+  } catch {
+    throw new InvalidCursorError('cursor is not valid base64url');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new InvalidCursorError('cursor does not decode to JSON');
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as { createdAt?: unknown }).createdAt !== 'string' ||
+    typeof (parsed as { applicationId?: unknown }).applicationId !== 'string'
+  ) {
+    throw new InvalidCursorError('cursor missing createdAt or applicationId');
+  }
+
+  return parsed as ApplicationsCursor;
+}


### PR DESCRIPTION
## Summary

Phase 5.3b-prep — `services/applications/src/grpc/cursor.ts` + tests. Same shape as `services/audit` (#904) and `services/moderation` (#905) cursor helpers.

Encodes `(created_at, application_id)` tuple for `ListApplications` pagination. Order is descending on `created_at` (newest first) — matches the rescue inbox + adopter dashboard surfaces. Ties break on the `application_id` PK so pagination stays deterministic when two applications land in the same millisecond.

Stable across new inserts because the projection's `applications.created_at` is **event-stamped at submit time, not at projection time** — backfilled events from a NATS replay land with their original timestamps, not now().

## Parallel-PR context

Only touches `services/applications/src/grpc/cursor.{ts,test.ts}` (new file). Sits in own service dir — concurrent with #904 / #905 / #906 (audit / moderation / matching cursors).

## Test plan

- [x] `npm test` in services/applications — 75/75 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_