### PR TITLE
feat(applications): phase 5.3c — gRPC server boot + index wiring

### DIFF
--- a/services/applications/src/grpc/server.test.ts
+++ b/services/applications/src/grpc/server.test.ts
@@ -1,0 +1,67 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+
+import { ApplicationsV1 } from '@adopt-dont-shop/proto';
+
+import type { ApplicationsConfig } from '../config.js';
+
+import { createGrpcServer } from './server.js';
+
+const quietLogger = {
+  info: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  debug: () => undefined,
+  silly: () => undefined,
+} as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
+
+const config: ApplicationsConfig = {
+  port: 5005,
+  grpcPort: 6005,
+  host: '127.0.0.1',
+  environment: 'test',
+  databaseUrl: 'postgres://test',
+  schema: 'applications',
+  natsUrl: 'nats://localhost:4222',
+};
+
+const pool = {} as unknown as Pool;
+const nats = {} as unknown as NatsConnection;
+
+describe('createGrpcServer', () => {
+  it('registers all 12 ApplicationService methods on the grpc.Server', () => {
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    const base = '/adopt_dont_shop.applications.v1.ApplicationService';
+    for (const method of [
+      'StartDraft',
+      'SaveDraftAnswers',
+      'SubmitDraft',
+      'StartReview',
+      'ScheduleHomeVisit',
+      'CompleteHomeVisit',
+      'Approve',
+      'Reject',
+      'Withdraw',
+      'MarkAdopted',
+      'Get',
+      'List',
+    ]) {
+      expect(handlers.has(`${base}/${method}`)).toBe(true);
+    }
+  });
+
+  it('matches every path from the canonical ApplicationServiceService Definition table', () => {
+    const definition = ApplicationsV1.ApplicationServiceService;
+    const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
+
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
+
+    for (const p of expectedPaths) {
+      expect(handlers.has(p)).toBe(true);
+    }
+  });
+});

--- a/services/applications/src/grpc/server.ts
+++ b/services/applications/src/grpc/server.ts
@@ -1,0 +1,150 @@
+// gRPC server boot — binds ApplicationServiceService to the
+// adapter-wrapped handlers and starts listening on
+// APPLICATIONS_GRPC_PORT.
+//
+// Same shape as services/moderation, services/matching,
+// services/audit. The handlers live across three files by concern:
+//   - handlers.ts        — draft lifecycle (SaveDraftAnswers, SubmitDraft)
+//   - review-handlers.ts — review/visit/decision (StartReview …
+//                          MarkAdopted)
+//   - read-handlers.ts   — query side (Get, List)
+// all sharing the (deps, principal, request) → Promise<response> shape
+// so the adapter wraps them uniformly.
+//
+// StartDraft is a deliberate UNIMPLEMENTED stub (same approach as
+// matching's Recommend/SearchPets). The pure domain requires a
+// non-empty rescueId at draft creation — a cross-schema pets lookup —
+// and StartDraftRequest doesn't carry one. It waits on the service.pets
+// gRPC client; the gateway maps UNIMPLEMENTED → 501 so callers degrade
+// gracefully rather than getting a silent failure.
+//
+// Dev uses insecure credentials (TLS terminates at nginx in front);
+// production keeps gRPC HTTP/2 cleartext on the cluster network until a
+// future deploy wants mTLS.
+
+import { promisify } from 'node:util';
+
+import {
+  Server,
+  ServerCredentials,
+  status,
+  type ServerUnaryCall,
+  type ServiceError,
+  type sendUnaryData,
+} from '@grpc/grpc-js';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { ApplicationsV1 } from '@adopt-dont-shop/proto';
+
+import type { ApplicationsConfig } from '../config.js';
+
+import { adapt } from './adapter.js';
+import { saveDraftAnswers, submitDraft } from './handlers.js';
+import { getApplication, listApplications } from './read-handlers.js';
+import {
+  approve,
+  completeHomeVisit,
+  markAdopted,
+  reject,
+  scheduleHomeVisit,
+  startReview,
+  withdraw,
+} from './review-handlers.js';
+
+export type CreateGrpcServerOptions = {
+  config: ApplicationsConfig;
+  pool: Pool;
+  nats: NatsConnection;
+  logger: Logger;
+};
+
+export type RunningGrpcServer = {
+  server: Server;
+  port: number;
+  shutdown: () => Promise<void>;
+};
+
+export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
+  const { config, pool, nats, logger } = opts;
+  const deps = { pool, nats };
+  const server = new Server();
+
+  const notImplemented =
+    (rpc: string) =>
+    (_call: ServerUnaryCall<unknown, unknown>, callback: sendUnaryData<unknown>): void => {
+      const err = new Error(`${rpc} not yet implemented`) as ServiceError;
+      err.code = status.UNIMPLEMENTED;
+      err.details = err.message;
+      callback(err, null);
+    };
+
+  server.addService(ApplicationsV1.ApplicationServiceService, {
+    // Draft lifecycle (handlers.ts). StartDraft deferred — see header.
+    startDraft: notImplemented('StartDraft'),
+    saveDraftAnswers: adapt(saveDraftAnswers, { deps, logger }),
+    submitDraft: adapt(submitDraft, { deps, logger }),
+    // Review / visit / decision (review-handlers.ts)
+    startReview: adapt(startReview, { deps, logger }),
+    scheduleHomeVisit: adapt(scheduleHomeVisit, { deps, logger }),
+    completeHomeVisit: adapt(completeHomeVisit, { deps, logger }),
+    approve: adapt(approve, { deps, logger }),
+    reject: adapt(reject, { deps, logger }),
+    withdraw: adapt(withdraw, { deps, logger }),
+    markAdopted: adapt(markAdopted, { deps, logger }),
+    // Query side (read-handlers.ts)
+    get: adapt(getApplication, { deps, logger }),
+    list: adapt(listApplications, { deps, logger }),
+  });
+
+  logger.info('gRPC ApplicationService registered', {
+    methods: [
+      'startDraft (stub)',
+      'saveDraftAnswers',
+      'submitDraft',
+      'startReview',
+      'scheduleHomeVisit',
+      'completeHomeVisit',
+      'approve',
+      'reject',
+      'withdraw',
+      'markAdopted',
+      'get',
+      'list',
+    ],
+    grpcPort: config.grpcPort,
+  });
+
+  return server;
+};
+
+export const startGrpcServer = async (
+  opts: CreateGrpcServerOptions
+): Promise<RunningGrpcServer> => {
+  const { config, logger } = opts;
+  const server = createGrpcServer(opts);
+
+  const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
+  const port = await bindAsync(
+    `${opts.config.host}:${config.grpcPort}`,
+    ServerCredentials.createInsecure()
+  );
+
+  logger.info('gRPC server listening', { port, host: opts.config.host });
+
+  return {
+    server,
+    port,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          resolve();
+        });
+      }),
+  };
+};

--- a/services/applications/src/index.ts
+++ b/services/applications/src/index.ts
@@ -1,21 +1,40 @@
+import { connect, type NatsConnection } from 'nats';
+
+import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.applications' });
 
+  let nats: NatsConnection | undefined;
+  let pool: ReturnType<typeof createDbClient> | undefined;
+  let grpc: RunningGrpcServer | undefined;
+  let httpClosed = false;
+
   try {
     const config = loadConfig();
-    const server = createServer({ config, logger });
 
-    await server.listen({ port: config.port, host: config.host });
+    // Connect deps FIRST so we crash here rather than after starting to
+    // accept traffic. Same boot order as services/moderation,
+    // services/audit, services/matching, services/rescue.
+    pool = createDbClient({
+      connectionString: config.databaseUrl,
+      schema: config.schema,
+    });
+    nats = await connect({ servers: config.natsUrl });
 
-    logger.info('service.applications listening', {
-      port: config.port,
-      host: config.host,
-      grpcPort: config.grpcPort,
+    grpc = await startGrpcServer({ config, pool, nats, logger });
+
+    const httpServer = createServer({ config, logger });
+    await httpServer.listen({ port: config.port, host: config.host });
+
+    logger.info('service.applications running', {
+      http: { port: config.port, host: config.host },
+      grpc: { port: grpc.port, host: config.host },
       schema: config.schema,
       natsUrl: config.natsUrl,
       environment: config.environment,
@@ -24,9 +43,27 @@ const main = async (): Promise<void> => {
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.applications shutting down', { signal });
       try {
-        await server.close();
+        if (!httpClosed) {
+          await httpServer.close();
+          httpClosed = true;
+        }
       } catch (err) {
-        logger.error('error during shutdown', { err });
+        logger.error('http close error', { err });
+      }
+      try {
+        await grpc?.shutdown();
+      } catch (err) {
+        logger.error('grpc shutdown error', { err });
+      }
+      try {
+        await nats?.drain();
+      } catch (err) {
+        logger.error('nats drain error', { err });
+      }
+      try {
+        await pool?.end();
+      } catch (err) {
+        logger.error('pool end error', { err });
       }
       process.exit(0);
     };
@@ -35,6 +72,21 @@ const main = async (): Promise<void> => {
     process.once('SIGINT', () => void shutdown('SIGINT'));
   } catch (err) {
     logger.error('service.applications failed to start', { err });
+    try {
+      await grpc?.shutdown();
+    } catch {
+      // Swallow — already on the failure path.
+    }
+    try {
+      await nats?.drain();
+    } catch {
+      // Same.
+    }
+    try {
+      await pool?.end();
+    } catch {
+      // Same.
+    }
     process.exit(1);
   }
 };


### PR DESCRIPTION
## What

Brings the applications vertical **online over gRPC**. Binds `ApplicationServiceService` to the adapter-wrapped handler batches shipped in #930 (draft), #931 (review/decision) and #932 (read), and wires `index.ts` to actually start it. Mirrors the `services/moderation` (#928), `audit`, `matching` server-boot shape exactly.

## Bindings (12 RPCs)

| RPC | Handler | Source |
|---|---|---|
| `StartDraft` | **UNIMPLEMENTED stub** | deferred — see below |
| `SaveDraftAnswers`, `SubmitDraft` | draft handlers | `handlers.ts` (#930) |
| `StartReview`, `ScheduleHomeVisit`, `CompleteHomeVisit`, `Approve`, `Reject`, `Withdraw`, `MarkAdopted` | review/decision | `review-handlers.ts` (#931) |
| `Get`, `List` | query side | `read-handlers.ts` (#932) |

## index.ts wiring

Now connects the pool + NATS **first** (crash before accepting traffic if a dep is down), starts the gRPC server, then the HTTP `/health/simple` surface — same boot order and graceful-shutdown teardown (http → grpc → nats drain → pool end) as the other extracted services.

## StartDraft deferral

A deliberate `UNIMPLEMENTED` stub, same approach as matching's `Recommend`/`SearchPets`. The pure domain requires a non-empty `rescueId` at draft creation — a cross-schema pets lookup — and `StartDraftRequest` doesn't carry one. It waits on the `service.pets` gRPC client to resolve `pet → rescue`. The gateway maps `UNIMPLEMENTED → 501` so callers degrade gracefully rather than hitting a silent failure.

## After this

The applications vertical is end-to-end over gRPC for all 11 live RPCs (10 commands + Get/List). Remaining: gateway REST routes (5.3d, `/api/applications/*`) and StartDraft once the pets client lands.

## Tests

- `server.test.ts` — asserts all 12 method paths register on the `grpc.Server`, and cross-checks against the canonical `ApplicationServiceService` definition table (same two-assertion shape as moderation's server test).
- Full `services/applications` suite green: **142 tests pass**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_