### PR TITLE
feat(applications): phase 5.3b — review + decision handlers

### DIFF
--- a/services/applications/src/grpc/command-runner.ts
+++ b/services/applications/src/grpc/command-runner.ts
@@ -1,0 +1,90 @@
+// Shared command-runner for the event-sourced ApplicationService
+// handlers. Extracted from handlers.ts so every handler file (draft
+// handlers, review/decision handlers) reuses the exact same
+// load → handle → append → project → publish-after-commit flow.
+//
+// runCommand is the single join point: pass an aggregateId + command +
+// a publishFor mapper, and it runs everything inside one
+// withTransaction. DomainError + ConcurrencyError translate to
+// HandlerError codes here so individual handlers stay declarative.
+
+import { withTransaction } from '@adopt-dont-shop/events';
+
+import {
+  apply as applyEvent,
+  DomainError,
+  handle,
+  type ApplicationCommand,
+  type ApplicationState,
+} from '../domain/index.js';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { appendEvents, ConcurrencyError, loadAggregate, projectReadModel } from './event-store.js';
+
+export type PublishEnvelope = { type: string; id: string; payload: unknown };
+
+// Translate the pure domain's DomainError codes into HandlerError
+// codes. ILLEGAL_TRANSITION / INVALID_INPUT → INVALID_ARGUMENT;
+// CONCURRENCY → INTERNAL with a "CONCURRENCY:" message (the gateway
+// maps that to 409 in Phase 5.3d); MISSING_AGGREGATE → NOT_FOUND.
+export function domainErrorToHandler(err: DomainError): HandlerError {
+  switch (err.code) {
+    case 'ILLEGAL_TRANSITION':
+    case 'INVALID_INPUT':
+      return new HandlerError('INVALID_ARGUMENT', err.message);
+    case 'MISSING_AGGREGATE':
+      return new HandlerError('NOT_FOUND', err.message);
+    case 'CONCURRENCY':
+      return new HandlerError('INTERNAL', `CONCURRENCY: ${err.message}`);
+    default:
+      return new HandlerError('INTERNAL', err.message);
+  }
+}
+
+// Runs the command against the loaded aggregate and persists the
+// resulting events. Returns the new folded state (caller maps to
+// proto). publishFor returns the NATS envelope to fire after commit,
+// or null to skip publishing.
+export async function runCommand(
+  deps: HandlerDeps,
+  aggregateId: string,
+  command: ApplicationCommand,
+  actorUserId: string,
+  publishFor: (state: ApplicationState) => PublishEnvelope | null
+): Promise<ApplicationState> {
+  return withTransaction(deps, async ({ client, publish }) => {
+    const state = await loadAggregate(client, aggregateId);
+
+    let events;
+    try {
+      events = handle(state, command);
+    } catch (err) {
+      if (err instanceof DomainError) {
+        throw domainErrorToHandler(err);
+      }
+      throw err;
+    }
+
+    try {
+      await appendEvents(client, aggregateId, state.version, events, actorUserId);
+    } catch (err) {
+      if (err instanceof ConcurrencyError) {
+        throw new HandlerError('INTERNAL', `CONCURRENCY: ${err.message}`);
+      }
+      throw err;
+    }
+
+    // Fold the new events onto the loaded state to get the post-command
+    // state, then project + publish.
+    const nextState = events.reduce<ApplicationState>((s, e) => applyEvent(s, e), state);
+
+    await projectReadModel(client, nextState);
+
+    const evt = publishFor(nextState);
+    if (evt !== null) {
+      publish(evt);
+    }
+
+    return nextState;
+  });
+}

--- a/services/applications/src/grpc/handlers.ts
+++ b/services/applications/src/grpc/handlers.ts
@@ -25,7 +25,6 @@
 // a 409.
 
 import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
-import { withTransaction } from '@adopt-dont-shop/events';
 import { APPLICATIONS_UPDATE } from '@adopt-dont-shop/lib.types';
 import type {
   SaveDraftAnswersRequest,
@@ -34,84 +33,11 @@ import type {
   SubmitDraftResponse,
 } from '@adopt-dont-shop/proto';
 
-import {
-  apply as applyEvent,
-  DomainError,
-  handle,
-  type ApplicationCommand,
-  type ApplicationState,
-  type Reference,
-} from '../domain/index.js';
+import type { ApplicationCommand, Reference } from '../domain/index.js';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { appendEvents, ConcurrencyError, loadAggregate, projectReadModel } from './event-store.js';
+import { runCommand } from './command-runner.js';
 import { stateToProto } from './state-mapper.js';
-
-// Translate the pure domain's DomainError codes into HandlerError
-// codes. ILLEGAL_TRANSITION / INVALID_INPUT → INVALID_ARGUMENT;
-// CONCURRENCY → INTERNAL with a message (the gateway maps the
-// CONCURRENCY message to 409 in Phase 5.3d); MISSING_AGGREGATE →
-// NOT_FOUND.
-function domainErrorToHandler(err: DomainError): HandlerError {
-  switch (err.code) {
-    case 'ILLEGAL_TRANSITION':
-    case 'INVALID_INPUT':
-      return new HandlerError('INVALID_ARGUMENT', err.message);
-    case 'MISSING_AGGREGATE':
-      return new HandlerError('NOT_FOUND', err.message);
-    case 'CONCURRENCY':
-      return new HandlerError('INTERNAL', `CONCURRENCY: ${err.message}`);
-    default:
-      return new HandlerError('INTERNAL', err.message);
-  }
-}
-
-// Runs the command against the loaded aggregate and persists the
-// resulting events. Shared by every write handler. Returns the new
-// folded state (caller maps to proto).
-async function runCommand(
-  deps: HandlerDeps,
-  aggregateId: string,
-  command: ApplicationCommand,
-  actorUserId: string,
-  publishFor: (state: ApplicationState) => { type: string; id: string; payload: unknown } | null
-): Promise<ApplicationState> {
-  return withTransaction(deps, async ({ client, publish }) => {
-    const state = await loadAggregate(client, aggregateId);
-
-    let events;
-    try {
-      events = handle(state, command);
-    } catch (err) {
-      if (err instanceof DomainError) {
-        throw domainErrorToHandler(err);
-      }
-      throw err;
-    }
-
-    try {
-      await appendEvents(client, aggregateId, state.version, events, actorUserId);
-    } catch (err) {
-      if (err instanceof ConcurrencyError) {
-        throw new HandlerError('INTERNAL', `CONCURRENCY: ${err.message}`);
-      }
-      throw err;
-    }
-
-    // Fold the new events onto the loaded state to get the post-command
-    // state, then project + publish.
-    const nextState = events.reduce<ApplicationState>((s, e) => applyEvent(s, e), state);
-
-    await projectReadModel(client, nextState);
-
-    const evt = publishFor(nextState);
-    if (evt !== null) {
-      publish(evt);
-    }
-
-    return nextState;
-  });
-}
 
 // --- SaveDraftAnswers ------------------------------------------------
 

--- a/services/applications/src/grpc/review-handlers.test.ts
+++ b/services/applications/src/grpc/review-handlers.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApplicationsV1 } from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import {
+  approve,
+  completeHomeVisit,
+  markAdopted,
+  reject,
+  scheduleHomeVisit,
+  startReview,
+  withdraw,
+} from './review-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'staff-1',
+    roles: overrides.roles ?? ['rescue_staff'],
+    permissions: overrides.permissions ?? [
+      'applications.review',
+      'applications.approve',
+      'applications.reject',
+      'applications.update',
+    ],
+    rescueId: 'rsc-1',
+  } as unknown as Parameters<typeof startReview>[1];
+}
+
+function makeDeps(eventRows: Array<unknown>): {
+  deps: HandlerDeps;
+  query: ReturnType<typeof vi.fn>;
+} {
+  const query = vi.fn();
+  query.mockResolvedValueOnce({ rows: eventRows });
+  query.mockResolvedValue({ rows: [] });
+  const pool = { query } as unknown as HandlerDeps['pool'];
+  return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
+}
+
+vi.mock('@adopt-dont-shop/events', async () => {
+  const actual =
+    await vi.importActual<typeof import('@adopt-dont-shop/events')>('@adopt-dont-shop/events');
+  return {
+    ...actual,
+    withTransaction: async (
+      deps: { pool: { query: ReturnType<typeof vi.fn> } },
+      fn: (scope: {
+        client: { query: ReturnType<typeof vi.fn> };
+        publish: ReturnType<typeof vi.fn>;
+      }) => Promise<unknown>
+    ) => {
+      const publish = vi.fn();
+      const client = { query: deps.pool.query };
+      const result = await fn({ client, publish });
+      (deps as { _publish?: ReturnType<typeof vi.fn> })._publish = publish;
+      return result;
+    },
+  };
+});
+
+function ev(type: string, version: number, extra: Record<string, unknown> = {}) {
+  return {
+    event_type: type,
+    version,
+    event_data: {
+      type,
+      applicationId: 'app-1',
+      at: `2026-06-0${version}T12:00:00.000Z`,
+      ...extra,
+    },
+  };
+}
+
+// A submitted application: draftCreated (v1) + draftSubmitted (v2).
+function submittedStream() {
+  return [
+    ev('draftCreated', 1, {
+      adopterId: 'usr-1',
+      petId: 'pet-1',
+      rescueId: 'rsc-1',
+    }),
+    ev('draftSubmitted', 2),
+  ];
+}
+
+// A stream advanced to under_review.
+function underReviewStream() {
+  return [...submittedStream(), ev('reviewStarted', 3, { actorUserId: 'staff-1', note: null })];
+}
+
+function publishOf(deps: HandlerDeps): ReturnType<typeof vi.fn> {
+  return (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+}
+
+describe('startReview', () => {
+  it('throws PERMISSION_DENIED without applications.review', async () => {
+    const { deps } = makeDeps(submittedStream());
+    await expect(
+      startReview(deps, makePrincipal({ permissions: [] }), { applicationId: 'app-1' })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws INVALID_ARGUMENT on missing application_id', async () => {
+    const { deps } = makeDeps([]);
+    await expect(startReview(deps, makePrincipal(), { applicationId: '' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('transitions submitted → under_review + publishes reviewStarted', async () => {
+    const { deps } = makeDeps(submittedStream());
+    const res = await startReview(deps, makePrincipal(), { applicationId: 'app-1', note: 'go' });
+    expect(res.application.status).toBe(
+      ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNDER_REVIEW
+    );
+    expect(publishOf(deps).mock.calls[0][0]).toMatchObject({ type: 'applications.reviewStarted' });
+  });
+});
+
+describe('scheduleHomeVisit', () => {
+  it('throws INVALID_ARGUMENT on missing scheduled_at', async () => {
+    const { deps } = makeDeps(underReviewStream());
+    await expect(
+      scheduleHomeVisit(deps, makePrincipal(), { applicationId: 'app-1', scheduledAt: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('transitions under_review → home_visit_scheduled', async () => {
+    const { deps } = makeDeps(underReviewStream());
+    const res = await scheduleHomeVisit(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      scheduledAt: '2026-06-10T14:00:00.000Z',
+    });
+    expect(res.application.status).toBe(
+      ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_HOME_VISIT_SCHEDULED
+    );
+    expect(publishOf(deps).mock.calls[0][0]).toMatchObject({
+      type: 'applications.homeVisitScheduled',
+    });
+  });
+});
+
+describe('completeHomeVisit', () => {
+  it('throws INVALID_ARGUMENT on UNSPECIFIED outcome', async () => {
+    const { deps } = makeDeps([
+      ...underReviewStream(),
+      ev('homeVisitScheduled', 4, {
+        scheduledAt: '2026-06-10T14:00:00.000Z',
+        actorUserId: 'staff-1',
+        note: null,
+      }),
+    ]);
+    await expect(
+      completeHomeVisit(deps, makePrincipal(), {
+        applicationId: 'app-1',
+        outcome: ApplicationsV1.HomeVisitOutcome.HOME_VISIT_OUTCOME_UNSPECIFIED,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('transitions home_visit_scheduled → home_visit_completed with outcome', async () => {
+    const { deps } = makeDeps([
+      ...underReviewStream(),
+      ev('homeVisitScheduled', 4, {
+        scheduledAt: '2026-06-10T14:00:00.000Z',
+        actorUserId: 'staff-1',
+        note: null,
+      }),
+    ]);
+    const res = await completeHomeVisit(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      outcome: ApplicationsV1.HomeVisitOutcome.HOME_VISIT_OUTCOME_PASSED,
+      notes: 'great fit',
+    });
+    expect(res.application.status).toBe(
+      ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_HOME_VISIT_COMPLETED
+    );
+    expect(res.application.homeVisitOutcome).toBe(
+      ApplicationsV1.HomeVisitOutcome.HOME_VISIT_OUTCOME_PASSED
+    );
+  });
+});
+
+// A stream advanced to home_visit_completed (passed) — ready for a
+// decision.
+function decidableStream() {
+  return [
+    ...underReviewStream(),
+    ev('homeVisitScheduled', 4, {
+      scheduledAt: '2026-06-10T14:00:00.000Z',
+      actorUserId: 'staff-1',
+      note: null,
+    }),
+    ev('homeVisitCompleted', 5, { outcome: 'passed', actorUserId: 'staff-1', notes: null }),
+  ];
+}
+
+describe('approve', () => {
+  it('throws PERMISSION_DENIED without applications.approve', async () => {
+    const { deps } = makeDeps(decidableStream());
+    await expect(
+      approve(deps, makePrincipal({ permissions: ['applications.review'] }), {
+        applicationId: 'app-1',
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('transitions home_visit_completed → approved + publishes approved', async () => {
+    const { deps } = makeDeps(decidableStream());
+    const res = await approve(deps, makePrincipal(), { applicationId: 'app-1', notes: 'ok' });
+    expect(res.application.status).toBe(
+      ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_APPROVED
+    );
+    expect(publishOf(deps).mock.calls[0][0]).toMatchObject({ type: 'applications.approved' });
+  });
+});
+
+describe('reject', () => {
+  it('throws INVALID_ARGUMENT on missing reason', async () => {
+    const { deps } = makeDeps(decidableStream());
+    await expect(
+      reject(deps, makePrincipal(), { applicationId: 'app-1', reason: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('transitions to rejected with a reason + publishes rejected', async () => {
+    const { deps } = makeDeps(decidableStream());
+    const res = await reject(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      reason: 'home unsuitable',
+    });
+    expect(res.application.status).toBe(
+      ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_REJECTED
+    );
+    expect(res.application.rejectionReason).toBe('home unsuitable');
+    expect(publishOf(deps).mock.calls[0][0]).toMatchObject({ type: 'applications.rejected' });
+  });
+});
+
+describe('withdraw', () => {
+  it('transitions to withdrawn + publishes withdrawn', async () => {
+    const { deps } = makeDeps(submittedStream());
+    const res = await withdraw(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      reason: 'found another pet',
+    });
+    expect(res.application.status).toBe(
+      ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_WITHDRAWN
+    );
+    expect(publishOf(deps).mock.calls[0][0]).toMatchObject({ type: 'applications.withdrawn' });
+  });
+});
+
+describe('markAdopted', () => {
+  it('throws PERMISSION_DENIED without applications.approve', async () => {
+    const { deps } = makeDeps([
+      ...decidableStream(),
+      ev('approved', 6, { actorUserId: 'staff-1', notes: null }),
+    ]);
+    await expect(
+      markAdopted(deps, makePrincipal({ permissions: ['applications.review'] }), {
+        applicationId: 'app-1',
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('transitions approved → adopted + publishes adopted', async () => {
+    const { deps } = makeDeps([
+      ...decidableStream(),
+      ev('approved', 6, { actorUserId: 'staff-1', notes: null }),
+    ]);
+    const res = await markAdopted(deps, makePrincipal(), { applicationId: 'app-1' });
+    expect(res.application.status).toBe(
+      ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_ADOPTED
+    );
+    expect(publishOf(deps).mock.calls[0][0]).toMatchObject({ type: 'applications.adopted' });
+  });
+});

--- a/services/applications/src/grpc/review-handlers.ts
+++ b/services/applications/src/grpc/review-handlers.ts
@@ -1,0 +1,298 @@
+// gRPC handler implementations for ApplicationService — batch 2.
+//
+// Phase 5.3b — the review / home-visit / decision lifecycle:
+// StartReview, ScheduleHomeVisit, CompleteHomeVisit, Approve, Reject,
+// Withdraw, MarkAdopted. Draft handlers shipped in #930 (and share the
+// runCommand machinery from command-runner.ts).
+//
+// State machine (from the pure domain in #879):
+//   submitted → under_review → home_visit_scheduled →
+//   home_visit_completed → approved | rejected | withdrawn → adopted
+//
+// Authz:
+//   - The review/visit/decision actions are rescue-staff operations —
+//     gate on APPLICATIONS_PROCESS (review/visit) /
+//     APPLICATIONS_APPROVE / APPLICATIONS_REJECT.
+//   - Withdraw is adopter-OR-staff (an adopter withdraws their own
+//     application; staff can withdraw on their behalf). Gated on
+//     APPLICATIONS_UPDATE.
+//   - MarkAdopted is a staff action (the pet was collected) — gate on
+//     APPLICATIONS_APPROVE.
+//
+// Every handler is `(deps, principal, request) → Promise<response>`
+// and routes through runCommand: load → handle → append → project →
+// publish-after-commit.
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import {
+  APPLICATIONS_APPROVE,
+  APPLICATIONS_PROCESS,
+  APPLICATIONS_REJECT,
+  APPLICATIONS_UPDATE,
+  type Permission,
+} from '@adopt-dont-shop/lib.types';
+import {
+  ApplicationsV1,
+  type ApproveRequest,
+  type ApproveResponse,
+  type CompleteHomeVisitRequest,
+  type CompleteHomeVisitResponse,
+  type MarkAdoptedRequest,
+  type MarkAdoptedResponse,
+  type RejectRequest,
+  type RejectResponse,
+  type ScheduleHomeVisitRequest,
+  type ScheduleHomeVisitResponse,
+  type StartReviewRequest,
+  type StartReviewResponse,
+  type WithdrawRequest,
+  type WithdrawResponse,
+} from '@adopt-dont-shop/proto';
+
+import type { ApplicationCommand, HomeVisitOutcome } from '../domain/index.js';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { runCommand } from './command-runner.js';
+import { homeVisitOutcomeToDb } from './enum-map.js';
+import { stateToProto } from './state-mapper.js';
+
+function ensure(principal: Principal, permission: Permission): void {
+  if (!requirePermission(principal, permission)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${permission}' required`);
+  }
+}
+
+function requireApplicationId(applicationId: string | undefined): string {
+  if (applicationId === undefined || applicationId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
+  }
+  return applicationId;
+}
+
+// --- StartReview -----------------------------------------------------
+
+export async function startReview(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: StartReviewRequest
+): Promise<StartReviewResponse> {
+  ensure(principal, APPLICATIONS_PROCESS);
+  const id = requireApplicationId(req.applicationId);
+
+  const command: ApplicationCommand = {
+    type: 'startReview',
+    actorUserId: principal.userId,
+    note: req.note ?? null,
+    at: new Date().toISOString(),
+  };
+
+  const state = await runCommand(deps, id, command, principal.userId, s => ({
+    type: 'applications.reviewStarted',
+    id,
+    payload: { applicationId: id, reviewerId: principal.userId, rescueId: s.rescueId },
+  }));
+
+  return { application: stateToProto(state) };
+}
+
+// --- ScheduleHomeVisit -----------------------------------------------
+
+export async function scheduleHomeVisit(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ScheduleHomeVisitRequest
+): Promise<ScheduleHomeVisitResponse> {
+  ensure(principal, APPLICATIONS_PROCESS);
+  const id = requireApplicationId(req.applicationId);
+  if (req.scheduledAt === undefined || req.scheduledAt === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'scheduled_at is required');
+  }
+
+  const command: ApplicationCommand = {
+    type: 'scheduleHomeVisit',
+    scheduledAt: req.scheduledAt,
+    actorUserId: principal.userId,
+    note: req.note ?? null,
+    at: new Date().toISOString(),
+  };
+
+  const state = await runCommand(deps, id, command, principal.userId, s => ({
+    type: 'applications.homeVisitScheduled',
+    id,
+    payload: {
+      applicationId: id,
+      adopterId: s.adopterId,
+      rescueId: s.rescueId,
+      scheduledAt: req.scheduledAt,
+    },
+  }));
+
+  return { application: stateToProto(state) };
+}
+
+// --- CompleteHomeVisit -----------------------------------------------
+
+export async function completeHomeVisit(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: CompleteHomeVisitRequest
+): Promise<CompleteHomeVisitResponse> {
+  ensure(principal, APPLICATIONS_PROCESS);
+  const id = requireApplicationId(req.applicationId);
+  if (req.outcome === undefined || req.outcome === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'outcome is required');
+  }
+
+  // Map the proto HomeVisitOutcome → the domain string. The enum-map
+  // homeVisitOutcomeToDb gives the DB form, which is the same string
+  // the domain uses.
+  const outcome = homeVisitOutcomeToDb(req.outcome) as HomeVisitOutcome;
+
+  const command: ApplicationCommand = {
+    type: 'completeHomeVisit',
+    outcome,
+    actorUserId: principal.userId,
+    notes: req.notes ?? null,
+    at: new Date().toISOString(),
+  };
+
+  const state = await runCommand(deps, id, command, principal.userId, s => ({
+    type: 'applications.homeVisitCompleted',
+    id,
+    payload: { applicationId: id, adopterId: s.adopterId, rescueId: s.rescueId, outcome },
+  }));
+
+  return { application: stateToProto(state) };
+}
+
+// --- Approve ---------------------------------------------------------
+
+export async function approve(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ApproveRequest
+): Promise<ApproveResponse> {
+  ensure(principal, APPLICATIONS_APPROVE);
+  const id = requireApplicationId(req.applicationId);
+
+  const command: ApplicationCommand = {
+    type: 'approve',
+    actorUserId: principal.userId,
+    notes: req.notes ?? null,
+    at: new Date().toISOString(),
+  };
+
+  const state = await runCommand(deps, id, command, principal.userId, s => ({
+    type: 'applications.approved',
+    id,
+    payload: {
+      applicationId: id,
+      adopterId: s.adopterId,
+      petId: s.petId,
+      rescueId: s.rescueId,
+      approvedBy: principal.userId,
+    },
+  }));
+
+  return { application: stateToProto(state) };
+}
+
+// --- Reject ----------------------------------------------------------
+
+export async function reject(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: RejectRequest
+): Promise<RejectResponse> {
+  ensure(principal, APPLICATIONS_REJECT);
+  const id = requireApplicationId(req.applicationId);
+  if (req.reason === undefined || req.reason === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'reason is required');
+  }
+
+  const command: ApplicationCommand = {
+    type: 'reject',
+    actorUserId: principal.userId,
+    reason: req.reason,
+    at: new Date().toISOString(),
+  };
+
+  const state = await runCommand(deps, id, command, principal.userId, s => ({
+    type: 'applications.rejected',
+    id,
+    payload: {
+      applicationId: id,
+      adopterId: s.adopterId,
+      petId: s.petId,
+      rescueId: s.rescueId,
+      rejectedBy: principal.userId,
+      reason: req.reason,
+    },
+  }));
+
+  return { application: stateToProto(state) };
+}
+
+// --- Withdraw --------------------------------------------------------
+
+export async function withdraw(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: WithdrawRequest
+): Promise<WithdrawResponse> {
+  // Adopter-or-staff. An adopter withdraws their own application; staff
+  // can withdraw on their behalf. The basic APPLICATIONS_UPDATE gate
+  // covers both; ownership is enforced by the domain only knowing the
+  // adopter (the gateway scopes adopter requests to their own id).
+  ensure(principal, APPLICATIONS_UPDATE);
+  const id = requireApplicationId(req.applicationId);
+
+  const command: ApplicationCommand = {
+    type: 'withdraw',
+    actorUserId: principal.userId,
+    reason: req.reason ?? null,
+    at: new Date().toISOString(),
+  };
+
+  const state = await runCommand(deps, id, command, principal.userId, s => ({
+    type: 'applications.withdrawn',
+    id,
+    payload: {
+      applicationId: id,
+      adopterId: s.adopterId,
+      rescueId: s.rescueId,
+      withdrawnBy: principal.userId,
+    },
+  }));
+
+  return { application: stateToProto(state) };
+}
+
+// --- MarkAdopted -----------------------------------------------------
+
+export async function markAdopted(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: MarkAdoptedRequest
+): Promise<MarkAdoptedResponse> {
+  ensure(principal, APPLICATIONS_APPROVE);
+  const id = requireApplicationId(req.applicationId);
+
+  const command: ApplicationCommand = {
+    type: 'markAdopted',
+    at: new Date().toISOString(),
+  };
+
+  const state = await runCommand(deps, id, command, principal.userId, s => ({
+    type: 'applications.adopted',
+    id,
+    payload: { applicationId: id, adopterId: s.adopterId, petId: s.petId, rescueId: s.rescueId },
+  }));
+
+  return { application: stateToProto(state) };
+}
+
+// Re-export so the gRPC server boot can register the proto enum
+// helper without a deep import (keeps the server's import surface
+// small).
+export { ApplicationsV1 };


### PR DESCRIPTION
## Summary

Phase 5.3b batch 2 — the review / home-visit / decision lifecycle: `StartReview`, `ScheduleHomeVisit`, `CompleteHomeVisit`, `Approve`, `Reject`, `Withdraw`, `MarkAdopted`. Draft handlers shipped in #930.

**Extracted `command-runner.ts`** — the shared event-sourcing flow (load → domain.handle → appendEvents → projectReadModel → publish-after-commit + DomainError/ConcurrencyError translation) so both `handlers.ts` (refactored to import it) and the new `review-handlers.ts` reuse the exact same machinery. No behaviour change to the draft handlers — just the extraction.

**State machine** (from #879's pure domain):
```
submitted → under_review → home_visit_scheduled →
home_visit_completed → approved | rejected | withdrawn → adopted
```
Each handler maps its proto request to an `ApplicationCommand` and routes through `runCommand`. The domain enforces legal transitions; an illegal one surfaces as INVALID_ARGUMENT.

**Authz**:
- StartReview / ScheduleHomeVisit / CompleteHomeVisit → `APPLICATIONS_PROCESS`
- Approve / MarkAdopted → `APPLICATIONS_APPROVE`
- Reject → `APPLICATIONS_REJECT`
- Withdraw → `APPLICATIONS_UPDATE` (adopter-or-staff)

Each publishes its domain event after commit (`applications.reviewStarted` / `homeVisitScheduled` / `homeVisitCompleted` / `approved` / `rejected` / `withdrawn` / `adopted`).

**10 of 10 application commands now handled** (draft trio in #930 + these 7); StartDraft remains deferred on the pets gRPC client for rescueId resolution.

## Test plan

- [x] `npm test` in services/applications — 123/123 green (all existing + 14 review-handler tests exercising each transition through the full event-stream fold)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_