### PR TITLE
feat(applications): add GetStats RPC for application counts

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
+++ b/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
@@ -84,6 +84,13 @@ service ApplicationService {
   // for the adopter / staff dashboards. Adopters see their own;
   // staff see their rescue's; admins see all.
   rpc List(ListApplicationsRequest) returns (ListApplicationsResponse);
+
+  // Read-side: application counts grouped by status, scoped the same
+  // way List is (adopters see their own; staff see their rescue's;
+  // admins see all and may narrow by rescue/adopter). Powers the
+  // rescue dashboard's stats cards. Returns RAW per-service-status
+  // counts — the gateway collapses them to the SPA's 4-state shape.
+  rpc GetStats(GetStatsRequest) returns (GetStatsResponse);
 }
 
 // --- ENUMs — value lists mirror the Postgres types verbatim ----------
@@ -303,4 +310,32 @@ message ListApplicationsRequest {
 message ListApplicationsResponse {
   repeated Application applications = 1;
   optional string next_cursor = 2;
+}
+
+// --- GetStats --------------------------------------------------------
+
+message GetStatsRequest {
+  // Optional filters. Admins + super_admin may pass either to narrow
+  // the counted set; rescue staff are pinned to their own rescue and
+  // adopters to their own user id regardless of these (the handler
+  // enforces scope from the principal).
+  optional string rescue_id_filter = 1;
+  optional string adopter_id_filter = 2;
+}
+
+message GetStatsResponse {
+  // Total non-deleted applications in scope (sum of the per-status
+  // counts below).
+  uint32 total = 1;
+  // RAW per-service-status counts — zero-filled for statuses with no
+  // rows. The gateway collapses these to the SPA's 4-state shape.
+  uint32 draft = 2;
+  uint32 submitted = 3;
+  uint32 under_review = 4;
+  uint32 home_visit_scheduled = 5;
+  uint32 home_visit_completed = 6;
+  uint32 approved = 7;
+  uint32 rejected = 8;
+  uint32 withdrawn = 9;
+  uint32 adopted = 10;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
@@ -338,6 +338,38 @@ export interface ListApplicationsResponse {
   nextCursor?: string | undefined;
 }
 
+export interface GetStatsRequest {
+  /**
+   * Optional filters. Admins + super_admin may pass either to narrow
+   * the counted set; rescue staff are pinned to their own rescue and
+   * adopters to their own user id regardless of these (the handler
+   * enforces scope from the principal).
+   */
+  rescueIdFilter?: string | undefined;
+  adopterIdFilter?: string | undefined;
+}
+
+export interface GetStatsResponse {
+  /**
+   * Total non-deleted applications in scope (sum of the per-status
+   * counts below).
+   */
+  total: number;
+  /**
+   * RAW per-service-status counts — zero-filled for statuses with no
+   * rows. The gateway collapses these to the SPA's 4-state shape.
+   */
+  draft: number;
+  submitted: number;
+  underReview: number;
+  homeVisitScheduled: number;
+  homeVisitCompleted: number;
+  approved: number;
+  rejected: number;
+  withdrawn: number;
+  adopted: number;
+}
+
 function createBaseApplication(): Application {
   return {
     applicationId: '',
@@ -2963,6 +2995,317 @@ export const ListApplicationsResponse: MessageFns<ListApplicationsResponse> = {
   },
 };
 
+function createBaseGetStatsRequest(): GetStatsRequest {
+  return { rescueIdFilter: undefined, adopterIdFilter: undefined };
+}
+
+export const GetStatsRequest: MessageFns<GetStatsRequest> = {
+  encode(message: GetStatsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.rescueIdFilter !== undefined) {
+      writer.uint32(10).string(message.rescueIdFilter);
+    }
+    if (message.adopterIdFilter !== undefined) {
+      writer.uint32(18).string(message.adopterIdFilter);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetStatsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetStatsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.rescueIdFilter = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.adopterIdFilter = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetStatsRequest {
+    return {
+      rescueIdFilter: isSet(object.rescueIdFilter)
+        ? globalThis.String(object.rescueIdFilter)
+        : isSet(object.rescue_id_filter)
+          ? globalThis.String(object.rescue_id_filter)
+          : undefined,
+      adopterIdFilter: isSet(object.adopterIdFilter)
+        ? globalThis.String(object.adopterIdFilter)
+        : isSet(object.adopter_id_filter)
+          ? globalThis.String(object.adopter_id_filter)
+          : undefined,
+    };
+  },
+
+  toJSON(message: GetStatsRequest): unknown {
+    const obj: any = {};
+    if (message.rescueIdFilter !== undefined) {
+      obj.rescueIdFilter = message.rescueIdFilter;
+    }
+    if (message.adopterIdFilter !== undefined) {
+      obj.adopterIdFilter = message.adopterIdFilter;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetStatsRequest>, I>>(base?: I): GetStatsRequest {
+    return GetStatsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetStatsRequest>, I>>(object: I): GetStatsRequest {
+    const message = createBaseGetStatsRequest();
+    message.rescueIdFilter = object.rescueIdFilter ?? undefined;
+    message.adopterIdFilter = object.adopterIdFilter ?? undefined;
+    return message;
+  },
+};
+
+function createBaseGetStatsResponse(): GetStatsResponse {
+  return {
+    total: 0,
+    draft: 0,
+    submitted: 0,
+    underReview: 0,
+    homeVisitScheduled: 0,
+    homeVisitCompleted: 0,
+    approved: 0,
+    rejected: 0,
+    withdrawn: 0,
+    adopted: 0,
+  };
+}
+
+export const GetStatsResponse: MessageFns<GetStatsResponse> = {
+  encode(message: GetStatsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.total !== 0) {
+      writer.uint32(8).uint32(message.total);
+    }
+    if (message.draft !== 0) {
+      writer.uint32(16).uint32(message.draft);
+    }
+    if (message.submitted !== 0) {
+      writer.uint32(24).uint32(message.submitted);
+    }
+    if (message.underReview !== 0) {
+      writer.uint32(32).uint32(message.underReview);
+    }
+    if (message.homeVisitScheduled !== 0) {
+      writer.uint32(40).uint32(message.homeVisitScheduled);
+    }
+    if (message.homeVisitCompleted !== 0) {
+      writer.uint32(48).uint32(message.homeVisitCompleted);
+    }
+    if (message.approved !== 0) {
+      writer.uint32(56).uint32(message.approved);
+    }
+    if (message.rejected !== 0) {
+      writer.uint32(64).uint32(message.rejected);
+    }
+    if (message.withdrawn !== 0) {
+      writer.uint32(72).uint32(message.withdrawn);
+    }
+    if (message.adopted !== 0) {
+      writer.uint32(80).uint32(message.adopted);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetStatsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetStatsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.draft = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.submitted = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.underReview = reader.uint32();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.homeVisitScheduled = reader.uint32();
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.homeVisitCompleted = reader.uint32();
+          continue;
+        }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.approved = reader.uint32();
+          continue;
+        }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.rejected = reader.uint32();
+          continue;
+        }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.withdrawn = reader.uint32();
+          continue;
+        }
+        case 10: {
+          if (tag !== 80) {
+            break;
+          }
+
+          message.adopted = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetStatsResponse {
+    return {
+      total: isSet(object.total) ? globalThis.Number(object.total) : 0,
+      draft: isSet(object.draft) ? globalThis.Number(object.draft) : 0,
+      submitted: isSet(object.submitted) ? globalThis.Number(object.submitted) : 0,
+      underReview: isSet(object.underReview)
+        ? globalThis.Number(object.underReview)
+        : isSet(object.under_review)
+          ? globalThis.Number(object.under_review)
+          : 0,
+      homeVisitScheduled: isSet(object.homeVisitScheduled)
+        ? globalThis.Number(object.homeVisitScheduled)
+        : isSet(object.home_visit_scheduled)
+          ? globalThis.Number(object.home_visit_scheduled)
+          : 0,
+      homeVisitCompleted: isSet(object.homeVisitCompleted)
+        ? globalThis.Number(object.homeVisitCompleted)
+        : isSet(object.home_visit_completed)
+          ? globalThis.Number(object.home_visit_completed)
+          : 0,
+      approved: isSet(object.approved) ? globalThis.Number(object.approved) : 0,
+      rejected: isSet(object.rejected) ? globalThis.Number(object.rejected) : 0,
+      withdrawn: isSet(object.withdrawn) ? globalThis.Number(object.withdrawn) : 0,
+      adopted: isSet(object.adopted) ? globalThis.Number(object.adopted) : 0,
+    };
+  },
+
+  toJSON(message: GetStatsResponse): unknown {
+    const obj: any = {};
+    if (message.total !== 0) {
+      obj.total = Math.round(message.total);
+    }
+    if (message.draft !== 0) {
+      obj.draft = Math.round(message.draft);
+    }
+    if (message.submitted !== 0) {
+      obj.submitted = Math.round(message.submitted);
+    }
+    if (message.underReview !== 0) {
+      obj.underReview = Math.round(message.underReview);
+    }
+    if (message.homeVisitScheduled !== 0) {
+      obj.homeVisitScheduled = Math.round(message.homeVisitScheduled);
+    }
+    if (message.homeVisitCompleted !== 0) {
+      obj.homeVisitCompleted = Math.round(message.homeVisitCompleted);
+    }
+    if (message.approved !== 0) {
+      obj.approved = Math.round(message.approved);
+    }
+    if (message.rejected !== 0) {
+      obj.rejected = Math.round(message.rejected);
+    }
+    if (message.withdrawn !== 0) {
+      obj.withdrawn = Math.round(message.withdrawn);
+    }
+    if (message.adopted !== 0) {
+      obj.adopted = Math.round(message.adopted);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetStatsResponse>, I>>(base?: I): GetStatsResponse {
+    return GetStatsResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetStatsResponse>, I>>(object: I): GetStatsResponse {
+    const message = createBaseGetStatsResponse();
+    message.total = object.total ?? 0;
+    message.draft = object.draft ?? 0;
+    message.submitted = object.submitted ?? 0;
+    message.underReview = object.underReview ?? 0;
+    message.homeVisitScheduled = object.homeVisitScheduled ?? 0;
+    message.homeVisitCompleted = object.homeVisitCompleted ?? 0;
+    message.approved = object.approved ?? 0;
+    message.rejected = object.rejected ?? 0;
+    message.withdrawn = object.withdrawn ?? 0;
+    message.adopted = object.adopted ?? 0;
+    return message;
+  },
+};
+
 /**
  * ApplicationService is the gRPC contract for the applications
  * vertical — the EVENT-SOURCED extraction. Owns the `applications.*`
@@ -3191,6 +3534,24 @@ export const ApplicationServiceService = {
     responseDeserialize: (value: Buffer): ListApplicationsResponse =>
       ListApplicationsResponse.decode(value),
   },
+  /**
+   * Read-side: application counts grouped by status, scoped the same
+   * way List is (adopters see their own; staff see their rescue's;
+   * admins see all and may narrow by rescue/adopter). Powers the
+   * rescue dashboard's stats cards. Returns RAW per-service-status
+   * counts — the gateway collapses them to the SPA's 4-state shape.
+   */
+  getStats: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/GetStats' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetStatsRequest): Buffer =>
+      Buffer.from(GetStatsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetStatsRequest => GetStatsRequest.decode(value),
+    responseSerialize: (value: GetStatsResponse): Buffer =>
+      Buffer.from(GetStatsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetStatsResponse => GetStatsResponse.decode(value),
+  },
 } as const;
 
 export interface ApplicationServiceServer extends UntypedServiceImplementation {
@@ -3268,6 +3629,14 @@ export interface ApplicationServiceServer extends UntypedServiceImplementation {
    * staff see their rescue's; admins see all.
    */
   list: handleUnaryCall<ListApplicationsRequest, ListApplicationsResponse>;
+  /**
+   * Read-side: application counts grouped by status, scoped the same
+   * way List is (adopters see their own; staff see their rescue's;
+   * admins see all and may narrow by rescue/adopter). Powers the
+   * rescue dashboard's stats cards. Returns RAW per-service-status
+   * counts — the gateway collapses them to the SPA's 4-state shape.
+   */
+  getStats: handleUnaryCall<GetStatsRequest, GetStatsResponse>;
 }
 
 export interface ApplicationServiceClient extends Client {
@@ -3512,6 +3881,28 @@ export interface ApplicationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: ListApplicationsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Read-side: application counts grouped by status, scoped the same
+   * way List is (adopters see their own; staff see their rescue's;
+   * admins see all and may narrow by rescue/adopter). Powers the
+   * rescue dashboard's stats cards. Returns RAW per-service-status
+   * counts — the gateway collapses them to the SPA's 4-state shape.
+   */
+  getStats(
+    request: GetStatsRequest,
+    callback: (error: ServiceError | null, response: GetStatsResponse) => void
+  ): ClientUnaryCall;
+  getStats(
+    request: GetStatsRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetStatsResponse) => void
+  ): ClientUnaryCall;
+  getStats(
+    request: GetStatsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetStatsResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -131,6 +131,8 @@ export type {
   GetApplicationResponse,
   ListApplicationsRequest,
   ListApplicationsResponse,
+  GetStatsRequest,
+  GetStatsResponse,
   ApplicationServiceServer,
   ApplicationServiceClient,
 } from './generated/proto/adopt_dont_shop/applications/v1/application.js';

--- a/services/applications/src/grpc/server.test.ts
+++ b/services/applications/src/grpc/server.test.ts
@@ -37,7 +37,7 @@ const petsClient = {
 } as unknown as Parameters<typeof createGrpcServer>[0]['petsClient'];
 
 describe('createGrpcServer', () => {
-  it('registers all 12 ApplicationService methods on the grpc.Server', () => {
+  it('registers all 13 ApplicationService methods on the grpc.Server', () => {
     const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
@@ -55,6 +55,7 @@ describe('createGrpcServer', () => {
       'MarkAdopted',
       'Get',
       'List',
+      'GetStats',
     ]) {
       expect(handlers.has(`${base}/${method}`)).toBe(true);
     }

--- a/services/applications/src/grpc/server.ts
+++ b/services/applications/src/grpc/server.ts
@@ -37,6 +37,7 @@ import { adapt } from './adapter.js';
 import { makeStartDraft, saveDraftAnswers, submitDraft } from './handlers.js';
 import { createPetsClient, type PetsClient } from './pets-client.js';
 import { getApplication, listApplications } from './read-handlers.js';
+import { getStats } from './stats-handlers.js';
 import {
   approve,
   completeHomeVisit,
@@ -87,6 +88,8 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     // Query side (read-handlers.ts)
     get: adapt(getApplication, { deps, logger }),
     list: adapt(listApplications, { deps, logger }),
+    // Stats (stats-handlers.ts)
+    getStats: adapt(getStats, { deps, logger }),
   });
 
   logger.info('gRPC ApplicationService registered', {
@@ -103,6 +106,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'markAdopted',
       'get',
       'list',
+      'getStats',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/applications/src/grpc/stats-handlers.test.ts
+++ b/services/applications/src/grpc/stats-handlers.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { getStats } from './stats-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{
+    userId: string;
+    roles: string[];
+    permissions: string[];
+    rescueId: string;
+  }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['adopter'],
+    permissions: overrides.permissions ?? ['applications.read'],
+    ...(overrides.rescueId !== undefined ? { rescueId: overrides.rescueId } : {}),
+  } as unknown as Parameters<typeof getStats>[1];
+}
+
+function makeDeps(): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn();
+  const pool = { query } as unknown as HandlerDeps['pool'];
+  return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
+}
+
+describe('getStats', () => {
+  it('throws PERMISSION_DENIED without applications.read', async () => {
+    const { deps } = makeDeps();
+    await expect(getStats(deps, makePrincipal({ permissions: [] }), {})).rejects.toBeInstanceOf(
+      HandlerError
+    );
+  });
+
+  it('scopes an adopter to their own user id', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await getStats(deps, makePrincipal({ userId: 'usr-7' }), {});
+
+    const params = query.mock.calls[0][1] as unknown[];
+    expect(params).toEqual(['usr-7']);
+  });
+
+  it('pins rescue staff to their own rescue', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await getStats(
+      deps,
+      makePrincipal({ userId: 'staff-1', roles: ['rescue_staff'], rescueId: 'rsc-9' }),
+      {}
+    );
+
+    const params = query.mock.calls[0][1] as unknown[];
+    expect(params).toEqual(['rsc-9']);
+  });
+
+  it('lets super_admin narrow by rescue and adopter filter', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await getStats(deps, makePrincipal({ roles: ['super_admin'] }), {
+      rescueIdFilter: 'rsc-2',
+      adopterIdFilter: 'usr-3',
+    });
+
+    const params = query.mock.calls[0][1] as unknown[];
+    expect(params).toEqual(['rsc-2', 'usr-3']);
+  });
+
+  it('returns zero-filled counts when no rows exist', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await getStats(deps, makePrincipal(), {});
+
+    expect(res).toEqual({
+      total: 0,
+      draft: 0,
+      submitted: 0,
+      underReview: 0,
+      homeVisitScheduled: 0,
+      homeVisitCompleted: 0,
+      approved: 0,
+      rejected: 0,
+      withdrawn: 0,
+      adopted: 0,
+    });
+  });
+
+  it('maps grouped counts onto the per-status response and sums the total', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({
+      rows: [
+        { status: 'submitted', count: '4' },
+        { status: 'under_review', count: '2' },
+        { status: 'approved', count: '1' },
+      ],
+    });
+
+    const res = await getStats(deps, makePrincipal(), {});
+
+    expect(res.total).toBe(7);
+    expect(res.submitted).toBe(4);
+    expect(res.underReview).toBe(2);
+    expect(res.approved).toBe(1);
+    expect(res.rejected).toBe(0);
+    expect(res.draft).toBe(0);
+  });
+});

--- a/services/applications/src/grpc/stats-handlers.ts
+++ b/services/applications/src/grpc/stats-handlers.ts
@@ -1,0 +1,96 @@
+// gRPC handler — GetStats (read side).
+//
+// Application counts grouped by status for the rescue dashboard's
+// stats cards. Reads straight off the `applications` read-model row
+// (deps.pool, no transaction) — a single GROUP BY, no event-stream
+// fold needed because counts only depend on the projected `status`
+// column.
+//
+// Authz + scoping mirror listApplications exactly:
+//   - super_admin sees everything, may narrow by rescue/adopter filter,
+//   - rescue staff are pinned to their own rescue (may narrow to one
+//     adopter),
+//   - adopters see only their own applications.
+//
+// The response exposes RAW per-service-status counts (zero-filled for
+// statuses with no rows); the gateway collapses them to the SPA's
+// 4-state shape.
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import { APPLICATIONS_VIEW } from '@adopt-dont-shop/lib.types';
+import type { GetStatsRequest, GetStatsResponse } from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { ALL_APPLICATION_STATUSES, type ApplicationStatusDb } from './enum-map.js';
+
+// A grouped-count row from the GROUP BY. Postgres COUNT(*) comes back
+// as a string (bigint), so parse it.
+type StatusCountRow = {
+  status: string;
+  count: string;
+};
+
+export async function getStats(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetStatsRequest
+): Promise<GetStatsResponse> {
+  if (!requirePermission(principal, APPLICATIONS_VIEW)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
+  }
+
+  const where: string[] = ['deleted_at IS NULL'];
+  const params: unknown[] = [];
+  let p = 1;
+
+  // Scope the counted set to what the principal is allowed to see —
+  // identical to listApplications.
+  const isSuperAdmin = principal.roles.includes('super_admin');
+  if (isSuperAdmin) {
+    if (req.rescueIdFilter !== undefined && req.rescueIdFilter !== '') {
+      where.push(`rescue_id = $${p++}`);
+      params.push(req.rescueIdFilter);
+    }
+    if (req.adopterIdFilter !== undefined && req.adopterIdFilter !== '') {
+      where.push(`user_id = $${p++}`);
+      params.push(req.adopterIdFilter);
+    }
+  } else if (principal.rescueId !== undefined) {
+    where.push(`rescue_id = $${p++}`);
+    params.push(principal.rescueId);
+    if (req.adopterIdFilter !== undefined && req.adopterIdFilter !== '') {
+      where.push(`user_id = $${p++}`);
+      params.push(req.adopterIdFilter);
+    }
+  } else {
+    where.push(`user_id = $${p++}`);
+    params.push(principal.userId);
+  }
+
+  const sql = `
+    SELECT status, COUNT(*) AS count
+    FROM applications
+    WHERE ${where.join(' AND ')}
+    GROUP BY status
+  `;
+
+  const { rows } = await deps.pool.query<StatusCountRow>(sql, params);
+
+  const counts = new Map<string, number>(rows.map(row => [row.status, Number(row.count)]));
+  const countFor = (status: ApplicationStatusDb): number => counts.get(status) ?? 0;
+
+  const total = ALL_APPLICATION_STATUSES.reduce((sum, status) => sum + countFor(status), 0);
+
+  return {
+    total,
+    draft: countFor('draft'),
+    submitted: countFor('submitted'),
+    underReview: countFor('under_review'),
+    homeVisitScheduled: countFor('home_visit_scheduled'),
+    homeVisitCompleted: countFor('home_visit_completed'),
+    approved: countFor('approved'),
+    rejected: countFor('rejected'),
+    withdrawn: countFor('withdrawn'),
+    adopted: countFor('adopted'),
+  };
+}


### PR DESCRIPTION
## What

Adds a `GetStats` RPC to the applications microservice that returns application counts grouped by status, for the rescue dashboard's stats cards. Service-side only — the gateway route for stats is wired separately.

## Changes

- **proto** (`packages/proto/proto/.../application.proto`): add `rpc GetStats(GetStatsRequest) returns (GetStatsResponse)` plus the two messages. `GetStatsRequest` carries optional `rescue_id_filter` / `adopter_id_filter`; `GetStatsResponse` carries `total` + RAW per-service-status counts (draft … adopted). The gateway collapses these to the SPA's 4-state shape later, consistent with `applications-view.ts`.
- **generated TS**: regenerated via `buf generate` (+ prettier, matching the committed format) and re-exported `GetStatsRequest` / `GetStatsResponse` from the proto package index.
- **handler** (`services/applications/src/grpc/stats-handlers.ts`): mirrors `read-handlers.ts` — `APPLICATIONS_VIEW` permission gate and `listApplications` scoping rules (super_admin sees all and may narrow by rescue/adopter filter; rescue staff pinned to their own rescue; adopters to their own user id). Runs a single `SELECT status, COUNT(*) … WHERE deleted_at IS NULL AND <scope> GROUP BY status`, zero-filling missing statuses and summing the total.
- **server**: bind `getStats` in the `addService` map and the logged method list.
- **tests**: new `stats-handlers.test.ts` (gate denial, adopter/rescue/admin scoping params, zero-fill, grouped counts + total) and updated `server.test.ts` method-path assertions.

## Verification

- `buf generate` then `tsc --noEmit` in `packages/proto` and `services/applications` — clean.
- `vitest run --root services/applications` — 16 files / 155 tests green.
- `eslint` on changed files — clean.

Note: `packages/proto`'s `check:fresh` script reports the committed generated output as stale on `main` already (it diffs raw `buf generate` output against the committed prettier-formatted files); left untouched as out of scope.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_