### PR TITLE
feat(matching): phase 9.3b-prep — row → proto mappers

### DIFF
--- a/services/matching/src/grpc/mapper.test.ts
+++ b/services/matching/src/grpc/mapper.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { MatchingV1 } from '@adopt-dont-shop/proto';
+
+import {
+  actionRowToProto,
+  sessionRowToProto,
+  type SwipeActionRow,
+  type SwipeSessionRow,
+} from './mapper.js';
+
+function baseSessionRow(overrides: Partial<SwipeSessionRow> = {}): SwipeSessionRow {
+  return {
+    session_id: '11111111-1111-1111-1111-111111111111',
+    user_id: '22222222-2222-2222-2222-222222222222',
+    start_time: new Date('2026-06-01T12:00:00.000Z'),
+    end_time: null,
+    total_swipes: 5,
+    likes: 2,
+    passes: 2,
+    super_likes: 1,
+    filters: { species: 'dog' },
+    ip_address: '1.2.3.4',
+    user_agent: 'Mozilla/5.0',
+    device_type: 'mobile',
+    is_active: true,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:05:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('sessionRowToProto', () => {
+  it('translates a populated open session', () => {
+    const proto = sessionRowToProto(baseSessionRow());
+    expect(proto).toEqual({
+      sessionId: '11111111-1111-1111-1111-111111111111',
+      userId: '22222222-2222-2222-2222-222222222222',
+      startTime: '2026-06-01T12:00:00.000Z',
+      totalSwipes: 5,
+      likes: 2,
+      passes: 2,
+      superLikes: 1,
+      filtersJson: '{"species":"dog"}',
+      ipAddress: '1.2.3.4',
+      userAgent: 'Mozilla/5.0',
+      deviceType: MatchingV1.DeviceType.DEVICE_TYPE_MOBILE,
+      isActive: true,
+      createdAt: '2026-06-01T12:00:00.000Z',
+      updatedAt: '2026-06-01T12:05:00.000Z',
+    });
+  });
+
+  it('omits userId for an anonymous browsing session', () => {
+    const proto = sessionRowToProto(baseSessionRow({ user_id: null }));
+    expect(proto.userId).toBeUndefined();
+  });
+
+  it('falls back to DEVICE_TYPE_UNKNOWN when device_type is NULL', () => {
+    const proto = sessionRowToProto(baseSessionRow({ device_type: null }));
+    expect(proto.deviceType).toBe(MatchingV1.DeviceType.DEVICE_TYPE_UNKNOWN);
+  });
+
+  it('normalises null filters to "{}"', () => {
+    const proto = sessionRowToProto(baseSessionRow({ filters: null }));
+    expect(proto.filtersJson).toBe('{}');
+  });
+
+  it('populates endTime for a closed session', () => {
+    const proto = sessionRowToProto(
+      baseSessionRow({
+        is_active: false,
+        end_time: new Date('2026-06-01T13:00:00.000Z'),
+      })
+    );
+    expect(proto.isActive).toBe(false);
+    expect(proto.endTime).toBe('2026-06-01T13:00:00.000Z');
+  });
+
+  it('omits ipAddress / userAgent when both NULL', () => {
+    const proto = sessionRowToProto(baseSessionRow({ ip_address: null, user_agent: null }));
+    expect(proto.ipAddress).toBeUndefined();
+    expect(proto.userAgent).toBeUndefined();
+  });
+});
+
+function baseActionRow(overrides: Partial<SwipeActionRow> = {}): SwipeActionRow {
+  return {
+    swipe_action_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    session_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    pet_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    user_id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+    action: 'super_like',
+    timestamp: new Date('2026-06-01T12:01:23.456Z'),
+    response_time: 1234,
+    device_type: 'mobile',
+    ...overrides,
+  };
+}
+
+describe('actionRowToProto', () => {
+  it('translates a populated swipe action', () => {
+    const proto = actionRowToProto(baseActionRow());
+    expect(proto).toEqual({
+      swipeActionId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      sessionId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      petId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      userId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      action: MatchingV1.SwipeAction.SWIPE_ACTION_SUPER_LIKE,
+      timestamp: '2026-06-01T12:01:23.456Z',
+      responseTime: 1234,
+      deviceType: 'mobile',
+    });
+  });
+
+  it('omits userId for an anonymous swipe', () => {
+    const proto = actionRowToProto(baseActionRow({ user_id: null }));
+    expect(proto.userId).toBeUndefined();
+  });
+
+  it('omits responseTime + deviceType when both NULL', () => {
+    const proto = actionRowToProto(baseActionRow({ response_time: null, device_type: null }));
+    expect(proto.responseTime).toBeUndefined();
+    expect(proto.deviceType).toBeUndefined();
+  });
+
+  it.each([
+    ['like', MatchingV1.SwipeAction.SWIPE_ACTION_LIKE],
+    ['pass', MatchingV1.SwipeAction.SWIPE_ACTION_PASS],
+    ['super_like', MatchingV1.SwipeAction.SWIPE_ACTION_SUPER_LIKE],
+    ['info', MatchingV1.SwipeAction.SWIPE_ACTION_INFO],
+  ] as const)('maps action %s to %i', (db, proto) => {
+    const event = actionRowToProto(baseActionRow({ action: db }));
+    expect(event.action).toBe(proto);
+  });
+
+  it('throws on an unknown action (schema drift guard)', () => {
+    expect(() => actionRowToProto(baseActionRow({ action: 'block' }))).toThrowError();
+  });
+});

--- a/services/matching/src/grpc/mapper.ts
+++ b/services/matching/src/grpc/mapper.ts
@@ -1,0 +1,102 @@
+// Row → proto mappers for SwipeSession + SwipeActionRecord.
+//
+// DB row shapes mirror matching.swipe_sessions + matching.swipe_actions
+// from #888. Proto messages are SwipeSession + SwipeActionRecord from
+// #891. Pure functions — no I/O.
+//
+// JSONB filters column stringifies via JSON.stringify; null normalises
+// to '{}' so the SPA never sees the JSON null literal (blob trick —
+// same as pets extra_json / rescue settings_json).
+
+import type { SwipeActionRecord, SwipeSession } from '@adopt-dont-shop/proto';
+
+import { deviceTypeFromDb, swipeActionFromDb } from './enum-map.js';
+
+// --- SwipeSession row → proto ----------------------------------------
+
+export type SwipeSessionRow = {
+  session_id: string;
+  user_id: string | null;
+  start_time: Date;
+  end_time: Date | null;
+  total_swipes: number;
+  likes: number;
+  passes: number;
+  super_likes: number;
+  filters: unknown;
+  ip_address: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export function sessionRowToProto(row: SwipeSessionRow): SwipeSession {
+  const session: SwipeSession = {
+    sessionId: row.session_id,
+    startTime: row.start_time.toISOString(),
+    totalSwipes: row.total_swipes,
+    likes: row.likes,
+    passes: row.passes,
+    superLikes: row.super_likes,
+    filtersJson: JSON.stringify(row.filters ?? {}),
+    // device_type column defaults to 'unknown' but is nullable in
+    // schema; fall back to DEVICE_TYPE_UNKNOWN if NULL.
+    deviceType:
+      row.device_type === null ? deviceTypeFromDb('unknown') : deviceTypeFromDb(row.device_type),
+    isActive: row.is_active,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+
+  if (row.user_id !== null) {
+    session.userId = row.user_id;
+  }
+  if (row.end_time !== null) {
+    session.endTime = row.end_time.toISOString();
+  }
+  if (row.ip_address !== null) {
+    session.ipAddress = row.ip_address;
+  }
+  if (row.user_agent !== null) {
+    session.userAgent = row.user_agent;
+  }
+
+  return session;
+}
+
+// --- SwipeActionRecord row → proto -----------------------------------
+
+export type SwipeActionRow = {
+  swipe_action_id: string;
+  session_id: string;
+  pet_id: string;
+  user_id: string | null;
+  action: string;
+  timestamp: Date;
+  response_time: number | null;
+  device_type: string | null;
+};
+
+export function actionRowToProto(row: SwipeActionRow): SwipeActionRecord {
+  const action: SwipeActionRecord = {
+    swipeActionId: row.swipe_action_id,
+    sessionId: row.session_id,
+    petId: row.pet_id,
+    action: swipeActionFromDb(row.action),
+    timestamp: row.timestamp.toISOString(),
+  };
+
+  if (row.user_id !== null) {
+    action.userId = row.user_id;
+  }
+  if (row.response_time !== null) {
+    action.responseTime = row.response_time;
+  }
+  if (row.device_type !== null) {
+    action.deviceType = row.device_type;
+  }
+
+  return action;
+}


### PR DESCRIPTION
## Summary

Phase 9.3b-prep — `services/matching/src/grpc/mapper.ts` + tests. Two pure boundary translators between `matching.swipe_sessions` + `matching.swipe_actions` row shapes (#888) and the `SwipeSession` + `SwipeActionRecord` proto messages (#891).

**`sessionRowToProto`**:
- JSONB `filters` stringify via `JSON.stringify`; null normalises to `'{}'` (blob trick — same as pets `extra_json`).
- NULL `device_type` falls back to `DEVICE_TYPE_UNKNOWN` (the schema default).
- NULL `user_id` (anonymous browsing), `end_time` (open session), `ip_address` / `user_agent` (cron / system events) **omitted** from proto rather than set to sentinel.

**`actionRowToProto`**:
- NULL `user_id` (anonymous swipe), `response_time`, `device_type` all omitted.
- `action` lookup via #893's enum-map; schema drift surfaces as a thrown Error from the mapper layer.

## Parallel-PR context

Only touches `services/matching/src/grpc/mapper.{ts,test.ts}` (new file). Concurrent with #910 (applications row mapper), both disjoint paths. Builds on #888 (schema) + #891 (proto) + #893 (enum-map).

## Test plan

- [x] `npm test` in services/matching — 59/59 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_