### PR TITLE
feat(pets,gateway): pet stats RPC + /api/v1/pets/stats route

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
+++ b/packages/proto/proto/adopt_dont_shop/pets/v1/pet.proto
@@ -46,6 +46,12 @@ service PetService {
   // Soft-delete a pet (sets deleted_at). Caller MUST have `pets.delete`
   // scoped to the rescue. Publishes `pets.deleted` after commit.
   rpc Delete(DeletePetRequest) returns (DeletePetResponse);
+
+  // Per-rescue (or platform-wide for admin) counts: total + per-status
+  // breakdown + the last-30-day adoption count + an estimated
+  // average-time-to-adoption. Drives the rescue dashboard widget.
+  // Self-scoped to the caller's rescue unless they hold pets.read:any.
+  rpc GetStats(GetPetStatsRequest) returns (GetPetStatsResponse);
 }
 
 // --- ENUMs — value lists mirror the Postgres types verbatim ----------
@@ -268,4 +274,32 @@ message DeletePetRequest {
 message DeletePetResponse {
   // Soft-delete sets deleted_at; success is signalled by gRPC status OK.
   bool deleted = 1;
+}
+
+// --- GetStats --------------------------------------------------------
+
+message GetPetStatsRequest {
+  // Optional override. Rescue staff get pinned to their own rescue_id
+  // regardless; admins / super_admin with `pets.read:any` may pass
+  // a different value (and pass empty for the platform-wide aggregate).
+  optional string rescue_id_filter = 1;
+}
+
+message GetPetStatsResponse {
+  // Total non-deleted pets in scope (sum of the per-status counts).
+  uint32 total = 1;
+  // Per-status counts — zero-filled for statuses with no rows.
+  uint32 available = 2;
+  uint32 pending = 3;
+  uint32 adopted = 4;
+  uint32 foster = 5;
+  uint32 medical_hold = 6;
+  uint32 behavioral_hold = 7;
+  uint32 not_available = 8;
+  uint32 deceased = 9;
+  // Adoptions completed in the last 30 days.
+  uint32 monthly_adoptions = 10;
+  // Mean days between created_at and adopted_at across the most recent
+  // 50 adoptions in scope. Zero when no adoptions have been recorded.
+  uint32 average_days_to_adoption = 11;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/pets/v1/pet.ts
@@ -494,6 +494,36 @@ export interface DeletePetResponse {
   deleted: boolean;
 }
 
+export interface GetPetStatsRequest {
+  /**
+   * Optional override. Rescue staff get pinned to their own rescue_id
+   * regardless; admins / super_admin with `pets.read:any` may pass
+   * a different value (and pass empty for the platform-wide aggregate).
+   */
+  rescueIdFilter?: string | undefined;
+}
+
+export interface GetPetStatsResponse {
+  /** Total non-deleted pets in scope (sum of the per-status counts). */
+  total: number;
+  /** Per-status counts — zero-filled for statuses with no rows. */
+  available: number;
+  pending: number;
+  adopted: number;
+  foster: number;
+  medicalHold: number;
+  behavioralHold: number;
+  notAvailable: number;
+  deceased: number;
+  /** Adoptions completed in the last 30 days. */
+  monthlyAdoptions: number;
+  /**
+   * Mean days between created_at and adopted_at across the most recent
+   * 50 adoptions in scope. Zero when no adoptions have been recorded.
+   */
+  averageDaysToAdoption: number;
+}
+
 function createBasePet(): Pet {
   return {
     petId: '',
@@ -3005,6 +3035,324 @@ export const DeletePetResponse: MessageFns<DeletePetResponse> = {
   },
 };
 
+function createBaseGetPetStatsRequest(): GetPetStatsRequest {
+  return { rescueIdFilter: undefined };
+}
+
+export const GetPetStatsRequest: MessageFns<GetPetStatsRequest> = {
+  encode(message: GetPetStatsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.rescueIdFilter !== undefined) {
+      writer.uint32(10).string(message.rescueIdFilter);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetPetStatsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetPetStatsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.rescueIdFilter = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetPetStatsRequest {
+    return {
+      rescueIdFilter: isSet(object.rescueIdFilter)
+        ? globalThis.String(object.rescueIdFilter)
+        : isSet(object.rescue_id_filter)
+          ? globalThis.String(object.rescue_id_filter)
+          : undefined,
+    };
+  },
+
+  toJSON(message: GetPetStatsRequest): unknown {
+    const obj: any = {};
+    if (message.rescueIdFilter !== undefined) {
+      obj.rescueIdFilter = message.rescueIdFilter;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetPetStatsRequest>, I>>(base?: I): GetPetStatsRequest {
+    return GetPetStatsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetPetStatsRequest>, I>>(object: I): GetPetStatsRequest {
+    const message = createBaseGetPetStatsRequest();
+    message.rescueIdFilter = object.rescueIdFilter ?? undefined;
+    return message;
+  },
+};
+
+function createBaseGetPetStatsResponse(): GetPetStatsResponse {
+  return {
+    total: 0,
+    available: 0,
+    pending: 0,
+    adopted: 0,
+    foster: 0,
+    medicalHold: 0,
+    behavioralHold: 0,
+    notAvailable: 0,
+    deceased: 0,
+    monthlyAdoptions: 0,
+    averageDaysToAdoption: 0,
+  };
+}
+
+export const GetPetStatsResponse: MessageFns<GetPetStatsResponse> = {
+  encode(message: GetPetStatsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.total !== 0) {
+      writer.uint32(8).uint32(message.total);
+    }
+    if (message.available !== 0) {
+      writer.uint32(16).uint32(message.available);
+    }
+    if (message.pending !== 0) {
+      writer.uint32(24).uint32(message.pending);
+    }
+    if (message.adopted !== 0) {
+      writer.uint32(32).uint32(message.adopted);
+    }
+    if (message.foster !== 0) {
+      writer.uint32(40).uint32(message.foster);
+    }
+    if (message.medicalHold !== 0) {
+      writer.uint32(48).uint32(message.medicalHold);
+    }
+    if (message.behavioralHold !== 0) {
+      writer.uint32(56).uint32(message.behavioralHold);
+    }
+    if (message.notAvailable !== 0) {
+      writer.uint32(64).uint32(message.notAvailable);
+    }
+    if (message.deceased !== 0) {
+      writer.uint32(72).uint32(message.deceased);
+    }
+    if (message.monthlyAdoptions !== 0) {
+      writer.uint32(80).uint32(message.monthlyAdoptions);
+    }
+    if (message.averageDaysToAdoption !== 0) {
+      writer.uint32(88).uint32(message.averageDaysToAdoption);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetPetStatsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetPetStatsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.available = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.pending = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.adopted = reader.uint32();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.foster = reader.uint32();
+          continue;
+        }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.medicalHold = reader.uint32();
+          continue;
+        }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.behavioralHold = reader.uint32();
+          continue;
+        }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.notAvailable = reader.uint32();
+          continue;
+        }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.deceased = reader.uint32();
+          continue;
+        }
+        case 10: {
+          if (tag !== 80) {
+            break;
+          }
+
+          message.monthlyAdoptions = reader.uint32();
+          continue;
+        }
+        case 11: {
+          if (tag !== 88) {
+            break;
+          }
+
+          message.averageDaysToAdoption = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetPetStatsResponse {
+    return {
+      total: isSet(object.total) ? globalThis.Number(object.total) : 0,
+      available: isSet(object.available) ? globalThis.Number(object.available) : 0,
+      pending: isSet(object.pending) ? globalThis.Number(object.pending) : 0,
+      adopted: isSet(object.adopted) ? globalThis.Number(object.adopted) : 0,
+      foster: isSet(object.foster) ? globalThis.Number(object.foster) : 0,
+      medicalHold: isSet(object.medicalHold)
+        ? globalThis.Number(object.medicalHold)
+        : isSet(object.medical_hold)
+          ? globalThis.Number(object.medical_hold)
+          : 0,
+      behavioralHold: isSet(object.behavioralHold)
+        ? globalThis.Number(object.behavioralHold)
+        : isSet(object.behavioral_hold)
+          ? globalThis.Number(object.behavioral_hold)
+          : 0,
+      notAvailable: isSet(object.notAvailable)
+        ? globalThis.Number(object.notAvailable)
+        : isSet(object.not_available)
+          ? globalThis.Number(object.not_available)
+          : 0,
+      deceased: isSet(object.deceased) ? globalThis.Number(object.deceased) : 0,
+      monthlyAdoptions: isSet(object.monthlyAdoptions)
+        ? globalThis.Number(object.monthlyAdoptions)
+        : isSet(object.monthly_adoptions)
+          ? globalThis.Number(object.monthly_adoptions)
+          : 0,
+      averageDaysToAdoption: isSet(object.averageDaysToAdoption)
+        ? globalThis.Number(object.averageDaysToAdoption)
+        : isSet(object.average_days_to_adoption)
+          ? globalThis.Number(object.average_days_to_adoption)
+          : 0,
+    };
+  },
+
+  toJSON(message: GetPetStatsResponse): unknown {
+    const obj: any = {};
+    if (message.total !== 0) {
+      obj.total = Math.round(message.total);
+    }
+    if (message.available !== 0) {
+      obj.available = Math.round(message.available);
+    }
+    if (message.pending !== 0) {
+      obj.pending = Math.round(message.pending);
+    }
+    if (message.adopted !== 0) {
+      obj.adopted = Math.round(message.adopted);
+    }
+    if (message.foster !== 0) {
+      obj.foster = Math.round(message.foster);
+    }
+    if (message.medicalHold !== 0) {
+      obj.medicalHold = Math.round(message.medicalHold);
+    }
+    if (message.behavioralHold !== 0) {
+      obj.behavioralHold = Math.round(message.behavioralHold);
+    }
+    if (message.notAvailable !== 0) {
+      obj.notAvailable = Math.round(message.notAvailable);
+    }
+    if (message.deceased !== 0) {
+      obj.deceased = Math.round(message.deceased);
+    }
+    if (message.monthlyAdoptions !== 0) {
+      obj.monthlyAdoptions = Math.round(message.monthlyAdoptions);
+    }
+    if (message.averageDaysToAdoption !== 0) {
+      obj.averageDaysToAdoption = Math.round(message.averageDaysToAdoption);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetPetStatsResponse>, I>>(base?: I): GetPetStatsResponse {
+    return GetPetStatsResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetPetStatsResponse>, I>>(
+    object: I
+  ): GetPetStatsResponse {
+    const message = createBaseGetPetStatsResponse();
+    message.total = object.total ?? 0;
+    message.available = object.available ?? 0;
+    message.pending = object.pending ?? 0;
+    message.adopted = object.adopted ?? 0;
+    message.foster = object.foster ?? 0;
+    message.medicalHold = object.medicalHold ?? 0;
+    message.behavioralHold = object.behavioralHold ?? 0;
+    message.notAvailable = object.notAvailable ?? 0;
+    message.deceased = object.deceased ?? 0;
+    message.monthlyAdoptions = object.monthlyAdoptions ?? 0;
+    message.averageDaysToAdoption = object.averageDaysToAdoption ?? 0;
+    return message;
+  },
+};
+
 /**
  * PetService is the gRPC contract for the pets vertical. It owns the
  * `pets.*` schema (Pet, PetMedia, Breed, UserFavorite, Rating,
@@ -3119,6 +3467,23 @@ export const PetServiceService = {
       Buffer.from(DeletePetResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): DeletePetResponse => DeletePetResponse.decode(value),
   },
+  /**
+   * Per-rescue (or platform-wide for admin) counts: total + per-status
+   * breakdown + the last-30-day adoption count + an estimated
+   * average-time-to-adoption. Drives the rescue dashboard widget.
+   * Self-scoped to the caller's rescue unless they hold pets.read:any.
+   */
+  getStats: {
+    path: '/adopt_dont_shop.pets.v1.PetService/GetStats' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetPetStatsRequest): Buffer =>
+      Buffer.from(GetPetStatsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetPetStatsRequest => GetPetStatsRequest.decode(value),
+    responseSerialize: (value: GetPetStatsResponse): Buffer =>
+      Buffer.from(GetPetStatsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetPetStatsResponse => GetPetStatsResponse.decode(value),
+  },
 } as const;
 
 export interface PetServiceServer extends UntypedServiceImplementation {
@@ -3155,6 +3520,13 @@ export interface PetServiceServer extends UntypedServiceImplementation {
    * scoped to the rescue. Publishes `pets.deleted` after commit.
    */
   delete: handleUnaryCall<DeletePetRequest, DeletePetResponse>;
+  /**
+   * Per-rescue (or platform-wide for admin) counts: total + per-status
+   * breakdown + the last-30-day adoption count + an estimated
+   * average-time-to-adoption. Drives the rescue dashboard widget.
+   * Self-scoped to the caller's rescue unless they hold pets.read:any.
+   */
+  getStats: handleUnaryCall<GetPetStatsRequest, GetPetStatsResponse>;
 }
 
 export interface PetServiceClient extends Client {
@@ -3274,6 +3646,27 @@ export interface PetServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: DeletePetResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Per-rescue (or platform-wide for admin) counts: total + per-status
+   * breakdown + the last-30-day adoption count + an estimated
+   * average-time-to-adoption. Drives the rescue dashboard widget.
+   * Self-scoped to the caller's rescue unless they hold pets.read:any.
+   */
+  getStats(
+    request: GetPetStatsRequest,
+    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void
+  ): ClientUnaryCall;
+  getStats(
+    request: GetPetStatsRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void
+  ): ClientUnaryCall;
+  getStats(
+    request: GetPetStatsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetPetStatsResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -134,6 +134,8 @@ export type {
   UpdatePetStatusResponse,
   DeletePetRequest,
   DeletePetResponse,
+  GetPetStatsRequest,
+  GetPetStatsResponse,
   PetServiceServer,
   PetServiceClient,
 } from './generated/proto/adopt_dont_shop/pets/v1/pet.js';

--- a/services/gateway/src/grpc-clients/pets-client.ts
+++ b/services/gateway/src/grpc-clients/pets-client.ts
@@ -20,6 +20,8 @@ import {
   type DeletePetResponse,
   type GetPetRequest,
   type GetPetResponse,
+  type GetPetStatsRequest,
+  type GetPetStatsResponse,
   type ListPetsRequest,
   type ListPetsResponse,
   type UpdatePetRequest,
@@ -35,6 +37,7 @@ export type PetsClient = {
   update(req: UpdatePetRequest, metadata: Metadata): Promise<UpdatePetResponse>;
   updateStatus(req: UpdatePetStatusRequest, metadata: Metadata): Promise<UpdatePetStatusResponse>;
   delete(req: DeletePetRequest, metadata: Metadata): Promise<DeletePetResponse>;
+  getStats(req: GetPetStatsRequest, metadata: Metadata): Promise<GetPetStatsResponse>;
   close(): void;
 };
 
@@ -67,6 +70,7 @@ export const createPetsClient = (opts: CreatePetsClientOptions): PetsClient => {
     update: (req, metadata) => callUnary(stub.update, req, metadata),
     updateStatus: (req, metadata) => callUnary(stub.updateStatus, req, metadata),
     delete: (req, metadata) => callUnary(stub.delete, req, metadata),
+    getStats: (req, metadata) => callUnary(stub.getStats, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -25,6 +25,7 @@ function makeClient(): {
   updateMock: ReturnType<typeof vi.fn>;
   updateStatusMock: ReturnType<typeof vi.fn>;
   deleteMock: ReturnType<typeof vi.fn>;
+  getStatsMock: ReturnType<typeof vi.fn>;
 } {
   const createMock = vi.fn();
   const getMock = vi.fn();
@@ -32,6 +33,7 @@ function makeClient(): {
   const updateMock = vi.fn();
   const updateStatusMock = vi.fn();
   const deleteMock = vi.fn();
+  const getStatsMock = vi.fn();
   const client: PetsClient = {
     create: createMock,
     get: getMock,
@@ -39,6 +41,7 @@ function makeClient(): {
     update: updateMock,
     updateStatus: updateStatusMock,
     delete: deleteMock,
+    getStats: getStatsMock,
     close: vi.fn(),
   };
   return {
@@ -49,6 +52,7 @@ function makeClient(): {
     updateMock,
     updateStatusMock,
     deleteMock,
+    getStatsMock,
   };
 }
 
@@ -370,6 +374,79 @@ describe('error mapping fallback', () => {
       getMock.mockRejectedValueOnce(new Error('connection refused'));
       const res = await app.inject({ method: 'GET', url: '/api/v1/pets/pet-1' });
       expect(res.statusCode).toBe(500);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('GET /api/v1/pets/stats', () => {
+  const STATS_FIXTURE = {
+    total: 22,
+    available: 10,
+    pending: 3,
+    adopted: 7,
+    foster: 0,
+    medicalHold: 2,
+    behavioralHold: 0,
+    notAvailable: 0,
+    deceased: 0,
+    monthlyAdoptions: 4,
+    averageDaysToAdoption: 13,
+  };
+
+  it('routes /stats to client.getStats (not /:id getter)', async () => {
+    const { client, getStatsMock, getMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      getStatsMock.mockResolvedValueOnce(STATS_FIXTURE);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/pets/stats',
+        headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'rescue_staff', 'x-rescue-id': 'rsc-1' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ success: true, data: STATS_FIXTURE });
+      expect(getMock).not.toHaveBeenCalled();
+      expect(getStatsMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('forwards optional rescueId query param', async () => {
+    const { client, getStatsMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      getStatsMock.mockResolvedValueOnce(STATS_FIXTURE);
+      await app.inject({
+        method: 'GET',
+        url: '/api/v1/pets/stats?rescueId=rsc-target',
+        headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'admin' },
+      });
+      const [grpcReq] = getStatsMock.mock.calls[0];
+      expect(grpcReq).toEqual({ rescueIdFilter: 'rsc-target' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('maps PERMISSION_DENIED → 403', async () => {
+    const { client, getStatsMock } = makeClient();
+    const app = await makeApp(client);
+    try {
+      getStatsMock.mockRejectedValueOnce({
+        code: grpcStatus.PERMISSION_DENIED,
+        details: 'no perms',
+      });
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/pets/stats',
+        headers: { 'x-user-id': 'usr-noperms', 'x-user-roles': 'adopter' },
+      });
+      expect(res.statusCode).toBe(403);
     } finally {
       await app.close();
     }

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -95,6 +95,18 @@ export const registerPetsRoutes = async (
     }
   });
 
+  // /stats must register BEFORE the dynamic /:id route so the literal
+  // segment wins Fastify's first-registered-wins matcher.
+  app.get('/api/v1/pets/stats', async (req, reply) => {
+    const query = req.query as Record<string, string | undefined>;
+    try {
+      const res = await client.getStats({ rescueIdFilter: query.rescueId }, buildMetadata(req));
+      return reply.send({ success: true, data: res });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
   app.get<{ Params: { id: string } }>(
     '/api/v1/pets/:id',
     { config: { rateLimit: PETS_RATE_LIMITS.get } },

--- a/services/pets/src/grpc/handlers.test.ts
+++ b/services/pets/src/grpc/handlers.test.ts
@@ -10,6 +10,7 @@ import {
   createPet,
   deletePet,
   getPet,
+  getPetStats,
   HandlerError,
   listPets,
   updatePet,
@@ -400,6 +401,125 @@ describe('deletePet', () => {
   it('PERMISSION_DENIED for staff at a different rescue', async () => {
     mocks.poolMock.query.mockResolvedValueOnce({ rows: [petRow()] });
     await expect(deletePet(mocks.deps, OTHER_STAFF, { petId: 'pet-1' })).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+});
+
+// --- getPetStats ----------------------------------------------------
+
+describe('getPetStats', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects principals without pets.read', async () => {
+    const noPermsAdopter: Principal = {
+      userId: 'usr-noperms' as UserId,
+      roles: ['adopter'],
+      permissions: [],
+    };
+    await expect(getPetStats(mocks.deps, noPermsAdopter, {})).rejects.toMatchObject({
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('returns 0 counts when no rows in scope', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] }) // status counts
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] }) // monthly
+      .mockResolvedValueOnce({ rows: [{ avg_days: null }] }); // avg days
+
+    const res = await getPetStats(mocks.deps, STAFF, {});
+    expect(res).toEqual({
+      total: 0,
+      available: 0,
+      pending: 0,
+      adopted: 0,
+      foster: 0,
+      medicalHold: 0,
+      behavioralHold: 0,
+      notAvailable: 0,
+      deceased: 0,
+      monthlyAdoptions: 0,
+      averageDaysToAdoption: 0,
+    });
+  });
+
+  it('aggregates per-status counts + monthly + avg', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          { status: 'available', count: '10' },
+          { status: 'pending', count: '3' },
+          { status: 'adopted', count: '7' },
+          { status: 'medical_hold', count: '2' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ count: '4' }] })
+      .mockResolvedValueOnce({ rows: [{ avg_days: '12.7' }] });
+
+    const res = await getPetStats(mocks.deps, STAFF, {});
+    expect(res.total).toBe(22);
+    expect(res.available).toBe(10);
+    expect(res.pending).toBe(3);
+    expect(res.adopted).toBe(7);
+    expect(res.medicalHold).toBe(2);
+    expect(res.behavioralHold).toBe(0);
+    expect(res.monthlyAdoptions).toBe(4);
+    expect(res.averageDaysToAdoption).toBe(13); // rounded from 12.7
+  });
+
+  it('pins rescue staff to their own rescue, ignoring rescue_id_filter', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ avg_days: null }] });
+
+    await getPetStats(mocks.deps, STAFF, { rescueIdFilter: 'rsc-other' });
+
+    const statusCall = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(statusCall[1]).toEqual([RESCUE_ID]); // not 'rsc-other'
+  });
+
+  it('lets pets.read:any admin pass a rescue_id_filter', async () => {
+    const adminAny: Principal = {
+      userId: 'svc-admin' as UserId,
+      roles: ['admin'],
+      permissions: ['pets.read' as Permission, 'pets.read:any' as Permission],
+    };
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ avg_days: null }] });
+
+    await getPetStats(mocks.deps, adminAny, { rescueIdFilter: 'rsc-target' });
+    const statusCall = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(statusCall[1]).toEqual(['rsc-target']);
+  });
+
+  it('platform-wide stats when admin omits rescue_id_filter', async () => {
+    const adminAny: Principal = {
+      userId: 'svc-admin' as UserId,
+      roles: ['admin'],
+      permissions: ['pets.read' as Permission, 'pets.read:any' as Permission],
+    };
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ avg_days: null }] });
+
+    await getPetStats(mocks.deps, adminAny, {});
+    const statusCall = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(statusCall[1]).toEqual([]); // no rescue scope
+  });
+
+  it('rejects when caller has pets.read but no rescue scope and no :any', async () => {
+    await expect(getPetStats(mocks.deps, ADOPTER, {})).rejects.toMatchObject({
       code: 'PERMISSION_DENIED',
     });
   });

--- a/services/pets/src/grpc/handlers.ts
+++ b/services/pets/src/grpc/handlers.ts
@@ -32,6 +32,8 @@ import {
   type DeletePetResponse,
   type GetPetRequest,
   type GetPetResponse,
+  type GetPetStatsRequest,
+  type GetPetStatsResponse,
   type ListPetsRequest,
   type ListPetsResponse,
   type Pet,
@@ -663,4 +665,120 @@ function parseJsonArray(raw: string | undefined): string[] {
   } catch {
     return [];
   }
+}
+
+// --- GetStats --------------------------------------------------------
+
+const PETS_READ_ANY: Permission = 'pets.read:any' as Permission;
+
+type StatusCountRow = { status: PetStatusDb; count: string };
+
+export async function getPetStats(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetPetStatsRequest
+): Promise<GetPetStatsResponse> {
+  if (!hasPermission(principal, PETS_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${PETS_READ}' required`);
+  }
+
+  // Resolve rescue scope. Rescue staff are pinned to their own
+  // rescue regardless of req.rescueIdFilter. Admins / super_admin
+  // (via pets.read:any) may pass a target rescue_id, or empty for
+  // platform-wide stats.
+  let rescueScope: string | null;
+  if (hasPermission(principal, PETS_READ_ANY)) {
+    rescueScope = req.rescueIdFilter ? req.rescueIdFilter : null;
+  } else if (principal.rescueId) {
+    rescueScope = principal.rescueId;
+  } else {
+    throw new HandlerError(
+      'PERMISSION_DENIED',
+      'rescue scope required — caller is not bound to a rescue and lacks pets.read:any'
+    );
+  }
+
+  // Build a single WHERE clause shared by all three queries below so
+  // pagination / status counts / monthly counts all agree on scope.
+  const where: string[] = ['deleted_at IS NULL'];
+  const params: unknown[] = [];
+  if (rescueScope) {
+    where.push(`rescue_id = $${params.length + 1}`);
+    params.push(rescueScope);
+  }
+  const whereClause = where.join(' AND ');
+
+  // Per-status counts in one round trip via GROUP BY.
+  const statusRes = await deps.pool.query<StatusCountRow>(
+    `SELECT status, COUNT(*)::text AS count
+     FROM pets.pets
+     WHERE ${whereClause}
+     GROUP BY status`,
+    params
+  );
+
+  const counts = {
+    available: 0,
+    pending: 0,
+    adopted: 0,
+    foster: 0,
+    medical_hold: 0,
+    behavioral_hold: 0,
+    not_available: 0,
+    deceased: 0,
+  };
+  for (const row of statusRes.rows) {
+    if (row.status in counts) {
+      counts[row.status] = Number.parseInt(row.count, 10);
+    }
+  }
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+
+  // Last-30-day adoptions (uses adopted_date so a backfilled status
+  // transition reflects the actual adoption date, not row mtime).
+  const monthlyRes = await deps.pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count
+     FROM pets.pets
+     WHERE ${whereClause}
+       AND status = 'adopted'
+       AND adopted_date IS NOT NULL
+       AND adopted_date >= now() - interval '30 days'`,
+    params
+  );
+  const monthlyAdoptions = Number.parseInt(monthlyRes.rows[0]?.count ?? '0', 10);
+
+  // Average days-to-adoption across the 50 most recent adoptions in
+  // scope. Postgres calculates the difference for us; we drop the
+  // sub-day fraction because the dashboard widget renders whole days.
+  const avgRes = await deps.pool.query<{ avg_days: string | null }>(
+    `
+    WITH recent AS (
+      SELECT EXTRACT(epoch FROM (adopted_date - created_at)) / 86400 AS days
+      FROM pets.pets
+      WHERE ${whereClause}
+        AND status = 'adopted'
+        AND adopted_date IS NOT NULL
+      ORDER BY adopted_date DESC
+      LIMIT 50
+    )
+    SELECT AVG(days)::text AS avg_days FROM recent
+    `,
+    params
+  );
+  const avgRaw = avgRes.rows[0]?.avg_days;
+  const averageDaysToAdoption = avgRaw ? Math.round(Number.parseFloat(avgRaw)) : 0;
+
+  return {
+    total,
+    available: counts.available,
+    pending: counts.pending,
+    adopted: counts.adopted,
+    foster: counts.foster,
+    medicalHold: counts.medical_hold,
+    behavioralHold: counts.behavioral_hold,
+    notAvailable: counts.not_available,
+    deceased: counts.deceased,
+    monthlyAdoptions,
+    averageDaysToAdoption,
+  };
 }

--- a/services/pets/src/grpc/server.ts
+++ b/services/pets/src/grpc/server.ts
@@ -19,7 +19,15 @@ import { PetsV1 } from '@adopt-dont-shop/proto';
 import type { PetsConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
-import { createPet, deletePet, getPet, listPets, updatePet, updatePetStatus } from './handlers.js';
+import {
+  createPet,
+  deletePet,
+  getPet,
+  getPetStats,
+  listPets,
+  updatePet,
+  updatePetStatus,
+} from './handlers.js';
 
 export type CreateGrpcServerOptions = {
   config: PetsConfig;
@@ -46,10 +54,11 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     update: adapt(updatePet, { deps, logger }),
     updateStatus: adapt(updatePetStatus, { deps, logger }),
     delete: adapt(deletePet, { deps, logger }),
+    getStats: adapt(getPetStats, { deps, logger }),
   });
 
   logger.info('gRPC PetService registered', {
-    methods: ['create', 'get', 'list', 'update', 'updateStatus', 'delete'],
+    methods: ['create', 'get', 'list', 'update', 'updateStatus', 'delete', 'getStats'],
     grpcPort: config.grpcPort,
   });
 


### PR DESCRIPTION
## Summary

Adds the rescue-scoped pet stats that the monolith's dashboard widget consumes. Foundation work for a future dashboard composition PR (which will join this with applications.GetStats + a rescue staff count).

### Pets service additions
- `PetService.GetStats` RPC with `rescue_id_filter` (optional)
- Returns: `total`, per-status counts (`available`, `pending`, `adopted`, `foster`, `medical_hold`, `behavioral_hold`, `not_available`, `deceased`), `monthly_adoptions` (last 30d), `average_days_to_adoption` (mean over the 50 most recent adoptions in scope)
- Handler runs three round-trips: per-status GROUP BY, monthly count, average days (windowed via a CTE)
- 7 new tests covering empty scope, aggregation correctness, rounding, rescue-staff pinning, admin scope overrides, and platform-wide aggregation

### Gateway additions
- `GET /api/v1/pets/stats?rescueId=...` → `PetService.GetStats`
- Registered BEFORE the dynamic `/:id` route so the literal `stats` segment wins Fastify's first-registered-wins matcher (note in the source explains it)
- 3 new tests covering routing, query param forwarding, and PERMISSION_DENIED → 403

### Permission model
- `pets.read` — required (rescue staff get scoped to their own rescue)
- `pets.read:any` — required to read a different rescue or platform-wide

## Test plan
- [x] `services/pets` — 94/94 tests pass
- [x] `services/gateway` — 333/333 tests pass
- [x] Type-check clean (proto regen + tsc)
- [x] Lint clean (pets); gateway has only pre-existing curly warnings
- [ ] Manual smoke against a running stack
- [ ] Dashboard PR will consume this RPC + apps.GetStats + a rescue staff count

## Out of scope
- Rescue staff count RPC — covered by existing `ListStaffMembers.pagination.total`, no new RPC needed
- Dashboard composition route at gateway — separate PR
- Activity feed (recent pets + applications) — separate PR

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_