### PR TITLE
build: containerise the extracted services — Dockerfile.service + compose

### DIFF
--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1.4
+#
+# Parameterised image for the extracted Node gRPC services + the gateway.
+# One Dockerfile, selected per service via build args:
+#   SERVICE      — the workspace package name (e.g. @adopt-dont-shop/service.audit)
+#   SERVICE_DIR  — the path under the repo root  (e.g. services/audit)
+#
+# Mirrors Dockerfile.app.optimized: `turbo prune --docker` computes the
+# dependency closure for the target service so the install/build layers only
+# carry what that service actually needs (its workspace deps: proto, events,
+# authz, db, observability, lib.types). Two targets:
+#   development — tsx watch HMR (used by docker-compose.yml)
+#   production  — compiled dist run with node (used by prod/staging)
+
+ARG NODE_VERSION=22.15.1
+
+# ---------------------------------------------------------------------------
+# base — shared foundation
+# ---------------------------------------------------------------------------
+FROM node:${NODE_VERSION}-alpine AS base
+# hadolint ignore=DL3018
+RUN apk update && apk upgrade && apk add --no-cache \
+    curl \
+    dumb-init \
+    && rm -rf /var/cache/apk/*
+WORKDIR /app
+# Husky is a dev-only git hook tool; not available (or wanted) in containers.
+ENV HUSKY=0
+
+# ---------------------------------------------------------------------------
+# pruner — produce the pruned subgraph for ${SERVICE}
+# ---------------------------------------------------------------------------
+FROM base AS pruner
+ARG SERVICE
+# Full monorepo source is needed so turbo can read every workspace package.json.
+# node_modules / dist are excluded via .dockerignore.
+COPY . .
+RUN npx -y turbo@2.9.16 prune ${SERVICE} --docker
+
+# ---------------------------------------------------------------------------
+# build — install the pruned deps + turbo build the service (+ its deps)
+# ---------------------------------------------------------------------------
+FROM base AS build
+ARG SERVICE
+# Workspace metadata + pruned lockfile first (cache-friendly install layer).
+COPY --from=pruner /app/out/json/ ./
+COPY --from=pruner /app/out/package-lock.json ./package-lock.json
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --prefer-offline
+# Pruned source — only the workspaces this service depends on.
+COPY --from=pruner /app/out/full/ ./
+# `^build` ordering means turbo builds the workspace deps (proto, events, …)
+# before the service itself.
+RUN --mount=type=cache,target=/app/.turbo \
+    npx turbo build --filter=${SERVICE}
+
+# ---------------------------------------------------------------------------
+# development — HMR via tsx watch (docker-compose.yml dev stack)
+# ---------------------------------------------------------------------------
+FROM build AS development
+ARG SERVICE_DIR
+ENV NODE_ENV=development
+WORKDIR /app/${SERVICE_DIR}
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+# Migrate the service's own schema (only services that own a schema define
+# db:migrate — the gateway doesn't, hence --if-present), then start with
+# watch-reload.
+CMD ["sh", "-c", "npm run db:migrate --if-present && npm run dev"]
+
+# ---------------------------------------------------------------------------
+# production — compiled dist run with node
+# ---------------------------------------------------------------------------
+FROM base AS production
+ARG SERVICE_DIR
+ENV NODE_ENV=production
+COPY --from=build /app ./
+WORKDIR /app/${SERVICE_DIR}
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["sh", "-c", "npm run db:migrate --if-present && npm run start"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -99,6 +99,36 @@ services:
           cpus: '0.25'
           memory: 128m
 
+  # NATS JetStream — event backbone for the extracted services. Required once
+  # any CUTOVER_<DOMAIN> flag is flipped on; harmless when all are off.
+  nats:
+    image: nats:2.10-alpine
+    container_name: ads_prod_nats
+    restart: always
+    ports: []
+    command: '-js -sd /data -m 8222'
+    volumes:
+      - nats_data:/data
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:8222/healthz | grep -q ok || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512m
+        reservations:
+          cpus: '0.25'
+          memory: 128m
+
   # Migration runner - one-shot init container that applies pending migrations
   # before the backend starts. Skipping this leaves the running service hitting
   # a stale schema on every release. [ADS-393]
@@ -398,6 +428,8 @@ volumes:
   postgres_data:
     driver: local
   redis_data:
+    driver: local
+  nats_data:
     driver: local
   uploads:
     driver: local

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -81,6 +81,37 @@ services:
           cpus: '0.1'
           memory: 64m
 
+  # NATS JetStream — the event backbone for the extracted services
+  # (publish-after-commit + idempotent subscribers). Required once any
+  # CUTOVER_<DOMAIN> flag is flipped on; harmless when all are off.
+  nats:
+    image: nats:2.10-alpine
+    container_name: ads_staging_nats
+    restart: always
+    ports: []
+    command: '-js -sd /data -m 8222'
+    volumes:
+      - nats_data:/data
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:8222/healthz | grep -q ok || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
+
   # One-shot init container: applies pending migrations before the backend
   # starts. [ADS-393]
   service-backend-migrate:
@@ -288,6 +319,7 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  nats_data:
   uploads:
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,25 @@
 # Eliminates unnecessary library services and uses npm workspace
 # Performance: 5-8 minutes instead of 60+ minutes
 
+# ----------------------------------------------------------------------------
+# Extracted-microservices shared config (anchors). The CAD-style services
+# (services/*) run under the `services` / `full` profiles so the default
+# `docker compose up` is unchanged (monolith-only). Bring the full topology
+# up with:  docker compose --profile services up --build
+# All extracted services share one Postgres (schema-per-service) + NATS + Redis.
+# ----------------------------------------------------------------------------
+x-service-env: &ms-env
+  NODE_ENV: ${NODE_ENV:-development}
+  DATABASE_URL: postgresql://${POSTGRES_USER:-adopt_user}:${POSTGRES_PASSWORD}@database:5432/${POSTGRES_DB:-adopt_dont_shop_dev}
+  NATS_URL: nats://nats:4222
+  REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+
+x-service-deps: &ms-deps
+  database:
+    condition: service_healthy
+  nats:
+    condition: service_healthy
+
 services:
   # ============================================================================
   # CORE INFRASTRUCTURE
@@ -379,6 +398,220 @@ services:
       loki:
         condition: service_healthy
     restart: unless-stopped
+
+  # ==========================================================================
+  # EXTRACTED MICROSERVICES (CAD-style). Opt-in via `--profile services`.
+  # The gateway fronts /api/* and proxies to the monolith for every domain
+  # whose CUTOVER_<DOMAIN> flag is off (the default), so bringing these up
+  # changes nothing until a flag is flipped. gRPC URL defaults in the gateway
+  # config (service-<name>:<port>) match these container names.
+  # ==========================================================================
+
+  service-gateway:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.gateway'
+        SERVICE_DIR: services/gateway
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      NATS_URL: nats://nats:4222
+      UPSTREAM_BACKEND_URL: http://service-backend:5000
+    ports:
+      - '127.0.0.1:4000:4000'
+    depends_on:
+      nats:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:4000/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
+  service-notifications:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.notifications'
+        SERVICE_DIR: services/notifications
+    environment:
+      <<: *ms-env
+    ports:
+      - '127.0.0.1:5001:5001'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5001/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
+  service-auth:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.auth'
+        SERVICE_DIR: services/auth
+    environment:
+      <<: *ms-env
+      JWT_SECRET: '${JWT_SECRET:?Error: JWT_SECRET required}'
+      JWT_REFRESH_SECRET: '${JWT_REFRESH_SECRET:?Error: JWT_REFRESH_SECRET required}'
+    ports:
+      - '127.0.0.1:5002:5002'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5002/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
+  service-pets:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.pets'
+        SERVICE_DIR: services/pets
+    environment:
+      <<: *ms-env
+    ports:
+      - '127.0.0.1:5003:5003'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5003/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
+  service-rescue:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.rescue'
+        SERVICE_DIR: services/rescue
+    environment:
+      <<: *ms-env
+    ports:
+      - '127.0.0.1:5004:5004'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5004/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
+  service-applications:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.applications'
+        SERVICE_DIR: services/applications
+    environment:
+      <<: *ms-env
+      PETS_GRPC_URL: service-pets:6003
+    ports:
+      - '127.0.0.1:5005:5005'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5005/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
+  service-moderation:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.moderation'
+        SERVICE_DIR: services/moderation
+    environment:
+      <<: *ms-env
+    ports:
+      - '127.0.0.1:5007:5007'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5007/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
+  service-matching:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.matching'
+        SERVICE_DIR: services/matching
+    environment:
+      <<: *ms-env
+      PETS_GRPC_URL: service-pets:6003
+    ports:
+      - '127.0.0.1:5008:5008'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5008/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+
+  service-audit:
+    profiles: ['services', 'full']
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+      target: development
+      args:
+        SERVICE: '@adopt-dont-shop/service.audit'
+        SERVICE_DIR: services/audit
+    environment:
+      <<: *ms-env
+    ports:
+      - '127.0.0.1:5009:5009'
+    depends_on: *ms-deps
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:5009/health/simple']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
 
 # ============================================================================
 # VOLUMES - Simplified to only what's needed


### PR DESCRIPTION
## What

Fixes the **#1 blocker** from the migration audit: every extracted service (and the gateway) existed only as source — **no Dockerfile, none in any `docker-compose`, NATS absent from staging/prod** — so nothing could run alongside the monolith and **no vertical could cut over** regardless of how complete its code was.

## Changes

- **`Dockerfile.service`** — one parameterised image for all the Node gRPC services + the gateway, selected per service via `SERVICE` + `SERVICE_DIR` build args. Uses `turbo prune --docker` to compute each service's dependency closure (its workspace deps: proto/events/authz/db/observability/lib.types) — the same proven pattern as `Dockerfile.app.optimized`. Two targets: `development` (tsx watch) and `production` (compiled `dist` via node). `db:migrate` runs `--if-present`, so the gateway (which owns no schema) is handled cleanly.
- **`docker-compose.yml`** — `service-gateway` + the 8 schema services (`auth/pets/rescue/applications/notifications/moderation/matching/audit`) under a **`services` / `full` profile**, so the default `docker compose up` stays monolith-only. Shared Postgres (schema-per-service) + NATS + Redis; healthchecks on `/health/simple`; the gateway's gRPC-URL defaults (`service-<name>:<port>`) already match these container names. **Validated with `docker compose --profile services config` (clean).**
- **NATS** added to `docker-compose.staging.yml` + `docker-compose.prod.yml` (the flagged gap — the event backbone the services need once a flag flips).

## Behaviour-preserving

Services are **opt-in** via the profile, and every `CUTOVER_<DOMAIN>` flag still defaults **off** — so the gateway proxies everything to the monolith until a flag is flipped. Bringing the stack up changes nothing until then:

```
docker compose --profile services up --build
```

## Validation note

Images were **not built in this environment** (no Docker daemon — CLI only). But `turbo prune` was validated for a service (correct dependency closure), the dev compose `config` renders cleanly, the staging/prod YAML parses, and the Dockerfile mirrors the already-working `Dockerfile.app.optimized`. The images build in CI/deploy.

## Follow-ups (noted, not in scope)

- Per-service HMR via source volume mounts (services currently run from baked-in source; the workspace-package `dist` clobbering issue needs the apps' Vite-alias-style handling).
- Staging/prod **service definitions** (image refs + secrets + replicas) — this PR adds NATS there; the per-service blocks are deploy-specific.
- CI image-build jobs per service.

This unblocks the cutover sequence: deploy → flip a flag (starting with the cleanest verticals, audit/pets) → validate → delete monolith code.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_