### PR TITLE
feat(notifications,gateway): admin cleanup of expired notifications

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
+++ b/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
@@ -70,6 +70,13 @@ service NotificationService {
   rpc ResetNotificationPreferences(ResetNotificationPreferencesRequest)
       returns (ResetNotificationPreferencesResponse);
 
+  // Admin-only: soft-delete notifications older than N days (default 30).
+  // Returns the affected row count. Requires `notifications.cleanup`.
+  // Operates on rows where `deleted_at IS NULL` so a re-run is a no-op
+  // for already-cleaned rows.
+  rpc CleanupExpiredNotifications(CleanupExpiredNotificationsRequest)
+      returns (CleanupExpiredNotificationsResponse);
+
   // --- Email queue ----------------------------------------------------
   // Phase 7 round-out. The service owns the email_queue table; other
   // services (auth, applications, chat) call SendEmail to enqueue a
@@ -635,4 +642,18 @@ message ResetNotificationPreferencesRequest {
 
 message ResetNotificationPreferencesResponse {
   NotificationPreferences preferences = 1;
+}
+
+// --- CleanupExpiredNotifications ------------------------------------
+
+message CleanupExpiredNotificationsRequest {
+  // Number of days of history to keep — anything older gets soft-
+  // deleted. Server enforces 1..3650 (10 years). Defaults to 30 when
+  // unset (treated as 0 here → DEFAULT).
+  uint32 days_to_keep = 1;
+}
+
+message CleanupExpiredNotificationsResponse {
+  // Number of rows that transitioned from kept → soft-deleted.
+  uint32 deleted_count = 1;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
@@ -1244,6 +1244,20 @@ export interface ResetNotificationPreferencesResponse {
   preferences?: NotificationPreferences | undefined;
 }
 
+export interface CleanupExpiredNotificationsRequest {
+  /**
+   * Number of days of history to keep — anything older gets soft-
+   * deleted. Server enforces 1..3650 (10 years). Defaults to 30 when
+   * unset (treated as 0 here → DEFAULT).
+   */
+  daysToKeep: number;
+}
+
+export interface CleanupExpiredNotificationsResponse {
+  /** Number of rows that transitioned from kept → soft-deleted. */
+  deletedCount: number;
+}
+
 function createBaseNotification(): Notification {
   return {
     notificationId: '',
@@ -6323,6 +6337,149 @@ export const ResetNotificationPreferencesResponse: MessageFns<ResetNotificationP
     },
   };
 
+function createBaseCleanupExpiredNotificationsRequest(): CleanupExpiredNotificationsRequest {
+  return { daysToKeep: 0 };
+}
+
+export const CleanupExpiredNotificationsRequest: MessageFns<CleanupExpiredNotificationsRequest> = {
+  encode(
+    message: CleanupExpiredNotificationsRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.daysToKeep !== 0) {
+      writer.uint32(8).uint32(message.daysToKeep);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CleanupExpiredNotificationsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCleanupExpiredNotificationsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.daysToKeep = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CleanupExpiredNotificationsRequest {
+    return {
+      daysToKeep: isSet(object.daysToKeep)
+        ? globalThis.Number(object.daysToKeep)
+        : isSet(object.days_to_keep)
+          ? globalThis.Number(object.days_to_keep)
+          : 0,
+    };
+  },
+
+  toJSON(message: CleanupExpiredNotificationsRequest): unknown {
+    const obj: any = {};
+    if (message.daysToKeep !== 0) {
+      obj.daysToKeep = Math.round(message.daysToKeep);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<CleanupExpiredNotificationsRequest>, I>>(
+    base?: I
+  ): CleanupExpiredNotificationsRequest {
+    return CleanupExpiredNotificationsRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<CleanupExpiredNotificationsRequest>, I>>(
+    object: I
+  ): CleanupExpiredNotificationsRequest {
+    const message = createBaseCleanupExpiredNotificationsRequest();
+    message.daysToKeep = object.daysToKeep ?? 0;
+    return message;
+  },
+};
+
+function createBaseCleanupExpiredNotificationsResponse(): CleanupExpiredNotificationsResponse {
+  return { deletedCount: 0 };
+}
+
+export const CleanupExpiredNotificationsResponse: MessageFns<CleanupExpiredNotificationsResponse> =
+  {
+    encode(
+      message: CleanupExpiredNotificationsResponse,
+      writer: BinaryWriter = new BinaryWriter()
+    ): BinaryWriter {
+      if (message.deletedCount !== 0) {
+        writer.uint32(8).uint32(message.deletedCount);
+      }
+      return writer;
+    },
+
+    decode(input: BinaryReader | Uint8Array, length?: number): CleanupExpiredNotificationsResponse {
+      const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+      const end = length === undefined ? reader.len : reader.pos + length;
+      const message = createBaseCleanupExpiredNotificationsResponse();
+      while (reader.pos < end) {
+        const tag = reader.uint32();
+        switch (tag >>> 3) {
+          case 1: {
+            if (tag !== 8) {
+              break;
+            }
+
+            message.deletedCount = reader.uint32();
+            continue;
+          }
+        }
+        if ((tag & 7) === 4 || tag === 0) {
+          break;
+        }
+        reader.skip(tag & 7);
+      }
+      return message;
+    },
+
+    fromJSON(object: any): CleanupExpiredNotificationsResponse {
+      return {
+        deletedCount: isSet(object.deletedCount)
+          ? globalThis.Number(object.deletedCount)
+          : isSet(object.deleted_count)
+            ? globalThis.Number(object.deleted_count)
+            : 0,
+      };
+    },
+
+    toJSON(message: CleanupExpiredNotificationsResponse): unknown {
+      const obj: any = {};
+      if (message.deletedCount !== 0) {
+        obj.deletedCount = Math.round(message.deletedCount);
+      }
+      return obj;
+    },
+
+    create<I extends Exact<DeepPartial<CleanupExpiredNotificationsResponse>, I>>(
+      base?: I
+    ): CleanupExpiredNotificationsResponse {
+      return CleanupExpiredNotificationsResponse.fromPartial(base ?? ({} as any));
+    },
+    fromPartial<I extends Exact<DeepPartial<CleanupExpiredNotificationsResponse>, I>>(
+      object: I
+    ): CleanupExpiredNotificationsResponse {
+      const message = createBaseCleanupExpiredNotificationsResponse();
+      message.deletedCount = object.deletedCount ?? 0;
+      return message;
+    },
+  };
+
 /**
  * NotificationService is the gRPC contract for the in-app notification
  * store. The gateway translates `POST/GET/DELETE /api/notifications/*`
@@ -6509,6 +6666,25 @@ export const NotificationServiceService = {
       ResetNotificationPreferencesResponse.decode(value),
   },
   /**
+   * Admin-only: soft-delete notifications older than N days (default 30).
+   * Returns the affected row count. Requires `notifications.cleanup`.
+   * Operates on rows where `deleted_at IS NULL` so a re-run is a no-op
+   * for already-cleaned rows.
+   */
+  cleanupExpiredNotifications: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/CleanupExpiredNotifications' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: CleanupExpiredNotificationsRequest): Buffer =>
+      Buffer.from(CleanupExpiredNotificationsRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): CleanupExpiredNotificationsRequest =>
+      CleanupExpiredNotificationsRequest.decode(value),
+    responseSerialize: (value: CleanupExpiredNotificationsResponse): Buffer =>
+      Buffer.from(CleanupExpiredNotificationsResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): CleanupExpiredNotificationsResponse =>
+      CleanupExpiredNotificationsResponse.decode(value),
+  },
+  /**
    * Enqueue an email. Returns the email_id immediately; delivery happens
    * asynchronously in the worker. Callers can supply a templateId +
    * templateData OR a pre-rendered subject + html_content; if both are
@@ -6676,6 +6852,16 @@ export interface NotificationServiceServer extends UntypedServiceImplementation 
   resetNotificationPreferences: handleUnaryCall<
     ResetNotificationPreferencesRequest,
     ResetNotificationPreferencesResponse
+  >;
+  /**
+   * Admin-only: soft-delete notifications older than N days (default 30).
+   * Returns the affected row count. Requires `notifications.cleanup`.
+   * Operates on rows where `deleted_at IS NULL` so a re-run is a no-op
+   * for already-cleaned rows.
+   */
+  cleanupExpiredNotifications: handleUnaryCall<
+    CleanupExpiredNotificationsRequest,
+    CleanupExpiredNotificationsResponse
   >;
   /**
    * Enqueue an email. Returns the email_id immediately; delivery happens
@@ -6912,6 +7098,27 @@ export interface NotificationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: ResetNotificationPreferencesResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Admin-only: soft-delete notifications older than N days (default 30).
+   * Returns the affected row count. Requires `notifications.cleanup`.
+   * Operates on rows where `deleted_at IS NULL` so a re-run is a no-op
+   * for already-cleaned rows.
+   */
+  cleanupExpiredNotifications(
+    request: CleanupExpiredNotificationsRequest,
+    callback: (error: ServiceError | null, response: CleanupExpiredNotificationsResponse) => void
+  ): ClientUnaryCall;
+  cleanupExpiredNotifications(
+    request: CleanupExpiredNotificationsRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: CleanupExpiredNotificationsResponse) => void
+  ): ClientUnaryCall;
+  cleanupExpiredNotifications(
+    request: CleanupExpiredNotificationsRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: CleanupExpiredNotificationsResponse) => void
   ): ClientUnaryCall;
   /**
    * Enqueue an email. Returns the email_id immediately; delivery happens

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -67,6 +67,8 @@ export type {
   UpdateNotificationPreferencesResponse,
   ResetNotificationPreferencesRequest,
   ResetNotificationPreferencesResponse,
+  CleanupExpiredNotificationsRequest,
+  CleanupExpiredNotificationsResponse,
   NotificationServiceServer,
   NotificationServiceClient,
 } from './generated/proto/adopt_dont_shop/notifications/v1/notification.js';

--- a/services/gateway/src/grpc-clients/notifications-client.ts
+++ b/services/gateway/src/grpc-clients/notifications-client.ts
@@ -40,6 +40,8 @@ import {
   type UpdateNotificationPreferencesResponse,
   type ResetNotificationPreferencesRequest,
   type ResetNotificationPreferencesResponse,
+  type CleanupExpiredNotificationsRequest,
+  type CleanupExpiredNotificationsResponse,
 } from '@adopt-dont-shop/proto';
 
 export type NotificationsClient = {
@@ -83,6 +85,10 @@ export type NotificationsClient = {
     req: ResetNotificationPreferencesRequest,
     metadata: Metadata
   ): Promise<ResetNotificationPreferencesResponse>;
+  cleanupExpiredNotifications(
+    req: CleanupExpiredNotificationsRequest,
+    metadata: Metadata
+  ): Promise<CleanupExpiredNotificationsResponse>;
   close(): void;
 };
 
@@ -134,6 +140,8 @@ export const createNotificationsClient = (
       callUnary(stub.updateNotificationPreferences, req, metadata),
     resetNotificationPreferences: (req, metadata) =>
       callUnary(stub.resetNotificationPreferences, req, metadata),
+    cleanupExpiredNotifications: (req, metadata) =>
+      callUnary(stub.cleanupExpiredNotifications, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/notifications.test.ts
+++ b/services/gateway/src/routes/notifications.test.ts
@@ -42,6 +42,7 @@ function makeClient(): NotificationsClient & {
   deleteNotificationMock: ReturnType<typeof vi.fn>;
   getNotificationPreferencesMock: ReturnType<typeof vi.fn>;
   updateNotificationPreferencesMock: ReturnType<typeof vi.fn>;
+  cleanupExpiredNotificationsMock: ReturnType<typeof vi.fn>;
 } {
   const createMock = vi.fn();
   const listMock = vi.fn();
@@ -52,6 +53,7 @@ function makeClient(): NotificationsClient & {
   const deleteNotificationMock = vi.fn();
   const getNotificationPreferencesMock = vi.fn();
   const updateNotificationPreferencesMock = vi.fn();
+  const cleanupExpiredNotificationsMock = vi.fn();
   return {
     create: createMock,
     list: listMock,
@@ -62,6 +64,7 @@ function makeClient(): NotificationsClient & {
     deleteNotification: deleteNotificationMock,
     getNotificationPreferences: getNotificationPreferencesMock,
     updateNotificationPreferences: updateNotificationPreferencesMock,
+    cleanupExpiredNotifications: cleanupExpiredNotificationsMock,
     close: vi.fn(),
     createMock,
     listMock,
@@ -72,6 +75,7 @@ function makeClient(): NotificationsClient & {
     deleteNotificationMock,
     getNotificationPreferencesMock,
     updateNotificationPreferencesMock,
+    cleanupExpiredNotificationsMock,
   };
 }
 
@@ -578,5 +582,71 @@ describe('GET/PUT /api/v1/notifications/preferences', () => {
     expect(grpcReq.digestFrequency).toBe(
       NotificationsV1.NotificationDigestFrequency.NOTIFICATION_DIGEST_FREQUENCY_DAILY
     );
+  });
+});
+
+// --- POST /api/v1/notifications/cleanup -----------------------------
+
+describe('POST /api/v1/notifications/cleanup', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns the deleted count', async () => {
+    client.cleanupExpiredNotificationsMock.mockResolvedValueOnce({ deletedCount: 5 });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/cleanup',
+      headers: { 'x-user-id': 'svc-admin', 'content-type': 'application/json' },
+      payload: { daysToKeep: 30 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      success: true,
+      data: { deletedCount: 5 },
+    });
+
+    const [grpcReq] = client.cleanupExpiredNotificationsMock.mock.calls[0] as [
+      { daysToKeep: number },
+      unknown,
+    ];
+    expect(grpcReq.daysToKeep).toBe(30);
+  });
+
+  it('accepts snake_case days_to_keep', async () => {
+    client.cleanupExpiredNotificationsMock.mockResolvedValueOnce({ deletedCount: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/cleanup',
+      headers: { 'x-user-id': 'svc-admin', 'content-type': 'application/json' },
+      payload: { days_to_keep: 60 },
+    });
+    const [grpcReq] = client.cleanupExpiredNotificationsMock.mock.calls[0] as [
+      { daysToKeep: number },
+      unknown,
+    ];
+    expect(grpcReq.daysToKeep).toBe(60);
+  });
+
+  it('maps PERMISSION_DENIED → 403', async () => {
+    client.cleanupExpiredNotificationsMock.mockRejectedValueOnce({
+      code: status.PERMISSION_DENIED,
+      details: 'admin only',
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/cleanup',
+      headers: { 'x-user-id': 'usr-1' },
+    });
+    expect(res.statusCode).toBe(403);
   });
 });

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -118,6 +118,23 @@ export const registerNotificationsRoutes = async (
     }
   });
 
+  // Admin cleanup — soft-delete notifications older than N days.
+  app.post('/api/v1/notifications/cleanup', async (req, reply) => {
+    const metadata = buildMetadata(req);
+    const body = (req.body ?? {}) as { daysToKeep?: number; days_to_keep?: number };
+    const daysToKeep = body.daysToKeep ?? body.days_to_keep ?? 0;
+    try {
+      const res = await client.cleanupExpiredNotifications({ daysToKeep }, metadata);
+      return reply.send({
+        success: true,
+        message: `Cleaned up ${res.deletedCount} expired notifications`,
+        data: { deletedCount: res.deletedCount },
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
   // Mark all unread as read.
   app.post('/api/v1/notifications/read-all', async (req, reply) => {
     const metadata = buildMetadata(req);

--- a/services/notifications/src/grpc/notification-prefs-handlers.test.ts
+++ b/services/notifications/src/grpc/notification-prefs-handlers.test.ts
@@ -7,6 +7,7 @@ import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
 import { NotificationsV1 } from '@adopt-dont-shop/proto';
 
 import {
+  cleanupExpiredNotifications,
   deleteNotification,
   getNotification,
   getNotificationPreferences,
@@ -508,5 +509,64 @@ describe('resetNotificationPreferences', () => {
     await expect(
       resetNotificationPreferences(mocks.deps, ADOPTER, { userId: 'usr-other' })
     ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+});
+
+// --- cleanupExpiredNotifications ------------------------------------
+
+describe('cleanupExpiredNotifications', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects principals without notifications.cleanup', async () => {
+    await expect(
+      cleanupExpiredNotifications(mocks.deps, ADOPTER, { daysToKeep: 30 })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects out-of-range days_to_keep', async () => {
+    const admin: Principal = {
+      userId: 'svc-admin' as UserId,
+      roles: ['admin'],
+      permissions: ['notifications.cleanup' as Permission],
+    };
+    await expect(
+      cleanupExpiredNotifications(mocks.deps, admin, { daysToKeep: 4000 })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('returns the deleted row count from the UPDATE', async () => {
+    const admin: Principal = {
+      userId: 'svc-admin' as UserId,
+      roles: ['admin'],
+      permissions: ['notifications.cleanup' as Permission],
+    };
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ notification_id: 'n-1' }, { notification_id: 'n-2' }],
+      rowCount: 2,
+    });
+    const res = await cleanupExpiredNotifications(mocks.deps, admin, { daysToKeep: 30 });
+    expect(res.deletedCount).toBe(2);
+
+    // Confirm days_to_keep is passed as the first parameter (stringified for interval).
+    const call = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(call[1]).toEqual(['30']);
+  });
+
+  it('defaults to 30 days when days_to_keep is 0', async () => {
+    const admin: Principal = {
+      userId: 'svc-admin' as UserId,
+      roles: ['admin'],
+      permissions: ['notifications.cleanup' as Permission],
+    };
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await cleanupExpiredNotifications(mocks.deps, admin, { daysToKeep: 0 });
+    const call = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(call[1]).toEqual(['30']);
   });
 });

--- a/services/notifications/src/grpc/notification-prefs-handlers.ts
+++ b/services/notifications/src/grpc/notification-prefs-handlers.ts
@@ -27,6 +27,8 @@ import {
   type NotificationPreferences as NotificationPreferencesProto,
   type ResetNotificationPreferencesRequest,
   type ResetNotificationPreferencesResponse,
+  type CleanupExpiredNotificationsRequest,
+  type CleanupExpiredNotificationsResponse,
   type UpdateNotificationPreferencesRequest,
   type UpdateNotificationPreferencesResponse,
 } from '@adopt-dont-shop/proto';
@@ -515,4 +517,43 @@ export async function resetNotificationPreferences(
     throw new HandlerError('INTERNAL', 'reset returned no rows');
   }
   return { preferences: prefsRowToProto(reset) };
+}
+
+// --- CleanupExpiredNotifications ------------------------------------
+
+const NOTIFICATIONS_CLEANUP: Permission = 'notifications.cleanup' as Permission;
+const DEFAULT_CLEANUP_DAYS = 30;
+const MAX_CLEANUP_DAYS = 3650; // 10 years
+
+export async function cleanupExpiredNotifications(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: CleanupExpiredNotificationsRequest
+): Promise<CleanupExpiredNotificationsResponse> {
+  if (!hasPermission(principal, NOTIFICATIONS_CLEANUP)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${NOTIFICATIONS_CLEANUP}' required`);
+  }
+  const daysToKeep = req.daysToKeep || DEFAULT_CLEANUP_DAYS;
+  if (daysToKeep < 1 || daysToKeep > MAX_CLEANUP_DAYS) {
+    throw new HandlerError(
+      'INVALID_ARGUMENT',
+      `days_to_keep must be between 1 and ${MAX_CLEANUP_DAYS}`
+    );
+  }
+
+  // Soft-delete in a single UPDATE — interval arithmetic happens in PG
+  // so the cutoff is consistent regardless of node-side clock drift.
+  // Filtering on deleted_at IS NULL keeps re-runs cheap (the row's
+  // already done) and bounded by the index on deleted_at.
+  const result = await deps.pool.query<{ notification_id: string }>(
+    `
+    UPDATE notifications.notifications
+    SET deleted_at = now(), updated_at = now(), version = version + 1
+    WHERE created_at < now() - ($1 || ' days')::interval
+      AND deleted_at IS NULL
+    RETURNING notification_id
+    `,
+    [daysToKeep.toString()]
+  );
+  return { deletedCount: result.rowCount ?? 0 };
 }

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -27,6 +27,7 @@ import {
 import { getEmailPreferences, sendEmail, updateEmailPreferences } from './email-handlers.js';
 import { createNotification, dismissNotification, listNotifications } from './handlers.js';
 import {
+  cleanupExpiredNotifications,
   deleteNotification,
   getNotification,
   getNotificationPreferences,
@@ -73,6 +74,10 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       deps: { pool, nats },
       logger,
     }),
+    cleanupExpiredNotifications: adapt(cleanupExpiredNotifications, {
+      deps: { pool, nats },
+      logger,
+    }),
     resetNotificationPreferences: adapt(resetNotificationPreferences, {
       deps: { pool, nats },
       logger,
@@ -97,6 +102,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'getNotificationPreferences',
       'updateNotificationPreferences',
       'resetNotificationPreferences',
+      'cleanupExpiredNotifications',
       'sendEmail',
       'getEmailPreferences',
       'updateEmailPreferences',


### PR DESCRIPTION
## Summary

Brings the monolith's admin-only `POST /api/v1/notifications/cleanup` over to the gateway + notifications service.

### Notifications service additions
- `NotificationService.CleanupExpiredNotifications(days_to_keep)` RPC → `{ deleted_count }`
- Admin-only: gated on `notifications.cleanup` permission
- Bounds: 1..3650 days; 0 → DEFAULT (30)
- Single `UPDATE ... SET deleted_at = now() WHERE created_at < now() - interval ...` — interval arithmetic in PG so the cutoff is consistent regardless of node-side clock drift
- Operates only on rows where `deleted_at IS NULL` so re-runs are no-ops (bounded by the existing index on deleted_at)
- 4 new tests covering permission gate, range validation, count return, default value

### Gateway additions
- `POST /api/v1/notifications/cleanup` → `CleanupExpiredNotifications` RPC
- Registered BEFORE the `/:id` dynamic route so the literal segment wins
- Accepts both `daysToKeep` (camelCase) and `days_to_keep` (snake_case) body keys
- Response: `{ success, message: 'Cleaned up N expired notifications', data: { deletedCount } }`
- 3 new tests

### Why soft-delete instead of the monolith's hard delete
The monolith ran `Notification.destroy()` which hard-deleted rows, losing audit information. The new RPC soft-deletes via `deleted_at` matching the rest of the service's pattern (DeleteNotification, MarkAllRead all use the same shape). This keeps the audit trail intact and allows future "undelete" if needed; it also bounds re-run cost via the deleted_at IS NULL filter.

## Test plan
- [x] `services/notifications` — 163/163 tests pass
- [x] `services/gateway` — 361/361 tests pass
- [x] Type-check clean
- [x] Lint clean (notifications); gateway has only pre-existing curly warnings

## Out of scope
- Bulk-create notifications (`POST /api/v1/notifications/bulk`) — separate PR
- Broadcast (`POST /api/v1/notifications/broadcast`) — cross-service, separate PR
- Permanent hard-delete of soft-deleted rows after additional retention — separate cron RPC

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_