### PR TITLE
feat(notifications): phase 5.4 — applications home-visit + adopted subscribers

### DIFF
--- a/services/notifications/src/nats/event-types.ts
+++ b/services/notifications/src/nats/event-types.ts
@@ -46,6 +46,38 @@ export type ApplicationRejectedEvent = {
   reason?: string;
 };
 
+// applications.homeVisitScheduled — service.applications emits when
+// rescue staff schedule the home visit. The adopter needs the date, so
+// this is a HIGH-priority in-app ping; the timestamp rides in data_json
+// for the SPA to format.
+export type ApplicationHomeVisitScheduledEvent = {
+  applicationId: string;
+  adopterId: UserId;
+  rescueId: string;
+  scheduledAt: string; // RFC 3339
+};
+
+// applications.homeVisitCompleted — emitted when staff record the visit
+// outcome. The adopter is told the visit is done (not the pass/fail
+// outcome, which stays in data_json for the dashboard to render with the
+// right framing).
+export type ApplicationHomeVisitCompletedEvent = {
+  applicationId: string;
+  adopterId: UserId;
+  rescueId: string;
+  outcome: string;
+};
+
+// applications.adopted — the final lifecycle event (pet collected /
+// adoption finalised). A celebratory HIGH-priority notification to the
+// adopter.
+export type ApplicationAdoptedEvent = {
+  applicationId: string;
+  adopterId: UserId;
+  petId: string;
+  rescueId: string;
+};
+
 // auth.userLoggedIn — service.auth publishes after every successful
 // login (Phase 2.3b). service.notifications surfaces a security
 // notification so the user can spot unrecognised sign-ins. Mirrors

--- a/services/notifications/src/nats/subscribers.test.ts
+++ b/services/notifications/src/nats/subscribers.test.ts
@@ -5,7 +5,10 @@ import type { UserId } from '@adopt-dont-shop/lib.types';
 import { NotificationsV1 } from '@adopt-dont-shop/proto';
 
 import {
+  buildApplicationAdoptedCreate,
   buildApplicationApprovedCreate,
+  buildApplicationHomeVisitCompletedCreate,
+  buildApplicationHomeVisitScheduledCreate,
   buildApplicationRejectedCreate,
   buildApplicationSubmittedCreate,
   buildAuthRoleAssignedCreate,
@@ -92,6 +95,63 @@ describe('event → CreateNotificationRequest translation', () => {
       expect(req.message).not.toContain('Reason:');
       const data = JSON.parse(req.dataJson) as Record<string, unknown>;
       expect(data.reason).toBeNull();
+    });
+  });
+
+  describe('buildApplicationHomeVisitScheduledCreate', () => {
+    it('targets the adopter with a HIGH-priority home-visit notification and carries the date', () => {
+      const req = buildApplicationHomeVisitScheduledCreate({
+        applicationId: 'app-1',
+        adopterId: 'usr-a' as UserId,
+        rescueId: 'res-1',
+        scheduledAt: '2026-06-10T14:00:00Z',
+      });
+
+      expect(req.userId).toBe('usr-a');
+      expect(req.type).toBe(
+        NotificationsV1.NotificationType.NOTIFICATION_TYPE_HOME_VISIT_SCHEDULED
+      );
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_HIGH);
+      expect(req.relatedEntityType).toBe(
+        NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_HOME_VISIT
+      );
+      const data = JSON.parse(req.dataJson) as Record<string, string>;
+      expect(data.scheduledAt).toBe('2026-06-10T14:00:00Z');
+    });
+  });
+
+  describe('buildApplicationHomeVisitCompletedCreate', () => {
+    it('keeps the pass/fail outcome out of the message body but in data_json', () => {
+      const req = buildApplicationHomeVisitCompletedCreate({
+        applicationId: 'app-1',
+        adopterId: 'usr-a' as UserId,
+        rescueId: 'res-1',
+        outcome: 'failed',
+      });
+
+      expect(req.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_APPLICATION_STATUS);
+      expect(req.message).not.toContain('failed');
+      const data = JSON.parse(req.dataJson) as Record<string, string>;
+      expect(data.outcome).toBe('failed');
+    });
+  });
+
+  describe('buildApplicationAdoptedCreate', () => {
+    it('produces a HIGH-priority celebratory notification related to the adoption', () => {
+      const req = buildApplicationAdoptedCreate({
+        applicationId: 'app-1',
+        adopterId: 'usr-a' as UserId,
+        petId: 'pet-1',
+        rescueId: 'res-1',
+      });
+
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_HIGH);
+      expect(req.title).toMatch(/complete/i);
+      expect(req.relatedEntityType).toBe(
+        NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_ADOPTION
+      );
+      const data = JSON.parse(req.dataJson) as Record<string, string>;
+      expect(data).toEqual({ applicationId: 'app-1', petId: 'pet-1', rescueId: 'res-1' });
     });
   });
 
@@ -192,7 +252,7 @@ describe('registerSubscribers', () => {
 
     const subs = registerSubscribers({ nats, deps, logger });
 
-    expect(subs).toHaveLength(10);
+    expect(subs).toHaveLength(13);
     // Subscribed subjects (raw nats.subscribe receives the subject as
     // first arg, then an options object containing `queue`).
     const subjects = subscribeFn.mock.calls.map(call => call[0]);
@@ -200,6 +260,9 @@ describe('registerSubscribers', () => {
       'applications.submitted',
       'applications.approved',
       'applications.rejected',
+      'applications.homeVisitScheduled',
+      'applications.homeVisitCompleted',
+      'applications.adopted',
       'auth.userLoggedIn',
       'auth.roleAssigned',
       'pets.statusChanged',

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -34,7 +34,10 @@ import { NotificationsV1, type CreateNotificationRequest } from '@adopt-dont-sho
 import { createNotification, type HandlerDeps } from '../grpc/handlers.js';
 
 import type {
+  ApplicationAdoptedEvent,
   ApplicationApprovedEvent,
+  ApplicationHomeVisitCompletedEvent,
+  ApplicationHomeVisitScheduledEvent,
   ApplicationRejectedEvent,
   ApplicationSubmittedEvent,
   AuthRoleAssignedEvent,
@@ -97,6 +100,44 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
       { subject: 'applications.rejected', queue: QUEUE_GROUP, onError },
       async payload => {
         await createNotification(deps, SYSTEM_PRINCIPAL, buildApplicationRejectedCreate(payload));
+      }
+    )
+  );
+
+  subscriptions.push(
+    subscribe<ApplicationHomeVisitScheduledEvent>(
+      nats,
+      { subject: 'applications.homeVisitScheduled', queue: QUEUE_GROUP, onError },
+      async payload => {
+        await createNotification(
+          deps,
+          SYSTEM_PRINCIPAL,
+          buildApplicationHomeVisitScheduledCreate(payload)
+        );
+      }
+    )
+  );
+
+  subscriptions.push(
+    subscribe<ApplicationHomeVisitCompletedEvent>(
+      nats,
+      { subject: 'applications.homeVisitCompleted', queue: QUEUE_GROUP, onError },
+      async payload => {
+        await createNotification(
+          deps,
+          SYSTEM_PRINCIPAL,
+          buildApplicationHomeVisitCompletedCreate(payload)
+        );
+      }
+    )
+  );
+
+  subscriptions.push(
+    subscribe<ApplicationAdoptedEvent>(
+      nats,
+      { subject: 'applications.adopted', queue: QUEUE_GROUP, onError },
+      async payload => {
+        await createNotification(deps, SYSTEM_PRINCIPAL, buildApplicationAdoptedCreate(payload));
       }
     )
   );
@@ -279,6 +320,75 @@ export const buildApplicationRejectedCreate = (
   templateVariablesJson: '{}',
   relatedEntityType:
     NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_APPLICATION,
+  relatedEntityId: event.applicationId,
+});
+
+// applications.homeVisitScheduled — the adopter needs the date, so a
+// HIGH-priority in-app ping. The timestamp rides in data_json (not the
+// message body) so the SPA formats it in the user's locale.
+export const buildApplicationHomeVisitScheduledCreate = (
+  event: ApplicationHomeVisitScheduledEvent
+): CreateNotificationRequest => ({
+  userId: event.adopterId as string,
+  type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_HOME_VISIT_SCHEDULED,
+  channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_HIGH,
+  title: 'Home visit scheduled',
+  message: 'A home visit has been scheduled for your application. Check the details for the date.',
+  dataJson: JSON.stringify({
+    applicationId: event.applicationId,
+    rescueId: event.rescueId,
+    scheduledAt: event.scheduledAt,
+  }),
+  templateVariablesJson: '{}',
+  relatedEntityType:
+    NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_HOME_VISIT,
+  relatedEntityId: event.applicationId,
+});
+
+// applications.homeVisitCompleted — tell the adopter the visit is done.
+// The pass/fail outcome stays in data_json so the dashboard frames it
+// appropriately rather than the raw enum landing in a notification body.
+export const buildApplicationHomeVisitCompletedCreate = (
+  event: ApplicationHomeVisitCompletedEvent
+): CreateNotificationRequest => ({
+  userId: event.adopterId as string,
+  type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_APPLICATION_STATUS,
+  channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL,
+  title: 'Home visit completed',
+  message: 'Your home visit is complete. The rescue will be in touch with the next steps.',
+  dataJson: JSON.stringify({
+    applicationId: event.applicationId,
+    rescueId: event.rescueId,
+    outcome: event.outcome,
+  }),
+  templateVariablesJson: '{}',
+  relatedEntityType:
+    NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_HOME_VISIT,
+  relatedEntityId: event.applicationId,
+});
+
+// applications.adopted — the celebratory final event. HIGH priority so
+// the SPA pinger surfaces it prominently.
+export const buildApplicationAdoptedCreate = (
+  event: ApplicationAdoptedEvent
+): CreateNotificationRequest => ({
+  userId: event.adopterId as string,
+  type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_APPLICATION_STATUS,
+  channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+  priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_HIGH,
+  title: 'Adoption complete! 🎉',
+  message:
+    'Congratulations — your adoption is now complete. Thank you for giving a pet a loving home!',
+  dataJson: JSON.stringify({
+    applicationId: event.applicationId,
+    petId: event.petId,
+    rescueId: event.rescueId,
+  }),
+  templateVariablesJson: '{}',
+  relatedEntityType:
+    NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_ADOPTION,
   relatedEntityId: event.applicationId,
 });
 


### PR DESCRIPTION
## What

Rounds out the adopter-facing applications notifications (Phase 5.4). `service.notifications` already consumed `applications.submitted` / `approved` / `rejected`; this adds the three remaining lifecycle events whose published payloads carry the `adopterId`, so **no cross-schema recipient lookup is needed**:

| Subject | Notification | Priority |
|---|---|---|
| `applications.homeVisitScheduled` | "Home visit scheduled" (date in `data_json` for SPA localisation) | HIGH |
| `applications.homeVisitCompleted` | "Home visit completed" (pass/fail outcome kept in `data_json`, not the body) | NORMAL |
| `applications.adopted` | "Adoption complete! 🎉" celebratory finish | HIGH |

Each goes through the canonical `createNotification` handler with `SYSTEM_PRINCIPAL`, the shared `notifications-workers` queue group, and the `@adopt-dont-shop/events.subscribe` poison-pill protection — identical discipline to the existing subscribers.

## Deliberately left out (for now)

- **`applications.reviewStarted`** — its published payload has no `adopterId` (only `reviewerId` + `rescueId`), so targeting the adopter would need a recipient lookup. Deferred, same recipient-discovery pattern as the pets/rescue events.
- **`applications.withdrawn`** — usually adopter-initiated, so notifying the actor about their own action is noise. A staff-initiated-withdrawal notification can land later with `withdrawnBy !== adopterId` discrimination.
- **Rescue-staff fan-out on submit** — still needs the rescue-staff lookup (the long-standing recipient-discovery deferral).

## Tests

- Three new translator tests: home-visit-scheduled carries the date + HIGH priority; home-visit-completed keeps the outcome out of the message body but in `data_json`; adopted is HIGH-priority + adoption-related.
- Updated the registration test: 10 → 13 subjects, with the three new `applications.*` subjects contiguous after `applications.rejected`.
- Full `services/notifications` suite green: **73 tests pass**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_