### PR TITLE
feat(audit): wire grpc + nats subscribers into boot

### DIFF
--- a/services/audit/src/index.ts
+++ b/services/audit/src/index.ts
@@ -1,32 +1,80 @@
+import { connect, type NatsConnection, type Subscription } from 'nats';
+
+import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
+import { registerSubscribers } from './nats/subscribers.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.audit' });
 
+  let nats: NatsConnection | undefined;
+  let pool: ReturnType<typeof createDbClient> | undefined;
+  let grpc: RunningGrpcServer | undefined;
+  let subscriptions: Subscription[] = [];
+  let httpClosed = false;
+
   try {
     const config = loadConfig();
-    const server = createServer({ config, logger });
 
-    await server.listen({ port: config.port, host: config.host });
+    // Connect deps FIRST so we crash here rather than after starting
+    // to accept traffic. Same boot order as services/rescue,
+    // services/pets, etc.
+    pool = createDbClient({
+      connectionString: config.databaseUrl,
+      schema: config.schema,
+    });
+    nats = await connect({ servers: config.natsUrl });
 
-    logger.info('service.audit listening', {
-      port: config.port,
-      host: config.host,
-      grpcPort: config.grpcPort,
+    grpc = await startGrpcServer({ config, pool, nats, logger });
+
+    // NATS subscribers register AFTER the gRPC server is up so the
+    // service is never in a state where it's accepting NATS messages
+    // without being able to serve any query routed through gRPC.
+    // Phase 10.4 — subscribes to *.actionTaken; persists every event.
+    subscriptions = registerSubscribers({ nats, pool, logger });
+
+    const httpServer = createServer({ config, logger });
+    await httpServer.listen({ port: config.port, host: config.host });
+
+    logger.info('service.audit running', {
+      http: { port: config.port, host: config.host },
+      grpc: { port: grpc.port, host: config.host },
       schema: config.schema,
       natsUrl: config.natsUrl,
+      natsSubscriptions: subscriptions.length,
       environment: config.environment,
     });
 
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.audit shutting down', { signal });
       try {
-        await server.close();
+        if (!httpClosed) {
+          await httpServer.close();
+          httpClosed = true;
+        }
       } catch (err) {
-        logger.error('error during shutdown', { err });
+        logger.error('http close error', { err });
+      }
+      try {
+        await grpc?.shutdown();
+      } catch (err) {
+        logger.error('grpc shutdown error', { err });
+      }
+      try {
+        // Draining the NatsConnection drains every Subscription on it
+        // — no need to drain each subscription handle individually.
+        await nats?.drain();
+      } catch (err) {
+        logger.error('nats drain error', { err });
+      }
+      try {
+        await pool?.end();
+      } catch (err) {
+        logger.error('pool end error', { err });
       }
       process.exit(0);
     };
@@ -35,6 +83,21 @@ const main = async (): Promise<void> => {
     process.once('SIGINT', () => void shutdown('SIGINT'));
   } catch (err) {
     logger.error('service.audit failed to start', { err });
+    try {
+      await grpc?.shutdown();
+    } catch {
+      // Swallow — already on the failure path.
+    }
+    try {
+      await nats?.drain();
+    } catch {
+      // Same.
+    }
+    try {
+      await pool?.end();
+    } catch {
+      // Same.
+    }
     process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

Wires the audit gRPC server + NATS subscribers into the boot sequence. Without this, the gRPC handlers from #915 and the NATS subscribers from #918 are defined but never actually start.

**Boot sequence**:
1. `createDbClient` pool against the audit schema
2. `connect` NATS
3. `startGrpcServer` (AuditQueryService binds to AUDIT_GRPC_PORT)
4. `registerSubscribers` (*.actionTaken NATS subscriber registers)
5. Fastify HTTP listen (/health/simple)

Subscribers register **AFTER** the gRPC server is up so the service is never in a state where it's accepting NATS messages without being able to serve a query routed through gRPC.

**Shutdown order** is the reverse: HTTP close → gRPC shutdown → NATS drain → pool end. Draining the NatsConnection drains every Subscription on it, so no per-subscription drain needed. Same pattern as `services/rescue/src/index.ts`.

Failure-path cleanup mirrors the rescue boot — any partial deps that connected before the failure get unwound.

## Test plan

- [x] `npm test` — 67/67 still passing (index.ts isn't unit-tested directly; the smoke test arrives via the docker-compose stack)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_