### PR TITLE
feat(gateway): /discovery/swipe/action alias → RecordSwipe RPC

### DIFF
--- a/services/gateway/src/routes/matching.test.ts
+++ b/services/gateway/src/routes/matching.test.ts
@@ -262,6 +262,63 @@ describe('POST /api/v1/matching/sessions/:id/swipes', () => {
   });
 });
 
+describe('POST /api/v1/discovery/swipe/action — SPA-facing alias', () => {
+  let app: FastifyInstance;
+  let recordSwipeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const m = makeClient();
+    recordSwipeMock = m.recordSwipeMock;
+    app = await makeApp(m.client);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 200 with the monolith envelope on success', async () => {
+    recordSwipeMock.mockResolvedValue({ action: SWIPE_FIXTURE, session: SESSION_FIXTURE });
+    const httpRes = await app.inject({
+      method: 'POST',
+      url: '/api/v1/discovery/swipe/action',
+      headers: ADOPTER_HEADERS,
+      payload: { sessionId: 'sess-1', petId: 'pet-1', action: 'like' },
+    });
+    expect(httpRes.statusCode).toBe(200);
+    expect(JSON.parse(httpRes.body)).toEqual({
+      success: true,
+      message: 'Swipe action recorded successfully',
+    });
+  });
+
+  it('forwards sessionId from body (not URL) to RecordSwipe', async () => {
+    recordSwipeMock.mockResolvedValue({ action: SWIPE_FIXTURE, session: SESSION_FIXTURE });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/discovery/swipe/action',
+      headers: ADOPTER_HEADERS,
+      payload: { sessionId: 'sess-body', petId: 'pet-1', action: 'pass' },
+    });
+    expect(recordSwipeMock.mock.calls[0][0]).toMatchObject({
+      sessionId: 'sess-body',
+      petId: 'pet-1',
+      action: MatchingV1.SwipeAction.SWIPE_ACTION_PASS,
+    });
+  });
+
+  it('returns 400 when sessionId is missing', async () => {
+    const httpRes = await app.inject({
+      method: 'POST',
+      url: '/api/v1/discovery/swipe/action',
+      headers: ADOPTER_HEADERS,
+      payload: { petId: 'pet-1', action: 'like' },
+    });
+    expect(httpRes.statusCode).toBe(400);
+    expect(JSON.parse(httpRes.body)).toEqual({ error: 'sessionId is required' });
+    expect(recordSwipeMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('GET /api/v1/matching/swipes', () => {
   let app: FastifyInstance;
   let listSwipeHistoryMock: ReturnType<typeof vi.fn>;

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -149,6 +149,37 @@ export const registerMatchingRoutes = async (
     }
   );
 
+  // POST /api/v1/discovery/swipe/action — SPA-facing alias for
+  // RecordSwipe used by lib.discovery. Body carries sessionId rather
+  // than the URL path. Returns 200 + a monolith-shaped envelope
+  // ({ success, message }) so the SPA doesn't notice the cutover.
+  app.post(
+    '/api/v1/discovery/swipe/action',
+    { config: { rateLimit: MATCHING_RATE_LIMITS.recordSwipe } },
+    async (req, reply) => {
+      const body = (req.body ?? {}) as RecordSwipeBody & { sessionId?: string };
+      if (!body.sessionId) {
+        return reply.code(400).send({ error: 'sessionId is required' });
+      }
+      const grpcReq: RecordSwipeRequest = {
+        sessionId: body.sessionId,
+        petId: body.petId ?? '',
+        action: parseSwipeAction(body.action),
+        responseTime: body.responseTime,
+        deviceType: body.deviceType,
+      };
+      try {
+        await client.recordSwipe(grpcReq, buildMetadata(req));
+        return reply.send({
+          success: true,
+          message: 'Swipe action recorded successfully',
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
   app.get(
     '/api/v1/matching/swipes',
     { config: { rateLimit: MATCHING_RATE_LIMITS.listSwipeHistory } },


### PR DESCRIPTION
## Summary

Adds the SPA-facing alias for swipe recording so `lib.discovery`'s `recordSwipeAction()` call can flip to the gateway as soon as `CUTOVER_MATCHING=true`.

The monolith exposes this at `/api/v1/discovery/swipe/action` with the `sessionId` in the body (not in the URL). The existing `/api/v1/matching/sessions/:id/swipes` keeps the proto-faithful shape for new consumers.

| Path | Source | Body shape | Response |
|---|---|---|---|
| `POST /api/v1/discovery/swipe/action` | SPA (`lib.discovery`) | `{ sessionId, petId, action, responseTime? }` | `{ success, message }` |
| `POST /api/v1/matching/sessions/:id/swipes` | proto-faithful | `{ petId, action, ... }` | proto JSON |

Both route to the same `RecordSwipe` gRPC.

## Test plan

- [x] `npx turbo test --filter=@adopt-dont-shop/service.gateway` — **287/287** (3 new: success envelope, body-vs-URL sessionId, 400 when missing)
- [x] `npx turbo type-check / lint` clean

## Cutover-readiness status — where we are

After this PR, every SPA path defined in `lib.api/src/constants/api-paths.ts` that I've audited is either covered by an extracted-service gateway route or proxied via the catch-all:

| Domain | Status |
|---|---|
| `/api/v1/auth/*` (login/register/logout/refresh/me/forgot/reset/change/update) | ✅ extracted + gateway |
| `/api/v1/sessions/*` | ✅ extracted + gateway (PR #962) |
| `/api/v1/devices/*` | ✅ extracted + gateway (PR #961) |
| `/api/v1/legal/*` | ✅ gateway-folded (PR #961) |
| `/api/v1/config` | ✅ gateway-folded (PR #961) |
| `/api/v1/pets/*` | ✅ extracted + gateway |
| `/api/v1/rescues/*` | ✅ extracted + gateway |
| `/api/v1/applications/*` | ✅ extracted + gateway |
| `/api/v1/chats/*` + `/api/v1/conversations/*` (alias) + WS fan-out | ✅ extracted + gateway |
| `/api/v1/notifications/*` (in-app + email queue + push + scheduler) | ✅ extracted + gateway |
| `/api/v1/moderation/*` + `/api/v1/admin/support/*` | ✅ extracted + gateway |
| `/api/v1/matching/*` + `/api/v1/discovery/queue` + `/api/v1/discovery/pets/more` + `/api/v1/discovery/swipe/action` + `/api/v1/search/pets` | ✅ extracted + gateway (this PR closes the swipe alias) |
| `/api/v1/audit/*` | ✅ extracted + gateway |

## Remaining gaps (catch-all proxy still required)

These keep the monolith alive but are low-frequency or admin-only — none block flipping the existing `CUTOVER_*` flags:

- **Admin tooling**: `/api/v1/admin/users`, `/api/v1/admin/dashboard`, `/api/v1/admin/rescues`, `/api/v1/admin/audit-logs` — staff/admin UI, separate PRs each
- **Users**: `/api/v1/users/profile|account|preferences` — SPA defines paths but the actually-used surface (`/auth/me`) is already gateway-routed
- **GDPR / privacy**: `/api/v1/gdpr/*`, `/api/v1/privacy/*` — explicitly deferred per the M7-M10 plan
- **CMS**: `/api/v1/cms/*` — admin CRUD; public reads continue via catch-all (see PR #961 deferred note)
- **Uploads**: `/api/v1/uploads/images` — staged image upload (applications has documents covered)
- **Reports / analytics**: `/api/v1/reports`, `/api/v1/analytics` — plan: fold into `service.audit`
- **Foster / staff / inbox / support (user-facing)** — bucket B items not yet extracted
- **Feature flags**: `/api/v1/features` — likely Statsig direct from SPA

Cutover-recommended order:
1. Flip `CUTOVER_AUTH` first (covers `/auth/*`, `/sessions/*`, `/devices/*`)
2. Flip `CUTOVER_NOTIFICATIONS` (covers `/notifications/*`, `/devices/*` shares)
3. Flip `CUTOVER_PETS`, `CUTOVER_RESCUE` together
4. Flip `CUTOVER_APPLICATIONS`, `CUTOVER_CHAT`, `CUTOVER_MODERATION`, `CUTOVER_MATCHING` together
5. `CUTOVER_AUDIT` last (every other service's audit subscription stays clean)

Cold-stack 2-browser smoke deferred to the cutover PR.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_