### PR TITLE
feat(matching): phase 9.3c — gRPC server boot + index wiring

### DIFF
--- a/services/matching/src/grpc/server.test.ts
+++ b/services/matching/src/grpc/server.test.ts
@@ -1,0 +1,58 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+
+import { MatchingV1 } from '@adopt-dont-shop/proto';
+
+import type { MatchingConfig } from '../config.js';
+
+import { createGrpcServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const config: MatchingConfig = {
+  port: 5008,
+  grpcPort: 6008,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'matching',
+  natsUrl: 'nats://localhost:4222',
+};
+
+const pool = {} as unknown as Pool;
+const nats = {} as unknown as NatsConnection;
+
+describe('createGrpcServer', () => {
+  it('registers all six MatchingService methods on the grpc.Server', () => {
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    expect(handlers.has('/adopt_dont_shop.matching.v1.MatchingService/StartSession')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.matching.v1.MatchingService/EndSession')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.matching.v1.MatchingService/RecordSwipe')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.matching.v1.MatchingService/ListSwipeHistory')).toBe(
+      true
+    );
+    expect(handlers.has('/adopt_dont_shop.matching.v1.MatchingService/Recommend')).toBe(true);
+    expect(handlers.has('/adopt_dont_shop.matching.v1.MatchingService/SearchPets')).toBe(true);
+  });
+
+  it('matches every path from the canonical MatchingServiceService Definition table', () => {
+    const definition = MatchingV1.MatchingServiceService;
+    const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
+
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    for (const p of expectedPaths) {
+      expect(handlers.has(p)).toBe(true);
+    }
+  });
+});

--- a/services/matching/src/grpc/server.ts
+++ b/services/matching/src/grpc/server.ts
@@ -1,0 +1,116 @@
+// gRPC server boot — binds MatchingServiceService to the
+// adapter-wrapped handlers and starts listening on
+// MATCHING_GRPC_PORT.
+//
+// Same shape as services/audit/src/grpc/server.ts /
+// services/rescue/src/grpc/server.ts.
+//
+// Phase 9.3c — registers the four handlers shipped in #920/#921
+// (StartSession, EndSession, RecordSwipe, ListSwipeHistory) plus
+// NOT_IMPLEMENTED stubs for Recommend + SearchPets. Those two will
+// gain real implementations once the service gains a service.pets
+// gRPC client (both need to read pet candidates from the pets
+// vertical). The stubs return grpc.status.UNIMPLEMENTED so callers
+// get an informative error and can degrade gracefully.
+
+import { promisify } from 'node:util';
+
+import {
+  Server,
+  ServerCredentials,
+  status,
+  type ServerUnaryCall,
+  type ServiceError,
+  type sendUnaryData,
+} from '@grpc/grpc-js';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { MatchingV1 } from '@adopt-dont-shop/proto';
+
+import type { MatchingConfig } from '../config.js';
+
+import { adapt } from './adapter.js';
+import { endSession, listSwipeHistory, recordSwipe, startSession } from './handlers.js';
+
+export type CreateGrpcServerOptions = {
+  config: MatchingConfig;
+  pool: Pool;
+  nats: NatsConnection;
+  logger: Logger;
+};
+
+export type RunningGrpcServer = {
+  server: Server;
+  port: number;
+  shutdown: () => Promise<void>;
+};
+
+export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
+  const { config, pool, nats, logger } = opts;
+  const deps = { pool, nats };
+  const server = new Server();
+
+  const notImplemented =
+    (rpc: string) =>
+    (_call: ServerUnaryCall<unknown, unknown>, callback: sendUnaryData<unknown>): void => {
+      const err = new Error(`${rpc} not yet implemented`) as ServiceError;
+      err.code = status.UNIMPLEMENTED;
+      err.details = err.message;
+      callback(err, null);
+    };
+
+  server.addService(MatchingV1.MatchingServiceService, {
+    startSession: adapt(startSession, { deps, logger }),
+    endSession: adapt(endSession, { deps, logger }),
+    recordSwipe: adapt(recordSwipe, { deps, logger }),
+    listSwipeHistory: adapt(listSwipeHistory, { deps, logger }),
+    recommend: notImplemented('Recommend'),
+    searchPets: notImplemented('SearchPets'),
+  });
+
+  logger.info('gRPC MatchingService registered', {
+    methods: [
+      'startSession',
+      'endSession',
+      'recordSwipe',
+      'listSwipeHistory',
+      'recommend (stub)',
+      'searchPets (stub)',
+    ],
+    grpcPort: config.grpcPort,
+  });
+
+  return server;
+};
+
+export const startGrpcServer = async (
+  opts: CreateGrpcServerOptions
+): Promise<RunningGrpcServer> => {
+  const { config, logger } = opts;
+  const server = createGrpcServer(opts);
+
+  const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
+  const port = await bindAsync(
+    `${opts.config.host}:${config.grpcPort}`,
+    ServerCredentials.createInsecure()
+  );
+
+  logger.info('gRPC server listening', { port, host: opts.config.host });
+
+  return {
+    server,
+    port,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          resolve();
+        });
+      }),
+  };
+};

--- a/services/matching/src/index.ts
+++ b/services/matching/src/index.ts
@@ -1,21 +1,40 @@
+import { connect, type NatsConnection } from 'nats';
+
+import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.matching' });
 
+  let nats: NatsConnection | undefined;
+  let pool: ReturnType<typeof createDbClient> | undefined;
+  let grpc: RunningGrpcServer | undefined;
+  let httpClosed = false;
+
   try {
     const config = loadConfig();
-    const server = createServer({ config, logger });
 
-    await server.listen({ port: config.port, host: config.host });
+    // Connect deps FIRST so we crash here rather than after starting
+    // to accept traffic. Same boot order as services/rescue,
+    // services/audit, services/pets.
+    pool = createDbClient({
+      connectionString: config.databaseUrl,
+      schema: config.schema,
+    });
+    nats = await connect({ servers: config.natsUrl });
 
-    logger.info('service.matching listening', {
-      port: config.port,
-      host: config.host,
-      grpcPort: config.grpcPort,
+    grpc = await startGrpcServer({ config, pool, nats, logger });
+
+    const httpServer = createServer({ config, logger });
+    await httpServer.listen({ port: config.port, host: config.host });
+
+    logger.info('service.matching running', {
+      http: { port: config.port, host: config.host },
+      grpc: { port: grpc.port, host: config.host },
       schema: config.schema,
       natsUrl: config.natsUrl,
       environment: config.environment,
@@ -24,9 +43,27 @@ const main = async (): Promise<void> => {
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.matching shutting down', { signal });
       try {
-        await server.close();
+        if (!httpClosed) {
+          await httpServer.close();
+          httpClosed = true;
+        }
       } catch (err) {
-        logger.error('error during shutdown', { err });
+        logger.error('http close error', { err });
+      }
+      try {
+        await grpc?.shutdown();
+      } catch (err) {
+        logger.error('grpc shutdown error', { err });
+      }
+      try {
+        await nats?.drain();
+      } catch (err) {
+        logger.error('nats drain error', { err });
+      }
+      try {
+        await pool?.end();
+      } catch (err) {
+        logger.error('pool end error', { err });
       }
       process.exit(0);
     };
@@ -35,6 +72,21 @@ const main = async (): Promise<void> => {
     process.once('SIGINT', () => void shutdown('SIGINT'));
   } catch (err) {
     logger.error('service.matching failed to start', { err });
+    try {
+      await grpc?.shutdown();
+    } catch {
+      // Swallow — already on the failure path.
+    }
+    try {
+      await nats?.drain();
+    } catch {
+      // Same.
+    }
+    try {
+      await pool?.end();
+    } catch {
+      // Same.
+    }
     process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

Phase 9.3c — gRPC server boot + index.ts wiring. Binds `MatchingServiceService` to the four adapter-wrapped handlers shipped in #920/#921 (StartSession, EndSession, RecordSwipe, ListSwipeHistory) plus `NOT_IMPLEMENTED` stubs for Recommend + SearchPets.

The NOT_IMPLEMENTED stubs return `grpc.status.UNIMPLEMENTED` with a descriptive details message so SPA callers can degrade gracefully (show a "feature coming soon" banner instead of a generic error). Both will gain real implementations once the service gains a service.pets gRPC client.

**`index.ts`** updated to wire `startGrpcServer` + `createDbClient` + nats `connect` into the boot sequence. Same shape as services/audit (#919), services/rescue, services/auth — pool first, NATS, gRPC, HTTP last. Shutdown order reverses cleanly.

**End-to-end pipeline now exists for matching**:
```
client → gateway REST → gRPC → MatchingService → handlers
  → enum-map / cursor / mapper → PG INSERT/UPDATE/SELECT → proto
```

## What's NOT here yet

- Phase 9.3b follow-up — Recommend + SearchPets real handlers (need service.pets gRPC client wired in)
- Phase 9.4 — Gateway-side NATS subscribers (matching.* events fire from the handlers; consumers later)
- Phase 9.5 — Gateway routes /api/matching/*
- Phase 9.6 — Cutover from monolith

## Test plan

- [x] `npm test` in services/matching — 88/88 green
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_