### PR TITLE
feat(gateway): wire GET /api/v1/applications/stats → GetStats

### DIFF
--- a/services/gateway/src/grpc-clients/applications-client.ts
+++ b/services/gateway/src/grpc-clients/applications-client.ts
@@ -17,6 +17,8 @@ import {
   type CompleteHomeVisitResponse,
   type GetApplicationRequest,
   type GetApplicationResponse,
+  type GetStatsRequest,
+  type GetStatsResponse,
   type ListApplicationsRequest,
   type ListApplicationsResponse,
   type MarkAdoptedRequest,
@@ -59,6 +61,7 @@ export type ApplicationsClient = {
   markAdopted(req: MarkAdoptedRequest, metadata: Metadata): Promise<MarkAdoptedResponse>;
   get(req: GetApplicationRequest, metadata: Metadata): Promise<GetApplicationResponse>;
   list(req: ListApplicationsRequest, metadata: Metadata): Promise<ListApplicationsResponse>;
+  getStats(req: GetStatsRequest, metadata: Metadata): Promise<GetStatsResponse>;
   close(): void;
 };
 
@@ -102,6 +105,7 @@ export const createApplicationsClient = (
     markAdopted: (req, metadata) => callUnary(stub.markAdopted, req, metadata),
     get: (req, metadata) => callUnary(stub.get, req, metadata),
     list: (req, metadata) => callUnary(stub.list, req, metadata),
+    getStats: (req, metadata) => callUnary(stub.getStats, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/applications-view.test.ts
+++ b/services/gateway/src/routes/applications-view.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ApplicationsV1, type Application } from '@adopt-dont-shop/proto';
 
-import { applicationToView, isHiddenFromFrontend } from './applications-view.js';
+import { applicationToView, isHiddenFromFrontend, statsToView } from './applications-view.js';
 
 const S = ApplicationsV1.ApplicationStatus;
 
@@ -112,5 +112,30 @@ describe('applicationToView — data blob', () => {
     expect(applicationToView(makeApp({ answersJson: '{}' }))?.data).toBeUndefined();
     expect(applicationToView(makeApp({ answersJson: 'not-json' }))?.data).toBeUndefined();
     expect(applicationToView(makeApp({ answersJson: '[1,2]' }))?.data).toBeUndefined();
+  });
+});
+
+describe('statsToView — count collapse', () => {
+  it('excludes drafts from total, folds review/visit into underReview, adopted into approved', () => {
+    const view = statsToView({
+      total: 12,
+      draft: 2,
+      submitted: 4,
+      underReview: 1,
+      homeVisitScheduled: 1,
+      homeVisitCompleted: 1,
+      approved: 1,
+      rejected: 1,
+      withdrawn: 1,
+      adopted: 1,
+    });
+    expect(view).toEqual({
+      total: 10, // 12 - 2 drafts
+      submitted: 4,
+      underReview: 3, // 1 + 1 + 1
+      approved: 2, // approved + adopted
+      rejected: 1,
+      pendingReferences: 0,
+    });
   });
 });

--- a/services/gateway/src/routes/applications-view.ts
+++ b/services/gateway/src/routes/applications-view.ts
@@ -25,7 +25,7 @@
 // documents are separate Stage B follow-ups; so is the data migration
 // that must backfill the (currently empty) event store before any flip.
 
-import { ApplicationsV1, type Application } from '@adopt-dont-shop/proto';
+import { ApplicationsV1, type Application, type GetStatsResponse } from '@adopt-dont-shop/proto';
 
 type FrontendStatus = 'submitted' | 'approved' | 'rejected' | 'withdrawn';
 type FrontendStage = 'pending' | 'reviewing' | 'visiting' | 'deciding' | 'resolved' | 'withdrawn';
@@ -108,6 +108,36 @@ export function applicationToView(app: Application): ApplicationView | null {
   }
 
   return view;
+}
+
+// The frontend ApplicationStatsSchema — counts the rescue dashboard shows.
+export type StatsView = {
+  total: number;
+  submitted: number;
+  underReview: number;
+  approved: number;
+  rejected: number;
+  pendingReferences: number;
+};
+
+// Collapse the service's raw per-status counts (GetStats) onto the
+// frontend's stats shape, the same collapse `applicationToView` applies
+// to a single application:
+//   - drafts are not frontend-visible → excluded from `total`.
+//   - the review/visit states fold into `underReview`.
+//   - `adopted` counts as `approved`.
+//   - `pendingReferences` has no service equivalent → 0.
+export function statsToView(stats: GetStatsResponse): StatsView {
+  const underReview = stats.underReview + stats.homeVisitScheduled + stats.homeVisitCompleted;
+  const approved = stats.approved + stats.adopted;
+  return {
+    total: stats.total - stats.draft,
+    submitted: stats.submitted,
+    underReview,
+    approved,
+    rejected: stats.rejected,
+    pendingReferences: 0,
+  };
 }
 
 // answersJson is the opaque blob the write path stored (the frontend's

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -41,6 +41,7 @@ function makeClient(): {
     'markAdopted',
     'get',
     'list',
+    'getStats',
   ]) {
     mocks[m] = vi.fn();
   }
@@ -247,6 +248,36 @@ describe('applications routes', () => {
       headers: ADOPTER,
     });
     expect(res.statusCode).toBe(404);
+  });
+
+  it('GET /api/v1/applications/stats collapses the counts to the frontend stats shape', async () => {
+    mocks.getStats.mockResolvedValue({
+      total: 10,
+      draft: 2,
+      submitted: 3,
+      underReview: 1,
+      homeVisitScheduled: 1,
+      homeVisitCompleted: 1,
+      approved: 1,
+      rejected: 1,
+      withdrawn: 0,
+      adopted: 0,
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/applications/stats?rescue=rsc-1',
+      headers: STAFF,
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as { data: Record<string, number> }).data).toEqual({
+      total: 8, // 10 - 2 drafts
+      submitted: 3,
+      underReview: 3, // under_review + home_visit_scheduled + home_visit_completed
+      approved: 1,
+      rejected: 1,
+      pendingReferences: 0,
+    });
+    expect(mocks.getStats.mock.calls[0][0]).toMatchObject({ rescueIdFilter: 'rsc-1' });
   });
 
   it('POST orchestrates StartDraft→SaveDraftAnswers→SubmitDraft and returns the view', async () => {

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -11,6 +11,7 @@
 //   POST   /api/v1/applications              → StartDraft+SaveDraftAnswers+SubmitDraft
 //   PATCH  /api/v1/applications/:id/status   → Approve | Reject | Withdraw
 //   PUT    /api/v1/applications/:id/withdraw → Withdraw
+//   GET    /api/v1/applications/stats        → GetStats (collapsed counts)
 //   GET    /api/v1/applications              → List  (drafts filtered)
 //   GET    /api/v1/applications/:id          → Get   (draft → 404)
 //
@@ -45,7 +46,7 @@ import {
 
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
 
-import { applicationToView, type ApplicationView } from './applications-view.js';
+import { applicationToView, statsToView, type ApplicationView } from './applications-view.js';
 
 export type ApplicationsRoutesOptions = {
   client: ApplicationsClient;
@@ -332,6 +333,22 @@ export const registerApplicationsRoutes = async (
   );
 
   // ---------- Reads ----------
+
+  // Registered before /:id so the static `stats` segment wins over the
+  // param route. Collapses the service's raw per-status counts to the
+  // SPA's ApplicationStatsSchema, wrapped in `{ data }`.
+  app.get('/api/v1/applications/stats', { config: { rateLimit: RL_READ } }, async (req, reply) => {
+    const q = req.query as Record<string, string | undefined>;
+    try {
+      const res = await client.getStats(
+        { rescueIdFilter: q.rescue, adopterIdFilter: q.adopter },
+        buildMetadata(req)
+      );
+      return reply.send({ data: statsToView(res) });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
 
   app.get('/api/v1/applications', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;


### PR DESCRIPTION
## What

Completes the stats vertical end-to-end now that the service-side `GetStats` RPC (#942) is merged. The gateway client gains `getStats`, and a new `GET /api/v1/applications/stats` route calls it and **collapses** the raw per-service-status counts onto the frontend's `ApplicationStatsSchema`, in the `{ data }` envelope — consistent with the single-application `applicationToView` collapse:

- `total` excludes drafts (not frontend-visible)
- `underReview` = `under_review + home_visit_scheduled + home_visit_completed`
- `approved` = `approved + adopted`
- `pendingReferences` = `0` (no service equivalent)
- `submitted`, `rejected` pass through

Registered **before** `/:id` so the static `stats` segment wins over the param route.

**Flag still off** — no behaviour change.

## Tests

- `statsToView` unit test (drafts excluded from total; review/visit folded into `underReview`; `adopted`→`approved`).
- Route test: `GET /api/v1/applications/stats` returns the collapsed `{ data }` shape and threads the `rescue` filter.
- Full `services/gateway` suite green: **159 tests**; `tsc --noEmit` clean; eslint clean.

## Cutover status

This closes the small follow-up I flagged. Remaining for the applications cutover (all tracked in ADR 0002, **monolith untouched, flag off**): verify #941's monolith-schema assumptions; deferred Stage B (`PUT /:id` update, pagination, documents); the 13-integration migration (Stage D); monolith deletion (Stage E).

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_