### PR TITLE
feat(notifications): consume chat.messageCreated → MESSAGE_RECEIVED row

### DIFF
--- a/services/notifications/src/nats/event-types.ts
+++ b/services/notifications/src/nats/event-types.ts
@@ -165,3 +165,17 @@ export type RescueStaffInvitedEvent = {
   invitedBy: string;
   expiration: string;
 };
+
+// chat.messageCreated — service.chat publishes after every committed
+// message insert. Payload mirrors what the gateway WS subscriber
+// already consumes; the notifications subscriber uses
+// `participantUserIds` to fan out an in-app NOTIFICATION_TYPE_MESSAGE_RECEIVED
+// row per recipient (sender excluded — they don't need to be told
+// about their own message).
+export type ChatMessageCreatedEvent = {
+  messageId: string;
+  chatId: string;
+  senderUserId: string;
+  body: string;
+  participantUserIds: string[];
+};

--- a/services/notifications/src/nats/subscribers.test.ts
+++ b/services/notifications/src/nats/subscribers.test.ts
@@ -13,6 +13,7 @@ import {
   buildApplicationSubmittedCreate,
   buildAuthRoleAssignedCreate,
   buildAuthUserLoggedInCreate,
+  buildChatMessageReceivedCreate,
   registerSubscribers,
 } from './subscribers.js';
 
@@ -209,6 +210,42 @@ describe('event → CreateNotificationRequest translation', () => {
       expect(req.message).toContain('Reason: community trust');
     });
   });
+
+  describe('buildChatMessageReceivedCreate', () => {
+    const baseEvent = {
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      senderUserId: 'usr-sender',
+      body: 'Hello!',
+      participantUserIds: ['usr-sender', 'usr-recipient'],
+    };
+
+    it('targets the recipient with an in-app MESSAGE_RECEIVED row at NORMAL priority', () => {
+      const req = buildChatMessageReceivedCreate(baseEvent, 'usr-recipient');
+      expect(req.userId).toBe('usr-recipient');
+      expect(req.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED);
+      expect(req.channel).toBe(NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP);
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL);
+      expect(req.title).toBe('New message');
+      expect(req.message).toBe('Hello!');
+      expect(req.relatedEntityType).toBe(
+        NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_MESSAGE
+      );
+      expect(req.relatedEntityId).toBe('msg-1');
+      const data = JSON.parse(req.dataJson) as Record<string, unknown>;
+      expect(data.chatId).toBe('chat-1');
+      expect(data.messageId).toBe('msg-1');
+      expect(data.senderUserId).toBe('usr-sender');
+    });
+
+    it('truncates bodies that exceed the preview cap with an ellipsis', () => {
+      const longBody = 'a'.repeat(500);
+      const req = buildChatMessageReceivedCreate({ ...baseEvent, body: longBody }, 'usr-recipient');
+      // 139 chars of body + the ellipsis terminator = 140 total preview.
+      expect(req.message.length).toBe(140);
+      expect(req.message.endsWith('…')).toBe(true);
+    });
+  });
 });
 
 // --- Subscriber registration ----------------------------------------
@@ -252,7 +289,7 @@ describe('registerSubscribers', () => {
 
     const subs = registerSubscribers({ nats, deps, logger });
 
-    expect(subs).toHaveLength(13);
+    expect(subs).toHaveLength(14);
     // Subscribed subjects (raw nats.subscribe receives the subject as
     // first arg, then an options object containing `queue`).
     const subjects = subscribeFn.mock.calls.map(call => call[0]);
@@ -270,6 +307,7 @@ describe('registerSubscribers', () => {
       'rescue.verified',
       'rescue.rejected',
       'rescue.staffInvited',
+      'chat.messageCreated',
     ]);
   });
 

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -42,6 +42,7 @@ import type {
   ApplicationSubmittedEvent,
   AuthRoleAssignedEvent,
   AuthUserLoggedInEvent,
+  ChatMessageCreatedEvent,
   PetDeletedEvent,
   PetStatusChangedEvent,
   RescueRejectedEvent,
@@ -238,6 +239,40 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
           rescueId: payload.rescueId,
           email: payload.email,
         });
+      }
+    )
+  );
+
+  // chat.messageCreated — fan a NOTIFICATION_TYPE_MESSAGE_RECEIVED row
+  // out to every recipient (participants minus the sender). The
+  // realtime ping is already handled by the gateway WS subscriber; this
+  // creates the durable Notification row so offline users have a
+  // record + an unread badge to come back to.
+  subscriptions.push(
+    subscribe<ChatMessageCreatedEvent>(
+      nats,
+      { subject: 'chat.messageCreated', queue: QUEUE_GROUP, onError },
+      async payload => {
+        const recipients = payload.participantUserIds.filter(id => id !== payload.senderUserId);
+        // Each recipient gets one in-app notification. Errors from a
+        // single recipient must not abort the others (CAD lesson #4 —
+        // poison-pill subscribers); wrap each in its own try/catch.
+        for (const userId of recipients) {
+          try {
+            await createNotification(
+              deps,
+              SYSTEM_PRINCIPAL,
+              buildChatMessageReceivedCreate(payload, userId)
+            );
+          } catch (err) {
+            logger.warn('chat.messageCreated notification create failed', {
+              chatId: payload.chatId,
+              messageId: payload.messageId,
+              recipientUserId: userId,
+              err: (err as Error)?.message ?? String(err),
+            });
+          }
+        }
       }
     )
   );
@@ -442,3 +477,35 @@ export const buildAuthRoleAssignedCreate = (
   relatedEntityType:
     NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_USER,
 });
+
+// Cap the message preview so we never store the full chat body on the
+// notification row — the SPA opens the chat to read more, and a runaway
+// 10k-char message shouldn't bloat the notifications.notifications row.
+const CHAT_PREVIEW_LIMIT = 140;
+
+export const buildChatMessageReceivedCreate = (
+  event: ChatMessageCreatedEvent,
+  recipientUserId: string
+): CreateNotificationRequest => {
+  const preview =
+    event.body.length > CHAT_PREVIEW_LIMIT
+      ? `${event.body.slice(0, CHAT_PREVIEW_LIMIT - 1)}…`
+      : event.body;
+  return {
+    userId: recipientUserId,
+    type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED,
+    channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+    priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL,
+    title: 'New message',
+    message: preview,
+    dataJson: JSON.stringify({
+      chatId: event.chatId,
+      messageId: event.messageId,
+      senderUserId: event.senderUserId,
+    }),
+    templateVariablesJson: '{}',
+    relatedEntityType:
+      NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_MESSAGE,
+    relatedEntityId: event.messageId,
+  };
+};


### PR DESCRIPTION
## Summary

Closes the last cross-service link for the chat vertical. The realtime ping already lands via the gateway WS subscriber (#959); this PR adds the durable in-app notification row so offline recipients see an unread badge on their next sign-in.

## What's in

- **`nats/event-types.ts`** — `ChatMessageCreatedEvent` shape matches what `services/chat/src/grpc/handlers.ts` publishes (includes `participantUserIds` so the consumer can fan out without calling back into the chat service).
- **`nats/subscribers.ts`** — subscribes to `chat.messageCreated` under the existing `notifications-workers` queue group. For each non-sender participant, creates a `NOTIFICATION_TYPE_MESSAGE_RECEIVED` row via the canonical `createNotification` handler. Per-recipient errors are caught + logged so one bad row doesn't abort the others (CAD lesson #4).
- **`buildChatMessageReceivedCreate`** — pure translation function. Caps the preview at 140 chars with a trailing ellipsis so a 10k-char message body doesn't bloat the `notifications.notifications` row.

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/service.notifications` — **128/128** (3 new tests: subscriber-count bumped to 14, plus two translation tests covering basic shape + truncation)
- [x] `npx turbo type-check / lint` clean

## What's done with this PR

The chat vertical is now feature-complete per the migration plan:

| Phase 6 deliverable | Status |
|---|---|
| Schema + migrations | ✅ already on main |
| gRPC handlers + server | ✅ #957 |
| Gateway REST routes | ✅ #958 |
| WebSocket fan-out via NATS | ✅ #959 |
| Moderation hook (content scan) | ✅ already on main (#952) |
| Notifications fan-out per Phase 1 pattern | ✅ this PR |

Monolith cutover (`CUTOVER_CHAT=true` + delete monolith chat code) stays deferred until every other extracted service is parity-verified, per the no-delete-until-everyone-is-ready rule.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_