### PR TITLE
feat(audit): phase 10.4 — NATS subscribers (*.actionTaken)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32679,6 +32679,7 @@
         "@adopt-dont-shop/proto": "*",
         "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
+        "nats": "^2.29.3",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"
       }

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -41,6 +41,7 @@
     "@adopt-dont-shop/proto": "*",
     "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
+    "nats": "^2.29.3",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.21.0"
   }

--- a/services/audit/src/nats/event-types.ts
+++ b/services/audit/src/nats/event-types.ts
@@ -1,0 +1,54 @@
+// Wire shape for the audit consumer.
+//
+// Every service that owns a state-changing surface publishes a
+// `<domain>.actionTaken` event with the same shape — that's the
+// uniformity the audit log relies on. Audit subscribes to the
+// wildcard subject `*.actionTaken` and persists every event row.
+//
+// The shape lives HERE (consumer-side) because no producer ships a
+// formal proto for it yet. Producers in Phase 10.4b (auth, pets,
+// rescue, applications, chat, notifications, moderation, matching)
+// will adopt the shared @adopt-dont-shop/proto.AuditEventPayload
+// once it lands; for now this is the contract.
+//
+// Same pattern as services/notifications/src/nats/event-types.ts
+// (Phase 1.4) — consumer documents the contract it depends on.
+
+export type AuditEventPayload = {
+  // Idempotency key — the producer's NATS message id. Persists as the
+  // PK on audit_events; JetStream redelivery becomes an ON CONFLICT
+  // DO NOTHING insert.
+  eventId: string;
+  // Source service identifier: 'service.auth', 'service.pets', etc.
+  // Used by the gateway's `service=` filter in Query (#915).
+  service: string;
+  // Full NATS subject the event was published on (the audit consumer
+  // subscribes to '*.actionTaken' so this comes from the message
+  // metadata, not the payload). Mirrors it into the row for stable
+  // forensic query.
+  subject: string;
+  // Domain aggregate the action targeted ('user', 'pet', 'application').
+  aggregateType: string;
+  // The aggregate's id (uuid string).
+  aggregateId: string;
+  // The user who triggered the action. NULL for system events
+  // (cron jobs, NATS replay backfills).
+  actorUserId?: string;
+  // Denormalised at write time so the trail stays readable when the
+  // user is gone.
+  actorEmailSnapshot?: string;
+  // Action name within the aggregate's domain — 'submit', 'approve',
+  // 'login', 'updateStatus'.
+  action: string;
+  // 'success' | 'denied' | 'failure'. The audit enum-map (#895) maps
+  // this to AuditV1.AuditOutcome.
+  outcome: string;
+  // When the action happened in the producer's clock (RFC 3339).
+  occurredAt: string;
+  // Full event body — schema-less. The producing service stamps
+  // whatever fields make sense for its event type.
+  payload?: unknown;
+  // Optional request context.
+  ipAddress?: string;
+  userAgent?: string;
+};

--- a/services/audit/src/nats/subscribers.test.ts
+++ b/services/audit/src/nats/subscribers.test.ts
@@ -1,0 +1,125 @@
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { persistAuditEvent } from './subscribers.js';
+import type { AuditEventPayload } from './event-types.js';
+
+function makePool(): { pool: Pool; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn().mockResolvedValue({ rowCount: 1 });
+  return {
+    pool: { query } as unknown as Pool,
+    query,
+  };
+}
+
+function basePayload(overrides: Partial<AuditEventPayload> = {}): AuditEventPayload {
+  return {
+    eventId: '11111111-1111-1111-1111-111111111111',
+    service: 'service.auth',
+    subject: 'auth.userLoggedIn',
+    aggregateType: 'user',
+    aggregateId: '22222222-2222-2222-2222-222222222222',
+    actorUserId: '33333333-3333-3333-3333-333333333333',
+    actorEmailSnapshot: 'user@example.com',
+    action: 'login',
+    outcome: 'success',
+    occurredAt: '2026-06-01T12:00:00.000Z',
+    payload: { source: 'web' },
+    ipAddress: '1.2.3.4',
+    userAgent: 'Mozilla/5.0',
+    ...overrides,
+  };
+}
+
+describe('persistAuditEvent', () => {
+  it('issues an INSERT with all payload fields in the expected positions', async () => {
+    const { pool, query } = makePool();
+    await persistAuditEvent(pool, basePayload(), 'auth.actionTaken');
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO audit_events');
+    expect(sql).toContain('ON CONFLICT (event_id) DO NOTHING');
+    expect(params).toEqual([
+      '11111111-1111-1111-1111-111111111111',
+      'service.auth',
+      'auth.userLoggedIn',
+      'user',
+      '22222222-2222-2222-2222-222222222222',
+      '33333333-3333-3333-3333-333333333333',
+      'user@example.com',
+      'login',
+      'success',
+      '2026-06-01T12:00:00.000Z',
+      '{"source":"web"}',
+      '1.2.3.4',
+      'Mozilla/5.0',
+    ]);
+  });
+
+  it('falls back to the NATS subject when payload.subject is missing', async () => {
+    const { pool, query } = makePool();
+    await persistAuditEvent(
+      pool,
+      basePayload({ subject: '' as unknown as string }),
+      'auth.actionTaken'
+    );
+
+    const [, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(params[2]).toBe('auth.actionTaken');
+  });
+
+  it('writes NULL for missing optional actor / context fields (system event)', async () => {
+    const { pool, query } = makePool();
+    await persistAuditEvent(
+      pool,
+      basePayload({
+        actorUserId: undefined,
+        actorEmailSnapshot: undefined,
+        ipAddress: undefined,
+        userAgent: undefined,
+      }),
+      'auth.actionTaken'
+    );
+
+    const [, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(params[5]).toBeNull(); // actor_user_id
+    expect(params[6]).toBeNull(); // actor_email_snapshot
+    expect(params[11]).toBeNull(); // ip_address
+    expect(params[12]).toBeNull(); // user_agent
+  });
+
+  it('serialises an absent payload as "{}" so the NOT NULL column has a value', async () => {
+    const { pool, query } = makePool();
+    await persistAuditEvent(pool, basePayload({ payload: undefined }), 'auth.actionTaken');
+
+    const [, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(params[10]).toBe('{}');
+  });
+
+  it('serialises complex payloads through JSON.stringify', async () => {
+    const { pool, query } = makePool();
+    await persistAuditEvent(
+      pool,
+      basePayload({ payload: { nested: { array: [1, 2, 3] } } }),
+      'auth.actionTaken'
+    );
+
+    const [, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(params[10]).toBe('{"nested":{"array":[1,2,3]}}');
+  });
+
+  it('treats a redelivered event as idempotent (ON CONFLICT DO NOTHING)', async () => {
+    // The mock doesn't actually enforce the constraint, but the SQL
+    // clause is what guarantees idempotency in production. This test
+    // pins the contract.
+    const { pool, query } = makePool();
+    const payload = basePayload();
+    await persistAuditEvent(pool, payload, 'auth.actionTaken');
+    await persistAuditEvent(pool, payload, 'auth.actionTaken');
+
+    expect(query).toHaveBeenCalledTimes(2);
+    const sql = (query.mock.calls[0] as [string, unknown[]])[0];
+    expect(sql).toContain('ON CONFLICT (event_id) DO NOTHING');
+  });
+});

--- a/services/audit/src/nats/subscribers.ts
+++ b/services/audit/src/nats/subscribers.ts
@@ -1,0 +1,100 @@
+// NATS subscriber for the audit vertical.
+//
+// Phase 10.4 — subscribes to the wildcard `*.actionTaken` subject so
+// every state-changing event from every service lands in audit_events.
+// Idempotent on event_id (the row PK) so JetStream redelivery / NATS
+// replay can't double-insert.
+//
+// Discipline:
+//   - @adopt-dont-shop/events.subscribe wraps the callback with the
+//     CAD-#4 poison-pill protection: handler exceptions go through
+//     onError, the loop continues, malformed JSON is a clean skip.
+//   - Single queue group ('audit-workers') so horizontally-scaled
+//     replicas share work — each event is persisted exactly once
+//     in the happy path.
+//   - INSERT uses ON CONFLICT DO NOTHING on the event_id PK so retries
+//     are safe. The row-level immutability trigger (#884) rejects any
+//     subsequent UPDATE / DELETE attempt.
+//
+// What's NOT here: dedup-by-eventId at the event-bus layer. The
+// ON CONFLICT clause is enough — we don't need a separate
+// processed_events table because the event_id IS the audit_events PK.
+
+import type { NatsConnection, Subscription } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { subscribe } from '@adopt-dont-shop/events';
+
+import type { AuditEventPayload } from './event-types.js';
+
+export type RegisterSubscribersOptions = {
+  nats: NatsConnection;
+  pool: Pool;
+  logger: Logger;
+};
+
+// Queue group is part of the deployment contract — changing it
+// elsewhere means duplicate handling during the rollover.
+const QUEUE_GROUP = 'audit-workers';
+
+const INSERT_SQL = `
+  INSERT INTO audit_events (
+    event_id, service, subject, aggregate_type, aggregate_id,
+    actor_user_id, actor_email_snapshot, action, outcome,
+    occurred_at, payload, ip_address, user_agent
+  )
+  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+  ON CONFLICT (event_id) DO NOTHING
+`;
+
+export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscription[] => {
+  const { nats, pool, logger } = opts;
+
+  const onError = (err: unknown, ctx: { subject: string }): void => {
+    logger.error('audit subscriber handler failed', {
+      subject: ctx.subject,
+      err: (err as Error)?.message ?? String(err),
+    });
+  };
+
+  return [
+    subscribe<AuditEventPayload>(
+      nats,
+      { subject: '*.actionTaken', queue: QUEUE_GROUP, onError },
+      async (payload, meta) => {
+        await persistAuditEvent(pool, payload, meta.subject);
+      }
+    ),
+  ];
+};
+
+// Exported for direct unit testing — the subscriber test exercises this
+// without bringing NATS into the loop.
+export async function persistAuditEvent(
+  pool: Pool,
+  payload: AuditEventPayload,
+  natsSubject: string
+): Promise<void> {
+  // The producer's payload.subject is what we trust; if it's missing,
+  // fall back to the NATS-level subject (e.g. 'auth.actionTaken'). This
+  // keeps the row populated even when an older producer doesn't stamp
+  // the subject explicitly.
+  const subjectForRow = payload.subject || natsSubject;
+
+  await pool.query(INSERT_SQL, [
+    payload.eventId,
+    payload.service,
+    subjectForRow,
+    payload.aggregateType,
+    payload.aggregateId,
+    payload.actorUserId ?? null,
+    payload.actorEmailSnapshot ?? null,
+    payload.action,
+    payload.outcome,
+    payload.occurredAt,
+    JSON.stringify(payload.payload ?? {}),
+    payload.ipAddress ?? null,
+    payload.userAgent ?? null,
+  ]);
+}


### PR DESCRIPTION
## Summary

Phase 10.4 — `services/audit/src/nats/` (subscribers + event-types). **The audit consumer.** Subscribes to the wildcard `*.actionTaken` subject so every state-changing event from every service lands in `audit_events`.

**Discipline**:
- `@adopt-dont-shop/events.subscribe` wraps the callback with CAD-#4 poison-pill protection: handler exceptions go through onError, malformed JSON is a clean skip, the loop never tears down.
- Single queue group (`audit-workers`) so horizontally-scaled replicas share work.
- INSERT uses `ON CONFLICT (event_id) DO NOTHING` — JetStream redelivery / NATS replay can't double-insert. The row-level immutability trigger from #884 rejects any subsequent UPDATE/DELETE. The PK constraint is the dedup mechanism so we don't need a separate `processed_events` table.

**`event-types.ts`** documents the `AuditEventPayload` wire contract the audit consumer depends on. Producers in Phase 10.4b (auth, pets, rescue, applications, chat, notifications, moderation, matching) will publish to `<domain>.actionTaken` with this shape. Same **"subscribe early, translate later"** pattern as Phase 3.4 notifications subscribers — wires the contract now, producers adopt it as they extract.

`persistAuditEvent` is exported for direct unit testing without bringing NATS into the loop. The subscriber's actual subscription is a one-liner over `@adopt-dont-shop/events.subscribe`.

## Test plan

- [x] `npm test` in services/audit — 67/67 green (all earlier tests + 6 subscriber tests covering field positions, NATS-subject fallback, system event NULLs, `'{}'` payload normalisation, complex payload, ON CONFLICT contract)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

## What's NOT here yet

- **Phase 10.4b** — producers in each service emit `<domain>.actionTaken` events with the AuditEventPayload shape (currently a slot — no producer ships these yet).
- **Phase 10.6** — Cutover: delete `auditLog.service.ts`, `audit-log-formatting.ts`, and the audit middleware from the residual monolith.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_