### PR TITLE
feat(notifications): phase 7 — email + push + scheduler round-out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23997,6 +23997,15 @@
       "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
@@ -26777,6 +26786,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -32501,27 +32531,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "service.backend/node_modules/resend": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
-      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
-      "license": "MIT",
-      "dependencies": {
-        "postal-mime": "2.7.4",
-        "standardwebhooks": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
-      }
-    },
     "service.backend/node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -33165,7 +33174,12 @@
         "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
-        "pg": "^8.21.0"
+        "nodemailer": "^8.0.8",
+        "pg": "^8.21.0",
+        "resend": "^6.12.4"
+      },
+      "devDependencies": {
+        "@types/nodemailer": "^8.0.0"
       }
     },
     "services/pets": {

--- a/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
+++ b/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
@@ -31,6 +31,32 @@ service NotificationService {
   // the same row without error. Publishes `notifications.dismissed`
   // on NATS after the DB commits.
   rpc Dismiss(DismissNotificationRequest) returns (DismissNotificationResponse);
+
+  // --- Email queue ----------------------------------------------------
+  // Phase 7 round-out. The service owns the email_queue table; other
+  // services (auth, applications, chat) call SendEmail to enqueue a
+  // transactional message and a background worker drains the queue,
+  // routing to the configured provider (console / ethereal / Resend).
+
+  // Enqueue an email. Returns the email_id immediately; delivery happens
+  // asynchronously in the worker. Callers can supply a templateId +
+  // templateData OR a pre-rendered subject + html_content; if both are
+  // present the template wins. `idempotency_key` is optional — when set
+  // a duplicate Send with the same key returns the same email_id.
+  rpc SendEmail(SendEmailRequest) returns (SendEmailResponse);
+
+  // --- Email preferences ----------------------------------------------
+  // Per-user opt-in/opt-out for the email channel.
+
+  // Read the calling principal's email preferences (or a target user's
+  // when the caller has email-prefs:read:any). Returns the canonical
+  // row, creating defaults on first read.
+  rpc GetEmailPreferences(GetEmailPreferencesRequest) returns (GetEmailPreferencesResponse);
+
+  // Partially update email preferences. Only provided fields are
+  // touched — unset fields keep their current value.
+  rpc UpdateEmailPreferences(UpdateEmailPreferencesRequest)
+      returns (UpdateEmailPreferencesResponse);
 }
 
 // Notification mirrors the `notifications.notifications` row plus the
@@ -200,4 +226,161 @@ message DismissNotificationResponse {
   // The updated row (status=READ, read_at=now). Idempotent: a second
   // Dismiss on the same notification_id returns the same payload.
   Notification notification = 1;
+}
+
+// --- Email queue ENUMs ------------------------------------------------
+
+enum EmailType {
+  EMAIL_TYPE_UNSPECIFIED = 0;
+  EMAIL_TYPE_TRANSACTIONAL = 1;
+  EMAIL_TYPE_NOTIFICATION = 2;
+  EMAIL_TYPE_MARKETING = 3;
+  EMAIL_TYPE_SYSTEM = 4;
+}
+
+enum EmailPriority {
+  EMAIL_PRIORITY_UNSPECIFIED = 0;
+  EMAIL_PRIORITY_LOW = 1;
+  EMAIL_PRIORITY_NORMAL = 2;
+  EMAIL_PRIORITY_HIGH = 3;
+  EMAIL_PRIORITY_URGENT = 4;
+}
+
+enum EmailStatus {
+  EMAIL_STATUS_UNSPECIFIED = 0;
+  EMAIL_STATUS_QUEUED = 1;
+  EMAIL_STATUS_SENDING = 2;
+  EMAIL_STATUS_SENT = 3;
+  EMAIL_STATUS_DELIVERED = 4;
+  EMAIL_STATUS_OPENED = 5;
+  EMAIL_STATUS_CLICKED = 6;
+  EMAIL_STATUS_FAILED = 7;
+  EMAIL_STATUS_BOUNCED = 8;
+  EMAIL_STATUS_UNSUBSCRIBED = 9;
+}
+
+enum EmailDigestFrequency {
+  EMAIL_DIGEST_FREQUENCY_UNSPECIFIED = 0;
+  EMAIL_DIGEST_FREQUENCY_IMMEDIATE = 1;
+  EMAIL_DIGEST_FREQUENCY_DAILY = 2;
+  EMAIL_DIGEST_FREQUENCY_WEEKLY = 3;
+  EMAIL_DIGEST_FREQUENCY_MONTHLY = 4;
+  EMAIL_DIGEST_FREQUENCY_NEVER = 5;
+}
+
+enum EmailFormat {
+  EMAIL_FORMAT_UNSPECIFIED = 0;
+  EMAIL_FORMAT_HTML = 1;
+  EMAIL_FORMAT_TEXT = 2;
+  EMAIL_FORMAT_BOTH = 3;
+}
+
+// --- SendEmail --------------------------------------------------------
+
+message SendEmailRequest {
+  // Recipient. Required.
+  string to_email = 1;
+  optional string to_name = 2;
+
+  // Sender override (defaults to the service's configured From).
+  optional string from_email = 3;
+  optional string from_name = 4;
+  optional string reply_to_email = 5;
+
+  // CC / BCC. Empty when omitted.
+  repeated string cc_emails = 6;
+  repeated string bcc_emails = 7;
+
+  // Either supply (subject + html_content) OR (template_id + template_data_json).
+  // When both arrive, template wins and the inline subject/content are ignored.
+  optional string subject = 8;
+  optional string html_content = 9;
+  optional string text_content = 10;
+  optional string template_id = 11;
+  // JSON-stringified payload for template variable substitution.
+  // Empty string == `{}`.
+  string template_data_json = 12;
+
+  EmailType type = 13;
+  EmailPriority priority = 14;
+
+  // Schedule for a future delivery. Absent = send as soon as the worker
+  // picks it up.
+  optional string scheduled_for = 15;
+
+  // Free-form metadata + tags for the row. JSON-stringified; empty string == `{}`.
+  string metadata_json = 16;
+  repeated string tags = 17;
+
+  // Tie the row to a user (for prefs enforcement + audit). Optional.
+  optional string user_id = 18;
+  optional string campaign_id = 19;
+
+  // Opt-in idempotency. When set, a duplicate SendEmail with the same
+  // key returns the same email_id without enqueueing a second row.
+  optional string idempotency_key = 20;
+}
+
+message SendEmailResponse {
+  // The row's emailId. Caller can poll the queue table for status; the
+  // worker publishes status changes on `notifications.email.*` topics.
+  string email_id = 1;
+  // True when the row was already present (idempotency_key collision).
+  bool already_queued = 2;
+}
+
+// --- EmailPreferences -------------------------------------------------
+
+message EmailPreferences {
+  string preference_id = 1;
+  string user_id = 2;
+  bool is_email_enabled = 3;
+  bool global_unsubscribe = 4;
+  // JSON-stringified array of per-category opt-in/out rows. Shape:
+  // [{type, enabled, frequency?}, ...]. Empty string == `[]`.
+  string preferences_json = 5;
+  string language = 6;
+  string timezone = 7;
+  EmailFormat email_format = 8;
+  EmailDigestFrequency digest_frequency = 9;
+  // HH:MM 24h.
+  string digest_time = 10;
+  string unsubscribe_token = 11;
+  optional string last_digest_sent = 12;
+  uint32 bounce_count = 13;
+  optional string last_bounce_at = 14;
+  bool is_blacklisted = 15;
+  optional string blacklist_reason = 16;
+  optional string blacklisted_at = 17;
+  string metadata_json = 18;
+  string created_at = 19;
+  string updated_at = 20;
+}
+
+message GetEmailPreferencesRequest {
+  // Optional target. Defaults to the calling principal. Callers without
+  // `email-prefs:read:any` may only read their own row.
+  optional string user_id = 1;
+}
+
+message GetEmailPreferencesResponse {
+  EmailPreferences preferences = 1;
+}
+
+message UpdateEmailPreferencesRequest {
+  optional string user_id = 1;
+
+  // All fields optional — only present fields are written.
+  optional bool is_email_enabled = 2;
+  optional bool global_unsubscribe = 3;
+  optional string preferences_json = 4;
+  optional string language = 5;
+  optional string timezone = 6;
+  EmailFormat email_format = 7;
+  EmailDigestFrequency digest_frequency = 8;
+  optional string digest_time = 9;
+}
+
+message UpdateEmailPreferencesResponse {
+  EmailPreferences preferences = 1;
 }

--- a/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
+++ b/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
@@ -57,6 +57,27 @@ service NotificationService {
   // touched — unset fields keep their current value.
   rpc UpdateEmailPreferences(UpdateEmailPreferencesRequest)
       returns (UpdateEmailPreferencesResponse);
+
+  // --- Push device tokens --------------------------------------------
+  // Phase 7 round-out. Clients (mobile, browser PWAs) register their
+  // FCM / APNs / web-push token with the notifications service; the
+  // push worker consumes `notifications.created` events for push-
+  // channel rows and dispatches via the configured provider.
+
+  // Idempotent on (user_id, device_token): a second Register with the
+  // same pair refreshes `last_used_at` and returns the existing row.
+  rpc RegisterDeviceToken(RegisterDeviceTokenRequest)
+      returns (RegisterDeviceTokenResponse);
+
+  // Soft-delete by token_id. Called when the client logs out or the
+  // user disables push. Idempotent: a second Unregister on the same
+  // token_id returns the same row without error.
+  rpc UnregisterDeviceToken(UnregisterDeviceTokenRequest)
+      returns (UnregisterDeviceTokenResponse);
+
+  // List active tokens for the calling principal. Self-scoped (admins
+  // need device-tokens:list:any to read another user's tokens).
+  rpc ListDeviceTokens(ListDeviceTokensRequest) returns (ListDeviceTokensResponse);
 }
 
 // Notification mirrors the `notifications.notifications` row plus the
@@ -383,4 +404,86 @@ message UpdateEmailPreferencesRequest {
 
 message UpdateEmailPreferencesResponse {
   EmailPreferences preferences = 1;
+}
+
+// --- Device token ENUMs ----------------------------------------------
+
+enum DevicePlatform {
+  DEVICE_PLATFORM_UNSPECIFIED = 0;
+  DEVICE_PLATFORM_IOS = 1;
+  DEVICE_PLATFORM_ANDROID = 2;
+  DEVICE_PLATFORM_WEB = 3;
+}
+
+enum DeviceTokenStatus {
+  DEVICE_TOKEN_STATUS_UNSPECIFIED = 0;
+  DEVICE_TOKEN_STATUS_ACTIVE = 1;
+  DEVICE_TOKEN_STATUS_INACTIVE = 2;
+  DEVICE_TOKEN_STATUS_EXPIRED = 3;
+  DEVICE_TOKEN_STATUS_INVALID = 4;
+}
+
+// --- DeviceToken row -------------------------------------------------
+
+message DeviceToken {
+  string token_id = 1;
+  string user_id = 2;
+  string device_token = 3;
+  DevicePlatform platform = 4;
+  optional string app_version = 5;
+  // JSON-stringified jsonb payload. Empty string == `{}`.
+  string device_info_json = 6;
+  DeviceTokenStatus status = 7;
+  optional string last_used_at = 8;
+  optional string expires_at = 9;
+  string created_at = 10;
+  string updated_at = 11;
+}
+
+// --- RegisterDeviceToken ---------------------------------------------
+
+message RegisterDeviceTokenRequest {
+  // Target user — optional. Defaults to the calling principal when
+  // omitted; cross-user registration requires device-tokens:write:any.
+  optional string user_id = 1;
+  string device_token = 2;
+  DevicePlatform platform = 3;
+  optional string app_version = 4;
+  // Optional jsonb metadata (model, OS version, app build, etc.).
+  // Empty string == `{}`.
+  string device_info_json = 5;
+}
+
+message RegisterDeviceTokenResponse {
+  DeviceToken token = 1;
+  // True when the (user_id, device_token) pair was already present
+  // and the call just refreshed last_used_at.
+  bool already_registered = 2;
+}
+
+// --- UnregisterDeviceToken -------------------------------------------
+
+message UnregisterDeviceTokenRequest {
+  string token_id = 1;
+}
+
+message UnregisterDeviceTokenResponse {
+  // The soft-deleted row (deleted_at stamped, status='inactive').
+  // Idempotent.
+  DeviceToken token = 1;
+}
+
+// --- ListDeviceTokens ------------------------------------------------
+
+message ListDeviceTokensRequest {
+  // Optional target. Defaults to the calling principal. Callers without
+  // device-tokens:list:any may only list their own tokens.
+  optional string user_id = 1;
+  // When true, include soft-deleted (deleted_at IS NOT NULL) rows.
+  // Default false.
+  bool include_inactive = 2;
+}
+
+message ListDeviceTokensResponse {
+  repeated DeviceToken tokens = 1;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
@@ -705,6 +705,102 @@ export function emailFormatToJSON(object: EmailFormat): string {
   }
 }
 
+export enum DevicePlatform {
+  DEVICE_PLATFORM_UNSPECIFIED = 0,
+  DEVICE_PLATFORM_IOS = 1,
+  DEVICE_PLATFORM_ANDROID = 2,
+  DEVICE_PLATFORM_WEB = 3,
+  UNRECOGNIZED = -1,
+}
+
+export function devicePlatformFromJSON(object: any): DevicePlatform {
+  switch (object) {
+    case 0:
+    case 'DEVICE_PLATFORM_UNSPECIFIED':
+      return DevicePlatform.DEVICE_PLATFORM_UNSPECIFIED;
+    case 1:
+    case 'DEVICE_PLATFORM_IOS':
+      return DevicePlatform.DEVICE_PLATFORM_IOS;
+    case 2:
+    case 'DEVICE_PLATFORM_ANDROID':
+      return DevicePlatform.DEVICE_PLATFORM_ANDROID;
+    case 3:
+    case 'DEVICE_PLATFORM_WEB':
+      return DevicePlatform.DEVICE_PLATFORM_WEB;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return DevicePlatform.UNRECOGNIZED;
+  }
+}
+
+export function devicePlatformToJSON(object: DevicePlatform): string {
+  switch (object) {
+    case DevicePlatform.DEVICE_PLATFORM_UNSPECIFIED:
+      return 'DEVICE_PLATFORM_UNSPECIFIED';
+    case DevicePlatform.DEVICE_PLATFORM_IOS:
+      return 'DEVICE_PLATFORM_IOS';
+    case DevicePlatform.DEVICE_PLATFORM_ANDROID:
+      return 'DEVICE_PLATFORM_ANDROID';
+    case DevicePlatform.DEVICE_PLATFORM_WEB:
+      return 'DEVICE_PLATFORM_WEB';
+    case DevicePlatform.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
+export enum DeviceTokenStatus {
+  DEVICE_TOKEN_STATUS_UNSPECIFIED = 0,
+  DEVICE_TOKEN_STATUS_ACTIVE = 1,
+  DEVICE_TOKEN_STATUS_INACTIVE = 2,
+  DEVICE_TOKEN_STATUS_EXPIRED = 3,
+  DEVICE_TOKEN_STATUS_INVALID = 4,
+  UNRECOGNIZED = -1,
+}
+
+export function deviceTokenStatusFromJSON(object: any): DeviceTokenStatus {
+  switch (object) {
+    case 0:
+    case 'DEVICE_TOKEN_STATUS_UNSPECIFIED':
+      return DeviceTokenStatus.DEVICE_TOKEN_STATUS_UNSPECIFIED;
+    case 1:
+    case 'DEVICE_TOKEN_STATUS_ACTIVE':
+      return DeviceTokenStatus.DEVICE_TOKEN_STATUS_ACTIVE;
+    case 2:
+    case 'DEVICE_TOKEN_STATUS_INACTIVE':
+      return DeviceTokenStatus.DEVICE_TOKEN_STATUS_INACTIVE;
+    case 3:
+    case 'DEVICE_TOKEN_STATUS_EXPIRED':
+      return DeviceTokenStatus.DEVICE_TOKEN_STATUS_EXPIRED;
+    case 4:
+    case 'DEVICE_TOKEN_STATUS_INVALID':
+      return DeviceTokenStatus.DEVICE_TOKEN_STATUS_INVALID;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return DeviceTokenStatus.UNRECOGNIZED;
+  }
+}
+
+export function deviceTokenStatusToJSON(object: DeviceTokenStatus): string {
+  switch (object) {
+    case DeviceTokenStatus.DEVICE_TOKEN_STATUS_UNSPECIFIED:
+      return 'DEVICE_TOKEN_STATUS_UNSPECIFIED';
+    case DeviceTokenStatus.DEVICE_TOKEN_STATUS_ACTIVE:
+      return 'DEVICE_TOKEN_STATUS_ACTIVE';
+    case DeviceTokenStatus.DEVICE_TOKEN_STATUS_INACTIVE:
+      return 'DEVICE_TOKEN_STATUS_INACTIVE';
+    case DeviceTokenStatus.DEVICE_TOKEN_STATUS_EXPIRED:
+      return 'DEVICE_TOKEN_STATUS_EXPIRED';
+    case DeviceTokenStatus.DEVICE_TOKEN_STATUS_INVALID:
+      return 'DEVICE_TOKEN_STATUS_INVALID';
+    case DeviceTokenStatus.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
 /**
  * Notification mirrors the `notifications.notifications` row plus the
  * JSON-stringified `data` / `template_variables` payloads. Kept as
@@ -926,6 +1022,75 @@ export interface UpdateEmailPreferencesRequest {
 
 export interface UpdateEmailPreferencesResponse {
   preferences?: EmailPreferences | undefined;
+}
+
+export interface DeviceToken {
+  tokenId: string;
+  userId: string;
+  deviceToken: string;
+  platform: DevicePlatform;
+  appVersion?: string | undefined;
+  /** JSON-stringified jsonb payload. Empty string == `{}`. */
+  deviceInfoJson: string;
+  status: DeviceTokenStatus;
+  lastUsedAt?: string | undefined;
+  expiresAt?: string | undefined;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RegisterDeviceTokenRequest {
+  /**
+   * Target user — optional. Defaults to the calling principal when
+   * omitted; cross-user registration requires device-tokens:write:any.
+   */
+  userId?: string | undefined;
+  deviceToken: string;
+  platform: DevicePlatform;
+  appVersion?: string | undefined;
+  /**
+   * Optional jsonb metadata (model, OS version, app build, etc.).
+   * Empty string == `{}`.
+   */
+  deviceInfoJson: string;
+}
+
+export interface RegisterDeviceTokenResponse {
+  token?: DeviceToken | undefined;
+  /**
+   * True when the (user_id, device_token) pair was already present
+   * and the call just refreshed last_used_at.
+   */
+  alreadyRegistered: boolean;
+}
+
+export interface UnregisterDeviceTokenRequest {
+  tokenId: string;
+}
+
+export interface UnregisterDeviceTokenResponse {
+  /**
+   * The soft-deleted row (deleted_at stamped, status='inactive').
+   * Idempotent.
+   */
+  token?: DeviceToken | undefined;
+}
+
+export interface ListDeviceTokensRequest {
+  /**
+   * Optional target. Defaults to the calling principal. Callers without
+   * device-tokens:list:any may only list their own tokens.
+   */
+  userId?: string | undefined;
+  /**
+   * When true, include soft-deleted (deleted_at IS NOT NULL) rows.
+   * Default false.
+   */
+  includeInactive: boolean;
+}
+
+export interface ListDeviceTokensResponse {
+  tokens: DeviceToken[];
 }
 
 function createBaseNotification(): Notification {
@@ -3687,6 +3852,816 @@ export const UpdateEmailPreferencesResponse: MessageFns<UpdateEmailPreferencesRe
   },
 };
 
+function createBaseDeviceToken(): DeviceToken {
+  return {
+    tokenId: '',
+    userId: '',
+    deviceToken: '',
+    platform: 0,
+    appVersion: undefined,
+    deviceInfoJson: '',
+    status: 0,
+    lastUsedAt: undefined,
+    expiresAt: undefined,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+export const DeviceToken: MessageFns<DeviceToken> = {
+  encode(message: DeviceToken, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.tokenId !== '') {
+      writer.uint32(10).string(message.tokenId);
+    }
+    if (message.userId !== '') {
+      writer.uint32(18).string(message.userId);
+    }
+    if (message.deviceToken !== '') {
+      writer.uint32(26).string(message.deviceToken);
+    }
+    if (message.platform !== 0) {
+      writer.uint32(32).int32(message.platform);
+    }
+    if (message.appVersion !== undefined) {
+      writer.uint32(42).string(message.appVersion);
+    }
+    if (message.deviceInfoJson !== '') {
+      writer.uint32(50).string(message.deviceInfoJson);
+    }
+    if (message.status !== 0) {
+      writer.uint32(56).int32(message.status);
+    }
+    if (message.lastUsedAt !== undefined) {
+      writer.uint32(66).string(message.lastUsedAt);
+    }
+    if (message.expiresAt !== undefined) {
+      writer.uint32(74).string(message.expiresAt);
+    }
+    if (message.createdAt !== '') {
+      writer.uint32(82).string(message.createdAt);
+    }
+    if (message.updatedAt !== '') {
+      writer.uint32(90).string(message.updatedAt);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DeviceToken {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeviceToken();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.tokenId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.deviceToken = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.platform = reader.int32() as any;
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.appVersion = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.deviceInfoJson = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.status = reader.int32() as any;
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.lastUsedAt = reader.string();
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.expiresAt = reader.string();
+          continue;
+        }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.createdAt = reader.string();
+          continue;
+        }
+        case 11: {
+          if (tag !== 90) {
+            break;
+          }
+
+          message.updatedAt = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DeviceToken {
+    return {
+      tokenId: isSet(object.tokenId)
+        ? globalThis.String(object.tokenId)
+        : isSet(object.token_id)
+          ? globalThis.String(object.token_id)
+          : '',
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : '',
+      deviceToken: isSet(object.deviceToken)
+        ? globalThis.String(object.deviceToken)
+        : isSet(object.device_token)
+          ? globalThis.String(object.device_token)
+          : '',
+      platform: isSet(object.platform) ? devicePlatformFromJSON(object.platform) : 0,
+      appVersion: isSet(object.appVersion)
+        ? globalThis.String(object.appVersion)
+        : isSet(object.app_version)
+          ? globalThis.String(object.app_version)
+          : undefined,
+      deviceInfoJson: isSet(object.deviceInfoJson)
+        ? globalThis.String(object.deviceInfoJson)
+        : isSet(object.device_info_json)
+          ? globalThis.String(object.device_info_json)
+          : '',
+      status: isSet(object.status) ? deviceTokenStatusFromJSON(object.status) : 0,
+      lastUsedAt: isSet(object.lastUsedAt)
+        ? globalThis.String(object.lastUsedAt)
+        : isSet(object.last_used_at)
+          ? globalThis.String(object.last_used_at)
+          : undefined,
+      expiresAt: isSet(object.expiresAt)
+        ? globalThis.String(object.expiresAt)
+        : isSet(object.expires_at)
+          ? globalThis.String(object.expires_at)
+          : undefined,
+      createdAt: isSet(object.createdAt)
+        ? globalThis.String(object.createdAt)
+        : isSet(object.created_at)
+          ? globalThis.String(object.created_at)
+          : '',
+      updatedAt: isSet(object.updatedAt)
+        ? globalThis.String(object.updatedAt)
+        : isSet(object.updated_at)
+          ? globalThis.String(object.updated_at)
+          : '',
+    };
+  },
+
+  toJSON(message: DeviceToken): unknown {
+    const obj: any = {};
+    if (message.tokenId !== '') {
+      obj.tokenId = message.tokenId;
+    }
+    if (message.userId !== '') {
+      obj.userId = message.userId;
+    }
+    if (message.deviceToken !== '') {
+      obj.deviceToken = message.deviceToken;
+    }
+    if (message.platform !== 0) {
+      obj.platform = devicePlatformToJSON(message.platform);
+    }
+    if (message.appVersion !== undefined) {
+      obj.appVersion = message.appVersion;
+    }
+    if (message.deviceInfoJson !== '') {
+      obj.deviceInfoJson = message.deviceInfoJson;
+    }
+    if (message.status !== 0) {
+      obj.status = deviceTokenStatusToJSON(message.status);
+    }
+    if (message.lastUsedAt !== undefined) {
+      obj.lastUsedAt = message.lastUsedAt;
+    }
+    if (message.expiresAt !== undefined) {
+      obj.expiresAt = message.expiresAt;
+    }
+    if (message.createdAt !== '') {
+      obj.createdAt = message.createdAt;
+    }
+    if (message.updatedAt !== '') {
+      obj.updatedAt = message.updatedAt;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DeviceToken>, I>>(base?: I): DeviceToken {
+    return DeviceToken.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DeviceToken>, I>>(object: I): DeviceToken {
+    const message = createBaseDeviceToken();
+    message.tokenId = object.tokenId ?? '';
+    message.userId = object.userId ?? '';
+    message.deviceToken = object.deviceToken ?? '';
+    message.platform = object.platform ?? 0;
+    message.appVersion = object.appVersion ?? undefined;
+    message.deviceInfoJson = object.deviceInfoJson ?? '';
+    message.status = object.status ?? 0;
+    message.lastUsedAt = object.lastUsedAt ?? undefined;
+    message.expiresAt = object.expiresAt ?? undefined;
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
+    return message;
+  },
+};
+
+function createBaseRegisterDeviceTokenRequest(): RegisterDeviceTokenRequest {
+  return {
+    userId: undefined,
+    deviceToken: '',
+    platform: 0,
+    appVersion: undefined,
+    deviceInfoJson: '',
+  };
+}
+
+export const RegisterDeviceTokenRequest: MessageFns<RegisterDeviceTokenRequest> = {
+  encode(
+    message: RegisterDeviceTokenRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.userId !== undefined) {
+      writer.uint32(10).string(message.userId);
+    }
+    if (message.deviceToken !== '') {
+      writer.uint32(18).string(message.deviceToken);
+    }
+    if (message.platform !== 0) {
+      writer.uint32(24).int32(message.platform);
+    }
+    if (message.appVersion !== undefined) {
+      writer.uint32(34).string(message.appVersion);
+    }
+    if (message.deviceInfoJson !== '') {
+      writer.uint32(42).string(message.deviceInfoJson);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RegisterDeviceTokenRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRegisterDeviceTokenRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.deviceToken = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.platform = reader.int32() as any;
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.appVersion = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.deviceInfoJson = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RegisterDeviceTokenRequest {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : undefined,
+      deviceToken: isSet(object.deviceToken)
+        ? globalThis.String(object.deviceToken)
+        : isSet(object.device_token)
+          ? globalThis.String(object.device_token)
+          : '',
+      platform: isSet(object.platform) ? devicePlatformFromJSON(object.platform) : 0,
+      appVersion: isSet(object.appVersion)
+        ? globalThis.String(object.appVersion)
+        : isSet(object.app_version)
+          ? globalThis.String(object.app_version)
+          : undefined,
+      deviceInfoJson: isSet(object.deviceInfoJson)
+        ? globalThis.String(object.deviceInfoJson)
+        : isSet(object.device_info_json)
+          ? globalThis.String(object.device_info_json)
+          : '',
+    };
+  },
+
+  toJSON(message: RegisterDeviceTokenRequest): unknown {
+    const obj: any = {};
+    if (message.userId !== undefined) {
+      obj.userId = message.userId;
+    }
+    if (message.deviceToken !== '') {
+      obj.deviceToken = message.deviceToken;
+    }
+    if (message.platform !== 0) {
+      obj.platform = devicePlatformToJSON(message.platform);
+    }
+    if (message.appVersion !== undefined) {
+      obj.appVersion = message.appVersion;
+    }
+    if (message.deviceInfoJson !== '') {
+      obj.deviceInfoJson = message.deviceInfoJson;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RegisterDeviceTokenRequest>, I>>(
+    base?: I
+  ): RegisterDeviceTokenRequest {
+    return RegisterDeviceTokenRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RegisterDeviceTokenRequest>, I>>(
+    object: I
+  ): RegisterDeviceTokenRequest {
+    const message = createBaseRegisterDeviceTokenRequest();
+    message.userId = object.userId ?? undefined;
+    message.deviceToken = object.deviceToken ?? '';
+    message.platform = object.platform ?? 0;
+    message.appVersion = object.appVersion ?? undefined;
+    message.deviceInfoJson = object.deviceInfoJson ?? '';
+    return message;
+  },
+};
+
+function createBaseRegisterDeviceTokenResponse(): RegisterDeviceTokenResponse {
+  return { token: undefined, alreadyRegistered: false };
+}
+
+export const RegisterDeviceTokenResponse: MessageFns<RegisterDeviceTokenResponse> = {
+  encode(
+    message: RegisterDeviceTokenResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.token !== undefined) {
+      DeviceToken.encode(message.token, writer.uint32(10).fork()).join();
+    }
+    if (message.alreadyRegistered !== false) {
+      writer.uint32(16).bool(message.alreadyRegistered);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RegisterDeviceTokenResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRegisterDeviceTokenResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.token = DeviceToken.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.alreadyRegistered = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RegisterDeviceTokenResponse {
+    return {
+      token: isSet(object.token) ? DeviceToken.fromJSON(object.token) : undefined,
+      alreadyRegistered: isSet(object.alreadyRegistered)
+        ? globalThis.Boolean(object.alreadyRegistered)
+        : isSet(object.already_registered)
+          ? globalThis.Boolean(object.already_registered)
+          : false,
+    };
+  },
+
+  toJSON(message: RegisterDeviceTokenResponse): unknown {
+    const obj: any = {};
+    if (message.token !== undefined) {
+      obj.token = DeviceToken.toJSON(message.token);
+    }
+    if (message.alreadyRegistered !== false) {
+      obj.alreadyRegistered = message.alreadyRegistered;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<RegisterDeviceTokenResponse>, I>>(
+    base?: I
+  ): RegisterDeviceTokenResponse {
+    return RegisterDeviceTokenResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<RegisterDeviceTokenResponse>, I>>(
+    object: I
+  ): RegisterDeviceTokenResponse {
+    const message = createBaseRegisterDeviceTokenResponse();
+    message.token =
+      object.token !== undefined && object.token !== null
+        ? DeviceToken.fromPartial(object.token)
+        : undefined;
+    message.alreadyRegistered = object.alreadyRegistered ?? false;
+    return message;
+  },
+};
+
+function createBaseUnregisterDeviceTokenRequest(): UnregisterDeviceTokenRequest {
+  return { tokenId: '' };
+}
+
+export const UnregisterDeviceTokenRequest: MessageFns<UnregisterDeviceTokenRequest> = {
+  encode(
+    message: UnregisterDeviceTokenRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.tokenId !== '') {
+      writer.uint32(10).string(message.tokenId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UnregisterDeviceTokenRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUnregisterDeviceTokenRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.tokenId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UnregisterDeviceTokenRequest {
+    return {
+      tokenId: isSet(object.tokenId)
+        ? globalThis.String(object.tokenId)
+        : isSet(object.token_id)
+          ? globalThis.String(object.token_id)
+          : '',
+    };
+  },
+
+  toJSON(message: UnregisterDeviceTokenRequest): unknown {
+    const obj: any = {};
+    if (message.tokenId !== '') {
+      obj.tokenId = message.tokenId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UnregisterDeviceTokenRequest>, I>>(
+    base?: I
+  ): UnregisterDeviceTokenRequest {
+    return UnregisterDeviceTokenRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UnregisterDeviceTokenRequest>, I>>(
+    object: I
+  ): UnregisterDeviceTokenRequest {
+    const message = createBaseUnregisterDeviceTokenRequest();
+    message.tokenId = object.tokenId ?? '';
+    return message;
+  },
+};
+
+function createBaseUnregisterDeviceTokenResponse(): UnregisterDeviceTokenResponse {
+  return { token: undefined };
+}
+
+export const UnregisterDeviceTokenResponse: MessageFns<UnregisterDeviceTokenResponse> = {
+  encode(
+    message: UnregisterDeviceTokenResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.token !== undefined) {
+      DeviceToken.encode(message.token, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UnregisterDeviceTokenResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUnregisterDeviceTokenResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.token = DeviceToken.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UnregisterDeviceTokenResponse {
+    return { token: isSet(object.token) ? DeviceToken.fromJSON(object.token) : undefined };
+  },
+
+  toJSON(message: UnregisterDeviceTokenResponse): unknown {
+    const obj: any = {};
+    if (message.token !== undefined) {
+      obj.token = DeviceToken.toJSON(message.token);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UnregisterDeviceTokenResponse>, I>>(
+    base?: I
+  ): UnregisterDeviceTokenResponse {
+    return UnregisterDeviceTokenResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UnregisterDeviceTokenResponse>, I>>(
+    object: I
+  ): UnregisterDeviceTokenResponse {
+    const message = createBaseUnregisterDeviceTokenResponse();
+    message.token =
+      object.token !== undefined && object.token !== null
+        ? DeviceToken.fromPartial(object.token)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseListDeviceTokensRequest(): ListDeviceTokensRequest {
+  return { userId: undefined, includeInactive: false };
+}
+
+export const ListDeviceTokensRequest: MessageFns<ListDeviceTokensRequest> = {
+  encode(
+    message: ListDeviceTokensRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.userId !== undefined) {
+      writer.uint32(10).string(message.userId);
+    }
+    if (message.includeInactive !== false) {
+      writer.uint32(16).bool(message.includeInactive);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ListDeviceTokensRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListDeviceTokensRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.includeInactive = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListDeviceTokensRequest {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : undefined,
+      includeInactive: isSet(object.includeInactive)
+        ? globalThis.Boolean(object.includeInactive)
+        : isSet(object.include_inactive)
+          ? globalThis.Boolean(object.include_inactive)
+          : false,
+    };
+  },
+
+  toJSON(message: ListDeviceTokensRequest): unknown {
+    const obj: any = {};
+    if (message.userId !== undefined) {
+      obj.userId = message.userId;
+    }
+    if (message.includeInactive !== false) {
+      obj.includeInactive = message.includeInactive;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListDeviceTokensRequest>, I>>(
+    base?: I
+  ): ListDeviceTokensRequest {
+    return ListDeviceTokensRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListDeviceTokensRequest>, I>>(
+    object: I
+  ): ListDeviceTokensRequest {
+    const message = createBaseListDeviceTokensRequest();
+    message.userId = object.userId ?? undefined;
+    message.includeInactive = object.includeInactive ?? false;
+    return message;
+  },
+};
+
+function createBaseListDeviceTokensResponse(): ListDeviceTokensResponse {
+  return { tokens: [] };
+}
+
+export const ListDeviceTokensResponse: MessageFns<ListDeviceTokensResponse> = {
+  encode(
+    message: ListDeviceTokensResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    for (const v of message.tokens) {
+      DeviceToken.encode(v!, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ListDeviceTokensResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListDeviceTokensResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.tokens.push(DeviceToken.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListDeviceTokensResponse {
+    return {
+      tokens: globalThis.Array.isArray(object?.tokens)
+        ? object.tokens.map((e: any) => DeviceToken.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: ListDeviceTokensResponse): unknown {
+    const obj: any = {};
+    if (message.tokens?.length) {
+      obj.tokens = message.tokens.map(e => DeviceToken.toJSON(e));
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListDeviceTokensResponse>, I>>(
+    base?: I
+  ): ListDeviceTokensResponse {
+    return ListDeviceTokensResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListDeviceTokensResponse>, I>>(
+    object: I
+  ): ListDeviceTokensResponse {
+    const message = createBaseListDeviceTokensResponse();
+    message.tokens = object.tokens?.map(e => DeviceToken.fromPartial(e)) || [];
+    return message;
+  },
+};
+
 /**
  * NotificationService is the gRPC contract for the in-app notification
  * store. The gateway translates `POST/GET/DELETE /api/notifications/*`
@@ -3812,6 +4787,58 @@ export const NotificationServiceService = {
     responseDeserialize: (value: Buffer): UpdateEmailPreferencesResponse =>
       UpdateEmailPreferencesResponse.decode(value),
   },
+  /**
+   * Idempotent on (user_id, device_token): a second Register with the
+   * same pair refreshes `last_used_at` and returns the existing row.
+   */
+  registerDeviceToken: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/RegisterDeviceToken' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: RegisterDeviceTokenRequest): Buffer =>
+      Buffer.from(RegisterDeviceTokenRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): RegisterDeviceTokenRequest =>
+      RegisterDeviceTokenRequest.decode(value),
+    responseSerialize: (value: RegisterDeviceTokenResponse): Buffer =>
+      Buffer.from(RegisterDeviceTokenResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): RegisterDeviceTokenResponse =>
+      RegisterDeviceTokenResponse.decode(value),
+  },
+  /**
+   * Soft-delete by token_id. Called when the client logs out or the
+   * user disables push. Idempotent: a second Unregister on the same
+   * token_id returns the same row without error.
+   */
+  unregisterDeviceToken: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/UnregisterDeviceToken' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: UnregisterDeviceTokenRequest): Buffer =>
+      Buffer.from(UnregisterDeviceTokenRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): UnregisterDeviceTokenRequest =>
+      UnregisterDeviceTokenRequest.decode(value),
+    responseSerialize: (value: UnregisterDeviceTokenResponse): Buffer =>
+      Buffer.from(UnregisterDeviceTokenResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): UnregisterDeviceTokenResponse =>
+      UnregisterDeviceTokenResponse.decode(value),
+  },
+  /**
+   * List active tokens for the calling principal. Self-scoped (admins
+   * need device-tokens:list:any to read another user's tokens).
+   */
+  listDeviceTokens: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/ListDeviceTokens' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: ListDeviceTokensRequest): Buffer =>
+      Buffer.from(ListDeviceTokensRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): ListDeviceTokensRequest =>
+      ListDeviceTokensRequest.decode(value),
+    responseSerialize: (value: ListDeviceTokensResponse): Buffer =>
+      Buffer.from(ListDeviceTokensResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): ListDeviceTokensResponse =>
+      ListDeviceTokensResponse.decode(value),
+  },
 } as const;
 
 export interface NotificationServiceServer extends UntypedServiceImplementation {
@@ -3858,6 +4885,25 @@ export interface NotificationServiceServer extends UntypedServiceImplementation 
     UpdateEmailPreferencesRequest,
     UpdateEmailPreferencesResponse
   >;
+  /**
+   * Idempotent on (user_id, device_token): a second Register with the
+   * same pair refreshes `last_used_at` and returns the existing row.
+   */
+  registerDeviceToken: handleUnaryCall<RegisterDeviceTokenRequest, RegisterDeviceTokenResponse>;
+  /**
+   * Soft-delete by token_id. Called when the client logs out or the
+   * user disables push. Idempotent: a second Unregister on the same
+   * token_id returns the same row without error.
+   */
+  unregisterDeviceToken: handleUnaryCall<
+    UnregisterDeviceTokenRequest,
+    UnregisterDeviceTokenResponse
+  >;
+  /**
+   * List active tokens for the calling principal. Self-scoped (admins
+   * need device-tokens:list:any to read another user's tokens).
+   */
+  listDeviceTokens: handleUnaryCall<ListDeviceTokensRequest, ListDeviceTokensResponse>;
 }
 
 export interface NotificationServiceClient extends Client {
@@ -3984,6 +5030,64 @@ export interface NotificationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: UpdateEmailPreferencesResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Idempotent on (user_id, device_token): a second Register with the
+   * same pair refreshes `last_used_at` and returns the existing row.
+   */
+  registerDeviceToken(
+    request: RegisterDeviceTokenRequest,
+    callback: (error: ServiceError | null, response: RegisterDeviceTokenResponse) => void
+  ): ClientUnaryCall;
+  registerDeviceToken(
+    request: RegisterDeviceTokenRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: RegisterDeviceTokenResponse) => void
+  ): ClientUnaryCall;
+  registerDeviceToken(
+    request: RegisterDeviceTokenRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: RegisterDeviceTokenResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Soft-delete by token_id. Called when the client logs out or the
+   * user disables push. Idempotent: a second Unregister on the same
+   * token_id returns the same row without error.
+   */
+  unregisterDeviceToken(
+    request: UnregisterDeviceTokenRequest,
+    callback: (error: ServiceError | null, response: UnregisterDeviceTokenResponse) => void
+  ): ClientUnaryCall;
+  unregisterDeviceToken(
+    request: UnregisterDeviceTokenRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: UnregisterDeviceTokenResponse) => void
+  ): ClientUnaryCall;
+  unregisterDeviceToken(
+    request: UnregisterDeviceTokenRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: UnregisterDeviceTokenResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * List active tokens for the calling principal. Self-scoped (admins
+   * need device-tokens:list:any to read another user's tokens).
+   */
+  listDeviceTokens(
+    request: ListDeviceTokensRequest,
+    callback: (error: ServiceError | null, response: ListDeviceTokensResponse) => void
+  ): ClientUnaryCall;
+  listDeviceTokens(
+    request: ListDeviceTokensRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: ListDeviceTokensResponse) => void
+  ): ClientUnaryCall;
+  listDeviceTokens(
+    request: ListDeviceTokensRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: ListDeviceTokensResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
@@ -420,6 +420,291 @@ export function notificationRelatedEntityTypeToJSON(object: NotificationRelatedE
   }
 }
 
+export enum EmailType {
+  EMAIL_TYPE_UNSPECIFIED = 0,
+  EMAIL_TYPE_TRANSACTIONAL = 1,
+  EMAIL_TYPE_NOTIFICATION = 2,
+  EMAIL_TYPE_MARKETING = 3,
+  EMAIL_TYPE_SYSTEM = 4,
+  UNRECOGNIZED = -1,
+}
+
+export function emailTypeFromJSON(object: any): EmailType {
+  switch (object) {
+    case 0:
+    case 'EMAIL_TYPE_UNSPECIFIED':
+      return EmailType.EMAIL_TYPE_UNSPECIFIED;
+    case 1:
+    case 'EMAIL_TYPE_TRANSACTIONAL':
+      return EmailType.EMAIL_TYPE_TRANSACTIONAL;
+    case 2:
+    case 'EMAIL_TYPE_NOTIFICATION':
+      return EmailType.EMAIL_TYPE_NOTIFICATION;
+    case 3:
+    case 'EMAIL_TYPE_MARKETING':
+      return EmailType.EMAIL_TYPE_MARKETING;
+    case 4:
+    case 'EMAIL_TYPE_SYSTEM':
+      return EmailType.EMAIL_TYPE_SYSTEM;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return EmailType.UNRECOGNIZED;
+  }
+}
+
+export function emailTypeToJSON(object: EmailType): string {
+  switch (object) {
+    case EmailType.EMAIL_TYPE_UNSPECIFIED:
+      return 'EMAIL_TYPE_UNSPECIFIED';
+    case EmailType.EMAIL_TYPE_TRANSACTIONAL:
+      return 'EMAIL_TYPE_TRANSACTIONAL';
+    case EmailType.EMAIL_TYPE_NOTIFICATION:
+      return 'EMAIL_TYPE_NOTIFICATION';
+    case EmailType.EMAIL_TYPE_MARKETING:
+      return 'EMAIL_TYPE_MARKETING';
+    case EmailType.EMAIL_TYPE_SYSTEM:
+      return 'EMAIL_TYPE_SYSTEM';
+    case EmailType.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
+export enum EmailPriority {
+  EMAIL_PRIORITY_UNSPECIFIED = 0,
+  EMAIL_PRIORITY_LOW = 1,
+  EMAIL_PRIORITY_NORMAL = 2,
+  EMAIL_PRIORITY_HIGH = 3,
+  EMAIL_PRIORITY_URGENT = 4,
+  UNRECOGNIZED = -1,
+}
+
+export function emailPriorityFromJSON(object: any): EmailPriority {
+  switch (object) {
+    case 0:
+    case 'EMAIL_PRIORITY_UNSPECIFIED':
+      return EmailPriority.EMAIL_PRIORITY_UNSPECIFIED;
+    case 1:
+    case 'EMAIL_PRIORITY_LOW':
+      return EmailPriority.EMAIL_PRIORITY_LOW;
+    case 2:
+    case 'EMAIL_PRIORITY_NORMAL':
+      return EmailPriority.EMAIL_PRIORITY_NORMAL;
+    case 3:
+    case 'EMAIL_PRIORITY_HIGH':
+      return EmailPriority.EMAIL_PRIORITY_HIGH;
+    case 4:
+    case 'EMAIL_PRIORITY_URGENT':
+      return EmailPriority.EMAIL_PRIORITY_URGENT;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return EmailPriority.UNRECOGNIZED;
+  }
+}
+
+export function emailPriorityToJSON(object: EmailPriority): string {
+  switch (object) {
+    case EmailPriority.EMAIL_PRIORITY_UNSPECIFIED:
+      return 'EMAIL_PRIORITY_UNSPECIFIED';
+    case EmailPriority.EMAIL_PRIORITY_LOW:
+      return 'EMAIL_PRIORITY_LOW';
+    case EmailPriority.EMAIL_PRIORITY_NORMAL:
+      return 'EMAIL_PRIORITY_NORMAL';
+    case EmailPriority.EMAIL_PRIORITY_HIGH:
+      return 'EMAIL_PRIORITY_HIGH';
+    case EmailPriority.EMAIL_PRIORITY_URGENT:
+      return 'EMAIL_PRIORITY_URGENT';
+    case EmailPriority.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
+export enum EmailStatus {
+  EMAIL_STATUS_UNSPECIFIED = 0,
+  EMAIL_STATUS_QUEUED = 1,
+  EMAIL_STATUS_SENDING = 2,
+  EMAIL_STATUS_SENT = 3,
+  EMAIL_STATUS_DELIVERED = 4,
+  EMAIL_STATUS_OPENED = 5,
+  EMAIL_STATUS_CLICKED = 6,
+  EMAIL_STATUS_FAILED = 7,
+  EMAIL_STATUS_BOUNCED = 8,
+  EMAIL_STATUS_UNSUBSCRIBED = 9,
+  UNRECOGNIZED = -1,
+}
+
+export function emailStatusFromJSON(object: any): EmailStatus {
+  switch (object) {
+    case 0:
+    case 'EMAIL_STATUS_UNSPECIFIED':
+      return EmailStatus.EMAIL_STATUS_UNSPECIFIED;
+    case 1:
+    case 'EMAIL_STATUS_QUEUED':
+      return EmailStatus.EMAIL_STATUS_QUEUED;
+    case 2:
+    case 'EMAIL_STATUS_SENDING':
+      return EmailStatus.EMAIL_STATUS_SENDING;
+    case 3:
+    case 'EMAIL_STATUS_SENT':
+      return EmailStatus.EMAIL_STATUS_SENT;
+    case 4:
+    case 'EMAIL_STATUS_DELIVERED':
+      return EmailStatus.EMAIL_STATUS_DELIVERED;
+    case 5:
+    case 'EMAIL_STATUS_OPENED':
+      return EmailStatus.EMAIL_STATUS_OPENED;
+    case 6:
+    case 'EMAIL_STATUS_CLICKED':
+      return EmailStatus.EMAIL_STATUS_CLICKED;
+    case 7:
+    case 'EMAIL_STATUS_FAILED':
+      return EmailStatus.EMAIL_STATUS_FAILED;
+    case 8:
+    case 'EMAIL_STATUS_BOUNCED':
+      return EmailStatus.EMAIL_STATUS_BOUNCED;
+    case 9:
+    case 'EMAIL_STATUS_UNSUBSCRIBED':
+      return EmailStatus.EMAIL_STATUS_UNSUBSCRIBED;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return EmailStatus.UNRECOGNIZED;
+  }
+}
+
+export function emailStatusToJSON(object: EmailStatus): string {
+  switch (object) {
+    case EmailStatus.EMAIL_STATUS_UNSPECIFIED:
+      return 'EMAIL_STATUS_UNSPECIFIED';
+    case EmailStatus.EMAIL_STATUS_QUEUED:
+      return 'EMAIL_STATUS_QUEUED';
+    case EmailStatus.EMAIL_STATUS_SENDING:
+      return 'EMAIL_STATUS_SENDING';
+    case EmailStatus.EMAIL_STATUS_SENT:
+      return 'EMAIL_STATUS_SENT';
+    case EmailStatus.EMAIL_STATUS_DELIVERED:
+      return 'EMAIL_STATUS_DELIVERED';
+    case EmailStatus.EMAIL_STATUS_OPENED:
+      return 'EMAIL_STATUS_OPENED';
+    case EmailStatus.EMAIL_STATUS_CLICKED:
+      return 'EMAIL_STATUS_CLICKED';
+    case EmailStatus.EMAIL_STATUS_FAILED:
+      return 'EMAIL_STATUS_FAILED';
+    case EmailStatus.EMAIL_STATUS_BOUNCED:
+      return 'EMAIL_STATUS_BOUNCED';
+    case EmailStatus.EMAIL_STATUS_UNSUBSCRIBED:
+      return 'EMAIL_STATUS_UNSUBSCRIBED';
+    case EmailStatus.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
+export enum EmailDigestFrequency {
+  EMAIL_DIGEST_FREQUENCY_UNSPECIFIED = 0,
+  EMAIL_DIGEST_FREQUENCY_IMMEDIATE = 1,
+  EMAIL_DIGEST_FREQUENCY_DAILY = 2,
+  EMAIL_DIGEST_FREQUENCY_WEEKLY = 3,
+  EMAIL_DIGEST_FREQUENCY_MONTHLY = 4,
+  EMAIL_DIGEST_FREQUENCY_NEVER = 5,
+  UNRECOGNIZED = -1,
+}
+
+export function emailDigestFrequencyFromJSON(object: any): EmailDigestFrequency {
+  switch (object) {
+    case 0:
+    case 'EMAIL_DIGEST_FREQUENCY_UNSPECIFIED':
+      return EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_UNSPECIFIED;
+    case 1:
+    case 'EMAIL_DIGEST_FREQUENCY_IMMEDIATE':
+      return EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_IMMEDIATE;
+    case 2:
+    case 'EMAIL_DIGEST_FREQUENCY_DAILY':
+      return EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_DAILY;
+    case 3:
+    case 'EMAIL_DIGEST_FREQUENCY_WEEKLY':
+      return EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_WEEKLY;
+    case 4:
+    case 'EMAIL_DIGEST_FREQUENCY_MONTHLY':
+      return EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_MONTHLY;
+    case 5:
+    case 'EMAIL_DIGEST_FREQUENCY_NEVER':
+      return EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_NEVER;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return EmailDigestFrequency.UNRECOGNIZED;
+  }
+}
+
+export function emailDigestFrequencyToJSON(object: EmailDigestFrequency): string {
+  switch (object) {
+    case EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_UNSPECIFIED:
+      return 'EMAIL_DIGEST_FREQUENCY_UNSPECIFIED';
+    case EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_IMMEDIATE:
+      return 'EMAIL_DIGEST_FREQUENCY_IMMEDIATE';
+    case EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_DAILY:
+      return 'EMAIL_DIGEST_FREQUENCY_DAILY';
+    case EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_WEEKLY:
+      return 'EMAIL_DIGEST_FREQUENCY_WEEKLY';
+    case EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_MONTHLY:
+      return 'EMAIL_DIGEST_FREQUENCY_MONTHLY';
+    case EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_NEVER:
+      return 'EMAIL_DIGEST_FREQUENCY_NEVER';
+    case EmailDigestFrequency.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
+export enum EmailFormat {
+  EMAIL_FORMAT_UNSPECIFIED = 0,
+  EMAIL_FORMAT_HTML = 1,
+  EMAIL_FORMAT_TEXT = 2,
+  EMAIL_FORMAT_BOTH = 3,
+  UNRECOGNIZED = -1,
+}
+
+export function emailFormatFromJSON(object: any): EmailFormat {
+  switch (object) {
+    case 0:
+    case 'EMAIL_FORMAT_UNSPECIFIED':
+      return EmailFormat.EMAIL_FORMAT_UNSPECIFIED;
+    case 1:
+    case 'EMAIL_FORMAT_HTML':
+      return EmailFormat.EMAIL_FORMAT_HTML;
+    case 2:
+    case 'EMAIL_FORMAT_TEXT':
+      return EmailFormat.EMAIL_FORMAT_TEXT;
+    case 3:
+    case 'EMAIL_FORMAT_BOTH':
+      return EmailFormat.EMAIL_FORMAT_BOTH;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return EmailFormat.UNRECOGNIZED;
+  }
+}
+
+export function emailFormatToJSON(object: EmailFormat): string {
+  switch (object) {
+    case EmailFormat.EMAIL_FORMAT_UNSPECIFIED:
+      return 'EMAIL_FORMAT_UNSPECIFIED';
+    case EmailFormat.EMAIL_FORMAT_HTML:
+      return 'EMAIL_FORMAT_HTML';
+    case EmailFormat.EMAIL_FORMAT_TEXT:
+      return 'EMAIL_FORMAT_TEXT';
+    case EmailFormat.EMAIL_FORMAT_BOTH:
+      return 'EMAIL_FORMAT_BOTH';
+    case EmailFormat.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
 /**
  * Notification mirrors the `notifications.notifications` row plus the
  * JSON-stringified `data` / `template_variables` payloads. Kept as
@@ -530,6 +815,117 @@ export interface DismissNotificationResponse {
    * Dismiss on the same notification_id returns the same payload.
    */
   notification?: Notification | undefined;
+}
+
+export interface SendEmailRequest {
+  /** Recipient. Required. */
+  toEmail: string;
+  toName?: string | undefined;
+  /** Sender override (defaults to the service's configured From). */
+  fromEmail?: string | undefined;
+  fromName?: string | undefined;
+  replyToEmail?: string | undefined;
+  /** CC / BCC. Empty when omitted. */
+  ccEmails: string[];
+  bccEmails: string[];
+  /**
+   * Either supply (subject + html_content) OR (template_id + template_data_json).
+   * When both arrive, template wins and the inline subject/content are ignored.
+   */
+  subject?: string | undefined;
+  htmlContent?: string | undefined;
+  textContent?: string | undefined;
+  templateId?: string | undefined;
+  /**
+   * JSON-stringified payload for template variable substitution.
+   * Empty string == `{}`.
+   */
+  templateDataJson: string;
+  type: EmailType;
+  priority: EmailPriority;
+  /**
+   * Schedule for a future delivery. Absent = send as soon as the worker
+   * picks it up.
+   */
+  scheduledFor?: string | undefined;
+  /** Free-form metadata + tags for the row. JSON-stringified; empty string == `{}`. */
+  metadataJson: string;
+  tags: string[];
+  /** Tie the row to a user (for prefs enforcement + audit). Optional. */
+  userId?: string | undefined;
+  campaignId?: string | undefined;
+  /**
+   * Opt-in idempotency. When set, a duplicate SendEmail with the same
+   * key returns the same email_id without enqueueing a second row.
+   */
+  idempotencyKey?: string | undefined;
+}
+
+export interface SendEmailResponse {
+  /**
+   * The row's emailId. Caller can poll the queue table for status; the
+   * worker publishes status changes on `notifications.email.*` topics.
+   */
+  emailId: string;
+  /** True when the row was already present (idempotency_key collision). */
+  alreadyQueued: boolean;
+}
+
+export interface EmailPreferences {
+  preferenceId: string;
+  userId: string;
+  isEmailEnabled: boolean;
+  globalUnsubscribe: boolean;
+  /**
+   * JSON-stringified array of per-category opt-in/out rows. Shape:
+   * [{type, enabled, frequency?}, ...]. Empty string == `[]`.
+   */
+  preferencesJson: string;
+  language: string;
+  timezone: string;
+  emailFormat: EmailFormat;
+  digestFrequency: EmailDigestFrequency;
+  /** HH:MM 24h. */
+  digestTime: string;
+  unsubscribeToken: string;
+  lastDigestSent?: string | undefined;
+  bounceCount: number;
+  lastBounceAt?: string | undefined;
+  isBlacklisted: boolean;
+  blacklistReason?: string | undefined;
+  blacklistedAt?: string | undefined;
+  metadataJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GetEmailPreferencesRequest {
+  /**
+   * Optional target. Defaults to the calling principal. Callers without
+   * `email-prefs:read:any` may only read their own row.
+   */
+  userId?: string | undefined;
+}
+
+export interface GetEmailPreferencesResponse {
+  preferences?: EmailPreferences | undefined;
+}
+
+export interface UpdateEmailPreferencesRequest {
+  userId?: string | undefined;
+  /** All fields optional — only present fields are written. */
+  isEmailEnabled?: boolean | undefined;
+  globalUnsubscribe?: boolean | undefined;
+  preferencesJson?: string | undefined;
+  language?: string | undefined;
+  timezone?: string | undefined;
+  emailFormat: EmailFormat;
+  digestFrequency: EmailDigestFrequency;
+  digestTime?: string | undefined;
+}
+
+export interface UpdateEmailPreferencesResponse {
+  preferences?: EmailPreferences | undefined;
 }
 
 function createBaseNotification(): Notification {
@@ -1851,6 +2247,1446 @@ export const DismissNotificationResponse: MessageFns<DismissNotificationResponse
   },
 };
 
+function createBaseSendEmailRequest(): SendEmailRequest {
+  return {
+    toEmail: '',
+    toName: undefined,
+    fromEmail: undefined,
+    fromName: undefined,
+    replyToEmail: undefined,
+    ccEmails: [],
+    bccEmails: [],
+    subject: undefined,
+    htmlContent: undefined,
+    textContent: undefined,
+    templateId: undefined,
+    templateDataJson: '',
+    type: 0,
+    priority: 0,
+    scheduledFor: undefined,
+    metadataJson: '',
+    tags: [],
+    userId: undefined,
+    campaignId: undefined,
+    idempotencyKey: undefined,
+  };
+}
+
+export const SendEmailRequest: MessageFns<SendEmailRequest> = {
+  encode(message: SendEmailRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.toEmail !== '') {
+      writer.uint32(10).string(message.toEmail);
+    }
+    if (message.toName !== undefined) {
+      writer.uint32(18).string(message.toName);
+    }
+    if (message.fromEmail !== undefined) {
+      writer.uint32(26).string(message.fromEmail);
+    }
+    if (message.fromName !== undefined) {
+      writer.uint32(34).string(message.fromName);
+    }
+    if (message.replyToEmail !== undefined) {
+      writer.uint32(42).string(message.replyToEmail);
+    }
+    for (const v of message.ccEmails) {
+      writer.uint32(50).string(v!);
+    }
+    for (const v of message.bccEmails) {
+      writer.uint32(58).string(v!);
+    }
+    if (message.subject !== undefined) {
+      writer.uint32(66).string(message.subject);
+    }
+    if (message.htmlContent !== undefined) {
+      writer.uint32(74).string(message.htmlContent);
+    }
+    if (message.textContent !== undefined) {
+      writer.uint32(82).string(message.textContent);
+    }
+    if (message.templateId !== undefined) {
+      writer.uint32(90).string(message.templateId);
+    }
+    if (message.templateDataJson !== '') {
+      writer.uint32(98).string(message.templateDataJson);
+    }
+    if (message.type !== 0) {
+      writer.uint32(104).int32(message.type);
+    }
+    if (message.priority !== 0) {
+      writer.uint32(112).int32(message.priority);
+    }
+    if (message.scheduledFor !== undefined) {
+      writer.uint32(122).string(message.scheduledFor);
+    }
+    if (message.metadataJson !== '') {
+      writer.uint32(130).string(message.metadataJson);
+    }
+    for (const v of message.tags) {
+      writer.uint32(138).string(v!);
+    }
+    if (message.userId !== undefined) {
+      writer.uint32(146).string(message.userId);
+    }
+    if (message.campaignId !== undefined) {
+      writer.uint32(154).string(message.campaignId);
+    }
+    if (message.idempotencyKey !== undefined) {
+      writer.uint32(162).string(message.idempotencyKey);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SendEmailRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSendEmailRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.toEmail = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.toName = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.fromEmail = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.fromName = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.replyToEmail = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.ccEmails.push(reader.string());
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.bccEmails.push(reader.string());
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.subject = reader.string();
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.htmlContent = reader.string();
+          continue;
+        }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.textContent = reader.string();
+          continue;
+        }
+        case 11: {
+          if (tag !== 90) {
+            break;
+          }
+
+          message.templateId = reader.string();
+          continue;
+        }
+        case 12: {
+          if (tag !== 98) {
+            break;
+          }
+
+          message.templateDataJson = reader.string();
+          continue;
+        }
+        case 13: {
+          if (tag !== 104) {
+            break;
+          }
+
+          message.type = reader.int32() as any;
+          continue;
+        }
+        case 14: {
+          if (tag !== 112) {
+            break;
+          }
+
+          message.priority = reader.int32() as any;
+          continue;
+        }
+        case 15: {
+          if (tag !== 122) {
+            break;
+          }
+
+          message.scheduledFor = reader.string();
+          continue;
+        }
+        case 16: {
+          if (tag !== 130) {
+            break;
+          }
+
+          message.metadataJson = reader.string();
+          continue;
+        }
+        case 17: {
+          if (tag !== 138) {
+            break;
+          }
+
+          message.tags.push(reader.string());
+          continue;
+        }
+        case 18: {
+          if (tag !== 146) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 19: {
+          if (tag !== 154) {
+            break;
+          }
+
+          message.campaignId = reader.string();
+          continue;
+        }
+        case 20: {
+          if (tag !== 162) {
+            break;
+          }
+
+          message.idempotencyKey = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SendEmailRequest {
+    return {
+      toEmail: isSet(object.toEmail)
+        ? globalThis.String(object.toEmail)
+        : isSet(object.to_email)
+          ? globalThis.String(object.to_email)
+          : '',
+      toName: isSet(object.toName)
+        ? globalThis.String(object.toName)
+        : isSet(object.to_name)
+          ? globalThis.String(object.to_name)
+          : undefined,
+      fromEmail: isSet(object.fromEmail)
+        ? globalThis.String(object.fromEmail)
+        : isSet(object.from_email)
+          ? globalThis.String(object.from_email)
+          : undefined,
+      fromName: isSet(object.fromName)
+        ? globalThis.String(object.fromName)
+        : isSet(object.from_name)
+          ? globalThis.String(object.from_name)
+          : undefined,
+      replyToEmail: isSet(object.replyToEmail)
+        ? globalThis.String(object.replyToEmail)
+        : isSet(object.reply_to_email)
+          ? globalThis.String(object.reply_to_email)
+          : undefined,
+      ccEmails: globalThis.Array.isArray(object?.ccEmails)
+        ? object.ccEmails.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.cc_emails)
+          ? object.cc_emails.map((e: any) => globalThis.String(e))
+          : [],
+      bccEmails: globalThis.Array.isArray(object?.bccEmails)
+        ? object.bccEmails.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.bcc_emails)
+          ? object.bcc_emails.map((e: any) => globalThis.String(e))
+          : [],
+      subject: isSet(object.subject) ? globalThis.String(object.subject) : undefined,
+      htmlContent: isSet(object.htmlContent)
+        ? globalThis.String(object.htmlContent)
+        : isSet(object.html_content)
+          ? globalThis.String(object.html_content)
+          : undefined,
+      textContent: isSet(object.textContent)
+        ? globalThis.String(object.textContent)
+        : isSet(object.text_content)
+          ? globalThis.String(object.text_content)
+          : undefined,
+      templateId: isSet(object.templateId)
+        ? globalThis.String(object.templateId)
+        : isSet(object.template_id)
+          ? globalThis.String(object.template_id)
+          : undefined,
+      templateDataJson: isSet(object.templateDataJson)
+        ? globalThis.String(object.templateDataJson)
+        : isSet(object.template_data_json)
+          ? globalThis.String(object.template_data_json)
+          : '',
+      type: isSet(object.type) ? emailTypeFromJSON(object.type) : 0,
+      priority: isSet(object.priority) ? emailPriorityFromJSON(object.priority) : 0,
+      scheduledFor: isSet(object.scheduledFor)
+        ? globalThis.String(object.scheduledFor)
+        : isSet(object.scheduled_for)
+          ? globalThis.String(object.scheduled_for)
+          : undefined,
+      metadataJson: isSet(object.metadataJson)
+        ? globalThis.String(object.metadataJson)
+        : isSet(object.metadata_json)
+          ? globalThis.String(object.metadata_json)
+          : '',
+      tags: globalThis.Array.isArray(object?.tags)
+        ? object.tags.map((e: any) => globalThis.String(e))
+        : [],
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : undefined,
+      campaignId: isSet(object.campaignId)
+        ? globalThis.String(object.campaignId)
+        : isSet(object.campaign_id)
+          ? globalThis.String(object.campaign_id)
+          : undefined,
+      idempotencyKey: isSet(object.idempotencyKey)
+        ? globalThis.String(object.idempotencyKey)
+        : isSet(object.idempotency_key)
+          ? globalThis.String(object.idempotency_key)
+          : undefined,
+    };
+  },
+
+  toJSON(message: SendEmailRequest): unknown {
+    const obj: any = {};
+    if (message.toEmail !== '') {
+      obj.toEmail = message.toEmail;
+    }
+    if (message.toName !== undefined) {
+      obj.toName = message.toName;
+    }
+    if (message.fromEmail !== undefined) {
+      obj.fromEmail = message.fromEmail;
+    }
+    if (message.fromName !== undefined) {
+      obj.fromName = message.fromName;
+    }
+    if (message.replyToEmail !== undefined) {
+      obj.replyToEmail = message.replyToEmail;
+    }
+    if (message.ccEmails?.length) {
+      obj.ccEmails = message.ccEmails;
+    }
+    if (message.bccEmails?.length) {
+      obj.bccEmails = message.bccEmails;
+    }
+    if (message.subject !== undefined) {
+      obj.subject = message.subject;
+    }
+    if (message.htmlContent !== undefined) {
+      obj.htmlContent = message.htmlContent;
+    }
+    if (message.textContent !== undefined) {
+      obj.textContent = message.textContent;
+    }
+    if (message.templateId !== undefined) {
+      obj.templateId = message.templateId;
+    }
+    if (message.templateDataJson !== '') {
+      obj.templateDataJson = message.templateDataJson;
+    }
+    if (message.type !== 0) {
+      obj.type = emailTypeToJSON(message.type);
+    }
+    if (message.priority !== 0) {
+      obj.priority = emailPriorityToJSON(message.priority);
+    }
+    if (message.scheduledFor !== undefined) {
+      obj.scheduledFor = message.scheduledFor;
+    }
+    if (message.metadataJson !== '') {
+      obj.metadataJson = message.metadataJson;
+    }
+    if (message.tags?.length) {
+      obj.tags = message.tags;
+    }
+    if (message.userId !== undefined) {
+      obj.userId = message.userId;
+    }
+    if (message.campaignId !== undefined) {
+      obj.campaignId = message.campaignId;
+    }
+    if (message.idempotencyKey !== undefined) {
+      obj.idempotencyKey = message.idempotencyKey;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SendEmailRequest>, I>>(base?: I): SendEmailRequest {
+    return SendEmailRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SendEmailRequest>, I>>(object: I): SendEmailRequest {
+    const message = createBaseSendEmailRequest();
+    message.toEmail = object.toEmail ?? '';
+    message.toName = object.toName ?? undefined;
+    message.fromEmail = object.fromEmail ?? undefined;
+    message.fromName = object.fromName ?? undefined;
+    message.replyToEmail = object.replyToEmail ?? undefined;
+    message.ccEmails = object.ccEmails?.map(e => e) || [];
+    message.bccEmails = object.bccEmails?.map(e => e) || [];
+    message.subject = object.subject ?? undefined;
+    message.htmlContent = object.htmlContent ?? undefined;
+    message.textContent = object.textContent ?? undefined;
+    message.templateId = object.templateId ?? undefined;
+    message.templateDataJson = object.templateDataJson ?? '';
+    message.type = object.type ?? 0;
+    message.priority = object.priority ?? 0;
+    message.scheduledFor = object.scheduledFor ?? undefined;
+    message.metadataJson = object.metadataJson ?? '';
+    message.tags = object.tags?.map(e => e) || [];
+    message.userId = object.userId ?? undefined;
+    message.campaignId = object.campaignId ?? undefined;
+    message.idempotencyKey = object.idempotencyKey ?? undefined;
+    return message;
+  },
+};
+
+function createBaseSendEmailResponse(): SendEmailResponse {
+  return { emailId: '', alreadyQueued: false };
+}
+
+export const SendEmailResponse: MessageFns<SendEmailResponse> = {
+  encode(message: SendEmailResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.emailId !== '') {
+      writer.uint32(10).string(message.emailId);
+    }
+    if (message.alreadyQueued !== false) {
+      writer.uint32(16).bool(message.alreadyQueued);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SendEmailResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSendEmailResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.emailId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.alreadyQueued = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SendEmailResponse {
+    return {
+      emailId: isSet(object.emailId)
+        ? globalThis.String(object.emailId)
+        : isSet(object.email_id)
+          ? globalThis.String(object.email_id)
+          : '',
+      alreadyQueued: isSet(object.alreadyQueued)
+        ? globalThis.Boolean(object.alreadyQueued)
+        : isSet(object.already_queued)
+          ? globalThis.Boolean(object.already_queued)
+          : false,
+    };
+  },
+
+  toJSON(message: SendEmailResponse): unknown {
+    const obj: any = {};
+    if (message.emailId !== '') {
+      obj.emailId = message.emailId;
+    }
+    if (message.alreadyQueued !== false) {
+      obj.alreadyQueued = message.alreadyQueued;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SendEmailResponse>, I>>(base?: I): SendEmailResponse {
+    return SendEmailResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SendEmailResponse>, I>>(object: I): SendEmailResponse {
+    const message = createBaseSendEmailResponse();
+    message.emailId = object.emailId ?? '';
+    message.alreadyQueued = object.alreadyQueued ?? false;
+    return message;
+  },
+};
+
+function createBaseEmailPreferences(): EmailPreferences {
+  return {
+    preferenceId: '',
+    userId: '',
+    isEmailEnabled: false,
+    globalUnsubscribe: false,
+    preferencesJson: '',
+    language: '',
+    timezone: '',
+    emailFormat: 0,
+    digestFrequency: 0,
+    digestTime: '',
+    unsubscribeToken: '',
+    lastDigestSent: undefined,
+    bounceCount: 0,
+    lastBounceAt: undefined,
+    isBlacklisted: false,
+    blacklistReason: undefined,
+    blacklistedAt: undefined,
+    metadataJson: '',
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+export const EmailPreferences: MessageFns<EmailPreferences> = {
+  encode(message: EmailPreferences, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.preferenceId !== '') {
+      writer.uint32(10).string(message.preferenceId);
+    }
+    if (message.userId !== '') {
+      writer.uint32(18).string(message.userId);
+    }
+    if (message.isEmailEnabled !== false) {
+      writer.uint32(24).bool(message.isEmailEnabled);
+    }
+    if (message.globalUnsubscribe !== false) {
+      writer.uint32(32).bool(message.globalUnsubscribe);
+    }
+    if (message.preferencesJson !== '') {
+      writer.uint32(42).string(message.preferencesJson);
+    }
+    if (message.language !== '') {
+      writer.uint32(50).string(message.language);
+    }
+    if (message.timezone !== '') {
+      writer.uint32(58).string(message.timezone);
+    }
+    if (message.emailFormat !== 0) {
+      writer.uint32(64).int32(message.emailFormat);
+    }
+    if (message.digestFrequency !== 0) {
+      writer.uint32(72).int32(message.digestFrequency);
+    }
+    if (message.digestTime !== '') {
+      writer.uint32(82).string(message.digestTime);
+    }
+    if (message.unsubscribeToken !== '') {
+      writer.uint32(90).string(message.unsubscribeToken);
+    }
+    if (message.lastDigestSent !== undefined) {
+      writer.uint32(98).string(message.lastDigestSent);
+    }
+    if (message.bounceCount !== 0) {
+      writer.uint32(104).uint32(message.bounceCount);
+    }
+    if (message.lastBounceAt !== undefined) {
+      writer.uint32(114).string(message.lastBounceAt);
+    }
+    if (message.isBlacklisted !== false) {
+      writer.uint32(120).bool(message.isBlacklisted);
+    }
+    if (message.blacklistReason !== undefined) {
+      writer.uint32(130).string(message.blacklistReason);
+    }
+    if (message.blacklistedAt !== undefined) {
+      writer.uint32(138).string(message.blacklistedAt);
+    }
+    if (message.metadataJson !== '') {
+      writer.uint32(146).string(message.metadataJson);
+    }
+    if (message.createdAt !== '') {
+      writer.uint32(154).string(message.createdAt);
+    }
+    if (message.updatedAt !== '') {
+      writer.uint32(162).string(message.updatedAt);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): EmailPreferences {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEmailPreferences();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.preferenceId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.isEmailEnabled = reader.bool();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.globalUnsubscribe = reader.bool();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.preferencesJson = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.language = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.timezone = reader.string();
+          continue;
+        }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.emailFormat = reader.int32() as any;
+          continue;
+        }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.digestFrequency = reader.int32() as any;
+          continue;
+        }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.digestTime = reader.string();
+          continue;
+        }
+        case 11: {
+          if (tag !== 90) {
+            break;
+          }
+
+          message.unsubscribeToken = reader.string();
+          continue;
+        }
+        case 12: {
+          if (tag !== 98) {
+            break;
+          }
+
+          message.lastDigestSent = reader.string();
+          continue;
+        }
+        case 13: {
+          if (tag !== 104) {
+            break;
+          }
+
+          message.bounceCount = reader.uint32();
+          continue;
+        }
+        case 14: {
+          if (tag !== 114) {
+            break;
+          }
+
+          message.lastBounceAt = reader.string();
+          continue;
+        }
+        case 15: {
+          if (tag !== 120) {
+            break;
+          }
+
+          message.isBlacklisted = reader.bool();
+          continue;
+        }
+        case 16: {
+          if (tag !== 130) {
+            break;
+          }
+
+          message.blacklistReason = reader.string();
+          continue;
+        }
+        case 17: {
+          if (tag !== 138) {
+            break;
+          }
+
+          message.blacklistedAt = reader.string();
+          continue;
+        }
+        case 18: {
+          if (tag !== 146) {
+            break;
+          }
+
+          message.metadataJson = reader.string();
+          continue;
+        }
+        case 19: {
+          if (tag !== 154) {
+            break;
+          }
+
+          message.createdAt = reader.string();
+          continue;
+        }
+        case 20: {
+          if (tag !== 162) {
+            break;
+          }
+
+          message.updatedAt = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): EmailPreferences {
+    return {
+      preferenceId: isSet(object.preferenceId)
+        ? globalThis.String(object.preferenceId)
+        : isSet(object.preference_id)
+          ? globalThis.String(object.preference_id)
+          : '',
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : '',
+      isEmailEnabled: isSet(object.isEmailEnabled)
+        ? globalThis.Boolean(object.isEmailEnabled)
+        : isSet(object.is_email_enabled)
+          ? globalThis.Boolean(object.is_email_enabled)
+          : false,
+      globalUnsubscribe: isSet(object.globalUnsubscribe)
+        ? globalThis.Boolean(object.globalUnsubscribe)
+        : isSet(object.global_unsubscribe)
+          ? globalThis.Boolean(object.global_unsubscribe)
+          : false,
+      preferencesJson: isSet(object.preferencesJson)
+        ? globalThis.String(object.preferencesJson)
+        : isSet(object.preferences_json)
+          ? globalThis.String(object.preferences_json)
+          : '',
+      language: isSet(object.language) ? globalThis.String(object.language) : '',
+      timezone: isSet(object.timezone) ? globalThis.String(object.timezone) : '',
+      emailFormat: isSet(object.emailFormat)
+        ? emailFormatFromJSON(object.emailFormat)
+        : isSet(object.email_format)
+          ? emailFormatFromJSON(object.email_format)
+          : 0,
+      digestFrequency: isSet(object.digestFrequency)
+        ? emailDigestFrequencyFromJSON(object.digestFrequency)
+        : isSet(object.digest_frequency)
+          ? emailDigestFrequencyFromJSON(object.digest_frequency)
+          : 0,
+      digestTime: isSet(object.digestTime)
+        ? globalThis.String(object.digestTime)
+        : isSet(object.digest_time)
+          ? globalThis.String(object.digest_time)
+          : '',
+      unsubscribeToken: isSet(object.unsubscribeToken)
+        ? globalThis.String(object.unsubscribeToken)
+        : isSet(object.unsubscribe_token)
+          ? globalThis.String(object.unsubscribe_token)
+          : '',
+      lastDigestSent: isSet(object.lastDigestSent)
+        ? globalThis.String(object.lastDigestSent)
+        : isSet(object.last_digest_sent)
+          ? globalThis.String(object.last_digest_sent)
+          : undefined,
+      bounceCount: isSet(object.bounceCount)
+        ? globalThis.Number(object.bounceCount)
+        : isSet(object.bounce_count)
+          ? globalThis.Number(object.bounce_count)
+          : 0,
+      lastBounceAt: isSet(object.lastBounceAt)
+        ? globalThis.String(object.lastBounceAt)
+        : isSet(object.last_bounce_at)
+          ? globalThis.String(object.last_bounce_at)
+          : undefined,
+      isBlacklisted: isSet(object.isBlacklisted)
+        ? globalThis.Boolean(object.isBlacklisted)
+        : isSet(object.is_blacklisted)
+          ? globalThis.Boolean(object.is_blacklisted)
+          : false,
+      blacklistReason: isSet(object.blacklistReason)
+        ? globalThis.String(object.blacklistReason)
+        : isSet(object.blacklist_reason)
+          ? globalThis.String(object.blacklist_reason)
+          : undefined,
+      blacklistedAt: isSet(object.blacklistedAt)
+        ? globalThis.String(object.blacklistedAt)
+        : isSet(object.blacklisted_at)
+          ? globalThis.String(object.blacklisted_at)
+          : undefined,
+      metadataJson: isSet(object.metadataJson)
+        ? globalThis.String(object.metadataJson)
+        : isSet(object.metadata_json)
+          ? globalThis.String(object.metadata_json)
+          : '',
+      createdAt: isSet(object.createdAt)
+        ? globalThis.String(object.createdAt)
+        : isSet(object.created_at)
+          ? globalThis.String(object.created_at)
+          : '',
+      updatedAt: isSet(object.updatedAt)
+        ? globalThis.String(object.updatedAt)
+        : isSet(object.updated_at)
+          ? globalThis.String(object.updated_at)
+          : '',
+    };
+  },
+
+  toJSON(message: EmailPreferences): unknown {
+    const obj: any = {};
+    if (message.preferenceId !== '') {
+      obj.preferenceId = message.preferenceId;
+    }
+    if (message.userId !== '') {
+      obj.userId = message.userId;
+    }
+    if (message.isEmailEnabled !== false) {
+      obj.isEmailEnabled = message.isEmailEnabled;
+    }
+    if (message.globalUnsubscribe !== false) {
+      obj.globalUnsubscribe = message.globalUnsubscribe;
+    }
+    if (message.preferencesJson !== '') {
+      obj.preferencesJson = message.preferencesJson;
+    }
+    if (message.language !== '') {
+      obj.language = message.language;
+    }
+    if (message.timezone !== '') {
+      obj.timezone = message.timezone;
+    }
+    if (message.emailFormat !== 0) {
+      obj.emailFormat = emailFormatToJSON(message.emailFormat);
+    }
+    if (message.digestFrequency !== 0) {
+      obj.digestFrequency = emailDigestFrequencyToJSON(message.digestFrequency);
+    }
+    if (message.digestTime !== '') {
+      obj.digestTime = message.digestTime;
+    }
+    if (message.unsubscribeToken !== '') {
+      obj.unsubscribeToken = message.unsubscribeToken;
+    }
+    if (message.lastDigestSent !== undefined) {
+      obj.lastDigestSent = message.lastDigestSent;
+    }
+    if (message.bounceCount !== 0) {
+      obj.bounceCount = Math.round(message.bounceCount);
+    }
+    if (message.lastBounceAt !== undefined) {
+      obj.lastBounceAt = message.lastBounceAt;
+    }
+    if (message.isBlacklisted !== false) {
+      obj.isBlacklisted = message.isBlacklisted;
+    }
+    if (message.blacklistReason !== undefined) {
+      obj.blacklistReason = message.blacklistReason;
+    }
+    if (message.blacklistedAt !== undefined) {
+      obj.blacklistedAt = message.blacklistedAt;
+    }
+    if (message.metadataJson !== '') {
+      obj.metadataJson = message.metadataJson;
+    }
+    if (message.createdAt !== '') {
+      obj.createdAt = message.createdAt;
+    }
+    if (message.updatedAt !== '') {
+      obj.updatedAt = message.updatedAt;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<EmailPreferences>, I>>(base?: I): EmailPreferences {
+    return EmailPreferences.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<EmailPreferences>, I>>(object: I): EmailPreferences {
+    const message = createBaseEmailPreferences();
+    message.preferenceId = object.preferenceId ?? '';
+    message.userId = object.userId ?? '';
+    message.isEmailEnabled = object.isEmailEnabled ?? false;
+    message.globalUnsubscribe = object.globalUnsubscribe ?? false;
+    message.preferencesJson = object.preferencesJson ?? '';
+    message.language = object.language ?? '';
+    message.timezone = object.timezone ?? '';
+    message.emailFormat = object.emailFormat ?? 0;
+    message.digestFrequency = object.digestFrequency ?? 0;
+    message.digestTime = object.digestTime ?? '';
+    message.unsubscribeToken = object.unsubscribeToken ?? '';
+    message.lastDigestSent = object.lastDigestSent ?? undefined;
+    message.bounceCount = object.bounceCount ?? 0;
+    message.lastBounceAt = object.lastBounceAt ?? undefined;
+    message.isBlacklisted = object.isBlacklisted ?? false;
+    message.blacklistReason = object.blacklistReason ?? undefined;
+    message.blacklistedAt = object.blacklistedAt ?? undefined;
+    message.metadataJson = object.metadataJson ?? '';
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
+    return message;
+  },
+};
+
+function createBaseGetEmailPreferencesRequest(): GetEmailPreferencesRequest {
+  return { userId: undefined };
+}
+
+export const GetEmailPreferencesRequest: MessageFns<GetEmailPreferencesRequest> = {
+  encode(
+    message: GetEmailPreferencesRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.userId !== undefined) {
+      writer.uint32(10).string(message.userId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetEmailPreferencesRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetEmailPreferencesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetEmailPreferencesRequest {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : undefined,
+    };
+  },
+
+  toJSON(message: GetEmailPreferencesRequest): unknown {
+    const obj: any = {};
+    if (message.userId !== undefined) {
+      obj.userId = message.userId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetEmailPreferencesRequest>, I>>(
+    base?: I
+  ): GetEmailPreferencesRequest {
+    return GetEmailPreferencesRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetEmailPreferencesRequest>, I>>(
+    object: I
+  ): GetEmailPreferencesRequest {
+    const message = createBaseGetEmailPreferencesRequest();
+    message.userId = object.userId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseGetEmailPreferencesResponse(): GetEmailPreferencesResponse {
+  return { preferences: undefined };
+}
+
+export const GetEmailPreferencesResponse: MessageFns<GetEmailPreferencesResponse> = {
+  encode(
+    message: GetEmailPreferencesResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.preferences !== undefined) {
+      EmailPreferences.encode(message.preferences, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetEmailPreferencesResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetEmailPreferencesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.preferences = EmailPreferences.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetEmailPreferencesResponse {
+    return {
+      preferences: isSet(object.preferences)
+        ? EmailPreferences.fromJSON(object.preferences)
+        : undefined,
+    };
+  },
+
+  toJSON(message: GetEmailPreferencesResponse): unknown {
+    const obj: any = {};
+    if (message.preferences !== undefined) {
+      obj.preferences = EmailPreferences.toJSON(message.preferences);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetEmailPreferencesResponse>, I>>(
+    base?: I
+  ): GetEmailPreferencesResponse {
+    return GetEmailPreferencesResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetEmailPreferencesResponse>, I>>(
+    object: I
+  ): GetEmailPreferencesResponse {
+    const message = createBaseGetEmailPreferencesResponse();
+    message.preferences =
+      object.preferences !== undefined && object.preferences !== null
+        ? EmailPreferences.fromPartial(object.preferences)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseUpdateEmailPreferencesRequest(): UpdateEmailPreferencesRequest {
+  return {
+    userId: undefined,
+    isEmailEnabled: undefined,
+    globalUnsubscribe: undefined,
+    preferencesJson: undefined,
+    language: undefined,
+    timezone: undefined,
+    emailFormat: 0,
+    digestFrequency: 0,
+    digestTime: undefined,
+  };
+}
+
+export const UpdateEmailPreferencesRequest: MessageFns<UpdateEmailPreferencesRequest> = {
+  encode(
+    message: UpdateEmailPreferencesRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.userId !== undefined) {
+      writer.uint32(10).string(message.userId);
+    }
+    if (message.isEmailEnabled !== undefined) {
+      writer.uint32(16).bool(message.isEmailEnabled);
+    }
+    if (message.globalUnsubscribe !== undefined) {
+      writer.uint32(24).bool(message.globalUnsubscribe);
+    }
+    if (message.preferencesJson !== undefined) {
+      writer.uint32(34).string(message.preferencesJson);
+    }
+    if (message.language !== undefined) {
+      writer.uint32(42).string(message.language);
+    }
+    if (message.timezone !== undefined) {
+      writer.uint32(50).string(message.timezone);
+    }
+    if (message.emailFormat !== 0) {
+      writer.uint32(56).int32(message.emailFormat);
+    }
+    if (message.digestFrequency !== 0) {
+      writer.uint32(64).int32(message.digestFrequency);
+    }
+    if (message.digestTime !== undefined) {
+      writer.uint32(74).string(message.digestTime);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpdateEmailPreferencesRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpdateEmailPreferencesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.isEmailEnabled = reader.bool();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.globalUnsubscribe = reader.bool();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.preferencesJson = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.language = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.timezone = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.emailFormat = reader.int32() as any;
+          continue;
+        }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.digestFrequency = reader.int32() as any;
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.digestTime = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpdateEmailPreferencesRequest {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : undefined,
+      isEmailEnabled: isSet(object.isEmailEnabled)
+        ? globalThis.Boolean(object.isEmailEnabled)
+        : isSet(object.is_email_enabled)
+          ? globalThis.Boolean(object.is_email_enabled)
+          : undefined,
+      globalUnsubscribe: isSet(object.globalUnsubscribe)
+        ? globalThis.Boolean(object.globalUnsubscribe)
+        : isSet(object.global_unsubscribe)
+          ? globalThis.Boolean(object.global_unsubscribe)
+          : undefined,
+      preferencesJson: isSet(object.preferencesJson)
+        ? globalThis.String(object.preferencesJson)
+        : isSet(object.preferences_json)
+          ? globalThis.String(object.preferences_json)
+          : undefined,
+      language: isSet(object.language) ? globalThis.String(object.language) : undefined,
+      timezone: isSet(object.timezone) ? globalThis.String(object.timezone) : undefined,
+      emailFormat: isSet(object.emailFormat)
+        ? emailFormatFromJSON(object.emailFormat)
+        : isSet(object.email_format)
+          ? emailFormatFromJSON(object.email_format)
+          : 0,
+      digestFrequency: isSet(object.digestFrequency)
+        ? emailDigestFrequencyFromJSON(object.digestFrequency)
+        : isSet(object.digest_frequency)
+          ? emailDigestFrequencyFromJSON(object.digest_frequency)
+          : 0,
+      digestTime: isSet(object.digestTime)
+        ? globalThis.String(object.digestTime)
+        : isSet(object.digest_time)
+          ? globalThis.String(object.digest_time)
+          : undefined,
+    };
+  },
+
+  toJSON(message: UpdateEmailPreferencesRequest): unknown {
+    const obj: any = {};
+    if (message.userId !== undefined) {
+      obj.userId = message.userId;
+    }
+    if (message.isEmailEnabled !== undefined) {
+      obj.isEmailEnabled = message.isEmailEnabled;
+    }
+    if (message.globalUnsubscribe !== undefined) {
+      obj.globalUnsubscribe = message.globalUnsubscribe;
+    }
+    if (message.preferencesJson !== undefined) {
+      obj.preferencesJson = message.preferencesJson;
+    }
+    if (message.language !== undefined) {
+      obj.language = message.language;
+    }
+    if (message.timezone !== undefined) {
+      obj.timezone = message.timezone;
+    }
+    if (message.emailFormat !== 0) {
+      obj.emailFormat = emailFormatToJSON(message.emailFormat);
+    }
+    if (message.digestFrequency !== 0) {
+      obj.digestFrequency = emailDigestFrequencyToJSON(message.digestFrequency);
+    }
+    if (message.digestTime !== undefined) {
+      obj.digestTime = message.digestTime;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpdateEmailPreferencesRequest>, I>>(
+    base?: I
+  ): UpdateEmailPreferencesRequest {
+    return UpdateEmailPreferencesRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpdateEmailPreferencesRequest>, I>>(
+    object: I
+  ): UpdateEmailPreferencesRequest {
+    const message = createBaseUpdateEmailPreferencesRequest();
+    message.userId = object.userId ?? undefined;
+    message.isEmailEnabled = object.isEmailEnabled ?? undefined;
+    message.globalUnsubscribe = object.globalUnsubscribe ?? undefined;
+    message.preferencesJson = object.preferencesJson ?? undefined;
+    message.language = object.language ?? undefined;
+    message.timezone = object.timezone ?? undefined;
+    message.emailFormat = object.emailFormat ?? 0;
+    message.digestFrequency = object.digestFrequency ?? 0;
+    message.digestTime = object.digestTime ?? undefined;
+    return message;
+  },
+};
+
+function createBaseUpdateEmailPreferencesResponse(): UpdateEmailPreferencesResponse {
+  return { preferences: undefined };
+}
+
+export const UpdateEmailPreferencesResponse: MessageFns<UpdateEmailPreferencesResponse> = {
+  encode(
+    message: UpdateEmailPreferencesResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.preferences !== undefined) {
+      EmailPreferences.encode(message.preferences, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpdateEmailPreferencesResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpdateEmailPreferencesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.preferences = EmailPreferences.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpdateEmailPreferencesResponse {
+    return {
+      preferences: isSet(object.preferences)
+        ? EmailPreferences.fromJSON(object.preferences)
+        : undefined,
+    };
+  },
+
+  toJSON(message: UpdateEmailPreferencesResponse): unknown {
+    const obj: any = {};
+    if (message.preferences !== undefined) {
+      obj.preferences = EmailPreferences.toJSON(message.preferences);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpdateEmailPreferencesResponse>, I>>(
+    base?: I
+  ): UpdateEmailPreferencesResponse {
+    return UpdateEmailPreferencesResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpdateEmailPreferencesResponse>, I>>(
+    object: I
+  ): UpdateEmailPreferencesResponse {
+    const message = createBaseUpdateEmailPreferencesResponse();
+    message.preferences =
+      object.preferences !== undefined && object.preferences !== null
+        ? EmailPreferences.fromPartial(object.preferences)
+        : undefined;
+    return message;
+  },
+};
+
 /**
  * NotificationService is the gRPC contract for the in-app notification
  * store. The gateway translates `POST/GET/DELETE /api/notifications/*`
@@ -1923,6 +3759,59 @@ export const NotificationServiceService = {
     responseDeserialize: (value: Buffer): DismissNotificationResponse =>
       DismissNotificationResponse.decode(value),
   },
+  /**
+   * Enqueue an email. Returns the email_id immediately; delivery happens
+   * asynchronously in the worker. Callers can supply a templateId +
+   * templateData OR a pre-rendered subject + html_content; if both are
+   * present the template wins. `idempotency_key` is optional — when set
+   * a duplicate Send with the same key returns the same email_id.
+   */
+  sendEmail: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/SendEmail' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: SendEmailRequest): Buffer =>
+      Buffer.from(SendEmailRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): SendEmailRequest => SendEmailRequest.decode(value),
+    responseSerialize: (value: SendEmailResponse): Buffer =>
+      Buffer.from(SendEmailResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): SendEmailResponse => SendEmailResponse.decode(value),
+  },
+  /**
+   * Read the calling principal's email preferences (or a target user's
+   * when the caller has email-prefs:read:any). Returns the canonical
+   * row, creating defaults on first read.
+   */
+  getEmailPreferences: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/GetEmailPreferences' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetEmailPreferencesRequest): Buffer =>
+      Buffer.from(GetEmailPreferencesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetEmailPreferencesRequest =>
+      GetEmailPreferencesRequest.decode(value),
+    responseSerialize: (value: GetEmailPreferencesResponse): Buffer =>
+      Buffer.from(GetEmailPreferencesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetEmailPreferencesResponse =>
+      GetEmailPreferencesResponse.decode(value),
+  },
+  /**
+   * Partially update email preferences. Only provided fields are
+   * touched — unset fields keep their current value.
+   */
+  updateEmailPreferences: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/UpdateEmailPreferences' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: UpdateEmailPreferencesRequest): Buffer =>
+      Buffer.from(UpdateEmailPreferencesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): UpdateEmailPreferencesRequest =>
+      UpdateEmailPreferencesRequest.decode(value),
+    responseSerialize: (value: UpdateEmailPreferencesResponse): Buffer =>
+      Buffer.from(UpdateEmailPreferencesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): UpdateEmailPreferencesResponse =>
+      UpdateEmailPreferencesResponse.decode(value),
+  },
 } as const;
 
 export interface NotificationServiceServer extends UntypedServiceImplementation {
@@ -1947,6 +3836,28 @@ export interface NotificationServiceServer extends UntypedServiceImplementation 
    * on NATS after the DB commits.
    */
   dismiss: handleUnaryCall<DismissNotificationRequest, DismissNotificationResponse>;
+  /**
+   * Enqueue an email. Returns the email_id immediately; delivery happens
+   * asynchronously in the worker. Callers can supply a templateId +
+   * templateData OR a pre-rendered subject + html_content; if both are
+   * present the template wins. `idempotency_key` is optional — when set
+   * a duplicate Send with the same key returns the same email_id.
+   */
+  sendEmail: handleUnaryCall<SendEmailRequest, SendEmailResponse>;
+  /**
+   * Read the calling principal's email preferences (or a target user's
+   * when the caller has email-prefs:read:any). Returns the canonical
+   * row, creating defaults on first read.
+   */
+  getEmailPreferences: handleUnaryCall<GetEmailPreferencesRequest, GetEmailPreferencesResponse>;
+  /**
+   * Partially update email preferences. Only provided fields are
+   * touched — unset fields keep their current value.
+   */
+  updateEmailPreferences: handleUnaryCall<
+    UpdateEmailPreferencesRequest,
+    UpdateEmailPreferencesResponse
+  >;
 }
 
 export interface NotificationServiceClient extends Client {
@@ -2012,6 +3923,67 @@ export interface NotificationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: DismissNotificationResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Enqueue an email. Returns the email_id immediately; delivery happens
+   * asynchronously in the worker. Callers can supply a templateId +
+   * templateData OR a pre-rendered subject + html_content; if both are
+   * present the template wins. `idempotency_key` is optional — when set
+   * a duplicate Send with the same key returns the same email_id.
+   */
+  sendEmail(
+    request: SendEmailRequest,
+    callback: (error: ServiceError | null, response: SendEmailResponse) => void
+  ): ClientUnaryCall;
+  sendEmail(
+    request: SendEmailRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SendEmailResponse) => void
+  ): ClientUnaryCall;
+  sendEmail(
+    request: SendEmailRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SendEmailResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Read the calling principal's email preferences (or a target user's
+   * when the caller has email-prefs:read:any). Returns the canonical
+   * row, creating defaults on first read.
+   */
+  getEmailPreferences(
+    request: GetEmailPreferencesRequest,
+    callback: (error: ServiceError | null, response: GetEmailPreferencesResponse) => void
+  ): ClientUnaryCall;
+  getEmailPreferences(
+    request: GetEmailPreferencesRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetEmailPreferencesResponse) => void
+  ): ClientUnaryCall;
+  getEmailPreferences(
+    request: GetEmailPreferencesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetEmailPreferencesResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Partially update email preferences. Only provided fields are
+   * touched — unset fields keep their current value.
+   */
+  updateEmailPreferences(
+    request: UpdateEmailPreferencesRequest,
+    callback: (error: ServiceError | null, response: UpdateEmailPreferencesResponse) => void
+  ): ClientUnaryCall;
+  updateEmailPreferences(
+    request: UpdateEmailPreferencesRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: UpdateEmailPreferencesResponse) => void
+  ): ClientUnaryCall;
+  updateEmailPreferences(
+    request: UpdateEmailPreferencesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: UpdateEmailPreferencesResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -45,6 +45,13 @@ export type {
   GetEmailPreferencesResponse,
   UpdateEmailPreferencesRequest,
   UpdateEmailPreferencesResponse,
+  DeviceToken as NotificationsDeviceToken,
+  RegisterDeviceTokenRequest,
+  RegisterDeviceTokenResponse,
+  UnregisterDeviceTokenRequest,
+  UnregisterDeviceTokenResponse,
+  ListDeviceTokensRequest,
+  ListDeviceTokensResponse,
   NotificationServiceServer,
   NotificationServiceClient,
 } from './generated/proto/adopt_dont_shop/notifications/v1/notification.js';

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -38,6 +38,13 @@ export type {
   ListNotificationsResponse,
   DismissNotificationRequest,
   DismissNotificationResponse,
+  SendEmailRequest,
+  SendEmailResponse,
+  EmailPreferences,
+  GetEmailPreferencesRequest,
+  GetEmailPreferencesResponse,
+  UpdateEmailPreferencesRequest,
+  UpdateEmailPreferencesResponse,
   NotificationServiceServer,
   NotificationServiceClient,
 } from './generated/proto/adopt_dont_shop/notifications/v1/notification.js';

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -42,6 +42,11 @@
     "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
-    "pg": "^8.21.0"
+    "nodemailer": "^8.0.8",
+    "pg": "^8.21.0",
+    "resend": "^6.12.4"
+  },
+  "devDependencies": {
+    "@types/nodemailer": "^8.0.0"
   }
 }

--- a/services/notifications/src/config.test.ts
+++ b/services/notifications/src/config.test.ts
@@ -25,6 +25,13 @@ describe('loadConfig', () => {
       NODE_ENV: 'production',
       DATABASE_URL: 'postgres://prod:secret@db.example.com:5432/notifications',
       NATS_URL: 'nats://nats.internal:4222',
+      // ADS-549: production needs a real email provider — console is
+      // rejected (silent drop of every transactional email). Resend is
+      // the production configuration.
+      EMAIL_PROVIDER: 'resend',
+      RESEND_API_KEY: 're_test_key',
+      DEFAULT_FROM_EMAIL: 'noreply@example.com',
+      DEFAULT_FROM_NAME: 'Adopt Test',
     });
 
     expect(config.port).toBe(5500);
@@ -34,6 +41,53 @@ describe('loadConfig', () => {
     expect(config.schema).toBe('notifications_test');
     expect(config.databaseUrl).toBe('postgres://prod:secret@db.example.com:5432/notifications');
     expect(config.natsUrl).toBe('nats://nats.internal:4222');
+    expect(config.emailProvider).toEqual({
+      kind: 'resend',
+      apiKey: 're_test_key',
+      fromEmail: 'noreply@example.com',
+      fromName: 'Adopt Test',
+      replyTo: undefined,
+    });
+    expect(config.emailWorkerEnabled).toBe(true);
+  });
+
+  it('defaults to the console email provider in non-production environments', () => {
+    const config = loadConfig({ DATABASE_URL: VALID_DB_URL });
+    expect(config.emailProvider).toEqual({ kind: 'console' });
+  });
+
+  it("rejects EMAIL_PROVIDER='console' in production", () => {
+    expect(() =>
+      loadConfig({
+        NODE_ENV: 'production',
+        DATABASE_URL: VALID_DB_URL,
+        EMAIL_PROVIDER: 'console',
+      })
+    ).toThrow(/not permitted in production/);
+  });
+
+  it("requires RESEND_API_KEY when EMAIL_PROVIDER='resend'", () => {
+    expect(() =>
+      loadConfig({
+        DATABASE_URL: VALID_DB_URL,
+        EMAIL_PROVIDER: 'resend',
+        DEFAULT_FROM_EMAIL: 'noreply@example.com',
+      })
+    ).toThrow(/requires RESEND_API_KEY/);
+  });
+
+  it('rejects an unknown EMAIL_PROVIDER value', () => {
+    expect(() => loadConfig({ DATABASE_URL: VALID_DB_URL, EMAIL_PROVIDER: 'sendgrid' })).toThrow(
+      /EMAIL_PROVIDER='sendgrid' is not recognised/
+    );
+  });
+
+  it('honours EMAIL_WORKER_ENABLED=false', () => {
+    const config = loadConfig({
+      DATABASE_URL: VALID_DB_URL,
+      EMAIL_WORKER_ENABLED: 'false',
+    });
+    expect(config.emailWorkerEnabled).toBe(false);
   });
 
   it('rejects a non-numeric NOTIFICATIONS_PORT', () => {

--- a/services/notifications/src/config.test.ts
+++ b/services/notifications/src/config.test.ts
@@ -32,6 +32,10 @@ describe('loadConfig', () => {
       RESEND_API_KEY: 're_test_key',
       DEFAULT_FROM_EMAIL: 'noreply@example.com',
       DEFAULT_FROM_NAME: 'Adopt Test',
+      // Push provider — fcm in production, same ADS-549 rule.
+      PUSH_PROVIDER: 'fcm',
+      FCM_SERVICE_ACCOUNT_JSON: '{"type":"service_account"}',
+      FCM_PROJECT_ID: 'gcp-project-id',
     });
 
     expect(config.port).toBe(5500);
@@ -49,11 +53,47 @@ describe('loadConfig', () => {
       replyTo: undefined,
     });
     expect(config.emailWorkerEnabled).toBe(true);
+    expect(config.pushProvider).toEqual({
+      kind: 'fcm',
+      serviceAccountJson: '{"type":"service_account"}',
+      projectId: 'gcp-project-id',
+    });
+    expect(config.pushWorkerEnabled).toBe(true);
   });
 
-  it('defaults to the console email provider in non-production environments', () => {
+  it('defaults to the console email + push providers in non-production environments', () => {
     const config = loadConfig({ DATABASE_URL: VALID_DB_URL });
     expect(config.emailProvider).toEqual({ kind: 'console' });
+    expect(config.pushProvider).toEqual({ kind: 'console' });
+  });
+
+  it("rejects PUSH_PROVIDER='console' in production", () => {
+    expect(() =>
+      loadConfig({
+        NODE_ENV: 'production',
+        DATABASE_URL: VALID_DB_URL,
+        EMAIL_PROVIDER: 'resend',
+        RESEND_API_KEY: 'k',
+        DEFAULT_FROM_EMAIL: 'from@example.com',
+        PUSH_PROVIDER: 'console',
+      })
+    ).toThrow(/not permitted in production/);
+  });
+
+  it("requires FCM_SERVICE_ACCOUNT_JSON when PUSH_PROVIDER='fcm'", () => {
+    expect(() =>
+      loadConfig({
+        DATABASE_URL: VALID_DB_URL,
+        PUSH_PROVIDER: 'fcm',
+        FCM_PROJECT_ID: 'gcp-project-id',
+      })
+    ).toThrow(/requires FCM_SERVICE_ACCOUNT_JSON/);
+  });
+
+  it('rejects an unknown PUSH_PROVIDER value', () => {
+    expect(() => loadConfig({ DATABASE_URL: VALID_DB_URL, PUSH_PROVIDER: 'apns' })).toThrow(
+      /PUSH_PROVIDER='apns' is not recognised/
+    );
   });
 
   it("rejects EMAIL_PROVIDER='console' in production", () => {

--- a/services/notifications/src/config.ts
+++ b/services/notifications/src/config.ts
@@ -41,6 +41,9 @@ export type NotificationsConfig = {
   pushProvider: PushProviderConfig;
   // Toggle the push worker (the NATS subscriber). Defaults to true.
   pushWorkerEnabled: boolean;
+  // Toggle the scheduled-jobs loop (weekly digest + future tasks).
+  // Defaults to true. Tests + the migrations-only smoke disable.
+  schedulerEnabled: boolean;
 };
 
 // Defaults match the wider stack:
@@ -78,6 +81,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): NotificationsC
     emailWorkerEnabled: env.EMAIL_WORKER_ENABLED?.trim() !== 'false',
     pushProvider: loadPushProviderConfig(env),
     pushWorkerEnabled: env.PUSH_WORKER_ENABLED?.trim() !== 'false',
+    schedulerEnabled: env.SCHEDULER_ENABLED?.trim() !== 'false',
   };
 };
 

--- a/services/notifications/src/config.ts
+++ b/services/notifications/src/config.ts
@@ -3,6 +3,10 @@ export type EmailProviderConfig =
   | { kind: 'ethereal' }
   | { kind: 'resend'; apiKey: string; fromEmail: string; fromName: string; replyTo?: string };
 
+export type PushProviderConfig =
+  | { kind: 'console' }
+  | { kind: 'fcm'; serviceAccountJson: string; projectId: string };
+
 export type NotificationsConfig = {
   // Port the HTTP surface listens on. Distinct from service.backend's
   // 5000 and service.gateway's 4000. The gRPC server listens on a
@@ -32,6 +36,11 @@ export type NotificationsConfig = {
   // Toggle the email queue worker. Defaults to true. Tests + the
   // migrations-only smoke set this to false to keep the loop quiet.
   emailWorkerEnabled: boolean;
+  // Push provider selection — Phase 7.2. Same ADS-549 rule: production
+  // refuses 'console' so an unconfigured push channel surfaces at boot.
+  pushProvider: PushProviderConfig;
+  // Toggle the push worker (the NATS subscriber). Defaults to true.
+  pushWorkerEnabled: boolean;
 };
 
 // Defaults match the wider stack:
@@ -67,7 +76,39 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): NotificationsC
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
     emailProvider: loadEmailProviderConfig(env),
     emailWorkerEnabled: env.EMAIL_WORKER_ENABLED?.trim() !== 'false',
+    pushProvider: loadPushProviderConfig(env),
+    pushWorkerEnabled: env.PUSH_WORKER_ENABLED?.trim() !== 'false',
   };
+};
+
+const loadPushProviderConfig = (env: NodeJS.ProcessEnv): PushProviderConfig => {
+  const requested = env.PUSH_PROVIDER?.trim().toLowerCase() ?? 'console';
+  const isProd = (env.NODE_ENV?.trim() ?? '').toLowerCase() === 'production';
+
+  switch (requested) {
+    case 'console':
+      if (isProd) {
+        throw new Error(
+          "PUSH_PROVIDER='console' is not permitted in production — every push notification would land in stdout"
+        );
+      }
+      return { kind: 'console' };
+    case 'fcm': {
+      const serviceAccountJson = env.FCM_SERVICE_ACCOUNT_JSON?.trim();
+      const projectId = env.FCM_PROJECT_ID?.trim();
+      if (!serviceAccountJson) {
+        throw new Error("PUSH_PROVIDER='fcm' requires FCM_SERVICE_ACCOUNT_JSON");
+      }
+      if (!projectId) {
+        throw new Error("PUSH_PROVIDER='fcm' requires FCM_PROJECT_ID");
+      }
+      return { kind: 'fcm', serviceAccountJson, projectId };
+    }
+    default:
+      throw new Error(
+        `PUSH_PROVIDER='${requested}' is not recognised (expected 'console' | 'fcm')`
+      );
+  }
 };
 
 const loadEmailProviderConfig = (env: NodeJS.ProcessEnv): EmailProviderConfig => {

--- a/services/notifications/src/config.ts
+++ b/services/notifications/src/config.ts
@@ -1,3 +1,8 @@
+export type EmailProviderConfig =
+  | { kind: 'console' }
+  | { kind: 'ethereal' }
+  | { kind: 'resend'; apiKey: string; fromEmail: string; fromName: string; replyTo?: string };
+
 export type NotificationsConfig = {
   // Port the HTTP surface listens on. Distinct from service.backend's
   // 5000 and service.gateway's 4000. The gRPC server listens on a
@@ -20,6 +25,13 @@ export type NotificationsConfig = {
   // NATS bus. Used by both the publish-after-commit pipeline (Create /
   // Dismiss handlers) and the fan-out subscriber (Phase 1.4).
   natsUrl: string;
+  // Email provider selection — Phase 7 round-out. ADS-549 rule: in
+  // production an unknown / unconfigured provider crashes boot rather
+  // than silently downgrading to console.
+  emailProvider: EmailProviderConfig;
+  // Toggle the email queue worker. Defaults to true. Tests + the
+  // migrations-only smoke set this to false to keep the loop quiet.
+  emailWorkerEnabled: boolean;
 };
 
 // Defaults match the wider stack:
@@ -53,7 +65,50 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): NotificationsC
     databaseUrl,
     schema: env.NOTIFICATIONS_SCHEMA?.trim() || DEFAULT_SCHEMA,
     natsUrl: env.NATS_URL?.trim() || DEFAULT_NATS_URL,
+    emailProvider: loadEmailProviderConfig(env),
+    emailWorkerEnabled: env.EMAIL_WORKER_ENABLED?.trim() !== 'false',
   };
+};
+
+const loadEmailProviderConfig = (env: NodeJS.ProcessEnv): EmailProviderConfig => {
+  const requested = env.EMAIL_PROVIDER?.trim().toLowerCase() ?? 'console';
+  const isProd = (env.NODE_ENV?.trim() ?? '').toLowerCase() === 'production';
+
+  switch (requested) {
+    case 'console':
+      // ADS-549: console in prod is a misconfig (every transactional
+      // email would land in stdout). Surface the misconfig — the boot
+      // path treats this as a fatal validation error.
+      if (isProd) {
+        throw new Error(
+          "EMAIL_PROVIDER='console' is not permitted in production — every transactional email would land in stdout"
+        );
+      }
+      return { kind: 'console' };
+    case 'ethereal':
+      return { kind: 'ethereal' };
+    case 'resend': {
+      const apiKey = env.RESEND_API_KEY?.trim();
+      const fromEmail = env.DEFAULT_FROM_EMAIL?.trim();
+      if (!apiKey) {
+        throw new Error("EMAIL_PROVIDER='resend' requires RESEND_API_KEY");
+      }
+      if (!fromEmail) {
+        throw new Error("EMAIL_PROVIDER='resend' requires DEFAULT_FROM_EMAIL");
+      }
+      return {
+        kind: 'resend',
+        apiKey,
+        fromEmail,
+        fromName: env.DEFAULT_FROM_NAME?.trim() || "Adopt Don't Shop",
+        replyTo: env.DEFAULT_REPLY_TO_EMAIL?.trim() || undefined,
+      };
+    }
+    default:
+      throw new Error(
+        `EMAIL_PROVIDER='${requested}' is not recognised (expected 'console' | 'ethereal' | 'resend')`
+      );
+  }
 };
 
 function parsePort(raw: string | undefined, fallback: number, name: string): number {

--- a/services/notifications/src/email/preferences.ts
+++ b/services/notifications/src/email/preferences.ts
@@ -1,0 +1,151 @@
+// Email preferences — per-user row in `email_preferences`. The service
+// auto-creates a default row on first read so the GetEmailPreferences
+// RPC always returns something. The `checkCanSend` helper bridges the
+// queue worker → preferences check: when a user has globally
+// unsubscribed or disabled email entirely, the queued row is short-
+// circuited to status='unsubscribed' instead of being dispatched.
+
+import { randomUUID } from 'node:crypto';
+
+import type { DbConn } from './queue.js';
+
+export type EmailPreferencesRow = {
+  preference_id: string;
+  user_id: string;
+  is_email_enabled: boolean;
+  global_unsubscribe: boolean;
+  preferences: Array<Record<string, unknown>>;
+  language: string;
+  timezone: string;
+  email_format: 'html' | 'text' | 'both';
+  digest_frequency: 'immediate' | 'daily' | 'weekly' | 'monthly' | 'never';
+  digest_time: string;
+  unsubscribe_token: string;
+  last_digest_sent: Date | null;
+  bounce_count: number;
+  last_bounce_at: Date | null;
+  is_blacklisted: boolean;
+  blacklist_reason: string | null;
+  blacklisted_at: Date | null;
+  metadata: Record<string, unknown>;
+  created_at: Date;
+  updated_at: Date;
+};
+
+const generateUnsubscribeToken = (): string =>
+  // 32-byte random — base16 is plenty for an unsubscribe link.
+  Array.from(crypto.getRandomValues(new Uint8Array(32)))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+
+export const findOrCreatePreferences = async (
+  conn: DbConn,
+  userId: string
+): Promise<EmailPreferencesRow> => {
+  const existing = await conn.query<EmailPreferencesRow>(
+    `SELECT * FROM email_preferences WHERE user_id = $1 LIMIT 1`,
+    [userId]
+  );
+  if (existing.rows[0]) {
+    return existing.rows[0];
+  }
+
+  const inserted = await conn.query<EmailPreferencesRow>(
+    `
+    INSERT INTO email_preferences (
+      preference_id, user_id, unsubscribe_token,
+      preferences, metadata,
+      created_at, updated_at
+    )
+    VALUES (
+      $1, $2, $3,
+      '[]'::jsonb, '{}'::jsonb,
+      now(), now()
+    )
+    -- A concurrent insert may have raced us; either path returns the row.
+    ON CONFLICT (user_id) DO UPDATE
+      SET updated_at = email_preferences.updated_at
+    RETURNING *
+    `,
+    [randomUUID(), userId, generateUnsubscribeToken()]
+  );
+  return inserted.rows[0];
+};
+
+export type PreferencesPatch = Partial<{
+  isEmailEnabled: boolean;
+  globalUnsubscribe: boolean;
+  preferences: Array<Record<string, unknown>>;
+  language: string;
+  timezone: string;
+  emailFormat: 'html' | 'text' | 'both';
+  digestFrequency: 'immediate' | 'daily' | 'weekly' | 'monthly' | 'never';
+  digestTime: string;
+}>;
+
+export const updatePreferences = async (
+  conn: DbConn,
+  userId: string,
+  patch: PreferencesPatch
+): Promise<EmailPreferencesRow> => {
+  // Ensure the row exists; the COALESCE pattern below means we can pass
+  // null for fields the caller didn't supply and keep the current value.
+  await findOrCreatePreferences(conn, userId);
+  const res = await conn.query<EmailPreferencesRow>(
+    `
+    UPDATE email_preferences
+    SET is_email_enabled  = COALESCE($2, is_email_enabled),
+        global_unsubscribe = COALESCE($3, global_unsubscribe),
+        preferences       = COALESCE($4::jsonb, preferences),
+        language          = COALESCE($5, language),
+        timezone          = COALESCE($6, timezone),
+        email_format      = COALESCE($7::email_preferences_format, email_format),
+        digest_frequency  = COALESCE($8::email_preferences_digest_frequency, digest_frequency),
+        digest_time       = COALESCE($9, digest_time),
+        updated_at        = now(),
+        version           = version + 1
+    WHERE user_id = $1
+    RETURNING *
+    `,
+    [
+      userId,
+      patch.isEmailEnabled ?? null,
+      patch.globalUnsubscribe ?? null,
+      patch.preferences ? JSON.stringify(patch.preferences) : null,
+      patch.language ?? null,
+      patch.timezone ?? null,
+      patch.emailFormat ?? null,
+      patch.digestFrequency ?? null,
+      patch.digestTime ?? null,
+    ]
+  );
+  return res.rows[0];
+};
+
+// True iff the email channel is open for `userId`. False when:
+//   - blacklisted (hard suppression — bounce / abuse)
+//   - global unsubscribe (user clicked unsubscribe-all)
+//   - email channel disabled
+// Per-type opt-outs in `preferences[]` are checked by the caller when
+// it knows the email's type — the worker doesn't.
+export const isEmailChannelOpen = async (conn: DbConn, userId: string): Promise<boolean> => {
+  const res = await conn.query<{
+    is_email_enabled: boolean;
+    global_unsubscribe: boolean;
+    is_blacklisted: boolean;
+  }>(
+    `
+    SELECT is_email_enabled, global_unsubscribe, is_blacklisted
+    FROM email_preferences
+    WHERE user_id = $1
+    LIMIT 1
+    `,
+    [userId]
+  );
+  const row = res.rows[0];
+  // Missing row = defaults (everything on), so allow.
+  if (!row) {
+    return true;
+  }
+  return row.is_email_enabled && !row.global_unsubscribe && !row.is_blacklisted;
+};

--- a/services/notifications/src/email/providers/base.ts
+++ b/services/notifications/src/email/providers/base.ts
@@ -1,0 +1,35 @@
+// Shared helpers for email providers. Stripping CR/LF on every header
+// field before composing the From/To strings is the one piece of
+// defense-in-depth all providers share — the SDKs reject CRLF too, but
+// catching it at the boundary keeps the protection independent of which
+// provider is wired up.
+
+import type { QueuedEmail } from '../types.js';
+
+export const stripCrlf = (s: string): string => s.replace(/[\r\n]+/g, ' ').trim();
+
+export const generateMessageId = (): string =>
+  `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+
+export type SanitizedEmail = {
+  from: string;
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+};
+
+export const sanitizeEmail = (email: QueuedEmail): SanitizedEmail => {
+  const fromName = stripCrlf(email.fromName ?? "Adopt Don't Shop");
+  const fromEmail = stripCrlf(email.fromEmail);
+  const toName = email.toName ? stripCrlf(email.toName) : '';
+  const toEmail = stripCrlf(email.toEmail);
+
+  return {
+    from: `${fromName} <${fromEmail}>`,
+    to: toName ? `${toName} <${toEmail}>` : toEmail,
+    subject: stripCrlf(email.subject),
+    html: email.htmlContent,
+    text: email.textContent ?? undefined,
+  };
+};

--- a/services/notifications/src/email/providers/console.ts
+++ b/services/notifications/src/email/providers/console.ts
@@ -1,0 +1,40 @@
+// ConsoleEmailProvider — default dev provider. Writes the email to
+// the service's structured logger so the developer can see what would
+// have been delivered. Never used in prod (the boot path crashes if the
+// requested provider isn't configured rather than silently falling
+// back).
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+import type { EmailProvider, ProviderSendResult, QueuedEmail } from '../types.js';
+
+import { generateMessageId, sanitizeEmail } from './base.js';
+
+export type ConsoleProviderDeps = {
+  logger: ReturnType<typeof createLogger>;
+};
+
+export const createConsoleProvider = (deps: ConsoleProviderDeps): EmailProvider => ({
+  async send(email: QueuedEmail): Promise<ProviderSendResult> {
+    const sanitized = sanitizeEmail(email);
+    const messageId = generateMessageId();
+
+    deps.logger.info('email.console.send', {
+      messageId,
+      from: sanitized.from,
+      to: sanitized.to,
+      cc: email.ccEmails,
+      bcc: email.bccEmails,
+      subject: sanitized.subject,
+      type: email.type,
+      priority: email.priority,
+      tags: email.tags,
+      attachmentCount: email.attachments.length,
+      htmlPreview: sanitized.html.slice(0, 400),
+    });
+
+    return { success: true, messageId };
+  },
+  getName: () => 'console',
+  validateConfiguration: () => true,
+});

--- a/services/notifications/src/email/providers/ethereal.ts
+++ b/services/notifications/src/email/providers/ethereal.ts
@@ -1,0 +1,80 @@
+// EtherealProvider — staging-friendly catcher backed by a nodemailer
+// test account. Useful in dev/staging when we want real SMTP flow but
+// don't want to spam real inboxes; the preview URL is logged for each
+// send so a developer can open the captured message.
+
+import nodemailer, { type Transporter } from 'nodemailer';
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+import type { EmailProvider, ProviderSendResult, QueuedEmail } from '../types.js';
+
+import { sanitizeEmail } from './base.js';
+
+// Match the monolith — without these caps a hung SMTP socket would
+// stall the queue worker indefinitely.
+const SMTP_TIMEOUT_MS = 10_000;
+
+export type EtherealProviderDeps = {
+  logger: ReturnType<typeof createLogger>;
+};
+
+type EtherealAccount = {
+  user: string;
+  pass: string;
+};
+
+const createTransporter = async (account: EtherealAccount): Promise<Transporter> =>
+  nodemailer.createTransport({
+    host: 'smtp.ethereal.email',
+    port: 587,
+    secure: false,
+    auth: { user: account.user, pass: account.pass },
+    connectionTimeout: SMTP_TIMEOUT_MS,
+    greetingTimeout: SMTP_TIMEOUT_MS,
+    socketTimeout: SMTP_TIMEOUT_MS,
+  });
+
+export const createEtherealProvider = (deps: EtherealProviderDeps): EmailProvider => {
+  let transporter: Transporter | null = null;
+
+  const ensureTransporter = async (): Promise<Transporter> => {
+    if (transporter) {
+      return transporter;
+    }
+    const account = await nodemailer.createTestAccount();
+    deps.logger.info('email.ethereal.account', {
+      user: account.user,
+      web: 'https://ethereal.email',
+    });
+    transporter = await createTransporter({ user: account.user, pass: account.pass });
+    return transporter;
+  };
+
+  return {
+    async send(email: QueuedEmail): Promise<ProviderSendResult> {
+      try {
+        const t = await ensureTransporter();
+        const sanitized = sanitizeEmail(email);
+        const info = await t.sendMail(sanitized);
+        deps.logger.info('email.ethereal.send_ok', {
+          messageId: info.messageId,
+          to: sanitized.to,
+          subject: sanitized.subject,
+          previewUrl: nodemailer.getTestMessageUrl(info),
+        });
+        return { success: true, messageId: info.messageId };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.logger.error('email.ethereal.send_error', {
+          to: email.toEmail,
+          subject: email.subject,
+          error: message,
+        });
+        return { success: false, error: message };
+      }
+    },
+    getName: () => 'ethereal',
+    validateConfiguration: () => true,
+  };
+};

--- a/services/notifications/src/email/providers/factory.ts
+++ b/services/notifications/src/email/providers/factory.ts
@@ -1,0 +1,36 @@
+// Provider factory — selects an email provider by name. Boot wires
+// the env-driven choice; tests construct providers directly.
+//
+// ADS-549 lesson preserved: in production, an unknown / unconfigured
+// provider must NOT silently fall back to console — every transactional
+// email would disappear into stdout. Callers (loadProvider() at boot)
+// surface the error so the process can exit non-zero.
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+import type { EmailProvider } from '../types.js';
+
+import { createConsoleProvider } from './console.js';
+import { createEtherealProvider } from './ethereal.js';
+import { createResendProvider, type ResendProviderConfig } from './resend.js';
+
+export type EmailProviderConfig =
+  | { kind: 'console' }
+  | { kind: 'ethereal' }
+  | { kind: 'resend'; resend: ResendProviderConfig };
+
+export type ProviderFactoryDeps = {
+  config: EmailProviderConfig;
+  logger: ReturnType<typeof createLogger>;
+};
+
+export const createProvider = (deps: ProviderFactoryDeps): EmailProvider => {
+  switch (deps.config.kind) {
+    case 'console':
+      return createConsoleProvider({ logger: deps.logger });
+    case 'ethereal':
+      return createEtherealProvider({ logger: deps.logger });
+    case 'resend':
+      return createResendProvider({ config: deps.config.resend, logger: deps.logger });
+  }
+};

--- a/services/notifications/src/email/providers/resend.ts
+++ b/services/notifications/src/email/providers/resend.ts
@@ -1,0 +1,89 @@
+// ResendProvider — production transactional email provider. Wraps the
+// Resend SDK with a per-send timeout so a hung API call can't stall the
+// queue worker.
+
+import { Resend } from 'resend';
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+import type { EmailProvider, ProviderSendResult, QueuedEmail } from '../types.js';
+
+import { sanitizeEmail } from './base.js';
+
+// 10s per-send budget. Resend's SDK doesn't accept an AbortSignal, so we
+// race the call against a timer (same pattern the monolith uses).
+const RESEND_SEND_TIMEOUT_MS = 10_000;
+
+export type ResendProviderConfig = {
+  apiKey: string;
+  fromEmail: string;
+  fromName: string;
+  replyTo?: string;
+};
+
+export type ResendProviderDeps = {
+  config: ResendProviderConfig;
+  logger: ReturnType<typeof createLogger>;
+  // Injectable for tests — defaults to a real Resend client.
+  client?: Pick<Resend, 'emails'>;
+};
+
+const withTimeout = async <T>(promise: Promise<T>, ms: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Resend send exceeded ${ms}ms timeout`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
+
+export const createResendProvider = (deps: ResendProviderDeps): EmailProvider => {
+  const client = deps.client ?? new Resend(deps.config.apiKey);
+
+  return {
+    async send(email: QueuedEmail): Promise<ProviderSendResult> {
+      const sanitized = sanitizeEmail(email);
+      const payload = {
+        from: sanitized.from,
+        to: sanitized.to,
+        subject: sanitized.subject,
+        html: sanitized.html,
+        ...(sanitized.text ? { text: sanitized.text } : {}),
+        ...(deps.config.replyTo ? { replyTo: deps.config.replyTo } : {}),
+      };
+
+      try {
+        const result = await withTimeout(client.emails.send(payload), RESEND_SEND_TIMEOUT_MS);
+        if (result.error !== null) {
+          deps.logger.error('email.resend.send_failed', {
+            to: sanitized.to,
+            subject: sanitized.subject,
+            error: result.error.message,
+          });
+          return { success: false, error: result.error.message };
+        }
+        deps.logger.info('email.resend.send_ok', {
+          messageId: result.data.id,
+          to: sanitized.to,
+          subject: sanitized.subject,
+        });
+        return { success: true, messageId: result.data.id };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.logger.error('email.resend.send_error', {
+          to: sanitized.to,
+          subject: sanitized.subject,
+          error: message,
+        });
+        return { success: false, error: message };
+      }
+    },
+    getName: () => 'resend',
+    validateConfiguration: () => Boolean(deps.config.apiKey) && Boolean(deps.config.fromEmail),
+  };
+};

--- a/services/notifications/src/email/queue.ts
+++ b/services/notifications/src/email/queue.ts
@@ -1,0 +1,276 @@
+// Email queue persistence — INSERT, claim-for-send, mark-sent/failed.
+// Pure data-access; the sender + worker compose these.
+//
+// `claimDueEmails` uses `SELECT ... FOR UPDATE SKIP LOCKED` so multiple
+// workers can drain the same queue without stepping on each other —
+// each row is locked, marked `status=sending`, and released back to the
+// pool when the dispatch completes (sent / failed update).
+
+import type { Pool, PoolClient } from 'pg';
+
+import type {
+  EmailAttachment,
+  EmailPriority,
+  EmailStatus,
+  EmailType,
+  QueuedEmail,
+} from './types.js';
+
+type EmailQueueRow = {
+  email_id: string;
+  template_id: string | null;
+  from_email: string;
+  from_name: string | null;
+  to_email: string;
+  to_name: string | null;
+  cc_emails: string[];
+  bcc_emails: string[];
+  reply_to_email: string | null;
+  subject: string;
+  html_content: string;
+  text_content: string | null;
+  template_data: Record<string, unknown>;
+  attachments: EmailAttachment[];
+  type: EmailType;
+  priority: EmailPriority;
+  status: EmailStatus;
+  scheduled_for: Date | null;
+  max_retries: number;
+  current_retries: number;
+  last_attempt_at: Date | null;
+  sent_at: Date | null;
+  failure_reason: string | null;
+  provider_id: string | null;
+  provider_message_id: string | null;
+  tracking: Record<string, unknown> | null;
+  metadata: Record<string, unknown>;
+  campaign_id: string | null;
+  user_id: string | null;
+  tags: string[];
+  idempotency_key: string | null;
+};
+
+export const rowToQueuedEmail = (row: EmailQueueRow): QueuedEmail => ({
+  emailId: row.email_id,
+  templateId: row.template_id,
+  fromEmail: row.from_email,
+  fromName: row.from_name,
+  toEmail: row.to_email,
+  toName: row.to_name,
+  ccEmails: row.cc_emails,
+  bccEmails: row.bcc_emails,
+  replyToEmail: row.reply_to_email,
+  subject: row.subject,
+  htmlContent: row.html_content,
+  textContent: row.text_content,
+  templateData: row.template_data,
+  attachments: row.attachments,
+  type: row.type,
+  priority: row.priority,
+  status: row.status,
+  scheduledFor: row.scheduled_for,
+  maxRetries: row.max_retries,
+  currentRetries: row.current_retries,
+  lastAttemptAt: row.last_attempt_at,
+  sentAt: row.sent_at,
+  failureReason: row.failure_reason,
+  providerId: row.provider_id,
+  providerMessageId: row.provider_message_id,
+  tracking: row.tracking,
+  metadata: row.metadata,
+  campaignId: row.campaign_id,
+  userId: row.user_id,
+  tags: row.tags,
+  idempotencyKey: row.idempotency_key,
+});
+
+export type InsertEmailQueueInput = {
+  emailId: string;
+  templateId?: string | null;
+  fromEmail: string;
+  fromName?: string | null;
+  toEmail: string;
+  toName?: string | null;
+  ccEmails?: string[];
+  bccEmails?: string[];
+  replyToEmail?: string | null;
+  subject: string;
+  htmlContent: string;
+  textContent?: string | null;
+  templateData?: Record<string, unknown>;
+  attachments?: EmailAttachment[];
+  type: EmailType;
+  priority: EmailPriority;
+  scheduledFor?: Date | null;
+  maxRetries?: number;
+  metadata?: Record<string, unknown>;
+  campaignId?: string | null;
+  userId?: string | null;
+  tags?: string[];
+  idempotencyKey?: string | null;
+  createdBy?: string | null;
+};
+
+// Conn type — accepts either a Pool or a PoolClient so callers can run
+// in their own transaction (the SendEmail handler uses a withTransaction
+// for publish-after-commit).
+export type DbConn = Pool | PoolClient;
+
+export const insertEmail = async (
+  conn: DbConn,
+  input: InsertEmailQueueInput
+): Promise<EmailQueueRow> => {
+  const res = await conn.query<EmailQueueRow>(
+    `
+    INSERT INTO email_queue (
+      email_id, template_id,
+      from_email, from_name, to_email, to_name,
+      cc_emails, bcc_emails, reply_to_email,
+      subject, html_content, text_content,
+      template_data, attachments,
+      type, priority, status,
+      scheduled_for, max_retries, current_retries,
+      metadata, campaign_id, user_id, tags,
+      idempotency_key,
+      created_by, updated_by, version,
+      created_at, updated_at
+    )
+    VALUES (
+      $1, $2,
+      $3, $4, $5, $6,
+      $7::text[], $8::text[], $9,
+      $10, $11, $12,
+      $13::jsonb, $14::jsonb,
+      $15, $16, 'queued',
+      $17, $18, 0,
+      $19::jsonb, $20, $21, $22::text[],
+      $23,
+      $24, $24, 0,
+      now(), now()
+    )
+    RETURNING *
+    `,
+    [
+      input.emailId,
+      input.templateId ?? null,
+      input.fromEmail,
+      input.fromName ?? null,
+      input.toEmail,
+      input.toName ?? null,
+      input.ccEmails ?? [],
+      input.bccEmails ?? [],
+      input.replyToEmail ?? null,
+      input.subject,
+      input.htmlContent,
+      input.textContent ?? null,
+      JSON.stringify(input.templateData ?? {}),
+      JSON.stringify(input.attachments ?? []),
+      input.type,
+      input.priority,
+      input.scheduledFor ?? null,
+      input.maxRetries ?? 3,
+      JSON.stringify(input.metadata ?? {}),
+      input.campaignId ?? null,
+      input.userId ?? null,
+      input.tags ?? [],
+      input.idempotencyKey ?? null,
+      input.createdBy ?? null,
+    ]
+  );
+  return res.rows[0];
+};
+
+// Look up an existing row by idempotency_key. Returns null when absent.
+export const findByIdempotencyKey = async (
+  conn: DbConn,
+  idempotencyKey: string
+): Promise<EmailQueueRow | null> => {
+  const res = await conn.query<EmailQueueRow>(
+    `SELECT * FROM email_queue WHERE idempotency_key = $1 LIMIT 1`,
+    [idempotencyKey]
+  );
+  return res.rows[0] ?? null;
+};
+
+// Claim up to `limit` rows that are due to send: status='queued' AND
+// (scheduled_for IS NULL OR scheduled_for <= now()). Sets them to
+// `sending` and stamps `last_attempt_at`. Returns the claimed rows.
+//
+// SKIP LOCKED so multiple worker instances draining the same queue
+// don't block each other.
+export const claimDueEmails = async (conn: DbConn, limit: number): Promise<QueuedEmail[]> => {
+  const res = await conn.query<EmailQueueRow>(
+    `
+    WITH due AS (
+      SELECT email_id
+      FROM email_queue
+      WHERE status = 'queued'
+        AND (scheduled_for IS NULL OR scheduled_for <= now())
+      ORDER BY
+        CASE priority
+          WHEN 'urgent' THEN 1
+          WHEN 'high'   THEN 2
+          WHEN 'normal' THEN 3
+          WHEN 'low'    THEN 4
+        END,
+        created_at
+      LIMIT $1
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE email_queue q
+    SET status = 'sending',
+        last_attempt_at = now(),
+        updated_at = now(),
+        version = q.version + 1
+    FROM due
+    WHERE q.email_id = due.email_id
+    RETURNING q.*
+    `,
+    [limit]
+  );
+  return res.rows.map(rowToQueuedEmail);
+};
+
+export const markSent = async (
+  conn: DbConn,
+  emailId: string,
+  providerMessageId: string | null
+): Promise<void> => {
+  await conn.query(
+    `
+    UPDATE email_queue
+    SET status = 'sent',
+        sent_at = now(),
+        provider_message_id = COALESCE($2, provider_message_id),
+        updated_at = now(),
+        version = version + 1
+    WHERE email_id = $1
+    `,
+    [emailId, providerMessageId]
+  );
+};
+
+export const markFailed = async (
+  conn: DbConn,
+  emailId: string,
+  reason: string,
+  retriable: boolean
+): Promise<void> => {
+  // Retriable failures go back to 'queued' and bump `current_retries`;
+  // when current_retries >= max_retries the row terminates as 'failed'.
+  await conn.query(
+    `
+    UPDATE email_queue
+    SET status = CASE
+        WHEN $3::boolean AND current_retries + 1 < max_retries THEN 'queued'::email_queue_status
+        ELSE 'failed'::email_queue_status
+      END,
+      current_retries = current_retries + 1,
+      failure_reason = $2,
+      updated_at = now(),
+      version = version + 1
+    WHERE email_id = $1
+    `,
+    [emailId, reason, retriable]
+  );
+};

--- a/services/notifications/src/email/renderer.ts
+++ b/services/notifications/src/email/renderer.ts
@@ -1,0 +1,45 @@
+// Simple `{{variable}}` template renderer. Matches the monolith's
+// behaviour without pulling Handlebars / Mustache as a dependency —
+// every transactional template the codebase ships uses plain double-
+// brace substitution. Unmatched placeholders are left intact so a typo
+// is visible in the rendered email rather than silently becoming an
+// empty string.
+
+const PLACEHOLDER_RE = /\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}/g;
+
+const dig = (obj: Record<string, unknown>, path: string): unknown => {
+  const parts = path.split('.');
+  let cur: unknown = obj;
+  for (const part of parts) {
+    if (cur && typeof cur === 'object' && part in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+};
+
+export const renderTemplate = (source: string, variables: Record<string, unknown>): string =>
+  source.replace(PLACEHOLDER_RE, (match, name: string) => {
+    const value = dig(variables, name);
+    if (value === undefined || value === null) {
+      return match;
+    }
+    return String(value);
+  });
+
+export type RenderedTemplate = {
+  subject: string;
+  htmlContent: string;
+  textContent: string | null;
+};
+
+export const renderEmailTemplate = (
+  template: { subject: string; htmlContent: string; textContent: string | null },
+  variables: Record<string, unknown>
+): RenderedTemplate => ({
+  subject: renderTemplate(template.subject, variables),
+  htmlContent: renderTemplate(template.htmlContent, variables),
+  textContent: template.textContent ? renderTemplate(template.textContent, variables) : null,
+});

--- a/services/notifications/src/email/templates.ts
+++ b/services/notifications/src/email/templates.ts
@@ -1,0 +1,69 @@
+// Template lookup — the SendEmail handler resolves a templateId or
+// template-name reference to a row from `email_templates`, applies the
+// render, then queues the resolved subject+html. Templates are seeded
+// (admin CRUD lives outside this service for now) so this is a read
+// surface only.
+
+import type { DbConn } from './queue.js';
+
+export type EmailTemplate = {
+  templateId: string;
+  name: string;
+  subject: string;
+  htmlContent: string;
+  textContent: string | null;
+  status: 'draft' | 'active' | 'inactive' | 'archived';
+};
+
+type EmailTemplateRow = {
+  template_id: string;
+  name: string;
+  subject: string;
+  html_content: string;
+  text_content: string | null;
+  status: 'draft' | 'active' | 'inactive' | 'archived';
+};
+
+const rowToTemplate = (row: EmailTemplateRow): EmailTemplate => ({
+  templateId: row.template_id,
+  name: row.name,
+  subject: row.subject,
+  htmlContent: row.html_content,
+  textContent: row.text_content,
+  status: row.status,
+});
+
+// Accepts either a UUID (templateId) or a string name. Returns the
+// active row or null when not found / not active.
+export const findActiveTemplate = async (
+  conn: DbConn,
+  ref: string
+): Promise<EmailTemplate | null> => {
+  const res = await conn.query<EmailTemplateRow>(
+    `
+    SELECT template_id, name, subject, html_content, text_content, status
+    FROM email_templates
+    WHERE (template_id::text = $1 OR name = $1)
+      AND deleted_at IS NULL
+      AND status = 'active'
+    ORDER BY locale = 'en' DESC
+    LIMIT 1
+    `,
+    [ref]
+  );
+  return res.rows[0] ? rowToTemplate(res.rows[0]) : null;
+};
+
+export const incrementTemplateUsage = async (conn: DbConn, templateId: string): Promise<void> => {
+  await conn.query(
+    `
+    UPDATE email_templates
+    SET usage_count = usage_count + 1,
+        last_used_at = now(),
+        updated_at = now(),
+        version = version + 1
+    WHERE template_id = $1
+    `,
+    [templateId]
+  );
+};

--- a/services/notifications/src/email/types.ts
+++ b/services/notifications/src/email/types.ts
@@ -1,0 +1,77 @@
+// Email module — provider-facing types.
+//
+// The DB row shape (snake_case columns from `email_queue`) is converted
+// to this plain `QueuedEmail` type before being handed to a provider.
+// Providers depend only on this shape, not on pg/Sequelize models,
+// so they can be swapped + unit-tested independently of storage.
+
+export type EmailType = 'transactional' | 'notification' | 'marketing' | 'system';
+export type EmailPriority = 'low' | 'normal' | 'high' | 'urgent';
+export type EmailStatus =
+  | 'queued'
+  | 'sending'
+  | 'sent'
+  | 'delivered'
+  | 'opened'
+  | 'clicked'
+  | 'failed'
+  | 'bounced'
+  | 'unsubscribed';
+
+export type EmailAttachment = {
+  filename: string;
+  // Base64-encoded payload. Providers either decode and embed (Resend,
+  // SES) or stream from a stored URL (S3); the queue keeps the encoded
+  // form for simplicity.
+  content: string;
+  contentType: string;
+  size: number;
+  inline?: boolean;
+  cid?: string;
+};
+
+export type QueuedEmail = {
+  emailId: string;
+  templateId?: string | null;
+  fromEmail: string;
+  fromName?: string | null;
+  toEmail: string;
+  toName?: string | null;
+  ccEmails: string[];
+  bccEmails: string[];
+  replyToEmail?: string | null;
+  subject: string;
+  htmlContent: string;
+  textContent?: string | null;
+  templateData: Record<string, unknown>;
+  attachments: EmailAttachment[];
+  type: EmailType;
+  priority: EmailPriority;
+  status: EmailStatus;
+  scheduledFor?: Date | null;
+  maxRetries: number;
+  currentRetries: number;
+  lastAttemptAt?: Date | null;
+  sentAt?: Date | null;
+  failureReason?: string | null;
+  providerId?: string | null;
+  providerMessageId?: string | null;
+  tracking?: Record<string, unknown> | null;
+  metadata: Record<string, unknown>;
+  campaignId?: string | null;
+  userId?: string | null;
+  tags: string[];
+  idempotencyKey?: string | null;
+};
+
+export type ProviderSendResult = {
+  success: boolean;
+  messageId?: string;
+  error?: string;
+};
+
+export type EmailProvider = {
+  send(email: QueuedEmail): Promise<ProviderSendResult>;
+  getName(): string;
+  validateConfiguration(): boolean;
+};

--- a/services/notifications/src/email/worker.test.ts
+++ b/services/notifications/src/email/worker.test.ts
@@ -1,0 +1,207 @@
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+import { describe, expect, it, vi } from 'vitest';
+
+import { startEmailWorker } from './worker.js';
+import type { EmailProvider, ProviderSendResult, QueuedEmail } from './types.js';
+
+const quietLogger = (): Logger => {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as Logger;
+};
+
+const queuedFixture = (overrides: Partial<QueuedEmail> = {}): QueuedEmail => ({
+  emailId: 'em-1',
+  templateId: null,
+  fromEmail: 'noreply@example.com',
+  fromName: 'Sender',
+  toEmail: 'jane@example.com',
+  toName: 'Jane',
+  ccEmails: [],
+  bccEmails: [],
+  replyToEmail: null,
+  subject: 'Hi',
+  htmlContent: '<p>Hi</p>',
+  textContent: null,
+  templateData: {},
+  attachments: [],
+  type: 'transactional',
+  priority: 'normal',
+  status: 'sending',
+  scheduledFor: null,
+  maxRetries: 3,
+  currentRetries: 0,
+  lastAttemptAt: null,
+  sentAt: null,
+  failureReason: null,
+  providerId: null,
+  providerMessageId: null,
+  tracking: null,
+  metadata: {},
+  campaignId: null,
+  userId: null,
+  tags: [],
+  idempotencyKey: null,
+  ...overrides,
+});
+
+// makePool builds a Pool double with a scriptable .query method.
+const makePool = (scripts: Array<{ rows: unknown[] }>) => {
+  const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
+  const pool = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      const next = scripts.shift();
+      if (!next) return { rows: [] };
+      return next;
+    }),
+  };
+  return { pool: pool as unknown as Pool, queries };
+};
+
+const makeProvider = (result: ProviderSendResult, name = 'test-provider'): EmailProvider => ({
+  send: vi.fn(async () => result),
+  getName: () => name,
+  validateConfiguration: () => true,
+});
+
+describe('email worker', () => {
+  it('tick() returns 0 when no rows are due', async () => {
+    const { pool } = makePool([{ rows: [] }]);
+    const worker = startEmailWorker({
+      pool,
+      nats: {} as never,
+      provider: makeProvider({ success: true }),
+      logger: quietLogger(),
+      pollIntervalMs: 60_000, // never auto-tick during the test
+    });
+    try {
+      const n = await worker.tick();
+      expect(n).toBe(0);
+    } finally {
+      await worker.stop();
+    }
+  });
+
+  it('marks the row sent when the provider succeeds', async () => {
+    const claimed = [queuedFixture({ emailId: 'em-A' })];
+    const { pool, queries } = makePool([
+      // claimDueEmails returns the claimed row.
+      { rows: claimed.map(toRow) },
+      // markSent UPDATE.
+      { rows: [] },
+    ]);
+    const provider = makeProvider({ success: true, messageId: 'prv-msg-1' });
+    const worker = startEmailWorker({
+      pool,
+      nats: {} as never,
+      provider,
+      logger: quietLogger(),
+      pollIntervalMs: 60_000,
+    });
+    try {
+      const n = await worker.tick();
+      expect(n).toBe(1);
+      expect(provider.send).toHaveBeenCalledTimes(1);
+      // Second query is markSent.
+      const markSentCall = queries[1];
+      expect(markSentCall.sql).toContain("SET status = 'sent'");
+      expect(markSentCall.params).toEqual(['em-A', 'prv-msg-1']);
+    } finally {
+      await worker.stop();
+    }
+  });
+
+  it('marks failed (retriable) when the provider returns success=false', async () => {
+    const claimed = [queuedFixture({ emailId: 'em-B' })];
+    const { pool, queries } = makePool([{ rows: claimed.map(toRow) }, { rows: [] }]);
+    const provider = makeProvider({ success: false, error: 'smtp 451' });
+    const worker = startEmailWorker({
+      pool,
+      nats: {} as never,
+      provider,
+      logger: quietLogger(),
+      pollIntervalMs: 60_000,
+    });
+    try {
+      await worker.tick();
+      const markFailedCall = queries[1];
+      expect(markFailedCall.sql).toContain('current_retries = current_retries + 1');
+      expect(markFailedCall.params).toEqual(['em-B', 'smtp 451', true]);
+    } finally {
+      await worker.stop();
+    }
+  });
+
+  it('short-circuits to unsubscribed when the user has opted out', async () => {
+    const claimed = [queuedFixture({ emailId: 'em-C', userId: 'usr-optout' })];
+    const { pool, queries } = makePool([
+      // claimDueEmails.
+      { rows: claimed.map(toRow) },
+      // isEmailChannelOpen → returns blocked row.
+      {
+        rows: [{ is_email_enabled: false, global_unsubscribe: false, is_blacklisted: false }],
+      },
+      // UPDATE → unsubscribed.
+      { rows: [] },
+    ]);
+    const provider = makeProvider({ success: true });
+    const worker = startEmailWorker({
+      pool,
+      nats: {} as never,
+      provider,
+      logger: quietLogger(),
+      pollIntervalMs: 60_000,
+    });
+    try {
+      await worker.tick();
+      expect(provider.send).not.toHaveBeenCalled();
+      const updateCall = queries[2];
+      expect(updateCall.sql).toContain("SET status = 'unsubscribed'");
+      expect(updateCall.params).toEqual(['em-C']);
+    } finally {
+      await worker.stop();
+    }
+  });
+});
+
+// Map QueuedEmail back to a flat row matching what claimDueEmails returns.
+function toRow(q: QueuedEmail): Record<string, unknown> {
+  return {
+    email_id: q.emailId,
+    template_id: q.templateId,
+    from_email: q.fromEmail,
+    from_name: q.fromName,
+    to_email: q.toEmail,
+    to_name: q.toName,
+    cc_emails: q.ccEmails,
+    bcc_emails: q.bccEmails,
+    reply_to_email: q.replyToEmail,
+    subject: q.subject,
+    html_content: q.htmlContent,
+    text_content: q.textContent,
+    template_data: q.templateData,
+    attachments: q.attachments,
+    type: q.type,
+    priority: q.priority,
+    status: q.status,
+    scheduled_for: q.scheduledFor,
+    max_retries: q.maxRetries,
+    current_retries: q.currentRetries,
+    last_attempt_at: q.lastAttemptAt,
+    sent_at: q.sentAt,
+    failure_reason: q.failureReason,
+    provider_id: q.providerId,
+    provider_message_id: q.providerMessageId,
+    tracking: q.tracking,
+    metadata: q.metadata,
+    campaign_id: q.campaignId,
+    user_id: q.userId,
+    tags: q.tags,
+    idempotency_key: q.idempotencyKey,
+  };
+}

--- a/services/notifications/src/email/worker.ts
+++ b/services/notifications/src/email/worker.ts
@@ -1,0 +1,166 @@
+// Email queue worker. Polls `email_queue` for status='queued' rows that
+// are due to send, claims them with FOR UPDATE SKIP LOCKED (so multiple
+// service instances don't double-send), and dispatches each via the
+// configured provider. Provider success → markSent. Provider failure →
+// markFailed with retriable=true so the row goes back to 'queued' and
+// the next poll picks it up; once `current_retries >= max_retries` the
+// row terminates as 'failed'.
+//
+// User preference enforcement: if the email is tied to a user_id AND
+// the user has opted out (global_unsubscribe / is_email_enabled=false /
+// is_blacklisted), the row is short-circuited to 'unsubscribed' without
+// being handed to the provider.
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { isEmailChannelOpen } from './preferences.js';
+import { claimDueEmails, markFailed, markSent } from './queue.js';
+import type { EmailProvider, QueuedEmail } from './types.js';
+
+export type EmailWorkerOptions = {
+  pool: Pool;
+  nats: NatsConnection;
+  provider: EmailProvider;
+  logger: Logger;
+  // Poll interval in ms. Default 2s — short enough for snappy dev
+  // feedback, long enough that idle pool consumption is negligible.
+  pollIntervalMs?: number;
+  // Max rows claimed per tick. Default 25 — bounded so a backlog
+  // doesn't monopolise the worker for one slow provider call.
+  batchSize?: number;
+};
+
+export type RunningEmailWorker = {
+  stop: () => Promise<void>;
+  // Exposed for tests + the smoke script — runs one batch synchronously
+  // and returns the count of emails dispatched.
+  tick: () => Promise<number>;
+};
+
+const DEFAULT_POLL_MS = 2_000;
+const DEFAULT_BATCH = 25;
+
+const dispatchOne = async (
+  pool: Pool,
+  provider: EmailProvider,
+  email: QueuedEmail,
+  logger: Logger
+): Promise<void> => {
+  // Preference check (when tied to a user).
+  if (email.userId) {
+    const open = await isEmailChannelOpen(pool, email.userId);
+    if (!open) {
+      // Re-using `markFailed` with retriable=false would terminate as
+      // 'failed' which mis-categorises an opt-out. The DB transition
+      // we want is sending → unsubscribed.
+      await pool.query(
+        `UPDATE email_queue
+         SET status = 'unsubscribed',
+             failure_reason = 'user opted out of email',
+             updated_at = now(),
+             version = version + 1
+         WHERE email_id = $1`,
+        [email.emailId]
+      );
+      logger.info('email.worker.unsubscribed', { emailId: email.emailId, userId: email.userId });
+      return;
+    }
+  }
+
+  const result = await provider.send(email);
+  if (result.success) {
+    await markSent(pool, email.emailId, result.messageId ?? null);
+    logger.info('email.worker.sent', {
+      emailId: email.emailId,
+      provider: provider.getName(),
+      messageId: result.messageId,
+    });
+  } else {
+    // Treat all provider failures as retriable — the markFailed query
+    // terminates the row once current_retries >= max_retries.
+    await markFailed(pool, email.emailId, result.error ?? 'provider returned failure', true);
+    logger.warn('email.worker.failed', {
+      emailId: email.emailId,
+      provider: provider.getName(),
+      error: result.error,
+    });
+  }
+};
+
+export const startEmailWorker = (opts: EmailWorkerOptions): RunningEmailWorker => {
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH;
+  let running = true;
+  let timer: NodeJS.Timeout | undefined;
+  let inflight = Promise.resolve<number>(0);
+
+  const tick = async (): Promise<number> => {
+    if (!running) {
+      return 0;
+    }
+    let claimed: QueuedEmail[] = [];
+    try {
+      claimed = await claimDueEmails(opts.pool, batchSize);
+    } catch (err) {
+      opts.logger.error('email.worker.claim_error', { err });
+      return 0;
+    }
+    if (claimed.length === 0) {
+      return 0;
+    }
+
+    // Dispatches run in parallel — a single slow provider call doesn't
+    // block the rest of the batch.
+    await Promise.all(
+      claimed.map(email =>
+        dispatchOne(opts.pool, opts.provider, email, opts.logger).catch(err => {
+          opts.logger.error('email.worker.dispatch_error', {
+            emailId: email.emailId,
+            err,
+          });
+          // Mark as retriable failure so it doesn't get stuck in 'sending'.
+          return markFailed(
+            opts.pool,
+            email.emailId,
+            err instanceof Error ? err.message : String(err),
+            true
+          ).catch(() => undefined);
+        })
+      )
+    );
+    return claimed.length;
+  };
+
+  const schedule = (): void => {
+    if (!running) {
+      return;
+    }
+    timer = setTimeout(() => {
+      inflight = tick()
+        .catch(err => {
+          opts.logger.error('email.worker.tick_error', { err });
+          return 0;
+        })
+        .finally(() => {
+          schedule();
+        }) as Promise<number>;
+    }, pollIntervalMs);
+  };
+
+  schedule();
+
+  return {
+    tick,
+    stop: async () => {
+      running = false;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      // Drain whatever is in flight so a shutdown doesn't leave rows
+      // stuck in 'sending' indefinitely.
+      await inflight.catch(() => undefined);
+    },
+  };
+};

--- a/services/notifications/src/grpc/device-token-handlers.test.ts
+++ b/services/notifications/src/grpc/device-token-handlers.test.ts
@@ -1,0 +1,270 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
+import {
+  NotificationsV1,
+  type RegisterDeviceTokenRequest,
+  type UnregisterDeviceTokenRequest,
+} from '@adopt-dont-shop/proto';
+
+import {
+  listDeviceTokensHandler,
+  registerDeviceTokenHandler,
+  unregisterDeviceTokenHandler,
+} from './device-token-handlers.js';
+
+// --- Fixtures + mocks ------------------------------------------------
+
+const ADOPTER_PRINCIPAL: Principal = {
+  userId: 'usr-adopter' as UserId,
+  roles: ['adopter'],
+  permissions: [
+    'notifications.device-tokens.read' as Permission,
+    'notifications.device-tokens.write' as Permission,
+  ],
+};
+
+const ADMIN_PRINCIPAL: Principal = {
+  userId: 'usr-admin' as UserId,
+  roles: ['admin'],
+  permissions: [
+    'notifications.device-tokens.read' as Permission,
+    'notifications.device-tokens.read:any' as Permission,
+    'notifications.device-tokens.write' as Permission,
+    'notifications.device-tokens.write:any' as Permission,
+  ],
+};
+
+const UNPRIVILEGED_PRINCIPAL: Principal = {
+  userId: 'usr-anyone' as UserId,
+  roles: ['adopter'],
+  permissions: [],
+};
+
+const tokenRowFixture = (overrides: Record<string, unknown> = {}) => ({
+  token_id: 'dt-1',
+  user_id: 'usr-adopter',
+  device_token: 'fcm-token-abcdef',
+  platform: 'android' as const,
+  app_version: '1.0.0',
+  device_info: {},
+  status: 'active' as const,
+  last_used_at: new Date('2026-06-01T00:00:00Z'),
+  expires_at: null,
+  created_at: new Date('2026-06-01T00:00:00Z'),
+  updated_at: new Date('2026-06-01T00:00:00Z'),
+  deleted_at: null,
+  ...overrides,
+});
+
+const makeMocks = () => {
+  const poolScript: Array<{ rows: unknown[] }> = [];
+  const pool = {
+    query: vi.fn(async () => {
+      const next = poolScript.shift();
+      return next ?? { rows: [] };
+    }),
+    connect: vi.fn(),
+  };
+  return {
+    pool: pool as unknown as Pool,
+    poolMock: pool,
+    poolScript,
+    deps: {
+      pool: pool as unknown as Pool,
+      nats: {} as unknown as NatsConnection,
+    },
+  };
+};
+
+const BASE_REGISTER: RegisterDeviceTokenRequest = {
+  userId: '',
+  deviceToken: 'fcm-token-abcdef',
+  platform: NotificationsV1.DevicePlatform.DEVICE_PLATFORM_ANDROID,
+  appVersion: '1.0.0',
+  deviceInfoJson: '',
+} as unknown as RegisterDeviceTokenRequest;
+
+// --- RegisterDeviceToken --------------------------------------------
+
+describe('registerDeviceTokenHandler', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('rejects when device_token is missing', async () => {
+    await expect(
+      registerDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, {
+        ...BASE_REGISTER,
+        deviceToken: '',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when platform is UNSPECIFIED', async () => {
+    await expect(
+      registerDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, {
+        ...BASE_REGISTER,
+        platform: NotificationsV1.DevicePlatform.DEVICE_PLATFORM_UNSPECIFIED,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when the principal lacks notifications.device-tokens.write', async () => {
+    await expect(
+      registerDeviceTokenHandler(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_REGISTER)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects non-object device_info_json', async () => {
+    await expect(
+      registerDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, {
+        ...BASE_REGISTER,
+        deviceInfoJson: '"not an object"',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects cross-user registration without :any permission', async () => {
+    await expect(
+      registerDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, {
+        ...BASE_REGISTER,
+        userId: 'usr-someone-else',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('inserts a new row and returns alreadyRegistered=false', async () => {
+    // registerDeviceToken: SELECT (empty) → INSERT.
+    mocks.poolScript.push({ rows: [] });
+    mocks.poolScript.push({ rows: [tokenRowFixture()] });
+
+    const res = await registerDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, BASE_REGISTER);
+
+    expect(res.alreadyRegistered).toBe(false);
+    expect(res.token?.userId).toBe('usr-adopter');
+    expect(res.token?.platform).toBe(NotificationsV1.DevicePlatform.DEVICE_PLATFORM_ANDROID);
+    expect(res.token?.status).toBe(NotificationsV1.DeviceTokenStatus.DEVICE_TOKEN_STATUS_ACTIVE);
+  });
+
+  it('refreshes an existing row and returns alreadyRegistered=true', async () => {
+    // SELECT returns existing row → UPDATE refreshed row.
+    mocks.poolScript.push({ rows: [tokenRowFixture()] });
+    mocks.poolScript.push({
+      rows: [tokenRowFixture({ last_used_at: new Date('2026-06-06T00:00:00Z') })],
+    });
+
+    const res = await registerDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, BASE_REGISTER);
+
+    expect(res.alreadyRegistered).toBe(true);
+  });
+
+  it('admin with :any can register on behalf of another user', async () => {
+    mocks.poolScript.push({ rows: [] });
+    mocks.poolScript.push({
+      rows: [tokenRowFixture({ user_id: 'usr-target' })],
+    });
+
+    const res = await registerDeviceTokenHandler(mocks.deps, ADMIN_PRINCIPAL, {
+      ...BASE_REGISTER,
+      userId: 'usr-target',
+    });
+
+    expect(res.token?.userId).toBe('usr-target');
+  });
+});
+
+// --- UnregisterDeviceToken ------------------------------------------
+
+describe('unregisterDeviceTokenHandler', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  const baseReq: UnregisterDeviceTokenRequest = { tokenId: 'dt-1' };
+
+  it('rejects when token_id is missing', async () => {
+    await expect(
+      unregisterDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, { tokenId: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when principal lacks write permission', async () => {
+    await expect(
+      unregisterDeviceTokenHandler(mocks.deps, UNPRIVILEGED_PRINCIPAL, baseReq)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('returns NOT_FOUND when token does not exist', async () => {
+    mocks.poolScript.push({ rows: [] });
+    await expect(
+      unregisterDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, baseReq)
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('rejects unregistering another user’s token without :any', async () => {
+    mocks.poolScript.push({ rows: [tokenRowFixture({ user_id: 'usr-other' })] });
+    await expect(
+      unregisterDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, baseReq)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('soft-deletes the row and returns it', async () => {
+    // getDeviceTokenById SELECT → unregisterDeviceToken UPDATE.
+    mocks.poolScript.push({ rows: [tokenRowFixture()] });
+    mocks.poolScript.push({
+      rows: [tokenRowFixture({ status: 'inactive', deleted_at: new Date() })],
+    });
+
+    const res = await unregisterDeviceTokenHandler(mocks.deps, ADOPTER_PRINCIPAL, baseReq);
+
+    expect(res.token?.status).toBe(NotificationsV1.DeviceTokenStatus.DEVICE_TOKEN_STATUS_INACTIVE);
+  });
+});
+
+// --- ListDeviceTokens -----------------------------------------------
+
+describe('listDeviceTokensHandler', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('rejects unprivileged principals', async () => {
+    await expect(
+      listDeviceTokensHandler(mocks.deps, UNPRIVILEGED_PRINCIPAL, {
+        userId: '',
+        includeInactive: false,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('returns the calling user’s tokens (self-scoped)', async () => {
+    mocks.poolScript.push({
+      rows: [tokenRowFixture(), tokenRowFixture({ token_id: 'dt-2' })],
+    });
+
+    const res = await listDeviceTokensHandler(mocks.deps, ADOPTER_PRINCIPAL, {
+      userId: '',
+      includeInactive: false,
+    });
+
+    expect(res.tokens).toHaveLength(2);
+    expect(res.tokens?.[0].tokenId).toBe('dt-1');
+    expect(res.tokens?.[1].tokenId).toBe('dt-2');
+  });
+
+  it('rejects cross-user list without :any', async () => {
+    await expect(
+      listDeviceTokensHandler(mocks.deps, ADOPTER_PRINCIPAL, {
+        userId: 'usr-other',
+        includeInactive: false,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+});

--- a/services/notifications/src/grpc/device-token-handlers.ts
+++ b/services/notifications/src/grpc/device-token-handlers.ts
@@ -1,0 +1,209 @@
+// gRPC handlers for the device-token surface: RegisterDeviceToken,
+// UnregisterDeviceToken, ListDeviceTokens.
+//
+// No NATS events for now — the push worker reads device_tokens on
+// demand when fanning a notification out. Future enhancement: publish
+// `notifications.device_token.registered` so analytics can count
+// active push installs.
+
+import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
+import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+import type { Permission } from '@adopt-dont-shop/lib.types';
+import {
+  NotificationsV1,
+  type ListDeviceTokensRequest,
+  type ListDeviceTokensResponse,
+  type NotificationsDeviceToken,
+  type RegisterDeviceTokenRequest,
+  type RegisterDeviceTokenResponse,
+  type UnregisterDeviceTokenRequest,
+  type UnregisterDeviceTokenResponse,
+} from '@adopt-dont-shop/proto';
+
+import {
+  getDeviceTokenById,
+  listDeviceTokensForUser,
+  registerDeviceToken,
+  unregisterDeviceToken,
+  type DeviceTokenRow,
+} from '../push/device-tokens.js';
+import type { DevicePlatform } from '../push/types.js';
+
+import { HandlerError } from './handlers.js';
+
+// --- Permissions -----------------------------------------------------
+
+const DEVICE_TOKENS_WRITE_SELF: Permission = 'notifications.device-tokens.write' as Permission;
+const DEVICE_TOKENS_WRITE_ANY: Permission = 'notifications.device-tokens.write:any' as Permission;
+const DEVICE_TOKENS_READ_SELF: Permission = 'notifications.device-tokens.read' as Permission;
+const DEVICE_TOKENS_READ_ANY: Permission = 'notifications.device-tokens.read:any' as Permission;
+
+// --- Enum maps -------------------------------------------------------
+
+const protoToPlatform: Record<NotificationsV1.DevicePlatform, DevicePlatform> = {
+  [NotificationsV1.DevicePlatform.DEVICE_PLATFORM_UNSPECIFIED]: 'web',
+  [NotificationsV1.DevicePlatform.DEVICE_PLATFORM_IOS]: 'ios',
+  [NotificationsV1.DevicePlatform.DEVICE_PLATFORM_ANDROID]: 'android',
+  [NotificationsV1.DevicePlatform.DEVICE_PLATFORM_WEB]: 'web',
+  [NotificationsV1.DevicePlatform.UNRECOGNIZED]: 'web',
+};
+
+const platformToProto = (v: DevicePlatform): NotificationsV1.DevicePlatform => {
+  switch (v) {
+    case 'ios':
+      return NotificationsV1.DevicePlatform.DEVICE_PLATFORM_IOS;
+    case 'android':
+      return NotificationsV1.DevicePlatform.DEVICE_PLATFORM_ANDROID;
+    case 'web':
+      return NotificationsV1.DevicePlatform.DEVICE_PLATFORM_WEB;
+  }
+};
+
+const statusToProto = (
+  v: 'active' | 'inactive' | 'expired' | 'invalid'
+): NotificationsV1.DeviceTokenStatus => {
+  switch (v) {
+    case 'active':
+      return NotificationsV1.DeviceTokenStatus.DEVICE_TOKEN_STATUS_ACTIVE;
+    case 'inactive':
+      return NotificationsV1.DeviceTokenStatus.DEVICE_TOKEN_STATUS_INACTIVE;
+    case 'expired':
+      return NotificationsV1.DeviceTokenStatus.DEVICE_TOKEN_STATUS_EXPIRED;
+    case 'invalid':
+      return NotificationsV1.DeviceTokenStatus.DEVICE_TOKEN_STATUS_INVALID;
+  }
+};
+
+const rowToProto = (row: DeviceTokenRow): NotificationsDeviceToken => ({
+  tokenId: row.token_id,
+  userId: row.user_id,
+  deviceToken: row.device_token,
+  platform: platformToProto(row.platform),
+  appVersion: row.app_version ?? undefined,
+  deviceInfoJson: JSON.stringify(row.device_info),
+  status: statusToProto(row.status),
+  lastUsedAt: row.last_used_at?.toISOString(),
+  expiresAt: row.expires_at?.toISOString(),
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+// Cross-user write / read gating shared with email-handlers.
+const resolveTargetUserId = (
+  principal: Principal,
+  requested: string | undefined,
+  selfPerm: Permission,
+  anyPerm: Permission
+): string => {
+  if (!hasPermission(principal, selfPerm)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${selfPerm}' required`);
+  }
+  const target = requested || (principal.userId as string);
+  if (target === principal.userId) {
+    return target;
+  }
+  if (!hasPermission(principal, anyPerm)) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      `'${anyPerm}' required to access another user's device tokens`
+    );
+  }
+  return target;
+};
+
+export type DeviceTokenDeps = WithTransactionDeps;
+
+// --- RegisterDeviceToken ---------------------------------------------
+
+export async function registerDeviceTokenHandler(
+  deps: DeviceTokenDeps,
+  principal: Principal,
+  req: RegisterDeviceTokenRequest
+): Promise<RegisterDeviceTokenResponse> {
+  if (!req.deviceToken) {
+    throw new HandlerError('INVALID_ARGUMENT', 'device_token is required');
+  }
+  if (req.platform === NotificationsV1.DevicePlatform.DEVICE_PLATFORM_UNSPECIFIED) {
+    throw new HandlerError('INVALID_ARGUMENT', 'platform is required');
+  }
+  const userId = resolveTargetUserId(
+    principal,
+    req.userId,
+    DEVICE_TOKENS_WRITE_SELF,
+    DEVICE_TOKENS_WRITE_ANY
+  );
+
+  let deviceInfo: Record<string, unknown> | undefined;
+  if (req.deviceInfoJson) {
+    try {
+      const parsed = JSON.parse(req.deviceInfoJson) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new HandlerError('INVALID_ARGUMENT', 'device_info_json must encode an object');
+      }
+      deviceInfo = parsed as Record<string, unknown>;
+    } catch (err) {
+      if (err instanceof HandlerError) {
+        throw err;
+      }
+      throw new HandlerError('INVALID_ARGUMENT', 'device_info_json could not be parsed');
+    }
+  }
+
+  const { row, alreadyRegistered } = await registerDeviceToken(deps.pool, {
+    userId,
+    deviceToken: req.deviceToken,
+    platform: protoToPlatform[req.platform],
+    appVersion: req.appVersion ?? null,
+    deviceInfo,
+  });
+
+  return { token: rowToProto(row), alreadyRegistered };
+}
+
+// --- UnregisterDeviceToken -------------------------------------------
+
+export async function unregisterDeviceTokenHandler(
+  deps: DeviceTokenDeps,
+  principal: Principal,
+  req: UnregisterDeviceTokenRequest
+): Promise<UnregisterDeviceTokenResponse> {
+  if (!req.tokenId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'token_id is required');
+  }
+  if (!hasPermission(principal, DEVICE_TOKENS_WRITE_SELF)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${DEVICE_TOKENS_WRITE_SELF}' required`);
+  }
+  const existing = await getDeviceTokenById(deps.pool, req.tokenId);
+  if (!existing) {
+    throw new HandlerError('NOT_FOUND', `device token '${req.tokenId}' not found`);
+  }
+  // Self-scope unless the principal has :any.
+  if (existing.user_id !== principal.userId && !hasPermission(principal, DEVICE_TOKENS_WRITE_ANY)) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      `'${DEVICE_TOKENS_WRITE_ANY}' required to unregister another user's device token`
+    );
+  }
+  const updated = await unregisterDeviceToken(deps.pool, req.tokenId);
+  if (!updated) {
+    throw new HandlerError('NOT_FOUND', `device token '${req.tokenId}' not found`);
+  }
+  return { token: rowToProto(updated) };
+}
+
+// --- ListDeviceTokens ------------------------------------------------
+
+export async function listDeviceTokensHandler(
+  deps: DeviceTokenDeps,
+  principal: Principal,
+  req: ListDeviceTokensRequest
+): Promise<ListDeviceTokensResponse> {
+  const userId = resolveTargetUserId(
+    principal,
+    req.userId,
+    DEVICE_TOKENS_READ_SELF,
+    DEVICE_TOKENS_READ_ANY
+  );
+  const rows = await listDeviceTokensForUser(deps.pool, userId, req.includeInactive);
+  return { tokens: rows.map(rowToProto) };
+}

--- a/services/notifications/src/grpc/email-handlers.test.ts
+++ b/services/notifications/src/grpc/email-handlers.test.ts
@@ -1,0 +1,361 @@
+import type { NatsConnection } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
+import {
+  NotificationsV1,
+  type SendEmailRequest,
+  type UpdateEmailPreferencesRequest,
+} from '@adopt-dont-shop/proto';
+
+import { getEmailPreferences, sendEmail, updateEmailPreferences } from './email-handlers.js';
+
+const SYSTEM_PRINCIPAL: Principal = {
+  userId: 'svc-auth' as UserId,
+  roles: ['admin'],
+  permissions: [
+    'notifications.email.send' as Permission,
+    'notifications.email-prefs.read' as Permission,
+    'notifications.email-prefs.update' as Permission,
+  ],
+};
+
+const ADOPTER_PRINCIPAL: Principal = {
+  userId: 'usr-adopter' as UserId,
+  roles: ['adopter'],
+  permissions: [
+    'notifications.email-prefs.read' as Permission,
+    'notifications.email-prefs.update' as Permission,
+  ],
+};
+
+const UNPRIVILEGED_PRINCIPAL: Principal = {
+  userId: 'usr-anyone' as UserId,
+  roles: ['adopter'],
+  permissions: [],
+};
+
+const prefsRowFixture = (overrides: Record<string, unknown> = {}) => ({
+  preference_id: 'pref-1',
+  user_id: 'usr-adopter',
+  is_email_enabled: true,
+  global_unsubscribe: false,
+  preferences: [],
+  language: 'en',
+  timezone: 'UTC',
+  email_format: 'html' as const,
+  digest_frequency: 'weekly' as const,
+  digest_time: '09:00',
+  unsubscribe_token: 'unsub-token-1',
+  last_digest_sent: null,
+  bounce_count: 0,
+  last_bounce_at: null,
+  is_blacklisted: false,
+  blacklist_reason: null,
+  blacklisted_at: null,
+  metadata: {},
+  created_at: new Date('2026-06-01T00:00:00Z'),
+  updated_at: new Date('2026-06-01T00:00:00Z'),
+  ...overrides,
+});
+
+// Make a mock that lets each test script its own pool.query and client.query
+// responses. Adopted from handlers.test.ts but with explicit scripts so
+// withTransaction's BEGIN/COMMIT noise doesn't consume real return values.
+function makeMocks() {
+  // The script holds the sequence of query results the next .query()
+  // call should return. BEGIN / COMMIT / ROLLBACK pass through.
+  const clientScript: Array<{ rows: unknown[] }> = [];
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      const op = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      const next = clientScript.shift();
+      if (!next) {
+        throw new Error(`client.query called with no scripted response for: ${sql.slice(0, 80)}`);
+      }
+      return next;
+    }),
+    release: vi.fn(),
+  };
+  const poolScript: Array<{ rows: unknown[] }> = [];
+  const pool = {
+    connect: vi.fn().mockResolvedValue(client),
+    query: vi.fn(async () => {
+      const next = poolScript.shift();
+      if (!next) return { rows: [] };
+      return next;
+    }),
+  };
+  const nats = { publish: vi.fn() };
+  return {
+    pool: pool as unknown as Pool,
+    client: client as unknown as PoolClient,
+    nats: nats as unknown as NatsConnection,
+    poolMock: pool,
+    clientMock: client,
+    natsMock: nats,
+    clientScript,
+    poolScript,
+    deps: {
+      pool: pool as unknown as Pool,
+      nats: nats as unknown as NatsConnection,
+    },
+  };
+}
+
+// Pull only the "real" client query calls (not BEGIN/COMMIT/ROLLBACK)
+// so assertions can match on the substantive queries.
+const realClientQueries = (mocks: ReturnType<typeof makeMocks>): string[] =>
+  (mocks.clientMock.query.mock.calls as Array<[string]>)
+    .map(([sql]) => sql.trim().split(/\s+/)[0].toUpperCase())
+    .filter(op => op !== 'BEGIN' && op !== 'COMMIT' && op !== 'ROLLBACK');
+
+const BASE_SEND_REQ: SendEmailRequest = {
+  toEmail: 'jane@example.com',
+  toName: 'Jane',
+  fromEmail: '',
+  fromName: '',
+  replyToEmail: '',
+  ccEmails: [],
+  bccEmails: [],
+  subject: 'Hello',
+  htmlContent: '<p>Hi</p>',
+  textContent: '',
+  templateId: '',
+  templateDataJson: '',
+  type: NotificationsV1.EmailType.EMAIL_TYPE_TRANSACTIONAL,
+  priority: NotificationsV1.EmailPriority.EMAIL_PRIORITY_NORMAL,
+  scheduledFor: '',
+  metadataJson: '',
+  tags: [],
+  userId: 'usr-adopter',
+  campaignId: '',
+  idempotencyKey: '',
+} as unknown as SendEmailRequest;
+
+describe('sendEmail', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects when the principal lacks notifications.email.send', async () => {
+    await expect(
+      sendEmail(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_SEND_REQ)
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects when to_email is missing', async () => {
+    await expect(
+      sendEmail(mocks.deps, SYSTEM_PRINCIPAL, { ...BASE_SEND_REQ, toEmail: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when neither template_id nor (subject + html_content) is supplied', async () => {
+    await expect(
+      sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+        ...BASE_SEND_REQ,
+        subject: '',
+        htmlContent: '',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when template_data_json is not a JSON object', async () => {
+    await expect(
+      sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+        ...BASE_SEND_REQ,
+        templateDataJson: '"not an object"',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('inlines subject + html → INSERT inside withTransaction and publishes after commit', async () => {
+    // Script: 1 INSERT into email_queue returning the row.
+    mocks.clientScript.push({ rows: [{ email_id: 'queued-1' }] });
+    const res = await sendEmail(mocks.deps, SYSTEM_PRINCIPAL, BASE_SEND_REQ);
+
+    expect(res.alreadyQueued).toBe(false);
+    expect(res.emailId).toBeTruthy();
+    expect(realClientQueries(mocks)).toEqual(['INSERT']);
+    expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
+    // publishStaged calls nats.publish(subject, JSON-envelope).
+    const [subject, body] = mocks.natsMock.publish.mock.calls[0];
+    expect(subject).toBe('notifications.email.queued');
+    const envelope = JSON.parse(body as string) as {
+      id: string;
+      payload: Record<string, unknown>;
+    };
+    expect(envelope.payload).toMatchObject({
+      userId: 'usr-adopter',
+      type: 'transactional',
+      priority: 'normal',
+    });
+  });
+
+  it('returns alreadyQueued=true when idempotency_key already present (pre-tx check)', async () => {
+    // pool.query (findByIdempotencyKey) returns the existing row.
+    mocks.poolScript.push({
+      rows: [{ email_id: 'queued-existing' }],
+    });
+
+    const res = await sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+      ...BASE_SEND_REQ,
+      idempotencyKey: 'send-once-key',
+    });
+
+    expect(res).toEqual({ emailId: 'queued-existing', alreadyQueued: true });
+    expect(realClientQueries(mocks)).toEqual([]); // no INSERT
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+
+  it('renders a template when template_id is supplied — looks up + increments usage', async () => {
+    // pool.query #1 = findActiveTemplate. Worker-side queries follow on the client.
+    mocks.poolScript.push({
+      rows: [
+        {
+          template_id: 'tpl-1',
+          name: 'welcome',
+          subject: 'Welcome {{name}}',
+          html_content: '<p>Hi {{name}}</p>',
+          text_content: null,
+          status: 'active',
+        },
+      ],
+    });
+    // client.query #1 = INSERT, #2 = increment usage.
+    mocks.clientScript.push({ rows: [{ email_id: 'tpl-queued-1' }] });
+    mocks.clientScript.push({ rows: [] });
+
+    const res = await sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+      ...BASE_SEND_REQ,
+      subject: '',
+      htmlContent: '',
+      templateId: 'tpl-1',
+      templateDataJson: '{"name":"Jane"}',
+    });
+
+    expect(res.alreadyQueued).toBe(false);
+    expect(realClientQueries(mocks)).toEqual(['INSERT', 'UPDATE']);
+    // INSERT call params include the rendered subject + html.
+    const insertCall = (mocks.clientMock.query.mock.calls as Array<[string, unknown[]]>).find(
+      ([sql]) => sql.includes('INSERT INTO email_queue')
+    );
+    expect(insertCall).toBeDefined();
+    const params = insertCall![1];
+    // From the insertEmail SQL: subject is param $10, html_content $11.
+    expect(params[9]).toBe('Welcome Jane');
+    expect(params[10]).toBe('<p>Hi Jane</p>');
+  });
+
+  it('returns NOT_FOUND when the referenced template is missing or inactive', async () => {
+    mocks.poolScript.push({ rows: [] });
+    await expect(
+      sendEmail(mocks.deps, SYSTEM_PRINCIPAL, {
+        ...BASE_SEND_REQ,
+        subject: '',
+        htmlContent: '',
+        templateId: 'tpl-missing',
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+describe('getEmailPreferences', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('rejects an unprivileged principal', async () => {
+    await expect(getEmailPreferences(mocks.deps, UNPRIVILEGED_PRINCIPAL, {})).rejects.toMatchObject(
+      { code: 'PERMISSION_DENIED' }
+    );
+  });
+
+  it('returns the calling user’s prefs row (self-read, no user_id supplied)', async () => {
+    // findOrCreatePreferences runs SELECT first; pool.query rows[0] = the row.
+    mocks.poolScript.push({ rows: [prefsRowFixture()] });
+
+    const res = await getEmailPreferences(mocks.deps, ADOPTER_PRINCIPAL, {});
+
+    expect(res.preferences?.userId).toBe('usr-adopter');
+    expect(res.preferences?.isEmailEnabled).toBe(true);
+    expect(res.preferences?.emailFormat).toBe(NotificationsV1.EmailFormat.EMAIL_FORMAT_HTML);
+    expect(res.preferences?.digestFrequency).toBe(
+      NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_WEEKLY
+    );
+  });
+
+  it('rejects cross-user reads without :any permission', async () => {
+    await expect(
+      getEmailPreferences(mocks.deps, ADOPTER_PRINCIPAL, { userId: 'usr-someone-else' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('allows cross-user read when principal has :any', async () => {
+    const adminAny: Principal = {
+      userId: 'svc-admin' as UserId,
+      roles: ['admin'],
+      permissions: [
+        'notifications.email-prefs.read' as Permission,
+        'notifications.email-prefs.read:any' as Permission,
+      ],
+    };
+    mocks.poolScript.push({ rows: [prefsRowFixture({ user_id: 'usr-other' })] });
+
+    const res = await getEmailPreferences(mocks.deps, adminAny, { userId: 'usr-other' });
+    expect(res.preferences?.userId).toBe('usr-other');
+  });
+});
+
+describe('updateEmailPreferences', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('rejects an unprivileged principal', async () => {
+    await expect(
+      updateEmailPreferences(
+        mocks.deps,
+        UNPRIVILEGED_PRINCIPAL,
+        {} as UpdateEmailPreferencesRequest
+      )
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects non-object preferences_json', async () => {
+    await expect(
+      updateEmailPreferences(mocks.deps, ADOPTER_PRINCIPAL, {
+        preferencesJson: '"not an array"',
+      } as UpdateEmailPreferencesRequest)
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('applies a self-update: find-or-create then UPDATE returns the row', async () => {
+    // findOrCreatePreferences SELECT then UPDATE.
+    mocks.poolScript.push({ rows: [prefsRowFixture()] });
+    mocks.poolScript.push({
+      rows: [prefsRowFixture({ global_unsubscribe: true })],
+    });
+
+    const res = await updateEmailPreferences(mocks.deps, ADOPTER_PRINCIPAL, {
+      globalUnsubscribe: true,
+    } as UpdateEmailPreferencesRequest);
+
+    expect(res.preferences?.globalUnsubscribe).toBe(true);
+  });
+});

--- a/services/notifications/src/grpc/email-handlers.ts
+++ b/services/notifications/src/grpc/email-handlers.ts
@@ -1,0 +1,411 @@
+// gRPC handlers for the email-channel surface: SendEmail,
+// GetEmailPreferences, UpdateEmailPreferences.
+//
+// SendEmail composes template lookup → render → insert into email_queue
+// → publish `notifications.email.queued` via withTransaction (publish-
+// after-commit). The worker (see ../email/worker.ts) drains the queue.
+
+import { randomUUID } from 'node:crypto';
+
+import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/events';
+import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
+import {
+  NotificationsV1,
+  type EmailPreferences as EmailPreferencesProto,
+  type GetEmailPreferencesRequest,
+  type GetEmailPreferencesResponse,
+  type SendEmailRequest,
+  type SendEmailResponse,
+  type UpdateEmailPreferencesRequest,
+  type UpdateEmailPreferencesResponse,
+} from '@adopt-dont-shop/proto';
+
+import {
+  findOrCreatePreferences,
+  updatePreferences,
+  type EmailPreferencesRow,
+  type PreferencesPatch,
+} from '../email/preferences.js';
+import { findByIdempotencyKey, insertEmail } from '../email/queue.js';
+import { renderEmailTemplate } from '../email/renderer.js';
+import { findActiveTemplate, incrementTemplateUsage } from '../email/templates.js';
+import type { EmailPriority, EmailType } from '../email/types.js';
+
+import { HandlerError } from './handlers.js';
+
+// --- Defaults --------------------------------------------------------
+
+const DEFAULT_FROM_EMAIL = process.env.DEFAULT_FROM_EMAIL ?? 'noreply@adoptdontshop.com';
+const DEFAULT_FROM_NAME = "Adopt Don't Shop";
+
+// --- Permissions -----------------------------------------------------
+
+const EMAIL_SEND: Permission = 'notifications.email.send' as Permission;
+const EMAIL_PREFS_READ_SELF: Permission = 'notifications.email-prefs.read' as Permission;
+const EMAIL_PREFS_READ_ANY: Permission = 'notifications.email-prefs.read:any' as Permission;
+const EMAIL_PREFS_WRITE_SELF: Permission = 'notifications.email-prefs.update' as Permission;
+const EMAIL_PREFS_WRITE_ANY: Permission = 'notifications.email-prefs.update:any' as Permission;
+
+// --- Enum maps --------------------------------------------------------
+
+const protoTypeToDb: Record<NotificationsV1.EmailType, EmailType> = {
+  [NotificationsV1.EmailType.EMAIL_TYPE_UNSPECIFIED]: 'system',
+  [NotificationsV1.EmailType.EMAIL_TYPE_TRANSACTIONAL]: 'transactional',
+  [NotificationsV1.EmailType.EMAIL_TYPE_NOTIFICATION]: 'notification',
+  [NotificationsV1.EmailType.EMAIL_TYPE_MARKETING]: 'marketing',
+  [NotificationsV1.EmailType.EMAIL_TYPE_SYSTEM]: 'system',
+  [NotificationsV1.EmailType.UNRECOGNIZED]: 'system',
+};
+
+const protoPriorityToDb: Record<NotificationsV1.EmailPriority, EmailPriority> = {
+  [NotificationsV1.EmailPriority.EMAIL_PRIORITY_UNSPECIFIED]: 'normal',
+  [NotificationsV1.EmailPriority.EMAIL_PRIORITY_LOW]: 'low',
+  [NotificationsV1.EmailPriority.EMAIL_PRIORITY_NORMAL]: 'normal',
+  [NotificationsV1.EmailPriority.EMAIL_PRIORITY_HIGH]: 'high',
+  [NotificationsV1.EmailPriority.EMAIL_PRIORITY_URGENT]: 'urgent',
+  [NotificationsV1.EmailPriority.UNRECOGNIZED]: 'normal',
+};
+
+const dbFormatToProto = (v: 'html' | 'text' | 'both'): NotificationsV1.EmailFormat => {
+  switch (v) {
+    case 'html':
+      return NotificationsV1.EmailFormat.EMAIL_FORMAT_HTML;
+    case 'text':
+      return NotificationsV1.EmailFormat.EMAIL_FORMAT_TEXT;
+    case 'both':
+      return NotificationsV1.EmailFormat.EMAIL_FORMAT_BOTH;
+  }
+};
+
+const protoFormatToDb = (v: NotificationsV1.EmailFormat): 'html' | 'text' | 'both' | null => {
+  switch (v) {
+    case NotificationsV1.EmailFormat.EMAIL_FORMAT_HTML:
+      return 'html';
+    case NotificationsV1.EmailFormat.EMAIL_FORMAT_TEXT:
+      return 'text';
+    case NotificationsV1.EmailFormat.EMAIL_FORMAT_BOTH:
+      return 'both';
+    default:
+      return null;
+  }
+};
+
+const dbFrequencyToProto = (
+  v: 'immediate' | 'daily' | 'weekly' | 'monthly' | 'never'
+): NotificationsV1.EmailDigestFrequency => {
+  switch (v) {
+    case 'immediate':
+      return NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_IMMEDIATE;
+    case 'daily':
+      return NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_DAILY;
+    case 'weekly':
+      return NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_WEEKLY;
+    case 'monthly':
+      return NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_MONTHLY;
+    case 'never':
+      return NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_NEVER;
+  }
+};
+
+const protoFrequencyToDb = (
+  v: NotificationsV1.EmailDigestFrequency
+): 'immediate' | 'daily' | 'weekly' | 'monthly' | 'never' | null => {
+  switch (v) {
+    case NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_IMMEDIATE:
+      return 'immediate';
+    case NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_DAILY:
+      return 'daily';
+    case NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_WEEKLY:
+      return 'weekly';
+    case NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_MONTHLY:
+      return 'monthly';
+    case NotificationsV1.EmailDigestFrequency.EMAIL_DIGEST_FREQUENCY_NEVER:
+      return 'never';
+    default:
+      return null;
+  }
+};
+
+// --- Header sanitization ---------------------------------------------
+
+// Same defense-in-depth strip the providers do, applied at the boundary
+// so the row in `email_queue` never holds CRLF in a header position.
+const stripHeader = (s: string): string => s.replace(/[\r\n]/g, '');
+const stripHeaderOpt = (s: string | undefined): string | undefined =>
+  s === undefined ? undefined : stripHeader(s);
+
+// --- SendEmail -------------------------------------------------------
+
+export type SendEmailDeps = WithTransactionDeps;
+
+const parseJson = (input: string | undefined, fallback: object): Record<string, unknown> => {
+  if (!input) {
+    return fallback as Record<string, unknown>;
+  }
+  try {
+    const parsed = JSON.parse(input) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    throw new HandlerError('INVALID_ARGUMENT', 'json field must encode an object');
+  } catch (err) {
+    if (err instanceof HandlerError) {
+      throw err;
+    }
+    throw new HandlerError('INVALID_ARGUMENT', 'json field could not be parsed');
+  }
+};
+
+export async function sendEmail(
+  deps: SendEmailDeps,
+  principal: Principal,
+  req: SendEmailRequest
+): Promise<SendEmailResponse> {
+  // Permission gate — only system services / admins enqueue email.
+  if (!hasPermission(principal, EMAIL_SEND)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${EMAIL_SEND}' required to enqueue email`);
+  }
+
+  // Input validation.
+  if (!req.toEmail) {
+    throw new HandlerError('INVALID_ARGUMENT', 'to_email is required');
+  }
+  const hasInline = Boolean(req.subject) && Boolean(req.htmlContent);
+  const hasTemplate = Boolean(req.templateId);
+  if (!hasInline && !hasTemplate) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      'either template_id or (subject + html_content) is required'
+    );
+  }
+
+  const templateData = parseJson(req.templateDataJson, {});
+  const metadata = parseJson(req.metadataJson, {});
+
+  const type = protoTypeToDb[req.type] ?? 'system';
+  const priority = protoPriorityToDb[req.priority] ?? 'normal';
+
+  // Resolve subject / html / text — template wins when present.
+  let subject: string;
+  let htmlContent: string;
+  let textContent: string | null;
+  let templateId: string | null = null;
+
+  // Idempotency short-circuit (outside the transaction — read-only).
+  if (req.idempotencyKey) {
+    const existing = await findByIdempotencyKey(deps.pool, req.idempotencyKey);
+    if (existing) {
+      return { emailId: existing.email_id, alreadyQueued: true };
+    }
+  }
+
+  if (hasTemplate) {
+    const tpl = await findActiveTemplate(deps.pool, req.templateId!);
+    if (!tpl) {
+      throw new HandlerError('NOT_FOUND', `template '${req.templateId}' not found or not active`);
+    }
+    const rendered = renderEmailTemplate(tpl, templateData);
+    subject = rendered.subject;
+    htmlContent = rendered.htmlContent;
+    textContent = rendered.textContent;
+    templateId = tpl.templateId;
+  } else {
+    subject = req.subject ?? '';
+    htmlContent = req.htmlContent ?? '';
+    textContent = req.textContent ?? null;
+  }
+
+  const emailId = randomUUID();
+  let alreadyQueued = false;
+
+  await withTransaction(deps, async ({ client, publish }) => {
+    try {
+      await insertEmail(client, {
+        emailId,
+        templateId,
+        fromEmail: stripHeader(req.fromEmail ?? DEFAULT_FROM_EMAIL),
+        fromName: stripHeaderOpt(req.fromName ?? DEFAULT_FROM_NAME),
+        toEmail: stripHeader(req.toEmail),
+        toName: stripHeaderOpt(req.toName),
+        ccEmails: (req.ccEmails ?? []).map(stripHeader),
+        bccEmails: (req.bccEmails ?? []).map(stripHeader),
+        replyToEmail: stripHeaderOpt(req.replyToEmail),
+        subject: stripHeader(subject),
+        htmlContent,
+        textContent,
+        templateData,
+        attachments: [],
+        type,
+        priority,
+        scheduledFor: req.scheduledFor ? new Date(req.scheduledFor) : null,
+        metadata,
+        campaignId: req.campaignId ?? null,
+        userId: req.userId ?? null,
+        tags: req.tags ?? [],
+        idempotencyKey: req.idempotencyKey ?? null,
+        createdBy: principal.userId as UserId,
+      });
+    } catch (err) {
+      // Unique-violation on idempotency_key — another caller raced us.
+      // Re-query and return the existing row.
+      const pgErr = err as { code?: string; constraint?: string };
+      if (
+        pgErr.code === '23505' &&
+        pgErr.constraint === 'email_queue_idempotency_key_unique' &&
+        req.idempotencyKey
+      ) {
+        const existing = await findByIdempotencyKey(client, req.idempotencyKey);
+        if (existing) {
+          alreadyQueued = true;
+          return;
+        }
+      }
+      throw err;
+    }
+
+    if (templateId) {
+      await incrementTemplateUsage(client, templateId);
+    }
+
+    publish({
+      type: 'notifications.email.queued',
+      id: `notifications.email.queued.${emailId}`,
+      payload: { emailId, userId: req.userId ?? null, type, priority },
+    });
+  });
+
+  if (alreadyQueued) {
+    // The race-loser case: a concurrent insert with the same idempotency
+    // key won. Re-resolve emailId by looking up the existing row.
+    const existing = await findByIdempotencyKey(deps.pool, req.idempotencyKey!);
+    return { emailId: existing?.email_id ?? emailId, alreadyQueued: true };
+  }
+
+  return { emailId, alreadyQueued: false };
+}
+
+// --- GetEmailPreferences ---------------------------------------------
+
+// Same deps shape as the rest of the service — keeps the grpc adapter's
+// type signature uniform even though preferences handlers don't publish
+// NATS events.
+export type EmailPrefsDeps = WithTransactionDeps;
+
+const rowToProto = (row: EmailPreferencesRow): EmailPreferencesProto => ({
+  preferenceId: row.preference_id,
+  userId: row.user_id,
+  isEmailEnabled: row.is_email_enabled,
+  globalUnsubscribe: row.global_unsubscribe,
+  preferencesJson: JSON.stringify(row.preferences),
+  language: row.language,
+  timezone: row.timezone,
+  emailFormat: dbFormatToProto(row.email_format),
+  digestFrequency: dbFrequencyToProto(row.digest_frequency),
+  digestTime: row.digest_time,
+  unsubscribeToken: row.unsubscribe_token,
+  lastDigestSent: row.last_digest_sent?.toISOString(),
+  bounceCount: row.bounce_count,
+  lastBounceAt: row.last_bounce_at?.toISOString(),
+  isBlacklisted: row.is_blacklisted,
+  blacklistReason: row.blacklist_reason ?? undefined,
+  blacklistedAt: row.blacklisted_at?.toISOString(),
+  metadataJson: JSON.stringify(row.metadata),
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+const resolveTargetUserId = (
+  principal: Principal,
+  requested: string | undefined,
+  readAny: Permission,
+  writeAny?: Permission
+): string => {
+  const target = requested || (principal.userId as string);
+  if (target === principal.userId) {
+    return target;
+  }
+  // Cross-user — must have the :any variant.
+  const perm = writeAny ?? readAny;
+  if (!hasPermission(principal, perm)) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      `'${perm}' required to access another user's email preferences`
+    );
+  }
+  return target;
+};
+
+export async function getEmailPreferences(
+  deps: EmailPrefsDeps,
+  principal: Principal,
+  req: GetEmailPreferencesRequest
+): Promise<GetEmailPreferencesResponse> {
+  // Self-read: gate on EMAIL_PREFS_READ_SELF (any authenticated user).
+  if (!hasPermission(principal, EMAIL_PREFS_READ_SELF)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${EMAIL_PREFS_READ_SELF}' required`);
+  }
+  const userId = resolveTargetUserId(principal, req.userId, EMAIL_PREFS_READ_ANY);
+  const row = await findOrCreatePreferences(deps.pool, userId);
+  return { preferences: rowToProto(row) };
+}
+
+// --- UpdateEmailPreferences ------------------------------------------
+
+export async function updateEmailPreferences(
+  deps: EmailPrefsDeps,
+  principal: Principal,
+  req: UpdateEmailPreferencesRequest
+): Promise<UpdateEmailPreferencesResponse> {
+  if (!hasPermission(principal, EMAIL_PREFS_WRITE_SELF)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${EMAIL_PREFS_WRITE_SELF}' required`);
+  }
+  const userId = resolveTargetUserId(
+    principal,
+    req.userId,
+    EMAIL_PREFS_READ_ANY,
+    EMAIL_PREFS_WRITE_ANY
+  );
+
+  const patch: PreferencesPatch = {};
+  if (req.isEmailEnabled !== undefined) {
+    patch.isEmailEnabled = req.isEmailEnabled;
+  }
+  if (req.globalUnsubscribe !== undefined) {
+    patch.globalUnsubscribe = req.globalUnsubscribe;
+  }
+  if (req.preferencesJson !== undefined) {
+    try {
+      const parsed = JSON.parse(req.preferencesJson) as unknown;
+      if (!Array.isArray(parsed)) {
+        throw new HandlerError('INVALID_ARGUMENT', 'preferences_json must encode an array');
+      }
+      patch.preferences = parsed as Array<Record<string, unknown>>;
+    } catch (err) {
+      if (err instanceof HandlerError) {
+        throw err;
+      }
+      throw new HandlerError('INVALID_ARGUMENT', 'preferences_json could not be parsed');
+    }
+  }
+  if (req.language !== undefined) {
+    patch.language = req.language;
+  }
+  if (req.timezone !== undefined) {
+    patch.timezone = req.timezone;
+  }
+  const fmt = protoFormatToDb(req.emailFormat);
+  if (fmt) {
+    patch.emailFormat = fmt;
+  }
+  const freq = protoFrequencyToDb(req.digestFrequency);
+  if (freq) {
+    patch.digestFrequency = freq;
+  }
+  if (req.digestTime !== undefined) {
+    patch.digestTime = req.digestTime;
+  }
+
+  const updated = await updatePreferences(deps.pool, userId, patch);
+  return { preferences: rowToProto(updated) };
+}

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -19,6 +19,7 @@ import { NotificationsV1 } from '@adopt-dont-shop/proto';
 import type { NotificationsConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
+import { getEmailPreferences, sendEmail, updateEmailPreferences } from './email-handlers.js';
 import { createNotification, dismissNotification, listNotifications } from './handlers.js';
 
 export type CreateGrpcServerOptions = {
@@ -49,10 +50,20 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     create: adapt(createNotification, { deps: { pool, nats }, logger }),
     list: adapt(listNotifications, { deps: { pool, nats }, logger }),
     dismiss: adapt(dismissNotification, { deps: { pool, nats }, logger }),
+    sendEmail: adapt(sendEmail, { deps: { pool, nats }, logger }),
+    getEmailPreferences: adapt(getEmailPreferences, { deps: { pool, nats }, logger }),
+    updateEmailPreferences: adapt(updateEmailPreferences, { deps: { pool, nats }, logger }),
   });
 
   logger.info('gRPC NotificationService registered', {
-    methods: ['create', 'list', 'dismiss'],
+    methods: [
+      'create',
+      'list',
+      'dismiss',
+      'sendEmail',
+      'getEmailPreferences',
+      'updateEmailPreferences',
+    ],
     grpcPort: config.grpcPort,
   });
 

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -19,6 +19,11 @@ import { NotificationsV1 } from '@adopt-dont-shop/proto';
 import type { NotificationsConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
+import {
+  listDeviceTokensHandler,
+  registerDeviceTokenHandler,
+  unregisterDeviceTokenHandler,
+} from './device-token-handlers.js';
 import { getEmailPreferences, sendEmail, updateEmailPreferences } from './email-handlers.js';
 import { createNotification, dismissNotification, listNotifications } from './handlers.js';
 
@@ -53,6 +58,9 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     sendEmail: adapt(sendEmail, { deps: { pool, nats }, logger }),
     getEmailPreferences: adapt(getEmailPreferences, { deps: { pool, nats }, logger }),
     updateEmailPreferences: adapt(updateEmailPreferences, { deps: { pool, nats }, logger }),
+    registerDeviceToken: adapt(registerDeviceTokenHandler, { deps: { pool, nats }, logger }),
+    unregisterDeviceToken: adapt(unregisterDeviceTokenHandler, { deps: { pool, nats }, logger }),
+    listDeviceTokens: adapt(listDeviceTokensHandler, { deps: { pool, nats }, logger }),
   });
 
   logger.info('gRPC NotificationService registered', {
@@ -63,6 +71,9 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'sendEmail',
       'getEmailPreferences',
       'updateEmailPreferences',
+      'registerDeviceToken',
+      'unregisterDeviceToken',
+      'listDeviceTokens',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -8,6 +8,8 @@ import { createProvider } from './email/providers/factory.js';
 import { startEmailWorker, type RunningEmailWorker } from './email/worker.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { registerSubscribers } from './nats/subscribers.js';
+import { createPushProvider } from './push/providers/factory.js';
+import { startPushWorker, type RunningPushWorker } from './push/worker.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
@@ -17,6 +19,7 @@ const main = async (): Promise<void> => {
   let pool: Awaited<ReturnType<typeof createDbClient>> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let emailWorker: RunningEmailWorker | undefined;
+  let pushWorker: RunningPushWorker | undefined;
   let httpClosed = false;
 
   try {
@@ -61,6 +64,23 @@ const main = async (): Promise<void> => {
       emailWorker = startEmailWorker({ pool, nats, provider, logger });
       logger.info('email worker started', { provider: provider.getName() });
     }
+    if (config.pushWorkerEnabled) {
+      const pushProviderConfig =
+        config.pushProvider.kind === 'fcm'
+          ? ({
+              kind: 'fcm',
+              fcm: {
+                serviceAccountJson: config.pushProvider.serviceAccountJson,
+                projectId: config.pushProvider.projectId,
+              },
+            } as const)
+          : config.pushProvider;
+      const provider = createPushProvider({ config: pushProviderConfig, logger });
+      if (!provider.validateConfiguration()) {
+        throw new Error(`push provider '${provider.getName()}' failed validateConfiguration()`);
+      }
+      pushWorker = startPushWorker({ pool, nats, provider, logger });
+    }
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });
 
@@ -87,6 +107,11 @@ const main = async (): Promise<void> => {
         await emailWorker?.stop();
       } catch (err) {
         logger.error('email worker stop error', { err });
+      }
+      try {
+        await pushWorker?.stop();
+      } catch (err) {
+        logger.error('push worker stop error', { err });
       }
       try {
         await grpc?.shutdown();

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -10,6 +10,8 @@ import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { registerSubscribers } from './nats/subscribers.js';
 import { createPushProvider } from './push/providers/factory.js';
 import { startPushWorker, type RunningPushWorker } from './push/worker.js';
+import { runWeeklyDigest } from './scheduler/jobs/weekly-digest.js';
+import { startScheduler, type RunningScheduler } from './scheduler/scheduler.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
@@ -20,6 +22,7 @@ const main = async (): Promise<void> => {
   let grpc: RunningGrpcServer | undefined;
   let emailWorker: RunningEmailWorker | undefined;
   let pushWorker: RunningPushWorker | undefined;
+  let scheduler: RunningScheduler | undefined;
   let httpClosed = false;
 
   try {
@@ -81,6 +84,24 @@ const main = async (): Promise<void> => {
       }
       pushWorker = startPushWorker({ pool, nats, provider, logger });
     }
+    if (config.schedulerEnabled) {
+      // Weekly digest: 7 days. Default tick is 60s — close enough to
+      // schedule precision for any cadence we run today. Each job's
+      // intervalMs governs when it actually fires.
+      const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+      scheduler = startScheduler(
+        [
+          {
+            name: 'weekly-digest',
+            intervalMs: ONE_WEEK_MS,
+            run: async () => {
+              await runWeeklyDigest({ deps: { pool: pool!, nats: nats! }, logger });
+            },
+          },
+        ],
+        { logger }
+      );
+    }
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });
 
@@ -112,6 +133,11 @@ const main = async (): Promise<void> => {
         await pushWorker?.stop();
       } catch (err) {
         logger.error('push worker stop error', { err });
+      }
+      try {
+        await scheduler?.stop();
+      } catch (err) {
+        logger.error('scheduler stop error', { err });
       }
       try {
         await grpc?.shutdown();

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -4,6 +4,8 @@ import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { createProvider } from './email/providers/factory.js';
+import { startEmailWorker, type RunningEmailWorker } from './email/worker.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { registerSubscribers } from './nats/subscribers.js';
 import { createServer } from './server.js';
@@ -14,6 +16,7 @@ const main = async (): Promise<void> => {
   let nats: NatsConnection | undefined;
   let pool: Awaited<ReturnType<typeof createDbClient>> | undefined;
   let grpc: RunningGrpcServer | undefined;
+  let emailWorker: RunningEmailWorker | undefined;
   let httpClosed = false;
 
   try {
@@ -34,6 +37,30 @@ const main = async (): Promise<void> => {
     // can't race against partially-constructed deps. Shutdown drains the
     // whole NATS connection later, which transparently cancels these.
     registerSubscribers({ nats, deps: { pool, nats }, logger });
+    // Email worker drains the email_queue table. Enabled by default;
+    // tests + the migrations-only smoke set EMAIL_WORKER_ENABLED=false
+    // to keep the loop quiet. Provider factory enforces ADS-549 (no
+    // silent console fallback in prod).
+    if (config.emailWorkerEnabled) {
+      const emailProviderConfig =
+        config.emailProvider.kind === 'resend'
+          ? ({
+              kind: 'resend',
+              resend: {
+                apiKey: config.emailProvider.apiKey,
+                fromEmail: config.emailProvider.fromEmail,
+                fromName: config.emailProvider.fromName,
+                replyTo: config.emailProvider.replyTo,
+              },
+            } as const)
+          : config.emailProvider;
+      const provider = createProvider({ config: emailProviderConfig, logger });
+      if (!provider.validateConfiguration()) {
+        throw new Error(`email provider '${provider.getName()}' failed validateConfiguration()`);
+      }
+      emailWorker = startEmailWorker({ pool, nats, provider, logger });
+      logger.info('email worker started', { provider: provider.getName() });
+    }
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });
 
@@ -55,6 +82,11 @@ const main = async (): Promise<void> => {
         }
       } catch (err) {
         logger.error('http close error', { err });
+      }
+      try {
+        await emailWorker?.stop();
+      } catch (err) {
+        logger.error('email worker stop error', { err });
       }
       try {
         await grpc?.shutdown();

--- a/services/notifications/src/migrations/004_create_email_queue.ts
+++ b/services/notifications/src/migrations/004_create_email_queue.ts
@@ -1,0 +1,103 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — email_queue.
+//
+// Direct port of service.backend's 00-baseline-039-email-queue.ts.
+// Append-only delivery queue; the worker takes a row, attempts the
+// provider send, and updates status in place. Three Postgres enums
+// (type / priority / status) declared inline. `paranoid: false` on
+// the monolith model — no `deleted_at`. The retention job hard-deletes
+// terminal rows after a configurable horizon.
+//
+// FKs (template_id → email_templates, user_id → auth.users,
+// created_by/updated_by → auth.users) are NOT declared here — the
+// schema-per-service rule means we never cross-schema FK to auth.
+// Application-level enforcement only.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('email_queue_type', ['transactional', 'notification', 'marketing', 'system']);
+  pgm.createType('email_queue_priority', ['low', 'normal', 'high', 'urgent']);
+  pgm.createType('email_queue_status', [
+    'queued',
+    'sending',
+    'sent',
+    'delivered',
+    'opened',
+    'clicked',
+    'failed',
+    'bounced',
+    'unsubscribed',
+  ]);
+
+  pgm.createTable('email_queue', {
+    email_id: { type: 'uuid', primaryKey: true },
+    template_id: { type: 'uuid' },
+    from_email: { type: 'varchar(320)', notNull: true },
+    from_name: { type: 'varchar(255)' },
+    to_email: { type: 'varchar(320)', notNull: true },
+    to_name: { type: 'varchar(255)' },
+    cc_emails: { type: 'text[]', notNull: true, default: pgm.func('ARRAY[]::text[]') },
+    bcc_emails: { type: 'text[]', notNull: true, default: pgm.func('ARRAY[]::text[]') },
+    reply_to_email: { type: 'varchar(320)' },
+    subject: { type: 'varchar(500)', notNull: true },
+    html_content: { type: 'text', notNull: true },
+    text_content: { type: 'text' },
+    template_data: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+    attachments: { type: 'jsonb', notNull: true, default: pgm.func("'[]'::jsonb") },
+    type: { type: 'email_queue_type', notNull: true },
+    priority: { type: 'email_queue_priority', notNull: true, default: 'normal' },
+    status: { type: 'email_queue_status', notNull: true, default: 'queued' },
+    scheduled_for: { type: 'timestamptz' },
+    max_retries: { type: 'integer', notNull: true, default: 3 },
+    current_retries: { type: 'integer', notNull: true, default: 0 },
+    last_attempt_at: { type: 'timestamptz' },
+    sent_at: { type: 'timestamptz' },
+    failure_reason: { type: 'text' },
+    provider_id: { type: 'varchar(64)' },
+    provider_message_id: { type: 'varchar(255)' },
+    tracking: { type: 'jsonb' },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+    campaign_id: { type: 'varchar(255)' },
+    user_id: { type: 'uuid' },
+    tags: { type: 'text[]', notNull: true, default: pgm.func('ARRAY[]::text[]') },
+    // Idempotency key — opt-in send-once semantics. Unique partial
+    // index below permits multiple NULLs (most sends) while enforcing
+    // uniqueness for callers that set it.
+    idempotency_key: { type: 'varchar(64)' },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('email_queue', 'status', { name: 'email_queue_status_idx' });
+  pgm.createIndex('email_queue', 'priority', { name: 'email_queue_priority_idx' });
+  pgm.createIndex('email_queue', 'type', { name: 'email_queue_type_idx' });
+  pgm.createIndex('email_queue', 'to_email', { name: 'email_queue_to_email_idx' });
+  pgm.createIndex('email_queue', 'user_id', { name: 'email_queue_user_id_idx' });
+  pgm.createIndex('email_queue', 'template_id', { name: 'email_queue_template_id_idx' });
+  pgm.createIndex('email_queue', 'campaign_id', { name: 'email_queue_campaign_id_idx' });
+  pgm.createIndex('email_queue', 'scheduled_for', { name: 'email_queue_scheduled_for_idx' });
+  pgm.createIndex('email_queue', 'sent_at', { name: 'email_queue_sent_at_idx' });
+  pgm.createIndex('email_queue', 'created_at', { name: 'email_queue_created_at_idx' });
+  pgm.createIndex('email_queue', 'tags', { method: 'gin', name: 'email_queue_tags_idx' });
+  pgm.createIndex('email_queue', ['status', 'priority', 'scheduled_for'], {
+    name: 'email_queue_processing_idx',
+  });
+  pgm.createIndex('email_queue', 'created_by', { name: 'email_queue_created_by_idx' });
+  pgm.createIndex('email_queue', 'updated_by', { name: 'email_queue_updated_by_idx' });
+  // Partial unique on idempotency_key — uniqueness only when set.
+  pgm.createIndex('email_queue', 'idempotency_key', {
+    name: 'email_queue_idempotency_key_unique',
+    unique: true,
+    where: 'idempotency_key IS NOT NULL',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('email_queue');
+  pgm.dropType('email_queue_status');
+  pgm.dropType('email_queue_priority');
+  pgm.dropType('email_queue_type');
+};

--- a/services/notifications/src/migrations/005_create_email_templates.ts
+++ b/services/notifications/src/migrations/005_create_email_templates.ts
@@ -1,0 +1,114 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — email_templates + email_template_versions.
+//
+// Direct port of service.backend's 00-baseline-037-email-templates.ts
+// and 00-baseline-038-email-template-versions.ts. Templates are the
+// authoring surface; versions are the immutable snapshot history.
+//
+// FKs (parent_template_id self-ref, last_modified_by → auth.users,
+// created_by/updated_by → auth.users) NOT declared — schema-per-service
+// rule prevents cross-schema FKs. Application-level enforcement.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('email_template_type', [
+    'transactional',
+    'notification',
+    'marketing',
+    'system',
+    'administrative',
+  ]);
+  pgm.createType('email_template_category', [
+    'welcome',
+    'password_reset',
+    'email_verification',
+    'application_update',
+    'adoption_confirmation',
+    'rescue_verification',
+    'staff_invitation',
+    'notification_digest',
+    'reminder',
+    'announcement',
+    'newsletter',
+    'system_alert',
+  ]);
+  pgm.createType('email_template_status', ['draft', 'active', 'inactive', 'archived']);
+
+  pgm.createTable('email_templates', {
+    template_id: { type: 'uuid', primaryKey: true },
+    name: { type: 'varchar(255)', notNull: true, unique: true },
+    description: { type: 'text' },
+    type: { type: 'email_template_type', notNull: true },
+    category: { type: 'email_template_category', notNull: true },
+    status: { type: 'email_template_status', notNull: true, default: 'draft' },
+    subject: { type: 'varchar(500)', notNull: true },
+    html_content: { type: 'text', notNull: true },
+    text_content: { type: 'text' },
+    variables: { type: 'jsonb', notNull: true, default: pgm.func("'[]'::jsonb") },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+    locale: { type: 'varchar(10)', notNull: true, default: 'en' },
+    parent_template_id: { type: 'uuid' },
+    current_version: { type: 'integer', notNull: true, default: 1 },
+    is_default: { type: 'boolean', notNull: true, default: false },
+    priority: { type: 'integer', notNull: true, default: 0 },
+    tags: { type: 'text[]', notNull: true, default: pgm.func('ARRAY[]::text[]') },
+    last_modified_by: { type: 'uuid' },
+    last_used_at: { type: 'timestamptz' },
+    usage_count: { type: 'integer', notNull: true, default: 0 },
+    test_emails_sent: { type: 'integer', notNull: true, default: 0 },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    deleted_at: { type: 'timestamptz' },
+  });
+
+  pgm.createIndex('email_templates', 'type', { name: 'email_templates_type_idx' });
+  pgm.createIndex('email_templates', 'category', { name: 'email_templates_category_idx' });
+  pgm.createIndex('email_templates', 'status', { name: 'email_templates_status_idx' });
+  pgm.createIndex('email_templates', 'locale', { name: 'email_templates_locale_idx' });
+  pgm.createIndex('email_templates', 'is_default', { name: 'email_templates_is_default_idx' });
+  pgm.createIndex('email_templates', 'parent_template_id', {
+    name: 'email_templates_parent_template_id_idx',
+  });
+  pgm.createIndex('email_templates', 'last_used_at', { name: 'email_templates_last_used_at_idx' });
+  pgm.createIndex('email_templates', 'tags', { method: 'gin', name: 'email_templates_tags_idx' });
+  pgm.createIndex('email_templates', 'deleted_at', { name: 'email_templates_deleted_at_idx' });
+
+  // email_template_versions — immutable history snapshots.
+  pgm.createTable('email_template_versions', {
+    version_id: { type: 'uuid', primaryKey: true },
+    template_id: {
+      type: 'uuid',
+      notNull: true,
+      references: '"email_templates"',
+      onDelete: 'CASCADE',
+    },
+    version_number: { type: 'integer', notNull: true },
+    subject: { type: 'varchar(500)', notNull: true },
+    html_content: { type: 'text', notNull: true },
+    text_content: { type: 'text' },
+    variables: { type: 'jsonb', notNull: true, default: pgm.func("'[]'::jsonb") },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+    change_summary: { type: 'text' },
+    created_by: { type: 'uuid' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('email_template_versions', ['template_id', 'version_number'], {
+    name: 'email_template_versions_template_id_version_unique',
+    unique: true,
+  });
+  pgm.createIndex('email_template_versions', 'template_id', {
+    name: 'email_template_versions_template_id_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('email_template_versions');
+  pgm.dropTable('email_templates');
+  pgm.dropType('email_template_status');
+  pgm.dropType('email_template_category');
+  pgm.dropType('email_template_type');
+};

--- a/services/notifications/src/migrations/006_create_email_preferences.ts
+++ b/services/notifications/src/migrations/006_create_email_preferences.ts
@@ -1,0 +1,83 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — email_preferences.
+//
+// Direct port of service.backend's 00-baseline-040-email-preferences.ts.
+// 1:1 with users — `user_id` carries both column-level UNIQUE and a
+// separate named unique index, mirroring the monolith's sync() output.
+//
+// Distinct from `user_notification_prefs` (003): that table stores the
+// in-app channel toggles and digest cadence. `email_preferences` is
+// purely the email-channel record — per-type opt-in/opt-out, bounce
+// tracking, unsubscribe-token surface, locale/format. The split is
+// preserved from the monolith because the surfaces evolve independently
+// (the bounce/blacklist columns belong to ops, the digest knobs to UX).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('email_preferences_format', ['html', 'text', 'both']);
+  pgm.createType('email_preferences_digest_frequency', [
+    'immediate',
+    'daily',
+    'weekly',
+    'monthly',
+    'never',
+  ]);
+
+  pgm.createTable('email_preferences', {
+    preference_id: { type: 'uuid', primaryKey: true },
+    user_id: { type: 'uuid', notNull: true, unique: true },
+    is_email_enabled: { type: 'boolean', notNull: true, default: true },
+    global_unsubscribe: { type: 'boolean', notNull: true, default: false },
+    preferences: { type: 'jsonb', notNull: true, default: pgm.func("'[]'::jsonb") },
+    language: { type: 'varchar(10)', notNull: true, default: 'en' },
+    timezone: { type: 'varchar(64)', notNull: true, default: 'UTC' },
+    email_format: { type: 'email_preferences_format', notNull: true, default: 'html' },
+    digest_frequency: {
+      type: 'email_preferences_digest_frequency',
+      notNull: true,
+      default: 'weekly',
+    },
+    digest_time: { type: 'varchar(5)', notNull: true, default: '09:00' },
+    unsubscribe_token: { type: 'varchar(64)', notNull: true, unique: true },
+    last_digest_sent: { type: 'timestamptz' },
+    bounce_count: { type: 'integer', notNull: true, default: 0 },
+    last_bounce_at: { type: 'timestamptz' },
+    is_blacklisted: { type: 'boolean', notNull: true, default: false },
+    blacklist_reason: { type: 'text' },
+    blacklisted_at: { type: 'timestamptz' },
+    metadata: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('email_preferences', 'is_email_enabled', {
+    name: 'email_preferences_is_email_enabled_idx',
+  });
+  pgm.createIndex('email_preferences', 'global_unsubscribe', {
+    name: 'email_preferences_global_unsubscribe_idx',
+  });
+  pgm.createIndex('email_preferences', 'is_blacklisted', {
+    name: 'email_preferences_is_blacklisted_idx',
+  });
+  pgm.createIndex('email_preferences', 'digest_frequency', {
+    name: 'email_preferences_digest_frequency_idx',
+  });
+  pgm.createIndex('email_preferences', 'last_digest_sent', {
+    name: 'email_preferences_last_digest_sent_idx',
+  });
+  pgm.createIndex('email_preferences', 'created_by', {
+    name: 'email_preferences_created_by_idx',
+  });
+  pgm.createIndex('email_preferences', 'updated_by', {
+    name: 'email_preferences_updated_by_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('email_preferences');
+  pgm.dropType('email_preferences_digest_frequency');
+  pgm.dropType('email_preferences_format');
+};

--- a/services/notifications/src/migrations/migrations.test.ts
+++ b/services/notifications/src/migrations/migrations.test.ts
@@ -46,6 +46,9 @@ describe('notifications migrations', () => {
     '001_create_notifications.ts',
     '002_create_device_tokens.ts',
     '003_create_user_notification_prefs.ts',
+    '004_create_email_queue.ts',
+    '005_create_email_templates.ts',
+    '006_create_email_preferences.ts',
   ])('%s exports `up` and `down` functions', async filename => {
     const mod = (await import(`./${filename}`)) as {
       up: unknown;

--- a/services/notifications/src/push/device-tokens.ts
+++ b/services/notifications/src/push/device-tokens.ts
@@ -1,0 +1,173 @@
+// Device-token persistence. The RPCs are thin wrappers around these
+// helpers; the worker uses `listActiveTokensForUser` to fan a push
+// notification out to every device the recipient registered.
+
+import { randomUUID } from 'node:crypto';
+
+import type { DbConn } from '../email/queue.js';
+
+import type { DevicePlatform, DeviceTokenStatus } from './types.js';
+
+export type DeviceTokenRow = {
+  token_id: string;
+  user_id: string;
+  device_token: string;
+  platform: DevicePlatform;
+  app_version: string | null;
+  device_info: Record<string, unknown>;
+  status: DeviceTokenStatus;
+  last_used_at: Date | null;
+  expires_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+};
+
+export type RegisterDeviceTokenInput = {
+  userId: string;
+  deviceToken: string;
+  platform: DevicePlatform;
+  appVersion?: string | null;
+  deviceInfo?: Record<string, unknown>;
+};
+
+// Upsert by (user_id, device_token). The partial unique index
+// `device_tokens_user_token_unique` enforces the uniqueness while
+// permitting historical soft-deleted rows.
+//
+// Returns the row + a flag indicating whether the registration was
+// new (false → call refreshed an existing row's last_used_at).
+export const registerDeviceToken = async (
+  conn: DbConn,
+  input: RegisterDeviceTokenInput
+): Promise<{ row: DeviceTokenRow; alreadyRegistered: boolean }> => {
+  // Look up first so we can report alreadyRegistered accurately.
+  const existing = await conn.query<DeviceTokenRow>(
+    `
+    SELECT * FROM device_tokens
+    WHERE user_id = $1 AND device_token = $2 AND deleted_at IS NULL
+    LIMIT 1
+    `,
+    [input.userId, input.deviceToken]
+  );
+
+  if (existing.rows[0]) {
+    const refreshed = await conn.query<DeviceTokenRow>(
+      `
+      UPDATE device_tokens
+      SET app_version = COALESCE($2, app_version),
+          device_info = COALESCE($3::jsonb, device_info),
+          platform    = $4,
+          status      = 'active',
+          last_used_at = now(),
+          updated_at  = now()
+      WHERE token_id = $1
+      RETURNING *
+      `,
+      [
+        existing.rows[0].token_id,
+        input.appVersion ?? null,
+        input.deviceInfo ? JSON.stringify(input.deviceInfo) : null,
+        input.platform,
+      ]
+    );
+    return { row: refreshed.rows[0], alreadyRegistered: true };
+  }
+
+  const inserted = await conn.query<DeviceTokenRow>(
+    `
+    INSERT INTO device_tokens (
+      token_id, user_id, device_token, platform,
+      app_version, device_info, status,
+      last_used_at, created_at, updated_at
+    )
+    VALUES (
+      $1, $2, $3, $4,
+      $5, $6::jsonb, 'active',
+      now(), now(), now()
+    )
+    RETURNING *
+    `,
+    [
+      randomUUID(),
+      input.userId,
+      input.deviceToken,
+      input.platform,
+      input.appVersion ?? null,
+      JSON.stringify(input.deviceInfo ?? {}),
+    ]
+  );
+  return { row: inserted.rows[0], alreadyRegistered: false };
+};
+
+// Soft-delete by token_id. Idempotent — a second call returns the
+// already-deleted row.
+export const unregisterDeviceToken = async (
+  conn: DbConn,
+  tokenId: string
+): Promise<DeviceTokenRow | null> => {
+  const res = await conn.query<DeviceTokenRow>(
+    `
+    UPDATE device_tokens
+    SET status     = 'inactive',
+        deleted_at = COALESCE(deleted_at, now()),
+        updated_at = now()
+    WHERE token_id = $1
+    RETURNING *
+    `,
+    [tokenId]
+  );
+  return res.rows[0] ?? null;
+};
+
+export const getDeviceTokenById = async (
+  conn: DbConn,
+  tokenId: string
+): Promise<DeviceTokenRow | null> => {
+  const res = await conn.query<DeviceTokenRow>(
+    `SELECT * FROM device_tokens WHERE token_id = $1 LIMIT 1`,
+    [tokenId]
+  );
+  return res.rows[0] ?? null;
+};
+
+export const listDeviceTokensForUser = async (
+  conn: DbConn,
+  userId: string,
+  includeInactive: boolean
+): Promise<DeviceTokenRow[]> => {
+  const res = await conn.query<DeviceTokenRow>(
+    `
+    SELECT * FROM device_tokens
+    WHERE user_id = $1
+      ${includeInactive ? '' : "AND deleted_at IS NULL AND status = 'active'"}
+    ORDER BY created_at DESC
+    `,
+    [userId]
+  );
+  return res.rows;
+};
+
+// Mark a token invalid — called by the push worker when the provider
+// reports the token is permanently rejected (FCM NotRegistered etc.).
+export const markDeviceTokenInvalid = async (
+  conn: DbConn,
+  tokenId: string,
+  reason: string
+): Promise<void> => {
+  await conn.query(
+    `
+    UPDATE device_tokens
+    SET status     = 'invalid',
+        device_info = jsonb_set(
+          COALESCE(device_info, '{}'::jsonb),
+          '{lastFailureReason}',
+          to_jsonb($2::text),
+          true
+        ),
+        updated_at = now()
+    WHERE token_id = $1
+    `,
+    [tokenId, reason]
+  );
+};

--- a/services/notifications/src/push/providers/console.ts
+++ b/services/notifications/src/push/providers/console.ts
@@ -1,0 +1,33 @@
+// ConsolePushProvider — dev-only default. Writes the would-be push
+// to the structured logger so developers can see what mobile / web
+// clients would have received. ADS-549-style guard lives in the
+// factory: production refuses 'console'.
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+import type { PushProvider, PushSendRequest, PushSendResult } from '../types.js';
+
+export type ConsolePushDeps = {
+  logger: ReturnType<typeof createLogger>;
+};
+
+const generateMessageId = (): string =>
+  `push_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+
+export const createConsolePushProvider = (deps: ConsolePushDeps): PushProvider => ({
+  async send(request: PushSendRequest): Promise<PushSendResult> {
+    const messageId = generateMessageId();
+    deps.logger.info('push.console.send', {
+      messageId,
+      platform: request.platform,
+      // Token preview only — never log the full token even in dev.
+      tokenPreview: `${request.token.slice(0, 10)}…`,
+      title: request.title,
+      body: request.body,
+      hasData: Boolean(request.data && Object.keys(request.data).length),
+    });
+    return { success: true, messageId };
+  },
+  getName: () => 'console',
+  validateConfiguration: () => true,
+});

--- a/services/notifications/src/push/providers/factory.ts
+++ b/services/notifications/src/push/providers/factory.ts
@@ -1,0 +1,26 @@
+// Push provider factory. Matches the email/factory shape — boot wires
+// the env-driven choice (console / fcm) and surfaces config errors as
+// fatal validation rather than silent fallback.
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+import type { PushProvider } from '../types.js';
+
+import { createConsolePushProvider } from './console.js';
+import { createFcmPushProvider, type FcmConfig } from './fcm.js';
+
+export type PushProviderConfig = { kind: 'console' } | { kind: 'fcm'; fcm: FcmConfig };
+
+export type ProviderFactoryDeps = {
+  config: PushProviderConfig;
+  logger: ReturnType<typeof createLogger>;
+};
+
+export const createPushProvider = (deps: ProviderFactoryDeps): PushProvider => {
+  switch (deps.config.kind) {
+    case 'console':
+      return createConsolePushProvider({ logger: deps.logger });
+    case 'fcm':
+      return createFcmPushProvider({ config: deps.config.fcm, logger: deps.logger });
+  }
+};

--- a/services/notifications/src/push/providers/fcm.ts
+++ b/services/notifications/src/push/providers/fcm.ts
@@ -1,0 +1,43 @@
+// FcmPushProvider — scaffold that mirrors the monolith's deferred
+// vendor wiring (service.backend/src/services/push-providers/fcm-provider.ts).
+// `firebase-admin` integration isn't in this repo yet; the provider
+// fails closed when selected so the boot path surfaces the misconfig
+// rather than silently swallowing pushes.
+//
+// When the vendor SDK is wired in, swap the body of `send()` for a
+// `messaging().send({...})` call and map the FCM error codes (`messaging/
+// registration-token-not-registered`, `messaging/invalid-registration-
+// token`) onto `tokenInvalid: true` so the worker marks the device_token
+// row `status='invalid'`.
+
+import type { createLogger } from '@adopt-dont-shop/observability';
+
+import type { PushProvider, PushSendRequest, PushSendResult } from '../types.js';
+
+export type FcmConfig = {
+  // GCP service-account JSON, supplied via FCM_SERVICE_ACCOUNT_JSON env.
+  serviceAccountJson: string;
+  // GCP project ID, supplied via FCM_PROJECT_ID env.
+  projectId: string;
+};
+
+export type FcmDeps = {
+  config: FcmConfig;
+  logger: ReturnType<typeof createLogger>;
+};
+
+export const createFcmPushProvider = (deps: FcmDeps): PushProvider => ({
+  async send(request: PushSendRequest): Promise<PushSendResult> {
+    deps.logger.error('push.fcm.not_implemented', {
+      tokenPreview: `${request.token.slice(0, 10)}…`,
+      title: request.title,
+    });
+    return {
+      success: false,
+      error: 'FCM provider not implemented — vendor wiring required',
+    };
+  },
+  getName: () => 'fcm',
+  validateConfiguration: () =>
+    Boolean(deps.config.serviceAccountJson) && Boolean(deps.config.projectId),
+});

--- a/services/notifications/src/push/types.ts
+++ b/services/notifications/src/push/types.ts
@@ -1,0 +1,32 @@
+// Push provider types. Mirrors the email module's shape: providers
+// depend on plain TS types, never on pg/Sequelize. The push worker
+// converts DB rows to PushSendRequest before invoking the provider.
+
+export type DevicePlatform = 'ios' | 'android' | 'web';
+export type DeviceTokenStatus = 'active' | 'inactive' | 'expired' | 'invalid';
+
+export type PushSendRequest = {
+  token: string;
+  platform: DevicePlatform;
+  title: string;
+  body: string;
+  // Opaque payload passed through to the device. For FCM this becomes
+  // `message.data`; for web-push it becomes JSON on the service worker.
+  data?: Record<string, unknown>;
+};
+
+export type PushSendResult = {
+  success: boolean;
+  messageId?: string;
+  error?: string;
+  // Set to true when the provider reports the token is permanently
+  // invalid (NotRegistered / InvalidArgument). The worker marks the
+  // device_token row `status='invalid'` so subsequent sends skip it.
+  tokenInvalid?: boolean;
+};
+
+export type PushProvider = {
+  send(request: PushSendRequest): Promise<PushSendResult>;
+  getName(): string;
+  validateConfiguration(): boolean;
+};

--- a/services/notifications/src/push/worker.ts
+++ b/services/notifications/src/push/worker.ts
@@ -1,0 +1,155 @@
+// Push worker. Listens for `notifications.created` on NATS; when the
+// notification's channel is PUSH, fan out to every active device_token
+// row for the recipient. Provider success → log + done. Provider
+// reports `tokenInvalid=true` → mark the row `status='invalid'` so
+// future fan-outs skip it.
+//
+// Unlike the email worker (poll-based on a queue table), push fan-out
+// is event-driven — the in-app notification row already serves as the
+// durable record; the push channel is purely a side-effect dispatch.
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { subscribe } from '@adopt-dont-shop/events';
+
+import { listDeviceTokensForUser, markDeviceTokenInvalid } from './device-tokens.js';
+import type { PushProvider, PushSendRequest } from './types.js';
+
+const QUEUE_GROUP = 'notifications-push-workers';
+
+export type PushWorkerEvent = {
+  notificationId: string;
+  userId: string;
+  type: string;
+  channel: string;
+  title?: string;
+  message?: string;
+  // JSON-stringified opaque data (mirrors the notifications.notifications
+  // `data` column the in-app create handler stores).
+  dataJson?: string;
+};
+
+export type PushWorkerOptions = {
+  pool: Pool;
+  nats: NatsConnection;
+  provider: PushProvider;
+  logger: Logger;
+};
+
+export type RunningPushWorker = {
+  // Closes the NATS subscription. The boot path drains the whole NATS
+  // connection on shutdown which handles this transitively, but
+  // returning a handle lets tests + the smoke script unwind cleanly.
+  stop: () => Promise<void>;
+};
+
+const dispatchOne = async (
+  request: PushSendRequest,
+  tokenId: string,
+  provider: PushProvider,
+  pool: Pool,
+  logger: Logger
+): Promise<void> => {
+  try {
+    const result = await provider.send(request);
+    if (result.success) {
+      logger.info('push.worker.sent', {
+        provider: provider.getName(),
+        tokenId,
+        messageId: result.messageId,
+      });
+      return;
+    }
+    logger.warn('push.worker.failed', {
+      provider: provider.getName(),
+      tokenId,
+      error: result.error,
+      tokenInvalid: result.tokenInvalid,
+    });
+    if (result.tokenInvalid) {
+      await markDeviceTokenInvalid(pool, tokenId, result.error ?? 'token reported invalid');
+    }
+  } catch (err) {
+    logger.error('push.worker.dispatch_error', {
+      provider: provider.getName(),
+      tokenId,
+      err,
+    });
+  }
+};
+
+export const startPushWorker = (opts: PushWorkerOptions): RunningPushWorker => {
+  const subscription = subscribe<PushWorkerEvent>(
+    opts.nats,
+    {
+      subject: 'notifications.created',
+      queue: QUEUE_GROUP,
+      onError: err => {
+        opts.logger.error('push.worker.subscriber_error', { err });
+      },
+    },
+    async ev => {
+      // Channel filter — only push-channel notifications fan out here.
+      // The createNotification handler publishes the lowercase Postgres
+      // value ('in_app' / 'email' / 'push' / 'sms'), not the proto enum.
+      if (ev.channel !== 'push') {
+        return;
+      }
+      if (!ev.userId) {
+        return;
+      }
+
+      const tokens = await listDeviceTokensForUser(opts.pool, ev.userId, false);
+      if (tokens.length === 0) {
+        opts.logger.info('push.worker.no_tokens', {
+          userId: ev.userId,
+          notificationId: ev.notificationId,
+        });
+        return;
+      }
+
+      let parsedData: Record<string, unknown> | undefined;
+      if (ev.dataJson) {
+        try {
+          const obj = JSON.parse(ev.dataJson) as unknown;
+          if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+            parsedData = obj as Record<string, unknown>;
+          }
+        } catch {
+          // Bad payload — skip data, still send the push.
+        }
+      }
+
+      await Promise.all(
+        tokens.map(token =>
+          dispatchOne(
+            {
+              token: token.device_token,
+              platform: token.platform,
+              title: ev.title ?? "Adopt Don't Shop",
+              body: ev.message ?? '',
+              data: { ...parsedData, notificationId: ev.notificationId },
+            },
+            token.token_id,
+            opts.provider,
+            opts.pool,
+            opts.logger
+          )
+        )
+      );
+    }
+  );
+
+  opts.logger.info('push worker started', {
+    provider: opts.provider.getName(),
+    subject: 'notifications.created',
+  });
+
+  return {
+    stop: async () => {
+      await subscription.drain().catch(() => undefined);
+    },
+  };
+};

--- a/services/notifications/src/scheduler/jobs/weekly-digest.test.ts
+++ b/services/notifications/src/scheduler/jobs/weekly-digest.test.ts
@@ -1,0 +1,84 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+import { describe, expect, it, vi } from 'vitest';
+
+import { runWeeklyDigest } from './weekly-digest.js';
+
+const quietLogger = (): Logger =>
+  ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }) as unknown as Logger;
+
+const makeMocks = () => {
+  const scripts: Array<{ rows: unknown[] }> = [];
+  const pool = {
+    query: vi.fn(async () => scripts.shift() ?? { rows: [] }),
+  };
+  return {
+    pool: pool as unknown as Pool,
+    nats: {} as unknown as NatsConnection,
+    poolMock: pool,
+    scripts,
+  };
+};
+
+describe('runWeeklyDigest', () => {
+  it('returns zeros when no opted-in users are present', async () => {
+    const mocks = makeMocks();
+    const summary = await runWeeklyDigest({
+      deps: { pool: mocks.pool, nats: mocks.nats },
+      logger: quietLogger(),
+    });
+    expect(summary).toEqual({ scanned: 0, scaffoldOnly: 0 });
+  });
+
+  it('walks the opted-in cohort, running the scaffold for each', async () => {
+    const mocks = makeMocks();
+    mocks.scripts.push({
+      rows: [{ user_id: 'usr-a' }, { user_id: 'usr-b' }, { user_id: 'usr-c' }],
+    });
+    const logger = quietLogger();
+    const summary = await runWeeklyDigest({
+      deps: { pool: mocks.pool, nats: mocks.nats },
+      logger,
+    });
+    expect(summary).toEqual({ scanned: 3, scaffoldOnly: 3 });
+    expect(logger.info).toHaveBeenCalledWith(
+      'scheduler.weekly_digest.scaffold',
+      expect.objectContaining({ userId: 'usr-a' })
+    );
+  });
+
+  it('continues past a per-user failure', async () => {
+    // Reach into runDigestForUser? It's not exported; instead we
+    // simulate failure by spying on logger.info — the scaffold logs
+    // there, so to test the catch path we'd need to inject a failing
+    // dependency. The current scaffold has no such dep, so we just
+    // assert the loop completes when the pool query throws on the
+    // second batch.
+    const mocks = makeMocks();
+    mocks.scripts.push({
+      rows: Array.from({ length: 500 }, (_, i) => ({ user_id: `usr-${i}` })),
+    });
+    mocks.poolMock.query.mockImplementationOnce(async () => mocks.scripts.shift() ?? { rows: [] });
+    mocks.poolMock.query.mockImplementationOnce(async () => {
+      throw new Error('db down');
+    });
+
+    const logger = quietLogger();
+    await expect(
+      runWeeklyDigest({
+        deps: { pool: mocks.pool, nats: mocks.nats },
+        logger,
+      })
+    ).rejects.toThrow(/db down/);
+    expect(logger.info).toHaveBeenCalledWith(
+      'scheduler.weekly_digest.scaffold',
+      expect.any(Object)
+    );
+  });
+});

--- a/services/notifications/src/scheduler/jobs/weekly-digest.ts
+++ b/services/notifications/src/scheduler/jobs/weekly-digest.ts
@@ -1,0 +1,116 @@
+// Weekly digest scheduled job.
+//
+// Ports service.backend/src/services/weekly-digest.service.ts, but the
+// data-source reads are split across services in the new architecture:
+//
+//   - "new matches near you" candidate list lives in services/pets
+//     (PetService.List + a future PetService.Recommend RPC)
+//   - "still waiting on your shortlist" reads UserFavorite from
+//     services/pets and excludes applied pets from services/applications
+//   - the active-user cohort lives in services/auth
+//
+// Cross-schema SELECTs are forbidden by the schema-per-service rule,
+// so this job's "real" implementation depends on three currently-
+// unwired gRPC calls. The version landed here is a SCAFFOLD: it walks
+// the email_preferences rows for users opted in to weekly digests and
+// logs a "would-build" line per candidate. When the upstream RPCs ship
+// (pets.ListFavorites, applications.ListByUser, auth.ListActiveUsers)
+// the body of `runDigestForUser` swaps in the real fan-out.
+//
+// Cadence: once per 7 days. Configured in the scheduler caller, not
+// here, so the smoke can dial it down to seconds for testing.
+
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+
+export type WeeklyDigestDeps = WithTransactionDeps;
+
+export type RunWeeklyDigestOptions = {
+  deps: WeeklyDigestDeps;
+  logger: Logger;
+  // Override the default principal used by the underlying
+  // notification-create path. Same shape the NATS subscribers use.
+  principal?: Principal;
+};
+
+// Page through opted-in users in bounded batches — the cohort grows
+// unbounded as the platform scales, so a single SELECT eventually
+// exhausts Node's heap (CAD lesson preserved from monolith).
+const BATCH_SIZE = 500;
+
+export type WeeklyDigestRunSummary = {
+  scanned: number;
+  scaffoldOnly: number;
+};
+
+type UserPrefsRow = {
+  user_id: string;
+};
+
+const fetchOptedInBatch = async (pool: Pool, offset: number): Promise<UserPrefsRow[]> => {
+  // Targets users with the email channel open AND the digest cadence
+  // explicitly set to weekly. is_blacklisted and global_unsubscribe
+  // are both respected.
+  const res = await pool.query<UserPrefsRow>(
+    `
+    SELECT user_id
+    FROM email_preferences
+    WHERE is_email_enabled = true
+      AND global_unsubscribe = false
+      AND is_blacklisted = false
+      AND digest_frequency = 'weekly'
+    ORDER BY user_id ASC
+    LIMIT $1 OFFSET $2
+    `,
+    [BATCH_SIZE, offset]
+  );
+  return res.rows;
+};
+
+const runDigestForUser = async (userId: string, logger: Logger): Promise<void> => {
+  // SCAFFOLD: the candidate fan-out (pets.recommend / pets.favorites /
+  // applications.listByUser) isn't wired yet. The full implementation
+  // mirrors the monolith's `buildDigestPayload` + `formatDigestMessage`
+  // + `NotificationService.createNotification` chain; for now we log
+  // the intent so the schedule + opt-in lookup itself is exercisable
+  // end-to-end without depending on unfinished services.
+  logger.info('scheduler.weekly_digest.scaffold', {
+    userId,
+    todo: 'fan-out via pets/applications gRPC once those RPCs ship',
+  });
+};
+
+export const runWeeklyDigest = async (
+  opts: RunWeeklyDigestOptions
+): Promise<WeeklyDigestRunSummary> => {
+  let scanned = 0;
+  let scaffoldOnly = 0;
+  let offset = 0;
+
+  for (;;) {
+    const rows = await fetchOptedInBatch(opts.deps.pool, offset);
+    for (const row of rows) {
+      scanned += 1;
+      try {
+        await runDigestForUser(row.user_id, opts.logger);
+        scaffoldOnly += 1;
+      } catch (err) {
+        opts.logger.warn('scheduler.weekly_digest.user_failed', {
+          userId: row.user_id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    if (rows.length < BATCH_SIZE) {
+      break;
+    }
+    offset += BATCH_SIZE;
+  }
+
+  opts.logger.info('scheduler.weekly_digest.done', { scanned, scaffoldOnly });
+  return { scanned, scaffoldOnly };
+};

--- a/services/notifications/src/scheduler/scheduler.test.ts
+++ b/services/notifications/src/scheduler/scheduler.test.ts
@@ -1,0 +1,128 @@
+import type { Logger } from 'winston';
+import { describe, expect, it, vi } from 'vitest';
+
+import { startScheduler, type ScheduledJob } from './scheduler.js';
+
+const quietLogger = (): Logger =>
+  ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }) as unknown as Logger;
+
+describe('scheduler', () => {
+  it('does not fire a job that is not yet due', async () => {
+    const runs: string[] = [];
+    const jobs: ScheduledJob[] = [
+      {
+        name: 'weekly',
+        intervalMs: 7 * 24 * 60 * 60 * 1000,
+        run: async () => {
+          runs.push('weekly');
+        },
+      },
+    ];
+    const now = 1_000_000;
+    const scheduler = startScheduler(jobs, {
+      logger: quietLogger(),
+      tickIntervalMs: 60_000,
+      now: () => now,
+    });
+    try {
+      const fired = await scheduler.tick();
+      expect(fired).toEqual([]);
+      expect(runs).toEqual([]);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+
+  it('runs a job with runOnStart=true on the next tick', async () => {
+    const runs: string[] = [];
+    const jobs: ScheduledJob[] = [
+      {
+        name: 'digest',
+        intervalMs: 60_000,
+        runOnStart: true,
+        run: async () => {
+          runs.push('digest');
+        },
+      },
+    ];
+    const scheduler = startScheduler(jobs, {
+      logger: quietLogger(),
+      tickIntervalMs: 60_000,
+      now: () => 1_000_000,
+    });
+    try {
+      const fired = await scheduler.tick();
+      expect(fired).toEqual(['digest']);
+      expect(runs).toEqual(['digest']);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+
+  it('catches errors from a job and continues scheduling', async () => {
+    const logger = quietLogger();
+    const jobs: ScheduledJob[] = [
+      {
+        name: 'flaky',
+        intervalMs: 60_000,
+        runOnStart: true,
+        run: async () => {
+          throw new Error('boom');
+        },
+      },
+    ];
+    const scheduler = startScheduler(jobs, {
+      logger,
+      tickIntervalMs: 60_000,
+      now: () => 1_000_000,
+    });
+    try {
+      await scheduler.tick();
+      expect(logger.error).toHaveBeenCalledWith(
+        'scheduler.job_failed',
+        expect.objectContaining({ name: 'flaky', err: 'boom' })
+      );
+    } finally {
+      await scheduler.stop();
+    }
+  });
+
+  it('refires a due job on a subsequent tick once interval has elapsed', async () => {
+    const runs: number[] = [];
+    let now = 1_000_000;
+    const jobs: ScheduledJob[] = [
+      {
+        name: 'hourly',
+        intervalMs: 3600_000,
+        runOnStart: true,
+        run: async () => {
+          runs.push(now);
+        },
+      },
+    ];
+    const scheduler = startScheduler(jobs, {
+      logger: quietLogger(),
+      tickIntervalMs: 60_000,
+      now: () => now,
+    });
+    try {
+      await scheduler.tick();
+      // Advance 30 minutes — still not due.
+      now += 30 * 60_000;
+      const midRun = await scheduler.tick();
+      expect(midRun).toEqual([]);
+      // Advance past the hour boundary — now due.
+      now += 31 * 60_000;
+      const lateRun = await scheduler.tick();
+      expect(lateRun).toEqual(['hourly']);
+      expect(runs.length).toBe(2);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});

--- a/services/notifications/src/scheduler/scheduler.ts
+++ b/services/notifications/src/scheduler/scheduler.ts
@@ -1,0 +1,128 @@
+// Tick-based scheduler for periodic notifications jobs. Each job is
+// registered with an interval; the scheduler walks the registered jobs
+// every tick and runs any whose `nextRunAt` has passed.
+//
+// Why not node-cron / agenda? Both pull in a heavy dep for the one
+// scheduled task this service currently runs (the weekly digest). The
+// tick loop matches the CAD-style "minimal external surface" approach
+// and is trivial to test with a mocked clock.
+//
+// Replicas + locking: this implementation does NOT lock across
+// instances yet. The first follow-up before running multiple replicas
+// is to swap the in-memory `nextRunAt` for a row in a `scheduled_jobs`
+// table that's claimed with FOR UPDATE SKIP LOCKED (same pattern as
+// the email queue worker).
+
+import type { Logger } from 'winston';
+
+export type ScheduledJob = {
+  name: string;
+  // Period between runs in milliseconds. The scheduler's tick interval
+  // bounds the precision — a 1 hour job with a 60s tick may run up to
+  // 60s late, which is fine for digest-style cadence.
+  intervalMs: number;
+  // Run on the next tick after construction (true) or wait
+  // intervalMs first (false, the default — avoids a thundering herd
+  // when the service boots).
+  runOnStart?: boolean;
+  // The async body. Errors are caught + logged; the next run schedules
+  // normally (one bad week shouldn't stop the digest forever).
+  run: () => Promise<void>;
+};
+
+export type SchedulerOptions = {
+  logger: Logger;
+  // Tick frequency in ms. Default 60s — short enough that jobs run
+  // close to their nominal cadence, long enough that idle CPU is
+  // negligible. Tests pass a smaller value.
+  tickIntervalMs?: number;
+  // Now provider — injectable so tests can advance time deterministically.
+  now?: () => number;
+};
+
+export type RunningScheduler = {
+  stop: () => Promise<void>;
+  // Exposed for tests + the smoke script — runs one tick synchronously
+  // and returns the names of jobs that fired.
+  tick: () => Promise<string[]>;
+};
+
+const DEFAULT_TICK_MS = 60_000;
+
+export const startScheduler = (jobs: ScheduledJob[], opts: SchedulerOptions): RunningScheduler => {
+  const tickIntervalMs = opts.tickIntervalMs ?? DEFAULT_TICK_MS;
+  const now = opts.now ?? Date.now;
+  let running = true;
+  let timer: NodeJS.Timeout | undefined;
+  let inflight = Promise.resolve();
+
+  // nextRunAt per job. runOnStart=true → fire next tick.
+  const nextRunAt = new Map<string, number>();
+  for (const job of jobs) {
+    nextRunAt.set(job.name, job.runOnStart ? 0 : now() + job.intervalMs);
+  }
+
+  const tick = async (): Promise<string[]> => {
+    if (!running) {
+      return [];
+    }
+    const ts = now();
+    const fired: string[] = [];
+    for (const job of jobs) {
+      const due = nextRunAt.get(job.name) ?? 0;
+      if (due > ts) {
+        continue;
+      }
+      fired.push(job.name);
+      // Schedule the next run BEFORE awaiting — a slow job can take longer
+      // than intervalMs, in which case the next tick still finds it due
+      // (intentional — caller may want overlapping runs blocked, but the
+      // current implementation simply re-runs as soon as the previous
+      // finishes).
+      nextRunAt.set(job.name, ts + job.intervalMs);
+      try {
+        await job.run();
+        opts.logger.info('scheduler.job_ok', { name: job.name });
+      } catch (err) {
+        opts.logger.error('scheduler.job_failed', {
+          name: job.name,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return fired;
+  };
+
+  const schedule = (): void => {
+    if (!running) {
+      return;
+    }
+    timer = setTimeout(() => {
+      inflight = tick()
+        .catch(err => {
+          opts.logger.error('scheduler.tick_error', { err });
+          return [] as string[];
+        })
+        .finally(() => {
+          schedule();
+        }) as unknown as Promise<void>;
+    }, tickIntervalMs);
+  };
+
+  schedule();
+  opts.logger.info('scheduler started', {
+    jobs: jobs.map(j => ({ name: j.name, intervalMs: j.intervalMs })),
+    tickIntervalMs,
+  });
+
+  return {
+    tick,
+    stop: async () => {
+      running = false;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      await inflight.catch(() => undefined);
+    },
+  };
+};


### PR DESCRIPTION
## Summary

Full Phase 7 round-out for the notifications service. Three commits on this branch each address one of the deliverables called out in the migration plan:

| Commit | Scope |
|---|---|
| **7.1** `email queue + provider abstraction` | `email_queue` / `email_templates` / `email_preferences` schemas, console / ethereal / Resend providers, `SendEmail` + `GetEmailPreferences` + `UpdateEmailPreferences` RPCs, polling worker with `FOR UPDATE SKIP LOCKED` |
| **7.2** `device tokens + push providers` | `RegisterDeviceToken` / `UnregisterDeviceToken` / `ListDeviceTokens` RPCs, console + FCM scaffold providers, event-driven push worker on `notifications.created` |
| **7.3** `scheduler + weekly digest scaffold` | Tick-based job scheduler and the weekly digest scaffold (walks opted-in users in `email_preferences`; full candidate fan-out deferred until pets/applications gRPC surfaces ship) |

Monolith email + push + digest stay in `service.backend` until cutover — per the no-delete-until-parity rule. Cutover (replacing monolith callers with gRPC `SendEmail` etc.) happens in a follow-up PR once this lands.

## Highlights

- **ADS-549 preserved** — production refuses `EMAIL_PROVIDER='console'` and `PUSH_PROVIDER='console'`. Unconfigured Resend / FCM surfaces as a fatal validation error at boot.
- **Schema-per-service rule honoured** — no cross-schema FKs, no cross-schema joins. The digest job's deferred cross-service reads are explicitly stubbed with a TODO referencing the missing gRPC surfaces.
- **Publish-after-commit** — `SendEmail` publishes `notifications.email.queued` only after the email_queue row commits, same `withTransaction` pattern the create-notification handler uses.
- **Multi-instance safety** — email worker uses `FOR UPDATE SKIP LOCKED`; push worker joins the `notifications-push-workers` queue group for NATS load-balancing.

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/service.notifications` — 126/126
- [x] `npx turbo type-check --filter=@adopt-dont-shop/service.notifications`
- [x] `npx turbo lint --filter=@adopt-dont-shop/service.notifications`
- [ ] Cold Docker stack with the new migrations applied — deferred to the cutover PR

## Deferred (follow-on PRs)

- Webhook receivers — Resend status events with idempotency
- Gateway routes for the user-facing email-prefs / device-tokens / notifications surface
- FCM wiring (`firebase-admin` SDK)
- Weekly digest's pets / applications / auth gRPC fan-out
- Cutover: replace monolith email / push / digest callers with the new gRPC RPCs

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP