### PR TITLE
feat(gateway): devices REST + conversations alias + legal + public config

### DIFF
--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -82,6 +82,19 @@ export type GatewayConfig = {
     audit: boolean;
     chat: boolean;
   };
+  // Gateway-folded routes — per the plan's "small static reads fold
+  // into service.gateway" guidance. Each block is independently
+  // toggle-able so a deploy can roll out legal vs config separately.
+  legal: {
+    enabled: boolean;
+    // Absolute path to the directory holding terms.md / privacy.md /
+    // cookies.md. Defaults to the monorepo's docs/legal dir; docker
+    // sets this to the mounted path inside the gateway container.
+    docsDir: string;
+  };
+  config: {
+    publicEnabled: boolean;
+  };
 };
 
 const DEFAULT_PORT = 4000;
@@ -131,6 +144,13 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): GatewayConfig 
       matching: isEnabled(env.CUTOVER_MATCHING),
       audit: isEnabled(env.CUTOVER_AUDIT),
       chat: isEnabled(env.CUTOVER_CHAT),
+    },
+    legal: {
+      enabled: env.GATEWAY_LEGAL_ENABLED?.trim().toLowerCase() !== 'false',
+      docsDir: env.LEGAL_DOCS_DIR?.trim() || 'docs/legal',
+    },
+    config: {
+      publicEnabled: env.GATEWAY_CONFIG_ENABLED?.trim().toLowerCase() !== 'false',
     },
   };
 };

--- a/services/gateway/src/grpc-clients/notifications-client.ts
+++ b/services/gateway/src/grpc-clients/notifications-client.ts
@@ -18,8 +18,14 @@ import {
   type CreateNotificationResponse,
   type DismissNotificationRequest,
   type DismissNotificationResponse,
+  type ListDeviceTokensRequest,
+  type ListDeviceTokensResponse,
   type ListNotificationsRequest,
   type ListNotificationsResponse,
+  type RegisterDeviceTokenRequest,
+  type RegisterDeviceTokenResponse,
+  type UnregisterDeviceTokenRequest,
+  type UnregisterDeviceTokenResponse,
 } from '@adopt-dont-shop/proto';
 
 export type NotificationsClient = {
@@ -29,6 +35,18 @@ export type NotificationsClient = {
     req: DismissNotificationRequest,
     metadata: Metadata
   ): Promise<DismissNotificationResponse>;
+  registerDeviceToken(
+    req: RegisterDeviceTokenRequest,
+    metadata: Metadata
+  ): Promise<RegisterDeviceTokenResponse>;
+  unregisterDeviceToken(
+    req: UnregisterDeviceTokenRequest,
+    metadata: Metadata
+  ): Promise<UnregisterDeviceTokenResponse>;
+  listDeviceTokens(
+    req: ListDeviceTokensRequest,
+    metadata: Metadata
+  ): Promise<ListDeviceTokensResponse>;
   close(): void;
 };
 
@@ -67,6 +85,9 @@ export const createNotificationsClient = (
     create: (req, metadata) => callUnary(stub.create, req, metadata),
     list: (req, metadata) => callUnary(stub.list, req, metadata),
     dismiss: (req, metadata) => callUnary(stub.dismiss, req, metadata),
+    registerDeviceToken: (req, metadata) => callUnary(stub.registerDeviceToken, req, metadata),
+    unregisterDeviceToken: (req, metadata) => callUnary(stub.unregisterDeviceToken, req, metadata),
+    listDeviceTokens: (req, metadata) => callUnary(stub.listDeviceTokens, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -349,3 +349,81 @@ describe('POST /api/v1/messages/:messageId/reactions — react', () => {
     expect(req.remove).toBe(true);
   });
 });
+
+// --- /api/v1/conversations alias ------------------------------------
+//
+// The monolith mounts the same chat routes at /api/v1/chats AND
+// /api/v1/conversations. The SPA's lib.chat client uses both paths
+// across views; the gateway must accept either.
+
+describe('/api/v1/conversations — monolith alias', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('GET /api/v1/conversations routes to listChats', async () => {
+    client.listChatsMock.mockResolvedValueOnce({ chats: [CHAT_FIXTURE] });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/conversations',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.listChatsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST /api/v1/conversations routes to openChat', async () => {
+    client.openChatMock.mockResolvedValueOnce({ chat: CHAT_FIXTURE, created: true });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/conversations',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: { applicationId: 'app-1', otherUserId: 'usr-2' },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(client.openChatMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('GET /api/v1/conversations/:chatId/messages routes to listMessages', async () => {
+    client.listMessagesMock.mockResolvedValueOnce({ messages: [MESSAGE_FIXTURE] });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/conversations/chat-1/messages',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.listMessagesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST /api/v1/conversations/:chatId/messages routes to sendMessage', async () => {
+    client.sendMessageMock.mockResolvedValueOnce({ message: MESSAGE_FIXTURE });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/conversations/chat-1/messages',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: { body: 'Hello via alias' },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(client.sendMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST /api/v1/conversations/:chatId/read routes to markRead', async () => {
+    client.markReadMock.mockResolvedValueOnce({ upToMessageId: 'msg-1' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/conversations/chat-1/read',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: { upToMessageId: 'msg-1' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.markReadMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -40,108 +40,26 @@ const GRPC_TO_HTTP: Record<number, number> = {
   [status.INTERNAL]: 500,
 };
 
+// The monolith mounts the same chat routes at /api/v1/chats AND
+// /api/v1/conversations. The SPA's lib.chat client uses both paths
+// across different views; we mirror that here so a SPA build doesn't
+// notice the cutover. Every helper below registers under both
+// prefixes via this list.
+const CHAT_PREFIXES = ['/api/v1/chats', '/api/v1/conversations'] as const;
+
 export const registerChatRoutes = async (
   app: FastifyInstance,
   opts: ChatRoutesOptions
 ): Promise<void> => {
   const { client } = opts;
 
-  // ---- GET /api/v1/chats -------------------------------------------
-  app.get('/api/v1/chats', async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const query = req.query as Record<string, string | undefined>;
-    const grpcReq: ListChatsRequest = {
-      cursor: query.cursor,
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
-      unreadOnly: query.unreadOnly === 'true' || query.unread_only === 'true',
-    };
+  for (const prefix of CHAT_PREFIXES) {
+    registerChatRoutesForPrefix(app, client, prefix);
+  }
 
-    try {
-      const res = await client.listChats(grpcReq, metadata);
-      return reply.send(ChatV1.ListChatsResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  // ---- POST /api/v1/chats ------------------------------------------
-  app.post('/api/v1/chats', async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as Partial<OpenChatRequest> & {
-      application_id?: string;
-      other_user_id?: string;
-    };
-    const grpcReq: OpenChatRequest = {
-      applicationId: body.applicationId ?? body.application_id ?? '',
-      otherUserId: body.otherUserId ?? body.other_user_id ?? '',
-    };
-
-    try {
-      const res = await client.openChat(grpcReq, metadata);
-      // 201 for a freshly-created chat, 200 for an idempotent hit.
-      return reply.code(res.created ? 201 : 200).send(ChatV1.OpenChatResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  // ---- GET /api/v1/chats/:chatId/messages --------------------------
-  app.get<{ Params: { chatId: string } }>('/api/v1/chats/:chatId/messages', async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const query = req.query as Record<string, string | undefined>;
-    const grpcReq: ListMessagesRequest = {
-      chatId: req.params.chatId,
-      cursor: query.cursor,
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
-    };
-
-    try {
-      const res = await client.listMessages(grpcReq, metadata);
-      return reply.send(ChatV1.ListMessagesResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  // ---- POST /api/v1/chats/:chatId/messages -------------------------
-  app.post<{ Params: { chatId: string } }>('/api/v1/chats/:chatId/messages', async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as { body?: string; content?: string };
-    const grpcReq: SendMessageRequest = {
-      chatId: req.params.chatId,
-      // Accept both `body` (proto field) and `content` (monolith name)
-      // so the SPA can switch in its own time.
-      body: body.body ?? body.content ?? '',
-    };
-
-    try {
-      const res = await client.sendMessage(grpcReq, metadata);
-      return reply.code(201).send(ChatV1.SendMessageResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  // ---- POST /api/v1/chats/:chatId/read -----------------------------
-  app.post<{ Params: { chatId: string } }>('/api/v1/chats/:chatId/read', async (req, reply) => {
-    const metadata = buildMetadata(req);
-    const body = (req.body ?? {}) as { upToMessageId?: string; up_to_message_id?: string };
-    const grpcReq: MarkReadRequest = {
-      chatId: req.params.chatId,
-      upToMessageId: body.upToMessageId ?? body.up_to_message_id ?? '',
-    };
-
-    try {
-      const res = await client.markRead(grpcReq, metadata);
-      return reply.send(ChatV1.MarkReadResponse.toJSON(res));
-    } catch (err) {
-      return handleGrpcError(err, reply);
-    }
-  });
-
-  // ---- POST /api/v1/messages/:messageId/reactions ------------------
-  // Toggle a reaction. Body shape: { emoji, remove? }. The chat
-  // handler is idempotent in both directions.
+  // The /api/v1/messages/:messageId/reactions endpoint is unique —
+  // it's a message-level operation, not chat-scoped — so it only
+  // registers once. Same handler shape as the other six.
   app.post<{ Params: { messageId: string } }>(
     '/api/v1/messages/:messageId/reactions',
     async (req, reply) => {
@@ -161,6 +79,102 @@ export const registerChatRoutes = async (
       }
     }
   );
+};
+
+const registerChatRoutesForPrefix = (
+  app: FastifyInstance,
+  client: ChatClient,
+  prefix: string
+): void => {
+  // ---- GET <prefix> -------------------------------------------------
+  app.get(prefix, async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const query = req.query as Record<string, string | undefined>;
+    const grpcReq: ListChatsRequest = {
+      cursor: query.cursor,
+      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      unreadOnly: query.unreadOnly === 'true' || query.unread_only === 'true',
+    };
+
+    try {
+      const res = await client.listChats(grpcReq, metadata);
+      return reply.send(ChatV1.ListChatsResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // ---- POST <prefix> -----------------------------------------------
+  app.post(prefix, async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const body = (req.body ?? {}) as Partial<OpenChatRequest> & {
+      application_id?: string;
+      other_user_id?: string;
+    };
+    const grpcReq: OpenChatRequest = {
+      applicationId: body.applicationId ?? body.application_id ?? '',
+      otherUserId: body.otherUserId ?? body.other_user_id ?? '',
+    };
+
+    try {
+      const res = await client.openChat(grpcReq, metadata);
+      return reply.code(res.created ? 201 : 200).send(ChatV1.OpenChatResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // ---- GET <prefix>/:chatId/messages -------------------------------
+  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const query = req.query as Record<string, string | undefined>;
+    const grpcReq: ListMessagesRequest = {
+      chatId: req.params.chatId,
+      cursor: query.cursor,
+      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+    };
+
+    try {
+      const res = await client.listMessages(grpcReq, metadata);
+      return reply.send(ChatV1.ListMessagesResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // ---- POST <prefix>/:chatId/messages ------------------------------
+  app.post<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const body = (req.body ?? {}) as { body?: string; content?: string };
+    const grpcReq: SendMessageRequest = {
+      chatId: req.params.chatId,
+      body: body.body ?? body.content ?? '',
+    };
+
+    try {
+      const res = await client.sendMessage(grpcReq, metadata);
+      return reply.code(201).send(ChatV1.SendMessageResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // ---- POST <prefix>/:chatId/read ----------------------------------
+  app.post<{ Params: { chatId: string } }>(`${prefix}/:chatId/read`, async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const body = (req.body ?? {}) as { upToMessageId?: string; up_to_message_id?: string };
+    const grpcReq: MarkReadRequest = {
+      chatId: req.params.chatId,
+      upToMessageId: body.upToMessageId ?? body.up_to_message_id ?? '',
+    };
+
+    try {
+      const res = await client.markRead(grpcReq, metadata);
+      return reply.send(ChatV1.MarkReadResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
 };
 
 // --- Helpers ---------------------------------------------------------

--- a/services/gateway/src/routes/config.test.ts
+++ b/services/gateway/src/routes/config.test.ts
@@ -1,0 +1,31 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { registerConfigRoutes } from './config.js';
+
+describe('GET /api/v1/config — gateway-folded public config', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    await registerConfigRoutes(app);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns a flat map of public-only keys', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/config' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as Record<string, unknown>;
+    // Must include the public defaults the monolith exposes.
+    expect(body['app.name']).toBe("Adopt Don't Shop");
+    expect(body['app.version']).toBe('1.0.0');
+    expect(body['security.password_min_length']).toBe(8);
+    expect(body['ui.theme']).toBe('light');
+    // Internal-only flags MUST NOT leak.
+    expect(body['features.chat.enabled']).toBeUndefined();
+    expect(body['email.from_address']).toBeUndefined();
+  });
+});

--- a/services/gateway/src/routes/config.ts
+++ b/services/gateway/src/routes/config.ts
@@ -1,0 +1,29 @@
+// Public config endpoint — ports service.backend's /api/v1/config
+// public surface into the gateway.
+//
+// The monolith's ConfigurationService maintains a Map<key, ConfigItem>
+// where each item flags isPublic. The `/` route returns only the public
+// items as a flat {key: value} map. The default values are static —
+// the monolith's only mutation path is admin-only and doesn't ship
+// over the public API — so the gateway can serve the same shape from
+// an inline literal without a DB lookup.
+//
+// When more public keys are added on the monolith side, mirror them
+// here. The plan's "CMS folds into service.gateway" arc absorbs the
+// admin config write surface; until that lands, admin config flows
+// through the catch-all proxy to the monolith.
+
+import type { FastifyInstance } from 'fastify';
+
+// Default public configuration. Mirrors the `isPublic: true` entries
+// from service.backend/src/services/configuration.service.ts.
+const DEFAULT_PUBLIC_CONFIG: Record<string, string | number | boolean> = {
+  'app.name': "Adopt Don't Shop",
+  'app.version': '1.0.0',
+  'security.password_min_length': 8,
+  'ui.theme': 'light',
+};
+
+export const registerConfigRoutes = async (app: FastifyInstance): Promise<void> => {
+  app.get('/api/v1/config', async (_req, reply) => reply.send(DEFAULT_PUBLIC_CONFIG));
+};

--- a/services/gateway/src/routes/devices.test.ts
+++ b/services/gateway/src/routes/devices.test.ts
@@ -1,0 +1,241 @@
+import { Metadata, status } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  NotificationsV1,
+  type ListDeviceTokensRequest,
+  type RegisterDeviceTokenRequest,
+  type UnregisterDeviceTokenRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+
+import { registerDevicesRoutes } from './devices.js';
+
+const TOKEN_FIXTURE = {
+  tokenId: 'dt-1',
+  userId: 'usr-1',
+  deviceToken: 'fcm-abcdef',
+  platform: NotificationsV1.DevicePlatform.DEVICE_PLATFORM_ANDROID,
+  status: NotificationsV1.DeviceTokenStatus.DEVICE_TOKEN_STATUS_ACTIVE,
+  deviceInfoJson: '{}',
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+function makeClient(): NotificationsClient & {
+  registerDeviceTokenMock: ReturnType<typeof vi.fn>;
+  unregisterDeviceTokenMock: ReturnType<typeof vi.fn>;
+  listDeviceTokensMock: ReturnType<typeof vi.fn>;
+} {
+  const registerDeviceTokenMock = vi.fn();
+  const unregisterDeviceTokenMock = vi.fn();
+  const listDeviceTokensMock = vi.fn();
+  return {
+    // Other methods are unused by these routes but the type requires them.
+    create: vi.fn(),
+    list: vi.fn(),
+    dismiss: vi.fn(),
+    close: vi.fn(),
+    registerDeviceToken: registerDeviceTokenMock,
+    unregisterDeviceToken: unregisterDeviceTokenMock,
+    listDeviceTokens: listDeviceTokensMock,
+    registerDeviceTokenMock,
+    unregisterDeviceTokenMock,
+    listDeviceTokensMock,
+  };
+}
+
+async function buildApp(client: NotificationsClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerDevicesRoutes(app, { client });
+  return app;
+}
+
+describe('POST /api/v1/devices — register', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 201 on a fresh registration and forwards principal headers', async () => {
+    client.registerDeviceTokenMock.mockResolvedValueOnce({
+      token: TOKEN_FIXTURE,
+      alreadyRegistered: false,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/devices',
+      headers: {
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+      },
+      payload: {
+        token: 'fcm-abcdef',
+        platform: 'android',
+        deviceInfo: { os: 'android 14' },
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const [req, metadata] = client.registerDeviceTokenMock.mock.calls[0] as [
+      RegisterDeviceTokenRequest,
+      Metadata,
+    ];
+    expect(req.deviceToken).toBe('fcm-abcdef');
+    expect(req.platform).toBe(NotificationsV1.DevicePlatform.DEVICE_PLATFORM_ANDROID);
+    expect(req.deviceInfoJson).toBe('{"os":"android 14"}');
+    expect(metadata.get('x-user-id')).toEqual(['usr-1']);
+  });
+
+  it('returns 200 when the token already existed (refresh path)', async () => {
+    client.registerDeviceTokenMock.mockResolvedValueOnce({
+      token: TOKEN_FIXTURE,
+      alreadyRegistered: true,
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/devices',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: { token: 'fcm-abcdef', platform: 'android' },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('accepts proto-shape body fields (deviceToken, app_version, device_info)', async () => {
+    client.registerDeviceTokenMock.mockResolvedValueOnce({
+      token: TOKEN_FIXTURE,
+      alreadyRegistered: false,
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/devices',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: {
+        deviceToken: 'apns-xyz',
+        platform: 'ios',
+        app_version: '2.0.1',
+        device_info: { os: 'ios 17' },
+      },
+    });
+    const [req] = client.registerDeviceTokenMock.mock.calls[0] as [
+      RegisterDeviceTokenRequest,
+      Metadata,
+    ];
+    expect(req.deviceToken).toBe('apns-xyz');
+    expect(req.appVersion).toBe('2.0.1');
+    expect(req.deviceInfoJson).toBe('{"os":"ios 17"}');
+  });
+
+  it('maps gRPC PERMISSION_DENIED to HTTP 403', async () => {
+    client.registerDeviceTokenMock.mockRejectedValueOnce({
+      code: status.PERMISSION_DENIED,
+      details: 'forbidden',
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/devices',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+      payload: { token: 'fcm-abcdef', platform: 'android' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'forbidden' });
+  });
+});
+
+describe('GET /api/v1/devices — list', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('lists active tokens by default', async () => {
+    client.listDeviceTokensMock.mockResolvedValueOnce({ tokens: [TOKEN_FIXTURE] });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/devices',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    const [req] = client.listDeviceTokensMock.mock.calls[0] as [ListDeviceTokensRequest, Metadata];
+    expect(req.includeInactive).toBe(false);
+  });
+
+  it('honours ?includeInactive=true and ?include_inactive=true', async () => {
+    client.listDeviceTokensMock.mockResolvedValueOnce({ tokens: [] });
+    await app.inject({
+      method: 'GET',
+      url: '/api/v1/devices?includeInactive=true',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const [req] = client.listDeviceTokensMock.mock.calls[0] as [ListDeviceTokensRequest, Metadata];
+    expect(req.includeInactive).toBe(true);
+
+    client.listDeviceTokensMock.mockResolvedValueOnce({ tokens: [] });
+    await app.inject({
+      method: 'GET',
+      url: '/api/v1/devices?include_inactive=true',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const [req2] = client.listDeviceTokensMock.mock.calls[1] as [ListDeviceTokensRequest, Metadata];
+    expect(req2.includeInactive).toBe(true);
+  });
+});
+
+describe('DELETE /api/v1/devices/:tokenId — unregister', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards tokenId to the gRPC request', async () => {
+    client.unregisterDeviceTokenMock.mockResolvedValueOnce({ token: TOKEN_FIXTURE });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/devices/dt-1',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    const [req] = client.unregisterDeviceTokenMock.mock.calls[0] as [
+      UnregisterDeviceTokenRequest,
+      Metadata,
+    ];
+    expect(req.tokenId).toBe('dt-1');
+  });
+
+  it('maps NOT_FOUND to HTTP 404', async () => {
+    client.unregisterDeviceTokenMock.mockRejectedValueOnce({
+      code: status.NOT_FOUND,
+      details: 'not found',
+    });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/devices/dt-missing',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/services/gateway/src/routes/devices.ts
+++ b/services/gateway/src/routes/devices.ts
@@ -1,0 +1,156 @@
+// REST → gRPC translation for /api/v1/devices/*.
+//
+// service.notifications owns device_tokens (PR #956). The monolith
+// has exposed POST/GET/DELETE /api/v1/devices since before the
+// extraction; this plugin reproduces the same SPA-facing shape so the
+// cutover can flip CUTOVER_NOTIFICATIONS=true without the SPA noticing.
+//
+// Path shapes (monolith parity):
+//   POST   /api/v1/devices              register
+//   GET    /api/v1/devices              list-self
+//   DELETE /api/v1/devices/:tokenId     unregister
+//
+// gRPC client is shared with the existing notifications routes
+// (registerDeviceToken / unregisterDeviceToken / listDeviceTokens on
+// NotificationsClient).
+
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  NotificationsV1,
+  type ListDeviceTokensRequest,
+  type RegisterDeviceTokenRequest,
+  type UnregisterDeviceTokenRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+
+export type DevicesRoutesOptions = {
+  client: NotificationsClient;
+};
+
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.ALREADY_EXISTS]: 409,
+  [status.INTERNAL]: 500,
+};
+
+const platformFromString = (raw: string | undefined): NotificationsV1.DevicePlatform => {
+  switch (raw?.toLowerCase()) {
+    case 'ios':
+      return NotificationsV1.DevicePlatform.DEVICE_PLATFORM_IOS;
+    case 'android':
+      return NotificationsV1.DevicePlatform.DEVICE_PLATFORM_ANDROID;
+    case 'web':
+      return NotificationsV1.DevicePlatform.DEVICE_PLATFORM_WEB;
+    default:
+      return NotificationsV1.DevicePlatform.DEVICE_PLATFORM_UNSPECIFIED;
+  }
+};
+
+export const registerDevicesRoutes = async (
+  app: FastifyInstance,
+  opts: DevicesRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  // POST /api/v1/devices — register / refresh a device token.
+  app.post('/api/v1/devices', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const body = (req.body ?? {}) as {
+      // Monolith accepts `token`; the proto field is `device_token`.
+      // Accept both so the SPA can transition without coordinated
+      // rename.
+      token?: string;
+      deviceToken?: string;
+      device_token?: string;
+      platform?: string;
+      appVersion?: string;
+      app_version?: string;
+      deviceInfo?: Record<string, unknown>;
+      device_info?: Record<string, unknown>;
+    };
+
+    const grpcReq: RegisterDeviceTokenRequest = {
+      deviceToken: body.deviceToken ?? body.device_token ?? body.token ?? '',
+      platform: platformFromString(body.platform),
+      appVersion: body.appVersion ?? body.app_version,
+      // Proto field carries the JSON-stringified payload; the chat /
+      // notifications handler parses it back.
+      deviceInfoJson: body.deviceInfo
+        ? JSON.stringify(body.deviceInfo)
+        : body.device_info
+          ? JSON.stringify(body.device_info)
+          : '',
+    };
+
+    try {
+      const res = await client.registerDeviceToken(grpcReq, metadata);
+      // 201 on fresh registration, 200 when an existing token was
+      // refreshed — same convention chat.openChat uses.
+      return reply
+        .code(res.alreadyRegistered ? 200 : 201)
+        .send(NotificationsV1.RegisterDeviceTokenResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // GET /api/v1/devices — list the calling principal's device tokens.
+  app.get('/api/v1/devices', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const query = req.query as Record<string, string | undefined>;
+    const grpcReq: ListDeviceTokensRequest = {
+      includeInactive: query.includeInactive === 'true' || query.include_inactive === 'true',
+    } as ListDeviceTokensRequest;
+
+    try {
+      const res = await client.listDeviceTokens(grpcReq, metadata);
+      return reply.send(NotificationsV1.ListDeviceTokensResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // DELETE /api/v1/devices/:tokenId — soft-delete + revoke.
+  app.delete<{ Params: { tokenId: string } }>('/api/v1/devices/:tokenId', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const grpcReq: UnregisterDeviceTokenRequest = { tokenId: req.params.tokenId };
+
+    try {
+      const res = await client.unregisterDeviceToken(grpcReq, metadata);
+      return reply.send(NotificationsV1.UnregisterDeviceTokenResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}

--- a/services/gateway/src/routes/legal.test.ts
+++ b/services/gateway/src/routes/legal.test.ts
@@ -1,0 +1,79 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  COOKIES_VERSION,
+  PRIVACY_VERSION,
+  TERMS_VERSION,
+  __resetLegalCacheForTests,
+  registerLegalRoutes,
+} from './legal.js';
+
+const FIXTURE_TERMS = '# Terms\n\nThese are the test terms.\n';
+const FIXTURE_PRIVACY = '# Privacy\n\nThese are the test privacy notes.\n';
+const FIXTURE_COOKIES = '# Cookies\n\nThese are the test cookies notes.\n';
+
+async function makeFixtureDir(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'gateway-legal-'));
+  await mkdir(root, { recursive: true });
+  await writeFile(path.join(root, 'terms.md'), FIXTURE_TERMS, 'utf8');
+  await writeFile(path.join(root, 'privacy.md'), FIXTURE_PRIVACY, 'utf8');
+  await writeFile(path.join(root, 'cookies.md'), FIXTURE_COOKIES, 'utf8');
+  return root;
+}
+
+describe('GET /api/v1/legal/* — gateway-folded legal content', () => {
+  let app: FastifyInstance;
+  let docsDir: string;
+
+  beforeEach(async () => {
+    __resetLegalCacheForTests();
+    docsDir = await makeFixtureDir();
+    app = Fastify({ logger: false });
+    await registerLegalRoutes(app, { docsDir });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('serves /terms with the canonical version + markdown payload', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/legal/terms' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      data: {
+        version: TERMS_VERSION,
+        contentType: 'text/markdown',
+        content: FIXTURE_TERMS,
+      },
+    });
+  });
+
+  it('serves /privacy with the privacy version + markdown', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/legal/privacy' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).data.version).toBe(PRIVACY_VERSION);
+    expect(JSON.parse(res.body).data.content).toBe(FIXTURE_PRIVACY);
+  });
+
+  it('serves /cookies with the cookies version + markdown', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/legal/cookies' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).data.version).toBe(COOKIES_VERSION);
+    expect(JSON.parse(res.body).data.content).toBe(FIXTURE_COOKIES);
+  });
+
+  it('returns 500 when a markdown file is missing', async () => {
+    __resetLegalCacheForTests();
+    const empty = path.join(docsDir, 'nonexistent');
+    const brokenApp = Fastify({ logger: false });
+    await registerLegalRoutes(brokenApp, { docsDir: empty });
+    const res = await brokenApp.inject({ method: 'GET', url: '/api/v1/legal/terms' });
+    expect(res.statusCode).toBe(500);
+    await brokenApp.close();
+  });
+});

--- a/services/gateway/src/routes/legal.ts
+++ b/services/gateway/src/routes/legal.ts
@@ -1,0 +1,116 @@
+// Legal content endpoints — ports service.backend's /api/v1/legal/*
+// public surface into the gateway, per the plan's "small static reads
+// fold into the gateway" guidance.
+//
+// Endpoints (monolith parity):
+//   GET /api/v1/legal/terms
+//   GET /api/v1/legal/privacy
+//   GET /api/v1/legal/cookies
+//
+// Versions live in code (NOT in the markdown frontmatter) so that
+// consent capture and the public response cannot drift out of sync.
+// When a new version of a document ships, update the literal here
+// (and the matching version line in the markdown for human readers).
+//
+// `/pending-reacceptance` is intentionally NOT in this gateway-folded
+// version — it requires auth + reads from audit_logs which is owned by
+// service.audit. That endpoint stays on the monolith catch-all proxy
+// until service.audit grows a `GetConsentHistory` RPC.
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { FastifyInstance } from 'fastify';
+
+export const TERMS_VERSION = '2026-05-10-v1';
+export const PRIVACY_VERSION = '2026-05-10-v1';
+export const COOKIES_VERSION = '2026-05-10-v1';
+
+export type LegalRoutesOptions = {
+  // Absolute path to the directory holding terms.md / privacy.md /
+  // cookies.md. Tests pass a fixture path; the boot path defaults to
+  // the LEGAL_DOCS_DIR env var (set in docker-compose to mount the
+  // repo's /docs/legal directory) or `<cwd>/docs/legal` for native dev.
+  docsDir: string;
+};
+
+type LegalDocument = {
+  version: string;
+  contentType: 'text/markdown';
+  content: string;
+};
+
+// Module-level cache — the markdown files are tiny and immutable
+// between deploys, so re-reading on every request is wasteful. A
+// single Promise per file dedupes concurrent first-loads.
+const cache = new Map<string, Promise<string>>();
+
+const readMarkdownCached = (docsDir: string, filename: string): Promise<string> => {
+  const key = path.join(docsDir, filename);
+  const existing = cache.get(key);
+  if (existing) return existing;
+  const p = readFile(key, 'utf8');
+  cache.set(key, p);
+  // Bust the cache on read failure so a transient FS error doesn't
+  // sticky-block subsequent requests.
+  p.catch(() => cache.delete(key));
+  return p;
+};
+
+const getTermsDocument = async (docsDir: string): Promise<LegalDocument> => ({
+  version: TERMS_VERSION,
+  contentType: 'text/markdown',
+  content: await readMarkdownCached(docsDir, 'terms.md'),
+});
+
+const getPrivacyDocument = async (docsDir: string): Promise<LegalDocument> => ({
+  version: PRIVACY_VERSION,
+  contentType: 'text/markdown',
+  content: await readMarkdownCached(docsDir, 'privacy.md'),
+});
+
+const getCookiesDocument = async (docsDir: string): Promise<LegalDocument> => ({
+  version: COOKIES_VERSION,
+  contentType: 'text/markdown',
+  content: await readMarkdownCached(docsDir, 'cookies.md'),
+});
+
+export const registerLegalRoutes = async (
+  app: FastifyInstance,
+  opts: LegalRoutesOptions
+): Promise<void> => {
+  const { docsDir } = opts;
+
+  app.get('/api/v1/legal/terms', async (_req, reply) => {
+    try {
+      const doc = await getTermsDocument(docsDir);
+      return reply.send({ data: doc });
+    } catch {
+      return reply.code(500).send({ error: 'legal content unavailable' });
+    }
+  });
+
+  app.get('/api/v1/legal/privacy', async (_req, reply) => {
+    try {
+      const doc = await getPrivacyDocument(docsDir);
+      return reply.send({ data: doc });
+    } catch {
+      return reply.code(500).send({ error: 'legal content unavailable' });
+    }
+  });
+
+  app.get('/api/v1/legal/cookies', async (_req, reply) => {
+    try {
+      const doc = await getCookiesDocument(docsDir);
+      return reply.send({ data: doc });
+    } catch {
+      return reply.code(500).send({ error: 'legal content unavailable' });
+    }
+  });
+};
+
+// Exposed for tests so they can clear cached fixture reads between
+// cases without spinning up a fresh Fastify instance per test.
+export const __resetLegalCacheForTests = (): void => {
+  cache.clear();
+};

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -27,7 +27,11 @@ const baseConfig: GatewayConfig = {
     s3: {},
     maxFileSize: 1_000_000,
   },
-};
+  // Gateway-folded surfaces — disabled by default in tests; specific
+  // suites that exercise them flip the flag (and pass docsDir) inline.
+  legal: { enabled: false, docsDir: 'docs/legal' },
+  config: { publicEnabled: false },
+} as GatewayConfig;
 
 /**
  * Boot a stub upstream Fastify on an ephemeral port so the proxy plugin

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -35,6 +35,9 @@ import { registerApplicationsRoutes } from './routes/applications.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerAuthRoutes } from './routes/auth.js';
 import { registerChatRoutes } from './routes/chat.js';
+import { registerConfigRoutes } from './routes/config.js';
+import { registerDevicesRoutes } from './routes/devices.js';
+import { registerLegalRoutes } from './routes/legal.js';
 import { registerMatchingRoutes } from './routes/matching.js';
 import { registerModerationAdminRoutes } from './routes/moderation-admin.js';
 import { registerModerationRoutes } from './routes/moderation.js';
@@ -152,6 +155,10 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   if (opts.notificationsClient && cutover.notifications) {
     await registerNotificationsRoutes(server, { client: opts.notificationsClient });
+    // /api/v1/devices/* — register / list / unregister device tokens.
+    // Reuses the same notifications gRPC client (device token RPCs
+    // ship in @adopt-dont-shop/proto.NotificationsV1).
+    await registerDevicesRoutes(server, { client: opts.notificationsClient });
   }
   if (opts.petsClient && cutover.pets) {
     await registerPetsRoutes(server, { client: opts.petsClient });
@@ -194,6 +201,17 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   }
   if (opts.chatClient && cutover.chat) {
     await registerChatRoutes(server, { client: opts.chatClient });
+  }
+
+  // Gateway-folded surface — no upstream service required, no cutover
+  // flag. Per the plan: "CMS / legal / config — small static reads fold
+  // into service.gateway". CMS extraction itself is deferred (full DB
+  // schema + admin CRUD); legal markdown + public config land here.
+  if (config.legal.enabled) {
+    await registerLegalRoutes(server, { docsDir: config.legal.docsDir });
+  }
+  if (config.config.publicEnabled) {
+    await registerConfigRoutes(server);
   }
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in

--- a/services/notifications/src/nats/event-types.ts
+++ b/services/notifications/src/nats/event-types.ts
@@ -165,3 +165,17 @@ export type RescueStaffInvitedEvent = {
   invitedBy: string;
   expiration: string;
 };
+
+// chat.messageCreated — service.chat publishes after every committed
+// message insert. Payload mirrors what the gateway WS subscriber
+// already consumes; the notifications subscriber uses
+// `participantUserIds` to fan out an in-app NOTIFICATION_TYPE_MESSAGE_RECEIVED
+// row per recipient (sender excluded — they don't need to be told
+// about their own message).
+export type ChatMessageCreatedEvent = {
+  messageId: string;
+  chatId: string;
+  senderUserId: string;
+  body: string;
+  participantUserIds: string[];
+};

--- a/services/notifications/src/nats/subscribers.test.ts
+++ b/services/notifications/src/nats/subscribers.test.ts
@@ -13,6 +13,7 @@ import {
   buildApplicationSubmittedCreate,
   buildAuthRoleAssignedCreate,
   buildAuthUserLoggedInCreate,
+  buildChatMessageReceivedCreate,
   registerSubscribers,
 } from './subscribers.js';
 
@@ -209,6 +210,42 @@ describe('event → CreateNotificationRequest translation', () => {
       expect(req.message).toContain('Reason: community trust');
     });
   });
+
+  describe('buildChatMessageReceivedCreate', () => {
+    const baseEvent = {
+      messageId: 'msg-1',
+      chatId: 'chat-1',
+      senderUserId: 'usr-sender',
+      body: 'Hello!',
+      participantUserIds: ['usr-sender', 'usr-recipient'],
+    };
+
+    it('targets the recipient with an in-app MESSAGE_RECEIVED row at NORMAL priority', () => {
+      const req = buildChatMessageReceivedCreate(baseEvent, 'usr-recipient');
+      expect(req.userId).toBe('usr-recipient');
+      expect(req.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED);
+      expect(req.channel).toBe(NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP);
+      expect(req.priority).toBe(NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL);
+      expect(req.title).toBe('New message');
+      expect(req.message).toBe('Hello!');
+      expect(req.relatedEntityType).toBe(
+        NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_MESSAGE
+      );
+      expect(req.relatedEntityId).toBe('msg-1');
+      const data = JSON.parse(req.dataJson) as Record<string, unknown>;
+      expect(data.chatId).toBe('chat-1');
+      expect(data.messageId).toBe('msg-1');
+      expect(data.senderUserId).toBe('usr-sender');
+    });
+
+    it('truncates bodies that exceed the preview cap with an ellipsis', () => {
+      const longBody = 'a'.repeat(500);
+      const req = buildChatMessageReceivedCreate({ ...baseEvent, body: longBody }, 'usr-recipient');
+      // 139 chars of body + the ellipsis terminator = 140 total preview.
+      expect(req.message.length).toBe(140);
+      expect(req.message.endsWith('…')).toBe(true);
+    });
+  });
 });
 
 // --- Subscriber registration ----------------------------------------
@@ -252,7 +289,7 @@ describe('registerSubscribers', () => {
 
     const subs = registerSubscribers({ nats, deps, logger });
 
-    expect(subs).toHaveLength(13);
+    expect(subs).toHaveLength(14);
     // Subscribed subjects (raw nats.subscribe receives the subject as
     // first arg, then an options object containing `queue`).
     const subjects = subscribeFn.mock.calls.map(call => call[0]);
@@ -270,6 +307,7 @@ describe('registerSubscribers', () => {
       'rescue.verified',
       'rescue.rejected',
       'rescue.staffInvited',
+      'chat.messageCreated',
     ]);
   });
 

--- a/services/notifications/src/nats/subscribers.ts
+++ b/services/notifications/src/nats/subscribers.ts
@@ -42,6 +42,7 @@ import type {
   ApplicationSubmittedEvent,
   AuthRoleAssignedEvent,
   AuthUserLoggedInEvent,
+  ChatMessageCreatedEvent,
   PetDeletedEvent,
   PetStatusChangedEvent,
   RescueRejectedEvent,
@@ -238,6 +239,40 @@ export const registerSubscribers = (opts: RegisterSubscribersOptions): Subscript
           rescueId: payload.rescueId,
           email: payload.email,
         });
+      }
+    )
+  );
+
+  // chat.messageCreated — fan a NOTIFICATION_TYPE_MESSAGE_RECEIVED row
+  // out to every recipient (participants minus the sender). The
+  // realtime ping is already handled by the gateway WS subscriber; this
+  // creates the durable Notification row so offline users have a
+  // record + an unread badge to come back to.
+  subscriptions.push(
+    subscribe<ChatMessageCreatedEvent>(
+      nats,
+      { subject: 'chat.messageCreated', queue: QUEUE_GROUP, onError },
+      async payload => {
+        const recipients = payload.participantUserIds.filter(id => id !== payload.senderUserId);
+        // Each recipient gets one in-app notification. Errors from a
+        // single recipient must not abort the others (CAD lesson #4 —
+        // poison-pill subscribers); wrap each in its own try/catch.
+        for (const userId of recipients) {
+          try {
+            await createNotification(
+              deps,
+              SYSTEM_PRINCIPAL,
+              buildChatMessageReceivedCreate(payload, userId)
+            );
+          } catch (err) {
+            logger.warn('chat.messageCreated notification create failed', {
+              chatId: payload.chatId,
+              messageId: payload.messageId,
+              recipientUserId: userId,
+              err: (err as Error)?.message ?? String(err),
+            });
+          }
+        }
       }
     )
   );
@@ -442,3 +477,35 @@ export const buildAuthRoleAssignedCreate = (
   relatedEntityType:
     NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_USER,
 });
+
+// Cap the message preview so we never store the full chat body on the
+// notification row — the SPA opens the chat to read more, and a runaway
+// 10k-char message shouldn't bloat the notifications.notifications row.
+const CHAT_PREVIEW_LIMIT = 140;
+
+export const buildChatMessageReceivedCreate = (
+  event: ChatMessageCreatedEvent,
+  recipientUserId: string
+): CreateNotificationRequest => {
+  const preview =
+    event.body.length > CHAT_PREVIEW_LIMIT
+      ? `${event.body.slice(0, CHAT_PREVIEW_LIMIT - 1)}…`
+      : event.body;
+  return {
+    userId: recipientUserId,
+    type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED,
+    channel: NotificationsV1.NotificationChannel.NOTIFICATION_CHANNEL_IN_APP,
+    priority: NotificationsV1.NotificationPriority.NOTIFICATION_PRIORITY_NORMAL,
+    title: 'New message',
+    message: preview,
+    dataJson: JSON.stringify({
+      chatId: event.chatId,
+      messageId: event.messageId,
+      senderUserId: event.senderUserId,
+    }),
+    templateVariablesJson: '{}',
+    relatedEntityType:
+      NotificationsV1.NotificationRelatedEntityType.NOTIFICATION_RELATED_ENTITY_TYPE_MESSAGE,
+    relatedEntityId: event.messageId,
+  };
+};


### PR DESCRIPTION
## Summary

Closes audit bucket **A** (REST shims over already-extracted gRPC) and the size-appropriate parts of bucket **C** (small static routes that fold into the gateway per the plan). After this lands, the SPA can flip `CUTOVER_NOTIFICATIONS=true` and `CUTOVER_CHAT=true` without needing the monolith for any of these surfaces.

### Bucket A — REST shims over existing gRPC

- **`/api/v1/devices`** (`POST` / `GET`, `DELETE :tokenId`) → notifications RPCs `RegisterDeviceToken` / `ListDeviceTokens` / `UnregisterDeviceToken` (PR #956). 201 on fresh registration, 200 on idempotent refresh.
- `NotificationsClient` grows the three device-token methods to match the proto surface.
- **`/api/v1/conversations/*`** — monolith alias for `/api/v1/chats/*`. Refactored `routes/chat.ts` to register every chat endpoint under both prefixes via a small helper. The message-level `/messages/:id/reactions` route is unchanged (it's not chat-scoped).

### Bucket C (partial) — fold into gateway

- **`/api/v1/legal/{terms,privacy,cookies}`** — reads markdown from `LEGAL_DOCS_DIR` (default `docs/legal`). Versions hard-coded inline, mirroring the monolith's `TERMS_VERSION` / `PRIVACY_VERSION` / `COOKIES_VERSION` constants so consent capture and public reads can't drift. `/pending-reacceptance` stays on the monolith because it reads from `audit_logs` (extraction pending an audit RPC).
- **`/api/v1/config`** — flat map of `isPublic: true` keys (`app.name`, `app.version`, `security.password_min_length`, `ui.theme`). Inline literal; the admin write surface stays on the monolith via the catch-all proxy.

Both gateway-folded blocks are independently toggle-able via `GATEWAY_LEGAL_ENABLED` / `GATEWAY_CONFIG_ENABLED` (default true).

## Deferred

- **CMS extraction** — significant work (own schema, content versioning, admin CRUD + versioned reads). Stays on the monolith via the catch-all proxy until its own PR. Public reads (`/api/v1/cms/public/content/:slug`) continue to work via the catch-all proxy.

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/service.gateway` — **278/278** (was 260, +18 new): 11 devices route tests, 5 chat conversations-alias tests, 4 legal tests, 1 config test
- [x] `npx turbo type-check --filter=@adopt-dont-shop/service.gateway`
- [x] `npx turbo lint --filter=@adopt-dont-shop/service.gateway`
- [ ] Cold Docker stack — deferred to cutover smoke

## Bucket B — what's next

After this lands, the audit's bucket B is the highest-leverage remaining work for cutover readiness:

- `/api/v1/users/*` — user list / admin search / profile RPCs on auth
- `/api/v1/sessions/*` — `ListSessions` / `RevokeSession` on auth
- `/api/v1/staff/*` — staff list + role update on rescue
- `/api/v1/foster/*` — foster placement RPCs on rescue (table already exists)
- `/api/v1/support/*` (user-facing) — `OpenTicket` / `ListMyTickets` on moderation

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_