### PR TITLE
feat(moderation): phase 8.3b — moderator action + evidence handlers

### DIFF
--- a/services/moderation/src/grpc/action-handlers.test.ts
+++ b/services/moderation/src/grpc/action-handlers.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ModerationV1,
+  type AddEvidenceRequest,
+  type ListModeratorActionsRequest,
+  type LogModeratorActionRequest,
+} from '@adopt-dont-shop/proto';
+
+import { addEvidence, listModeratorActions, logModeratorAction } from './action-handlers.js';
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { encodeCursor } from './cursor.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'mod-1',
+    roles: overrides.roles ?? ['moderator'],
+    permissions: overrides.permissions ?? ['admin.dashboard'],
+    rescueId: undefined,
+  } as unknown as Parameters<typeof addEvidence>[1];
+}
+
+function makeDeps(steps: Array<unknown>): {
+  deps: HandlerDeps;
+  query: ReturnType<typeof vi.fn>;
+} {
+  const queryMock = vi.fn();
+  for (const step of steps) {
+    queryMock.mockResolvedValueOnce(step);
+  }
+  const pool = { query: queryMock } as unknown as HandlerDeps['pool'];
+  const deps: HandlerDeps = { pool, nats: {} } as unknown as HandlerDeps;
+  return { deps, query: queryMock };
+}
+
+vi.mock('@adopt-dont-shop/events', async () => {
+  const actual =
+    await vi.importActual<typeof import('@adopt-dont-shop/events')>('@adopt-dont-shop/events');
+  return {
+    ...actual,
+    withTransaction: async (
+      deps: { pool: { query: ReturnType<typeof vi.fn> } },
+      fn: (scope: {
+        client: { query: ReturnType<typeof vi.fn> };
+        publish: ReturnType<typeof vi.fn>;
+      }) => Promise<unknown>
+    ) => {
+      const publish = vi.fn();
+      const client = { query: deps.pool.query };
+      const result = await fn({ client, publish });
+      (deps as { _publish?: ReturnType<typeof vi.fn> })._publish = publish;
+      return result;
+    },
+  };
+});
+
+function actionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    action_id: 'act-1',
+    moderator_id: 'mod-1',
+    report_id: 'rpt-1',
+    target_entity_type: 'user',
+    target_entity_id: 'usr-2',
+    target_user_id: 'usr-2',
+    action_type: 'warning_issued',
+    severity: 'medium',
+    reason: 'First infraction',
+    description: null,
+    metadata: {},
+    duration: null,
+    expires_at: null,
+    is_active: true,
+    acknowledged_at: null,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function evidenceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    evidence_id: 'ev-1',
+    parent_type: 'report',
+    parent_id: 'rpt-1',
+    type: 'screenshot',
+    content: 's3://x/abc.png',
+    description: null,
+    uploaded_at: new Date('2026-06-01T12:30:00.000Z'),
+    ...overrides,
+  };
+}
+
+const VALID_LOG_REQ: LogModeratorActionRequest = {
+  targetEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_USER,
+  targetEntityId: 'usr-2',
+  actionType: ModerationV1.ModeratorActionType.MODERATOR_ACTION_TYPE_WARNING_ISSUED,
+  severity: ModerationV1.Severity.SEVERITY_MEDIUM,
+  reason: 'First infraction',
+};
+
+describe('logModeratorAction', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      logModeratorAction(deps, makePrincipal({ permissions: [] }), VALID_LOG_REQ)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it.each([
+    ['targetEntityId', { ...VALID_LOG_REQ, targetEntityId: '' }],
+    ['reason', { ...VALID_LOG_REQ, reason: '' }],
+    [
+      'actionType',
+      {
+        ...VALID_LOG_REQ,
+        actionType: ModerationV1.ModeratorActionType.MODERATOR_ACTION_TYPE_UNSPECIFIED,
+      },
+    ],
+    ['severity', { ...VALID_LOG_REQ, severity: ModerationV1.Severity.SEVERITY_UNSPECIFIED }],
+  ])('throws INVALID_ARGUMENT on missing %s', async (_field, req) => {
+    const { deps } = makeDeps([]);
+    await expect(
+      logModeratorAction(deps, makePrincipal(), req as LogModeratorActionRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('inserts an action with NULL expires_at when no duration (permanent)', async () => {
+    const { deps, query } = makeDeps([{ rows: [actionRow()] }]);
+    await logModeratorAction(deps, makePrincipal(), VALID_LOG_REQ);
+    // expires_at param is index 12 (0-based) in the INSERT.
+    expect(query.mock.calls[0][1][12]).toBeNull();
+  });
+
+  it('derives expires_at from a duration in days', async () => {
+    const { deps, query } = makeDeps([{ rows: [actionRow({ duration: 7 })] }]);
+    await logModeratorAction(deps, makePrincipal(), { ...VALID_LOG_REQ, duration: 7 });
+    expect(query.mock.calls[0][1][12]).not.toBeNull();
+  });
+
+  it('publishes moderation.actionLogged', async () => {
+    const { deps } = makeDeps([{ rows: [actionRow()] }]);
+    await logModeratorAction(deps, makePrincipal(), VALID_LOG_REQ);
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.actionLogged' });
+  });
+});
+
+describe('listModeratorActions', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      listModeratorActions(
+        deps,
+        makePrincipal({ permissions: [] }),
+        {} as ListModeratorActionsRequest
+      )
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('filters by target_user / report / action_type', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    await listModeratorActions(deps, makePrincipal(), {
+      targetUserId: 'usr-2',
+      reportId: 'rpt-1',
+      actionType: ModerationV1.ModeratorActionType.MODERATOR_ACTION_TYPE_USER_BANNED,
+    } as ListModeratorActionsRequest);
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('target_user_id = $1');
+    expect(sql).toContain('report_id = $2');
+    expect(sql).toContain('action_type = $3');
+  });
+
+  it('emits nextCursor when more rows than limit', async () => {
+    const eleven = Array.from({ length: 11 }, (_, i) =>
+      actionRow({ action_id: `a-${i}`, created_at: new Date(2026, 5, 1, 12, 0, 0, i) })
+    );
+    const { deps } = makeDeps([{ rows: eleven }]);
+    const res = await listModeratorActions(deps, makePrincipal(), {
+      limit: 10,
+    } as ListModeratorActionsRequest);
+    expect(res.actions).toHaveLength(10);
+    expect(res.nextCursor).toBeDefined();
+  });
+
+  it('decodes a cursor into the WHERE clause', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    const cursor = encodeCursor({ createdAt: '2026-06-01T12:00:00.000Z', id: 'a-x' });
+    await listModeratorActions(deps, makePrincipal(), { cursor } as ListModeratorActionsRequest);
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('created_at <');
+    expect(sql).toContain('action_id <');
+  });
+});
+
+describe('addEvidence', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      addEvidence(deps, makePrincipal({ permissions: [] }), {
+        parentType: ModerationV1.EvidenceParentType.EVIDENCE_PARENT_TYPE_REPORT,
+        parentId: 'rpt-1',
+        type: ModerationV1.EvidenceType.EVIDENCE_TYPE_SCREENSHOT,
+        content: 's3://x',
+      } as AddEvidenceRequest)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it.each([
+    [
+      'parentId',
+      {
+        parentType: ModerationV1.EvidenceParentType.EVIDENCE_PARENT_TYPE_REPORT,
+        parentId: '',
+        type: ModerationV1.EvidenceType.EVIDENCE_TYPE_SCREENSHOT,
+        content: 's3://x',
+      },
+    ],
+    [
+      'content',
+      {
+        parentType: ModerationV1.EvidenceParentType.EVIDENCE_PARENT_TYPE_REPORT,
+        parentId: 'rpt-1',
+        type: ModerationV1.EvidenceType.EVIDENCE_TYPE_SCREENSHOT,
+        content: '',
+      },
+    ],
+    [
+      'parentType',
+      {
+        parentType: ModerationV1.EvidenceParentType.EVIDENCE_PARENT_TYPE_UNSPECIFIED,
+        parentId: 'rpt-1',
+        type: ModerationV1.EvidenceType.EVIDENCE_TYPE_SCREENSHOT,
+        content: 's3://x',
+      },
+    ],
+  ])('throws INVALID_ARGUMENT on missing %s', async (_field, req) => {
+    const { deps } = makeDeps([]);
+    await expect(
+      addEvidence(deps, makePrincipal(), req as AddEvidenceRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('inserts evidence + publishes moderation.evidenceAdded', async () => {
+    const { deps } = makeDeps([{ rows: [evidenceRow()] }]);
+    const res = await addEvidence(deps, makePrincipal(), {
+      parentType: ModerationV1.EvidenceParentType.EVIDENCE_PARENT_TYPE_REPORT,
+      parentId: 'rpt-1',
+      type: ModerationV1.EvidenceType.EVIDENCE_TYPE_SCREENSHOT,
+      content: 's3://x/abc.png',
+    });
+    expect(res.evidence.evidenceId).toBe('ev-1');
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.evidenceAdded' });
+  });
+});

--- a/services/moderation/src/grpc/action-handlers.ts
+++ b/services/moderation/src/grpc/action-handlers.ts
@@ -1,0 +1,301 @@
+// gRPC handler implementations for ModerationService — batch 2.
+//
+// Phase 8.3b — ships the moderator-action + evidence surface:
+// LogModeratorAction, ListModeratorActions, AddEvidence. The report
+// lifecycle handlers (FileReport, GetReport, ListReports,
+// AssignReport, ResolveReport) shipped in #924. Sanctions + support
+// tickets follow in the next batch.
+//
+// Same discipline as handlers.ts: withTransaction for writes, gate on
+// ADMIN_DASHBOARD (placeholder until lib.types ships MODERATION_*),
+// $-indexed SQL params, mappers from #913 for row → proto.
+
+import { randomUUID } from 'node:crypto';
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction } from '@adopt-dont-shop/events';
+import { ADMIN_DASHBOARD } from '@adopt-dont-shop/lib.types';
+import type {
+  AddEvidenceRequest,
+  AddEvidenceResponse,
+  ListModeratorActionsRequest,
+  ListModeratorActionsResponse,
+  LogModeratorActionRequest,
+  LogModeratorActionResponse,
+} from '@adopt-dont-shop/proto';
+
+import {
+  actionRowToProto,
+  evidenceRowToProto,
+  type EvidenceRow,
+  type ModeratorActionRow,
+} from './action-evidence-mapper.js';
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
+import {
+  actionTypeToDb,
+  entityTypeToDb,
+  evidenceParentTypeToDb,
+  evidenceTypeToDb,
+  severityToDb,
+} from './enum-map.js';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function clampLimit(raw: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.trunc(raw), MAX_LIMIT);
+}
+
+function ensureModerationPermission(principal: Principal): void {
+  if (!requirePermission(principal, ADMIN_DASHBOARD)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_DASHBOARD}' required`);
+  }
+}
+
+function parseMetadataJson(raw: string | undefined): string {
+  if (raw === undefined || raw === '') {
+    return '{}';
+  }
+  try {
+    const obj = JSON.parse(raw) as unknown;
+    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+      throw new Error('metadata_json must encode a JSON object');
+    }
+    return JSON.stringify(obj);
+  } catch (err) {
+    throw new HandlerError('INVALID_ARGUMENT', `metadata_json invalid: ${(err as Error).message}`);
+  }
+}
+
+// --- LogModeratorAction ----------------------------------------------
+
+export async function logModeratorAction(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: LogModeratorActionRequest
+): Promise<LogModeratorActionResponse> {
+  ensureModerationPermission(principal);
+
+  if (req.targetEntityId === undefined || req.targetEntityId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'target_entity_id is required');
+  }
+  if (req.targetEntityType === undefined || req.targetEntityType === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'target_entity_type is required');
+  }
+  if (req.actionType === undefined || req.actionType === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'action_type is required');
+  }
+  if (req.severity === undefined || req.severity === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'severity is required');
+  }
+  if (req.reason === undefined || req.reason === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'reason is required');
+  }
+
+  const targetEntityTypeDb = entityTypeToDb(req.targetEntityType);
+  const actionTypeDb = actionTypeToDb(req.actionType);
+  const severityDb = severityToDb(req.severity);
+  const metadataJson = parseMetadataJson(req.metadataJson);
+
+  // duration is in days; expires_at is derived only when a duration
+  // is supplied (permanent actions leave it NULL).
+  const expiresAt =
+    req.duration !== undefined && req.duration > 0
+      ? new Date(Date.now() + req.duration * 24 * 60 * 60 * 1000).toISOString()
+      : null;
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    const actionId = randomUUID();
+    const inserted = await client.query<ModeratorActionRow>(
+      `INSERT INTO moderator_actions (
+         action_id, moderator_id, report_id, target_entity_type,
+         target_entity_id, target_user_id, action_type, severity, reason,
+         description, metadata, duration, expires_at, is_active
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12, $13, true)
+       RETURNING action_id, moderator_id, report_id, target_entity_type,
+                 target_entity_id, target_user_id, action_type, severity, reason,
+                 description, metadata, duration, expires_at, is_active,
+                 acknowledged_at, created_at, updated_at`,
+      [
+        actionId,
+        principal.userId,
+        req.reportId ?? null,
+        targetEntityTypeDb,
+        req.targetEntityId,
+        req.targetUserId ?? null,
+        actionTypeDb,
+        severityDb,
+        req.reason,
+        req.description ?? null,
+        metadataJson,
+        req.duration ?? null,
+        expiresAt,
+      ]
+    );
+
+    if (inserted.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'insert returned no rows');
+    }
+
+    publish({
+      type: 'moderation.actionLogged',
+      id: actionId,
+      payload: {
+        actionId,
+        moderatorId: principal.userId,
+        reportId: req.reportId ?? null,
+        targetEntityType: targetEntityTypeDb,
+        targetEntityId: req.targetEntityId,
+        targetUserId: req.targetUserId ?? null,
+        actionType: actionTypeDb,
+        severity: severityDb,
+      },
+    });
+
+    return { action: actionRowToProto(inserted.rows[0]) };
+  });
+}
+
+// --- ListModeratorActions --------------------------------------------
+
+export async function listModeratorActions(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListModeratorActionsRequest
+): Promise<ListModeratorActionsResponse> {
+  ensureModerationPermission(principal);
+
+  const limit = clampLimit(req.limit);
+
+  const where: string[] = [];
+  const params: unknown[] = [];
+  let p = 1;
+
+  if (req.targetUserId !== undefined && req.targetUserId !== '') {
+    where.push(`target_user_id = $${p++}`);
+    params.push(req.targetUserId);
+  }
+  if (req.reportId !== undefined && req.reportId !== '') {
+    where.push(`report_id = $${p++}`);
+    params.push(req.reportId);
+  }
+  if (req.actionType !== undefined && req.actionType !== 0) {
+    where.push(`action_type = $${p++}`);
+    params.push(actionTypeToDb(req.actionType));
+  }
+
+  if (req.cursor !== undefined && req.cursor !== '') {
+    let cursor;
+    try {
+      cursor = decodeCursor(req.cursor);
+    } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        throw new HandlerError('INVALID_ARGUMENT', err.message);
+      }
+      throw err;
+    }
+    where.push(`(created_at < $${p++} OR (created_at = $${p - 1} AND action_id < $${p++}))`);
+    params.push(cursor.createdAt);
+    params.push(cursor.id);
+  }
+
+  const whereSql = where.length === 0 ? '' : `WHERE ${where.join(' AND ')}`;
+  params.push(limit + 1);
+  const sql = `
+    SELECT action_id, moderator_id, report_id, target_entity_type,
+           target_entity_id, target_user_id, action_type, severity, reason,
+           description, metadata, duration, expires_at, is_active,
+           acknowledged_at, created_at, updated_at
+    FROM moderator_actions
+    ${whereSql}
+    ORDER BY created_at DESC, action_id DESC
+    LIMIT $${p}
+  `;
+
+  const { rows } = await deps.pool.query<ModeratorActionRow>(sql, params);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const actions = pageRows.map(actionRowToProto);
+
+  const response: ListModeratorActionsResponse = { actions };
+  if (hasMore && pageRows.length > 0) {
+    const last = pageRows[pageRows.length - 1];
+    response.nextCursor = encodeCursor({
+      createdAt: last.created_at.toISOString(),
+      id: last.action_id,
+    });
+  }
+
+  return response;
+}
+
+// --- AddEvidence -----------------------------------------------------
+
+export async function addEvidence(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AddEvidenceRequest
+): Promise<AddEvidenceResponse> {
+  ensureModerationPermission(principal);
+
+  if (req.parentId === undefined || req.parentId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'parent_id is required');
+  }
+  if (req.parentType === undefined || req.parentType === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'parent_type is required');
+  }
+  if (req.type === undefined || req.type === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'type is required');
+  }
+  if (req.content === undefined || req.content === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'content is required');
+  }
+
+  const parentTypeDb = evidenceParentTypeToDb(req.parentType);
+  const typeDb = evidenceTypeToDb(req.type);
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    const evidenceId = randomUUID();
+    const inserted = await client.query<EvidenceRow>(
+      `INSERT INTO moderation_evidence (
+         evidence_id, parent_type, parent_id, type, content, description,
+         created_by, updated_by
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+       RETURNING evidence_id, parent_type, parent_id, type, content,
+                 description, uploaded_at`,
+      [
+        evidenceId,
+        parentTypeDb,
+        req.parentId,
+        typeDb,
+        req.content,
+        req.description ?? null,
+        principal.userId,
+      ]
+    );
+
+    if (inserted.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'insert returned no rows');
+    }
+
+    publish({
+      type: 'moderation.evidenceAdded',
+      id: evidenceId,
+      payload: {
+        evidenceId,
+        parentType: parentTypeDb,
+        parentId: req.parentId,
+        type: typeDb,
+      },
+    });
+
+    return { evidence: evidenceRowToProto(inserted.rows[0]) };
+  });
+}


### PR DESCRIPTION
## Summary

Phase 8.3b batch 2 — moderator-action + evidence handlers: `LogModeratorAction`, `ListModeratorActions`, `AddEvidence`. Report lifecycle shipped in #924; sanctions + support tickets follow next.

Lands in `action-handlers.ts` (separate file from `handlers.ts`) to keep each PR reviewable — same cohesion-by-concern split as the moderation row mappers (#912/#913/#914).

**`logModeratorAction`**:
- Validates target entity id/type, action_type, severity, reason; UNSPECIFIED enums → INVALID_ARGUMENT.
- `duration` (days) derives `expires_at`; NULL duration = permanent action (expires_at stays NULL).
- INSERT `is_active=true` + publishes `moderation.actionLogged`.

**`listModeratorActions`**:
- Filters by target_user / report / action_type.
- `(created_at, action_id) DESC` keyset pagination — powers the admin user-history modal.

**`addEvidence`**:
- Polymorphic via `(parent_type, parent_id)` — attaches to a report OR a moderator_action.
- Validates parent id/type, evidence type, content; `created_by = updated_by = principal`.
- Publishes `moderation.evidenceAdded`.

All gate on `ADMIN_DASHBOARD` (placeholder until lib.types ships a `MODERATION_*` namespace).

## Test plan

- [x] `npm test` in services/moderation — 218/218 green (all existing tests + 17 action-handler tests)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_