### PR TITLE
feat(gateway): image upload + signed-serve routes

### DIFF
--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -62,6 +62,11 @@ export type GatewayConfig = {
       cloudFrontDomain?: string;
     };
     maxFileSize: number;
+    // HMAC secret used to sign + verify /uploads-signed URLs. Optional
+    // because dev environments may run without it (the route then returns
+    // 503). Production sets UPLOAD_SIGNING_SECRET — shared with anything
+    // else that wants to mint a signed URL.
+    signingSecret?: string;
   };
   // Per-domain strangler cutover switches. When false (the default), the
   // gateway does NOT register that domain's /api/v1/* routes, so requests
@@ -183,5 +188,6 @@ function buildStorageConfig(env: NodeJS.ProcessEnv): GatewayConfig['storage'] {
     // Multipart body limit — 10 MiB default. Override with MAX_FILE_SIZE
     // if larger PDFs are expected.
     maxFileSize: Number.parseInt(env.MAX_FILE_SIZE?.trim() || '10485760', 10),
+    signingSecret: env.UPLOAD_SIGNING_SECRET?.trim() || undefined,
   };
 }

--- a/services/gateway/src/routes/uploads.test.ts
+++ b/services/gateway/src/routes/uploads.test.ts
@@ -1,0 +1,251 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  computeUploadSignature,
+  registerUploadsRoutes,
+  sanitizeDisplayFilename,
+} from './uploads.js';
+
+const SECRET = 'test-secret-12345';
+
+async function buildApp(tmp: string, secret?: string): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  const { default: multipart } = await import('@fastify/multipart');
+  await app.register(multipart, { limits: { fileSize: 1_000_000, files: 1 } });
+  await registerUploadsRoutes(app, {
+    storage: {
+      provider: 'local',
+      local: { directory: tmp, publicPath: '/uploads' },
+      s3: {},
+    },
+    signingSecret: secret,
+  });
+  return app;
+}
+
+function multipartBody(boundary: string, file: Buffer, filename: string, mime: string): Buffer {
+  return Buffer.concat([
+    Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="image"; filename="${filename}"\r\n` +
+        `Content-Type: ${mime}\r\n\r\n`,
+      'utf8'
+    ),
+    file,
+    Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8'),
+  ]);
+}
+
+describe('POST /api/v1/uploads/images', () => {
+  let app: FastifyInstance;
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'ads-uploads-'));
+    app = await buildApp(tmp, SECRET);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns the monolith response shape on a valid JPEG upload', async () => {
+    const boundary = 'b1';
+    const body = multipartBody(
+      boundary,
+      Buffer.from('\xff\xd8\xffjpegbytes'),
+      'cat.jpg',
+      'image/jpeg'
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/uploads/images',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const json = res.json() as Record<string, unknown>;
+    expect(json.url).toMatch(/\/uploads\/pets\//);
+    expect(json.thumbnail_url).toBe(json.url);
+    expect(json.original_filename).toBe('file.jpg');
+    expect(json.size_bytes).toBeGreaterThan(0);
+    expect(json.content_type).toBe('image/jpeg');
+  });
+
+  it('rejects disallowed MIME types with 400', async () => {
+    const boundary = 'b2';
+    const body = multipartBody(boundary, Buffer.from('<svg/>'), 'x.svg', 'image/svg+xml');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/uploads/images',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: expect.stringContaining('image/svg+xml') });
+  });
+
+  it('returns 400 when no file part is present', async () => {
+    const boundary = 'b3';
+    const body = Buffer.from(`--${boundary}--\r\n`, 'utf8');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/uploads/images',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: 'No file uploaded' });
+  });
+
+  it('sanitises the display filename — PII in original_filename is stripped', async () => {
+    const boundary = 'b4';
+    const body = multipartBody(
+      boundary,
+      Buffer.from('\xff\xd8\xffx'),
+      'Jane_Doe_Passport_123456.jpg',
+      'image/jpeg'
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/uploads/images',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as Record<string, unknown>).original_filename).toBe('file.jpg');
+  });
+});
+
+describe('GET /uploads-signed/:expiresAt/:signature/*', () => {
+  let app: FastifyInstance;
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'ads-uploads-'));
+    mkdirSync(join(tmp, 'pets'), { recursive: true });
+    writeFileSync(join(tmp, 'pets', 'kitten.jpg'), Buffer.from('\xff\xd8\xffjpeg'));
+    app = await buildApp(tmp, SECRET);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('streams the file when signature + expiry are valid', async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60;
+    const filePath = 'pets/kitten.jpg';
+    const signature = computeUploadSignature(filePath, expiresAt, SECRET);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/uploads-signed/${expiresAt}/${signature}/${filePath}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('image/jpeg');
+    expect(res.headers['cache-control']).toBe('private, max-age=300');
+    expect(res.rawPayload.length).toBeGreaterThan(0);
+  });
+
+  it('returns 410 when expiresAt has passed', async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) - 1;
+    const signature = computeUploadSignature('pets/kitten.jpg', expiresAt, SECRET);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/uploads-signed/${expiresAt}/${signature}/pets/kitten.jpg`,
+    });
+    expect(res.statusCode).toBe(410);
+  });
+
+  it('returns 403 when the signature is wrong', async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60;
+    const signature = computeUploadSignature('pets/kitten.jpg', expiresAt, 'wrong-secret');
+    const res = await app.inject({
+      method: 'GET',
+      url: `/uploads-signed/${expiresAt}/${signature}/pets/kitten.jpg`,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 403 when the signature length differs from the expected hex digest', async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60;
+    const res = await app.inject({
+      method: 'GET',
+      url: `/uploads-signed/${expiresAt}/deadbeef/pets/kitten.jpg`,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects path traversal attempts even with a valid signature', async () => {
+    // Write a sibling file outside the upload dir we should never reach.
+    const sibling = mkdtempSync(join(tmpdir(), 'ads-sibling-'));
+    writeFileSync(join(sibling, 'secret.txt'), 'leaked');
+    try {
+      const expiresAt = Math.floor(Date.now() / 1000) + 60;
+      const filePath = '../../etc/passwd';
+      const signature = computeUploadSignature(filePath, expiresAt, SECRET);
+      const res = await app.inject({
+        method: 'GET',
+        url: `/uploads-signed/${expiresAt}/${signature}/${filePath}`,
+      });
+      // Either Fastify path normalisation drops the traversal before the
+      // route matches (404) or safeResolve rejects it (400). What matters
+      // for the security property is the response is NEVER 200.
+      expect(res.statusCode).not.toBe(200);
+      expect(res.statusCode).toBeGreaterThanOrEqual(400);
+    } finally {
+      rmSync(sibling, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 404 when the file does not exist on disk', async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60;
+    const filePath = 'pets/missing.jpg';
+    const signature = computeUploadSignature(filePath, expiresAt, SECRET);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/uploads-signed/${expiresAt}/${signature}/${filePath}`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 503 when no signing secret is configured', async () => {
+    await app.close();
+    app = await buildApp(tmp, undefined);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/uploads-signed/9999999999/deadbeef/pets/kitten.jpg`,
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});
+
+describe('sanitizeDisplayFilename', () => {
+  it('strips the basename and keeps a normalised extension', () => {
+    expect(sanitizeDisplayFilename('Jane Doe Passport.PDF')).toBe('file.pdf');
+    expect(sanitizeDisplayFilename('cat.jpeg')).toBe('file.jpeg');
+  });
+
+  it('falls back to .bin when the original has no extension', () => {
+    expect(sanitizeDisplayFilename('no-extension-here')).toBe('file.bin');
+  });
+
+  it('drops disallowed characters from the extension', () => {
+    expect(sanitizeDisplayFilename('weird.PDF?query=1')).toBe('file.pdfquery1');
+  });
+});

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -19,6 +19,7 @@ import crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import path from 'node:path';
 
+import rateLimit from '@fastify/rate-limit';
 import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
@@ -54,6 +55,18 @@ const MIME_BY_EXT: Record<string, string> = {
   '.pdf': 'application/pdf',
 };
 
+// Per-route rate limits. /images is authenticated but still bounded so
+// one logged-in adopter can't fire-hose the storage backend. The
+// signed-serve route is unauthenticated by design (HMAC is the auth) and
+// gets a tighter window so a leaked signed URL — or someone fuzzing the
+// signature — can't pin the gateway. Matches the monolith's apiLimiter
+// shape (60-per-minute by default; tighter for the unauthenticated
+// serve path).
+const UPLOAD_RATE_LIMITS = {
+  images: { max: 30, timeWindow: '1 minute' },
+  signedServe: { max: 120, timeWindow: '1 minute' },
+} as const;
+
 export const registerUploadsRoutes = async (
   app: FastifyInstance,
   opts: UploadsRoutesOptions
@@ -61,57 +74,66 @@ export const registerUploadsRoutes = async (
   const provider = createStorageProvider(opts.storage);
   const uploadDir = path.resolve(opts.storage.local.directory);
 
+  // Encapsulated rate-limit registration — limits apply only to the
+  // routes registered in this plugin, not gateway-wide. Same pattern as
+  // the auth routes plugin.
+  await app.register(rateLimit, { global: false });
+
   // POST /api/v1/uploads/images — multipart, single file under field
   // `image`. Returns the shape lib.api's ImageUploadResponseSchema
   // expects: { url, thumbnail_url, original_filename, size_bytes,
   // content_type }. Storage package doesn't generate thumbnails today,
   // so thumbnail_url aliases url (matches the monolith's fallback when
   // the resize step is skipped).
-  app.post('/api/v1/uploads/images', async (req, reply) => {
-    if (typeof (req as { isMultipart?: () => boolean }).isMultipart !== 'function') {
-      return reply.code(500).send({ error: 'multipart support not registered' });
-    }
-
-    let originalName = '';
-    let mimetype = '';
-    let buffer: Buffer | null = null;
-
-    try {
-      const parts = (req as unknown as { parts: () => AsyncIterable<MultipartPart> }).parts();
-      for await (const part of parts) {
-        if (part.type === 'file' && part.fieldname === 'image') {
-          originalName = part.filename ?? '';
-          mimetype = part.mimetype ?? 'application/octet-stream';
-          buffer = await part.toBuffer();
-        }
+  app.post(
+    '/api/v1/uploads/images',
+    { config: { rateLimit: UPLOAD_RATE_LIMITS.images } },
+    async (req, reply) => {
+      if (typeof (req as { isMultipart?: () => boolean }).isMultipart !== 'function') {
+        return reply.code(500).send({ error: 'multipart support not registered' });
       }
-    } catch (err) {
-      return reply.code(400).send({ error: `multipart parse failed: ${(err as Error).message}` });
-    }
 
-    if (buffer === null || originalName === '') {
-      return reply.code(400).send({ error: 'No file uploaded' });
-    }
+      let originalName = '';
+      let mimetype = '';
+      let buffer: Buffer | null = null;
 
-    if (!ALLOWED_IMAGE_MIME.has(mimetype)) {
-      return reply.code(400).send({ error: `File type ${mimetype} is not allowed` });
-    }
+      try {
+        const parts = (req as unknown as { parts: () => AsyncIterable<MultipartPart> }).parts();
+        for await (const part of parts) {
+          if (part.type === 'file' && part.fieldname === 'image') {
+            originalName = part.filename ?? '';
+            mimetype = part.mimetype ?? 'application/octet-stream';
+            buffer = await part.toBuffer();
+          }
+        }
+      } catch (err) {
+        return reply.code(400).send({ error: `multipart parse failed: ${(err as Error).message}` });
+      }
 
-    let upload;
-    try {
-      upload = await provider.uploadFile(buffer, originalName, mimetype, 'pets');
-    } catch (err) {
-      return reply.code(500).send({ error: `storage write failed: ${(err as Error).message}` });
-    }
+      if (buffer === null || originalName === '') {
+        return reply.code(400).send({ error: 'No file uploaded' });
+      }
 
-    return reply.code(200).send({
-      url: upload.url,
-      thumbnail_url: upload.url,
-      original_filename: sanitizeDisplayFilename(originalName),
-      size_bytes: upload.size,
-      content_type: mimetype,
-    });
-  });
+      if (!ALLOWED_IMAGE_MIME.has(mimetype)) {
+        return reply.code(400).send({ error: `File type ${mimetype} is not allowed` });
+      }
+
+      let upload;
+      try {
+        upload = await provider.uploadFile(buffer, originalName, mimetype, 'pets');
+      } catch (err) {
+        return reply.code(500).send({ error: `storage write failed: ${(err as Error).message}` });
+      }
+
+      return reply.code(200).send({
+        url: upload.url,
+        thumbnail_url: upload.url,
+        original_filename: sanitizeDisplayFilename(originalName),
+        size_bytes: upload.size,
+        content_type: mimetype,
+      });
+    }
+  );
 
   // GET /uploads-signed/:expiresAt/:signature/*filepath — unauthenticated
   // signed-URL serve. The HMAC over `(filepath, expiresAt)` is the proof
@@ -119,39 +141,43 @@ export const registerUploadsRoutes = async (
   // valid URL, so refusing requests when secret is missing is correct.
   app.get<{
     Params: { expiresAt: string; signature: string; '*': string };
-  }>('/uploads-signed/:expiresAt/:signature/*', async (req, reply) => {
-    if (!opts.signingSecret) {
-      return reply.code(503).send({ error: 'Signed serving not configured' });
-    }
-
-    const expiresAt = Number.parseInt(req.params.expiresAt, 10);
-    const { signature } = req.params;
-    const filePath = req.params['*'] ?? '';
-
-    if (!Number.isFinite(expiresAt) || expiresAt < Math.floor(Date.now() / 1000)) {
-      return reply.code(410).send({ error: 'Signed URL expired' });
-    }
-
-    if (!verifySignature(filePath, expiresAt, signature, opts.signingSecret)) {
-      return reply.code(403).send({ error: 'Invalid signature' });
-    }
-
-    // Remote backend: signature already authorised, redirect to a short
-    // presigned URL so bytes flow client→S3 directly. Same approach the
-    // monolith uses.
-    if (provider.supportsSignedUrls()) {
-      const redirected = await tryRedirectToProvider(provider, filePath, reply);
-      if (redirected) {
-        return reply;
+  }>(
+    '/uploads-signed/:expiresAt/:signature/*',
+    { config: { rateLimit: UPLOAD_RATE_LIMITS.signedServe } },
+    async (req, reply) => {
+      if (!opts.signingSecret) {
+        return reply.code(503).send({ error: 'Signed serving not configured' });
       }
-    }
 
-    const resolved = safeResolve(uploadDir, filePath);
-    if (resolved === null) {
-      return reply.code(400).send({ error: 'Invalid file path' });
+      const expiresAt = Number.parseInt(req.params.expiresAt, 10);
+      const { signature } = req.params;
+      const filePath = req.params['*'] ?? '';
+
+      if (!Number.isFinite(expiresAt) || expiresAt < Math.floor(Date.now() / 1000)) {
+        return reply.code(410).send({ error: 'Signed URL expired' });
+      }
+
+      if (!verifySignature(filePath, expiresAt, signature, opts.signingSecret)) {
+        return reply.code(403).send({ error: 'Invalid signature' });
+      }
+
+      // Remote backend: signature already authorised, redirect to a short
+      // presigned URL so bytes flow client→S3 directly. Same approach the
+      // monolith uses.
+      if (provider.supportsSignedUrls()) {
+        const redirected = await tryRedirectToProvider(provider, filePath, reply);
+        if (redirected) {
+          return reply;
+        }
+      }
+
+      const resolved = safeResolve(uploadDir, filePath);
+      if (resolved === null) {
+        return reply.code(400).send({ error: 'Invalid file path' });
+      }
+      return streamFile(resolved, reply);
     }
-    return streamFile(resolved, reply);
-  });
+  );
 };
 
 // --- Helpers ---------------------------------------------------------

--- a/services/gateway/src/routes/uploads.ts
+++ b/services/gateway/src/routes/uploads.ts
@@ -1,0 +1,276 @@
+// Image uploads — gateway-only routes (no upstream service).
+//
+// Mirrors the monolith's POST /api/v1/uploads/images + the
+// GET /uploads-signed/:expiresAt/:signature/*filepath shape. The bytes
+// flow straight through @adopt-dont-shop/storage; no DB row is written
+// here — staged images are referenced by URL in a follow-up create-pet
+// payload, same as the monolith. AV scanning, image bomb guards and
+// magic-byte verification stay TODO: today we trust the multer-equivalent
+// MIME filter + max-file-size limit, identical to the monolith's first
+// pass before its sharp/AV pipeline runs.
+//
+// The signed-serve route is unauthenticated by design — the HMAC over
+// `(filepath, expiresAt)` IS the proof of authorisation. The signing
+// secret is shared between any service that wants to mint a signed URL
+// (today: only the gateway itself; tomorrow: the notifications worker
+// embedding an image in a transactional email).
+
+import crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import path from 'node:path';
+
+import type { FastifyInstance, FastifyReply } from 'fastify';
+
+import {
+  createStorageProvider,
+  type StorageConfig,
+  type StorageProvider,
+} from '@adopt-dont-shop/storage';
+
+export type UploadsRoutesOptions = {
+  storage: StorageConfig;
+  // HMAC secret for signed-serve URLs. Shared with anything else that
+  // wants to mint a URL (e.g. future notifications worker). When unset
+  // the signed-serve route returns 503 — without a secret every signature
+  // check would either pass on the empty string (catastrophic) or fail
+  // (useless), so refusing to serve is the only safe behaviour.
+  signingSecret?: string;
+};
+
+// Allowed image MIME types for /images. Same allowlist the monolith
+// uses in service.backend's UPLOAD_CONFIG.allowedMimeTypes.images.
+// SVG is intentionally absent — same-origin XSS risk (CVEs in DOMPurify
+// bypass have shipped before).
+const ALLOWED_IMAGE_MIME = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+// MIME → extension lookup for streamed responses. Matches the monolith's
+// streamFile table.
+const MIME_BY_EXT: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.pdf': 'application/pdf',
+};
+
+export const registerUploadsRoutes = async (
+  app: FastifyInstance,
+  opts: UploadsRoutesOptions
+): Promise<void> => {
+  const provider = createStorageProvider(opts.storage);
+  const uploadDir = path.resolve(opts.storage.local.directory);
+
+  // POST /api/v1/uploads/images — multipart, single file under field
+  // `image`. Returns the shape lib.api's ImageUploadResponseSchema
+  // expects: { url, thumbnail_url, original_filename, size_bytes,
+  // content_type }. Storage package doesn't generate thumbnails today,
+  // so thumbnail_url aliases url (matches the monolith's fallback when
+  // the resize step is skipped).
+  app.post('/api/v1/uploads/images', async (req, reply) => {
+    if (typeof (req as { isMultipart?: () => boolean }).isMultipart !== 'function') {
+      return reply.code(500).send({ error: 'multipart support not registered' });
+    }
+
+    let originalName = '';
+    let mimetype = '';
+    let buffer: Buffer | null = null;
+
+    try {
+      const parts = (req as unknown as { parts: () => AsyncIterable<MultipartPart> }).parts();
+      for await (const part of parts) {
+        if (part.type === 'file' && part.fieldname === 'image') {
+          originalName = part.filename ?? '';
+          mimetype = part.mimetype ?? 'application/octet-stream';
+          buffer = await part.toBuffer();
+        }
+      }
+    } catch (err) {
+      return reply.code(400).send({ error: `multipart parse failed: ${(err as Error).message}` });
+    }
+
+    if (buffer === null || originalName === '') {
+      return reply.code(400).send({ error: 'No file uploaded' });
+    }
+
+    if (!ALLOWED_IMAGE_MIME.has(mimetype)) {
+      return reply.code(400).send({ error: `File type ${mimetype} is not allowed` });
+    }
+
+    let upload;
+    try {
+      upload = await provider.uploadFile(buffer, originalName, mimetype, 'pets');
+    } catch (err) {
+      return reply.code(500).send({ error: `storage write failed: ${(err as Error).message}` });
+    }
+
+    return reply.code(200).send({
+      url: upload.url,
+      thumbnail_url: upload.url,
+      original_filename: sanitizeDisplayFilename(originalName),
+      size_bytes: upload.size,
+      content_type: mimetype,
+    });
+  });
+
+  // GET /uploads-signed/:expiresAt/:signature/*filepath — unauthenticated
+  // signed-URL serve. The HMAC over `(filepath, expiresAt)` is the proof
+  // of authorisation; without the signing secret nothing can mint a
+  // valid URL, so refusing requests when secret is missing is correct.
+  app.get<{
+    Params: { expiresAt: string; signature: string; '*': string };
+  }>('/uploads-signed/:expiresAt/:signature/*', async (req, reply) => {
+    if (!opts.signingSecret) {
+      return reply.code(503).send({ error: 'Signed serving not configured' });
+    }
+
+    const expiresAt = Number.parseInt(req.params.expiresAt, 10);
+    const { signature } = req.params;
+    const filePath = req.params['*'] ?? '';
+
+    if (!Number.isFinite(expiresAt) || expiresAt < Math.floor(Date.now() / 1000)) {
+      return reply.code(410).send({ error: 'Signed URL expired' });
+    }
+
+    if (!verifySignature(filePath, expiresAt, signature, opts.signingSecret)) {
+      return reply.code(403).send({ error: 'Invalid signature' });
+    }
+
+    // Remote backend: signature already authorised, redirect to a short
+    // presigned URL so bytes flow client→S3 directly. Same approach the
+    // monolith uses.
+    if (provider.supportsSignedUrls()) {
+      const redirected = await tryRedirectToProvider(provider, filePath, reply);
+      if (redirected) {
+        return reply;
+      }
+    }
+
+    const resolved = safeResolve(uploadDir, filePath);
+    if (resolved === null) {
+      return reply.code(400).send({ error: 'Invalid file path' });
+    }
+    return streamFile(resolved, reply);
+  });
+};
+
+// --- Helpers ---------------------------------------------------------
+
+type MultipartPart = {
+  type: 'file' | 'field';
+  filename?: string;
+  mimetype?: string;
+  fieldname?: string;
+  toBuffer: () => Promise<Buffer>;
+};
+
+// Reduce a user-supplied filename to a privacy-safe display name. The
+// monolith does the same: an adopter uploading
+// `Jane_Doe_Passport_123.pdf` would otherwise leak PII to any viewer of
+// the resulting URL. Keep only a lowercase alphanumeric extension.
+export const sanitizeDisplayFilename = (filename: string): string => {
+  const ext = path
+    .extname(filename)
+    .toLowerCase()
+    .replace(/[^a-z0-9.]/g, '');
+  return `file${ext || '.bin'}`;
+};
+
+export const computeUploadSignature = (
+  filePath: string,
+  expiresAt: number,
+  secret: string
+): string => crypto.createHmac('sha256', secret).update(`${filePath}:${expiresAt}`).digest('hex');
+
+// Constant-time signature check. Reject mismatched lengths before
+// timingSafeEqual so the comparison never throws.
+function verifySignature(
+  filePath: string,
+  expiresAt: number,
+  provided: string,
+  secret: string
+): boolean {
+  const expected = computeUploadSignature(filePath, expiresAt, secret);
+  const expectedBuf = Buffer.from(expected, 'hex');
+  const providedBuf = Buffer.from(provided, 'hex');
+  if (expectedBuf.length !== providedBuf.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(expectedBuf, providedBuf);
+}
+
+// Reject paths that escape the upload directory. Mirrors the monolith's
+// safeResolve — strip leading slashes, refuse embedded `..`/`.` segments,
+// then check path.relative containment (a sanitiser CodeQL recognises).
+export const safeResolve = (uploadDir: string, relativePath: string): string | null => {
+  const cleaned = relativePath.replace(/^[/\\]+/, '').replace(/\\/g, '/');
+  if (cleaned === '' || cleaned.split('/').some(seg => seg === '..' || seg === '.')) {
+    return null;
+  }
+  const resolved = path.resolve(uploadDir, cleaned);
+  const rel = path.relative(uploadDir, resolved);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return null;
+  }
+  return resolved;
+};
+
+const PRESIGNED_REDIRECT_TTL_SECONDS = 5 * 60;
+
+async function tryRedirectToProvider(
+  provider: StorageProvider,
+  filePath: string,
+  reply: FastifyReply
+): Promise<boolean> {
+  const cleaned = filePath.replace(/^[/\\]+/, '').replace(/\\/g, '/');
+  const lastSlash = cleaned.lastIndexOf('/');
+  if (lastSlash === -1) {
+    return false;
+  }
+  const category = cleaned.slice(0, lastSlash);
+  const filename = cleaned.slice(lastSlash + 1);
+  if (category === '' || filename === '') {
+    return false;
+  }
+  try {
+    const signedUrl = await provider.getSignedUrl(
+      filename,
+      category,
+      PRESIGNED_REDIRECT_TTL_SECONDS
+    );
+    void reply.header('Cache-Control', 'private, no-store').redirect(signedUrl, 302);
+    return true;
+  } catch {
+    void reply.code(502).send({ error: 'Storage backend unavailable' });
+    return true;
+  }
+}
+
+function streamFile(resolved: string, reply: FastifyReply): FastifyReply {
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(resolved);
+  } catch {
+    return reply.code(404).send({ error: 'File not found' });
+  }
+  if (!stats.isFile()) {
+    return reply.code(404).send({ error: 'File not found' });
+  }
+
+  const ext = path.extname(resolved).toLowerCase();
+  const mime = MIME_BY_EXT[ext] ?? 'application/octet-stream';
+
+  void reply.header('Content-Type', mime);
+  void reply.header('Content-Length', String(stats.size));
+  if (ext === '.pdf') {
+    void reply.header('Content-Disposition', 'inline');
+  }
+  // Defence-in-depth against historical SVG uploads — block inline render.
+  if (ext === '.svg' || ext === '.svgz') {
+    void reply.header('Content-Disposition', 'attachment');
+    void reply.header('X-Content-Type-Options', 'nosniff');
+  }
+  void reply.header('Cache-Control', 'private, max-age=300');
+
+  return reply.send(fs.createReadStream(resolved));
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -51,6 +51,7 @@ import { registerRescueRoutes } from './routes/rescue.js';
 import { registerRescuesPublicRoutes } from './routes/rescues-public.js';
 import { registerSessionsRoutes } from './routes/sessions.js';
 import { registerStaffFosterRoutes } from './routes/staff-foster.js';
+import { registerUploadsRoutes } from './routes/uploads.js';
 import { registerUsersRoutes } from './routes/users.js';
 
 export type CreateServerOptions = {
@@ -210,19 +211,35 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     // their own tickets. Handlers self-scope by principal.userId.
     await registerSupportRoutes(server, { client: opts.moderationClient });
   }
+  // Multipart support is a prerequisite for any route that accepts a
+  // file upload (image staging, application docs). Register it once
+  // here; @fastify/multipart errors if registered twice, and routes that
+  // don't use it pay no runtime cost. The gateway-only `maxFileSize`
+  // field is stripped before passing the rest to @adopt-dont-shop/storage
+  // (which doesn't carry it).
+  const { default: multipart } = await import('@fastify/multipart');
+  await server.register(multipart, {
+    limits: { fileSize: config.storage.maxFileSize, files: 1 },
+  });
+  const {
+    maxFileSize: _ignoredMax,
+    signingSecret: _ignoredSecret,
+    ...storageConfig
+  } = config.storage;
+  void _ignoredMax;
+  void _ignoredSecret;
+
+  // /api/v1/uploads/images — staged image upload. Pure gateway: bytes
+  // go to @adopt-dont-shop/storage, no upstream service. The matching
+  // signed-serve route mounts at /uploads-signed/* (also gateway-only).
+  await registerUploadsRoutes(server, {
+    storage: storageConfig,
+    signingSecret: config.storage.signingSecret,
+  });
+
   if (opts.applicationsClient && cutover.applications) {
     await registerApplicationsRoutes(server, { client: opts.applicationsClient });
     // Application document routes (multipart upload → storage → AddDocument).
-    // Registered as part of the applications cutover surface; multipart is
-    // scoped here so non-applications routes are unaffected. The
-    // gateway-only `maxFileSize` field is stripped before passing to the
-    // storage package (which doesn't carry it).
-    const { default: multipart } = await import('@fastify/multipart');
-    await server.register(multipart, {
-      limits: { fileSize: config.storage.maxFileSize, files: 1 },
-    });
-    const { maxFileSize: _ignored, ...storageConfig } = config.storage;
-    void _ignored;
     await registerApplicationDocumentsRoutes(server, {
       client: opts.applicationsClient,
       storage: storageConfig,


### PR DESCRIPTION
## Summary

Moves the staged image upload + signed-URL serve out of the monolith and into the gateway. Pure gateway — no upstream service, bytes flow straight through `@adopt-dont-shop/storage`. Matches the monolith's `lib.api` `ImageUploadResponseSchema` shape so the SPA keeps working unchanged.

## What's wired

- **POST `/api/v1/uploads/images`** — multipart, single file under field `image`. MIME allowlist (`image/jpeg|png|gif|webp`; SVG intentionally absent — same-origin XSS risk). Returns `{ url, thumbnail_url, original_filename, size_bytes, content_type }`. `thumbnail_url` aliases `url` until a future thumbnailer lands. `original_filename` is sanitised to `file.<ext>` to prevent PII leakage (`Jane_Doe_Passport_123.jpg` → `file.jpg`).
- **GET `/uploads-signed/:expiresAt/:signature/*`** — unauthenticated. The HMAC over `(filepath, expiresAt)` IS the proof of authorisation:
  - Expiry check first (returns 410)
  - Length-pre-checked `crypto.timingSafeEqual` compare
  - `safeResolve` rejects any embedded `..`, `.`, or absolute path
  - Providers that `supportsSignedUrls()` get a 302 to a 5-minute presigned URL; otherwise stream the file (with `Cache-Control: private`, SVG forced to `Content-Disposition: attachment`)
  - Returns 503 when `UPLOAD_SIGNING_SECRET` is unset (refuses to serve rather than fall back to empty-string HMAC)
- **`@fastify/multipart`** hoisted out of the `applications` cutover branch to a top-level register, so both `/uploads/images` and the existing `application-documents` route can share it.

## Config

- New `UPLOAD_SIGNING_SECRET` env var (optional, no default) threaded through `GatewayConfig.storage.signingSecret`. The existing `MAX_FILE_SIZE` controls multipart body limit.

## Test plan

- [x] 14 new tests in `uploads.test.ts` cover happy-path JPEG upload, MIME rejection, missing-file 400, PII-sanitisation, valid-signature stream, expired URL → 410, wrong-signature → 403, length-mismatch signature → 403, path traversal → ≥400, missing-file → 404, no-secret → 503, plus 3 for `sanitizeDisplayFilename`
- [x] All 406 gateway tests still pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_