### PR TITLE
fix(security): enforce per-resource access check on application activity log (ADS-770)

### DIFF
--- a/service.backend/src/__tests__/routes/application.routes.test.ts
+++ b/service.backend/src/__tests__/routes/application.routes.test.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import express, { NextFunction, Response } from 'express';
 import request from 'supertest';
 import { AuthenticatedRequest } from '../../types';
+import { errorHandler, ForbiddenError } from '../../middleware/error-handler';
 
 vi.mock('../../utils/logger', () => ({
   logger: {
@@ -45,6 +46,7 @@ vi.mock('../../services/application.service', () => ({
     validateApplicationAnswers: vi.fn(),
     updateHomeVisit: vi.fn(),
     getApplicationActivityLog: vi.fn(),
+    assertApplicationAccess: vi.fn(),
   },
   default: {
     getApplications: vi.fn(),
@@ -62,6 +64,7 @@ vi.mock('../../services/application.service', () => ({
     validateApplicationAnswers: vi.fn(),
     updateHomeVisit: vi.fn(),
     getApplicationActivityLog: vi.fn(),
+    assertApplicationAccess: vi.fn(),
   },
 }));
 
@@ -150,6 +153,7 @@ vi.mock('../../middleware/rbac', () => ({
 
 import applicationRouter from '../../routes/application.routes';
 import { ApplicationService } from '../../services/application.service';
+import { UserType } from '../../models/User';
 
 const mockAdopterUser = {
   userId: 'adopter-uuid-1',
@@ -182,6 +186,7 @@ const buildApp = () => {
   const app = express();
   app.use(express.json());
   app.use('/api/v1/applications', applicationRouter);
+  app.use(errorHandler);
   return app;
 };
 
@@ -596,6 +601,54 @@ describe('Application routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ success: true, data: activity });
+    });
+
+    it('returns 403 when a rescue staff member from a different rescue requests the activity log', async () => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockRescueStaffUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+      vi.mocked(ApplicationService.assertApplicationAccess).mockRejectedValue(
+        new ForbiddenError('Access denied')
+      );
+
+      const res = await request(buildApp()).get(`/api/v1/applications/${applicationId}/activity`);
+
+      expect(res.status).toBe(403);
+      expect(ApplicationService.getApplicationActivityLog).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when an adopter requests another adopter activity log', async () => {
+      vi.mocked(ApplicationService.assertApplicationAccess).mockRejectedValue(
+        new ForbiddenError('Access denied')
+      );
+
+      const res = await request(buildApp()).get(`/api/v1/applications/${applicationId}/activity`);
+
+      expect(res.status).toBe(403);
+      expect(ApplicationService.getApplicationActivityLog).not.toHaveBeenCalled();
+    });
+
+    it('calls assertApplicationAccess with the caller identity before fetching the log', async () => {
+      authenticateTokenMock.mockImplementation(
+        (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
+          req.user = mockRescueStaffUser as AuthenticatedRequest['user'];
+          next();
+        }
+      );
+      vi.mocked(ApplicationService.assertApplicationAccess).mockResolvedValue(undefined);
+      vi.mocked(ApplicationService.getApplicationActivityLog).mockResolvedValue([]);
+
+      await request(buildApp()).get(`/api/v1/applications/${applicationId}/activity`);
+
+      expect(ApplicationService.assertApplicationAccess).toHaveBeenCalledWith(
+        applicationId,
+        mockRescueStaffUser.userId,
+        mockRescueStaffUser.userType
+      );
+      expect(ApplicationService.getApplicationActivityLog).toHaveBeenCalled();
     });
   });
 });

--- a/service.backend/src/controllers/application.controller.ts
+++ b/service.backend/src/controllers/application.controller.ts
@@ -350,6 +350,11 @@ export class ApplicationController extends BaseController {
   // Get application activity log (paginated audit-log entries).
   getApplicationActivityLog = async (req: AuthenticatedRequest, res: Response) => {
     const { applicationId } = req.params;
+    await ApplicationService.assertApplicationAccess(
+      applicationId,
+      req.user!.userId,
+      req.user!.userType as UserType
+    );
     const { from, to, limit, offset } = req.query;
     const activity = await ApplicationService.getApplicationActivityLog(applicationId, {
       from: typeof from === 'string' ? from : undefined,


### PR DESCRIPTION
## Summary

- **Security fix for ADS-770** (Urgent): `GET /:applicationId/activity` was gated only by `APPLICATION_READ` permission but not by per-resource ownership, allowing any rescue staff member to read audit trail entries for applications belonging to other rescues/adopters.
- Added `ApplicationService.assertApplicationAccess(applicationId, userId, userType)` at the top of `getApplicationActivityLog` — the same pattern already used by every other application endpoint and by `applicationTimeline.controller.ts`.
- Added 3 new tests: cross-rescue 403, cross-adopter 403, and an assertion that the access check fires before the service call.

## Affected files

- `service.backend/src/controllers/application.controller.ts` — one `assertApplicationAccess` call added
- `service.backend/src/__tests__/routes/application.routes.test.ts` — mock updated, 3 new test cases, `errorHandler` wired into test app

## Test plan

- [x] All 26 existing + new tests pass (`vitest run application.routes.test.ts`)
- [x] Cross-rescue caller receives 403
- [x] Cross-adopter caller receives 403
- [x] Rescue staff accessing their own application's log still gets 200
- [x] No regression in unauthenticated (401) or permission-denied (403) paths

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbQXcgfXHF5qKsZgcKAGjX)_