### PR TITLE
feat(applications): phase 5.3b-prep — row → proto mappers

### DIFF
--- a/services/applications/src/grpc/mapper.test.ts
+++ b/services/applications/src/grpc/mapper.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApplicationsV1 } from '@adopt-dont-shop/proto';
+
+import {
+  applicationRowToProto,
+  timelineRowToProto,
+  type ApplicationRow,
+  type TimelineEntryRow,
+} from './mapper.js';
+
+function baseApplicationRow(overrides: Partial<ApplicationRow> = {}): ApplicationRow {
+  return {
+    application_id: '11111111-1111-1111-1111-111111111111',
+    user_id: '22222222-2222-2222-2222-222222222222',
+    pet_id: '33333333-3333-3333-3333-333333333333',
+    rescue_id: '44444444-4444-4444-4444-444444444444',
+    status: 'submitted',
+    version: 3,
+    answers: { hasYard: true, otherPets: 'cat' },
+    references: [{ name: 'Jane Doe', email: 'jane@example.com' }],
+    submitted_at: new Date('2026-06-01T12:00:00.000Z'),
+    review_started_at: null,
+    home_visit_scheduled_at: null,
+    home_visit_completed_at: null,
+    home_visit_outcome: null,
+    home_visit_notes: null,
+    decided_at: null,
+    decided_by: null,
+    decision_notes: null,
+    rejection_reason: null,
+    adopted_at: null,
+    created_at: new Date('2026-05-30T08:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('applicationRowToProto', () => {
+  it('translates a freshly-submitted application', () => {
+    const proto = applicationRowToProto(baseApplicationRow());
+    expect(proto).toEqual({
+      applicationId: '11111111-1111-1111-1111-111111111111',
+      adopterId: '22222222-2222-2222-2222-222222222222',
+      petId: '33333333-3333-3333-3333-333333333333',
+      rescueId: '44444444-4444-4444-4444-444444444444',
+      status: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_SUBMITTED,
+      answersJson: '{"hasYard":true,"otherPets":"cat"}',
+      referencesJson: '[{"name":"Jane Doe","email":"jane@example.com"}]',
+      version: 3,
+      submittedAt: '2026-06-01T12:00:00.000Z',
+      createdAt: '2026-05-30T08:00:00.000Z',
+      updatedAt: '2026-06-01T12:00:00.000Z',
+    });
+  });
+
+  it('normalises null answers / references to "{}" / "[]"', () => {
+    const proto = applicationRowToProto(baseApplicationRow({ answers: null, references: null }));
+    expect(proto.answersJson).toBe('{}');
+    expect(proto.referencesJson).toBe('[]');
+  });
+
+  it('omits home_visit_outcome when NULL (draft / submitted state)', () => {
+    const proto = applicationRowToProto(baseApplicationRow());
+    expect(proto.homeVisitOutcome).toBeUndefined();
+  });
+
+  it('populates all timestamps + outcome for an approved application', () => {
+    const proto = applicationRowToProto(
+      baseApplicationRow({
+        status: 'approved',
+        review_started_at: new Date('2026-06-02T09:00:00.000Z'),
+        home_visit_scheduled_at: new Date('2026-06-05T14:00:00.000Z'),
+        home_visit_completed_at: new Date('2026-06-05T15:30:00.000Z'),
+        home_visit_outcome: 'passed',
+        home_visit_notes: 'Family + yard great fit.',
+        decided_at: new Date('2026-06-06T10:00:00.000Z'),
+        decided_by: '55555555-5555-5555-5555-555555555555',
+        decision_notes: 'Approved.',
+      })
+    );
+    expect(proto.status).toBe(ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_APPROVED);
+    expect(proto.reviewStartedAt).toBe('2026-06-02T09:00:00.000Z');
+    expect(proto.homeVisitScheduledAt).toBe('2026-06-05T14:00:00.000Z');
+    expect(proto.homeVisitCompletedAt).toBe('2026-06-05T15:30:00.000Z');
+    expect(proto.homeVisitOutcome).toBe(ApplicationsV1.HomeVisitOutcome.HOME_VISIT_OUTCOME_PASSED);
+    expect(proto.homeVisitNotes).toBe('Family + yard great fit.');
+    expect(proto.decidedAt).toBe('2026-06-06T10:00:00.000Z');
+    expect(proto.decidedBy).toBe('55555555-5555-5555-5555-555555555555');
+    expect(proto.decisionNotes).toBe('Approved.');
+  });
+
+  it('throws on an unknown status (schema drift guard)', () => {
+    expect(() => applicationRowToProto(baseApplicationRow({ status: 'maybe' }))).toThrowError();
+  });
+});
+
+function baseTimelineRow(overrides: Partial<TimelineEntryRow> = {}): TimelineEntryRow {
+  return {
+    transition_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    application_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    from_status: 'submitted',
+    to_status: 'under_review',
+    transitioned_by: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    transitioned_at: new Date('2026-06-02T09:00:00.000Z'),
+    reason: 'Started review.',
+    ...overrides,
+  };
+}
+
+describe('timelineRowToProto', () => {
+  it('translates a standard transition', () => {
+    const proto = timelineRowToProto(baseTimelineRow());
+    expect(proto).toEqual({
+      entryId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      applicationId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      fromStatus: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_SUBMITTED,
+      toStatus: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNDER_REVIEW,
+      actorUserId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      occurredAt: '2026-06-02T09:00:00.000Z',
+      note: 'Started review.',
+    });
+  });
+
+  it('surfaces UNSPECIFIED for the first transition (from_status NULL)', () => {
+    const proto = timelineRowToProto(
+      baseTimelineRow({ from_status: null, to_status: 'draft', reason: null })
+    );
+    expect(proto.fromStatus).toBe(ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED);
+    expect(proto.toStatus).toBe(ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_DRAFT);
+    expect(proto.note).toBeUndefined();
+  });
+
+  it('emits empty actorUserId when transitioned_by is NULL (system transition)', () => {
+    const proto = timelineRowToProto(baseTimelineRow({ transitioned_by: null }));
+    expect(proto.actorUserId).toBe('');
+  });
+});

--- a/services/applications/src/grpc/mapper.ts
+++ b/services/applications/src/grpc/mapper.ts
@@ -1,0 +1,133 @@
+// Row → proto mappers for Application + TimelineEntry.
+//
+// The DB row shapes mirror the applications + application_status_transitions
+// tables from #887. The proto messages are the Application + TimelineEntry
+// types from #878. Pure functions — no I/O, no logger.
+//
+// Two transformations worth flagging:
+//   - JSONB columns (answers, references) stringify via JSON.stringify.
+//     Empty objects/arrays normalise to '{}' / '[]' so the SPA never has
+//     to handle the JSON `null` literal (the blob trick — pets extra_json,
+//     rescue settings_json, moderation metadata_json).
+//   - NULL optional timestamp + outcome columns are omitted from the
+//     proto rather than set to a sentinel; the proto's `optional`
+//     fields carry the semantic "this stage hasn't happened yet".
+
+import type { Application, ApplicationsV1, TimelineEntry } from '@adopt-dont-shop/proto';
+
+import { homeVisitOutcomeFromDb, statusFromDb } from './enum-map.js';
+
+// --- Application row → proto -----------------------------------------
+
+export type ApplicationRow = {
+  application_id: string;
+  user_id: string;
+  pet_id: string;
+  rescue_id: string;
+  status: string;
+  version: number;
+  answers: unknown;
+  references: unknown;
+  submitted_at: Date | null;
+  review_started_at: Date | null;
+  home_visit_scheduled_at: Date | null;
+  home_visit_completed_at: Date | null;
+  home_visit_outcome: string | null;
+  home_visit_notes: string | null;
+  decided_at: Date | null;
+  decided_by: string | null;
+  decision_notes: string | null;
+  rejection_reason: string | null;
+  adopted_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export function applicationRowToProto(row: ApplicationRow): Application {
+  const app: Application = {
+    applicationId: row.application_id,
+    adopterId: row.user_id,
+    petId: row.pet_id,
+    rescueId: row.rescue_id,
+    status: statusFromDb(row.status),
+    answersJson: JSON.stringify(row.answers ?? {}),
+    referencesJson: JSON.stringify(row.references ?? []),
+    version: row.version,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+
+  if (row.submitted_at !== null) {
+    app.submittedAt = row.submitted_at.toISOString();
+  }
+  if (row.review_started_at !== null) {
+    app.reviewStartedAt = row.review_started_at.toISOString();
+  }
+  if (row.home_visit_scheduled_at !== null) {
+    app.homeVisitScheduledAt = row.home_visit_scheduled_at.toISOString();
+  }
+  if (row.home_visit_completed_at !== null) {
+    app.homeVisitCompletedAt = row.home_visit_completed_at.toISOString();
+  }
+  if (row.home_visit_outcome !== null) {
+    app.homeVisitOutcome = homeVisitOutcomeFromDb(row.home_visit_outcome);
+  }
+  if (row.home_visit_notes !== null) {
+    app.homeVisitNotes = row.home_visit_notes;
+  }
+  if (row.decided_at !== null) {
+    app.decidedAt = row.decided_at.toISOString();
+  }
+  if (row.decided_by !== null) {
+    app.decidedBy = row.decided_by;
+  }
+  if (row.decision_notes !== null) {
+    app.decisionNotes = row.decision_notes;
+  }
+  if (row.rejection_reason !== null) {
+    app.rejectionReason = row.rejection_reason;
+  }
+  if (row.adopted_at !== null) {
+    app.adoptedAt = row.adopted_at.toISOString();
+  }
+
+  return app;
+}
+
+// --- TimelineEntry row → proto ---------------------------------------
+
+export type TimelineEntryRow = {
+  transition_id: string;
+  application_id: string;
+  // from_status is NULL on the first transition (draft creation); the
+  // proto requires it so we surface UNSPECIFIED for that case rather
+  // than dropping the entry. (The SPA renders "Application started"
+  // for from_status=UNSPECIFIED.)
+  from_status: string | null;
+  to_status: string;
+  // The principal whose command produced the transition. Soft pointer
+  // to auth.users.
+  transitioned_by: string | null;
+  transitioned_at: Date;
+  reason: string | null;
+};
+
+export function timelineRowToProto(row: TimelineEntryRow): TimelineEntry {
+  const entry: TimelineEntry = {
+    entryId: row.transition_id,
+    applicationId: row.application_id,
+    fromStatus:
+      row.from_status === null
+        ? (0 as ApplicationsV1.ApplicationStatus)
+        : statusFromDb(row.from_status),
+    toStatus: statusFromDb(row.to_status),
+    actorUserId: row.transitioned_by ?? '',
+    occurredAt: row.transitioned_at.toISOString(),
+  };
+
+  if (row.reason !== null) {
+    entry.note = row.reason;
+  }
+
+  return entry;
+}


### PR DESCRIPTION
## Summary

Phase 5.3b-prep — `services/applications/src/grpc/mapper.ts` + tests. Two pure boundary translators between the applications + status_transitions row shapes (#887) and the `Application` + `TimelineEntry` proto messages (#878).

**`applicationRowToProto`**:
- JSONB `answers` / `references` stringify via `JSON.stringify`; null normalises to `'{}'` / `'[]'` so the SPA never sees the JSON null literal (blob trick — pets `extra_json`, rescue `settings_json`).
- Optional timestamp + outcome + note columns **omitted** from proto when NULL rather than set to a sentinel; the proto's `optional` fields carry "this stage hasn't happened yet" semantics.
- `status` + `home_visit_outcome` lookups via #909's enum-map; schema drift surfaces as a thrown Error from the mapper layer.

**`timelineRowToProto`**:
- `from_status` NULL → `APPLICATION_STATUS_UNSPECIFIED` (the SPA renders "Application started" for that case rather than dropping the entry).
- `transitioned_by` NULL → empty `actorUserId` string (system transitions like cron-promoted expired drafts).

## Parallel-PR context

Only touches `services/applications/src/grpc/mapper.{ts,test.ts}` (new file). Sits in own service dir. Builds on #909 (applications enum-map, merged).

## Test plan

- [x] `npm test` in services/applications — 99/99 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_