### PR TITLE
feat(applications): phase 5.5 — StartDraft via service.pets gRPC client

### DIFF
--- a/services/applications/src/config.test.ts
+++ b/services/applications/src/config.test.ts
@@ -16,6 +16,7 @@ describe('loadConfig', () => {
     expect(config.databaseUrl).toBe(REQUIRED.DATABASE_URL);
     expect(config.schema).toBe('applications');
     expect(config.natsUrl).toBe('nats://nats:4222');
+    expect(config.petsGrpcUrl).toBe('service-pets:6003');
   });
 
   it('honours all env overrides when set', () => {
@@ -27,6 +28,7 @@ describe('loadConfig', () => {
       NODE_ENV: 'production',
       DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/applications',
       NATS_URL: 'nats://nats.internal:4222',
+      PETS_GRPC_URL: 'service-pets.internal:6003',
     });
 
     expect(config.port).toBe(5500);
@@ -36,6 +38,7 @@ describe('loadConfig', () => {
     expect(config.schema).toBe('applications_test');
     expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/applications');
     expect(config.natsUrl).toBe('nats://nats.internal:4222');
+    expect(config.petsGrpcUrl).toBe('service-pets.internal:6003');
   });
 
   it('rejects a non-numeric APPLICATIONS_PORT', () => {

--- a/services/applications/src/config.ts
+++ b/services/applications/src/config.ts
@@ -26,6 +26,11 @@ export type ApplicationsConfig = {
   // is the multi-consumer event firehose that justifies the
   // event-sourced design.
   natsUrl: string;
+  // service.pets gRPC URL — StartDraft resolves pet → rescue via
+  // PetService.Get before commanding the domain (the cross-schema FK
+  // the database can't enforce). Defaults to the same service-pets:6003
+  // address the gateway uses.
+  petsGrpcUrl: string;
 };
 
 const DEFAULT_PORT = 5005;
@@ -33,6 +38,7 @@ const DEFAULT_GRPC_PORT = 6005;
 const DEFAULT_HOST = '0.0.0.0';
 const DEFAULT_SCHEMA = 'applications';
 const DEFAULT_NATS_URL = 'nats://nats:4222';
+const DEFAULT_PETS_GRPC_URL = 'service-pets:6003';
 
 export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ApplicationsConfig => {
   const port = parsePort(env.APPLICATIONS_PORT, DEFAULT_PORT, 'APPLICATIONS_PORT');
@@ -55,6 +61,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ApplicationsCo
     databaseUrl,
     schema: env.APPLICATIONS_SCHEMA?.trim() || DEFAULT_SCHEMA,
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+    petsGrpcUrl: env.PETS_GRPC_URL?.trim() || DEFAULT_PETS_GRPC_URL,
   };
 };
 

--- a/services/applications/src/grpc/command-runner.ts
+++ b/services/applications/src/grpc/command-runner.ts
@@ -14,6 +14,7 @@ import {
   apply as applyEvent,
   DomainError,
   handle,
+  INITIAL_STATE,
   type ApplicationCommand,
   type ApplicationState,
 } from '../domain/index.js';
@@ -77,6 +78,50 @@ export async function runCommand(
     // Fold the new events onto the loaded state to get the post-command
     // state, then project + publish.
     const nextState = events.reduce<ApplicationState>((s, e) => applyEvent(s, e), state);
+
+    await projectReadModel(client, nextState);
+
+    const evt = publishFor(nextState);
+    if (evt !== null) {
+      publish(evt);
+    }
+
+    return nextState;
+  });
+}
+
+// Create-flow counterpart to runCommand. StartDraft is the one command
+// that operates on a FRESH aggregate: the pure domain mints the
+// applicationId inside the DraftCreated event, so the caller can't know
+// the aggregate id up front. We run handle() against INITIAL_STATE,
+// read the minted id off the produced event, and append from version 0.
+// A freshly-minted UUID can't collide, so there's no optimistic-
+// concurrency path here.
+export async function runCreateCommand(
+  deps: HandlerDeps,
+  command: ApplicationCommand,
+  actorUserId: string,
+  publishFor: (state: ApplicationState) => PublishEnvelope | null
+): Promise<ApplicationState> {
+  return withTransaction(deps, async ({ client, publish }) => {
+    let events;
+    try {
+      events = handle(INITIAL_STATE, command);
+    } catch (err) {
+      if (err instanceof DomainError) {
+        throw domainErrorToHandler(err);
+      }
+      throw err;
+    }
+
+    // Every application event carries the aggregate's id; the create
+    // command always produces exactly the DraftCreated event whose
+    // applicationId IS the new aggregate id.
+    const aggregateId = events[0].applicationId;
+
+    await appendEvents(client, aggregateId, 0, events, actorUserId);
+
+    const nextState = events.reduce<ApplicationState>((s, e) => applyEvent(s, e), INITIAL_STATE);
 
     await projectReadModel(client, nextState);
 

--- a/services/applications/src/grpc/handlers.test.ts
+++ b/services/applications/src/grpc/handlers.test.ts
@@ -7,7 +7,8 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { saveDraftAnswers, submitDraft } from './handlers.js';
+import { makeStartDraft, saveDraftAnswers, submitDraft } from './handlers.js';
+import type { PetsClient } from './pets-client.js';
 
 function makePrincipal(
   overrides: Partial<{ userId: string; permissions: string[]; roles: string[] }> = {}
@@ -144,6 +145,67 @@ describe('saveDraftAnswers', () => {
     });
     const refs = JSON.parse(res.application.referencesJson) as Array<Record<string, string>>;
     expect(refs[0]).toMatchObject({ name: 'Jane', email: 'j@e.com', relationship: 'friend' });
+  });
+});
+
+describe('makeStartDraft', () => {
+  function makePetsClient(getPet: ReturnType<typeof vi.fn>): PetsClient {
+    return { getPet, close: vi.fn() } as unknown as PetsClient;
+  }
+
+  it('throws PERMISSION_DENIED when the caller is not the adopter', async () => {
+    const { deps } = makeDeps([]);
+    const startDraft = makeStartDraft(makePetsClient(vi.fn()));
+    await expect(
+      startDraft(deps, makePrincipal({ userId: 'usr-1' }), { adopterId: 'usr-2', petId: 'pet-1' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('throws INVALID_ARGUMENT on missing pet_id', async () => {
+    const { deps } = makeDeps([]);
+    const startDraft = makeStartDraft(makePetsClient(vi.fn()));
+    await expect(
+      startDraft(deps, makePrincipal(), { adopterId: 'usr-1', petId: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('resolves pet → rescue, creates the draft, publishes applications.draftCreated', async () => {
+    const getPet = vi.fn().mockResolvedValue({ pet: { petId: 'pet-1', rescueId: 'rsc-1' } });
+    const { deps } = makeDeps([]);
+    const startDraft = makeStartDraft(makePetsClient(getPet));
+
+    const res = await startDraft(deps, makePrincipal(), { adopterId: 'usr-1', petId: 'pet-1' });
+
+    expect(res.application.status).toBe(ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_DRAFT);
+    expect(res.application.adopterId).toBe('usr-1');
+    expect(res.application.petId).toBe('pet-1');
+    expect(res.application.rescueId).toBe('rsc-1');
+    expect(res.application.applicationId).not.toBe('');
+
+    // The pet lookup forwarded the adopter's identity as metadata.
+    const metadata = getPet.mock.calls[0][1];
+    expect(metadata.get('x-user-id')).toEqual(['usr-1']);
+
+    const publish = (deps as { _publish?: ReturnType<typeof vi.fn> })._publish!;
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'applications.draftCreated' });
+  });
+
+  it('maps a pets NOT_FOUND (grpc code 5) onto INVALID_ARGUMENT', async () => {
+    const getPet = vi.fn().mockRejectedValue({ code: 5 });
+    const { deps } = makeDeps([]);
+    const startDraft = makeStartDraft(makePetsClient(getPet));
+    await expect(
+      startDraft(deps, makePrincipal(), { adopterId: 'usr-1', petId: 'pet-x' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects a pet with no owning rescue', async () => {
+    const getPet = vi.fn().mockResolvedValue({ pet: { petId: 'pet-1' } });
+    const { deps } = makeDeps([]);
+    const startDraft = makeStartDraft(makePetsClient(getPet));
+    await expect(
+      startDraft(deps, makePrincipal(), { adopterId: 'usr-1', petId: 'pet-1' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 });
 

--- a/services/applications/src/grpc/handlers.ts
+++ b/services/applications/src/grpc/handlers.ts
@@ -1,14 +1,13 @@
 // gRPC handler implementations for ApplicationService — batch 1.
 //
-// Phase 5.3b — ships SaveDraftAnswers + SubmitDraft (the
-// existing-aggregate draft operations). StartDraft is DEFERRED: the
-// pure domain requires a non-empty rescueId at draft creation (a
-// cross-schema pets-vertical lookup), and the proto StartDraftRequest
-// doesn't carry rescue_id — so StartDraft needs the service.pets gRPC
-// client to resolve pet → rescue first. The review/visit/decision
-// RPCs (StartReview, ScheduleHomeVisit, CompleteHomeVisit, Approve,
-// Reject, Withdraw, MarkAdopted) and the read RPCs (GetApplication,
-// ListApplications) follow in focused batches.
+// Draft handlers: StartDraft, SaveDraftAnswers, SubmitDraft.
+// StartDraft (Phase 5.5) is the create-flow — it resolves pet → rescue
+// via the service.pets gRPC client before commanding the domain (the
+// cross-schema FK the proto request can't carry), then mints a fresh
+// aggregate via runCreateCommand. SaveDraftAnswers + SubmitDraft
+// (Phase 5.3b) operate on an existing aggregate with optimistic
+// concurrency. The review/visit/decision RPCs live in
+// review-handlers.ts and the read RPCs in read-handlers.ts.
 //
 // This is the EVENT-SOURCED vertical. Each write handler:
 //   1. loadAggregate — fold the event stream into current state
@@ -25,10 +24,12 @@
 // a 409.
 
 import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
-import { APPLICATIONS_UPDATE } from '@adopt-dont-shop/lib.types';
+import { APPLICATIONS_CREATE, APPLICATIONS_UPDATE, type UserId } from '@adopt-dont-shop/lib.types';
 import type {
   SaveDraftAnswersRequest,
   SaveDraftAnswersResponse,
+  StartDraftRequest,
+  StartDraftResponse,
   SubmitDraftRequest,
   SubmitDraftResponse,
 } from '@adopt-dont-shop/proto';
@@ -36,8 +37,96 @@ import type {
 import type { ApplicationCommand, Reference } from '../domain/index.js';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
-import { runCommand } from './command-runner.js';
+import { runCommand, runCreateCommand } from './command-runner.js';
+import type { PetsClient } from './pets-client.js';
+import { principalToMetadata } from './principal.js';
 import { stateToProto } from './state-mapper.js';
+
+// --- StartDraft ------------------------------------------------------
+//
+// The only command on a fresh aggregate, and the only one needing a
+// cross-vertical lookup: StartDraftRequest carries pet_id but not the
+// rescue that owns it, and the pure domain requires the rescueId. So
+// the handler resolves pet → rescue via service.pets before commanding
+// the domain. It's a factory closing over the PetsClient so the gRPC
+// server boot injects the real client and tests inject a stub.
+//
+// The grpc-js status codes service.pets can return are mapped onto our
+// HandlerError codes: a missing pet is the caller's bad pet_id (400),
+// not our 404; a denied pets read propagates as PERMISSION_DENIED.
+
+const PETS_GRPC_NOT_FOUND = 5;
+const PETS_GRPC_PERMISSION_DENIED = 7;
+
+export function makeStartDraft(
+  petsClient: PetsClient
+): (
+  deps: HandlerDeps,
+  principal: Principal,
+  req: StartDraftRequest
+) => Promise<StartDraftResponse> {
+  return async (deps, principal, req) => {
+    if (req.adopterId === undefined || req.adopterId === '') {
+      throw new HandlerError('INVALID_ARGUMENT', 'adopter_id is required');
+    }
+    if (req.petId === undefined || req.petId === '') {
+      throw new HandlerError('INVALID_ARGUMENT', 'pet_id is required');
+    }
+    // Adopters mint their own drafts; super_admin can mint for anyone.
+    if (!requirePermission(principal, APPLICATIONS_CREATE, { userId: req.adopterId as UserId })) {
+      throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_CREATE}' required`);
+    }
+
+    const rescueId = await resolveRescueId(petsClient, principal, req.petId);
+
+    const command: ApplicationCommand = {
+      type: 'startDraft',
+      adopterId: req.adopterId,
+      petId: req.petId,
+      rescueId,
+      at: new Date().toISOString(),
+    };
+
+    const state = await runCreateCommand(deps, command, principal.userId, s => ({
+      type: 'applications.draftCreated',
+      id: s.applicationId,
+      payload: {
+        applicationId: s.applicationId,
+        adopterId: s.adopterId,
+        petId: s.petId,
+        rescueId: s.rescueId,
+      },
+    }));
+
+    return { application: stateToProto(state) };
+  };
+}
+
+async function resolveRescueId(
+  petsClient: PetsClient,
+  principal: Principal,
+  petId: string
+): Promise<string> {
+  let res;
+  try {
+    res = await petsClient.getPet({ petId }, principalToMetadata(principal));
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    if (code === PETS_GRPC_NOT_FOUND) {
+      throw new HandlerError('INVALID_ARGUMENT', `pet ${petId} not found`);
+    }
+    if (code === PETS_GRPC_PERMISSION_DENIED) {
+      throw new HandlerError('PERMISSION_DENIED', 'not allowed to read the pet');
+    }
+    throw new HandlerError('INTERNAL', 'failed to resolve pet rescue');
+  }
+
+  const rescueId = res.pet?.rescueId;
+  if (rescueId === undefined || rescueId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', `pet ${petId} has no owning rescue`);
+  }
+  return rescueId;
+}
 
 // --- SaveDraftAnswers ------------------------------------------------
 

--- a/services/applications/src/grpc/pets-client.ts
+++ b/services/applications/src/grpc/pets-client.ts
@@ -1,0 +1,43 @@
+// Service-to-service gRPC client for service.pets.
+//
+// StartDraft is the only ApplicationService RPC that needs a cross-
+// vertical lookup: the pure domain requires the rescue that owns the
+// pet, but StartDraftRequest only carries pet_id (the SPA doesn't know
+// the rescue). So the handler resolves pet → rescue via PetService.Get
+// before commanding the domain — the cross-schema FK we can't enforce
+// in the database, enforced here at the application layer instead.
+//
+// Only the Get RPC is wrapped — that's all this vertical needs from
+// pets. The interface is exported so the gRPC server boot can inject a
+// real client and tests can substitute a stub.
+
+import { credentials, type Metadata } from '@grpc/grpc-js';
+
+import { PetsV1, type GetPetRequest, type GetPetResponse } from '@adopt-dont-shop/proto';
+
+export type PetsClient = {
+  getPet(req: GetPetRequest, metadata: Metadata): Promise<GetPetResponse>;
+  close(): void;
+};
+
+export type CreatePetsClientOptions = {
+  address: string;
+};
+
+export const createPetsClient = (opts: CreatePetsClientOptions): PetsClient => {
+  const stub = new PetsV1.PetServiceClient(opts.address, credentials.createInsecure());
+
+  return {
+    getPet: (req, metadata) =>
+      new Promise<GetPetResponse>((resolve, reject) => {
+        stub.get(req, metadata, (err: unknown, res: GetPetResponse) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(res);
+        });
+      }),
+    close: () => stub.close(),
+  };
+};

--- a/services/applications/src/grpc/principal.test.ts
+++ b/services/applications/src/grpc/principal.test.ts
@@ -1,7 +1,10 @@
 import { Metadata } from '@grpc/grpc-js';
 import { describe, expect, it } from 'vitest';
 
-import { extractPrincipal, MissingPrincipalError } from './principal.js';
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+import { extractPrincipal, MissingPrincipalError, principalToMetadata } from './principal.js';
 
 function build(headers: Record<string, string>): Metadata {
   const m = new Metadata();
@@ -66,5 +69,26 @@ describe('extractPrincipal', () => {
       })
     );
     expect(p.permissions).toEqual(['applications.read']);
+  });
+});
+
+describe('principalToMetadata', () => {
+  const principal: Principal = {
+    userId: 'usr-1' as UserId,
+    roles: ['adopter', 'rescue_staff'] as UserRole[],
+    permissions: ['pets.read', 'applications.create'] as Permission[],
+    rescueId: 'rsc-1' as RescueId,
+  };
+
+  it('round-trips back through extractPrincipal', () => {
+    const restored = extractPrincipal(principalToMetadata(principal));
+    expect(restored).toEqual(principal);
+  });
+
+  it('comma-joins roles + permissions and omits rescue-id when absent', () => {
+    const m = principalToMetadata({ ...principal, rescueId: undefined });
+    expect(m.get('x-user-roles')).toEqual(['adopter,rescue_staff']);
+    expect(m.get('x-user-permissions')).toEqual(['pets.read,applications.create']);
+    expect(m.get('x-rescue-id')).toEqual([]);
   });
 });

--- a/services/applications/src/grpc/principal.ts
+++ b/services/applications/src/grpc/principal.ts
@@ -13,7 +13,7 @@
 // token-minting flow on this surface (auth handles that). Even
 // `StartDraft` requires a principal because drafts are user-scoped.
 
-import type { Metadata } from '@grpc/grpc-js';
+import { Metadata } from '@grpc/grpc-js';
 
 import type { Principal } from '@adopt-dont-shop/authz';
 import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
@@ -56,6 +56,23 @@ export function extractPrincipal(metadata: Metadata): Principal {
     permissions,
     rescueId,
   };
+}
+
+// Inverse of extractPrincipal — serialises a Principal back into the
+// x-user-* metadata headers for an OUTBOUND service-to-service call.
+// StartDraft uses this to forward the adopter's identity to
+// service.pets (whose Get gate requires the caller's `pets.read`), so
+// the downstream service runs its own authz against the real principal
+// rather than a synthesized system identity.
+export function principalToMetadata(principal: Principal): Metadata {
+  const metadata = new Metadata();
+  metadata.set('x-user-id', principal.userId);
+  metadata.set('x-user-roles', principal.roles.join(','));
+  metadata.set('x-user-permissions', principal.permissions.join(','));
+  if (principal.rescueId !== undefined) {
+    metadata.set('x-rescue-id', principal.rescueId);
+  }
+  return metadata;
 }
 
 function headerOne(metadata: Metadata, key: string): string | undefined {

--- a/services/applications/src/grpc/server.test.ts
+++ b/services/applications/src/grpc/server.test.ts
@@ -24,14 +24,21 @@ const config: ApplicationsConfig = {
   databaseUrl: 'postgres://test',
   schema: 'applications',
   natsUrl: 'nats://localhost:4222',
+  petsGrpcUrl: 'service-pets:6003',
 };
 
 const pool = {} as unknown as Pool;
 const nats = {} as unknown as NatsConnection;
+// Inject a stub pets client so the test doesn't construct a real gRPC
+// channel just to assert handler registration.
+const petsClient = {
+  getPet: () => Promise.reject(new Error('not used')),
+  close: () => undefined,
+} as unknown as Parameters<typeof createGrpcServer>[0]['petsClient'];
 
 describe('createGrpcServer', () => {
   it('registers all 12 ApplicationService methods on the grpc.Server', () => {
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     const base = '/adopt_dont_shop.applications.v1.ApplicationService';
@@ -57,7 +64,7 @@ describe('createGrpcServer', () => {
     const definition = ApplicationsV1.ApplicationServiceService;
     const expectedPaths = Object.values(definition).map(d => (d as { path: string }).path);
 
-    const server = createGrpcServer({ config, pool, nats, logger: quietLogger });
+    const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
     for (const p of expectedPaths) {

--- a/services/applications/src/grpc/server.ts
+++ b/services/applications/src/grpc/server.ts
@@ -11,12 +11,11 @@
 // all sharing the (deps, principal, request) → Promise<response> shape
 // so the adapter wraps them uniformly.
 //
-// StartDraft is a deliberate UNIMPLEMENTED stub (same approach as
-// matching's Recommend/SearchPets). The pure domain requires a
-// non-empty rescueId at draft creation — a cross-schema pets lookup —
-// and StartDraftRequest doesn't carry one. It waits on the service.pets
-// gRPC client; the gateway maps UNIMPLEMENTED → 501 so callers degrade
-// gracefully rather than getting a silent failure.
+// StartDraft is now live: it resolves pet → rescue via a service.pets
+// gRPC client (the pure domain requires the rescueId, which
+// StartDraftRequest doesn't carry) before commanding the domain. The
+// client is injected so tests can stub it; real boot builds one from
+// config.petsGrpcUrl.
 //
 // Dev uses insecure credentials (TLS terminates at nginx in front);
 // production keeps gRPC HTTP/2 cleartext on the cluster network until a
@@ -24,14 +23,7 @@
 
 import { promisify } from 'node:util';
 
-import {
-  Server,
-  ServerCredentials,
-  status,
-  type ServerUnaryCall,
-  type ServiceError,
-  type sendUnaryData,
-} from '@grpc/grpc-js';
+import { Server, ServerCredentials } from '@grpc/grpc-js';
 
 import type { NatsConnection } from 'nats';
 import type { Pool } from 'pg';
@@ -42,7 +34,8 @@ import { ApplicationsV1 } from '@adopt-dont-shop/proto';
 import type { ApplicationsConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
-import { saveDraftAnswers, submitDraft } from './handlers.js';
+import { makeStartDraft, saveDraftAnswers, submitDraft } from './handlers.js';
+import { createPetsClient, type PetsClient } from './pets-client.js';
 import { getApplication, listApplications } from './read-handlers.js';
 import {
   approve,
@@ -59,6 +52,11 @@ export type CreateGrpcServerOptions = {
   pool: Pool;
   nats: NatsConnection;
   logger: Logger;
+  // Injected for StartDraft's pet → rescue lookup. Optional: when
+  // omitted (createGrpcServer called directly, e.g. in tests) a lazy
+  // client is built from config.petsGrpcUrl. startGrpcServer always
+  // builds + owns one so it can close it on shutdown.
+  petsClient?: PetsClient;
 };
 
 export type RunningGrpcServer = {
@@ -70,20 +68,12 @@ export type RunningGrpcServer = {
 export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   const { config, pool, nats, logger } = opts;
   const deps = { pool, nats };
+  const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
   const server = new Server();
 
-  const notImplemented =
-    (rpc: string) =>
-    (_call: ServerUnaryCall<unknown, unknown>, callback: sendUnaryData<unknown>): void => {
-      const err = new Error(`${rpc} not yet implemented`) as ServiceError;
-      err.code = status.UNIMPLEMENTED;
-      err.details = err.message;
-      callback(err, null);
-    };
-
   server.addService(ApplicationsV1.ApplicationServiceService, {
-    // Draft lifecycle (handlers.ts). StartDraft deferred — see header.
-    startDraft: notImplemented('StartDraft'),
+    // Draft lifecycle (handlers.ts).
+    startDraft: adapt(makeStartDraft(petsClient), { deps, logger }),
     saveDraftAnswers: adapt(saveDraftAnswers, { deps, logger }),
     submitDraft: adapt(submitDraft, { deps, logger }),
     // Review / visit / decision (review-handlers.ts)
@@ -101,7 +91,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
 
   logger.info('gRPC ApplicationService registered', {
     methods: [
-      'startDraft (stub)',
+      'startDraft',
       'saveDraftAnswers',
       'submitDraft',
       'startReview',
@@ -124,7 +114,9 @@ export const startGrpcServer = async (
   opts: CreateGrpcServerOptions
 ): Promise<RunningGrpcServer> => {
   const { config, logger } = opts;
-  const server = createGrpcServer(opts);
+  // Build + own the pets client here so it's closed on shutdown.
+  const petsClient = opts.petsClient ?? createPetsClient({ address: config.petsGrpcUrl });
+  const server = createGrpcServer({ ...opts, petsClient });
 
   const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
   const port = await bindAsync(
@@ -142,6 +134,11 @@ export const startGrpcServer = async (
         server.tryShutdown(err => {
           if (err) {
             logger.error('gRPC server shutdown error', { err });
+          }
+          try {
+            petsClient.close();
+          } catch (closeErr) {
+            logger.error('pets client close error', { err: closeErr });
           }
           resolve();
         });


### PR DESCRIPTION
## What

Implements the **last** `ApplicationService` RPC — **StartDraft** — removing the UNIMPLEMENTED stub. The applications vertical is now feature-complete over gRPC (all 12 RPCs live).

StartDraft is the one command that (a) operates on a **fresh aggregate** and (b) needs a **cross-vertical lookup**: the pure domain requires the rescue that owns the pet, but `StartDraftRequest` only carries `pet_id`. So the handler resolves pet → rescue via a new service-to-service **`service.pets` gRPC client** before commanding the domain — the cross-schema FK the database can't enforce, enforced at the application layer.

## Pieces

| File | Role |
|---|---|
| **`pets-client.ts`** | Thin `PetService.Get` wrapper (all this vertical needs from pets). Injected into the gRPC server so tests stub it; `startGrpcServer` builds + owns one and closes it on shutdown. |
| **`principalToMetadata`** (principal.ts) | Serialises the adopter's `Principal` back into `x-user-*` headers so the pets `Get` gate (which requires `pets.read`) runs its own authz against the **real caller**, not a synthesized system identity. Round-trips with `extractPrincipal`. |
| **`runCreateCommand`** (command-runner.ts) | Create-flow counterpart to `runCommand`. The domain mints the `applicationId` inside `DraftCreated`, so the caller can't supply the aggregate id up front — we read it off the produced event and append from version 0. No optimistic-concurrency path (a fresh UUID can't collide). |
| **`makeStartDraft`** (handlers.ts) | Gates on `applications.create` scoped to the adopter (adopter-or-super_admin), resolves the rescue, runs the create command, publishes `applications.draftCreated`. |

## Error mapping

- pets `NOT_FOUND` → `INVALID_ARGUMENT` (a bad `pet_id` the adopter supplied is a 400, not our 404).
- pets `PERMISSION_DENIED` → propagates as `PERMISSION_DENIED`.
- a pet with no owning rescue → `INVALID_ARGUMENT`.

`config` gains `petsGrpcUrl` (default `service-pets:6003`).

## Cutover readiness

With this, the applications gRPC surface is 100% implemented and the gateway already routes `/api/applications/*` to it (#934). The vertical is **cutover-ready**. Remaining cutover steps (separate, and the last one is destructive — would confirm first):
1. Verify/align the frontend `lib.applications` against the gateway's REST contract (proto-JSON shapes).
2. Remove the residual applications code from the monolith (5.3f).

## Tests

- `makeStartDraft`: caller-not-adopter → 403; missing pet_id → 400; happy path resolves rescue + creates draft + publishes `draftCreated` + forwards `x-user-id` metadata to pets; pets NOT_FOUND → 400; pet with no rescue → 400.
- `principalToMetadata`: round-trips through `extractPrincipal`; comma-joins roles/permissions; omits `x-rescue-id` when absent.
- Full `services/applications` suite green: **149 tests pass**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_