### PR TITLE
feat(gateway): matching — wire Recommend + SearchPets via frontend contracts

### DIFF
--- a/services/gateway/src/routes/matching-view.test.ts
+++ b/services/gateway/src/routes/matching-view.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PetCandidate, RecommendResponse, SearchPetsResponse } from '@adopt-dont-shop/proto';
+
+import { petCandidateToView, recommendToQueue, searchToView } from './matching-view.js';
+
+function makeCandidate(overrides: Partial<PetCandidate> = {}): PetCandidate {
+  return {
+    petId: 'pet-1',
+    name: 'Rex',
+    species: 'dog',
+    rescueId: 'rsc-1',
+    score: 0.83,
+    breed: 'Labrador',
+    age: '3 years',
+    shortDescription: 'Good boy',
+    primaryImageUrl: '/uploads/pets/pet-1.jpg',
+    ...overrides,
+  } as PetCandidate;
+}
+
+describe('petCandidateToView', () => {
+  it('maps camelCase to snake_case + includes the score by default', () => {
+    expect(petCandidateToView(makeCandidate())).toEqual({
+      pet_id: 'pet-1',
+      name: 'Rex',
+      rescue_id: 'rsc-1',
+      type: 'dog',
+      breed: 'Labrador',
+      age: '3 years',
+      short_description: 'Good boy',
+      primary_image_url: '/uploads/pets/pet-1.jpg',
+      score: 0.83,
+    });
+  });
+
+  it('omits the score on plain search results', () => {
+    const v = petCandidateToView(makeCandidate(), false);
+    expect('score' in v).toBe(false);
+  });
+
+  it('omits optional fields when absent', () => {
+    const v = petCandidateToView({
+      petId: 'pet-2',
+      name: 'Whiskers',
+      species: 'cat',
+      rescueId: 'rsc-1',
+      score: 0,
+    } as PetCandidate);
+    expect(v).toMatchObject({ pet_id: 'pet-2', type: 'cat', score: 0 });
+    expect('breed' in v).toBe(false);
+    expect('primary_image_url' in v).toBe(false);
+  });
+});
+
+describe('recommendToQueue', () => {
+  it('builds the discovery queue envelope and inverts exhausted → hasMore', () => {
+    const env = recommendToQueue({
+      candidates: [makeCandidate(), makeCandidate({ petId: 'pet-2' })],
+      exhausted: false,
+    } as RecommendResponse);
+    expect(env).toEqual({
+      pets: [
+        expect.objectContaining({ pet_id: 'pet-1', score: 0.83 }),
+        expect.objectContaining({ pet_id: 'pet-2', score: 0.83 }),
+      ],
+      currentIndex: 0,
+      hasMore: true,
+      nextBatchSize: 20,
+    });
+  });
+
+  it('reports hasMore false when exhausted', () => {
+    const env = recommendToQueue({ candidates: [], exhausted: true } as RecommendResponse);
+    expect(env.hasMore).toBe(false);
+  });
+});
+
+describe('searchToView', () => {
+  it('drops the score on search results and forwards next_cursor when present', () => {
+    const env = searchToView({
+      results: [makeCandidate()],
+      nextCursor: 'cur-2',
+    } as SearchPetsResponse);
+    expect(env.next_cursor).toBe('cur-2');
+    expect('score' in env.results[0]).toBe(false);
+  });
+
+  it('omits next_cursor when absent or empty', () => {
+    const env = searchToView({ results: [], nextCursor: '' } as SearchPetsResponse);
+    expect('next_cursor' in env).toBe(false);
+  });
+});

--- a/services/gateway/src/routes/matching-view.ts
+++ b/services/gateway/src/routes/matching-view.ts
@@ -1,0 +1,95 @@
+// Stage B — matching response adapter.
+//
+// service.matching returns proto-JSON PetCandidate (camelCase, optional
+// breed/age/image). The frontend uses two contracts on top of these:
+//
+//   1. lib.discovery — POST /api/v1/discovery/queue returns
+//      { pets: Pet[], currentIndex, hasMore, nextBatchSize }. The "pets"
+//      shape is the snake_case lib.pets PetSchema (only pet_id + name
+//      are required; everything else optional), and pages of more pets
+//      come from POST /api/v1/discovery/pets/more.
+//   2. lib.search — GET /api/v1/search/pets returns a paginated list.
+//
+// Both surfaces are read-only, so the adapter is one-directional: proto
+// PetCandidate → frontend pet view, then build the per-route envelope.
+
+import type { PetCandidate, RecommendResponse, SearchPetsResponse } from '@adopt-dont-shop/proto';
+
+export type DiscoveryPetView = {
+  pet_id: string;
+  name: string;
+  rescue_id: string;
+  type?: string;
+  breed?: string;
+  age?: string;
+  short_description?: string;
+  primary_image_url?: string;
+  // The recommender's score, on [0,1]. Plain search doesn't carry it.
+  score?: number;
+};
+
+// proto PetCandidate.species → frontend `type` (the lib.pets enum:
+// 'dog'|'cat'|'rabbit'|…). Pass through untouched — the proto stores the
+// lowercase token in `species` already.
+export function petCandidateToView(c: PetCandidate, includeScore = true): DiscoveryPetView {
+  const view: DiscoveryPetView = {
+    pet_id: c.petId,
+    name: c.name,
+    rescue_id: c.rescueId,
+  };
+  if (c.species !== undefined && c.species !== '') {
+    view.type = c.species;
+  }
+  if (c.breed !== undefined) {
+    view.breed = c.breed;
+  }
+  if (c.age !== undefined) {
+    view.age = c.age;
+  }
+  if (c.shortDescription !== undefined) {
+    view.short_description = c.shortDescription;
+  }
+  if (c.primaryImageUrl !== undefined) {
+    view.primary_image_url = c.primaryImageUrl;
+  }
+  // Score is only meaningful on Recommend responses — SearchPets drops it.
+  if (includeScore) {
+    view.score = c.score;
+  }
+  return view;
+}
+
+export type DiscoveryQueueView = {
+  pets: DiscoveryPetView[];
+  currentIndex: number;
+  hasMore: boolean;
+  nextBatchSize: number;
+};
+
+// Recommend → the discovery queue the SPA expects. `hasMore` is the
+// inverse of the recommender's `exhausted` flag; `nextBatchSize` mirrors
+// the default the frontend service requests.
+export function recommendToQueue(res: RecommendResponse): DiscoveryQueueView {
+  return {
+    pets: res.candidates.map(c => petCandidateToView(c, true)),
+    currentIndex: 0,
+    hasMore: !res.exhausted,
+    nextBatchSize: 20,
+  };
+}
+
+export type SearchPetsView = {
+  results: DiscoveryPetView[];
+  next_cursor?: string;
+};
+
+// SearchPets carries no score per the proto comment, so the view omits it.
+export function searchToView(res: SearchPetsResponse): SearchPetsView {
+  const view: SearchPetsView = {
+    results: res.results.map(c => petCandidateToView(c, false)),
+  };
+  if (res.nextCursor !== undefined && res.nextCursor !== '') {
+    view.next_cursor = res.nextCursor;
+  }
+  return view;
+}

--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -22,21 +22,33 @@ function makeClient(): {
   endSessionMock: ReturnType<typeof vi.fn>;
   recordSwipeMock: ReturnType<typeof vi.fn>;
   listSwipeHistoryMock: ReturnType<typeof vi.fn>;
+  recommendMock: ReturnType<typeof vi.fn>;
+  searchPetsMock: ReturnType<typeof vi.fn>;
 } {
   const startSessionMock = vi.fn();
   const endSessionMock = vi.fn();
   const recordSwipeMock = vi.fn();
   const listSwipeHistoryMock = vi.fn();
+  const recommendMock = vi.fn();
+  const searchPetsMock = vi.fn();
   const client: MatchingClient = {
     startSession: startSessionMock,
     endSession: endSessionMock,
     recordSwipe: recordSwipeMock,
     listSwipeHistory: listSwipeHistoryMock,
-    recommend: vi.fn(),
-    searchPets: vi.fn(),
+    recommend: recommendMock,
+    searchPets: searchPetsMock,
     close: vi.fn(),
   };
-  return { client, startSessionMock, endSessionMock, recordSwipeMock, listSwipeHistoryMock };
+  return {
+    client,
+    startSessionMock,
+    endSessionMock,
+    recordSwipeMock,
+    listSwipeHistoryMock,
+    recommendMock,
+    searchPetsMock,
+  };
 }
 
 async function makeApp(client: MatchingClient): Promise<FastifyInstance> {
@@ -281,5 +293,145 @@ describe('GET /api/v1/matching/swipes', () => {
       actionFilter: MatchingV1.SwipeAction.SWIPE_ACTION_SUPER_LIKE,
     });
     expect(httpRes.json()).toMatchObject({ nextCursor: 'cursor-2' });
+  });
+});
+
+describe('POST /api/v1/discovery/queue (Recommend)', () => {
+  let app: FastifyInstance;
+  let recommendMock: ReturnType<typeof vi.fn>;
+  let startSessionMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    recommendMock = m.recommendMock;
+    startSessionMock = m.startSessionMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('opens a session implicitly then returns the discovery-queue envelope', async () => {
+    startSessionMock.mockResolvedValueOnce({
+      session: SESSION_FIXTURE,
+      created: true,
+    } satisfies StartSessionResponse);
+    recommendMock.mockResolvedValueOnce({
+      candidates: [
+        {
+          petId: 'pet-1',
+          name: 'Rex',
+          species: 'dog',
+          rescueId: 'rsc-1',
+          score: 0.9,
+        },
+      ],
+      exhausted: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/discovery/queue',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: { filters: { species: 'dog' }, limit: 10 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      pets: [{ pet_id: 'pet-1', type: 'dog', score: 0.9 }],
+      currentIndex: 0,
+      hasMore: true,
+      nextBatchSize: 20,
+    });
+    // StartSession was called with the filters; then Recommend with the session.
+    expect(startSessionMock.mock.calls[0][0].filtersJson).toBe('{"species":"dog"}');
+    expect(recommendMock.mock.calls[0][0]).toMatchObject({
+      sessionId: 'sess-1',
+      limit: 10,
+      filtersJsonOverride: '{"species":"dog"}',
+    });
+  });
+
+  it('uses the supplied sessionId without opening a new one', async () => {
+    recommendMock.mockResolvedValueOnce({ candidates: [], exhausted: true });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/discovery/queue',
+      payload: { sessionId: 'sess-9' },
+    });
+    expect(startSessionMock).not.toHaveBeenCalled();
+    expect(recommendMock.mock.calls[0][0].sessionId).toBe('sess-9');
+  });
+});
+
+describe('POST /api/v1/discovery/pets/more (Recommend, paged)', () => {
+  it('rejects when sessionId is missing', async () => {
+    const m = makeClient();
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/discovery/pets/more',
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(m.recommendMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('forwards the sessionId + limit', async () => {
+    const m = makeClient();
+    m.recommendMock.mockResolvedValueOnce({
+      candidates: [{ petId: 'pet-2', name: 'Sam', species: 'cat', rescueId: 'rsc-1', score: 0.4 }],
+      exhausted: false,
+    });
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/discovery/pets/more',
+        payload: { sessionId: 'sess-1', limit: 5 },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(m.recommendMock.mock.calls[0][0]).toMatchObject({
+        sessionId: 'sess-1',
+        limit: 5,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('GET /api/v1/search/pets (SearchPets)', () => {
+  it('forwards q/filters/cursor/limit and returns the view envelope', async () => {
+    const m = makeClient();
+    m.searchPetsMock.mockResolvedValueOnce({
+      results: [{ petId: 'pet-1', name: 'Rex', species: 'dog', rescueId: 'rsc-1', score: 0 }],
+      nextCursor: 'cur-2',
+    });
+    const app = await makeApp(m.client);
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/search/pets?q=rex&limit=10&cursor=abc&filters=%7B%22species%22%3A%22dog%22%7D',
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { results: Array<Record<string, unknown>>; next_cursor?: string };
+      expect(body.next_cursor).toBe('cur-2');
+      expect(body.results[0]).toMatchObject({ pet_id: 'pet-1', type: 'dog' });
+      // No recommender score on plain search.
+      expect('score' in body.results[0]).toBe(false);
+      expect(m.searchPetsMock.mock.calls[0][0]).toMatchObject({
+        query: 'rex',
+        cursor: 'abc',
+        limit: 10,
+        filtersJson: '{"species":"dog"}',
+      });
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -13,10 +13,12 @@
 //   POST /api/v1/matching/sessions/:id/swipes             → RecordSwipe
 //   GET  /api/v1/matching/swipes                          → ListSwipeHistory
 //
-// Recommend + SearchPets aren't wired yet — the matching gRPC server
-// returns UNIMPLEMENTED for them (#922 stubs). When those handlers
-// ship the gateway will gain `/api/v1/matching/recommend` +
-// `/api/v1/matching/search` routes.
+// Recommend + SearchPets — wired via the frontend lib.discovery /
+// lib.search contracts (response shapes adapted via matching-view.ts):
+//
+//   POST /api/v1/discovery/queue                          → Recommend
+//   POST /api/v1/discovery/pets/more                      → Recommend (page)
+//   GET  /api/v1/search/pets                              → SearchPets
 //
 // Authz: PETS_VIEW (matching is a pet-browsing surface). The Phase
 // 2.5 authenticate middleware stamps x-user-* metadata; the matching
@@ -30,11 +32,15 @@ import {
   MatchingV1,
   type EndSessionRequest,
   type ListSwipeHistoryRequest,
+  type RecommendRequest,
   type RecordSwipeRequest,
+  type SearchPetsRequest,
   type StartSessionRequest,
 } from '@adopt-dont-shop/proto';
 
 import type { MatchingClient } from '../grpc-clients/matching-client.js';
+
+import { recommendToQueue, searchToView } from './matching-view.js';
 
 export type MatchingRoutesOptions = {
   client: MatchingClient;
@@ -59,6 +65,9 @@ const MATCHING_RATE_LIMITS = {
   endSession: { max: 30, timeWindow: '1 minute' },
   recordSwipe: { max: 240, timeWindow: '1 minute' },
   listSwipeHistory: { max: 60, timeWindow: '1 minute' },
+  // Discovery + search are the chatty browse paths.
+  recommend: { max: 120, timeWindow: '1 minute' },
+  search: { max: 120, timeWindow: '1 minute' },
 } as const;
 
 type StartSessionBody = {
@@ -158,7 +167,115 @@ export const registerMatchingRoutes = async (
       }
     }
   );
+
+  // POST /api/v1/discovery/queue — initial recommendations. Body matches
+  // lib.discovery.getDiscoveryQueue: { filters, userId?, limit? }. We
+  // need a sessionId for Recommend; if the SPA doesn't pass one we
+  // start a session implicitly using the filters as the session filters.
+  app.post(
+    '/api/v1/discovery/queue',
+    { config: { rateLimit: MATCHING_RATE_LIMITS.recommend } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as DiscoveryQueueBody;
+      const filtersJson = body.filters !== undefined ? JSON.stringify(body.filters) : '';
+      try {
+        const sessionId = body.sessionId ?? (await openSession(client, req, filtersJson));
+        const grpcReq: RecommendRequest = {
+          sessionId,
+          limit: clampLimit(body.limit),
+          filtersJsonOverride: filtersJson !== '' ? filtersJson : undefined,
+        };
+        const res = await client.recommend(grpcReq, buildMetadata(req));
+        return reply.send(recommendToQueue(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // POST /api/v1/discovery/pets/more — page of more recommendations for
+  // an active session.
+  app.post(
+    '/api/v1/discovery/pets/more',
+    { config: { rateLimit: MATCHING_RATE_LIMITS.recommend } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as DiscoveryQueueBody;
+      if (body.sessionId === undefined || body.sessionId === '') {
+        return reply.code(400).send({ error: 'sessionId is required' });
+      }
+      const grpcReq: RecommendRequest = {
+        sessionId: body.sessionId,
+        limit: clampLimit(body.limit),
+        filtersJsonOverride: body.filters !== undefined ? JSON.stringify(body.filters) : undefined,
+      };
+      try {
+        const res = await client.recommend(grpcReq, buildMetadata(req));
+        return reply.send(recommendToQueue(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
+  // GET /api/v1/search/pets — lib.search free-text + filters search.
+  app.get(
+    '/api/v1/search/pets',
+    { config: { rateLimit: MATCHING_RATE_LIMITS.search } },
+    async (req, reply) => {
+      const query = req.query as Record<string, string | undefined>;
+      const grpcReq: SearchPetsRequest = {
+        query: query.q ?? query.query,
+        filtersJson: query.filters,
+        cursor: query.cursor,
+        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      };
+      try {
+        const res = await client.searchPets(grpcReq, buildMetadata(req));
+        return reply.send(searchToView(res));
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
 };
+
+type DiscoveryQueueBody = {
+  sessionId?: string;
+  filters?: Record<string, unknown>;
+  userId?: string;
+  limit?: number;
+};
+
+function clampLimit(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) {
+    return 20;
+  }
+  return Math.min(Math.max(Math.trunc(raw), 1), 100);
+}
+
+// Implicit-session helper: when the SPA doesn't carry a sessionId on
+// /discovery/queue, mint one via StartSession (web device by default).
+async function openSession(
+  client: MatchingClient,
+  req: FastifyRequest,
+  filtersJson: string
+): Promise<string> {
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  const ua = typeof headers['user-agent'] === 'string' ? headers['user-agent'] : undefined;
+  const res = await client.startSession(
+    {
+      filtersJson,
+      // The User-Agent is the SPA in a browser; DESKTOP is the closest
+      // bucket the proto offers (no DEVICE_TYPE_WEB exists). Caller can
+      // override by calling /matching/sessions explicitly with `deviceType`.
+      deviceType: MatchingV1.DeviceType.DEVICE_TYPE_DESKTOP,
+      userAgent: ua,
+      ipAddress: req.ip,
+    },
+    buildMetadata(req)
+  );
+  return res.session?.sessionId ?? '';
+}
 
 // --- Helpers ---------------------------------------------------------
 


### PR DESCRIPTION
## What

Closes the last matching gap. The audit flagged: 4 of 6 RPCs were exposed at the gateway (sessions/swipes/swipe-history) but the **implemented** Recommend + SearchPets handlers were **unreachable**. This wires them via the frontend's `lib.discovery` + `lib.search` contracts. Matching is now **complete end-to-end** — fully flip-ready.

### Routes added (responses adapted to the frontend, not raw proto-JSON)

| | |
|---|---|
| `POST /api/v1/discovery/queue` | Recommend. Opens a session implicitly when `sessionId` is absent (uses the User-Agent + `req.ip`; `DESKTOP` device type — the proto has no `DEVICE_TYPE_WEB`). |
| `POST /api/v1/discovery/pets/more` | Recommend (paged). 400 without `sessionId`. |
| `GET /api/v1/search/pets` | SearchPets (`q`/`filters`/`cursor`/`limit`). |

### `matching-view.ts` (Stage B adapter)

- `petCandidateToView` — camelCase → snake_case (`pet_id`, `rescue_id`, `short_description`, `primary_image_url`), optional-aware (omits absent fields); the proto stores the lowercase species token (`'dog'`) so it passes through to the frontend's `type`.
- `recommendToQueue` — RecommendResponse → `lib.discovery`'s `{ pets, currentIndex, hasMore, nextBatchSize }`, **inverting `exhausted` → `hasMore`**.
- `searchToView` — drops the recommender score (per the proto's own comment — search is relevance-ordered), forwards `next_cursor` when present.

**Flag still off — behaviour-preserving.**

## Matching vertical state — complete

Schema ✅ · proto ✅ · handlers (incl. Recommend/SearchPets) ✅ · server ✅ · NATS publishers (sessionStarted/sessionEnded/swipeRecorded) ✅ · **gateway routes (all 6 RPCs + frontend discovery + search contracts)** ✅

The simplified rule-based scorer (vs the monolith's 711-line engine with embedding/CF/LLM scorers) is a **separate** parity decision documented in the audit; this PR just makes what exists reachable.

## Tests

- `matching-view.test.ts` — field renames, score-inclusion modes, optional omission, queue envelope + hasMore inversion, search drops score + cursor handling.
- `matching.test.ts` — discovery/queue happy path (StartSession + Recommend), implicit session open vs caller-supplied, pets/more 400 on missing sessionId, search params + envelope + score omitted.
- Full `services/gateway` suite green: **193 tests**; `tsc --noEmit` clean; eslint clean.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_