### PR TITLE
feat(gateway): stage B — pets mutation adapter (frontend payload → proto)

### DIFF
--- a/services/gateway/src/routes/pets-view.test.ts
+++ b/services/gateway/src/routes/pets-view.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import { PetsV1, type Pet } from '@adopt-dont-shop/proto';
 
-import { listToEnvelope, petToView } from './pets-view.js';
+import {
+  listToEnvelope,
+  petToView,
+  viewToCreateRequest,
+  viewToUpdateRequest,
+} from './pets-view.js';
 
 function makePet(overrides: Partial<Pet> = {}): Pet {
   return {
@@ -100,5 +105,70 @@ describe('listToEnvelope', () => {
   it('reports hasNext false when there is no cursor', () => {
     const env = listToEnvelope({ pets: [makePet()] } as PetsV1.ListPetsResponse);
     expect(env.meta.hasNext).toBe(false);
+  });
+});
+
+describe('viewToCreateRequest', () => {
+  it('maps the frontend snake_case/token payload to the proto request', () => {
+    const req = viewToCreateRequest({
+      name: 'Rex',
+      rescue_id: 'rsc-1',
+      type: 'dog',
+      gender: 'male',
+      size: 'large',
+      age_group: 'adult',
+      short_description: 'good boy',
+      age_years: 3,
+      house_trained: true,
+      temperament: ['friendly', 'calm'],
+      tags: ['puppy'],
+      adoption_fee: '125.00',
+      good_with_children: true,
+      vaccination_status: 'up_to_date',
+    });
+    expect(req).toMatchObject({
+      name: 'Rex',
+      rescueId: 'rsc-1',
+      type: PetsV1.PetType.PET_TYPE_DOG,
+      gender: PetsV1.PetGender.PET_GENDER_MALE,
+      size: PetsV1.PetSize.PET_SIZE_LARGE,
+      ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
+      shortDescription: 'good boy',
+      ageYears: 3,
+      houseTrained: true,
+      temperamentJson: '["friendly","calm"]',
+      tagsJson: '["puppy"]',
+      adoptionFeeMinor: 12500,
+    });
+    // long-tail fields the core message lacks go into extra_json.
+    expect(JSON.parse(req.extraJson)).toEqual({
+      good_with_children: true,
+      vaccination_status: 'up_to_date',
+    });
+  });
+
+  it('accepts the SCREAMING proto enum form too, and unknown → UNSPECIFIED', () => {
+    expect(viewToCreateRequest({ type: 'PET_TYPE_CAT' }).type).toBe(PetsV1.PetType.PET_TYPE_CAT);
+    expect(viewToCreateRequest({ type: 'platypus' }).type).toBe(
+      PetsV1.PetType.PET_TYPE_UNSPECIFIED
+    );
+  });
+});
+
+describe('viewToUpdateRequest', () => {
+  it('sets only the supplied fields (partial)', () => {
+    const req = viewToUpdateRequest('pet-1', { name: 'Rexy', featured: true });
+    expect(req.petId).toBe('pet-1');
+    expect(req.name).toBe('Rexy');
+    expect(req.featured).toBe(true);
+    // not supplied → left unset
+    expect(req.size).toBeUndefined();
+    expect(req.shortDescription).toBeUndefined();
+  });
+
+  it('packs unknown fields into extra_json and maps enum tokens when present', () => {
+    const req = viewToUpdateRequest('pet-1', { size: 'small', medical_notes: 'none' });
+    expect(req.size).toBe(PetsV1.PetSize.PET_SIZE_SMALL);
+    expect(JSON.parse(req.extraJson ?? '{}')).toEqual({ medical_notes: 'none' });
   });
 });

--- a/services/gateway/src/routes/pets-view.ts
+++ b/services/gateway/src/routes/pets-view.ts
@@ -15,7 +15,13 @@
 // and `meta.total`/`totalPages` are best-effort (the proto List is keyset,
 // so there's no global count without a separate query).
 
-import { PetsV1, type ListPetsResponse, type Pet } from '@adopt-dont-shop/proto';
+import {
+  PetsV1,
+  type CreatePetRequest,
+  type ListPetsResponse,
+  type Pet,
+  type UpdatePetRequest,
+} from '@adopt-dont-shop/proto';
 
 // A proto int enum → the frontend's lowercase token (strip the SCREAMING
 // prefix). 0 (UNSPECIFIED) / -1 (UNRECOGNIZED) → undefined (omit — the
@@ -131,4 +137,225 @@ export function listToEnvelope(res: ListPetsResponse): {
     data,
     meta: { page: 1, total: data.length, totalPages: 1, hasNext, hasPrev: false },
   };
+}
+
+// --- Inverse adapter: frontend payload → proto request -----------------
+//
+// The SPA's create/update payload is the snake_case Pet shape (string enum
+// tokens, arrays, the long-tail good_with_*/vaccination_status/… fields),
+// produced by lib.pets' transformPetDataForAPI. These map it back to the
+// proto request: enum tokens → ints, arrays → *_json, and every field the
+// core proto message doesn't carry is packed into extra_json.
+
+// snake_case (and camelCase fallback) keys consumed by the core proto
+// fields — everything else in the body is packed into extra_json.
+const CORE_KEYS = new Set([
+  'name',
+  'rescue_id',
+  'rescueId',
+  'type',
+  'status',
+  'gender',
+  'size',
+  'age_group',
+  'ageGroup',
+  'breed_id',
+  'breedId',
+  'secondary_breed_id',
+  'secondaryBreedId',
+  'short_description',
+  'shortDescription',
+  'long_description',
+  'longDescription',
+  'age_years',
+  'ageYears',
+  'age_months',
+  'ageMonths',
+  'adoption_fee',
+  'adoptionFee',
+  'adoption_fee_minor',
+  'adoption_fee_currency',
+  'special_needs',
+  'specialNeeds',
+  'house_trained',
+  'houseTrained',
+  'featured',
+  'priority_listing',
+  'priorityListing',
+  'temperament',
+  'tags',
+]);
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v !== '' ? v : undefined;
+}
+function int(v: unknown): number | undefined {
+  if (typeof v === 'number') {
+    return Math.trunc(v);
+  }
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number.parseInt(v, 10);
+    return Number.isNaN(n) ? undefined : n;
+  }
+  return undefined;
+}
+function boolean(v: unknown): boolean | undefined {
+  return typeof v === 'boolean' ? v : undefined;
+}
+function jsonArray(v: unknown): string | undefined {
+  return Array.isArray(v) ? JSON.stringify(v) : undefined;
+}
+// adoption_fee arrives as a decimal string/number; the proto wants minor units.
+function feeToMinor(v: unknown): number | undefined {
+  const n = typeof v === 'number' ? v : typeof v === 'string' ? Number.parseFloat(v) : NaN;
+  return Number.isFinite(n) ? Math.round(n * 100) : undefined;
+}
+
+// Accept the lowercase token ('dog') OR the SCREAMING proto name; unknown /
+// absent → UNSPECIFIED (the service then validates).
+function tokenToEnum(
+  fromJSON: (s: string) => number,
+  prefix: string,
+  raw: unknown,
+  unspecified: number
+): number {
+  if (typeof raw !== 'string' || raw === '') {
+    return unspecified;
+  }
+  const candidate = raw.startsWith(prefix) ? raw : `${prefix}${raw.toUpperCase()}`;
+  try {
+    const v = fromJSON(candidate);
+    return v < 0 ? unspecified : v;
+  } catch {
+    return unspecified;
+  }
+}
+
+function pickExtra(b: Record<string, unknown>): string {
+  const extra = Object.fromEntries(Object.entries(b).filter(([k]) => !CORE_KEYS.has(k)));
+  return JSON.stringify(extra);
+}
+
+export function viewToCreateRequest(body: unknown): CreatePetRequest {
+  const b = (body ?? {}) as Record<string, unknown>;
+  return {
+    name: str(b.name) ?? '',
+    rescueId: str(b.rescue_id ?? b.rescueId) ?? '',
+    type: tokenToEnum(
+      PetsV1.petTypeFromJSON,
+      'PET_TYPE_',
+      b.type,
+      PetsV1.PetType.PET_TYPE_UNSPECIFIED
+    ),
+    gender: tokenToEnum(
+      PetsV1.petGenderFromJSON,
+      'PET_GENDER_',
+      b.gender,
+      PetsV1.PetGender.PET_GENDER_UNSPECIFIED
+    ),
+    size: tokenToEnum(
+      PetsV1.petSizeFromJSON,
+      'PET_SIZE_',
+      b.size,
+      PetsV1.PetSize.PET_SIZE_UNSPECIFIED
+    ),
+    ageGroup: tokenToEnum(
+      PetsV1.petAgeGroupFromJSON,
+      'PET_AGE_GROUP_',
+      b.age_group ?? b.ageGroup,
+      PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED
+    ),
+    breedId: str(b.breed_id ?? b.breedId),
+    secondaryBreedId: str(b.secondary_breed_id ?? b.secondaryBreedId),
+    shortDescription: str(b.short_description ?? b.shortDescription),
+    longDescription: str(b.long_description ?? b.longDescription),
+    ageYears: int(b.age_years ?? b.ageYears),
+    ageMonths: int(b.age_months ?? b.ageMonths),
+    adoptionFeeMinor: feeToMinor(b.adoption_fee ?? b.adoptionFee ?? b.adoption_fee_minor),
+    adoptionFeeCurrency: str(b.adoption_fee_currency),
+    specialNeeds: boolean(b.special_needs ?? b.specialNeeds) ?? false,
+    houseTrained: boolean(b.house_trained ?? b.houseTrained) ?? false,
+    temperamentJson: jsonArray(b.temperament) ?? '[]',
+    tagsJson: jsonArray(b.tags) ?? '[]',
+    extraJson: pickExtra(b),
+  };
+}
+
+// Partial: only fields present in the body are set (the proto Update message
+// writes just the supplied ones). extra_json is always sent so long-tail
+// edits land; enum/scalars only when present.
+export function viewToUpdateRequest(petId: string, body: unknown): UpdatePetRequest {
+  const b = (body ?? {}) as Record<string, unknown>;
+  const req: UpdatePetRequest = { petId, extraJson: pickExtra(b) };
+
+  const name = str(b.name);
+  if (name !== undefined) {
+    req.name = name;
+  }
+  const shortDescription = str(b.short_description ?? b.shortDescription);
+  if (shortDescription !== undefined) {
+    req.shortDescription = shortDescription;
+  }
+  const longDescription = str(b.long_description ?? b.longDescription);
+  if (longDescription !== undefined) {
+    req.longDescription = longDescription;
+  }
+  if (b.gender !== undefined) {
+    req.gender = tokenToEnum(
+      PetsV1.petGenderFromJSON,
+      'PET_GENDER_',
+      b.gender,
+      PetsV1.PetGender.PET_GENDER_UNSPECIFIED
+    );
+  }
+  if (b.size !== undefined) {
+    req.size = tokenToEnum(
+      PetsV1.petSizeFromJSON,
+      'PET_SIZE_',
+      b.size,
+      PetsV1.PetSize.PET_SIZE_UNSPECIFIED
+    );
+  }
+  if (b.age_group !== undefined || b.ageGroup !== undefined) {
+    req.ageGroup = tokenToEnum(
+      PetsV1.petAgeGroupFromJSON,
+      'PET_AGE_GROUP_',
+      b.age_group ?? b.ageGroup,
+      PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED
+    );
+  }
+  const breedId = str(b.breed_id ?? b.breedId);
+  if (breedId !== undefined) {
+    req.breedId = breedId;
+  }
+  const fee = feeToMinor(b.adoption_fee ?? b.adoptionFee ?? b.adoption_fee_minor);
+  if (fee !== undefined) {
+    req.adoptionFeeMinor = fee;
+  }
+  const specialNeeds = boolean(b.special_needs ?? b.specialNeeds);
+  if (specialNeeds !== undefined) {
+    req.specialNeeds = specialNeeds;
+  }
+  const houseTrained = boolean(b.house_trained ?? b.houseTrained);
+  if (houseTrained !== undefined) {
+    req.houseTrained = houseTrained;
+  }
+  const featured = boolean(b.featured);
+  if (featured !== undefined) {
+    req.featured = featured;
+  }
+  const priorityListing = boolean(b.priority_listing ?? b.priorityListing);
+  if (priorityListing !== undefined) {
+    req.priorityListing = priorityListing;
+  }
+  const temperament = jsonArray(b.temperament);
+  if (temperament !== undefined) {
+    req.temperamentJson = temperament;
+  }
+  const tags = jsonArray(b.tags);
+  if (tags !== undefined) {
+    req.tagsJson = tags;
+  }
+
+  return req;
 }

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -196,26 +196,34 @@ describe('POST /api/v1/pets', () => {
         method: 'POST',
         url: '/api/v1/pets',
         headers: { 'x-user-id': 'usr-staff', 'x-user-roles': 'rescue_staff' },
+        // Frontend (lib.pets) payload: snake_case + token enums + long tail.
         payload: {
           name: 'Rex',
-          rescueId: 'rsc-1',
-          type: PetsV1.PetType.PET_TYPE_DOG,
-          gender: PetsV1.PetGender.PET_GENDER_MALE,
-          size: PetsV1.PetSize.PET_SIZE_LARGE,
-          ageGroup: PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT,
-          specialNeeds: false,
-          houseTrained: true,
-          temperamentJson: '["friendly"]',
-          tagsJson: '[]',
-          extraJson: '{}',
+          rescue_id: 'rsc-1',
+          type: 'dog',
+          gender: 'male',
+          size: 'large',
+          age_group: 'adult',
+          house_trained: true,
+          temperament: ['friendly'],
+          good_with_children: true,
+          adoption_fee: '125.00',
         },
       });
 
       expect(res.statusCode).toBe(201);
+      // Response is the frontend view envelope.
+      expect((res.json() as { success: boolean }).success).toBe(true);
       const [req] = createMock.mock.calls[0];
       expect(req.name).toBe('Rex');
       expect(req.rescueId).toBe('rsc-1');
       expect(req.type).toBe(PetsV1.PetType.PET_TYPE_DOG);
+      expect(req.ageGroup).toBe(PetsV1.PetAgeGroup.PET_AGE_GROUP_ADULT);
+      expect(req.houseTrained).toBe(true);
+      expect(req.temperamentJson).toBe('["friendly"]');
+      expect(req.adoptionFeeMinor).toBe(12500);
+      // long-tail field not on the core message is packed into extra_json.
+      expect(JSON.parse(req.extraJson)).toMatchObject({ good_with_children: true });
     } finally {
       await app.close();
     }
@@ -256,8 +264,9 @@ describe('PATCH /api/v1/pets/:id', () => {
         payload: { name: 'Rexy' },
       });
       expect(res.statusCode).toBe(200);
-      const body = res.json() as { pet: { name: string } };
-      expect(body.pet.name).toBe('Rexy');
+      const body = res.json() as { success: boolean; data: { name: string } };
+      expect(body.success).toBe(true);
+      expect(body.data.name).toBe('Rexy');
       const [req] = updateMock.mock.calls[0];
       expect(req.petId).toBe('pet-1');
       expect(req.name).toBe('Rexy');
@@ -335,7 +344,7 @@ describe('POST /api/v1/pets/:id/status', () => {
 });
 
 describe('DELETE /api/v1/pets/:id', () => {
-  it('soft-deletes and returns { deleted: true }', async () => {
+  it('soft-deletes and returns { success: true }', async () => {
     const { client, deleteMock } = makeClient();
     const app = await makeApp(client);
     try {
@@ -344,7 +353,7 @@ describe('DELETE /api/v1/pets/:id', () => {
 
       const res = await app.inject({ method: 'DELETE', url: '/api/v1/pets/pet-1' });
       expect(res.statusCode).toBe(200);
-      expect(res.json()).toMatchObject({ deleted: true });
+      expect(res.json()).toMatchObject({ success: true });
       const [req] = deleteMock.mock.calls[0];
       expect(req.petId).toBe('pet-1');
     } finally {

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -23,17 +23,16 @@ import rateLimit from '@fastify/rate-limit';
 import { Metadata, status } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
-import {
-  PetsV1,
-  type CreatePetRequest,
-  type ListPetsRequest,
-  type UpdatePetRequest,
-  type UpdatePetStatusRequest,
-} from '@adopt-dont-shop/proto';
+import { PetsV1, type ListPetsRequest, type UpdatePetStatusRequest } from '@adopt-dont-shop/proto';
 
 import type { PetsClient } from '../grpc-clients/pets-client.js';
 
-import { listToEnvelope, petToView } from './pets-view.js';
+import {
+  listToEnvelope,
+  petToView,
+  viewToCreateRequest,
+  viewToUpdateRequest,
+} from './pets-view.js';
 
 export type PetsRoutesOptions = {
   client: PetsClient;
@@ -62,10 +61,8 @@ const PETS_RATE_LIMITS = {
   delete: { max: 30, timeWindow: '1 minute' },
 } as const;
 
-// Body shapes — kept narrow so a client typo doesn't get silently
-// forwarded as undefined to the proto encoder.
-type CreatePetBody = Partial<CreatePetRequest>;
-type UpdatePetBody = Partial<Omit<UpdatePetRequest, 'petId'>>;
+// The status route still takes a small bespoke body (the create/update
+// payloads are adapted from the frontend shape in pets-view.ts).
 type UpdateStatusBody = {
   toStatus?: string;
   reason?: string;
@@ -118,31 +115,14 @@ export const registerPetsRoutes = async (
     '/api/v1/pets',
     { config: { rateLimit: PETS_RATE_LIMITS.create } },
     async (req, reply) => {
-      const body = (req.body ?? {}) as CreatePetBody;
-      const grpcReq: CreatePetRequest = {
-        name: body.name ?? '',
-        rescueId: body.rescueId ?? '',
-        type: body.type ?? PetsV1.PetType.PET_TYPE_UNSPECIFIED,
-        gender: body.gender ?? PetsV1.PetGender.PET_GENDER_UNSPECIFIED,
-        size: body.size ?? PetsV1.PetSize.PET_SIZE_UNSPECIFIED,
-        ageGroup: body.ageGroup ?? PetsV1.PetAgeGroup.PET_AGE_GROUP_UNSPECIFIED,
-        breedId: body.breedId,
-        secondaryBreedId: body.secondaryBreedId,
-        shortDescription: body.shortDescription,
-        longDescription: body.longDescription,
-        ageYears: body.ageYears,
-        ageMonths: body.ageMonths,
-        adoptionFeeMinor: body.adoptionFeeMinor,
-        adoptionFeeCurrency: body.adoptionFeeCurrency,
-        specialNeeds: body.specialNeeds ?? false,
-        houseTrained: body.houseTrained ?? false,
-        temperamentJson: body.temperamentJson ?? '[]',
-        tagsJson: body.tagsJson ?? '[]',
-        extraJson: body.extraJson ?? '{}',
-      };
+      // Stage B: adapt the frontend snake_case/token payload → proto.
+      const grpcReq = viewToCreateRequest(req.body);
       try {
         const res = await client.create(grpcReq, buildMetadata(req));
-        return reply.code(201).send(PetsV1.CreatePetResponse.toJSON(res));
+        if (res.pet === undefined) {
+          return reply.code(500).send({ success: false, error: 'create returned no pet' });
+        }
+        return reply.code(201).send({ success: true, data: petToView(res.pet) });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -153,11 +133,13 @@ export const registerPetsRoutes = async (
     '/api/v1/pets/:id',
     { config: { rateLimit: PETS_RATE_LIMITS.update } },
     async (req, reply) => {
-      const body = (req.body ?? {}) as UpdatePetBody;
-      const grpcReq: UpdatePetRequest = { petId: req.params.id, ...body };
+      const grpcReq = viewToUpdateRequest(req.params.id, req.body);
       try {
         const res = await client.update(grpcReq, buildMetadata(req));
-        return reply.send(PetsV1.UpdatePetResponse.toJSON(res));
+        if (res.pet === undefined) {
+          return reply.code(404).send({ success: false, error: 'pet not found' });
+        }
+        return reply.send({ success: true, data: petToView(res.pet) });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -176,7 +158,10 @@ export const registerPetsRoutes = async (
       };
       try {
         const res = await client.updateStatus(grpcReq, buildMetadata(req));
-        return reply.send(PetsV1.UpdatePetStatusResponse.toJSON(res));
+        if (res.pet === undefined) {
+          return reply.code(404).send({ success: false, error: 'pet not found' });
+        }
+        return reply.send({ success: true, data: petToView(res.pet) });
       } catch (err) {
         return handleGrpcError(err, reply);
       }
@@ -188,8 +173,8 @@ export const registerPetsRoutes = async (
     { config: { rateLimit: PETS_RATE_LIMITS.delete } },
     async (req, reply) => {
       try {
-        const res = await client.delete({ petId: req.params.id }, buildMetadata(req));
-        return reply.send(PetsV1.DeletePetResponse.toJSON(res));
+        await client.delete({ petId: req.params.id }, buildMetadata(req));
+        return reply.send({ success: true });
       } catch (err) {
         return handleGrpcError(err, reply);
       }


### PR DESCRIPTION
## What

Completes the pets contract so **`CUTOVER_PETS` is fully flip-ready** — not just reads (#947). The create/update/status/delete routes now speak the frontend `lib.pets` shape on **both** sides.

### Inverse adapter (`pets-view.ts`)

`viewToCreateRequest` / `viewToUpdateRequest` — the inverse of `petToView`. The SPA's payload (produced by `transformPetDataForAPI`) is snake_case + string enum tokens + `temperament`/`tags` arrays + the long-tail `good_with_*`/`vaccination_status`/… fields. These map it back to the proto request:

- enum **tokens → ints** (accepts `'dog'` *or* `PET_TYPE_DOG`; unknown → UNSPECIFIED so the service 400s)
- arrays → `temperament_json` / `tags_json`
- `adoption_fee` decimal → **minor units**
- every field the core proto message doesn't carry → **`extra_json`**
- **Update is partial** — only supplied fields are set

### Routes (`routes/pets.ts`)

- create / update / status → `{ success, data: <view> }` (201 for create)
- delete → `{ success: true }`
- missing pet → `404 { success: false }`

**Flag still off — no behaviour change.**

## Pets is now fully flip-ready

With **#947 (reads)** + this (writes), every `/api/v1/pets/*` path the SPA uses returns/accepts the frontend contract. To validate end-to-end: deploy (`--profile services`, #946), `CUTOVER_PETS=true`, exercise browse + rescue-staff create/edit/status in the SPA, flip back to roll back. Monolith pets code untouched.

(Carried-forward gaps, all optional/non-fatal: breed *name* needs a lookup; keyset list has no global `total`.)

## Tests

- `viewToCreateRequest` — snake_case/token → proto mapping, extra_json packing, SCREAMING-form + unknown→UNSPECIFIED.
- `viewToUpdateRequest` — partial (only supplied fields), enum + extra_json.
- Updated the create/update/delete route tests to the frontend-shape contract.
- Full `services/gateway` suite green: **172 tests**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_