### PR TITLE
feat(chat,gateway): websocket fan-out for chat.* events

### DIFF
--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -220,13 +220,16 @@ describe('sendMessage', () => {
   it('inserts the message and publishes chat.messageCreated after commit', async () => {
     // isParticipantOrAdmin → one row
     mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
-    // INSERT message, UPDATE chats.updated_at
+    // INSERT message, UPDATE chats.updated_at, SELECT participants
     mocks.clientScript.push({ rows: [messageRowFixture()] });
     mocks.clientScript.push({ rows: [] });
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
 
     const res = await sendMessage(mocks.deps, ADOPTER_PRINCIPAL, BASE_SEND);
     expect(res.message?.body).toBe('Hello world');
-    expect(realClientQueries(mocks)).toEqual(['INSERT', 'UPDATE']);
+    expect(realClientQueries(mocks)).toEqual(['INSERT', 'UPDATE', 'SELECT']);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.messageCreated');
   });
 });
@@ -345,13 +348,16 @@ describe('markRead', () => {
   it('stamps reads + bumps the participant last_read_at watermark', async () => {
     mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
     mocks.poolScript.push({ rows: [{ created_at: new Date('2026-06-01T00:01:00Z') }] });
-    // INSERT message_reads, UPDATE chat_participants
+    // INSERT message_reads, UPDATE chat_participants, SELECT participants
     mocks.clientScript.push({ rows: [] });
     mocks.clientScript.push({ rows: [] });
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
 
     const res = await markRead(mocks.deps, ADOPTER_PRINCIPAL, BASE_MARK);
     expect(res.upToMessageId).toBe('msg-1');
-    expect(realClientQueries(mocks)).toEqual(['INSERT', 'UPDATE']);
+    expect(realClientQueries(mocks)).toEqual(['INSERT', 'UPDATE', 'SELECT']);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.messageRead');
   });
 });
@@ -383,7 +389,10 @@ describe('react', () => {
     mocks.poolScript.push({ rows: [{ chat_id: 'chat-1' }] });
     // isParticipantOrAdmin → ok
     mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
-    // Inside withTransaction: INSERT reaction
+    // Inside withTransaction: SELECT participants, INSERT reaction
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
     mocks.clientScript.push({ rows: [] });
     // After-commit: re-fetch message, reactions
     mocks.poolScript.push({ rows: [messageRowFixture()] });
@@ -401,14 +410,17 @@ describe('react', () => {
 
     const res = await react(mocks.deps, ADOPTER_PRINCIPAL, BASE_REACT);
     expect(res.message?.reactions).toHaveLength(1);
-    expect(realClientQueries(mocks)).toEqual(['INSERT']);
+    expect(realClientQueries(mocks)).toEqual(['SELECT', 'INSERT']);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.reactionAdded');
   });
 
   it('removes a reaction and publishes chat.reactionRemoved', async () => {
     mocks.poolScript.push({ rows: [{ chat_id: 'chat-1' }] });
     mocks.poolScript.push({ rows: [{ chat_participant_id: 'p-1' }] });
-    // DELETE reaction
+    // Inside withTransaction: SELECT participants, DELETE reaction
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
     mocks.clientScript.push({ rows: [] });
     // Re-fetch
     mocks.poolScript.push({ rows: [messageRowFixture()] });
@@ -419,7 +431,7 @@ describe('react', () => {
       remove: true,
     });
     expect(res.message?.reactions).toHaveLength(0);
-    expect(realClientQueries(mocks)).toEqual(['DELETE']);
+    expect(realClientQueries(mocks)).toEqual(['SELECT', 'DELETE']);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.reactionRemoved');
   });
 });

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -126,6 +126,23 @@ const loadChatParticipants = async (deps: HandlerDeps, chatId: string): Promise<
   return res.rows.map(r => r.participant_id);
 };
 
+// Same lookup but on an open transactional client — used by SendMessage /
+// MarkRead / React to include the participant list in their NATS event
+// payloads so the gateway can fan to every member of the chat without
+// calling back into this service.
+const loadChatParticipantsTx = async (
+  client: Parameters<Parameters<typeof withTransaction>[1]>[0]['client'],
+  chatId: string
+): Promise<string[]> => {
+  const res = await client.query<{ participant_id: string }>(
+    `SELECT participant_id FROM chat_participants
+     WHERE chat_id = $1 AND deleted_at IS NULL
+     ORDER BY created_at ASC`,
+    [chatId]
+  );
+  return res.rows.map(r => r.participant_id);
+};
+
 const loadLastMessagePreview = async (
   deps: HandlerDeps,
   chatId: string
@@ -355,6 +372,7 @@ export async function sendMessage(
     // surfaces it. messages_chat_created_idx handles the actual sort.
     await client.query(`UPDATE chats SET updated_at = now() WHERE chat_id = $1`, [req.chatId]);
 
+    const participantUserIds = await loadChatParticipantsTx(client, req.chatId);
     publish({
       type: 'chat.messageCreated',
       id: `chat.messageCreated.${messageId}`,
@@ -363,6 +381,7 @@ export async function sendMessage(
         chatId: req.chatId,
         senderUserId: principal.userId,
         body: req.body,
+        participantUserIds,
       },
     });
   });
@@ -573,6 +592,7 @@ export async function markRead(
       [req.chatId, principal.userId]
     );
 
+    const participantUserIds = await loadChatParticipantsTx(client, req.chatId);
     publish({
       type: 'chat.messageRead',
       id: `chat.messageRead.${req.chatId}.${principal.userId}.${req.upToMessageId}`,
@@ -580,6 +600,7 @@ export async function markRead(
         chatId: req.chatId,
         userId: principal.userId,
         upToMessageId: req.upToMessageId,
+        participantUserIds,
       },
     });
   });
@@ -619,6 +640,7 @@ export async function react(
   }
 
   await withTransaction(deps, async ({ client, publish }) => {
+    const participantUserIds = await loadChatParticipantsTx(client, chatId);
     if (req.remove) {
       await client.query(
         `DELETE FROM message_reactions
@@ -633,6 +655,7 @@ export async function react(
           chatId,
           userId: principal.userId,
           emoji: req.emoji,
+          participantUserIds,
         },
       });
     } else {
@@ -652,6 +675,7 @@ export async function react(
           chatId,
           userId: principal.userId,
           emoji: req.emoji,
+          participantUserIds,
         },
       });
     }

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -14,6 +14,7 @@ import { createNotificationsClient } from './grpc-clients/notifications-client.j
 import { createPetsClient } from './grpc-clients/pets-client.js';
 import { createRescueClient } from './grpc-clients/rescue-client.js';
 import { createServer } from './server.js';
+import { registerChatSubscribers } from './ws/chat-subscriber.js';
 import { registerNotificationSubscribers } from './ws/notifications-subscriber.js';
 import { SocketRegistry } from './ws/socket-registry.js';
 import { attachSocketServer } from './ws/socket-server.js';
@@ -73,6 +74,7 @@ const main = async (): Promise<void> => {
     const registry = new SocketRegistry();
     io = attachSocketServer({ httpServer: server.server, registry, logger });
     registerNotificationSubscribers({ nats, registry, logger });
+    registerChatSubscribers({ nats, registry, logger });
 
     logger.info('service.gateway listening', {
       port: config.port,

--- a/services/gateway/src/ws/chat-subscriber.test.ts
+++ b/services/gateway/src/ws/chat-subscriber.test.ts
@@ -1,0 +1,268 @@
+import type { NatsConnection, Subscription } from 'nats';
+import type { Socket } from 'socket.io';
+import type { Logger } from 'winston';
+import { describe, expect, it, vi } from 'vitest';
+
+import { registerChatSubscribers } from './chat-subscriber.js';
+import { SocketRegistry } from './socket-registry.js';
+
+function fakeSocket(): Socket & { emit: ReturnType<typeof vi.fn> } {
+  return { emit: vi.fn() } as unknown as Socket & { emit: ReturnType<typeof vi.fn> };
+}
+
+function quietLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    silly: vi.fn(),
+  } as unknown as Logger;
+}
+
+// Reused from notifications-subscriber.test.ts — same shape but kept
+// inline so each WS subscriber test is self-contained.
+function makeNats(): {
+  nats: NatsConnection;
+  subscribeFn: ReturnType<typeof vi.fn>;
+  push: (subject: string, payload: unknown, id?: string) => Promise<void>;
+} {
+  const queues = new Map<
+    string,
+    { resolve: (msg: { subject: string; data: Uint8Array } | typeof DONE) => void }[]
+  >();
+  const DONE = Symbol('done');
+
+  const subscribeFn = vi.fn((subject: string) => {
+    const sub = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: (): Promise<{ value: { subject: string; data: Uint8Array }; done: boolean }> => {
+            return new Promise(resolve => {
+              const waiters = queues.get(subject) ?? [];
+              waiters.push({
+                resolve: msg => {
+                  if (msg === DONE) {
+                    resolve({ value: undefined as never, done: true });
+                  } else {
+                    resolve({ value: msg, done: false });
+                  }
+                },
+              });
+              queues.set(subject, waiters);
+            });
+          },
+        };
+      },
+    };
+    return sub as unknown as Subscription;
+  });
+
+  const nats = { subscribe: subscribeFn } as unknown as NatsConnection;
+
+  const push = async (subject: string, payload: unknown, id = 'evt-1'): Promise<void> => {
+    const waiters = queues.get(subject);
+    const waiter = waiters?.shift();
+    if (!waiter) {
+      throw new Error(`no waiter on ${subject}`);
+    }
+    const envelope = { id, occurredAt: '2026-06-01T10:00:00Z', payload };
+    waiter.resolve({
+      subject,
+      data: new TextEncoder().encode(JSON.stringify(envelope)),
+    });
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  return { nats, subscribeFn, push };
+}
+
+describe('registerChatSubscribers — wiring', () => {
+  it('subscribes to all four chat.* subjects', () => {
+    const { nats, subscribeFn } = makeNats();
+    registerChatSubscribers({ nats, registry: new SocketRegistry(), logger: quietLogger() });
+
+    expect(subscribeFn).toHaveBeenCalledTimes(4);
+    const subjects = subscribeFn.mock.calls.map(c => c[0]);
+    expect(subjects).toEqual([
+      'chat.messageCreated',
+      'chat.messageRead',
+      'chat.reactionAdded',
+      'chat.reactionRemoved',
+    ]);
+  });
+
+  it('does NOT use a queue group — every replica sees every event', () => {
+    const { nats, subscribeFn } = makeNats();
+    registerChatSubscribers({ nats, registry: new SocketRegistry(), logger: quietLogger() });
+    for (const call of subscribeFn.mock.calls) {
+      expect(call[1]).toBeUndefined();
+    }
+  });
+});
+
+describe('registerChatSubscribers — fan-out', () => {
+  it('emits chat:message:created to every participant socket on THIS replica', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const s1 = fakeSocket();
+    const s2 = fakeSocket();
+    const otherUserSocket = fakeSocket();
+    registry.add('usr-adopter', s1);
+    registry.add('usr-rescue', s2);
+    registry.add('usr-bystander', otherUserSocket);
+
+    registerChatSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('chat.messageCreated', {
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      senderUserId: 'usr-adopter',
+      body: 'Hello',
+      participantUserIds: ['usr-adopter', 'usr-rescue'],
+    });
+
+    // Both participants receive — sender included so their other tabs
+    // get the new message too.
+    expect(s1.emit).toHaveBeenCalledWith(
+      'chat:message:created',
+      expect.objectContaining({
+        messageId: 'msg-1',
+        chatId: 'chat-1',
+        senderUserId: 'usr-adopter',
+        body: 'Hello',
+      })
+    );
+    expect(s2.emit).toHaveBeenCalledWith('chat:message:created', expect.any(Object));
+    // Non-participant gets nothing.
+    expect(otherUserSocket.emit).not.toHaveBeenCalled();
+  });
+
+  it('strips participantUserIds from the emitted payload', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const s1 = fakeSocket();
+    registry.add('usr-adopter', s1);
+    registerChatSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('chat.messageCreated', {
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      senderUserId: 'usr-adopter',
+      body: 'Hi',
+      participantUserIds: ['usr-adopter', 'usr-rescue'],
+    });
+
+    const [, payload] = s1.emit.mock.calls[0] as [string, Record<string, unknown>];
+    expect(payload).not.toHaveProperty('participantUserIds');
+  });
+
+  it('emits chat:message:read on chat.messageRead', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const s1 = fakeSocket();
+    const s2 = fakeSocket();
+    registry.add('usr-adopter', s1);
+    registry.add('usr-rescue', s2);
+    registerChatSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('chat.messageRead', {
+      chatId: 'chat-1',
+      userId: 'usr-rescue',
+      upToMessageId: 'msg-1',
+      participantUserIds: ['usr-adopter', 'usr-rescue'],
+    });
+
+    expect(s1.emit).toHaveBeenCalledWith(
+      'chat:message:read',
+      expect.objectContaining({
+        chatId: 'chat-1',
+        userId: 'usr-rescue',
+        upToMessageId: 'msg-1',
+      })
+    );
+    expect(s2.emit).toHaveBeenCalledWith('chat:message:read', expect.any(Object));
+  });
+
+  it('emits chat:reaction:added on chat.reactionAdded', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const s1 = fakeSocket();
+    registry.add('usr-adopter', s1);
+    registerChatSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('chat.reactionAdded', {
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      userId: 'usr-rescue',
+      emoji: '👍',
+      participantUserIds: ['usr-adopter'],
+    });
+
+    expect(s1.emit).toHaveBeenCalledWith(
+      'chat:reaction:added',
+      expect.objectContaining({
+        messageId: 'msg-1',
+        chatId: 'chat-1',
+        userId: 'usr-rescue',
+        emoji: '👍',
+      })
+    );
+  });
+
+  it('emits chat:reaction:removed on chat.reactionRemoved', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const s1 = fakeSocket();
+    registry.add('usr-adopter', s1);
+    registerChatSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('chat.reactionRemoved', {
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      userId: 'usr-rescue',
+      emoji: '👍',
+      participantUserIds: ['usr-adopter'],
+    });
+
+    expect(s1.emit).toHaveBeenCalledWith('chat:reaction:removed', expect.any(Object));
+  });
+
+  it('dedupes duplicate participant entries in the event payload', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const s1 = fakeSocket();
+    registry.add('usr-adopter', s1);
+    registerChatSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('chat.messageCreated', {
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      senderUserId: 'usr-adopter',
+      body: 'Hi',
+      participantUserIds: ['usr-adopter', 'usr-adopter'],
+    });
+
+    expect(s1.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits nothing when no participant has a socket on this replica', async () => {
+    const { nats, push } = makeNats();
+    const registry = new SocketRegistry();
+    const s1 = fakeSocket();
+    registry.add('usr-other', s1);
+    registerChatSubscribers({ nats, registry, logger: quietLogger() });
+
+    await push('chat.messageCreated', {
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      senderUserId: 'usr-adopter',
+      body: 'Hi',
+      participantUserIds: ['usr-adopter', 'usr-rescue'],
+    });
+
+    expect(s1.emit).not.toHaveBeenCalled();
+  });
+});

--- a/services/gateway/src/ws/chat-subscriber.ts
+++ b/services/gateway/src/ws/chat-subscriber.ts
@@ -1,0 +1,140 @@
+// NATS → Socket.IO fan-out for chat.* domain events.
+//
+// service.chat publishes chat.messageCreated / chat.messageRead /
+// chat.reactionAdded / chat.reactionRemoved on the bus after every
+// committed write. Each event payload includes `participantUserIds`
+// so this subscriber can fan to every active member of the chat on
+// THIS gateway replica without calling back into the chat service.
+//
+// SPA-facing event shapes (kebab-case names match the existing
+// notification:* convention from notifications-subscriber):
+//
+//   socket.emit('chat:message:created', { messageId, chatId, senderUserId, body })
+//   socket.emit('chat:message:read',    { chatId, userId, upToMessageId })
+//   socket.emit('chat:reaction:added',  { messageId, chatId, userId, emoji })
+//   socket.emit('chat:reaction:removed',{ messageId, chatId, userId, emoji })
+//
+// Same no-queue-group fan-out strategy as the notifications subscriber:
+// each replica subscribes independently so every replica sees every
+// event; the replica that holds a participant's socket emits, others
+// no-op via the empty registry lookup.
+//
+// chat.created is intentionally NOT fanned here — the SPA doesn't need
+// to react to a chat being opened in real-time (the user that opened it
+// already has the response; the other participant picks it up on their
+// next ListChats refresh / chat-list re-fetch).
+
+import type { NatsConnection, Subscription } from 'nats';
+import type { Logger } from 'winston';
+
+import { subscribe } from '@adopt-dont-shop/events';
+
+import type { SocketRegistry } from './socket-registry.js';
+
+export type RegisterChatSubscribersOptions = {
+  nats: NatsConnection;
+  registry: SocketRegistry;
+  logger: Logger;
+};
+
+// Common base: every chat.* event carries the participants so the
+// gateway can multiplex without a chat-service round-trip.
+type ChatEventBase = { participantUserIds: string[] };
+
+type MessageCreatedPayload = ChatEventBase & {
+  messageId: string;
+  chatId: string;
+  senderUserId: string;
+  body: string;
+};
+
+type MessageReadPayload = ChatEventBase & {
+  chatId: string;
+  userId: string;
+  upToMessageId: string;
+};
+
+type ReactionPayload = ChatEventBase & {
+  messageId: string;
+  chatId: string;
+  userId: string;
+  emoji: string;
+};
+
+// Strip the `participantUserIds` field before emitting to clients —
+// the SPA doesn't need to see the fan-out list and including it would
+// leak participant identity to anyone with a socket in any chat.
+const stripParticipants = <T extends ChatEventBase>(p: T): Omit<T, 'participantUserIds'> => {
+  const { participantUserIds: _ignored, ...rest } = p;
+  void _ignored;
+  return rest;
+};
+
+const fanToParticipants = <T extends ChatEventBase>(
+  registry: SocketRegistry,
+  payload: T,
+  eventName: string
+): void => {
+  const emitPayload = stripParticipants(payload);
+  // Dedupe — a participant could (theoretically) appear twice in the
+  // event payload. Defensive only; the chat handler should already
+  // emit a unique list.
+  const seen = new Set<string>();
+  for (const userId of payload.participantUserIds) {
+    if (seen.has(userId)) {
+      continue;
+    }
+    seen.add(userId);
+    for (const socket of registry.socketsFor(userId)) {
+      socket.emit(eventName, emitPayload);
+    }
+  }
+};
+
+export const registerChatSubscribers = (opts: RegisterChatSubscribersOptions): Subscription[] => {
+  const { nats, registry, logger } = opts;
+
+  const onError = (err: unknown, ctx: { subject: string }): void => {
+    logger.error('chat ws subscriber failed', {
+      subject: ctx.subject,
+      err: (err as Error)?.message ?? String(err),
+    });
+  };
+
+  const subs: Subscription[] = [];
+
+  subs.push(
+    subscribe<MessageCreatedPayload>(nats, { subject: 'chat.messageCreated', onError }, payload =>
+      fanToParticipants(registry, payload, 'chat:message:created')
+    )
+  );
+
+  subs.push(
+    subscribe<MessageReadPayload>(nats, { subject: 'chat.messageRead', onError }, payload =>
+      fanToParticipants(registry, payload, 'chat:message:read')
+    )
+  );
+
+  subs.push(
+    subscribe<ReactionPayload>(nats, { subject: 'chat.reactionAdded', onError }, payload =>
+      fanToParticipants(registry, payload, 'chat:reaction:added')
+    )
+  );
+
+  subs.push(
+    subscribe<ReactionPayload>(nats, { subject: 'chat.reactionRemoved', onError }, payload =>
+      fanToParticipants(registry, payload, 'chat:reaction:removed')
+    )
+  );
+
+  logger.info('gateway chat WS subscribers registered', {
+    subjects: [
+      'chat.messageCreated',
+      'chat.messageRead',
+      'chat.reactionAdded',
+      'chat.reactionRemoved',
+    ],
+  });
+
+  return subs;
+};


### PR DESCRIPTION
## Summary

Closes the real-time loop on the chat vertical. Chat events now carry the participant list in the NATS payload, and the gateway's new `chat-subscriber` fans them out to active Socket.IO sockets per replica — same pattern as the existing notifications subscriber, no Redis pub/sub between gateway replicas.

## What changes

### `services/chat/src/grpc/handlers.ts`

Every `chat.*` event publish site loads `chat_participants` inside the transaction and includes the list as `participantUserIds`. Applied to:
- `chat.messageCreated`
- `chat.messageRead`
- `chat.reactionAdded`
- `chat.reactionRemoved`

`chat.created` already carried `participantUserIds` — unchanged.

### `services/gateway/src/ws/chat-subscriber.ts`

NATS → Socket.IO bridge for the four `chat.*` subjects. SPA-facing event names are kebab-case to match the existing `notification:*` convention:

| NATS subject | SPA event name |
|---|---|
| `chat.messageCreated` | `chat:message:created` |
| `chat.messageRead` | `chat:message:read` |
| `chat.reactionAdded` | `chat:reaction:added` |
| `chat.reactionRemoved` | `chat:reaction:removed` |

The internal `participantUserIds` field is stripped before emitting — the SPA doesn't need it, and including it would leak the participant list to anyone with a socket on this replica.

`chat.created` is intentionally NOT fanned: the user that opened the chat already has the response, and the other participant picks it up on the next `ListChats` refresh.

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/service.chat` — **37/37**
- [x] `npx turbo test --filter=@adopt-dont-shop/service.gateway` — **260/260** (10 new subscriber tests + chat handler tests updated for the new `SELECT participants` step)
- [x] `npx turbo type-check / lint` clean for both
- [ ] Cold Docker stack 2-browser smoke (two clients, same chat, one sends → other receives in real time) — deferred to monolith cutover PR

## Deferred (chat-vertical follow-ons)

- NATS subscribers inside `services/chat/src/nats/` (e.g. moderation consumer for content scanning on `chat.messageCreated`).
- Monolith cutover — flip `CUTOVER_CHAT=true` and delete the monolith's chat controllers.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_