### PR TITLE
feat(gateway): phase 8.5 — /api/moderation/* routes

### DIFF
--- a/services/gateway/src/grpc-clients/moderation-client.ts
+++ b/services/gateway/src/grpc-clients/moderation-client.ts
@@ -1,0 +1,126 @@
+// Promise-wrapped client for service.moderation.
+//
+// Phase 8.5 surface — all 15 ModerationService RPCs. Same
+// Promise-wrapped shape as other grpc-clients (audit / matching /
+// rescue / pets / auth).
+//
+// The interface is exported so tests can substitute a mock; the
+// routes depend on the shape, not the @grpc/grpc-js client.
+
+import { credentials, Metadata } from '@grpc/grpc-js';
+
+import {
+  ModerationV1,
+  type AddEvidenceRequest,
+  type AddEvidenceResponse,
+  type AppealSanctionRequest,
+  type AppealSanctionResponse,
+  type AssignReportRequest,
+  type AssignReportResponse,
+  type FileReportRequest,
+  type FileReportResponse,
+  type GetReportRequest,
+  type GetReportResponse,
+  type GetSupportTicketRequest,
+  type GetSupportTicketResponse,
+  type IssueSanctionRequest,
+  type IssueSanctionResponse,
+  type ListModeratorActionsRequest,
+  type ListModeratorActionsResponse,
+  type ListReportsRequest,
+  type ListReportsResponse,
+  type ListSupportTicketsRequest,
+  type ListSupportTicketsResponse,
+  type ListUserSanctionsRequest,
+  type ListUserSanctionsResponse,
+  type LogModeratorActionRequest,
+  type LogModeratorActionResponse,
+  type OpenSupportTicketRequest,
+  type OpenSupportTicketResponse,
+  type ResolveReportRequest,
+  type ResolveReportResponse,
+  type RespondToTicketRequest,
+  type RespondToTicketResponse,
+} from '@adopt-dont-shop/proto';
+
+export type ModerationClient = {
+  fileReport(req: FileReportRequest, metadata: Metadata): Promise<FileReportResponse>;
+  getReport(req: GetReportRequest, metadata: Metadata): Promise<GetReportResponse>;
+  listReports(req: ListReportsRequest, metadata: Metadata): Promise<ListReportsResponse>;
+  assignReport(req: AssignReportRequest, metadata: Metadata): Promise<AssignReportResponse>;
+  resolveReport(req: ResolveReportRequest, metadata: Metadata): Promise<ResolveReportResponse>;
+  logModeratorAction(
+    req: LogModeratorActionRequest,
+    metadata: Metadata
+  ): Promise<LogModeratorActionResponse>;
+  listModeratorActions(
+    req: ListModeratorActionsRequest,
+    metadata: Metadata
+  ): Promise<ListModeratorActionsResponse>;
+  addEvidence(req: AddEvidenceRequest, metadata: Metadata): Promise<AddEvidenceResponse>;
+  issueSanction(req: IssueSanctionRequest, metadata: Metadata): Promise<IssueSanctionResponse>;
+  listUserSanctions(
+    req: ListUserSanctionsRequest,
+    metadata: Metadata
+  ): Promise<ListUserSanctionsResponse>;
+  appealSanction(req: AppealSanctionRequest, metadata: Metadata): Promise<AppealSanctionResponse>;
+  openSupportTicket(
+    req: OpenSupportTicketRequest,
+    metadata: Metadata
+  ): Promise<OpenSupportTicketResponse>;
+  getSupportTicket(
+    req: GetSupportTicketRequest,
+    metadata: Metadata
+  ): Promise<GetSupportTicketResponse>;
+  listSupportTickets(
+    req: ListSupportTicketsRequest,
+    metadata: Metadata
+  ): Promise<ListSupportTicketsResponse>;
+  respondToTicket(
+    req: RespondToTicketRequest,
+    metadata: Metadata
+  ): Promise<RespondToTicketResponse>;
+  close(): void;
+};
+
+export type CreateModerationClientOptions = {
+  address: string;
+};
+
+export const createModerationClient = (opts: CreateModerationClientOptions): ModerationClient => {
+  const stub = new ModerationV1.ModerationServiceClient(opts.address, credentials.createInsecure());
+
+  const callUnary = <Req, Res>(
+    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> =>
+    new Promise<Res>((resolve, reject) => {
+      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(res);
+      });
+    });
+
+  return {
+    fileReport: (req, metadata) => callUnary(stub.fileReport, req, metadata),
+    getReport: (req, metadata) => callUnary(stub.getReport, req, metadata),
+    listReports: (req, metadata) => callUnary(stub.listReports, req, metadata),
+    assignReport: (req, metadata) => callUnary(stub.assignReport, req, metadata),
+    resolveReport: (req, metadata) => callUnary(stub.resolveReport, req, metadata),
+    logModeratorAction: (req, metadata) => callUnary(stub.logModeratorAction, req, metadata),
+    listModeratorActions: (req, metadata) => callUnary(stub.listModeratorActions, req, metadata),
+    addEvidence: (req, metadata) => callUnary(stub.addEvidence, req, metadata),
+    issueSanction: (req, metadata) => callUnary(stub.issueSanction, req, metadata),
+    listUserSanctions: (req, metadata) => callUnary(stub.listUserSanctions, req, metadata),
+    appealSanction: (req, metadata) => callUnary(stub.appealSanction, req, metadata),
+    openSupportTicket: (req, metadata) => callUnary(stub.openSupportTicket, req, metadata),
+    getSupportTicket: (req, metadata) => callUnary(stub.getSupportTicket, req, metadata),
+    listSupportTickets: (req, metadata) => callUnary(stub.listSupportTickets, req, metadata),
+    respondToTicket: (req, metadata) => callUnary(stub.respondToTicket, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/gateway/src/routes/moderation.test.ts
+++ b/services/gateway/src/routes/moderation.test.ts
@@ -1,0 +1,256 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ModerationV1 } from '@adopt-dont-shop/proto';
+
+import type { ModerationClient } from '../grpc-clients/moderation-client.js';
+
+import { registerModerationRoutes } from './moderation.js';
+
+function makeClient(): {
+  client: ModerationClient;
+  mocks: Record<string, ReturnType<typeof vi.fn>>;
+} {
+  const mocks: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of [
+    'fileReport',
+    'getReport',
+    'listReports',
+    'assignReport',
+    'resolveReport',
+    'logModeratorAction',
+    'listModeratorActions',
+    'addEvidence',
+    'issueSanction',
+    'listUserSanctions',
+    'appealSanction',
+    'openSupportTicket',
+    'getSupportTicket',
+    'listSupportTickets',
+    'respondToTicket',
+  ]) {
+    mocks[m] = vi.fn();
+  }
+  const client = { ...mocks, close: vi.fn() } as unknown as ModerationClient;
+  return { client, mocks };
+}
+
+async function makeApp(client: ModerationClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerModerationRoutes(app, { client });
+  return app;
+}
+
+const HEADERS = {
+  'x-user-id': 'mod-1',
+  'x-user-roles': 'admin',
+  'x-user-permissions': 'admin.dashboard',
+};
+
+describe('moderation report routes', () => {
+  let app: FastifyInstance;
+  let mocks: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    mocks = m.mocks;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('POST /api/moderation/reports → FileReport with parsed enums, 201', async () => {
+    mocks.fileReport.mockResolvedValue({ report: { reportId: 'rpt-1' } });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/moderation/reports',
+      headers: HEADERS,
+      payload: {
+        reportedEntityType: 'user',
+        reportedEntityId: 'usr-2',
+        category: 'harassment',
+        severity: 'high',
+        title: 'Abuse',
+        description: 'Threats',
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(mocks.fileReport.mock.calls[0][0]).toMatchObject({
+      reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_USER,
+      category: ModerationV1.ReportCategory.REPORT_CATEGORY_HARASSMENT,
+      severity: ModerationV1.Severity.SEVERITY_HIGH,
+    });
+  });
+
+  it('accepts SCREAMING proto-form enums too', async () => {
+    mocks.fileReport.mockResolvedValue({ report: { reportId: 'rpt-1' } });
+    await app.inject({
+      method: 'POST',
+      url: '/api/moderation/reports',
+      headers: HEADERS,
+      payload: {
+        reportedEntityType: 'REPORT_ENTITY_TYPE_PET',
+        reportedEntityId: 'pet-1',
+        category: 'REPORT_CATEGORY_SPAM',
+        severity: 'SEVERITY_LOW',
+        title: 'x',
+        description: 'y',
+      },
+    });
+    expect(mocks.fileReport.mock.calls[0][0]).toMatchObject({
+      reportedEntityType: ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_PET,
+      category: ModerationV1.ReportCategory.REPORT_CATEGORY_SPAM,
+    });
+  });
+
+  it('GET /api/moderation/reports → ListReports with filters', async () => {
+    mocks.listReports.mockResolvedValue({ reports: [] });
+    await app.inject({
+      method: 'GET',
+      url: '/api/moderation/reports?status=pending&severity=high&limit=10',
+      headers: HEADERS,
+    });
+    expect(mocks.listReports.mock.calls[0][0]).toMatchObject({
+      status: ModerationV1.ReportStatus.REPORT_STATUS_PENDING,
+      severity: ModerationV1.Severity.SEVERITY_HIGH,
+      limit: 10,
+    });
+  });
+
+  it('GET /api/moderation/reports/:id passes includeTransitions', async () => {
+    mocks.getReport.mockResolvedValue({ report: { reportId: 'rpt-1' }, transitions: [] });
+    await app.inject({
+      method: 'GET',
+      url: '/api/moderation/reports/rpt-1?transitions=true',
+      headers: HEADERS,
+    });
+    expect(mocks.getReport.mock.calls[0][0]).toMatchObject({
+      reportId: 'rpt-1',
+      includeTransitions: true,
+    });
+  });
+
+  it('POST /api/moderation/reports/:id/assign threads moderatorId', async () => {
+    mocks.assignReport.mockResolvedValue({ report: { reportId: 'rpt-1' } });
+    await app.inject({
+      method: 'POST',
+      url: '/api/moderation/reports/rpt-1/assign',
+      headers: HEADERS,
+      payload: { moderatorId: 'mod-2' },
+    });
+    expect(mocks.assignReport.mock.calls[0][0]).toMatchObject({
+      reportId: 'rpt-1',
+      moderatorId: 'mod-2',
+    });
+  });
+
+  it('maps PERMISSION_DENIED → 403', async () => {
+    mocks.listReports.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'nope' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/moderation/reports',
+      headers: HEADERS,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('moderation sanction + ticket routes', () => {
+  let app: FastifyInstance;
+  let mocks: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    mocks = m.mocks;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('GET /api/moderation/users/:userId/sanctions → ListUserSanctions', async () => {
+    mocks.listUserSanctions.mockResolvedValue({ sanctions: [] });
+    await app.inject({
+      method: 'GET',
+      url: '/api/moderation/users/usr-2/sanctions?includeInactive=true',
+      headers: HEADERS,
+    });
+    expect(mocks.listUserSanctions.mock.calls[0][0]).toMatchObject({
+      userId: 'usr-2',
+      includeInactive: true,
+    });
+  });
+
+  it('POST /api/moderation/sanctions/:id/appeal → AppealSanction', async () => {
+    mocks.appealSanction.mockResolvedValue({ sanction: { sanctionId: 'sanc-1' } });
+    await app.inject({
+      method: 'POST',
+      url: '/api/moderation/sanctions/sanc-1/appeal',
+      headers: HEADERS,
+      payload: { appealReason: 'provoked' },
+    });
+    expect(mocks.appealSanction.mock.calls[0][0]).toMatchObject({
+      sanctionId: 'sanc-1',
+      appealReason: 'provoked',
+    });
+  });
+
+  it('POST /api/moderation/tickets → OpenSupportTicket, 201', async () => {
+    mocks.openSupportTicket.mockResolvedValue({ ticket: { ticketId: 'tkt-1' } });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/moderation/tickets',
+      headers: HEADERS,
+      payload: {
+        userEmail: 'u@e.com',
+        subject: 'Help',
+        description: 'Locked out',
+        priority: 'normal',
+        category: 'technical_issue',
+        tags: ['login'],
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(mocks.openSupportTicket.mock.calls[0][0]).toMatchObject({
+      userEmail: 'u@e.com',
+      priority: ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_NORMAL,
+      category: ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_TECHNICAL_ISSUE,
+    });
+  });
+
+  it('POST /api/moderation/tickets/:id/responses → RespondToTicket', async () => {
+    mocks.respondToTicket.mockResolvedValue({ response: { responseId: 'rsp-1' } });
+    await app.inject({
+      method: 'POST',
+      url: '/api/moderation/tickets/tkt-1/responses',
+      headers: HEADERS,
+      payload: { content: 'Try X', isInternal: true },
+    });
+    expect(mocks.respondToTicket.mock.calls[0][0]).toMatchObject({
+      ticketId: 'tkt-1',
+      content: 'Try X',
+      isInternal: true,
+    });
+  });
+
+  it('threads x-user-* metadata to the gRPC client', async () => {
+    mocks.issueSanction.mockResolvedValue({ sanction: { sanctionId: 'sanc-1' } });
+    await app.inject({
+      method: 'POST',
+      url: '/api/moderation/sanctions',
+      headers: HEADERS,
+      payload: {
+        userId: 'usr-2',
+        sanctionType: 'temporary_ban',
+        reason: 'harassment',
+        description: 'abuse',
+      },
+    });
+    const metadata = mocks.issueSanction.mock.calls[0][1];
+    expect(metadata.get('x-user-id')).toEqual(['mod-1']);
+  });
+});

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -1,0 +1,548 @@
+// REST → gRPC translation for /api/moderation/*.
+//
+// Phase 8.5 cutover. Same strangler-fig shape as routes/audit.ts
+// (#917) / routes/matching.ts (#923) — registers BEFORE the catch-all
+// proxy so first-registered-wins prefix routing picks it off.
+//
+// Route map (all 15 ModerationService RPCs):
+//
+//   Reports
+//   POST   /api/moderation/reports                       → FileReport
+//   GET    /api/moderation/reports                       → ListReports
+//   GET    /api/moderation/reports/:id                   → GetReport
+//   POST   /api/moderation/reports/:id/assign            → AssignReport
+//   POST   /api/moderation/reports/:id/resolve           → ResolveReport
+//   Moderator actions
+//   POST   /api/moderation/actions                       → LogModeratorAction
+//   GET    /api/moderation/actions                       → ListModeratorActions
+//   Evidence
+//   POST   /api/moderation/evidence                      → AddEvidence
+//   Sanctions
+//   POST   /api/moderation/sanctions                     → IssueSanction
+//   GET    /api/moderation/users/:userId/sanctions       → ListUserSanctions
+//   POST   /api/moderation/sanctions/:id/appeal          → AppealSanction
+//   Support tickets
+//   POST   /api/moderation/tickets                       → OpenSupportTicket
+//   GET    /api/moderation/tickets                       → ListSupportTickets
+//   GET    /api/moderation/tickets/:id                   → GetSupportTicket
+//   POST   /api/moderation/tickets/:id/responses         → RespondToTicket
+//
+// Authz lives in the handlers (most gate on admin.dashboard;
+// FileReport + OpenSupportTicket are open to any authenticated user;
+// ListUserSanctions allows self-or-admin). The gateway stamps
+// x-user-* metadata via the Phase 2.5 authenticate middleware.
+
+import rateLimit from '@fastify/rate-limit';
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  ModerationV1,
+  type AddEvidenceRequest,
+  type AppealSanctionRequest,
+  type AssignReportRequest,
+  type FileReportRequest,
+  type IssueSanctionRequest,
+  type ListModeratorActionsRequest,
+  type ListReportsRequest,
+  type ListSupportTicketsRequest,
+  type LogModeratorActionRequest,
+  type OpenSupportTicketRequest,
+  type ResolveReportRequest,
+  type RespondToTicketRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { ModerationClient } from '../grpc-clients/moderation-client.js';
+
+export type ModerationRoutesOptions = {
+  client: ModerationClient;
+};
+
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.INTERNAL]: 500,
+};
+
+// Writes 30/min, reads 120/min — moderation is admin-driven so these
+// are sized for human use.
+const RL_WRITE = { max: 30, timeWindow: '1 minute' } as const;
+const RL_READ = { max: 120, timeWindow: '1 minute' } as const;
+
+export const registerModerationRoutes = async (
+  app: FastifyInstance,
+  opts: ModerationRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  await app.register(rateLimit, { global: false });
+
+  // ---------- Reports ----------
+
+  app.post('/api/moderation/reports', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    const grpcReq: FileReportRequest = {
+      reportedEntityType: parseEntityType(b.reportedEntityType as string | undefined),
+      reportedEntityId: (b.reportedEntityId as string) ?? '',
+      reportedUserId: b.reportedUserId as string | undefined,
+      category: parseCategory(b.category as string | undefined),
+      severity: parseSeverity(b.severity as string | undefined),
+      title: (b.title as string) ?? '',
+      description: (b.description as string) ?? '',
+      metadataJson: b.metadataJson as string | undefined,
+    };
+    try {
+      const res = await client.fileReport(grpcReq, buildMetadata(req));
+      return reply.code(201).send(ModerationV1.FileReportResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get('/api/moderation/reports', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+    const q = req.query as Record<string, string | undefined>;
+    const grpcReq: ListReportsRequest = {
+      cursor: q.cursor,
+      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      status: parseReportStatus(q.status),
+      severity: parseSeverity(q.severity),
+      category: parseCategory(q.category),
+      assignedModerator: q.assigned,
+    };
+    try {
+      const res = await client.listReports(grpcReq, buildMetadata(req));
+      return reply.send(ModerationV1.ListReportsResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get<{ Params: { id: string } }>(
+    '/api/moderation/reports/:id',
+    { config: { rateLimit: RL_READ } },
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      try {
+        const res = await client.getReport(
+          { reportId: req.params.id, includeTransitions: q.transitions === 'true' },
+          buildMetadata(req)
+        );
+        return reply.send(ModerationV1.GetReportResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/moderation/reports/:id/assign',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: AssignReportRequest = {
+        reportId: req.params.id,
+        moderatorId: (b.moderatorId as string) ?? '',
+        reason: b.reason as string | undefined,
+      };
+      try {
+        const res = await client.assignReport(grpcReq, buildMetadata(req));
+        return reply.send(ModerationV1.AssignReportResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/moderation/reports/:id/resolve',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: ResolveReportRequest = {
+        reportId: req.params.id,
+        resolution: (b.resolution as string) ?? '',
+        resolutionNotes: b.resolutionNotes as string | undefined,
+      };
+      try {
+        const res = await client.resolveReport(grpcReq, buildMetadata(req));
+        return reply.send(ModerationV1.ResolveReportResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // ---------- Moderator actions ----------
+
+  app.post('/api/moderation/actions', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    const grpcReq: LogModeratorActionRequest = {
+      reportId: b.reportId as string | undefined,
+      targetEntityType: parseEntityType(b.targetEntityType as string | undefined),
+      targetEntityId: (b.targetEntityId as string) ?? '',
+      targetUserId: b.targetUserId as string | undefined,
+      actionType: parseActionType(b.actionType as string | undefined),
+      severity: parseSeverity(b.severity as string | undefined),
+      reason: (b.reason as string) ?? '',
+      description: b.description as string | undefined,
+      metadataJson: b.metadataJson as string | undefined,
+      duration: b.duration as number | undefined,
+    };
+    try {
+      const res = await client.logModeratorAction(grpcReq, buildMetadata(req));
+      return reply.code(201).send(ModerationV1.LogModeratorActionResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get('/api/moderation/actions', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+    const q = req.query as Record<string, string | undefined>;
+    const grpcReq: ListModeratorActionsRequest = {
+      cursor: q.cursor,
+      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      targetUserId: q.user,
+      reportId: q.report,
+      actionType: parseActionType(q.action),
+    };
+    try {
+      const res = await client.listModeratorActions(grpcReq, buildMetadata(req));
+      return reply.send(ModerationV1.ListModeratorActionsResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // ---------- Evidence ----------
+
+  app.post('/api/moderation/evidence', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    const grpcReq: AddEvidenceRequest = {
+      parentType: parseEvidenceParentType(b.parentType as string | undefined),
+      parentId: (b.parentId as string) ?? '',
+      type: parseEvidenceType(b.type as string | undefined),
+      content: (b.content as string) ?? '',
+      description: b.description as string | undefined,
+    };
+    try {
+      const res = await client.addEvidence(grpcReq, buildMetadata(req));
+      return reply.code(201).send(ModerationV1.AddEvidenceResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // ---------- Sanctions ----------
+
+  app.post('/api/moderation/sanctions', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    const grpcReq: IssueSanctionRequest = {
+      userId: (b.userId as string) ?? '',
+      sanctionType: parseSanctionType(b.sanctionType as string | undefined),
+      reason: parseSanctionReason(b.reason as string | undefined),
+      description: (b.description as string) ?? '',
+      duration: b.duration as number | undefined,
+      reportId: b.reportId as string | undefined,
+      moderatorActionId: b.moderatorActionId as string | undefined,
+    };
+    try {
+      const res = await client.issueSanction(grpcReq, buildMetadata(req));
+      return reply.code(201).send(ModerationV1.IssueSanctionResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get<{ Params: { userId: string } }>(
+    '/api/moderation/users/:userId/sanctions',
+    { config: { rateLimit: RL_READ } },
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      try {
+        const res = await client.listUserSanctions(
+          { userId: req.params.userId, includeInactive: q.includeInactive === 'true' },
+          buildMetadata(req)
+        );
+        return reply.send(ModerationV1.ListUserSanctionsResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/moderation/sanctions/:id/appeal',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: AppealSanctionRequest = {
+        sanctionId: req.params.id,
+        appealReason: (b.appealReason as string) ?? '',
+      };
+      try {
+        const res = await client.appealSanction(grpcReq, buildMetadata(req));
+        return reply.send(ModerationV1.AppealSanctionResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // ---------- Support tickets ----------
+
+  app.post('/api/moderation/tickets', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    const grpcReq: OpenSupportTicketRequest = {
+      userId: b.userId as string | undefined,
+      userEmail: (b.userEmail as string) ?? '',
+      userName: b.userName as string | undefined,
+      priority: parseTicketPriority(b.priority as string | undefined),
+      category: parseTicketCategory(b.category as string | undefined),
+      subject: (b.subject as string) ?? '',
+      description: (b.description as string) ?? '',
+      tags: (b.tags as string[]) ?? [],
+    };
+    try {
+      const res = await client.openSupportTicket(grpcReq, buildMetadata(req));
+      return reply.code(201).send(ModerationV1.OpenSupportTicketResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get('/api/moderation/tickets', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+    const q = req.query as Record<string, string | undefined>;
+    const grpcReq: ListSupportTicketsRequest = {
+      cursor: q.cursor,
+      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      status: parseTicketStatus(q.status),
+      priority: parseTicketPriority(q.priority),
+      category: parseTicketCategory(q.category),
+      assignedTo: q.assigned,
+      userId: q.user,
+    };
+    try {
+      const res = await client.listSupportTickets(grpcReq, buildMetadata(req));
+      return reply.send(ModerationV1.ListSupportTicketsResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get<{ Params: { id: string } }>(
+    '/api/moderation/tickets/:id',
+    { config: { rateLimit: RL_READ } },
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      try {
+        const res = await client.getSupportTicket(
+          { ticketId: req.params.id, includeResponses: q.responses === 'true' },
+          buildMetadata(req)
+        );
+        return reply.send(ModerationV1.GetSupportTicketResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/moderation/tickets/:id/responses',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: RespondToTicketRequest = {
+        ticketId: req.params.id,
+        content: (b.content as string) ?? '',
+        isInternal: (b.isInternal as boolean) ?? false,
+      };
+      try {
+        const res = await client.respondToTicket(grpcReq, buildMetadata(req));
+        return reply.code(201).send(ModerationV1.RespondToTicketResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}
+
+// Enum parsers — each accepts DB form ('harassment') AND the SCREAMING
+// proto form ('REPORT_CATEGORY_HARASSMENT'). Unknown coerces to
+// UNSPECIFIED so the moderation service's INVALID_ARGUMENT guard
+// produces a clean 400.
+
+function parseEnum<E extends Record<string, string | number>>(
+  enumObj: E,
+  prefix: string,
+  fromJSON: (s: string) => number,
+  unspecified: number,
+  unrecognized: number,
+  raw: string | undefined
+): number {
+  if (!raw) {
+    return unspecified;
+  }
+  const upper = `${prefix}_${raw.toUpperCase()}`;
+  const candidate = Object.values(enumObj).includes(upper as never) ? upper : raw;
+  const out = fromJSON(candidate);
+  return out === unrecognized ? unspecified : out;
+}
+
+function parseEntityType(raw: string | undefined): ModerationV1.ReportEntityType {
+  return parseEnum(
+    ModerationV1.ReportEntityType,
+    'REPORT_ENTITY_TYPE',
+    ModerationV1.reportEntityTypeFromJSON,
+    ModerationV1.ReportEntityType.REPORT_ENTITY_TYPE_UNSPECIFIED,
+    ModerationV1.ReportEntityType.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseCategory(raw: string | undefined): ModerationV1.ReportCategory {
+  return parseEnum(
+    ModerationV1.ReportCategory,
+    'REPORT_CATEGORY',
+    ModerationV1.reportCategoryFromJSON,
+    ModerationV1.ReportCategory.REPORT_CATEGORY_UNSPECIFIED,
+    ModerationV1.ReportCategory.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseSeverity(raw: string | undefined): ModerationV1.Severity {
+  return parseEnum(
+    ModerationV1.Severity,
+    'SEVERITY',
+    ModerationV1.severityFromJSON,
+    ModerationV1.Severity.SEVERITY_UNSPECIFIED,
+    ModerationV1.Severity.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseReportStatus(raw: string | undefined): ModerationV1.ReportStatus {
+  return parseEnum(
+    ModerationV1.ReportStatus,
+    'REPORT_STATUS',
+    ModerationV1.reportStatusFromJSON,
+    ModerationV1.ReportStatus.REPORT_STATUS_UNSPECIFIED,
+    ModerationV1.ReportStatus.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseActionType(raw: string | undefined): ModerationV1.ModeratorActionType {
+  return parseEnum(
+    ModerationV1.ModeratorActionType,
+    'MODERATOR_ACTION_TYPE',
+    ModerationV1.moderatorActionTypeFromJSON,
+    ModerationV1.ModeratorActionType.MODERATOR_ACTION_TYPE_UNSPECIFIED,
+    ModerationV1.ModeratorActionType.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseEvidenceParentType(raw: string | undefined): ModerationV1.EvidenceParentType {
+  return parseEnum(
+    ModerationV1.EvidenceParentType,
+    'EVIDENCE_PARENT_TYPE',
+    ModerationV1.evidenceParentTypeFromJSON,
+    ModerationV1.EvidenceParentType.EVIDENCE_PARENT_TYPE_UNSPECIFIED,
+    ModerationV1.EvidenceParentType.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseEvidenceType(raw: string | undefined): ModerationV1.EvidenceType {
+  return parseEnum(
+    ModerationV1.EvidenceType,
+    'EVIDENCE_TYPE',
+    ModerationV1.evidenceTypeFromJSON,
+    ModerationV1.EvidenceType.EVIDENCE_TYPE_UNSPECIFIED,
+    ModerationV1.EvidenceType.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseSanctionType(raw: string | undefined): ModerationV1.SanctionType {
+  return parseEnum(
+    ModerationV1.SanctionType,
+    'SANCTION_TYPE',
+    ModerationV1.sanctionTypeFromJSON,
+    ModerationV1.SanctionType.SANCTION_TYPE_UNSPECIFIED,
+    ModerationV1.SanctionType.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseSanctionReason(raw: string | undefined): ModerationV1.SanctionReason {
+  return parseEnum(
+    ModerationV1.SanctionReason,
+    'SANCTION_REASON',
+    ModerationV1.sanctionReasonFromJSON,
+    ModerationV1.SanctionReason.SANCTION_REASON_UNSPECIFIED,
+    ModerationV1.SanctionReason.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseTicketStatus(raw: string | undefined): ModerationV1.SupportTicketStatus {
+  return parseEnum(
+    ModerationV1.SupportTicketStatus,
+    'SUPPORT_TICKET_STATUS',
+    ModerationV1.supportTicketStatusFromJSON,
+    ModerationV1.SupportTicketStatus.SUPPORT_TICKET_STATUS_UNSPECIFIED,
+    ModerationV1.SupportTicketStatus.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseTicketPriority(raw: string | undefined): ModerationV1.SupportTicketPriority {
+  return parseEnum(
+    ModerationV1.SupportTicketPriority,
+    'SUPPORT_TICKET_PRIORITY',
+    ModerationV1.supportTicketPriorityFromJSON,
+    ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_UNSPECIFIED,
+    ModerationV1.SupportTicketPriority.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseTicketCategory(raw: string | undefined): ModerationV1.SupportTicketCategory {
+  return parseEnum(
+    ModerationV1.SupportTicketCategory,
+    'SUPPORT_TICKET_CATEGORY',
+    ModerationV1.supportTicketCategoryFromJSON,
+    ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_UNSPECIFIED,
+    ModerationV1.SupportTicketCategory.UNRECOGNIZED,
+    raw
+  );
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -23,6 +23,7 @@ import type { GatewayConfig } from './config.js';
 import type { AuditClient } from './grpc-clients/audit-client.js';
 import type { AuthClient } from './grpc-clients/auth-client.js';
 import type { MatchingClient } from './grpc-clients/matching-client.js';
+import type { ModerationClient } from './grpc-clients/moderation-client.js';
 import type { NotificationsClient } from './grpc-clients/notifications-client.js';
 import type { PetsClient } from './grpc-clients/pets-client.js';
 import type { RescueClient } from './grpc-clients/rescue-client.js';
@@ -30,6 +31,7 @@ import { registerAuthenticate } from './middleware/authenticate.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerMatchingRoutes } from './routes/matching.js';
+import { registerModerationRoutes } from './routes/moderation.js';
 import { registerNotificationsRoutes } from './routes/notifications.js';
 import { registerPetsRoutes } from './routes/pets.js';
 import { registerRescueRoutes } from './routes/rescue.js';
@@ -66,6 +68,9 @@ export type CreateServerOptions = {
   // gRPC client to service.matching — Phase 9.5 cuts /api/matching/*
   // over to this address. Same optional shape as the other clients.
   matchingClient?: MatchingClient;
+  // gRPC client to service.moderation — Phase 8.5 cuts
+  // /api/moderation/* over to this address. Same optional shape.
+  moderationClient?: ModerationClient;
 };
 
 export const createServer = async (opts: CreateServerOptions): Promise<FastifyInstance> => {
@@ -139,6 +144,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   if (opts.matchingClient) {
     await registerMatchingRoutes(server, { client: opts.matchingClient });
+  }
+  if (opts.moderationClient) {
+    await registerModerationRoutes(server, { client: opts.moderationClient });
   }
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in


### PR DESCRIPTION
## Summary

Phase 8.5 cutover — `/api/moderation/*` lands on the gateway's moderation-routes plugin. Same strangler-fig shape as Phase 10.5 (audit) / 9.5 (matching). **15 routes mapping all 15 ModerationService RPCs** to a RESTful surface:

| Resource | Routes |
|---|---|
| Reports | `POST/GET /reports`, `GET /reports/:id`, `POST /reports/:id/assign`, `/reports/:id/resolve` |
| Actions | `POST/GET /actions` |
| Evidence | `POST /evidence` |
| Sanctions | `POST /sanctions`, `GET /users/:userId/sanctions`, `POST /sanctions/:id/appeal` |
| Tickets | `POST/GET /tickets`, `GET /tickets/:id`, `POST /tickets/:id/responses` |

**Generic `parseEnum` helper** handles all 11 moderation enums — accepts DB form (`harassment`) AND SCREAMING proto form (`REPORT_CATEGORY_HARASSMENT`); unknown coerces to UNSPECIFIED so the moderation service's INVALID_ARGUMENT guard produces a clean 400. One helper + 11 thin wrappers — far less boilerplate than 11 hand-written parse functions.

**Authz** lives in the handlers (most gate on `admin.dashboard`; FileReport + OpenSupportTicket open to any authenticated user; ListUserSanctions self-or-admin). Gateway stamps `x-user-*` via the Phase 2.5 authenticate middleware. Writes 30/min, reads 120/min.

`ModerationClient` + `createModerationClient` ship alongside the routes — Promise-wrapped, same shape as `audit-client` / `matching-client`. Wired into `createServer` as optional `moderationClient`.

## Test plan

- [x] `npm test` in services/gateway — 118/118 green (all earlier tests + 11 moderation route tests)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `node scripts/check-workflow-paths.mjs` + `check-workspace-consistency.mjs` — OK

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_