### PR TITLE
feat(gateway): phase 5.3d — /api/applications/* routes + wire all grpc clients

### DIFF
--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -30,6 +30,18 @@ export type GatewayConfig = {
   // service.rescue gRPC URL — Phase 4.5 cuts /api/rescue/* over to
   // this address.
   rescueGrpcUrl: string;
+  // service.applications gRPC URL — Phase 5.3d cuts /api/applications/*
+  // over to this address.
+  applicationsGrpcUrl: string;
+  // service.moderation gRPC URL — Phase 8.5 cuts /api/moderation/* over
+  // to this address.
+  moderationGrpcUrl: string;
+  // service.matching gRPC URL — Phase 9.5 cuts /api/matching/* over to
+  // this address.
+  matchingGrpcUrl: string;
+  // service.audit gRPC URL — Phase 10.5 cuts /api/audit/* over to this
+  // address.
+  auditGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 4000;
@@ -40,6 +52,10 @@ const DEFAULT_NOTIFICATIONS_GRPC_URL = 'service-notifications:6001';
 const DEFAULT_AUTH_GRPC_URL = 'service-auth:6002';
 const DEFAULT_PETS_GRPC_URL = 'service-pets:6003';
 const DEFAULT_RESCUE_GRPC_URL = 'service-rescue:6004';
+const DEFAULT_APPLICATIONS_GRPC_URL = 'service-applications:6005';
+const DEFAULT_MODERATION_GRPC_URL = 'service-moderation:6007';
+const DEFAULT_MATCHING_GRPC_URL = 'service-matching:6008';
+const DEFAULT_AUDIT_GRPC_URL = 'service-audit:6009';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig => {
   const portRaw = env.GATEWAY_PORT?.trim();
@@ -58,5 +74,9 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     authGrpcUrl: env.AUTH_GRPC_URL?.trim() || DEFAULT_AUTH_GRPC_URL,
     petsGrpcUrl: env.PETS_GRPC_URL?.trim() || DEFAULT_PETS_GRPC_URL,
     rescueGrpcUrl: env.RESCUE_GRPC_URL?.trim() || DEFAULT_RESCUE_GRPC_URL,
+    applicationsGrpcUrl: env.APPLICATIONS_GRPC_URL?.trim() || DEFAULT_APPLICATIONS_GRPC_URL,
+    moderationGrpcUrl: env.MODERATION_GRPC_URL?.trim() || DEFAULT_MODERATION_GRPC_URL,
+    matchingGrpcUrl: env.MATCHING_GRPC_URL?.trim() || DEFAULT_MATCHING_GRPC_URL,
+    auditGrpcUrl: env.AUDIT_GRPC_URL?.trim() || DEFAULT_AUDIT_GRPC_URL,
   };
 };

--- a/services/gateway/src/grpc-clients/applications-client.ts
+++ b/services/gateway/src/grpc-clients/applications-client.ts
@@ -1,0 +1,107 @@
+// Promise-wrapped client for service.applications.
+//
+// Phase 5.3d surface — all 12 ApplicationService RPCs. Same
+// Promise-wrapped shape as the other grpc-clients (moderation / audit /
+// matching / rescue / pets / auth).
+//
+// The interface is exported so tests can substitute a mock; the routes
+// depend on the shape, not the @grpc/grpc-js client.
+
+import { credentials, Metadata } from '@grpc/grpc-js';
+
+import {
+  ApplicationsV1,
+  type ApproveRequest,
+  type ApproveResponse,
+  type CompleteHomeVisitRequest,
+  type CompleteHomeVisitResponse,
+  type GetApplicationRequest,
+  type GetApplicationResponse,
+  type ListApplicationsRequest,
+  type ListApplicationsResponse,
+  type MarkAdoptedRequest,
+  type MarkAdoptedResponse,
+  type RejectRequest,
+  type RejectResponse,
+  type SaveDraftAnswersRequest,
+  type SaveDraftAnswersResponse,
+  type ScheduleHomeVisitRequest,
+  type ScheduleHomeVisitResponse,
+  type StartDraftRequest,
+  type StartDraftResponse,
+  type StartReviewRequest,
+  type StartReviewResponse,
+  type SubmitDraftRequest,
+  type SubmitDraftResponse,
+  type WithdrawRequest,
+  type WithdrawResponse,
+} from '@adopt-dont-shop/proto';
+
+export type ApplicationsClient = {
+  startDraft(req: StartDraftRequest, metadata: Metadata): Promise<StartDraftResponse>;
+  saveDraftAnswers(
+    req: SaveDraftAnswersRequest,
+    metadata: Metadata
+  ): Promise<SaveDraftAnswersResponse>;
+  submitDraft(req: SubmitDraftRequest, metadata: Metadata): Promise<SubmitDraftResponse>;
+  startReview(req: StartReviewRequest, metadata: Metadata): Promise<StartReviewResponse>;
+  scheduleHomeVisit(
+    req: ScheduleHomeVisitRequest,
+    metadata: Metadata
+  ): Promise<ScheduleHomeVisitResponse>;
+  completeHomeVisit(
+    req: CompleteHomeVisitRequest,
+    metadata: Metadata
+  ): Promise<CompleteHomeVisitResponse>;
+  approve(req: ApproveRequest, metadata: Metadata): Promise<ApproveResponse>;
+  reject(req: RejectRequest, metadata: Metadata): Promise<RejectResponse>;
+  withdraw(req: WithdrawRequest, metadata: Metadata): Promise<WithdrawResponse>;
+  markAdopted(req: MarkAdoptedRequest, metadata: Metadata): Promise<MarkAdoptedResponse>;
+  get(req: GetApplicationRequest, metadata: Metadata): Promise<GetApplicationResponse>;
+  list(req: ListApplicationsRequest, metadata: Metadata): Promise<ListApplicationsResponse>;
+  close(): void;
+};
+
+export type CreateApplicationsClientOptions = {
+  address: string;
+};
+
+export const createApplicationsClient = (
+  opts: CreateApplicationsClientOptions
+): ApplicationsClient => {
+  const stub = new ApplicationsV1.ApplicationServiceClient(
+    opts.address,
+    credentials.createInsecure()
+  );
+
+  const callUnary = <Req, Res>(
+    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> =>
+    new Promise<Res>((resolve, reject) => {
+      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(res);
+      });
+    });
+
+  return {
+    startDraft: (req, metadata) => callUnary(stub.startDraft, req, metadata),
+    saveDraftAnswers: (req, metadata) => callUnary(stub.saveDraftAnswers, req, metadata),
+    submitDraft: (req, metadata) => callUnary(stub.submitDraft, req, metadata),
+    startReview: (req, metadata) => callUnary(stub.startReview, req, metadata),
+    scheduleHomeVisit: (req, metadata) => callUnary(stub.scheduleHomeVisit, req, metadata),
+    completeHomeVisit: (req, metadata) => callUnary(stub.completeHomeVisit, req, metadata),
+    approve: (req, metadata) => callUnary(stub.approve, req, metadata),
+    reject: (req, metadata) => callUnary(stub.reject, req, metadata),
+    withdraw: (req, metadata) => callUnary(stub.withdraw, req, metadata),
+    markAdopted: (req, metadata) => callUnary(stub.markAdopted, req, metadata),
+    get: (req, metadata) => callUnary(stub.get, req, metadata),
+    list: (req, metadata) => callUnary(stub.list, req, metadata),
+    close: () => stub.close(),
+  };
+};

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -4,7 +4,11 @@ import type { Server as IOServer } from 'socket.io';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { createApplicationsClient } from './grpc-clients/applications-client.js';
+import { createAuditClient } from './grpc-clients/audit-client.js';
 import { createAuthClient } from './grpc-clients/auth-client.js';
+import { createMatchingClient } from './grpc-clients/matching-client.js';
+import { createModerationClient } from './grpc-clients/moderation-client.js';
 import { createNotificationsClient } from './grpc-clients/notifications-client.js';
 import { createPetsClient } from './grpc-clients/pets-client.js';
 import { createRescueClient } from './grpc-clients/rescue-client.js';
@@ -22,16 +26,27 @@ const main = async (): Promise<void> => {
   let authClient: ReturnType<typeof createAuthClient> | undefined;
   let petsClient: ReturnType<typeof createPetsClient> | undefined;
   let rescueClient: ReturnType<typeof createRescueClient> | undefined;
+  let auditClient: ReturnType<typeof createAuditClient> | undefined;
+  let matchingClient: ReturnType<typeof createMatchingClient> | undefined;
+  let moderationClient: ReturnType<typeof createModerationClient> | undefined;
+  let applicationsClient: ReturnType<typeof createApplicationsClient> | undefined;
 
   try {
     const config = loadConfig();
 
     // gRPC clients to extracted services come up before Fastify so the
-    // route plugins / middleware can close over them.
+    // route plugins / middleware can close over them. The channels are
+    // lazy — constructing a client doesn't open a connection until the
+    // first call — so a service that isn't running yet doesn't block
+    // gateway boot.
     notificationsClient = createNotificationsClient({ address: config.notificationsGrpcUrl });
     authClient = createAuthClient({ address: config.authGrpcUrl });
     petsClient = createPetsClient({ address: config.petsGrpcUrl });
     rescueClient = createRescueClient({ address: config.rescueGrpcUrl });
+    auditClient = createAuditClient({ address: config.auditGrpcUrl });
+    matchingClient = createMatchingClient({ address: config.matchingGrpcUrl });
+    moderationClient = createModerationClient({ address: config.moderationGrpcUrl });
+    applicationsClient = createApplicationsClient({ address: config.applicationsGrpcUrl });
 
     const server = await createServer({
       config,
@@ -40,6 +55,10 @@ const main = async (): Promise<void> => {
       authClient,
       petsClient,
       rescueClient,
+      auditClient,
+      matchingClient,
+      moderationClient,
+      applicationsClient,
     });
 
     await server.listen({ port: config.port, host: config.host });
@@ -60,6 +79,10 @@ const main = async (): Promise<void> => {
       authGrpcUrl: config.authGrpcUrl,
       petsGrpcUrl: config.petsGrpcUrl,
       rescueGrpcUrl: config.rescueGrpcUrl,
+      auditGrpcUrl: config.auditGrpcUrl,
+      matchingGrpcUrl: config.matchingGrpcUrl,
+      moderationGrpcUrl: config.moderationGrpcUrl,
+      applicationsGrpcUrl: config.applicationsGrpcUrl,
       environment: config.environment,
     });
 
@@ -102,6 +125,26 @@ const main = async (): Promise<void> => {
       } catch (err) {
         logger.error('rescue client close error', { err });
       }
+      try {
+        auditClient?.close();
+      } catch (err) {
+        logger.error('audit client close error', { err });
+      }
+      try {
+        matchingClient?.close();
+      } catch (err) {
+        logger.error('matching client close error', { err });
+      }
+      try {
+        moderationClient?.close();
+      } catch (err) {
+        logger.error('moderation client close error', { err });
+      }
+      try {
+        applicationsClient?.close();
+      } catch (err) {
+        logger.error('applications client close error', { err });
+      }
       process.exit(0);
     };
 
@@ -131,6 +174,26 @@ const main = async (): Promise<void> => {
     }
     try {
       rescueClient?.close();
+    } catch {
+      // Same.
+    }
+    try {
+      auditClient?.close();
+    } catch {
+      // Same.
+    }
+    try {
+      matchingClient?.close();
+    } catch {
+      // Same.
+    }
+    try {
+      moderationClient?.close();
+    } catch {
+      // Same.
+    }
+    try {
+      applicationsClient?.close();
     } catch {
       // Same.
     }

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -1,0 +1,248 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApplicationsV1 } from '@adopt-dont-shop/proto';
+
+import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
+
+import { registerApplicationsRoutes } from './applications.js';
+
+// A minimally-complete Application proto so the response toJSON encoders
+// (which throw on an undefined enum) don't blow up.
+const APP = {
+  applicationId: 'app-1',
+  adopterId: 'usr-1',
+  petId: 'pet-1',
+  rescueId: 'rsc-1',
+  status: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_DRAFT,
+  answersJson: '{}',
+  referencesJson: '[]',
+  version: 1,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
+function makeClient(): {
+  client: ApplicationsClient;
+  mocks: Record<string, ReturnType<typeof vi.fn>>;
+} {
+  const mocks: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of [
+    'startDraft',
+    'saveDraftAnswers',
+    'submitDraft',
+    'startReview',
+    'scheduleHomeVisit',
+    'completeHomeVisit',
+    'approve',
+    'reject',
+    'withdraw',
+    'markAdopted',
+    'get',
+    'list',
+  ]) {
+    mocks[m] = vi.fn();
+  }
+  const client = { ...mocks, close: vi.fn() } as unknown as ApplicationsClient;
+  return { client, mocks };
+}
+
+async function makeApp(client: ApplicationsClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerApplicationsRoutes(app, { client });
+  return app;
+}
+
+const ADOPTER = {
+  'x-user-id': 'usr-1',
+  'x-user-roles': 'adopter',
+  'x-user-permissions': 'applications.read,applications.update',
+};
+
+const STAFF = {
+  'x-user-id': 'staff-1',
+  'x-user-roles': 'rescue_staff',
+  'x-user-permissions': 'applications.review,applications.approve,applications.reject',
+  'x-rescue-id': 'rsc-1',
+};
+
+describe('applications routes', () => {
+  let app: FastifyInstance;
+  let mocks: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    mocks = m.mocks;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('PATCH /api/applications/:id/answers threads expectedVersion + patch', async () => {
+    mocks.saveDraftAnswers.mockResolvedValue({ application: APP });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/applications/app-1/answers',
+      headers: ADOPTER,
+      payload: { expectedVersion: 3, answersPatchJson: '{"q1":"a"}' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mocks.saveDraftAnswers.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      expectedVersion: 3,
+      answersPatchJson: '{"q1":"a"}',
+    });
+  });
+
+  it('POST /api/applications/:id/submit threads expectedVersion', async () => {
+    mocks.submitDraft.mockResolvedValue({ application: APP });
+    await app.inject({
+      method: 'POST',
+      url: '/api/applications/app-1/submit',
+      headers: ADOPTER,
+      payload: { expectedVersion: 4 },
+    });
+    expect(mocks.submitDraft.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      expectedVersion: 4,
+    });
+  });
+
+  it('POST /api/applications/:id/review forwards the staff note', async () => {
+    mocks.startReview.mockResolvedValue({ application: APP });
+    await app.inject({
+      method: 'POST',
+      url: '/api/applications/app-1/review',
+      headers: STAFF,
+      payload: { note: 'opening' },
+    });
+    expect(mocks.startReview.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      note: 'opening',
+    });
+  });
+
+  it('POST /api/applications/:id/home-visit/complete parses the outcome enum', async () => {
+    mocks.completeHomeVisit.mockResolvedValue({ application: APP });
+    await app.inject({
+      method: 'POST',
+      url: '/api/applications/app-1/home-visit/complete',
+      headers: STAFF,
+      payload: { outcome: 'passed', notes: 'great fit' },
+    });
+    expect(mocks.completeHomeVisit.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      outcome: ApplicationsV1.HomeVisitOutcome.HOME_VISIT_OUTCOME_PASSED,
+    });
+  });
+
+  it('accepts the SCREAMING proto-form outcome too', async () => {
+    mocks.completeHomeVisit.mockResolvedValue({ application: APP });
+    await app.inject({
+      method: 'POST',
+      url: '/api/applications/app-1/home-visit/complete',
+      headers: STAFF,
+      payload: { outcome: 'HOME_VISIT_OUTCOME_FAILED' },
+    });
+    expect(mocks.completeHomeVisit.mock.calls[0][0]).toMatchObject({
+      outcome: ApplicationsV1.HomeVisitOutcome.HOME_VISIT_OUTCOME_FAILED,
+    });
+  });
+
+  it('POST /api/applications/:id/reject requires a reason field', async () => {
+    mocks.reject.mockResolvedValue({ application: APP });
+    await app.inject({
+      method: 'POST',
+      url: '/api/applications/app-1/reject',
+      headers: STAFF,
+      payload: { reason: 'home unsuitable' },
+    });
+    expect(mocks.reject.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      reason: 'home unsuitable',
+    });
+  });
+
+  it('POST /api/applications/:id/adopt needs no body', async () => {
+    mocks.markAdopted.mockResolvedValue({ application: APP });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/applications/app-1/adopt',
+      headers: STAFF,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mocks.markAdopted.mock.calls[0][0]).toMatchObject({ applicationId: 'app-1' });
+  });
+
+  it('GET /api/applications → List with parsed status filter + scoping query', async () => {
+    mocks.list.mockResolvedValue({ applications: [APP] });
+    await app.inject({
+      method: 'GET',
+      url: '/api/applications?status=submitted&limit=10&rescue=rsc-1&adopter=usr-9',
+      headers: STAFF,
+    });
+    expect(mocks.list.mock.calls[0][0]).toMatchObject({
+      statusFilter: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_SUBMITTED,
+      limit: 10,
+      rescueIdFilter: 'rsc-1',
+      adopterIdFilter: 'usr-9',
+    });
+  });
+
+  it('GET /api/applications/:id passes includeTimeline', async () => {
+    mocks.get.mockResolvedValue({ application: APP, timeline: [] });
+    await app.inject({
+      method: 'GET',
+      url: '/api/applications/app-1?timeline=true',
+      headers: ADOPTER,
+    });
+    expect(mocks.get.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      includeTimeline: true,
+    });
+  });
+
+  it('maps a service UNIMPLEMENTED (StartDraft stub) → 501', async () => {
+    mocks.startDraft.mockRejectedValue({
+      code: grpcStatus.UNIMPLEMENTED,
+      details: 'StartDraft not yet implemented',
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/applications',
+      headers: ADOPTER,
+      payload: { adopterId: 'usr-1', petId: 'pet-1' },
+    });
+    expect(res.statusCode).toBe(501);
+  });
+
+  it('maps PERMISSION_DENIED → 403 and NOT_FOUND → 404', async () => {
+    mocks.list.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'nope' });
+    const denied = await app.inject({ method: 'GET', url: '/api/applications', headers: ADOPTER });
+    expect(denied.statusCode).toBe(403);
+
+    mocks.get.mockRejectedValue({ code: grpcStatus.NOT_FOUND, details: 'gone' });
+    const missing = await app.inject({
+      method: 'GET',
+      url: '/api/applications/app-x',
+      headers: ADOPTER,
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it('threads x-user-* metadata to the gRPC client', async () => {
+    mocks.approve.mockResolvedValue({ application: APP });
+    await app.inject({
+      method: 'POST',
+      url: '/api/applications/app-1/approve',
+      headers: STAFF,
+      payload: { notes: 'ok' },
+    });
+    const metadata = mocks.approve.mock.calls[0][1];
+    expect(metadata.get('x-user-id')).toEqual(['staff-1']);
+    expect(metadata.get('x-rescue-id')).toEqual(['rsc-1']);
+  });
+});

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -1,0 +1,363 @@
+// REST → gRPC translation for /api/applications/*.
+//
+// Phase 5.3d cutover. Same strangler-fig shape as routes/moderation.ts
+// (#929) / routes/matching.ts (#923) — registers BEFORE the catch-all
+// proxy so first-registered-wins prefix routing picks it off.
+//
+// Route map (all 12 ApplicationService RPCs):
+//
+//   Drafts
+//   POST   /api/applications                              → StartDraft
+//   PATCH  /api/applications/:id/answers                  → SaveDraftAnswers
+//   POST   /api/applications/:id/submit                   → SubmitDraft
+//   Review / home visit / decision
+//   POST   /api/applications/:id/review                   → StartReview
+//   POST   /api/applications/:id/home-visit/schedule      → ScheduleHomeVisit
+//   POST   /api/applications/:id/home-visit/complete      → CompleteHomeVisit
+//   POST   /api/applications/:id/approve                  → Approve
+//   POST   /api/applications/:id/reject                   → Reject
+//   POST   /api/applications/:id/withdraw                 → Withdraw
+//   POST   /api/applications/:id/adopt                    → MarkAdopted
+//   Reads
+//   GET    /api/applications                              → List
+//   GET    /api/applications/:id                          → Get
+//
+// Authz lives in the handlers (adopters act on their own drafts; rescue
+// staff gate on applications.review/approve/reject; reads scope to
+// owner/rescue/admin). The gateway stamps x-user-* metadata via the
+// Phase 2.5 authenticate middleware.
+//
+// StartDraft is currently an UNIMPLEMENTED stub on the service (it needs
+// the service.pets gRPC client to resolve pet → rescue), which maps to
+// 501 here so the SPA gets an honest "not yet" rather than a fall-through
+// to the monolith.
+
+import rateLimit from '@fastify/rate-limit';
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  ApplicationsV1,
+  type ApproveRequest,
+  type CompleteHomeVisitRequest,
+  type ListApplicationsRequest,
+  type RejectRequest,
+  type SaveDraftAnswersRequest,
+  type ScheduleHomeVisitRequest,
+  type StartReviewRequest,
+  type SubmitDraftRequest,
+  type WithdrawRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
+
+export type ApplicationsRoutesOptions = {
+  client: ApplicationsClient;
+};
+
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.UNIMPLEMENTED]: 501,
+  [status.INTERNAL]: 500,
+};
+
+// Writes 30/min, reads 120/min — adopter + rescue-staff human use.
+const RL_WRITE = { max: 30, timeWindow: '1 minute' } as const;
+const RL_READ = { max: 120, timeWindow: '1 minute' } as const;
+
+const num = (raw: unknown): number =>
+  typeof raw === 'number' ? raw : typeof raw === 'string' ? Number.parseInt(raw, 10) || 0 : 0;
+
+export const registerApplicationsRoutes = async (
+  app: FastifyInstance,
+  opts: ApplicationsRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  await app.register(rateLimit, { global: false });
+
+  // ---------- Drafts ----------
+
+  app.post('/api/applications', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    try {
+      const res = await client.startDraft(
+        { adopterId: (b.adopterId as string) ?? '', petId: (b.petId as string) ?? '' },
+        buildMetadata(req)
+      );
+      return reply.code(201).send(ApplicationsV1.StartDraftResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.patch<{ Params: { id: string } }>(
+    '/api/applications/:id/answers',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: SaveDraftAnswersRequest = {
+        applicationId: req.params.id,
+        expectedVersion: num(b.expectedVersion),
+        answersPatchJson: (b.answersPatchJson as string) ?? '',
+        referencesJson: b.referencesJson as string | undefined,
+      };
+      try {
+        const res = await client.saveDraftAnswers(grpcReq, buildMetadata(req));
+        return reply.send(ApplicationsV1.SaveDraftAnswersResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/applications/:id/submit',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: SubmitDraftRequest = {
+        applicationId: req.params.id,
+        expectedVersion: num(b.expectedVersion),
+      };
+      try {
+        const res = await client.submitDraft(grpcReq, buildMetadata(req));
+        return reply.send(ApplicationsV1.SubmitDraftResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // ---------- Review / home visit / decision ----------
+
+  app.post<{ Params: { id: string } }>(
+    '/api/applications/:id/review',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: StartReviewRequest = {
+        applicationId: req.params.id,
+        note: b.note as string | undefined,
+      };
+      try {
+        const res = await client.startReview(grpcReq, buildMetadata(req));
+        return reply.send(ApplicationsV1.StartReviewResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/applications/:id/home-visit/schedule',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: ScheduleHomeVisitRequest = {
+        applicationId: req.params.id,
+        scheduledAt: (b.scheduledAt as string) ?? '',
+        note: b.note as string | undefined,
+      };
+      try {
+        const res = await client.scheduleHomeVisit(grpcReq, buildMetadata(req));
+        return reply.send(ApplicationsV1.ScheduleHomeVisitResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/applications/:id/home-visit/complete',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: CompleteHomeVisitRequest = {
+        applicationId: req.params.id,
+        outcome: parseHomeVisitOutcome(b.outcome as string | undefined),
+        notes: b.notes as string | undefined,
+      };
+      try {
+        const res = await client.completeHomeVisit(grpcReq, buildMetadata(req));
+        return reply.send(ApplicationsV1.CompleteHomeVisitResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/applications/:id/approve',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: ApproveRequest = {
+        applicationId: req.params.id,
+        notes: b.notes as string | undefined,
+      };
+      try {
+        const res = await client.approve(grpcReq, buildMetadata(req));
+        return reply.send(ApplicationsV1.ApproveResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/applications/:id/reject',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: RejectRequest = {
+        applicationId: req.params.id,
+        reason: (b.reason as string) ?? '',
+      };
+      try {
+        const res = await client.reject(grpcReq, buildMetadata(req));
+        return reply.send(ApplicationsV1.RejectResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/applications/:id/withdraw',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: WithdrawRequest = {
+        applicationId: req.params.id,
+        reason: b.reason as string | undefined,
+      };
+      try {
+        const res = await client.withdraw(grpcReq, buildMetadata(req));
+        return reply.send(ApplicationsV1.WithdrawResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  app.post<{ Params: { id: string } }>(
+    '/api/applications/:id/adopt',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      try {
+        const res = await client.markAdopted({ applicationId: req.params.id }, buildMetadata(req));
+        return reply.send(ApplicationsV1.MarkAdoptedResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // ---------- Reads ----------
+
+  app.get('/api/applications', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+    const q = req.query as Record<string, string | undefined>;
+    const grpcReq: ListApplicationsRequest = {
+      cursor: q.cursor,
+      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      statusFilter: parseStatus(q.status),
+      rescueIdFilter: q.rescue,
+      adopterIdFilter: q.adopter,
+    };
+    try {
+      const res = await client.list(grpcReq, buildMetadata(req));
+      return reply.send(ApplicationsV1.ListApplicationsResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.get<{ Params: { id: string } }>(
+    '/api/applications/:id',
+    { config: { rateLimit: RL_READ } },
+    async (req, reply) => {
+      const q = req.query as Record<string, string | undefined>;
+      try {
+        const res = await client.get(
+          { applicationId: req.params.id, includeTimeline: q.timeline === 'true' },
+          buildMetadata(req)
+        );
+        return reply.send(ApplicationsV1.GetApplicationResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}
+
+// Enum parsers — accept the DB form ('passed', 'approved') AND the
+// SCREAMING proto form ('HOME_VISIT_OUTCOME_PASSED'). Unknown coerces
+// to UNSPECIFIED so the service's INVALID_ARGUMENT guard produces a
+// clean 400.
+function parseEnum<E extends Record<string, string | number>>(
+  enumObj: E,
+  prefix: string,
+  fromJSON: (s: string) => number,
+  unspecified: number,
+  unrecognized: number,
+  raw: string | undefined
+): number {
+  if (!raw) {
+    return unspecified;
+  }
+  const upper = `${prefix}_${raw.toUpperCase()}`;
+  const candidate = Object.values(enumObj).includes(upper as never) ? upper : raw;
+  const out = fromJSON(candidate);
+  return out === unrecognized ? unspecified : out;
+}
+
+function parseStatus(raw: string | undefined): ApplicationsV1.ApplicationStatus {
+  return parseEnum(
+    ApplicationsV1.ApplicationStatus,
+    'APPLICATION_STATUS',
+    ApplicationsV1.applicationStatusFromJSON,
+    ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_UNSPECIFIED,
+    ApplicationsV1.ApplicationStatus.UNRECOGNIZED,
+    raw
+  );
+}
+
+function parseHomeVisitOutcome(raw: string | undefined): ApplicationsV1.HomeVisitOutcome {
+  return parseEnum(
+    ApplicationsV1.HomeVisitOutcome,
+    'HOME_VISIT_OUTCOME',
+    ApplicationsV1.homeVisitOutcomeFromJSON,
+    ApplicationsV1.HomeVisitOutcome.HOME_VISIT_OUTCOME_UNSPECIFIED,
+    ApplicationsV1.HomeVisitOutcome.UNRECOGNIZED,
+    raw
+  );
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -20,6 +20,7 @@ import { createLogger } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { GatewayConfig } from './config.js';
+import type { ApplicationsClient } from './grpc-clients/applications-client.js';
 import type { AuditClient } from './grpc-clients/audit-client.js';
 import type { AuthClient } from './grpc-clients/auth-client.js';
 import type { MatchingClient } from './grpc-clients/matching-client.js';
@@ -28,6 +29,7 @@ import type { NotificationsClient } from './grpc-clients/notifications-client.js
 import type { PetsClient } from './grpc-clients/pets-client.js';
 import type { RescueClient } from './grpc-clients/rescue-client.js';
 import { registerAuthenticate } from './middleware/authenticate.js';
+import { registerApplicationsRoutes } from './routes/applications.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerMatchingRoutes } from './routes/matching.js';
@@ -71,6 +73,9 @@ export type CreateServerOptions = {
   // gRPC client to service.moderation — Phase 8.5 cuts
   // /api/moderation/* over to this address. Same optional shape.
   moderationClient?: ModerationClient;
+  // gRPC client to service.applications — Phase 5.3d cuts
+  // /api/applications/* over to this address. Same optional shape.
+  applicationsClient?: ApplicationsClient;
 };
 
 export const createServer = async (opts: CreateServerOptions): Promise<FastifyInstance> => {
@@ -147,6 +152,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   if (opts.moderationClient) {
     await registerModerationRoutes(server, { client: opts.moderationClient });
+  }
+  if (opts.applicationsClient) {
+    await registerApplicationsRoutes(server, { client: opts.applicationsClient });
   }
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in


### PR DESCRIPTION
## What

Cuts `/api/applications/*` over to `service.applications` — REST → gRPC translation for all 12 `ApplicationService` RPCs, registered before the catch-all proxy (first-registered-wins). Same strangler-fig shape as `routes/moderation.ts` (#929). Completes the applications vertical's request path (5.3a proto → 5.2 domain → 5.3b handlers → 5.3c server boot → **5.3d gateway**).

## Route map

| Method + path | RPC |
|---|---|
| `POST /api/applications` | StartDraft |
| `PATCH /api/applications/:id/answers` | SaveDraftAnswers |
| `POST /api/applications/:id/submit` | SubmitDraft |
| `POST /api/applications/:id/review` | StartReview |
| `POST /api/applications/:id/home-visit/schedule` | ScheduleHomeVisit |
| `POST /api/applications/:id/home-visit/complete` | CompleteHomeVisit |
| `POST /api/applications/:id/approve` | Approve |
| `POST /api/applications/:id/reject` | Reject |
| `POST /api/applications/:id/withdraw` | Withdraw |
| `POST /api/applications/:id/adopt` | MarkAdopted |
| `GET /api/applications` | List |
| `GET /api/applications/:id` | Get |

Enum query/body params accept both DB form (`passed`, `submitted`) and SCREAMING proto form, coercing unknown → UNSPECIFIED so the service's `INVALID_ARGUMENT` guard yields a clean 400. **StartDraft maps `UNIMPLEMENTED → 501`** (the service stub is deferred on the pets lookup) so the SPA gets an honest "not yet" rather than a silent fall-through to the monolith.

## Also: closes a real wiring gap (the "backfill all 4" decision)

The audit (#917), matching (#923) and moderation (#929) gateway routes were registered in `server.ts`, but their clients were **never constructed in `index.ts`** and had **no gRPC URL in `config.ts`** — so `createServer` was called without those clients and the routes never registered in production. Requests for `/api/audit/*`, `/api/matching/*`, `/api/moderation/*` were still falling through the catch-all to the monolith; the cutovers weren't actually live (only exercised in tests with mock clients).

This PR wires **all four** extracted clients (applications, moderation, matching, audit) into `config.ts` (gRPC URLs) and `index.ts` (construction, pass to `createServer`, close on shutdown + failure path), so the strangler routing is genuinely live. gRPC channels are lazy — constructing a client for a service that isn't running yet doesn't block gateway boot (same as the existing pets/rescue clients).

Default addresses follow the existing `service-<name>:<grpcPort>` convention: applications `6005`, moderation `6007`, matching `6008`, audit `6009`.

> Note: the extracted services aren't in `docker-compose` yet (a later infra phase), so these addresses are aspirational — consistent with the pre-existing notifications/auth/pets/rescue defaults.

## Tests

- `routes/applications.test.ts` — answers/submit threading, note forwarding, outcome enum parsing (both forms), reject reason, body-less adopt, List status-filter + scoping params, Get includeTimeline, **UNIMPLEMENTED → 501**, PERMISSION_DENIED → 403, NOT_FOUND → 404, x-user-* metadata threading.
- Full `services/gateway` suite green: **130 tests pass**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_