### PR TITLE
feat(chat,gateway): soft-delete chat

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
+++ b/packages/proto/proto/adopt_dont_shop/chat/v1/chat.proto
@@ -71,6 +71,12 @@ service ChatService {
   // ids + last-message preview. Caller MUST be a participant or
   // super_admin; non-participants get NOT_FOUND (no enumeration).
   rpc GetChat(GetChatRequest) returns (GetChatResponse);
+
+  // Soft-delete a chat (sets deleted_at). Caller MUST be a participant
+  // or super_admin. Idempotent — a second delete on the same chat
+  // returns the same row without re-publishing. Publishes chat.deleted
+  // with the participant list for WS fan-out.
+  rpc DeleteChat(DeleteChatRequest) returns (DeleteChatResponse);
 }
 
 // --- Messages --------------------------------------------------------
@@ -271,5 +277,16 @@ message GetChatRequest {
 }
 
 message GetChatResponse {
+  Chat chat = 1;
+}
+
+// --- DeleteChat ------------------------------------------------------
+
+message DeleteChatRequest {
+  string chat_id = 1;
+  optional string reason = 2;
+}
+
+message DeleteChatResponse {
   Chat chat = 1;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/chat/v1/chat.ts
@@ -232,6 +232,15 @@ export interface GetChatResponse {
   chat?: Chat | undefined;
 }
 
+export interface DeleteChatRequest {
+  chatId: string;
+  reason?: string | undefined;
+}
+
+export interface DeleteChatResponse {
+  chat?: Chat | undefined;
+}
+
 function createBaseChat(): Chat {
   return {
     chatId: '',
@@ -2415,6 +2424,145 @@ export const GetChatResponse: MessageFns<GetChatResponse> = {
   },
 };
 
+function createBaseDeleteChatRequest(): DeleteChatRequest {
+  return { chatId: '', reason: undefined };
+}
+
+export const DeleteChatRequest: MessageFns<DeleteChatRequest> = {
+  encode(message: DeleteChatRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.chatId !== '') {
+      writer.uint32(10).string(message.chatId);
+    }
+    if (message.reason !== undefined) {
+      writer.uint32(18).string(message.reason);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DeleteChatRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeleteChatRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chatId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.reason = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DeleteChatRequest {
+    return {
+      chatId: isSet(object.chatId)
+        ? globalThis.String(object.chatId)
+        : isSet(object.chat_id)
+          ? globalThis.String(object.chat_id)
+          : '',
+      reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
+    };
+  },
+
+  toJSON(message: DeleteChatRequest): unknown {
+    const obj: any = {};
+    if (message.chatId !== '') {
+      obj.chatId = message.chatId;
+    }
+    if (message.reason !== undefined) {
+      obj.reason = message.reason;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DeleteChatRequest>, I>>(base?: I): DeleteChatRequest {
+    return DeleteChatRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DeleteChatRequest>, I>>(object: I): DeleteChatRequest {
+    const message = createBaseDeleteChatRequest();
+    message.chatId = object.chatId ?? '';
+    message.reason = object.reason ?? undefined;
+    return message;
+  },
+};
+
+function createBaseDeleteChatResponse(): DeleteChatResponse {
+  return { chat: undefined };
+}
+
+export const DeleteChatResponse: MessageFns<DeleteChatResponse> = {
+  encode(message: DeleteChatResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.chat !== undefined) {
+      Chat.encode(message.chat, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): DeleteChatResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeleteChatResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chat = Chat.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DeleteChatResponse {
+    return { chat: isSet(object.chat) ? Chat.fromJSON(object.chat) : undefined };
+  },
+
+  toJSON(message: DeleteChatResponse): unknown {
+    const obj: any = {};
+    if (message.chat !== undefined) {
+      obj.chat = Chat.toJSON(message.chat);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DeleteChatResponse>, I>>(base?: I): DeleteChatResponse {
+    return DeleteChatResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<DeleteChatResponse>, I>>(object: I): DeleteChatResponse {
+    const message = createBaseDeleteChatResponse();
+    message.chat =
+      object.chat !== undefined && object.chat !== null ? Chat.fromPartial(object.chat) : undefined;
+    return message;
+  },
+};
+
 /**
  * ChatService is the gRPC contract for the chat vertical. It owns
  * the `chat.*` schema (Chat, ChatParticipant, Message, MessageReaction,
@@ -2601,6 +2749,23 @@ export const ChatServiceService = {
       Buffer.from(GetChatResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): GetChatResponse => GetChatResponse.decode(value),
   },
+  /**
+   * Soft-delete a chat (sets deleted_at). Caller MUST be a participant
+   * or super_admin. Idempotent — a second delete on the same chat
+   * returns the same row without re-publishing. Publishes chat.deleted
+   * with the participant list for WS fan-out.
+   */
+  deleteChat: {
+    path: '/adopt_dont_shop.chat.v1.ChatService/DeleteChat' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: DeleteChatRequest): Buffer =>
+      Buffer.from(DeleteChatRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): DeleteChatRequest => DeleteChatRequest.decode(value),
+    responseSerialize: (value: DeleteChatResponse): Buffer =>
+      Buffer.from(DeleteChatResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): DeleteChatResponse => DeleteChatResponse.decode(value),
+  },
 } as const;
 
 export interface ChatServiceServer extends UntypedServiceImplementation {
@@ -2669,6 +2834,13 @@ export interface ChatServiceServer extends UntypedServiceImplementation {
    * super_admin; non-participants get NOT_FOUND (no enumeration).
    */
   getChat: handleUnaryCall<GetChatRequest, GetChatResponse>;
+  /**
+   * Soft-delete a chat (sets deleted_at). Caller MUST be a participant
+   * or super_admin. Idempotent — a second delete on the same chat
+   * returns the same row without re-publishing. Publishes chat.deleted
+   * with the participant list for WS fan-out.
+   */
+  deleteChat: handleUnaryCall<DeleteChatRequest, DeleteChatResponse>;
 }
 
 export interface ChatServiceClient extends Client {
@@ -2876,6 +3048,27 @@ export interface ChatServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: GetChatResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Soft-delete a chat (sets deleted_at). Caller MUST be a participant
+   * or super_admin. Idempotent — a second delete on the same chat
+   * returns the same row without re-publishing. Publishes chat.deleted
+   * with the participant list for WS fan-out.
+   */
+  deleteChat(
+    request: DeleteChatRequest,
+    callback: (error: ServiceError | null, response: DeleteChatResponse) => void
+  ): ClientUnaryCall;
+  deleteChat(
+    request: DeleteChatRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: DeleteChatResponse) => void
+  ): ClientUnaryCall;
+  deleteChat(
+    request: DeleteChatRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: DeleteChatResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -245,6 +245,8 @@ export type {
   DeleteMessageResponse,
   GetChatRequest,
   GetChatResponse,
+  DeleteChatRequest,
+  DeleteChatResponse,
   ChatServiceServer,
   ChatServiceClient,
 } from './generated/proto/adopt_dont_shop/chat/v1/chat.js';

--- a/services/chat/src/grpc/handlers.test.ts
+++ b/services/chat/src/grpc/handlers.test.ts
@@ -20,6 +20,7 @@ import {
   markRead,
   openChat,
   react,
+  deleteChat,
   deleteMessage,
   getChat,
   getChatUnreadCount,
@@ -747,5 +748,91 @@ describe('getChat', () => {
     expect(res.chat?.chatId).toBe('chat-1');
     expect(res.chat?.participantUserIds).toEqual(['usr-adopter', 'usr-rescue']);
     expect(res.chat?.lastMessagePreview).toBe('Hi there');
+  });
+});
+
+// --- deleteChat -----------------------------------------------------
+
+describe('deleteChat', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('rejects missing chat_id', async () => {
+    await expect(deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: '' })).rejects.toMatchObject({
+      code: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('rejects principals without chat.read', async () => {
+    await expect(
+      deleteChat(mocks.deps, UNPRIVILEGED_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('returns NOT_FOUND (no enumeration) when caller is not a participant', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('returns NOT_FOUND when the chat row is gone', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+    await expect(
+      deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('is idempotent on an already-deleted chat (no write, no publish)', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] });
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ ...chatRowFixture(), deleted_at: new Date('2026-06-05T12:00:00Z') }],
+    });
+    // chatRowToProto helpers
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await deleteChat(mocks.deps, ADOPTER_PRINCIPAL, { chatId: 'chat-1' });
+    expect(res.chat?.chatId).toBe('chat-1');
+    expect(mocks.clientMock.query).not.toHaveBeenCalled();
+    expect(mocks.natsMock.publish).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes inside withTransaction and publishes chat.deleted', async () => {
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [{ chat_participant_id: 'p-1' }] });
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ ...chatRowFixture(), deleted_at: null }],
+    });
+    // Inside withTransaction: UPDATE returning + participants
+    mocks.clientScript.push({ rows: [chatRowFixture()] });
+    mocks.clientScript.push({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    // After commit chatRowToProto helpers
+    mocks.poolMock.query.mockResolvedValueOnce({
+      rows: [{ participant_id: 'usr-adopter' }, { participant_id: 'usr-rescue' }],
+    });
+    mocks.poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await deleteChat(mocks.deps, ADOPTER_PRINCIPAL, {
+      chatId: 'chat-1',
+      reason: 'cleanup',
+    });
+    expect(res.chat?.chatId).toBe('chat-1');
+    expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
+    expect(mocks.natsMock.publish.mock.calls[0][0]).toBe('chat.deleted');
+    const envelope = JSON.parse(mocks.natsMock.publish.mock.calls[0][1] as string) as {
+      payload: { reason: string | null; participantUserIds: string[] };
+    };
+    expect(envelope.payload.reason).toBe('cleanup');
+    expect(envelope.payload.participantUserIds).toEqual(['usr-adopter', 'usr-rescue']);
   });
 });

--- a/services/chat/src/grpc/handlers.ts
+++ b/services/chat/src/grpc/handlers.ts
@@ -24,6 +24,8 @@ import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/even
 import type { Permission } from '@adopt-dont-shop/lib.types';
 import type {
   Chat,
+  DeleteChatRequest,
+  DeleteChatResponse,
   DeleteMessageRequest,
   DeleteMessageResponse,
   GetChatRequest,
@@ -1002,4 +1004,71 @@ export async function getChat(
   }
 
   return { chat: await chatRowToProto(deps, result.rows[0]) };
+}
+
+// --- DeleteChat -----------------------------------------------------
+
+export async function deleteChat(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: DeleteChatRequest
+): Promise<DeleteChatResponse> {
+  if (!req.chatId) {
+    throw new HandlerError('INVALID_ARGUMENT', 'chat_id is required');
+  }
+  if (!hasPermission(principal, CHAT_READ)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${CHAT_READ}' required`);
+  }
+  // Participant-or-admin gate. Non-participants get NOT_FOUND posture
+  // so the row's existence isn't enumerable.
+  if (!(await isParticipantOrAdmin(deps, principal, req.chatId))) {
+    throw new HandlerError('NOT_FOUND', `chat ${req.chatId} not found`);
+  }
+
+  // Fetch the row to decide idempotent vs first-time delete.
+  const existing = await deps.pool.query<ChatRow & { deleted_at: Date | null }>(
+    `SELECT * FROM chats WHERE chat_id = $1 LIMIT 1`,
+    [req.chatId]
+  );
+  if (existing.rows.length === 0) {
+    throw new HandlerError('NOT_FOUND', `chat ${req.chatId} not found`);
+  }
+  const row = existing.rows[0];
+
+  // Idempotent — already deleted.
+  if (row.deleted_at) {
+    return { chat: await chatRowToProto(deps, row) };
+  }
+
+  let updated: ChatRow | undefined;
+  await withTransaction(deps, async ({ client, publish }) => {
+    const result = await client.query<ChatRow>(
+      `
+      UPDATE chats
+      SET deleted_at = now(), updated_at = now()
+      WHERE chat_id = $1
+      RETURNING *
+      `,
+      [req.chatId]
+    );
+    updated = result.rows[0];
+
+    const participantUserIds = await loadChatParticipantsTx(client, req.chatId);
+
+    publish({
+      type: 'chat.deleted',
+      id: `chat.deleted.${req.chatId}`,
+      payload: {
+        chatId: req.chatId,
+        deletedBy: principal.userId,
+        reason: req.reason ?? null,
+        participantUserIds,
+      },
+    });
+  });
+
+  if (!updated) {
+    throw new HandlerError('INTERNAL', 'delete returned no rows');
+  }
+  return { chat: await chatRowToProto(deps, updated) };
 }

--- a/services/chat/src/grpc/server.ts
+++ b/services/chat/src/grpc/server.ts
@@ -15,6 +15,7 @@ import type { ChatConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
 import {
+  deleteChat,
   deleteMessage,
   getChat,
   getChatUnreadCount,
@@ -56,6 +57,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     getChatUnreadCount: adapt(getChatUnreadCount, { deps, logger }),
     deleteMessage: adapt(deleteMessage, { deps, logger }),
     getChat: adapt(getChat, { deps, logger }),
+    deleteChat: adapt(deleteChat, { deps, logger }),
   });
 
   logger.info('gRPC ChatService registered', {
@@ -70,6 +72,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'getChatUnreadCount',
       'deleteMessage',
       'getChat',
+      'deleteChat',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/gateway/src/grpc-clients/chat-client.ts
+++ b/services/gateway/src/grpc-clients/chat-client.ts
@@ -28,6 +28,8 @@ import {
   type DeleteMessageResponse,
   type GetChatRequest,
   type GetChatResponse,
+  type DeleteChatRequest,
+  type DeleteChatResponse,
 } from '@adopt-dont-shop/proto';
 
 export type ChatClient = {
@@ -44,6 +46,7 @@ export type ChatClient = {
   ): Promise<GetChatUnreadCountResponse>;
   deleteMessage(req: DeleteMessageRequest, metadata: Metadata): Promise<DeleteMessageResponse>;
   getChat(req: GetChatRequest, metadata: Metadata): Promise<GetChatResponse>;
+  deleteChat(req: DeleteChatRequest, metadata: Metadata): Promise<DeleteChatResponse>;
   close(): void;
 };
 
@@ -80,6 +83,7 @@ export const createChatClient = (opts: CreateChatClientOptions): ChatClient => {
     getChatUnreadCount: (req, metadata) => callUnary(stub.getChatUnreadCount, req, metadata),
     deleteMessage: (req, metadata) => callUnary(stub.deleteMessage, req, metadata),
     getChat: (req, metadata) => callUnary(stub.getChat, req, metadata),
+    deleteChat: (req, metadata) => callUnary(stub.deleteChat, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/chat.test.ts
+++ b/services/gateway/src/routes/chat.test.ts
@@ -46,8 +46,10 @@ function makeClient(): ChatClient & {
   getChatUnreadCountMock: ReturnType<typeof vi.fn>;
   deleteMessageMock: ReturnType<typeof vi.fn>;
   getChatMock: ReturnType<typeof vi.fn>;
+  deleteChatMock: ReturnType<typeof vi.fn>;
 } {
   const openChatMock = vi.fn();
+  const deleteChatMock = vi.fn();
   const sendMessageMock = vi.fn();
   const listMessagesMock = vi.fn();
   const listChatsMock = vi.fn();
@@ -68,6 +70,7 @@ function makeClient(): ChatClient & {
     getChatUnreadCount: getChatUnreadCountMock,
     deleteMessage: deleteMessageMock,
     getChat: getChatMock,
+    deleteChat: deleteChatMock,
     close: vi.fn(),
     openChatMock,
     sendMessageMock,
@@ -79,6 +82,7 @@ function makeClient(): ChatClient & {
     getChatUnreadCountMock,
     deleteMessageMock,
     getChatMock,
+    deleteChatMock,
   };
 }
 
@@ -763,5 +767,71 @@ describe('GET /api/v1/chats/:chatId', () => {
     expect(res.statusCode).toBe(200);
     expect(client.getChatUnreadCountMock).toHaveBeenCalledTimes(1);
     expect(client.getChatMock).not.toHaveBeenCalled();
+  });
+});
+
+// --- DELETE /api/v1/chats/:chatId -----------------------------------
+
+describe('DELETE /api/v1/chats/:chatId', () => {
+  let app: FastifyInstance;
+  let client: ReturnType<typeof makeClient>;
+
+  beforeEach(async () => {
+    client = makeClient();
+    app = await buildApp(client);
+  });
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('forwards chat id + reason and returns success envelope', async () => {
+    client.deleteChatMock.mockResolvedValueOnce({ chat: CHAT_FIXTURE });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/chats/chat-1',
+      headers: {
+        'x-user-id': 'usr-1',
+        'x-user-roles': 'adopter',
+        'content-type': 'application/json',
+      },
+      payload: { reason: 'cleanup' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { success: boolean; message: string; data: { chatId: string } };
+    expect(body.success).toBe(true);
+    expect(body.message).toBe('Chat deleted');
+    expect(body.data.chatId).toBe('chat-1');
+    const [grpcReq] = client.deleteChatMock.mock.calls[0] as [
+      { chatId: string; reason?: string },
+      Metadata,
+    ];
+    expect(grpcReq.chatId).toBe('chat-1');
+    expect(grpcReq.reason).toBe('cleanup');
+  });
+
+  it('maps NOT_FOUND → 404', async () => {
+    client.deleteChatMock.mockRejectedValueOnce({
+      code: status.NOT_FOUND,
+      details: 'gone',
+    });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/chats/missing',
+      headers: { 'x-user-id': 'usr-1' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('reachable via /api/v1/conversations alias', async () => {
+    client.deleteChatMock.mockResolvedValueOnce({ chat: CHAT_FIXTURE });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/conversations/chat-1',
+      headers: { 'x-user-id': 'usr-1' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(client.deleteChatMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -204,6 +204,29 @@ const registerChatRoutesForPrefix = (
     }
   });
 
+  // ---- DELETE <prefix>/:chatId -------------------------------------
+  // Soft-delete (archive) a chat. Participant-or-admin only.
+  app.delete<{ Params: { chatId: string }; Body?: { reason?: string } }>(
+    `${prefix}/:chatId`,
+    async (req, reply) => {
+      const metadata = buildMetadata(req);
+      const body = (req.body ?? {}) as { reason?: string };
+      try {
+        const res = await client.deleteChat(
+          { chatId: req.params.chatId, reason: body.reason },
+          metadata
+        );
+        return reply.send({
+          success: true,
+          message: 'Chat deleted',
+          data: res.chat ? ChatV1.Chat.toJSON(res.chat) : null,
+        });
+      } catch (err) {
+        return handleGrpcError(err, reply);
+      }
+    }
+  );
+
   // ---- GET <prefix>/:chatId/messages -------------------------------
   app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, async (req, reply) => {
     const metadata = buildMetadata(req);


### PR DESCRIPTION
## Summary

Adds `DeleteChat` RPC + `DELETE /api/v1/chats/:chatId` (and `/conversations` alias) — soft-deletes (archives) a whole chat.

### Chat service additions
- `ChatService.DeleteChat(chat_id, reason?)` RPC → `{ chat }`
- Handler order:
  1. INVALID_ARGUMENT on empty chat_id
  2. PERMISSION_DENIED without `chat.read`
  3. Participant-or-admin gate → NOT_FOUND for non-participants (no enumeration)
  4. Idempotent — returns the already-deleted row without re-publishing
  5. UPDATE inside `withTransaction`; publish `chat.deleted` post-commit
- Event payload includes the participant list for WS fan-out (so the gateway can drop those open sockets)
- 5 new handler tests covering invalid input, no perms, non-participant NOT_FOUND, missing chat NOT_FOUND, idempotency, full publish path

### Gateway additions
- `DELETE /api/v1/chats/:chatId` → `DeleteChat` RPC; body `{ reason?: string }`
- Response: `{ success, message: 'Chat deleted', data: Chat }`
- 3 new route tests including NOT_FOUND mapping and `/conversations` alias

## Test plan
- [x] `services/chat` — 64/64 tests pass
- [x] `services/gateway` — 369/369 tests pass
- [x] Type-check clean (proto regen + tsc)
- [x] Lint clean (both services)

## Out of scope
- `PUT /:chatId` / `PATCH /:chatId` (chat update / status change) — separate PR
- Chat participants management — separate PR
- Chat analytics — separate PR (admin)

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_