### PR TITLE
feat(gateway): stage B — pets proto-JSON → frontend lib.pets adapter

### DIFF
--- a/services/gateway/src/routes/pets-view.test.ts
+++ b/services/gateway/src/routes/pets-view.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { PetsV1, type Pet } from '@adopt-dont-shop/proto';
+
+import { listToEnvelope, petToView } from './pets-view.js';
+
+function makePet(overrides: Partial<Pet> = {}): Pet {
+  return {
+    petId: 'pet-1',
+    name: 'Rex',
+    rescueId: 'rsc-1',
+    type: PetsV1.PetType.PET_TYPE_DOG,
+    status: PetsV1.PetStatus.PET_STATUS_AVAILABLE,
+    gender: PetsV1.PetGender.PET_GENDER_MALE,
+    size: PetsV1.PetSize.PET_SIZE_LARGE,
+    ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+    archived: false,
+    featured: true,
+    priorityListing: false,
+    specialNeeds: false,
+    houseTrained: true,
+    temperamentJson: '[]',
+    tagsJson: '[]',
+    extraJson: '{}',
+    viewCount: 3,
+    favoriteCount: 1,
+    applicationCount: 0,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-02T00:00:00.000Z',
+    ...overrides,
+  } as Pet;
+}
+
+describe('petToView', () => {
+  it('renames fields to snake_case and lowercases the enum tokens', () => {
+    const v = petToView(makePet());
+    expect(v).toMatchObject({
+      pet_id: 'pet-1',
+      name: 'Rex',
+      rescue_id: 'rsc-1',
+      type: 'dog',
+      status: 'available',
+      gender: 'male',
+      size: 'large',
+      age_group: 'adult',
+      featured: true,
+      house_trained: true,
+      view_count: 3,
+    });
+  });
+
+  it('maps multi-word enum values to snake_case tokens', () => {
+    const v = petToView(makePet({ status: PetsV1.PetStatus.PET_STATUS_MEDICAL_HOLD }));
+    expect(v.status).toBe('medical_hold');
+  });
+
+  it('omits enum fields that are UNSPECIFIED', () => {
+    const v = petToView(makePet({ status: PetsV1.PetStatus.PET_STATUS_UNSPECIFIED }));
+    expect('status' in v).toBe(false);
+  });
+
+  it('parses the temperament/tags JSON arrays and unpacks extra_json long-tail', () => {
+    const v = petToView(
+      makePet({
+        temperamentJson: '["calm","friendly"]',
+        tagsJson: '["puppy"]',
+        extraJson: '{"good_with_children":true,"vaccination_status":"up_to_date"}',
+      })
+    );
+    expect(v.temperament).toEqual(['calm', 'friendly']);
+    expect(v.tags).toEqual(['puppy']);
+    expect(v.good_with_children).toBe(true);
+    expect(v.vaccination_status).toBe('up_to_date');
+  });
+
+  it('lets core proto fields win over extra_json on conflict', () => {
+    const v = petToView(makePet({ name: 'Rex', extraJson: '{"name":"STALE"}' }));
+    expect(v.name).toBe('Rex');
+  });
+
+  it('formats adoption_fee from minor units', () => {
+    const v = petToView(makePet({ adoptionFeeMinor: 12500 }));
+    expect(v.adoption_fee).toBe('125.00');
+  });
+});
+
+describe('listToEnvelope', () => {
+  it('wraps pets in the { success, data, meta } envelope and surfaces hasNext from the cursor', () => {
+    const env = listToEnvelope({
+      pets: [makePet(), makePet({ petId: 'pet-2' })],
+      nextCursor: 'abc',
+    } as PetsV1.ListPetsResponse);
+    expect(env.success).toBe(true);
+    expect(env.data).toHaveLength(2);
+    expect(env.data[0]).toMatchObject({ pet_id: 'pet-1', status: 'available' });
+    expect(env.meta.hasNext).toBe(true);
+    expect(env.meta.hasPrev).toBe(false);
+  });
+
+  it('reports hasNext false when there is no cursor', () => {
+    const env = listToEnvelope({ pets: [makePet()] } as PetsV1.ListPetsResponse);
+    expect(env.meta.hasNext).toBe(false);
+  });
+});

--- a/services/gateway/src/routes/pets-view.ts
+++ b/services/gateway/src/routes/pets-view.ts
@@ -1,0 +1,134 @@
+// Stage B (ADR 0002) — pets response adapter.
+//
+// service.pets returns proto-JSON; the frontend lib.pets `PetSchema`
+// expects snake_case fields, lowercase enum tokens, the long-tail fields
+// unpacked from the proto's `extra_json` blob, and a `{ success, data,
+// meta }` envelope. This module is that translation so flipping
+// CUTOVER_PETS serves a shape the SPA's Zod parse accepts.
+//
+// Only `pet_id` + `name` are required on the frontend schema; everything
+// else is optional, so we map what the proto carries and omit the rest.
+//
+// Known gaps (flagged for follow-up, all non-fatal — the fields are
+// optional): the proto carries `breed_id`/`secondary_breed_id`, not the
+// breed NAME the frontend's `breed` field wants (needs a breed lookup);
+// and `meta.total`/`totalPages` are best-effort (the proto List is keyset,
+// so there's no global count without a separate query).
+
+import { PetsV1, type ListPetsResponse, type Pet } from '@adopt-dont-shop/proto';
+
+// A proto int enum → the frontend's lowercase token (strip the SCREAMING
+// prefix). 0 (UNSPECIFIED) / -1 (UNRECOGNIZED) → undefined (omit — the
+// field is optional).
+function enumToken(
+  toJSON: (v: number) => string,
+  value: number,
+  prefix: string
+): string | undefined {
+  if (value <= 0) {
+    return undefined;
+  }
+  return toJSON(value).slice(prefix.length).toLowerCase();
+}
+
+function parseArray(json: string | undefined): unknown[] | undefined {
+  if (json === undefined || json === '' || json === '[]') {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseObject(json: string | undefined): Record<string, unknown> {
+  if (json === undefined || json === '' || json === '{}') {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(json);
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+// Drop keys whose value is undefined so the emitted JSON matches the
+// frontend's "absent vs present" expectations.
+function prune(obj: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined));
+}
+
+export function petToView(p: Pet): Record<string, unknown> {
+  // extra_json carries the long tail (good_with_*, vaccination_status,
+  // location, medical_notes, breed name if the service stored it, …).
+  // Spread it first so the core proto fields below take precedence.
+  const extra = parseObject(p.extraJson);
+
+  const core: Record<string, unknown> = {
+    pet_id: p.petId,
+    name: p.name,
+    rescue_id: p.rescueId,
+    type: enumToken(PetsV1.petTypeToJSON, p.type, 'PET_TYPE_'),
+    status: enumToken(PetsV1.petStatusToJSON, p.status, 'PET_STATUS_'),
+    gender: enumToken(PetsV1.petGenderToJSON, p.gender, 'PET_GENDER_'),
+    size: enumToken(PetsV1.petSizeToJSON, p.size, 'PET_SIZE_'),
+    age_group: enumToken(PetsV1.petAgeGroupToJSON, p.ageGroup, 'PET_AGE_GROUP_'),
+    short_description: p.shortDescription,
+    long_description: p.longDescription,
+    age_years: p.ageYears,
+    age_months: p.ageMonths,
+    color: p.color,
+    archived: p.archived,
+    featured: p.featured,
+    priority_listing: p.priorityListing,
+    special_needs: p.specialNeeds,
+    house_trained: p.houseTrained,
+    temperament: parseArray(p.temperamentJson),
+    tags: parseArray(p.tagsJson),
+    view_count: p.viewCount,
+    favorite_count: p.favoriteCount,
+    application_count: p.applicationCount,
+    available_since: p.availableSince,
+    adopted_date: p.adoptedDate,
+    created_at: p.createdAt,
+    updated_at: p.updatedAt,
+  };
+
+  // adoption_fee: the proto splits it into minor units + currency; the
+  // frontend wants a decimal string. Format when present.
+  if (p.adoptionFeeMinor !== undefined) {
+    core.adoption_fee = (p.adoptionFeeMinor / 100).toFixed(2);
+  }
+
+  return prune({ ...extra, ...core });
+}
+
+export type PetsListMeta = {
+  page: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+};
+
+// Best-effort page meta from a keyset page. `total`/`totalPages` reflect
+// the current page only (the proto List is keyset; no global count) —
+// `hasNext` is driven by the cursor so the SPA can page forward.
+export function listToEnvelope(res: ListPetsResponse): {
+  success: true;
+  data: Record<string, unknown>[];
+  meta: PetsListMeta;
+} {
+  const data = res.pets.map(petToView);
+  const hasNext = res.nextCursor !== undefined && res.nextCursor !== '';
+  return {
+    success: true,
+    data,
+    meta: { page: 1, total: data.length, totalPages: 1, hasNext, hasPrev: false },
+  };
+}

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -107,9 +107,11 @@ describe('GET /api/v1/pets', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    const body = res.json() as { pets: unknown[]; nextCursor?: string };
-    expect(body.pets).toHaveLength(1);
-    expect(body.nextCursor).toBe('abc');
+    // Stage B envelope: { success, data, meta }.
+    const body = res.json() as { success: boolean; data: unknown[]; meta: { hasNext: boolean } };
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.meta.hasNext).toBe(true);
 
     const [req, metadata] = listMock.mock.calls[0];
     expect(req.limit).toBe(10);
@@ -152,8 +154,10 @@ describe('GET /api/v1/pets/:id', () => {
         headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
       });
       expect(res.statusCode).toBe(200);
-      const body = res.json() as { pet: { petId: string } };
-      expect(body.pet.petId).toBe('pet-1');
+      // Stage B: { success, data: <snake_case view> }.
+      const body = res.json() as { success: boolean; data: { pet_id: string } };
+      expect(body.success).toBe(true);
+      expect(body.data.pet_id).toBe('pet-1');
       const [req, metadata] = getMock.mock.calls[0];
       expect(req.petId).toBe('pet-1');
       expect(metadata.get('x-user-id')[0]).toBe('usr-1');

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -33,6 +33,8 @@ import {
 
 import type { PetsClient } from '../grpc-clients/pets-client.js';
 
+import { listToEnvelope, petToView } from './pets-view.js';
+
 export type PetsRoutesOptions = {
   client: PetsClient;
 };
@@ -89,7 +91,8 @@ export const registerPetsRoutes = async (
     };
     try {
       const res = await client.list(grpcReq, buildMetadata(req));
-      return reply.send(PetsV1.ListPetsResponse.toJSON(res));
+      // Stage B: frontend lib.pets shape ({ success, data, meta }).
+      return reply.send(listToEnvelope(res));
     } catch (err) {
       return handleGrpcError(err, reply);
     }
@@ -101,7 +104,10 @@ export const registerPetsRoutes = async (
     async (req, reply) => {
       try {
         const res = await client.get({ petId: req.params.id }, buildMetadata(req));
-        return reply.send(PetsV1.GetPetResponse.toJSON(res));
+        if (res.pet === undefined) {
+          return reply.code(404).send({ success: false, error: 'pet not found' });
+        }
+        return reply.send({ success: true, data: petToView(res.pet) });
       } catch (err) {
         return handleGrpcError(err, reply);
       }


### PR DESCRIPTION
## What

Builds the **pets Stage-B view adapter** so **`CUTOVER_PETS` is flip-ready** — the first real cutover candidate (option 1: real + reversible, monolith untouched). The gateway now adapts `service.pets`' proto-JSON to the frontend `lib.pets` contract, so the SPA's `PetSchema` Zod parse accepts it.

### `pets-view.ts`

- **`petToView()`** — proto `Pet` → frontend shape:
  - camelCase → **snake_case** (`petId`→`pet_id`, `shortDescription`→`short_description`, …)
  - int enums → **lowercase tokens** (`PET_STATUS_MEDICAL_HOLD`→`medical_hold`; `status/type/gender/size/age_group`; UNSPECIFIED omitted)
  - `temperament_json`/`tags_json` → arrays
  - the **`extra_json` long tail** (`good_with_*`, `vaccination_status`, `location`, `medical_notes`, …) spread in; core proto fields win on conflict
  - `adoption_fee` composed from `adoption_fee_minor`
- **`listToEnvelope()`** — wraps results in the `{ success, data, meta }` envelope `lib.pets` expects; `meta.hasNext` driven by the keyset cursor.
- **`routes/pets.ts`** — `GET /api/v1/pets` and `/:id` return the view; `/:id` 404s a missing pet with `{ success: false }`.

**Flag still off — no behaviour change.**

## Documented gaps (all optional fields → non-fatal)

- **breed name** — the proto carries `breed_id`, not the breed *name* the frontend's `breed` field wants (needs a breed lookup; comes through `extra_json` if the service stored it).
- **`meta.total` / `totalPages`** — the proto List is keyset, so there's no global count without a separate query; reported best-effort (current page).
- The **mutation routes** (create/update/status/delete) still return raw proto-JSON — rescue-staff/admin surfaces, a follow-up before those flows are validated under the flag.

## Cutover readiness for pets

With this + the deployability work (#946), pets can be flipped in **staging** to validate end-to-end: deploy the stack (`--profile services`), set `CUTOVER_PETS=true` on the gateway, and confirm the SPA's pet list/detail render against the live service — **reversible** (flag off → back to monolith), monolith code left intact.

## Tests

- `pets-view.test.ts` — field renames, enum tokens (incl. multi-word + UNSPECIFIED-omit), array/extra_json unpack, core-wins-over-extra, adoption_fee, list envelope + hasNext.
- Updated the two pets route tests to the new envelope/view shape.
- Full `services/gateway` suite green: **168 tests**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_