### PR TITLE
feat(gateway): analytics ingestion fold

### DIFF
--- a/services/gateway/src/routes/analytics.test.ts
+++ b/services/gateway/src/routes/analytics.test.ts
@@ -1,0 +1,205 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from 'winston';
+
+import { registerAnalyticsRoutes } from './analytics.js';
+
+function makeLogger(): Logger & { infoMock: ReturnType<typeof vi.fn> } {
+  const infoMock = vi.fn();
+  return {
+    info: infoMock,
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    infoMock,
+  } as unknown as Logger & { infoMock: ReturnType<typeof vi.fn> };
+}
+
+async function buildApp(logger: Logger): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await registerAnalyticsRoutes(app, { logger });
+  return app;
+}
+
+describe('POST /api/v1/analytics/pageviews', () => {
+  let app: FastifyInstance;
+  let logger: ReturnType<typeof makeLogger>;
+
+  beforeEach(async () => {
+    logger = makeLogger();
+    app = await buildApp(logger);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 201 with success envelope', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/pageviews',
+      headers: { 'content-type': 'application/json', 'x-user-id': 'usr-1' },
+      payload: { path: '/pets', timestamp: '2026-06-07T12:00:00Z' },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({ success: true, message: 'Pageview recorded' });
+  });
+
+  it('logs the pageview with the principal user id when present', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/pageviews',
+      headers: { 'content-type': 'application/json', 'x-user-id': 'usr-1' },
+      payload: { path: '/pets', sessionId: 'sess-1' },
+    });
+    expect(logger.infoMock).toHaveBeenCalledWith(
+      'Pageview recorded',
+      expect.objectContaining({
+        type: 'pageview',
+        data: expect.objectContaining({
+          path: '/pets',
+          userId: 'usr-1',
+          sessionId: 'sess-1',
+        }),
+      })
+    );
+  });
+
+  it('accepts anonymous traffic (no x-user-id)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/pageviews',
+      headers: { 'content-type': 'application/json' },
+      payload: { path: '/landing' },
+    });
+    expect(res.statusCode).toBe(201);
+    const call = logger.infoMock.mock.calls[0] as [string, { data: { userId: undefined } }];
+    expect(call[1].data.userId).toBeUndefined();
+  });
+
+  it('truncates oversize user agent / referrer strings', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/pageviews',
+      headers: { 'content-type': 'application/json' },
+      payload: {
+        path: '/x',
+        userAgent: 'x'.repeat(1000),
+        referrer: 'y'.repeat(1000),
+      },
+    });
+    const call = logger.infoMock.mock.calls[0] as [
+      string,
+      { data: { userAgent: string; referrer: string } },
+    ];
+    expect(call[1].data.userAgent.length).toBe(256);
+    expect(call[1].data.referrer.length).toBe(256);
+  });
+});
+
+describe('POST /api/v1/analytics/events', () => {
+  let app: FastifyInstance;
+  let logger: ReturnType<typeof makeLogger>;
+  beforeEach(async () => {
+    logger = makeLogger();
+    app = await buildApp(logger);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 201 and logs the single event', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/events',
+      headers: { 'content-type': 'application/json' },
+      payload: { event: 'pet_favorited', properties: { petId: 'pet-1' } },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({ success: true, message: 'Event recorded' });
+    const call = logger.infoMock.mock.calls[0] as [
+      string,
+      { data: { event: string; properties: Record<string, unknown> } },
+    ];
+    expect(call[1].data.event).toBe('pet_favorited');
+    expect(call[1].data.properties).toEqual({ petId: 'pet-1' });
+  });
+
+  it("falls back to 'unknown' when no name field is provided", async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/events',
+      headers: { 'content-type': 'application/json' },
+      payload: { properties: {} },
+    });
+    const call = logger.infoMock.mock.calls[0] as [string, { data: { event: string } }];
+    expect(call[1].data.event).toBe('unknown');
+  });
+});
+
+describe('POST /api/v1/analytics/events/batch', () => {
+  let app: FastifyInstance;
+  let logger: ReturnType<typeof makeLogger>;
+  beforeEach(async () => {
+    logger = makeLogger();
+    app = await buildApp(logger);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 201 with the processed count', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/events/batch',
+      headers: { 'content-type': 'application/json' },
+      payload: { events: [{ event: 'a' }, { event: 'b' }, { event: 'c' }] },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({ success: true, message: 'Events recorded', processed: 3 });
+  });
+
+  it('rejects when events is not an array', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/events/batch',
+      headers: { 'content-type': 'application/json' },
+      payload: { events: 'nope' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects a batch larger than the cap', async () => {
+    const events = Array.from({ length: 1001 }, () => ({ event: 'x' }));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/analytics/events/batch',
+      headers: { 'content-type': 'application/json' },
+      payload: { events },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /api/v1/analytics/health', () => {
+  it('returns a healthy payload', async () => {
+    const logger = makeLogger();
+    const app = await buildApp(logger);
+    try {
+      const res = await app.inject({ method: 'GET', url: '/api/v1/analytics/health' });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as {
+        success: boolean;
+        status: string;
+        service: string;
+        timestamp: string;
+      };
+      expect(body.success).toBe(true);
+      expect(body.status).toBe('healthy');
+      expect(body.service).toBe('analytics');
+      expect(Date.parse(body.timestamp)).not.toBeNaN();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/services/gateway/src/routes/analytics.ts
+++ b/services/gateway/src/routes/analytics.ts
@@ -1,0 +1,144 @@
+// Gateway-folded /api/v1/analytics/* surface.
+//
+// Per the migration plan: "small static reads + log-only ingestion fold
+// into service.gateway". The monolith's analytics endpoints (pageviews,
+// events, batched events) are pure log-and-acknowledge — the data
+// never lands in a database, only in winston which ships to Loki. The
+// gateway can absorb them without a backing service.
+//
+// Path map mirrors service.backend's analytics.routes.ts:
+//   POST /api/v1/analytics/pageviews     → 201 { success, message }
+//   POST /api/v1/analytics/events        → 201 { success, message }
+//   POST /api/v1/analytics/events/batch  → 201 { success, message, processed }
+//   GET  /api/v1/analytics/health        → 200 { success, status, service, timestamp }
+//
+// Pageviews + events accept anonymous traffic (no auth header
+// required); the principal-headers populated by the authenticate
+// middleware are forwarded to the log line as `userId` when present.
+
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type { Logger } from 'winston';
+
+export type AnalyticsRoutesOptions = {
+  logger: Logger;
+};
+
+type PageviewBody = {
+  path?: string;
+  url?: string;
+  timestamp?: string;
+  sessionId?: string;
+  referrer?: string;
+  userAgent?: string;
+};
+
+type EventBody = {
+  event?: string;
+  name?: string;
+  type?: string;
+  timestamp?: string;
+  properties?: Record<string, unknown>;
+  sessionId?: string;
+};
+
+type BatchBody = {
+  events?: EventBody[];
+};
+
+const userIdFromHeaders = (req: FastifyRequest): string | undefined => {
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  const raw = headers['x-user-id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+};
+
+const sessionLengthCap = 256;
+
+// Truncate operator-supplied strings so a hostile client can't blow up
+// the winston shipper's per-line buffer. Same defence we apply at every
+// other ingestion seam.
+const cap = (s: string | undefined): string | undefined => {
+  if (!s) return s;
+  return s.length > sessionLengthCap ? s.slice(0, sessionLengthCap) : s;
+};
+
+export const registerAnalyticsRoutes = async (
+  app: FastifyInstance,
+  opts: AnalyticsRoutesOptions
+): Promise<void> => {
+  const { logger } = opts;
+
+  app.post('/api/v1/analytics/pageviews', async (req, reply) => {
+    const body = (req.body ?? {}) as PageviewBody;
+    const pagePath = body.path || body.url || req.url || 'unknown';
+    logger.info('Pageview recorded', {
+      service: 'analytics',
+      type: 'pageview',
+      data: {
+        path: cap(pagePath),
+        timestamp: body.timestamp || new Date().toISOString(),
+        userId: userIdFromHeaders(req),
+        sessionId: cap(body.sessionId),
+        referrer: cap(body.referrer),
+        userAgent: cap(body.userAgent),
+        ip: req.ip,
+      },
+    });
+    return reply.code(201).send({ success: true, message: 'Pageview recorded' });
+  });
+
+  app.post('/api/v1/analytics/events', async (req, reply) => {
+    const body = (req.body ?? {}) as EventBody;
+    const eventName = body.event || body.name || body.type || 'unknown';
+    logger.info('Analytics event recorded', {
+      service: 'analytics',
+      type: 'single_event',
+      data: {
+        event: cap(eventName),
+        timestamp: body.timestamp || new Date().toISOString(),
+        properties: body.properties || {},
+        userId: userIdFromHeaders(req),
+        sessionId: cap(body.sessionId),
+        ip: req.ip,
+      },
+    });
+    return reply.code(201).send({ success: true, message: 'Event recorded' });
+  });
+
+  app.post('/api/v1/analytics/events/batch', async (req, reply) => {
+    const body = (req.body ?? {}) as BatchBody;
+    if (!Array.isArray(body.events)) {
+      return reply.code(400).send({ success: false, message: 'Events must be an array' });
+    }
+    // Same cap-per-batch the monolith implied (no explicit limit but
+    // logging 10k events in one line would be wasteful). 1000 covers
+    // any sane analytics flush window.
+    const MAX_BATCH = 1000;
+    if (body.events.length > MAX_BATCH) {
+      return reply.code(400).send({ success: false, message: `Batch size exceeds ${MAX_BATCH}` });
+    }
+    logger.info('Batch events recorded', {
+      service: 'analytics',
+      type: 'batch_events',
+      count: body.events.length,
+      userId: userIdFromHeaders(req),
+      ip: req.ip,
+      events: body.events.map(event => ({
+        event: cap(event.event || event.name || event.type || 'unknown'),
+        timestamp: event.timestamp || new Date().toISOString(),
+        properties: event.properties || {},
+      })),
+    });
+    return reply.code(201).send({
+      success: true,
+      message: 'Events recorded',
+      processed: body.events.length,
+    });
+  });
+
+  app.get('/api/v1/analytics/health', async () => ({
+    success: true,
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    service: 'analytics',
+  }));
+};

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -31,6 +31,7 @@ import type { PetsClient } from './grpc-clients/pets-client.js';
 import type { RescueClient } from './grpc-clients/rescue-client.js';
 import { registerAuthenticate } from './middleware/authenticate.js';
 import { registerApplicationDocumentsRoutes } from './routes/application-documents.js';
+import { registerAnalyticsRoutes } from './routes/analytics.js';
 import { registerApplicationsRoutes } from './routes/applications.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerAuthRoutes } from './routes/auth.js';
@@ -255,6 +256,10 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   if (config.config.publicEnabled) {
     await registerConfigRoutes(server);
   }
+  // Analytics ingestion (pageviews + custom events) — the monolith
+  // implementation was log-only (winston → Loki, no DB). Folds here so
+  // the SPA's analytics flushes don't pay an extra http-proxy hop.
+  await registerAnalyticsRoutes(server, { logger });
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in
   // place for every /api/* path that isn't owned by an extracted


### PR DESCRIPTION
## Summary

Folds the monolith's `/api/v1/analytics/*` ingestion surface into the gateway. The monolith implementation was log-only — pageviews and events never landed in a database, they were just emitted as structured winston lines that ship to Loki. Since there's no DB to own, there's no backing service to extract; the gateway absorbs them directly.

### Routes
| Method | Path | Returns |
|---|---|---|
| POST | `/api/v1/analytics/pageviews` | `201 { success, message }` |
| POST | `/api/v1/analytics/events` | `201 { success, message }` |
| POST | `/api/v1/analytics/events/batch` | `201 { success, message, processed }` |
| GET | `/api/v1/analytics/health` | `200 { success, status: 'healthy', service, timestamp }` |

### Notable parity / hardening
- Same structured-log shape the monolith emitted (`service: 'analytics'`, `type: 'pageview'|'single_event'|'batch_events'`, `data: {...}`) so existing Loki dashboards keep working
- Anonymous traffic allowed — userId is forwarded from the principal headers when present, otherwise omitted
- All client-supplied strings (path, sessionId, referrer, userAgent, event name) capped at 256 chars so a hostile client can't bloat the log shipper buffer
- Batch capped at 1000 events per request (the monolith had no explicit cap; this matches a sane analytics flush window)

## Test plan
- [x] `services/gateway` — 351/351 tests pass (10 new in `analytics.test.ts`: 201 envelopes, x-user-id forwarding, anonymous traffic, string truncation, "unknown" fallback, non-array events → 400, oversized batch → 400, health payload)
- [x] Type-check clean
- [x] Lint clean (gateway has only pre-existing curly warnings)
- [ ] Manual smoke against a running stack

## Follow-ups
- Monolith `analytics.routes.ts` + `analytics.controller.ts` can be deleted in the final cleanup PR
- `analytics.service.ts` (the platform metrics / dashboard analytics methods) is a separate concern — those are admin reporting endpoints not exposed by `analytics.routes.ts`, defer to the analytics-extraction PR

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_