### PR TITLE
feat(moderation): phase 8.3b-prep — ModeratorAction + Evidence mappers

### DIFF
--- a/services/moderation/src/grpc/action-evidence-mapper.test.ts
+++ b/services/moderation/src/grpc/action-evidence-mapper.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { ModerationV1 } from '@adopt-dont-shop/proto';
+
+import {
+  actionRowToProto,
+  evidenceRowToProto,
+  type EvidenceRow,
+  type ModeratorActionRow,
+} from './action-evidence-mapper.js';
+
+function baseActionRow(overrides: Partial<ModeratorActionRow> = {}): ModeratorActionRow {
+  return {
+    action_id: '11111111-1111-1111-1111-111111111111',
+    moderator_id: 'mod-1',
+    report_id: 'rpt-1',
+    target_entity_type: 'user',
+    target_entity_id: 'usr-1',
+    target_user_id: 'usr-1',
+    action_type: 'warning_issued',
+    severity: 'medium',
+    reason: 'First infraction',
+    description: null,
+    metadata: {},
+    duration: null,
+    expires_at: null,
+    is_active: true,
+    acknowledged_at: null,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('actionRowToProto', () => {
+  it('translates a warning issued without a duration', () => {
+    const proto = actionRowToProto(baseActionRow());
+    expect(proto).toEqual({
+      actionId: '11111111-1111-1111-1111-111111111111',
+      moderatorId: 'mod-1',
+      reportId: 'rpt-1',
+      targetEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_USER,
+      targetEntityId: 'usr-1',
+      targetUserId: 'usr-1',
+      actionType: ModerationV1.ModeratorActionType.MODERATOR_ACTION_TYPE_WARNING_ISSUED,
+      severity: ModerationV1.Severity.SEVERITY_MEDIUM,
+      reason: 'First infraction',
+      metadataJson: '{}',
+      isActive: true,
+      createdAt: '2026-06-01T12:00:00.000Z',
+      updatedAt: '2026-06-01T12:00:00.000Z',
+    });
+  });
+
+  it('populates duration + expiresAt for a temporary suspension', () => {
+    const proto = actionRowToProto(
+      baseActionRow({
+        action_type: 'user_suspended',
+        severity: 'high',
+        duration: 7,
+        expires_at: new Date('2026-06-08T12:00:00.000Z'),
+      })
+    );
+    expect(proto.actionType).toBe(
+      ModerationV1.ModeratorActionType.MODERATOR_ACTION_TYPE_USER_SUSPENDED
+    );
+    expect(proto.duration).toBe(7);
+    expect(proto.expiresAt).toBe('2026-06-08T12:00:00.000Z');
+  });
+
+  it('omits report_id for an auto-flagged action (no originating report)', () => {
+    const proto = actionRowToProto(baseActionRow({ report_id: null }));
+    expect(proto.reportId).toBeUndefined();
+  });
+
+  it('omits target_user_id for non-user targets (content removed on pet listing)', () => {
+    const proto = actionRowToProto(
+      baseActionRow({
+        target_entity_type: 'pet',
+        target_user_id: null,
+        action_type: 'content_removed',
+      })
+    );
+    expect(proto.targetUserId).toBeUndefined();
+    expect(proto.targetEntityType).toBe(ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_PET);
+  });
+
+  it('populates acknowledgedAt for a dismissed sanction banner', () => {
+    const proto = actionRowToProto(
+      baseActionRow({ acknowledged_at: new Date('2026-06-02T10:00:00.000Z') })
+    );
+    expect(proto.acknowledgedAt).toBe('2026-06-02T10:00:00.000Z');
+  });
+
+  it('normalises null metadata to "{}"', () => {
+    const proto = actionRowToProto(baseActionRow({ metadata: null }));
+    expect(proto.metadataJson).toBe('{}');
+  });
+
+  it('throws on unknown action_type (schema drift)', () => {
+    expect(() => actionRowToProto(baseActionRow({ action_type: 'censored' }))).toThrowError();
+  });
+});
+
+function baseEvidenceRow(overrides: Partial<EvidenceRow> = {}): EvidenceRow {
+  return {
+    evidence_id: '22222222-2222-2222-2222-222222222222',
+    parent_type: 'report',
+    parent_id: 'rpt-1',
+    type: 'screenshot',
+    content: 's3://moderation-evidence/screenshots/abc.png',
+    description: 'Screenshot of abusive DM',
+    uploaded_at: new Date('2026-06-01T12:30:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('evidenceRowToProto', () => {
+  it('translates a screenshot evidence attached to a report', () => {
+    const proto = evidenceRowToProto(baseEvidenceRow());
+    expect(proto).toEqual({
+      evidenceId: '22222222-2222-2222-2222-222222222222',
+      parentType: ModerationV1.EvidenceParentType.EVIDENCE_PARENT_TYPE_REPORT,
+      parentId: 'rpt-1',
+      type: ModerationV1.EvidenceType.EVIDENCE_TYPE_SCREENSHOT,
+      content: 's3://moderation-evidence/screenshots/abc.png',
+      description: 'Screenshot of abusive DM',
+      uploadedAt: '2026-06-01T12:30:00.000Z',
+    });
+  });
+
+  it('handles a url-type evidence attached to a moderator_action', () => {
+    const proto = evidenceRowToProto(
+      baseEvidenceRow({
+        parent_type: 'moderator_action',
+        type: 'url',
+        content: 'https://example.com/policy-violation',
+      })
+    );
+    expect(proto.parentType).toBe(
+      ModerationV1.EvidenceParentType.EVIDENCE_PARENT_TYPE_MODERATOR_ACTION
+    );
+    expect(proto.type).toBe(ModerationV1.EvidenceType.EVIDENCE_TYPE_URL);
+    expect(proto.content).toBe('https://example.com/policy-violation');
+  });
+
+  it('omits description when NULL', () => {
+    const proto = evidenceRowToProto(baseEvidenceRow({ description: null }));
+    expect(proto.description).toBeUndefined();
+  });
+
+  it('throws on unknown evidence type (schema drift)', () => {
+    expect(() => evidenceRowToProto(baseEvidenceRow({ type: 'video' }))).toThrowError();
+  });
+});

--- a/services/moderation/src/grpc/action-evidence-mapper.ts
+++ b/services/moderation/src/grpc/action-evidence-mapper.ts
@@ -1,0 +1,107 @@
+// Row → proto mappers for ModeratorAction + Evidence.
+//
+// DB row shapes mirror moderation.moderator_actions +
+// moderation.moderation_evidence from #886. Proto messages are
+// ModeratorAction + Evidence from #889. Pure functions — no I/O.
+//
+// metadata JSONB column on moderator_actions stringifies via
+// JSON.stringify; null normalises to '{}' (blob trick — same as
+// Report.metadataJson in mapper.ts).
+
+import type { Evidence, ModeratorAction } from '@adopt-dont-shop/proto';
+
+import {
+  actionTypeFromDb,
+  entityTypeFromDb,
+  evidenceParentTypeFromDb,
+  evidenceTypeFromDb,
+  severityFromDb,
+} from './enum-map.js';
+
+// --- ModeratorAction row → proto -------------------------------------
+
+export type ModeratorActionRow = {
+  action_id: string;
+  moderator_id: string;
+  report_id: string | null;
+  target_entity_type: string;
+  target_entity_id: string;
+  target_user_id: string | null;
+  action_type: string;
+  severity: string;
+  reason: string;
+  description: string | null;
+  metadata: unknown;
+  duration: number | null;
+  expires_at: Date | null;
+  is_active: boolean;
+  acknowledged_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export function actionRowToProto(row: ModeratorActionRow): ModeratorAction {
+  const action: ModeratorAction = {
+    actionId: row.action_id,
+    moderatorId: row.moderator_id,
+    targetEntityType: entityTypeFromDb(row.target_entity_type),
+    targetEntityId: row.target_entity_id,
+    actionType: actionTypeFromDb(row.action_type),
+    severity: severityFromDb(row.severity),
+    reason: row.reason,
+    metadataJson: JSON.stringify(row.metadata ?? {}),
+    isActive: row.is_active,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+
+  if (row.report_id !== null) {
+    action.reportId = row.report_id;
+  }
+  if (row.target_user_id !== null) {
+    action.targetUserId = row.target_user_id;
+  }
+  if (row.description !== null) {
+    action.description = row.description;
+  }
+  if (row.duration !== null) {
+    action.duration = row.duration;
+  }
+  if (row.expires_at !== null) {
+    action.expiresAt = row.expires_at.toISOString();
+  }
+  if (row.acknowledged_at !== null) {
+    action.acknowledgedAt = row.acknowledged_at.toISOString();
+  }
+
+  return action;
+}
+
+// --- Evidence row → proto --------------------------------------------
+
+export type EvidenceRow = {
+  evidence_id: string;
+  parent_type: string;
+  parent_id: string;
+  type: string;
+  content: string;
+  description: string | null;
+  uploaded_at: Date;
+};
+
+export function evidenceRowToProto(row: EvidenceRow): Evidence {
+  const evidence: Evidence = {
+    evidenceId: row.evidence_id,
+    parentType: evidenceParentTypeFromDb(row.parent_type),
+    parentId: row.parent_id,
+    type: evidenceTypeFromDb(row.type),
+    content: row.content,
+    uploadedAt: row.uploaded_at.toISOString(),
+  };
+
+  if (row.description !== null) {
+    evidence.description = row.description;
+  }
+
+  return evidence;
+}


### PR DESCRIPTION
## Summary

Phase 8.3b-prep — `services/moderation/src/grpc/action-evidence-mapper.ts` + tests. Two more pure row→proto translators for moderation, continuing the pattern from #912 (Report mapper).

**`actionRowToProto`**:
- `metadata` JSONB stringifies via `JSON.stringify`; null normalises to `'{}'` (blob trick).
- `report_id` NULL → omitted (auto-flagged content scans don't originate from a report).
- `target_user_id` NULL → omitted (non-user targets like `content_removed` on a pet listing).
- `duration` / `expires_at` / `acknowledged_at` all NULL-omitted; the proto's `optional` fields carry the right semantics for permanent actions vs temporary suspensions vs un-acknowledged sanction banners.

**`evidenceRowToProto`**:
- Polymorphic `parent_type` maps to `EVIDENCE_PARENT_TYPE_REPORT` or `EVIDENCE_PARENT_TYPE_MODERATOR_ACTION` via #892's enum-map.
- `description` NULL → omitted.

## Parallel-PR context

Only touches `services/moderation/src/grpc/action-evidence-mapper.{ts,test.ts}` (new file). Sits alongside #912's existing `mapper.ts`. Builds on #886 (schema) + #889 (proto) + #892 (enum-map).

## Test plan

- [x] `npm test` in services/moderation — 161/161 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_