### PR TITLE
feat(chat,gateway): get chat by id

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
+++ b/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
@@ -66,6 +66,11 @@ service ChatService {
   // a second delete on the same message returns the same row.
   // Publishes chat.messageDeleted.
   rpc DeleteMessage(DeleteMessageRequest) returns (DeleteMessageResponse);
+
+  // Fetch a chat by id. Returns the canonical Chat row + participant
+  // ids + last-message preview. Caller MUST be a participant or
+  // super_admin; non-participants get NOT_FOUND (no enumeration).
+  rpc GetChat(GetChatRequest) returns (GetChatResponse);
 }
 
 // --- Messages --------------------------------------------------------
@@ -257,4 +262,14 @@ message DeleteMessageRequest {
 
 message DeleteMessageResponse {
   Message message = 1;
+}
+
+// --- GetChat ---------------------------------------------------------
+
+message GetChatRequest {
+  string chat_id = 1;
+}
+
+message GetChatResponse {
+  Chat chat = 1;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
@@ -224,6 +224,14 @@ export interface DeleteMessageResponse {
   message?: Message | undefined;
 }
 
+export interface GetChatRequest {
+  chatId: string;
+}
+
+export interface GetChatResponse {
+  chat?: Chat | undefined;
+}
+
 function createBaseChat(): Chat {
   return {
     chatId: '',
@@ -2284,6 +2292,129 @@ export const DeleteMessageResponse: MessageFns<DeleteMessageResponse> = {
   },
 };
 
+function createBaseGetChatRequest(): GetChatRequest {
+  return { chatId: '' };
+}
+
+export const GetChatRequest: MessageFns<GetChatRequest> = {
+  encode(message: GetChatRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.chatId !== '') {
+      writer.uint32(10).string(message.chatId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetChatRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetChatRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chatId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetChatRequest {
+    return {
+      chatId: isSet(object.chatId)
+        ? globalThis.String(object.chatId)
+        : isSet(object.chat_id)
+          ? globalThis.String(object.chat_id)
+          : '',
+    };
+  },
+
+  toJSON(message: GetChatRequest): unknown {
+    const obj: any = {};
+    if (message.chatId !== '') {
+      obj.chatId = message.chatId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetChatRequest>, I>>(base?: I): GetChatRequest {
+    return GetChatRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetChatRequest>, I>>(object: I): GetChatRequest {
+    const message = createBaseGetChatRequest();
+    message.chatId = object.chatId ?? '';
+    return message;
+  },
+};
+
+function createBaseGetChatResponse(): GetChatResponse {
+  return { chat: undefined };
+}
+
+export const GetChatResponse: MessageFns<GetChatResponse> = {
+  encode(message: GetChatResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.chat !== undefined) {
+      Chat.encode(message.chat, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetChatResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetChatResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chat = Chat.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetChatResponse {
+    return { chat: isSet(object.chat) ? Chat.fromJSON(object.chat) : undefined };
+  },
+
+  toJSON(message: GetChatResponse): unknown {
+    const obj: any = {};
+    if (message.chat !== undefined) {
+      obj.chat = Chat.toJSON(message.chat);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetChatResponse>, I>>(base?: I): GetChatResponse {
+    return GetChatResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetChatResponse>, I>>(object: I): GetChatResponse {
+    const message = createBaseGetChatResponse();
+    message.chat =
+      object.chat !== undefined && object.chat !== null ? Chat.fromPartial(object.chat) : undefined;
+    return message;
+  },
+};
+
 /**
  * ChatService is the gRPC contract for the chat vertical. It owns
  * the `chat.*` schema (Chat, ChatParticipant, Message, MessageReaction,
@@ -2454,6 +2585,22 @@ export const ChatServiceService = {
     responseDeserialize: (value: Buffer): DeleteMessageResponse =>
       DeleteMessageResponse.decode(value),
   },
+  /**
+   * Fetch a chat by id. Returns the canonical Chat row + participant
+   * ids + last-message preview. Caller MUST be a participant or
+   * super_admin; non-participants get NOT_FOUND (no enumeration).
+   */
+  getChat: {
+    path: '/adopt_dont_shop.chat.v1.ChatService/GetChat' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetChatRequest): Buffer =>
+      Buffer.from(GetChatRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetChatRequest => GetChatRequest.decode(value),
+    responseSerialize: (value: GetChatResponse): Buffer =>
+      Buffer.from(GetChatResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetChatResponse => GetChatResponse.decode(value),
+  },
 } as const;
 
 export interface ChatServiceServer extends UntypedServiceImplementation {
@@ -2516,6 +2663,12 @@ export interface ChatServiceServer extends UntypedServiceImplementation {
    * Publishes chat.messageDeleted.
    */
   deleteMessage: handleUnaryCall<DeleteMessageRequest, DeleteMessageResponse>;
+  /**
+   * Fetch a chat by id. Returns the canonical Chat row + participant
+   * ids + last-message preview. Caller MUST be a participant or
+   * super_admin; non-participants get NOT_FOUND (no enumeration).
+   */
+  getChat: handleUnaryCall<GetChatRequest, GetChatResponse>;
 }
 
 export interface ChatServiceClient extends Client {
@@ -2703,6 +2856,26 @@ export interface ChatServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: DeleteMessageResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Fetch a chat by id. Returns the canonical Chat row + participant
+   * ids + last-message preview. Caller MUST be a participant or
+   * super_admin; non-participants get NOT_FOUND (no enumeration).
+   */
+  getChat(
+    request: GetChatRequest,
+    callback: (error: ServiceError | null, response: GetChatResponse) => void
+  ): ClientUnaryCall;
+  getChat(
+    request: GetChatRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetChatResponse) => void
+  ): ClientUnaryCall;
+  getChat(
+    request: GetChatRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetChatResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -243,6 +243,8 @@ export type {
   GetChatUnreadCountResponse,
   DeleteMessageRequest,
   DeleteMessageResponse,
+  GetChatRequest,
+  GetChatResponse,
   ChatServiceServer,
   ChatServiceClient,
 } from './generated/proto/adopt_dont_shop/chat/v1/chat.js';

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -21,6 +21,7 @@ import {
   openChat,
   react,
   deleteMessage,
+  getChat,
   getChatUnreadCount,
   searchChats,
   sendMessage,
@@ -685,5 +686,66 @@ describe('deleteMessage', () => {
     const res = await deleteMessage(mocks.deps, ADOPTER_PRINCIPAL, { messageId: 'msg-1' });
     expect(res.message?.deletedAt).toBeDefined();
     expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+});
+
+// --- getChat --------------------------------------------------------
+
+describe('getChat', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects missing chat_id', async () => {
+    await expect(getChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: '' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('rejects principals without chat.read', async () => {
+    await expect(
+      getChat(mocks.deps, UNPRIVILEGED_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('returns NOT_FOUND (no enumeration) for non-participants', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      getChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('returns NOT_FOUND when the row is soft-deleted or missing', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      getChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('returns the chat for a participant + populates last message preview', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [chatRowFixture()] });
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          content: 'Hi there',
+          sender_id: 'usr-rescue',
+          created_at: new Date('2026-06-05T12:00:00Z'),
+        },
+      ],
+    });
+
+    const res = await getChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' });
+    expect(res.chat?.chatId).toBe('chat-1');
+    expect(res.chat?.participantUserIds).toEqual(['usr-adopter', 'usr-rescue']);
+    expect(res.chat?.lastMessagePreview).toBe('Hi there');
   });
 });

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -26,6 +26,8 @@ import type {
   Chat,
   DeleteMessageRequest,
   DeleteMessageResponse,
+  GetChatRequest,
+  GetChatResponse,
   GetChatUnreadCountRequest,
   GetChatUnreadCountResponse,
   ListChatsRequest,
@@ -969,4 +971,35 @@ export async function deleteMessage(
   return {
     message: messageRowToProto(updated, reactions.get(updated.message_id) ?? []),
   };
+}
+
+// --- GetChat --------------------------------------------------------
+
+export async function getChat(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: GetChatRequest
+): Promise<GetChatResponse> {
+  if (!req.chatId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'chat_id is required');
+  }
+  if (!hasPermission(principal, CHAT_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_READ}' required`);
+  }
+
+  // Participant-or-admin gate first so non-participants get NOT_FOUND
+  // posture without learning whether the row exists.
+  if (!(await isParticipantOrAdmin(deps, principal, req.chatId))) {
+    throw new HandlerError('NOT_FOUND', `chat ${req.chatId} not found`);
+  }
+
+  const result = await deps.pool.query<ChatRow>(
+    `SELECT * FROM chats WHERE chat_id = $1 AND deleted_at IS NULL LIMIT 1`,
+    [req.chatId]
+  );
+  if (result.rows.length === 0) {
+    throw new HandlerError('NOT_FOUND', `chat ${req.chatId} not found`);
+  }
+
+  return { chat: await chatRowToProto(deps, result.rows[0]) };
 }

--- a/services/chat/src/grpc/server.ts
+++ b/services/chat/src/grpc/server.ts
@@ -16,6 +16,7 @@ import type { ChatConfig } from '../config.js';
 import { adapt } from './adapter.js';
 import {
   deleteMessage,
+  getChat,
   getChatUnreadCount,
   listChats,
   listMessages,
@@ -54,6 +55,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     searchChats: adapt(searchChats, { deps, logger }),
     getChatUnreadCount: adapt(getChatUnreadCount, { deps, logger }),
     deleteMessage: adapt(deleteMessage, { deps, logger }),
+    getChat: adapt(getChat, { deps, logger }),
   });
 
   logger.info('gRPC ChatService registered', {
@@ -67,6 +69,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'searchChats',
       'getChatUnreadCount',
       'deleteMessage',
+      'getChat',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/gateway/src/grpc-clients/chat-client.ts
+++ b/services/gateway/src/grpc-clients/chat-client.ts
@@ -26,6 +26,8 @@ import {
   type GetChatUnreadCountResponse,
   type DeleteMessageRequest,
   type DeleteMessageResponse,
+  type GetChatRequest,
+  type GetChatResponse,
 } from '@adopt-dont-shop/proto';
 
 export type ChatClient = {
@@ -41,6 +43,7 @@ export type ChatClient = {
     metadata: Metadata
   ): Promise<GetChatUnreadCountResponse>;
   deleteMessage(req: DeleteMessageRequest, metadata: Metadata): Promise<DeleteMessageResponse>;
+  getChat(req: GetChatRequest, metadata: Metadata): Promise<GetChatResponse>;
   close(): void;
 };
 
@@ -76,6 +79,7 @@ export const createChatClient = (opts: CreateChatClientOptions): ChatClient => {
     searchChats: (req, metadata) => callUnary(stub.searchChats, req, metadata),
     getChatUnreadCount: (req, metadata) => callUnary(stub.getChatUnreadCount, req, metadata),
     deleteMessage: (req, metadata) => callUnary(stub.deleteMessage, req, metadata),
+    getChat: (req, metadata) => callUnary(stub.getChat, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -45,6 +45,7 @@ function makeClient(): ChatClient & {
   searchChatsMock: ReturnType<typeof vi.fn>;
   getChatUnreadCountMock: ReturnType<typeof vi.fn>;
   deleteMessageMock: ReturnType<typeof vi.fn>;
+  getChatMock: ReturnType<typeof vi.fn>;
 } {
   const openChatMock = vi.fn();
   const sendMessageMock = vi.fn();
@@ -55,6 +56,7 @@ function makeClient(): ChatClient & {
   const searchChatsMock = vi.fn();
   const getChatUnreadCountMock = vi.fn();
   const deleteMessageMock = vi.fn();
+  const getChatMock = vi.fn();
   return {
     openChat: openChatMock,
     sendMessage: sendMessageMock,
@@ -65,6 +67,7 @@ function makeClient(): ChatClient & {
     searchChats: searchChatsMock,
     getChatUnreadCount: getChatUnreadCountMock,
     deleteMessage: deleteMessageMock,
+    getChat: getChatMock,
     close: vi.fn(),
     openChatMock,
     sendMessageMock,
@@ -75,6 +78,7 @@ function makeClient(): ChatClient & {
     searchChatsMock,
     getChatUnreadCountMock,
     deleteMessageMock,
+    getChatMock,
   };
 }
 
@@ -681,5 +685,83 @@ describe('DELETE /api/v1/chats/:chatId/messages/:messageId', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(client.deleteMessageMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- GET /api/v1/chats/:chatId --------------------------------------
+
+describe('GET /api/v1/chats/:chatId', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns the chat inside a success envelope', async () => {
+    client.getChatMock.mockResolvedValueOnce({ chat: CHAT_FIXTURE });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/chat-1',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { success: boolean; data: { chatId: string } };
+    expect(body.success).toBe(true);
+    expect(body.data.chatId).toBe('chat-1');
+    const [grpcReq] = client.getChatMock.mock.calls[0] as [{ chatId: string }, Metadata];
+    expect(grpcReq.chatId).toBe('chat-1');
+  });
+
+  it('maps NOT_FOUND → 404', async () => {
+    client.getChatMock.mockRejectedValueOnce({
+      code: status.NOT_FOUND,
+      details: 'gone',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/missing',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('reachable via /api/v1/conversations alias', async () => {
+    client.getChatMock.mockResolvedValueOnce({ chat: CHAT_FIXTURE });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/conversations/chat-1',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.getChatMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('the search literal still wins over the dynamic :chatId match', async () => {
+    client.searchChatsMock.mockResolvedValueOnce({ hits: [], page: 1, limit: 20, total: 0 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/search?query=hello',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.searchChatsMock).toHaveBeenCalledTimes(1);
+    expect(client.getChatMock).not.toHaveBeenCalled();
+  });
+
+  it('the unread-count literal still wins over the dynamic :chatId match', async () => {
+    client.getChatUnreadCountMock.mockResolvedValueOnce({ unreadCount: 1 });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/chats/chat-1/unread-count',
+      headers: { 'x-user-id': 'usr-1', 'x-user-roles': 'adopter' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.getChatUnreadCountMock).toHaveBeenCalledTimes(1);
+    expect(client.getChatMock).not.toHaveBeenCalled();
   });
 });

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -183,6 +183,27 @@ const registerChatRoutesForPrefix = (
     }
   });
 
+  // ---- GET <prefix>/:chatId ----------------------------------------
+  // Fetch single chat details. Registered AFTER the more-specific
+  // /:chatId/{unread-count,messages,read} routes above so they win
+  // Fastify's first-registered-wins matcher. Returns the monolith
+  // envelope { success, data: Chat } where Chat is the proto JSON.
+  app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId`, async (req, reply) => {
+    const metadata = buildMetadata(req);
+    try {
+      const res = await client.getChat({ chatId: req.params.chatId }, metadata);
+      if (!res.chat) {
+        return reply.code(404).send({ success: false, error: 'Chat not found' });
+      }
+      return reply.send({
+        success: true,
+        data: ChatV1.Chat.toJSON(res.chat),
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+
   // ---- GET <prefix>/:chatId/messages -------------------------------
   app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, async (req, reply) => {
     const metadata = buildMetadata(req);


### PR DESCRIPTION
## Summary

Adds `GetChat` RPC + `GET /api/v1/chats/:chatId` (and `/conversations` alias). Returns the canonical Chat row with participant ids + last-message preview embedded — the SPA uses this for chat header rendering and to navigate to a single chat without paying for the full ListChats round-trip.

### Chat service additions
- `ChatService.GetChat(chat_id)` RPC → `{ chat }`
- Handler order:
  1. INVALID_ARGUMENT on empty chat_id
  2. PERMISSION_DENIED without `chat.read`
  3. Participant-or-admin gate first → NOT_FOUND for non-participants (no enumeration of row existence)
  4. SELECT FROM chats; NOT_FOUND on missing/soft-deleted
- Returns the proto Chat shape via the existing `chatRowToProto` helper (participant ids + last-message preview hydrated)
- 5 new tests

### Gateway additions
- `GET /api/v1/chats/:chatId` → `GetChat` RPC
- Response: `{ success, data: Chat }` (proto JSON)
- 5 new tests including explicit assertions that the literal `/search` and `/:chatId/unread-count` segments still beat the dynamic `:chatId` matcher

## Test plan
- [x] `services/chat` — 58/58 tests pass
- [x] `services/gateway` — 366/366 tests pass
- [x] Type-check clean (proto regen + tsc)
- [x] Lint clean (chat); gateway has only pre-existing curly warnings

## Out of scope
- Chat with embedded messages payload — the monolith returned messages inline in `getChatById`; we'll let the SPA call `/:chatId/messages` separately. Same total round-trips, cleaner separation.
- Chat archive/update/delete (`PUT/PATCH/DELETE /:chatId`) — separate PR
- Chat participants management — separate PR

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_