### PR TITLE
feat(gateway): stage B — applications proto-JSON ↔ frontend contract adapter (read + write)

### DIFF
--- a/docs/adr/0002-applications-strangler-cutover.md
+++ b/docs/adr/0002-applications-strangler-cutover.md
@@ -119,15 +119,44 @@ Add a translation layer in `routes/applications.ts` (or a dedicated
 Cover the mapping with golden-fixture tests asserting a real `ApplicationSchema`
 `parse()` succeeds.
 
+**Decisions confirmed (June 2026):**
+
+- **Status: gateway collapse.** The service's 9 states map onto the frontend's
+  4-value `status` + 6-value `stage` in the gateway; the frontend is untouched.
+  The table (service → status/stage): `submitted`→submitted/pending,
+  `under_review`→submitted/reviewing, `home_visit_scheduled`→submitted/visiting,
+  `home_visit_completed`→submitted/deciding, `approved`→approved/resolved,
+  `rejected`→rejected/resolved, `withdrawn`→withdrawn/withdrawn,
+  `adopted`→approved/resolved. `draft` + UNSPECIFIED have no frontend
+  representation — List filters them out and Get 404s them.
+- **Read path shipped** in `routes/applications-view.ts` (`applicationToView`) +
+  the List/Get routes, wrapped in the `{ data }` envelope the SPA expects. Flag
+  stays off.
+- **Still to do for Stage B:** the WRITE path is a protocol adapter, not a field
+  rename — the frontend's single `submitApplication(data)` POST maps to the
+  service's draft flow (StartDraft → SaveDraftAnswers → SubmitDraft), and
+  `updateStatus`/`withdraw` map to the specific command RPCs. Pagination
+  (keyset cursor) and `ApplicationWithPetInfo` pet-join fields are also TBD.
+
 ### Stage C — fill the missing surface (fixes Gap 3, part 1)
 
-For documents / stats / questions / timeline, either:
+For documents / stats / questions / timeline:
 
-1. implement them in `services/applications` (proto + handlers + gateway), or
-2. **transitionally proxy** just those sub-paths to the monolith from the
-   gateway, so the path flip in Stage A doesn't 404 them.
+**Decision confirmed (June 2026): build natively** in `services/applications`
+(proto + handlers + gateway) rather than transitionally proxying to the monolith.
+A `GetStats` RPC (counts by status off the read model) is the bounded first
+piece; documents (file upload metadata + storage) is the larger one.
 
-Recommend (2) first (keeps the cutover moving), then (1) as follow-ups.
+### Stage D.0 — data migration (NEWLY IDENTIFIED PREREQUISITE)
+
+Not in the original plan, and it gates flipping `CUTOVER_APPLICATIONS` on for any
+real environment: **the new event store is empty.** The monolith's existing
+`applications` rows (and their answers/references/transitions) must be backfilled
+into `services/applications`' event store — most cleanly as a one-off
+`draftCreated`/`draftSubmitted`/… event synthesis per historical application, or
+a projection-only seed of the read model with a sentinel event. Until this runs,
+flipping the flag would show every adopter an empty application history. Sequence
+it after Stages B+C and before the cutover flip.
 
 ### Stage D — migrate the monolith integrations (fixes Gap 3, part 2)
 

--- a/services/gateway/src/routes/applications-view.test.ts
+++ b/services/gateway/src/routes/applications-view.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApplicationsV1, type Application } from '@adopt-dont-shop/proto';
+
+import { applicationToView, isHiddenFromFrontend } from './applications-view.js';
+
+const S = ApplicationsV1.ApplicationStatus;
+
+function makeApp(overrides: Partial<Application> = {}): Application {
+  return {
+    applicationId: 'app-1',
+    adopterId: 'usr-1',
+    petId: 'pet-1',
+    rescueId: 'rsc-1',
+    status: S.APPLICATION_STATUS_SUBMITTED,
+    answersJson: '{}',
+    referencesJson: '[]',
+    version: 2,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-02T00:00:00.000Z',
+    ...overrides,
+  } as Application;
+}
+
+describe('applicationToView — status collapse', () => {
+  const cases: Array<[number, string | null, string | null]> = [
+    [S.APPLICATION_STATUS_UNSPECIFIED, null, null],
+    [S.APPLICATION_STATUS_DRAFT, null, null],
+    [S.APPLICATION_STATUS_SUBMITTED, 'submitted', 'pending'],
+    [S.APPLICATION_STATUS_UNDER_REVIEW, 'submitted', 'reviewing'],
+    [S.APPLICATION_STATUS_HOME_VISIT_SCHEDULED, 'submitted', 'visiting'],
+    [S.APPLICATION_STATUS_HOME_VISIT_COMPLETED, 'submitted', 'deciding'],
+    [S.APPLICATION_STATUS_APPROVED, 'approved', 'resolved'],
+    [S.APPLICATION_STATUS_REJECTED, 'rejected', 'resolved'],
+    [S.APPLICATION_STATUS_WITHDRAWN, 'withdrawn', 'withdrawn'],
+    [S.APPLICATION_STATUS_ADOPTED, 'approved', 'resolved'],
+  ];
+
+  it.each(cases)('maps service status %i → (%s, %s)', (status, expectedStatus, expectedStage) => {
+    const view = applicationToView(makeApp({ status }));
+    if (expectedStatus === null) {
+      expect(view).toBeNull();
+      expect(isHiddenFromFrontend(makeApp({ status }))).toBe(true);
+      return;
+    }
+    expect(view).not.toBeNull();
+    expect(view?.status).toBe(expectedStatus);
+    expect(view?.stage).toBe(expectedStage);
+    expect(isHiddenFromFrontend(makeApp({ status }))).toBe(false);
+  });
+});
+
+describe('applicationToView — field mapping', () => {
+  it('renames proto fields to the frontend shape', () => {
+    const view = applicationToView(
+      makeApp({
+        applicationId: 'app-9',
+        adopterId: 'usr-9',
+        petId: 'pet-9',
+        rescueId: 'rsc-9',
+        status: S.APPLICATION_STATUS_APPROVED,
+        submittedAt: '2026-06-03T00:00:00.000Z',
+        decidedAt: '2026-06-05T00:00:00.000Z',
+        decidedBy: 'staff-1',
+        decisionNotes: 'great home',
+      })
+    );
+    expect(view).toMatchObject({
+      id: 'app-9',
+      userId: 'usr-9',
+      petId: 'pet-9',
+      rescueId: 'rsc-9',
+      status: 'approved',
+      submittedAt: '2026-06-03T00:00:00.000Z',
+      reviewedAt: '2026-06-05T00:00:00.000Z',
+      reviewedBy: 'staff-1',
+      reviewNotes: 'great home',
+    });
+  });
+
+  it('falls back reviewedAt → reviewStartedAt and reviewNotes → rejectionReason', () => {
+    const view = applicationToView(
+      makeApp({
+        status: S.APPLICATION_STATUS_REJECTED,
+        reviewStartedAt: '2026-06-04T00:00:00.000Z',
+        rejectionReason: 'no yard',
+      })
+    );
+    expect(view?.reviewedAt).toBe('2026-06-04T00:00:00.000Z');
+    expect(view?.reviewNotes).toBe('no yard');
+  });
+
+  it('emits null for stage timestamps the application has not reached', () => {
+    const view = applicationToView(makeApp({ status: S.APPLICATION_STATUS_SUBMITTED }));
+    expect(view?.submittedAt).toBeNull();
+    expect(view?.reviewedAt).toBeNull();
+    expect(view?.reviewedBy).toBeNull();
+    expect(view?.reviewNotes).toBeNull();
+  });
+});
+
+describe('applicationToView — data blob', () => {
+  it('parses a non-empty answersJson into the nested data object', () => {
+    const view = applicationToView(
+      makeApp({ answersJson: '{"personalInfo":{"firstName":"Jo"},"answers":{"q1":"a"}}' })
+    );
+    expect(view?.data).toEqual({ personalInfo: { firstName: 'Jo' }, answers: { q1: 'a' } });
+  });
+
+  it('omits data when answersJson is empty / "{}" / malformed / a non-object', () => {
+    expect(applicationToView(makeApp({ answersJson: '' }))?.data).toBeUndefined();
+    expect(applicationToView(makeApp({ answersJson: '{}' }))?.data).toBeUndefined();
+    expect(applicationToView(makeApp({ answersJson: 'not-json' }))?.data).toBeUndefined();
+    expect(applicationToView(makeApp({ answersJson: '[1,2]' }))?.data).toBeUndefined();
+  });
+});

--- a/services/gateway/src/routes/applications-view.ts
+++ b/services/gateway/src/routes/applications-view.ts
@@ -1,0 +1,129 @@
+// Stage B (ADR 0002) — applications response adapter.
+//
+// The service.applications gRPC surface returns proto-JSON that diverges
+// from the frontend's `ApplicationSchema` (lib.applications). This module
+// is the read-side translation: a decoded proto `Application` →
+// the frontend's view shape, so flipping CUTOVER_APPLICATIONS on serves a
+// shape the SPA's Zod parse accepts unchanged.
+//
+// Two divergences handled here:
+//
+//  1. Status collapse. The service has a 9-state lifecycle; the frontend
+//     has a 4-value `status` plus a finer optional `stage`. We map each
+//     service state onto a (status, stage) pair — the `stage` enum was
+//     clearly designed for exactly this granularity. `draft` and the
+//     UNSPECIFIED sentinel map to null: a draft is not a frontend-visible
+//     "application" (the SPA's status enum has no draft), so the read
+//     routes filter those out / 404 them.
+//
+//  2. Field + envelope shape. applicationId→id, adopterId→userId, the
+//     `answersJson` blob → the nested `data` object, and the frontend
+//     wraps every payload in `{ data: ... }` (the routes do the wrap).
+//
+// Pure functions, no I/O — unit-tested against the frontend's required
+// fields. The WRITE path (1 REST call → N gRPC commands), stats, and
+// documents are separate Stage B follow-ups; so is the data migration
+// that must backfill the (currently empty) event store before any flip.
+
+import { ApplicationsV1, type Application } from '@adopt-dont-shop/proto';
+
+type FrontendStatus = 'submitted' | 'approved' | 'rejected' | 'withdrawn';
+type FrontendStage = 'pending' | 'reviewing' | 'visiting' | 'deciding' | 'resolved' | 'withdrawn';
+
+// The frontend ApplicationSchema view. Only id/petId/userId/rescueId/
+// status/createdAt/updatedAt are required there; the rest are
+// optional/nullish, so we emit null for "not reached yet" and omit
+// `data` when there are no answers.
+export type ApplicationView = {
+  id: string;
+  petId: string;
+  userId: string;
+  rescueId: string;
+  status: FrontendStatus;
+  stage: FrontendStage;
+  submittedAt: string | null;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  reviewNotes: string | null;
+  data?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const S = ApplicationsV1.ApplicationStatus;
+
+// 9 service states → (frontend status, stage). null = not shown to the
+// frontend (draft / unspecified): the SPA has no way to render it.
+const STATUS_VIEW: ReadonlyMap<number, { status: FrontendStatus; stage: FrontendStage } | null> =
+  new Map([
+    [S.APPLICATION_STATUS_UNSPECIFIED, null],
+    [S.APPLICATION_STATUS_DRAFT, null],
+    [S.APPLICATION_STATUS_SUBMITTED, { status: 'submitted', stage: 'pending' }],
+    [S.APPLICATION_STATUS_UNDER_REVIEW, { status: 'submitted', stage: 'reviewing' }],
+    [S.APPLICATION_STATUS_HOME_VISIT_SCHEDULED, { status: 'submitted', stage: 'visiting' }],
+    [S.APPLICATION_STATUS_HOME_VISIT_COMPLETED, { status: 'submitted', stage: 'deciding' }],
+    [S.APPLICATION_STATUS_APPROVED, { status: 'approved', stage: 'resolved' }],
+    [S.APPLICATION_STATUS_REJECTED, { status: 'rejected', stage: 'resolved' }],
+    [S.APPLICATION_STATUS_WITHDRAWN, { status: 'withdrawn', stage: 'withdrawn' }],
+    // Post-adoption is still "approved" to the SPA; the pet collection is
+    // surfaced elsewhere.
+    [S.APPLICATION_STATUS_ADOPTED, { status: 'approved', stage: 'resolved' }],
+  ]);
+
+// True when the application has no frontend-visible representation
+// (draft / unspecified) — the read routes skip these.
+export function isHiddenFromFrontend(app: Application): boolean {
+  const mapped = STATUS_VIEW.get(app.status);
+  return mapped === undefined || mapped === null;
+}
+
+// Map a decoded proto Application to the frontend view, or null when the
+// application is not frontend-visible (draft / unspecified).
+export function applicationToView(app: Application): ApplicationView | null {
+  const mapped = STATUS_VIEW.get(app.status);
+  if (mapped === undefined || mapped === null) {
+    return null;
+  }
+
+  const view: ApplicationView = {
+    id: app.applicationId,
+    petId: app.petId,
+    userId: app.adopterId,
+    rescueId: app.rescueId,
+    status: mapped.status,
+    stage: mapped.stage,
+    submittedAt: app.submittedAt ?? null,
+    // "reviewed" on the frontend means the decision (or, before that, the
+    // review opening). Prefer the decision timestamp.
+    reviewedAt: app.decidedAt ?? app.reviewStartedAt ?? null,
+    reviewedBy: app.decidedBy ?? null,
+    reviewNotes: app.decisionNotes ?? app.rejectionReason ?? null,
+    createdAt: app.createdAt,
+    updatedAt: app.updatedAt,
+  };
+
+  const data = parseAnswers(app.answersJson);
+  if (data !== undefined) {
+    view.data = data;
+  }
+
+  return view;
+}
+
+// answersJson is the opaque blob the write path stored (the frontend's
+// own nested `data` object round-trips through it). Empty / invalid → omit
+// `data` entirely (the field is optional on the frontend schema).
+function parseAnswers(answersJson: string | undefined): Record<string, unknown> | undefined {
+  if (answersJson === undefined || answersJson === '' || answersJson === '{}') {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(answersJson);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return undefined;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -205,6 +205,50 @@ describe('applications routes', () => {
     });
   });
 
+  // A submitted (frontend-visible) application for the Stage B view tests.
+  const SUBMITTED = {
+    ...APP,
+    status: ApplicationsV1.ApplicationStatus.APPLICATION_STATUS_SUBMITTED,
+    answersJson: '{"personalInfo":{"firstName":"Jo"}}',
+  };
+
+  it('List returns the frontend view wrapped in { data } and drops drafts', async () => {
+    mocks.list.mockResolvedValue({ applications: [SUBMITTED, APP] }); // APP is a draft
+    const res = await app.inject({ method: 'GET', url: '/api/v1/applications', headers: STAFF });
+    const body = res.json() as { data: Array<Record<string, unknown>> };
+    expect(body.data).toHaveLength(1); // the draft was filtered out
+    expect(body.data[0]).toMatchObject({
+      id: 'app-1',
+      userId: 'usr-1',
+      status: 'submitted',
+      stage: 'pending',
+      data: { personalInfo: { firstName: 'Jo' } },
+    });
+  });
+
+  it('Get returns the frontend view in { data } for a visible application', async () => {
+    mocks.get.mockResolvedValue({ application: SUBMITTED, timeline: [] });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications/app-1',
+      headers: ADOPTER,
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as { data: { status: string } }).data).toMatchObject({
+      status: 'submitted',
+    });
+  });
+
+  it('Get 404s a draft application (no frontend representation)', async () => {
+    mocks.get.mockResolvedValue({ application: APP, timeline: [] }); // APP is a draft
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications/app-1',
+      headers: ADOPTER,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
   it('maps a service UNIMPLEMENTED (StartDraft stub) → 501', async () => {
     mocks.startDraft.mockRejectedValue({
       code: grpcStatus.UNIMPLEMENTED,

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -249,6 +249,91 @@ describe('applications routes', () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it('POST orchestrates StartDraft→SaveDraftAnswers→SubmitDraft and returns the view', async () => {
+    mocks.startDraft.mockResolvedValue({ application: { ...APP, version: 1 } });
+    mocks.saveDraftAnswers.mockResolvedValue({ application: { ...APP, version: 2 } });
+    mocks.submitDraft.mockResolvedValue({ application: SUBMITTED });
+
+    const payload = { userId: 'usr-1', petId: 'pet-1', personalInfo: { firstName: 'Jo' } };
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/applications',
+      headers: ADOPTER,
+      payload,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect((res.json() as { data: { status: string } }).data).toMatchObject({
+      status: 'submitted',
+    });
+    expect(mocks.startDraft.mock.calls[0][0]).toEqual({ adopterId: 'usr-1', petId: 'pet-1' });
+    // The whole frontend data blob is stored as answers, version threaded.
+    expect(mocks.saveDraftAnswers.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      expectedVersion: 1,
+      answersPatchJson: JSON.stringify(payload),
+    });
+    expect(mocks.submitDraft.mock.calls[0][0]).toEqual({
+      applicationId: 'app-1',
+      expectedVersion: 2,
+    });
+  });
+
+  it('PATCH /:id/status approved → Approve, returns the view', async () => {
+    mocks.approve.mockResolvedValue({ application: SUBMITTED });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/applications/app-1/status',
+      headers: STAFF,
+      payload: { status: 'approved', notes: 'great home' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mocks.approve.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      notes: 'great home',
+    });
+    expect((res.json() as { data: unknown }).data).toBeDefined();
+  });
+
+  it('PATCH /:id/status rejected → Reject with reason from notes', async () => {
+    mocks.reject.mockResolvedValue({ application: SUBMITTED });
+    await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/applications/app-1/status',
+      headers: STAFF,
+      payload: { status: 'rejected', notes: 'no yard' },
+    });
+    expect(mocks.reject.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      reason: 'no yard',
+    });
+  });
+
+  it('PATCH /:id/status with an unsupported target → 400', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/applications/app-1/status',
+      headers: STAFF,
+      payload: { status: 'under_review' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('PUT /:id/withdraw → Withdraw, returns the view', async () => {
+    mocks.withdraw.mockResolvedValue({ application: SUBMITTED });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/applications/app-1/withdraw',
+      headers: ADOPTER,
+      payload: { reason: 'found another pet' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mocks.withdraw.mock.calls[0][0]).toMatchObject({
+      applicationId: 'app-1',
+      reason: 'found another pet',
+    });
+  });
+
   it('maps a service UNIMPLEMENTED (StartDraft stub) → 501', async () => {
     mocks.startDraft.mockRejectedValue({
       code: grpcStatus.UNIMPLEMENTED,

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -51,6 +51,8 @@ import {
 
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
 
+import { applicationToView, type ApplicationView } from './applications-view.js';
+
 export type ApplicationsRoutesOptions = {
   client: ApplicationsClient;
 };
@@ -271,7 +273,12 @@ export const registerApplicationsRoutes = async (
     };
     try {
       const res = await client.list(grpcReq, buildMetadata(req));
-      return reply.send(ApplicationsV1.ListApplicationsResponse.toJSON(res));
+      // Stage B: map to the frontend view + drop draft/unspecified rows,
+      // and wrap in the `{ data }` envelope the SPA expects.
+      const data = res.applications
+        .map(applicationToView)
+        .filter((v): v is ApplicationView => v !== null);
+      return reply.send({ data });
     } catch (err) {
       return handleGrpcError(err, reply);
     }
@@ -287,7 +294,14 @@ export const registerApplicationsRoutes = async (
           { applicationId: req.params.id, includeTimeline: q.timeline === 'true' },
           buildMetadata(req)
         );
-        return reply.send(ApplicationsV1.GetApplicationResponse.toJSON(res));
+        // Stage B: a draft / unspecified application has no frontend
+        // representation — treat it as not found rather than emitting a
+        // shape the SPA can't parse.
+        const view = res.application ? applicationToView(res.application) : null;
+        if (view === null) {
+          return reply.code(404).send({ error: 'application not found' });
+        }
+        return reply.send({ data: view });
       } catch (err) {
         return handleGrpcError(err, reply);
       }

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -4,33 +4,26 @@
 // (#929) / routes/matching.ts (#923) — registers BEFORE the catch-all
 // proxy so first-registered-wins prefix routing picks it off.
 //
-// Route map (all 12 ApplicationService RPCs):
+// Two layers (ADR 0002, Stage B):
 //
-//   Drafts
-//   POST   /api/v1/applications                              → StartDraft
-//   PATCH  /api/v1/applications/:id/answers                  → SaveDraftAnswers
-//   POST   /api/v1/applications/:id/submit                   → SubmitDraft
-//   Review / home visit / decision
-//   POST   /api/v1/applications/:id/review                   → StartReview
-//   POST   /api/v1/applications/:id/home-visit/schedule      → ScheduleHomeVisit
-//   POST   /api/v1/applications/:id/home-visit/complete      → CompleteHomeVisit
-//   POST   /api/v1/applications/:id/approve                  → Approve
-//   POST   /api/v1/applications/:id/reject                   → Reject
-//   POST   /api/v1/applications/:id/withdraw                 → Withdraw
-//   POST   /api/v1/applications/:id/adopt                    → MarkAdopted
-//   Reads
-//   GET    /api/v1/applications                              → List
-//   GET    /api/v1/applications/:id                          → Get
+//   Frontend contract (what lib.applications calls) — responses use the
+//   collapsed view shape (applications-view.ts) in a `{ data }` envelope:
+//   POST   /api/v1/applications              → StartDraft+SaveDraftAnswers+SubmitDraft
+//   PATCH  /api/v1/applications/:id/status   → Approve | Reject | Withdraw
+//   PUT    /api/v1/applications/:id/withdraw → Withdraw
+//   GET    /api/v1/applications              → List  (drafts filtered)
+//   GET    /api/v1/applications/:id          → Get   (draft → 404)
 //
-// Authz lives in the handlers (adopters act on their own drafts; rescue
-// staff gate on applications.review/approve/reject; reads scope to
-// owner/rescue/admin). The gateway stamps x-user-* metadata via the
-// Phase 2.5 authenticate middleware.
+//   Service-shaped routes (granular RPCs for rescue-staff / internal
+//   callers) — responses are raw proto-JSON:
+//   PATCH  /:id/answers, POST /:id/submit, POST /:id/review,
+//   POST /:id/home-visit/{schedule,complete}, POST /:id/{approve,reject,
+//   withdraw,adopt}.
 //
-// StartDraft is currently an UNIMPLEMENTED stub on the service (it needs
-// the service.pets gRPC client to resolve pet → rescue), which maps to
-// 501 here so the SPA gets an honest "not yet" rather than a fall-through
-// to the monolith.
+// Authz lives in the service handlers; the gateway stamps x-user-*
+// metadata via the Phase 2.5 authenticate middleware. These routes only
+// serve traffic when CUTOVER_APPLICATIONS is on (else /api/v1/* proxies
+// to the monolith) — see server.ts.
 
 import rateLimit from '@fastify/rate-limit';
 import { Metadata, status } from '@grpc/grpc-js';
@@ -38,6 +31,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import {
   ApplicationsV1,
+  type Application,
   type ApproveRequest,
   type CompleteHomeVisitRequest,
   type ListApplicationsRequest,
@@ -82,20 +76,97 @@ export const registerApplicationsRoutes = async (
 
   await app.register(rateLimit, { global: false });
 
-  // ---------- Drafts ----------
+  // ---------- Frontend write contract (lib.applications) ----------
+  //
+  // The SPA's create is a single POST carrying the whole ApplicationData
+  // object; the service models it as draft → submitted. So the gateway
+  // ORCHESTRATES StartDraft → SaveDraftAnswers → SubmitDraft, threading
+  // the optimistic-concurrency version from each response into the next,
+  // and stores the frontend's data blob verbatim as answers so it
+  // round-trips on read (applications-view.ts parses it back into `data`).
 
   app.post('/api/v1/applications', { config: { rateLimit: RL_WRITE } }, async (req, reply) => {
     const b = (req.body ?? {}) as Record<string, unknown>;
+    const adopterId = (b.userId as string) ?? (b.adopterId as string) ?? headerUserId(req) ?? '';
+    const petId = (b.petId as string) ?? '';
+    const meta = buildMetadata(req);
     try {
-      const res = await client.startDraft(
-        { adopterId: (b.adopterId as string) ?? '', petId: (b.petId as string) ?? '' },
-        buildMetadata(req)
+      const started = await client.startDraft({ adopterId, petId }, meta);
+      const draft = requireApplication(started.application);
+
+      const saved = await client.saveDraftAnswers(
+        {
+          applicationId: draft.applicationId,
+          expectedVersion: draft.version,
+          answersPatchJson: JSON.stringify(b),
+        },
+        meta
       );
-      return reply.code(201).send(ApplicationsV1.StartDraftResponse.toJSON(res));
+      const withAnswers = requireApplication(saved.application);
+
+      const submitted = await client.submitDraft(
+        { applicationId: withAnswers.applicationId, expectedVersion: withAnswers.version },
+        meta
+      );
+      return sendView(reply, submitted.application, 201);
     } catch (err) {
       return handleGrpcError(err, reply);
     }
   });
+
+  // PATCH /:id/status — the SPA's updateApplicationStatus. The frontend's
+  // 4-value status maps onto the service's decision commands.
+  app.patch<{ Params: { id: string } }>(
+    '/api/v1/applications/:id/status',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const target = b.status as string | undefined;
+      const notes = b.notes as string | undefined;
+      const id = req.params.id;
+      const meta = buildMetadata(req);
+      try {
+        if (target === 'approved') {
+          const res = await client.approve({ applicationId: id, notes }, meta);
+          return sendView(reply, res.application);
+        }
+        if (target === 'rejected') {
+          const res = await client.reject({ applicationId: id, reason: notes ?? '' }, meta);
+          return sendView(reply, res.application);
+        }
+        if (target === 'withdrawn') {
+          const res = await client.withdraw({ applicationId: id, reason: notes }, meta);
+          return sendView(reply, res.application);
+        }
+        return reply.code(400).send({ error: `unsupported status transition: ${target ?? ''}` });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // PUT /:id/withdraw — the SPA's withdrawApplication.
+  app.put<{ Params: { id: string } }>(
+    '/api/v1/applications/:id/withdraw',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      try {
+        const res = await client.withdraw(
+          { applicationId: req.params.id, reason: b.reason as string | undefined },
+          buildMetadata(req)
+        );
+        return sendView(reply, res.application);
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // ---------- Service-shaped routes (draft + staff lifecycle) ----------
+  // Lower-level RPC routes retained for rescue-staff / internal callers
+  // that drive the granular lifecycle (the SPA's lib.applications uses the
+  // frontend contract above). Responses are proto-JSON.
 
   app.patch<{ Params: { id: string } }>(
     '/api/v1/applications/:id/answers',
@@ -321,6 +392,38 @@ function buildMetadata(req: FastifyRequest): Metadata {
     }
   }
   return m;
+}
+
+function headerUserId(req: FastifyRequest): string | undefined {
+  const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+// Every gRPC command response carries the updated Application; this should
+// always be present after a successful call, but the proto field is
+// optional, so guard it rather than assert. A plain Error (no grpc `code`)
+// maps to 500 via handleGrpcError's default branch.
+function requireApplication(application: Application | undefined): Application {
+  if (application === undefined) {
+    throw new Error('the service returned no application');
+  }
+  return application;
+}
+
+// Send the frontend view in the `{ data }` envelope. A successful write
+// should leave the application in a frontend-visible state; if the view
+// is null (e.g. it's still a draft — not a frontend write flow) we 500
+// rather than emit a shape the SPA can't parse.
+function sendView(
+  reply: FastifyReply,
+  application: Application | undefined,
+  code = 200
+): FastifyReply {
+  const view = application ? applicationToView(application) : null;
+  if (view === null) {
+    return reply.code(500).send({ error: 'unexpected application state' });
+  }
+  return reply.code(code).send({ data: view });
 }
 
 type GrpcError = { code?: number; details?: string; message?: string };

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -257,10 +257,10 @@ describe('createServer — per-domain cutover gate', () => {
 
     const res = await server.inject({ method: 'GET', url: '/api/v1/applications' });
 
-    // The gateway route served it (empty page from the stub client —
-    // ts-proto's toJSON omits the empty repeated field, so {}); the
-    // monolith ({ from: 'monolith' }) was never hit.
-    expect(res.json()).toEqual({});
+    // The gateway route served it — the Stage B view adapter wraps the
+    // (empty) result in the frontend's `{ data }` envelope; the monolith
+    // ({ from: 'monolith' }) was never hit.
+    expect(res.json()).toEqual({ data: [] });
     expect(upstreamHits).toBe(0);
   });
 });


### PR DESCRIPTION
## What

**Stage B** of the cutover (ADR 0002): the gateway adapter that bridges the service's proto-JSON gRPC surface to the frontend's `lib.applications` contract, so a future `CUTOVER_APPLICATIONS` flip serves a shape the SPA parses unchanged. **Flag stays off — no behaviour change.**

### Read path

- **`routes/applications-view.ts`** — pure `applicationToView()`: status collapse (9 service states → frontend 4-status + 6-stage; `draft`/UNSPECIFIED → not frontend-visible), field renames (`applicationId`→`id`, `adopterId`→`userId`), `answersJson` blob → nested `data`.
- **List** maps + filters drafts; **Get** returns `{ data: view }` and 404s drafts.

| service | → status / stage |
|---|---|
| submitted | submitted / pending |
| under_review | submitted / reviewing |
| home_visit_scheduled | submitted / visiting |
| home_visit_completed | submitted / deciding |
| approved · adopted | approved / resolved |
| rejected | rejected / resolved |
| withdrawn | withdrawn / withdrawn |
| draft · unspecified | (filtered / 404) |

### Write path

The SPA's write calls become the service's command RPCs, same `{ data: view }` envelope:

- **POST /api/v1/applications** — the one-shot submit. Orchestrates **StartDraft → SaveDraftAnswers → SubmitDraft**, threading the optimistic-concurrency version from each response into the next, and stores the frontend's whole `data` blob as answers so it round-trips on read.
- **PATCH /api/v1/applications/:id/status** — maps the 4-value frontend status onto **Approve / Reject** (reason ← notes) **/ Withdraw**; unsupported targets → 400.
- **PUT /api/v1/applications/:id/withdraw** — Withdraw.

The granular RPC routes (draft answers/submit, review, home-visit, approve/reject/adopt) are retained as **service-shaped** routes for rescue-staff / internal callers (raw proto-JSON).

## ADR updated + a newly identified prerequisite

ADR 0002 records the confirmed decisions (gateway collapse; build documents/stats natively) and **Stage D.0 — data migration**: the new event store is **empty**, so flipping the flag without backfilling the monolith's applications would show every adopter an empty history. (A first-cut backfill is up as #941.)

## Deferred (documented)

- `PUT /:id` update — the service only allows answer edits in `draft`/`under_review`, a semantic mismatch with the monolith's freer edit.
- Pagination (keyset cursor) and `ApplicationWithPetInfo` pet-join fields.
- Stage C native `GetStats` (in flight) + documents.

## Tests

- `applications-view.test.ts` — all 10 status mappings, field renames + fallbacks, `data` blob parse edge cases.
- `applications.test.ts` — List `{ data }` + draft filtering; Get `{ data }` / 404; **submit orchestration** (3-call version threading + data-blob storage); status → approve/reject/withdraw + 400; PUT withdraw.
- Full `services/gateway` suite green: **157 tests**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP