### PR TITLE
feat(applications): phase 5.3b — read handlers (Get + List)

### DIFF
--- a/services/applications/src/grpc/event-store.ts
+++ b/services/applications/src/grpc/event-store.ts
@@ -18,7 +18,7 @@
 // read-model projection commit atomically, and NATS publishes only
 // after commit (publish-after-commit).
 
-import type { PoolClient } from 'pg';
+import type { PoolClient, QueryResult, QueryResultRow } from 'pg';
 
 import {
   apply,
@@ -30,6 +30,13 @@ import {
 // pg's 23505 is unique_violation. The (aggregate_id, version) UNIQUE
 // index trips this when two writers race at the same version.
 const PG_UNIQUE_VIOLATION = '23505';
+
+// Both `Pool` and `PoolClient` satisfy this — the write path passes the
+// transaction's PoolClient, the read path (Get/List handlers) passes
+// the pool directly since reads don't need a transaction.
+export type Queryable = {
+  query<R extends QueryResultRow>(text: string, values?: unknown[]): Promise<QueryResult<R>>;
+};
 
 export class ConcurrencyError extends Error {
   constructor(message: string) {
@@ -44,15 +51,41 @@ type EventRow = {
   version: number;
 };
 
+// A persisted event row with its forensic metadata. The read-side
+// timeline projection (GetApplication include_timeline) needs the
+// event_id (stable entry id), occurred_at (when it happened) and
+// actor_user_id (who did it) that the folded ApplicationState drops.
+export type EventStoreRow = {
+  event_id: string;
+  event_data: ApplicationEvent;
+  occurred_at: Date;
+  actor_user_id: string | null;
+  version: number;
+};
+
+// loadEventRows reads the raw event stream for an aggregate in version
+// order, metadata included. Returns [] for an unknown aggregate. Both
+// loadAggregate and the read-side timeline builder fold over these.
+export async function loadEventRows(
+  db: Queryable,
+  aggregateId: string
+): Promise<ReadonlyArray<EventStoreRow>> {
+  const { rows } = await db.query<EventStoreRow>(
+    `SELECT event_id, event_data, occurred_at, actor_user_id, version
+     FROM application_events
+     WHERE aggregate_id = $1
+     ORDER BY version ASC`,
+    [aggregateId]
+  );
+  return rows;
+}
+
 // loadAggregate reads + folds the event stream. Returns INITIAL_STATE
 // when no events exist (a fresh aggregate). The folded state's
 // `version` matches the highest event version, which is the optimistic-
 // concurrency cursor the caller checks against expected_version.
-export async function loadAggregate(
-  client: PoolClient,
-  aggregateId: string
-): Promise<ApplicationState> {
-  const { rows } = await client.query<EventRow>(
+export async function loadAggregate(db: Queryable, aggregateId: string): Promise<ApplicationState> {
+  const { rows } = await db.query<EventRow>(
     `SELECT event_type, event_data, version
      FROM application_events
      WHERE aggregate_id = $1

--- a/services/applications/src/grpc/read-handlers.test.ts
+++ b/services/applications/src/grpc/read-handlers.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApplicationsV1 } from '@adopt-dont-shop/proto';
+
+import type { ApplicationEvent } from '../domain/index.js';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { getApplication, listApplications } from './read-handlers.js';
+
+const S = ApplicationsV1.ApplicationStatus;
+
+function makePrincipal(
+  overrides: Partial<{
+    userId: string;
+    roles: string[];
+    permissions: string[];
+    rescueId: string;
+  }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['adopter'],
+    permissions: overrides.permissions ?? ['applications.read'],
+    ...(overrides.rescueId !== undefined ? { rescueId: overrides.rescueId } : {}),
+  } as unknown as Parameters<typeof getApplication>[1];
+}
+
+function makeDeps(): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn();
+  const pool = { query } as unknown as HandlerDeps['pool'];
+  return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
+}
+
+// An event-store row as loadEventRows reads it.
+function storeRow(version: number, event: ApplicationEvent, actor: string | null = null): unknown {
+  return {
+    event_id: `evt-${version}`,
+    event_data: event,
+    occurred_at: new Date(`2026-06-0${version}T12:00:00.000Z`),
+    actor_user_id: actor,
+    version,
+  };
+}
+
+const draftCreated: ApplicationEvent = {
+  type: 'draftCreated',
+  applicationId: 'app-1',
+  adopterId: 'usr-1',
+  petId: 'pet-1',
+  rescueId: 'rsc-1',
+  at: '2026-06-01T12:00:00.000Z',
+};
+
+const draftSubmitted: ApplicationEvent = {
+  type: 'draftSubmitted',
+  applicationId: 'app-1',
+  at: '2026-06-02T12:00:00.000Z',
+};
+
+// A submitted application's event-store rows (loadEventRows shape).
+function submittedRows(): unknown[] {
+  return [storeRow(1, draftCreated), storeRow(2, draftSubmitted)];
+}
+
+// A submitted application's rows as loadAggregate reads them (just
+// event_data matters — fold ignores the rest).
+function aggregateRows(): unknown[] {
+  return [{ event_data: draftCreated }, { event_data: draftSubmitted }];
+}
+
+describe('getApplication', () => {
+  it('throws INVALID_ARGUMENT on missing application_id', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      getApplication(deps, makePrincipal(), { applicationId: '', includeTimeline: false })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('throws NOT_FOUND for an unknown aggregate', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      getApplication(deps, makePrincipal(), { applicationId: 'app-x', includeTimeline: false })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('lets the owning adopter read their application', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: submittedRows() });
+    const res = await getApplication(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      includeTimeline: false,
+    });
+    expect(res.application.status).toBe(S.APPLICATION_STATUS_SUBMITTED);
+    expect(res.application.adopterId).toBe('usr-1');
+    expect(res.timeline).toEqual([]);
+  });
+
+  it('denies a different adopter', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: submittedRows() });
+    await expect(
+      getApplication(deps, makePrincipal({ userId: 'usr-2' }), {
+        applicationId: 'app-1',
+        includeTimeline: false,
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('lets rescue staff of the application’s rescue read it', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: submittedRows() });
+    const res = await getApplication(
+      deps,
+      makePrincipal({ userId: 'staff-1', roles: ['rescue_staff'], rescueId: 'rsc-1' }),
+      { applicationId: 'app-1', includeTimeline: false }
+    );
+    expect(res.application.status).toBe(S.APPLICATION_STATUS_SUBMITTED);
+  });
+
+  it('includes the timeline when requested', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: submittedRows() });
+    const res = await getApplication(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      includeTimeline: true,
+    });
+    expect(res.timeline).toHaveLength(2);
+    expect(res.timeline[1]).toMatchObject({ toStatus: S.APPLICATION_STATUS_SUBMITTED });
+  });
+});
+
+describe('listApplications', () => {
+  it('throws PERMISSION_DENIED without applications.read', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      listApplications(deps, makePrincipal({ permissions: [] }), {
+        limit: 20,
+        statusFilter: S.APPLICATION_STATUS_UNSPECIFIED,
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('scopes an adopter to their own user id and folds each aggregate', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({
+      rows: [{ application_id: 'app-1', created_at: new Date('2026-06-02T12:00:00.000Z') }],
+    });
+    query.mockResolvedValue({ rows: aggregateRows() });
+
+    const res = await listApplications(deps, makePrincipal({ userId: 'usr-1' }), {
+      limit: 20,
+      statusFilter: S.APPLICATION_STATUS_UNSPECIFIED,
+    });
+
+    expect(res.applications).toHaveLength(1);
+    expect(res.applications[0].status).toBe(S.APPLICATION_STATUS_SUBMITTED);
+    // The index query is parameterised with the principal's own user id.
+    const indexParams = query.mock.calls[0][1] as unknown[];
+    expect(indexParams).toContain('usr-1');
+    expect(res.nextCursor).toBeUndefined();
+  });
+
+  it('pins rescue staff to their own rescue', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+    await listApplications(
+      deps,
+      makePrincipal({ userId: 'staff-1', roles: ['rescue_staff'], rescueId: 'rsc-9' }),
+      { limit: 20, statusFilter: S.APPLICATION_STATUS_UNSPECIFIED }
+    );
+    const indexParams = query.mock.calls[0][1] as unknown[];
+    expect(indexParams).toContain('rsc-9');
+  });
+
+  it('applies a status filter as the DB enum string', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+    await listApplications(deps, makePrincipal(), {
+      limit: 20,
+      statusFilter: S.APPLICATION_STATUS_APPROVED,
+    });
+    const indexParams = query.mock.calls[0][1] as unknown[];
+    expect(indexParams).toContain('approved');
+  });
+
+  it('emits a next_cursor when more rows exist', async () => {
+    const { deps, query } = makeDeps();
+    // limit 1 → fetch 2; two index rows means hasMore.
+    query.mockResolvedValueOnce({
+      rows: [
+        { application_id: 'app-1', created_at: new Date('2026-06-02T12:00:00.000Z') },
+        { application_id: 'app-0', created_at: new Date('2026-06-01T12:00:00.000Z') },
+      ],
+    });
+    query.mockResolvedValue({ rows: aggregateRows() });
+
+    const res = await listApplications(deps, makePrincipal(), {
+      limit: 1,
+      statusFilter: S.APPLICATION_STATUS_UNSPECIFIED,
+    });
+
+    expect(res.applications).toHaveLength(1);
+    expect(res.nextCursor).toBeDefined();
+  });
+});

--- a/services/applications/src/grpc/read-handlers.ts
+++ b/services/applications/src/grpc/read-handlers.ts
@@ -1,0 +1,195 @@
+// gRPC handler implementations for ApplicationService — batch 3 (reads).
+//
+// Phase 5.3b — the query side: Get + List. The command handlers
+// (#930 draft, #931 review/decision) own the write path; these two are
+// read-only and run OUTSIDE a transaction (straight off deps.pool).
+//
+// Read strategy — event-stream fold, not the read-model row:
+//   The applications read-model row (migration 002) only carries the
+//   live status/answers/version; the lifecycle timestamps the proto
+//   needs (submitted_at, review_started_at, decided_at, …) aren't
+//   projected onto it. So a complete Application proto can only be
+//   built by folding the event stream. Get folds the one aggregate;
+//   List uses the read-model row purely as a filter + keyset-pagination
+//   INDEX (status, user_id, rescue_id, created_at, application_id are
+//   real columns) then folds each aggregate in the page.
+//
+// Authz:
+//   - Get: adopter-owns OR rescue-staff-of-the-app's-rescue OR admin.
+//     The owner/rescue is only known after the fold, so the scope check
+//     runs post-load (an unknown id still 404s before leaking scope).
+//   - List: the principal's scope decides the forced filter — admins
+//     see everything (and may filter by rescue/adopter), rescue staff
+//     are pinned to their own rescue, adopters to their own user id.
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { APPLICATIONS_VIEW, type RescueId, type UserId } from '@adopt-dont-shop/lib.types';
+import {
+  ApplicationsV1,
+  type GetApplicationRequest,
+  type GetApplicationResponse,
+  type ListApplicationsRequest,
+  type ListApplicationsResponse,
+} from '@adopt-dont-shop/proto';
+
+import { fold } from '../domain/index.js';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { decodeCursor, encodeCursor, InvalidCursorError } from './cursor.js';
+import { statusToDb } from './enum-map.js';
+import { loadAggregate, loadEventRows } from './event-store.js';
+import { stateToProto } from './state-mapper.js';
+import { buildTimeline } from './timeline.js';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+function clampLimit(raw: number): number {
+  if (raw <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.trunc(raw), MAX_LIMIT);
+}
+
+// An index row from the applications read model — just enough to filter,
+// order and keyset-paginate. The full proto comes from folding each
+// aggregate's event stream.
+type IndexRow = {
+  application_id: string;
+  created_at: Date;
+};
+
+// --- Get -------------------------------------------------------------
+
+export async function getApplication(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetApplicationRequest
+): Promise<GetApplicationResponse> {
+  if (req.applicationId === undefined || req.applicationId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
+  }
+
+  const rows = await loadEventRows(deps.pool, req.applicationId);
+  if (rows.length === 0) {
+    throw new HandlerError('NOT_FOUND', 'application not found');
+  }
+
+  const state = fold(rows.map(r => r.event_data));
+
+  // Adopter-owns OR rescue-staff-of-this-rescue OR admin. super_admin
+  // short-circuits both checks inside requirePermission.
+  const canRead =
+    requirePermission(principal, APPLICATIONS_VIEW, { userId: state.adopterId as UserId }) ||
+    requirePermission(principal, APPLICATIONS_VIEW, { rescueId: state.rescueId as RescueId });
+  if (!canRead) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
+  }
+
+  const response: GetApplicationResponse = {
+    application: stateToProto(state),
+    timeline: [],
+  };
+  if (req.includeTimeline === true) {
+    response.timeline = buildTimeline(rows);
+  }
+
+  return response;
+}
+
+// --- List ------------------------------------------------------------
+
+export async function listApplications(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListApplicationsRequest
+): Promise<ListApplicationsResponse> {
+  if (!requirePermission(principal, APPLICATIONS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
+  }
+
+  const limit = clampLimit(req.limit);
+
+  const where: string[] = ['deleted_at IS NULL'];
+  const params: unknown[] = [];
+  let p = 1;
+
+  // Scope the result set to what the principal is allowed to see.
+  const isSuperAdmin = principal.roles.includes('super_admin');
+  if (isSuperAdmin) {
+    if (req.rescueIdFilter !== undefined && req.rescueIdFilter !== '') {
+      where.push(`rescue_id = $${p++}`);
+      params.push(req.rescueIdFilter);
+    }
+    if (req.adopterIdFilter !== undefined && req.adopterIdFilter !== '') {
+      where.push(`user_id = $${p++}`);
+      params.push(req.adopterIdFilter);
+    }
+  } else if (principal.rescueId !== undefined) {
+    // Rescue staff — pinned to their own rescue, may narrow to one adopter.
+    where.push(`rescue_id = $${p++}`);
+    params.push(principal.rescueId);
+    if (req.adopterIdFilter !== undefined && req.adopterIdFilter !== '') {
+      where.push(`user_id = $${p++}`);
+      params.push(req.adopterIdFilter);
+    }
+  } else {
+    // Adopter — their own applications only.
+    where.push(`user_id = $${p++}`);
+    params.push(principal.userId);
+  }
+
+  if (req.statusFilter !== ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED) {
+    where.push(`status = $${p++}`);
+    params.push(statusToDb(req.statusFilter));
+  }
+
+  if (req.cursor !== undefined && req.cursor !== '') {
+    let cursor;
+    try {
+      cursor = decodeCursor(req.cursor);
+    } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        throw new HandlerError('INVALID_ARGUMENT', err.message);
+      }
+      throw err;
+    }
+    // (created_at, application_id) < (cursor) in DESC order.
+    where.push(`(created_at < $${p++} OR (created_at = $${p - 1} AND application_id < $${p++}))`);
+    params.push(cursor.createdAt);
+    params.push(cursor.applicationId);
+  }
+
+  // Fetch limit+1 to detect a next page without a separate COUNT(*).
+  params.push(limit + 1);
+  const sql = `
+    SELECT application_id, created_at
+    FROM applications
+    WHERE ${where.join(' AND ')}
+    ORDER BY created_at DESC, application_id DESC
+    LIMIT $${p}
+  `;
+
+  const { rows } = await deps.pool.query<IndexRow>(sql, params);
+
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+
+  // Fold each aggregate's event stream into the full proto. The index
+  // row guarantees the aggregate exists, so loadAggregate never returns
+  // the empty INITIAL_STATE here.
+  const applications = await Promise.all(
+    pageRows.map(async row => stateToProto(await loadAggregate(deps.pool, row.application_id)))
+  );
+
+  const response: ListApplicationsResponse = { applications };
+  if (hasMore && pageRows.length > 0) {
+    const last = pageRows[pageRows.length - 1];
+    response.nextCursor = encodeCursor({
+      createdAt: last.created_at.toISOString(),
+      applicationId: last.application_id,
+    });
+  }
+
+  return response;
+}

--- a/services/applications/src/grpc/timeline.test.ts
+++ b/services/applications/src/grpc/timeline.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApplicationsV1 } from '@adopt-dont-shop/proto';
+
+import type { ApplicationEvent } from '../domain/index.js';
+
+import type { EventStoreRow } from './event-store.js';
+import { buildTimeline } from './timeline.js';
+
+const S = ApplicationsV1.ApplicationStatus;
+
+function row(version: number, event: ApplicationEvent, actor: string | null = null): EventStoreRow {
+  return {
+    event_id: `evt-${version}`,
+    event_data: event,
+    occurred_at: new Date(`2026-06-0${version}T12:00:00.000Z`),
+    actor_user_id: actor,
+    version,
+  };
+}
+
+const created = row(1, {
+  type: 'draftCreated',
+  applicationId: 'app-1',
+  adopterId: 'usr-1',
+  petId: 'pet-1',
+  rescueId: 'rsc-1',
+  at: '2026-06-01T12:00:00.000Z',
+});
+
+const answersSaved = row(2, {
+  type: 'draftAnswersSaved',
+  applicationId: 'app-1',
+  answersPatch: { q1: 'a' },
+  references: null,
+  at: '2026-06-02T12:00:00.000Z',
+});
+
+const submitted = row(3, {
+  type: 'draftSubmitted',
+  applicationId: 'app-1',
+  at: '2026-06-03T12:00:00.000Z',
+});
+
+describe('buildTimeline', () => {
+  it('returns no entries for an empty stream', () => {
+    expect(buildTimeline([])).toEqual([]);
+  });
+
+  it('opens the timeline with from_status UNSPECIFIED on draftCreated', () => {
+    const [entry] = buildTimeline([created]);
+    expect(entry).toMatchObject({
+      entryId: 'evt-1',
+      applicationId: 'app-1',
+      fromStatus: S.APPLICATION_STATUS_UNSPECIFIED,
+      toStatus: S.APPLICATION_STATUS_DRAFT,
+      occurredAt: '2026-06-01T12:00:00.000Z',
+    });
+  });
+
+  it('skips events that do not change status', () => {
+    const entries = buildTimeline([created, answersSaved, submitted]);
+    // draftAnswersSaved (v2) leaves status at draft → no entry for it.
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({
+      fromStatus: S.APPLICATION_STATUS_DRAFT,
+      toStatus: S.APPLICATION_STATUS_SUBMITTED,
+    });
+  });
+
+  it('stamps the actor that produced the transition', () => {
+    const reviewStarted = row(
+      4,
+      {
+        type: 'reviewStarted',
+        applicationId: 'app-1',
+        actorUserId: 'staff-1',
+        note: null,
+        at: '2026-06-04T12:00:00.000Z',
+      },
+      'staff-1'
+    );
+    const entries = buildTimeline([created, submitted, reviewStarted]);
+    expect(entries[2]).toMatchObject({
+      toStatus: S.APPLICATION_STATUS_UNDER_REVIEW,
+      actorUserId: 'staff-1',
+    });
+  });
+
+  it('surfaces the reason/notes an event carried as the entry note', () => {
+    const rejected = row(4, {
+      type: 'rejected',
+      applicationId: 'app-1',
+      actorUserId: 'staff-1',
+      reason: 'home unsuitable',
+      at: '2026-06-04T12:00:00.000Z',
+    });
+    const entries = buildTimeline([created, submitted, rejected]);
+    expect(entries[2]).toMatchObject({
+      toStatus: S.APPLICATION_STATUS_REJECTED,
+      note: 'home unsuitable',
+    });
+  });
+
+  it('does not set a note when the event carried none', () => {
+    expect(buildTimeline([created])[0].note).toBeUndefined();
+  });
+});

--- a/services/applications/src/grpc/timeline.ts
+++ b/services/applications/src/grpc/timeline.ts
@@ -1,0 +1,71 @@
+// Event-stream → TimelineEntry projection.
+//
+// The SPA's application timeline is the chronological list of STATUS
+// transitions. We derive it straight from the event stream rather than
+// the application_status_transitions read-model table: the projector
+// (event-store.ts projectReadModel) only maintains the `applications`
+// row, so the transitions table isn't populated yet. The event stream
+// is the authoritative source either way — folding it incrementally
+// gives us the (from_status → to_status) pair plus the forensic
+// metadata (who, when) each entry needs.
+//
+// An entry is emitted for an event only when it changes the aggregate's
+// status. The first event (draftCreated) always emits — from_status
+// UNSPECIFIED — so the timeline opens with "application started".
+// Non-status events (e.g. draftAnswersSaved) and idempotent re-runs
+// (a second startReview) produce no entry.
+
+import { ApplicationsV1, type TimelineEntry } from '@adopt-dont-shop/proto';
+
+import {
+  apply,
+  INITIAL_STATE,
+  type ApplicationEvent,
+  type ApplicationStatus,
+} from '../domain/index.js';
+
+import { statusFromDb } from './enum-map.js';
+import type { EventStoreRow } from './event-store.js';
+
+const UNSPECIFIED = ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED;
+
+// Surface the human-readable reason/note an event carried, when it has
+// one. Different events name the field differently (reason | note |
+// notes) so we check each in turn.
+function noteOf(event: ApplicationEvent): string | null {
+  const candidate = event as { reason?: unknown; note?: unknown; notes?: unknown };
+  const value = candidate.reason ?? candidate.note ?? candidate.notes;
+  return typeof value === 'string' && value !== '' ? value : null;
+}
+
+export function buildTimeline(rows: ReadonlyArray<EventStoreRow>): TimelineEntry[] {
+  const entries: TimelineEntry[] = [];
+  let state = INITIAL_STATE;
+  let prevStatus: ApplicationStatus | null = null;
+
+  for (const row of rows) {
+    const next = apply(state, row.event_data);
+    const changed = prevStatus === null || next.status !== prevStatus;
+
+    if (changed) {
+      const entry: TimelineEntry = {
+        entryId: row.event_id,
+        applicationId: next.applicationId,
+        fromStatus: prevStatus === null ? UNSPECIFIED : statusFromDb(prevStatus),
+        toStatus: statusFromDb(next.status),
+        actorUserId: row.actor_user_id ?? '',
+        occurredAt: row.occurred_at.toISOString(),
+      };
+      const note = noteOf(row.event_data);
+      if (note !== null) {
+        entry.note = note;
+      }
+      entries.push(entry);
+    }
+
+    state = next;
+    prevStatus = next.status;
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## What

Adds the **query side** of `ApplicationService` — `getApplication` and `listApplications` — completing the handler set after #930 (draft) and #931 (review/decision). All 10 write commands + both reads now have pure `(deps, principal, request) → Promise<response>` handlers.

## Read strategy — event-stream fold, not the read-model row

The applications read-model row (migration 002) only projects the **live** `status` / `answers` / `version`; the lifecycle timestamps the proto carries (`submitted_at`, `review_started_at`, `decided_at`, …) are **not** projected onto it. So a complete `Application` proto can only be built by folding the event stream:

- **Get** folds the one aggregate (`loadEventRows` → `fold` → `stateToProto`).
- **List** uses the read-model row purely as a **filter + keyset-pagination index** (`status`, `user_id`, `rescue_id`, `created_at`, `application_id` are real columns), then folds each aggregate in the page. `LIMIT+1` for `hasMore`; base64-JSON `(created_at, application_id)` cursor, same shape as audit/moderation.

## Timeline (`Get include_timeline`)

Derived **directly from the event stream**, not the `application_status_transitions` table — the projector (`projectReadModel`) only maintains the `applications` row and doesn't populate the transitions table yet. The event stream is the authoritative source either way: `buildTimeline` folds incrementally and emits an entry on each **status change**, opening with `from_status = UNSPECIFIED`. Non-status events (`draftAnswersSaved`) and idempotent re-runs (a second `startReview`) produce no entry.

## Authz

- **Get**: adopter-owns **OR** rescue-staff-of-the-app's-rescue **OR** admin. The owner/rescue is only known after the fold, so the scope check runs post-load (an unknown id still 404s before any scope leaks).
- **List**: the principal's scope forces the filter — `super_admin` sees all (may filter by rescue/adopter), rescue staff are pinned to their own `rescue_id`, adopters to their own `user_id`.

## event-store changes

- `loadEventRows` — raw event rows with forensic metadata (`event_id`, `occurred_at`, `actor_user_id`) the folded state drops.
- Structural `Queryable` type so `loadEventRows` / `loadAggregate` accept both `Pool` (reads, no transaction) and `PoolClient` (writes, in transaction). No behaviour change to the write path.

## Notes for reviewers

- ⚠️ **Schema/mapper mismatch carried forward (not introduced here):** `mapper.ts` (#910) `ApplicationRow` uses domain-style column names (`answers`, `references`, `home_visit_scheduled_at`, `decided_by`, …) that **don't match** migration 002's actual columns (`documents`, `visit_scheduled_at`, `actioned_by`, …). This PR deliberately **avoids** `applicationRowToProto` for exactly that reason and serves reads via the event-stream fold. `mapper.ts` / migration 002 still need reconciling in a follow-up.
- The gRPC **server boot** (binding draft + review + read handlers, StartDraft stub/deferral, `index.ts` wiring) is the next PR — this batch ships the read handlers standalone, matching the #930/#931 cadence.

## Tests

- `timeline.test.ts` — empty stream, UNSPECIFIED open, non-status events skipped, actor stamping, note extraction.
- `read-handlers.test.ts` — Get (invalid arg / not-found / owner / denied-other-adopter / staff / include_timeline) and List (perm-denied / adopter-scoped / staff-pinned / status filter / next_cursor).
- Full `services/applications` suite green: **140 tests pass**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_