### PR TITLE
feat(audit): phase 10.3b — gRPC handlers (Query + GetByTarget)

### DIFF
--- a/services/audit/src/grpc/handlers.test.ts
+++ b/services/audit/src/grpc/handlers.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AuditV1, type AuditQueryRequest } from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { encodeCursor } from './cursor.js';
+import { getByTarget, query } from './handlers.js';
+
+function makePrincipal(overrides: Partial<{ userId: string; permissions: string[] }> = {}) {
+  return {
+    userId: overrides.userId ?? 'admin-1',
+    roles: ['admin'],
+    permissions: overrides.permissions ?? ['admin.audit_logs'],
+    rescueId: undefined,
+  } as unknown as Parameters<typeof query>[1];
+}
+
+type FakeRow = {
+  event_id: string;
+  service: string;
+  subject: string;
+  aggregate_type: string;
+  aggregate_id: string;
+  actor_user_id: string | null;
+  actor_email_snapshot: string | null;
+  action: string;
+  outcome: string;
+  occurred_at: Date;
+  recorded_at: Date;
+  payload: unknown;
+  ip_address: string | null;
+  user_agent: string | null;
+};
+
+function makeRow(overrides: Partial<FakeRow> = {}): FakeRow {
+  return {
+    event_id: '11111111-1111-1111-1111-111111111111',
+    service: 'service.auth',
+    subject: 'auth.userLoggedIn',
+    aggregate_type: 'user',
+    aggregate_id: '22222222-2222-2222-2222-222222222222',
+    actor_user_id: '33333333-3333-3333-3333-333333333333',
+    actor_email_snapshot: 'user@example.com',
+    action: 'login',
+    outcome: 'success',
+    occurred_at: new Date('2026-06-01T12:00:00.000Z'),
+    recorded_at: new Date('2026-06-01T12:00:00.500Z'),
+    payload: { source: 'web' },
+    ip_address: '1.2.3.4',
+    user_agent: 'Mozilla/5.0',
+    ...overrides,
+  };
+}
+
+function makeDeps(rows: FakeRow[]): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
+  const queryMock = vi.fn(() => Promise.resolve({ rows }));
+  return {
+    deps: { pool: { query: queryMock }, nats: {} } as unknown as HandlerDeps,
+    query: queryMock,
+  };
+}
+
+describe('query', () => {
+  it('throws PERMISSION_DENIED when principal lacks admin.audit_logs', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      query(deps, makePrincipal({ permissions: ['pets.read'] }), { limit: 10 } as AuditQueryRequest)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('returns events with no filters, defaulting limit', async () => {
+    const { deps, query: qmock } = makeDeps([makeRow()]);
+    const res = await query(deps, makePrincipal(), {} as AuditQueryRequest);
+    expect(res.events).toHaveLength(1);
+    expect(res.events[0].eventId).toBe('11111111-1111-1111-1111-111111111111');
+    // No filters → only the LIMIT+1 placeholder
+    expect(qmock.mock.calls[0][1]).toHaveLength(1);
+    expect(qmock.mock.calls[0][1][0]).toBe(51);
+  });
+
+  it('clamps limit above MAX_LIMIT to 200', async () => {
+    const { deps, query: qmock } = makeDeps([]);
+    await query(deps, makePrincipal(), { limit: 9999 } as AuditQueryRequest);
+    expect(qmock.mock.calls[0][1][0]).toBe(201);
+  });
+
+  it('floor-clamps negative / non-finite limit to default 50', async () => {
+    const { deps, query: qmock } = makeDeps([]);
+    await query(deps, makePrincipal(), { limit: -5 } as AuditQueryRequest);
+    expect(qmock.mock.calls[0][1][0]).toBe(51);
+  });
+
+  it('applies all filters', async () => {
+    const { deps, query: qmock } = makeDeps([]);
+    await query(deps, makePrincipal(), {
+      service: 'service.auth',
+      subject: 'auth.userLoggedIn',
+      actorUserId: 'usr-1',
+      outcome: AuditV1.AuditOutcome.AUDIT_OUTCOME_DENIED,
+      occurredAtFrom: '2026-06-01T00:00:00Z',
+      occurredAtTo: '2026-06-02T00:00:00Z',
+      limit: 25,
+    } as AuditQueryRequest);
+    const sql = qmock.mock.calls[0][0] as string;
+    expect(sql).toContain('service = $1');
+    expect(sql).toContain('subject = $2');
+    expect(sql).toContain('actor_user_id = $3');
+    expect(sql).toContain('outcome = $4');
+    expect(sql).toContain('occurred_at >= $5');
+    expect(sql).toContain('occurred_at < $6');
+    expect(qmock.mock.calls[0][1]).toEqual([
+      'service.auth',
+      'auth.userLoggedIn',
+      'usr-1',
+      'denied',
+      '2026-06-01T00:00:00Z',
+      '2026-06-02T00:00:00Z',
+      26,
+    ]);
+  });
+
+  it('decodes and applies a cursor', async () => {
+    const { deps, query: qmock } = makeDeps([]);
+    const cursor = encodeCursor({
+      occurredAt: '2026-06-01T11:00:00.000Z',
+      eventId: '99999999-9999-9999-9999-999999999999',
+    });
+    await query(deps, makePrincipal(), { cursor, limit: 10 } as AuditQueryRequest);
+    const sql = qmock.mock.calls[0][0] as string;
+    expect(sql).toContain('occurred_at <');
+    expect(sql).toContain('event_id <');
+  });
+
+  it('throws INVALID_ARGUMENT on a malformed cursor', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      query(deps, makePrincipal(), { cursor: '!!!', limit: 10 } as AuditQueryRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('emits a nextCursor only when there are more rows', async () => {
+    const noMore = await query(makeDeps([makeRow()]).deps, makePrincipal(), {
+      limit: 10,
+    } as AuditQueryRequest);
+    expect(noMore.nextCursor).toBeUndefined();
+
+    const eleven = Array.from({ length: 11 }, (_, i) =>
+      makeRow({ event_id: `${i}`, occurred_at: new Date(2026, 0, 1, 12, 0, 0, i) })
+    );
+    const more = await query(makeDeps(eleven).deps, makePrincipal(), {
+      limit: 10,
+    } as AuditQueryRequest);
+    expect(more.events).toHaveLength(10);
+    expect(more.nextCursor).toBeDefined();
+  });
+});
+
+describe('getByTarget', () => {
+  it('throws PERMISSION_DENIED when principal lacks admin.audit_logs', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      getByTarget(deps, makePrincipal({ permissions: [] }), {
+        aggregateType: 'user',
+        aggregateId: 'usr-1',
+        limit: 10,
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws INVALID_ARGUMENT on missing aggregate_type', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      getByTarget(deps, makePrincipal(), { aggregateType: '', aggregateId: 'x', limit: 10 })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws INVALID_ARGUMENT on missing aggregate_id', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      getByTarget(deps, makePrincipal(), { aggregateType: 'user', aggregateId: '', limit: 10 })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('queries with the (aggregate_type, aggregate_id) compound idx', async () => {
+    const { deps, query: qmock } = makeDeps([makeRow({ aggregate_id: 'app-1' })]);
+    const res = await getByTarget(deps, makePrincipal(), {
+      aggregateType: 'application',
+      aggregateId: 'app-1',
+      limit: 50,
+    });
+    expect(res.events).toHaveLength(1);
+    expect(qmock.mock.calls[0][1][0]).toBe('application');
+    expect(qmock.mock.calls[0][1][1]).toBe('app-1');
+  });
+
+  it('threads a cursor through and emits nextCursor when more rows present', async () => {
+    const eleven = Array.from({ length: 11 }, (_, i) =>
+      makeRow({ event_id: `${i}`, occurred_at: new Date(2026, 0, 1, 12, 0, 0, i) })
+    );
+    const res = await getByTarget(makeDeps(eleven).deps, makePrincipal(), {
+      aggregateType: 'pet',
+      aggregateId: 'pet-1',
+      limit: 10,
+    });
+    expect(res.events).toHaveLength(10);
+    expect(res.nextCursor).toBeDefined();
+  });
+});

--- a/services/audit/src/grpc/handlers.ts
+++ b/services/audit/src/grpc/handlers.ts
@@ -1,0 +1,205 @@
+// gRPC handler implementations for AuditQueryService.{Query, GetByTarget}.
+//
+// Both are read-only — the audit service is the sole producer of
+// audit_events via its Phase 10.4 NATS subscriber. These RPCs serve
+// the gateway's `view Audit`-gated GET /api/audit/* surface.
+//
+// Authz: both gate on the `admin.audit_logs` permission (ADMIN_AUDIT_LOGS
+// from lib.types). The gateway gates first; this re-check is
+// defence-in-depth (CAD pattern — handler doesn't trust the metadata
+// stamped on a request to imply the metadata stamper checked the
+// permission).
+//
+// Pure handlers — `(deps, principal, request) → Promise<response>`. The
+// adapter (shipped in #900) wraps these in the grpc-js (call, callback)
+// signature.
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { ADMIN_AUDIT_LOGS } from '@adopt-dont-shop/lib.types';
+import type {
+  AuditEvent,
+  AuditGetByTargetRequest,
+  AuditGetByTargetResponse,
+  AuditQueryRequest,
+  AuditQueryResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
+import { outcomeToDb } from './enum-map.js';
+import { rowToProto, type AuditEventRow } from './mapper.js';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function clampLimit(raw: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.trunc(raw), MAX_LIMIT);
+}
+
+function ensureViewAudit(principal: Principal): void {
+  if (!requirePermission(principal, ADMIN_AUDIT_LOGS)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_AUDIT_LOGS}' required`);
+  }
+}
+
+// --- Query -----------------------------------------------------------
+
+export async function query(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AuditQueryRequest
+): Promise<AuditQueryResponse> {
+  ensureViewAudit(principal);
+
+  const limit = clampLimit(req.limit);
+
+  // Build the WHERE clause from the optional filters. We track the
+  // parameter index so the placeholders match what we push into
+  // `params`. Descending sort on (occurred_at, event_id) — the
+  // cursor encodes the same tuple so keyset pagination is stable.
+  const where: string[] = [];
+  const params: unknown[] = [];
+  let p = 1;
+
+  if (req.service !== undefined && req.service !== '') {
+    where.push(`service = $${p++}`);
+    params.push(req.service);
+  }
+  if (req.subject !== undefined && req.subject !== '') {
+    where.push(`subject = $${p++}`);
+    params.push(req.subject);
+  }
+  if (req.actorUserId !== undefined && req.actorUserId !== '') {
+    where.push(`actor_user_id = $${p++}`);
+    params.push(req.actorUserId);
+  }
+  if (req.outcome !== undefined && req.outcome !== 0) {
+    where.push(`outcome = $${p++}`);
+    params.push(outcomeToDb(req.outcome));
+  }
+  if (req.occurredAtFrom !== undefined && req.occurredAtFrom !== '') {
+    where.push(`occurred_at >= $${p++}`);
+    params.push(req.occurredAtFrom);
+  }
+  if (req.occurredAtTo !== undefined && req.occurredAtTo !== '') {
+    where.push(`occurred_at < $${p++}`);
+    params.push(req.occurredAtTo);
+  }
+
+  if (req.cursor !== undefined && req.cursor !== '') {
+    let cursor;
+    try {
+      cursor = decodeCursor(req.cursor);
+    } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        throw new HandlerError('INVALID_ARGUMENT', err.message);
+      }
+      throw err;
+    }
+    // (occurred_at, event_id) < (cursor.occurredAt, cursor.eventId)
+    // in DESC order — i.e. older rows OR same-time-different-id-later.
+    where.push(`(occurred_at < $${p++} OR (occurred_at = $${p - 1} AND event_id < $${p++}))`);
+    params.push(cursor.occurredAt);
+    params.push(cursor.eventId);
+  }
+
+  const whereSql = where.length === 0 ? '' : `WHERE ${where.join(' AND ')}`;
+  // Fetch limit+1 so we know whether there's a next page without a
+  // separate COUNT(*) query.
+  params.push(limit + 1);
+  const sql = `
+    SELECT event_id, service, subject, aggregate_type, aggregate_id,
+           actor_user_id, actor_email_snapshot, action, outcome,
+           occurred_at, recorded_at, payload, ip_address, user_agent
+    FROM audit_events
+    ${whereSql}
+    ORDER BY occurred_at DESC, event_id DESC
+    LIMIT $${p}
+  `;
+
+  const { rows } = await deps.pool.query<AuditEventRow>(sql, params);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const events = pageRows.map(rowToProto);
+
+  const response: AuditQueryResponse = { events };
+  if (hasMore && pageRows.length > 0) {
+    const last = pageRows[pageRows.length - 1];
+    response.nextCursor = encodeCursor({
+      occurredAt: last.occurred_at.toISOString(),
+      eventId: last.event_id,
+    });
+  }
+
+  return response;
+}
+
+// --- GetByTarget -----------------------------------------------------
+
+export async function getByTarget(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AuditGetByTargetRequest
+): Promise<AuditGetByTargetResponse> {
+  ensureViewAudit(principal);
+
+  if (req.aggregateType === undefined || req.aggregateType === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'aggregate_type is required');
+  }
+  if (req.aggregateId === undefined || req.aggregateId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'aggregate_id is required');
+  }
+
+  const limit = clampLimit(req.limit);
+
+  const where: string[] = ['aggregate_type = $1', 'aggregate_id = $2'];
+  const params: unknown[] = [req.aggregateType, req.aggregateId];
+  let p = 3;
+
+  if (req.cursor !== undefined && req.cursor !== '') {
+    let cursor;
+    try {
+      cursor = decodeCursor(req.cursor);
+    } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        throw new HandlerError('INVALID_ARGUMENT', err.message);
+      }
+      throw err;
+    }
+    where.push(`(occurred_at < $${p++} OR (occurred_at = $${p - 1} AND event_id < $${p++}))`);
+    params.push(cursor.occurredAt);
+    params.push(cursor.eventId);
+  }
+
+  params.push(limit + 1);
+  const sql = `
+    SELECT event_id, service, subject, aggregate_type, aggregate_id,
+           actor_user_id, actor_email_snapshot, action, outcome,
+           occurred_at, recorded_at, payload, ip_address, user_agent
+    FROM audit_events
+    WHERE ${where.join(' AND ')}
+    ORDER BY occurred_at DESC, event_id DESC
+    LIMIT $${p}
+  `;
+
+  const { rows } = await deps.pool.query<AuditEventRow>(sql, params);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const events: AuditEvent[] = pageRows.map(rowToProto);
+
+  const response: AuditGetByTargetResponse = { events };
+  if (hasMore && pageRows.length > 0) {
+    const last = pageRows[pageRows.length - 1];
+    response.nextCursor = encodeCursor({
+      occurredAt: last.occurred_at.toISOString(),
+      eventId: last.event_id,
+    });
+  }
+
+  return response;
+}


### PR DESCRIPTION
## Summary

Phase 10.3b — `services/audit/src/grpc/handlers.ts` + tests. **AuditQueryService handler implementations** — completes the end-to-end read surface for the audit vertical.

Pure handlers `(deps, principal, request) → Promise<response>` over the adapter from #900 + cursor from #904 + mapper from #908 + enum-map from #895.

**`query`**:
- **Authz**: `requirePermission(ADMIN_AUDIT_LOGS)` — defence-in-depth against the gateway gating in Phase 10.5.
- Builds WHERE clause dynamically from optional filters (`service`, `subject`, `actor_user_id`, `outcome`, `occurred_at_from`/`_to`). Empty strings + UNSPECIFIED enum sentinel both treated as "no filter".
- Limit clamps to `MAX_LIMIT=200`; `<= 0` / non-finite falls back to `DEFAULT_LIMIT=50`.
- Cursor → `(occurred_at, event_id) DESC` keyset; `SELECT LIMIT+1` to determine `hasMore` without a COUNT query. `nextCursor` populated only when more rows exist.
- `InvalidCursorError` → `HandlerError('INVALID_ARGUMENT')`.

**`getByTarget`**:
- Same authz, limit, cursor, and pagination patterns.
- `aggregate_type` + `aggregate_id` required (empty → `INVALID_ARGUMENT`).
- Hits the `(aggregate_type, aggregate_id)` compound idx from #884.

## Parallel-PR context

Only touches `services/audit/src/grpc/handlers.{ts,test.ts}` (new file). Sits alongside all merged audit gRPC modules. Next step is wiring these handlers into the gRPC server boot (Phase 10.3c).

## Test plan

- [x] `npm test` in services/audit — 59/59 green (9 boot + 5 migrations + 4 enum-map + 5 principal + 8 adapter + 5 cursor + 10 mapper + 13 handlers)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_