### PR TITLE
docs(frontend): fix ApplicationStatus casing, feature-flag claim, lib.auth exports

### DIFF
--- a/app.client/src/docs/STATSIG_FEATURE_FLAGS.md
+++ b/app.client/src/docs/STATSIG_FEATURE_FLAGS.md
@@ -39,7 +39,7 @@ function MyComponent() {
 - `advanced_search_filters` — toggles the advanced filter UI in `SearchPage`
 - `new_hero_design` — toggles the new hero variant in `HomePage`
 
-Gate identifiers ship as constants in `@adopt-dont-shop/lib.feature-flags` under `KNOWN_GATES` — see that package's README for the full list and prefer the constants over string literals.
+These two are passed as string literals to `useFeatureGate(...)`. The broader catalog of platform-wide gates ships as constants in `@adopt-dont-shop/lib.feature-flags` under `KNOWN_GATES` — prefer those constants when you're adding a gate that appears in the catalog.
 
 ### Setting up new gates in Statsig Console:
 

--- a/docs/frontend/app-rescue-prd.md
+++ b/docs/frontend/app-rescue-prd.md
@@ -30,7 +30,7 @@ The Rescue App is the operational hub for rescue organizations to manage pets, r
 
 **Backend status model (authoritative):**
 
-`ApplicationStatus = SUBMITTED | APPROVED | REJECTED | WITHDRAWN`
+`ApplicationStatus = 'submitted' | 'approved' | 'rejected' | 'withdrawn'`
 
 **Frontend stage presentation (UI-only):**
 
@@ -38,7 +38,7 @@ For richer UX, the rescue app maps backend status + side-effects (home visits, r
 
 `PENDING → REVIEWING → VISITING → DECIDING → RESOLVED`
 
-These stages are **display-only**; they do not persist as a backend column. Stage transitions in the UI translate to status changes (only the SUBMITTED → {APPROVED, REJECTED, WITHDRAWN} transitions are accepted by the backend). Final-outcome `CONDITIONAL` is not currently supported and is on roadmap (would require backend status model change).
+These stages are **display-only**; they do not persist as a backend column. Stage transitions in the UI translate to status changes (only the `submitted` → {`approved`, `rejected`, `withdrawn`} transitions are accepted by the backend). Final-outcome `conditional` is not currently supported and is on roadmap (would require backend status model change).
 
 **Core Features:**
 

--- a/lib.auth/README.md
+++ b/lib.auth/README.md
@@ -27,7 +27,10 @@ From `@adopt-dont-shop/lib.auth`:
 
 - `AuthProvider`, `AuthContext` — provider + raw context
 - `useAuth()` — hook that throws if used outside `AuthProvider`
-- `AuthLayout`, `LoginForm`, `RegisterForm`, `TwoFactorSettings` — UI components (plus `*Props` types)
+- `PermissionsProvider`, `PermissionsContext`, `usePermissions()` — permission set for the current user
+- `useHasPermission()`, `useHasAnyPermission()`, `useHasAllPermissions()` — permission-check hooks
+- `PermissionGate` — declarative component gate (plus `PermissionGateProps`)
+- `AuthLayout`, `LoginForm`, `RegisterForm`, `SocialSignInButtons`, `TwoFactorSettings` — UI components (plus `*Props` types)
 
 **Types**
 
@@ -121,9 +124,9 @@ Token storage (local):
 ```
 lib.auth/
 ├── src/
-│   ├── components/          AuthLayout, LoginForm, RegisterForm, TwoFactorSettings
-│   ├── contexts/            AuthContext + AuthProvider
-│   ├── hooks/               useAuth
+│   ├── components/          AuthLayout, LoginForm, RegisterForm, SocialSignInButtons, TwoFactorSettings, PermissionGate
+│   ├── contexts/            AuthContext + AuthProvider, PermissionsContext + PermissionsProvider
+│   ├── hooks/               useAuth, useHasPermission (+ useHasAnyPermission, useHasAllPermissions)
 │   ├── services/            AuthService + singleton
 │   ├── types/               shared types
 │   └── index.ts             public entrypoint


### PR DESCRIPTION
## Summary

Three concrete inaccuracies fixed across frontend-facing docs, each verified against the current source tree.

| File | Was | Now | Verified against |
|---|---|---|---|
| `docs/frontend/app-rescue-prd.md:33,41` | Backend `ApplicationStatus = SUBMITTED \| APPROVED \| REJECTED \| WITHDRAWN` (uppercase) | `'submitted' \| 'approved' \| 'rejected' \| 'withdrawn'` (lowercase) | `lib.types/src/types/domain-status.ts:68` (`APPLICATION_STATUSES`) |
| `app.client/src/docs/STATSIG_FEATURE_FLAGS.md:42` | Says `advanced_search_filters` and `new_hero_design` "ship as constants under `KNOWN_GATES`" | Removed — they don't. The doc now correctly notes they pass as string literals, with `KNOWN_GATES` covering the broader platform catalogue | `lib.feature-flags/src/types/index.ts:45-56` — `KNOWN_GATES` doesn't contain either name |
| `lib.auth/README.md` Exports / Project-structure sections | Listed only `AuthLayout`, `LoginForm`, `RegisterForm`, `TwoFactorSettings` | Added `PermissionGate`, `PermissionsProvider`/`Context`, `usePermissions`, `useHasPermission` (+ Any/All variants), `SocialSignInButtons` | `lib.auth/src/index.ts` |

The UI stage names in `app-rescue-prd.md` (line 39: `PENDING → REVIEWING → …`) were intentionally left uppercase — they match the local UPPERCASE type at `app.rescue/src/types/applicationStages.ts:3-8`. The only mismatches were the references to the *backend* status model.

## Test plan

- [x] `git diff` reviewed — 3 files, +10/-7 changes
- [x] Each correction cross-referenced to the source file in the table

https://claude.ai/code/session_01ARBeMrMgVWCLZ7aNVtjfGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARBeMrMgVWCLZ7aNVtjfGJ)_