### PR TITLE
feat(chat,gateway): full-text chat search

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
+++ b/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
@@ -43,6 +43,14 @@ service ChatService {
   // `emoji` indicates add; an explicit Remove uses a separate field.
   // Idempotent. Publishes chat.reactionAdded or chat.reactionRemoved.
   rpc React(ReactRequest) returns (ReactResponse);
+
+  // Full-text search across the calling principal's chats. Matches on
+  // message content (uses the messages.search_vector tsvector). Returns
+  // chats with their best-matching message preview, ordered by recency
+  // of the match. Self-scoped — only chats the caller participates in
+  // are returned (super_admin still scoped this way; staff cross-chat
+  // search is a separate admin RPC).
+  rpc SearchChats(SearchChatsRequest) returns (SearchChatsResponse);
 }
 
 // --- Messages --------------------------------------------------------
@@ -173,4 +181,42 @@ message ReactRequest {
 
 message ReactResponse {
   Message message = 1;
+}
+
+// --- SearchChats -----------------------------------------------------
+
+message SearchChatsRequest {
+  // Free-form search text. Server enforces 1..100 chars; longer or
+  // shorter strings return INVALID_ARGUMENT.
+  string query = 1;
+  // Offset-based pagination — matches the monolith's page/limit shape
+  // (the SPA already drives it that way). 1-indexed.
+  uint32 page = 2;
+  // Defaults to 20, max 100.
+  uint32 limit = 3;
+  // Optional rescue scope — limit results to chats anchored on a
+  // specific rescue. The caller's participation is enforced
+  // independently regardless of this filter.
+  optional string rescue_id = 4;
+}
+
+// SearchChatHit pairs the chat row with the best matching message
+// (the most recent message whose content matches the query). The SPA
+// renders this as a search result card.
+message SearchChatHit {
+  Chat chat = 1;
+  // The matching message preview. Present only when at least one
+  // message in the chat matched — when this is unset, the chat row
+  // would not have been returned.
+  Message match = 2;
+}
+
+message SearchChatsResponse {
+  repeated SearchChatHit hits = 1;
+  uint32 page = 2;
+  uint32 limit = 3;
+  // Total matching distinct chats — drives the SPA's pagination
+  // controls. Returned in addition to the page so the client can
+  // compute total_pages = ceil(total / limit).
+  uint32 total = 4;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
@@ -155,6 +155,54 @@ export interface ReactResponse {
   message?: Message | undefined;
 }
 
+export interface SearchChatsRequest {
+  /**
+   * Free-form search text. Server enforces 1..100 chars; longer or
+   * shorter strings return INVALID_ARGUMENT.
+   */
+  query: string;
+  /**
+   * Offset-based pagination — matches the monolith's page/limit shape
+   * (the SPA already drives it that way). 1-indexed.
+   */
+  page: number;
+  /** Defaults to 20, max 100. */
+  limit: number;
+  /**
+   * Optional rescue scope — limit results to chats anchored on a
+   * specific rescue. The caller's participation is enforced
+   * independently regardless of this filter.
+   */
+  rescueId?: string | undefined;
+}
+
+/**
+ * SearchChatHit pairs the chat row with the best matching message
+ * (the most recent message whose content matches the query). The SPA
+ * renders this as a search result card.
+ */
+export interface SearchChatHit {
+  chat?: Chat | undefined;
+  /**
+   * The matching message preview. Present only when at least one
+   * message in the chat matched — when this is unset, the chat row
+   * would not have been returned.
+   */
+  match?: Message | undefined;
+}
+
+export interface SearchChatsResponse {
+  hits: SearchChatHit[];
+  page: number;
+  limit: number;
+  /**
+   * Total matching distinct chats — drives the SPA's pagination
+   * controls. Returned in addition to the page so the client can
+   * compute total_pages = ceil(total / limit).
+   */
+  total: number;
+}
+
 function createBaseChat(): Chat {
   return {
     chatId: '',
@@ -1624,6 +1672,310 @@ export const ReactResponse: MessageFns<ReactResponse> = {
   },
 };
 
+function createBaseSearchChatsRequest(): SearchChatsRequest {
+  return { query: '', page: 0, limit: 0, rescueId: undefined };
+}
+
+export const SearchChatsRequest: MessageFns<SearchChatsRequest> = {
+  encode(message: SearchChatsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.query !== '') {
+      writer.uint32(10).string(message.query);
+    }
+    if (message.page !== 0) {
+      writer.uint32(16).uint32(message.page);
+    }
+    if (message.limit !== 0) {
+      writer.uint32(24).uint32(message.limit);
+    }
+    if (message.rescueId !== undefined) {
+      writer.uint32(34).string(message.rescueId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SearchChatsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSearchChatsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.query = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.limit = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.rescueId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SearchChatsRequest {
+    return {
+      query: isSet(object.query) ? globalThis.String(object.query) : '',
+      page: isSet(object.page) ? globalThis.Number(object.page) : 0,
+      limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
+      rescueId: isSet(object.rescueId)
+        ? globalThis.String(object.rescueId)
+        : isSet(object.rescue_id)
+          ? globalThis.String(object.rescue_id)
+          : undefined,
+    };
+  },
+
+  toJSON(message: SearchChatsRequest): unknown {
+    const obj: any = {};
+    if (message.query !== '') {
+      obj.query = message.query;
+    }
+    if (message.page !== 0) {
+      obj.page = Math.round(message.page);
+    }
+    if (message.limit !== 0) {
+      obj.limit = Math.round(message.limit);
+    }
+    if (message.rescueId !== undefined) {
+      obj.rescueId = message.rescueId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SearchChatsRequest>, I>>(base?: I): SearchChatsRequest {
+    return SearchChatsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SearchChatsRequest>, I>>(object: I): SearchChatsRequest {
+    const message = createBaseSearchChatsRequest();
+    message.query = object.query ?? '';
+    message.page = object.page ?? 0;
+    message.limit = object.limit ?? 0;
+    message.rescueId = object.rescueId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseSearchChatHit(): SearchChatHit {
+  return { chat: undefined, match: undefined };
+}
+
+export const SearchChatHit: MessageFns<SearchChatHit> = {
+  encode(message: SearchChatHit, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.chat !== undefined) {
+      Chat.encode(message.chat, writer.uint32(10).fork()).join();
+    }
+    if (message.match !== undefined) {
+      Message.encode(message.match, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SearchChatHit {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSearchChatHit();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chat = Chat.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.match = Message.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SearchChatHit {
+    return {
+      chat: isSet(object.chat) ? Chat.fromJSON(object.chat) : undefined,
+      match: isSet(object.match) ? Message.fromJSON(object.match) : undefined,
+    };
+  },
+
+  toJSON(message: SearchChatHit): unknown {
+    const obj: any = {};
+    if (message.chat !== undefined) {
+      obj.chat = Chat.toJSON(message.chat);
+    }
+    if (message.match !== undefined) {
+      obj.match = Message.toJSON(message.match);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SearchChatHit>, I>>(base?: I): SearchChatHit {
+    return SearchChatHit.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SearchChatHit>, I>>(object: I): SearchChatHit {
+    const message = createBaseSearchChatHit();
+    message.chat =
+      object.chat !== undefined && object.chat !== null ? Chat.fromPartial(object.chat) : undefined;
+    message.match =
+      object.match !== undefined && object.match !== null
+        ? Message.fromPartial(object.match)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseSearchChatsResponse(): SearchChatsResponse {
+  return { hits: [], page: 0, limit: 0, total: 0 };
+}
+
+export const SearchChatsResponse: MessageFns<SearchChatsResponse> = {
+  encode(message: SearchChatsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.hits) {
+      SearchChatHit.encode(v!, writer.uint32(10).fork()).join();
+    }
+    if (message.page !== 0) {
+      writer.uint32(16).uint32(message.page);
+    }
+    if (message.limit !== 0) {
+      writer.uint32(24).uint32(message.limit);
+    }
+    if (message.total !== 0) {
+      writer.uint32(32).uint32(message.total);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SearchChatsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSearchChatsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.hits.push(SearchChatHit.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.limit = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SearchChatsResponse {
+    return {
+      hits: globalThis.Array.isArray(object?.hits)
+        ? object.hits.map((e: any) => SearchChatHit.fromJSON(e))
+        : [],
+      page: isSet(object.page) ? globalThis.Number(object.page) : 0,
+      limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
+      total: isSet(object.total) ? globalThis.Number(object.total) : 0,
+    };
+  },
+
+  toJSON(message: SearchChatsResponse): unknown {
+    const obj: any = {};
+    if (message.hits?.length) {
+      obj.hits = message.hits.map(e => SearchChatHit.toJSON(e));
+    }
+    if (message.page !== 0) {
+      obj.page = Math.round(message.page);
+    }
+    if (message.limit !== 0) {
+      obj.limit = Math.round(message.limit);
+    }
+    if (message.total !== 0) {
+      obj.total = Math.round(message.total);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SearchChatsResponse>, I>>(base?: I): SearchChatsResponse {
+    return SearchChatsResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SearchChatsResponse>, I>>(
+    object: I
+  ): SearchChatsResponse {
+    const message = createBaseSearchChatsResponse();
+    message.hits = object.hits?.map(e => SearchChatHit.fromPartial(e)) || [];
+    message.page = object.page ?? 0;
+    message.limit = object.limit ?? 0;
+    message.total = object.total ?? 0;
+    return message;
+  },
+};
+
 /**
  * ChatService is the gRPC contract for the chat vertical. It owns
  * the `chat.*` schema (Chat, ChatParticipant, Message, MessageReaction,
@@ -1736,6 +2088,25 @@ export const ChatServiceService = {
       Buffer.from(ReactResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): ReactResponse => ReactResponse.decode(value),
   },
+  /**
+   * Full-text search across the calling principal's chats. Matches on
+   * message content (uses the messages.search_vector tsvector). Returns
+   * chats with their best-matching message preview, ordered by recency
+   * of the match. Self-scoped — only chats the caller participates in
+   * are returned (super_admin still scoped this way; staff cross-chat
+   * search is a separate admin RPC).
+   */
+  searchChats: {
+    path: '/adopt_dont_shop.chat.v1.ChatService/SearchChats' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: SearchChatsRequest): Buffer =>
+      Buffer.from(SearchChatsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): SearchChatsRequest => SearchChatsRequest.decode(value),
+    responseSerialize: (value: SearchChatsResponse): Buffer =>
+      Buffer.from(SearchChatsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): SearchChatsResponse => SearchChatsResponse.decode(value),
+  },
 } as const;
 
 export interface ChatServiceServer extends UntypedServiceImplementation {
@@ -1773,6 +2144,15 @@ export interface ChatServiceServer extends UntypedServiceImplementation {
    * Idempotent. Publishes chat.reactionAdded or chat.reactionRemoved.
    */
   react: handleUnaryCall<ReactRequest, ReactResponse>;
+  /**
+   * Full-text search across the calling principal's chats. Matches on
+   * message content (uses the messages.search_vector tsvector). Returns
+   * chats with their best-matching message preview, ordered by recency
+   * of the match. Self-scoped — only chats the caller participates in
+   * are returned (super_admin still scoped this way; staff cross-chat
+   * search is a separate admin RPC).
+   */
+  searchChats: handleUnaryCall<SearchChatsRequest, SearchChatsResponse>;
 }
 
 export interface ChatServiceClient extends Client {
@@ -1893,6 +2273,29 @@ export interface ChatServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: ReactResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Full-text search across the calling principal's chats. Matches on
+   * message content (uses the messages.search_vector tsvector). Returns
+   * chats with their best-matching message preview, ordered by recency
+   * of the match. Self-scoped — only chats the caller participates in
+   * are returned (super_admin still scoped this way; staff cross-chat
+   * search is a separate admin RPC).
+   */
+  searchChats(
+    request: SearchChatsRequest,
+    callback: (error: ServiceError | null, response: SearchChatsResponse) => void
+  ): ClientUnaryCall;
+  searchChats(
+    request: SearchChatsRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SearchChatsResponse) => void
+  ): ClientUnaryCall;
+  searchChats(
+    request: SearchChatsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SearchChatsResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -223,6 +223,9 @@ export type {
   MarkReadResponse,
   ReactRequest,
   ReactResponse,
+  SearchChatsRequest,
+  SearchChatsResponse,
+  SearchChatHit,
   ChatServiceServer,
   ChatServiceClient,
 } from './generated/proto/adopt_dont_shop/chat/v1/chat.js';

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -20,6 +20,7 @@ import {
   markRead,
   openChat,
   react,
+  searchChats,
   sendMessage,
 } from './handlers.js';
 
@@ -433,6 +434,140 @@ describe('react', () => {
     expect(res.message?.reactions).toHaveLength(0);
     expect(realClientQueries(mocks)).toEqual(['SELECT', 'DELETE']);
     expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.reactionRemoved');
+  });
+});
+
+// --- searchChats -----------------------------------------------------
+
+describe('searchChats', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects an empty query', async () => {
+    await expect(
+      searchChats(mocks.deps, ADOPTER_PRINCIPAL, { query: '', page: 1, limit: 20 })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects a query longer than 100 chars', async () => {
+    await expect(
+      searchChats(mocks.deps, ADOPTER_PRINCIPAL, { query: 'a'.repeat(101), page: 1, limit: 20 })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects an unprivileged principal', async () => {
+    await expect(
+      searchChats(mocks.deps, UNPRIVILEGED_PRINCIPAL, { query: 'cat', page: 1, limit: 20 })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('returns empty hits when count is 0 (no FTS match)', async () => {
+    mocks.poolScript.push({ rows: [{ total: '0' }] });
+
+    const res = await searchChats(mocks.deps, ADOPTER_PRINCIPAL, {
+      query: 'unfindable',
+      page: 1,
+      limit: 20,
+    });
+
+    expect(res).toEqual({ hits: [], page: 1, limit: 20, total: 0 });
+  });
+
+  it('returns hits with chat + match populated', async () => {
+    // SELECT COUNT(*) — total
+    mocks.poolScript.push({ rows: [{ total: '1' }] });
+    // The outer ORDERED SELECT — one matching chat + message row
+    mocks.poolScript.push({
+      rows: [
+        {
+          c_chat_id: 'chat-1',
+          c_application_id: 'app-1',
+          c_rescue_id: '00000000-0000-0000-0000-000000000000',
+          c_pet_id: null,
+          c_status: 'active',
+          c_created_at: new Date('2026-06-01T00:00:00Z'),
+          c_updated_at: new Date('2026-06-01T00:00:00Z'),
+          m_message_id: 'msg-9',
+          m_chat_id: 'chat-1',
+          m_sender_id: 'usr-rescue',
+          m_content: 'About that adoption',
+          m_edited_at: null,
+          m_deleted_at: null,
+          m_created_at: new Date('2026-06-01T00:30:00Z'),
+        },
+      ],
+    });
+    // Reactions lookup for matching message id
+    mocks.poolScript.push({ rows: [] });
+    // chatRowToProto helpers — participants then last-message-preview
+    mocks.poolScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolScript.push({
+      rows: [
+        {
+          content: 'About that adoption',
+          sender_id: 'usr-rescue',
+          created_at: new Date('2026-06-01T00:30:00Z'),
+        },
+      ],
+    });
+
+    const res = await searchChats(mocks.deps, ADOPTER_PRINCIPAL, {
+      query: 'adoption',
+      page: 1,
+      limit: 20,
+    });
+
+    expect(res.total).toBe(1);
+    expect(res.hits).toHaveLength(1);
+    expect(res.hits[0].chat?.chatId).toBe('chat-1');
+    expect(res.hits[0].match?.messageId).toBe('msg-9');
+    expect(res.hits[0].match?.body).toBe('About that adoption');
+  });
+
+  it('respects an optional rescue_id filter (binds it as a param)', async () => {
+    mocks.poolScript.push({ rows: [{ total: '0' }] });
+
+    await searchChats(mocks.deps, ADOPTER_PRINCIPAL, {
+      query: 'cat',
+      page: 1,
+      limit: 20,
+      rescueId: 'rsc-1',
+    });
+
+    const countCall = mocks.poolMock.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('COUNT(DISTINCT c.chat_id)')
+    );
+    expect(countCall).toBeDefined();
+    const params = countCall![1] as unknown[];
+    // 'english', query, principal.userId, rescueId
+    expect(params).toEqual(['english', 'cat', 'usr-adopter', 'rsc-1']);
+  });
+
+  it('passes pagination params through correctly', async () => {
+    mocks.poolScript.push({ rows: [{ total: '5' }] });
+    mocks.poolScript.push({ rows: [] });
+
+    await searchChats(mocks.deps, ADOPTER_PRINCIPAL, {
+      query: 'cat',
+      page: 2,
+      limit: 10,
+    });
+
+    // The hits SELECT receives limit + offset as the last two params.
+    const hitsCall = mocks.poolMock.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('hits') && sql.includes('LIMIT')
+    );
+    expect(hitsCall).toBeDefined();
+    const params = hitsCall![1] as unknown[];
+    expect(params[params.length - 2]).toBe(10); // limit
+    expect(params[params.length - 1]).toBe(10); // offset = (page-1)*limit
   });
 });
 

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -36,6 +36,9 @@ import type {
   OpenChatResponse,
   ReactRequest,
   ReactResponse,
+  SearchChatHit,
+  SearchChatsRequest,
+  SearchChatsResponse,
   SendMessageRequest,
   SendMessageResponse,
 } from '@adopt-dont-shop/proto';
@@ -694,4 +697,151 @@ export async function react(
   return {
     message: messageRowToProto(after.rows[0], reactions.get(req.messageId) ?? []),
   };
+}
+
+// --- SearchChats -----------------------------------------------------
+
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_SEARCH_LIMIT = 100;
+const MAX_QUERY_LEN = 100;
+
+export async function searchChats(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: SearchChatsRequest
+): Promise<SearchChatsResponse> {
+  if (!req.query || req.query.trim().length === 0) {
+    throw new HandlerError('INVALID_ARGUMENT', 'query is required');
+  }
+  const query = req.query.trim();
+  if (query.length > MAX_QUERY_LEN) {
+    throw new HandlerError('INVALID_ARGUMENT', `query must be <= ${MAX_QUERY_LEN} chars`);
+  }
+  if (!hasPermission(principal, CHAT_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_READ}' required`);
+  }
+
+  const limit = clampLimit(req.limit, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT);
+  const page = Math.max(req.page || 1, 1);
+  const offset = (page - 1) * limit;
+
+  // websearch_to_tsquery understands quoted phrases + "or" + leading "-"
+  // exclusion the way users expect from a search box, without the strict
+  // syntax to_tsquery requires. It returns no rows on an empty parse,
+  // which is the right behaviour for a stray punctuation-only query.
+  const tsQuery = 'websearch_to_tsquery($1, $2)';
+
+  // Self-scope: a message-content match still has to be in a chat the
+  // caller participates in. The `archived` filter mirrors the monolith.
+  const baseWhere: string[] = [
+    `c.status <> 'archived'`,
+    `c.deleted_at IS NULL`,
+    `p.participant_id = $3`,
+    `p.deleted_at IS NULL`,
+    `m.deleted_at IS NULL`,
+    `m.search_vector @@ ${tsQuery}`,
+  ];
+  const params: unknown[] = ['english', query, principal.userId];
+  let nextParam = 4;
+
+  if (req.rescueId) {
+    baseWhere.push(`c.rescue_id = $${nextParam}`);
+    params.push(req.rescueId);
+    nextParam += 1;
+  }
+
+  // Total distinct chat count — drives the SPA pagination ribbon.
+  const countSql = `
+    SELECT COUNT(DISTINCT c.chat_id)::text AS total
+    FROM chats c
+    JOIN chat_participants p ON p.chat_id = c.chat_id
+    JOIN messages m ON m.chat_id = c.chat_id
+    WHERE ${baseWhere.join(' AND ')}
+  `;
+  const countRes = await deps.pool.query<{ total: string }>(countSql, params);
+  const total = Number.parseInt(countRes.rows[0]?.total ?? '0', 10);
+
+  if (total === 0) {
+    return { hits: [], page, limit, total: 0 };
+  }
+
+  // For each matching chat, surface the most recent matching message
+  // (DISTINCT ON ordered by chat + created_at DESC). Sort the outer
+  // result by that match's recency so the SPA gets the freshest matches
+  // first, then deterministic chat_id tiebreaker.
+  const hitsSql = `
+    SELECT DISTINCT ON (c.chat_id)
+      c.chat_id AS c_chat_id, c.application_id AS c_application_id,
+      c.rescue_id AS c_rescue_id, c.pet_id AS c_pet_id,
+      c.status AS c_status,
+      c.created_at AS c_created_at, c.updated_at AS c_updated_at,
+      m.message_id AS m_message_id, m.chat_id AS m_chat_id,
+      m.sender_id AS m_sender_id, m.content AS m_content,
+      m.edited_at AS m_edited_at, m.deleted_at AS m_deleted_at,
+      m.created_at AS m_created_at
+    FROM chats c
+    JOIN chat_participants p ON p.chat_id = c.chat_id
+    JOIN messages m ON m.chat_id = c.chat_id
+    WHERE ${baseWhere.join(' AND ')}
+    ORDER BY c.chat_id, m.created_at DESC
+    LIMIT $${nextParam}
+    OFFSET $${nextParam + 1}
+  `;
+  // Wrap the DISTINCT ON in an outer SELECT so we can order by match
+  // recency without violating DISTINCT ON's ordering rule.
+  const orderedSql = `
+    SELECT * FROM (${hitsSql.replace(/LIMIT.*$/s, '')}) hits
+    ORDER BY m_created_at DESC, c_chat_id ASC
+    LIMIT $${nextParam}
+    OFFSET $${nextParam + 1}
+  `;
+  const hitsRes = await deps.pool.query<{
+    c_chat_id: string;
+    c_application_id: string | null;
+    c_rescue_id: string;
+    c_pet_id: string | null;
+    c_status: ChatRow['status'];
+    c_created_at: Date;
+    c_updated_at: Date;
+    m_message_id: string;
+    m_chat_id: string;
+    m_sender_id: string;
+    m_content: string;
+    m_edited_at: Date | null;
+    m_deleted_at: Date | null;
+    m_created_at: Date;
+  }>(orderedSql, [...params, limit, offset]);
+
+  // Reactions: load all matching message ids in one shot.
+  const messageIds = hitsRes.rows.map(r => r.m_message_id);
+  const reactionMap = await loadMessageReactions(deps, messageIds);
+
+  const hits: SearchChatHit[] = await Promise.all(
+    hitsRes.rows.map(async row => {
+      const chatRow: ChatRow = {
+        chat_id: row.c_chat_id,
+        application_id: row.c_application_id,
+        rescue_id: row.c_rescue_id,
+        pet_id: row.c_pet_id,
+        status: row.c_status,
+        created_at: row.c_created_at,
+        updated_at: row.c_updated_at,
+      };
+      const msgRow: MessageRow = {
+        message_id: row.m_message_id,
+        chat_id: row.m_chat_id,
+        sender_id: row.m_sender_id,
+        content: row.m_content,
+        edited_at: row.m_edited_at,
+        deleted_at: row.m_deleted_at,
+        created_at: row.m_created_at,
+      };
+      return {
+        chat: await chatRowToProto(deps, chatRow),
+        match: messageRowToProto(msgRow, reactionMap.get(row.m_message_id) ?? []),
+      };
+    })
+  );
+
+  return { hits, page, limit, total };
 }

--- a/services/chat/src/grpc/server.ts
+++ b/services/chat/src/grpc/server.ts
@@ -14,7 +14,15 @@ import { ChatV1 } from '@adopt-dont-shop/proto';
 import type { ChatConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
-import { listChats, listMessages, markRead, openChat, react, sendMessage } from './handlers.js';
+import {
+  listChats,
+  listMessages,
+  markRead,
+  openChat,
+  react,
+  searchChats,
+  sendMessage,
+} from './handlers.js';
 
 export type CreateGrpcServerOptions = {
   config: ChatConfig;
@@ -41,10 +49,19 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     listChats: adapt(listChats, { deps, logger }),
     markRead: adapt(markRead, { deps, logger }),
     react: adapt(react, { deps, logger }),
+    searchChats: adapt(searchChats, { deps, logger }),
   });
 
   logger.info('gRPC ChatService registered', {
-    methods: ['openChat', 'sendMessage', 'listMessages', 'listChats', 'markRead', 'react'],
+    methods: [
+      'openChat',
+      'sendMessage',
+      'listMessages',
+      'listChats',
+      'markRead',
+      'react',
+      'searchChats',
+    ],
     grpcPort: config.grpcPort,
   });
 

--- a/services/gateway/src/grpc-clients/chat-client.ts
+++ b/services/gateway/src/grpc-clients/chat-client.ts
@@ -18,6 +18,8 @@ import {
   type OpenChatResponse,
   type ReactRequest,
   type ReactResponse,
+  type SearchChatsRequest,
+  type SearchChatsResponse,
   type SendMessageRequest,
   type SendMessageResponse,
 } from '@adopt-dont-shop/proto';
@@ -29,6 +31,7 @@ export type ChatClient = {
   listChats(req: ListChatsRequest, metadata: Metadata): Promise<ListChatsResponse>;
   markRead(req: MarkReadRequest, metadata: Metadata): Promise<MarkReadResponse>;
   react(req: ReactRequest, metadata: Metadata): Promise<ReactResponse>;
+  searchChats(req: SearchChatsRequest, metadata: Metadata): Promise<SearchChatsResponse>;
   close(): void;
 };
 
@@ -61,6 +64,7 @@ export const createChatClient = (opts: CreateChatClientOptions): ChatClient => {
     listChats: (req, metadata) => callUnary(stub.listChats, req, metadata),
     markRead: (req, metadata) => callUnary(stub.markRead, req, metadata),
     react: (req, metadata) => callUnary(stub.react, req, metadata),
+    searchChats: (req, metadata) => callUnary(stub.searchChats, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -8,6 +8,7 @@ import type {
   MarkReadRequest,
   OpenChatRequest,
   ReactRequest,
+  SearchChatsRequest,
   SendMessageRequest,
 } from '@adopt-dont-shop/proto';
 
@@ -41,6 +42,7 @@ function makeClient(): ChatClient & {
   listChatsMock: ReturnType<typeof vi.fn>;
   markReadMock: ReturnType<typeof vi.fn>;
   reactMock: ReturnType<typeof vi.fn>;
+  searchChatsMock: ReturnType<typeof vi.fn>;
 } {
   const openChatMock = vi.fn();
   const sendMessageMock = vi.fn();
@@ -48,6 +50,7 @@ function makeClient(): ChatClient & {
   const listChatsMock = vi.fn();
   const markReadMock = vi.fn();
   const reactMock = vi.fn();
+  const searchChatsMock = vi.fn();
   return {
     openChat: openChatMock,
     sendMessage: sendMessageMock,
@@ -55,6 +58,7 @@ function makeClient(): ChatClient & {
     listChats: listChatsMock,
     markRead: markReadMock,
     react: reactMock,
+    searchChats: searchChatsMock,
     close: vi.fn(),
     openChatMock,
     sendMessageMock,
@@ -62,6 +66,7 @@ function makeClient(): ChatClient & {
     listChatsMock,
     markReadMock,
     reactMock,
+    searchChatsMock,
   };
 }
 
@@ -425,5 +430,102 @@ describe('/api/v1/conversations — monolith alias', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(client.markReadMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- GET /api/v1/chats/search ---------------------------------------
+
+describe('GET /api/v1/chats/search', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards query, page, limit, rescue_id to SearchChats', async () => {
+    client.searchChatsMock.mockResolvedValueOnce({ hits: [], page: 2, limit: 10, total: 0 });
+
+    await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/search?query=adoption&page=2&limit=10&rescueId=rsc-1',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    const [grpcReq] = client.searchChatsMock.mock.calls[0] as [SearchChatsRequest, Metadata];
+    expect(grpcReq.query).toBe('adoption');
+    expect(grpcReq.page).toBe(2);
+    expect(grpcReq.limit).toBe(10);
+    expect(grpcReq.rescueId).toBe('rsc-1');
+  });
+
+  it('also accepts q + rescue_id snake_case aliases', async () => {
+    client.searchChatsMock.mockResolvedValueOnce({ hits: [], page: 1, limit: 20, total: 0 });
+    await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/search?q=adoption&rescue_id=rsc-2',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    const [grpcReq] = client.searchChatsMock.mock.calls[0] as [SearchChatsRequest, Metadata];
+    expect(grpcReq.query).toBe('adoption');
+    expect(grpcReq.rescueId).toBe('rsc-2');
+  });
+
+  it('returns the monolith-compatible { chats, pagination } envelope', async () => {
+    client.searchChatsMock.mockResolvedValueOnce({
+      hits: [{ chat: CHAT_FIXTURE, match: MESSAGE_FIXTURE }],
+      page: 1,
+      limit: 20,
+      total: 1,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/search?query=hello',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      success: boolean;
+      data: {
+        chats: Array<{ chatId: string; matched_message: { messageId: string } | null }>;
+        pagination: { page: number; limit: number; total: number; totalPages: number };
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.chats).toHaveLength(1);
+    expect(body.data.chats[0].chatId).toBe('chat-1');
+    expect(body.data.chats[0].matched_message?.messageId).toBe('msg-1');
+    expect(body.data.pagination).toEqual({ page: 1, limit: 20, total: 1, totalPages: 1 });
+  });
+
+  it('maps gRPC INVALID_ARGUMENT to HTTP 400', async () => {
+    client.searchChatsMock.mockRejectedValueOnce({
+      code: status.INVALID_ARGUMENT,
+      details: 'query is required',
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/search?query=',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('also reachable via /api/v1/conversations/search alias', async () => {
+    client.searchChatsMock.mockResolvedValueOnce({ hits: [], page: 1, limit: 20, total: 0 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/conversations/search?query=adoption',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.searchChatsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -20,6 +20,7 @@ import {
   type MarkReadRequest,
   type OpenChatRequest,
   type ReactRequest,
+  type SearchChatsRequest,
   type SendMessageRequest,
 } from '@adopt-dont-shop/proto';
 
@@ -119,6 +120,47 @@ const registerChatRoutesForPrefix = (
     try {
       const res = await client.openChat(grpcReq, metadata);
       return reply.code(res.created ? 201 : 200).send(ChatV1.OpenChatResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // ---- GET <prefix>/search ----------------------------------------
+  // Must register BEFORE the :chatId routes so the static segment
+  // wins Fastify's first-registered-wins matcher.
+  app.get(`${prefix}/search`, async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const query = req.query as Record<string, string | undefined>;
+    const grpcReq: SearchChatsRequest = {
+      query: query.query ?? query.q ?? '',
+      page: query.page ? Number.parseInt(query.page, 10) : 1,
+      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      rescueId: query.rescueId ?? query.rescue_id,
+    };
+
+    try {
+      const res = await client.searchChats(grpcReq, metadata);
+      // Match the monolith ConversationsController.searchConversations
+      // body shape: { chats, pagination } so the SPA's existing search
+      // handler keeps working unchanged.
+      const total = res.total;
+      const limit = res.limit;
+      const page = res.page;
+      return reply.send({
+        success: true,
+        data: {
+          chats: res.hits.map(h => ({
+            ...(ChatV1.Chat.toJSON(h.chat!) as Record<string, unknown>),
+            matched_message: h.match ? ChatV1.Message.toJSON(h.match) : null,
+          })),
+          pagination: {
+            page,
+            limit,
+            total,
+            totalPages: limit > 0 ? Math.ceil(total / limit) : 0,
+          },
+        },
+      });
     } catch (err) {
       return handleGrpcError(err, reply);
     }


### PR DESCRIPTION
## Summary

Brings the monolith's `GET /api/v1/chats/search` (and `/api/v1/conversations/search` alias) endpoint over to the gateway + service.chat. Backed by the existing `messages.search_vector` tsvector + GIN index that ships in chat migration 004.

### New gRPC RPC
- `ChatService.SearchChats(query, page, limit, rescue_id?)` →
  `{ hits: [{ chat, match }], page, limit, total }`

### How the search works
- `websearch_to_tsquery('english', $query)` — accepts quoted phrases, `or`, leading `-` exclusion. Empty parse → 0 rows (the right answer for punctuation-only queries).
- For each matching chat, `DISTINCT ON (chat_id)` picks the most recent matching message and surfaces it as the `match`.
- Self-scoped: results filtered through `chat_participants p ON p.participant_id = $principal`. Even super_admin goes through this filter (staff cross-chat search will be a separate admin RPC).
- Outer wrapper `ORDER BY m_created_at DESC, c_chat_id ASC` for freshness-first ordering + deterministic tiebreaker.
- Archived chats excluded (matches monolith).

### New REST route
- `GET /api/v1/chats/search?query=...&page=...&limit=...&rescueId=...`
- Also registered at `/api/v1/conversations/search` (the dual-mount the existing chat routes use — preserves the SPA's two-path tradition).
- Response shape mirrors the monolith verbatim: `{ success, data: { chats: [...with matched_message], pagination: { page, limit, total, totalPages } } }`.
- Accepts both `query` + `q`, and both `rescueId` + `rescue_id` aliases.

### Permission model
- `chat.read` — same as ListChats / ListMessages.

## Test plan
- [x] `services/chat` — 44/44 tests pass (7 new in handlers.test.ts: empty query, length cap, principal gate, zero-results short-circuit, full hits hydration, rescue_id binding, pagination params)
- [x] `services/gateway` — 323/323 tests pass (5 new in chat.test.ts: query forwarding, snake_case + `q` aliases, envelope shape, INVALID_ARGUMENT → 400, conversations/search alias)
- [x] Type-check clean (proto regen + tsc both services)
- [x] Lint clean (chat) — only pre-existing curly-warnings remain on `support.ts`

## Out of scope
- Chat analytics / admin surface — separate PR
- Chat get-by-id / participants / attachments — separate PRs
- Reactions are already covered; this PR doesn't touch them
- Frontend cutover (point `lib.chat`'s search at the gateway) — separate PR

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_