### PR TITLE
feat(gateway): phase 9.5 — /api/matching/* routes

### DIFF
--- a/services/gateway/src/grpc-clients/matching-client.ts
+++ b/services/gateway/src/grpc-clients/matching-client.ts
@@ -1,0 +1,76 @@
+// Promise-wrapped client for service.matching.
+//
+// Phase 9.5 surface — 4 of 6 RPCs that have real handlers
+// (StartSession, EndSession, RecordSwipe, ListSwipeHistory).
+// Recommend + SearchPets return UNIMPLEMENTED from the matching
+// gRPC server (see services/matching/src/grpc/server.ts NOT_IMPLEMENTED
+// stubs); the client exposes them anyway so the gateway can surface
+// the upstream UNIMPLEMENTED as a 501 instead of routing requests
+// to URLs that don't exist.
+//
+// Same Promise-wrapped shape as other grpc-clients (rescue / pets /
+// auth / notifications / audit).
+
+import { credentials, Metadata } from '@grpc/grpc-js';
+
+import {
+  MatchingV1,
+  type EndSessionRequest,
+  type EndSessionResponse,
+  type ListSwipeHistoryRequest,
+  type ListSwipeHistoryResponse,
+  type RecommendRequest,
+  type RecommendResponse,
+  type RecordSwipeRequest,
+  type RecordSwipeResponse,
+  type SearchPetsRequest,
+  type SearchPetsResponse,
+  type StartSessionRequest,
+  type StartSessionResponse,
+} from '@adopt-dont-shop/proto';
+
+export type MatchingClient = {
+  startSession(req: StartSessionRequest, metadata: Metadata): Promise<StartSessionResponse>;
+  endSession(req: EndSessionRequest, metadata: Metadata): Promise<EndSessionResponse>;
+  recordSwipe(req: RecordSwipeRequest, metadata: Metadata): Promise<RecordSwipeResponse>;
+  listSwipeHistory(
+    req: ListSwipeHistoryRequest,
+    metadata: Metadata
+  ): Promise<ListSwipeHistoryResponse>;
+  recommend(req: RecommendRequest, metadata: Metadata): Promise<RecommendResponse>;
+  searchPets(req: SearchPetsRequest, metadata: Metadata): Promise<SearchPetsResponse>;
+  close(): void;
+};
+
+export type CreateMatchingClientOptions = {
+  address: string;
+};
+
+export const createMatchingClient = (opts: CreateMatchingClientOptions): MatchingClient => {
+  const stub = new MatchingV1.MatchingServiceClient(opts.address, credentials.createInsecure());
+
+  const callUnary = <Req, Res>(
+    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> =>
+    new Promise<Res>((resolve, reject) => {
+      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(res);
+      });
+    });
+
+  return {
+    startSession: (req, metadata) => callUnary(stub.startSession, req, metadata),
+    endSession: (req, metadata) => callUnary(stub.endSession, req, metadata),
+    recordSwipe: (req, metadata) => callUnary(stub.recordSwipe, req, metadata),
+    listSwipeHistory: (req, metadata) => callUnary(stub.listSwipeHistory, req, metadata),
+    recommend: (req, metadata) => callUnary(stub.recommend, req, metadata),
+    searchPets: (req, metadata) => callUnary(stub.searchPets, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -1,0 +1,285 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MatchingV1,
+  type EndSessionResponse,
+  type ListSwipeHistoryResponse,
+  type RecordSwipeResponse,
+  type StartSessionResponse,
+  type SwipeActionRecord,
+  type SwipeSession,
+} from '@adopt-dont-shop/proto';
+
+import type { MatchingClient } from '../grpc-clients/matching-client.js';
+
+import { registerMatchingRoutes } from './matching.js';
+
+function makeClient(): {
+  client: MatchingClient;
+  startSessionMock: ReturnType<typeof vi.fn>;
+  endSessionMock: ReturnType<typeof vi.fn>;
+  recordSwipeMock: ReturnType<typeof vi.fn>;
+  listSwipeHistoryMock: ReturnType<typeof vi.fn>;
+} {
+  const startSessionMock = vi.fn();
+  const endSessionMock = vi.fn();
+  const recordSwipeMock = vi.fn();
+  const listSwipeHistoryMock = vi.fn();
+  const client: MatchingClient = {
+    startSession: startSessionMock,
+    endSession: endSessionMock,
+    recordSwipe: recordSwipeMock,
+    listSwipeHistory: listSwipeHistoryMock,
+    recommend: vi.fn(),
+    searchPets: vi.fn(),
+    close: vi.fn(),
+  };
+  return { client, startSessionMock, endSessionMock, recordSwipeMock, listSwipeHistoryMock };
+}
+
+async function makeApp(client: MatchingClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerMatchingRoutes(app, { client });
+  return app;
+}
+
+const SESSION_FIXTURE: SwipeSession = {
+  sessionId: 'sess-1',
+  userId: 'usr-1',
+  startTime: '2026-06-01T12:00:00.000Z',
+  totalSwipes: 0,
+  likes: 0,
+  passes: 0,
+  superLikes: 0,
+  filtersJson: '{}',
+  deviceType: MatchingV1.DeviceType.DEVICE_TYPE_MOBILE,
+  isActive: true,
+  createdAt: '2026-06-01T12:00:00.000Z',
+  updatedAt: '2026-06-01T12:00:00.000Z',
+};
+
+const SWIPE_FIXTURE: SwipeActionRecord = {
+  swipeActionId: 'swp-1',
+  sessionId: 'sess-1',
+  petId: 'pet-1',
+  userId: 'usr-1',
+  action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+  timestamp: '2026-06-01T12:01:00.000Z',
+};
+
+const ADOPTER_HEADERS = {
+  'x-user-id': 'usr-1',
+  'x-user-roles': 'adopter',
+  'x-user-permissions': 'pets.read',
+};
+
+describe('POST /api/matching/sessions', () => {
+  let app: FastifyInstance;
+  let startSessionMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    startSessionMock = m.startSessionMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 201 when StartSession creates a new session', async () => {
+    const res: StartSessionResponse = { session: SESSION_FIXTURE, created: true };
+    startSessionMock.mockResolvedValue(res);
+
+    const httpRes = await app.inject({
+      method: 'POST',
+      url: '/api/matching/sessions',
+      headers: ADOPTER_HEADERS,
+      payload: { filtersJson: '{"species":"dog"}', deviceType: 'mobile' },
+    });
+
+    expect(httpRes.statusCode).toBe(201);
+    expect(startSessionMock.mock.calls[0][0]).toMatchObject({
+      filtersJson: '{"species":"dog"}',
+      deviceType: MatchingV1.DeviceType.DEVICE_TYPE_MOBILE,
+    });
+  });
+
+  it('returns 200 when StartSession returns an existing session (created=false)', async () => {
+    startSessionMock.mockResolvedValue({ session: SESSION_FIXTURE, created: false });
+
+    const httpRes = await app.inject({
+      method: 'POST',
+      url: '/api/matching/sessions',
+      headers: ADOPTER_HEADERS,
+      payload: {},
+    });
+
+    expect(httpRes.statusCode).toBe(200);
+  });
+
+  it('threads x-user-* metadata to the gRPC client', async () => {
+    startSessionMock.mockResolvedValue({ session: SESSION_FIXTURE, created: true });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/matching/sessions',
+      headers: ADOPTER_HEADERS,
+      payload: {},
+    });
+
+    const metadata = startSessionMock.mock.calls[0][1];
+    expect(metadata.get('x-user-id')).toEqual(['usr-1']);
+    expect(metadata.get('x-user-permissions')).toEqual(['pets.read']);
+  });
+
+  it('accepts SCREAMING proto-form deviceType', async () => {
+    startSessionMock.mockResolvedValue({ session: SESSION_FIXTURE, created: true });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/matching/sessions',
+      headers: ADOPTER_HEADERS,
+      payload: { deviceType: 'DEVICE_TYPE_TABLET' },
+    });
+
+    expect(startSessionMock.mock.calls[0][0]).toMatchObject({
+      deviceType: MatchingV1.DeviceType.DEVICE_TYPE_TABLET,
+    });
+  });
+
+  it.each([
+    [grpcStatus.INVALID_ARGUMENT, 400],
+    [grpcStatus.UNAUTHENTICATED, 401],
+    [grpcStatus.PERMISSION_DENIED, 403],
+    [grpcStatus.INTERNAL, 500],
+  ])('maps gRPC code %i to HTTP %i', async (gCode, httpCode) => {
+    startSessionMock.mockRejectedValue({ code: gCode, details: 'oops' });
+
+    const httpRes = await app.inject({
+      method: 'POST',
+      url: '/api/matching/sessions',
+      headers: ADOPTER_HEADERS,
+      payload: {},
+    });
+
+    expect(httpRes.statusCode).toBe(httpCode);
+    expect(httpRes.json()).toMatchObject({ error: 'oops' });
+  });
+});
+
+describe('POST /api/matching/sessions/:id/end', () => {
+  let app: FastifyInstance;
+  let endSessionMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    endSessionMock = m.endSessionMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('threads :id as sessionId', async () => {
+    const res: EndSessionResponse = { session: { ...SESSION_FIXTURE, isActive: false } };
+    endSessionMock.mockResolvedValue(res);
+
+    const httpRes = await app.inject({
+      method: 'POST',
+      url: '/api/matching/sessions/sess-42/end',
+      headers: ADOPTER_HEADERS,
+      payload: {},
+    });
+
+    expect(httpRes.statusCode).toBe(200);
+    expect(endSessionMock.mock.calls[0][0]).toMatchObject({ sessionId: 'sess-42' });
+  });
+});
+
+describe('POST /api/matching/sessions/:id/swipes', () => {
+  let app: FastifyInstance;
+  let recordSwipeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    recordSwipeMock = m.recordSwipeMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('threads body + sessionId, returns 201', async () => {
+    const res: RecordSwipeResponse = { action: SWIPE_FIXTURE, session: SESSION_FIXTURE };
+    recordSwipeMock.mockResolvedValue(res);
+
+    const httpRes = await app.inject({
+      method: 'POST',
+      url: '/api/matching/sessions/sess-1/swipes',
+      headers: ADOPTER_HEADERS,
+      payload: { petId: 'pet-1', action: 'like', responseTime: 1234 },
+    });
+
+    expect(httpRes.statusCode).toBe(201);
+    expect(recordSwipeMock.mock.calls[0][0]).toMatchObject({
+      sessionId: 'sess-1',
+      petId: 'pet-1',
+      action: MatchingV1.SwipeAction.SWIPE_ACTION_LIKE,
+      responseTime: 1234,
+    });
+  });
+
+  it('coerces unknown action string to UNSPECIFIED (matching service surfaces 400)', async () => {
+    recordSwipeMock.mockResolvedValue({ action: SWIPE_FIXTURE, session: SESSION_FIXTURE });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/matching/sessions/sess-1/swipes',
+      headers: ADOPTER_HEADERS,
+      payload: { petId: 'pet-1', action: 'block' },
+    });
+
+    expect(recordSwipeMock.mock.calls[0][0]).toMatchObject({
+      action: MatchingV1.SwipeAction.SWIPE_ACTION_UNSPECIFIED,
+    });
+  });
+});
+
+describe('GET /api/matching/swipes', () => {
+  let app: FastifyInstance;
+  let listSwipeHistoryMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    listSwipeHistoryMock = m.listSwipeHistoryMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards limit + cursor + action filter as ListSwipeHistory request', async () => {
+    const res: ListSwipeHistoryResponse = { actions: [SWIPE_FIXTURE], nextCursor: 'cursor-2' };
+    listSwipeHistoryMock.mockResolvedValue(res);
+
+    const httpRes = await app.inject({
+      method: 'GET',
+      url: '/api/matching/swipes?limit=25&cursor=abc&action=super_like',
+      headers: ADOPTER_HEADERS,
+    });
+
+    expect(httpRes.statusCode).toBe(200);
+    expect(listSwipeHistoryMock.mock.calls[0][0]).toMatchObject({
+      limit: 25,
+      cursor: 'abc',
+      actionFilter: MatchingV1.SwipeAction.SWIPE_ACTION_SUPER_LIKE,
+    });
+    expect(httpRes.json()).toMatchObject({ nextCursor: 'cursor-2' });
+  });
+});

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -1,0 +1,214 @@
+// REST → gRPC translation for /api/matching/*.
+//
+// Phase 9.5 cutover. Same shape as routes/audit.ts (#917) /
+// routes/rescue.ts / routes/auth.ts — Fastify plugin registers
+// BEFORE the strangler-fig http-proxy catch-all, so first-
+// registered-wins prefix routing picks it for /api/matching/*
+// before the catch-all sees them.
+//
+// Route map:
+//
+//   POST /api/matching/sessions                        → StartSession
+//   POST /api/matching/sessions/:id/end                → EndSession
+//   POST /api/matching/sessions/:id/swipes             → RecordSwipe
+//   GET  /api/matching/swipes                          → ListSwipeHistory
+//
+// Recommend + SearchPets aren't wired yet — the matching gRPC server
+// returns UNIMPLEMENTED for them (#922 stubs). When those handlers
+// ship the gateway will gain `/api/matching/recommend` +
+// `/api/matching/search` routes.
+//
+// Authz: PETS_VIEW (matching is a pet-browsing surface). The Phase
+// 2.5 authenticate middleware stamps x-user-* metadata; the matching
+// handlers re-check the permission as defence-in-depth.
+
+import rateLimit from '@fastify/rate-limit';
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  MatchingV1,
+  type EndSessionRequest,
+  type ListSwipeHistoryRequest,
+  type RecordSwipeRequest,
+  type StartSessionRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { MatchingClient } from '../grpc-clients/matching-client.js';
+
+export type MatchingRoutesOptions = {
+  client: MatchingClient;
+};
+
+// Adds UNIMPLEMENTED → 501 for the Recommend / SearchPets stubs.
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.UNIMPLEMENTED]: 501,
+  [status.INTERNAL]: 500,
+};
+
+// Per-route rate limits. Swipes are the chatty path so they get a
+// higher ceiling; sessions are bookended (~2 per browsing session)
+// so the lower ceiling is fine. History is a paginated read.
+const MATCHING_RATE_LIMITS = {
+  startSession: { max: 30, timeWindow: '1 minute' },
+  endSession: { max: 30, timeWindow: '1 minute' },
+  recordSwipe: { max: 240, timeWindow: '1 minute' },
+  listSwipeHistory: { max: 60, timeWindow: '1 minute' },
+} as const;
+
+type StartSessionBody = {
+  filtersJson?: string;
+  deviceType?: string;
+  userAgent?: string;
+  ipAddress?: string;
+};
+
+type RecordSwipeBody = {
+  petId?: string;
+  action?: string;
+  responseTime?: number;
+  deviceType?: string;
+};
+
+export const registerMatchingRoutes = async (
+  app: FastifyInstance,
+  opts: MatchingRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  await app.register(rateLimit, { global: false });
+
+  app.post(
+    '/api/matching/sessions',
+    { config: { rateLimit: MATCHING_RATE_LIMITS.startSession } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as StartSessionBody;
+      const grpcReq: StartSessionRequest = {
+        filtersJson: body.filtersJson ?? '',
+        deviceType: parseDeviceType(body.deviceType),
+        userAgent: body.userAgent,
+        ipAddress: body.ipAddress,
+      };
+      try {
+        const res = await client.startSession(grpcReq, buildMetadata(req));
+        return reply
+          .code(res.created ? 201 : 200)
+          .send(MatchingV1.StartSessionResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/matching/sessions/:id/end',
+    { config: { rateLimit: MATCHING_RATE_LIMITS.endSession } },
+    async (req, reply) => {
+      const grpcReq: EndSessionRequest = { sessionId: req.params.id };
+      try {
+        const res = await client.endSession(grpcReq, buildMetadata(req));
+        return reply.send(MatchingV1.EndSessionResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/matching/sessions/:id/swipes',
+    { config: { rateLimit: MATCHING_RATE_LIMITS.recordSwipe } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as RecordSwipeBody;
+      const grpcReq: RecordSwipeRequest = {
+        sessionId: req.params.id,
+        petId: body.petId ?? '',
+        action: parseSwipeAction(body.action),
+        responseTime: body.responseTime,
+        deviceType: body.deviceType,
+      };
+      try {
+        const res = await client.recordSwipe(grpcReq, buildMetadata(req));
+        return reply.code(201).send(MatchingV1.RecordSwipeResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.get(
+    '/api/matching/swipes',
+    { config: { rateLimit: MATCHING_RATE_LIMITS.listSwipeHistory } },
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: ListSwipeHistoryRequest = {
+        cursor: query.cursor,
+        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        actionFilter: parseSwipeAction(query.action),
+      };
+      try {
+        const res = await client.listSwipeHistory(grpcReq, buildMetadata(req));
+        return reply.send(MatchingV1.ListSwipeHistoryResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}
+
+// parseSwipeAction accepts DB form ('like' / 'pass' / 'super_like'
+// / 'info') AND SCREAMING proto form ('SWIPE_ACTION_LIKE'). Unknown
+// coerces to UNSPECIFIED so the matching service's INVALID_ARGUMENT
+// guard produces a clean 400.
+function parseSwipeAction(raw: string | undefined): MatchingV1.SwipeAction {
+  if (!raw) {
+    return MatchingV1.SwipeAction.SWIPE_ACTION_UNSPECIFIED;
+  }
+  const upper = `SWIPE_ACTION_${raw.toUpperCase()}`;
+  const candidate = Object.values(MatchingV1.SwipeAction).includes(upper as never) ? upper : raw;
+  const out = MatchingV1.swipeActionFromJSON(candidate);
+  return out === MatchingV1.SwipeAction.UNRECOGNIZED
+    ? MatchingV1.SwipeAction.SWIPE_ACTION_UNSPECIFIED
+    : out;
+}
+
+// Same shape for the device type enum.
+function parseDeviceType(raw: string | undefined): MatchingV1.DeviceType {
+  if (!raw) {
+    return MatchingV1.DeviceType.DEVICE_TYPE_UNSPECIFIED;
+  }
+  const upper = `DEVICE_TYPE_${raw.toUpperCase()}`;
+  const candidate = Object.values(MatchingV1.DeviceType).includes(upper as never) ? upper : raw;
+  const out = MatchingV1.deviceTypeFromJSON(candidate);
+  return out === MatchingV1.DeviceType.UNRECOGNIZED
+    ? MatchingV1.DeviceType.DEVICE_TYPE_UNSPECIFIED
+    : out;
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -22,12 +22,14 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import type { GatewayConfig } from './config.js';
 import type { AuditClient } from './grpc-clients/audit-client.js';
 import type { AuthClient } from './grpc-clients/auth-client.js';
+import type { MatchingClient } from './grpc-clients/matching-client.js';
 import type { NotificationsClient } from './grpc-clients/notifications-client.js';
 import type { PetsClient } from './grpc-clients/pets-client.js';
 import type { RescueClient } from './grpc-clients/rescue-client.js';
 import { registerAuthenticate } from './middleware/authenticate.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerAuthRoutes } from './routes/auth.js';
+import { registerMatchingRoutes } from './routes/matching.js';
 import { registerNotificationsRoutes } from './routes/notifications.js';
 import { registerPetsRoutes } from './routes/pets.js';
 import { registerRescueRoutes } from './routes/rescue.js';
@@ -61,6 +63,9 @@ export type CreateServerOptions = {
   // gRPC client to service.audit — Phase 10.5 cuts /api/audit/* over
   // to this address. Same optional shape as the other clients.
   auditClient?: AuditClient;
+  // gRPC client to service.matching — Phase 9.5 cuts /api/matching/*
+  // over to this address. Same optional shape as the other clients.
+  matchingClient?: MatchingClient;
 };
 
 export const createServer = async (opts: CreateServerOptions): Promise<FastifyInstance> => {
@@ -131,6 +136,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   if (opts.auditClient) {
     await registerAuditRoutes(server, { client: opts.auditClient });
+  }
+  if (opts.matchingClient) {
+    await registerMatchingRoutes(server, { client: opts.matchingClient });
   }
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in


### PR DESCRIPTION
## Summary

Phase 9.5 cutover — `/api/matching/*` now lands on the gateway's matching-routes plugin instead of falling through to the residual monolith. Same strangler-fig shape as Phase 10.5 (audit) / 4.5 (rescue) / 3.5 (pets).

**Four routes** for the 4 wired RPCs (Recommend + SearchPets stay in UNIMPLEMENTED limbo on the server side until the service.pets gRPC client lands):

- `POST /api/matching/sessions` → StartSession (`201` on `created=true`, `200` on existing)
- `POST /api/matching/sessions/:id/end` → EndSession
- `POST /api/matching/sessions/:id/swipes` → RecordSwipe (`201`)
- `GET /api/matching/swipes` → ListSwipeHistory (with `limit` / `cursor` / `action` filter)

**Enum parsing**: `parseSwipeAction` / `parseDeviceType` accept both DB form (`like`, `mobile`) and SCREAMING proto form (`SWIPE_ACTION_LIKE`, `DEVICE_TYPE_MOBILE`); unknown coerces to UNSPECIFIED so the matching service's INVALID_ARGUMENT guard surfaces a clean 400.

**`GRPC_TO_HTTP`** adds `UNIMPLEMENTED → 501` for the Recommend / SearchPets stubs — SPA can degrade to a "feature coming soon" banner.

**Rate limits**: swipes get 240/min (chatty), sessions 30/min (start + end), history 60/min. Auth headers stamped by the Phase 2.5 authenticate middleware; matching handlers re-check `PETS_VIEW` defence-in-depth.

`MatchingClient` + `createMatchingClient` ship alongside the routes plugin — same Promise-wrapped shape as `audit-client` / `rescue-client` / `pets-client` / `auth-client`. Wired into `createServer` as an optional `matchingClient`.

## Test plan

- [x] `npm test` in services/gateway — 107/107 green (all earlier tests + 10 matching route tests)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_