### PR TITLE
feat(gateway): applications cutover readiness — PUT /:id update + runbook

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -15,6 +15,7 @@ decide in 10 seconds whether to escalate.
 | [`deploy-rollback.md`](./deploy-rollback.md)     | Bad deploy: image is live but error rate is up           |
 | [`migration-failure.md`](./migration-failure.md) | `service-backend-migrate` exited non-zero; backend won't start |
 | [`maintenance-mode.md`](./maintenance-mode.md)   | Planned outage, controlled brownout, or kill-switch needed |
+| [`applications-cutover.md`](./applications-cutover.md) | Flipping `/api/v1/applications/*` to the microservice (or rolling back) |
 
 ## On-call principles
 

--- a/docs/runbooks/applications-cutover.md
+++ b/docs/runbooks/applications-cutover.md
@@ -1,0 +1,110 @@
+# Applications strangler cutover
+
+How to move `/api/v1/applications/*` traffic from the residual monolith to
+`service.applications`, validate it, and roll back. Implements the flip of
+`CUTOVER_APPLICATIONS` from ADR 0002.
+
+**Default state:** `CUTOVER_APPLICATIONS=false`. The gateway does NOT register
+the applications routes, so `/api/v1/applications/*` proxies to the monolith —
+today's behaviour. Flipping the flag is the cutover; flipping it back is the
+rollback (instant, no data move).
+
+## ⚠️ Go / no-go — read before flipping
+
+The contract + backfill are ready, but the flip is **gated on data ownership**.
+Confirm ALL of these before enabling in any shared environment:
+
+1. **`service.applications` is deployed and healthy** and reachable from the
+   gateway at `APPLICATIONS_GRPC_URL` (default `service-applications:6005`).
+2. **The backfill has run** (see below) and the new event store's row count
+   matches `SELECT count(*) FROM public.applications WHERE deleted_at IS NULL`.
+   The backfill's schema assumptions are verified against the monolith models.
+3. **The 13 monolith integrations are migrated, OR you accept staleness.** This
+   is the real blocker. After the flip, the SPA's writes go to
+   `service.applications`; the monolith's `applications` table stops receiving
+   them. Anything in the monolith that still reads that table directly — GDPR
+   erasure, analytics, weekly-digest, admin export, user/rescue deletion
+   cascades, upload-ACL, etc. (ADR 0002 Gap 3) — will see **stale** data. Do
+   NOT flip in production until Stage D migrates those consumers off the model
+   (or a transitional event-sync keeps the monolith table current). Flipping in
+   a staging/preview environment to validate the contract is fine.
+4. **Known contract gaps are acceptable for the environment** (see "Known gaps").
+
+## Pre-flight
+
+```bash
+# 1. Deploy service.applications; confirm health + migrations.
+curl -fsS http://service-applications:5005/health/simple
+
+# 2. Run the one-off backfill (idempotent — safe to re-run). It synthesizes an
+#    event stream per monolith application into the event store and projects the
+#    read model. Reads public.applications + application_answers/_references.
+#    (Run mechanism — npm script vs scheduled job — TBD with the team; the
+#    script is services/applications/src/backfill/run-backfill.ts.)
+
+# 3. Reconcile counts (should match):
+psql "$DATABASE_URL" -c "SELECT count(*) FROM public.applications WHERE deleted_at IS NULL;"
+psql "$DATABASE_URL" -c "SELECT count(*) FROM applications;"  # the new read model
+```
+
+## Enable
+
+Set on the GATEWAY environment, then restart/redeploy the gateway:
+
+```bash
+CUTOVER_APPLICATIONS=true
+APPLICATIONS_GRPC_URL=service-applications:6005   # if not already set
+```
+
+The gateway now registers `/api/v1/applications/*` and serves it from the
+service; everything else still proxies to the monolith.
+
+## Validate (smoke, as a seeded adopter + rescue-staff persona)
+
+```
+GET   /api/v1/applications                  → 200, { data: [...] } (no drafts)
+GET   /api/v1/applications/stats?rescue=…    → 200, { data: { total, submitted, underReview, approved, rejected, pendingReferences } }
+GET   /api/v1/applications/:id               → 200, { data: {...} } (404 for a draft id)
+POST  /api/v1/applications                   → 201, { data: { status: 'submitted', … } }
+PATCH /api/v1/applications/:id/status        → 200 (approved/rejected/withdrawn)
+PUT   /api/v1/applications/:id/withdraw       → 200
+```
+
+Each response must satisfy the SPA's `ApplicationSchema` / `ApplicationStatsSchema`
+Zod parse — the gateway view adapter (`routes/applications-view.ts`) guarantees
+the shape. Open `app.client` and confirm the application list, detail, and
+submit flows render without an "Error loading applications" page.
+
+## Rollback
+
+```bash
+CUTOVER_APPLICATIONS=false   # restart the gateway
+```
+
+Instant: the routes deregister and `/api/v1/applications/*` proxies to the
+monolith again. No data move is needed — the monolith table was never deleted.
+(Writes made to `service.applications` while the flag was on remain only in the
+new store; if you flipped in production and took writes, reconcile before
+re-enabling — another reason not to flip prod before Stage D.)
+
+## Known gaps (as of the cutover-readiness milestone)
+
+- **Documents** — upload/list/remove. Service-side metadata RPCs are being added;
+  the gateway multipart + object-storage upload path is a remaining follow-up.
+  Until both land, document features 404 under the flag.
+- **`PUT /:id` update** behaviour change: the service only allows answer edits
+  while `draft` / `under_review`; editing a decided application returns 400
+  (the monolith allowed freer edits).
+- **List pagination** — the gateway returns the first page; the SPA's current
+  list methods don't pass a cursor, so this is not user-visible, but large
+  rescue inboxes are not yet paged.
+- **No NATS publish from the backfill** — historical applications are seeded
+  without re-emitting `applications.*` events (intentional; downstream
+  consumers already hold the monolith's history).
+
+## Per-vertical note
+
+The same `CUTOVER_<DOMAIN>` switch exists for every extracted vertical (auth,
+pets, rescue, moderation, matching, audit). Each needs its own contract audit +
+view adapter + this same go/no-go before its flag is flipped — applications is
+the worked example.

--- a/services/gateway/src/routes/applications.test.ts
+++ b/services/gateway/src/routes/applications.test.ts
@@ -350,6 +350,25 @@ describe('applications routes', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('PUT /:id (update) reads the current version then SaveDraftAnswers with the blob', async () => {
+    mocks.get.mockResolvedValue({ application: { ...SUBMITTED, version: 5 }, timeline: [] });
+    mocks.saveDraftAnswers.mockResolvedValue({ application: SUBMITTED });
+    const payload = { personalInfo: { firstName: 'Jo' } };
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/applications/app-1',
+      headers: ADOPTER,
+      payload,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mocks.get.mock.calls[0][0]).toMatchObject({ applicationId: 'app-1' });
+    expect(mocks.saveDraftAnswers.mock.calls[0][0]).toEqual({
+      applicationId: 'app-1',
+      expectedVersion: 5,
+      answersPatchJson: JSON.stringify(payload),
+    });
+  });
+
   it('PUT /:id/withdraw → Withdraw, returns the view', async () => {
     mocks.withdraw.mockResolvedValue({ application: SUBMITTED });
     const res = await app.inject({

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -9,6 +9,7 @@
 //   Frontend contract (what lib.applications calls) — responses use the
 //   collapsed view shape (applications-view.ts) in a `{ data }` envelope:
 //   POST   /api/v1/applications              → StartDraft+SaveDraftAnswers+SubmitDraft
+//   PUT    /api/v1/applications/:id          → Get(version)+SaveDraftAnswers (edit)
 //   PATCH  /api/v1/applications/:id/status   → Approve | Reject | Withdraw
 //   PUT    /api/v1/applications/:id/withdraw → Withdraw
 //   GET    /api/v1/applications/stats        → GetStats (collapsed counts)
@@ -156,6 +157,33 @@ export const registerApplicationsRoutes = async (
         const res = await client.withdraw(
           { applicationId: req.params.id, reason: b.reason as string | undefined },
           buildMetadata(req)
+        );
+        return sendView(reply, res.application);
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // PUT /:id — the SPA's updateApplication (edit answers). The frontend
+  // sends the whole ApplicationData blob without a version, so we Get the
+  // current version first, then SaveDraftAnswers with the blob. NOTE the
+  // behaviour change vs the monolith: the service only allows answer edits
+  // while the application is in `draft` / `under_review`; editing a
+  // decided application surfaces the service's INVALID_ARGUMENT as 400.
+  app.put<{ Params: { id: string } }>(
+    '/api/v1/applications/:id',
+    { config: { rateLimit: RL_WRITE } },
+    async (req, reply) => {
+      const b = (req.body ?? {}) as Record<string, unknown>;
+      const id = req.params.id;
+      const meta = buildMetadata(req);
+      try {
+        const current = await client.get({ applicationId: id, includeTimeline: false }, meta);
+        const version = current.application?.version ?? 0;
+        const res = await client.saveDraftAnswers(
+          { applicationId: id, expectedVersion: version, answersPatchJson: JSON.stringify(b) },
+          meta
         );
         return sendView(reply, res.application);
       } catch (err) {


### PR DESCRIPTION
## What

Gets the applications vertical **ready to migrate**: closes the tractable contract gap and documents the flip as a controlled operation. **Flag still off, monolith untouched.**

### `PUT /api/v1/applications/:id` (update)

The SPA's `updateApplication`. The frontend sends the whole `ApplicationData` blob without a version, so the gateway **Gets the current version, then SaveDraftAnswers** with the blob, returning `{ data: view }`. Documented behaviour change: the service only allows answer edits while `draft`/`under_review`, so editing a decided application returns **400** (the monolith allowed freer edits).

### Cutover runbook (`docs/runbooks/applications-cutover.md`)

The go/no-go + **enable / validate / rollback** procedure for `CUTOVER_APPLICATIONS`. It calls out the **real gate**: after the flip, SPA writes go to the service and the monolith's `applications` table goes stale, but the **13 monolith integrations still read that table** — so a *production* flip must wait on **Stage D** (migrate those consumers) or an event-sync; staging contract-validation is fine. Rollback is instant (flag off → traffic returns to the monolith; no data move). Added to the runbook index.

## Backfill verification (recorded)

Confirmed #941's assumptions against the live monolith models — `public.applications` + every column it reads, the 4-state `ApplicationStatus`, and `application_answers`/`application_references` all match. **Production-data risk cleared.**

## Where readiness stands

- ✅ Contract: list, get, stats, submit, status, withdraw, **update**
- ✅ Backfill verified
- ✅ Runbook (flip is a controlled, reversible op)
- 🔜 **Documents** — service-side metadata RPCs in flight (agent); gateway upload path is the last remaining gap
- ⛔ **Production flip gated on Stage D** (the 13 integrations) — documented, not a surprise at flip time

## Tests

- `PUT /:id` test: reads current version via Get, then SaveDraftAnswers with the JSON blob + threaded version.
- Full `services/gateway` suite green: **160 tests**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_