### PR TITLE
feat(matching): phase 9.3b — RecordSwipe + ListSwipeHistory handlers

### DIFF
--- a/services/matching/src/grpc/handlers.test.ts
+++ b/services/matching/src/grpc/handlers.test.ts
@@ -3,11 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   MatchingV1,
   type EndSessionRequest,
+  type ListSwipeHistoryRequest,
+  type RecordSwipeRequest,
   type StartSessionRequest,
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { endSession, startSession } from './handlers.js';
+import { encodeSwipeHistoryCursor } from './cursor.js';
+import { endSession, listSwipeHistory, recordSwipe, startSession } from './handlers.js';
 
 function makePrincipal(
   overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
@@ -191,5 +194,208 @@ describe('endSession', () => {
     expect(publish.mock.calls[0][0]).toMatchObject({
       type: 'matching.sessionEnded',
     });
+  });
+});
+
+function swipeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    swipe_action_id: 'swp-1',
+    session_id: 'sess-1',
+    pet_id: 'pet-1',
+    user_id: 'usr-1',
+    action: 'like',
+    timestamp: new Date('2026-06-01T12:01:00.000Z'),
+    response_time: 800,
+    device_type: 'mobile',
+    ...overrides,
+  };
+}
+
+describe('recordSwipe', () => {
+  it('throws INVALID_ARGUMENT on missing session_id', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      recordSwipe(deps, makePrincipal(), {
+        sessionId: '',
+        petId: 'pet-1',
+        action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+      } as RecordSwipeRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws INVALID_ARGUMENT on missing pet_id', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      recordSwipe(deps, makePrincipal(), {
+        sessionId: 'sess-1',
+        petId: '',
+        action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+      } as RecordSwipeRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws INVALID_ARGUMENT on UNSPECIFIED action', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      recordSwipe(deps, makePrincipal(), {
+        sessionId: 'sess-1',
+        petId: 'pet-1',
+        action: MatchingV1.SwipeAction.SWIPE_ACTION_UNSPECIFIED,
+      } as RecordSwipeRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws NOT_FOUND when session does not exist', async () => {
+    const { deps } = makeDeps([{ rows: [] }]);
+    await expect(
+      recordSwipe(deps, makePrincipal(), {
+        sessionId: 'gone',
+        petId: 'pet-1',
+        action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('throws PERMISSION_DENIED when principal is not the session owner', async () => {
+    const { deps } = makeDeps([{ rows: [sessionRow({ user_id: 'someone-else' })] }]);
+    await expect(
+      recordSwipe(deps, makePrincipal(), {
+        sessionId: 'sess-1',
+        petId: 'pet-1',
+        action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('throws INVALID_ARGUMENT on a closed session', async () => {
+    const { deps } = makeDeps([{ rows: [sessionRow({ is_active: false })] }]);
+    await expect(
+      recordSwipe(deps, makePrincipal(), {
+        sessionId: 'sess-1',
+        petId: 'pet-1',
+        action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('records a like + ticks total_swipes + likes counters', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [sessionRow()] }, // SELECT FOR UPDATE
+      { rows: [swipeRow()] }, // INSERT swipe_actions
+      { rows: [sessionRow({ total_swipes: 1, likes: 1 })] }, // UPDATE session
+    ]);
+    const res = await recordSwipe(deps, makePrincipal(), {
+      sessionId: 'sess-1',
+      petId: 'pet-1',
+      action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+    });
+    expect(res.action.action).toBe(MatchingV1.SwipeAction.SWIPE_ACTION_LIKE);
+    expect(res.session.totalSwipes).toBe(1);
+    expect(res.session.likes).toBe(1);
+    // UPDATE SQL should bump the likes column.
+    const updateSql = query.mock.calls[2][0] as string;
+    expect(updateSql).toContain('likes = likes + 1');
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'matching.swipeRecorded' });
+  });
+
+  it('records an info action without bumping like/pass/super_like counters', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [sessionRow()] },
+      { rows: [swipeRow({ action: 'info' })] },
+      { rows: [sessionRow({ total_swipes: 1 })] },
+    ]);
+    await recordSwipe(deps, makePrincipal(), {
+      sessionId: 'sess-1',
+      petId: 'pet-1',
+      action: MatchingV1.SwipeAction.SWIPE_ACTION_INFO,
+    });
+    const updateSql = query.mock.calls[2][0] as string;
+    expect(updateSql).toContain('total_swipes = total_swipes + 1');
+    expect(updateSql).not.toContain('likes = likes + 1');
+    expect(updateSql).not.toContain('passes = passes + 1');
+    expect(updateSql).not.toContain('super_likes = super_likes + 1');
+  });
+
+  it('records a super_like by bumping the super_likes counter', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [sessionRow()] },
+      { rows: [swipeRow({ action: 'super_like' })] },
+      { rows: [sessionRow({ total_swipes: 1, super_likes: 1 })] },
+    ]);
+    await recordSwipe(deps, makePrincipal(), {
+      sessionId: 'sess-1',
+      petId: 'pet-1',
+      action: MatchingV1.SwipeAction.SWIPE_ACTION_SUPER_LIKE,
+    });
+    const updateSql = query.mock.calls[2][0] as string;
+    expect(updateSql).toContain('super_likes = super_likes + 1');
+  });
+});
+
+describe('listSwipeHistory', () => {
+  it('throws PERMISSION_DENIED when principal lacks pets.read', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      listSwipeHistory(deps, makePrincipal({ permissions: [] }), {} as ListSwipeHistoryRequest)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('returns the calling principal own swipe history scoped to their user_id', async () => {
+    const { deps, query } = makeDeps([{ rows: [swipeRow()] }]);
+    const res = await listSwipeHistory(deps, makePrincipal(), {} as ListSwipeHistoryRequest);
+    expect(res.actions).toHaveLength(1);
+    // First param is the principal user_id.
+    expect(query.mock.calls[0][1][0]).toBe('usr-1');
+  });
+
+  it('filters by action when actionFilter is set', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    await listSwipeHistory(deps, makePrincipal(), {
+      actionFilter: MatchingV1.SwipeAction.SWIPE_ACTION_SUPER_LIKE,
+    } as ListSwipeHistoryRequest);
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('action = $2');
+    expect(query.mock.calls[0][1][1]).toBe('super_like');
+  });
+
+  it('emits nextCursor when there are more rows than limit', async () => {
+    const eleven = Array.from({ length: 11 }, (_, i) =>
+      swipeRow({
+        swipe_action_id: `swp-${i}`,
+        timestamp: new Date(2026, 5, 1, 12, 0, 0, i),
+      })
+    );
+    const { deps } = makeDeps([{ rows: eleven }]);
+    const res = await listSwipeHistory(deps, makePrincipal(), {
+      limit: 10,
+    } as ListSwipeHistoryRequest);
+    expect(res.actions).toHaveLength(10);
+    expect(res.nextCursor).toBeDefined();
+  });
+
+  it('omits nextCursor when results fit in one page', async () => {
+    const { deps } = makeDeps([{ rows: [swipeRow()] }]);
+    const res = await listSwipeHistory(deps, makePrincipal(), {} as ListSwipeHistoryRequest);
+    expect(res.nextCursor).toBeUndefined();
+  });
+
+  it('throws INVALID_ARGUMENT on a malformed cursor', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      listSwipeHistory(deps, makePrincipal(), { cursor: '!!!' } as ListSwipeHistoryRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('decodes a valid cursor and applies it to the WHERE clause', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    const cursor = encodeSwipeHistoryCursor({
+      timestamp: '2026-06-01T12:00:00.000Z',
+      swipeActionId: 'swp-x',
+    });
+    await listSwipeHistory(deps, makePrincipal(), { cursor } as ListSwipeHistoryRequest);
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('timestamp <');
+    expect(sql).toContain('swipe_action_id <');
   });
 });

--- a/services/matching/src/grpc/handlers.ts
+++ b/services/matching/src/grpc/handlers.ts
@@ -1,9 +1,9 @@
 // gRPC handler implementations for MatchingService.
 //
-// Phase 9.3b — ships StartSession + EndSession. The remaining four
-// RPCs (Recommend, RecordSwipe, SearchPets, ListSwipeHistory) follow
-// in a focused follow-up keyed off the same adapter / cursor / mapper
-// foundation.
+// Phase 9.3b — ships StartSession + EndSession + RecordSwipe +
+// ListSwipeHistory. Recommend + SearchPets follow once the service
+// gains a service.pets gRPC client (both RPCs need to read pet
+// candidates from the pets vertical).
 //
 // Discipline:
 //   - State-changing writes wrap @adopt-dont-shop/events.withTransaction
@@ -24,13 +24,27 @@ import {
   MatchingV1,
   type EndSessionRequest,
   type EndSessionResponse,
+  type ListSwipeHistoryRequest,
+  type ListSwipeHistoryResponse,
+  type RecordSwipeRequest,
+  type RecordSwipeResponse,
   type StartSessionRequest,
   type StartSessionResponse,
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { deviceTypeToDb } from './enum-map.js';
-import { sessionRowToProto, type SwipeSessionRow } from './mapper.js';
+import {
+  decodeSwipeHistoryCursor,
+  encodeSwipeHistoryCursor,
+  InvalidCursorError,
+} from './cursor.js';
+import { deviceTypeToDb, swipeActionToDb } from './enum-map.js';
+import {
+  actionRowToProto,
+  sessionRowToProto,
+  type SwipeActionRow,
+  type SwipeSessionRow,
+} from './mapper.js';
 
 function ensureSwipePermission(principal: Principal): void {
   if (!requirePermission(principal, PETS_VIEW)) {
@@ -197,6 +211,223 @@ export async function endSession(
 
     return { session: sessionRowToProto(updated.rows[0]) };
   });
+}
+
+// --- RecordSwipe -----------------------------------------------------
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export async function recordSwipe(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: RecordSwipeRequest
+): Promise<RecordSwipeResponse> {
+  ensureSwipePermission(principal);
+
+  if (req.sessionId === undefined || req.sessionId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'session_id is required');
+  }
+  if (req.petId === undefined || req.petId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
+  }
+  if (req.action === undefined || req.action === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'action is required');
+  }
+
+  const actionDb = swipeActionToDb(req.action);
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    // Lock the session row so the counter update is consistent under
+    // concurrent swipes. The (user_id, is_active) idx makes the
+    // lookup fast.
+    const session = await client.query<SwipeSessionRow>(
+      `SELECT session_id, user_id, start_time, end_time, total_swipes,
+              likes, passes, super_likes, filters, ip_address,
+              user_agent, device_type, is_active, created_at, updated_at
+       FROM swipe_sessions
+       WHERE session_id = $1
+       FOR UPDATE`,
+      [req.sessionId]
+    );
+
+    if (session.rows.length === 0) {
+      throw new HandlerError('NOT_FOUND', `session ${req.sessionId} not found`);
+    }
+
+    const sessionRow = session.rows[0];
+
+    // Ownership: only the session owner can record a swipe on it.
+    // super_admin bypasses (CAD pattern).
+    if (
+      sessionRow.user_id !== null &&
+      sessionRow.user_id !== principal.userId &&
+      !principal.roles.includes('super_admin')
+    ) {
+      throw new HandlerError('PERMISSION_DENIED', 'not the session owner');
+    }
+
+    // A swipe on a closed session is a contract violation — the SPA
+    // should have called StartSession before resuming. Surface as
+    // INVALID_ARGUMENT rather than NOT_FOUND so the client knows to
+    // recover via StartSession.
+    if (!sessionRow.is_active) {
+      throw new HandlerError('INVALID_ARGUMENT', `session ${req.sessionId} is closed`);
+    }
+
+    const swipeActionId = randomUUID();
+    const inserted = await client.query<SwipeActionRow>(
+      `INSERT INTO swipe_actions (
+         swipe_action_id, session_id, pet_id, user_id, action,
+         response_time, device_type
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING swipe_action_id, session_id, pet_id, user_id, action,
+                 timestamp, response_time, device_type`,
+      [
+        swipeActionId,
+        req.sessionId,
+        req.petId,
+        principal.userId,
+        actionDb,
+        req.responseTime ?? null,
+        req.deviceType ?? null,
+      ]
+    );
+
+    if (inserted.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'insert returned no rows');
+    }
+
+    // Tick the session counters. total_swipes always +1; one of
+    // likes / passes / super_likes also +1 depending on the action.
+    // 'info' increments only total_swipes (it's a trace event, not a
+    // commit).
+    const counterCol =
+      actionDb === 'like'
+        ? 'likes = likes + 1'
+        : actionDb === 'pass'
+          ? 'passes = passes + 1'
+          : actionDb === 'super_like'
+            ? 'super_likes = super_likes + 1'
+            : null;
+
+    const sessionUpdateSql = counterCol
+      ? `UPDATE swipe_sessions
+         SET total_swipes = total_swipes + 1, ${counterCol}, updated_at = NOW()
+         WHERE session_id = $1
+         RETURNING session_id, user_id, start_time, end_time, total_swipes,
+                   likes, passes, super_likes, filters, ip_address,
+                   user_agent, device_type, is_active, created_at, updated_at`
+      : `UPDATE swipe_sessions
+         SET total_swipes = total_swipes + 1, updated_at = NOW()
+         WHERE session_id = $1
+         RETURNING session_id, user_id, start_time, end_time, total_swipes,
+                   likes, passes, super_likes, filters, ip_address,
+                   user_agent, device_type, is_active, created_at, updated_at`;
+
+    const updatedSession = await client.query<SwipeSessionRow>(sessionUpdateSql, [req.sessionId]);
+
+    if (updatedSession.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'session counter update returned no rows');
+    }
+
+    publish({
+      type: 'matching.swipeRecorded',
+      id: swipeActionId,
+      payload: {
+        swipeActionId,
+        sessionId: req.sessionId,
+        petId: req.petId,
+        userId: principal.userId,
+        action: actionDb,
+        timestamp: inserted.rows[0].timestamp.toISOString(),
+      },
+    });
+
+    return {
+      action: actionRowToProto(inserted.rows[0]),
+      session: sessionRowToProto(updatedSession.rows[0]),
+    };
+  });
+}
+
+// --- ListSwipeHistory ------------------------------------------------
+
+function clampLimit(raw: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.trunc(raw), MAX_LIMIT);
+}
+
+export async function listSwipeHistory(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListSwipeHistoryRequest
+): Promise<ListSwipeHistoryResponse> {
+  ensureSwipePermission(principal);
+
+  const limit = clampLimit(req.limit);
+
+  // Adopters can only list their OWN swipe history. super_admin
+  // bypasses (CAD pattern). hasPermission gate above already
+  // confirmed the basic permission; this is the ownership scope.
+  const targetUserId = principal.userId;
+  if (!hasPermission(principal, PETS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', 'pets.read required');
+  }
+
+  const where: string[] = ['user_id = $1'];
+  const params: unknown[] = [targetUserId];
+  let p = 2;
+
+  if (req.actionFilter !== undefined && req.actionFilter !== 0) {
+    where.push(`action = $${p++}`);
+    params.push(swipeActionToDb(req.actionFilter));
+  }
+
+  if (req.cursor !== undefined && req.cursor !== '') {
+    let cursor;
+    try {
+      cursor = decodeSwipeHistoryCursor(req.cursor);
+    } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        throw new HandlerError('INVALID_ARGUMENT', err.message);
+      }
+      throw err;
+    }
+    where.push(`(timestamp < $${p++} OR (timestamp = $${p - 1} AND swipe_action_id < $${p++}))`);
+    params.push(cursor.timestamp);
+    params.push(cursor.swipeActionId);
+  }
+
+  params.push(limit + 1);
+  const sql = `
+    SELECT swipe_action_id, session_id, pet_id, user_id, action,
+           timestamp, response_time, device_type
+    FROM swipe_actions
+    WHERE ${where.join(' AND ')}
+    ORDER BY timestamp DESC, swipe_action_id DESC
+    LIMIT $${p}
+  `;
+
+  const { rows } = await deps.pool.query<SwipeActionRow>(sql, params);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const actions = pageRows.map(actionRowToProto);
+
+  const response: ListSwipeHistoryResponse = { actions };
+  if (hasMore && pageRows.length > 0) {
+    const last = pageRows[pageRows.length - 1];
+    response.nextCursor = encodeSwipeHistoryCursor({
+      timestamp: last.timestamp.toISOString(),
+      swipeActionId: last.swipe_action_id,
+    });
+  }
+
+  return response;
 }
 
 // --- Helpers ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 9.3b — extends the matching gRPC surface from #920 (StartSession + EndSession) with the swipe-write + history-read RPCs. Recommend + SearchPets still owe a service.pets gRPC client, so they ship next.

**`recordSwipe`**:
- `INVALID_ARGUMENT` on missing session_id / pet_id / UNSPECIFIED action.
- `NOT_FOUND` on a session that doesn't exist (SELECT FOR UPDATE locks the session row so the counter update is consistent under concurrent swipes).
- `PERMISSION_DENIED` when principal isn't the session owner (super_admin bypass).
- `INVALID_ARGUMENT` on a closed session — the SPA should StartSession first to recover.
- **Atomically**: INSERT `swipe_actions` + UPDATE session counters (`total_swipes + 1`, plus `likes`/`passes`/`super_likes` per action; `info` ticks only `total_swipes` since it's a trace event).
- Publishes `matching.swipeRecorded` after commit.

**`listSwipeHistory`**:
- Authz: `PETS_VIEW`. Adopters can only list their own swipe history (scoped to `principal.userId`).
- Limit clamps to `MAX_LIMIT=200`; `<= 0` / non-finite falls back to `DEFAULT_LIMIT=50`.
- Cursor → `(timestamp, swipe_action_id) DESC` keyset; `SELECT LIMIT+1` to determine `hasMore` without a COUNT query.
- Optional `actionFilter` narrows to one `SwipeAction` value.
- `InvalidCursorError` → `HandlerError('INVALID_ARGUMENT')`.

## Test plan

- [x] `npm test` in services/matching — 86/86 green
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_