### PR TITLE
docs(adr): 0002 — applications strangler-fig cutover plan

### DIFF
--- a/docs/adr/0002-applications-strangler-cutover.md
+++ b/docs/adr/0002-applications-strangler-cutover.md
@@ -1,0 +1,175 @@
+# ADR 0002 — Applications strangler-fig cutover plan
+
+- Status: Proposed
+- Date: 2026-06-06
+- Scope: `services/applications`, `services/gateway`, `services/api` (residual
+  monolith), `lib.applications`
+
+## Context
+
+The applications domain has been extracted into an event-sourced microservice
+(`services/applications`). As of June 2026 the gRPC surface is **feature
+complete** — all 12 `ApplicationService` RPCs are implemented (StartDraft,
+SaveDraftAnswers, SubmitDraft, StartReview, ScheduleHomeVisit,
+CompleteHomeVisit, Approve, Reject, Withdraw, MarkAdopted, Get, List), the
+gRPC server boots, the gateway has `/api/applications/*` REST routes, and
+`service.notifications` consumes the `applications.*` events.
+
+Preparing the final cutover (retire the monolith's applications code) surfaced
+three blocking gaps. They are documented here so the cutover is sequenced
+deliberately rather than attempted as a single destructive delete.
+
+### Gap 1 — the extracted services are "dark" (path-version mismatch)
+
+The frontend libraries call **`/api/v1/<domain>/*`**:
+
+```
+lib.applications → /api/v1/applications, /api/v1/applications/:id, …
+lib.pets         → /api/v1/pets, /api/v1/pets/:id, …
+```
+
+The gateway's service-specific routes are registered at **`/api/<domain>`**
+(no `v1`):
+
+```
+routes/applications.ts → /api/applications, /api/applications/:id/submit, …
+routes/pets.ts         → /api/pets, …
+routes/moderation.ts   → /api/moderation, …
+```
+
+Fastify's first-registered-wins routing never matches these against the
+frontend's `/api/v1/...` requests, so **every** frontend call falls through the
+catch-all proxy (`prefix: '/api'`, `rewritePrefix: '/api'`) straight to the
+residual monolith. The extracted services — pets, applications, moderation,
+audit, matching — are registered and tested but receive **zero production
+traffic**. The earlier "cutover" PRs (e.g. pets #867) wired the routes but
+never actually moved any traffic, because the path version was never aligned.
+
+This is systemic, not specific to applications. It must be fixed once, for all
+verticals, as the foundation of any real cutover.
+
+### Gap 2 — response-shape divergence (proto-JSON vs the frontend contract)
+
+The gateway returns ts-proto `toJSON` output. The frontend's Zod
+`ApplicationSchema` expects a different shape:
+
+| Concept | Gateway proto-JSON | Frontend `ApplicationSchema` |
+|---|---|---|
+| id | `applicationId` | `id` |
+| adopter | `adopterId` | `userId` |
+| status | `"APPLICATION_STATUS_SUBMITTED"` | `"submitted"` (lowercase) |
+| answers | `answersJson` (stringified blob) | nested camelCase `data` object (`personalInfo`, `livingConditions`, `petExperience`, `references`, `additionalInfo`, `answers`) |
+| references | inside `answersJson` | `data.references` |
+| extra fields | — | `stage`, `priority`, `reviewedAt`, `reviewedBy`, `reviewNotes`, `documents[]` |
+
+If only the path (Gap 1) were fixed, `ApplicationSchema.parse()` would throw on
+every response. The path fix and a shape adapter must ship together.
+
+### Gap 3 — missing surface + a deep monolith dependency web
+
+The frontend uses endpoints the service does not yet implement:
+
+- documents: `POST/GET /:id/documents`, `DELETE /:id/documents/:documentId`
+- stats: `GET /applications/stats`
+- questions: rescue-scoped application questions
+- timeline / history: `GET /:id/history`
+
+And the monolith's `Application` model is read **directly** by ~13 other
+services and middleware, any of which breaks if the model is deleted before it
+is migrated:
+
+GDPR erasure, analytics, weekly-digest, user-deletion cascade,
+rescue lifecycle, admin export, upload-ACL, socket broadcasts, notifications,
+audit hooks, abuse rate-limits (`applicationCreate*Limiter`), idempotency keys,
+field-level permissions (`fieldMask('applications', …)`).
+
+The unique constraint `UNIQUE (user_id, pet_id) WHERE deleted_at IS NULL AND
+status NOT IN ('rejected','withdrawn')` already exists in the new schema
+(migration 002), so that invariant is preserved.
+
+## Decision
+
+Cut over in **staged, individually-shippable PRs**. Do not delete any monolith
+applications code until every consumer in Gap 3 has been migrated off direct
+model access and the frontend is served end-to-end by the new service through a
+compatibility layer. Sequence:
+
+### Stage A — align the gateway path (fixes Gap 1, all verticals)
+
+Move the gateway service routes from `/api/<domain>` to `/api/v1/<domain>` so
+they actually intercept frontend traffic before the catch-all. This is a
+foundational, low-risk change but it makes the (currently dark) services live —
+so it MUST land together with Stage B for applications, and the other verticals
+need their own shape audits before their paths are flipped. Recommend a feature
+flag / per-domain enablement so each vertical goes live only when its shape
+adapter is ready.
+
+### Stage B — gateway compatibility adapter for applications (fixes Gap 2)
+
+Add a translation layer in `routes/applications.ts` (or a dedicated
+`applications-view.ts`):
+
+- response: proto-JSON → frontend `ApplicationSchema` shape (`applicationId`→`id`,
+  `adopterId`→`userId`, status enum → lowercase, parse `answersJson` back into
+  the nested `data` object, surface `stage`/`priority`/`reviewedAt`/… from the
+  proto optionals).
+- request: frontend payload → gRPC request (the inverse — collapse the nested
+  `data` object into `answersJson`, map `id`/`userId`).
+
+Cover the mapping with golden-fixture tests asserting a real `ApplicationSchema`
+`parse()` succeeds.
+
+### Stage C — fill the missing surface (fixes Gap 3, part 1)
+
+For documents / stats / questions / timeline, either:
+
+1. implement them in `services/applications` (proto + handlers + gateway), or
+2. **transitionally proxy** just those sub-paths to the monolith from the
+   gateway, so the path flip in Stage A doesn't 404 them.
+
+Recommend (2) first (keeps the cutover moving), then (1) as follow-ups.
+
+### Stage D — migrate the monolith integrations (fixes Gap 3, part 2)
+
+Peel each of the ~13 consumers off the `Application` Sequelize model, one PR at
+a time, replacing direct reads/writes with either a gRPC call to
+`service.applications` or consumption of an `applications.*` NATS event:
+
+1. notifications + socket broadcasts → already event-driven; verify parity.
+2. audit hooks → the service already emits its own audit; confirm coverage.
+3. analytics / weekly-digest / admin export → read via gRPC List/Get or a new
+   stats RPC.
+4. GDPR erasure → an `EraseUserApplications` / `EraseRescueApplications` RPC.
+5. user / rescue deletion cascade → coordinate via gRPC or an event the service
+   consumes.
+6. upload-ACL, abuse rate-limits, idempotency, field-permissions → move the
+   enforcement to the gateway or the service.
+
+### Stage E — delete the monolith applications code (destructive — last)
+
+Only after Stages A–D: remove routes, controllers, services, models,
+validation, and the now-unused migrations/seeders from `services/api`, and drop
+the transitional proxy from Stage C. Requires explicit sign-off.
+
+## Consequences
+
+- The vertical's gRPC surface being complete is necessary but **not sufficient**
+  for cutover — the gateway contract bridge (A+B+C) is the real cutover work,
+  and the monolith integration migration (D) is the bulk of the effort.
+- Until Stage A ships, the new service is correct but unused; the monolith
+  remains the source of truth for applications. No data is at risk.
+- Each stage is independently shippable and reversible (flip the flag / restore
+  the route) until Stage E.
+
+## Lessons (for the Notion "Things that bit us" / "Things we'd do differently")
+
+- **Verify the path, not just the route module.** A "gateway routes" PR that
+  registers `/api/<domain>` while clients call `/api/v1/<domain>` is dark — it
+  passes its own tests (which hit the registered path) but never serves a real
+  request. Every prior vertical cutover shipped in this state. The route test
+  must assert the path clients actually use, and an integration smoke must hit
+  the gateway on the client's real URL.
+- **A proto-JSON gRPC surface is not a drop-in REST replacement.** ts-proto
+  `toJSON` (SCREAMING enum names, `*_json` blob fields, proto field names) and a
+  hand-written REST contract diverge by default. Budget a translation layer per
+  vertical, or migrate the client — don't assume transparency.


### PR DESCRIPTION
## What

Writes up the applications cutover plan as an ADR (planning only — **no code changed**), per the agreed "stop and write up the plan" decision.

The applications gRPC vertical is feature-complete (all 12 RPCs live, server boot, gateway routes, notifications), but investigating the final cutover surfaced **three blocking gaps** that mean it is *not* drop-in cutover-ready:

1. **Path-version mismatch (systemic).** The frontend calls `/api/v1/<domain>`; the gateway registers `/api/<domain>`. Fastify never matches, so every frontend request falls through the catch-all to the monolith — the extracted services (pets, applications, moderation, audit, matching) are **dark**, receiving zero production traffic. Earlier "cutover" PRs wired routes but never moved traffic.
2. **Response-shape divergence.** proto-JSON (`applicationId`/`adopterId`, `answersJson` blob, `APPLICATION_STATUS_*`) vs the frontend's camelCase `ApplicationSchema` (`id`/`userId`, nested `data` object, lowercase `status`). A path fix alone would make `ApplicationSchema.parse()` throw.
3. **Missing surface + dependency web.** Documents/stats/questions/timeline aren't implemented, and ~13 monolith services read the `Application` model directly (GDPR, analytics, digest, user/rescue/admin cascades, upload-ACL, sockets, notifications, audit, rate-limits, idempotency, field-permissions).

## The plan (staged, individually shippable)

- **A** — align gateway paths to `/api/v1/<domain>` (foundational, all verticals; flag per-domain).
- **B** — gateway compatibility adapter for applications (proto-JSON ↔ `ApplicationSchema`), with golden-fixture `parse()` tests.
- **C** — fill the missing surface (transitionally proxy documents/stats/questions/timeline to the monolith, then build natively).
- **D** — migrate the ~13 monolith integrations off direct model access (gRPC/NATS), one PR each.
- **E** — delete the monolith applications code (destructive — last, with sign-off).

Full detail, including the two lessons (verify the *path* not just the route module; a proto-JSON surface isn't a drop-in REST replacement), is in `docs/adr/0002-applications-strangler-cutover.md`.

## Why this matters

The path-version finding affects **every** extracted vertical, not just applications — none of the prior cutovers are actually serving frontend traffic. This ADR is the foundation for sequencing the real cutover safely.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_