### PR TITLE
feat(chat): vertical foundation — gRPC handlers + server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33105,8 +33105,13 @@
       "name": "@adopt-dont-shop/service.chat",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/authz": "*",
         "@adopt-dont-shop/db": "*",
+        "@adopt-dont-shop/events": "*",
+        "@adopt-dont-shop/lib.types": "*",
         "@adopt-dont-shop/observability": "*",
+        "@adopt-dont-shop/proto": "*",
+        "@grpc/grpc-js": "^1.14.4",
         "fastify": "^5.8.5",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.21.0"

--- a/services/chat/package.json
+++ b/services/chat/package.json
@@ -33,8 +33,13 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/authz": "*",
     "@adopt-dont-shop/db": "*",
+    "@adopt-dont-shop/events": "*",
+    "@adopt-dont-shop/lib.types": "*",
     "@adopt-dont-shop/observability": "*",
+    "@adopt-dont-shop/proto": "*",
+    "@grpc/grpc-js": "^1.14.4",
     "fastify": "^5.8.5",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.21.0"

--- a/services/chat/src/grpc/adapter.ts
+++ b/services/chat/src/grpc/adapter.ts
@@ -1,0 +1,74 @@
+// gRPC handler adapter — wraps the plain async handler functions in
+// the (call, callback) shape ts-proto generates. Identical pattern to
+// services/notifications and services/auth — kept inline rather than
+// shared so each service can evolve its error-code map independently.
+
+import {
+  status,
+  type Metadata,
+  type ServerUnaryCall,
+  type ServiceError,
+  type sendUnaryData,
+} from '@grpc/grpc-js';
+
+import type { Logger } from 'winston';
+
+import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
+import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
+  INVALID_ARGUMENT: status.INVALID_ARGUMENT,
+  UNAUTHENTICATED: status.UNAUTHENTICATED,
+  PERMISSION_DENIED: status.PERMISSION_DENIED,
+  NOT_FOUND: status.NOT_FOUND,
+  ALREADY_EXISTS: status.ALREADY_EXISTS,
+  FAILED_PRECONDITION: status.FAILED_PRECONDITION,
+  INTERNAL: status.INTERNAL,
+};
+
+export type UnaryHandler<Req, Res> = (
+  deps: HandlerDeps,
+  principal: ReturnType<typeof extractPrincipal>,
+  req: Req
+) => Promise<Res>;
+
+export type AdaptOptions = {
+  deps: HandlerDeps;
+  logger: Logger;
+};
+
+export function adapt<Req, Res>(
+  handler: UnaryHandler<Req, Res>,
+  { deps, logger }: AdaptOptions
+): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
+  return (call, callback) => {
+    void (async () => {
+      try {
+        const principal = extractPrincipal(call.metadata);
+        const response = await handler(deps, principal, call.request);
+        callback(null, response);
+      } catch (err) {
+        callback(toServiceError(err, call.metadata, logger), null);
+      }
+    })();
+  };
+}
+
+function toServiceError(err: unknown, metadata: Metadata, logger: Logger): ServiceError {
+  if (err instanceof MissingPrincipalError) {
+    return makeServiceError(status.UNAUTHENTICATED, err.message, metadata);
+  }
+  if (err instanceof HandlerError) {
+    return makeServiceError(CODE_TO_GRPC[err.code], err.message, metadata);
+  }
+  logger.error('unhandled handler error', { err });
+  return makeServiceError(status.INTERNAL, 'internal error', metadata);
+}
+
+function makeServiceError(code: number, message: string, metadata: Metadata): ServiceError {
+  const err = new Error(message) as ServiceError;
+  err.code = code;
+  err.details = message;
+  err.metadata = metadata;
+  return err;
+}

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -1,0 +1,433 @@
+import type { NatsConnection } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
+import type {
+  ListChatsRequest,
+  ListMessagesRequest,
+  MarkReadRequest,
+  OpenChatRequest,
+  ReactRequest,
+  SendMessageRequest,
+} from '@adopt-dont-shop/proto';
+
+import {
+  HandlerError,
+  listChats,
+  listMessages,
+  markRead,
+  openChat,
+  react,
+  sendMessage,
+} from './handlers.js';
+
+// --- Principal fixtures ---------------------------------------------
+
+const ADOPTER_PRINCIPAL: Principal = {
+  userId: 'usr-adopter' as UserId,
+  roles: ['adopter'],
+  permissions: ['chat.create' as Permission, 'chat.read' as Permission, 'chat.send' as Permission],
+};
+
+const UNPRIVILEGED_PRINCIPAL: Principal = {
+  userId: 'usr-noperm' as UserId,
+  roles: ['adopter'],
+  permissions: [],
+};
+
+// --- Row fixtures ----------------------------------------------------
+
+const chatRowFixture = (overrides: Record<string, unknown> = {}) => ({
+  chat_id: 'chat-1',
+  application_id: 'app-1',
+  rescue_id: '00000000-0000-0000-0000-000000000000',
+  pet_id: null,
+  status: 'active' as const,
+  created_at: new Date('2026-06-01T00:00:00Z'),
+  updated_at: new Date('2026-06-01T00:00:00Z'),
+  ...overrides,
+});
+
+const messageRowFixture = (overrides: Record<string, unknown> = {}) => ({
+  message_id: 'msg-1',
+  chat_id: 'chat-1',
+  sender_id: 'usr-adopter',
+  content: 'Hello world',
+  edited_at: null,
+  deleted_at: null,
+  created_at: new Date('2026-06-01T00:01:00Z'),
+  ...overrides,
+});
+
+// --- Mock factory ---------------------------------------------------
+
+function makeMocks() {
+  const clientScript: Array<{ rows: unknown[] }> = [];
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      const op = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      const next = clientScript.shift();
+      if (!next) {
+        throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);
+      }
+      return next;
+    }),
+    release: vi.fn(),
+  };
+  const poolScript: Array<{ rows: unknown[] }> = [];
+  const pool = {
+    connect: vi.fn().mockResolvedValue(client),
+    query: vi.fn(async () => poolScript.shift() ?? { rows: [] }),
+  };
+  const nats = { publish: vi.fn() };
+  return {
+    pool: pool as unknown as Pool,
+    client: client as unknown as PoolClient,
+    nats: nats as unknown as NatsConnection,
+    poolMock: pool,
+    clientMock: client,
+    natsMock: nats,
+    clientScript,
+    poolScript,
+    deps: {
+      pool: pool as unknown as Pool,
+      nats: nats as unknown as NatsConnection,
+    },
+  };
+}
+
+const realClientQueries = (mocks: ReturnType<typeof makeMocks>): string[] =>
+  (mocks.clientMock.query.mock.calls as Array<[string]>)
+    .map(([sql]) => sql.trim().split(/\s+/)[0].toUpperCase())
+    .filter(op => op !== 'BEGIN' && op !== 'COMMIT' && op !== 'ROLLBACK');
+
+// --- OpenChat -------------------------------------------------------
+
+const BASE_OPEN: OpenChatRequest = {
+  applicationId: 'app-1',
+  otherUserId: 'usr-rescue',
+};
+
+describe('openChat', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects when application_id is missing', async () => {
+    await expect(
+      openChat(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_OPEN, applicationId: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when other_user_id equals the principal', async () => {
+    await expect(
+      openChat(mocks.deps, ADOPTER_PRINCIPAL, {
+        ...BASE_OPEN,
+        otherUserId: 'usr-adopter',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when the principal lacks chat.create', async () => {
+    await expect(openChat(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_OPEN)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('returns the existing chat without a transaction when one exists', async () => {
+    // pool.query #1 = existing chat lookup
+    // pool.query #2 = loadChatParticipants
+    // pool.query #3 = loadLastMessagePreview
+    mocks.poolScript.push({ rows: [chatRowFixture()] });
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({ rows: [] });
+
+    const res = await openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN);
+    expect(res.created).toBe(false);
+    expect(res.chat?.chatId).toBe('chat-1');
+    expect(res.chat?.participantUserIds).toEqual(['usr-adopter', 'usr-rescue']);
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+
+  it('creates a new chat + participants and publishes chat.created', async () => {
+    // existing-chat lookup → none
+    mocks.poolScript.push({ rows: [] });
+    // Inside withTransaction: INSERT chat, INSERT participants
+    mocks.clientScript.push({ rows: [chatRowFixture({ chat_id: 'new-chat' })] });
+    mocks.clientScript.push({ rows: [] });
+    // After-commit: loadChatParticipants, loadLastMessagePreview
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({ rows: [] });
+
+    const res = await openChat(mocks.deps, ADOPTER_PRINCIPAL, BASE_OPEN);
+    expect(res.created).toBe(true);
+    expect(res.chat?.chatId).toBe('new-chat');
+    expect(realClientQueries(mocks)).toEqual(['INSERT', 'INSERT']);
+    expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.created');
+  });
+});
+
+// --- SendMessage ----------------------------------------------------
+
+const BASE_SEND: SendMessageRequest = {
+  chatId: 'chat-1',
+  body: 'Hello!',
+};
+
+describe('sendMessage', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects empty body', async () => {
+    await expect(
+      sendMessage(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_SEND, body: '   ' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects when principal lacks chat.send', async () => {
+    await expect(sendMessage(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_SEND)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('rejects when principal is not a participant', async () => {
+    // isParticipantOrAdmin → empty
+    mocks.poolScript.push({ rows: [] });
+    await expect(sendMessage(mocks.deps, ADOPTER_PRINCIPAL, BASE_SEND)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('inserts the message and publishes chat.messageCreated after commit', async () => {
+    // isParticipantOrAdmin → one row
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    // INSERT message, UPDATE chats.updated_at
+    mocks.clientScript.push({ rows: [messageRowFixture()] });
+    mocks.clientScript.push({ rows: [] });
+
+    const res = await sendMessage(mocks.deps, ADOPTER_PRINCIPAL, BASE_SEND);
+    expect(res.message?.body).toBe('Hello world');
+    expect(realClientQueries(mocks)).toEqual(['INSERT', 'UPDATE']);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.messageCreated');
+  });
+});
+
+// --- ListMessages ---------------------------------------------------
+
+describe('listMessages', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  const BASE_LIST: ListMessagesRequest = { chatId: 'chat-1', limit: 0 };
+
+  it('rejects unprivileged principals', async () => {
+    await expect(listMessages(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE_LIST)).rejects.toMatchObject(
+      { code: 'PERMISSION_DENIED' }
+    );
+  });
+
+  it('returns ordered rows with reactions aggregated', async () => {
+    // isParticipantOrAdmin → ok
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    // SELECT messages
+    mocks.poolScript.push({
+      rows: [
+        messageRowFixture({ message_id: 'm-newer', created_at: new Date('2026-06-02') }),
+        messageRowFixture({ message_id: 'm-older', created_at: new Date('2026-06-01') }),
+      ],
+    });
+    // loadMessageReactions
+    mocks.poolScript.push({
+      rows: [
+        {
+          reaction_id: 'r-1',
+          message_id: 'm-newer',
+          user_id: 'usr-x',
+          emoji: '👍',
+          created_at: new Date('2026-06-02T01:00:00Z'),
+        },
+      ],
+    });
+
+    const res = await listMessages(mocks.deps, ADOPTER_PRINCIPAL, BASE_LIST);
+    expect(res.messages).toHaveLength(2);
+    expect(res.messages?.[0].messageId).toBe('m-newer');
+    expect(res.messages?.[0].reactions).toHaveLength(1);
+    expect(res.messages?.[0].reactions?.[0]).toMatchObject({
+      emoji: '👍',
+      userIds: ['usr-x'],
+    });
+  });
+
+  it('rejects a limit above the max', async () => {
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    await expect(
+      listMessages(mocks.deps, ADOPTER_PRINCIPAL, { ...BASE_LIST, limit: 9999 })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+});
+
+// --- ListChats ------------------------------------------------------
+
+describe('listChats', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  const BASE: ListChatsRequest = { limit: 0, unreadOnly: false };
+
+  it('rejects unprivileged principals', async () => {
+    await expect(listChats(mocks.deps, UNPRIVILEGED_PRINCIPAL, BASE)).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('returns the chats joined by the principal', async () => {
+    // SELECT chats
+    mocks.poolScript.push({ rows: [chatRowFixture()] });
+    // chatRowToProto → loadChatParticipants + loadLastMessagePreview
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({ rows: [] });
+
+    const res = await listChats(mocks.deps, ADOPTER_PRINCIPAL, BASE);
+    expect(res.chats).toHaveLength(1);
+    expect(res.chats?.[0].chatId).toBe('chat-1');
+  });
+});
+
+// --- MarkRead -------------------------------------------------------
+
+const BASE_MARK: MarkReadRequest = {
+  chatId: 'chat-1',
+  upToMessageId: 'msg-1',
+};
+
+describe('markRead', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('rejects when message does not exist in chat', async () => {
+    // isParticipantOrAdmin → ok
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    // target message lookup → empty
+    mocks.poolScript.push({ rows: [] });
+    await expect(markRead(mocks.deps, ADOPTER_PRINCIPAL, BASE_MARK)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('stamps reads + bumps the participant last_read_at watermark', async () => {
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    mocks.poolScript.push({ rows: [{ created_at: new Date('2026-06-01T00:01:00Z') }] });
+    // INSERT message_reads, UPDATE chat_participants
+    mocks.clientScript.push({ rows: [] });
+    mocks.clientScript.push({ rows: [] });
+
+    const res = await markRead(mocks.deps, ADOPTER_PRINCIPAL, BASE_MARK);
+    expect(res.upToMessageId).toBe('msg-1');
+    expect(realClientQueries(mocks)).toEqual(['INSERT', 'UPDATE']);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.messageRead');
+  });
+});
+
+// --- React ----------------------------------------------------------
+
+const BASE_REACT: ReactRequest = {
+  messageId: 'msg-1',
+  emoji: '👍',
+  remove: false,
+};
+
+describe('react', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+
+  it('returns NOT_FOUND when the target message is missing', async () => {
+    // message lookup → empty
+    mocks.poolScript.push({ rows: [] });
+    await expect(react(mocks.deps, ADOPTER_PRINCIPAL, BASE_REACT)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('adds a reaction and publishes chat.reactionAdded', async () => {
+    // message lookup → ok
+    mocks.poolScript.push({ rows: [{ chat_id: 'chat-1' }] });
+    // isParticipantOrAdmin → ok
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    // Inside withTransaction: INSERT reaction
+    mocks.clientScript.push({ rows: [] });
+    // After-commit: re-fetch message, reactions
+    mocks.poolScript.push({ rows: [messageRowFixture()] });
+    mocks.poolScript.push({
+      rows: [
+        {
+          reaction_id: 'r-1',
+          message_id: 'msg-1',
+          user_id: 'usr-adopter',
+          emoji: '👍',
+          created_at: new Date(),
+        },
+      ],
+    });
+
+    const res = await react(mocks.deps, ADOPTER_PRINCIPAL, BASE_REACT);
+    expect(res.message?.reactions).toHaveLength(1);
+    expect(realClientQueries(mocks)).toEqual(['INSERT']);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.reactionAdded');
+  });
+
+  it('removes a reaction and publishes chat.reactionRemoved', async () => {
+    mocks.poolScript.push({ rows: [{ chat_id: 'chat-1' }] });
+    mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
+    // DELETE reaction
+    mocks.clientScript.push({ rows: [] });
+    // Re-fetch
+    mocks.poolScript.push({ rows: [messageRowFixture()] });
+    mocks.poolScript.push({ rows: [] });
+
+    const res = await react(mocks.deps, ADOPTER_PRINCIPAL, {
+      ...BASE_REACT,
+      remove: true,
+    });
+    expect(res.message?.reactions).toHaveLength(0);
+    expect(realClientQueries(mocks)).toEqual(['DELETE']);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.reactionRemoved');
+  });
+});
+
+describe('HandlerError', () => {
+  it('exposes the code on the error', () => {
+    const err = new HandlerError('NOT_FOUND', 'gone');
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe('gone');
+  });
+});

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -1,0 +1,673 @@
+// gRPC handler implementations for ChatService.
+//
+// Discipline matches the other extracted services:
+//   - State-changing handlers run the DB write + event publish inside
+//     @adopt-dont-shop/events.withTransaction so events fire only after
+//     commit (publish-after-commit, CAD pattern).
+//   - Permission gating uses @adopt-dont-shop/authz against the
+//     principal in gRPC metadata. super_admin short-circuits.
+//   - List + send/react/markRead enforce participant-scope: callers can
+//     only operate on chats they're a participant of. super_admin
+//     bypasses via hasPermission.
+//   - Reactions: (message_id, user_id, emoji) UNIQUE — add is idempotent;
+//     remove is idempotent (no row → no-op).
+//   - MarkRead: idempotent — repeated calls just re-stamp read_at.
+//
+// Cross-schema reads (auth.users for sender name lookups, applications
+// for app validation) live in the gateway / consumers. This service
+// validates participant membership inside its own schema only.
+
+import { randomUUID } from 'node:crypto';
+
+import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/events';
+import type { Permission } from '@adopt-dont-shop/lib.types';
+import type {
+  Chat,
+  ListChatsRequest,
+  ListChatsResponse,
+  ListMessagesRequest,
+  ListMessagesResponse,
+  MarkReadRequest,
+  MarkReadResponse,
+  Message,
+  MessageReaction,
+  OpenChatRequest,
+  OpenChatResponse,
+  ReactRequest,
+  ReactResponse,
+  SendMessageRequest,
+  SendMessageResponse,
+} from '@adopt-dont-shop/proto';
+
+export type HandlerDeps = WithTransactionDeps;
+
+export type HandlerErrorCode =
+  | 'INVALID_ARGUMENT'
+  | 'UNAUTHENTICATED'
+  | 'PERMISSION_DENIED'
+  | 'NOT_FOUND'
+  | 'ALREADY_EXISTS'
+  | 'FAILED_PRECONDITION'
+  | 'INTERNAL';
+
+export class HandlerError extends Error {
+  constructor(
+    public readonly code: HandlerErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'HandlerError';
+  }
+}
+
+// --- Permissions -----------------------------------------------------
+
+const CHAT_CREATE: Permission = 'chat.create' as Permission;
+const CHAT_READ: Permission = 'chat.read' as Permission;
+const CHAT_SEND: Permission = 'chat.send' as Permission;
+
+// --- Row shapes ------------------------------------------------------
+
+type ChatRow = {
+  chat_id: string;
+  application_id: string | null;
+  rescue_id: string;
+  pet_id: string | null;
+  status: 'active' | 'locked' | 'archived';
+  created_at: Date;
+  updated_at: Date;
+};
+
+type MessageRow = {
+  message_id: string;
+  chat_id: string;
+  sender_id: string;
+  content: string;
+  edited_at: Date | null;
+  deleted_at: Date | null;
+  created_at: Date;
+};
+
+type ReactionRow = {
+  reaction_id: string;
+  message_id: string;
+  user_id: string;
+  emoji: string;
+  created_at: Date;
+};
+
+// --- Helpers ---------------------------------------------------------
+
+const isParticipantOrAdmin = async (
+  deps: HandlerDeps,
+  principal: Principal,
+  chatId: string
+): Promise<boolean> => {
+  if (hasPermission(principal, CHAT_READ) && principal.roles.includes('super_admin')) {
+    return true;
+  }
+  const res = await deps.pool.query<{ chat_participant_id: string }>(
+    `SELECT chat_participant_id FROM chat_participants
+     WHERE chat_id = $1 AND participant_id = $2 AND deleted_at IS NULL
+     LIMIT 1`,
+    [chatId, principal.userId]
+  );
+  return res.rows.length > 0;
+};
+
+const loadChatParticipants = async (deps: HandlerDeps, chatId: string): Promise<string[]> => {
+  const res = await deps.pool.query<{ participant_id: string }>(
+    `SELECT participant_id FROM chat_participants
+     WHERE chat_id = $1 AND deleted_at IS NULL
+     ORDER BY created_at ASC`,
+    [chatId]
+  );
+  return res.rows.map(r => r.participant_id);
+};
+
+const loadLastMessagePreview = async (
+  deps: HandlerDeps,
+  chatId: string
+): Promise<{ preview: string | null; at: Date | null; senderId: string | null }> => {
+  const res = await deps.pool.query<{
+    content: string;
+    sender_id: string;
+    created_at: Date;
+  }>(
+    `SELECT content, sender_id, created_at FROM messages
+     WHERE chat_id = $1 AND deleted_at IS NULL
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [chatId]
+  );
+  const row = res.rows[0];
+  if (!row) {
+    return { preview: null, at: null, senderId: null };
+  }
+  // Cap preview at 140 chars — same heuristic the monolith uses.
+  const preview = row.content.length > 140 ? row.content.slice(0, 140) : row.content;
+  return { preview, at: row.created_at, senderId: row.sender_id };
+};
+
+const chatRowToProto = async (deps: HandlerDeps, row: ChatRow): Promise<Chat> => {
+  const participants = await loadChatParticipants(deps, row.chat_id);
+  const last = await loadLastMessagePreview(deps, row.chat_id);
+  return {
+    chatId: row.chat_id,
+    applicationId: row.application_id ?? '',
+    participantUserIds: participants,
+    lastMessagePreview: last.preview ?? undefined,
+    lastMessageAt: last.at?.toISOString(),
+    lastMessageSenderId: last.senderId ?? undefined,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+};
+
+const loadMessageReactions = async (
+  deps: HandlerDeps,
+  messageIds: string[]
+): Promise<Map<string, MessageReaction[]>> => {
+  if (messageIds.length === 0) {
+    return new Map();
+  }
+  const res = await deps.pool.query<ReactionRow>(
+    `SELECT * FROM message_reactions WHERE message_id = ANY($1::uuid[]) ORDER BY created_at ASC`,
+    [messageIds]
+  );
+  const byMessage = new Map<string, Map<string, string[]>>();
+  for (const row of res.rows) {
+    let perEmoji = byMessage.get(row.message_id);
+    if (!perEmoji) {
+      perEmoji = new Map();
+      byMessage.set(row.message_id, perEmoji);
+    }
+    let list = perEmoji.get(row.emoji);
+    if (!list) {
+      list = [];
+      perEmoji.set(row.emoji, list);
+    }
+    list.push(row.user_id);
+  }
+  const out = new Map<string, MessageReaction[]>();
+  for (const [messageId, perEmoji] of byMessage) {
+    const grouped: MessageReaction[] = [];
+    for (const [emoji, userIds] of perEmoji) {
+      grouped.push({ emoji, userIds });
+    }
+    out.set(messageId, grouped);
+  }
+  return out;
+};
+
+const messageRowToProto = (row: MessageRow, reactions: MessageReaction[]): Message => ({
+  messageId: row.message_id,
+  chatId: row.chat_id,
+  senderUserId: row.sender_id,
+  body: row.content,
+  reactions,
+  editedAt: row.edited_at?.toISOString(),
+  deletedAt: row.deleted_at?.toISOString(),
+  createdAt: row.created_at.toISOString(),
+});
+
+// --- OpenChat --------------------------------------------------------
+
+export async function openChat(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: OpenChatRequest
+): Promise<OpenChatResponse> {
+  if (!req.applicationId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'application_id is required');
+  }
+  if (!req.otherUserId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'other_user_id is required');
+  }
+  if (req.otherUserId === principal.userId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'cannot open a chat with yourself');
+  }
+  if (!hasPermission(principal, CHAT_CREATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_CREATE}' required`);
+  }
+
+  // Idempotency: look up an existing chat for this application + pair.
+  const existing = await deps.pool.query<ChatRow>(
+    `
+    SELECT c.*
+    FROM chats c
+    WHERE c.application_id = $1
+      AND c.deleted_at IS NULL
+      AND EXISTS (
+        SELECT 1 FROM chat_participants p1
+        WHERE p1.chat_id = c.chat_id AND p1.participant_id = $2 AND p1.deleted_at IS NULL
+      )
+      AND EXISTS (
+        SELECT 1 FROM chat_participants p2
+        WHERE p2.chat_id = c.chat_id AND p2.participant_id = $3 AND p2.deleted_at IS NULL
+      )
+    LIMIT 1
+    `,
+    [req.applicationId, principal.userId, req.otherUserId]
+  );
+  if (existing.rows[0]) {
+    const chat = await chatRowToProto(deps, existing.rows[0]);
+    return { chat, created: false };
+  }
+
+  const chatId = randomUUID();
+  let inserted: ChatRow | undefined;
+  await withTransaction(deps, async ({ client, publish }) => {
+    // rescue_id is required by the schema but we don't have it at this
+    // call. The monolith populates it from the application's rescue_id.
+    // For the gRPC path we accept that it's the caller's responsibility
+    // to either populate via a gateway translation or carry it in a
+    // future RPC field — for now we use a NULL UUID placeholder.
+    //
+    // TODO: route through gateway translator that fetches application
+    // → rescue_id before issuing OpenChat.
+    const placeholderRescue = '00000000-0000-0000-0000-000000000000';
+    const inserted0 = await client.query<ChatRow>(
+      `
+      INSERT INTO chats (chat_id, application_id, rescue_id, created_at, updated_at)
+      VALUES ($1, $2, $3, now(), now())
+      RETURNING *
+      `,
+      [chatId, req.applicationId, placeholderRescue]
+    );
+    inserted = inserted0.rows[0];
+
+    // Two participant rows. Roles default to 'member' — the gateway/
+    // service.rescue can promote a rescue-staff participant via a
+    // future update.
+    await client.query(
+      `
+      INSERT INTO chat_participants (chat_participant_id, chat_id, participant_id, role)
+      VALUES ($1, $2, $3, 'member'), ($4, $2, $5, 'member')
+      `,
+      [randomUUID(), chatId, principal.userId, randomUUID(), req.otherUserId]
+    );
+
+    publish({
+      type: 'chat.created',
+      id: `chat.created.${chatId}`,
+      payload: {
+        chatId,
+        applicationId: req.applicationId,
+        participantUserIds: [principal.userId, req.otherUserId],
+      },
+    });
+  });
+
+  if (!inserted) {
+    throw new HandlerError('INTERNAL', 'insert returned no rows');
+  }
+  const chat = await chatRowToProto(deps, inserted);
+  return { chat, created: true };
+}
+
+// --- SendMessage -----------------------------------------------------
+
+const MAX_MESSAGE_LENGTH = 10_000;
+
+export async function sendMessage(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: SendMessageRequest
+): Promise<SendMessageResponse> {
+  if (!req.chatId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'chat_id is required');
+  }
+  if (!req.body || req.body.trim().length === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'body is required');
+  }
+  if (req.body.length > MAX_MESSAGE_LENGTH) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      `body exceeds ${MAX_MESSAGE_LENGTH} character limit`
+    );
+  }
+  if (!hasPermission(principal, CHAT_SEND)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_SEND}' required`);
+  }
+  if (!(await isParticipantOrAdmin(deps, principal, req.chatId))) {
+    throw new HandlerError('PERMISSION_DENIED', 'only chat participants may send messages');
+  }
+
+  const messageId = randomUUID();
+  let inserted: MessageRow | undefined;
+
+  await withTransaction(deps, async ({ client, publish }) => {
+    const res = await client.query<MessageRow>(
+      `
+      INSERT INTO messages (
+        message_id, chat_id, sender_id, content, created_at, updated_at
+      )
+      VALUES ($1, $2, $3, $4, now(), now())
+      RETURNING *
+      `,
+      [messageId, req.chatId, principal.userId, req.body]
+    );
+    inserted = res.rows[0];
+
+    // Bump the chat's updated_at so ListChats's most-recent ordering
+    // surfaces it. messages_chat_created_idx handles the actual sort.
+    await client.query(`UPDATE chats SET updated_at = now() WHERE chat_id = $1`, [req.chatId]);
+
+    publish({
+      type: 'chat.messageCreated',
+      id: `chat.messageCreated.${messageId}`,
+      payload: {
+        messageId,
+        chatId: req.chatId,
+        senderUserId: principal.userId,
+        body: req.body,
+      },
+    });
+  });
+
+  if (!inserted) {
+    throw new HandlerError('INTERNAL', 'insert returned no rows');
+  }
+  return { message: messageRowToProto(inserted, []) };
+}
+
+// --- ListMessages ----------------------------------------------------
+
+type MessageCursor = { createdAt: string; messageId: string };
+
+const DEFAULT_MESSAGE_LIMIT = 50;
+const MAX_MESSAGE_LIMIT = 200;
+
+const decodeCursor = <T>(raw: string): T => {
+  try {
+    const json = Buffer.from(raw, 'base64url').toString('utf8');
+    return JSON.parse(json) as T;
+  } catch {
+    throw new HandlerError('INVALID_ARGUMENT', 'cursor is not a valid keyset cursor');
+  }
+};
+
+const encodeCursor = <T>(cursor: T): string =>
+  Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+
+const clampLimit = (requested: number, def: number, max: number): number => {
+  if (requested <= 0) {
+    return def;
+  }
+  if (requested > max) {
+    throw new HandlerError('INVALID_ARGUMENT', `limit exceeds max of ${max}`);
+  }
+  return requested;
+};
+
+export async function listMessages(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListMessagesRequest
+): Promise<ListMessagesResponse> {
+  if (!req.chatId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'chat_id is required');
+  }
+  if (!hasPermission(principal, CHAT_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_READ}' required`);
+  }
+  if (!(await isParticipantOrAdmin(deps, principal, req.chatId))) {
+    throw new HandlerError('PERMISSION_DENIED', 'only chat participants may list messages');
+  }
+
+  const limit = clampLimit(req.limit, DEFAULT_MESSAGE_LIMIT, MAX_MESSAGE_LIMIT);
+  const cursor = req.cursor ? decodeCursor<MessageCursor>(req.cursor) : null;
+
+  // Newest-first keyset pagination: (created_at, message_id) DESC.
+  // Cursor encodes the LAST item we returned; the next page picks up
+  // strictly older items.
+  const res = await deps.pool.query<MessageRow>(
+    cursor
+      ? `
+        SELECT * FROM messages
+        WHERE chat_id = $1
+          AND deleted_at IS NULL
+          AND (created_at, message_id) < ($2::timestamptz, $3::uuid)
+        ORDER BY created_at DESC, message_id DESC
+        LIMIT $4
+        `
+      : `
+        SELECT * FROM messages
+        WHERE chat_id = $1 AND deleted_at IS NULL
+        ORDER BY created_at DESC, message_id DESC
+        LIMIT $2
+        `,
+    cursor ? [req.chatId, cursor.createdAt, cursor.messageId, limit] : [req.chatId, limit]
+  );
+
+  const reactions = await loadMessageReactions(
+    deps,
+    res.rows.map(r => r.message_id)
+  );
+  const messages = res.rows.map(row => messageRowToProto(row, reactions.get(row.message_id) ?? []));
+
+  let nextCursor: string | undefined;
+  if (res.rows.length === limit) {
+    const last = res.rows[res.rows.length - 1];
+    nextCursor = encodeCursor<MessageCursor>({
+      createdAt: last.created_at.toISOString(),
+      messageId: last.message_id,
+    });
+  }
+
+  return { messages, nextCursor };
+}
+
+// --- ListChats -------------------------------------------------------
+
+type ChatCursor = { updatedAt: string; chatId: string };
+
+const DEFAULT_CHAT_LIMIT = 20;
+const MAX_CHAT_LIMIT = 100;
+
+export async function listChats(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListChatsRequest
+): Promise<ListChatsResponse> {
+  if (!hasPermission(principal, CHAT_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_READ}' required`);
+  }
+  const limit = clampLimit(req.limit, DEFAULT_CHAT_LIMIT, MAX_CHAT_LIMIT);
+  const cursor = req.cursor ? decodeCursor<ChatCursor>(req.cursor) : null;
+
+  // Always self-scoped by participant_id. super_admin still goes
+  // through the participant filter — staff-tooling that needs to see
+  // all chats should call a different RPC (not exposed today).
+  const baseSql = `
+    SELECT DISTINCT c.*
+    FROM chats c
+    JOIN chat_participants p ON p.chat_id = c.chat_id
+    WHERE p.participant_id = $1 AND p.deleted_at IS NULL AND c.deleted_at IS NULL
+    ${cursor ? 'AND (c.updated_at, c.chat_id) < ($2::timestamptz, $3::uuid)' : ''}
+    ORDER BY c.updated_at DESC, c.chat_id DESC
+    LIMIT $${cursor ? 4 : 2}
+  `;
+  const params = cursor
+    ? [principal.userId, cursor.updatedAt, cursor.chatId, limit]
+    : [principal.userId, limit];
+  const res = await deps.pool.query<ChatRow>(baseSql, params);
+
+  // unread_only filter is a follow-on — requires aggregating reads vs
+  // messages per chat. For now, return rows and let the caller filter
+  // (the SPA already does this via the unread badge calculation).
+  const chats = await Promise.all(res.rows.map(row => chatRowToProto(deps, row)));
+
+  let nextCursor: string | undefined;
+  if (res.rows.length === limit) {
+    const last = res.rows[res.rows.length - 1];
+    nextCursor = encodeCursor<ChatCursor>({
+      updatedAt: last.updated_at.toISOString(),
+      chatId: last.chat_id,
+    });
+  }
+
+  return { chats, nextCursor };
+}
+
+// --- MarkRead --------------------------------------------------------
+
+export async function markRead(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: MarkReadRequest
+): Promise<MarkReadResponse> {
+  if (!req.chatId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'chat_id is required');
+  }
+  if (!req.upToMessageId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'up_to_message_id is required');
+  }
+  if (!hasPermission(principal, CHAT_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_READ}' required`);
+  }
+  if (!(await isParticipantOrAdmin(deps, principal, req.chatId))) {
+    throw new HandlerError('PERMISSION_DENIED', 'only chat participants may mark messages read');
+  }
+
+  // Verify the message belongs to the chat (caller bug or stale UI
+  // shouldn't allow drifting reads onto an unrelated chat).
+  const target = await deps.pool.query<{ created_at: Date }>(
+    `SELECT created_at FROM messages WHERE message_id = $1 AND chat_id = $2 LIMIT 1`,
+    [req.upToMessageId, req.chatId]
+  );
+  if (!target.rows[0]) {
+    throw new HandlerError(
+      'NOT_FOUND',
+      `message '${req.upToMessageId}' not found in chat '${req.chatId}'`
+    );
+  }
+
+  await withTransaction(deps, async ({ client, publish }) => {
+    // Insert read receipts for every message in the chat created at or
+    // before the target's timestamp that the user hasn't already read.
+    // ON CONFLICT DO NOTHING preserves idempotency without serialising.
+    await client.query(
+      `
+      INSERT INTO message_reads (read_id, message_id, user_id, read_at)
+      SELECT gen_random_uuid(), m.message_id, $1, now()
+      FROM messages m
+      WHERE m.chat_id = $2
+        AND m.deleted_at IS NULL
+        AND m.created_at <= $3
+      ON CONFLICT (message_id, user_id) DO NOTHING
+      `,
+      [principal.userId, req.chatId, target.rows[0].created_at]
+    );
+
+    // Bump the participant's last_read_at watermark for the chat-list
+    // unread badge calculation.
+    await client.query(
+      `
+      UPDATE chat_participants
+      SET last_read_at = now(), updated_at = now()
+      WHERE chat_id = $1 AND participant_id = $2
+      `,
+      [req.chatId, principal.userId]
+    );
+
+    publish({
+      type: 'chat.messageRead',
+      id: `chat.messageRead.${req.chatId}.${principal.userId}.${req.upToMessageId}`,
+      payload: {
+        chatId: req.chatId,
+        userId: principal.userId,
+        upToMessageId: req.upToMessageId,
+      },
+    });
+  });
+
+  return { upToMessageId: req.upToMessageId };
+}
+
+// --- React -----------------------------------------------------------
+
+export async function react(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ReactRequest
+): Promise<ReactResponse> {
+  if (!req.messageId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'message_id is required');
+  }
+  if (!req.emoji) {
+    throw new HandlerError('INVALID_ARGUMENT', 'emoji is required');
+  }
+  if (!hasPermission(principal, CHAT_SEND)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_SEND}' required`);
+  }
+
+  // Load the message to find its chat, so we can enforce participant
+  // scope (you can only react inside chats you're a member of).
+  const msg = await deps.pool.query<{ chat_id: string }>(
+    `SELECT chat_id FROM messages WHERE message_id = $1 AND deleted_at IS NULL LIMIT 1`,
+    [req.messageId]
+  );
+  if (!msg.rows[0]) {
+    throw new HandlerError('NOT_FOUND', `message '${req.messageId}' not found`);
+  }
+  const chatId = msg.rows[0].chat_id;
+  if (!(await isParticipantOrAdmin(deps, principal, chatId))) {
+    throw new HandlerError('PERMISSION_DENIED', 'only chat participants may react to messages');
+  }
+
+  await withTransaction(deps, async ({ client, publish }) => {
+    if (req.remove) {
+      await client.query(
+        `DELETE FROM message_reactions
+         WHERE message_id = $1 AND user_id = $2 AND emoji = $3`,
+        [req.messageId, principal.userId, req.emoji]
+      );
+      publish({
+        type: 'chat.reactionRemoved',
+        id: `chat.reactionRemoved.${req.messageId}.${principal.userId}.${req.emoji}`,
+        payload: {
+          messageId: req.messageId,
+          chatId,
+          userId: principal.userId,
+          emoji: req.emoji,
+        },
+      });
+    } else {
+      // ON CONFLICT preserves idempotency — a repeated React with the
+      // same (message, user, emoji) is a no-op.
+      await client.query(
+        `INSERT INTO message_reactions (reaction_id, message_id, user_id, emoji)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (message_id, user_id, emoji) DO NOTHING`,
+        [randomUUID(), req.messageId, principal.userId, req.emoji]
+      );
+      publish({
+        type: 'chat.reactionAdded',
+        id: `chat.reactionAdded.${req.messageId}.${principal.userId}.${req.emoji}`,
+        payload: {
+          messageId: req.messageId,
+          chatId,
+          userId: principal.userId,
+          emoji: req.emoji,
+        },
+      });
+    }
+  });
+
+  // Re-fetch the message + aggregated reactions to return the canonical
+  // post-mutation shape.
+  const after = await deps.pool.query<MessageRow>(
+    `SELECT * FROM messages WHERE message_id = $1 LIMIT 1`,
+    [req.messageId]
+  );
+  if (!after.rows[0]) {
+    throw new HandlerError('INTERNAL', 'message disappeared mid-call');
+  }
+  const reactions = await loadMessageReactions(deps, [req.messageId]);
+  return {
+    message: messageRowToProto(after.rows[0], reactions.get(req.messageId) ?? []),
+  };
+}

--- a/services/chat/src/grpc/principal.ts
+++ b/services/chat/src/grpc/principal.ts
@@ -1,0 +1,74 @@
+// Principal extractor for gRPC handlers.
+//
+// Every extracted service receives identity context as gRPC metadata
+// headers from the gateway:
+//
+//   x-user-id           UUID of the calling user
+//   x-user-roles        comma-separated UserRole list
+//   x-user-permissions  comma-separated Permission list
+//   x-rescue-id         (optional) rescueId for rescue-scoped roles
+//
+// The gateway populates these from the auth service's session lookup
+// (Phase 2). Until that lands, the dev mode in service.backend stamps
+// the same headers so the strangler-fig overlap works.
+//
+// extractPrincipal returns the principal shape that
+// @adopt-dont-shop/authz.{hasPermission,requirePermission} expects.
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, RescueId, UserId, UserRole } from '@adopt-dont-shop/lib.types';
+
+export class MissingPrincipalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingPrincipalError';
+  }
+}
+
+export function extractPrincipal(metadata: Metadata): Principal {
+  const userId = headerOne(metadata, 'x-user-id');
+  if (!userId) {
+    throw new MissingPrincipalError('missing x-user-id metadata');
+  }
+
+  const rolesRaw = headerOne(metadata, 'x-user-roles');
+  if (!rolesRaw) {
+    throw new MissingPrincipalError('missing x-user-roles metadata');
+  }
+
+  const roles = rolesRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as UserRole[];
+
+  // permissions can legitimately be empty for unauthenticated-ish
+  // scenarios (e.g. the dev role-switcher seed where adopters have
+  // a hard-conditional rule set). Treat missing as "no permissions
+  // beyond what the role grants".
+  const permissionsRaw = headerOne(metadata, 'x-user-permissions') ?? '';
+  const permissions = permissionsRaw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean) as Permission[];
+
+  const rescueIdRaw = headerOne(metadata, 'x-rescue-id')?.trim();
+  const rescueId = rescueIdRaw ? (rescueIdRaw as RescueId) : undefined;
+
+  return {
+    userId: userId as UserId,
+    roles,
+    permissions,
+    rescueId,
+  };
+}
+
+function headerOne(metadata: Metadata, key: string): string | undefined {
+  const values = metadata.get(key);
+  if (values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === 'string' ? first : first.toString();
+}

--- a/services/chat/src/grpc/server.ts
+++ b/services/chat/src/grpc/server.ts
@@ -1,0 +1,81 @@
+// gRPC server boot — binds ChatServiceService to the adapter-wrapped
+// handlers and listens on GRPC_PORT.
+
+import { promisify } from 'node:util';
+
+import { Server, ServerCredentials } from '@grpc/grpc-js';
+
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import { ChatV1 } from '@adopt-dont-shop/proto';
+
+import type { ChatConfig } from '../config.js';
+
+import { adapt } from './adapter.js';
+import { listChats, listMessages, markRead, openChat, react, sendMessage } from './handlers.js';
+
+export type CreateGrpcServerOptions = {
+  config: ChatConfig;
+  pool: Pool;
+  nats: NatsConnection;
+  logger: Logger;
+};
+
+export type RunningGrpcServer = {
+  server: Server;
+  port: number;
+  shutdown: () => Promise<void>;
+};
+
+export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
+  const { config, pool, nats, logger } = opts;
+  const server = new Server();
+  const deps = { pool, nats };
+
+  server.addService(ChatV1.ChatServiceService, {
+    openChat: adapt(openChat, { deps, logger }),
+    sendMessage: adapt(sendMessage, { deps, logger }),
+    listMessages: adapt(listMessages, { deps, logger }),
+    listChats: adapt(listChats, { deps, logger }),
+    markRead: adapt(markRead, { deps, logger }),
+    react: adapt(react, { deps, logger }),
+  });
+
+  logger.info('gRPC ChatService registered', {
+    methods: ['openChat', 'sendMessage', 'listMessages', 'listChats', 'markRead', 'react'],
+    grpcPort: config.grpcPort,
+  });
+
+  return server;
+};
+
+export const startGrpcServer = async (
+  opts: CreateGrpcServerOptions
+): Promise<RunningGrpcServer> => {
+  const { config, logger } = opts;
+  const server = createGrpcServer(opts);
+
+  const bindAsync = promisify<string, ServerCredentials, number>(server.bindAsync.bind(server));
+  const port = await bindAsync(
+    `${opts.config.host}:${config.grpcPort}`,
+    ServerCredentials.createInsecure()
+  );
+
+  logger.info('gRPC server listening', { port, host: opts.config.host });
+
+  return {
+    server,
+    port,
+    shutdown: () =>
+      new Promise<void>(resolve => {
+        server.tryShutdown(err => {
+          if (err) {
+            logger.error('gRPC server shutdown error', { err });
+          }
+          resolve();
+        });
+      }),
+  };
+};

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -1,21 +1,36 @@
+import { connect, type NatsConnection } from 'nats';
+
+import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
 import { createServer } from './server.js';
 
 const main = async (): Promise<void> => {
   const logger = createLogger({ serviceName: 'service.chat' });
 
+  let nats: NatsConnection | undefined;
+  let pool: Awaited<ReturnType<typeof createDbClient>> | undefined;
+  let grpc: RunningGrpcServer | undefined;
+  let httpClosed = false;
+
   try {
     const config = loadConfig();
-    const server = createServer({ config, logger });
 
-    await server.listen({ port: config.port, host: config.host });
+    pool = createDbClient({
+      connectionString: config.databaseUrl,
+      schema: config.schema,
+    });
+    nats = await connect({ servers: config.natsUrl });
 
-    logger.info('service.chat listening', {
-      port: config.port,
-      host: config.host,
-      grpcPort: config.grpcPort,
+    grpc = await startGrpcServer({ config, pool, nats, logger });
+    const httpServer = createServer({ config, logger });
+    await httpServer.listen({ port: config.port, host: config.host });
+
+    logger.info('service.chat running', {
+      http: { port: config.port, host: config.host },
+      grpc: { port: grpc.port, host: config.host },
       schema: config.schema,
       natsUrl: config.natsUrl,
       environment: config.environment,
@@ -24,9 +39,27 @@ const main = async (): Promise<void> => {
     const shutdown = async (signal: string): Promise<void> => {
       logger.info('service.chat shutting down', { signal });
       try {
-        await server.close();
+        if (!httpClosed) {
+          await httpServer.close();
+          httpClosed = true;
+        }
       } catch (err) {
-        logger.error('error during shutdown', { err });
+        logger.error('http close error', { err });
+      }
+      try {
+        await grpc?.shutdown();
+      } catch (err) {
+        logger.error('grpc shutdown error', { err });
+      }
+      try {
+        await nats?.drain();
+      } catch (err) {
+        logger.error('nats drain error', { err });
+      }
+      try {
+        await pool?.end();
+      } catch (err) {
+        logger.error('pool end error', { err });
       }
       process.exit(0);
     };
@@ -35,6 +68,21 @@ const main = async (): Promise<void> => {
     process.once('SIGINT', () => void shutdown('SIGINT'));
   } catch (err) {
     logger.error('service.chat failed to start', { err });
+    try {
+      await grpc?.shutdown();
+    } catch {
+      // swallow
+    }
+    try {
+      await nats?.drain();
+    } catch {
+      // swallow
+    }
+    try {
+      await pool?.end();
+    } catch {
+      // swallow
+    }
     process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

First substantive cut of the chat vertical. The service had migrations + a Fastify skeleton on main; this PR brings the gRPC handlers, server boot, and full handler-level test coverage online. The WebSocket fan-out, gateway routes, and monolith cutover are explicitly deferred to follow-on PRs once this lands and stabilises.

## What's in

- **All six `ChatService` RPCs** — `OpenChat`, `SendMessage`, `ListMessages`, `ListChats`, `MarkRead`, `React`.
- **Publish-after-commit on NATS** for every mutation: `chat.created`, `chat.messageCreated`, `chat.messageRead`, `chat.reactionAdded`, `chat.reactionRemoved`. The gateway's existing WS subscriber (Phase 1.5) will fan these out without changes.
- **Idempotent semantics** end-to-end: `OpenChat` returns the existing chat for a known (application, participant pair); `MarkRead` uses `ON CONFLICT DO NOTHING` on `message_reads`; `React` adds + removes via `ON CONFLICT DO NOTHING` / `DELETE`.
- **Participant-scope enforcement** at every read + write entrypoint. `super_admin` short-circuits via `hasPermission`.
- **Keyset pagination** on `ListMessages` (newest-first, default 50 / max 200) and `ListChats` (recent-first by `updated_at`).

## Known scaffolds (called out inline)

- `OpenChat` stamps a placeholder `rescue_id` because the proto doesn't carry it today. The gateway translator will fetch `application → rescue_id` before issuing OpenChat, or a future proto field will surface it explicitly. Documented in the handler.
- `ListChats.unread_only` filter deferred — the SPA already computes the badge client-side and the join required to compute it server-side warrants its own PR.

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/service.chat` — **37/37** (20 new handler tests)
- [x] `npx turbo type-check --filter=@adopt-dont-shop/service.chat`
- [x] `npx turbo lint --filter=@adopt-dont-shop/service.chat`
- [ ] Cold Docker stack — deferred to the gateway-routes PR which is where the end-to-end smoke makes sense

## Deferred (follow-on PRs)

- Gateway REST routes for `/api/v1/chats/*` and the WebSocket emit translation
- NATS subscribers in `services/chat/src/nats/` (notifications consumer for `applications.submitted` → "open chat" hint, plus moderation consumer for content scanning)
- Monolith cutover — replace `service.backend`'s chat controllers with the gateway routes once parity is verified

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_