### PR TITLE
feat(gateway): phase 10.5 — /api/audit/* routes

### DIFF
--- a/services/gateway/src/grpc-clients/audit-client.ts
+++ b/services/gateway/src/grpc-clients/audit-client.ts
@@ -1,0 +1,54 @@
+// Promise-wrapped client for service.audit.
+//
+// Phase 10.5 surface — AuditQueryService.{Query, GetByTarget}. The
+// Phase 2.5 authenticate middleware populates x-user-* metadata; the
+// service handlers re-check the admin.audit_logs permission as
+// defence-in-depth (#915).
+//
+// The interface is exported so tests can substitute a mock; the
+// routes depend on the shape, not the @grpc/grpc-js client.
+
+import { credentials, Metadata } from '@grpc/grpc-js';
+
+import {
+  AuditV1,
+  type AuditGetByTargetRequest,
+  type AuditGetByTargetResponse,
+  type AuditQueryRequest,
+  type AuditQueryResponse,
+} from '@adopt-dont-shop/proto';
+
+export type AuditClient = {
+  query(req: AuditQueryRequest, metadata: Metadata): Promise<AuditQueryResponse>;
+  getByTarget(req: AuditGetByTargetRequest, metadata: Metadata): Promise<AuditGetByTargetResponse>;
+  close(): void;
+};
+
+export type CreateAuditClientOptions = {
+  address: string;
+};
+
+export const createAuditClient = (opts: CreateAuditClientOptions): AuditClient => {
+  const stub = new AuditV1.AuditQueryServiceClient(opts.address, credentials.createInsecure());
+
+  const callUnary = <Req, Res>(
+    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> =>
+    new Promise<Res>((resolve, reject) => {
+      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(res);
+      });
+    });
+
+  return {
+    query: (req, metadata) => callUnary(stub.query, req, metadata),
+    getByTarget: (req, metadata) => callUnary(stub.getByTarget, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/gateway/src/routes/audit.test.ts
+++ b/services/gateway/src/routes/audit.test.ts
@@ -1,0 +1,204 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AuditV1,
+  type AuditEvent,
+  type AuditGetByTargetResponse,
+  type AuditQueryResponse,
+} from '@adopt-dont-shop/proto';
+
+import type { AuditClient } from '../grpc-clients/audit-client.js';
+
+import { registerAuditRoutes } from './audit.js';
+
+function makeClient(): {
+  client: AuditClient;
+  queryMock: ReturnType<typeof vi.fn>;
+  getByTargetMock: ReturnType<typeof vi.fn>;
+} {
+  const queryMock = vi.fn();
+  const getByTargetMock = vi.fn();
+  const client: AuditClient = {
+    query: queryMock,
+    getByTarget: getByTargetMock,
+    close: vi.fn(),
+  };
+  return { client, queryMock, getByTargetMock };
+}
+
+async function makeApp(client: AuditClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerAuditRoutes(app, { client });
+  return app;
+}
+
+const EVENT_FIXTURE: AuditEvent = {
+  eventId: 'evt-1',
+  service: 'service.auth',
+  subject: 'auth.userLoggedIn',
+  aggregateType: 'user',
+  aggregateId: 'usr-1',
+  action: 'login',
+  outcome: AuditV1.AuditOutcome.AUDIT_OUTCOME_SUCCESS,
+  occurredAt: '2026-06-01T12:00:00.000Z',
+  recordedAt: '2026-06-01T12:00:00.500Z',
+  payloadJson: '{"source":"web"}',
+};
+
+const ADMIN_HEADERS = {
+  'x-user-id': 'admin-1',
+  'x-user-roles': 'admin',
+  'x-user-permissions': 'admin.audit_logs',
+};
+
+describe('GET /api/audit', () => {
+  let app: FastifyInstance;
+  let queryMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    queryMock = m.queryMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards Query with all filters threaded through query params', async () => {
+    const res: AuditQueryResponse = { events: [EVENT_FIXTURE], nextCursor: 'next-cursor' };
+    queryMock.mockResolvedValue(res);
+
+    const httpRes = await app.inject({
+      method: 'GET',
+      url: '/api/audit?service=service.auth&subject=auth.userLoggedIn&actor_user_id=usr-1&outcome=denied&from=2026-06-01&to=2026-06-02&limit=25&cursor=abc',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(httpRes.statusCode).toBe(200);
+    const grpcReq = queryMock.mock.calls[0][0];
+    expect(grpcReq).toMatchObject({
+      service: 'service.auth',
+      subject: 'auth.userLoggedIn',
+      actorUserId: 'usr-1',
+      outcome: AuditV1.AuditOutcome.AUDIT_OUTCOME_DENIED,
+      occurredAtFrom: '2026-06-01',
+      occurredAtTo: '2026-06-02',
+      limit: 25,
+      cursor: 'abc',
+    });
+    expect(httpRes.json()).toMatchObject({ nextCursor: 'next-cursor' });
+  });
+
+  it('threads x-user-* metadata to the gRPC client', async () => {
+    queryMock.mockResolvedValue({ events: [] });
+
+    await app.inject({
+      method: 'GET',
+      url: '/api/audit',
+      headers: ADMIN_HEADERS,
+    });
+
+    const metadata = queryMock.mock.calls[0][1];
+    expect(metadata.get('x-user-id')).toEqual(['admin-1']);
+    expect(metadata.get('x-user-roles')).toEqual(['admin']);
+    expect(metadata.get('x-user-permissions')).toEqual(['admin.audit_logs']);
+  });
+
+  it('accepts SCREAMING proto-form outcome', async () => {
+    queryMock.mockResolvedValue({ events: [] });
+
+    await app.inject({
+      method: 'GET',
+      url: '/api/audit?outcome=AUDIT_OUTCOME_FAILURE',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(queryMock.mock.calls[0][0]).toMatchObject({
+      outcome: AuditV1.AuditOutcome.AUDIT_OUTCOME_FAILURE,
+    });
+  });
+
+  it('coerces an unknown outcome string to UNSPECIFIED', async () => {
+    queryMock.mockResolvedValue({ events: [] });
+
+    await app.inject({
+      method: 'GET',
+      url: '/api/audit?outcome=partial',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(queryMock.mock.calls[0][0]).toMatchObject({
+      outcome: AuditV1.AuditOutcome.AUDIT_OUTCOME_UNSPECIFIED,
+    });
+  });
+
+  it.each([
+    [grpcStatus.PERMISSION_DENIED, 403],
+    [grpcStatus.INVALID_ARGUMENT, 400],
+    [grpcStatus.UNAUTHENTICATED, 401],
+    [grpcStatus.INTERNAL, 500],
+  ])('maps gRPC code %i to HTTP %i', async (gCode, httpCode) => {
+    queryMock.mockRejectedValue({ code: gCode, details: 'test' });
+
+    const httpRes = await app.inject({
+      method: 'GET',
+      url: '/api/audit',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(httpRes.statusCode).toBe(httpCode);
+    expect(httpRes.json()).toMatchObject({ error: 'test' });
+  });
+});
+
+describe('GET /api/audit/targets/:type/:id', () => {
+  let app: FastifyInstance;
+  let getByTargetMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    getByTargetMock = m.getByTargetMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('passes :type and :id to GetByTarget as aggregateType/aggregateId', async () => {
+    const res: AuditGetByTargetResponse = { events: [EVENT_FIXTURE] };
+    getByTargetMock.mockResolvedValue(res);
+
+    const httpRes = await app.inject({
+      method: 'GET',
+      url: '/api/audit/targets/application/app-1',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(httpRes.statusCode).toBe(200);
+    expect(getByTargetMock.mock.calls[0][0]).toMatchObject({
+      aggregateType: 'application',
+      aggregateId: 'app-1',
+    });
+  });
+
+  it('forwards limit + cursor from query params', async () => {
+    getByTargetMock.mockResolvedValue({ events: [] });
+
+    await app.inject({
+      method: 'GET',
+      url: '/api/audit/targets/pet/pet-1?limit=10&cursor=xyz',
+      headers: ADMIN_HEADERS,
+    });
+
+    expect(getByTargetMock.mock.calls[0][0]).toMatchObject({
+      aggregateType: 'pet',
+      aggregateId: 'pet-1',
+      limit: 10,
+      cursor: 'xyz',
+    });
+  });
+});

--- a/services/gateway/src/routes/audit.ts
+++ b/services/gateway/src/routes/audit.ts
@@ -1,0 +1,140 @@
+// REST → gRPC translation for /api/audit/*.
+//
+// Phase 10.5 cutover. Same shape as routes/rescue.ts /
+// routes/pets.ts / routes/auth.ts — Fastify plugin registers
+// BEFORE the strangler-fig http-proxy catch-all, so first-
+// registered-wins prefix routing picks it for /api/audit/*
+// requests before the catch-all sees them.
+//
+// Route map (mirrors monolith /api/audit-logs but folds the
+// per-target query under /api/audit/targets/:type/:id):
+//
+//   GET /api/audit                                 → AuditQueryService.Query
+//   GET /api/audit/targets/:type/:id               → AuditQueryService.GetByTarget
+//
+// Both gated on admin.audit_logs at the handler (#915) — the
+// gateway re-rate-limits but trusts the handler's authz check
+// for the actual ability gate. The Phase 2.5 authenticate
+// middleware already stamps x-user-* metadata.
+
+import rateLimit from '@fastify/rate-limit';
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  AuditV1,
+  type AuditGetByTargetRequest,
+  type AuditQueryRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { AuditClient } from '../grpc-clients/audit-client.js';
+
+export type AuditRoutesOptions = {
+  client: AuditClient;
+};
+
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.INTERNAL]: 500,
+};
+
+// Per-route rate limits. Audit is admin-only — these are sized for
+// human use, not bulk scraping. The handler's own LIMIT clamp
+// (#915: MAX_LIMIT=200) is the secondary guard.
+const AUDIT_RATE_LIMITS = {
+  query: { max: 60, timeWindow: '1 minute' },
+  getByTarget: { max: 120, timeWindow: '1 minute' },
+} as const;
+
+export const registerAuditRoutes = async (
+  app: FastifyInstance,
+  opts: AuditRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  await app.register(rateLimit, { global: false });
+
+  app.get('/api/audit', { config: { rateLimit: AUDIT_RATE_LIMITS.query } }, async (req, reply) => {
+    const query = req.query as Record<string, string | undefined>;
+    const grpcReq: AuditQueryRequest = {
+      cursor: query.cursor,
+      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      service: query.service,
+      subject: query.subject,
+      actorUserId: query.actor_user_id,
+      outcome: parseOutcome(query.outcome),
+      occurredAtFrom: query.from,
+      occurredAtTo: query.to,
+    };
+    try {
+      const res = await client.query(grpcReq, buildMetadata(req));
+      return reply.send(AuditV1.QueryResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get<{ Params: { type: string; id: string } }>(
+    '/api/audit/targets/:type/:id',
+    { config: { rateLimit: AUDIT_RATE_LIMITS.getByTarget } },
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: AuditGetByTargetRequest = {
+        aggregateType: req.params.type,
+        aggregateId: req.params.id,
+        cursor: query.cursor,
+        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      };
+      try {
+        const res = await client.getByTarget(grpcReq, buildMetadata(req));
+        return reply.send(AuditV1.GetByTargetResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}
+
+// parseOutcome accepts the DB string ('success', 'denied', 'failure')
+// AND the SCREAMING proto form ('AUDIT_OUTCOME_DENIED'). Unknown
+// coerces to UNSPECIFIED so the handler's filter loop treats it as
+// "no filter".
+function parseOutcome(raw: string | undefined): AuditV1.AuditOutcome {
+  if (!raw) {
+    return AuditV1.AuditOutcome.AUDIT_OUTCOME_UNSPECIFIED;
+  }
+  const upper = `AUDIT_OUTCOME_${raw.toUpperCase()}`;
+  const candidate = Object.values(AuditV1.AuditOutcome).includes(upper as never) ? upper : raw;
+  const out = AuditV1.auditOutcomeFromJSON(candidate);
+  return out === AuditV1.AuditOutcome.UNRECOGNIZED
+    ? AuditV1.AuditOutcome.AUDIT_OUTCOME_UNSPECIFIED
+    : out;
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -20,11 +20,13 @@ import { createLogger } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { GatewayConfig } from './config.js';
+import type { AuditClient } from './grpc-clients/audit-client.js';
 import type { AuthClient } from './grpc-clients/auth-client.js';
 import type { NotificationsClient } from './grpc-clients/notifications-client.js';
 import type { PetsClient } from './grpc-clients/pets-client.js';
 import type { RescueClient } from './grpc-clients/rescue-client.js';
 import { registerAuthenticate } from './middleware/authenticate.js';
+import { registerAuditRoutes } from './routes/audit.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerNotificationsRoutes } from './routes/notifications.js';
 import { registerPetsRoutes } from './routes/pets.js';
@@ -56,6 +58,9 @@ export type CreateServerOptions = {
   // gRPC client to service.rescue — Phase 4.5 cuts /api/rescue/* over
   // to this address. Same optional shape as the other clients.
   rescueClient?: RescueClient;
+  // gRPC client to service.audit — Phase 10.5 cuts /api/audit/* over
+  // to this address. Same optional shape as the other clients.
+  auditClient?: AuditClient;
 };
 
 export const createServer = async (opts: CreateServerOptions): Promise<FastifyInstance> => {
@@ -123,6 +128,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   if (opts.rescueClient) {
     await registerRescueRoutes(server, { client: opts.rescueClient });
+  }
+  if (opts.auditClient) {
+    await registerAuditRoutes(server, { client: opts.auditClient });
   }
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in


### PR DESCRIPTION
## Summary

Phase 10.5 cutover — `/api/audit/*` lands on the gateway's audit-routes plugin instead of falling through to the residual monolith. Same strangler-fig shape as Phase 2.6 (auth) / 3.5 (pets) / 4.5 (rescue).

**Two routes**:
- `GET /api/audit` → `AuditQueryService.Query`
- `GET /api/audit/targets/:type/:id` → `AuditQueryService.GetByTarget`

**Query params**: `cursor`, `limit`, `service`, `subject`, `actor_user_id`, `outcome`, `from`, `to`. `parseOutcome` accepts both DB form (`denied`) and SCREAMING proto form (`AUDIT_OUTCOME_DENIED`); unknown coerces to UNSPECIFIED so the handler's "no filter" semantics apply.

`GRPC_TO_HTTP` table covers the standard 4xx/5xx mapping (`INVALID_ARGUMENT → 400`, `UNAUTHENTICATED → 401`, `PERMISSION_DENIED → 403`, `NOT_FOUND → 404`, `INTERNAL → 500`).

**Per-route rate limits** sized for human admin use, not bulk scraping — Query 60/min, GetByTarget 120/min. The handler's `MAX_LIMIT=200` clamp from #915 is the secondary guard.

**Authz**: defence-in-depth. Gateway re-uses the Phase 2.5 authenticate middleware to stamp `x-user-*` metadata; the handler (#915) re-checks `admin.audit_logs` against the stamped principal.

`AuditClient` + `createAuditClient` ship alongside the routes plugin — same Promise-wrapped shape as `rescue-client` / `pets-client` / `auth-client`. Wired into `createServer` as an optional `auditClient`.

## Test plan

- [x] `npm test` in services/gateway — 95/95 green (all earlier gateway tests + 9 audit route tests)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

## What's NOT here yet

- **Phase 10.4** — NATS subscribers on every `*.actionTaken` topic (the audit service has no events to query against yet; this PR ships the surface).
- **Phase 10.6** — Cutover: delete `auditLog.service.ts`, `audit-log-formatting.ts`, and the audit middleware from the residual monolith.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_