### PR TITLE
feat(storage): extract reusable packages/storage (local + S3 providers)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4882,6 +4882,10 @@
       "resolved": "services/rescue",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/storage": {
+      "resolved": "packages/storage",
+      "link": true
+    },
     "node_modules/@apideck/better-ajv-errors": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
@@ -5049,6 +5053,317 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.2.tgz",
+      "integrity": "sha512-PIha+kauTbp6IRmOpYktPTrlfrrSqDVixvhO/EUOFOf62DPX81CaJoHJreuA1m9HYpSKyXf99BKjU1dvJPeUfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1063.0.tgz",
+      "integrity": "sha512-ETn+vvmZVK1MmOZwVBXmWANpmD5iTbzojIqyEIoZ86qo+8oWy35S8QyQNE/ZDI+WHgMU1dS+VSYbpRl1QkEySg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/credential-provider-node": "^3.972.52",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.27",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.48",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.32",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.18.tgz",
+      "integrity": "sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.11",
+        "@aws-sdk/xml-builder": "^3.972.28",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.44.tgz",
+      "integrity": "sha512-3hKJVrZ7bqXzDAXCQp+OaQ1ASN+vWstaNuEH418wQVl//cRZhqhfR9Bjk1qIWmgUGe8/D3gdO73PgidRj378EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.46.tgz",
+      "integrity": "sha512-VhwC9pGAZHhiQ2xSViyOPDFqvr9aRxGCAXZtADsUhU3R65nad7y//CwynE6mQnWNR+suRlqE79W36IVayL+m1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.50.tgz",
+      "integrity": "sha512-09Xi6ovxiK42+De/qBGF71sT5F2bWgYM+1fFyDwSOpy1xpsQ5R/naIu7MVDpH6Dic36QNc8dAv4KADtMGK2JYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/credential-provider-env": "^3.972.44",
+        "@aws-sdk/credential-provider-http": "^3.972.46",
+        "@aws-sdk/credential-provider-login": "^3.972.49",
+        "@aws-sdk/credential-provider-process": "^3.972.44",
+        "@aws-sdk/credential-provider-sso": "^3.972.49",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.49",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.49.tgz",
+      "integrity": "sha512-EfJF/1Fh9mI4pZyoheU2RY9xUhTcugIZNkD63+orXMkYj/QXacJNbKVDUK90Yv5hE+aX+rt9J/EZ9Qr3vKOa7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.52.tgz",
+      "integrity": "sha512-7QX+PbyiWBEOVipJq8Nke/TqXT6lAPLE7fvTaopa39/IVWuLfS+Fzdy71sZJONf/mLGgmtj6aU17+REw3+aRrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.44",
+        "@aws-sdk/credential-provider-http": "^3.972.46",
+        "@aws-sdk/credential-provider-ini": "^3.972.50",
+        "@aws-sdk/credential-provider-process": "^3.972.44",
+        "@aws-sdk/credential-provider-sso": "^3.972.49",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.49",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.44.tgz",
+      "integrity": "sha512-V+UUhZpRP7QDRhi+qgBDisM9tUBnYmMje8Bk77A6MZsfeGeGdMsQXmaHP1CDYFcept0o/Rz5g2Y0TMeVlG9dzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.49.tgz",
+      "integrity": "sha512-9QqOYGuh5tZ76OzaT68kwI78AH+5lS/uZGGvkfxb3fc8FzRrIz2jOufNTliEBEeSAwmgK2rWLNsK+IB3zbtNPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/token-providers": "3.1063.0",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.49.tgz",
+      "integrity": "sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.27.tgz",
+      "integrity": "sha512-bZqezPLdllFC4VAeV/f+EIc/hz56ab3TD/+4zNCgOgmG5ZHAE5dMHrX1gtTwdcQXbPr3KR7x3zTC3zuCTE6+ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.48.tgz",
+      "integrity": "sha512-MRTqx8wD/T3REt6LTT3/yN8rrp6+xIHrbUekkDYJTYWVch70mwtdJBovR4qKJz1jIPlbN+9R/Sn6R04BfsglzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.32",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.17.tgz",
+      "integrity": "sha512-lDRgraoTfKRawUyc176Ow93mrNrOho/x+EoK4C+lKU+vKkHWhNhzvSMVAx0WEJUJoeQxxDN5ZdKMfiGEyNejig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.32",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1063.0.tgz",
+      "integrity": "sha512-uYDuWEbBYz/DfS0sEbDA3BeBCNNaLiE+dmblIRrmU02bhoqsotJb3qWfx0+I3JlukC7Vk8wRuyRgjZzq1FyXGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.32",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.32.tgz",
+      "integrity": "sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1063.0.tgz",
+      "integrity": "sha512-nYDaWWdzjKiDP5xj8k4oUgcYd4WPgzfAOgdU5vJsaqH/07Dfvm7ffisHCFJ+NEl7kUC9JEIUxh0kznvenbo3NQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/types": {
       "version": "3.973.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.11.tgz",
@@ -5068,6 +5383,20 @@
       "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.28.tgz",
+      "integrity": "sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -30408,6 +30737,19 @@
       "devDependencies": {
         "@bufbuild/buf": "^1.70.0",
         "ts-proto": "^2.11.8"
+      }
+    },
+    "packages/storage": {
+      "name": "@adopt-dont-shop/storage",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.1061.0",
+        "@aws-sdk/s3-request-presigner": "^3.1061.0",
+        "fs-extra": "^11.3.5",
+        "sharp": "^0.34.2"
+      },
+      "devDependencies": {
+        "@types/fs-extra": "^11.0.4"
       }
     },
     "service.backend": {

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,0 +1,64 @@
+# @adopt-dont-shop/storage
+
+Config-injected file storage abstraction for backend microservices. A single
+`StorageProvider` contract backed by two implementations — local filesystem and
+S3 — extracted from `service.backend`'s storage service with no coupling to the
+monolith's global config, logger, or uuid helpers.
+
+## Usage
+
+```ts
+import { createStorageProvider, type StorageConfig } from '@adopt-dont-shop/storage';
+
+const config: StorageConfig = {
+  provider: 's3', // or 'local'
+  local: { directory: 'uploads', publicPath: '/uploads' },
+  s3: {
+    bucket: process.env.S3_BUCKET_NAME,
+    region: process.env.S3_REGION,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    cloudFrontDomain: process.env.CLOUDFRONT_DOMAIN,
+  },
+  // Optional: any object with info/warn/error. Defaults to a no-op.
+  logger: console,
+};
+
+const storage = createStorageProvider(config);
+
+const { url, filename, size } = await storage.uploadFile(
+  buffer,
+  'photo.jpg',
+  'image/jpeg',
+  'pets'
+);
+```
+
+## Contract
+
+`StorageProvider` exposes `uploadFile`, `deleteFile`, `getFileInfo`, `getName`,
+`validateConfiguration`, `supportsSignedUrls`, and `getSignedUrl`.
+
+- **Local** processes `image/*` content through sharp (resize >1920px, convert
+  to JPEG) and writes to disk under `<directory>/<category>/`. Non-image content
+  (e.g. `application/pdf`) is stored untouched. `supportsSignedUrls()` is
+  `false`; `getSignedUrl()` throws.
+- **S3** uploads with SSE-S3 and `Content-Disposition: attachment` for
+  non-image content, and mints short-lived signed URLs via the presigner.
+  `supportsSignedUrls()` is `true`.
+
+## Decoupling notes
+
+- Config is injected via `createStorageProvider(config)` — there is no global
+  config import.
+- Filenames use `node:crypto`'s `randomUUID()`.
+- Logging goes through an optional minimal logger (`{ info?, warn?, error? }`),
+  defaulting to a no-op.
+- The sharp pixel cap is a hard-coded `MAX_IMAGE_PIXELS = 100_000_000`.
+
+## Out of scope: malware / AV scanning
+
+Antivirus scanning is **not** included in this package — the monolith's AV
+providers are intentionally not ported. Consumers (e.g. the gateway) use this
+package without AV for now. Wiring a scanning step in front of `uploadFile` is a
+documented follow-up.

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@adopt-dont-shop/storage",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Config-injected file storage abstraction for backend microservices — local filesystem and S3 providers behind a single StorageProvider contract. Dependency-light extraction of service.backend's storage service with no global config/logger coupling. Malware scanning is intentionally out of scope (documented follow-up).",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.1061.0",
+    "@aws-sdk/s3-request-presigner": "^3.1061.0",
+    "fs-extra": "^11.3.5",
+    "sharp": "^0.34.2"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^11.0.4"
+  }
+}

--- a/packages/storage/src/base-provider.ts
+++ b/packages/storage/src/base-provider.ts
@@ -1,0 +1,28 @@
+export type StorageCategory = 'pets' | 'users' | 'documents';
+
+export type UploadResult = {
+  url: string;
+  filename: string;
+  size: number;
+};
+
+export type FileInfo = { exists: true; size: number; modified: Date } | { exists: false };
+
+export interface StorageProvider {
+  uploadFile(
+    file: Buffer,
+    originalName: string,
+    contentType: string,
+    category?: StorageCategory
+  ): Promise<UploadResult>;
+  deleteFile(filename: string, category?: string): Promise<void>;
+  getFileInfo(filename: string, category?: string): Promise<FileInfo>;
+  getName(): string;
+  validateConfiguration(): boolean;
+  // Returns true when the provider serves content via signed redirect rather than
+  // streaming bytes through Node. Drives the serve route's redirect-vs-stream branch.
+  supportsSignedUrls(): boolean;
+  // Mints a short-lived URL for direct client access. Only meaningful when
+  // supportsSignedUrls() returns true; local provider throws.
+  getSignedUrl(filename: string, category?: string, expiresInSeconds?: number): Promise<string>;
+}

--- a/packages/storage/src/config.ts
+++ b/packages/storage/src/config.ts
@@ -1,0 +1,41 @@
+// Minimal logger contract. Providers accept any object with these optional
+// methods (e.g. a Winston logger) and fall back to a no-op when omitted, so the
+// package stays decoupled from any one logging implementation.
+export type StorageLogger = {
+  info?: (message: string, meta?: unknown) => void;
+  warn?: (message: string, meta?: unknown) => void;
+  error?: (message: string, meta?: unknown) => void;
+};
+
+export type LocalStorageConfig = {
+  directory: string;
+  publicPath: string;
+};
+
+export type S3StorageConfig = {
+  bucket?: string;
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  cloudFrontDomain?: string;
+};
+
+// Mirrors the monolith's `config.storage` shape. Injected into providers via
+// the factory rather than read from a global, so any service can own its own
+// configuration source.
+export type StorageConfig = {
+  provider: 'local' | 's3';
+  local: LocalStorageConfig;
+  s3: S3StorageConfig;
+  logger?: StorageLogger;
+};
+
+const NOOP = () => {};
+
+// Resolve a logger that always has callable info/warn/error methods, so call
+// sites never need to null-check.
+export const resolveLogger = (logger?: StorageLogger): Required<StorageLogger> => ({
+  info: logger?.info ?? NOOP,
+  warn: logger?.warn ?? NOOP,
+  error: logger?.error ?? NOOP,
+});

--- a/packages/storage/src/factory.test.ts
+++ b/packages/storage/src/factory.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createStorageProvider } from './factory.js';
+import type { StorageConfig } from './config.js';
+
+const dirs: string[] = [];
+
+const makeLocalConfig = async (): Promise<StorageConfig> => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'storage-factory-'));
+  dirs.push(directory);
+  return {
+    provider: 'local',
+    local: { directory, publicPath: '/uploads' },
+    s3: {},
+  };
+};
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map(d => rm(d, { recursive: true, force: true })));
+});
+
+describe('createStorageProvider', () => {
+  it('returns the local provider for provider "local"', async () => {
+    const provider = createStorageProvider(await makeLocalConfig());
+    expect(provider.getName()).toBe('local');
+  });
+
+  it('returns the s3 provider for provider "s3"', () => {
+    const config: StorageConfig = {
+      provider: 's3',
+      local: { directory: 'uploads', publicPath: '/uploads' },
+      s3: {
+        bucket: 'b',
+        region: 'eu-west-2',
+        accessKeyId: 'k',
+        secretAccessKey: 's',
+      },
+    };
+
+    const provider = createStorageProvider(config);
+    expect(provider.getName()).toBe('s3');
+  });
+
+  it('throws when the s3 provider is misconfigured', () => {
+    const config: StorageConfig = {
+      provider: 's3',
+      local: { directory: 'uploads', publicPath: '/uploads' },
+      s3: { bucket: 'b' },
+    };
+
+    expect(() => createStorageProvider(config)).toThrow(/misconfigured/);
+  });
+});

--- a/packages/storage/src/factory.ts
+++ b/packages/storage/src/factory.ts
@@ -1,0 +1,21 @@
+import type { StorageProvider } from './base-provider.js';
+import type { StorageConfig } from './config.js';
+import { LocalStorageProvider } from './local-storage-provider.js';
+import { S3StorageProvider } from './s3-storage-provider.js';
+
+// Config-injected factory: returns a Local or S3 provider based on
+// `config.provider`. Callers own where the config comes from — there is no
+// global config import.
+export const createStorageProvider = (config: StorageConfig): StorageProvider => {
+  if (config.provider === 's3') {
+    const provider = new S3StorageProvider(config.s3, config.logger);
+    if (!provider.validateConfiguration()) {
+      throw new Error(
+        'S3 storage provider misconfigured: bucket, region, accessKeyId and secretAccessKey are required'
+      );
+    }
+    return provider;
+  }
+
+  return new LocalStorageProvider(config.local, config.logger);
+};

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,0 +1,14 @@
+// NOTE: Malware / AV scanning is intentionally OUT OF SCOPE for this package.
+// The monolith's AV providers are not ported here. Callers (e.g. the gateway)
+// use this package without AV for now; integrating a scanning step is a
+// documented follow-up.
+export { createStorageProvider } from './factory.js';
+export { LocalStorageProvider } from './local-storage-provider.js';
+export { S3StorageProvider } from './s3-storage-provider.js';
+export type { FileInfo, StorageCategory, StorageProvider, UploadResult } from './base-provider.js';
+export type {
+  LocalStorageConfig,
+  S3StorageConfig,
+  StorageConfig,
+  StorageLogger,
+} from './config.js';

--- a/packages/storage/src/local-storage-provider.test.ts
+++ b/packages/storage/src/local-storage-provider.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LocalStorageProvider } from './local-storage-provider.js';
+import type { LocalStorageConfig } from './config.js';
+
+const makeConfig = (directory: string): LocalStorageConfig => ({
+  directory,
+  publicPath: '/uploads',
+});
+
+// A minimal valid 1x1 PNG so sharp has real image bytes to process.
+const ONE_BY_ONE_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC',
+  'base64'
+);
+
+describe('LocalStorageProvider', () => {
+  let dir: string;
+  let provider: LocalStorageProvider;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'storage-local-'));
+    provider = new LocalStorageProvider(makeConfig(dir));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes an uploaded file and returns url, filename and size with the public path', async () => {
+    const result = await provider.uploadFile(ONE_BY_ONE_PNG, 'cat.png', 'image/png', 'pets');
+
+    expect(result.filename).toMatch(/\.png$/);
+    expect(result.url).toBe(`/uploads/pets/${result.filename}`);
+    expect(result.size).toBeGreaterThan(0);
+
+    const onDisk = await readFile(path.join(dir, 'pets', result.filename));
+    expect(onDisk.length).toBe(result.size);
+  });
+
+  it('stores a PDF untouched without running it through image processing', async () => {
+    const pdfBytes = Buffer.from('%PDF-1.4 fake pdf body', 'utf8');
+
+    const result = await provider.uploadFile(pdfBytes, 'form.pdf', 'application/pdf', 'documents');
+
+    expect(result.size).toBe(pdfBytes.length);
+    const onDisk = await readFile(path.join(dir, 'documents', result.filename));
+    expect(onDisk.equals(pdfBytes)).toBe(true);
+  });
+
+  it('reports file info for an existing file and absence for a missing one', async () => {
+    const result = await provider.uploadFile(ONE_BY_ONE_PNG, 'cat.png', 'image/png', 'pets');
+
+    const info = await provider.getFileInfo(result.filename, 'pets');
+    expect(info.exists).toBe(true);
+    if (info.exists) {
+      expect(info.size).toBe(result.size);
+      expect(info.modified).toBeInstanceOf(Date);
+    }
+
+    const missing = await provider.getFileInfo('nope.png', 'pets');
+    expect(missing.exists).toBe(false);
+  });
+
+  it('deletes a file', async () => {
+    await mkdir(path.join(dir, 'documents'), { recursive: true });
+    const target = path.join(dir, 'documents', 'gone.txt');
+    await writeFile(target, 'bye');
+
+    await provider.deleteFile('gone.txt', 'documents');
+
+    const info = await provider.getFileInfo('gone.txt', 'documents');
+    expect(info.exists).toBe(false);
+  });
+
+  it('identifies itself and does not support signed urls', async () => {
+    expect(provider.getName()).toBe('local');
+    expect(provider.supportsSignedUrls()).toBe(false);
+    expect(provider.validateConfiguration()).toBe(true);
+  });
+
+  it('throws when asked for a signed url', async () => {
+    await expect(provider.getSignedUrl()).rejects.toThrow(/does not generate signed URLs/);
+  });
+});

--- a/packages/storage/src/local-storage-provider.ts
+++ b/packages/storage/src/local-storage-provider.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import fs from 'fs-extra';
+import sharp from 'sharp';
+import type { FileInfo, StorageCategory, StorageProvider, UploadResult } from './base-provider.js';
+import { type LocalStorageConfig, type StorageLogger, resolveLogger } from './config.js';
+
+// Cap decoded pixels so a small-on-disk image declaring extreme header
+// dimensions (e.g. 100000x100000) can't make sharp allocate
+// width*height*channels bytes and OOM the process. Hard-coded here to keep the
+// package free of monolith config coupling.
+const MAX_IMAGE_PIXELS = 100_000_000;
+
+export class LocalStorageProvider implements StorageProvider {
+  private readonly uploadDir: string;
+  private readonly publicPath: string;
+  private readonly logger: Required<StorageLogger>;
+
+  constructor(localConfig: LocalStorageConfig, logger?: StorageLogger) {
+    this.uploadDir = path.resolve(localConfig.directory);
+    this.publicPath = localConfig.publicPath;
+    this.logger = resolveLogger(logger);
+  }
+
+  async uploadFile(
+    file: Buffer,
+    originalName: string,
+    contentType: string,
+    category: StorageCategory = 'documents'
+  ): Promise<UploadResult> {
+    try {
+      const fileExtension = path.extname(originalName);
+      const filename = `${randomUUID()}${fileExtension}`;
+      const relativePath = path.join(category, filename);
+      const fullPath = path.join(this.uploadDir, relativePath);
+
+      // Ensure the category directory exists before writing. The constructor
+      // also seeds the standard subdirs, but that runs asynchronously, so this
+      // removes any ordering dependency on it.
+      await fs.ensureDir(path.dirname(fullPath));
+
+      let processedBuffer = file;
+
+      // Process images only — non-image content (e.g. application/pdf) passes
+      // through untouched.
+      if (contentType.startsWith('image/')) {
+        processedBuffer = await this.processImage(file, contentType);
+      }
+
+      await fs.writeFile(fullPath, processedBuffer);
+
+      const url = `${this.publicPath}/${relativePath.replace(/\\/g, '/')}`;
+
+      this.logger.info(`File uploaded locally: ${filename}`, {
+        originalName,
+        size: processedBuffer.length,
+        category,
+        url,
+      });
+
+      return {
+        url,
+        filename,
+        size: processedBuffer.length,
+      };
+    } catch (error) {
+      this.logger.error('Failed to upload file to local storage:', error);
+      throw error;
+    }
+  }
+
+  private async processImage(buffer: Buffer, contentType: string): Promise<Buffer> {
+    try {
+      const image = sharp(buffer, { limitInputPixels: MAX_IMAGE_PIXELS });
+      const metadata = await image.metadata();
+
+      // Resize if too large (max 1920x1080)
+      if (metadata.width && metadata.width > 1920) {
+        return await image
+          .resize(1920, 1080, {
+            fit: 'inside',
+            withoutEnlargement: true,
+          })
+          .jpeg({ quality: 85 })
+          .toBuffer();
+      }
+
+      // Convert to JPEG for consistency and smaller size
+      if (contentType !== 'image/jpeg') {
+        return await image.jpeg({ quality: 90 }).toBuffer();
+      }
+
+      return buffer;
+    } catch (error) {
+      this.logger.warn('Image processing failed, using original:', error);
+      return buffer;
+    }
+  }
+
+  async deleteFile(filename: string, category: string = 'documents'): Promise<void> {
+    try {
+      const filePath = path.join(this.uploadDir, category, filename);
+      await fs.remove(filePath);
+      this.logger.info(`File deleted: ${filename}`);
+    } catch (error) {
+      this.logger.error('Failed to delete file:', error);
+      throw error;
+    }
+  }
+
+  async getFileInfo(filename: string, category: string = 'documents'): Promise<FileInfo> {
+    try {
+      const filePath = path.join(this.uploadDir, category, filename);
+      const stats = await fs.stat(filePath);
+      return {
+        exists: true,
+        size: stats.size,
+        modified: stats.mtime,
+      };
+    } catch {
+      return { exists: false };
+    }
+  }
+
+  getName(): string {
+    return 'local';
+  }
+
+  validateConfiguration(): boolean {
+    return Boolean(this.uploadDir);
+  }
+
+  supportsSignedUrls(): boolean {
+    return false;
+  }
+
+  async getSignedUrl(): Promise<string> {
+    throw new Error('Local storage provider does not generate signed URLs');
+  }
+}

--- a/packages/storage/src/s3-storage-provider.test.ts
+++ b/packages/storage/src/s3-storage-provider.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PutObjectCommand, type S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { S3StorageProvider } from './s3-storage-provider.js';
+import type { S3StorageConfig } from './config.js';
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn(async () => 'https://signed.example/object?sig=abc'),
+}));
+
+const fullConfig: S3StorageConfig = {
+  bucket: 'my-bucket',
+  region: 'eu-west-2',
+  accessKeyId: 'key',
+  secretAccessKey: 'secret',
+};
+
+type FakeClient = { send: ReturnType<typeof vi.fn> };
+
+const makeClient = (): FakeClient => ({ send: vi.fn(async () => ({})) });
+
+// The provider only depends on S3Client's `send`; a stub satisfies the contract
+// without an `any` cast at the call site.
+const asClient = (client: FakeClient): S3Client => client as unknown as S3Client;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('S3StorageProvider', () => {
+  it('issues a PutObject and returns the S3 URL on upload', async () => {
+    const client = makeClient();
+    const provider = new S3StorageProvider(fullConfig, undefined, asClient(client));
+
+    const result = await provider.uploadFile(
+      Buffer.from('bytes'),
+      'photo.jpg',
+      'image/jpeg',
+      'pets'
+    );
+
+    expect(client.send).toHaveBeenCalledTimes(1);
+    const command = client.send.mock.calls[0][0];
+    expect(command).toBeInstanceOf(PutObjectCommand);
+    expect(command.input.Bucket).toBe('my-bucket');
+    expect(command.input.Key).toBe(`pets/${result.filename}`);
+    expect(command.input.ServerSideEncryption).toBe('AES256');
+    expect(result.url).toBe(`https://my-bucket.s3.eu-west-2.amazonaws.com/pets/${result.filename}`);
+    expect(result.size).toBe(5);
+  });
+
+  it('returns a CloudFront URL when a domain is configured', async () => {
+    const client = makeClient();
+    const provider = new S3StorageProvider(
+      { ...fullConfig, cloudFrontDomain: 'cdn.example.com' },
+      undefined,
+      asClient(client)
+    );
+
+    const result = await provider.uploadFile(
+      Buffer.from('x'),
+      'doc.pdf',
+      'application/pdf',
+      'documents'
+    );
+
+    expect(result.url).toBe(`https://cdn.example.com/documents/${result.filename}`);
+  });
+
+  it('mints a signed url via the presigner', async () => {
+    const client = makeClient();
+    const provider = new S3StorageProvider(fullConfig, undefined, asClient(client));
+
+    const url = await provider.getSignedUrl('file.jpg', 'pets', 120);
+
+    expect(url).toBe('https://signed.example/object?sig=abc');
+    expect(getSignedUrl).toHaveBeenCalledWith(expect.anything(), expect.anything(), {
+      expiresIn: 120,
+    });
+  });
+
+  it('identifies itself and supports signed urls', () => {
+    const provider = new S3StorageProvider(fullConfig, undefined, asClient(makeClient()));
+    expect(provider.getName()).toBe('s3');
+    expect(provider.supportsSignedUrls()).toBe(true);
+    expect(provider.validateConfiguration()).toBe(true);
+  });
+
+  it('reports misconfiguration and throws when used without full credentials', async () => {
+    const provider = new S3StorageProvider(
+      { bucket: 'only-bucket' },
+      undefined,
+      asClient(makeClient())
+    );
+    expect(provider.validateConfiguration()).toBe(false);
+    await expect(
+      provider.uploadFile(Buffer.from('x'), 'a.jpg', 'image/jpeg', 'pets')
+    ).rejects.toThrow(/misconfigured/);
+  });
+});

--- a/packages/storage/src/s3-storage-provider.ts
+++ b/packages/storage/src/s3-storage-provider.ts
@@ -1,0 +1,217 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import type { FileInfo, StorageCategory, StorageProvider, UploadResult } from './base-provider.js';
+import { type S3StorageConfig, type StorageLogger, resolveLogger } from './config.js';
+
+type ValidatedS3Config = {
+  bucket: string;
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  cloudFrontDomain?: string;
+};
+
+const DEFAULT_SIGNED_URL_TTL_SECONDS = 5 * 60;
+
+const IMAGE_CONTENT_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+const isInlineSafeContentType = (contentType: string): boolean =>
+  IMAGE_CONTENT_TYPES.has(contentType);
+
+export class S3StorageProvider implements StorageProvider {
+  private readonly config: S3StorageConfig;
+  private readonly validated: ValidatedS3Config | null;
+  private readonly client: S3Client;
+  private readonly logger: Required<StorageLogger>;
+
+  constructor(s3Config: S3StorageConfig, logger?: StorageLogger, client?: S3Client) {
+    this.config = s3Config;
+    this.validated = S3StorageProvider.validate(s3Config);
+    this.logger = resolveLogger(logger);
+    this.client =
+      client ??
+      new S3Client({
+        region: s3Config.region ?? 'us-east-1',
+        credentials:
+          s3Config.accessKeyId && s3Config.secretAccessKey
+            ? {
+                accessKeyId: s3Config.accessKeyId,
+                secretAccessKey: s3Config.secretAccessKey,
+              }
+            : undefined,
+      });
+  }
+
+  private static validate(s3Config: S3StorageConfig): ValidatedS3Config | null {
+    if (
+      !s3Config.bucket ||
+      !s3Config.region ||
+      !s3Config.accessKeyId ||
+      !s3Config.secretAccessKey
+    ) {
+      return null;
+    }
+    return {
+      bucket: s3Config.bucket,
+      region: s3Config.region,
+      accessKeyId: s3Config.accessKeyId,
+      secretAccessKey: s3Config.secretAccessKey,
+      cloudFrontDomain: s3Config.cloudFrontDomain,
+    };
+  }
+
+  private requireConfig(): ValidatedS3Config {
+    if (!this.validated) {
+      throw new Error(
+        'S3 storage provider misconfigured: bucket, region, accessKeyId and secretAccessKey are required'
+      );
+    }
+    return this.validated;
+  }
+
+  async uploadFile(
+    file: Buffer,
+    originalName: string,
+    contentType: string,
+    category: StorageCategory = 'documents'
+  ): Promise<UploadResult> {
+    const { bucket } = this.requireConfig();
+    const ext = path.extname(originalName);
+    const filename = `${randomUUID()}${ext}`;
+    const key = `${category}/${filename}`;
+
+    // Non-image uploads land with Content-Disposition: attachment so a browser
+    // never renders an HTML/PDF polyglot inline from the CDN origin. Images use
+    // their content-type as declared so they can be embedded with <img>.
+    const contentDisposition = isInlineSafeContentType(contentType) ? undefined : 'attachment';
+
+    try {
+      await this.client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: file,
+          ContentType: contentType,
+          // Defence-in-depth: enforce SSE-S3 even if the bucket default is misconfigured.
+          ServerSideEncryption: 'AES256',
+          ...(contentDisposition ? { ContentDisposition: contentDisposition } : {}),
+        })
+      );
+
+      const url = this.buildUrl(key);
+
+      // Do not log `url` — for private categories the URL is a credential-equivalent
+      // identifier. Key + size are enough for ops correlation.
+      this.logger.info('File uploaded to S3', { key, size: file.length, category });
+
+      return { url, filename, size: file.length };
+    } catch (error) {
+      this.logger.error('Failed to upload file to S3:', error);
+      throw error;
+    }
+  }
+
+  async deleteFile(filename: string, category: string = 'documents'): Promise<void> {
+    const { bucket } = this.requireConfig();
+    const key = `${category}/${filename}`;
+    try {
+      await this.client.send(
+        new DeleteObjectCommand({
+          Bucket: bucket,
+          Key: key,
+        })
+      );
+      this.logger.info(`File deleted from S3: ${key}`);
+    } catch (error) {
+      this.logger.error('Failed to delete file from S3:', error);
+      throw error;
+    }
+  }
+
+  async getFileInfo(filename: string, category: string = 'documents'): Promise<FileInfo> {
+    const { bucket } = this.requireConfig();
+    const key = `${category}/${filename}`;
+    try {
+      const response = await this.client.send(
+        new HeadObjectCommand({
+          Bucket: bucket,
+          Key: key,
+        })
+      );
+      return {
+        exists: true,
+        size: response.ContentLength ?? 0,
+        modified: response.LastModified ?? new Date(),
+      };
+    } catch (error) {
+      // Only "not found" maps to exists:false. AccessDenied, throttling, network
+      // errors must surface so callers don't make decisions on a misleading
+      // "doesn't exist" answer (e.g. orphan-cleanup deciding the DB row is stale).
+      if (S3StorageProvider.isNotFoundError(error)) {
+        return { exists: false };
+      }
+      this.logger.error('S3 HeadObject failed:', error);
+      throw error;
+    }
+  }
+
+  private static isNotFoundError(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null) {
+      return false;
+    }
+    const candidate = error as {
+      name?: unknown;
+      Code?: unknown;
+      $metadata?: { httpStatusCode?: unknown };
+    };
+    if (candidate.name === 'NotFound' || candidate.name === 'NoSuchKey') {
+      return true;
+    }
+    if (candidate.Code === 'NotFound' || candidate.Code === 'NoSuchKey') {
+      return true;
+    }
+    return candidate.$metadata?.httpStatusCode === 404;
+  }
+
+  getName(): string {
+    return 's3';
+  }
+
+  validateConfiguration(): boolean {
+    return this.validated !== null;
+  }
+
+  supportsSignedUrls(): boolean {
+    return true;
+  }
+
+  async getSignedUrl(
+    filename: string,
+    category: string = 'documents',
+    expiresInSeconds: number = DEFAULT_SIGNED_URL_TTL_SECONDS
+  ): Promise<string> {
+    const { bucket } = this.requireConfig();
+    const key = `${category}/${filename}`;
+    const command = new GetObjectCommand({ Bucket: bucket, Key: key });
+    return getSignedUrl(this.client, command, { expiresIn: expiresInSeconds });
+  }
+
+  private buildUrl(key: string): string {
+    // Stored on the upload row for backwards compatibility with existing callers
+    // that read the URL directly. Private content is *not* served from this URL —
+    // the caller rewrites the URL for private categories to route through an
+    // auth-gated serve route.
+    if (this.config.cloudFrontDomain) {
+      return `https://${this.config.cloudFrontDomain}/${key}`;
+    }
+    return `https://${this.config.bucket}.s3.${this.config.region}.amazonaws.com/${key}`;
+  }
+}

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## What

Extracts `service.backend`'s storage abstraction into a new dependency-light, **config-injected** workspace package `@adopt-dont-shop/storage` (`packages/storage`). The gateway (and later other services) will use it to store uploaded files.

This is an **additive** extraction — the monolith's copy under `service.backend/src/services/storage/` is left untouched.

## Decoupling from the monolith

- **Config-injected**: providers take their config via constructor args; no global `config` import. New `StorageConfig` type mirrors `config.storage`. `createStorageProvider(config)` selects local vs s3.
- **uuid**: `node:crypto`'s `randomUUID()` instead of the monolith's `generateCryptoUuid`.
- **logger**: optional minimal logger (`{ info?, warn?, error? }`) defaulting to a no-op — the monolith logger is not imported.
- **image-limits**: `MAX_IMAGE_PIXELS = 100_000_000` hard-coded with a comment; the `image/*` guard is preserved so non-image content (e.g. `application/pdf`) passes through sharp untouched.

## Exported API

- `createStorageProvider(config: StorageConfig): StorageProvider`
- `StorageProvider` (interface — implemented contract), `LocalStorageProvider`, `S3StorageProvider`
- types: `StorageConfig`, `StorageCategory`, `UploadResult`, `FileInfo`, `LocalStorageConfig`, `S3StorageConfig`, `StorageLogger`

## Runtime deps added

`fs-extra`, `sharp`, `@aws-sdk/client-s3`, `@aws-sdk/s3-request-presigner` (+ `@types/fs-extra` dev) — pinned to the same versions `service.backend` already uses.

## Out of scope

Malware / AV scanning is intentionally **not** ported (documented in the package README + `index.ts`). The gateway calls this without AV for now; a scanning step is a follow-up.

## Verification

- `npm install` resolves
- `tsc --noEmit` clean
- `vitest run` → 14 passing (Local: upload/PDF-passthrough/delete/getFileInfo/getName/signed-url-throws; S3: PutObject + URL/CloudFront/presigner/getName, mocked AWS; factory: local/s3/misconfig)
- `eslint packages/storage/src` clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_