### PR TITLE
feat(moderation): phase 8.3b-prep — Report row → proto mapper

### DIFF
--- a/services/moderation/src/grpc/mapper.test.ts
+++ b/services/moderation/src/grpc/mapper.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import { ModerationV1 } from '@adopt-dont-shop/proto';
+
+import {
+  reportRowToProto,
+  transitionRowToProto,
+  type ReportRow,
+  type ReportStatusTransitionRow,
+} from './mapper.js';
+
+function baseReportRow(overrides: Partial<ReportRow> = {}): ReportRow {
+  return {
+    report_id: '11111111-1111-1111-1111-111111111111',
+    reporter_id: '22222222-2222-2222-2222-222222222222',
+    reported_entity_type: 'user',
+    reported_entity_id: '33333333-3333-3333-3333-333333333333',
+    reported_user_id: '33333333-3333-3333-3333-333333333333',
+    category: 'harassment',
+    severity: 'high',
+    status: 'pending',
+    title: 'Abusive DMs',
+    description: 'User sent threatening messages.',
+    metadata: { screenshot_count: 3 },
+    assigned_moderator: null,
+    assigned_at: null,
+    resolved_by: null,
+    resolved_at: null,
+    resolution: null,
+    resolution_notes: null,
+    escalated_to: null,
+    escalated_at: null,
+    escalation_reason: null,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('reportRowToProto', () => {
+  it('translates a freshly-filed pending report', () => {
+    const proto = reportRowToProto(baseReportRow());
+    expect(proto).toEqual({
+      reportId: '11111111-1111-1111-1111-111111111111',
+      reporterId: '22222222-2222-2222-2222-222222222222',
+      reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_USER,
+      reportedEntityId: '33333333-3333-3333-3333-333333333333',
+      reportedUserId: '33333333-3333-3333-3333-333333333333',
+      category: ModerationV1.ReportCategory.REPORT_CATEGORY_HARASSMENT,
+      severity: ModerationV1.Severity.SEVERITY_HIGH,
+      status: ModerationV1.ReportStatus.REPORT_STATUS_PENDING,
+      title: 'Abusive DMs',
+      description: 'User sent threatening messages.',
+      metadataJson: '{"screenshot_count":3}',
+      createdAt: '2026-06-01T12:00:00.000Z',
+      updatedAt: '2026-06-01T12:00:00.000Z',
+    });
+  });
+
+  it('populates the resolution chain for a resolved report', () => {
+    const proto = reportRowToProto(
+      baseReportRow({
+        status: 'resolved',
+        assigned_moderator: 'mod-1',
+        assigned_at: new Date('2026-06-02T09:00:00.000Z'),
+        resolved_by: 'mod-1',
+        resolved_at: new Date('2026-06-03T15:00:00.000Z'),
+        resolution: 'action_taken',
+        resolution_notes: 'User suspended for 7 days.',
+      })
+    );
+    expect(proto.status).toBe(ModerationV1.ReportStatus.REPORT_STATUS_RESOLVED);
+    expect(proto.assignedModerator).toBe('mod-1');
+    expect(proto.assignedAt).toBe('2026-06-02T09:00:00.000Z');
+    expect(proto.resolvedBy).toBe('mod-1');
+    expect(proto.resolvedAt).toBe('2026-06-03T15:00:00.000Z');
+    expect(proto.resolution).toBe('action_taken');
+    expect(proto.resolutionNotes).toBe('User suspended for 7 days.');
+  });
+
+  it('populates the escalation chain for an escalated report', () => {
+    const proto = reportRowToProto(
+      baseReportRow({
+        status: 'escalated',
+        escalated_to: 'admin-1',
+        escalated_at: new Date('2026-06-04T11:00:00.000Z'),
+        escalation_reason: 'Requires legal review.',
+      })
+    );
+    expect(proto.status).toBe(ModerationV1.ReportStatus.REPORT_STATUS_ESCALATED);
+    expect(proto.escalatedTo).toBe('admin-1');
+    expect(proto.escalatedAt).toBe('2026-06-04T11:00:00.000Z');
+    expect(proto.escalationReason).toBe('Requires legal review.');
+  });
+
+  it('omits reportedUserId for a non-user-entity report', () => {
+    const proto = reportRowToProto(
+      baseReportRow({
+        reported_entity_type: 'pet',
+        reported_user_id: null,
+      })
+    );
+    expect(proto.reportedUserId).toBeUndefined();
+    expect(proto.reportedEntityType).toBe(ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_PET);
+  });
+
+  it('normalises null metadata to "{}"', () => {
+    const proto = reportRowToProto(baseReportRow({ metadata: null }));
+    expect(proto.metadataJson).toBe('{}');
+  });
+
+  it('throws on unknown category (schema drift)', () => {
+    expect(() => reportRowToProto(baseReportRow({ category: 'rant' }))).toThrowError();
+  });
+});
+
+function baseTransitionRow(
+  overrides: Partial<ReportStatusTransitionRow> = {}
+): ReportStatusTransitionRow {
+  return {
+    transition_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    report_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    from_status: 'pending',
+    to_status: 'under_review',
+    transitioned_at: new Date('2026-06-02T09:00:00.000Z'),
+    transitioned_by: 'mod-1',
+    reason: 'Started review.',
+    ...overrides,
+  };
+}
+
+describe('transitionRowToProto', () => {
+  it('translates a standard transition', () => {
+    const proto = transitionRowToProto(baseTransitionRow());
+    expect(proto).toEqual({
+      transitionId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      reportId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      fromStatus: ModerationV1.ReportStatus.REPORT_STATUS_PENDING,
+      toStatus: ModerationV1.ReportStatus.REPORT_STATUS_UNDER_REVIEW,
+      transitionedAt: '2026-06-02T09:00:00.000Z',
+      transitionedBy: 'mod-1',
+      reason: 'Started review.',
+    });
+  });
+
+  it('omits fromStatus for the first transition (report creation)', () => {
+    const proto = transitionRowToProto(
+      baseTransitionRow({ from_status: null, to_status: 'pending', reason: null })
+    );
+    expect(proto.fromStatus).toBeUndefined();
+    expect(proto.toStatus).toBe(ModerationV1.ReportStatus.REPORT_STATUS_PENDING);
+    expect(proto.reason).toBeUndefined();
+  });
+
+  it('omits transitionedBy when NULL (system transition)', () => {
+    const proto = transitionRowToProto(baseTransitionRow({ transitioned_by: null }));
+    expect(proto.transitionedBy).toBeUndefined();
+  });
+});

--- a/services/moderation/src/grpc/mapper.ts
+++ b/services/moderation/src/grpc/mapper.ts
@@ -1,0 +1,136 @@
+// Row → proto mappers for Report + ReportStatusTransition.
+//
+// DB row shapes mirror moderation.reports + moderation.report_status_transitions
+// from #886. Proto messages are Report + ReportStatusTransition from
+// #889. Pure functions — no I/O.
+//
+// metadata JSONB column stringifies via JSON.stringify; null
+// normalises to '{}' (blob trick — same as pets extra_json /
+// rescue settings_json / applications answers_json).
+//
+// The other moderation row mappers (ModeratorAction, Evidence,
+// UserSanction, SupportTicket, SupportTicketResponse) port in
+// follow-up PRs to keep diffs reviewable.
+
+import type { Report, ReportStatusTransition } from '@adopt-dont-shop/proto';
+
+import {
+  categoryFromDb,
+  entityTypeFromDb,
+  reportStatusFromDb,
+  severityFromDb,
+} from './enum-map.js';
+
+// --- Report row → proto ----------------------------------------------
+
+export type ReportRow = {
+  report_id: string;
+  reporter_id: string;
+  reported_entity_type: string;
+  reported_entity_id: string;
+  reported_user_id: string | null;
+  category: string;
+  severity: string;
+  status: string;
+  title: string;
+  description: string;
+  metadata: unknown;
+  assigned_moderator: string | null;
+  assigned_at: Date | null;
+  resolved_by: string | null;
+  resolved_at: Date | null;
+  resolution: string | null;
+  resolution_notes: string | null;
+  escalated_to: string | null;
+  escalated_at: Date | null;
+  escalation_reason: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export function reportRowToProto(row: ReportRow): Report {
+  const report: Report = {
+    reportId: row.report_id,
+    reporterId: row.reporter_id,
+    reportedEntityType: entityTypeFromDb(row.reported_entity_type),
+    reportedEntityId: row.reported_entity_id,
+    category: categoryFromDb(row.category),
+    severity: severityFromDb(row.severity),
+    status: reportStatusFromDb(row.status),
+    title: row.title,
+    description: row.description,
+    metadataJson: JSON.stringify(row.metadata ?? {}),
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+
+  if (row.reported_user_id !== null) {
+    report.reportedUserId = row.reported_user_id;
+  }
+  if (row.assigned_moderator !== null) {
+    report.assignedModerator = row.assigned_moderator;
+  }
+  if (row.assigned_at !== null) {
+    report.assignedAt = row.assigned_at.toISOString();
+  }
+  if (row.resolved_by !== null) {
+    report.resolvedBy = row.resolved_by;
+  }
+  if (row.resolved_at !== null) {
+    report.resolvedAt = row.resolved_at.toISOString();
+  }
+  if (row.resolution !== null) {
+    report.resolution = row.resolution;
+  }
+  if (row.resolution_notes !== null) {
+    report.resolutionNotes = row.resolution_notes;
+  }
+  if (row.escalated_to !== null) {
+    report.escalatedTo = row.escalated_to;
+  }
+  if (row.escalated_at !== null) {
+    report.escalatedAt = row.escalated_at.toISOString();
+  }
+  if (row.escalation_reason !== null) {
+    report.escalationReason = row.escalation_reason;
+  }
+
+  return report;
+}
+
+// --- ReportStatusTransition row → proto ------------------------------
+
+export type ReportStatusTransitionRow = {
+  transition_id: string;
+  report_id: string;
+  // from_status is NULL on the first transition (report creation —
+  // status goes from "implicit none" to 'pending'). The proto's
+  // from_status is `optional` so we omit rather than set to a
+  // sentinel.
+  from_status: string | null;
+  to_status: string;
+  transitioned_at: Date;
+  transitioned_by: string | null;
+  reason: string | null;
+};
+
+export function transitionRowToProto(row: ReportStatusTransitionRow): ReportStatusTransition {
+  const transition: ReportStatusTransition = {
+    transitionId: row.transition_id,
+    reportId: row.report_id,
+    toStatus: reportStatusFromDb(row.to_status),
+    transitionedAt: row.transitioned_at.toISOString(),
+  };
+
+  if (row.from_status !== null) {
+    transition.fromStatus = reportStatusFromDb(row.from_status);
+  }
+  if (row.transitioned_by !== null) {
+    transition.transitionedBy = row.transitioned_by;
+  }
+  if (row.reason !== null) {
+    transition.reason = row.reason;
+  }
+
+  return transition;
+}


### PR DESCRIPTION
## Summary

Phase 8.3b-prep — `services/moderation/src/grpc/mapper.ts` + tests. Two pure boundary translators between `moderation.reports` + `moderation.report_status_transitions` row shapes (#886) and the `Report` + `ReportStatusTransition` proto messages (#889).

**`reportRowToProto`**:
- `metadata` JSONB stringifies via `JSON.stringify`; null normalises to `'{}'` (blob trick).
- Optional resolution + escalation chain columns **omitted** from proto when NULL.
- `reportedUserId` only populated for user-typed reports (`REPORT_ENTITY_TYPE_USER`).
- `entity_type` / `category` / `severity` / `status` lookups via #892's enum-map; schema drift surfaces as thrown Error.

**`transitionRowToProto`**:
- `from_status` NULL → **omitted** (first transition on report creation).
- `transitioned_by` NULL → omitted (system transitions).

The remaining moderation row mappers (ModeratorAction, Evidence, UserSanction, SupportTicket, SupportTicketResponse) port in follow-up PRs to keep diffs reviewable.

## Parallel-PR context

Only touches `services/moderation/src/grpc/mapper.{ts,test.ts}` (new file). Sits in own service dir. Builds on #886 (schema) + #889 (proto) + #892 (enum-map).

## Test plan

- [x] `npm test` in services/moderation — 150/150 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_