### PR TITLE
feat(lib.components): add PetImage component with no-image fallback (ADS-14)

### DIFF
--- a/app.client/src/components/PetCard.tsx
+++ b/app.client/src/components/PetCard.tsx
@@ -2,7 +2,7 @@ import { useAuth } from '@adopt-dont-shop/lib.auth';
 import { useFavorites } from '@/contexts/FavoritesContext';
 import { useStatsig } from '@/hooks/useStatsig';
 import { Pet } from '@/services';
-import { Badge, Button, Card, ProgressiveImage } from '@adopt-dont-shop/lib.components';
+import { Badge, Button, Card, PetImage } from '@adopt-dont-shop/lib.components';
 import React, { useState } from 'react';
 import { MdFavorite, MdFavoriteBorder, MdLocationOn } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
@@ -192,16 +192,7 @@ export const PetCard: React.FC<PetCardProps> = ({
       onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && handleCardClick()}
     >
       <div className={styles.imageContainer}>
-        {resolvedImageUrl ? (
-          <ProgressiveImage
-            src={resolvedImageUrl}
-            alt={pet.name}
-            errorFallback={<div className={styles.placeholderImage} />}
-            placeholder={<div className={styles.placeholderImage} />}
-          />
-        ) : (
-          <div className={styles.placeholderImage} />
-        )}
+        <PetImage src={resolvedImageUrl} alt={pet.name} />
 
         <Badge variant={getStatusColor(pet.status)} className={styles.statusBadge}>
           {getStatusLabel(pet.status)}

--- a/app.client/src/setup-tests.ts
+++ b/app.client/src/setup-tests.ts
@@ -304,6 +304,16 @@ vi.mock('@adopt-dont-shop/lib.components', () => ({
       errored ? errorFallback : null
     );
   },
+  PetImage: ({
+    src,
+    alt,
+    className,
+  }: {
+    src?: string;
+    alt: string;
+    className?: string;
+    eager?: boolean;
+  }) => React.createElement('img', { src, alt, className }),
   toast: Object.assign(vi.fn(), {
     success: vi.fn(),
     error: vi.fn(),

--- a/lib.components/src/components/ui/PetImage/PetImage.test.tsx
+++ b/lib.components/src/components/ui/PetImage/PetImage.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import noImage from '../ImageGallery/no-image.png';
+import { PetImage } from './PetImage';
+
+describe('PetImage', () => {
+  describe('when a valid image URL is provided', () => {
+    it('displays the image with the correct alt text', () => {
+      render(<PetImage src='https://example.com/cat.jpg' alt='Whiskers' eager />);
+      // getByRole (hidden: false by default) excludes the placeholder inside aria-hidden
+      expect(screen.getByRole('img', { name: 'Whiskers' })).toBeInTheDocument();
+    });
+
+    it('uses the provided URL as the image source', () => {
+      render(<PetImage src='https://example.com/cat.jpg' alt='Whiskers' eager />);
+      const img = screen.getByRole('img', { name: 'Whiskers' }) as HTMLImageElement;
+      expect(img.src).toContain('cat.jpg');
+    });
+
+    it('shows the no-image fallback when the image fails to load', () => {
+      render(<PetImage src='https://example.com/broken.jpg' alt='Broken pet' eager />);
+      // Before error: only the main img is accessible (placeholder is aria-hidden)
+      const mainImg = screen.getByRole('img', { name: 'Broken pet' }) as HTMLImageElement;
+      fireEvent.error(mainImg);
+      // After error: errorFallback (no-image) replaces the aria-hidden placeholder
+      const allImgs = screen.getAllByRole('img', { name: 'Broken pet' }) as HTMLImageElement[];
+      expect(allImgs.some(img => img.getAttribute('src') === noImage)).toBe(true);
+    });
+  });
+
+  describe('when no image URL is provided', () => {
+    it('renders the no-image fallback when src is undefined', () => {
+      render(<PetImage src={undefined} alt='No photo' />);
+      const img = screen.getByAltText('No photo') as HTMLImageElement;
+      expect(img).toHaveAttribute('src', noImage);
+    });
+
+    it('renders the no-image fallback when src is an empty string', () => {
+      render(<PetImage src='' alt='No photo' />);
+      const img = screen.getByAltText('No photo') as HTMLImageElement;
+      expect(img).toHaveAttribute('src', noImage);
+    });
+  });
+});

--- a/lib.components/src/components/ui/PetImage/PetImage.tsx
+++ b/lib.components/src/components/ui/PetImage/PetImage.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import noImage from '../ImageGallery/no-image.png';
+import { ProgressiveImage } from '../ProgressiveImage';
+
+export type PetImageProps = {
+  src: string | undefined;
+  alt: string;
+  className?: string;
+  eager?: boolean;
+};
+
+const NoImageFallback = ({ alt, className }: { alt: string; className?: string }) => (
+  <img src={noImage} alt={alt} className={className} />
+);
+
+export const PetImage: React.FC<PetImageProps> = ({ src, alt, className, eager }) => {
+  if (!src) {
+    return <img src={noImage} alt={alt} className={className} />;
+  }
+
+  return (
+    <ProgressiveImage
+      src={src}
+      alt={alt}
+      className={className}
+      eager={eager}
+      placeholder={<NoImageFallback alt={alt} className={className} />}
+      errorFallback={<NoImageFallback alt={alt} className={className} />}
+    />
+  );
+};
+
+PetImage.displayName = 'PetImage';

--- a/lib.components/src/components/ui/PetImage/index.ts
+++ b/lib.components/src/components/ui/PetImage/index.ts
@@ -1,0 +1,2 @@
+export { PetImage } from './PetImage';
+export type { PetImageProps } from './PetImage';

--- a/lib.components/src/index.ts
+++ b/lib.components/src/index.ts
@@ -146,9 +146,11 @@ export type { WidgetPickerProps, WidgetPreset } from './components/reports/Widge
 export { DrillDownModal } from './components/reports/DrillDownModal';
 export type { DrillDownModalProps } from './components/reports/DrillDownModal';
 
-// ADS-14: Shared image component
+// ADS-14: Shared image components
 export { ProgressiveImage } from './components/ui/ProgressiveImage';
 export type { ProgressiveImageProps } from './components/ui/ProgressiveImage';
+export { PetImage } from './components/ui/PetImage';
+export type { PetImageProps } from './components/ui/PetImage';
 
 // PWA install prompt
 export { InstallPwaBanner } from './components/ui/InstallPwaBanner';


### PR DESCRIPTION
## Summary

- Adds a `PetImage` component to `lib.components` that wraps `ProgressiveImage` with a built-in `no-image.png` fallback, removing the repeated conditional-render pattern scattered across call sites
- Exports `PetImage` and `PetImageProps` from the `lib.components` package barrel
- Migrates `app.client/src/components/PetCard.tsx` as the first consumer, replacing a 9-line conditional block with a single `<PetImage>` element

## Why

Closes ADS-14. Before this change, every component that displays a pet photo needed to call `resolveFileUrl`, check for undefined, conditionally render `ProgressiveImage`, and provide a custom error/placeholder fallback — independently. This is fragmented and makes future changes (e.g. S3 migration, fallback design update) require touching every call site. `PetImage` centralises the fallback pattern in one place.

## Test plan

- [x] 5 unit tests covering: renders with valid src, uses correct src, shows no-image fallback on undefined src, shows no-image fallback on empty string src, shows no-image fallback on image load error
- [x] `lib.components` TypeScript compiles clean (`tsc --noEmit`)
- [x] Pre-commit lint-staged passes (prettier + eslint)
- [ ] Remaining call sites (`SwipeCard`, `PetHeroCard`, `PetSummary`, `PetDetailsPage`, `app.rescue`) to be migrated in follow-up commits

## Risks/Blockers

None. The soft dependency on ADS-13 (S3 migration) does not block this — `PetImage` accepts a pre-resolved `src` string, so the URL resolution strategy can change independently.

https://claude.ai/code/session_01DRpYQKBPGQwcYNWg98c3YB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRpYQKBPGQwcYNWg98c3YB)_