### PR TITLE
feat(moderation): phase 8.3c — gRPC server boot + index wiring

### DIFF
--- a/services/moderation/src/grpc/server.test.ts
+++ b/services/moderation/src/grpc/server.test.ts
@@ -1,0 +1,70 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+
+import { ModerationV1 } from '@adopt-dont-shop/proto';
+
+import type { ModerationConfig } from '../config.js';
+
+import { createGrpcServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const config: ModerationConfig = {
+  port: 5007,
+  grpcPort: 6007,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'moderation',
+  natsUrl: 'nats://localhost:4222',
+};
+
+const pool = {} as unknown as Pool;
+const nats = {} as unknown as NatsConnection;
+
+describe('createGrpcServer', () => {
+  it('registers all 15 ModerationService methods on the grpc.Server', () => {
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    const base = '/adopt_dont_shop.moderation.v1.ModerationService';
+    for (const method of [
+      'FileReport',
+      'GetReport',
+      'ListReports',
+      'AssignReport',
+      'ResolveReport',
+      'LogModeratorAction',
+      'ListModeratorActions',
+      'AddEvidence',
+      'IssueSanction',
+      'ListUserSanctions',
+      'AppealSanction',
+      'OpenSupportTicket',
+      'GetSupportTicket',
+      'ListSupportTickets',
+      'RespondToTicket',
+    ]) {
+      expect(handlers.has(`${base}/${method}`)).toBe(true);
+    }
+  });
+
+  it('matches every path from the canonical ModerationServiceService Definition table', () => {
+    const definition = ModerationV1.ModerationServiceService;
+    const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
+
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    for (const p of expectedPaths) {
+      expect(handlers.has(p)).toBe(true);
+    }
+  });
+});

--- a/services/moderation/src/grpc/server.ts
+++ b/services/moderation/src/grpc/server.ts
@@ -1,0 +1,120 @@
+// gRPC server boot — binds ModerationServiceService to all 15
+// adapter-wrapped handlers and starts listening on
+// MODERATION_GRPC_PORT.
+//
+// Same shape as services/audit/src/grpc/server.ts /
+// services/matching/src/grpc/server.ts. Handlers live across 4 files
+// (report lifecycle in handlers.ts, moderator actions + evidence in
+// action-handlers.ts, sanctions in sanction-handlers.ts, support
+// tickets in ticket-handlers.ts); they all share the
+// (deps, principal, request) → Promise<response> shape so the adapter
+// wraps them uniformly.
+//
+// Dev uses insecure credentials (TLS terminates at nginx in front);
+// production keeps gRPC HTTP/2 cleartext on the cluster network until
+// a future deploy wants mTLS.
+
+import { promisify } from 'node:util';
+
+import { Server, ServerCredentials } from '@grpc/grpc-js';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { ModerationV1 } from '@adopt-dont-shop/proto';
+
+import type { ModerationConfig } from '../config.js';
+
+import { addEvidence, listModeratorActions, logModeratorAction } from './action-handlers.js';
+import { adapt } from './adapter.js';
+import { assignReport, fileReport, getReport, listReports, resolveReport } from './handlers.js';
+import { appealSanction, issueSanction, listUserSanctions } from './sanction-handlers.js';
+import {
+  getSupportTicket,
+  listSupportTickets,
+  openSupportTicket,
+  respondToTicket,
+} from './ticket-handlers.js';
+
+export type CreateGrpcServerOptions = {
+  config: ModerationConfig;
+  pool: Pool;
+  nats: NatsConnection;
+  logger: Logger;
+};
+
+export type RunningGrpcServer = {
+  server: Server;
+  port: number;
+  shutdown: () => Promise<void>;
+};
+
+export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
+  const { config, pool, nats, logger } = opts;
+  const deps = { pool, nats };
+  const server = new Server();
+
+  server.addService(ModerationV1.ModerationServiceService, {
+    // Report lifecycle (handlers.ts)
+    fileReport: adapt(fileReport, { deps, logger }),
+    getReport: adapt(getReport, { deps, logger }),
+    listReports: adapt(listReports, { deps, logger }),
+    assignReport: adapt(assignReport, { deps, logger }),
+    resolveReport: adapt(resolveReport, { deps, logger }),
+    // Moderator actions + evidence (action-handlers.ts)
+    logModeratorAction: adapt(logModeratorAction, { deps, logger }),
+    listModeratorActions: adapt(listModeratorActions, { deps, logger }),
+    addEvidence: adapt(addEvidence, { deps, logger }),
+    // Sanctions (sanction-handlers.ts)
+    issueSanction: adapt(issueSanction, { deps, logger }),
+    listUserSanctions: adapt(listUserSanctions, { deps, logger }),
+    appealSanction: adapt(appealSanction, { deps, logger }),
+    // Support tickets (ticket-handlers.ts)
+    openSupportTicket: adapt(openSupportTicket, { deps, logger }),
+    getSupportTicket: adapt(getSupportTicket, { deps, logger }),
+    listSupportTickets: adapt(listSupportTickets, { deps, logger }),
+    respondToTicket: adapt(respondToTicket, { deps, logger }),
+  });
+
+  logger.info('gRPC ModerationService registered', {
+    methodCount: 15,
+    grpcPort: config.grpcPort,
+  });
+  // Note: 15 methods registered above — FileReport, GetReport,
+  // ListReports, AssignReport, ResolveReport, LogModeratorAction,
+  // ListModeratorActions, AddEvidence, IssueSanction,
+  // ListUserSanctions, AppealSanction, OpenSupportTicket,
+  // GetSupportTicket, ListSupportTickets, RespondToTicket.
+
+  return server;
+};
+
+export const startGrpcServer = async (
+  opts: CreateGrpcServerOptions
+): Promise<RunningGrpcServer> => {
+  const { config, logger } = opts;
+  const server = createGrpcServer(opts);
+
+  const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
+  const port = await bindAsync(
+    `${opts.config.host}:${config.grpcPort}`,
+    ServerCredentials.createInsecure()
+  );
+
+  logger.info('gRPC server listening', { port, host: opts.config.host });
+
+  return {
+    server,
+    port,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          resolve();
+        });
+      }),
+  };
+};

--- a/services/moderation/src/index.ts
+++ b/services/moderation/src/index.ts
@@ -1,21 +1,40 @@
+import { connect, type NatsConnection } from 'nats';
+
+import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.moderation' });
 
+  let nats: NatsConnection | undefined;
+  let pool: ReturnType<typeof createDbClient> | undefined;
+  let grpc: RunningGrpcServer | undefined;
+  let httpClosed = false;
+
   try {
     const config = loadConfig();
-    const server = createServer({ config, logger });
 
-    await server.listen({ port: config.port, host: config.host });
+    // Connect deps FIRST so we crash here rather than after starting
+    // to accept traffic. Same boot order as services/audit,
+    // services/matching, services/rescue.
+    pool = createDbClient({
+      connectionString: config.databaseUrl,
+      schema: config.schema,
+    });
+    nats = await connect({ servers: config.natsUrl });
 
-    logger.info('service.moderation listening', {
-      port: config.port,
-      host: config.host,
-      grpcPort: config.grpcPort,
+    grpc = await startGrpcServer({ config, pool, nats, logger });
+
+    const httpServer = createServer({ config, logger });
+    await httpServer.listen({ port: config.port, host: config.host });
+
+    logger.info('service.moderation running', {
+      http: { port: config.port, host: config.host },
+      grpc: { port: grpc.port, host: config.host },
       schema: config.schema,
       natsUrl: config.natsUrl,
       environment: config.environment,
@@ -24,9 +43,27 @@ const main = async (): Promise<void> => {
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.moderation shutting down', { signal });
       try {
-        await server.close();
+        if (!httpClosed) {
+          await httpServer.close();
+          httpClosed = true;
+        }
       } catch (err) {
-        logger.error('error during shutdown', { err });
+        logger.error('http close error', { err });
+      }
+      try {
+        await grpc?.shutdown();
+      } catch (err) {
+        logger.error('grpc shutdown error', { err });
+      }
+      try {
+        await nats?.drain();
+      } catch (err) {
+        logger.error('nats drain error', { err });
+      }
+      try {
+        await pool?.end();
+      } catch (err) {
+        logger.error('pool end error', { err });
       }
       process.exit(0);
     };
@@ -35,6 +72,21 @@ const main = async (): Promise<void> => {
     process.once('SIGINT', () => void shutdown('SIGINT'));
   } catch (err) {
     logger.error('service.moderation failed to start', { err });
+    try {
+      await grpc?.shutdown();
+    } catch {
+      // Swallow — already on the failure path.
+    }
+    try {
+      await nats?.drain();
+    } catch {
+      // Same.
+    }
+    try {
+      await pool?.end();
+    } catch {
+      // Same.
+    }
     process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

Phase 8.3c — gRPC server boot + index.ts wiring. Binds `ModerationServiceService` to all 15 adapter-wrapped handlers across the 4 handler files (report lifecycle, moderator actions + evidence, sanctions, support tickets) and wires `startGrpcServer` + `createDbClient` + nats `connect` into the boot sequence.

Same shape as services/audit (#919) / services/matching (#922) — pool first, NATS, gRPC, HTTP last; shutdown reverses cleanly with failure-path cleanup.

**End-to-end pipeline now exists for moderation**:
```
gateway → gRPC → ModerationService → handlers
  → enum-map / cursor / mappers → PG writes/reads → proto
```

## What's NOT here yet

- **Phase 8.4** — NATS subscribers on `chat.messageCreated` / `pets.created` / `applications.submitted` (content scanning + auto-report triggers)
- **Phase 8.5** — Gateway routes `/api/moderation/*`
- **Phase 8.6** — Cutover from monolith

## Test plan

- [x] `npm test` in services/moderation — 259/259 green (all 14 handler-file suites + 2 grpc server tests: 15-method path registration + canonical Definition table match)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_