### PR TITLE
docs(backend): fix Sequelize version, JWT expiry, and health endpoints

### DIFF
--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-PostgreSQL 16 with the PostGIS extension and Sequelize 7. Models live in `service.backend/src/models/` and are mirrored 1:1 by baseline migrations under `service.backend/src/migrations/`. This document is a high-level reference — the source of truth is always the model file.
+PostgreSQL 16 with the PostGIS extension and Sequelize 6. Models live in `service.backend/src/models/` and are mirrored 1:1 by baseline migrations under `service.backend/src/migrations/`. This document is a high-level reference — the source of truth is always the model file.
 
 ## Entity Relationships
 

--- a/docs/backend/deployment.md
+++ b/docs/backend/deployment.md
@@ -62,7 +62,7 @@ CORS_ORIGIN=https://adoptdontshop.example,https://admin.adoptdontshop.example
 ### Optional tuning
 
 ```bash
-JWT_EXPIRES_IN=1h          # default 1h
+JWT_EXPIRES_IN=15m         # default 15m
 JWT_REFRESH_EXPIRES_IN=7d  # default 7d
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100

--- a/docs/backend/troubleshooting.md
+++ b/docs/backend/troubleshooting.md
@@ -22,14 +22,14 @@ LOG_LEVEL=debug npm run dev
 ### Health Check Diagnostics
 
 ```bash
-# Basic health check
+# Basic liveness probe (status + timestamp)
 curl http://localhost:5000/health
 
-# Detailed health check with service status
-curl http://localhost:5000/health/detailed
+# Readiness probe — checks DB, Redis, and queue together
+curl http://localhost:5000/health/ready
 
-# Database health check
-curl http://localhost:5000/health/db
+# Per-service detail (admin auth required)
+curl http://localhost:5000/api/v1/health/services
 ```
 
 ## Database Issues

--- a/service.backend/README.md
+++ b/service.backend/README.md
@@ -260,7 +260,7 @@ UPLOAD_SIGNING_SECRET=...
 CORS_ORIGIN=https://yourdomain.com
 
 # Optional tuning
-JWT_EXPIRES_IN=1h            # default 1h; refresh tokens last 7 days
+JWT_EXPIRES_IN=15m           # default 15m; refresh tokens last 7 days
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
 ```


### PR DESCRIPTION
## Summary

Documentation accuracy pass over backend docs — four concrete inaccuracies fixed, each verified against the current source tree.

| File | Was | Now | Verified against |
|---|---|---|---|
| `docs/backend/database-schema.md:5` | "Sequelize 7" | "Sequelize 6" | `service.backend/package.json` → `"sequelize": "^6.37.5"` |
| `service.backend/README.md:263` | `JWT_EXPIRES_IN=1h` (claims default 1h) | `JWT_EXPIRES_IN=15m` (default 15m) | `service.backend/src/config/index.ts:53` → `process.env.JWT_EXPIRES_IN \|\| '15m'` |
| `docs/backend/deployment.md:65` | `JWT_EXPIRES_IN=1h` | `JWT_EXPIRES_IN=15m` | same |
| `docs/backend/troubleshooting.md:22-33` | `/health/detailed` and `/health/db` (neither exists) | `/health/ready` + `/api/v1/health/services` | `service.backend/src/index.ts:486-502` and `:413-440` |

`docs/backend/service-backend-prd.md` already says "JWT access tokens (15 min)" and `docs/backend/implementation-guide.md` already shows `JWT_EXPIRES_IN=15m`, so they were left alone.

## Test plan

- [x] `git diff` reviewed — only the four lines above changed
- [x] Each new value cross-referenced to the file path noted in the table

https://claude.ai/code/session_01ARBeMrMgVWCLZ7aNVtjfGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARBeMrMgVWCLZ7aNVtjfGJ)_