### PR TITLE
feat(moderation): phase 8.3b — report lifecycle handlers

### DIFF
--- a/services/moderation/src/grpc/handlers.test.ts
+++ b/services/moderation/src/grpc/handlers.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ModerationV1,
+  type AssignReportRequest,
+  type FileReportRequest,
+  type GetReportRequest,
+  type ListReportsRequest,
+  type ResolveReportRequest,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { encodeCursor } from './cursor.js';
+import { assignReport, fileReport, getReport, listReports, resolveReport } from './handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['adopter'],
+    permissions: overrides.permissions ?? ['admin.dashboard'],
+    rescueId: undefined,
+  } as unknown as Parameters<typeof getReport>[1];
+}
+
+function makeDeps(steps: Array<unknown>): {
+  deps: HandlerDeps;
+  query: ReturnType<typeof vi.fn>;
+} {
+  const queryMock = vi.fn();
+  for (const step of steps) {
+    queryMock.mockResolvedValueOnce(step);
+  }
+  const pool = { query: queryMock } as unknown as HandlerDeps['pool'];
+  const deps: HandlerDeps = { pool, nats: {} } as unknown as HandlerDeps;
+  return { deps, query: queryMock };
+}
+
+// Patch withTransaction to a deterministic in-memory scope.
+vi.mock('@adopt-dont-shop/events', async () => {
+  const actual =
+    await vi.importActual<typeof import('@adopt-dont-shop/events')>('@adopt-dont-shop/events');
+  return {
+    ...actual,
+    withTransaction: async (
+      deps: { pool: { query: ReturnType<typeof vi.fn> } },
+      fn: (scope: {
+        client: { query: ReturnType<typeof vi.fn> };
+        publish: ReturnType<typeof vi.fn>;
+      }) => Promise<unknown>
+    ) => {
+      const publish = vi.fn();
+      const client = { query: deps.pool.query };
+      const result = await fn({ client, publish });
+      (deps as { _publish?: ReturnType<typeof vi.fn> })._publish = publish;
+      return result;
+    },
+  };
+});
+
+function reportRow(overrides: Record<string, unknown> = {}) {
+  return {
+    report_id: 'rpt-1',
+    reporter_id: 'usr-1',
+    reported_entity_type: 'user',
+    reported_entity_id: 'usr-2',
+    reported_user_id: 'usr-2',
+    category: 'harassment',
+    severity: 'high',
+    status: 'pending',
+    title: 'Abusive DMs',
+    description: 'Threats sent.',
+    metadata: {},
+    assigned_moderator: null,
+    assigned_at: null,
+    resolved_by: null,
+    resolved_at: null,
+    resolution: null,
+    resolution_notes: null,
+    escalated_to: null,
+    escalated_at: null,
+    escalation_reason: null,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+const VALID_FILE_REQ: FileReportRequest = {
+  reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_USER,
+  reportedEntityId: 'usr-2',
+  category: ModerationV1.ReportCategory.REPORT_CATEGORY_HARASSMENT,
+  severity: ModerationV1.Severity.SEVERITY_HIGH,
+  title: 'Abusive DMs',
+  description: 'Threats sent.',
+};
+
+describe('fileReport', () => {
+  it('does NOT require admin permission (any authenticated user can file)', async () => {
+    const { deps } = makeDeps([{ rows: [reportRow()] }]);
+    const res = await fileReport(deps, makePrincipal({ permissions: [] }), VALID_FILE_REQ);
+    expect(res.report.reportId).toBe('rpt-1');
+  });
+
+  it.each([
+    ['reportedEntityId', { ...VALID_FILE_REQ, reportedEntityId: '' }],
+    ['title', { ...VALID_FILE_REQ, title: '' }],
+    ['description', { ...VALID_FILE_REQ, description: '' }],
+    [
+      'reportedEntityType',
+      {
+        ...VALID_FILE_REQ,
+        reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_UNSPECIFIED,
+      },
+    ],
+    [
+      'category',
+      { ...VALID_FILE_REQ, category: ModerationV1.ReportCategory.REPORT_CATEGORY_UNSPECIFIED },
+    ],
+    ['severity', { ...VALID_FILE_REQ, severity: ModerationV1.Severity.SEVERITY_UNSPECIFIED }],
+  ])('throws INVALID_ARGUMENT on missing %s', async (_field, req) => {
+    const { deps } = makeDeps([]);
+    await expect(fileReport(deps, makePrincipal(), req as FileReportRequest)).rejects.toMatchObject(
+      {
+        code: 'INVALID_ARGUMENT',
+      }
+    );
+  });
+
+  it('inserts a pending report + publishes moderation.reportFiled', async () => {
+    const { deps } = makeDeps([{ rows: [reportRow()] }]);
+    await fileReport(deps, makePrincipal(), VALID_FILE_REQ);
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.reportFiled' });
+  });
+
+  it('throws INVALID_ARGUMENT on malformed metadata_json', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      fileReport(deps, makePrincipal(), { ...VALID_FILE_REQ, metadataJson: 'not-json' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+});
+
+describe('getReport', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      getReport(deps, makePrincipal({ permissions: [] }), { reportId: 'rpt-1' } as GetReportRequest)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws NOT_FOUND when the report does not exist', async () => {
+    const { deps } = makeDeps([{ rows: [] }]);
+    await expect(
+      getReport(deps, makePrincipal(), { reportId: 'gone' } as GetReportRequest)
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('returns the report without transitions by default', async () => {
+    const { deps, query } = makeDeps([{ rows: [reportRow()] }]);
+    const res = await getReport(deps, makePrincipal(), { reportId: 'rpt-1' } as GetReportRequest);
+    expect(res.report.reportId).toBe('rpt-1');
+    expect(res.transitions).toEqual([]);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes transitions when include_transitions is true', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [reportRow()] },
+      {
+        rows: [
+          {
+            transition_id: 't-1',
+            report_id: 'rpt-1',
+            from_status: null,
+            to_status: 'pending',
+            transitioned_at: new Date('2026-06-01T12:00:00.000Z'),
+            transitioned_by: null,
+            reason: null,
+          },
+        ],
+      },
+    ]);
+    const res = await getReport(deps, makePrincipal(), {
+      reportId: 'rpt-1',
+      includeTransitions: true,
+    });
+    expect(res.transitions).toHaveLength(1);
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('listReports', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      listReports(deps, makePrincipal({ permissions: [] }), {} as ListReportsRequest)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('applies status / severity / category / assigned filters', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    await listReports(deps, makePrincipal(), {
+      status: ModerationV1.ReportStatus.REPORT_STATUS_PENDING,
+      severity: ModerationV1.Severity.SEVERITY_HIGH,
+      category: ModerationV1.ReportCategory.REPORT_CATEGORY_SPAM,
+      assignedModerator: 'mod-1',
+      limit: 10,
+    } as ListReportsRequest);
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('status = $1');
+    expect(sql).toContain('severity = $2');
+    expect(sql).toContain('category = $3');
+    expect(sql).toContain('assigned_moderator = $4');
+  });
+
+  it('treats empty assignedModerator string as IS NULL filter', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    await listReports(deps, makePrincipal(), {
+      assignedModerator: '',
+    } as ListReportsRequest);
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('assigned_moderator IS NULL');
+  });
+
+  it('emits nextCursor when more rows than limit', async () => {
+    const eleven = Array.from({ length: 11 }, (_, i) =>
+      reportRow({ report_id: `r-${i}`, created_at: new Date(2026, 5, 1, 12, 0, 0, i) })
+    );
+    const { deps } = makeDeps([{ rows: eleven }]);
+    const res = await listReports(deps, makePrincipal(), { limit: 10 } as ListReportsRequest);
+    expect(res.reports).toHaveLength(10);
+    expect(res.nextCursor).toBeDefined();
+  });
+
+  it('throws INVALID_ARGUMENT on a malformed cursor', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      listReports(deps, makePrincipal(), { cursor: '!!!' } as ListReportsRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('decodes a valid cursor into the WHERE clause', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    const cursor = encodeCursor({ createdAt: '2026-06-01T12:00:00.000Z', id: 'r-x' });
+    await listReports(deps, makePrincipal(), { cursor } as ListReportsRequest);
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('created_at <');
+    expect(sql).toContain('report_id <');
+  });
+});
+
+describe('assignReport', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      assignReport(deps, makePrincipal({ permissions: [] }), {
+        reportId: 'rpt-1',
+        moderatorId: 'mod-1',
+      } as AssignReportRequest)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws NOT_FOUND on a missing report', async () => {
+    const { deps } = makeDeps([{ rows: [] }]);
+    await expect(
+      assignReport(deps, makePrincipal(), { reportId: 'gone', moderatorId: 'mod-1' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('updates assignment + inserts transition + publishes reportAssigned', async () => {
+    const { deps } = makeDeps([
+      { rows: [reportRow()] }, // SELECT FOR UPDATE
+      { rows: [reportRow({ assigned_moderator: 'mod-1' })] }, // UPDATE RETURNING
+      { rows: [] }, // INSERT transition
+      { rows: [reportRow({ assigned_moderator: 'mod-1', status: 'under_review' })] }, // final SELECT
+    ]);
+    const res = await assignReport(deps, makePrincipal(), {
+      reportId: 'rpt-1',
+      moderatorId: 'mod-1',
+    });
+    expect(res.report.assignedModerator).toBe('mod-1');
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.reportAssigned' });
+  });
+});
+
+describe('resolveReport', () => {
+  it('throws INVALID_ARGUMENT on missing resolution', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      resolveReport(deps, makePrincipal(), {
+        reportId: 'rpt-1',
+        resolution: '',
+      } as ResolveReportRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws NOT_FOUND on a missing report', async () => {
+    const { deps } = makeDeps([{ rows: [] }]);
+    await expect(
+      resolveReport(deps, makePrincipal(), { reportId: 'gone', resolution: 'action_taken' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('writes resolution + transition + publishes reportResolved', async () => {
+    const { deps } = makeDeps([
+      { rows: [{ status: 'under_review' }] }, // SELECT status FOR UPDATE
+      { rows: [] }, // UPDATE
+      { rows: [] }, // INSERT transition
+      { rows: [reportRow({ status: 'resolved', resolution: 'action_taken' })] }, // final SELECT
+    ]);
+    const res = await resolveReport(deps, makePrincipal(), {
+      reportId: 'rpt-1',
+      resolution: 'action_taken',
+      resolutionNotes: 'User suspended.',
+    });
+    expect(res.report.status).toBe(ModerationV1.ReportStatus.REPORT_STATUS_RESOLVED);
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.reportResolved' });
+  });
+});

--- a/services/moderation/src/grpc/handlers.ts
+++ b/services/moderation/src/grpc/handlers.ts
@@ -1,0 +1,457 @@
+// gRPC handler implementations for ModerationService.
+//
+// Phase 8.3b — first batch ships the report lifecycle:
+// FileReport, GetReport, ListReports, AssignReport, ResolveReport.
+// The remaining 9 RPCs (LogModeratorAction, ListModeratorActions,
+// AddEvidence, IssueSanction, ListUserSanctions, AppealSanction,
+// OpenSupportTicket, GetSupportTicket, ListSupportTickets,
+// RespondToTicket) ship in focused follow-ups.
+//
+// Discipline:
+//   - State-changing writes wrap @adopt-dont-shop/events.withTransaction
+//     so NATS events only fire after the row writes commit.
+//   - Authz: FileReport is open to any authenticated principal
+//     (any user can file a report). The rest gate on ADMIN_DASHBOARD
+//     as a placeholder until lib.types ships a MODERATION_* namespace.
+//   - SQL parameters use $-indexed placeholders, never string-spliced
+//     values. The mapper from #912 handles row → proto translation.
+
+import { randomUUID } from 'node:crypto';
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction } from '@adopt-dont-shop/events';
+import { ADMIN_DASHBOARD } from '@adopt-dont-shop/lib.types';
+import type {
+  AssignReportRequest,
+  AssignReportResponse,
+  FileReportRequest,
+  FileReportResponse,
+  GetReportRequest,
+  GetReportResponse,
+  ListReportsRequest,
+  ListReportsResponse,
+  ResolveReportRequest,
+  ResolveReportResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
+import { categoryToDb, entityTypeToDb, reportStatusToDb, severityToDb } from './enum-map.js';
+import {
+  reportRowToProto,
+  transitionRowToProto,
+  type ReportRow,
+  type ReportStatusTransitionRow,
+} from './mapper.js';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function clampLimit(raw: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.trunc(raw), MAX_LIMIT);
+}
+
+function ensureModerationPermission(principal: Principal): void {
+  if (!requirePermission(principal, ADMIN_DASHBOARD)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_DASHBOARD}' required`);
+  }
+}
+
+// --- FileReport ------------------------------------------------------
+
+export async function fileReport(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: FileReportRequest
+): Promise<FileReportResponse> {
+  // FileReport is open to any authenticated principal — anyone can
+  // file a report. The principal is required (the adapter ensures it
+  // exists) but no permission gate beyond that.
+  if (req.reportedEntityId === undefined || req.reportedEntityId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'reported_entity_id is required');
+  }
+  if (req.title === undefined || req.title === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'title is required');
+  }
+  if (req.description === undefined || req.description === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'description is required');
+  }
+  if (req.reportedEntityType === undefined || req.reportedEntityType === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'reported_entity_type is required');
+  }
+  if (req.category === undefined || req.category === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'category is required');
+  }
+  if (req.severity === undefined || req.severity === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'severity is required');
+  }
+
+  const entityTypeDb = entityTypeToDb(req.reportedEntityType);
+  const categoryDb = categoryToDb(req.category);
+  const severityDb = severityToDb(req.severity);
+  const metadataJson = parseMetadataJson(req.metadataJson);
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    const reportId = randomUUID();
+    const inserted = await client.query<ReportRow>(
+      `INSERT INTO reports (
+         report_id, reporter_id, reported_entity_type, reported_entity_id,
+         reported_user_id, category, severity, status, title, description,
+         metadata
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8, $9, $10::jsonb)
+       RETURNING report_id, reporter_id, reported_entity_type, reported_entity_id,
+                 reported_user_id, category, severity, status, title, description,
+                 metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,
+                 resolution, resolution_notes, escalated_to, escalated_at,
+                 escalation_reason, created_at, updated_at`,
+      [
+        reportId,
+        principal.userId,
+        entityTypeDb,
+        req.reportedEntityId,
+        req.reportedUserId ?? null,
+        categoryDb,
+        severityDb,
+        req.title,
+        req.description,
+        metadataJson,
+      ]
+    );
+
+    if (inserted.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'insert returned no rows');
+    }
+
+    publish({
+      type: 'moderation.reportFiled',
+      id: reportId,
+      payload: {
+        reportId,
+        reporterId: principal.userId,
+        reportedEntityType: entityTypeDb,
+        reportedEntityId: req.reportedEntityId,
+        category: categoryDb,
+        severity: severityDb,
+      },
+    });
+
+    return { report: reportRowToProto(inserted.rows[0]) };
+  });
+}
+
+// --- GetReport -------------------------------------------------------
+
+export async function getReport(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetReportRequest
+): Promise<GetReportResponse> {
+  ensureModerationPermission(principal);
+
+  if (req.reportId === undefined || req.reportId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'report_id is required');
+  }
+
+  const { rows } = await deps.pool.query<ReportRow>(
+    `SELECT report_id, reporter_id, reported_entity_type, reported_entity_id,
+            reported_user_id, category, severity, status, title, description,
+            metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,
+            resolution, resolution_notes, escalated_to, escalated_at,
+            escalation_reason, created_at, updated_at
+     FROM reports
+     WHERE report_id = $1`,
+    [req.reportId]
+  );
+
+  if (rows.length === 0) {
+    throw new HandlerError('NOT_FOUND', `report ${req.reportId} not found`);
+  }
+
+  const response: GetReportResponse = {
+    report: reportRowToProto(rows[0]),
+    transitions: [],
+  };
+
+  if (req.includeTransitions) {
+    const transitions = await deps.pool.query<ReportStatusTransitionRow>(
+      `SELECT transition_id, report_id, from_status, to_status,
+              transitioned_at, transitioned_by, reason
+       FROM report_status_transitions
+       WHERE report_id = $1
+       ORDER BY transitioned_at ASC`,
+      [req.reportId]
+    );
+    response.transitions = transitions.rows.map(transitionRowToProto);
+  }
+
+  return response;
+}
+
+// --- ListReports -----------------------------------------------------
+
+export async function listReports(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListReportsRequest
+): Promise<ListReportsResponse> {
+  ensureModerationPermission(principal);
+
+  const limit = clampLimit(req.limit);
+
+  const where: string[] = [];
+  const params: unknown[] = [];
+  let p = 1;
+
+  if (req.status !== undefined && req.status !== 0) {
+    where.push(`status = $${p++}`);
+    params.push(reportStatusToDb(req.status));
+  }
+  if (req.severity !== undefined && req.severity !== 0) {
+    where.push(`severity = $${p++}`);
+    params.push(severityToDb(req.severity));
+  }
+  if (req.category !== undefined && req.category !== 0) {
+    where.push(`category = $${p++}`);
+    params.push(categoryToDb(req.category));
+  }
+  if (req.assignedModerator !== undefined) {
+    if (req.assignedModerator === '') {
+      where.push(`assigned_moderator IS NULL`);
+    } else {
+      where.push(`assigned_moderator = $${p++}`);
+      params.push(req.assignedModerator);
+    }
+  }
+
+  if (req.cursor !== undefined && req.cursor !== '') {
+    let cursor;
+    try {
+      cursor = decodeCursor(req.cursor);
+    } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        throw new HandlerError('INVALID_ARGUMENT', err.message);
+      }
+      throw err;
+    }
+    where.push(`(created_at < $${p++} OR (created_at = $${p - 1} AND report_id < $${p++}))`);
+    params.push(cursor.createdAt);
+    params.push(cursor.id);
+  }
+
+  const whereSql = where.length === 0 ? '' : `WHERE ${where.join(' AND ')}`;
+  params.push(limit + 1);
+  const sql = `
+    SELECT report_id, reporter_id, reported_entity_type, reported_entity_id,
+           reported_user_id, category, severity, status, title, description,
+           metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,
+           resolution, resolution_notes, escalated_to, escalated_at,
+           escalation_reason, created_at, updated_at
+    FROM reports
+    ${whereSql}
+    ORDER BY created_at DESC, report_id DESC
+    LIMIT $${p}
+  `;
+
+  const { rows } = await deps.pool.query<ReportRow>(sql, params);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const reports = pageRows.map(reportRowToProto);
+
+  const response: ListReportsResponse = { reports };
+  if (hasMore && pageRows.length > 0) {
+    const last = pageRows[pageRows.length - 1];
+    response.nextCursor = encodeCursor({
+      createdAt: last.created_at.toISOString(),
+      id: last.report_id,
+    });
+  }
+
+  return response;
+}
+
+// --- AssignReport ----------------------------------------------------
+
+export async function assignReport(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AssignReportRequest
+): Promise<AssignReportResponse> {
+  ensureModerationPermission(principal);
+
+  if (req.reportId === undefined || req.reportId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'report_id is required');
+  }
+  if (req.moderatorId === undefined || req.moderatorId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'moderator_id is required');
+  }
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    const existing = await client.query<ReportRow>(
+      `SELECT report_id, reporter_id, reported_entity_type, reported_entity_id,
+              reported_user_id, category, severity, status, title, description,
+              metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,
+              resolution, resolution_notes, escalated_to, escalated_at,
+              escalation_reason, created_at, updated_at
+       FROM reports
+       WHERE report_id = $1
+       FOR UPDATE`,
+      [req.reportId]
+    );
+
+    if (existing.rows.length === 0) {
+      throw new HandlerError('NOT_FOUND', `report ${req.reportId} not found`);
+    }
+
+    const row = existing.rows[0];
+
+    // The trigger from #886 mig 003 propagates the to_status into
+    // reports.status when we insert a status transition. So we INSERT
+    // the transition AND explicitly UPDATE the assignment columns;
+    // the trigger handles the status update.
+    const updated = await client.query<ReportRow>(
+      `UPDATE reports
+       SET assigned_moderator = $1,
+           assigned_at = NOW(),
+           updated_at = NOW()
+       WHERE report_id = $2
+       RETURNING report_id, reporter_id, reported_entity_type, reported_entity_id,
+                 reported_user_id, category, severity, status, title, description,
+                 metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,
+                 resolution, resolution_notes, escalated_to, escalated_at,
+                 escalation_reason, created_at, updated_at`,
+      [req.moderatorId, req.reportId]
+    );
+
+    if (updated.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'update returned no rows');
+    }
+
+    // Insert status transition; the trigger propagates to_status to
+    // reports.status atomically.
+    await client.query(
+      `INSERT INTO report_status_transitions (
+         transition_id, report_id, from_status, to_status, transitioned_by, reason
+       )
+       VALUES ($1, $2, $3, 'under_review', $4, $5)`,
+      [randomUUID(), req.reportId, row.status, principal.userId, req.reason ?? null]
+    );
+
+    publish({
+      type: 'moderation.reportAssigned',
+      id: req.reportId,
+      payload: {
+        reportId: req.reportId,
+        moderatorId: req.moderatorId,
+        assignedBy: principal.userId,
+      },
+    });
+
+    // Re-fetch to capture the trigger-propagated status.
+    const final = await client.query<ReportRow>(
+      `SELECT report_id, reporter_id, reported_entity_type, reported_entity_id,
+              reported_user_id, category, severity, status, title, description,
+              metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,
+              resolution, resolution_notes, escalated_to, escalated_at,
+              escalation_reason, created_at, updated_at
+       FROM reports
+       WHERE report_id = $1`,
+      [req.reportId]
+    );
+
+    return { report: reportRowToProto(final.rows[0]) };
+  });
+}
+
+// --- ResolveReport ---------------------------------------------------
+
+export async function resolveReport(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ResolveReportRequest
+): Promise<ResolveReportResponse> {
+  ensureModerationPermission(principal);
+
+  if (req.reportId === undefined || req.reportId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'report_id is required');
+  }
+  if (req.resolution === undefined || req.resolution === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'resolution is required');
+  }
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    const existing = await client.query<ReportRow>(
+      `SELECT status FROM reports WHERE report_id = $1 FOR UPDATE`,
+      [req.reportId]
+    );
+
+    if (existing.rows.length === 0) {
+      throw new HandlerError('NOT_FOUND', `report ${req.reportId} not found`);
+    }
+
+    const fromStatus = existing.rows[0].status;
+
+    await client.query(
+      `UPDATE reports
+       SET resolved_by = $1,
+           resolved_at = NOW(),
+           resolution = $2,
+           resolution_notes = $3,
+           updated_at = NOW()
+       WHERE report_id = $4`,
+      [principal.userId, req.resolution, req.resolutionNotes ?? null, req.reportId]
+    );
+
+    await client.query(
+      `INSERT INTO report_status_transitions (
+         transition_id, report_id, from_status, to_status, transitioned_by, reason
+       )
+       VALUES ($1, $2, $3, 'resolved', $4, $5)`,
+      [randomUUID(), req.reportId, fromStatus, principal.userId, req.resolutionNotes ?? null]
+    );
+
+    publish({
+      type: 'moderation.reportResolved',
+      id: req.reportId,
+      payload: {
+        reportId: req.reportId,
+        resolvedBy: principal.userId,
+        resolution: req.resolution,
+      },
+    });
+
+    const final = await client.query<ReportRow>(
+      `SELECT report_id, reporter_id, reported_entity_type, reported_entity_id,
+              reported_user_id, category, severity, status, title, description,
+              metadata, assigned_moderator, assigned_at, resolved_by, resolved_at,
+              resolution, resolution_notes, escalated_to, escalated_at,
+              escalation_reason, created_at, updated_at
+       FROM reports
+       WHERE report_id = $1`,
+      [req.reportId]
+    );
+
+    return { report: reportRowToProto(final.rows[0]) };
+  });
+}
+
+// --- Helpers ---------------------------------------------------------
+
+function parseMetadataJson(raw: string | undefined): string {
+  if (raw === undefined || raw === '') {
+    return '{}';
+  }
+  try {
+    const obj = JSON.parse(raw) as unknown;
+    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+      throw new Error('metadata_json must encode a JSON object');
+    }
+    return JSON.stringify(obj);
+  } catch (err) {
+    throw new HandlerError('INVALID_ARGUMENT', `metadata_json invalid: ${(err as Error).message}`);
+  }
+}


### PR DESCRIPTION
## Summary

Phase 8.3b — first batch of ModerationService handlers: the **report lifecycle** (FileReport, GetReport, ListReports, AssignReport, ResolveReport). The remaining 9 RPCs (moderator actions, evidence, sanctions, support tickets) ship in focused follow-ups.

Pure handlers over the adapter from #902 + cursor from #905 + enum-map from #892 + mapper from #912.

**`fileReport`**:
- Open to any authenticated principal — anyone can file a report. No admin gate.
- Validates all required fields; UNSPECIFIED enums rejected as INVALID_ARGUMENT.
- `metadata_json` blob trick (null → `'{}'`, validates object shape).
- INSERT `status='pending'` + publishes `moderation.reportFiled`.

**`getReport` / `listReports` / `assignReport` / `resolveReport`**:
- Gate on `ADMIN_DASHBOARD` (placeholder until lib.types ships a `MODERATION_*` namespace — Bite #19 pattern from the lessons doc).
- `getReport` optionally hydrates the status-transition timeline.
- `listReports` filters by status / severity / category / assigned_moderator (empty string → IS NULL); `(created_at, report_id) DESC` keyset pagination.
- `assignReport` + `resolveReport` INSERT a `report_status_transitions` row; the #886 mig-003 AFTER INSERT trigger propagates `to_status` to `reports.status` atomically, then we re-SELECT to capture it. Both publish their NATS events.

## Test plan

- [x] `npm test` in services/moderation — 201/201 green (all existing tests + 23 handler tests)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_