### PR TITLE
feat(chat,gateway): per-chat unread count

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
+++ b/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
@@ -51,6 +51,13 @@ service ChatService {
   // are returned (super_admin still scoped this way; staff cross-chat
   // search is a separate admin RPC).
   rpc SearchChats(SearchChatsRequest) returns (SearchChatsResponse);
+
+  // Per-chat unread count for the calling principal. Counts messages
+  // not authored by the caller that lack a matching message_reads row
+  // (i.e. the caller has never opened them). Requires participant
+  // membership (or super_admin).
+  rpc GetChatUnreadCount(GetChatUnreadCountRequest)
+      returns (GetChatUnreadCountResponse);
 }
 
 // --- Messages --------------------------------------------------------
@@ -219,4 +226,14 @@ message SearchChatsResponse {
   // controls. Returned in addition to the page so the client can
   // compute total_pages = ceil(total / limit).
   uint32 total = 4;
+}
+
+// --- GetChatUnreadCount ----------------------------------------------
+
+message GetChatUnreadCountRequest {
+  string chat_id = 1;
+}
+
+message GetChatUnreadCountResponse {
+  uint32 unread_count = 1;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
@@ -203,6 +203,14 @@ export interface SearchChatsResponse {
   total: number;
 }
 
+export interface GetChatUnreadCountRequest {
+  chatId: string;
+}
+
+export interface GetChatUnreadCountResponse {
+  unreadCount: number;
+}
+
 function createBaseChat(): Chat {
   return {
     chatId: '',
@@ -1976,6 +1984,148 @@ export const SearchChatsResponse: MessageFns<SearchChatsResponse> = {
   },
 };
 
+function createBaseGetChatUnreadCountRequest(): GetChatUnreadCountRequest {
+  return { chatId: '' };
+}
+
+export const GetChatUnreadCountRequest: MessageFns<GetChatUnreadCountRequest> = {
+  encode(
+    message: GetChatUnreadCountRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.chatId !== '') {
+      writer.uint32(10).string(message.chatId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetChatUnreadCountRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetChatUnreadCountRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chatId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetChatUnreadCountRequest {
+    return {
+      chatId: isSet(object.chatId)
+        ? globalThis.String(object.chatId)
+        : isSet(object.chat_id)
+          ? globalThis.String(object.chat_id)
+          : '',
+    };
+  },
+
+  toJSON(message: GetChatUnreadCountRequest): unknown {
+    const obj: any = {};
+    if (message.chatId !== '') {
+      obj.chatId = message.chatId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetChatUnreadCountRequest>, I>>(
+    base?: I
+  ): GetChatUnreadCountRequest {
+    return GetChatUnreadCountRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetChatUnreadCountRequest>, I>>(
+    object: I
+  ): GetChatUnreadCountRequest {
+    const message = createBaseGetChatUnreadCountRequest();
+    message.chatId = object.chatId ?? '';
+    return message;
+  },
+};
+
+function createBaseGetChatUnreadCountResponse(): GetChatUnreadCountResponse {
+  return { unreadCount: 0 };
+}
+
+export const GetChatUnreadCountResponse: MessageFns<GetChatUnreadCountResponse> = {
+  encode(
+    message: GetChatUnreadCountResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.unreadCount !== 0) {
+      writer.uint32(8).uint32(message.unreadCount);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetChatUnreadCountResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetChatUnreadCountResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.unreadCount = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetChatUnreadCountResponse {
+    return {
+      unreadCount: isSet(object.unreadCount)
+        ? globalThis.Number(object.unreadCount)
+        : isSet(object.unread_count)
+          ? globalThis.Number(object.unread_count)
+          : 0,
+    };
+  },
+
+  toJSON(message: GetChatUnreadCountResponse): unknown {
+    const obj: any = {};
+    if (message.unreadCount !== 0) {
+      obj.unreadCount = Math.round(message.unreadCount);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetChatUnreadCountResponse>, I>>(
+    base?: I
+  ): GetChatUnreadCountResponse {
+    return GetChatUnreadCountResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetChatUnreadCountResponse>, I>>(
+    object: I
+  ): GetChatUnreadCountResponse {
+    const message = createBaseGetChatUnreadCountResponse();
+    message.unreadCount = object.unreadCount ?? 0;
+    return message;
+  },
+};
+
 /**
  * ChatService is the gRPC contract for the chat vertical. It owns
  * the `chat.*` schema (Chat, ChatParticipant, Message, MessageReaction,
@@ -2107,6 +2257,25 @@ export const ChatServiceService = {
       Buffer.from(SearchChatsResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): SearchChatsResponse => SearchChatsResponse.decode(value),
   },
+  /**
+   * Per-chat unread count for the calling principal. Counts messages
+   * not authored by the caller that lack a matching message_reads row
+   * (i.e. the caller has never opened them). Requires participant
+   * membership (or super_admin).
+   */
+  getChatUnreadCount: {
+    path: '/adopt_dont_shop.chat.v1.ChatService/GetChatUnreadCount' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetChatUnreadCountRequest): Buffer =>
+      Buffer.from(GetChatUnreadCountRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetChatUnreadCountRequest =>
+      GetChatUnreadCountRequest.decode(value),
+    responseSerialize: (value: GetChatUnreadCountResponse): Buffer =>
+      Buffer.from(GetChatUnreadCountResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetChatUnreadCountResponse =>
+      GetChatUnreadCountResponse.decode(value),
+  },
 } as const;
 
 export interface ChatServiceServer extends UntypedServiceImplementation {
@@ -2153,6 +2322,13 @@ export interface ChatServiceServer extends UntypedServiceImplementation {
    * search is a separate admin RPC).
    */
   searchChats: handleUnaryCall<SearchChatsRequest, SearchChatsResponse>;
+  /**
+   * Per-chat unread count for the calling principal. Counts messages
+   * not authored by the caller that lack a matching message_reads row
+   * (i.e. the caller has never opened them). Requires participant
+   * membership (or super_admin).
+   */
+  getChatUnreadCount: handleUnaryCall<GetChatUnreadCountRequest, GetChatUnreadCountResponse>;
 }
 
 export interface ChatServiceClient extends Client {
@@ -2296,6 +2472,27 @@ export interface ChatServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: SearchChatsResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Per-chat unread count for the calling principal. Counts messages
+   * not authored by the caller that lack a matching message_reads row
+   * (i.e. the caller has never opened them). Requires participant
+   * membership (or super_admin).
+   */
+  getChatUnreadCount(
+    request: GetChatUnreadCountRequest,
+    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void
+  ): ClientUnaryCall;
+  getChatUnreadCount(
+    request: GetChatUnreadCountRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void
+  ): ClientUnaryCall;
+  getChatUnreadCount(
+    request: GetChatUnreadCountRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetChatUnreadCountResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -237,6 +237,8 @@ export type {
   SearchChatsRequest,
   SearchChatsResponse,
   SearchChatHit,
+  GetChatUnreadCountRequest,
+  GetChatUnreadCountResponse,
   ChatServiceServer,
   ChatServiceClient,
 } from './generated/proto/adopt_dont_shop/chat/v1/chat.js';

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -20,6 +20,7 @@ import {
   markRead,
   openChat,
   react,
+  getChatUnreadCount,
   searchChats,
   sendMessage,
 } from './handlers.js';
@@ -568,6 +569,63 @@ describe('searchChats', () => {
     const params = hitsCall![1] as unknown[];
     expect(params[params.length - 2]).toBe(10); // limit
     expect(params[params.length - 1]).toBe(10); // offset = (page-1)*limit
+  });
+});
+
+// --- getChatUnreadCount ---------------------------------------------
+
+describe('getChatUnreadCount', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects missing chat_id', async () => {
+    await expect(
+      getChatUnreadCount(mocks.deps, ADOPTER_PRINCIPAL, { chatId: '' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('rejects principals without chat.read', async () => {
+    await expect(
+      getChatUnreadCount(mocks.deps, UNPRIVILEGED_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('returns NOT_FOUND (no enumeration) when caller is not a participant', async () => {
+    // isParticipantOrAdmin SELECT returns no rows.
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      getChatUnreadCount(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('returns the unread count for a participant', async () => {
+    // Participant check passes
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ chat_participant_id: 'p-1' }],
+    });
+    // COUNT query
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ count: '5' }] });
+
+    const res = await getChatUnreadCount(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' });
+    expect(res.unreadCount).toBe(5);
+
+    // Confirm the binding: $1 = chatId, $2 = principal.userId.
+    const countCall = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+    expect(countCall[1]).toEqual(['chat-1', 'usr-adopter']);
+  });
+
+  it('returns 0 when no unread messages', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ chat_participant_id: 'p-1' }],
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ count: '0' }] });
+    const res = await getChatUnreadCount(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' });
+    expect(res.unreadCount).toBe(0);
   });
 });
 

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -24,6 +24,8 @@ import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/even
 import type { Permission } from '@adopt-dont-shop/lib.types';
 import type {
   Chat,
+  GetChatUnreadCountRequest,
+  GetChatUnreadCountResponse,
   ListChatsRequest,
   ListChatsResponse,
   ListMessagesRequest,
@@ -844,4 +846,43 @@ export async function searchChats(
   );
 
   return { hits, page, limit, total };
+}
+
+// --- GetChatUnreadCount ---------------------------------------------
+
+export async function getChatUnreadCount(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetChatUnreadCountRequest
+): Promise<GetChatUnreadCountResponse> {
+  if (!req.chatId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'chat_id is required');
+  }
+  if (!hasPermission(principal, CHAT_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_READ}' required`);
+  }
+  if (!(await isParticipantOrAdmin(deps, principal, req.chatId))) {
+    // Don't enumerate — same response shape as a missing chat.
+    throw new HandlerError('NOT_FOUND', `chat ${req.chatId} not found`);
+  }
+
+  // "Unread for user" = messages in the chat NOT authored by the user
+  // that have no matching message_reads row for the user. The LEFT
+  // JOIN-NULL pattern keeps the count in SQL without loading message
+  // rows into Node memory. deleted_at is filtered out — soft-deleted
+  // messages don't count toward unread.
+  const result = await deps.pool.query<{ count: string }>(
+    `
+    SELECT COUNT(*)::text AS count
+    FROM messages m
+    LEFT JOIN message_reads r ON r.message_id = m.message_id AND r.user_id = $2
+    WHERE m.chat_id = $1
+      AND m.sender_id <> $2
+      AND m.deleted_at IS NULL
+      AND r.read_id IS NULL
+    `,
+    [req.chatId, principal.userId]
+  );
+
+  return { unreadCount: Number.parseInt(result.rows[0]?.count ?? '0', 10) };
 }

--- a/services/chat/src/grpc/server.ts
+++ b/services/chat/src/grpc/server.ts
@@ -15,6 +15,7 @@ import type { ChatConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
 import {
+  getChatUnreadCount,
   listChats,
   listMessages,
   markRead,
@@ -50,6 +51,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     markRead: adapt(markRead, { deps, logger }),
     react: adapt(react, { deps, logger }),
     searchChats: adapt(searchChats, { deps, logger }),
+    getChatUnreadCount: adapt(getChatUnreadCount, { deps, logger }),
   });
 
   logger.info('gRPC ChatService registered', {
@@ -61,6 +63,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'markRead',
       'react',
       'searchChats',
+      'getChatUnreadCount',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/gateway/src/grpc-clients/chat-client.ts
+++ b/services/gateway/src/grpc-clients/chat-client.ts
@@ -22,6 +22,8 @@ import {
   type SearchChatsResponse,
   type SendMessageRequest,
   type SendMessageResponse,
+  type GetChatUnreadCountRequest,
+  type GetChatUnreadCountResponse,
 } from '@adopt-dont-shop/proto';
 
 export type ChatClient = {
@@ -32,6 +34,10 @@ export type ChatClient = {
   markRead(req: MarkReadRequest, metadata: Metadata): Promise<MarkReadResponse>;
   react(req: ReactRequest, metadata: Metadata): Promise<ReactResponse>;
   searchChats(req: SearchChatsRequest, metadata: Metadata): Promise<SearchChatsResponse>;
+  getChatUnreadCount(
+    req: GetChatUnreadCountRequest,
+    metadata: Metadata
+  ): Promise<GetChatUnreadCountResponse>;
   close(): void;
 };
 
@@ -65,6 +71,7 @@ export const createChatClient = (opts: CreateChatClientOptions): ChatClient => {
     markRead: (req, metadata) => callUnary(stub.markRead, req, metadata),
     react: (req, metadata) => callUnary(stub.react, req, metadata),
     searchChats: (req, metadata) => callUnary(stub.searchChats, req, metadata),
+    getChatUnreadCount: (req, metadata) => callUnary(stub.getChatUnreadCount, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -43,6 +43,7 @@ function makeClient(): ChatClient & {
   markReadMock: ReturnType<typeof vi.fn>;
   reactMock: ReturnType<typeof vi.fn>;
   searchChatsMock: ReturnType<typeof vi.fn>;
+  getChatUnreadCountMock: ReturnType<typeof vi.fn>;
 } {
   const openChatMock = vi.fn();
   const sendMessageMock = vi.fn();
@@ -51,6 +52,7 @@ function makeClient(): ChatClient & {
   const markReadMock = vi.fn();
   const reactMock = vi.fn();
   const searchChatsMock = vi.fn();
+  const getChatUnreadCountMock = vi.fn();
   return {
     openChat: openChatMock,
     sendMessage: sendMessageMock,
@@ -59,6 +61,7 @@ function makeClient(): ChatClient & {
     markRead: markReadMock,
     react: reactMock,
     searchChats: searchChatsMock,
+    getChatUnreadCount: getChatUnreadCountMock,
     close: vi.fn(),
     openChatMock,
     sendMessageMock,
@@ -67,6 +70,7 @@ function makeClient(): ChatClient & {
     markReadMock,
     reactMock,
     searchChatsMock,
+    getChatUnreadCountMock,
   };
 }
 
@@ -527,5 +531,59 @@ describe('GET /api/v1/chats/search', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(client.searchChatsMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- GET /api/v1/chats/:chatId/unread-count -------------------------
+
+describe('GET /api/v1/chats/:chatId/unread-count', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns success envelope with unread count', async () => {
+    client.getChatUnreadCountMock.mockResolvedValueOnce({ unreadCount: 7 });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/chat-1/unread-count',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ success: true, data: { unreadCount: 7 } });
+    const [grpcReq] = client.getChatUnreadCountMock.mock.calls[0] as [{ chatId: string }, Metadata];
+    expect(grpcReq.chatId).toBe('chat-1');
+  });
+
+  it('maps NOT_FOUND → 404', async () => {
+    client.getChatUnreadCountMock.mockRejectedValueOnce({
+      code: status.NOT_FOUND,
+      details: 'gone',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/missing/unread-count',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('reachable via /api/v1/conversations alias', async () => {
+    client.getChatUnreadCountMock.mockResolvedValueOnce({ unreadCount: 0 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/conversations/chat-1/unread-count',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.getChatUnreadCountMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -166,6 +166,23 @@ const registerChatRoutesForPrefix = (
     }
   });
 
+  // ---- GET <prefix>/:chatId/unread-count ---------------------------
+  // Single-chat unread count for the calling principal. Returns the
+  // monolith envelope { success, data: { unreadCount } } so the SPA's
+  // lib.chat consumer keeps working.
+  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/unread-count`, async (req, reply) => {
+    const metadata = buildMetadata(req);
+    try {
+      const res = await client.getChatUnreadCount({ chatId: req.params.chatId }, metadata);
+      return reply.send({
+        success: true,
+        data: { unreadCount: res.unreadCount },
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
   // ---- GET <prefix>/:chatId/messages -------------------------------
   app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, async (req, reply) => {
     const metadata = buildMetadata(req);


### PR DESCRIPTION
## Summary

Brings the monolith's `GET /api/v1/chats/:chatId/unread-count` (and `/conversations/:chatId/unread-count` alias) over to the gateway + chat service.

### Chat service additions
- `ChatService.GetChatUnreadCount(chat_id)` RPC → `{ unread_count }`
- Handler: participant check + single LEFT JOIN-NULL `COUNT(*)` SQL (no message rows loaded into Node memory)
- Filters out soft-deleted messages (`m.deleted_at IS NULL`)
- Returns NOT_FOUND for non-participants (no enumeration)
- 5 new tests

### Gateway additions
- `GET /api/v1/chats/:chatId/unread-count` → `{ success, data: { unreadCount } }` (monolith parity envelope)
- Registered for BOTH `/chats` and `/conversations` prefixes via the existing dual-mount
- 3 new tests covering success, NOT_FOUND mapping, alias path

## Test plan
- [x] `services/chat` — 49/49 tests pass
- [x] `services/gateway` — 354/354 tests pass
- [x] Type-check clean (proto regen + tsc)
- [x] Lint clean (chat); gateway only pre-existing curly warnings

## Out of scope
- `GET /:chatId` (chat details) — separate PR
- `GET /:chatId/activity` — separate PR
- `GET/POST/DELETE /:chatId/participants` — separate PR
- Chat attachments — separate PR (needs file storage like applications)

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_