### PR TITLE
feat(moderation): phase 8.3b — support ticket handlers (14/14 complete)

### DIFF
--- a/services/moderation/src/grpc/ticket-handlers.test.ts
+++ b/services/moderation/src/grpc/ticket-handlers.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ModerationV1,
+  type GetSupportTicketRequest,
+  type ListSupportTicketsRequest,
+  type OpenSupportTicketRequest,
+  type RespondToTicketRequest,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  getSupportTicket,
+  listSupportTickets,
+  openSupportTicket,
+  respondToTicket,
+} from './ticket-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'staff-1',
+    roles: overrides.roles ?? ['admin'],
+    permissions: overrides.permissions ?? ['admin.dashboard'],
+    rescueId: undefined,
+  } as unknown as Parameters<typeof openSupportTicket>[1];
+}
+
+function makeDeps(steps: Array<unknown>): {
+  deps: HandlerDeps;
+  query: ReturnType<typeof vi.fn>;
+} {
+  const queryMock = vi.fn();
+  for (const step of steps) {
+    queryMock.mockResolvedValueOnce(step);
+  }
+  const pool = { query: queryMock } as unknown as HandlerDeps['pool'];
+  const deps: HandlerDeps = { pool, nats: {} } as unknown as HandlerDeps;
+  return { deps, query: queryMock };
+}
+
+vi.mock('@adopt-dont-shop/events', async () => {
+  const actual =
+    await vi.importActual<typeof import('@adopt-dont-shop/events')>('@adopt-dont-shop/events');
+  return {
+    ...actual,
+    withTransaction: async (
+      deps: { pool: { query: ReturnType<typeof vi.fn> } },
+      fn: (scope: {
+        client: { query: ReturnType<typeof vi.fn> };
+        publish: ReturnType<typeof vi.fn>;
+      }) => Promise<unknown>
+    ) => {
+      const publish = vi.fn();
+      const client = { query: deps.pool.query };
+      const result = await fn({ client, publish });
+      (deps as { _publish?: ReturnType<typeof vi.fn> })._publish = publish;
+      return result;
+    },
+  };
+});
+
+function ticketRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ticket_id: 'tkt-1',
+    user_id: 'usr-1',
+    user_email: 'user@example.com',
+    user_name: 'Test User',
+    assigned_to: null,
+    status: 'open',
+    priority: 'normal',
+    category: 'general_question',
+    subject: 'Cannot log in',
+    description: 'Locked out.',
+    tags: ['login'],
+    metadata: {},
+    first_response_at: null,
+    last_response_at: null,
+    resolved_at: null,
+    closed_at: null,
+    created_at: new Date('2026-06-01T12:00:00.000Z'),
+    updated_at: new Date('2026-06-01T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function responseRow(overrides: Record<string, unknown> = {}) {
+  return {
+    response_id: 'rsp-1',
+    ticket_id: 'tkt-1',
+    responder_id: 'staff-1',
+    responder_type: 'staff',
+    content: 'Try clearing cookies.',
+    is_internal: false,
+    created_at: new Date('2026-06-01T13:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+const VALID_OPEN: OpenSupportTicketRequest = {
+  userEmail: 'user@example.com',
+  subject: 'Cannot log in',
+  description: 'Locked out.',
+  priority: ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_NORMAL,
+  category: ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_GENERAL_QUESTION,
+  tags: ['login'],
+};
+
+describe('openSupportTicket', () => {
+  it('does NOT require admin (any authenticated user can open a ticket)', async () => {
+    const { deps } = makeDeps([{ rows: [ticketRow()] }]);
+    const res = await openSupportTicket(deps, makePrincipal({ permissions: [] }), VALID_OPEN);
+    expect(res.ticket.ticketId).toBe('tkt-1');
+  });
+
+  it.each([
+    ['userEmail', { ...VALID_OPEN, userEmail: '' }],
+    ['subject', { ...VALID_OPEN, subject: '' }],
+    ['description', { ...VALID_OPEN, description: '' }],
+    [
+      'priority',
+      {
+        ...VALID_OPEN,
+        priority: ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_UNSPECIFIED,
+      },
+    ],
+    [
+      'category',
+      {
+        ...VALID_OPEN,
+        category: ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_UNSPECIFIED,
+      },
+    ],
+  ])('throws INVALID_ARGUMENT on missing %s', async (_field, req) => {
+    const { deps } = makeDeps([]);
+    await expect(
+      openSupportTicket(deps, makePrincipal(), req as OpenSupportTicketRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('falls back to principal.userId when request user_id is absent', async () => {
+    const { deps, query } = makeDeps([{ rows: [ticketRow()] }]);
+    await openSupportTicket(deps, makePrincipal({ userId: 'usr-9' }), VALID_OPEN);
+    // user_id param at index 1 (0-based).
+    expect(query.mock.calls[0][1][1]).toBe('usr-9');
+  });
+
+  it('publishes moderation.ticketOpened', async () => {
+    const { deps } = makeDeps([{ rows: [ticketRow()] }]);
+    await openSupportTicket(deps, makePrincipal(), VALID_OPEN);
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.ticketOpened' });
+  });
+});
+
+describe('getSupportTicket', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      getSupportTicket(deps, makePrincipal({ permissions: [] }), {
+        ticketId: 'tkt-1',
+      } as GetSupportTicketRequest)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws NOT_FOUND on a missing ticket', async () => {
+    const { deps } = makeDeps([{ rows: [] }]);
+    await expect(
+      getSupportTicket(deps, makePrincipal(), { ticketId: 'gone' } as GetSupportTicketRequest)
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('returns the ticket without responses by default', async () => {
+    const { deps, query } = makeDeps([{ rows: [ticketRow()] }]);
+    const res = await getSupportTicket(deps, makePrincipal(), {
+      ticketId: 'tkt-1',
+    } as GetSupportTicketRequest);
+    expect(res.ticket.ticketId).toBe('tkt-1');
+    expect(res.responses).toEqual([]);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates the response thread when include_responses is true', async () => {
+    const { deps, query } = makeDeps([{ rows: [ticketRow()] }, { rows: [responseRow()] }]);
+    const res = await getSupportTicket(deps, makePrincipal(), {
+      ticketId: 'tkt-1',
+      includeResponses: true,
+    });
+    expect(res.responses).toHaveLength(1);
+    expect(query).toHaveBeenCalledTimes(2);
+    // The thread query excludes soft-deleted responses.
+    expect(query.mock.calls[1][0]).toContain('deleted_at IS NULL');
+  });
+});
+
+describe('listSupportTickets', () => {
+  it('throws PERMISSION_DENIED without admin.dashboard', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      listSupportTickets(deps, makePrincipal({ permissions: [] }), {} as ListSupportTicketsRequest)
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('applies status / priority / category / assigned_to / user filters', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    await listSupportTickets(deps, makePrincipal(), {
+      status: ModerationV1.SupportTicketStatus.SUPPORT_TICKET_STATUS_OPEN,
+      priority: ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_HIGH,
+      category: ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_TECHNICAL_ISSUE,
+      assignedTo: 'staff-1',
+      userId: 'usr-1',
+    } as ListSupportTicketsRequest);
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toContain('status = $1');
+    expect(sql).toContain('priority = $2');
+    expect(sql).toContain('category = $3');
+    expect(sql).toContain('assigned_to = $4');
+    expect(sql).toContain('user_id = $5');
+  });
+
+  it('treats empty assignedTo as IS NULL filter', async () => {
+    const { deps, query } = makeDeps([{ rows: [] }]);
+    await listSupportTickets(deps, makePrincipal(), {
+      assignedTo: '',
+    } as ListSupportTicketsRequest);
+    expect(query.mock.calls[0][0]).toContain('assigned_to IS NULL');
+  });
+
+  it('emits nextCursor when more rows than limit', async () => {
+    const eleven = Array.from({ length: 11 }, (_, i) =>
+      ticketRow({ ticket_id: `t-${i}`, created_at: new Date(2026, 5, 1, 12, 0, 0, i) })
+    );
+    const { deps } = makeDeps([{ rows: eleven }]);
+    const res = await listSupportTickets(deps, makePrincipal(), {
+      limit: 10,
+    } as ListSupportTicketsRequest);
+    expect(res.tickets).toHaveLength(10);
+    expect(res.nextCursor).toBeDefined();
+  });
+});
+
+describe('respondToTicket', () => {
+  it('throws INVALID_ARGUMENT on missing content', async () => {
+    const { deps } = makeDeps([]);
+    await expect(
+      respondToTicket(deps, makePrincipal(), {
+        ticketId: 'tkt-1',
+        content: '',
+      } as RespondToTicketRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws NOT_FOUND on a missing ticket', async () => {
+    const { deps } = makeDeps([{ rows: [] }]);
+    await expect(
+      respondToTicket(deps, makePrincipal(), { ticketId: 'gone', content: 'hi' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('inserts a staff response + bumps timestamps + publishes ticketResponded', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [{ ticket_id: 'tkt-1' }] }, // SELECT FOR UPDATE
+      { rows: [responseRow()] }, // INSERT response
+      { rows: [] }, // UPDATE ticket timestamps
+    ]);
+    const res = await respondToTicket(deps, makePrincipal(), {
+      ticketId: 'tkt-1',
+      content: 'Try clearing cookies.',
+    });
+    expect(res.response.responseId).toBe('rsp-1');
+    // The UPDATE keeps first_response_at via COALESCE.
+    expect(query.mock.calls[2][0]).toContain('COALESCE(first_response_at, NOW())');
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'moderation.ticketResponded' });
+  });
+
+  it('marks an internal staff response', async () => {
+    const { deps, query } = makeDeps([
+      { rows: [{ ticket_id: 'tkt-1' }] },
+      { rows: [responseRow({ is_internal: true })] },
+      { rows: [] },
+    ]);
+    const res = await respondToTicket(deps, makePrincipal(), {
+      ticketId: 'tkt-1',
+      content: 'Internal note',
+      isInternal: true,
+    });
+    expect(res.response.isInternal).toBe(true);
+    // is_internal param at index 4 (0-based) on the INSERT.
+    expect(query.mock.calls[1][1][4]).toBe(true);
+  });
+});

--- a/services/moderation/src/grpc/ticket-handlers.ts
+++ b/services/moderation/src/grpc/ticket-handlers.ts
@@ -1,0 +1,338 @@
+// gRPC handler implementations for ModerationService — batch 4 (final).
+//
+// Phase 8.3b — ships the support-ticket surface: OpenSupportTicket,
+// GetSupportTicket, ListSupportTickets, RespondToTicket. This
+// completes the 14-RPC ModerationService set (report lifecycle #924,
+// moderator actions + evidence #925, sanctions #926, tickets here).
+//
+// Same discipline: withTransaction for writes, ticket reads gate on
+// ADMIN_DASHBOARD (placeholder until lib.types ships MODERATION_*),
+// $-indexed SQL params, mappers from #914 for row → proto.
+//
+// Note: OpenSupportTicket is OPEN to any principal AND to
+// unauthenticated callers (the proto carries user_id as optional).
+// The gateway will route unauthenticated ticket opens; here we treat
+// a missing principal as the unauth case (the adapter's adaptUnauth
+// variant passes a synthetic principal — for now any authenticated
+// user can open one).
+
+import { randomUUID } from 'node:crypto';
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction } from '@adopt-dont-shop/events';
+import { ADMIN_DASHBOARD } from '@adopt-dont-shop/lib.types';
+import type {
+  GetSupportTicketRequest,
+  GetSupportTicketResponse,
+  ListSupportTicketsRequest,
+  ListSupportTicketsResponse,
+  OpenSupportTicketRequest,
+  OpenSupportTicketResponse,
+  RespondToTicketRequest,
+  RespondToTicketResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
+import { ticketCategoryToDb, ticketPriorityToDb, ticketStatusToDb } from './enum-map.js';
+import {
+  responseRowToProto,
+  ticketRowToProto,
+  type SupportTicketResponseRow,
+  type SupportTicketRow,
+} from './sanction-ticket-mapper.js';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+const TICKET_SELECT = `
+  ticket_id, user_id, user_email, user_name, assigned_to, status,
+  priority, category, subject, description, tags, metadata,
+  first_response_at, last_response_at, resolved_at, closed_at,
+  created_at, updated_at
+`;
+
+const RESPONSE_SELECT = `
+  response_id, ticket_id, responder_id, responder_type, content,
+  is_internal, created_at
+`;
+
+function clampLimit(raw: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.trunc(raw), MAX_LIMIT);
+}
+
+function ensureModerationPermission(principal: Principal): void {
+  if (!requirePermission(principal, ADMIN_DASHBOARD)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_DASHBOARD}' required`);
+  }
+}
+
+// --- OpenSupportTicket -----------------------------------------------
+
+export async function openSupportTicket(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: OpenSupportTicketRequest
+): Promise<OpenSupportTicketResponse> {
+  // Open to any authenticated principal — anyone can open a ticket.
+  // No admin gate (the adapter ensures the principal exists).
+  if (req.userEmail === undefined || req.userEmail === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'user_email is required');
+  }
+  if (req.subject === undefined || req.subject === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'subject is required');
+  }
+  if (req.description === undefined || req.description === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'description is required');
+  }
+  if (req.priority === undefined || req.priority === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'priority is required');
+  }
+  if (req.category === undefined || req.category === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'category is required');
+  }
+
+  const priorityDb = ticketPriorityToDb(req.priority);
+  const categoryDb = ticketCategoryToDb(req.category);
+  // Prefer the request's explicit user_id; fall back to the
+  // principal. Unauthenticated opens pass neither — column is
+  // nullable.
+  const userId = req.userId !== undefined && req.userId !== '' ? req.userId : principal.userId;
+  const tags = req.tags ?? [];
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    const ticketId = randomUUID();
+    const inserted = await client.query<SupportTicketRow>(
+      `INSERT INTO support_tickets (
+         ticket_id, user_id, user_email, user_name, status, priority,
+         category, subject, description, tags
+       )
+       VALUES ($1, $2, $3, $4, 'open', $5, $6, $7, $8, $9)
+       RETURNING ${TICKET_SELECT}`,
+      [
+        ticketId,
+        userId ?? null,
+        req.userEmail,
+        req.userName ?? null,
+        priorityDb,
+        categoryDb,
+        req.subject,
+        req.description,
+        tags,
+      ]
+    );
+
+    if (inserted.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'insert returned no rows');
+    }
+
+    publish({
+      type: 'moderation.ticketOpened',
+      id: ticketId,
+      payload: {
+        ticketId,
+        userId: userId ?? null,
+        userEmail: req.userEmail,
+        priority: priorityDb,
+        category: categoryDb,
+      },
+    });
+
+    return { ticket: ticketRowToProto(inserted.rows[0]) };
+  });
+}
+
+// --- GetSupportTicket ------------------------------------------------
+
+export async function getSupportTicket(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetSupportTicketRequest
+): Promise<GetSupportTicketResponse> {
+  ensureModerationPermission(principal);
+
+  if (req.ticketId === undefined || req.ticketId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'ticket_id is required');
+  }
+
+  const { rows } = await deps.pool.query<SupportTicketRow>(
+    `SELECT ${TICKET_SELECT} FROM support_tickets WHERE ticket_id = $1`,
+    [req.ticketId]
+  );
+
+  if (rows.length === 0) {
+    throw new HandlerError('NOT_FOUND', `ticket ${req.ticketId} not found`);
+  }
+
+  const response: GetSupportTicketResponse = {
+    ticket: ticketRowToProto(rows[0]),
+    responses: [],
+  };
+
+  if (req.includeResponses) {
+    const responses = await deps.pool.query<SupportTicketResponseRow>(
+      `SELECT ${RESPONSE_SELECT}
+       FROM support_ticket_responses
+       WHERE ticket_id = $1 AND deleted_at IS NULL
+       ORDER BY created_at ASC`,
+      [req.ticketId]
+    );
+    response.responses = responses.rows.map(responseRowToProto);
+  }
+
+  return response;
+}
+
+// --- ListSupportTickets ----------------------------------------------
+
+export async function listSupportTickets(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListSupportTicketsRequest
+): Promise<ListSupportTicketsResponse> {
+  ensureModerationPermission(principal);
+
+  const limit = clampLimit(req.limit);
+
+  const where: string[] = [];
+  const params: unknown[] = [];
+  let p = 1;
+
+  if (req.status !== undefined && req.status !== 0) {
+    where.push(`status = $${p++}`);
+    params.push(ticketStatusToDb(req.status));
+  }
+  if (req.priority !== undefined && req.priority !== 0) {
+    where.push(`priority = $${p++}`);
+    params.push(ticketPriorityToDb(req.priority));
+  }
+  if (req.category !== undefined && req.category !== 0) {
+    where.push(`category = $${p++}`);
+    params.push(ticketCategoryToDb(req.category));
+  }
+  if (req.assignedTo !== undefined) {
+    if (req.assignedTo === '') {
+      where.push(`assigned_to IS NULL`);
+    } else {
+      where.push(`assigned_to = $${p++}`);
+      params.push(req.assignedTo);
+    }
+  }
+  if (req.userId !== undefined && req.userId !== '') {
+    where.push(`user_id = $${p++}`);
+    params.push(req.userId);
+  }
+
+  if (req.cursor !== undefined && req.cursor !== '') {
+    let cursor;
+    try {
+      cursor = decodeCursor(req.cursor);
+    } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        throw new HandlerError('INVALID_ARGUMENT', err.message);
+      }
+      throw err;
+    }
+    where.push(`(created_at < $${p++} OR (created_at = $${p - 1} AND ticket_id < $${p++}))`);
+    params.push(cursor.createdAt);
+    params.push(cursor.id);
+  }
+
+  const whereSql = where.length === 0 ? '' : `WHERE ${where.join(' AND ')}`;
+  params.push(limit + 1);
+  const sql = `
+    SELECT ${TICKET_SELECT}
+    FROM support_tickets
+    ${whereSql}
+    ORDER BY created_at DESC, ticket_id DESC
+    LIMIT $${p}
+  `;
+
+  const { rows } = await deps.pool.query<SupportTicketRow>(sql, params);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const tickets = pageRows.map(ticketRowToProto);
+
+  const response: ListSupportTicketsResponse = { tickets };
+  if (hasMore && pageRows.length > 0) {
+    const last = pageRows[pageRows.length - 1];
+    response.nextCursor = encodeCursor({
+      createdAt: last.created_at.toISOString(),
+      id: last.ticket_id,
+    });
+  }
+
+  return response;
+}
+
+// --- RespondToTicket -------------------------------------------------
+
+export async function respondToTicket(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: RespondToTicketRequest
+): Promise<RespondToTicketResponse> {
+  ensureModerationPermission(principal);
+
+  if (req.ticketId === undefined || req.ticketId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'ticket_id is required');
+  }
+  if (req.content === undefined || req.content === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'content is required');
+  }
+
+  return withTransaction(deps, async ({ client, publish }) => {
+    // Lock the ticket so the last_response_at update is consistent.
+    const ticket = await client.query<{ ticket_id: string }>(
+      `SELECT ticket_id FROM support_tickets WHERE ticket_id = $1 FOR UPDATE`,
+      [req.ticketId]
+    );
+
+    if (ticket.rows.length === 0) {
+      throw new HandlerError('NOT_FOUND', `ticket ${req.ticketId} not found`);
+    }
+
+    const responseId = randomUUID();
+    const inserted = await client.query<SupportTicketResponseRow>(
+      `INSERT INTO support_ticket_responses (
+         response_id, ticket_id, responder_id, responder_type, content,
+         is_internal
+       )
+       VALUES ($1, $2, $3, 'staff', $4, $5)
+       RETURNING ${RESPONSE_SELECT}`,
+      [responseId, req.ticketId, principal.userId, req.content, req.isInternal ?? false]
+    );
+
+    if (inserted.rows.length !== 1) {
+      throw new HandlerError('INTERNAL', 'insert returned no rows');
+    }
+
+    // Bump the ticket's response timestamps. first_response_at is set
+    // only once (COALESCE keeps an existing value).
+    await client.query(
+      `UPDATE support_tickets
+       SET first_response_at = COALESCE(first_response_at, NOW()),
+           last_response_at = NOW(),
+           updated_at = NOW()
+       WHERE ticket_id = $1`,
+      [req.ticketId]
+    );
+
+    publish({
+      type: 'moderation.ticketResponded',
+      id: responseId,
+      payload: {
+        responseId,
+        ticketId: req.ticketId,
+        responderId: principal.userId,
+        isInternal: req.isInternal ?? false,
+      },
+    });
+
+    return { response: responseRowToProto(inserted.rows[0]) };
+  });
+}


### PR DESCRIPTION
## Summary

Phase 8.3b final batch — support-ticket handlers. **Completes all 14 ModerationService RPCs.** OpenSupportTicket, GetSupportTicket, ListSupportTickets, RespondToTicket. (Report lifecycle #924, moderator actions + evidence #925, sanctions #926, tickets here.)

**`openSupportTicket`**:
- Open to any authenticated principal (no admin gate) — anyone can open a ticket. The proto carries `user_id` as optional for the unauthenticated case; falls back to `principal.userId` when absent.
- Validates user_email, subject, description, priority, category.
- `text[]` tags forwarded as-is. INSERT `status='open'` + publishes `moderation.ticketOpened`.

**`getSupportTicket`**:
- Gate on `ADMIN_DASHBOARD`. Optionally hydrates the response thread (excluding soft-deleted responses via `deleted_at IS NULL`).

**`listSupportTickets`**:
- Filters by status / priority / category / assigned_to (empty → IS NULL) / user_id. `(created_at, ticket_id) DESC` keyset.

**`respondToTicket`**:
- SELECT FOR UPDATE on the ticket so the timestamp bump is consistent. INSERT `responder_type='staff'` response.
- Bumps `first_response_at` (COALESCE keeps existing) + `last_response_at`. `is_internal` flag for staff-only notes. Publishes `moderation.ticketResponded`.

**ModerationService is now FULLY HANDLED** — all 14 RPCs across 4 handler files (`handlers.ts`, `action-handlers.ts`, `sanction-handlers.ts`, `ticket-handlers.ts`). Next: gRPC server boot wiring all 14 + index.ts.

## Test plan

- [x] `npm test` in services/moderation — 257/257 green (all existing + 20 ticket-handler tests)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_