### PR TITLE
feat(auth,notifications,gateway): user profile + composed preferences

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
+++ b/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
@@ -100,6 +100,25 @@ service AuthService {
   // a different user — the two cases are indistinguishable on purpose
   // (no cross-user session enumeration).
   rpc RevokeSession(RevokeSessionRequest) returns (RevokeSessionResponse);
+
+  // --- Privacy preferences ------------------------------------------
+  // Phase 2.6+: profile-visibility + show-location + data-export
+  // toggles. Stored in user_privacy_prefs, 1:1 with users. The
+  // gateway's /api/v1/users/preferences endpoint composes these with
+  // the in-app notification prefs from service.notifications for the
+  // monolith's unified shape.
+
+  rpc GetPrivacyPreferences(GetPrivacyPreferencesRequest)
+      returns (GetPrivacyPreferencesResponse);
+
+  rpc UpdatePrivacyPreferences(UpdatePrivacyPreferencesRequest)
+      returns (UpdatePrivacyPreferencesResponse);
+
+  // Destroy + recreate the row so the table-level defaults are the
+  // single source of truth for "factory settings". Returns the freshly
+  // created defaults row.
+  rpc ResetPrivacyPreferences(ResetPrivacyPreferencesRequest)
+      returns (ResetPrivacyPreferencesResponse);
 }
 
 // --- Shared messages --------------------------------------------------
@@ -404,4 +423,60 @@ message RevokeSessionResponse {
   // already-revoked session returns the same id without error (NATS
   // event is suppressed on the second call).
   string session_id = 1;
+}
+
+
+// --- Privacy preferences ------------------------------------------
+
+enum ProfileVisibility {
+  PROFILE_VISIBILITY_UNSPECIFIED = 0;
+  PROFILE_VISIBILITY_PUBLIC = 1;
+  PROFILE_VISIBILITY_RESCUES_ONLY = 2;
+  PROFILE_VISIBILITY_PRIVATE = 3;
+}
+
+// PrivacyPreferences mirrors auth.user_privacy_prefs verbatim.
+message PrivacyPreferences {
+  string user_id = 1;
+  ProfileVisibility profile_visibility = 2;
+  bool show_last_seen = 3;
+  bool show_location = 4;
+  bool allow_search_indexing = 5;
+  bool allow_data_export = 6;
+  string created_at = 7;
+  string updated_at = 8;
+}
+
+message GetPrivacyPreferencesRequest {
+  // Optional. Defaults to the calling principal. Callers without
+  // privacy-prefs:read:any may only read their own row.
+  optional string user_id = 1;
+}
+
+message GetPrivacyPreferencesResponse {
+  PrivacyPreferences preferences = 1;
+}
+
+message UpdatePrivacyPreferencesRequest {
+  optional string user_id = 1;
+  // Only set fields are written — scalars get the proto3 optional
+  // presence treatment (set_* discipline; absent leaves the column
+  // untouched).
+  ProfileVisibility profile_visibility = 2;
+  optional bool show_last_seen = 3;
+  optional bool show_location = 4;
+  optional bool allow_search_indexing = 5;
+  optional bool allow_data_export = 6;
+}
+
+message UpdatePrivacyPreferencesResponse {
+  PrivacyPreferences preferences = 1;
+}
+
+message ResetPrivacyPreferencesRequest {
+  optional string user_id = 1;
+}
+
+message ResetPrivacyPreferencesResponse {
+  PrivacyPreferences preferences = 1;
 }

--- a/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
+++ b/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
@@ -65,6 +65,11 @@ service NotificationService {
   rpc UpdateNotificationPreferences(UpdateNotificationPreferencesRequest)
       returns (UpdateNotificationPreferencesResponse);
 
+  // Destroy + recreate so the table-level defaults are the single
+  // source of truth for "factory settings". Idempotent.
+  rpc ResetNotificationPreferences(ResetNotificationPreferencesRequest)
+      returns (ResetNotificationPreferencesResponse);
+
   // --- Email queue ----------------------------------------------------
   // Phase 7 round-out. The service owns the email_queue table; other
   // services (auth, applications, chat) call SendEmail to enqueue a
@@ -621,5 +626,13 @@ message UpdateNotificationPreferencesRequest {
 }
 
 message UpdateNotificationPreferencesResponse {
+  NotificationPreferences preferences = 1;
+}
+
+message ResetNotificationPreferencesRequest {
+  optional string user_id = 1;
+}
+
+message ResetNotificationPreferencesResponse {
   NotificationPreferences preferences = 1;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
@@ -150,6 +150,51 @@ export function userStatusToJSON(object: UserStatus): string {
   }
 }
 
+export enum ProfileVisibility {
+  PROFILE_VISIBILITY_UNSPECIFIED = 0,
+  PROFILE_VISIBILITY_PUBLIC = 1,
+  PROFILE_VISIBILITY_RESCUES_ONLY = 2,
+  PROFILE_VISIBILITY_PRIVATE = 3,
+  UNRECOGNIZED = -1,
+}
+
+export function profileVisibilityFromJSON(object: any): ProfileVisibility {
+  switch (object) {
+    case 0:
+    case 'PROFILE_VISIBILITY_UNSPECIFIED':
+      return ProfileVisibility.PROFILE_VISIBILITY_UNSPECIFIED;
+    case 1:
+    case 'PROFILE_VISIBILITY_PUBLIC':
+      return ProfileVisibility.PROFILE_VISIBILITY_PUBLIC;
+    case 2:
+    case 'PROFILE_VISIBILITY_RESCUES_ONLY':
+      return ProfileVisibility.PROFILE_VISIBILITY_RESCUES_ONLY;
+    case 3:
+    case 'PROFILE_VISIBILITY_PRIVATE':
+      return ProfileVisibility.PROFILE_VISIBILITY_PRIVATE;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return ProfileVisibility.UNRECOGNIZED;
+  }
+}
+
+export function profileVisibilityToJSON(object: ProfileVisibility): string {
+  switch (object) {
+    case ProfileVisibility.PROFILE_VISIBILITY_UNSPECIFIED:
+      return 'PROFILE_VISIBILITY_UNSPECIFIED';
+    case ProfileVisibility.PROFILE_VISIBILITY_PUBLIC:
+      return 'PROFILE_VISIBILITY_PUBLIC';
+    case ProfileVisibility.PROFILE_VISIBILITY_RESCUES_ONLY:
+      return 'PROFILE_VISIBILITY_RESCUES_ONLY';
+    case ProfileVisibility.PROFILE_VISIBILITY_PRIVATE:
+      return 'PROFILE_VISIBILITY_PRIVATE';
+    case ProfileVisibility.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
 /**
  * Principal is the flattened identity the gateway forwards downstream
  * as gRPC metadata. ValidateToken returns it; GetMe returns a richer
@@ -454,6 +499,56 @@ export interface RevokeSessionResponse {
    * event is suppressed on the second call).
    */
   sessionId: string;
+}
+
+/** PrivacyPreferences mirrors auth.user_privacy_prefs verbatim. */
+export interface PrivacyPreferences {
+  userId: string;
+  profileVisibility: ProfileVisibility;
+  showLastSeen: boolean;
+  showLocation: boolean;
+  allowSearchIndexing: boolean;
+  allowDataExport: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GetPrivacyPreferencesRequest {
+  /**
+   * Optional. Defaults to the calling principal. Callers without
+   * privacy-prefs:read:any may only read their own row.
+   */
+  userId?: string | undefined;
+}
+
+export interface GetPrivacyPreferencesResponse {
+  preferences?: PrivacyPreferences | undefined;
+}
+
+export interface UpdatePrivacyPreferencesRequest {
+  userId?: string | undefined;
+  /**
+   * Only set fields are written — scalars get the proto3 optional
+   * presence treatment (set_* discipline; absent leaves the column
+   * untouched).
+   */
+  profileVisibility: ProfileVisibility;
+  showLastSeen?: boolean | undefined;
+  showLocation?: boolean | undefined;
+  allowSearchIndexing?: boolean | undefined;
+  allowDataExport?: boolean | undefined;
+}
+
+export interface UpdatePrivacyPreferencesResponse {
+  preferences?: PrivacyPreferences | undefined;
+}
+
+export interface ResetPrivacyPreferencesRequest {
+  userId?: string | undefined;
+}
+
+export interface ResetPrivacyPreferencesResponse {
+  preferences?: PrivacyPreferences | undefined;
 }
 
 function createBasePrincipal(): Principal {
@@ -3763,6 +3858,755 @@ export const RevokeSessionResponse: MessageFns<RevokeSessionResponse> = {
   },
 };
 
+function createBasePrivacyPreferences(): PrivacyPreferences {
+  return {
+    userId: '',
+    profileVisibility: 0,
+    showLastSeen: false,
+    showLocation: false,
+    allowSearchIndexing: false,
+    allowDataExport: false,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+export const PrivacyPreferences: MessageFns<PrivacyPreferences> = {
+  encode(message: PrivacyPreferences, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.userId !== '') {
+      writer.uint32(10).string(message.userId);
+    }
+    if (message.profileVisibility !== 0) {
+      writer.uint32(16).int32(message.profileVisibility);
+    }
+    if (message.showLastSeen !== false) {
+      writer.uint32(24).bool(message.showLastSeen);
+    }
+    if (message.showLocation !== false) {
+      writer.uint32(32).bool(message.showLocation);
+    }
+    if (message.allowSearchIndexing !== false) {
+      writer.uint32(40).bool(message.allowSearchIndexing);
+    }
+    if (message.allowDataExport !== false) {
+      writer.uint32(48).bool(message.allowDataExport);
+    }
+    if (message.createdAt !== '') {
+      writer.uint32(58).string(message.createdAt);
+    }
+    if (message.updatedAt !== '') {
+      writer.uint32(66).string(message.updatedAt);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PrivacyPreferences {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePrivacyPreferences();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.profileVisibility = reader.int32() as any;
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.showLastSeen = reader.bool();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.showLocation = reader.bool();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.allowSearchIndexing = reader.bool();
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.allowDataExport = reader.bool();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.createdAt = reader.string();
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.updatedAt = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PrivacyPreferences {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : '',
+      profileVisibility: isSet(object.profileVisibility)
+        ? profileVisibilityFromJSON(object.profileVisibility)
+        : isSet(object.profile_visibility)
+          ? profileVisibilityFromJSON(object.profile_visibility)
+          : 0,
+      showLastSeen: isSet(object.showLastSeen)
+        ? globalThis.Boolean(object.showLastSeen)
+        : isSet(object.show_last_seen)
+          ? globalThis.Boolean(object.show_last_seen)
+          : false,
+      showLocation: isSet(object.showLocation)
+        ? globalThis.Boolean(object.showLocation)
+        : isSet(object.show_location)
+          ? globalThis.Boolean(object.show_location)
+          : false,
+      allowSearchIndexing: isSet(object.allowSearchIndexing)
+        ? globalThis.Boolean(object.allowSearchIndexing)
+        : isSet(object.allow_search_indexing)
+          ? globalThis.Boolean(object.allow_search_indexing)
+          : false,
+      allowDataExport: isSet(object.allowDataExport)
+        ? globalThis.Boolean(object.allowDataExport)
+        : isSet(object.allow_data_export)
+          ? globalThis.Boolean(object.allow_data_export)
+          : false,
+      createdAt: isSet(object.createdAt)
+        ? globalThis.String(object.createdAt)
+        : isSet(object.created_at)
+          ? globalThis.String(object.created_at)
+          : '',
+      updatedAt: isSet(object.updatedAt)
+        ? globalThis.String(object.updatedAt)
+        : isSet(object.updated_at)
+          ? globalThis.String(object.updated_at)
+          : '',
+    };
+  },
+
+  toJSON(message: PrivacyPreferences): unknown {
+    const obj: any = {};
+    if (message.userId !== '') {
+      obj.userId = message.userId;
+    }
+    if (message.profileVisibility !== 0) {
+      obj.profileVisibility = profileVisibilityToJSON(message.profileVisibility);
+    }
+    if (message.showLastSeen !== false) {
+      obj.showLastSeen = message.showLastSeen;
+    }
+    if (message.showLocation !== false) {
+      obj.showLocation = message.showLocation;
+    }
+    if (message.allowSearchIndexing !== false) {
+      obj.allowSearchIndexing = message.allowSearchIndexing;
+    }
+    if (message.allowDataExport !== false) {
+      obj.allowDataExport = message.allowDataExport;
+    }
+    if (message.createdAt !== '') {
+      obj.createdAt = message.createdAt;
+    }
+    if (message.updatedAt !== '') {
+      obj.updatedAt = message.updatedAt;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PrivacyPreferences>, I>>(base?: I): PrivacyPreferences {
+    return PrivacyPreferences.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<PrivacyPreferences>, I>>(object: I): PrivacyPreferences {
+    const message = createBasePrivacyPreferences();
+    message.userId = object.userId ?? '';
+    message.profileVisibility = object.profileVisibility ?? 0;
+    message.showLastSeen = object.showLastSeen ?? false;
+    message.showLocation = object.showLocation ?? false;
+    message.allowSearchIndexing = object.allowSearchIndexing ?? false;
+    message.allowDataExport = object.allowDataExport ?? false;
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
+    return message;
+  },
+};
+
+function createBaseGetPrivacyPreferencesRequest(): GetPrivacyPreferencesRequest {
+  return { userId: undefined };
+}
+
+export const GetPrivacyPreferencesRequest: MessageFns<GetPrivacyPreferencesRequest> = {
+  encode(
+    message: GetPrivacyPreferencesRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.userId !== undefined) {
+      writer.uint32(10).string(message.userId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetPrivacyPreferencesRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetPrivacyPreferencesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetPrivacyPreferencesRequest {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : undefined,
+    };
+  },
+
+  toJSON(message: GetPrivacyPreferencesRequest): unknown {
+    const obj: any = {};
+    if (message.userId !== undefined) {
+      obj.userId = message.userId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetPrivacyPreferencesRequest>, I>>(
+    base?: I
+  ): GetPrivacyPreferencesRequest {
+    return GetPrivacyPreferencesRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetPrivacyPreferencesRequest>, I>>(
+    object: I
+  ): GetPrivacyPreferencesRequest {
+    const message = createBaseGetPrivacyPreferencesRequest();
+    message.userId = object.userId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseGetPrivacyPreferencesResponse(): GetPrivacyPreferencesResponse {
+  return { preferences: undefined };
+}
+
+export const GetPrivacyPreferencesResponse: MessageFns<GetPrivacyPreferencesResponse> = {
+  encode(
+    message: GetPrivacyPreferencesResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.preferences !== undefined) {
+      PrivacyPreferences.encode(message.preferences, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetPrivacyPreferencesResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetPrivacyPreferencesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.preferences = PrivacyPreferences.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetPrivacyPreferencesResponse {
+    return {
+      preferences: isSet(object.preferences)
+        ? PrivacyPreferences.fromJSON(object.preferences)
+        : undefined,
+    };
+  },
+
+  toJSON(message: GetPrivacyPreferencesResponse): unknown {
+    const obj: any = {};
+    if (message.preferences !== undefined) {
+      obj.preferences = PrivacyPreferences.toJSON(message.preferences);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetPrivacyPreferencesResponse>, I>>(
+    base?: I
+  ): GetPrivacyPreferencesResponse {
+    return GetPrivacyPreferencesResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetPrivacyPreferencesResponse>, I>>(
+    object: I
+  ): GetPrivacyPreferencesResponse {
+    const message = createBaseGetPrivacyPreferencesResponse();
+    message.preferences =
+      object.preferences !== undefined && object.preferences !== null
+        ? PrivacyPreferences.fromPartial(object.preferences)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseUpdatePrivacyPreferencesRequest(): UpdatePrivacyPreferencesRequest {
+  return {
+    userId: undefined,
+    profileVisibility: 0,
+    showLastSeen: undefined,
+    showLocation: undefined,
+    allowSearchIndexing: undefined,
+    allowDataExport: undefined,
+  };
+}
+
+export const UpdatePrivacyPreferencesRequest: MessageFns<UpdatePrivacyPreferencesRequest> = {
+  encode(
+    message: UpdatePrivacyPreferencesRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.userId !== undefined) {
+      writer.uint32(10).string(message.userId);
+    }
+    if (message.profileVisibility !== 0) {
+      writer.uint32(16).int32(message.profileVisibility);
+    }
+    if (message.showLastSeen !== undefined) {
+      writer.uint32(24).bool(message.showLastSeen);
+    }
+    if (message.showLocation !== undefined) {
+      writer.uint32(32).bool(message.showLocation);
+    }
+    if (message.allowSearchIndexing !== undefined) {
+      writer.uint32(40).bool(message.allowSearchIndexing);
+    }
+    if (message.allowDataExport !== undefined) {
+      writer.uint32(48).bool(message.allowDataExport);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpdatePrivacyPreferencesRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpdatePrivacyPreferencesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.profileVisibility = reader.int32() as any;
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.showLastSeen = reader.bool();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.showLocation = reader.bool();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.allowSearchIndexing = reader.bool();
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.allowDataExport = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpdatePrivacyPreferencesRequest {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : undefined,
+      profileVisibility: isSet(object.profileVisibility)
+        ? profileVisibilityFromJSON(object.profileVisibility)
+        : isSet(object.profile_visibility)
+          ? profileVisibilityFromJSON(object.profile_visibility)
+          : 0,
+      showLastSeen: isSet(object.showLastSeen)
+        ? globalThis.Boolean(object.showLastSeen)
+        : isSet(object.show_last_seen)
+          ? globalThis.Boolean(object.show_last_seen)
+          : undefined,
+      showLocation: isSet(object.showLocation)
+        ? globalThis.Boolean(object.showLocation)
+        : isSet(object.show_location)
+          ? globalThis.Boolean(object.show_location)
+          : undefined,
+      allowSearchIndexing: isSet(object.allowSearchIndexing)
+        ? globalThis.Boolean(object.allowSearchIndexing)
+        : isSet(object.allow_search_indexing)
+          ? globalThis.Boolean(object.allow_search_indexing)
+          : undefined,
+      allowDataExport: isSet(object.allowDataExport)
+        ? globalThis.Boolean(object.allowDataExport)
+        : isSet(object.allow_data_export)
+          ? globalThis.Boolean(object.allow_data_export)
+          : undefined,
+    };
+  },
+
+  toJSON(message: UpdatePrivacyPreferencesRequest): unknown {
+    const obj: any = {};
+    if (message.userId !== undefined) {
+      obj.userId = message.userId;
+    }
+    if (message.profileVisibility !== 0) {
+      obj.profileVisibility = profileVisibilityToJSON(message.profileVisibility);
+    }
+    if (message.showLastSeen !== undefined) {
+      obj.showLastSeen = message.showLastSeen;
+    }
+    if (message.showLocation !== undefined) {
+      obj.showLocation = message.showLocation;
+    }
+    if (message.allowSearchIndexing !== undefined) {
+      obj.allowSearchIndexing = message.allowSearchIndexing;
+    }
+    if (message.allowDataExport !== undefined) {
+      obj.allowDataExport = message.allowDataExport;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpdatePrivacyPreferencesRequest>, I>>(
+    base?: I
+  ): UpdatePrivacyPreferencesRequest {
+    return UpdatePrivacyPreferencesRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpdatePrivacyPreferencesRequest>, I>>(
+    object: I
+  ): UpdatePrivacyPreferencesRequest {
+    const message = createBaseUpdatePrivacyPreferencesRequest();
+    message.userId = object.userId ?? undefined;
+    message.profileVisibility = object.profileVisibility ?? 0;
+    message.showLastSeen = object.showLastSeen ?? undefined;
+    message.showLocation = object.showLocation ?? undefined;
+    message.allowSearchIndexing = object.allowSearchIndexing ?? undefined;
+    message.allowDataExport = object.allowDataExport ?? undefined;
+    return message;
+  },
+};
+
+function createBaseUpdatePrivacyPreferencesResponse(): UpdatePrivacyPreferencesResponse {
+  return { preferences: undefined };
+}
+
+export const UpdatePrivacyPreferencesResponse: MessageFns<UpdatePrivacyPreferencesResponse> = {
+  encode(
+    message: UpdatePrivacyPreferencesResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.preferences !== undefined) {
+      PrivacyPreferences.encode(message.preferences, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpdatePrivacyPreferencesResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpdatePrivacyPreferencesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.preferences = PrivacyPreferences.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpdatePrivacyPreferencesResponse {
+    return {
+      preferences: isSet(object.preferences)
+        ? PrivacyPreferences.fromJSON(object.preferences)
+        : undefined,
+    };
+  },
+
+  toJSON(message: UpdatePrivacyPreferencesResponse): unknown {
+    const obj: any = {};
+    if (message.preferences !== undefined) {
+      obj.preferences = PrivacyPreferences.toJSON(message.preferences);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UpdatePrivacyPreferencesResponse>, I>>(
+    base?: I
+  ): UpdatePrivacyPreferencesResponse {
+    return UpdatePrivacyPreferencesResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<UpdatePrivacyPreferencesResponse>, I>>(
+    object: I
+  ): UpdatePrivacyPreferencesResponse {
+    const message = createBaseUpdatePrivacyPreferencesResponse();
+    message.preferences =
+      object.preferences !== undefined && object.preferences !== null
+        ? PrivacyPreferences.fromPartial(object.preferences)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseResetPrivacyPreferencesRequest(): ResetPrivacyPreferencesRequest {
+  return { userId: undefined };
+}
+
+export const ResetPrivacyPreferencesRequest: MessageFns<ResetPrivacyPreferencesRequest> = {
+  encode(
+    message: ResetPrivacyPreferencesRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.userId !== undefined) {
+      writer.uint32(10).string(message.userId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ResetPrivacyPreferencesRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResetPrivacyPreferencesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ResetPrivacyPreferencesRequest {
+    return {
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : undefined,
+    };
+  },
+
+  toJSON(message: ResetPrivacyPreferencesRequest): unknown {
+    const obj: any = {};
+    if (message.userId !== undefined) {
+      obj.userId = message.userId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ResetPrivacyPreferencesRequest>, I>>(
+    base?: I
+  ): ResetPrivacyPreferencesRequest {
+    return ResetPrivacyPreferencesRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ResetPrivacyPreferencesRequest>, I>>(
+    object: I
+  ): ResetPrivacyPreferencesRequest {
+    const message = createBaseResetPrivacyPreferencesRequest();
+    message.userId = object.userId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseResetPrivacyPreferencesResponse(): ResetPrivacyPreferencesResponse {
+  return { preferences: undefined };
+}
+
+export const ResetPrivacyPreferencesResponse: MessageFns<ResetPrivacyPreferencesResponse> = {
+  encode(
+    message: ResetPrivacyPreferencesResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.preferences !== undefined) {
+      PrivacyPreferences.encode(message.preferences, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ResetPrivacyPreferencesResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResetPrivacyPreferencesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.preferences = PrivacyPreferences.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ResetPrivacyPreferencesResponse {
+    return {
+      preferences: isSet(object.preferences)
+        ? PrivacyPreferences.fromJSON(object.preferences)
+        : undefined,
+    };
+  },
+
+  toJSON(message: ResetPrivacyPreferencesResponse): unknown {
+    const obj: any = {};
+    if (message.preferences !== undefined) {
+      obj.preferences = PrivacyPreferences.toJSON(message.preferences);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ResetPrivacyPreferencesResponse>, I>>(
+    base?: I
+  ): ResetPrivacyPreferencesResponse {
+    return ResetPrivacyPreferencesResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ResetPrivacyPreferencesResponse>, I>>(
+    object: I
+  ): ResetPrivacyPreferencesResponse {
+    const message = createBaseResetPrivacyPreferencesResponse();
+    message.preferences =
+      object.preferences !== undefined && object.preferences !== null
+        ? PrivacyPreferences.fromPartial(object.preferences)
+        : undefined;
+    return message;
+  },
+};
+
 /**
  * AuthService is the gRPC contract for the auth vertical. It owns the
  * `auth.*` schema (User, Role, Permission, RefreshToken, RevokedToken,
@@ -4028,6 +4872,50 @@ export const AuthServiceService = {
     responseDeserialize: (value: Buffer): RevokeSessionResponse =>
       RevokeSessionResponse.decode(value),
   },
+  getPrivacyPreferences: {
+    path: '/adopt_dont_shop.auth.v1.AuthService/GetPrivacyPreferences' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetPrivacyPreferencesRequest): Buffer =>
+      Buffer.from(GetPrivacyPreferencesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetPrivacyPreferencesRequest =>
+      GetPrivacyPreferencesRequest.decode(value),
+    responseSerialize: (value: GetPrivacyPreferencesResponse): Buffer =>
+      Buffer.from(GetPrivacyPreferencesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetPrivacyPreferencesResponse =>
+      GetPrivacyPreferencesResponse.decode(value),
+  },
+  updatePrivacyPreferences: {
+    path: '/adopt_dont_shop.auth.v1.AuthService/UpdatePrivacyPreferences' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: UpdatePrivacyPreferencesRequest): Buffer =>
+      Buffer.from(UpdatePrivacyPreferencesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): UpdatePrivacyPreferencesRequest =>
+      UpdatePrivacyPreferencesRequest.decode(value),
+    responseSerialize: (value: UpdatePrivacyPreferencesResponse): Buffer =>
+      Buffer.from(UpdatePrivacyPreferencesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): UpdatePrivacyPreferencesResponse =>
+      UpdatePrivacyPreferencesResponse.decode(value),
+  },
+  /**
+   * Destroy + recreate the row so the table-level defaults are the
+   * single source of truth for "factory settings". Returns the freshly
+   * created defaults row.
+   */
+  resetPrivacyPreferences: {
+    path: '/adopt_dont_shop.auth.v1.AuthService/ResetPrivacyPreferences' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: ResetPrivacyPreferencesRequest): Buffer =>
+      Buffer.from(ResetPrivacyPreferencesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): ResetPrivacyPreferencesRequest =>
+      ResetPrivacyPreferencesRequest.decode(value),
+    responseSerialize: (value: ResetPrivacyPreferencesResponse): Buffer =>
+      Buffer.from(ResetPrivacyPreferencesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): ResetPrivacyPreferencesResponse =>
+      ResetPrivacyPreferencesResponse.decode(value),
+  },
 } as const;
 
 export interface AuthServiceServer extends UntypedServiceImplementation {
@@ -4116,6 +5004,23 @@ export interface AuthServiceServer extends UntypedServiceImplementation {
    * (no cross-user session enumeration).
    */
   revokeSession: handleUnaryCall<RevokeSessionRequest, RevokeSessionResponse>;
+  getPrivacyPreferences: handleUnaryCall<
+    GetPrivacyPreferencesRequest,
+    GetPrivacyPreferencesResponse
+  >;
+  updatePrivacyPreferences: handleUnaryCall<
+    UpdatePrivacyPreferencesRequest,
+    UpdatePrivacyPreferencesResponse
+  >;
+  /**
+   * Destroy + recreate the row so the table-level defaults are the
+   * single source of truth for "factory settings". Returns the freshly
+   * created defaults row.
+   */
+  resetPrivacyPreferences: handleUnaryCall<
+    ResetPrivacyPreferencesRequest,
+    ResetPrivacyPreferencesResponse
+  >;
 }
 
 export interface AuthServiceClient extends Client {
@@ -4413,6 +5318,56 @@ export interface AuthServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: RevokeSessionResponse) => void
+  ): ClientUnaryCall;
+  getPrivacyPreferences(
+    request: GetPrivacyPreferencesRequest,
+    callback: (error: ServiceError | null, response: GetPrivacyPreferencesResponse) => void
+  ): ClientUnaryCall;
+  getPrivacyPreferences(
+    request: GetPrivacyPreferencesRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetPrivacyPreferencesResponse) => void
+  ): ClientUnaryCall;
+  getPrivacyPreferences(
+    request: GetPrivacyPreferencesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetPrivacyPreferencesResponse) => void
+  ): ClientUnaryCall;
+  updatePrivacyPreferences(
+    request: UpdatePrivacyPreferencesRequest,
+    callback: (error: ServiceError | null, response: UpdatePrivacyPreferencesResponse) => void
+  ): ClientUnaryCall;
+  updatePrivacyPreferences(
+    request: UpdatePrivacyPreferencesRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: UpdatePrivacyPreferencesResponse) => void
+  ): ClientUnaryCall;
+  updatePrivacyPreferences(
+    request: UpdatePrivacyPreferencesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: UpdatePrivacyPreferencesResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Destroy + recreate the row so the table-level defaults are the
+   * single source of truth for "factory settings". Returns the freshly
+   * created defaults row.
+   */
+  resetPrivacyPreferences(
+    request: ResetPrivacyPreferencesRequest,
+    callback: (error: ServiceError | null, response: ResetPrivacyPreferencesResponse) => void
+  ): ClientUnaryCall;
+  resetPrivacyPreferences(
+    request: ResetPrivacyPreferencesRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: ResetPrivacyPreferencesResponse) => void
+  ): ClientUnaryCall;
+  resetPrivacyPreferences(
+    request: ResetPrivacyPreferencesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: ResetPrivacyPreferencesResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
@@ -1236,6 +1236,14 @@ export interface UpdateNotificationPreferencesResponse {
   preferences?: NotificationPreferences | undefined;
 }
 
+export interface ResetNotificationPreferencesRequest {
+  userId?: string | undefined;
+}
+
+export interface ResetNotificationPreferencesResponse {
+  preferences?: NotificationPreferences | undefined;
+}
+
 function createBaseNotification(): Notification {
   return {
     notificationId: '',
@@ -6167,6 +6175,154 @@ export const UpdateNotificationPreferencesResponse: MessageFns<UpdateNotificatio
     },
   };
 
+function createBaseResetNotificationPreferencesRequest(): ResetNotificationPreferencesRequest {
+  return { userId: undefined };
+}
+
+export const ResetNotificationPreferencesRequest: MessageFns<ResetNotificationPreferencesRequest> =
+  {
+    encode(
+      message: ResetNotificationPreferencesRequest,
+      writer: BinaryWriter = new BinaryWriter()
+    ): BinaryWriter {
+      if (message.userId !== undefined) {
+        writer.uint32(10).string(message.userId);
+      }
+      return writer;
+    },
+
+    decode(input: BinaryReader | Uint8Array, length?: number): ResetNotificationPreferencesRequest {
+      const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+      const end = length === undefined ? reader.len : reader.pos + length;
+      const message = createBaseResetNotificationPreferencesRequest();
+      while (reader.pos < end) {
+        const tag = reader.uint32();
+        switch (tag >>> 3) {
+          case 1: {
+            if (tag !== 10) {
+              break;
+            }
+
+            message.userId = reader.string();
+            continue;
+          }
+        }
+        if ((tag & 7) === 4 || tag === 0) {
+          break;
+        }
+        reader.skip(tag & 7);
+      }
+      return message;
+    },
+
+    fromJSON(object: any): ResetNotificationPreferencesRequest {
+      return {
+        userId: isSet(object.userId)
+          ? globalThis.String(object.userId)
+          : isSet(object.user_id)
+            ? globalThis.String(object.user_id)
+            : undefined,
+      };
+    },
+
+    toJSON(message: ResetNotificationPreferencesRequest): unknown {
+      const obj: any = {};
+      if (message.userId !== undefined) {
+        obj.userId = message.userId;
+      }
+      return obj;
+    },
+
+    create<I extends Exact<DeepPartial<ResetNotificationPreferencesRequest>, I>>(
+      base?: I
+    ): ResetNotificationPreferencesRequest {
+      return ResetNotificationPreferencesRequest.fromPartial(base ?? ({} as any));
+    },
+    fromPartial<I extends Exact<DeepPartial<ResetNotificationPreferencesRequest>, I>>(
+      object: I
+    ): ResetNotificationPreferencesRequest {
+      const message = createBaseResetNotificationPreferencesRequest();
+      message.userId = object.userId ?? undefined;
+      return message;
+    },
+  };
+
+function createBaseResetNotificationPreferencesResponse(): ResetNotificationPreferencesResponse {
+  return { preferences: undefined };
+}
+
+export const ResetNotificationPreferencesResponse: MessageFns<ResetNotificationPreferencesResponse> =
+  {
+    encode(
+      message: ResetNotificationPreferencesResponse,
+      writer: BinaryWriter = new BinaryWriter()
+    ): BinaryWriter {
+      if (message.preferences !== undefined) {
+        NotificationPreferences.encode(message.preferences, writer.uint32(10).fork()).join();
+      }
+      return writer;
+    },
+
+    decode(
+      input: BinaryReader | Uint8Array,
+      length?: number
+    ): ResetNotificationPreferencesResponse {
+      const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+      const end = length === undefined ? reader.len : reader.pos + length;
+      const message = createBaseResetNotificationPreferencesResponse();
+      while (reader.pos < end) {
+        const tag = reader.uint32();
+        switch (tag >>> 3) {
+          case 1: {
+            if (tag !== 10) {
+              break;
+            }
+
+            message.preferences = NotificationPreferences.decode(reader, reader.uint32());
+            continue;
+          }
+        }
+        if ((tag & 7) === 4 || tag === 0) {
+          break;
+        }
+        reader.skip(tag & 7);
+      }
+      return message;
+    },
+
+    fromJSON(object: any): ResetNotificationPreferencesResponse {
+      return {
+        preferences: isSet(object.preferences)
+          ? NotificationPreferences.fromJSON(object.preferences)
+          : undefined,
+      };
+    },
+
+    toJSON(message: ResetNotificationPreferencesResponse): unknown {
+      const obj: any = {};
+      if (message.preferences !== undefined) {
+        obj.preferences = NotificationPreferences.toJSON(message.preferences);
+      }
+      return obj;
+    },
+
+    create<I extends Exact<DeepPartial<ResetNotificationPreferencesResponse>, I>>(
+      base?: I
+    ): ResetNotificationPreferencesResponse {
+      return ResetNotificationPreferencesResponse.fromPartial(base ?? ({} as any));
+    },
+    fromPartial<I extends Exact<DeepPartial<ResetNotificationPreferencesResponse>, I>>(
+      object: I
+    ): ResetNotificationPreferencesResponse {
+      const message = createBaseResetNotificationPreferencesResponse();
+      message.preferences =
+        object.preferences !== undefined && object.preferences !== null
+          ? NotificationPreferences.fromPartial(object.preferences)
+          : undefined;
+      return message;
+    },
+  };
+
 /**
  * NotificationService is the gRPC contract for the in-app notification
  * store. The gateway translates `POST/GET/DELETE /api/notifications/*`
@@ -6336,6 +6492,23 @@ export const NotificationServiceService = {
       UpdateNotificationPreferencesResponse.decode(value),
   },
   /**
+   * Destroy + recreate so the table-level defaults are the single
+   * source of truth for "factory settings". Idempotent.
+   */
+  resetNotificationPreferences: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/ResetNotificationPreferences' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: ResetNotificationPreferencesRequest): Buffer =>
+      Buffer.from(ResetNotificationPreferencesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): ResetNotificationPreferencesRequest =>
+      ResetNotificationPreferencesRequest.decode(value),
+    responseSerialize: (value: ResetNotificationPreferencesResponse): Buffer =>
+      Buffer.from(ResetNotificationPreferencesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): ResetNotificationPreferencesResponse =>
+      ResetNotificationPreferencesResponse.decode(value),
+  },
+  /**
    * Enqueue an email. Returns the email_id immediately; delivery happens
    * asynchronously in the worker. Callers can supply a templateId +
    * templateData OR a pre-rendered subject + html_content; if both are
@@ -6495,6 +6668,14 @@ export interface NotificationServiceServer extends UntypedServiceImplementation 
   updateNotificationPreferences: handleUnaryCall<
     UpdateNotificationPreferencesRequest,
     UpdateNotificationPreferencesResponse
+  >;
+  /**
+   * Destroy + recreate so the table-level defaults are the single
+   * source of truth for "factory settings". Idempotent.
+   */
+  resetNotificationPreferences: handleUnaryCall<
+    ResetNotificationPreferencesRequest,
+    ResetNotificationPreferencesResponse
   >;
   /**
    * Enqueue an email. Returns the email_id immediately; delivery happens
@@ -6712,6 +6893,25 @@ export interface NotificationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: UpdateNotificationPreferencesResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Destroy + recreate so the table-level defaults are the single
+   * source of truth for "factory settings". Idempotent.
+   */
+  resetNotificationPreferences(
+    request: ResetNotificationPreferencesRequest,
+    callback: (error: ServiceError | null, response: ResetNotificationPreferencesResponse) => void
+  ): ClientUnaryCall;
+  resetNotificationPreferences(
+    request: ResetNotificationPreferencesRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: ResetNotificationPreferencesResponse) => void
+  ): ClientUnaryCall;
+  resetNotificationPreferences(
+    request: ResetNotificationPreferencesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: ResetNotificationPreferencesResponse) => void
   ): ClientUnaryCall;
   /**
    * Enqueue an email. Returns the email_id immediately; delivery happens

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -65,6 +65,8 @@ export type {
   GetNotificationPreferencesResponse,
   UpdateNotificationPreferencesRequest,
   UpdateNotificationPreferencesResponse,
+  ResetNotificationPreferencesRequest,
+  ResetNotificationPreferencesResponse,
   NotificationServiceServer,
   NotificationServiceClient,
 } from './generated/proto/adopt_dont_shop/notifications/v1/notification.js';
@@ -105,6 +107,13 @@ export type {
   ListSessionsResponse,
   RevokeSessionRequest,
   RevokeSessionResponse,
+  PrivacyPreferences,
+  GetPrivacyPreferencesRequest,
+  GetPrivacyPreferencesResponse,
+  UpdatePrivacyPreferencesRequest,
+  UpdatePrivacyPreferencesResponse,
+  ResetPrivacyPreferencesRequest,
+  ResetPrivacyPreferencesResponse,
   AuthServiceServer,
   AuthServiceClient,
 } from './generated/proto/adopt_dont_shop/auth/v1/auth.js';

--- a/services/auth/src/grpc/privacy-prefs-handlers.test.ts
+++ b/services/auth/src/grpc/privacy-prefs-handlers.test.ts
@@ -1,0 +1,260 @@
+import type { NatsConnection } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
+import { AuthV1 } from '@adopt-dont-shop/proto';
+
+import type { HandlerDeps } from './handlers.js';
+import {
+  getPrivacyPreferences,
+  resetPrivacyPreferences,
+  updatePrivacyPreferences,
+} from './privacy-prefs-handlers.js';
+
+// --- Principals -------------------------------------------------------
+
+const SELF: Principal = {
+  userId: 'usr-self' as UserId,
+  roles: ['adopter'],
+  permissions: ['auth.privacy-prefs.read' as Permission, 'auth.privacy-prefs.update' as Permission],
+};
+
+const ADMIN_ANY: Principal = {
+  userId: 'svc-admin' as UserId,
+  roles: ['admin'],
+  permissions: [
+    'auth.privacy-prefs.read' as Permission,
+    'auth.privacy-prefs.read:any' as Permission,
+    'auth.privacy-prefs.update' as Permission,
+    'auth.privacy-prefs.update:any' as Permission,
+  ],
+};
+
+const NO_PERMS: Principal = {
+  userId: 'usr-nobody' as UserId,
+  roles: [],
+  permissions: [],
+};
+
+// --- Mocks ------------------------------------------------------------
+
+function makeMocks() {
+  const clientScript: Array<{ rows: unknown[] }> = [];
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      const op = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      const next = clientScript.shift();
+      if (!next) {
+        throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);
+      }
+      return next;
+    }),
+    release: vi.fn(),
+  };
+  const poolScript: Array<{ rows: unknown[] }> = [];
+  const pool = {
+    connect: vi.fn().mockResolvedValue(client),
+    query: vi.fn(async () => poolScript.shift() ?? { rows: [] }),
+  };
+  const nats = { publish: vi.fn() };
+  // HandlerDeps requires passwordHasher + tokenIssuer — privacy handlers
+  // never read them so we stub with no-op fakes.
+  const deps: HandlerDeps = {
+    pool: pool as unknown as Pool,
+    nats: nats as unknown as NatsConnection,
+    passwordHasher: { hash: vi.fn(), verify: vi.fn() } as unknown as HandlerDeps['passwordHasher'],
+    tokenIssuer: {
+      mintTokens: vi.fn(),
+      mintAccess: vi.fn(),
+      mintRefresh: vi.fn(),
+    } as unknown as HandlerDeps['tokenIssuer'],
+  };
+  return {
+    pool: pool as unknown as Pool,
+    client: client as unknown as PoolClient,
+    nats: nats as unknown as NatsConnection,
+    poolMock: pool,
+    clientMock: client,
+    natsMock: nats,
+    clientScript,
+    poolScript,
+    deps,
+  };
+}
+
+const prefsRow = (overrides: Record<string, unknown> = {}) => ({
+  user_id: 'usr-self',
+  profile_visibility: 'rescues_only' as const,
+  show_last_seen: false,
+  show_location: true,
+  allow_search_indexing: false,
+  allow_data_export: true,
+  created_at: new Date('2026-06-01T00:00:00Z'),
+  updated_at: new Date('2026-06-01T00:00:00Z'),
+  ...overrides,
+});
+
+// --- getPrivacyPreferences -------------------------------------------
+
+describe('getPrivacyPreferences', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects principals without auth.privacy-prefs.read', async () => {
+    await expect(getPrivacyPreferences(mocks.deps, NO_PERMS, {})).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('returns the existing row for the calling principal', async () => {
+    mocks.poolScript.push({ rows: [prefsRow()] });
+
+    const res = await getPrivacyPreferences(mocks.deps, SELF, {});
+
+    expect(res.preferences?.userId).toBe('usr-self');
+    expect(res.preferences?.profileVisibility).toBe(
+      AuthV1.ProfileVisibility.PROFILE_VISIBILITY_RESCUES_ONLY
+    );
+    expect(res.preferences?.showLocation).toBe(true);
+    expect(res.preferences?.allowDataExport).toBe(true);
+  });
+
+  it('auto-creates a defaults row on first read', async () => {
+    mocks.poolScript.push({ rows: [] }); // SELECT
+    mocks.poolScript.push({ rows: [prefsRow()] }); // INSERT RETURNING
+
+    const res = await getPrivacyPreferences(mocks.deps, SELF, {});
+
+    expect(res.preferences?.userId).toBe('usr-self');
+  });
+
+  it('rejects cross-user read without :any', async () => {
+    await expect(
+      getPrivacyPreferences(mocks.deps, SELF, { userId: 'usr-other' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('allows cross-user read with :any', async () => {
+    mocks.poolScript.push({ rows: [prefsRow({ user_id: 'usr-other' })] });
+    const res = await getPrivacyPreferences(mocks.deps, ADMIN_ANY, { userId: 'usr-other' });
+    expect(res.preferences?.userId).toBe('usr-other');
+  });
+});
+
+// --- updatePrivacyPreferences ----------------------------------------
+
+describe('updatePrivacyPreferences', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects principals without update perm', async () => {
+    await expect(updatePrivacyPreferences(mocks.deps, NO_PERMS, {})).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('writes only the boolean fields that were set', async () => {
+    mocks.poolScript.push({ rows: [prefsRow()] }); // findOrCreate SELECT
+    mocks.poolScript.push({
+      rows: [prefsRow({ show_location: false, allow_search_indexing: true })],
+    }); // UPDATE RETURNING
+
+    const res = await updatePrivacyPreferences(mocks.deps, SELF, {
+      showLocation: false,
+      allowSearchIndexing: true,
+    });
+
+    expect(res.preferences?.showLocation).toBe(false);
+    expect(res.preferences?.allowSearchIndexing).toBe(true);
+
+    const updateCall = mocks.poolMock.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE user_privacy_prefs')
+    );
+    expect(updateCall).toBeDefined();
+    const sql = updateCall![0] as string;
+    expect(sql).toContain('show_location = $1');
+    expect(sql).toContain('allow_search_indexing = $2');
+    expect(sql).not.toContain('show_last_seen');
+    expect(sql).not.toContain('allow_data_export');
+  });
+
+  it('maps profile_visibility enum and writes it', async () => {
+    mocks.poolScript.push({ rows: [prefsRow()] });
+    mocks.poolScript.push({ rows: [prefsRow({ profile_visibility: 'private' })] });
+
+    const res = await updatePrivacyPreferences(mocks.deps, SELF, {
+      profileVisibility: AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PRIVATE,
+    });
+
+    expect(res.preferences?.profileVisibility).toBe(
+      AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PRIVATE
+    );
+  });
+
+  it('no-op patch returns current row without UPDATE', async () => {
+    mocks.poolScript.push({ rows: [prefsRow()] }); // findOrCreate
+    mocks.poolScript.push({ rows: [prefsRow()] }); // SELECT current
+    const res = await updatePrivacyPreferences(mocks.deps, SELF, {});
+    expect(res.preferences?.userId).toBe('usr-self');
+    const updateCalls = mocks.poolMock.query.mock.calls.filter(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE user_privacy_prefs')
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('rejects cross-user write without :any', async () => {
+    await expect(
+      updatePrivacyPreferences(mocks.deps, SELF, { userId: 'usr-other', showLocation: false })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+});
+
+// --- resetPrivacyPreferences -----------------------------------------
+
+describe('resetPrivacyPreferences', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects principals without update perm', async () => {
+    await expect(resetPrivacyPreferences(mocks.deps, NO_PERMS, {})).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('deletes + inserts defaults inside withTransaction, publishes once', async () => {
+    mocks.clientScript.push({ rows: [] }); // DELETE
+    mocks.clientScript.push({ rows: [prefsRow()] }); // INSERT RETURNING
+
+    const res = await resetPrivacyPreferences(mocks.deps, SELF, {});
+
+    expect(res.preferences?.userId).toBe('usr-self');
+    expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('auth.privacyPrefsReset');
+  });
+
+  it('rejects cross-user reset without :any', async () => {
+    await expect(
+      resetPrivacyPreferences(mocks.deps, SELF, { userId: 'usr-other' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+});

--- a/services/auth/src/grpc/privacy-prefs-handlers.ts
+++ b/services/auth/src/grpc/privacy-prefs-handlers.ts
@@ -1,0 +1,243 @@
+// gRPC handler implementations for AuthService.{GetPrivacyPreferences,
+// UpdatePrivacyPreferences, ResetPrivacyPreferences}.
+//
+// Mirrors the notifications-prefs handler pattern (PR #967):
+//   - hasPermission gate on the self/any permission split
+//   - Auto-create the row on first read so the response is always
+//     populated
+//   - Partial update via the set-* discipline — proto3 optional/scalar
+//     presence drives which columns get written
+//   - Reset is a destroy + recreate so the table-level defaults are
+//     the single source of truth for "factory settings"
+
+import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction } from '@adopt-dont-shop/events';
+import type { Permission } from '@adopt-dont-shop/lib.types';
+import {
+  AuthV1,
+  type GetPrivacyPreferencesRequest,
+  type GetPrivacyPreferencesResponse,
+  type PrivacyPreferences as PrivacyPreferencesProto,
+  type ResetPrivacyPreferencesRequest,
+  type ResetPrivacyPreferencesResponse,
+  type UpdatePrivacyPreferencesRequest,
+  type UpdatePrivacyPreferencesResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './handlers.js';
+
+// Privacy-prefs handlers don't need passwordHasher / tokenIssuer, but
+// the shared adapter is typed against HandlerDeps so we accept the
+// full shape and ignore the unused fields.
+export type PrivacyPrefsDeps = HandlerDeps;
+
+// --- Permissions -----------------------------------------------------
+
+const PRIVACY_PREFS_READ: Permission = 'auth.privacy-prefs.read' as Permission;
+const PRIVACY_PREFS_READ_ANY: Permission = 'auth.privacy-prefs.read:any' as Permission;
+const PRIVACY_PREFS_UPDATE: Permission = 'auth.privacy-prefs.update' as Permission;
+const PRIVACY_PREFS_UPDATE_ANY: Permission = 'auth.privacy-prefs.update:any' as Permission;
+
+// --- Row + enum mapping ---------------------------------------------
+
+type ProfileVisibilityDb = 'public' | 'rescues_only' | 'private';
+
+type PrivacyPrefsRow = {
+  user_id: string;
+  profile_visibility: ProfileVisibilityDb;
+  show_last_seen: boolean;
+  show_location: boolean;
+  allow_search_indexing: boolean;
+  allow_data_export: boolean;
+  created_at: Date;
+  updated_at: Date;
+};
+
+const dbVisibilityToProto = (v: ProfileVisibilityDb): AuthV1.ProfileVisibility => {
+  switch (v) {
+    case 'public':
+      return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PUBLIC;
+    case 'rescues_only':
+      return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_RESCUES_ONLY;
+    case 'private':
+      return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PRIVATE;
+  }
+};
+
+const protoVisibilityToDb = (v: AuthV1.ProfileVisibility): ProfileVisibilityDb | null => {
+  switch (v) {
+    case AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PUBLIC:
+      return 'public';
+    case AuthV1.ProfileVisibility.PROFILE_VISIBILITY_RESCUES_ONLY:
+      return 'rescues_only';
+    case AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PRIVATE:
+      return 'private';
+    default:
+      return null;
+  }
+};
+
+const rowToProto = (row: PrivacyPrefsRow): PrivacyPreferencesProto => ({
+  userId: row.user_id,
+  profileVisibility: dbVisibilityToProto(row.profile_visibility),
+  showLastSeen: row.show_last_seen,
+  showLocation: row.show_location,
+  allowSearchIndexing: row.allow_search_indexing,
+  allowDataExport: row.allow_data_export,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+// --- Helpers ---------------------------------------------------------
+
+const resolveTargetUserId = (
+  principal: Principal,
+  requested: string | undefined,
+  anyPerm: Permission
+): string => {
+  const target = requested || (principal.userId as string);
+  if (target === principal.userId) {
+    return target;
+  }
+  if (!hasPermission(principal, anyPerm)) {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      `'${anyPerm}' required to access another user's privacy preferences`
+    );
+  }
+  return target;
+};
+
+const findOrCreatePrefs = async (
+  deps: PrivacyPrefsDeps,
+  userId: string
+): Promise<PrivacyPrefsRow> => {
+  const existing = await deps.pool.query<PrivacyPrefsRow>(
+    `SELECT * FROM user_privacy_prefs WHERE user_id = $1`,
+    [userId]
+  );
+  if (existing.rows[0]) {
+    return existing.rows[0];
+  }
+  const inserted = await deps.pool.query<PrivacyPrefsRow>(
+    `
+    INSERT INTO user_privacy_prefs (user_id)
+    VALUES ($1)
+    ON CONFLICT (user_id) DO UPDATE SET user_id = EXCLUDED.user_id
+    RETURNING *
+    `,
+    [userId]
+  );
+  return inserted.rows[0];
+};
+
+// --- GetPrivacyPreferences -------------------------------------------
+
+export async function getPrivacyPreferences(
+  deps: PrivacyPrefsDeps,
+  principal: Principal,
+  req: GetPrivacyPreferencesRequest
+): Promise<GetPrivacyPreferencesResponse> {
+  if (!hasPermission(principal, PRIVACY_PREFS_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PRIVACY_PREFS_READ}' required`);
+  }
+  const userId = resolveTargetUserId(principal, req.userId, PRIVACY_PREFS_READ_ANY);
+  const row = await findOrCreatePrefs(deps, userId);
+  return { preferences: rowToProto(row) };
+}
+
+// --- UpdatePrivacyPreferences ----------------------------------------
+
+export async function updatePrivacyPreferences(
+  deps: PrivacyPrefsDeps,
+  principal: Principal,
+  req: UpdatePrivacyPreferencesRequest
+): Promise<UpdatePrivacyPreferencesResponse> {
+  if (!hasPermission(principal, PRIVACY_PREFS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PRIVACY_PREFS_UPDATE}' required`);
+  }
+  const userId = resolveTargetUserId(principal, req.userId, PRIVACY_PREFS_UPDATE_ANY);
+
+  // Ensure the row exists so the UPDATE has something to write.
+  await findOrCreatePrefs(deps, userId);
+
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  let n = 1;
+
+  const setBool = (column: string, v: boolean | undefined): void => {
+    if (v !== undefined) {
+      sets.push(`${column} = $${n}`);
+      params.push(v);
+      n++;
+    }
+  };
+
+  const visibility = protoVisibilityToDb(req.profileVisibility);
+  if (visibility) {
+    sets.push(`profile_visibility = $${n}`);
+    params.push(visibility);
+    n++;
+  }
+  setBool('show_last_seen', req.showLastSeen);
+  setBool('show_location', req.showLocation);
+  setBool('allow_search_indexing', req.allowSearchIndexing);
+  setBool('allow_data_export', req.allowDataExport);
+
+  if (sets.length === 0) {
+    const current = await deps.pool.query<PrivacyPrefsRow>(
+      `SELECT * FROM user_privacy_prefs WHERE user_id = $1`,
+      [userId]
+    );
+    return { preferences: rowToProto(current.rows[0]) };
+  }
+
+  sets.push('updated_at = now()');
+  sets.push('version = version + 1');
+  params.push(userId);
+
+  const result = await deps.pool.query<PrivacyPrefsRow>(
+    `
+    UPDATE user_privacy_prefs
+    SET ${sets.join(', ')}
+    WHERE user_id = $${n}
+    RETURNING *
+    `,
+    params
+  );
+  return { preferences: rowToProto(result.rows[0]) };
+}
+
+// --- ResetPrivacyPreferences -----------------------------------------
+
+export async function resetPrivacyPreferences(
+  deps: PrivacyPrefsDeps,
+  principal: Principal,
+  req: ResetPrivacyPreferencesRequest
+): Promise<ResetPrivacyPreferencesResponse> {
+  if (!hasPermission(principal, PRIVACY_PREFS_UPDATE)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PRIVACY_PREFS_UPDATE}' required`);
+  }
+  const userId = resolveTargetUserId(principal, req.userId, PRIVACY_PREFS_UPDATE_ANY);
+
+  let reset: PrivacyPrefsRow | undefined;
+  await withTransaction(deps, async ({ client, publish }) => {
+    await client.query(`DELETE FROM user_privacy_prefs WHERE user_id = $1`, [userId]);
+    const inserted = await client.query<PrivacyPrefsRow>(
+      `INSERT INTO user_privacy_prefs (user_id) VALUES ($1) RETURNING *`,
+      [userId]
+    );
+    reset = inserted.rows[0];
+
+    publish({
+      type: 'auth.privacyPrefsReset',
+      id: `auth.privacyPrefsReset.${userId}.${Date.now()}`,
+      payload: { userId },
+    });
+  });
+
+  if (!reset) {
+    throw new HandlerError('INTERNAL', 'reset returned no rows');
+  }
+  return { preferences: rowToProto(reset) };
+}

--- a/services/auth/src/grpc/server.ts
+++ b/services/auth/src/grpc/server.ts
@@ -37,6 +37,11 @@ import {
   validateToken,
   type HandlerDeps,
 } from './handlers.js';
+import {
+  getPrivacyPreferences,
+  resetPrivacyPreferences,
+  updatePrivacyPreferences,
+} from './privacy-prefs-handlers.js';
 import { listSessions, revokeSession } from './session-handlers.js';
 
 export type CreateGrpcServerOptions = {
@@ -80,6 +85,11 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     // Session management — list active refresh-token chains + revoke.
     listSessions: adapt(listSessions, { deps, logger }),
     revokeSession: adapt(revokeSession, { deps, logger }),
+    // Privacy preferences — 1:1 with users; gateway composes these with
+    // notifications.user_notification_prefs for the unified API.
+    getPrivacyPreferences: adapt(getPrivacyPreferences, { deps, logger }),
+    updatePrivacyPreferences: adapt(updatePrivacyPreferences, { deps, logger }),
+    resetPrivacyPreferences: adapt(resetPrivacyPreferences, { deps, logger }),
   });
 
   logger.info('gRPC AuthService registered', {
@@ -99,6 +109,9 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'updateAccount',
       'listSessions',
       'revokeSession',
+      'getPrivacyPreferences',
+      'updatePrivacyPreferences',
+      'resetPrivacyPreferences',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/auth/src/migrations/008_create_user_privacy_prefs.ts
+++ b/services/auth/src/migrations/008_create_user_privacy_prefs.ts
@@ -1,0 +1,48 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// Per-table baseline — user_privacy_prefs.
+//
+// Direct port of service.backend's 00-baseline-057-user-privacy-prefs.ts.
+// 1:1 with users — `user_id` is both the primary key here and the FK
+// to auth.users. The companion table (user_notification_prefs) lives
+// in the notifications schema; the gateway composes both for the
+// monolith's unified /api/v1/users/preferences endpoint.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createType('user_profile_visibility', ['public', 'rescues_only', 'private']);
+
+  pgm.createTable('user_privacy_prefs', {
+    user_id: {
+      type: 'uuid',
+      primaryKey: true,
+      references: 'users(user_id)',
+      onDelete: 'CASCADE',
+    },
+    profile_visibility: {
+      type: 'user_profile_visibility',
+      notNull: true,
+      default: 'rescues_only',
+    },
+    show_last_seen: { type: 'boolean', notNull: true, default: false },
+    show_location: { type: 'boolean', notNull: true, default: true },
+    allow_search_indexing: { type: 'boolean', notNull: true, default: false },
+    allow_data_export: { type: 'boolean', notNull: true, default: true },
+    created_by: { type: 'uuid' },
+    updated_by: { type: 'uuid' },
+    version: { type: 'integer', notNull: true, default: 0 },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('user_privacy_prefs', 'created_by', {
+    name: 'user_privacy_prefs_created_by_idx',
+  });
+  pgm.createIndex('user_privacy_prefs', 'updated_by', {
+    name: 'user_privacy_prefs_updated_by_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('user_privacy_prefs');
+  pgm.dropType('user_profile_visibility');
+};

--- a/services/gateway/src/grpc-clients/auth-client.ts
+++ b/services/gateway/src/grpc-clients/auth-client.ts
@@ -43,6 +43,12 @@ import {
   type ListSessionsResponse,
   type RevokeSessionRequest,
   type RevokeSessionResponse,
+  type GetPrivacyPreferencesRequest,
+  type GetPrivacyPreferencesResponse,
+  type UpdatePrivacyPreferencesRequest,
+  type UpdatePrivacyPreferencesResponse,
+  type ResetPrivacyPreferencesRequest,
+  type ResetPrivacyPreferencesResponse,
 } from '@adopt-dont-shop/proto';
 
 export type AuthClient = {
@@ -64,6 +70,18 @@ export type AuthClient = {
   updateAccount(req: UpdateAccountRequest, metadata: Metadata): Promise<UpdateAccountResponse>;
   listSessions(req: ListSessionsRequest, metadata: Metadata): Promise<ListSessionsResponse>;
   revokeSession(req: RevokeSessionRequest, metadata: Metadata): Promise<RevokeSessionResponse>;
+  getPrivacyPreferences(
+    req: GetPrivacyPreferencesRequest,
+    metadata: Metadata
+  ): Promise<GetPrivacyPreferencesResponse>;
+  updatePrivacyPreferences(
+    req: UpdatePrivacyPreferencesRequest,
+    metadata: Metadata
+  ): Promise<UpdatePrivacyPreferencesResponse>;
+  resetPrivacyPreferences(
+    req: ResetPrivacyPreferencesRequest,
+    metadata: Metadata
+  ): Promise<ResetPrivacyPreferencesResponse>;
   close(): void;
 };
 
@@ -105,6 +123,11 @@ export const createAuthClient = (opts: CreateAuthClientOptions): AuthClient => {
     updateAccount: (req, metadata) => callUnary(stub.updateAccount, req, metadata),
     listSessions: (req, metadata) => callUnary(stub.listSessions, req, metadata),
     revokeSession: (req, metadata) => callUnary(stub.revokeSession, req, metadata),
+    getPrivacyPreferences: (req, metadata) => callUnary(stub.getPrivacyPreferences, req, metadata),
+    updatePrivacyPreferences: (req, metadata) =>
+      callUnary(stub.updatePrivacyPreferences, req, metadata),
+    resetPrivacyPreferences: (req, metadata) =>
+      callUnary(stub.resetPrivacyPreferences, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/grpc-clients/notifications-client.ts
+++ b/services/gateway/src/grpc-clients/notifications-client.ts
@@ -38,6 +38,8 @@ import {
   type UnregisterDeviceTokenResponse,
   type UpdateNotificationPreferencesRequest,
   type UpdateNotificationPreferencesResponse,
+  type ResetNotificationPreferencesRequest,
+  type ResetNotificationPreferencesResponse,
 } from '@adopt-dont-shop/proto';
 
 export type NotificationsClient = {
@@ -77,6 +79,10 @@ export type NotificationsClient = {
     req: UpdateNotificationPreferencesRequest,
     metadata: Metadata
   ): Promise<UpdateNotificationPreferencesResponse>;
+  resetNotificationPreferences(
+    req: ResetNotificationPreferencesRequest,
+    metadata: Metadata
+  ): Promise<ResetNotificationPreferencesResponse>;
   close(): void;
 };
 
@@ -126,6 +132,8 @@ export const createNotificationsClient = (
       callUnary(stub.getNotificationPreferences, req, metadata),
     updateNotificationPreferences: (req, metadata) =>
       callUnary(stub.updateNotificationPreferences, req, metadata),
+    resetNotificationPreferences: (req, metadata) =>
+      callUnary(stub.resetNotificationPreferences, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/users.test.ts
+++ b/services/gateway/src/routes/users.test.ts
@@ -1,0 +1,404 @@
+import { Metadata, status } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AuthV1,
+  NotificationsV1,
+  type UpdateAccountRequest,
+  type UpdateNotificationPreferencesRequest,
+  type UpdatePrivacyPreferencesRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { AuthClient } from '../grpc-clients/auth-client.js';
+import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+
+import { registerUsersRoutes } from './users.js';
+
+// --- Fixtures -------------------------------------------------------
+
+const NOTIF_PREFS_FIXTURE: NotificationsV1.NotificationPreferences = {
+  userId: 'usr-1',
+  emailEnabled: true,
+  pushEnabled: true,
+  smsEnabled: false,
+  digestFrequency: NotificationsV1.NotificationDigestFrequency.NOTIFICATION_DIGEST_FREQUENCY_WEEKLY,
+  applicationUpdates: true,
+  petMatches: true,
+  rescueUpdates: true,
+  chatMessages: true,
+  timezone: 'UTC',
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const PRIVACY_PREFS_FIXTURE: AuthV1.PrivacyPreferences = {
+  userId: 'usr-1',
+  profileVisibility: AuthV1.ProfileVisibility.PROFILE_VISIBILITY_RESCUES_ONLY,
+  showLastSeen: false,
+  showLocation: true,
+  allowSearchIndexing: false,
+  allowDataExport: true,
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const ME_FIXTURE: AuthV1.GetMeResponse = {
+  user: {
+    userId: 'usr-1',
+    email: 'user@example.com',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    role: AuthV1.UserRole.USER_ROLE_ADOPTER,
+    status: AuthV1.UserStatus.USER_STATUS_ACTIVE,
+    emailVerified: true,
+    twoFactorEnabled: false,
+    permissions: [],
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+  } as unknown as AuthV1.User,
+};
+
+// --- Mocks ----------------------------------------------------------
+
+function makeAuthClient(): AuthClient & {
+  getMeMock: ReturnType<typeof vi.fn>;
+  updateAccountMock: ReturnType<typeof vi.fn>;
+  getPrivacyPreferencesMock: ReturnType<typeof vi.fn>;
+  updatePrivacyPreferencesMock: ReturnType<typeof vi.fn>;
+  resetPrivacyPreferencesMock: ReturnType<typeof vi.fn>;
+} {
+  const getMeMock = vi.fn();
+  const updateAccountMock = vi.fn();
+  const getPrivacyPreferencesMock = vi.fn();
+  const updatePrivacyPreferencesMock = vi.fn();
+  const resetPrivacyPreferencesMock = vi.fn();
+  return {
+    // We only use these four — the rest are stubs satisfying the type.
+    getMe: getMeMock,
+    updateAccount: updateAccountMock,
+    getPrivacyPreferences: getPrivacyPreferencesMock,
+    updatePrivacyPreferences: updatePrivacyPreferencesMock,
+    resetPrivacyPreferences: resetPrivacyPreferencesMock,
+    login: vi.fn(),
+    logout: vi.fn(),
+    refreshToken: vi.fn(),
+    validateToken: vi.fn(),
+    assignRole: vi.fn(),
+    register: vi.fn(),
+    verifyEmail: vi.fn(),
+    resendVerification: vi.fn(),
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+    changePassword: vi.fn(),
+    listSessions: vi.fn(),
+    revokeSession: vi.fn(),
+    close: vi.fn(),
+    getMeMock,
+    updateAccountMock,
+    getPrivacyPreferencesMock,
+    updatePrivacyPreferencesMock,
+    resetPrivacyPreferencesMock,
+  };
+}
+
+function makeNotifClient(): NotificationsClient & {
+  getNotificationPreferencesMock: ReturnType<typeof vi.fn>;
+  updateNotificationPreferencesMock: ReturnType<typeof vi.fn>;
+  resetNotificationPreferencesMock: ReturnType<typeof vi.fn>;
+} {
+  const getNotificationPreferencesMock = vi.fn();
+  const updateNotificationPreferencesMock = vi.fn();
+  const resetNotificationPreferencesMock = vi.fn();
+  return {
+    getNotificationPreferences: getNotificationPreferencesMock,
+    updateNotificationPreferences: updateNotificationPreferencesMock,
+    resetNotificationPreferences: resetNotificationPreferencesMock,
+    create: vi.fn(),
+    list: vi.fn(),
+    dismiss: vi.fn(),
+    getNotification: vi.fn(),
+    getUnreadCount: vi.fn(),
+    markAllRead: vi.fn(),
+    deleteNotification: vi.fn(),
+    registerDeviceToken: vi.fn(),
+    unregisterDeviceToken: vi.fn(),
+    listDeviceTokens: vi.fn(),
+    close: vi.fn(),
+    getNotificationPreferencesMock,
+    updateNotificationPreferencesMock,
+    resetNotificationPreferencesMock,
+  };
+}
+
+async function buildApp(auth: AuthClient, notif: NotificationsClient): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerUsersRoutes(app, { authClient: auth, notificationsClient: notif });
+  return app;
+}
+
+// --- GET /api/v1/users/profile --------------------------------------
+
+describe('GET /api/v1/users/profile', () => {
+  let app: FastifyInstance;
+  let auth: ReturnType<typeof makeAuthClient>;
+  let notif: ReturnType<typeof makeNotifClient>;
+
+  beforeEach(async () => {
+    auth = makeAuthClient();
+    notif = makeNotifClient();
+    app = await buildApp(auth, notif);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('routes to authClient.getMe and forwards metadata', async () => {
+    auth.getMeMock.mockResolvedValueOnce(ME_FIXTURE);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/users/profile',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(auth.getMeMock).toHaveBeenCalledTimes(1);
+    const [, metadata] = auth.getMeMock.mock.calls[0] as [unknown, Metadata];
+    expect(metadata.get('x-user-id')).toEqual(['usr-1']);
+  });
+});
+
+// --- PUT /api/v1/users/profile --------------------------------------
+
+describe('PUT /api/v1/users/profile', () => {
+  let app: FastifyInstance;
+  let auth: ReturnType<typeof makeAuthClient>;
+  let notif: ReturnType<typeof makeNotifClient>;
+
+  beforeEach(async () => {
+    auth = makeAuthClient();
+    notif = makeNotifClient();
+    app = await buildApp(auth, notif);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('maps camelCase + snake_case body keys to UpdateAccount', async () => {
+    auth.updateAccountMock.mockResolvedValueOnce({ user: ME_FIXTURE.user });
+
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/users/profile',
+      headers: {
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+        'content-type': 'application/json',
+      },
+      payload: {
+        firstName: 'Jane',
+        last_name: 'Smith',
+        phone_number: '+1234',
+        bio: 'hi',
+      },
+    });
+
+    const [grpcReq] = auth.updateAccountMock.mock.calls[0] as [UpdateAccountRequest, Metadata];
+    expect(grpcReq.firstName).toBe('Jane');
+    expect(grpcReq.lastName).toBe('Smith');
+    expect(grpcReq.phoneNumber).toBe('+1234');
+    expect(grpcReq.bio).toBe('hi');
+  });
+});
+
+// --- GET /api/v1/users/preferences ----------------------------------
+
+describe('GET /api/v1/users/preferences', () => {
+  let app: FastifyInstance;
+  let auth: ReturnType<typeof makeAuthClient>;
+  let notif: ReturnType<typeof makeNotifClient>;
+
+  beforeEach(async () => {
+    auth = makeAuthClient();
+    notif = makeNotifClient();
+    app = await buildApp(auth, notif);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('composes the monolith-shaped preferences from both backing services', async () => {
+    notif.getNotificationPreferencesMock.mockResolvedValueOnce({
+      preferences: NOTIF_PREFS_FIXTURE,
+    });
+    auth.getPrivacyPreferencesMock.mockResolvedValueOnce({ preferences: PRIVACY_PREFS_FIXTURE });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/users/preferences',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      success: true,
+      data: {
+        emailNotifications: true,
+        pushNotifications: true,
+        smsNotifications: false,
+        privacySettings: {
+          profileVisibility: 'rescues_only',
+          showLocation: true,
+          showContactInfo: false,
+        },
+      },
+    });
+  });
+
+  it('propagates a gRPC NOT_FOUND from either backing call as a 404', async () => {
+    notif.getNotificationPreferencesMock.mockRejectedValueOnce({
+      code: status.NOT_FOUND,
+      details: 'gone',
+    });
+    auth.getPrivacyPreferencesMock.mockResolvedValueOnce({ preferences: PRIVACY_PREFS_FIXTURE });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/users/preferences',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// --- PUT /api/v1/users/preferences ----------------------------------
+
+describe('PUT /api/v1/users/preferences', () => {
+  let app: FastifyInstance;
+  let auth: ReturnType<typeof makeAuthClient>;
+  let notif: ReturnType<typeof makeNotifClient>;
+
+  beforeEach(async () => {
+    auth = makeAuthClient();
+    notif = makeNotifClient();
+    app = await buildApp(auth, notif);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('splits the body across notif + privacy update RPCs', async () => {
+    notif.updateNotificationPreferencesMock.mockResolvedValueOnce({
+      preferences: { ...NOTIF_PREFS_FIXTURE, emailEnabled: false },
+    });
+    auth.updatePrivacyPreferencesMock.mockResolvedValueOnce({
+      preferences: {
+        ...PRIVACY_PREFS_FIXTURE,
+        profileVisibility: AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PRIVATE,
+        showLocation: false,
+      },
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/users/preferences',
+      headers: {
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+        'content-type': 'application/json',
+      },
+      payload: {
+        emailNotifications: false,
+        privacySettings: { profileVisibility: 'private', showLocation: false },
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const [notifReq] = notif.updateNotificationPreferencesMock.mock.calls[0] as [
+      UpdateNotificationPreferencesRequest,
+      Metadata,
+    ];
+    expect(notifReq.emailEnabled).toBe(false);
+
+    const [privReq] = auth.updatePrivacyPreferencesMock.mock.calls[0] as [
+      UpdatePrivacyPreferencesRequest,
+      Metadata,
+    ];
+    expect(privReq.profileVisibility).toBe(AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PRIVATE);
+    expect(privReq.showLocation).toBe(false);
+
+    const body = res.json() as { data: Record<string, unknown> };
+    expect(body.data.emailNotifications).toBe(false);
+    expect((body.data.privacySettings as Record<string, unknown>).profileVisibility).toBe(
+      'private'
+    );
+  });
+
+  it('still calls both even when one slice has no fields (handler no-ops)', async () => {
+    notif.updateNotificationPreferencesMock.mockResolvedValueOnce({
+      preferences: NOTIF_PREFS_FIXTURE,
+    });
+    auth.updatePrivacyPreferencesMock.mockResolvedValueOnce({
+      preferences: PRIVACY_PREFS_FIXTURE,
+    });
+
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/users/preferences',
+      headers: {
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+        'content-type': 'application/json',
+      },
+      payload: { emailNotifications: false },
+    });
+
+    expect(notif.updateNotificationPreferencesMock).toHaveBeenCalledTimes(1);
+    expect(auth.updatePrivacyPreferencesMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- POST /api/v1/users/preferences/reset ---------------------------
+
+describe('POST /api/v1/users/preferences/reset', () => {
+  let app: FastifyInstance;
+  let auth: ReturnType<typeof makeAuthClient>;
+  let notif: ReturnType<typeof makeNotifClient>;
+
+  beforeEach(async () => {
+    auth = makeAuthClient();
+    notif = makeNotifClient();
+    app = await buildApp(auth, notif);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('calls both reset RPCs and returns composed defaults', async () => {
+    notif.resetNotificationPreferencesMock.mockResolvedValueOnce({
+      preferences: NOTIF_PREFS_FIXTURE,
+    });
+    auth.resetPrivacyPreferencesMock.mockResolvedValueOnce({ preferences: PRIVACY_PREFS_FIXTURE });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/users/preferences/reset',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(notif.resetNotificationPreferencesMock).toHaveBeenCalledTimes(1);
+    expect(auth.resetPrivacyPreferencesMock).toHaveBeenCalledTimes(1);
+    const body = res.json() as {
+      success: boolean;
+      message: string;
+      data: { emailNotifications: boolean };
+    };
+    expect(body.success).toBe(true);
+    expect(body.message).toMatch(/reset/i);
+    expect(body.data.emailNotifications).toBe(true);
+  });
+});

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -1,0 +1,260 @@
+// REST → gRPC translation for /api/v1/users/* — the SPA-facing user
+// surface that the monolith served via UserController.
+//
+// This plugin spans TWO backend services:
+//   - service.auth  — profile (GetMe / UpdateAccount RPCs) + privacy
+//                     preferences (GetPrivacyPreferences /
+//                     UpdatePrivacyPreferences / ResetPrivacyPreferences)
+//   - service.notifications — the in-app channel preferences
+//                     (GetNotificationPreferences /
+//                     UpdateNotificationPreferences /
+//                     ResetNotificationPreferences) that the monolith's
+//                     /preferences endpoint composes into a single
+//                     response shape.
+//
+// The monolith's UserPreferences DTO is the union of the two underlying
+// rows. We preserve that contract here so the SPA's lib.api client
+// keeps working without a re-spin.
+
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  AuthV1,
+  NotificationsV1,
+  type GetMeRequest,
+  type GetPrivacyPreferencesRequest,
+  type ResetPrivacyPreferencesRequest,
+  type UpdateAccountRequest,
+  type UpdateNotificationPreferencesRequest,
+  type UpdatePrivacyPreferencesRequest,
+} from '@adopt-dont-shop/proto';
+
+import type { AuthClient } from '../grpc-clients/auth-client.js';
+import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+
+export type UsersRoutesOptions = {
+  authClient: AuthClient;
+  notificationsClient: NotificationsClient;
+};
+
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.INTERNAL]: 500,
+};
+
+const visibilityProtoToString = (v: AuthV1.ProfileVisibility): string => {
+  switch (v) {
+    case AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PUBLIC:
+      return 'public';
+    case AuthV1.ProfileVisibility.PROFILE_VISIBILITY_RESCUES_ONLY:
+      return 'rescues_only';
+    case AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PRIVATE:
+      return 'private';
+    default:
+      return 'rescues_only';
+  }
+};
+
+const visibilityStringToProto = (raw: string | undefined): AuthV1.ProfileVisibility => {
+  if (!raw) return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_UNSPECIFIED;
+  switch (raw) {
+    case 'public':
+      return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PUBLIC;
+    case 'rescues_only':
+    case 'friends': // monolith legacy synonym
+      return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_RESCUES_ONLY;
+    case 'private':
+      return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PRIVATE;
+    default:
+      return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_UNSPECIFIED;
+  }
+};
+
+// Combine the two backing-service responses into the monolith's
+// UserPreferences shape.
+const composePreferences = (
+  notif: NotificationsV1.NotificationPreferences,
+  privacy: AuthV1.PrivacyPreferences
+): Record<string, unknown> => ({
+  emailNotifications: notif.emailEnabled,
+  pushNotifications: notif.pushEnabled,
+  smsNotifications: notif.smsEnabled,
+  privacySettings: {
+    profileVisibility: visibilityProtoToString(privacy.profileVisibility),
+    showLocation: privacy.showLocation,
+    showContactInfo: false,
+  },
+});
+
+const buildNotifPatch = (body: Record<string, unknown>): UpdateNotificationPreferencesRequest => {
+  const out: UpdateNotificationPreferencesRequest = {
+    digestFrequency:
+      NotificationsV1.NotificationDigestFrequency.NOTIFICATION_DIGEST_FREQUENCY_UNSPECIFIED,
+  };
+  if (typeof body.emailNotifications === 'boolean') {
+    out.emailEnabled = body.emailNotifications;
+  }
+  if (typeof body.pushNotifications === 'boolean') {
+    out.pushEnabled = body.pushNotifications;
+  }
+  if (typeof body.smsNotifications === 'boolean') {
+    out.smsEnabled = body.smsNotifications;
+  }
+  return out;
+};
+
+const buildPrivacyPatch = (body: Record<string, unknown>): UpdatePrivacyPreferencesRequest => {
+  const out: UpdatePrivacyPreferencesRequest = {
+    profileVisibility: AuthV1.ProfileVisibility.PROFILE_VISIBILITY_UNSPECIFIED,
+  };
+  const privacy = body.privacySettings as Record<string, unknown> | undefined;
+  if (privacy) {
+    if (typeof privacy.profileVisibility === 'string') {
+      out.profileVisibility = visibilityStringToProto(privacy.profileVisibility);
+    }
+    if (typeof privacy.showLocation === 'boolean') {
+      out.showLocation = privacy.showLocation;
+    }
+  }
+  return out;
+};
+
+export const registerUsersRoutes = async (
+  app: FastifyInstance,
+  opts: UsersRoutesOptions
+): Promise<void> => {
+  const { authClient, notificationsClient } = opts;
+
+  // --- GET /api/v1/users/profile -------------------------------------
+  // The monolith mounts both /profile and /account for the same payload.
+  // The /account routes already live in routes/auth.ts; we add /profile
+  // here so lib.api's user.getProfile() call lands on a single seam.
+  app.get('/api/v1/users/profile', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    try {
+      const res = await authClient.getMe({} as GetMeRequest, metadata);
+      return reply.send(AuthV1.GetMeResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  app.put('/api/v1/users/profile', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const b = (req.body ?? {}) as Record<string, unknown>;
+    const str = (k1: string, k2?: string): string | undefined => {
+      const v = (b[k1] ?? (k2 ? b[k2] : undefined)) as unknown;
+      return typeof v === 'string' ? v : undefined;
+    };
+    const grpcReq: UpdateAccountRequest = {
+      firstName: str('firstName', 'first_name'),
+      lastName: str('lastName', 'last_name'),
+      phoneNumber: str('phoneNumber', 'phone_number'),
+      bio: str('bio'),
+      timezone: str('timezone'),
+      language: str('language'),
+      country: str('country'),
+      city: str('city'),
+      addressLine1: str('addressLine1', 'address_line_1'),
+      addressLine2: str('addressLine2', 'address_line_2'),
+      postalCode: str('postalCode', 'postal_code'),
+    };
+    try {
+      const res = await authClient.updateAccount(grpcReq, metadata);
+      return reply.send(AuthV1.UpdateAccountResponse.toJSON(res));
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // --- GET /api/v1/users/preferences --------------------------------
+  // Fetches both backing rows in parallel and composes.
+  app.get('/api/v1/users/preferences', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    try {
+      const [notif, privacy] = await Promise.all([
+        notificationsClient.getNotificationPreferences({}, metadata),
+        authClient.getPrivacyPreferences({} as GetPrivacyPreferencesRequest, metadata),
+      ]);
+      return reply.send({
+        success: true,
+        data: composePreferences(notif.preferences!, privacy.preferences!),
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // --- PUT /api/v1/users/preferences --------------------------------
+  // Splits the unified body across the two backing RPCs. Either patch
+  // may be empty (no fields supplied for that slice) — the underlying
+  // handlers no-op on an empty patch and return the current row, which
+  // we then re-compose into the unified response.
+  app.put('/api/v1/users/preferences', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    try {
+      const [notif, privacy] = await Promise.all([
+        notificationsClient.updateNotificationPreferences(buildNotifPatch(body), metadata),
+        authClient.updatePrivacyPreferences(buildPrivacyPatch(body), metadata),
+      ]);
+      return reply.send({
+        success: true,
+        message: 'Preferences updated successfully',
+        data: composePreferences(notif.preferences!, privacy.preferences!),
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
+  // --- POST /api/v1/users/preferences/reset -------------------------
+  // Destroy + recreate both backing rows so the table-level defaults
+  // win. The monolith returns the fresh defaults in the response body.
+  app.post('/api/v1/users/preferences/reset', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    try {
+      const [notif, privacy] = await Promise.all([
+        notificationsClient.resetNotificationPreferences({}, metadata),
+        authClient.resetPrivacyPreferences({} as ResetPrivacyPreferencesRequest, metadata),
+      ]);
+      return reply.send({
+        success: true,
+        message: 'Preferences reset to defaults',
+        data: composePreferences(notif.preferences!, privacy.preferences!),
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+};
+
+// --- Helpers ---------------------------------------------------------
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    success: false,
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -48,6 +48,7 @@ import { registerRescueRoutes } from './routes/rescue.js';
 import { registerRescuesPublicRoutes } from './routes/rescues-public.js';
 import { registerSessionsRoutes } from './routes/sessions.js';
 import { registerStaffFosterRoutes } from './routes/staff-foster.js';
+import { registerUsersRoutes } from './routes/users.js';
 
 export type CreateServerOptions = {
   config: GatewayConfig;
@@ -165,6 +166,16 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     // Reuses the same notifications gRPC client (device token RPCs
     // ship in @adopt-dont-shop/proto.NotificationsV1).
     await registerDevicesRoutes(server, { client: opts.notificationsClient });
+  }
+  // /api/v1/users/* — profile + composed preferences. Requires BOTH
+  // auth (profile + privacy prefs) and notifications (in-app channel
+  // prefs) cutover so the unified GET /preferences can compose without
+  // partial data.
+  if (opts.authClient && opts.notificationsClient && cutover.auth && cutover.notifications) {
+    await registerUsersRoutes(server, {
+      authClient: opts.authClient,
+      notificationsClient: opts.notificationsClient,
+    });
   }
   if (opts.petsClient && cutover.pets) {
     await registerPetsRoutes(server, { client: opts.petsClient });

--- a/services/notifications/src/grpc/notification-prefs-handlers.test.ts
+++ b/services/notifications/src/grpc/notification-prefs-handlers.test.ts
@@ -12,6 +12,7 @@ import {
   getNotificationPreferences,
   getUnreadCount,
   markAllRead,
+  resetNotificationPreferences,
   updateNotificationPreferences,
 } from './notification-prefs-handlers.js';
 
@@ -471,6 +472,41 @@ describe('updateNotificationPreferences', () => {
         userId: 'usr-other',
         emailEnabled: false,
       })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+});
+
+// --- resetNotificationPreferences ------------------------------------
+
+describe('resetNotificationPreferences', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects principals without notifications.prefs.update', async () => {
+    await expect(resetNotificationPreferences(mocks.deps, NO_PERMS, {})).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('deletes + inserts defaults inside withTransaction, publishes once', async () => {
+    mocks.clientScript.push({ rows: [] }); // DELETE
+    mocks.clientScript.push({ rows: [prefsRow()] }); // INSERT RETURNING
+
+    const res = await resetNotificationPreferences(mocks.deps, ADOPTER, {});
+
+    expect(res.preferences?.userId).toBe('usr-adopter');
+    expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('notifications.prefsReset');
+  });
+
+  it('rejects cross-user reset without :any', async () => {
+    await expect(
+      resetNotificationPreferences(mocks.deps, ADOPTER, { userId: 'usr-other' })
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
   });
 });

--- a/services/notifications/src/grpc/notification-prefs-handlers.ts
+++ b/services/notifications/src/grpc/notification-prefs-handlers.ts
@@ -25,6 +25,8 @@ import {
   type MarkAllReadRequest,
   type MarkAllReadResponse,
   type NotificationPreferences as NotificationPreferencesProto,
+  type ResetNotificationPreferencesRequest,
+  type ResetNotificationPreferencesResponse,
   type UpdateNotificationPreferencesRequest,
   type UpdateNotificationPreferencesResponse,
 } from '@adopt-dont-shop/proto';
@@ -477,4 +479,40 @@ export async function updateNotificationPreferences(
     params
   );
   return { preferences: prefsRowToProto(result.rows[0]) };
+}
+
+// --- ResetNotificationPreferences -----------------------------------
+
+export async function resetNotificationPreferences(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ResetNotificationPreferencesRequest
+): Promise<ResetNotificationPreferencesResponse> {
+  if (!hasPermission(principal, PREFS_WRITE_SELF)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PREFS_WRITE_SELF}' required`);
+  }
+  const userId = resolveTargetUserId(principal, req.userId, PREFS_WRITE_ANY);
+
+  let reset: PrefsRow | undefined;
+  await withTransaction(deps, async ({ client, publish }) => {
+    await client.query(`DELETE FROM notifications.user_notification_prefs WHERE user_id = $1`, [
+      userId,
+    ]);
+    const inserted = await client.query<PrefsRow>(
+      `INSERT INTO notifications.user_notification_prefs (user_id) VALUES ($1) RETURNING *`,
+      [userId]
+    );
+    reset = inserted.rows[0];
+
+    publish({
+      type: 'notifications.prefsReset',
+      id: `notifications.prefsReset.${userId}.${Date.now()}`,
+      payload: { userId },
+    });
+  });
+
+  if (!reset) {
+    throw new HandlerError('INTERNAL', 'reset returned no rows');
+  }
+  return { preferences: prefsRowToProto(reset) };
 }

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -32,6 +32,7 @@ import {
   getNotificationPreferences,
   getUnreadCount,
   markAllRead,
+  resetNotificationPreferences,
   updateNotificationPreferences,
 } from './notification-prefs-handlers.js';
 
@@ -72,6 +73,10 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       deps: { pool, nats },
       logger,
     }),
+    resetNotificationPreferences: adapt(resetNotificationPreferences, {
+      deps: { pool, nats },
+      logger,
+    }),
     sendEmail: adapt(sendEmail, { deps: { pool, nats }, logger }),
     getEmailPreferences: adapt(getEmailPreferences, { deps: { pool, nats }, logger }),
     updateEmailPreferences: adapt(updateEmailPreferences, { deps: { pool, nats }, logger }),
@@ -91,6 +96,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'deleteNotification',
       'getNotificationPreferences',
       'updateNotificationPreferences',
+      'resetNotificationPreferences',
       'sendEmail',
       'getEmailPreferences',
       'updateEmailPreferences',


### PR DESCRIPTION
## Summary

Brings the monolith's `/api/v1/users/profile` + `/api/v1/users/preferences` surface (plus `/preferences/reset`) over to the gateway. Two backing services are touched because the monolith's `UserPreferences` DTO is the union of two underlying rows:
- `notifications.user_notification_prefs` (email/push/sms + per-category toggles) — already there since PR #967
- `auth.user_privacy_prefs` (profile-visibility, show-location, allow-search-indexing, allow-data-export) — added in this PR

The gateway composes both in parallel for `GET /preferences`; splits the body across both for `PUT /preferences`; calls both `Reset` RPCs for `POST /preferences/reset`. The SPA's `BaseResponse<UserPreferences>` contract is unchanged.

### Auth service additions
- Migration `008_create_user_privacy_prefs.ts` — direct port of monolith's baseline-057. user_id PK + FK to users.user_id (cascade delete).
- `AuthService.{GetPrivacyPreferences, UpdatePrivacyPreferences, ResetPrivacyPreferences}` RPCs
- `privacy-prefs-handlers.ts` — self-scoped + `:any` permission split, partial UPDATE via set-* discipline, Reset destroys + recreates inside `withTransaction` + publishes `auth.privacyPrefsReset`
- 13 new tests

### Notifications service additions
- `NotificationService.ResetNotificationPreferences` RPC (same shape as the auth Reset)
- 3 new tests added to `notification-prefs-handlers.test.ts`

### Gateway additions
- `/api/v1/users/profile` GET → `auth.GetMe`; PUT → `auth.UpdateAccount` (camelCase + snake_case body alias)
- `/api/v1/users/preferences` GET → composes both services in parallel
- `/api/v1/users/preferences` PUT → splits body across both services in parallel
- `/api/v1/users/preferences/reset` POST → calls both Reset RPCs in parallel
- Wired in `server.ts` behind `cutover.auth && cutover.notifications` so partial-cutover envs don't try to compose against a missing service
- 7 new route tests

## Test plan
- [x] `services/auth` — 132/132
- [x] `services/notifications` — 159/159
- [x] `services/gateway` — 330/330
- [x] Type-check clean (proto regen + tsc all three services)
- [x] Lint clean (auth, notifications); gateway only pre-existing curly warnings
- [ ] Manual smoke: hit /api/v1/users/profile + /preferences from `app.client` once the stack is up
- [ ] Frontend cutover — lib.api `user.getProfile()` / `getUserPreferences()` are already shaped for these endpoints; no client change needed

## Out of scope
- Admin user management routes (`/api/v1/users/:userId`, `/search`, `/statistics`) — separate PR
- DELETE /api/v1/users/account → folds into the GDPR PR
- Field-permissions migration — separate PR
- Frontend cutover verification (`lib.api`/`app.*`) — separate PR

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_