### PR TITLE
feat(applications): backfill event store from monolith applications (stage D.0)

### DIFF
--- a/services/applications/src/backfill/backfill-event-store.test.ts
+++ b/services/applications/src/backfill/backfill-event-store.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PoolClient } from 'pg';
+
+import { backfillApplication } from './backfill-event-store.js';
+import type { MonolithApplicationInput } from './map-monolith-application.js';
+
+const input = (overrides: Partial<MonolithApplicationInput> = {}): MonolithApplicationInput => ({
+  applicationId: '11111111-1111-1111-1111-111111111111',
+  userId: '22222222-2222-2222-2222-222222222222',
+  petId: '33333333-3333-3333-3333-333333333333',
+  rescueId: '44444444-4444-4444-4444-444444444444',
+  status: 'approved',
+  answers: { hasYard: true },
+  references: [],
+  createdAt: '2026-01-01T10:00:00.000Z',
+  submittedAt: '2026-01-02T10:00:00.000Z',
+  reviewedAt: '2026-01-03T10:00:00.000Z',
+  decidedAt: '2026-01-04T10:00:00.000Z',
+  actionedBy: '55555555-5555-5555-5555-555555555555',
+  rejectionReason: null,
+  withdrawalReason: null,
+  ...overrides,
+});
+
+// A scripted client: every INSERT reports `rowCount` from the supplied
+// queue (1 = inserted, 0 = ON CONFLICT no-op); the final projection
+// UPSERT resolves empty.
+function makeClient(insertRowCounts: ReadonlyArray<number>): {
+  client: PoolClient;
+  query: ReturnType<typeof vi.fn>;
+} {
+  const counts = [...insertRowCounts];
+  const query = vi.fn((text: string) => {
+    if (text.includes('INSERT INTO application_events')) {
+      return Promise.resolve({ rowCount: counts.shift() ?? 0, rows: [] });
+    }
+    return Promise.resolve({ rowCount: 0, rows: [] });
+  });
+  const client = { query } as unknown as PoolClient;
+  return { client, query };
+}
+
+describe('backfillApplication', () => {
+  it('inserts one event per synthesized event then projects the read model', async () => {
+    // approved with answers → draftCreated, draftAnswersSaved,
+    // draftSubmitted, reviewStarted, approved = 5 events.
+    const { client, query } = makeClient([1, 1, 1, 1, 1]);
+    const outcome = await backfillApplication(client, input());
+
+    expect(outcome.totalEvents).toBe(5);
+    expect(outcome.insertedEvents).toBe(5);
+
+    const inserts = query.mock.calls.filter(c =>
+      String(c[0]).includes('INSERT INTO application_events')
+    );
+    expect(inserts).toHaveLength(5);
+    const projections = query.mock.calls.filter(c =>
+      String(c[0]).includes('INSERT INTO applications')
+    );
+    expect(projections).toHaveLength(1);
+  });
+
+  it('inserts events at sequential versions starting from 1', async () => {
+    const { client, query } = makeClient([1, 1, 1]);
+    await backfillApplication(client, input({ status: 'submitted', answers: {} }));
+
+    const versions = query.mock.calls
+      .filter(c => String(c[0]).includes('INSERT INTO application_events'))
+      .map(c => (c[1] as unknown[])[1]);
+    expect(versions).toEqual([1, 2]); // submitted (no answers) = draftCreated, draftSubmitted
+  });
+
+  it('uses ON CONFLICT DO NOTHING so re-runs do not duplicate events', async () => {
+    const { client, query } = makeClient([0, 0]);
+    const outcome = await backfillApplication(client, input({ status: 'submitted', answers: {} }));
+
+    // Every insert collided (rowCount 0) → nothing newly inserted, but
+    // the projection still runs (idempotent UPSERT).
+    expect(outcome.insertedEvents).toBe(0);
+    expect(outcome.totalEvents).toBe(2);
+    const insertSql = String(query.mock.calls[0][0]);
+    expect(insertSql).toContain('ON CONFLICT (aggregate_id, version) DO NOTHING');
+  });
+
+  it('stamps the monolith actioned_by as the actor on every event row', async () => {
+    const { client, query } = makeClient([1, 1, 1, 1, 1]);
+    await backfillApplication(client, input());
+
+    const actors = query.mock.calls
+      .filter(c => String(c[0]).includes('INSERT INTO application_events'))
+      .map(c => (c[1] as unknown[])[5]);
+    expect(new Set(actors)).toEqual(new Set(['55555555-5555-5555-5555-555555555555']));
+  });
+
+  it('stamps a null actor when the monolith never recorded actioned_by', async () => {
+    const { client, query } = makeClient([1, 1, 1, 1, 1]);
+    await backfillApplication(client, input({ actionedBy: null }));
+
+    const actors = query.mock.calls
+      .filter(c => String(c[0]).includes('INSERT INTO application_events'))
+      .map(c => (c[1] as unknown[])[5]);
+    expect(new Set(actors)).toEqual(new Set([null]));
+  });
+
+  it('stamps occurred_at from the event domain timestamp', async () => {
+    const { client, query } = makeClient([1, 1]);
+    await backfillApplication(client, input({ status: 'submitted', answers: {} }));
+
+    const firstInsert = query.mock.calls.find(c =>
+      String(c[0]).includes('INSERT INTO application_events')
+    );
+    // params: [aggregateId, version, type, data, occurred_at, actor]
+    expect((firstInsert?.[1] as unknown[])[4]).toBe('2026-01-01T10:00:00.000Z');
+  });
+});

--- a/services/applications/src/backfill/backfill-event-store.ts
+++ b/services/applications/src/backfill/backfill-event-store.ts
@@ -1,0 +1,103 @@
+// Idempotent persistence for the Stage D.0 backfill.
+//
+// Differs from the live write path (grpc/event-store.ts appendEvents) in
+// ONE way: it inserts with `ON CONFLICT (aggregate_id, version) DO
+// NOTHING` instead of letting the UNIQUE violation surface as a
+// ConcurrencyError. That makes a re-run of the backfill a clean no-op —
+// the second pass synthesizes the same versioned events for the same
+// aggregate_id (the aggregate_id IS the monolith application id), every
+// INSERT collides, nothing changes.
+//
+// occurred_at is the monolith's domain timestamp (event.at). recorded_at
+// is left to its DEFAULT now() — migration 001 documents that
+// occurred_at and recorded_at intentionally differ for backfilled /
+// replayed events, which is exactly this case.
+//
+// The read-model projection reuses grpc/event-store.ts projectReadModel
+// verbatim (already an idempotent UPSERT keyed on application_id), so a
+// re-run re-projects the identical folded state.
+
+import type { PoolClient } from 'pg';
+
+import { fold, type ApplicationEvent } from '../domain/index.js';
+import { projectReadModel } from '../grpc/event-store.js';
+
+import {
+  mapMonolithApplication,
+  type MonolithApplicationInput,
+} from './map-monolith-application.js';
+
+// Inserts one synthesized event at an explicit version with
+// ON CONFLICT DO NOTHING. Returns true when a row was actually inserted
+// (false when it already existed — the idempotent re-run case).
+async function insertEventIdempotent(
+  client: PoolClient,
+  aggregateId: string,
+  version: number,
+  event: ApplicationEvent,
+  actorUserId: string | null
+): Promise<boolean> {
+  const { rowCount } = await client.query(
+    `INSERT INTO application_events (
+       event_id, aggregate_id, version, event_type, event_data,
+       occurred_at, actor_user_id
+     )
+     VALUES (gen_random_uuid(), $1, $2, $3, $4::jsonb, $5, $6)
+     ON CONFLICT (aggregate_id, version) DO NOTHING`,
+    [aggregateId, version, event.type, JSON.stringify(event), event.at, actorUserId]
+  );
+  return (rowCount ?? 0) > 0;
+}
+
+// The actor stamped on the event-store rows. The monolith's
+// actioned_by is the decision-maker; we stamp it on every backfilled
+// row for forensic continuity. Null when the monolith never recorded a
+// decision-maker (legacy / system rows).
+const resolveActor = (input: MonolithApplicationInput): string | null =>
+  input.actionedBy && input.actionedBy.length > 0 ? input.actionedBy : null;
+
+export type BackfillOutcome = {
+  applicationId: string;
+  // Number of event rows newly inserted this run (0 on a re-run).
+  insertedEvents: number;
+  // Total events in the synthesized sequence (constant across runs).
+  totalEvents: number;
+};
+
+// Backfill one monolith application: synthesize its event chain, insert
+// each event idempotently, then project the folded read model. Runs
+// inside the caller's transaction so the events + projection commit
+// atomically per application.
+export async function backfillApplication(
+  client: PoolClient,
+  input: MonolithApplicationInput
+): Promise<BackfillOutcome> {
+  const events = mapMonolithApplication(input);
+  const actor = resolveActor(input);
+
+  let inserted = 0;
+  let version = 0;
+  for (const event of events) {
+    version += 1;
+    const didInsert = await insertEventIdempotent(
+      client,
+      input.applicationId,
+      version,
+      event,
+      actor
+    );
+    if (didInsert) {
+      inserted += 1;
+    }
+  }
+
+  // Project the read-model row from the full folded state. Idempotent
+  // UPSERT — safe to re-run even when no events were inserted this pass.
+  await projectReadModel(client, fold(events));
+
+  return {
+    applicationId: input.applicationId,
+    insertedEvents: inserted,
+    totalEvents: events.length,
+  };
+}

--- a/services/applications/src/backfill/map-monolith-application.test.ts
+++ b/services/applications/src/backfill/map-monolith-application.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import { fold } from '../domain/index.js';
+import {
+  expectedStatus,
+  mapMonolithApplication,
+  REJECTION_REASON_FALLBACK,
+  type MonolithApplicationInput,
+  type MonolithApplicationStatus,
+} from './map-monolith-application.js';
+
+const CREATED_AT = '2026-01-01T10:00:00.000Z';
+const SUBMITTED_AT = '2026-01-02T10:00:00.000Z';
+const REVIEWED_AT = '2026-01-03T10:00:00.000Z';
+const DECIDED_AT = '2026-01-04T10:00:00.000Z';
+
+const base = (overrides: Partial<MonolithApplicationInput> = {}): MonolithApplicationInput => ({
+  applicationId: '11111111-1111-1111-1111-111111111111',
+  userId: '22222222-2222-2222-2222-222222222222',
+  petId: '33333333-3333-3333-3333-333333333333',
+  rescueId: '44444444-4444-4444-4444-444444444444',
+  status: 'submitted',
+  answers: {},
+  references: [],
+  createdAt: CREATED_AT,
+  submittedAt: SUBMITTED_AT,
+  reviewedAt: REVIEWED_AT,
+  decidedAt: DECIDED_AT,
+  actionedBy: '55555555-5555-5555-5555-555555555555',
+  rejectionReason: null,
+  withdrawalReason: null,
+  ...overrides,
+});
+
+const eventTypes = (input: MonolithApplicationInput): ReadonlyArray<string> =>
+  mapMonolithApplication(input).map(e => e.type);
+
+describe('mapMonolithApplication — event sequence per source status', () => {
+  it('submitted → draftCreated, draftSubmitted', () => {
+    expect(eventTypes(base({ status: 'submitted' }))).toEqual(['draftCreated', 'draftSubmitted']);
+  });
+
+  it('approved → draftCreated, draftSubmitted, reviewStarted, approved', () => {
+    expect(eventTypes(base({ status: 'approved' }))).toEqual([
+      'draftCreated',
+      'draftSubmitted',
+      'reviewStarted',
+      'approved',
+    ]);
+  });
+
+  it('rejected → draftCreated, draftSubmitted, reviewStarted, rejected', () => {
+    expect(eventTypes(base({ status: 'rejected', rejectionReason: 'No fenced garden' }))).toEqual([
+      'draftCreated',
+      'draftSubmitted',
+      'reviewStarted',
+      'rejected',
+    ]);
+  });
+
+  it('withdrawn → draftCreated, draftSubmitted, withdrawn (no review)', () => {
+    expect(eventTypes(base({ status: 'withdrawn' }))).toEqual([
+      'draftCreated',
+      'draftSubmitted',
+      'withdrawn',
+    ]);
+  });
+});
+
+describe('mapMonolithApplication — folds to the correct terminal status', () => {
+  const statuses: ReadonlyArray<MonolithApplicationStatus> = [
+    'submitted',
+    'approved',
+    'rejected',
+    'withdrawn',
+  ];
+
+  it.each(statuses)('%s folds to the matching domain status', status => {
+    const input = base({ status, rejectionReason: 'reason' });
+    const state = fold(mapMonolithApplication(input));
+    expect(state.status).toBe(expectedStatus(status));
+  });
+
+  it('carries the immutable identity fields onto the folded state', () => {
+    const state = fold(mapMonolithApplication(base({ status: 'approved' })));
+    expect(state.applicationId).toBe('11111111-1111-1111-1111-111111111111');
+    expect(state.adopterId).toBe('22222222-2222-2222-2222-222222222222');
+    expect(state.petId).toBe('33333333-3333-3333-3333-333333333333');
+    expect(state.rescueId).toBe('44444444-4444-4444-4444-444444444444');
+  });
+});
+
+describe('mapMonolithApplication — answers / references carried through', () => {
+  it('emits draftAnswersSaved when answers are present', () => {
+    const input = base({ answers: { hasYard: true, householdSize: 3 } });
+    expect(eventTypes(input)).toContain('draftAnswersSaved');
+    const state = fold(mapMonolithApplication(input));
+    expect(state.answers).toEqual({ hasYard: true, householdSize: 3 });
+  });
+
+  it('emits draftAnswersSaved when only references are present', () => {
+    const references = [{ name: 'Vet Bob', email: 'bob@vets.example', relationship: 'vet' }];
+    const input = base({ references });
+    expect(eventTypes(input)).toContain('draftAnswersSaved');
+    const state = fold(mapMonolithApplication(input));
+    expect(state.references).toEqual(references);
+  });
+
+  it('omits draftAnswersSaved when there are no answers and no references', () => {
+    expect(eventTypes(base())).not.toContain('draftAnswersSaved');
+    const state = fold(mapMonolithApplication(base()));
+    expect(state.answers).toEqual({});
+    expect(state.references).toEqual([]);
+  });
+});
+
+describe('mapMonolithApplication — timestamp preservation', () => {
+  it('stamps draftCreated.at from createdAt and draftSubmitted.at from submittedAt', () => {
+    const events = mapMonolithApplication(base({ status: 'submitted' }));
+    const created = events.find(e => e.type === 'draftCreated');
+    const submitted = events.find(e => e.type === 'draftSubmitted');
+    expect(created?.at).toBe(CREATED_AT);
+    expect(submitted?.at).toBe(SUBMITTED_AT);
+  });
+
+  it('stamps reviewStarted from reviewedAt and the decision from decidedAt', () => {
+    const events = mapMonolithApplication(base({ status: 'approved' }));
+    const review = events.find(e => e.type === 'reviewStarted');
+    const approved = events.find(e => e.type === 'approved');
+    expect(review?.at).toBe(REVIEWED_AT);
+    expect(approved?.at).toBe(DECIDED_AT);
+  });
+
+  it('folds lifecycle timestamps onto the read-model state', () => {
+    const state = fold(mapMonolithApplication(base({ status: 'approved' })));
+    expect(state.createdAt).toBe(CREATED_AT);
+    expect(state.submittedAt).toBe(SUBMITTED_AT);
+    expect(state.reviewStartedAt).toBe(REVIEWED_AT);
+    expect(state.decidedAt).toBe(DECIDED_AT);
+    expect(state.decidedBy).toBe('55555555-5555-5555-5555-555555555555');
+  });
+
+  it('falls back to createdAt when submittedAt is null (legacy rows)', () => {
+    const events = mapMonolithApplication(base({ status: 'submitted', submittedAt: null }));
+    const submitted = events.find(e => e.type === 'draftSubmitted');
+    expect(submitted?.at).toBe(CREATED_AT);
+  });
+
+  it('falls back to the decision time for reviewStarted when reviewedAt is null', () => {
+    const events = mapMonolithApplication(
+      base({ status: 'approved', reviewedAt: null, decidedAt: DECIDED_AT })
+    );
+    const review = events.find(e => e.type === 'reviewStarted');
+    expect(review?.at).toBe(DECIDED_AT);
+  });
+});
+
+describe('mapMonolithApplication — decision detail preservation', () => {
+  it('preserves the rejection reason when present', () => {
+    const state = fold(
+      mapMonolithApplication(base({ status: 'rejected', rejectionReason: 'No fenced garden' }))
+    );
+    expect(state.rejectionReason).toBe('No fenced garden');
+  });
+
+  it('substitutes the fallback reason when the monolith rejection_reason is null', () => {
+    const state = fold(mapMonolithApplication(base({ status: 'rejected', rejectionReason: null })));
+    expect(state.rejectionReason).toBe(REJECTION_REASON_FALLBACK);
+  });
+
+  it('carries the withdrawal reason (nullable) onto decisionNotes', () => {
+    const state = fold(
+      mapMonolithApplication(base({ status: 'withdrawn', withdrawalReason: 'Found another pet' }))
+    );
+    expect(state.decisionNotes).toBe('Found another pet');
+  });
+});
+
+describe('mapMonolithApplication — idempotency contract (deterministic output)', () => {
+  it('produces identical event sequences across repeated calls', () => {
+    const input = base({ status: 'approved', answers: { a: 1 } });
+    expect(mapMonolithApplication(input)).toEqual(mapMonolithApplication(input));
+  });
+
+  it('keys every event aggregate on the monolith application id', () => {
+    const input = base({ status: 'rejected', rejectionReason: 'x' });
+    for (const event of mapMonolithApplication(input)) {
+      expect(event.applicationId).toBe(input.applicationId);
+    }
+  });
+});

--- a/services/applications/src/backfill/map-monolith-application.ts
+++ b/services/applications/src/backfill/map-monolith-application.ts
@@ -1,0 +1,202 @@
+// Pure mapping: a monolith application row → the minimal valid event
+// sequence that folds (via the domain `apply`) to the equivalent
+// current status in the new event-sourced model.
+//
+// This is the heart of ADR Stage D.0 (0002-applications-strangler-
+// cutover.md). The monolith's `applications` table carries a COLLAPSED
+// 4-state status (submitted | approved | rejected | withdrawn) — it
+// never modelled the intermediate review / home-visit states. The new
+// domain has 9. We synthesize the *minimal* event chain that lands on
+// the right terminal status; the richer intermediate states
+// (under_review, home_visit_*) are simply absent for backfilled
+// aggregates because the monolith never recorded them.
+//
+// Mapping (monolith status → events):
+//   submitted → draftCreated [, draftAnswersSaved] , draftSubmitted
+//   approved  → draftCreated [, draftAnswersSaved] , draftSubmitted,
+//               reviewStarted, approved
+//   rejected  → draftCreated [, draftAnswersSaved] , draftSubmitted,
+//               reviewStarted, rejected
+//   withdrawn → draftCreated [, draftAnswersSaved] , draftSubmitted,
+//               withdrawn
+//
+// `reviewStarted` is interposed before approved/rejected because the
+// domain's read model derives `reviewStartedAt` from it and the
+// monolith's `reviewed_at` / `actioned_by` carry that information — we
+// would otherwise drop it. Withdrawn skips review: a monolith
+// withdrawal could happen straight from submitted.
+//
+// IMPORTANT: this function bypasses the domain's command handlers
+// (`handle`) on purpose — handlers enforce live-write invariants
+// (version checks, actor requirements) that don't apply to a faithful
+// historical replay. It emits events directly and relies on `apply` /
+// `fold` to reconstruct state, exactly as event-store hydration does.
+
+import type { ApplicationEvent, ApplicationStatus, Reference } from '../domain/index.js';
+
+// The monolith's collapsed status set. Source of truth:
+// service.backend/src/models/Application.ts ApplicationStatus enum.
+export type MonolithApplicationStatus = 'submitted' | 'approved' | 'rejected' | 'withdrawn';
+
+// The fields of a monolith application row this backfill needs. A
+// faithful subset of service.backend/src/models/Application.ts +
+// the extracted application_answers / application_references tables
+// (plan 2.1). Timestamps are ISO-8601 strings (the script stringifies
+// the pg Date before calling this pure function).
+export type MonolithApplicationInput = {
+  applicationId: string;
+  userId: string;
+  petId: string;
+  rescueId: string;
+  status: MonolithApplicationStatus;
+  // Merged answers map, rebuilt from application_answers rows
+  // (question_key → answer_value). Empty object when the application
+  // has no recorded answers.
+  answers: Record<string, unknown>;
+  // References rebuilt from application_references rows. Empty array
+  // when none.
+  references: ReadonlyArray<Reference>;
+  // ISO-8601. Monolith `created_at` — when the draft first existed.
+  createdAt: string;
+  // ISO-8601. Monolith `submitted_at`. Falls back to createdAt when
+  // null (older rows predate the column) — see resolveSubmittedAt.
+  submittedAt: string | null;
+  // ISO-8601. Monolith `reviewed_at`. Used for the synthesized
+  // reviewStarted timestamp on approved/rejected. Falls back to the
+  // decision time when null.
+  reviewedAt: string | null;
+  // ISO-8601. Monolith `decision_at` / `actioned_at` — when the
+  // terminal decision landed.
+  decidedAt: string | null;
+  // Monolith `actioned_by` — the staff user who approved/rejected.
+  // Null for system / legacy decisions.
+  actionedBy: string | null;
+  // Monolith `rejection_reason`. The domain's `rejected` event
+  // REQUIRES a non-empty reason; we substitute a sentinel when the
+  // monolith row left it null (legacy rows predate the NOT NULL
+  // expectation). See REJECTION_REASON_FALLBACK.
+  rejectionReason: string | null;
+  // Monolith `withdrawal_reason`. Optional on the domain's withdrawn
+  // event (null allowed).
+  withdrawalReason: string | null;
+};
+
+// The domain's `rejected` event requires a non-empty reason (see
+// commands.ts reject handler). Monolith rows with a null
+// rejection_reason get this sentinel so the read model is still
+// populated and folds cleanly. Flagged as an OPEN QUESTION in the PR.
+export const REJECTION_REASON_FALLBACK = 'Rejected (reason not recorded in legacy data)';
+
+// `at` for the terminal decision event. Prefer the explicit decision
+// timestamp; fall back to submittedAt, then createdAt, so `at` is
+// never null (events carry non-null ISO strings).
+const resolveDecisionAt = (input: MonolithApplicationInput): string =>
+  input.decidedAt ?? resolveSubmittedAt(input);
+
+// `at` for draftSubmitted. Older monolith rows may have a null
+// submitted_at; fall back to createdAt so the timeline stays ordered.
+const resolveSubmittedAt = (input: MonolithApplicationInput): string =>
+  input.submittedAt ?? input.createdAt;
+
+// `at` for the synthesized reviewStarted. Prefer reviewed_at; fall back
+// to the decision time so review is never stamped after the decision.
+const resolveReviewStartedAt = (input: MonolithApplicationInput): string =>
+  input.reviewedAt ?? resolveDecisionAt(input);
+
+const draftCreated = (input: MonolithApplicationInput): ApplicationEvent => ({
+  type: 'draftCreated',
+  applicationId: input.applicationId,
+  adopterId: input.userId,
+  petId: input.petId,
+  rescueId: input.rescueId,
+  at: input.createdAt,
+});
+
+// Only emitted when there's something to carry — an empty answers map
+// AND no references means no draftAnswersSaved event (keeps the chain
+// minimal and the read model's documents blob is `{}` either way).
+const draftAnswersSaved = (input: MonolithApplicationInput): ApplicationEvent => ({
+  type: 'draftAnswersSaved',
+  applicationId: input.applicationId,
+  answersPatch: input.answers,
+  references: input.references.length > 0 ? input.references : null,
+  at: input.createdAt,
+});
+
+const draftSubmitted = (input: MonolithApplicationInput): ApplicationEvent => ({
+  type: 'draftSubmitted',
+  applicationId: input.applicationId,
+  at: resolveSubmittedAt(input),
+});
+
+const reviewStarted = (input: MonolithApplicationInput): ApplicationEvent => ({
+  type: 'reviewStarted',
+  applicationId: input.applicationId,
+  actorUserId: input.actionedBy ?? '',
+  note: null,
+  at: resolveReviewStartedAt(input),
+});
+
+const approved = (input: MonolithApplicationInput): ApplicationEvent => ({
+  type: 'approved',
+  applicationId: input.applicationId,
+  actorUserId: input.actionedBy ?? '',
+  notes: null,
+  at: resolveDecisionAt(input),
+});
+
+const rejected = (input: MonolithApplicationInput): ApplicationEvent => ({
+  type: 'rejected',
+  applicationId: input.applicationId,
+  actorUserId: input.actionedBy ?? '',
+  reason: input.rejectionReason ?? REJECTION_REASON_FALLBACK,
+  at: resolveDecisionAt(input),
+});
+
+const withdrawn = (input: MonolithApplicationInput): ApplicationEvent => ({
+  type: 'withdrawn',
+  applicationId: input.applicationId,
+  actorUserId: input.actionedBy ?? '',
+  reason: input.withdrawalReason,
+  at: resolveDecisionAt(input),
+});
+
+const hasAnswerData = (input: MonolithApplicationInput): boolean =>
+  Object.keys(input.answers).length > 0 || input.references.length > 0;
+
+// The shared prefix every backfilled aggregate gets: it existed as a
+// draft, optionally captured answers, and was submitted.
+const submittedChain = (input: MonolithApplicationInput): ReadonlyArray<ApplicationEvent> => {
+  const created = draftCreated(input);
+  const submitted = draftSubmitted(input);
+  return hasAnswerData(input)
+    ? [created, draftAnswersSaved(input), submitted]
+    : [created, submitted];
+};
+
+// Map one monolith row to its synthesized event sequence. Pure — no
+// I/O, deterministic, immutable. The caller appends these with
+// sequential versions (1..n) and projects the folded read model.
+export function mapMonolithApplication(
+  input: MonolithApplicationInput
+): ReadonlyArray<ApplicationEvent> {
+  const base = submittedChain(input);
+
+  switch (input.status) {
+    case 'submitted':
+      return base;
+    case 'approved':
+      return [...base, reviewStarted(input), approved(input)];
+    case 'rejected':
+      return [...base, reviewStarted(input), rejected(input)];
+    case 'withdrawn':
+      return [...base, withdrawn(input)];
+  }
+}
+
+// Convenience for callers/tests: the terminal status the synthesized
+// chain folds to. Mirrors the mapping table above. (The script asserts
+// fold(events).status === expectedStatus(input.status) as a safety net.)
+export function expectedStatus(status: MonolithApplicationStatus): ApplicationStatus {
+  return status;
+}

--- a/services/applications/src/backfill/read-monolith-row.test.ts
+++ b/services/applications/src/backfill/read-monolith-row.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { isKnownStatus, rowToInput, type MonolithApplicationRow } from './read-monolith-row.js';
+
+const row = (overrides: Partial<MonolithApplicationRow> = {}): MonolithApplicationRow => ({
+  application_id: '11111111-1111-1111-1111-111111111111',
+  user_id: '22222222-2222-2222-2222-222222222222',
+  pet_id: '33333333-3333-3333-3333-333333333333',
+  rescue_id: '44444444-4444-4444-4444-444444444444',
+  status: 'submitted',
+  created_at: new Date('2026-01-01T10:00:00.000Z'),
+  submitted_at: new Date('2026-01-02T10:00:00.000Z'),
+  reviewed_at: null,
+  decision_at: null,
+  actioned_by: null,
+  rejection_reason: null,
+  withdrawal_reason: null,
+  answers: null,
+  references: null,
+  ...overrides,
+});
+
+describe('isKnownStatus', () => {
+  it.each(['submitted', 'approved', 'rejected', 'withdrawn'])('accepts %s', status => {
+    expect(isKnownStatus(status)).toBe(true);
+  });
+
+  it('rejects an unknown status', () => {
+    expect(isKnownStatus('under_review')).toBe(false);
+    expect(isKnownStatus('')).toBe(false);
+  });
+});
+
+describe('rowToInput', () => {
+  it('normalises Date timestamps to ISO-8601 strings', () => {
+    const input = rowToInput(row());
+    expect(input.createdAt).toBe('2026-01-01T10:00:00.000Z');
+    expect(input.submittedAt).toBe('2026-01-02T10:00:00.000Z');
+    expect(input.reviewedAt).toBeNull();
+    expect(input.decidedAt).toBeNull();
+  });
+
+  it('defaults null answers to an empty object', () => {
+    expect(rowToInput(row({ answers: null })).answers).toEqual({});
+  });
+
+  it('passes a populated answers map through', () => {
+    expect(rowToInput(row({ answers: { hasYard: true } })).answers).toEqual({ hasYard: true });
+  });
+
+  it('maps reference rows, defaulting a null email to empty string', () => {
+    const input = rowToInput(
+      row({
+        references: [
+          { name: 'Vet Bob', email: null, relationship: 'vet' },
+          { name: 'Jane', email: 'jane@example.com', relationship: 'friend' },
+        ],
+      })
+    );
+    expect(input.references).toEqual([
+      { name: 'Vet Bob', email: '', relationship: 'vet' },
+      { name: 'Jane', email: 'jane@example.com', relationship: 'friend' },
+    ]);
+  });
+
+  it('throws on an unmappable status, naming the application id', () => {
+    expect(() => rowToInput(row({ status: 'archived' }))).toThrow(
+      /application 11111111-1111-1111-1111-111111111111 has unmappable status 'archived'/
+    );
+  });
+});

--- a/services/applications/src/backfill/read-monolith-row.ts
+++ b/services/applications/src/backfill/read-monolith-row.ts
@@ -1,0 +1,100 @@
+// Pure adapter: a raw row read from the monolith's public.applications
+// table (joined with aggregated answers/references) → the
+// MonolithApplicationInput the mapping consumes.
+//
+// Kept separate + pure so the SQL-shape → domain-input translation is
+// testable without a database. The script (run-backfill.ts) owns the
+// actual query; this owns the row-shape contract.
+//
+// Timestamps arrive from pg as Date objects (or null); we normalise to
+// ISO-8601 strings here so the event `at` fields are plain strings.
+
+import type { Reference } from '../domain/index.js';
+
+import {
+  type MonolithApplicationInput,
+  type MonolithApplicationStatus,
+} from './map-monolith-application.js';
+
+// The raw row shape the backfill query yields. snake_case to match the
+// monolith's column names. answers / references arrive pre-aggregated
+// as jsonb (see run-backfill.ts query).
+export type MonolithApplicationRow = {
+  application_id: string;
+  user_id: string;
+  pet_id: string;
+  rescue_id: string;
+  status: string;
+  created_at: Date;
+  submitted_at: Date | null;
+  reviewed_at: Date | null;
+  decision_at: Date | null;
+  actioned_by: string | null;
+  rejection_reason: string | null;
+  withdrawal_reason: string | null;
+  // Aggregated { question_key: answer_value } map. null when the
+  // application has no answer rows.
+  answers: Record<string, unknown> | null;
+  // Aggregated reference list. null when the application has no
+  // reference rows. Each element carries the monolith reference's
+  // name / email / relationship — the only fields the domain's
+  // Reference type models.
+  references: ReadonlyArray<RawReference> | null;
+};
+
+type RawReference = {
+  name: string;
+  email: string | null;
+  relationship: string;
+};
+
+// The monolith's 4 collapsed statuses. Any other value is a data
+// integrity surprise the script surfaces rather than silently mapping.
+const KNOWN_STATUSES: ReadonlySet<string> = new Set([
+  'submitted',
+  'approved',
+  'rejected',
+  'withdrawn',
+]);
+
+export function isKnownStatus(status: string): status is MonolithApplicationStatus {
+  return KNOWN_STATUSES.has(status);
+}
+
+const toIso = (value: Date | null): string | null => (value === null ? null : value.toISOString());
+
+// Drop reference rows that don't carry the required name/relationship —
+// the domain Reference type needs both. email is optional in the domain
+// (string), so a null monolith email becomes an empty string.
+const toReference = (raw: RawReference): Reference => ({
+  name: raw.name,
+  email: raw.email ?? '',
+  relationship: raw.relationship,
+});
+
+// Throws on an unknown status — the caller (script) catches and reports
+// the offending application id rather than guessing a mapping.
+export function rowToInput(row: MonolithApplicationRow): MonolithApplicationInput {
+  if (!isKnownStatus(row.status)) {
+    throw new Error(
+      `application ${row.application_id} has unmappable status '${row.status}' (expected one of submitted|approved|rejected|withdrawn)`
+    );
+  }
+
+  return {
+    applicationId: row.application_id,
+    userId: row.user_id,
+    petId: row.pet_id,
+    rescueId: row.rescue_id,
+    status: row.status,
+    answers: row.answers ?? {},
+    references: (row.references ?? []).map(toReference),
+    createdAt: row.created_at.toISOString(),
+    submittedAt: toIso(row.submitted_at),
+    reviewedAt: toIso(row.reviewed_at),
+    decidedAt: toIso(row.decision_at),
+    actionedBy: row.actioned_by,
+    rejectionReason: row.rejection_reason,
+    withdrawalReason: row.withdrawal_reason,
+  };
+}

--- a/services/applications/src/backfill/run-backfill.ts
+++ b/services/applications/src/backfill/run-backfill.ts
@@ -1,0 +1,172 @@
+// Stage D.0 backfill runner — seeds the (empty) applications event
+// store from the monolith's existing applications so a future cutover
+// doesn't show adopters an empty history. See ADR
+// docs/adr/0002-applications-strangler-cutover.md.
+//
+// Invoked manually (not part of `db:migrate`) — it's a one-shot data
+// migration, idempotent so it can be re-run safely:
+//
+//   tsx services/applications/src/backfill/run-backfill.ts
+//
+// It reads the monolith table FULLY-QUALIFIED as public.applications.
+// This is deliberate: the connection's search_path is
+// `applications, public` (see @adopt-dont-shop/db createDbClient), so an
+// UNqualified `applications` would resolve to THIS service's read-model
+// table, not the monolith's. The two tables share a name in different
+// schemas of the same physical Postgres.
+//
+// Per application: synthesize the event chain, insert events with
+// ON CONFLICT DO NOTHING, project the read model — all in one
+// transaction so a crash mid-run leaves each application either fully
+// backfilled or untouched (and a re-run finishes the rest).
+
+import { createDbClient } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+import type { PoolClient } from 'pg';
+
+import { loadConfig } from '../config.js';
+
+import { backfillApplication } from './backfill-event-store.js';
+import { rowToInput, type MonolithApplicationRow } from './read-monolith-row.js';
+
+// Reads the monolith applications + their answers/references, aggregated
+// into the per-row shape rowToInput expects. Soft-deleted monolith rows
+// (deleted_at IS NOT NULL) are EXCLUDED — paranoid deletes are not
+// history an adopter should see post-cutover. See OPEN QUESTIONS in the
+// PR if closed/erased applications must be carried too.
+//
+// answers come from public.application_answers (plan 2.1 extracted
+// table); references from public.application_references. Both are
+// aggregated to jsonb so each application is a single row.
+const SELECT_MONOLITH_APPLICATIONS = `
+  SELECT
+    a.application_id,
+    a.user_id,
+    a.pet_id,
+    a.rescue_id,
+    a.status,
+    a.created_at,
+    a.submitted_at,
+    a.reviewed_at,
+    a.decision_at,
+    a.actioned_by,
+    a.rejection_reason,
+    a.withdrawal_reason,
+    (
+      SELECT jsonb_object_agg(ans.question_key, ans.answer_value)
+      FROM public.application_answers ans
+      WHERE ans.application_id = a.application_id
+    ) AS answers,
+    (
+      SELECT jsonb_agg(
+               jsonb_build_object(
+                 'name', ref.name,
+                 'email', ref.email,
+                 'relationship', ref.relationship
+               )
+               ORDER BY ref.order_index
+             )
+      FROM public.application_references ref
+      WHERE ref.application_id = a.application_id
+    ) AS references
+  FROM public.applications a
+  WHERE a.deleted_at IS NULL
+  ORDER BY a.created_at ASC
+`;
+
+type RunSummary = {
+  applicationsProcessed: number;
+  eventsInserted: number;
+  skipped: number;
+};
+
+// Process one application in its own transaction. Returns the per-row
+// outcome, or null when the row was skipped (unmappable status) — the
+// status surprise is logged and the run continues rather than aborting
+// the whole backfill on one bad row.
+async function processRow(
+  client: PoolClient,
+  row: MonolithApplicationRow,
+  logger: ReturnType<typeof createLogger>
+): Promise<number | null> {
+  let input;
+  try {
+    input = rowToInput(row);
+  } catch (err) {
+    logger.warn('skipping application with unmappable status', {
+      applicationId: row.application_id,
+      status: row.status,
+      err,
+    });
+    return null;
+  }
+
+  await client.query('BEGIN');
+  try {
+    const outcome = await backfillApplication(client, input);
+    await client.query('COMMIT');
+    return outcome.insertedEvents;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+}
+
+export async function runBackfill(
+  pool: ReturnType<typeof createDbClient>,
+  logger: ReturnType<typeof createLogger>
+): Promise<RunSummary> {
+  const { rows } = await pool.query<MonolithApplicationRow>(SELECT_MONOLITH_APPLICATIONS);
+  logger.info('backfill: monolith applications read', { count: rows.length });
+
+  const summary: RunSummary = { applicationsProcessed: 0, eventsInserted: 0, skipped: 0 };
+
+  const client = await pool.connect();
+  try {
+    for (const row of rows) {
+      const inserted = await processRow(client, row, logger);
+      if (inserted === null) {
+        summary.skipped += 1;
+        continue;
+      }
+      summary.applicationsProcessed += 1;
+      summary.eventsInserted += inserted;
+    }
+  } finally {
+    client.release();
+  }
+
+  return summary;
+}
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.applications.backfill' });
+  let pool: ReturnType<typeof createDbClient> | undefined;
+  // The backfill does NOT publish NATS events — downstream consumers
+  // (notifications) must not re-fire for historical applications. We
+  // intentionally never connect to NATS here.
+
+  try {
+    const config = loadConfig();
+    pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });
+
+    logger.info('backfill: starting', { schema: config.schema });
+    const summary = await runBackfill(pool, logger);
+    logger.info('backfill: complete', summary);
+  } catch (err) {
+    logger.error('backfill: failed', { err });
+    process.exitCode = 1;
+  } finally {
+    try {
+      await pool?.end();
+    } catch {
+      // best-effort
+    }
+  }
+};
+
+// Only run when invoked directly (tsx run-backfill.ts), not when
+// imported by tests.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}


### PR DESCRIPTION
## What

FIRST CUT of the ADR 0002 **Stage D.0** data-migration backfill: seed the (currently empty) applications microservice event store from the monolith's existing applications, so a future cutover doesn't show adopters an empty history.

Work is confined to `services/applications/src/backfill/`. Nothing in `packages/proto/`, `services/applications/src/grpc/server.ts`, or `services/gateway/` is touched.

## How it bridges the two models

The monolith's `applications` table carries a **collapsed 4-state** status (`submitted | approved | rejected | withdrawn`); the new event-sourced domain has 9. Per monolith application we synthesize the **minimal valid event sequence** that folds (via the domain's `apply`/`fold`) to the equivalent terminal status, then project the read-model row using the existing `grpc/event-store.ts projectReadModel` helper.

### Mapping chosen (monolith status → events)

| Monolith status | Synthesized events |
|---|---|
| `submitted` | draftCreated [, draftAnswersSaved] , draftSubmitted |
| `approved` | draftCreated [, draftAnswersSaved] , draftSubmitted, reviewStarted, approved |
| `rejected` | draftCreated [, draftAnswersSaved] , draftSubmitted, reviewStarted, rejected |
| `withdrawn` | draftCreated [, draftAnswersSaved] , draftSubmitted, withdrawn |

- `draftAnswersSaved` is only emitted when the application has answers and/or references (rebuilt from the plan-2.1 `application_answers` / `application_references` tables), carrying them into the read model's `documents` blob.
- `reviewStarted` is interposed before approved/rejected so the monolith's `reviewed_at` / `actioned_by` survive as `reviewStartedAt` in the read model. Withdrawn skips review.
- Intermediate states the monolith never recorded (`under_review`, `home_visit_*`) are simply absent for backfilled aggregates — by design.
- Original timestamps are preserved: `draftCreated.at`=created_at, `draftSubmitted.at`=submitted_at, `reviewStarted.at`=reviewed_at, decision `at`=decision_at. `occurred_at` carries the domain time; `recorded_at` is left to its `DEFAULT now()` (migration 001 documents these intentionally differ for backfilled events).

### Idempotency

Events insert with `ON CONFLICT (aggregate_id, version) DO NOTHING`, with the `aggregate_id` **keyed off the monolith application id** (used verbatim — it's already a UUID). A second run synthesizes the identical versioned events, every INSERT collides, and the read-model UPSERT re-projects the same state — a clean no-op.

### Cross-schema

The runner reads the monolith table **fully-qualified as `public.applications`** (+ `public.application_answers` / `public.application_references`). This is deliberate: the connection's `search_path` is `applications, public`, so an unqualified `applications` would resolve to *this* service's read-model table.

## Files

- `map-monolith-application.ts` — pure monolith-status → event-list mapping (the testable core)
- `read-monolith-row.ts` — pure raw-DB-row → domain-input adapter
- `backfill-event-store.ts` — idempotent event insert + read-model projection (reuses `projectReadModel`)
- `run-backfill.ts` — `tsx`-invokable orchestration: `tsx services/applications/src/backfill/run-backfill.ts`
- thorough Vitest coverage of the pure layers and the persistence contract (38 backfill tests)

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` (whole service) — 187 passed
- `npx eslint src/backfill/` — clean

## OPEN QUESTIONS / ASSUMPTIONS

This is a reviewed FIRST CUT — the following need sign-off before this runs against real data:

1. **Run mechanism.** Implemented as a standalone idempotent `tsx` script (not a `node-pg-migrate` migration), because the backfill is a one-shot data move that reads a *different* service's table and shouldn't gate the schema-migration sequence. Confirm this is preferred over a numbered migration.
2. **Monolith source columns assumed.** Read `public.applications` columns: `application_id, user_id, pet_id, rescue_id, status, created_at, submitted_at, reviewed_at, decision_at, actioned_by, rejection_reason, withdrawal_reason, deleted_at`. Answers/references are read from the plan-2.1 extracted tables `application_answers` (question_key/answer_value) and `application_references` (name/email/relationship/order_index), NOT from a JSONB column on the row. Confirm these table/column names match production.
3. **Soft-deleted rows EXCLUDED.** The query filters `deleted_at IS NULL`. Paranoid-deleted monolith applications are not carried over. If erased/closed applications must appear in post-cutover history, this needs revisiting (and a way to represent a soft-deleted aggregate in the new read model, which the projection doesn't currently set).
4. **Rejection reason fallback.** The domain's `rejected` event requires a non-empty reason; monolith rows with a null `rejection_reason` get a sentinel string (`"Rejected (reason not recorded in legacy data)"`). Confirm that's acceptable vs. e.g. relaxing the invariant for backfill.
5. **Actor on synthesized events.** The monolith's `actioned_by` is stamped on every event row's `actor_user_id` (null when absent). `reviewStarted`/`approved`/`rejected`/`withdrawn` use it as `actorUserId`; where null it folds to an empty string in the state. Confirm that's the desired forensic attribution.
6. **No NATS publish.** The backfill intentionally does not publish `applications.*` events, so downstream consumers (notifications) don't re-fire for historical applications. Confirm no downstream needs a replay signal.
7. **`final_outcome` / `priority` / `stage` / tags / scores etc.** Not carried — the event model doesn't represent them, and the projection only writes the columns `projectReadModel` knows about. If the gateway shape adapter (Stage B) needs them on backfilled rows, that's a follow-up.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_