### PR TITLE
feat(gateway): stage A — align routes to /api/v1 + per-domain cutover flags

### DIFF
--- a/services/gateway/src/config.test.ts
+++ b/services/gateway/src/config.test.ts
@@ -12,6 +12,35 @@ describe('loadConfig', () => {
     expect(config.natsUrl).toBe('nats://nats:4222');
   });
 
+  it('defaults every cutover flag to false (all domains proxy to the monolith)', () => {
+    const config = loadConfig({});
+    expect(config.cutover).toEqual({
+      auth: false,
+      notifications: false,
+      pets: false,
+      rescue: false,
+      applications: false,
+      moderation: false,
+      matching: false,
+      audit: false,
+    });
+  });
+
+  it('enables a cutover flag only for the exact string "true" (case-insensitive)', () => {
+    const config = loadConfig({
+      CUTOVER_PETS: 'true',
+      CUTOVER_AUTH: 'TRUE',
+      CUTOVER_APPLICATIONS: 'false',
+      CUTOVER_MATCHING: '1',
+      CUTOVER_AUDIT: '',
+    });
+    expect(config.cutover.pets).toBe(true);
+    expect(config.cutover.auth).toBe(true);
+    expect(config.cutover.applications).toBe(false);
+    expect(config.cutover.matching).toBe(false);
+    expect(config.cutover.audit).toBe(false);
+  });
+
   it('honours GATEWAY_PORT / GATEWAY_HOST / UPSTREAM_BACKEND_URL / NODE_ENV / NATS_URL when set', () => {
     const config = loadConfig({
       GATEWAY_PORT: '4321',

--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -42,6 +42,24 @@ export type GatewayConfig = {
   // service.audit gRPC URL — Phase 10.5 cuts /api/audit/* over to this
   // address.
   auditGrpcUrl: string;
+  // Per-domain strangler cutover switches. When false (the default), the
+  // gateway does NOT register that domain's /api/v1/* routes, so requests
+  // fall through the catch-all proxy to the residual monolith — today's
+  // behaviour. Flip a domain to true ONLY once its gateway routes return
+  // a frontend-compatible response shape (see ADR 0002 — the gRPC
+  // proto-JSON shape diverges from the frontend contract, so a per-domain
+  // adapter must land before that domain goes live). Env:
+  // CUTOVER_<DOMAIN>=true.
+  cutover: {
+    auth: boolean;
+    notifications: boolean;
+    pets: boolean;
+    rescue: boolean;
+    applications: boolean;
+    moderation: boolean;
+    matching: boolean;
+    audit: boolean;
+  };
 };
 
 const DEFAULT_PORT = 4000;
@@ -78,5 +96,22 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
     moderationGrpcUrl: env.MODERATION_GRPC_URL?.trim() || DEFAULT_MODERATION_GRPC_URL,
     matchingGrpcUrl: env.MATCHING_GRPC_URL?.trim() || DEFAULT_MATCHING_GRPC_URL,
     auditGrpcUrl: env.AUDIT_GRPC_URL?.trim() || DEFAULT_AUDIT_GRPC_URL,
+    cutover: {
+      auth: isEnabled(env.CUTOVER_AUTH),
+      notifications: isEnabled(env.CUTOVER_NOTIFICATIONS),
+      pets: isEnabled(env.CUTOVER_PETS),
+      rescue: isEnabled(env.CUTOVER_RESCUE),
+      applications: isEnabled(env.CUTOVER_APPLICATIONS),
+      moderation: isEnabled(env.CUTOVER_MODERATION),
+      matching: isEnabled(env.CUTOVER_MATCHING),
+      audit: isEnabled(env.CUTOVER_AUDIT),
+    },
   };
 };
+
+// A cutover flag is on only for the exact string "true" (case-insensitive).
+// Anything else — unset, "false", "0", "" — leaves the domain proxied to
+// the monolith.
+function isEnabled(raw: string | undefined): boolean {
+  return raw?.trim().toLowerCase() === 'true';
+}

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -81,11 +81,11 @@ describe('applications routes', () => {
     await app.close();
   });
 
-  it('PATCH /api/applications/:id/answers threads expectedVersion + patch', async () => {
+  it('PATCH /api/v1/applications/:id/answers threads expectedVersion + patch', async () => {
     mocks.saveDraftAnswers.mockResolvedValue({ application: APP });
     const res = await app.inject({
       method: 'PATCH',
-      url: '/api/applications/app-1/answers',
+      url: '/api/v1/applications/app-1/answers',
       headers: ADOPTER,
       payload: { expectedVersion: 3, answersPatchJson: '{"q1":"a"}' },
     });
@@ -97,11 +97,11 @@ describe('applications routes', () => {
     });
   });
 
-  it('POST /api/applications/:id/submit threads expectedVersion', async () => {
+  it('POST /api/v1/applications/:id/submit threads expectedVersion', async () => {
     mocks.submitDraft.mockResolvedValue({ application: APP });
     await app.inject({
       method: 'POST',
-      url: '/api/applications/app-1/submit',
+      url: '/api/v1/applications/app-1/submit',
       headers: ADOPTER,
       payload: { expectedVersion: 4 },
     });
@@ -111,11 +111,11 @@ describe('applications routes', () => {
     });
   });
 
-  it('POST /api/applications/:id/review forwards the staff note', async () => {
+  it('POST /api/v1/applications/:id/review forwards the staff note', async () => {
     mocks.startReview.mockResolvedValue({ application: APP });
     await app.inject({
       method: 'POST',
-      url: '/api/applications/app-1/review',
+      url: '/api/v1/applications/app-1/review',
       headers: STAFF,
       payload: { note: 'opening' },
     });
@@ -125,11 +125,11 @@ describe('applications routes', () => {
     });
   });
 
-  it('POST /api/applications/:id/home-visit/complete parses the outcome enum', async () => {
+  it('POST /api/v1/applications/:id/home-visit/complete parses the outcome enum', async () => {
     mocks.completeHomeVisit.mockResolvedValue({ application: APP });
     await app.inject({
       method: 'POST',
-      url: '/api/applications/app-1/home-visit/complete',
+      url: '/api/v1/applications/app-1/home-visit/complete',
       headers: STAFF,
       payload: { outcome: 'passed', notes: 'great fit' },
     });
@@ -143,7 +143,7 @@ describe('applications routes', () => {
     mocks.completeHomeVisit.mockResolvedValue({ application: APP });
     await app.inject({
       method: 'POST',
-      url: '/api/applications/app-1/home-visit/complete',
+      url: '/api/v1/applications/app-1/home-visit/complete',
       headers: STAFF,
       payload: { outcome: 'HOME_VISIT_OUTCOME_FAILED' },
     });
@@ -152,11 +152,11 @@ describe('applications routes', () => {
     });
   });
 
-  it('POST /api/applications/:id/reject requires a reason field', async () => {
+  it('POST /api/v1/applications/:id/reject requires a reason field', async () => {
     mocks.reject.mockResolvedValue({ application: APP });
     await app.inject({
       method: 'POST',
-      url: '/api/applications/app-1/reject',
+      url: '/api/v1/applications/app-1/reject',
       headers: STAFF,
       payload: { reason: 'home unsuitable' },
     });
@@ -166,22 +166,22 @@ describe('applications routes', () => {
     });
   });
 
-  it('POST /api/applications/:id/adopt needs no body', async () => {
+  it('POST /api/v1/applications/:id/adopt needs no body', async () => {
     mocks.markAdopted.mockResolvedValue({ application: APP });
     const res = await app.inject({
       method: 'POST',
-      url: '/api/applications/app-1/adopt',
+      url: '/api/v1/applications/app-1/adopt',
       headers: STAFF,
     });
     expect(res.statusCode).toBe(200);
     expect(mocks.markAdopted.mock.calls[0][0]).toMatchObject({ applicationId: 'app-1' });
   });
 
-  it('GET /api/applications → List with parsed status filter + scoping query', async () => {
+  it('GET /api/v1/applications → List with parsed status filter + scoping query', async () => {
     mocks.list.mockResolvedValue({ applications: [APP] });
     await app.inject({
       method: 'GET',
-      url: '/api/applications?status=submitted&limit=10&rescue=rsc-1&adopter=usr-9',
+      url: '/api/v1/applications?status=submitted&limit=10&rescue=rsc-1&adopter=usr-9',
       headers: STAFF,
     });
     expect(mocks.list.mock.calls[0][0]).toMatchObject({
@@ -192,11 +192,11 @@ describe('applications routes', () => {
     });
   });
 
-  it('GET /api/applications/:id passes includeTimeline', async () => {
+  it('GET /api/v1/applications/:id passes includeTimeline', async () => {
     mocks.get.mockResolvedValue({ application: APP, timeline: [] });
     await app.inject({
       method: 'GET',
-      url: '/api/applications/app-1?timeline=true',
+      url: '/api/v1/applications/app-1?timeline=true',
       headers: ADOPTER,
     });
     expect(mocks.get.mock.calls[0][0]).toMatchObject({
@@ -212,7 +212,7 @@ describe('applications routes', () => {
     });
     const res = await app.inject({
       method: 'POST',
-      url: '/api/applications',
+      url: '/api/v1/applications',
       headers: ADOPTER,
       payload: { adopterId: 'usr-1', petId: 'pet-1' },
     });
@@ -221,13 +221,17 @@ describe('applications routes', () => {
 
   it('maps PERMISSION_DENIED → 403 and NOT_FOUND → 404', async () => {
     mocks.list.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'nope' });
-    const denied = await app.inject({ method: 'GET', url: '/api/applications', headers: ADOPTER });
+    const denied = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications',
+      headers: ADOPTER,
+    });
     expect(denied.statusCode).toBe(403);
 
     mocks.get.mockRejectedValue({ code: grpcStatus.NOT_FOUND, details: 'gone' });
     const missing = await app.inject({
       method: 'GET',
-      url: '/api/applications/app-x',
+      url: '/api/v1/applications/app-x',
       headers: ADOPTER,
     });
     expect(missing.statusCode).toBe(404);
@@ -237,7 +241,7 @@ describe('applications routes', () => {
     mocks.approve.mockResolvedValue({ application: APP });
     await app.inject({
       method: 'POST',
-      url: '/api/applications/app-1/approve',
+      url: '/api/v1/applications/app-1/approve',
       headers: STAFF,
       payload: { notes: 'ok' },
     });

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -1,4 +1,4 @@
-// REST → gRPC translation for /api/applications/*.
+// REST → gRPC translation for /api/v1/applications/*.
 //
 // Phase 5.3d cutover. Same strangler-fig shape as routes/moderation.ts
 // (#929) / routes/matching.ts (#923) — registers BEFORE the catch-all
@@ -7,20 +7,20 @@
 // Route map (all 12 ApplicationService RPCs):
 //
 //   Drafts
-//   POST   /api/applications                              → StartDraft
-//   PATCH  /api/applications/:id/answers                  → SaveDraftAnswers
-//   POST   /api/applications/:id/submit                   → SubmitDraft
+//   POST   /api/v1/applications                              → StartDraft
+//   PATCH  /api/v1/applications/:id/answers                  → SaveDraftAnswers
+//   POST   /api/v1/applications/:id/submit                   → SubmitDraft
 //   Review / home visit / decision
-//   POST   /api/applications/:id/review                   → StartReview
-//   POST   /api/applications/:id/home-visit/schedule      → ScheduleHomeVisit
-//   POST   /api/applications/:id/home-visit/complete      → CompleteHomeVisit
-//   POST   /api/applications/:id/approve                  → Approve
-//   POST   /api/applications/:id/reject                   → Reject
-//   POST   /api/applications/:id/withdraw                 → Withdraw
-//   POST   /api/applications/:id/adopt                    → MarkAdopted
+//   POST   /api/v1/applications/:id/review                   → StartReview
+//   POST   /api/v1/applications/:id/home-visit/schedule      → ScheduleHomeVisit
+//   POST   /api/v1/applications/:id/home-visit/complete      → CompleteHomeVisit
+//   POST   /api/v1/applications/:id/approve                  → Approve
+//   POST   /api/v1/applications/:id/reject                   → Reject
+//   POST   /api/v1/applications/:id/withdraw                 → Withdraw
+//   POST   /api/v1/applications/:id/adopt                    → MarkAdopted
 //   Reads
-//   GET    /api/applications                              → List
-//   GET    /api/applications/:id                          → Get
+//   GET    /api/v1/applications                              → List
+//   GET    /api/v1/applications/:id                          → Get
 //
 // Authz lives in the handlers (adopters act on their own drafts; rescue
 // staff gate on applications.review/approve/reject; reads scope to
@@ -82,7 +82,7 @@ export const registerApplicationsRoutes = async (
 
   // ---------- Drafts ----------
 
-  app.post('/api/applications', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
+  app.post('/api/v1/applications', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
     const b = (req.body ?? {}) as Record<string, unknown>;
     try {
       const res = await client.startDraft(
@@ -96,7 +96,7 @@ export const registerApplicationsRoutes = async (
   });
 
   app.patch<{ Params: { id: string } }>(
-    '/api/applications/:id/answers',
+    '/api/v1/applications/:id/answers',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -116,7 +116,7 @@ export const registerApplicationsRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/applications/:id/submit',
+    '/api/v1/applications/:id/submit',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -136,7 +136,7 @@ export const registerApplicationsRoutes = async (
   // ---------- Review / home visit / decision ----------
 
   app.post<{ Params: { id: string } }>(
-    '/api/applications/:id/review',
+    '/api/v1/applications/:id/review',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -154,7 +154,7 @@ export const registerApplicationsRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/applications/:id/home-visit/schedule',
+    '/api/v1/applications/:id/home-visit/schedule',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -173,7 +173,7 @@ export const registerApplicationsRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/applications/:id/home-visit/complete',
+    '/api/v1/applications/:id/home-visit/complete',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -192,7 +192,7 @@ export const registerApplicationsRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/applications/:id/approve',
+    '/api/v1/applications/:id/approve',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -210,7 +210,7 @@ export const registerApplicationsRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/applications/:id/reject',
+    '/api/v1/applications/:id/reject',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -228,7 +228,7 @@ export const registerApplicationsRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/applications/:id/withdraw',
+    '/api/v1/applications/:id/withdraw',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -246,7 +246,7 @@ export const registerApplicationsRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/applications/:id/adopt',
+    '/api/v1/applications/:id/adopt',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       try {
@@ -260,7 +260,7 @@ export const registerApplicationsRoutes = async (
 
   // ---------- Reads ----------
 
-  app.get('/api/applications', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/applications', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const grpcReq: ListApplicationsRequest = {
       cursor: q.cursor,
@@ -278,7 +278,7 @@ export const registerApplicationsRoutes = async (
   });
 
   app.get<{ Params: { id: string } }>(
-    '/api/applications/:id',
+    '/api/v1/applications/:id',
     { config: { rateLimit: RL_READ } },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;

--- a/services/gateway/src/routes/audit.test.ts
+++ b/services/gateway/src/routes/audit.test.ts
@@ -53,7 +53,7 @@ const ADMIN_HEADERS = {
   'x-user-permissions': 'admin.audit_logs',
 };
 
-describe('GET /api/audit', () => {
+describe('GET /api/v1/audit', () => {
   let app: FastifyInstance;
   let queryMock: ReturnType<typeof vi.fn>;
 
@@ -73,7 +73,7 @@ describe('GET /api/audit', () => {
 
     const httpRes = await app.inject({
       method: 'GET',
-      url: '/api/audit?service=service.auth&subject=auth.userLoggedIn&actor_user_id=usr-1&outcome=denied&from=2026-06-01&to=2026-06-02&limit=25&cursor=abc',
+      url: '/api/v1/audit?service=service.auth&subject=auth.userLoggedIn&actor_user_id=usr-1&outcome=denied&from=2026-06-01&to=2026-06-02&limit=25&cursor=abc',
       headers: ADMIN_HEADERS,
     });
 
@@ -97,7 +97,7 @@ describe('GET /api/audit', () => {
 
     await app.inject({
       method: 'GET',
-      url: '/api/audit',
+      url: '/api/v1/audit',
       headers: ADMIN_HEADERS,
     });
 
@@ -112,7 +112,7 @@ describe('GET /api/audit', () => {
 
     await app.inject({
       method: 'GET',
-      url: '/api/audit?outcome=AUDIT_OUTCOME_FAILURE',
+      url: '/api/v1/audit?outcome=AUDIT_OUTCOME_FAILURE',
       headers: ADMIN_HEADERS,
     });
 
@@ -126,7 +126,7 @@ describe('GET /api/audit', () => {
 
     await app.inject({
       method: 'GET',
-      url: '/api/audit?outcome=partial',
+      url: '/api/v1/audit?outcome=partial',
       headers: ADMIN_HEADERS,
     });
 
@@ -145,7 +145,7 @@ describe('GET /api/audit', () => {
 
     const httpRes = await app.inject({
       method: 'GET',
-      url: '/api/audit',
+      url: '/api/v1/audit',
       headers: ADMIN_HEADERS,
     });
 
@@ -154,7 +154,7 @@ describe('GET /api/audit', () => {
   });
 });
 
-describe('GET /api/audit/targets/:type/:id', () => {
+describe('GET /api/v1/audit/targets/:type/:id', () => {
   let app: FastifyInstance;
   let getByTargetMock: ReturnType<typeof vi.fn>;
 
@@ -174,7 +174,7 @@ describe('GET /api/audit/targets/:type/:id', () => {
 
     const httpRes = await app.inject({
       method: 'GET',
-      url: '/api/audit/targets/application/app-1',
+      url: '/api/v1/audit/targets/application/app-1',
       headers: ADMIN_HEADERS,
     });
 
@@ -190,7 +190,7 @@ describe('GET /api/audit/targets/:type/:id', () => {
 
     await app.inject({
       method: 'GET',
-      url: '/api/audit/targets/pet/pet-1?limit=10&cursor=xyz',
+      url: '/api/v1/audit/targets/pet/pet-1?limit=10&cursor=xyz',
       headers: ADMIN_HEADERS,
     });
 

--- a/services/gateway/src/routes/audit.ts
+++ b/services/gateway/src/routes/audit.ts
@@ -1,16 +1,16 @@
-// REST → gRPC translation for /api/audit/*.
+// REST → gRPC translation for /api/v1/audit/*.
 //
 // Phase 10.5 cutover. Same shape as routes/rescue.ts /
 // routes/pets.ts / routes/auth.ts — Fastify plugin registers
 // BEFORE the strangler-fig http-proxy catch-all, so first-
-// registered-wins prefix routing picks it for /api/audit/*
+// registered-wins prefix routing picks it for /api/v1/audit/*
 // requests before the catch-all sees them.
 //
-// Route map (mirrors monolith /api/audit-logs but folds the
-// per-target query under /api/audit/targets/:type/:id):
+// Route map (mirrors monolith /api/v1/audit-logs but folds the
+// per-target query under /api/v1/audit/targets/:type/:id):
 //
-//   GET /api/audit                                 → AuditQueryService.Query
-//   GET /api/audit/targets/:type/:id               → AuditQueryService.GetByTarget
+//   GET /api/v1/audit                                 → AuditQueryService.Query
+//   GET /api/v1/audit/targets/:type/:id               → AuditQueryService.GetByTarget
 //
 // Both gated on admin.audit_logs at the handler (#915) — the
 // gateway re-rate-limits but trusts the handler's authz check
@@ -58,28 +58,32 @@ export const registerAuditRoutes = async (
 
   await app.register(rateLimit, { global: false });
 
-  app.get('/api/audit', { config: { rateLimit: AUDIT_RATE_LIMITS.query } }, async (req, reply) => {
-    const query = req.query as Record<string, string | undefined>;
-    const grpcReq: AuditQueryRequest = {
-      cursor: query.cursor,
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
-      service: query.service,
-      subject: query.subject,
-      actorUserId: query.actor_user_id,
-      outcome: parseOutcome(query.outcome),
-      occurredAtFrom: query.from,
-      occurredAtTo: query.to,
-    };
-    try {
-      const res = await client.query(grpcReq, buildMetadata(req));
-      return reply.send(AuditV1.QueryResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.get(
+    '/api/v1/audit',
+    { config: { rateLimit: AUDIT_RATE_LIMITS.query } },
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: AuditQueryRequest = {
+        cursor: query.cursor,
+        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        service: query.service,
+        subject: query.subject,
+        actorUserId: query.actor_user_id,
+        outcome: parseOutcome(query.outcome),
+        occurredAtFrom: query.from,
+        occurredAtTo: query.to,
+      };
+      try {
+        const res = await client.query(grpcReq, buildMetadata(req));
+        return reply.send(AuditV1.QueryResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   app.get<{ Params: { type: string; id: string } }>(
-    '/api/audit/targets/:type/:id',
+    '/api/v1/audit/targets/:type/:id',
     { config: { rateLimit: AUDIT_RATE_LIMITS.getByTarget } },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;

--- a/services/gateway/src/routes/auth.test.ts
+++ b/services/gateway/src/routes/auth.test.ts
@@ -69,7 +69,7 @@ const LOGIN_RES: LoginResponse = {
   permissions: ['pets.read'],
 };
 
-describe('POST /api/auth/login', () => {
+describe('POST /api/v1/auth/login', () => {
   let app: FastifyInstance;
   let loginMock: ReturnType<typeof vi.fn>;
 
@@ -87,7 +87,7 @@ describe('POST /api/auth/login', () => {
     loginMock.mockResolvedValueOnce(LOGIN_RES);
     const res = await app.inject({
       method: 'POST',
-      url: '/api/auth/login',
+      url: '/api/v1/auth/login',
       headers: { 'user-agent': 'vitest' },
       payload: { email: 'alex@example.com', password: 'hunter2' },
     });
@@ -114,7 +114,7 @@ describe('POST /api/auth/login', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/api/auth/login',
+      url: '/api/v1/auth/login',
       payload: { email: 'alex@example.com', password: 'wrong' },
     });
     expect(res.statusCode).toBe(401);
@@ -130,14 +130,14 @@ describe('POST /api/auth/login', () => {
     );
     const res = await app.inject({
       method: 'POST',
-      url: '/api/auth/login',
+      url: '/api/v1/auth/login',
       payload: { password: 'x' },
     });
     expect(res.statusCode).toBe(400);
   });
 });
 
-describe('POST /api/auth/logout', () => {
+describe('POST /api/v1/auth/logout', () => {
   let app: FastifyInstance;
   let logoutMock: ReturnType<typeof vi.fn>;
 
@@ -157,7 +157,7 @@ describe('POST /api/auth/logout', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/api/auth/logout',
+      url: '/api/v1/auth/logout',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
       payload: { refreshToken: 'r.jwt' },
     });
@@ -170,7 +170,7 @@ describe('POST /api/auth/logout', () => {
   });
 });
 
-describe('POST /api/auth/refresh-token', () => {
+describe('POST /api/v1/auth/refresh-token', () => {
   it('forwards the refreshToken and returns the rotated TokenPair', async () => {
     const { client, refreshMock } = makeClient();
     const app = await makeApp(client);
@@ -187,7 +187,7 @@ describe('POST /api/auth/refresh-token', () => {
 
       const res = await app.inject({
         method: 'POST',
-        url: '/api/auth/refresh-token',
+        url: '/api/v1/auth/refresh-token',
         payload: { refreshToken: 'r.jwt' },
       });
 
@@ -200,7 +200,7 @@ describe('POST /api/auth/refresh-token', () => {
   });
 });
 
-describe('GET /api/auth/me', () => {
+describe('GET /api/v1/auth/me', () => {
   it('threads x-user-* metadata to GetMe and returns the user + roles + permissions', async () => {
     const { client, getMeMock } = makeClient();
     const app = await makeApp(client);
@@ -214,7 +214,7 @@ describe('GET /api/auth/me', () => {
 
       const res = await app.inject({
         method: 'GET',
-        url: '/api/auth/me',
+        url: '/api/v1/auth/me',
         headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
       });
 
@@ -230,7 +230,7 @@ describe('GET /api/auth/me', () => {
   });
 });
 
-describe('POST /api/auth/assign-role', () => {
+describe('POST /api/v1/auth/assign-role', () => {
   let app: FastifyInstance;
   let assignMock: ReturnType<typeof vi.fn>;
 
@@ -252,7 +252,7 @@ describe('POST /api/auth/assign-role', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/api/auth/assign-role',
+      url: '/api/v1/auth/assign-role',
       headers: { 'x-user-id': 'usr-admin', 'x-user-roles': 'admin' },
       payload: { targetUserId: 'usr-1', role: 'rescue_staff', reason: 'onboarding' },
     });
@@ -268,7 +268,7 @@ describe('POST /api/auth/assign-role', () => {
     assignMock.mockResolvedValueOnce({ roles: [] });
     await app.inject({
       method: 'POST',
-      url: '/api/auth/assign-role',
+      url: '/api/v1/auth/assign-role',
       payload: { targetUserId: 'usr-1', role: 'USER_ROLE_MODERATOR' },
     });
     const [req] = assignMock.mock.calls[0];
@@ -279,7 +279,7 @@ describe('POST /api/auth/assign-role', () => {
     assignMock.mockResolvedValueOnce({ roles: [] });
     await app.inject({
       method: 'POST',
-      url: '/api/auth/assign-role',
+      url: '/api/v1/auth/assign-role',
       payload: { targetUserId: 'usr-1', role: 'not_a_role' },
     });
     const [req] = assignMock.mock.calls[0];
@@ -295,7 +295,7 @@ describe('POST /api/auth/assign-role', () => {
     );
     const res = await app.inject({
       method: 'POST',
-      url: '/api/auth/assign-role',
+      url: '/api/v1/auth/assign-role',
       payload: { targetUserId: 'usr-1', role: 'admin' },
     });
     expect(res.statusCode).toBe(403);
@@ -311,7 +311,7 @@ describe('error mapping fallback', () => {
       loginMock.mockRejectedValueOnce(new Error('connection refused'));
       const res = await app.inject({
         method: 'POST',
-        url: '/api/auth/login',
+        url: '/api/v1/auth/login',
         payload: { email: 'a@b', password: 'c' },
       });
       expect(res.statusCode).toBe(500);

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -1,18 +1,18 @@
-// REST → gRPC translation for /api/auth/*.
+// REST → gRPC translation for /api/v1/auth/*.
 //
 // Phase 2.6 cutover: this Fastify plugin registers BEFORE the
 // strangler-fig http-proxy catch-all, so Fastify's first-registered-
-// wins prefix routing picks it for /api/auth/* requests before the
+// wins prefix routing picks it for /api/v1/auth/* requests before the
 // catch-all sees them. Same shape as routes/notifications.ts.
 //
-// Route map (matches the monolith's existing /api/auth/* surface so
+// Route map (matches the monolith's existing /api/v1/auth/* surface so
 // the SPA + lib.auth React contexts don't have to change):
 //
-//   POST /api/auth/login           → AuthService.Login
-//   POST /api/auth/logout          → AuthService.Logout
-//   POST /api/auth/refresh-token   → AuthService.RefreshToken
-//   GET  /api/auth/me              → AuthService.GetMe
-//   POST /api/auth/assign-role     → AuthService.AssignRole  (admin-only)
+//   POST /api/v1/auth/login           → AuthService.Login
+//   POST /api/v1/auth/logout          → AuthService.Logout
+//   POST /api/v1/auth/refresh-token   → AuthService.RefreshToken
+//   GET  /api/v1/auth/me              → AuthService.GetMe
+//   POST /api/v1/auth/assign-role     → AuthService.AssignRole  (admin-only)
 //
 // The authenticate middleware (Phase 2.5) already populates the
 // x-user-* metadata headers for routes whose handler relies on the
@@ -98,7 +98,7 @@ export const registerAuthRoutes = async (
   await app.register(rateLimit, { global: false });
 
   app.post(
-    '/api/auth/login',
+    '/api/v1/auth/login',
     { config: { rateLimit: AUTH_RATE_LIMITS.login } },
     async (req, reply) => {
       const body = (req.body ?? {}) as LoginBody;
@@ -119,7 +119,7 @@ export const registerAuthRoutes = async (
   );
 
   app.post(
-    '/api/auth/logout',
+    '/api/v1/auth/logout',
     { config: { rateLimit: AUTH_RATE_LIMITS.logout } },
     async (req, reply) => {
       const body = (req.body ?? {}) as LogoutBody;
@@ -135,7 +135,7 @@ export const registerAuthRoutes = async (
   );
 
   app.post(
-    '/api/auth/refresh-token',
+    '/api/v1/auth/refresh-token',
     { config: { rateLimit: AUTH_RATE_LIMITS.refreshToken } },
     async (req, reply) => {
       const body = (req.body ?? {}) as RefreshTokenBody;
@@ -150,17 +150,21 @@ export const registerAuthRoutes = async (
     }
   );
 
-  app.get('/api/auth/me', { config: { rateLimit: AUTH_RATE_LIMITS.getMe } }, async (req, reply) => {
-    try {
-      const res = await client.getMe({}, buildMetadata(req));
-      return reply.send(AuthV1.GetMeResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.get(
+    '/api/v1/auth/me',
+    { config: { rateLimit: AUTH_RATE_LIMITS.getMe } },
+    async (req, reply) => {
+      try {
+        const res = await client.getMe({}, buildMetadata(req));
+        return reply.send(AuthV1.GetMeResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   app.post(
-    '/api/auth/assign-role',
+    '/api/v1/auth/assign-role',
     { config: { rateLimit: AUTH_RATE_LIMITS.assignRole } },
     async (req, reply) => {
       const body = (req.body ?? {}) as AssignRoleBody;

--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -75,7 +75,7 @@ const ADOPTER_HEADERS = {
   'x-user-permissions': 'pets.read',
 };
 
-describe('POST /api/matching/sessions', () => {
+describe('POST /api/v1/matching/sessions', () => {
   let app: FastifyInstance;
   let startSessionMock: ReturnType<typeof vi.fn>;
 
@@ -95,7 +95,7 @@ describe('POST /api/matching/sessions', () => {
 
     const httpRes = await app.inject({
       method: 'POST',
-      url: '/api/matching/sessions',
+      url: '/api/v1/matching/sessions',
       headers: ADOPTER_HEADERS,
       payload: { filtersJson: '{"species":"dog"}', deviceType: 'mobile' },
     });
@@ -112,7 +112,7 @@ describe('POST /api/matching/sessions', () => {
 
     const httpRes = await app.inject({
       method: 'POST',
-      url: '/api/matching/sessions',
+      url: '/api/v1/matching/sessions',
       headers: ADOPTER_HEADERS,
       payload: {},
     });
@@ -125,7 +125,7 @@ describe('POST /api/matching/sessions', () => {
 
     await app.inject({
       method: 'POST',
-      url: '/api/matching/sessions',
+      url: '/api/v1/matching/sessions',
       headers: ADOPTER_HEADERS,
       payload: {},
     });
@@ -140,7 +140,7 @@ describe('POST /api/matching/sessions', () => {
 
     await app.inject({
       method: 'POST',
-      url: '/api/matching/sessions',
+      url: '/api/v1/matching/sessions',
       headers: ADOPTER_HEADERS,
       payload: { deviceType: 'DEVICE_TYPE_TABLET' },
     });
@@ -160,7 +160,7 @@ describe('POST /api/matching/sessions', () => {
 
     const httpRes = await app.inject({
       method: 'POST',
-      url: '/api/matching/sessions',
+      url: '/api/v1/matching/sessions',
       headers: ADOPTER_HEADERS,
       payload: {},
     });
@@ -170,7 +170,7 @@ describe('POST /api/matching/sessions', () => {
   });
 });
 
-describe('POST /api/matching/sessions/:id/end', () => {
+describe('POST /api/v1/matching/sessions/:id/end', () => {
   let app: FastifyInstance;
   let endSessionMock: ReturnType<typeof vi.fn>;
 
@@ -190,7 +190,7 @@ describe('POST /api/matching/sessions/:id/end', () => {
 
     const httpRes = await app.inject({
       method: 'POST',
-      url: '/api/matching/sessions/sess-42/end',
+      url: '/api/v1/matching/sessions/sess-42/end',
       headers: ADOPTER_HEADERS,
       payload: {},
     });
@@ -200,7 +200,7 @@ describe('POST /api/matching/sessions/:id/end', () => {
   });
 });
 
-describe('POST /api/matching/sessions/:id/swipes', () => {
+describe('POST /api/v1/matching/sessions/:id/swipes', () => {
   let app: FastifyInstance;
   let recordSwipeMock: ReturnType<typeof vi.fn>;
 
@@ -220,7 +220,7 @@ describe('POST /api/matching/sessions/:id/swipes', () => {
 
     const httpRes = await app.inject({
       method: 'POST',
-      url: '/api/matching/sessions/sess-1/swipes',
+      url: '/api/v1/matching/sessions/sess-1/swipes',
       headers: ADOPTER_HEADERS,
       payload: { petId: 'pet-1', action: 'like', responseTime: 1234 },
     });
@@ -239,7 +239,7 @@ describe('POST /api/matching/sessions/:id/swipes', () => {
 
     await app.inject({
       method: 'POST',
-      url: '/api/matching/sessions/sess-1/swipes',
+      url: '/api/v1/matching/sessions/sess-1/swipes',
       headers: ADOPTER_HEADERS,
       payload: { petId: 'pet-1', action: 'block' },
     });
@@ -250,7 +250,7 @@ describe('POST /api/matching/sessions/:id/swipes', () => {
   });
 });
 
-describe('GET /api/matching/swipes', () => {
+describe('GET /api/v1/matching/swipes', () => {
   let app: FastifyInstance;
   let listSwipeHistoryMock: ReturnType<typeof vi.fn>;
 
@@ -270,7 +270,7 @@ describe('GET /api/matching/swipes', () => {
 
     const httpRes = await app.inject({
       method: 'GET',
-      url: '/api/matching/swipes?limit=25&cursor=abc&action=super_like',
+      url: '/api/v1/matching/swipes?limit=25&cursor=abc&action=super_like',
       headers: ADOPTER_HEADERS,
     });
 

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -1,22 +1,22 @@
-// REST → gRPC translation for /api/matching/*.
+// REST → gRPC translation for /api/v1/matching/*.
 //
 // Phase 9.5 cutover. Same shape as routes/audit.ts (#917) /
 // routes/rescue.ts / routes/auth.ts — Fastify plugin registers
 // BEFORE the strangler-fig http-proxy catch-all, so first-
-// registered-wins prefix routing picks it for /api/matching/*
+// registered-wins prefix routing picks it for /api/v1/matching/*
 // before the catch-all sees them.
 //
 // Route map:
 //
-//   POST /api/matching/sessions                        → StartSession
-//   POST /api/matching/sessions/:id/end                → EndSession
-//   POST /api/matching/sessions/:id/swipes             → RecordSwipe
-//   GET  /api/matching/swipes                          → ListSwipeHistory
+//   POST /api/v1/matching/sessions                        → StartSession
+//   POST /api/v1/matching/sessions/:id/end                → EndSession
+//   POST /api/v1/matching/sessions/:id/swipes             → RecordSwipe
+//   GET  /api/v1/matching/swipes                          → ListSwipeHistory
 //
 // Recommend + SearchPets aren't wired yet — the matching gRPC server
 // returns UNIMPLEMENTED for them (#922 stubs). When those handlers
-// ship the gateway will gain `/api/matching/recommend` +
-// `/api/matching/search` routes.
+// ship the gateway will gain `/api/v1/matching/recommend` +
+// `/api/v1/matching/search` routes.
 //
 // Authz: PETS_VIEW (matching is a pet-browsing surface). The Phase
 // 2.5 authenticate middleware stamps x-user-* metadata; the matching
@@ -84,7 +84,7 @@ export const registerMatchingRoutes = async (
   await app.register(rateLimit, { global: false });
 
   app.post(
-    '/api/matching/sessions',
+    '/api/v1/matching/sessions',
     { config: { rateLimit: MATCHING_RATE_LIMITS.startSession } },
     async (req, reply) => {
       const body = (req.body ?? {}) as StartSessionBody;
@@ -106,7 +106,7 @@ export const registerMatchingRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/matching/sessions/:id/end',
+    '/api/v1/matching/sessions/:id/end',
     { config: { rateLimit: MATCHING_RATE_LIMITS.endSession } },
     async (req, reply) => {
       const grpcReq: EndSessionRequest = { sessionId: req.params.id };
@@ -120,7 +120,7 @@ export const registerMatchingRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/matching/sessions/:id/swipes',
+    '/api/v1/matching/sessions/:id/swipes',
     { config: { rateLimit: MATCHING_RATE_LIMITS.recordSwipe } },
     async (req, reply) => {
       const body = (req.body ?? {}) as RecordSwipeBody;
@@ -141,7 +141,7 @@ export const registerMatchingRoutes = async (
   );
 
   app.get(
-    '/api/matching/swipes',
+    '/api/v1/matching/swipes',
     { config: { rateLimit: MATCHING_RATE_LIMITS.listSwipeHistory } },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;

--- a/services/gateway/src/routes/moderation.test.ts
+++ b/services/gateway/src/routes/moderation.test.ts
@@ -62,11 +62,11 @@ describe('moderation report routes', () => {
     await app.close();
   });
 
-  it('POST /api/moderation/reports → FileReport with parsed enums, 201', async () => {
+  it('POST /api/v1/moderation/reports → FileReport with parsed enums, 201', async () => {
     mocks.fileReport.mockResolvedValue({ report: { reportId: 'rpt-1' } });
     const res = await app.inject({
       method: 'POST',
-      url: '/api/moderation/reports',
+      url: '/api/v1/moderation/reports',
       headers: HEADERS,
       payload: {
         reportedEntityType: 'user',
@@ -89,7 +89,7 @@ describe('moderation report routes', () => {
     mocks.fileReport.mockResolvedValue({ report: { reportId: 'rpt-1' } });
     await app.inject({
       method: 'POST',
-      url: '/api/moderation/reports',
+      url: '/api/v1/moderation/reports',
       headers: HEADERS,
       payload: {
         reportedEntityType: 'REPORT_ENTITY_TYPE_PET',
@@ -106,11 +106,11 @@ describe('moderation report routes', () => {
     });
   });
 
-  it('GET /api/moderation/reports → ListReports with filters', async () => {
+  it('GET /api/v1/moderation/reports → ListReports with filters', async () => {
     mocks.listReports.mockResolvedValue({ reports: [] });
     await app.inject({
       method: 'GET',
-      url: '/api/moderation/reports?status=pending&severity=high&limit=10',
+      url: '/api/v1/moderation/reports?status=pending&severity=high&limit=10',
       headers: HEADERS,
     });
     expect(mocks.listReports.mock.calls[0][0]).toMatchObject({
@@ -120,11 +120,11 @@ describe('moderation report routes', () => {
     });
   });
 
-  it('GET /api/moderation/reports/:id passes includeTransitions', async () => {
+  it('GET /api/v1/moderation/reports/:id passes includeTransitions', async () => {
     mocks.getReport.mockResolvedValue({ report: { reportId: 'rpt-1' }, transitions: [] });
     await app.inject({
       method: 'GET',
-      url: '/api/moderation/reports/rpt-1?transitions=true',
+      url: '/api/v1/moderation/reports/rpt-1?transitions=true',
       headers: HEADERS,
     });
     expect(mocks.getReport.mock.calls[0][0]).toMatchObject({
@@ -133,11 +133,11 @@ describe('moderation report routes', () => {
     });
   });
 
-  it('POST /api/moderation/reports/:id/assign threads moderatorId', async () => {
+  it('POST /api/v1/moderation/reports/:id/assign threads moderatorId', async () => {
     mocks.assignReport.mockResolvedValue({ report: { reportId: 'rpt-1' } });
     await app.inject({
       method: 'POST',
-      url: '/api/moderation/reports/rpt-1/assign',
+      url: '/api/v1/moderation/reports/rpt-1/assign',
       headers: HEADERS,
       payload: { moderatorId: 'mod-2' },
     });
@@ -151,7 +151,7 @@ describe('moderation report routes', () => {
     mocks.listReports.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'nope' });
     const res = await app.inject({
       method: 'GET',
-      url: '/api/moderation/reports',
+      url: '/api/v1/moderation/reports',
       headers: HEADERS,
     });
     expect(res.statusCode).toBe(403);
@@ -172,11 +172,11 @@ describe('moderation sanction + ticket routes', () => {
     await app.close();
   });
 
-  it('GET /api/moderation/users/:userId/sanctions → ListUserSanctions', async () => {
+  it('GET /api/v1/moderation/users/:userId/sanctions → ListUserSanctions', async () => {
     mocks.listUserSanctions.mockResolvedValue({ sanctions: [] });
     await app.inject({
       method: 'GET',
-      url: '/api/moderation/users/usr-2/sanctions?includeInactive=true',
+      url: '/api/v1/moderation/users/usr-2/sanctions?includeInactive=true',
       headers: HEADERS,
     });
     expect(mocks.listUserSanctions.mock.calls[0][0]).toMatchObject({
@@ -185,11 +185,11 @@ describe('moderation sanction + ticket routes', () => {
     });
   });
 
-  it('POST /api/moderation/sanctions/:id/appeal → AppealSanction', async () => {
+  it('POST /api/v1/moderation/sanctions/:id/appeal → AppealSanction', async () => {
     mocks.appealSanction.mockResolvedValue({ sanction: { sanctionId: 'sanc-1' } });
     await app.inject({
       method: 'POST',
-      url: '/api/moderation/sanctions/sanc-1/appeal',
+      url: '/api/v1/moderation/sanctions/sanc-1/appeal',
       headers: HEADERS,
       payload: { appealReason: 'provoked' },
     });
@@ -199,11 +199,11 @@ describe('moderation sanction + ticket routes', () => {
     });
   });
 
-  it('POST /api/moderation/tickets → OpenSupportTicket, 201', async () => {
+  it('POST /api/v1/moderation/tickets → OpenSupportTicket, 201', async () => {
     mocks.openSupportTicket.mockResolvedValue({ ticket: { ticketId: 'tkt-1' } });
     const res = await app.inject({
       method: 'POST',
-      url: '/api/moderation/tickets',
+      url: '/api/v1/moderation/tickets',
       headers: HEADERS,
       payload: {
         userEmail: 'u@e.com',
@@ -222,11 +222,11 @@ describe('moderation sanction + ticket routes', () => {
     });
   });
 
-  it('POST /api/moderation/tickets/:id/responses → RespondToTicket', async () => {
+  it('POST /api/v1/moderation/tickets/:id/responses → RespondToTicket', async () => {
     mocks.respondToTicket.mockResolvedValue({ response: { responseId: 'rsp-1' } });
     await app.inject({
       method: 'POST',
-      url: '/api/moderation/tickets/tkt-1/responses',
+      url: '/api/v1/moderation/tickets/tkt-1/responses',
       headers: HEADERS,
       payload: { content: 'Try X', isInternal: true },
     });
@@ -241,7 +241,7 @@ describe('moderation sanction + ticket routes', () => {
     mocks.issueSanction.mockResolvedValue({ sanction: { sanctionId: 'sanc-1' } });
     await app.inject({
       method: 'POST',
-      url: '/api/moderation/sanctions',
+      url: '/api/v1/moderation/sanctions',
       headers: HEADERS,
       payload: {
         userId: 'usr-2',

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -1,4 +1,4 @@
-// REST → gRPC translation for /api/moderation/*.
+// REST → gRPC translation for /api/v1/moderation/*.
 //
 // Phase 8.5 cutover. Same strangler-fig shape as routes/audit.ts
 // (#917) / routes/matching.ts (#923) — registers BEFORE the catch-all
@@ -7,25 +7,25 @@
 // Route map (all 15 ModerationService RPCs):
 //
 //   Reports
-//   POST   /api/moderation/reports                       → FileReport
-//   GET    /api/moderation/reports                       → ListReports
-//   GET    /api/moderation/reports/:id                   → GetReport
-//   POST   /api/moderation/reports/:id/assign            → AssignReport
-//   POST   /api/moderation/reports/:id/resolve           → ResolveReport
+//   POST   /api/v1/moderation/reports                       → FileReport
+//   GET    /api/v1/moderation/reports                       → ListReports
+//   GET    /api/v1/moderation/reports/:id                   → GetReport
+//   POST   /api/v1/moderation/reports/:id/assign            → AssignReport
+//   POST   /api/v1/moderation/reports/:id/resolve           → ResolveReport
 //   Moderator actions
-//   POST   /api/moderation/actions                       → LogModeratorAction
-//   GET    /api/moderation/actions                       → ListModeratorActions
+//   POST   /api/v1/moderation/actions                       → LogModeratorAction
+//   GET    /api/v1/moderation/actions                       → ListModeratorActions
 //   Evidence
-//   POST   /api/moderation/evidence                      → AddEvidence
+//   POST   /api/v1/moderation/evidence                      → AddEvidence
 //   Sanctions
-//   POST   /api/moderation/sanctions                     → IssueSanction
-//   GET    /api/moderation/users/:userId/sanctions       → ListUserSanctions
-//   POST   /api/moderation/sanctions/:id/appeal          → AppealSanction
+//   POST   /api/v1/moderation/sanctions                     → IssueSanction
+//   GET    /api/v1/moderation/users/:userId/sanctions       → ListUserSanctions
+//   POST   /api/v1/moderation/sanctions/:id/appeal          → AppealSanction
 //   Support tickets
-//   POST   /api/moderation/tickets                       → OpenSupportTicket
-//   GET    /api/moderation/tickets                       → ListSupportTickets
-//   GET    /api/moderation/tickets/:id                   → GetSupportTicket
-//   POST   /api/moderation/tickets/:id/responses         → RespondToTicket
+//   POST   /api/v1/moderation/tickets                       → OpenSupportTicket
+//   GET    /api/v1/moderation/tickets                       → ListSupportTickets
+//   GET    /api/v1/moderation/tickets/:id                   → GetSupportTicket
+//   POST   /api/v1/moderation/tickets/:id/responses         → RespondToTicket
 //
 // Authz lives in the handlers (most gate on admin.dashboard;
 // FileReport + OpenSupportTicket are open to any authenticated user;
@@ -82,27 +82,31 @@ export const registerModerationRoutes = async (
 
   // ---------- Reports ----------
 
-  app.post('/api/moderation/reports', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
-    const b = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: FileReportRequest = {
-      reportedEntityType: parseEntityType(b.reportedEntityType as string | undefined),
-      reportedEntityId: (b.reportedEntityId as string) ?? '',
-      reportedUserId: b.reportedUserId as string | undefined,
-      category: parseCategory(b.category as string | undefined),
-      severity: parseSeverity(b.severity as string | undefined),
-      title: (b.title as string) ?? '',
-      description: (b.description as string) ?? '',
-      metadataJson: b.metadataJson as string | undefined,
-    };
-    try {
-      const res = await client.fileReport(grpcReq, buildMetadata(req));
-      return reply.code(201).send(ModerationV1.FileReportResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.post(
+    '/api/v1/moderation/reports',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: FileReportRequest = {
+        reportedEntityType: parseEntityType(b.reportedEntityType as string | undefined),
+        reportedEntityId: (b.reportedEntityId as string) ?? '',
+        reportedUserId: b.reportedUserId as string | undefined,
+        category: parseCategory(b.category as string | undefined),
+        severity: parseSeverity(b.severity as string | undefined),
+        title: (b.title as string) ?? '',
+        description: (b.description as string) ?? '',
+        metadataJson: b.metadataJson as string | undefined,
+      };
+      try {
+        const res = await client.fileReport(grpcReq, buildMetadata(req));
+        return reply.code(201).send(ModerationV1.FileReportResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.get('/api/moderation/reports', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/moderation/reports', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const grpcReq: ListReportsRequest = {
       cursor: q.cursor,
@@ -121,7 +125,7 @@ export const registerModerationRoutes = async (
   });
 
   app.get<{ Params: { id: string } }>(
-    '/api/moderation/reports/:id',
+    '/api/v1/moderation/reports/:id',
     { config: { rateLimit: RL_READ } },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
@@ -138,7 +142,7 @@ export const registerModerationRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/moderation/reports/:id/assign',
+    '/api/v1/moderation/reports/:id/assign',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -157,7 +161,7 @@ export const registerModerationRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/moderation/reports/:id/resolve',
+    '/api/v1/moderation/reports/:id/resolve',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -177,29 +181,33 @@ export const registerModerationRoutes = async (
 
   // ---------- Moderator actions ----------
 
-  app.post('/api/moderation/actions', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
-    const b = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: LogModeratorActionRequest = {
-      reportId: b.reportId as string | undefined,
-      targetEntityType: parseEntityType(b.targetEntityType as string | undefined),
-      targetEntityId: (b.targetEntityId as string) ?? '',
-      targetUserId: b.targetUserId as string | undefined,
-      actionType: parseActionType(b.actionType as string | undefined),
-      severity: parseSeverity(b.severity as string | undefined),
-      reason: (b.reason as string) ?? '',
-      description: b.description as string | undefined,
-      metadataJson: b.metadataJson as string | undefined,
-      duration: b.duration as number | undefined,
-    };
-    try {
-      const res = await client.logModeratorAction(grpcReq, buildMetadata(req));
-      return reply.code(201).send(ModerationV1.LogModeratorActionResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.post(
+    '/api/v1/moderation/actions',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: LogModeratorActionRequest = {
+        reportId: b.reportId as string | undefined,
+        targetEntityType: parseEntityType(b.targetEntityType as string | undefined),
+        targetEntityId: (b.targetEntityId as string) ?? '',
+        targetUserId: b.targetUserId as string | undefined,
+        actionType: parseActionType(b.actionType as string | undefined),
+        severity: parseSeverity(b.severity as string | undefined),
+        reason: (b.reason as string) ?? '',
+        description: b.description as string | undefined,
+        metadataJson: b.metadataJson as string | undefined,
+        duration: b.duration as number | undefined,
+      };
+      try {
+        const res = await client.logModeratorAction(grpcReq, buildMetadata(req));
+        return reply.code(201).send(ModerationV1.LogModeratorActionResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.get('/api/moderation/actions', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/moderation/actions', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const grpcReq: ListModeratorActionsRequest = {
       cursor: q.cursor,
@@ -218,46 +226,54 @@ export const registerModerationRoutes = async (
 
   // ---------- Evidence ----------
 
-  app.post('/api/moderation/evidence', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
-    const b = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: AddEvidenceRequest = {
-      parentType: parseEvidenceParentType(b.parentType as string | undefined),
-      parentId: (b.parentId as string) ?? '',
-      type: parseEvidenceType(b.type as string | undefined),
-      content: (b.content as string) ?? '',
-      description: b.description as string | undefined,
-    };
-    try {
-      const res = await client.addEvidence(grpcReq, buildMetadata(req));
-      return reply.code(201).send(ModerationV1.AddEvidenceResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.post(
+    '/api/v1/moderation/evidence',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: AddEvidenceRequest = {
+        parentType: parseEvidenceParentType(b.parentType as string | undefined),
+        parentId: (b.parentId as string) ?? '',
+        type: parseEvidenceType(b.type as string | undefined),
+        content: (b.content as string) ?? '',
+        description: b.description as string | undefined,
+      };
+      try {
+        const res = await client.addEvidence(grpcReq, buildMetadata(req));
+        return reply.code(201).send(ModerationV1.AddEvidenceResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   // ---------- Sanctions ----------
 
-  app.post('/api/moderation/sanctions', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
-    const b = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: IssueSanctionRequest = {
-      userId: (b.userId as string) ?? '',
-      sanctionType: parseSanctionType(b.sanctionType as string | undefined),
-      reason: parseSanctionReason(b.reason as string | undefined),
-      description: (b.description as string) ?? '',
-      duration: b.duration as number | undefined,
-      reportId: b.reportId as string | undefined,
-      moderatorActionId: b.moderatorActionId as string | undefined,
-    };
-    try {
-      const res = await client.issueSanction(grpcReq, buildMetadata(req));
-      return reply.code(201).send(ModerationV1.IssueSanctionResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.post(
+    '/api/v1/moderation/sanctions',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: IssueSanctionRequest = {
+        userId: (b.userId as string) ?? '',
+        sanctionType: parseSanctionType(b.sanctionType as string | undefined),
+        reason: parseSanctionReason(b.reason as string | undefined),
+        description: (b.description as string) ?? '',
+        duration: b.duration as number | undefined,
+        reportId: b.reportId as string | undefined,
+        moderatorActionId: b.moderatorActionId as string | undefined,
+      };
+      try {
+        const res = await client.issueSanction(grpcReq, buildMetadata(req));
+        return reply.code(201).send(ModerationV1.IssueSanctionResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   app.get<{ Params: { userId: string } }>(
-    '/api/moderation/users/:userId/sanctions',
+    '/api/v1/moderation/users/:userId/sanctions',
     { config: { rateLimit: RL_READ } },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
@@ -274,7 +290,7 @@ export const registerModerationRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/moderation/sanctions/:id/appeal',
+    '/api/v1/moderation/sanctions/:id/appeal',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;
@@ -293,27 +309,31 @@ export const registerModerationRoutes = async (
 
   // ---------- Support tickets ----------
 
-  app.post('/api/moderation/tickets', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
-    const b = (req.body ?? {}) as Record<string, unknown>;
-    const grpcReq: OpenSupportTicketRequest = {
-      userId: b.userId as string | undefined,
-      userEmail: (b.userEmail as string) ?? '',
-      userName: b.userName as string | undefined,
-      priority: parseTicketPriority(b.priority as string | undefined),
-      category: parseTicketCategory(b.category as string | undefined),
-      subject: (b.subject as string) ?? '',
-      description: (b.description as string) ?? '',
-      tags: (b.tags as string[]) ?? [],
-    };
-    try {
-      const res = await client.openSupportTicket(grpcReq, buildMetadata(req));
-      return reply.code(201).send(ModerationV1.OpenSupportTicketResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.post(
+    '/api/v1/moderation/tickets',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const grpcReq: OpenSupportTicketRequest = {
+        userId: b.userId as string | undefined,
+        userEmail: (b.userEmail as string) ?? '',
+        userName: b.userName as string | undefined,
+        priority: parseTicketPriority(b.priority as string | undefined),
+        category: parseTicketCategory(b.category as string | undefined),
+        subject: (b.subject as string) ?? '',
+        description: (b.description as string) ?? '',
+        tags: (b.tags as string[]) ?? [],
+      };
+      try {
+        const res = await client.openSupportTicket(grpcReq, buildMetadata(req));
+        return reply.code(201).send(ModerationV1.OpenSupportTicketResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
-  app.get('/api/moderation/tickets', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+  app.get('/api/v1/moderation/tickets', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
     const grpcReq: ListSupportTicketsRequest = {
       cursor: q.cursor,
@@ -333,7 +353,7 @@ export const registerModerationRoutes = async (
   });
 
   app.get<{ Params: { id: string } }>(
-    '/api/moderation/tickets/:id',
+    '/api/v1/moderation/tickets/:id',
     { config: { rateLimit: RL_READ } },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
@@ -350,7 +370,7 @@ export const registerModerationRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/moderation/tickets/:id/responses',
+    '/api/v1/moderation/tickets/:id/responses',
     { config: { rateLimit: RL_WRITE } },
     async (req, reply) => {
       const b = (req.body ?? {}) as Record<string, unknown>;

--- a/services/gateway/src/routes/notifications.test.ts
+++ b/services/gateway/src/routes/notifications.test.ts
@@ -59,7 +59,7 @@ async function buildApp(client: NotificationsClient): Promise<FastifyInstance> {
 
 // --- Tests ----------------------------------------------------------
 
-describe('GET /api/notifications — list', () => {
+describe('GET /api/v1/notifications — list', () => {
   let app: FastifyInstance;
   let client: ReturnType<typeof makeClient>;
 
@@ -77,7 +77,7 @@ describe('GET /api/notifications — list', () => {
 
     await app.inject({
       method: 'GET',
-      url: '/api/notifications',
+      url: '/api/v1/notifications',
       headers: {
         'x-user-id': 'usr-1',
         'x-user-roles': 'adopter',
@@ -96,7 +96,7 @@ describe('GET /api/notifications — list', () => {
 
     await app.inject({
       method: 'GET',
-      url: '/api/notifications?limit=50&cursor=abc&status=pending',
+      url: '/api/v1/notifications?limit=50&cursor=abc&status=pending',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -116,7 +116,7 @@ describe('GET /api/notifications — list', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/notifications',
+      url: '/api/v1/notifications',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -137,7 +137,7 @@ describe('GET /api/notifications — list', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/notifications',
+      url: '/api/v1/notifications',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -153,7 +153,7 @@ describe('GET /api/notifications — list', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/notifications',
+      url: '/api/v1/notifications',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -166,7 +166,7 @@ describe('GET /api/notifications — list', () => {
       details: 'missing x-user-id metadata',
     });
 
-    const res = await app.inject({ method: 'GET', url: '/api/notifications' });
+    const res = await app.inject({ method: 'GET', url: '/api/v1/notifications' });
 
     expect(res.statusCode).toBe(401);
   });
@@ -176,7 +176,7 @@ describe('GET /api/notifications — list', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/notifications',
+      url: '/api/v1/notifications',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -184,7 +184,7 @@ describe('GET /api/notifications — list', () => {
   });
 });
 
-describe('POST /api/notifications — create', () => {
+describe('POST /api/v1/notifications — create', () => {
   let app: FastifyInstance;
   let client: ReturnType<typeof makeClient>;
 
@@ -202,7 +202,7 @@ describe('POST /api/notifications — create', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/api/notifications',
+      url: '/api/v1/notifications',
       headers: {
         'x-user-id': 'svc-1',
         'x-user-roles': 'admin',
@@ -227,7 +227,7 @@ describe('POST /api/notifications — create', () => {
 
     await app.inject({
       method: 'POST',
-      url: '/api/notifications',
+      url: '/api/v1/notifications',
       headers: { 'x-user-id': 'svc', 'content-type': 'application/json' },
       payload: {
         userId: 'usr-1',
@@ -255,7 +255,7 @@ describe('POST /api/notifications — create', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/api/notifications',
+      url: '/api/v1/notifications',
       headers: { 'x-user-id': 'svc', 'content-type': 'application/json' },
       payload: { userId: 'usr-1' },
     });
@@ -264,7 +264,7 @@ describe('POST /api/notifications — create', () => {
   });
 });
 
-describe('DELETE /api/notifications/:id — dismiss', () => {
+describe('DELETE /api/v1/notifications/:id — dismiss', () => {
   let app: FastifyInstance;
   let client: ReturnType<typeof makeClient>;
 
@@ -282,7 +282,7 @@ describe('DELETE /api/notifications/:id — dismiss', () => {
 
     await app.inject({
       method: 'DELETE',
-      url: '/api/notifications/n-77',
+      url: '/api/v1/notifications/n-77',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -300,7 +300,7 @@ describe('DELETE /api/notifications/:id — dismiss', () => {
 
     const res = await app.inject({
       method: 'DELETE',
-      url: '/api/notifications/n-77',
+      url: '/api/v1/notifications/n-77',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -316,7 +316,7 @@ describe('DELETE /api/notifications/:id — dismiss', () => {
 
     const res = await app.inject({
       method: 'DELETE',
-      url: '/api/notifications/n-missing',
+      url: '/api/v1/notifications/n-missing',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -1,8 +1,8 @@
-// REST → gRPC translation for /api/notifications/*.
+// REST → gRPC translation for /api/v1/notifications/*.
 //
 // Phase 1.6 cutover: this Fastify plugin registers BEFORE the
 // strangler-fig http-proxy catch-all, so Fastify's first-registered-
-// wins prefix routing picks it for /api/notifications/* requests
+// wins prefix routing picks it for /api/v1/notifications/* requests
 // before the catch-all sees them. Every other /api/* path still hits
 // the monolith.
 //
@@ -50,7 +50,7 @@ export const registerNotificationsRoutes = async (
 ): Promise<void> => {
   const { client } = opts;
 
-  app.get('/api/notifications', async (req, reply) => {
+  app.get('/api/v1/notifications', async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
 
@@ -72,7 +72,7 @@ export const registerNotificationsRoutes = async (
     }
   });
 
-  app.post('/api/notifications', async (req, reply) => {
+  app.post('/api/v1/notifications', async (req, reply) => {
     const metadata = buildMetadata(req);
     const body = (req.body ?? {}) as Partial<CreateNotificationRequest>;
 
@@ -106,7 +106,7 @@ export const registerNotificationsRoutes = async (
     }
   });
 
-  app.delete<{ Params: { id: string } }>('/api/notifications/:id', async (req, reply) => {
+  app.delete<{ Params: { id: string } }>('/api/v1/notifications/:id', async (req, reply) => {
     const metadata = buildMetadata(req);
     const grpcReq: DismissNotificationRequest = { notificationId: req.params.id };
 

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -82,7 +82,7 @@ const PET_FIXTURE: Pet = {
   updatedAt: '2026-06-01T00:00:00Z',
 };
 
-describe('GET /api/pets', () => {
+describe('GET /api/v1/pets', () => {
   let app: FastifyInstance;
   let listMock: ReturnType<typeof vi.fn>;
 
@@ -102,7 +102,7 @@ describe('GET /api/pets', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/pets?status=available&type=dog&size=large&limit=10&rescueId=rsc-1',
+      url: '/api/v1/pets?status=available&type=dog&size=large&limit=10&rescueId=rsc-1',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -122,7 +122,7 @@ describe('GET /api/pets', () => {
 
   it('coerces an unknown status to UNSPECIFIED (service returns 400)', async () => {
     listMock.mockResolvedValueOnce({ pets: [] });
-    await app.inject({ method: 'GET', url: '/api/pets?status=not_a_status' });
+    await app.inject({ method: 'GET', url: '/api/v1/pets?status=not_a_status' });
     const [req] = listMock.mock.calls[0];
     expect(req.statusFilter).toBe(PetsV1.PetStatus.PET_STATUS_UNSPECIFIED);
   });
@@ -134,12 +134,12 @@ describe('GET /api/pets', () => {
         details: 'bad limit',
       })
     );
-    const res = await app.inject({ method: 'GET', url: '/api/pets?limit=200' });
+    const res = await app.inject({ method: 'GET', url: '/api/v1/pets?limit=200' });
     expect(res.statusCode).toBe(400);
   });
 });
 
-describe('GET /api/pets/:id', () => {
+describe('GET /api/v1/pets/:id', () => {
   it('forwards the path param + x-user-* metadata and returns the pet', async () => {
     const { client, getMock } = makeClient();
     const app = await makeApp(client);
@@ -148,7 +148,7 @@ describe('GET /api/pets/:id', () => {
       getMock.mockResolvedValueOnce(getRes);
       const res = await app.inject({
         method: 'GET',
-        url: '/api/pets/pet-1',
+        url: '/api/v1/pets/pet-1',
         headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
       });
       expect(res.statusCode).toBe(200);
@@ -172,7 +172,7 @@ describe('GET /api/pets/:id', () => {
           details: 'pet ghost not found',
         })
       );
-      const res = await app.inject({ method: 'GET', url: '/api/pets/ghost' });
+      const res = await app.inject({ method: 'GET', url: '/api/v1/pets/ghost' });
       expect(res.statusCode).toBe(404);
     } finally {
       await app.close();
@@ -180,7 +180,7 @@ describe('GET /api/pets/:id', () => {
   });
 });
 
-describe('POST /api/pets', () => {
+describe('POST /api/v1/pets', () => {
   it('returns 201 on success and threads body fields into the gRPC request', async () => {
     const { client, createMock } = makeClient();
     const app = await makeApp(client);
@@ -190,7 +190,7 @@ describe('POST /api/pets', () => {
 
       const res = await app.inject({
         method: 'POST',
-        url: '/api/pets',
+        url: '/api/v1/pets',
         headers: { 'x-user-id': 'usr-staff', 'x-user-roles': 'rescue_staff' },
         payload: {
           name: 'Rex',
@@ -229,7 +229,7 @@ describe('POST /api/pets', () => {
       );
       const res = await app.inject({
         method: 'POST',
-        url: '/api/pets',
+        url: '/api/v1/pets',
         payload: { name: 'Rex', rescueId: 'rsc-other' },
       });
       expect(res.statusCode).toBe(403);
@@ -239,7 +239,7 @@ describe('POST /api/pets', () => {
   });
 });
 
-describe('PATCH /api/pets/:id', () => {
+describe('PATCH /api/v1/pets/:id', () => {
   it('threads the path param + body fields', async () => {
     const { client, updateMock } = makeClient();
     const app = await makeApp(client);
@@ -248,7 +248,7 @@ describe('PATCH /api/pets/:id', () => {
       updateMock.mockResolvedValueOnce(updateRes);
       const res = await app.inject({
         method: 'PATCH',
-        url: '/api/pets/pet-1',
+        url: '/api/v1/pets/pet-1',
         payload: { name: 'Rexy' },
       });
       expect(res.statusCode).toBe(200);
@@ -263,7 +263,7 @@ describe('PATCH /api/pets/:id', () => {
   });
 });
 
-describe('POST /api/pets/:id/status', () => {
+describe('POST /api/v1/pets/:id/status', () => {
   let app: FastifyInstance;
   let updateStatusMock: ReturnType<typeof vi.fn>;
 
@@ -292,7 +292,7 @@ describe('POST /api/pets/:id/status', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/api/pets/pet-1/status',
+      url: '/api/v1/pets/pet-1/status',
       payload: { toStatus: 'pending', reason: 'application opened' },
     });
 
@@ -307,7 +307,7 @@ describe('POST /api/pets/:id/status', () => {
     updateStatusMock.mockResolvedValueOnce({ pet: PET_FIXTURE });
     await app.inject({
       method: 'POST',
-      url: '/api/pets/pet-1/status',
+      url: '/api/v1/pets/pet-1/status',
       payload: { toStatus: 'PET_STATUS_ADOPTED' },
     });
     const [req] = updateStatusMock.mock.calls[0];
@@ -323,14 +323,14 @@ describe('POST /api/pets/:id/status', () => {
     );
     const res = await app.inject({
       method: 'POST',
-      url: '/api/pets/pet-1/status',
+      url: '/api/v1/pets/pet-1/status',
       payload: { toStatus: 'adopted' },
     });
     expect(res.statusCode).toBe(400);
   });
 });
 
-describe('DELETE /api/pets/:id', () => {
+describe('DELETE /api/v1/pets/:id', () => {
   it('soft-deletes and returns { deleted: true }', async () => {
     const { client, deleteMock } = makeClient();
     const app = await makeApp(client);
@@ -338,7 +338,7 @@ describe('DELETE /api/pets/:id', () => {
       const delRes: DeletePetResponse = { deleted: true };
       deleteMock.mockResolvedValueOnce(delRes);
 
-      const res = await app.inject({ method: 'DELETE', url: '/api/pets/pet-1' });
+      const res = await app.inject({ method: 'DELETE', url: '/api/v1/pets/pet-1' });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toMatchObject({ deleted: true });
       const [req] = deleteMock.mock.calls[0];
@@ -355,7 +355,7 @@ describe('error mapping fallback', () => {
     const app = await makeApp(client);
     try {
       getMock.mockRejectedValueOnce(new Error('connection refused'));
-      const res = await app.inject({ method: 'GET', url: '/api/pets/pet-1' });
+      const res = await app.inject({ method: 'GET', url: '/api/v1/pets/pet-1' });
       expect(res.statusCode).toBe(500);
     } finally {
       await app.close();

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -1,19 +1,19 @@
-// REST → gRPC translation for /api/pets/*.
+// REST → gRPC translation for /api/v1/pets/*.
 //
 // Phase 3.5 cutover: this Fastify plugin registers BEFORE the
 // strangler-fig http-proxy catch-all, so Fastify's first-registered-
-// wins prefix routing picks it for /api/pets/* requests before the
+// wins prefix routing picks it for /api/v1/pets/* requests before the
 // catch-all sees them. Same shape as routes/auth.ts.
 //
 // Route map (mirrors the surface the SPA + lib.pets React contexts
 // already use):
 //
-//   GET    /api/pets             → PetService.List
-//   GET    /api/pets/:id         → PetService.Get
-//   POST   /api/pets             → PetService.Create
-//   PATCH  /api/pets/:id         → PetService.Update
-//   POST   /api/pets/:id/status  → PetService.UpdateStatus
-//   DELETE /api/pets/:id         → PetService.Delete
+//   GET    /api/v1/pets             → PetService.List
+//   GET    /api/v1/pets/:id         → PetService.Get
+//   POST   /api/v1/pets             → PetService.Create
+//   PATCH  /api/v1/pets/:id         → PetService.Update
+//   POST   /api/v1/pets/:id/status  → PetService.UpdateStatus
+//   DELETE /api/v1/pets/:id         → PetService.Delete
 //
 // The authenticate middleware (Phase 2.5) already populates the
 // x-user-* metadata headers — every PetService RPC requires a
@@ -77,7 +77,7 @@ export const registerPetsRoutes = async (
 
   await app.register(rateLimit, { global: false });
 
-  app.get('/api/pets', { config: { rateLimit: PETS_RATE_LIMITS.list } }, async (req, reply) => {
+  app.get('/api/v1/pets', { config: { rateLimit: PETS_RATE_LIMITS.list } }, async (req, reply) => {
     const query = req.query as Record<string, string | undefined>;
     const grpcReq: ListPetsRequest = {
       cursor: query.cursor,
@@ -96,7 +96,7 @@ export const registerPetsRoutes = async (
   });
 
   app.get<{ Params: { id: string } }>(
-    '/api/pets/:id',
+    '/api/v1/pets/:id',
     { config: { rateLimit: PETS_RATE_LIMITS.get } },
     async (req, reply) => {
       try {
@@ -108,39 +108,43 @@ export const registerPetsRoutes = async (
     }
   );
 
-  app.post('/api/pets', { config: { rateLimit: PETS_RATE_LIMITS.create } }, async (req, reply) => {
-    const body = (req.body ?? {}) as CreatePetBody;
-    const grpcReq: CreatePetRequest = {
-      name: body.name ?? '',
-      rescueId: body.rescueId ?? '',
-      type: body.type ?? PetsV1.PetType.PET_TYPE_UNSPECIFIED,
-      gender: body.gender ?? PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
-      size: body.size ?? PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
-      ageGroup: body.ageGroup ?? PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED,
-      breedId: body.breedId,
-      secondaryBreedId: body.secondaryBreedId,
-      shortDescription: body.shortDescription,
-      longDescription: body.longDescription,
-      ageYears: body.ageYears,
-      ageMonths: body.ageMonths,
-      adoptionFeeMinor: body.adoptionFeeMinor,
-      adoptionFeeCurrency: body.adoptionFeeCurrency,
-      specialNeeds: body.specialNeeds ?? false,
-      houseTrained: body.houseTrained ?? false,
-      temperamentJson: body.temperamentJson ?? '[]',
-      tagsJson: body.tagsJson ?? '[]',
-      extraJson: body.extraJson ?? '{}',
-    };
-    try {
-      const res = await client.create(grpcReq, buildMetadata(req));
-      return reply.code(201).send(PetsV1.CreatePetResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.post(
+    '/api/v1/pets',
+    { config: { rateLimit: PETS_RATE_LIMITS.create } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as CreatePetBody;
+      const grpcReq: CreatePetRequest = {
+        name: body.name ?? '',
+        rescueId: body.rescueId ?? '',
+        type: body.type ?? PetsV1.PetType.PET_TYPE_UNSPECIFIED,
+        gender: body.gender ?? PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
+        size: body.size ?? PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
+        ageGroup: body.ageGroup ?? PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED,
+        breedId: body.breedId,
+        secondaryBreedId: body.secondaryBreedId,
+        shortDescription: body.shortDescription,
+        longDescription: body.longDescription,
+        ageYears: body.ageYears,
+        ageMonths: body.ageMonths,
+        adoptionFeeMinor: body.adoptionFeeMinor,
+        adoptionFeeCurrency: body.adoptionFeeCurrency,
+        specialNeeds: body.specialNeeds ?? false,
+        houseTrained: body.houseTrained ?? false,
+        temperamentJson: body.temperamentJson ?? '[]',
+        tagsJson: body.tagsJson ?? '[]',
+        extraJson: body.extraJson ?? '{}',
+      };
+      try {
+        const res = await client.create(grpcReq, buildMetadata(req));
+        return reply.code(201).send(PetsV1.CreatePetResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   app.patch<{ Params: { id: string } }>(
-    '/api/pets/:id',
+    '/api/v1/pets/:id',
     { config: { rateLimit: PETS_RATE_LIMITS.update } },
     async (req, reply) => {
       const body = (req.body ?? {}) as UpdatePetBody;
@@ -155,7 +159,7 @@ export const registerPetsRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/pets/:id/status',
+    '/api/v1/pets/:id/status',
     { config: { rateLimit: PETS_RATE_LIMITS.updateStatus } },
     async (req, reply) => {
       const body = (req.body ?? {}) as UpdateStatusBody;
@@ -174,7 +178,7 @@ export const registerPetsRoutes = async (
   );
 
   app.delete<{ Params: { id: string } }>(
-    '/api/pets/:id',
+    '/api/v1/pets/:id',
     { config: { rateLimit: PETS_RATE_LIMITS.delete } },
     async (req, reply) => {
       try {

--- a/services/gateway/src/routes/rescue.test.ts
+++ b/services/gateway/src/routes/rescue.test.ts
@@ -65,7 +65,7 @@ const RESCUE_FIXTURE: Rescue = {
   updatedAt: '2026-06-01T00:00:00Z',
 };
 
-describe('GET /api/rescue', () => {
+describe('GET /api/v1/rescue', () => {
   let app: FastifyInstance;
   let listMock: ReturnType<typeof vi.fn>;
 
@@ -85,7 +85,7 @@ describe('GET /api/rescue', () => {
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/rescue?status=verified&limit=10',
+      url: '/api/v1/rescue?status=verified&limit=10',
       headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
     });
 
@@ -100,7 +100,7 @@ describe('GET /api/rescue', () => {
 
   it('coerces an unknown status to UNSPECIFIED', async () => {
     listMock.mockResolvedValueOnce({ rescues: [] });
-    await app.inject({ method: 'GET', url: '/api/rescue?status=not_a_status' });
+    await app.inject({ method: 'GET', url: '/api/v1/rescue?status=not_a_status' });
     const [req] = listMock.mock.calls[0];
     expect(req.statusFilter).toBe(RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED);
   });
@@ -112,12 +112,12 @@ describe('GET /api/rescue', () => {
         details: 'limit must be <= 100',
       })
     );
-    const res = await app.inject({ method: 'GET', url: '/api/rescue?limit=200' });
+    const res = await app.inject({ method: 'GET', url: '/api/v1/rescue?limit=200' });
     expect(res.statusCode).toBe(400);
   });
 });
 
-describe('GET /api/rescue/:id', () => {
+describe('GET /api/v1/rescue/:id', () => {
   it('threads the path param and returns the rescue', async () => {
     const { client, getMock } = makeClient();
     const app = await makeApp(client);
@@ -126,7 +126,7 @@ describe('GET /api/rescue/:id', () => {
       getMock.mockResolvedValueOnce(getRes);
       const res = await app.inject({
         method: 'GET',
-        url: '/api/rescue/rsc-1',
+        url: '/api/v1/rescue/rsc-1',
         headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
       });
       expect(res.statusCode).toBe(200);
@@ -150,7 +150,7 @@ describe('GET /api/rescue/:id', () => {
           details: 'rescue ghost not found',
         })
       );
-      const res = await app.inject({ method: 'GET', url: '/api/rescue/ghost' });
+      const res = await app.inject({ method: 'GET', url: '/api/v1/rescue/ghost' });
       expect(res.statusCode).toBe(404);
     } finally {
       await app.close();
@@ -158,7 +158,7 @@ describe('GET /api/rescue/:id', () => {
   });
 });
 
-describe('POST /api/rescue', () => {
+describe('POST /api/v1/rescue', () => {
   it('returns 201 + threads body fields into the gRPC request', async () => {
     const { client, createMock } = makeClient();
     const app = await makeApp(client);
@@ -168,7 +168,7 @@ describe('POST /api/rescue', () => {
 
       const res = await app.inject({
         method: 'POST',
-        url: '/api/rescue',
+        url: '/api/v1/rescue',
         headers: { 'x-user-id': 'usr-admin', 'x-user-roles': 'admin' },
         payload: {
           name: 'Pawsome',
@@ -201,7 +201,7 @@ describe('POST /api/rescue', () => {
       );
       const res = await app.inject({
         method: 'POST',
-        url: '/api/rescue',
+        url: '/api/v1/rescue',
         payload: { name: 'Pawsome', email: 'hi@p.example' },
       });
       expect(res.statusCode).toBe(403);
@@ -211,7 +211,7 @@ describe('POST /api/rescue', () => {
   });
 });
 
-describe('PATCH /api/rescue/:id', () => {
+describe('PATCH /api/v1/rescue/:id', () => {
   it('threads path param + body fields', async () => {
     const { client, updateMock } = makeClient();
     const app = await makeApp(client);
@@ -220,7 +220,7 @@ describe('PATCH /api/rescue/:id', () => {
       updateMock.mockResolvedValueOnce(updateRes);
       const res = await app.inject({
         method: 'PATCH',
-        url: '/api/rescue/rsc-1',
+        url: '/api/v1/rescue/rsc-1',
         payload: { name: 'Pawsome 2' },
       });
       expect(res.statusCode).toBe(200);
@@ -235,7 +235,7 @@ describe('PATCH /api/rescue/:id', () => {
   });
 });
 
-describe('POST /api/rescue/:id/verify', () => {
+describe('POST /api/v1/rescue/:id/verify', () => {
   let app: FastifyInstance;
   let verifyMock: ReturnType<typeof vi.fn>;
 
@@ -257,7 +257,7 @@ describe('POST /api/rescue/:id/verify', () => {
 
     const res = await app.inject({
       method: 'POST',
-      url: '/api/rescue/rsc-1/verify',
+      url: '/api/v1/rescue/rsc-1/verify',
       payload: { toStatus: 'verified', verificationSource: 'companies_house' },
     });
 
@@ -274,7 +274,7 @@ describe('POST /api/rescue/:id/verify', () => {
     verifyMock.mockResolvedValueOnce({ rescue: RESCUE_FIXTURE });
     await app.inject({
       method: 'POST',
-      url: '/api/rescue/rsc-1/verify',
+      url: '/api/v1/rescue/rsc-1/verify',
       payload: { toStatus: 'RESCUE_STATUS_REJECTED', failureReason: 'no docs' },
     });
     const [req] = verifyMock.mock.calls[0];
@@ -291,14 +291,14 @@ describe('POST /api/rescue/:id/verify', () => {
     );
     const res = await app.inject({
       method: 'POST',
-      url: '/api/rescue/rsc-1/verify',
+      url: '/api/v1/rescue/rsc-1/verify',
       payload: { toStatus: 'rejected' },
     });
     expect(res.statusCode).toBe(400);
   });
 });
 
-describe('POST /api/rescue/:id/invitations', () => {
+describe('POST /api/v1/rescue/:id/invitations', () => {
   it('returns 201 + the token alongside the invitation', async () => {
     const { client, inviteStaffMock } = makeClient();
     const app = await makeApp(client);
@@ -318,7 +318,7 @@ describe('POST /api/rescue/:id/invitations', () => {
 
       const res = await app.inject({
         method: 'POST',
-        url: '/api/rescue/rsc-1/invitations',
+        url: '/api/v1/rescue/rsc-1/invitations',
         payload: { email: 'new@p.example', title: 'Volunteer' },
       });
 
@@ -338,7 +338,7 @@ describe('error mapping fallback', () => {
     const app = await makeApp(client);
     try {
       getMock.mockRejectedValueOnce(new Error('connection refused'));
-      const res = await app.inject({ method: 'GET', url: '/api/rescue/rsc-1' });
+      const res = await app.inject({ method: 'GET', url: '/api/v1/rescue/rsc-1' });
       expect(res.statusCode).toBe(500);
     } finally {
       await app.close();

--- a/services/gateway/src/routes/rescue.ts
+++ b/services/gateway/src/routes/rescue.ts
@@ -1,18 +1,18 @@
-// REST → gRPC translation for /api/rescue/*.
+// REST → gRPC translation for /api/v1/rescue/*.
 //
 // Phase 4.5 cutover: this Fastify plugin registers BEFORE the
 // strangler-fig http-proxy catch-all, so Fastify's first-registered-
-// wins prefix routing picks it for /api/rescue/* requests before the
+// wins prefix routing picks it for /api/v1/rescue/* requests before the
 // catch-all sees them. Same shape as routes/pets.ts / routes/auth.ts.
 //
-// Route map (mirrors the monolith's existing /api/rescue/* surface):
+// Route map (mirrors the monolith's existing /api/v1/rescue/* surface):
 //
-//   GET    /api/rescue                    → RescueService.List
-//   GET    /api/rescue/:id                → RescueService.Get
-//   POST   /api/rescue                    → RescueService.Create
-//   PATCH  /api/rescue/:id                → RescueService.Update
-//   POST   /api/rescue/:id/verify         → RescueService.Verify
-//   POST   /api/rescue/:id/invitations    → RescueService.InviteStaff
+//   GET    /api/v1/rescue                    → RescueService.List
+//   GET    /api/v1/rescue/:id                → RescueService.Get
+//   POST   /api/v1/rescue                    → RescueService.Create
+//   PATCH  /api/v1/rescue/:id                → RescueService.Update
+//   POST   /api/v1/rescue/:id/verify         → RescueService.Verify
+//   POST   /api/v1/rescue/:id/invitations    → RescueService.InviteStaff
 //
 // The Phase 2.5 authenticate middleware already populates x-user-*
 // metadata; every RescueService RPC requires a principal.
@@ -79,23 +79,27 @@ export const registerRescueRoutes = async (
 
   await app.register(rateLimit, { global: false });
 
-  app.get('/api/rescue', { config: { rateLimit: RESCUE_RATE_LIMITS.list } }, async (req, reply) => {
-    const query = req.query as Record<string, string | undefined>;
-    const grpcReq: ListRescuesRequest = {
-      cursor: query.cursor,
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
-      statusFilter: parseStatus(query.status),
-    };
-    try {
-      const res = await client.list(grpcReq, buildMetadata(req));
-      return reply.send(RescueV1.ListRescuesResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
+  app.get(
+    '/api/v1/rescue',
+    { config: { rateLimit: RESCUE_RATE_LIMITS.list } },
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: ListRescuesRequest = {
+        cursor: query.cursor,
+        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        statusFilter: parseStatus(query.status),
+      };
+      try {
+        const res = await client.list(grpcReq, buildMetadata(req));
+        return reply.send(RescueV1.ListRescuesResponse.toJSON(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
     }
-  });
+  );
 
   app.get<{ Params: { id: string } }>(
-    '/api/rescue/:id',
+    '/api/v1/rescue/:id',
     { config: { rateLimit: RESCUE_RATE_LIMITS.get } },
     async (req, reply) => {
       try {
@@ -108,7 +112,7 @@ export const registerRescueRoutes = async (
   );
 
   app.post(
-    '/api/rescue',
+    '/api/v1/rescue',
     { config: { rateLimit: RESCUE_RATE_LIMITS.create } },
     async (req, reply) => {
       const body = (req.body ?? {}) as CreateRescueBody;
@@ -141,7 +145,7 @@ export const registerRescueRoutes = async (
   );
 
   app.patch<{ Params: { id: string } }>(
-    '/api/rescue/:id',
+    '/api/v1/rescue/:id',
     { config: { rateLimit: RESCUE_RATE_LIMITS.update } },
     async (req, reply) => {
       const body = (req.body ?? {}) as UpdateRescueBody;
@@ -156,7 +160,7 @@ export const registerRescueRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/rescue/:id/verify',
+    '/api/v1/rescue/:id/verify',
     { config: { rateLimit: RESCUE_RATE_LIMITS.verify } },
     async (req, reply) => {
       const body = (req.body ?? {}) as VerifyBody;
@@ -176,7 +180,7 @@ export const registerRescueRoutes = async (
   );
 
   app.post<{ Params: { id: string } }>(
-    '/api/rescue/:id/invitations',
+    '/api/v1/rescue/:id/invitations',
     { config: { rateLimit: RESCUE_RATE_LIMITS.inviteStaff } },
     async (req, reply) => {
       const body = (req.body ?? {}) as InviteStaffBody;

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -186,3 +186,81 @@ describe('createServer — strangler-fig /api/* proxy', () => {
     expect(receivedUrl).toBe('/api/pets?species=cat&age=2');
   });
 });
+
+// Stage A — the per-domain cutover gate. With the flag OFF (default) the
+// gateway must NOT register the domain's /api/v1/* routes even when a
+// client is wired, so the frontend's request still proxies to the
+// monolith. With the flag ON the gateway intercepts it.
+describe('createServer — per-domain cutover gate', () => {
+  let upstream: { instance: FastifyInstance; url: string };
+  let server: FastifyInstance;
+
+  const allOff = {
+    auth: false,
+    notifications: false,
+    pets: false,
+    rescue: false,
+    applications: false,
+    moderation: false,
+    matching: false,
+    audit: false,
+  } as const;
+
+  // A stub applications client whose List resolves an empty page. Only
+  // the List path is exercised here.
+  const applicationsClient = {
+    list: () => Promise.resolve({ applications: [] }),
+  } as unknown as Parameters<typeof createServer>[0]['applicationsClient'];
+
+  afterEach(async () => {
+    await server?.close();
+    await upstream?.instance?.close();
+  });
+
+  it('proxies /api/v1/applications to the monolith when cutover.applications is OFF (even with a client)', async () => {
+    let upstreamHits = 0;
+    upstream = await startUpstream(s => {
+      s.get('/api/v1/applications', async () => {
+        upstreamHits++;
+        return { from: 'monolith' };
+      });
+    });
+    server = await createServer({
+      config: { ...baseConfig, upstreamBackendUrl: upstream.url, cutover: { ...allOff } },
+      logger: quietLogger,
+      applicationsClient,
+    });
+
+    const res = await server.inject({ method: 'GET', url: '/api/v1/applications' });
+
+    expect(res.json()).toEqual({ from: 'monolith' });
+    expect(upstreamHits).toBe(1);
+  });
+
+  it('intercepts /api/v1/applications at the gateway route when cutover.applications is ON', async () => {
+    let upstreamHits = 0;
+    upstream = await startUpstream(s => {
+      s.get('/api/v1/applications', async () => {
+        upstreamHits++;
+        return { from: 'monolith' };
+      });
+    });
+    server = await createServer({
+      config: {
+        ...baseConfig,
+        upstreamBackendUrl: upstream.url,
+        cutover: { ...allOff, applications: true },
+      },
+      logger: quietLogger,
+      applicationsClient,
+    });
+
+    const res = await server.inject({ method: 'GET', url: '/api/v1/applications' });
+
+    // The gateway route served it (empty page from the stub client —
+    // ts-proto's toJSON omits the empty repeated field, so {}); the
+    // monolith ({ from: 'monolith' }) was never hit.
+    expect(res.json()).toEqual({});
+    expect(upstreamHits).toBe(0);
+  });
+});

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -125,35 +125,41 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     await registerAuthenticate(server, { authClient: opts.authClient, logger });
   }
 
-  // Service-specific routes register BEFORE the catch-all proxy.
-  // Fastify's first-registered-wins prefix routing picks them off
-  // before the catch-all sees the request.
+  // Service-specific routes register at /api/v1/<domain> BEFORE the
+  // catch-all proxy — Fastify's first-registered-wins prefix routing
+  // picks them off before the catch-all sees the request.
   //
-  // Phase 2.6: /api/auth/* now lands here instead of the monolith.
-  // The authClient is re-used from the authenticate middleware so
-  // we don't open a second gRPC channel for the same upstream.
-  if (opts.authClient) {
+  // Each domain registers ONLY when (a) its gRPC client is wired and
+  // (b) its per-domain cutover flag is on. The flag defaults off, so by
+  // default these routes are NOT registered and /api/v1/* falls through
+  // to the residual monolith — preserving today's behaviour. A domain
+  // goes live only once its routes return a frontend-compatible shape
+  // (ADR 0002). NOTE: the authenticate middleware above is independent
+  // of cutover.auth and always runs; only the /api/v1/auth/* ROUTES are
+  // gated here.
+  const { cutover } = config;
+  if (opts.authClient && cutover.auth) {
     await registerAuthRoutes(server, { client: opts.authClient });
   }
-  if (opts.notificationsClient) {
+  if (opts.notificationsClient && cutover.notifications) {
     await registerNotificationsRoutes(server, { client: opts.notificationsClient });
   }
-  if (opts.petsClient) {
+  if (opts.petsClient && cutover.pets) {
     await registerPetsRoutes(server, { client: opts.petsClient });
   }
-  if (opts.rescueClient) {
+  if (opts.rescueClient && cutover.rescue) {
     await registerRescueRoutes(server, { client: opts.rescueClient });
   }
-  if (opts.auditClient) {
+  if (opts.auditClient && cutover.audit) {
     await registerAuditRoutes(server, { client: opts.auditClient });
   }
-  if (opts.matchingClient) {
+  if (opts.matchingClient && cutover.matching) {
     await registerMatchingRoutes(server, { client: opts.matchingClient });
   }
-  if (opts.moderationClient) {
+  if (opts.moderationClient && cutover.moderation) {
     await registerModerationRoutes(server, { client: opts.moderationClient });
   }
-  if (opts.applicationsClient) {
+  if (opts.applicationsClient && cutover.applications) {
     await registerApplicationsRoutes(server, { client: opts.applicationsClient });
   }
 


### PR DESCRIPTION
## What

**Stage A** of the cutover plan (ADR 0002). Fixes the systemic path-version mismatch that left every extracted service **dark**.

### The bug

The frontend libraries call **`/api/v1/<domain>`** (`lib.api` `API_BASE_PATH = '/api/v1'`), but every gateway service route was registered at **`/api/<domain>`** (no `v1`). Fastify never matched them, so all frontend traffic fell through the catch-all proxy to the **monolith** — auth, notifications, pets, rescue, applications, moderation, matching, audit were all registered, tested, and receiving zero production traffic.

### The fix

1. **Path alignment** — every `routes/<domain>.ts` now registers at `/api/v1/<domain>` (paths + route tests updated).
2. **Per-domain cutover flags** — new gateway config `cutover.<domain>` (env `CUTOVER_<DOMAIN>`), **default off**. `server.ts` registers a domain's routes only when its client is wired **and** its flag is on; otherwise the routes aren't registered and `/api/v1/*` still proxies to the monolith.

### Why it's safe (behaviour-preserving)

Flags default off → **no domain goes live** on merge. A domain is enabled (flag flipped) only once its gateway routes return a **frontend-compatible response shape** — that's Stage B, since the gRPC proto-JSON shape (`applicationId`/`answersJson`/`APPLICATION_STATUS_*`) diverges from the frontend's `ApplicationSchema` (`id`/nested `data`/lowercase status). Flipping a path live without its adapter would break the frontend, so the flag holds each vertical until Stage B lands.

The **authenticate middleware** is independent of `cutover.auth` and still runs on every request (stripping/stamping `x-user-*`); only the `/api/v1/auth/*` **routes** are gated.

## Tests

- New server test proves the gate both ways: with `cutover.applications` **off** the request proxies to the monolith even with a client wired; with it **on** the gateway route intercepts (monolith never hit).
- New config tests: all flags default false; a flag enables only for the exact string `"true"` (case-insensitive) — `"1"`/`"false"`/`""` stay off.
- Full `services/gateway` suite green: **134 tests pass**; `tsc --noEmit` clean; eslint clean.

## Follow-ups (per ADR 0002)

- **Stage B** — per-domain proto-JSON ↔ frontend-contract adapters; then flip `CUTOVER_<DOMAIN>=true` for each as it's verified.
- Stages C–E (missing surface, integration migration, monolith deletion) remain; **no monolith code deleted here**.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_