### PR TITLE
feat(audit): phase 10.3c — gRPC server boot

### DIFF
--- a/services/audit/src/grpc/server.test.ts
+++ b/services/audit/src/grpc/server.test.ts
@@ -1,0 +1,52 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+
+import { AuditV1 } from '@adopt-dont-shop/proto';
+
+import type { AuditConfig } from '../config.js';
+
+import { createGrpcServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const config: AuditConfig = {
+  port: 5009,
+  grpcPort: 6009,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'audit',
+  natsUrl: 'nats://localhost:4222',
+};
+
+const pool = {} as unknown as Pool;
+const nats = {} as unknown as NatsConnection;
+
+describe('createGrpcServer', () => {
+  it('registers both AuditQueryService methods on the grpc.Server', () => {
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    expect(handlers.has('/adopt_dont_shop.audit.v1.AuditQueryService/Query')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.audit.v1.AuditQueryService/GetByTarget')).toBe(true);
+  });
+
+  it('matches every path from the canonical AuditQueryServiceService Definition table', () => {
+    const definition = AuditV1.AuditQueryServiceService;
+    const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
+
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    for (const p of expectedPaths) {
+      expect(handlers.has(p)).toBe(true);
+    }
+  });
+});

--- a/services/audit/src/grpc/server.ts
+++ b/services/audit/src/grpc/server.ts
@@ -1,0 +1,82 @@
+// gRPC server boot — binds AuditQueryServiceService to the two
+// adapter-wrapped handlers and starts listening on AUDIT_GRPC_PORT.
+//
+// Same shape as services/rescue/src/grpc/server.ts. Dev uses
+// insecure credentials (TLS terminates at nginx in front);
+// production keeps gRPC HTTP/2 cleartext on the cluster network
+// until a future deploy wants mTLS.
+
+import { promisify } from 'node:util';
+
+import { Server, ServerCredentials } from '@grpc/grpc-js';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { AuditV1 } from '@adopt-dont-shop/proto';
+
+import type { AuditConfig } from '../config.js';
+
+import { adapt } from './adapter.js';
+import { getByTarget, query } from './handlers.js';
+
+export type CreateGrpcServerOptions = {
+  config: AuditConfig;
+  pool: Pool;
+  nats: NatsConnection;
+  logger: Logger;
+};
+
+export type RunningGrpcServer = {
+  server: Server;
+  port: number;
+  shutdown: () => Promise<void>;
+};
+
+export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
+  const { config, pool, nats, logger } = opts;
+  const deps = { pool, nats };
+  const server = new Server();
+
+  server.addService(AuditV1.AuditQueryServiceService, {
+    query: adapt(query, { deps, logger }),
+    getByTarget: adapt(getByTarget, { deps, logger }),
+  });
+
+  logger.info('gRPC AuditQueryService registered', {
+    methods: ['query', 'getByTarget'],
+    grpcPort: config.grpcPort,
+  });
+
+  return server;
+};
+
+export const startGrpcServer = async (
+  opts: CreateGrpcServerOptions
+): Promise<RunningGrpcServer> => {
+  const { config, logger } = opts;
+  const server = createGrpcServer(opts);
+
+  const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
+  const port = await bindAsync(
+    `${opts.config.host}:${config.grpcPort}`,
+    ServerCredentials.createInsecure()
+  );
+
+  logger.info('gRPC server listening', { port, host: opts.config.host });
+
+  return {
+    server,
+    port,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          resolve();
+        });
+      }),
+  };
+};


### PR DESCRIPTION
## Summary

Phase 10.3c — `services/audit/src/grpc/server.ts` + tests. **Final piece of the audit gRPC vertical.** `createGrpcServer` binds `AuditQueryServiceService` to the two adapter-wrapped handlers (`query`, `getByTarget`) from #915, and `startGrpcServer` listens on `AUDIT_GRPC_PORT`.

Same shape as `services/rescue/src/grpc/server.ts`. Insecure credentials in dev (TLS terminates at nginx in front); production keeps gRPC HTTP/2 cleartext on the cluster network until a future deploy wants mTLS.

**End-to-end pipeline now exists for the audit vertical**:
```
gateway → gRPC → AuditQueryService → handlers
  → enum-map / cursor / mapper → PG SELECT → AuditEvent proto
```

## What's NOT here yet

- **Phase 10.4** — NATS subscribers on every `*.actionTaken` topic.
- **Phase 10.5** — Gateway routes `GET /api/audit/*` gated on `admin.audit_logs`.
- **Phase 10.6** — Cutover: delete `auditLog.service.ts`, `audit-log-formatting.ts`, and the audit middleware from the residual monolith.

## Test plan

- [x] `npm test` in services/audit — 61/61 green (all earlier tests + 2 grpc server: path registration + canonical Definition table match)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_