### PR TITLE
feat(audit): phase 10.3b-prep — row → AuditEvent mapper

### DIFF
--- a/services/audit/src/grpc/mapper.test.ts
+++ b/services/audit/src/grpc/mapper.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { AuditV1 } from '@adopt-dont-shop/proto';
+
+import { rowToProto, type AuditEventRow } from './mapper.js';
+
+function baseRow(overrides: Partial<AuditEventRow> = {}): AuditEventRow {
+  return {
+    event_id: '11111111-1111-1111-1111-111111111111',
+    service: 'service.auth',
+    subject: 'auth.userLoggedIn',
+    aggregate_type: 'user',
+    aggregate_id: '22222222-2222-2222-2222-222222222222',
+    actor_user_id: '33333333-3333-3333-3333-333333333333',
+    actor_email_snapshot: 'user@example.com',
+    action: 'login',
+    outcome: 'success',
+    occurred_at: new Date('2026-06-01T12:00:00.000Z'),
+    recorded_at: new Date('2026-06-01T12:00:01.500Z'),
+    payload: { source: 'web', ip: '1.2.3.4' },
+    ip_address: '1.2.3.4',
+    user_agent: 'Mozilla/5.0',
+    ...overrides,
+  };
+}
+
+describe('rowToProto', () => {
+  it('translates a fully-populated row to the AuditEvent proto', () => {
+    const proto = rowToProto(baseRow());
+    expect(proto).toEqual({
+      eventId: '11111111-1111-1111-1111-111111111111',
+      service: 'service.auth',
+      subject: 'auth.userLoggedIn',
+      aggregateType: 'user',
+      aggregateId: '22222222-2222-2222-2222-222222222222',
+      action: 'login',
+      outcome: AuditV1.AuditOutcome.AUDIT_OUTCOME_SUCCESS,
+      occurredAt: '2026-06-01T12:00:00.000Z',
+      recordedAt: '2026-06-01T12:00:01.500Z',
+      payloadJson: '{"source":"web","ip":"1.2.3.4"}',
+      actorUserId: '33333333-3333-3333-3333-333333333333',
+      actorEmailSnapshot: 'user@example.com',
+      ipAddress: '1.2.3.4',
+      userAgent: 'Mozilla/5.0',
+    });
+  });
+
+  it('omits actor_user_id from the proto when the column is NULL (system event)', () => {
+    const proto = rowToProto(
+      baseRow({ actor_user_id: null, actor_email_snapshot: null, subject: 'pets.adopted' })
+    );
+    expect(proto.actorUserId).toBeUndefined();
+    expect(proto.actorEmailSnapshot).toBeUndefined();
+  });
+
+  it('omits ip_address / user_agent when NULL (cron-originated event)', () => {
+    const proto = rowToProto(baseRow({ ip_address: null, user_agent: null }));
+    expect(proto.ipAddress).toBeUndefined();
+    expect(proto.userAgent).toBeUndefined();
+  });
+
+  it('stringifies the JSONB payload', () => {
+    const proto = rowToProto(baseRow({ payload: { complex: { nested: [1, 2, 3] } } }));
+    expect(proto.payloadJson).toBe('{"complex":{"nested":[1,2,3]}}');
+  });
+
+  it('handles a NULL payload by emitting "{}"', () => {
+    const proto = rowToProto(baseRow({ payload: null }));
+    expect(proto.payloadJson).toBe('{}');
+  });
+
+  it.each([
+    ['success', AuditV1.AuditOutcome.AUDIT_OUTCOME_SUCCESS],
+    ['denied', AuditV1.AuditOutcome.AUDIT_OUTCOME_DENIED],
+    ['failure', AuditV1.AuditOutcome.AUDIT_OUTCOME_FAILURE],
+  ] as const)('maps outcome %s to %i', (db, proto) => {
+    const event = rowToProto(baseRow({ outcome: db }));
+    expect(event.outcome).toBe(proto);
+  });
+
+  it('throws on an unknown outcome (schema drift guard)', () => {
+    expect(() => rowToProto(baseRow({ outcome: 'partial' }))).toThrowError();
+  });
+
+  it('serialises timestamps with millisecond precision', () => {
+    const proto = rowToProto(
+      baseRow({
+        occurred_at: new Date('2026-06-01T12:00:00.123Z'),
+        recorded_at: new Date('2026-06-01T12:00:01.987Z'),
+      })
+    );
+    expect(proto.occurredAt).toBe('2026-06-01T12:00:00.123Z');
+    expect(proto.recordedAt).toBe('2026-06-01T12:00:01.987Z');
+  });
+});

--- a/services/audit/src/grpc/mapper.ts
+++ b/services/audit/src/grpc/mapper.ts
@@ -1,0 +1,67 @@
+// Row → proto mapper for AuditEvent.
+//
+// The DB row mirrors the audit.audit_events shape from #884; the proto
+// message mirrors the AuditEvent type from #894. This file is the
+// boundary translator — null DB columns map to omitted proto optionals,
+// Date columns serialise via toISOString, and the JSONB payload
+// stringifies for the gateway's REST surface (the blob trick — same as
+// pets extra_json / rescue settings_json / moderation metadata_json).
+//
+// Pure function. No I/O, no logger. Handlers compose this onto every
+// row returned by SELECT.
+
+import type { AuditEvent } from '@adopt-dont-shop/proto';
+
+import { outcomeFromDb } from './enum-map.js';
+
+export type AuditEventRow = {
+  event_id: string;
+  service: string;
+  subject: string;
+  aggregate_type: string;
+  aggregate_id: string;
+  actor_user_id: string | null;
+  actor_email_snapshot: string | null;
+  action: string;
+  // The DB CHECK isn't enforced — the schema uses varchar(16) — but
+  // the enum-map will throw on anything other than 'success' / 'denied'
+  // / 'failure', protecting the proto contract.
+  outcome: string;
+  occurred_at: Date;
+  recorded_at: Date;
+  // pg returns JSONB as a parsed JS value. The row column is `payload`;
+  // the proto carries the stringified blob.
+  payload: unknown;
+  ip_address: string | null;
+  user_agent: string | null;
+};
+
+export function rowToProto(row: AuditEventRow): AuditEvent {
+  const event: AuditEvent = {
+    eventId: row.event_id,
+    service: row.service,
+    subject: row.subject,
+    aggregateType: row.aggregate_type,
+    aggregateId: row.aggregate_id,
+    action: row.action,
+    outcome: outcomeFromDb(row.outcome),
+    occurredAt: row.occurred_at.toISOString(),
+    recordedAt: row.recorded_at.toISOString(),
+    payloadJson: JSON.stringify(row.payload ?? {}),
+  };
+
+  if (row.actor_user_id !== null) {
+    event.actorUserId = row.actor_user_id;
+  }
+  if (row.actor_email_snapshot !== null) {
+    event.actorEmailSnapshot = row.actor_email_snapshot;
+  }
+  if (row.ip_address !== null) {
+    event.ipAddress = row.ip_address;
+  }
+  if (row.user_agent !== null) {
+    event.userAgent = row.user_agent;
+  }
+
+  return event;
+}


### PR DESCRIPTION
## Summary

Phase 10.3b-prep — `services/audit/src/grpc/mapper.ts` + tests. Boundary translator between the `audit.audit_events` row shape (#884) and the `AuditEvent` proto type (#894). Pure function, no I/O — the handlers compose this onto every row returned by SELECT.

**Translations**:
- Date columns serialise via `toISOString` (preserves ms precision).
- JSONB `payload` stringifies via `JSON.stringify`; NULL payloads emit `'{}'` (defensive — the column is NOT NULL in #884 but the parser still handles `undefined` gracefully).
- NULL optionals (`actor_user_id`, `actor_email_snapshot`, `ip_address`, `user_agent`) are **omitted** from the proto rather than set to a sentinel; cron-originated + system events surface clean.
- `outcome` maps via #895's enum-map (throws on schema drift).

## Parallel-PR context

Only touches `services/audit/src/grpc/mapper.{ts,test.ts}` (new file). Zero deps changes. Foundation for the audit handlers' SELECT result handling.

## Test plan

- [x] `npm test` in services/audit — 46/46 green (9 boot + 5 migrations + 4 enum-map + 5 principal + 8 adapter + 5 cursor + 10 mapper)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_