### PR TITLE
feat(moderation): phase 8.3b-prep — Sanction + Ticket mappers

### DIFF
--- a/services/moderation/src/grpc/sanction-ticket-mapper.test.ts
+++ b/services/moderation/src/grpc/sanction-ticket-mapper.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+
+import { ModerationV1 } from '@adopt-dont-shop/proto';
+
+import {
+  responseRowToProto,
+  sanctionRowToProto,
+  ticketRowToProto,
+  type SupportTicketResponseRow,
+  type SupportTicketRow,
+  type UserSanctionRow,
+} from './sanction-ticket-mapper.js';
+
+function baseSanctionRow(overrides: Partial<UserSanctionRow> = {}): UserSanctionRow {
+  return {
+    sanction_id: '11111111-1111-1111-1111-111111111111',
+    user_id: 'usr-1',
+    sanction_type: 'temporary_ban',
+    reason: 'harassment',
+    description: 'Repeated abusive messages',
+    is_active: true,
+    start_date: new Date('2026-06-01T12:00:00.000Z'),
+    end_date: new Date('2026-06-08T12:00:00.000Z'),
+    duration: 7,
+    issued_by: 'mod-1',
+    report_id: 'rpt-1',
+    moderator_action_id: 'act-1',
+    appealed_at: null,
+    appeal_reason: null,
+    appeal_status: null,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('sanctionRowToProto', () => {
+  it('translates an active temporary ban', () => {
+    const proto = sanctionRowToProto(baseSanctionRow());
+    expect(proto).toEqual({
+      sanctionId: '11111111-1111-1111-1111-111111111111',
+      userId: 'usr-1',
+      sanctionType: ModerationV1.SanctionType.SANCTION_TYPE_TEMPORARY_BAN,
+      reason: ModerationV1.SanctionReason.SANCTION_REASON_HARASSMENT,
+      description: 'Repeated abusive messages',
+      isActive: true,
+      startDate: '2026-06-01T12:00:00.000Z',
+      endDate: '2026-06-08T12:00:00.000Z',
+      duration: 7,
+      issuedBy: 'mod-1',
+      reportId: 'rpt-1',
+      moderatorActionId: 'act-1',
+      createdAt: '2026-06-01T12:00:00.000Z',
+      updatedAt: '2026-06-01T12:00:00.000Z',
+    });
+  });
+
+  it('handles a permanent ban (no end_date / duration)', () => {
+    const proto = sanctionRowToProto(
+      baseSanctionRow({
+        sanction_type: 'permanent_ban',
+        end_date: null,
+        duration: null,
+      })
+    );
+    expect(proto.sanctionType).toBe(ModerationV1.SanctionType.SANCTION_TYPE_PERMANENT_BAN);
+    expect(proto.endDate).toBeUndefined();
+    expect(proto.duration).toBeUndefined();
+  });
+
+  it('populates the appeal chain', () => {
+    const proto = sanctionRowToProto(
+      baseSanctionRow({
+        appealed_at: new Date('2026-06-02T10:00:00.000Z'),
+        appeal_reason: 'I was provoked.',
+        appeal_status: 'pending',
+      })
+    );
+    expect(proto.appealedAt).toBe('2026-06-02T10:00:00.000Z');
+    expect(proto.appealReason).toBe('I was provoked.');
+    // appeal_status is forwarded raw — string, not enum.
+    expect(proto.appealStatus).toBe('pending');
+  });
+
+  it('omits report_id + moderator_action_id when sanction is direct (no originator)', () => {
+    const proto = sanctionRowToProto(
+      baseSanctionRow({ report_id: null, moderator_action_id: null })
+    );
+    expect(proto.reportId).toBeUndefined();
+    expect(proto.moderatorActionId).toBeUndefined();
+  });
+
+  it('throws on unknown reason (schema drift)', () => {
+    expect(() => sanctionRowToProto(baseSanctionRow({ reason: 'just_because' }))).toThrowError();
+  });
+});
+
+function baseTicketRow(overrides: Partial<SupportTicketRow> = {}): SupportTicketRow {
+  return {
+    ticket_id: '22222222-2222-2222-2222-222222222222',
+    user_id: 'usr-1',
+    user_email: 'user@example.com',
+    user_name: 'Test User',
+    assigned_to: null,
+    status: 'open',
+    priority: 'normal',
+    category: 'general_question',
+    subject: 'Cannot log in',
+    description: 'Tried 3 times, still locked out.',
+    tags: ['login', 'auth'],
+    metadata: { ip: '1.2.3.4' },
+    first_response_at: null,
+    last_response_at: null,
+    resolved_at: null,
+    closed_at: null,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('ticketRowToProto', () => {
+  it('translates a freshly-opened ticket', () => {
+    const proto = ticketRowToProto(baseTicketRow());
+    expect(proto).toEqual({
+      ticketId: '22222222-2222-2222-2222-222222222222',
+      userId: 'usr-1',
+      userEmail: 'user@example.com',
+      userName: 'Test User',
+      status: ModerationV1.SupportTicketStatus.SUPPORT_TICKET_STATUS_OPEN,
+      priority: ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_NORMAL,
+      category: ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_GENERAL_QUESTION,
+      subject: 'Cannot log in',
+      description: 'Tried 3 times, still locked out.',
+      tags: ['login', 'auth'],
+      metadataJson: '{"ip":"1.2.3.4"}',
+      createdAt: '2026-06-01T12:00:00.000Z',
+      updatedAt: '2026-06-01T12:00:00.000Z',
+    });
+  });
+
+  it('handles a ticket from an unauthenticated user (no user_id / user_name)', () => {
+    const proto = ticketRowToProto(baseTicketRow({ user_id: null, user_name: null }));
+    expect(proto.userId).toBeUndefined();
+    expect(proto.userName).toBeUndefined();
+    // user_email is always required (the contact channel).
+    expect(proto.userEmail).toBe('user@example.com');
+  });
+
+  it('populates the resolution chain for a resolved ticket', () => {
+    const proto = ticketRowToProto(
+      baseTicketRow({
+        status: 'resolved',
+        assigned_to: 'staff-1',
+        first_response_at: new Date('2026-06-01T13:00:00.000Z'),
+        last_response_at: new Date('2026-06-01T14:00:00.000Z'),
+        resolved_at: new Date('2026-06-01T14:30:00.000Z'),
+      })
+    );
+    expect(proto.status).toBe(ModerationV1.SupportTicketStatus.SUPPORT_TICKET_STATUS_RESOLVED);
+    expect(proto.assignedTo).toBe('staff-1');
+    expect(proto.firstResponseAt).toBe('2026-06-01T13:00:00.000Z');
+    expect(proto.lastResponseAt).toBe('2026-06-01T14:00:00.000Z');
+    expect(proto.resolvedAt).toBe('2026-06-01T14:30:00.000Z');
+  });
+
+  it('normalises null metadata to "{}"', () => {
+    const proto = ticketRowToProto(baseTicketRow({ metadata: null }));
+    expect(proto.metadataJson).toBe('{}');
+  });
+
+  it('forwards tags as a string[] (Postgres text[])', () => {
+    const proto = ticketRowToProto(baseTicketRow({ tags: ['urgent', 'data-loss', 'paid-tier'] }));
+    expect(proto.tags).toEqual(['urgent', 'data-loss', 'paid-tier']);
+  });
+
+  it('throws on unknown category (schema drift)', () => {
+    expect(() => ticketRowToProto(baseTicketRow({ category: 'spam' }))).toThrowError();
+  });
+});
+
+function baseResponseRow(
+  overrides: Partial<SupportTicketResponseRow> = {}
+): SupportTicketResponseRow {
+  return {
+    response_id: '33333333-3333-3333-3333-333333333333',
+    ticket_id: '22222222-2222-2222-2222-222222222222',
+    responder_id: 'staff-1',
+    responder_type: 'staff',
+    content: 'Try clearing your cookies.',
+    is_internal: false,
+    created_at: new Date('2026-06-01T13:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('responseRowToProto', () => {
+  it('translates a public staff response', () => {
+    const proto = responseRowToProto(baseResponseRow());
+    expect(proto).toEqual({
+      responseId: '33333333-3333-3333-3333-333333333333',
+      ticketId: '22222222-2222-2222-2222-222222222222',
+      responderId: 'staff-1',
+      responderType: ModerationV1.SupportTicketResponderType.SUPPORT_TICKET_RESPONDER_TYPE_STAFF,
+      content: 'Try clearing your cookies.',
+      isInternal: false,
+      createdAt: '2026-06-01T13:00:00.000Z',
+    });
+  });
+
+  it('marks an internal staff note', () => {
+    const proto = responseRowToProto(
+      baseResponseRow({
+        is_internal: true,
+        content: 'User is on free tier — escalate gently.',
+      })
+    );
+    expect(proto.isInternal).toBe(true);
+  });
+
+  it('handles a user response', () => {
+    const proto = responseRowToProto(
+      baseResponseRow({
+        responder_id: 'usr-1',
+        responder_type: 'user',
+        content: 'That worked, thanks!',
+      })
+    );
+    expect(proto.responderType).toBe(
+      ModerationV1.SupportTicketResponderType.SUPPORT_TICKET_RESPONDER_TYPE_USER
+    );
+  });
+
+  it('throws on unknown responder_type (schema drift)', () => {
+    expect(() => responseRowToProto(baseResponseRow({ responder_type: 'bot' }))).toThrowError();
+  });
+});

--- a/services/moderation/src/grpc/sanction-ticket-mapper.ts
+++ b/services/moderation/src/grpc/sanction-ticket-mapper.ts
@@ -1,0 +1,171 @@
+// Row → proto mappers for UserSanction + SupportTicket +
+// SupportTicketResponse. Completes the moderation row-mapper set
+// (Report + ReportStatusTransition in mapper.ts, ModeratorAction +
+// Evidence in action-evidence-mapper.ts, this file ships the rest).
+//
+// DB row shapes mirror moderation.user_sanctions +
+// moderation.support_tickets + moderation.support_ticket_responses
+// from #886. Proto messages are UserSanction + SupportTicket +
+// SupportTicketResponse from #889. Pure functions — no I/O.
+
+import type { SupportTicket, SupportTicketResponse, UserSanction } from '@adopt-dont-shop/proto';
+
+import {
+  responderTypeFromDb,
+  sanctionReasonFromDb,
+  sanctionTypeFromDb,
+  ticketCategoryFromDb,
+  ticketPriorityFromDb,
+  ticketStatusFromDb,
+} from './enum-map.js';
+
+// --- UserSanction row → proto ----------------------------------------
+
+export type UserSanctionRow = {
+  sanction_id: string;
+  user_id: string;
+  sanction_type: string;
+  reason: string;
+  description: string;
+  is_active: boolean;
+  start_date: Date;
+  end_date: Date | null;
+  duration: number | null;
+  issued_by: string;
+  report_id: string | null;
+  moderator_action_id: string | null;
+  appealed_at: Date | null;
+  appeal_reason: string | null;
+  // appeal_status is a Postgres enum (pending / approved / rejected)
+  // but the proto carries it as an `optional string` so the gateway
+  // forwards the raw value unchanged. No enum-map dispatch here.
+  appeal_status: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export function sanctionRowToProto(row: UserSanctionRow): UserSanction {
+  const sanction: UserSanction = {
+    sanctionId: row.sanction_id,
+    userId: row.user_id,
+    sanctionType: sanctionTypeFromDb(row.sanction_type),
+    reason: sanctionReasonFromDb(row.reason),
+    description: row.description,
+    isActive: row.is_active,
+    startDate: row.start_date.toISOString(),
+    issuedBy: row.issued_by,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+
+  if (row.end_date !== null) {
+    sanction.endDate = row.end_date.toISOString();
+  }
+  if (row.duration !== null) {
+    sanction.duration = row.duration;
+  }
+  if (row.report_id !== null) {
+    sanction.reportId = row.report_id;
+  }
+  if (row.moderator_action_id !== null) {
+    sanction.moderatorActionId = row.moderator_action_id;
+  }
+  if (row.appealed_at !== null) {
+    sanction.appealedAt = row.appealed_at.toISOString();
+  }
+  if (row.appeal_reason !== null) {
+    sanction.appealReason = row.appeal_reason;
+  }
+  if (row.appeal_status !== null) {
+    sanction.appealStatus = row.appeal_status;
+  }
+
+  return sanction;
+}
+
+// --- SupportTicket row → proto ---------------------------------------
+
+export type SupportTicketRow = {
+  ticket_id: string;
+  user_id: string | null;
+  user_email: string;
+  user_name: string | null;
+  assigned_to: string | null;
+  status: string;
+  priority: string;
+  category: string;
+  subject: string;
+  description: string;
+  tags: string[];
+  metadata: unknown;
+  first_response_at: Date | null;
+  last_response_at: Date | null;
+  resolved_at: Date | null;
+  closed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export function ticketRowToProto(row: SupportTicketRow): SupportTicket {
+  const ticket: SupportTicket = {
+    ticketId: row.ticket_id,
+    userEmail: row.user_email,
+    status: ticketStatusFromDb(row.status),
+    priority: ticketPriorityFromDb(row.priority),
+    category: ticketCategoryFromDb(row.category),
+    subject: row.subject,
+    description: row.description,
+    tags: row.tags,
+    metadataJson: JSON.stringify(row.metadata ?? {}),
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+
+  if (row.user_id !== null) {
+    ticket.userId = row.user_id;
+  }
+  if (row.user_name !== null) {
+    ticket.userName = row.user_name;
+  }
+  if (row.assigned_to !== null) {
+    ticket.assignedTo = row.assigned_to;
+  }
+  if (row.first_response_at !== null) {
+    ticket.firstResponseAt = row.first_response_at.toISOString();
+  }
+  if (row.last_response_at !== null) {
+    ticket.lastResponseAt = row.last_response_at.toISOString();
+  }
+  if (row.resolved_at !== null) {
+    ticket.resolvedAt = row.resolved_at.toISOString();
+  }
+  if (row.closed_at !== null) {
+    ticket.closedAt = row.closed_at.toISOString();
+  }
+
+  return ticket;
+}
+
+// --- SupportTicketResponse row → proto -------------------------------
+
+export type SupportTicketResponseRow = {
+  response_id: string;
+  ticket_id: string;
+  responder_id: string;
+  responder_type: string;
+  content: string;
+  is_internal: boolean;
+  created_at: Date;
+};
+
+export function responseRowToProto(row: SupportTicketResponseRow): SupportTicketResponse {
+  return {
+    responseId: row.response_id,
+    ticketId: row.ticket_id,
+    responderId: row.responder_id,
+    responderType: responderTypeFromDb(row.responder_type),
+    content: row.content,
+    isInternal: row.is_internal,
+    createdAt: row.created_at.toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary

Phase 8.3b-prep — `services/moderation/src/grpc/sanction-ticket-mapper.ts` + tests. Completes the moderation row-mapper set. Three pure boundary translators between `moderation.user_sanctions` + `moderation.support_tickets` + `moderation.support_ticket_responses` row shapes (#886) and the `UserSanction` + `SupportTicket` + `SupportTicketResponse` proto messages (#889).

**`sanctionRowToProto`**:
- Permanent ban: `end_date` + `duration` NULL-omitted.
- Active appeal: `appealed_at` + `appeal_reason` + `appeal_status` all populate when set.
- `appeal_status` is a Postgres enum but the proto carries it as `optional string` — gateway forwards raw, no enum-map dispatch.
- Direct sanction (no originator): `report_id` + `moderator_action_id` both NULL-omitted.

**`ticketRowToProto`**:
- `text[]` tags array forwarded as `string[]`.
- `metadata` JSONB stringifies; null normalises to `'{}'`.
- Unauthenticated user: `user_id` + `user_name` NULL-omitted; `user_email` always required (the contact channel).
- Resolution chain (`assigned_to` / `first_response_at` / `last_response_at` / `resolved_at` / `closed_at`) all optional.

**`responseRowToProto`**:
- Simplest mapper of the set — no optionals. `responder_type` maps via #892's enum-map (staff or user).
- `is_internal` flag carries forward unchanged.

## Parallel-PR context

Only touches `services/moderation/src/grpc/sanction-ticket-mapper.{ts,test.ts}` (new file). Sits alongside #912's `mapper.ts` + #913's `action-evidence-mapper.ts`. Builds on #886 (schema) + #889 (proto) + #892 (enum-map).

## Test plan

- [x] `npm test` in services/moderation — 176/176 green
- [x] type-check, lint, format clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_