### PR TITLE
feat(moderation): phase 8.3b — user sanction handlers

### DIFF
--- a/services/moderation/src/grpc/sanction-handlers.test.ts
+++ b/services/moderation/src/grpc/sanction-handlers.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ModerationV1,
+  type AppealSanctionRequest,
+  type IssueSanctionRequest,
+  type ListUserSanctionsRequest,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { appealSanction, issueSanction, listUserSanctions } from './sanction-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'mod-1',
+    roles: overrides.roles ?? ['moderator'],
+    permissions: overrides.permissions ?? ['admin.dashboard'],
+    rescueId: undefined,
+  } as unknown as Parameters<typeof issueSanction>[1];
+}
+
+function makeDeps(steps: Array<unknown>): {
+  deps: HandlerDeps;
+  query: ReturnType<typeof vi.fn>;
+} {
+  const queryMock = vi.fn();
+  for (const step of steps) {
+    queryMock.mockResolvedValueOnce(step);
+  }
+  const pool = { query: queryMock } as unknown as HandlerDeps['pool'];
+  const deps: HandlerDeps = { pool, nats: {} } as unknown as HandlerDeps;
+  return { deps, query: queryMock };
+}
+
+vi.mock('@adopt-dont-shop/events', async () => {
+  const actual =
+    await vi.importActual<typeof import('@adopt-dont-shop/events')>('@adopt-dont-shop/events');
+  return {
+    ...actual,
+    withTransaction: async (
+      deps: { pool: { query: ReturnType<typeof vi.fn> } },
+      fn: (scope: {
+        client: { query: ReturnType<typeof vi.fn> };
+        publish: ReturnType<typeof vi.fn>;
+      }) => Promise<unknown>
+    ) => {
+      const publish = vi.fn();
+      const client = { query: deps.pool.query };
+      const result = await fn({ client, publish });
+      (deps as { _publish?: ReturnType<typeof vi.fn> })._publish = publish;
+      return result;
+    },
+  };
+});
+
+function sanctionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    sanction_id: 'sanc-1',
+    user_id: 'usr-2',
+    sanction_type: 'temporary_ban',
+    reason: 'harassment',
+    description: 'Abusive behaviour',
+    is_active: true,
+    start_date: new Date('2026-06-01T12:00:00.000Z'),
+    end_date: new Date('2026-06-08T12:00:00.000Z'),
+    duration: 7,
+    issued_by: 'mod-1',
+    report_id: null,
+    moderator_action_id: null,
+    appealed_at: null,
+    appeal_reason: null,
+    appeal_status: null,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+const VALID_ISSUE: IssueSanctionRequest = {
+  userId: 'usr-2',
+  sanctionType: ModerationV1.SanctionType.SANCTION_TYPE_TEMPORARY_BAN,
+  reason: ModerationV1.SanctionReason.SANCTION_REASON_HARASSMENT,
+  description: 'Abusive behaviour',
+  duration: 7,
+};
+
+describe('issueSanction', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      issueSanction(deps, makePrincipal({ permissions: [] }), VALID_ISSUE)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it.each([
+    ['userId', { ...VALID_ISSUE, userId: '' }],
+    ['description', { ...VALID_ISSUE, description: '' }],
+    [
+      'sanctionType',
+      { ...VALID_ISSUE, sanctionType: ModerationV1.SanctionType.SANCTION_TYPE_UNSPECIFIED },
+    ],
+    ['reason', { ...VALID_ISSUE, reason: ModerationV1.SanctionReason.SANCTION_REASON_UNSPECIFIED }],
+  ])('throws INVALID_ARGUMENT on missing %s', async (_field, req) => {
+    const { deps } = makeDeps([]);
+    await expect(
+      issueSanction(deps, makePrincipal(), req as IssueSanctionRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('derives issued_by_role from the principal roles', async () => {
+    const { deps, query } = makeDeps([{ rows: [sanctionRow()] }]);
+    await issueSanction(deps, makePrincipal({ roles: ['admin'] }), VALID_ISSUE);
+    // issued_by_role param at index 8 (0-based).
+    expect(query.mock.calls[0][1][8]).toBe('ADMIN');
+  });
+
+  it('uses SUPER_ADMIN role when the principal is a super_admin', async () => {
+    const { deps, query } = makeDeps([{ rows: [sanctionRow()] }]);
+    await issueSanction(deps, makePrincipal({ roles: ['super_admin'] }), VALID_ISSUE);
+    expect(query.mock.calls[0][1][8]).toBe('SUPER_ADMIN');
+  });
+
+  it('derives end_date from a duration; permanent ban leaves it NULL', async () => {
+    const withDuration = makeDeps([{ rows: [sanctionRow()] }]);
+    await issueSanction(withDuration.deps, makePrincipal(), VALID_ISSUE);
+    expect(withDuration.query.mock.calls[0][1][5]).not.toBeNull(); // end_date
+
+    const permanent = makeDeps([{ rows: [sanctionRow({ end_date: null, duration: null })] }]);
+    await issueSanction(permanent.deps, makePrincipal(), {
+      ...VALID_ISSUE,
+      sanctionType: ModerationV1.SanctionType.SANCTION_TYPE_PERMANENT_BAN,
+      duration: undefined,
+    });
+    expect(permanent.query.mock.calls[0][1][5]).toBeNull();
+  });
+
+  it('publishes moderation.sanctionIssued', async () => {
+    const { deps } = makeDeps([{ rows: [sanctionRow()] }]);
+    await issueSanction(deps, makePrincipal(), VALID_ISSUE);
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.sanctionIssued' });
+  });
+});
+
+describe('listUserSanctions', () => {
+  it('throws INVALID_ARGUMENT on missing user_id', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      listUserSanctions(deps, makePrincipal(), { userId: '' } as ListUserSanctionsRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('allows a user to list their OWN sanctions without admin permission', async () => {
+    const { deps } = makeDeps([{ rows: [sanctionRow({ user_id: 'usr-2' })] }]);
+    const res = await listUserSanctions(deps, makePrincipal({ userId: 'usr-2', permissions: [] }), {
+      userId: 'usr-2',
+    });
+    expect(res.sanctions).toHaveLength(1);
+  });
+
+  it("throws PERMISSION_DENIED listing another user's sanctions without admin", async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      listUserSanctions(deps, makePrincipal({ userId: 'usr-1', permissions: [] }), {
+        userId: 'usr-2',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('defaults to active-only; include_inactive returns full history', async () => {
+    const activeOnly = makeDeps([{ rows: [] }]);
+    await listUserSanctions(activeOnly.deps, makePrincipal(), { userId: 'usr-2' });
+    expect(activeOnly.query.mock.calls[0][0]).toContain('is_active = true');
+
+    const all = makeDeps([{ rows: [] }]);
+    await listUserSanctions(all.deps, makePrincipal(), { userId: 'usr-2', includeInactive: true });
+    expect(all.query.mock.calls[0][0]).not.toContain('is_active = true');
+  });
+});
+
+describe('appealSanction', () => {
+  it('throws INVALID_ARGUMENT on missing appeal_reason', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      appealSanction(deps, makePrincipal(), {
+        sanctionId: 'sanc-1',
+        appealReason: '',
+      } as AppealSanctionRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws NOT_FOUND on a missing sanction', async () => {
+    const { deps } = makeDeps([{ rows: [] }]);
+    await expect(
+      appealSanction(deps, makePrincipal({ userId: 'usr-2' }), {
+        sanctionId: 'gone',
+        appealReason: 'I was provoked',
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it("throws PERMISSION_DENIED appealing another user's sanction", async () => {
+    const { deps } = makeDeps([{ rows: [sanctionRow({ user_id: 'usr-2' })] }]);
+    await expect(
+      appealSanction(deps, makePrincipal({ userId: 'usr-99' }), {
+        sanctionId: 'sanc-1',
+        appealReason: 'not mine',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('throws INVALID_ARGUMENT when the sanction already has an appeal', async () => {
+    const { deps } = makeDeps([
+      { rows: [sanctionRow({ user_id: 'usr-2', appeal_status: 'pending' })] },
+    ]);
+    await expect(
+      appealSanction(deps, makePrincipal({ userId: 'usr-2' }), {
+        sanctionId: 'sanc-1',
+        appealReason: 'again',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('records the appeal + publishes moderation.sanctionAppealed', async () => {
+    const { deps } = makeDeps([
+      { rows: [sanctionRow({ user_id: 'usr-2' })] }, // SELECT FOR UPDATE
+      {
+        rows: [
+          sanctionRow({ user_id: 'usr-2', appeal_status: 'pending', appeal_reason: 'provoked' }),
+        ],
+      }, // UPDATE RETURNING
+    ]);
+    const res = await appealSanction(deps, makePrincipal({ userId: 'usr-2' }), {
+      sanctionId: 'sanc-1',
+      appealReason: 'provoked',
+    });
+    expect(res.sanction.appealStatus).toBe('pending');
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.sanctionAppealed' });
+  });
+
+  it('lets a super_admin appeal on a user behalf', async () => {
+    const { deps } = makeDeps([
+      { rows: [sanctionRow({ user_id: 'usr-2' })] },
+      { rows: [sanctionRow({ user_id: 'usr-2', appeal_status: 'pending' })] },
+    ]);
+    const res = await appealSanction(
+      deps,
+      makePrincipal({ userId: 'sa-1', roles: ['super_admin'] }),
+      {
+        sanctionId: 'sanc-1',
+        appealReason: 'support escalation',
+      }
+    );
+    expect(res.sanction.appealStatus).toBe('pending');
+  });
+});

--- a/services/moderation/src/grpc/sanction-handlers.ts
+++ b/services/moderation/src/grpc/sanction-handlers.ts
@@ -1,0 +1,236 @@
+// gRPC handler implementations for ModerationService — batch 3.
+//
+// Phase 8.3b — ships the user-sanction surface: IssueSanction,
+// ListUserSanctions, AppealSanction. Report lifecycle shipped in
+// #924; moderator actions + evidence in #925; support tickets follow
+// in the final batch.
+//
+// Same discipline: withTransaction for writes, gate on ADMIN_DASHBOARD
+// (placeholder until lib.types ships MODERATION_*), $-indexed SQL
+// params, sanction mapper from #914 for row → proto.
+
+import { randomUUID } from 'node:crypto';
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction } from '@adopt-dont-shop/events';
+import { ADMIN_DASHBOARD } from '@adopt-dont-shop/lib.types';
+import type {
+  AppealSanctionRequest,
+  AppealSanctionResponse,
+  IssueSanctionRequest,
+  IssueSanctionResponse,
+  ListUserSanctionsRequest,
+  ListUserSanctionsResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { sanctionReasonToDb, sanctionTypeToDb } from './enum-map.js';
+import { sanctionRowToProto, type UserSanctionRow } from './sanction-ticket-mapper.js';
+
+const SANCTION_SELECT = `
+  sanction_id, user_id, sanction_type, reason, description, is_active,
+  start_date, end_date, duration, issued_by, report_id,
+  moderator_action_id, appealed_at, appeal_reason, appeal_status,
+  created_at, updated_at
+`;
+
+function ensureModerationPermission(principal: Principal): void {
+  if (!requirePermission(principal, ADMIN_DASHBOARD)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_DASHBOARD}' required`);
+  }
+}
+
+// issued_by_role is a NOT NULL enum on the row. Derive it from the
+// principal's roles — the highest-privilege role they hold. The
+// monolith stamped this so a sanction's provenance survives even if
+// the issuer's role changes later.
+function deriveIssuedByRole(principal: Principal): 'SUPER_ADMIN' | 'ADMIN' | 'MODERATOR' {
+  if (principal.roles.includes('super_admin')) {
+    return 'SUPER_ADMIN';
+  }
+  if (principal.roles.includes('admin')) {
+    return 'ADMIN';
+  }
+  return 'MODERATOR';
+}
+
+// --- IssueSanction ---------------------------------------------------
+
+export async function issueSanction(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: IssueSanctionRequest
+): Promise<IssueSanctionResponse> {
+  ensureModerationPermission(principal);
+
+  if (req.userId === undefined || req.userId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_id is required');
+  }
+  if (req.sanctionType === undefined || req.sanctionType === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'sanction_type is required');
+  }
+  if (req.reason === undefined || req.reason === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'reason is required');
+  }
+  if (req.description === undefined || req.description === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'description is required');
+  }
+
+  const sanctionTypeDb = sanctionTypeToDb(req.sanctionType);
+  const reasonDb = sanctionReasonToDb(req.reason);
+  const issuedByRole = deriveIssuedByRole(principal);
+
+  // duration (days) derives end_date; permanent_ban leaves it NULL.
+  const endDate =
+    req.duration !== undefined && req.duration > 0
+      ? new Date(Date.now() + req.duration * 24 * 60 * 60 * 1000).toISOString()
+      : null;
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    const sanctionId = randomUUID();
+    const inserted = await client.query<UserSanctionRow>(
+      `INSERT INTO user_sanctions (
+         sanction_id, user_id, sanction_type, reason, description,
+         is_active, end_date, duration, issued_by, issued_by_role,
+         report_id, moderator_action_id
+       )
+       VALUES ($1, $2, $3, $4, $5, true, $6, $7, $8, $9, $10, $11)
+       RETURNING ${SANCTION_SELECT}`,
+      [
+        sanctionId,
+        req.userId,
+        sanctionTypeDb,
+        reasonDb,
+        req.description,
+        endDate,
+        req.duration ?? null,
+        principal.userId,
+        issuedByRole,
+        req.reportId ?? null,
+        req.moderatorActionId ?? null,
+      ]
+    );
+
+    if (inserted.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'insert returned no rows');
+    }
+
+    publish({
+      type: 'moderation.sanctionIssued',
+      id: sanctionId,
+      payload: {
+        sanctionId,
+        userId: req.userId,
+        sanctionType: sanctionTypeDb,
+        reason: reasonDb,
+        issuedBy: principal.userId,
+      },
+    });
+
+    return { sanction: sanctionRowToProto(inserted.rows[0]) };
+  });
+}
+
+// --- ListUserSanctions -----------------------------------------------
+
+export async function listUserSanctions(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListUserSanctionsRequest
+): Promise<ListUserSanctionsResponse> {
+  // A user can list their OWN sanctions (the banner query); moderators
+  // can list anyone's. The gate: either the principal is the target
+  // user, OR they hold the moderation permission.
+  if (req.userId === undefined || req.userId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_id is required');
+  }
+  if (req.userId !== principal.userId && !requirePermission(principal, ADMIN_DASHBOARD)) {
+    throw new HandlerError('PERMISSION_DENIED', 'can only list your own sanctions');
+  }
+
+  // Default: active sanctions only (the banner). include_inactive
+  // returns the full history.
+  const activeFilter = req.includeInactive ? '' : 'AND is_active = true';
+
+  const { rows } = await deps.pool.query<UserSanctionRow>(
+    `SELECT ${SANCTION_SELECT}
+     FROM user_sanctions
+     WHERE user_id = $1 ${activeFilter}
+     ORDER BY start_date DESC`,
+    [req.userId]
+  );
+
+  return { sanctions: rows.map(sanctionRowToProto) };
+}
+
+// --- AppealSanction --------------------------------------------------
+
+export async function appealSanction(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AppealSanctionRequest
+): Promise<AppealSanctionResponse> {
+  // The SANCTIONED user files the appeal — not a moderator. So the
+  // gate is ownership: the principal must be the sanction's target.
+  if (req.sanctionId === undefined || req.sanctionId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'sanction_id is required');
+  }
+  if (req.appealReason === undefined || req.appealReason === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'appeal_reason is required');
+  }
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    const existing = await client.query<UserSanctionRow>(
+      `SELECT ${SANCTION_SELECT}
+       FROM user_sanctions
+       WHERE sanction_id = $1
+       FOR UPDATE`,
+      [req.sanctionId]
+    );
+
+    if (existing.rows.length === 0) {
+      throw new HandlerError('NOT_FOUND', `sanction ${req.sanctionId} not found`);
+    }
+
+    const row = existing.rows[0];
+
+    // Only the sanctioned user can appeal their own sanction.
+    // super_admin can appeal on a user's behalf (support workflow).
+    if (row.user_id !== principal.userId && !principal.roles.includes('super_admin')) {
+      throw new HandlerError('PERMISSION_DENIED', 'can only appeal your own sanction');
+    }
+
+    // Already-appealed sanctions can't be re-appealed (appeal_status
+    // is set once the appeal lands).
+    if (row.appeal_status !== null) {
+      throw new HandlerError('INVALID_ARGUMENT', 'sanction already has an appeal');
+    }
+
+    const updated = await client.query<UserSanctionRow>(
+      `UPDATE user_sanctions
+       SET appealed_at = NOW(),
+           appeal_reason = $1,
+           appeal_status = 'pending',
+           updated_at = NOW()
+       WHERE sanction_id = $2
+       RETURNING ${SANCTION_SELECT}`,
+      [req.appealReason, req.sanctionId]
+    );
+
+    if (updated.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'update returned no rows');
+    }
+
+    publish({
+      type: 'moderation.sanctionAppealed',
+      id: req.sanctionId,
+      payload: {
+        sanctionId: req.sanctionId,
+        userId: row.user_id,
+        appealedBy: principal.userId,
+      },
+    });
+
+    return { sanction: sanctionRowToProto(updated.rows[0]) };
+  });
+}


### PR DESCRIPTION
## Summary

Phase 8.3b batch 3 — user-sanction handlers: `IssueSanction`, `ListUserSanctions`, `AppealSanction`. Report lifecycle (#924), moderator actions + evidence (#925); support tickets close out the 14-RPC set next.

**`issueSanction`**:
- Gate on `ADMIN_DASHBOARD`. Validates user_id, sanction_type, reason, description.
- `issued_by_role` (NOT NULL enum) derived from the principal's highest-privilege role (SUPER_ADMIN > ADMIN > MODERATOR) — the monolith stamped this so a sanction's provenance survives the issuer's later role changes.
- `duration` (days) derives `end_date`; permanent_ban leaves it NULL.
- INSERT `is_active=true` + publishes `moderation.sanctionIssued`.

**`listUserSanctions`**:
- **Ownership-OR-admin gate**: a user can list their OWN sanctions (the banner query) without admin permission; listing anyone else's requires `ADMIN_DASHBOARD`.
- Default active-only (the banner); `include_inactive` returns the full history.

**`appealSanction`**:
- The **sanctioned user** files the appeal, not a moderator — gate is ownership (super_admin can appeal on a user's behalf for support escalations).
- `NOT_FOUND` on missing sanction; `INVALID_ARGUMENT` if already appealed (appeal_status set once).
- Sets `appeal_status='pending'` + publishes `moderation.sanctionAppealed`.

## Test plan

- [x] `npm test` in services/moderation — 237/237 green (all existing + 19 sanction-handler tests)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_