### PR TITLE
feat(applications): add application document metadata RPCs

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
+++ b/packages/proto/proto/adopt_dont_shop/applications/v1/application.proto
@@ -91,6 +91,21 @@ service ApplicationService {
   // rescue dashboard's stats cards. Returns RAW per-service-status
   // counts — the gateway collapses them to the SPA's 4-state shape.
   rpc GetStats(GetStatsRequest) returns (GetStatsResponse);
+
+  // Document metadata — append a row referencing an already-stored
+  // file URL. The gateway owns the multipart upload + object storage;
+  // this surface only persists the METADATA. Caller MUST hold
+  // applications.update for the application's rescue.
+  rpc AddDocument(AddDocumentRequest) returns (AddDocumentResponse);
+
+  // Document metadata — list the non-deleted documents attached to an
+  // application, scoped the same way Get is (adopter-owns OR rescue-
+  // staff-of-the-app's-rescue OR admin).
+  rpc ListDocuments(ListDocumentsRequest) returns (ListDocumentsResponse);
+
+  // Document metadata — soft-delete one document. Caller MUST hold
+  // applications.update for the application's rescue.
+  rpc RemoveDocument(RemoveDocumentRequest) returns (RemoveDocumentResponse);
 }
 
 // --- ENUMs — value lists mirror the Postgres types verbatim ----------
@@ -339,3 +354,48 @@ message GetStatsResponse {
   uint32 withdrawn = 9;
   uint32 adopted = 10;
 }
+
+// --- Documents -------------------------------------------------------
+
+// Document — metadata for a file attached to an application. The file
+// bytes live in object storage (owned by the gateway); this row only
+// references the stored `url`. Mirrors the SPA's Document shape.
+message Document {
+  string document_id = 1;
+  string application_id = 2;
+  string type = 3;
+  string filename = 4;
+  string url = 5;
+  optional uint32 size = 6;
+  optional string mime_type = 7;
+  string uploaded_at = 8;
+}
+
+message AddDocumentRequest {
+  string application_id = 1;
+  string type = 2;
+  string filename = 3;
+  // URL of the already-stored file (the caller owns the upload).
+  string url = 4;
+  optional uint32 size = 5;
+  optional string mime_type = 6;
+}
+
+message AddDocumentResponse {
+  Document document = 1;
+}
+
+message ListDocumentsRequest {
+  string application_id = 1;
+}
+
+message ListDocumentsResponse {
+  repeated Document documents = 1;
+}
+
+message RemoveDocumentRequest {
+  string application_id = 1;
+  string document_id = 2;
+}
+
+message RemoveDocumentResponse {}

--- a/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/applications/v1/application.ts
@@ -370,6 +370,51 @@ export interface GetStatsResponse {
   adopted: number;
 }
 
+/**
+ * Document — metadata for a file attached to an application. The file
+ * bytes live in object storage (owned by the gateway); this row only
+ * references the stored `url`. Mirrors the SPA's Document shape.
+ */
+export interface Document {
+  documentId: string;
+  applicationId: string;
+  type: string;
+  filename: string;
+  url: string;
+  size?: number | undefined;
+  mimeType?: string | undefined;
+  uploadedAt: string;
+}
+
+export interface AddDocumentRequest {
+  applicationId: string;
+  type: string;
+  filename: string;
+  /** URL of the already-stored file (the caller owns the upload). */
+  url: string;
+  size?: number | undefined;
+  mimeType?: string | undefined;
+}
+
+export interface AddDocumentResponse {
+  document?: Document | undefined;
+}
+
+export interface ListDocumentsRequest {
+  applicationId: string;
+}
+
+export interface ListDocumentsResponse {
+  documents: Document[];
+}
+
+export interface RemoveDocumentRequest {
+  applicationId: string;
+  documentId: string;
+}
+
+export interface RemoveDocumentResponse {}
+
 function createBaseApplication(): Application {
   return {
     applicationId: '',
@@ -3306,6 +3351,684 @@ export const GetStatsResponse: MessageFns<GetStatsResponse> = {
   },
 };
 
+function createBaseDocument(): Document {
+  return {
+    documentId: '',
+    applicationId: '',
+    type: '',
+    filename: '',
+    url: '',
+    size: undefined,
+    mimeType: undefined,
+    uploadedAt: '',
+  };
+}
+
+export const Document: MessageFns<Document> = {
+  encode(message: Document, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.documentId !== '') {
+      writer.uint32(10).string(message.documentId);
+    }
+    if (message.applicationId !== '') {
+      writer.uint32(18).string(message.applicationId);
+    }
+    if (message.type !== '') {
+      writer.uint32(26).string(message.type);
+    }
+    if (message.filename !== '') {
+      writer.uint32(34).string(message.filename);
+    }
+    if (message.url !== '') {
+      writer.uint32(42).string(message.url);
+    }
+    if (message.size !== undefined) {
+      writer.uint32(48).uint32(message.size);
+    }
+    if (message.mimeType !== undefined) {
+      writer.uint32(58).string(message.mimeType);
+    }
+    if (message.uploadedAt !== '') {
+      writer.uint32(66).string(message.uploadedAt);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): Document {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDocument();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.documentId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.applicationId = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.type = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.filename = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.url = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.size = reader.uint32();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.mimeType = reader.string();
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.uploadedAt = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Document {
+    return {
+      documentId: isSet(object.documentId)
+        ? globalThis.String(object.documentId)
+        : isSet(object.document_id)
+          ? globalThis.String(object.document_id)
+          : '',
+      applicationId: isSet(object.applicationId)
+        ? globalThis.String(object.applicationId)
+        : isSet(object.application_id)
+          ? globalThis.String(object.application_id)
+          : '',
+      type: isSet(object.type) ? globalThis.String(object.type) : '',
+      filename: isSet(object.filename) ? globalThis.String(object.filename) : '',
+      url: isSet(object.url) ? globalThis.String(object.url) : '',
+      size: isSet(object.size) ? globalThis.Number(object.size) : undefined,
+      mimeType: isSet(object.mimeType)
+        ? globalThis.String(object.mimeType)
+        : isSet(object.mime_type)
+          ? globalThis.String(object.mime_type)
+          : undefined,
+      uploadedAt: isSet(object.uploadedAt)
+        ? globalThis.String(object.uploadedAt)
+        : isSet(object.uploaded_at)
+          ? globalThis.String(object.uploaded_at)
+          : '',
+    };
+  },
+
+  toJSON(message: Document): unknown {
+    const obj: any = {};
+    if (message.documentId !== '') {
+      obj.documentId = message.documentId;
+    }
+    if (message.applicationId !== '') {
+      obj.applicationId = message.applicationId;
+    }
+    if (message.type !== '') {
+      obj.type = message.type;
+    }
+    if (message.filename !== '') {
+      obj.filename = message.filename;
+    }
+    if (message.url !== '') {
+      obj.url = message.url;
+    }
+    if (message.size !== undefined) {
+      obj.size = Math.round(message.size);
+    }
+    if (message.mimeType !== undefined) {
+      obj.mimeType = message.mimeType;
+    }
+    if (message.uploadedAt !== '') {
+      obj.uploadedAt = message.uploadedAt;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Document>, I>>(base?: I): Document {
+    return Document.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Document>, I>>(object: I): Document {
+    const message = createBaseDocument();
+    message.documentId = object.documentId ?? '';
+    message.applicationId = object.applicationId ?? '';
+    message.type = object.type ?? '';
+    message.filename = object.filename ?? '';
+    message.url = object.url ?? '';
+    message.size = object.size ?? undefined;
+    message.mimeType = object.mimeType ?? undefined;
+    message.uploadedAt = object.uploadedAt ?? '';
+    return message;
+  },
+};
+
+function createBaseAddDocumentRequest(): AddDocumentRequest {
+  return {
+    applicationId: '',
+    type: '',
+    filename: '',
+    url: '',
+    size: undefined,
+    mimeType: undefined,
+  };
+}
+
+export const AddDocumentRequest: MessageFns<AddDocumentRequest> = {
+  encode(message: AddDocumentRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.applicationId !== '') {
+      writer.uint32(10).string(message.applicationId);
+    }
+    if (message.type !== '') {
+      writer.uint32(18).string(message.type);
+    }
+    if (message.filename !== '') {
+      writer.uint32(26).string(message.filename);
+    }
+    if (message.url !== '') {
+      writer.uint32(34).string(message.url);
+    }
+    if (message.size !== undefined) {
+      writer.uint32(40).uint32(message.size);
+    }
+    if (message.mimeType !== undefined) {
+      writer.uint32(50).string(message.mimeType);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AddDocumentRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAddDocumentRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.applicationId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.type = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.filename = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.url = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.size = reader.uint32();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.mimeType = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AddDocumentRequest {
+    return {
+      applicationId: isSet(object.applicationId)
+        ? globalThis.String(object.applicationId)
+        : isSet(object.application_id)
+          ? globalThis.String(object.application_id)
+          : '',
+      type: isSet(object.type) ? globalThis.String(object.type) : '',
+      filename: isSet(object.filename) ? globalThis.String(object.filename) : '',
+      url: isSet(object.url) ? globalThis.String(object.url) : '',
+      size: isSet(object.size) ? globalThis.Number(object.size) : undefined,
+      mimeType: isSet(object.mimeType)
+        ? globalThis.String(object.mimeType)
+        : isSet(object.mime_type)
+          ? globalThis.String(object.mime_type)
+          : undefined,
+    };
+  },
+
+  toJSON(message: AddDocumentRequest): unknown {
+    const obj: any = {};
+    if (message.applicationId !== '') {
+      obj.applicationId = message.applicationId;
+    }
+    if (message.type !== '') {
+      obj.type = message.type;
+    }
+    if (message.filename !== '') {
+      obj.filename = message.filename;
+    }
+    if (message.url !== '') {
+      obj.url = message.url;
+    }
+    if (message.size !== undefined) {
+      obj.size = Math.round(message.size);
+    }
+    if (message.mimeType !== undefined) {
+      obj.mimeType = message.mimeType;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AddDocumentRequest>, I>>(base?: I): AddDocumentRequest {
+    return AddDocumentRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AddDocumentRequest>, I>>(object: I): AddDocumentRequest {
+    const message = createBaseAddDocumentRequest();
+    message.applicationId = object.applicationId ?? '';
+    message.type = object.type ?? '';
+    message.filename = object.filename ?? '';
+    message.url = object.url ?? '';
+    message.size = object.size ?? undefined;
+    message.mimeType = object.mimeType ?? undefined;
+    return message;
+  },
+};
+
+function createBaseAddDocumentResponse(): AddDocumentResponse {
+  return { document: undefined };
+}
+
+export const AddDocumentResponse: MessageFns<AddDocumentResponse> = {
+  encode(message: AddDocumentResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.document !== undefined) {
+      Document.encode(message.document, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): AddDocumentResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAddDocumentResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.document = Document.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): AddDocumentResponse {
+    return { document: isSet(object.document) ? Document.fromJSON(object.document) : undefined };
+  },
+
+  toJSON(message: AddDocumentResponse): unknown {
+    const obj: any = {};
+    if (message.document !== undefined) {
+      obj.document = Document.toJSON(message.document);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<AddDocumentResponse>, I>>(base?: I): AddDocumentResponse {
+    return AddDocumentResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<AddDocumentResponse>, I>>(
+    object: I
+  ): AddDocumentResponse {
+    const message = createBaseAddDocumentResponse();
+    message.document =
+      object.document !== undefined && object.document !== null
+        ? Document.fromPartial(object.document)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseListDocumentsRequest(): ListDocumentsRequest {
+  return { applicationId: '' };
+}
+
+export const ListDocumentsRequest: MessageFns<ListDocumentsRequest> = {
+  encode(message: ListDocumentsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.applicationId !== '') {
+      writer.uint32(10).string(message.applicationId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ListDocumentsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListDocumentsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.applicationId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListDocumentsRequest {
+    return {
+      applicationId: isSet(object.applicationId)
+        ? globalThis.String(object.applicationId)
+        : isSet(object.application_id)
+          ? globalThis.String(object.application_id)
+          : '',
+    };
+  },
+
+  toJSON(message: ListDocumentsRequest): unknown {
+    const obj: any = {};
+    if (message.applicationId !== '') {
+      obj.applicationId = message.applicationId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListDocumentsRequest>, I>>(base?: I): ListDocumentsRequest {
+    return ListDocumentsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListDocumentsRequest>, I>>(
+    object: I
+  ): ListDocumentsRequest {
+    const message = createBaseListDocumentsRequest();
+    message.applicationId = object.applicationId ?? '';
+    return message;
+  },
+};
+
+function createBaseListDocumentsResponse(): ListDocumentsResponse {
+  return { documents: [] };
+}
+
+export const ListDocumentsResponse: MessageFns<ListDocumentsResponse> = {
+  encode(message: ListDocumentsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.documents) {
+      Document.encode(v!, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ListDocumentsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListDocumentsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.documents.push(Document.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListDocumentsResponse {
+    return {
+      documents: globalThis.Array.isArray(object?.documents)
+        ? object.documents.map((e: any) => Document.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: ListDocumentsResponse): unknown {
+    const obj: any = {};
+    if (message.documents?.length) {
+      obj.documents = message.documents.map(e => Document.toJSON(e));
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListDocumentsResponse>, I>>(base?: I): ListDocumentsResponse {
+    return ListDocumentsResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListDocumentsResponse>, I>>(
+    object: I
+  ): ListDocumentsResponse {
+    const message = createBaseListDocumentsResponse();
+    message.documents = object.documents?.map(e => Document.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseRemoveDocumentRequest(): RemoveDocumentRequest {
+  return { applicationId: '', documentId: '' };
+}
+
+export const RemoveDocumentRequest: MessageFns<RemoveDocumentRequest> = {
+  encode(message: RemoveDocumentRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.applicationId !== '') {
+      writer.uint32(10).string(message.applicationId);
+    }
+    if (message.documentId !== '') {
+      writer.uint32(18).string(message.documentId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RemoveDocumentRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRemoveDocumentRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.applicationId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.documentId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RemoveDocumentRequest {
+    return {
+      applicationId: isSet(object.applicationId)
+        ? globalThis.String(object.applicationId)
+        : isSet(object.application_id)
+          ? globalThis.String(object.application_id)
+          : '',
+      documentId: isSet(object.documentId)
+        ? globalThis.String(object.documentId)
+        : isSet(object.document_id)
+          ? globalThis.String(object.document_id)
+          : '',
+    };
+  },
+
+  toJSON(message: RemoveDocumentRequest): unknown {
+    const obj: any = {};
+    if (message.applicationId !== '') {
+      obj.applicationId = message.applicationId;
+    }
+    if (message.documentId !== '') {
+      obj.documentId = message.documentId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RemoveDocumentRequest>, I>>(base?: I): RemoveDocumentRequest {
+    return RemoveDocumentRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RemoveDocumentRequest>, I>>(
+    object: I
+  ): RemoveDocumentRequest {
+    const message = createBaseRemoveDocumentRequest();
+    message.applicationId = object.applicationId ?? '';
+    message.documentId = object.documentId ?? '';
+    return message;
+  },
+};
+
+function createBaseRemoveDocumentResponse(): RemoveDocumentResponse {
+  return {};
+}
+
+export const RemoveDocumentResponse: MessageFns<RemoveDocumentResponse> = {
+  encode(_: RemoveDocumentResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RemoveDocumentResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRemoveDocumentResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): RemoveDocumentResponse {
+    return {};
+  },
+
+  toJSON(_: RemoveDocumentResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RemoveDocumentResponse>, I>>(
+    base?: I
+  ): RemoveDocumentResponse {
+    return RemoveDocumentResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RemoveDocumentResponse>, I>>(
+    _: I
+  ): RemoveDocumentResponse {
+    const message = createBaseRemoveDocumentResponse();
+    return message;
+  },
+};
+
 /**
  * ApplicationService is the gRPC contract for the applications
  * vertical — the EVENT-SOURCED extraction. Owns the `applications.*`
@@ -3552,6 +4275,57 @@ export const ApplicationServiceService = {
       Buffer.from(GetStatsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): GetStatsResponse => GetStatsResponse.decode(value),
   },
+  /**
+   * Document metadata — append a row referencing an already-stored
+   * file URL. The gateway owns the multipart upload + object storage;
+   * this surface only persists the METADATA. Caller MUST hold
+   * applications.update for the application's rescue.
+   */
+  addDocument: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/AddDocument' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: AddDocumentRequest): Buffer =>
+      Buffer.from(AddDocumentRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): AddDocumentRequest => AddDocumentRequest.decode(value),
+    responseSerialize: (value: AddDocumentResponse): Buffer =>
+      Buffer.from(AddDocumentResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): AddDocumentResponse => AddDocumentResponse.decode(value),
+  },
+  /**
+   * Document metadata — list the non-deleted documents attached to an
+   * application, scoped the same way Get is (adopter-owns OR rescue-
+   * staff-of-the-app's-rescue OR admin).
+   */
+  listDocuments: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/ListDocuments' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: ListDocumentsRequest): Buffer =>
+      Buffer.from(ListDocumentsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): ListDocumentsRequest => ListDocumentsRequest.decode(value),
+    responseSerialize: (value: ListDocumentsResponse): Buffer =>
+      Buffer.from(ListDocumentsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): ListDocumentsResponse =>
+      ListDocumentsResponse.decode(value),
+  },
+  /**
+   * Document metadata — soft-delete one document. Caller MUST hold
+   * applications.update for the application's rescue.
+   */
+  removeDocument: {
+    path: '/adopt_dont_shop.applications.v1.ApplicationService/RemoveDocument' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: RemoveDocumentRequest): Buffer =>
+      Buffer.from(RemoveDocumentRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): RemoveDocumentRequest =>
+      RemoveDocumentRequest.decode(value),
+    responseSerialize: (value: RemoveDocumentResponse): Buffer =>
+      Buffer.from(RemoveDocumentResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): RemoveDocumentResponse =>
+      RemoveDocumentResponse.decode(value),
+  },
 } as const;
 
 export interface ApplicationServiceServer extends UntypedServiceImplementation {
@@ -3637,6 +4411,24 @@ export interface ApplicationServiceServer extends UntypedServiceImplementation {
    * counts — the gateway collapses them to the SPA's 4-state shape.
    */
   getStats: handleUnaryCall<GetStatsRequest, GetStatsResponse>;
+  /**
+   * Document metadata — append a row referencing an already-stored
+   * file URL. The gateway owns the multipart upload + object storage;
+   * this surface only persists the METADATA. Caller MUST hold
+   * applications.update for the application's rescue.
+   */
+  addDocument: handleUnaryCall<AddDocumentRequest, AddDocumentResponse>;
+  /**
+   * Document metadata — list the non-deleted documents attached to an
+   * application, scoped the same way Get is (adopter-owns OR rescue-
+   * staff-of-the-app's-rescue OR admin).
+   */
+  listDocuments: handleUnaryCall<ListDocumentsRequest, ListDocumentsResponse>;
+  /**
+   * Document metadata — soft-delete one document. Caller MUST hold
+   * applications.update for the application's rescue.
+   */
+  removeDocument: handleUnaryCall<RemoveDocumentRequest, RemoveDocumentResponse>;
 }
 
 export interface ApplicationServiceClient extends Client {
@@ -3903,6 +4695,66 @@ export interface ApplicationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: GetStatsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Document metadata — append a row referencing an already-stored
+   * file URL. The gateway owns the multipart upload + object storage;
+   * this surface only persists the METADATA. Caller MUST hold
+   * applications.update for the application's rescue.
+   */
+  addDocument(
+    request: AddDocumentRequest,
+    callback: (error: ServiceError | null, response: AddDocumentResponse) => void
+  ): ClientUnaryCall;
+  addDocument(
+    request: AddDocumentRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: AddDocumentResponse) => void
+  ): ClientUnaryCall;
+  addDocument(
+    request: AddDocumentRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: AddDocumentResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Document metadata — list the non-deleted documents attached to an
+   * application, scoped the same way Get is (adopter-owns OR rescue-
+   * staff-of-the-app's-rescue OR admin).
+   */
+  listDocuments(
+    request: ListDocumentsRequest,
+    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void
+  ): ClientUnaryCall;
+  listDocuments(
+    request: ListDocumentsRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void
+  ): ClientUnaryCall;
+  listDocuments(
+    request: ListDocumentsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: ListDocumentsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Document metadata — soft-delete one document. Caller MUST hold
+   * applications.update for the application's rescue.
+   */
+  removeDocument(
+    request: RemoveDocumentRequest,
+    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void
+  ): ClientUnaryCall;
+  removeDocument(
+    request: RemoveDocumentRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void
+  ): ClientUnaryCall;
+  removeDocument(
+    request: RemoveDocumentRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: RemoveDocumentResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -133,6 +133,13 @@ export type {
   ListApplicationsResponse,
   GetStatsRequest,
   GetStatsResponse,
+  Document,
+  AddDocumentRequest,
+  AddDocumentResponse,
+  ListDocumentsRequest,
+  ListDocumentsResponse,
+  RemoveDocumentRequest,
+  RemoveDocumentResponse,
   ApplicationServiceServer,
   ApplicationServiceClient,
 } from './generated/proto/adopt_dont_shop/applications/v1/application.js';

--- a/services/applications/src/grpc/document-handlers.test.ts
+++ b/services/applications/src/grpc/document-handlers.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+import { addDocument, listDocuments, removeDocument } from './document-handlers.js';
+
+function makePrincipal(
+  overrides: Partial<{
+    userId: string;
+    roles: string[];
+    permissions: string[];
+    rescueId: string;
+  }> = {}
+) {
+  return {
+    userId: overrides.userId ?? 'usr-1',
+    roles: overrides.roles ?? ['adopter'],
+    permissions: overrides.permissions ?? ['applications.read', 'applications.update'],
+    ...(overrides.rescueId !== undefined ? { rescueId: overrides.rescueId } : {}),
+  } as unknown as Parameters<typeof addDocument>[1];
+}
+
+function makeDeps(): { deps: HandlerDeps; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn();
+  const pool = { query } as unknown as HandlerDeps['pool'];
+  return { deps: { pool, nats: {} } as unknown as HandlerDeps, query };
+}
+
+const documentRow = {
+  document_id: 'doc-1',
+  application_id: 'app-1',
+  type: 'reference',
+  filename: 'ref.pdf',
+  url: 'https://files/ref.pdf',
+  size: 2048,
+  mime_type: 'application/pdf',
+  created_at: new Date('2026-06-06T10:00:00.000Z'),
+};
+
+describe('addDocument', () => {
+  it('throws PERMISSION_DENIED without applications.update', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      addDocument(deps, makePrincipal({ permissions: ['applications.read'] }), {
+        applicationId: 'app-1',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'https://files/ref.pdf',
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('throws INVALID_ARGUMENT when application_id is empty', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      addDocument(deps, makePrincipal(), {
+        applicationId: '',
+        type: 'reference',
+        filename: 'ref.pdf',
+        url: 'https://files/ref.pdf',
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('inserts the metadata row and returns the mapped Document', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [documentRow] });
+
+    const res = await addDocument(deps, makePrincipal({ userId: 'usr-9' }), {
+      applicationId: 'app-1',
+      type: 'reference',
+      filename: 'ref.pdf',
+      url: 'https://files/ref.pdf',
+      size: 2048,
+      mimeType: 'application/pdf',
+    });
+
+    const params = query.mock.calls[0][1] as unknown[];
+    // application_id, type, filename, url, size, mime_type, uploaded_by
+    expect(params.slice(1)).toEqual([
+      'app-1',
+      'reference',
+      'ref.pdf',
+      'https://files/ref.pdf',
+      2048,
+      'application/pdf',
+      'usr-9',
+    ]);
+    expect(res.document).toEqual({
+      documentId: 'doc-1',
+      applicationId: 'app-1',
+      type: 'reference',
+      filename: 'ref.pdf',
+      url: 'https://files/ref.pdf',
+      size: 2048,
+      mimeType: 'application/pdf',
+      uploadedAt: '2026-06-06T10:00:00.000Z',
+    });
+  });
+
+  it('persists null for omitted size / mime_type', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({
+      rows: [{ ...documentRow, size: null, mime_type: null }],
+    });
+
+    const res = await addDocument(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      type: 'reference',
+      filename: 'ref.pdf',
+      url: 'https://files/ref.pdf',
+    });
+
+    const params = query.mock.calls[0][1] as unknown[];
+    expect(params[5]).toBeNull();
+    expect(params[6]).toBeNull();
+    expect(res.document?.size).toBeUndefined();
+    expect(res.document?.mimeType).toBeUndefined();
+  });
+});
+
+describe('listDocuments', () => {
+  it('throws NOT_FOUND when the application does not exist', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      listDocuments(deps, makePrincipal(), { applicationId: 'missing' })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('denies an adopter who is not the application owner', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rows: [{ user_id: 'someone-else', rescue_id: 'rsc-1' }] });
+
+    await expect(
+      listDocuments(deps, makePrincipal({ userId: 'usr-1' }), { applicationId: 'app-1' })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('lets the owning adopter list their documents', async () => {
+    const { deps, query } = makeDeps();
+    query
+      .mockResolvedValueOnce({ rows: [{ user_id: 'usr-1', rescue_id: 'rsc-1' }] })
+      .mockResolvedValueOnce({ rows: [documentRow] });
+
+    const res = await listDocuments(deps, makePrincipal({ userId: 'usr-1' }), {
+      applicationId: 'app-1',
+    });
+
+    expect(res.documents).toHaveLength(1);
+    expect(res.documents[0].documentId).toBe('doc-1');
+  });
+
+  it('lets rescue staff of the application rescue list documents', async () => {
+    const { deps, query } = makeDeps();
+    query
+      .mockResolvedValueOnce({ rows: [{ user_id: 'other', rescue_id: 'rsc-9' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await listDocuments(
+      deps,
+      makePrincipal({ userId: 'staff-1', roles: ['rescue_staff'], rescueId: 'rsc-9' }),
+      { applicationId: 'app-1' }
+    );
+
+    expect(res.documents).toEqual([]);
+  });
+});
+
+describe('removeDocument', () => {
+  it('throws PERMISSION_DENIED without applications.update', async () => {
+    const { deps } = makeDeps();
+    await expect(
+      removeDocument(deps, makePrincipal({ permissions: ['applications.read'] }), {
+        applicationId: 'app-1',
+        documentId: 'doc-1',
+      })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+
+  it('soft-deletes the document and returns an empty response', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rowCount: 1 });
+
+    const res = await removeDocument(deps, makePrincipal(), {
+      applicationId: 'app-1',
+      documentId: 'doc-1',
+    });
+
+    const params = query.mock.calls[0][1] as unknown[];
+    expect(params).toEqual(['doc-1', 'app-1']);
+    expect(res).toEqual({});
+  });
+
+  it('throws NOT_FOUND when no live document matches', async () => {
+    const { deps, query } = makeDeps();
+    query.mockResolvedValueOnce({ rowCount: 0 });
+
+    await expect(
+      removeDocument(deps, makePrincipal(), { applicationId: 'app-1', documentId: 'gone' })
+    ).rejects.toBeInstanceOf(HandlerError);
+  });
+});

--- a/services/applications/src/grpc/document-handlers.ts
+++ b/services/applications/src/grpc/document-handlers.ts
@@ -1,0 +1,177 @@
+// gRPC handlers — application document METADATA (read + write).
+//
+// Document rows reference a file already stored in object storage (the
+// gateway owns the multipart upload + storage); this surface only
+// persists / reads / soft-deletes the metadata row. Mirrors the SPA's
+// Document shape.
+//
+// All three run OUTSIDE a transaction (straight off deps.pool) — a
+// single INSERT / SELECT / UPDATE each.
+//
+// Authz:
+//   - addDocument / removeDocument: gate APPLICATIONS_UPDATE (same plain
+//     gate the write handlers use; the rescue owns the application).
+//   - listDocuments: gate APPLICATIONS_VIEW with the SAME owner / rescue /
+//     admin scoping as getApplication — read the application's user_id /
+//     rescue_id from the read model, then adopter-owns OR rescue-staff-of-
+//     this-rescue OR admin.
+
+import { randomUUID } from 'node:crypto';
+
+import { requirePermission, type Principal } from '@adopt-dont-shop/authz';
+import {
+  APPLICATIONS_UPDATE,
+  APPLICATIONS_VIEW,
+  type RescueId,
+  type UserId,
+} from '@adopt-dont-shop/lib.types';
+import type {
+  AddDocumentRequest,
+  AddDocumentResponse,
+  Document,
+  ListDocumentsRequest,
+  ListDocumentsResponse,
+  RemoveDocumentRequest,
+  RemoveDocumentResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './adapter.js';
+
+// A document metadata row as stored. size / mime_type / uploaded_by are
+// nullable; created_at is the canonical upload timestamp.
+type DocumentRow = {
+  document_id: string;
+  application_id: string;
+  type: string;
+  filename: string;
+  url: string;
+  size: number | null;
+  mime_type: string | null;
+  created_at: Date;
+};
+
+// The slice of the applications read model needed to scope a read.
+type OwnerRow = {
+  user_id: string;
+  rescue_id: string;
+};
+
+function rowToProto(row: DocumentRow): Document {
+  const doc: Document = {
+    documentId: row.document_id,
+    applicationId: row.application_id,
+    type: row.type,
+    filename: row.filename,
+    url: row.url,
+    uploadedAt: row.created_at.toISOString(),
+  };
+  if (row.size !== null) {
+    doc.size = row.size;
+  }
+  if (row.mime_type !== null) {
+    doc.mimeType = row.mime_type;
+  }
+  return doc;
+}
+
+// --- AddDocument -----------------------------------------------------
+
+export async function addDocument(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: AddDocumentRequest
+): Promise<AddDocumentResponse> {
+  if (!requirePermission(principal, APPLICATIONS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_UPDATE}' required`);
+  }
+  if (req.applicationId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
+  }
+
+  const sql = `
+    INSERT INTO application_documents
+      (document_id, application_id, type, filename, url, size, mime_type, uploaded_by)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    RETURNING document_id, application_id, type, filename, url, size, mime_type, created_at
+  `;
+  const params = [
+    randomUUID(),
+    req.applicationId,
+    req.type,
+    req.filename,
+    req.url,
+    req.size ?? null,
+    req.mimeType ?? null,
+    principal.userId,
+  ];
+
+  const { rows } = await deps.pool.query<DocumentRow>(sql, params);
+
+  return { document: rowToProto(rows[0]) };
+}
+
+// --- ListDocuments ---------------------------------------------------
+
+export async function listDocuments(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListDocumentsRequest
+): Promise<ListDocumentsResponse> {
+  if (req.applicationId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
+  }
+
+  // Scope from the application's owner / rescue — the read model row.
+  const owner = await deps.pool.query<OwnerRow>(
+    `SELECT user_id, rescue_id FROM applications WHERE application_id = $1 AND deleted_at IS NULL`,
+    [req.applicationId]
+  );
+  if (owner.rows.length === 0) {
+    throw new HandlerError('NOT_FOUND', 'application not found');
+  }
+
+  const { user_id, rescue_id } = owner.rows[0];
+  const canRead =
+    requirePermission(principal, APPLICATIONS_VIEW, { userId: user_id as UserId }) ||
+    requirePermission(principal, APPLICATIONS_VIEW, { rescueId: rescue_id as RescueId });
+  if (!canRead) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_VIEW}' required`);
+  }
+
+  const { rows } = await deps.pool.query<DocumentRow>(
+    `SELECT document_id, application_id, type, filename, url, size, mime_type, created_at
+       FROM application_documents
+      WHERE application_id = $1 AND deleted_at IS NULL
+      ORDER BY created_at ASC`,
+    [req.applicationId]
+  );
+
+  return { documents: rows.map(rowToProto) };
+}
+
+// --- RemoveDocument --------------------------------------------------
+
+export async function removeDocument(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: RemoveDocumentRequest
+): Promise<RemoveDocumentResponse> {
+  if (!requirePermission(principal, APPLICATIONS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${APPLICATIONS_UPDATE}' required`);
+  }
+  if (req.documentId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'document_id is required');
+  }
+
+  const { rowCount } = await deps.pool.query(
+    `UPDATE application_documents
+        SET deleted_at = now()
+      WHERE document_id = $1 AND application_id = $2 AND deleted_at IS NULL`,
+    [req.documentId, req.applicationId]
+  );
+  if (rowCount === 0) {
+    throw new HandlerError('NOT_FOUND', 'document not found');
+  }
+
+  return {};
+}

--- a/services/applications/src/grpc/server.test.ts
+++ b/services/applications/src/grpc/server.test.ts
@@ -37,7 +37,7 @@ const petsClient = {
 } as unknown as Parameters<typeof createGrpcServer>[0]['petsClient'];
 
 describe('createGrpcServer', () => {
-  it('registers all 13 ApplicationService methods on the grpc.Server', () => {
+  it('registers all 16 ApplicationService methods on the grpc.Server', () => {
     const server = createGrpcServer({ config, pool, nats, logger: quietLogger, petsClient });
     const handlers = (server as unknown as { handlers: Map<string, unknown> }).handlers;
 
@@ -56,6 +56,9 @@ describe('createGrpcServer', () => {
       'Get',
       'List',
       'GetStats',
+      'AddDocument',
+      'ListDocuments',
+      'RemoveDocument',
     ]) {
       expect(handlers.has(`${base}/${method}`)).toBe(true);
     }

--- a/services/applications/src/grpc/server.ts
+++ b/services/applications/src/grpc/server.ts
@@ -36,6 +36,7 @@ import type { ApplicationsConfig } from '../config.js';
 import { adapt } from './adapter.js';
 import { makeStartDraft, saveDraftAnswers, submitDraft } from './handlers.js';
 import { createPetsClient, type PetsClient } from './pets-client.js';
+import { addDocument, listDocuments, removeDocument } from './document-handlers.js';
 import { getApplication, listApplications } from './read-handlers.js';
 import { getStats } from './stats-handlers.js';
 import {
@@ -90,6 +91,10 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     list: adapt(listApplications, { deps, logger }),
     // Stats (stats-handlers.ts)
     getStats: adapt(getStats, { deps, logger }),
+    // Document metadata (document-handlers.ts)
+    addDocument: adapt(addDocument, { deps, logger }),
+    listDocuments: adapt(listDocuments, { deps, logger }),
+    removeDocument: adapt(removeDocument, { deps, logger }),
   });
 
   logger.info('gRPC ApplicationService registered', {
@@ -107,6 +112,9 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'get',
       'list',
       'getStats',
+      'addDocument',
+      'listDocuments',
+      'removeDocument',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/applications/src/migrations/008_create_application_documents.ts
+++ b/services/applications/src/migrations/008_create_application_documents.ts
@@ -1,0 +1,37 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — application_documents.
+//
+// Document METADATA rows for files attached to an application. The file
+// bytes live in object storage — the gateway owns the multipart upload
+// and writes the stored URL here; this table only references it. Mirrors
+// the SPA's Document shape (id, applicationId, type, filename, url,
+// uploadedAt, size?, mimeType?).
+//
+// application_id / uploaded_by are cross-schema soft pointers
+// (applications.applications / auth.users) — no DB REFERENCES per the
+// schema-per-service rule. Soft-delete via deleted_at so removals leave
+// an audit trail and don't cascade.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('application_documents', {
+    document_id: { type: 'uuid', primaryKey: true },
+    application_id: { type: 'uuid', notNull: true },
+    type: { type: 'text', notNull: true },
+    filename: { type: 'text', notNull: true },
+    url: { type: 'text', notNull: true },
+    size: { type: 'integer' },
+    mime_type: { type: 'text' },
+    uploaded_by: { type: 'uuid' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('application_documents', 'application_id', {
+    name: 'application_documents_application_id_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('application_documents');
+};

--- a/services/applications/src/migrations/migrations.test.ts
+++ b/services/applications/src/migrations/migrations.test.ts
@@ -24,7 +24,7 @@ async function listMigrationFiles(): Promise<string[]> {
 describe('applications migrations', () => {
   it('has migration files following the NNN_snake_case.ts naming convention', async () => {
     const files = await listMigrationFiles();
-    expect(files.length).toBeGreaterThanOrEqual(7);
+    expect(files.length).toBeGreaterThanOrEqual(8);
     for (const f of files) {
       expect(f).toMatch(MIGRATION_FILENAME_PATTERN);
     }
@@ -46,6 +46,7 @@ describe('applications migrations', () => {
     '005_create_home_visit_status_transitions.ts',
     '006_install_home_visit_status_propagation_trigger.ts',
     '007_create_application_drafts.ts',
+    '008_create_application_documents.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;


### PR DESCRIPTION
## What

Adds native application-document **METADATA** support to the applications microservice — the service-side metadata CRUD the rescue/adopter document feature needs. Mirrors PR #942 (`GetStats`) end-to-end. Scoped to `packages/proto/` and `services/applications/` only; the gateway document routes (multipart + file storage + wiring) are a separate follow-up.

These RPCs store + return document **metadata** rows that reference an already-stored file URL — the actual file bytes (multipart, object storage) are handled at the gateway later.

## Changes

- **Migration `008_create_application_documents.ts`** — `application_documents` table (`document_id` uuid PK, `application_id`, `type`, `filename`, `url`, `size?`, `mime_type?`, `uploaded_by?`, `created_at`, `deleted_at`) + index on `application_id`; `up` and `down`.
- **Proto** — `AddDocument` / `ListDocuments` / `RemoveDocument` RPCs plus a `Document` message. Regenerated ts-proto output; re-exported the new types from the proto index.
- **Handlers (`document-handlers.ts`)**
  - `addDocument` — gates `APPLICATIONS_UPDATE`, INSERTs a row, returns the `Document`.
  - `listDocuments` — gates `APPLICATIONS_VIEW` with the same owner/rescue/admin scoping as `read-handlers.ts` (reads the application's `user_id`/`rescue_id` from the read model); `WHERE application_id = $1 AND deleted_at IS NULL`.
  - `removeDocument` — gates `APPLICATIONS_UPDATE`, soft-deletes (`deleted_at = now()`).
- **Server** — bound all three (addService map + logged method list); updated `server.test.ts` path assertions (13 → 16).

## Document shape

```
Document {
  document_id, application_id, type, filename, url,
  optional uint32 size, optional string mime_type, uploaded_at
}
```
Mirrors the SPA's `Document` shape (`id, applicationId, type, filename, url, uploadedAt, size?, mimeType?`).

## Verification

- proto regenerated; `tsc --noEmit` clean in `packages/proto` and `services/applications`
- `vitest run --root services/applications` → 20 files / 205 tests green; proto package → 65 tests green
- `eslint` clean on all changed files

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_