### PR TITLE
feat(auth,notifications,gateway): admin notification broadcast

### DIFF
--- a/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
+++ b/packages/proto/proto/adopt_dont_shop/auth/v1/auth.proto
@@ -194,6 +194,19 @@ service AuthService {
   // Delete a single override, reverting that field to the lib.types default.
   rpc DeleteFieldPermission(DeleteFieldPermissionRequest)
     returns (DeleteFieldPermissionResponse);
+
+  // --- Broadcast cohort lookup ----------------------------------------
+
+  // Resolve a user cohort to a set of user_ids. The notifications
+  // service calls this from its Broadcast RPC so it can fan out a
+  // single admin notification across the targeted users without the
+  // admin having to enumerate them. admin.users.broadcast.
+  //
+  // Cohorts compose (AND): any user_type filter AND any status filter
+  // AND the verified-email filter all apply together. Pagination via
+  // page/limit; the caller iterates until total is consumed.
+  rpc ListUserIdsByCohort(ListUserIdsByCohortRequest)
+    returns (ListUserIdsByCohortResponse);
 }
 
 // --- Shared messages --------------------------------------------------
@@ -786,4 +799,28 @@ message DeleteFieldPermissionResponse {
   // True if a row was deleted; false if no override existed for that key
   // (the field already used the default).
   bool deleted = 1;
+}
+
+// --- ListUserIdsByCohort ---------------------------------------------
+
+message ListUserIdsByCohortRequest {
+  // Filter to users with these types (admin / adopter / rescue_staff /
+  // ...). Empty means any.
+  repeated UserRole user_types = 1;
+  // Filter to users with these statuses (active / suspended / ...).
+  // Empty means active-only — the broadcast safe default.
+  repeated UserStatus statuses = 2;
+  // When true, only include users whose email is verified.
+  optional bool email_verified = 3;
+  // 1-based page index.
+  uint32 page = 4;
+  // Page size; clamped server-side.
+  uint32 limit = 5;
+}
+
+message ListUserIdsByCohortResponse {
+  repeated string user_ids = 1;
+  uint32 total = 2;
+  uint32 page = 3;
+  uint32 total_pages = 4;
 }

--- a/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
+++ b/packages/proto/proto/adopt_dont_shop/notifications/v1/notification.proto
@@ -136,6 +136,16 @@ service NotificationService {
   // List active tokens for the calling principal. Self-scoped (admins
   // need device-tokens:list:any to read another user's tokens).
   rpc ListDeviceTokens(ListDeviceTokensRequest) returns (ListDeviceTokensResponse);
+
+  // --- Broadcast ----------------------------------------------------
+
+  // Fan a single in-app notification across a cohort of users. The
+  // service resolves the cohort via AuthService.ListUserIdsByCohort
+  // and creates one notification row per recipient, honouring each
+  // user's in-app preference and DND window (skipping silently if
+  // either says no). Returns aggregate counters so the admin UI can
+  // confirm the reach. admin.notifications.broadcast.
+  rpc Broadcast(BroadcastRequest) returns (BroadcastResponse);
 }
 
 // Notification mirrors the `notifications.notifications` row plus the
@@ -791,4 +801,50 @@ message PreviewEmailTemplateResponse {
   string subject = 1;
   string html_content = 2;
   optional string text_content = 3;
+}
+
+// --- Broadcast --------------------------------------------------------
+
+// Recipient cohort. Reuses the auth-side filter shape so the admin UI
+// builds a single payload that flows through Broadcast → auth.
+message BroadcastCohort {
+  // String form of auth.UserRole (admin / adopter / rescue_staff / ...).
+  // Empty means any.
+  repeated string user_types = 1;
+  // String form of auth.UserStatus. Empty means active-only (the safe
+  // broadcast default).
+  repeated string statuses = 2;
+  optional bool email_verified = 3;
+}
+
+message BroadcastRequest {
+  // The cohort that should receive the notification.
+  BroadcastCohort cohort = 1;
+  // Type tag — drives the per-user channel toggle on the prefs check
+  // (e.g. NOTIFICATION_TYPE_ANNOUNCEMENT is admin-broadcast). Defaults
+  // to NOTIFICATION_TYPE_ANNOUNCEMENT when omitted.
+  NotificationType type = 2;
+  string title = 3;
+  string message = 4;
+  // Per-notification action URL embedded into the row.
+  optional string action_url = 5;
+  // Free-form JSON-encoded blob the SPA may render alongside the
+  // message.
+  optional string data_json = 6;
+  // Defer delivery to a future timestamp (server stores; worker fires
+  // when due). Empty = send immediately.
+  optional string scheduled_for = 7;
+}
+
+message BroadcastResponse {
+  // Number of users the cohort lookup returned.
+  uint32 targeted = 1;
+  // Number actually written to the notifications table (after prefs +
+  // DND filtering).
+  uint32 delivered = 2;
+  // Suppressed by per-user channel preference or DND window.
+  uint32 suppressed = 3;
+  // Failed inserts (unexpected DB errors); the loop continues so a
+  // single bad row doesn't poison the batch.
+  uint32 failed = 4;
 }

--- a/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/auth/v1/auth.ts
@@ -868,6 +868,32 @@ export interface DeleteFieldPermissionResponse {
   deleted: boolean;
 }
 
+export interface ListUserIdsByCohortRequest {
+  /**
+   * Filter to users with these types (admin / adopter / rescue_staff /
+   * ...). Empty means any.
+   */
+  userTypes: UserRole[];
+  /**
+   * Filter to users with these statuses (active / suspended / ...).
+   * Empty means active-only — the broadcast safe default.
+   */
+  statuses: UserStatus[];
+  /** When true, only include users whose email is verified. */
+  emailVerified?: boolean | undefined;
+  /** 1-based page index. */
+  page: number;
+  /** Page size; clamped server-side. */
+  limit: number;
+}
+
+export interface ListUserIdsByCohortResponse {
+  userIds: string[];
+  total: number;
+  page: number;
+  totalPages: number;
+}
+
 function createBasePrincipal(): Principal {
   return { userId: '', roles: [], permissions: [], rescueId: undefined };
 }
@@ -8125,6 +8151,294 @@ export const DeleteFieldPermissionResponse: MessageFns<DeleteFieldPermissionResp
   },
 };
 
+function createBaseListUserIdsByCohortRequest(): ListUserIdsByCohortRequest {
+  return { userTypes: [], statuses: [], emailVerified: undefined, page: 0, limit: 0 };
+}
+
+export const ListUserIdsByCohortRequest: MessageFns<ListUserIdsByCohortRequest> = {
+  encode(
+    message: ListUserIdsByCohortRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    writer.uint32(10).fork();
+    for (const v of message.userTypes) {
+      writer.int32(v);
+    }
+    writer.join();
+    writer.uint32(18).fork();
+    for (const v of message.statuses) {
+      writer.int32(v);
+    }
+    writer.join();
+    if (message.emailVerified !== undefined) {
+      writer.uint32(24).bool(message.emailVerified);
+    }
+    if (message.page !== 0) {
+      writer.uint32(32).uint32(message.page);
+    }
+    if (message.limit !== 0) {
+      writer.uint32(40).uint32(message.limit);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ListUserIdsByCohortRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListUserIdsByCohortRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag === 8) {
+            message.userTypes.push(reader.int32() as any);
+
+            continue;
+          }
+
+          if (tag === 10) {
+            const end2 = reader.uint32() + reader.pos;
+            while (reader.pos < end2) {
+              message.userTypes.push(reader.int32() as any);
+            }
+
+            continue;
+          }
+
+          break;
+        }
+        case 2: {
+          if (tag === 16) {
+            message.statuses.push(reader.int32() as any);
+
+            continue;
+          }
+
+          if (tag === 18) {
+            const end2 = reader.uint32() + reader.pos;
+            while (reader.pos < end2) {
+              message.statuses.push(reader.int32() as any);
+            }
+
+            continue;
+          }
+
+          break;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.emailVerified = reader.bool();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.limit = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListUserIdsByCohortRequest {
+    return {
+      userTypes: globalThis.Array.isArray(object?.userTypes)
+        ? object.userTypes.map((e: any) => userRoleFromJSON(e))
+        : globalThis.Array.isArray(object?.user_types)
+          ? object.user_types.map((e: any) => userRoleFromJSON(e))
+          : [],
+      statuses: globalThis.Array.isArray(object?.statuses)
+        ? object.statuses.map((e: any) => userStatusFromJSON(e))
+        : [],
+      emailVerified: isSet(object.emailVerified)
+        ? globalThis.Boolean(object.emailVerified)
+        : isSet(object.email_verified)
+          ? globalThis.Boolean(object.email_verified)
+          : undefined,
+      page: isSet(object.page) ? globalThis.Number(object.page) : 0,
+      limit: isSet(object.limit) ? globalThis.Number(object.limit) : 0,
+    };
+  },
+
+  toJSON(message: ListUserIdsByCohortRequest): unknown {
+    const obj: any = {};
+    if (message.userTypes?.length) {
+      obj.userTypes = message.userTypes.map(e => userRoleToJSON(e));
+    }
+    if (message.statuses?.length) {
+      obj.statuses = message.statuses.map(e => userStatusToJSON(e));
+    }
+    if (message.emailVerified !== undefined) {
+      obj.emailVerified = message.emailVerified;
+    }
+    if (message.page !== 0) {
+      obj.page = Math.round(message.page);
+    }
+    if (message.limit !== 0) {
+      obj.limit = Math.round(message.limit);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListUserIdsByCohortRequest>, I>>(
+    base?: I
+  ): ListUserIdsByCohortRequest {
+    return ListUserIdsByCohortRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListUserIdsByCohortRequest>, I>>(
+    object: I
+  ): ListUserIdsByCohortRequest {
+    const message = createBaseListUserIdsByCohortRequest();
+    message.userTypes = object.userTypes?.map(e => e) || [];
+    message.statuses = object.statuses?.map(e => e) || [];
+    message.emailVerified = object.emailVerified ?? undefined;
+    message.page = object.page ?? 0;
+    message.limit = object.limit ?? 0;
+    return message;
+  },
+};
+
+function createBaseListUserIdsByCohortResponse(): ListUserIdsByCohortResponse {
+  return { userIds: [], total: 0, page: 0, totalPages: 0 };
+}
+
+export const ListUserIdsByCohortResponse: MessageFns<ListUserIdsByCohortResponse> = {
+  encode(
+    message: ListUserIdsByCohortResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    for (const v of message.userIds) {
+      writer.uint32(10).string(v!);
+    }
+    if (message.total !== 0) {
+      writer.uint32(16).uint32(message.total);
+    }
+    if (message.page !== 0) {
+      writer.uint32(24).uint32(message.page);
+    }
+    if (message.totalPages !== 0) {
+      writer.uint32(32).uint32(message.totalPages);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ListUserIdsByCohortResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListUserIdsByCohortResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userIds.push(reader.string());
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.total = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.page = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.totalPages = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListUserIdsByCohortResponse {
+    return {
+      userIds: globalThis.Array.isArray(object?.userIds)
+        ? object.userIds.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.user_ids)
+          ? object.user_ids.map((e: any) => globalThis.String(e))
+          : [],
+      total: isSet(object.total) ? globalThis.Number(object.total) : 0,
+      page: isSet(object.page) ? globalThis.Number(object.page) : 0,
+      totalPages: isSet(object.totalPages)
+        ? globalThis.Number(object.totalPages)
+        : isSet(object.total_pages)
+          ? globalThis.Number(object.total_pages)
+          : 0,
+    };
+  },
+
+  toJSON(message: ListUserIdsByCohortResponse): unknown {
+    const obj: any = {};
+    if (message.userIds?.length) {
+      obj.userIds = message.userIds;
+    }
+    if (message.total !== 0) {
+      obj.total = Math.round(message.total);
+    }
+    if (message.page !== 0) {
+      obj.page = Math.round(message.page);
+    }
+    if (message.totalPages !== 0) {
+      obj.totalPages = Math.round(message.totalPages);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListUserIdsByCohortResponse>, I>>(
+    base?: I
+  ): ListUserIdsByCohortResponse {
+    return ListUserIdsByCohortResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListUserIdsByCohortResponse>, I>>(
+    object: I
+  ): ListUserIdsByCohortResponse {
+    const message = createBaseListUserIdsByCohortResponse();
+    message.userIds = object.userIds?.map(e => e) || [];
+    message.total = object.total ?? 0;
+    message.page = object.page ?? 0;
+    message.totalPages = object.totalPages ?? 0;
+    return message;
+  },
+};
+
 /**
  * AuthService is the gRPC contract for the auth vertical. It owns the
  * `auth.*` schema (User, Role, Permission, RefreshToken, RevokedToken,
@@ -8677,6 +8991,29 @@ export const AuthServiceService = {
     responseDeserialize: (value: Buffer): DeleteFieldPermissionResponse =>
       DeleteFieldPermissionResponse.decode(value),
   },
+  /**
+   * Resolve a user cohort to a set of user_ids. The notifications
+   * service calls this from its Broadcast RPC so it can fan out a
+   * single admin notification across the targeted users without the
+   * admin having to enumerate them. admin.users.broadcast.
+   *
+   * Cohorts compose (AND): any user_type filter AND any status filter
+   * AND the verified-email filter all apply together. Pagination via
+   * page/limit; the caller iterates until total is consumed.
+   */
+  listUserIdsByCohort: {
+    path: '/adopt_dont_shop.auth.v1.AuthService/ListUserIdsByCohort' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: ListUserIdsByCohortRequest): Buffer =>
+      Buffer.from(ListUserIdsByCohortRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): ListUserIdsByCohortRequest =>
+      ListUserIdsByCohortRequest.decode(value),
+    responseSerialize: (value: ListUserIdsByCohortResponse): Buffer =>
+      Buffer.from(ListUserIdsByCohortResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): ListUserIdsByCohortResponse =>
+      ListUserIdsByCohortResponse.decode(value),
+  },
 } as const;
 
 export interface AuthServiceServer extends UntypedServiceImplementation {
@@ -8869,6 +9206,17 @@ export interface AuthServiceServer extends UntypedServiceImplementation {
     DeleteFieldPermissionRequest,
     DeleteFieldPermissionResponse
   >;
+  /**
+   * Resolve a user cohort to a set of user_ids. The notifications
+   * service calls this from its Broadcast RPC so it can fan out a
+   * single admin notification across the targeted users without the
+   * admin having to enumerate them. admin.users.broadcast.
+   *
+   * Cohorts compose (AND): any user_type filter AND any status filter
+   * AND the verified-email filter all apply together. Pagination via
+   * page/limit; the caller iterates until total is consumed.
+   */
+  listUserIdsByCohort: handleUnaryCall<ListUserIdsByCohortRequest, ListUserIdsByCohortResponse>;
 }
 
 export interface AuthServiceClient extends Client {
@@ -9510,6 +9858,31 @@ export interface AuthServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: DeleteFieldPermissionResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Resolve a user cohort to a set of user_ids. The notifications
+   * service calls this from its Broadcast RPC so it can fan out a
+   * single admin notification across the targeted users without the
+   * admin having to enumerate them. admin.users.broadcast.
+   *
+   * Cohorts compose (AND): any user_type filter AND any status filter
+   * AND the verified-email filter all apply together. Pagination via
+   * page/limit; the caller iterates until total is consumed.
+   */
+  listUserIdsByCohort(
+    request: ListUserIdsByCohortRequest,
+    callback: (error: ServiceError | null, response: ListUserIdsByCohortResponse) => void
+  ): ClientUnaryCall;
+  listUserIdsByCohort(
+    request: ListUserIdsByCohortRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: ListUserIdsByCohortResponse) => void
+  ): ClientUnaryCall;
+  listUserIdsByCohort(
+    request: ListUserIdsByCohortRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: ListUserIdsByCohortResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/notifications/v1/notification.ts
@@ -1471,6 +1471,66 @@ export interface PreviewEmailTemplateResponse {
   textContent?: string | undefined;
 }
 
+/**
+ * Recipient cohort. Reuses the auth-side filter shape so the admin UI
+ * builds a single payload that flows through Broadcast → auth.
+ */
+export interface BroadcastCohort {
+  /**
+   * String form of auth.UserRole (admin / adopter / rescue_staff / ...).
+   * Empty means any.
+   */
+  userTypes: string[];
+  /**
+   * String form of auth.UserStatus. Empty means active-only (the safe
+   * broadcast default).
+   */
+  statuses: string[];
+  emailVerified?: boolean | undefined;
+}
+
+export interface BroadcastRequest {
+  /** The cohort that should receive the notification. */
+  cohort?: BroadcastCohort | undefined;
+  /**
+   * Type tag — drives the per-user channel toggle on the prefs check
+   * (e.g. NOTIFICATION_TYPE_ANNOUNCEMENT is admin-broadcast). Defaults
+   * to NOTIFICATION_TYPE_ANNOUNCEMENT when omitted.
+   */
+  type: NotificationType;
+  title: string;
+  message: string;
+  /** Per-notification action URL embedded into the row. */
+  actionUrl?: string | undefined;
+  /**
+   * Free-form JSON-encoded blob the SPA may render alongside the
+   * message.
+   */
+  dataJson?: string | undefined;
+  /**
+   * Defer delivery to a future timestamp (server stores; worker fires
+   * when due). Empty = send immediately.
+   */
+  scheduledFor?: string | undefined;
+}
+
+export interface BroadcastResponse {
+  /** Number of users the cohort lookup returned. */
+  targeted: number;
+  /**
+   * Number actually written to the notifications table (after prefs +
+   * DND filtering).
+   */
+  delivered: number;
+  /** Suppressed by per-user channel preference or DND window. */
+  suppressed: number;
+  /**
+   * Failed inserts (unexpected DB errors); the loop continues so a
+   * single bad row doesn't poison the batch.
+   */
+  failed: number;
+}
+
 function createBaseNotification(): Notification {
   return {
     notificationId: '',
@@ -8399,6 +8459,395 @@ export const PreviewEmailTemplateResponse: MessageFns<PreviewEmailTemplateRespon
   },
 };
 
+function createBaseBroadcastCohort(): BroadcastCohort {
+  return { userTypes: [], statuses: [], emailVerified: undefined };
+}
+
+export const BroadcastCohort: MessageFns<BroadcastCohort> = {
+  encode(message: BroadcastCohort, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.userTypes) {
+      writer.uint32(10).string(v!);
+    }
+    for (const v of message.statuses) {
+      writer.uint32(18).string(v!);
+    }
+    if (message.emailVerified !== undefined) {
+      writer.uint32(24).bool(message.emailVerified);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): BroadcastCohort {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBroadcastCohort();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.userTypes.push(reader.string());
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.statuses.push(reader.string());
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.emailVerified = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BroadcastCohort {
+    return {
+      userTypes: globalThis.Array.isArray(object?.userTypes)
+        ? object.userTypes.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.user_types)
+          ? object.user_types.map((e: any) => globalThis.String(e))
+          : [],
+      statuses: globalThis.Array.isArray(object?.statuses)
+        ? object.statuses.map((e: any) => globalThis.String(e))
+        : [],
+      emailVerified: isSet(object.emailVerified)
+        ? globalThis.Boolean(object.emailVerified)
+        : isSet(object.email_verified)
+          ? globalThis.Boolean(object.email_verified)
+          : undefined,
+    };
+  },
+
+  toJSON(message: BroadcastCohort): unknown {
+    const obj: any = {};
+    if (message.userTypes?.length) {
+      obj.userTypes = message.userTypes;
+    }
+    if (message.statuses?.length) {
+      obj.statuses = message.statuses;
+    }
+    if (message.emailVerified !== undefined) {
+      obj.emailVerified = message.emailVerified;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BroadcastCohort>, I>>(base?: I): BroadcastCohort {
+    return BroadcastCohort.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<BroadcastCohort>, I>>(object: I): BroadcastCohort {
+    const message = createBaseBroadcastCohort();
+    message.userTypes = object.userTypes?.map(e => e) || [];
+    message.statuses = object.statuses?.map(e => e) || [];
+    message.emailVerified = object.emailVerified ?? undefined;
+    return message;
+  },
+};
+
+function createBaseBroadcastRequest(): BroadcastRequest {
+  return {
+    cohort: undefined,
+    type: 0,
+    title: '',
+    message: '',
+    actionUrl: undefined,
+    dataJson: undefined,
+    scheduledFor: undefined,
+  };
+}
+
+export const BroadcastRequest: MessageFns<BroadcastRequest> = {
+  encode(message: BroadcastRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.cohort !== undefined) {
+      BroadcastCohort.encode(message.cohort, writer.uint32(10).fork()).join();
+    }
+    if (message.type !== 0) {
+      writer.uint32(16).int32(message.type);
+    }
+    if (message.title !== '') {
+      writer.uint32(26).string(message.title);
+    }
+    if (message.message !== '') {
+      writer.uint32(34).string(message.message);
+    }
+    if (message.actionUrl !== undefined) {
+      writer.uint32(42).string(message.actionUrl);
+    }
+    if (message.dataJson !== undefined) {
+      writer.uint32(50).string(message.dataJson);
+    }
+    if (message.scheduledFor !== undefined) {
+      writer.uint32(58).string(message.scheduledFor);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): BroadcastRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBroadcastRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.cohort = BroadcastCohort.decode(reader, reader.uint32());
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.type = reader.int32() as any;
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.title = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.message = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.actionUrl = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.dataJson = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.scheduledFor = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BroadcastRequest {
+    return {
+      cohort: isSet(object.cohort) ? BroadcastCohort.fromJSON(object.cohort) : undefined,
+      type: isSet(object.type) ? notificationTypeFromJSON(object.type) : 0,
+      title: isSet(object.title) ? globalThis.String(object.title) : '',
+      message: isSet(object.message) ? globalThis.String(object.message) : '',
+      actionUrl: isSet(object.actionUrl)
+        ? globalThis.String(object.actionUrl)
+        : isSet(object.action_url)
+          ? globalThis.String(object.action_url)
+          : undefined,
+      dataJson: isSet(object.dataJson)
+        ? globalThis.String(object.dataJson)
+        : isSet(object.data_json)
+          ? globalThis.String(object.data_json)
+          : undefined,
+      scheduledFor: isSet(object.scheduledFor)
+        ? globalThis.String(object.scheduledFor)
+        : isSet(object.scheduled_for)
+          ? globalThis.String(object.scheduled_for)
+          : undefined,
+    };
+  },
+
+  toJSON(message: BroadcastRequest): unknown {
+    const obj: any = {};
+    if (message.cohort !== undefined) {
+      obj.cohort = BroadcastCohort.toJSON(message.cohort);
+    }
+    if (message.type !== 0) {
+      obj.type = notificationTypeToJSON(message.type);
+    }
+    if (message.title !== '') {
+      obj.title = message.title;
+    }
+    if (message.message !== '') {
+      obj.message = message.message;
+    }
+    if (message.actionUrl !== undefined) {
+      obj.actionUrl = message.actionUrl;
+    }
+    if (message.dataJson !== undefined) {
+      obj.dataJson = message.dataJson;
+    }
+    if (message.scheduledFor !== undefined) {
+      obj.scheduledFor = message.scheduledFor;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BroadcastRequest>, I>>(base?: I): BroadcastRequest {
+    return BroadcastRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<BroadcastRequest>, I>>(object: I): BroadcastRequest {
+    const message = createBaseBroadcastRequest();
+    message.cohort =
+      object.cohort !== undefined && object.cohort !== null
+        ? BroadcastCohort.fromPartial(object.cohort)
+        : undefined;
+    message.type = object.type ?? 0;
+    message.title = object.title ?? '';
+    message.message = object.message ?? '';
+    message.actionUrl = object.actionUrl ?? undefined;
+    message.dataJson = object.dataJson ?? undefined;
+    message.scheduledFor = object.scheduledFor ?? undefined;
+    return message;
+  },
+};
+
+function createBaseBroadcastResponse(): BroadcastResponse {
+  return { targeted: 0, delivered: 0, suppressed: 0, failed: 0 };
+}
+
+export const BroadcastResponse: MessageFns<BroadcastResponse> = {
+  encode(message: BroadcastResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.targeted !== 0) {
+      writer.uint32(8).uint32(message.targeted);
+    }
+    if (message.delivered !== 0) {
+      writer.uint32(16).uint32(message.delivered);
+    }
+    if (message.suppressed !== 0) {
+      writer.uint32(24).uint32(message.suppressed);
+    }
+    if (message.failed !== 0) {
+      writer.uint32(32).uint32(message.failed);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): BroadcastResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBroadcastResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.targeted = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.delivered = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.suppressed = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.failed = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BroadcastResponse {
+    return {
+      targeted: isSet(object.targeted) ? globalThis.Number(object.targeted) : 0,
+      delivered: isSet(object.delivered) ? globalThis.Number(object.delivered) : 0,
+      suppressed: isSet(object.suppressed) ? globalThis.Number(object.suppressed) : 0,
+      failed: isSet(object.failed) ? globalThis.Number(object.failed) : 0,
+    };
+  },
+
+  toJSON(message: BroadcastResponse): unknown {
+    const obj: any = {};
+    if (message.targeted !== 0) {
+      obj.targeted = Math.round(message.targeted);
+    }
+    if (message.delivered !== 0) {
+      obj.delivered = Math.round(message.delivered);
+    }
+    if (message.suppressed !== 0) {
+      obj.suppressed = Math.round(message.suppressed);
+    }
+    if (message.failed !== 0) {
+      obj.failed = Math.round(message.failed);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BroadcastResponse>, I>>(base?: I): BroadcastResponse {
+    return BroadcastResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<BroadcastResponse>, I>>(object: I): BroadcastResponse {
+    const message = createBaseBroadcastResponse();
+    message.targeted = object.targeted ?? 0;
+    message.delivered = object.delivered ?? 0;
+    message.suppressed = object.suppressed ?? 0;
+    message.failed = object.failed ?? 0;
+    return message;
+  },
+};
+
 /**
  * NotificationService is the gRPC contract for the in-app notification
  * store. The gateway translates `POST/GET/DELETE /api/notifications/*`
@@ -8790,6 +9239,25 @@ export const NotificationServiceService = {
     responseDeserialize: (value: Buffer): ListDeviceTokensResponse =>
       ListDeviceTokensResponse.decode(value),
   },
+  /**
+   * Fan a single in-app notification across a cohort of users. The
+   * service resolves the cohort via AuthService.ListUserIdsByCohort
+   * and creates one notification row per recipient, honouring each
+   * user's in-app preference and DND window (skipping silently if
+   * either says no). Returns aggregate counters so the admin UI can
+   * confirm the reach. admin.notifications.broadcast.
+   */
+  broadcast: {
+    path: '/adopt_dont_shop.notifications.v1.NotificationService/Broadcast' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: BroadcastRequest): Buffer =>
+      Buffer.from(BroadcastRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): BroadcastRequest => BroadcastRequest.decode(value),
+    responseSerialize: (value: BroadcastResponse): Buffer =>
+      Buffer.from(BroadcastResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): BroadcastResponse => BroadcastResponse.decode(value),
+  },
 } as const;
 
 export interface NotificationServiceServer extends UntypedServiceImplementation {
@@ -8915,6 +9383,15 @@ export interface NotificationServiceServer extends UntypedServiceImplementation 
    * need device-tokens:list:any to read another user's tokens).
    */
   listDeviceTokens: handleUnaryCall<ListDeviceTokensRequest, ListDeviceTokensResponse>;
+  /**
+   * Fan a single in-app notification across a cohort of users. The
+   * service resolves the cohort via AuthService.ListUserIdsByCohort
+   * and creates one notification row per recipient, honouring each
+   * user's in-app preference and DND window (skipping silently if
+   * either says no). Returns aggregate counters so the admin UI can
+   * confirm the reach. admin.notifications.broadcast.
+   */
+  broadcast: handleUnaryCall<BroadcastRequest, BroadcastResponse>;
 }
 
 export interface NotificationServiceClient extends Client {
@@ -9343,6 +9820,29 @@ export interface NotificationServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: ListDeviceTokensResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * Fan a single in-app notification across a cohort of users. The
+   * service resolves the cohort via AuthService.ListUserIdsByCohort
+   * and creates one notification row per recipient, honouring each
+   * user's in-app preference and DND window (skipping silently if
+   * either says no). Returns aggregate counters so the admin UI can
+   * confirm the reach. admin.notifications.broadcast.
+   */
+  broadcast(
+    request: BroadcastRequest,
+    callback: (error: ServiceError | null, response: BroadcastResponse) => void
+  ): ClientUnaryCall;
+  broadcast(
+    request: BroadcastRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: BroadcastResponse) => void
+  ): ClientUnaryCall;
+  broadcast(
+    request: BroadcastRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: BroadcastResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -82,6 +82,9 @@ export type {
   DeleteEmailTemplateResponse,
   PreviewEmailTemplateRequest,
   PreviewEmailTemplateResponse,
+  BroadcastCohort,
+  BroadcastRequest,
+  BroadcastResponse,
   NotificationServiceServer,
   NotificationServiceClient,
 } from './generated/proto/adopt_dont_shop/notifications/v1/notification.js';
@@ -161,6 +164,8 @@ export type {
   BulkUpsertFieldPermissionsResponse,
   DeleteFieldPermissionRequest,
   DeleteFieldPermissionResponse,
+  ListUserIdsByCohortRequest,
+  ListUserIdsByCohortResponse,
   AuthServiceServer,
   AuthServiceClient,
 } from './generated/proto/adopt_dont_shop/auth/v1/auth.js';

--- a/services/auth/src/grpc/admin-handlers.test.ts
+++ b/services/auth/src/grpc/admin-handlers.test.ts
@@ -13,6 +13,7 @@ import {
   deactivateUser,
   getUserPermissions,
   getUserStatistics,
+  listUserIdsByCohort,
   reactivateUser,
   searchUsers,
 } from './admin-handlers.js';
@@ -438,5 +439,120 @@ describe('bulkUpdateUsers', () => {
     expect(res.results.find(r => r.userId === 'usr-1')?.success).toBe(true);
     expect(res.results.find(r => r.userId === 'usr-missing')?.success).toBe(false);
     expect(mocks.natsMock.publish).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- listUserIdsByCohort --------------------------------------------
+
+const BROADCASTER: Principal = {
+  userId: 'svc-bcast' as UserId,
+  roles: ['admin'],
+  permissions: ['admin.users.broadcast' as Permission],
+};
+
+describe('listUserIdsByCohort', () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  beforeEach(() => {
+    mocks = makeMocks();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('rejects callers without admin.users.broadcast', async () => {
+    await expect(
+      listUserIdsByCohort(mocks.deps, NO_PERMS, {
+        userTypes: [],
+        statuses: [],
+        page: 1,
+        limit: 100,
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('defaults to status=active when no statuses are supplied', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ total: '2' }] })
+      .mockResolvedValueOnce({ rows: [{ user_id: 'u-1' }, { user_id: 'u-2' }] });
+
+    const res = await listUserIdsByCohort(mocks.deps, BROADCASTER, {
+      userTypes: [],
+      statuses: [],
+      page: 1,
+      limit: 50,
+    });
+
+    expect(res.total).toBe(2);
+    expect(res.userIds).toEqual(['u-1', 'u-2']);
+    const [countSql] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(countSql).toContain("status = 'active'");
+  });
+
+  it('filters by user_types IN list', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await listUserIdsByCohort(mocks.deps, BROADCASTER, {
+      userTypes: [AuthV1.UserRole.USER_ROLE_ADOPTER, AuthV1.UserRole.USER_ROLE_RESCUE_STAFF],
+      statuses: [],
+      page: 1,
+      limit: 50,
+    });
+
+    const [countSql, countParams] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(countSql).toContain('user_type IN');
+    expect(countParams).toContain('adopter');
+    expect(countParams).toContain('rescue_staff');
+  });
+
+  it('filters by statuses IN list (overrides the active default)', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await listUserIdsByCohort(mocks.deps, BROADCASTER, {
+      userTypes: [],
+      statuses: [AuthV1.UserStatus.USER_STATUS_SUSPENDED],
+      page: 1,
+      limit: 50,
+    });
+
+    const [countSql, countParams] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(countSql).toContain('status IN');
+    expect(countSql).not.toContain("status = 'active'");
+    expect(countParams).toContain('suspended');
+  });
+
+  it('applies email_verified filter when set', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ total: '0' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await listUserIdsByCohort(mocks.deps, BROADCASTER, {
+      userTypes: [],
+      statuses: [],
+      emailVerified: true,
+      page: 1,
+      limit: 50,
+    });
+
+    const [countSql] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
+    expect(countSql).toContain('email_verified');
+  });
+
+  it('paginates: total + page + totalPages reflect the count', async () => {
+    mocks.poolMock.query
+      .mockResolvedValueOnce({ rows: [{ total: '237' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await listUserIdsByCohort(mocks.deps, BROADCASTER, {
+      userTypes: [],
+      statuses: [],
+      page: 3,
+      limit: 50,
+    });
+
+    expect(res.total).toBe(237);
+    expect(res.page).toBe(3);
+    expect(res.totalPages).toBe(5);
   });
 });

--- a/services/auth/src/grpc/admin-handlers.ts
+++ b/services/auth/src/grpc/admin-handlers.ts
@@ -26,6 +26,8 @@ import {
   type GetUserStatisticsResponse,
   type ReactivateUserRequest,
   type ReactivateUserResponse,
+  type ListUserIdsByCohortRequest,
+  type ListUserIdsByCohortResponse,
   type SearchUsersRequest,
   type SearchUsersResponse,
 } from '@adopt-dont-shop/proto';
@@ -499,5 +501,77 @@ export async function bulkUpdateUsers(
     successCount: results.length - failedCount,
     failedCount,
     results,
+  };
+}
+
+// --- ListUserIdsByCohort ---------------------------------------------
+
+const ADMIN_USERS_BROADCAST: Permission = 'admin.users.broadcast' as Permission;
+
+export async function listUserIdsByCohort(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: ListUserIdsByCohortRequest
+): Promise<ListUserIdsByCohortResponse> {
+  if (!hasPermission(principal, ADMIN_USERS_BROADCAST)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_USERS_BROADCAST}' required`);
+  }
+
+  const limit = clampLimit(req.limit);
+  const page = Math.max(req.page || 1, 1);
+  const offset = (page - 1) * limit;
+
+  const where: string[] = ['deleted_at IS NULL'];
+  const params: unknown[] = [];
+
+  // user_types filter — empty list means any.
+  const types = (req.userTypes ?? []).filter(t => t !== AuthV1.UserRole.USER_ROLE_UNSPECIFIED);
+  if (types.length > 0) {
+    const placeholders = types.map((_, i) => `$${params.length + 1 + i}`).join(', ');
+    where.push(`user_type IN (${placeholders})`);
+    for (const t of types) {
+      params.push(roleToDb(t));
+    }
+  }
+
+  // statuses filter — empty list means active-only (safe default).
+  const statuses = (req.statuses ?? []).filter(
+    s => s !== AuthV1.UserStatus.USER_STATUS_UNSPECIFIED
+  );
+  if (statuses.length > 0) {
+    const placeholders = statuses.map((_, i) => `$${params.length + 1 + i}`).join(', ');
+    where.push(`status IN (${placeholders})`);
+    for (const s of statuses) {
+      params.push(statusToDb(s));
+    }
+  } else {
+    where.push(`status = 'active'`);
+  }
+
+  if (req.emailVerified !== undefined) {
+    where.push(`email_verified = $${params.length + 1}`);
+    params.push(req.emailVerified);
+  }
+
+  const whereSql = `WHERE ${where.join(' AND ')}`;
+  const countRes = await deps.pool.query<{ total: string }>(
+    `SELECT COUNT(*)::text AS total FROM auth.users ${whereSql}`,
+    params
+  );
+  const total = Number.parseInt(countRes.rows[0]?.total ?? '0', 10);
+
+  const result = await deps.pool.query<{ user_id: string }>(
+    `SELECT user_id FROM auth.users ${whereSql}
+       ORDER BY created_at ASC
+       LIMIT $${params.length + 1}
+       OFFSET $${params.length + 2}`,
+    [...params, limit, offset]
+  );
+
+  return {
+    userIds: result.rows.map(r => r.user_id),
+    total,
+    page,
+    totalPages: limit > 0 ? Math.ceil(total / limit) : 0,
   };
 }

--- a/services/auth/src/grpc/server.ts
+++ b/services/auth/src/grpc/server.ts
@@ -44,6 +44,7 @@ import {
   deactivateUser,
   getUserPermissions,
   getUserStatistics,
+  listUserIdsByCohort,
   reactivateUser,
   searchUsers,
 } from './admin-handlers.js';
@@ -118,6 +119,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     getUserStatistics: adapt(getUserStatistics, { deps, logger }),
     getUserPermissions: adapt(getUserPermissions, { deps, logger }),
     bulkUpdateUsers: adapt(bulkUpdateUsers, { deps, logger }),
+    listUserIdsByCohort: adapt(listUserIdsByCohort, { deps, logger }),
     // Field-level permissions admin — /api/v1/field-permissions/*.
     getFieldPermissionDefaults: adapt(getFieldPermissionDefaults, { deps, logger }),
     getFieldPermissionDefaultsForRole: adapt(getFieldPermissionDefaultsForRole, { deps, logger }),
@@ -159,6 +161,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'getUserStatistics',
       'getUserPermissions',
       'bulkUpdateUsers',
+      'listUserIdsByCohort',
       'getFieldPermissionDefaults',
       'getFieldPermissionDefaultsForRole',
       'listFieldPermissionOverrides',

--- a/services/gateway/src/grpc-clients/notifications-client.ts
+++ b/services/gateway/src/grpc-clients/notifications-client.ts
@@ -125,6 +125,10 @@ export type NotificationsClient = {
     req: PreviewEmailTemplateRequest,
     metadata: Metadata
   ): Promise<PreviewEmailTemplateResponse>;
+  broadcast(
+    req: import('@adopt-dont-shop/proto').BroadcastRequest,
+    metadata: Metadata
+  ): Promise<import('@adopt-dont-shop/proto').BroadcastResponse>;
   close(): void;
 };
 
@@ -184,6 +188,7 @@ export const createNotificationsClient = (
     updateEmailTemplate: (req, metadata) => callUnary(stub.updateEmailTemplate, req, metadata),
     deleteEmailTemplate: (req, metadata) => callUnary(stub.deleteEmailTemplate, req, metadata),
     previewEmailTemplate: (req, metadata) => callUnary(stub.previewEmailTemplate, req, metadata),
+    broadcast: (req, metadata) => callUnary(stub.broadcast, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/routes/broadcast.test.ts
+++ b/services/gateway/src/routes/broadcast.test.ts
@@ -1,0 +1,130 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+
+import { registerBroadcastRoutes } from './broadcast.js';
+
+function makeClient(): { client: NotificationsClient; broadcast: ReturnType<typeof vi.fn> } {
+  const broadcastFn = vi.fn();
+  const client = { broadcast: broadcastFn } as unknown as NotificationsClient;
+  return { client, broadcast: broadcastFn };
+}
+
+const ADMIN_HEADERS = {
+  'x-user-id': 'usr-admin',
+  'x-user-roles': 'admin',
+  'x-user-permissions': 'admin.notifications.broadcast',
+};
+
+describe('POST /api/v1/notifications/broadcast', () => {
+  let app: FastifyInstance;
+  let broadcast: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    const { client, broadcast: b } = makeClient();
+    broadcast = b;
+    await registerBroadcastRoutes(app, { client });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns the aggregate counter envelope', async () => {
+    broadcast.mockResolvedValue({ targeted: 10, delivered: 8, suppressed: 1, failed: 1 });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: {
+        cohort: { userTypes: ['adopter'] },
+        title: 'Hello',
+        message: 'Heads up',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      success: true,
+      targeted: 10,
+      delivered: 8,
+      suppressed: 1,
+      failed: 1,
+    });
+  });
+
+  it('accepts snake_case body keys too', async () => {
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: {
+        cohort: { user_types: ['adopter'], email_verified: true },
+        title: 'T',
+        message: 'M',
+        action_url: '/announcements/1',
+        scheduled_for: '2030-01-01T00:00:00Z',
+      },
+    });
+    const [grpcReq] = broadcast.mock.calls[0];
+    expect(grpcReq.cohort.userTypes).toEqual(['adopter']);
+    expect(grpcReq.cohort.emailVerified).toBe(true);
+    expect(grpcReq.actionUrl).toBe('/announcements/1');
+    expect(grpcReq.scheduledFor).toBe('2030-01-01T00:00:00Z');
+  });
+
+  it('encodes a `data` object body into dataJson', async () => {
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: {
+        cohort: {},
+        title: 'T',
+        message: 'M',
+        data: { severity: 'high' },
+      },
+    });
+    const [grpcReq] = broadcast.mock.calls[0];
+    expect(grpcReq.dataJson).toBe('{"severity":"high"}');
+  });
+
+  it('maps gRPC INVALID_ARGUMENT → 400', async () => {
+    broadcast.mockRejectedValue({ code: grpcStatus.INVALID_ARGUMENT, details: 'bad' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: { cohort: {}, title: '', message: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('maps gRPC PERMISSION_DENIED → 403', async () => {
+    broadcast.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'nope' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: { cohort: {}, title: 't', message: 'm' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('forwards principal headers to the gRPC client', async () => {
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: { cohort: {}, title: 't', message: 'm' },
+    });
+    const [, metadata] = broadcast.mock.calls[0];
+    expect(metadata.get('x-user-id')).toEqual(['usr-admin']);
+    expect(metadata.get('x-user-permissions')).toEqual(['admin.notifications.broadcast']);
+  });
+});

--- a/services/gateway/src/routes/broadcast.ts
+++ b/services/gateway/src/routes/broadcast.ts
@@ -1,0 +1,110 @@
+// POST /api/v1/notifications/broadcast — admin fan-out across a cohort.
+//
+// Thin REST → gRPC translation: parse the JSON body into BroadcastRequest,
+// forward principal metadata, return the aggregate counters.
+
+import { Metadata, status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import type { BroadcastRequest } from '@adopt-dont-shop/proto';
+
+import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+
+export type BroadcastRoutesOptions = {
+  client: NotificationsClient;
+};
+
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.INTERNAL]: 500,
+};
+
+export const registerBroadcastRoutes = async (
+  app: FastifyInstance,
+  opts: BroadcastRoutesOptions
+): Promise<void> => {
+  const { client } = opts;
+
+  app.post('/api/v1/notifications/broadcast', async (req, reply) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const cohort = (body.cohort ?? {}) as Record<string, unknown>;
+
+    const grpcReq: BroadcastRequest = {
+      cohort: {
+        userTypes: Array.isArray(cohort.userTypes)
+          ? (cohort.userTypes as string[])
+          : Array.isArray(cohort.user_types)
+            ? (cohort.user_types as string[])
+            : [],
+        statuses: Array.isArray(cohort.statuses) ? (cohort.statuses as string[]) : [],
+        emailVerified:
+          typeof cohort.emailVerified === 'boolean'
+            ? cohort.emailVerified
+            : typeof cohort.email_verified === 'boolean'
+              ? cohort.email_verified
+              : undefined,
+      },
+      type: 0,
+      title: typeof body.title === 'string' ? body.title : '',
+      message: typeof body.message === 'string' ? body.message : '',
+      actionUrl:
+        typeof body.actionUrl === 'string'
+          ? body.actionUrl
+          : typeof body.action_url === 'string'
+            ? body.action_url
+            : undefined,
+      dataJson:
+        typeof body.data === 'object' && body.data !== null
+          ? JSON.stringify(body.data)
+          : typeof body.dataJson === 'string'
+            ? body.dataJson
+            : undefined,
+      scheduledFor:
+        typeof body.scheduledFor === 'string'
+          ? body.scheduledFor
+          : typeof body.scheduled_for === 'string'
+            ? body.scheduled_for
+            : undefined,
+    };
+
+    try {
+      const res = await client.broadcast(grpcReq, buildMetadata(req));
+      return reply.send({
+        success: true,
+        targeted: res.targeted,
+        delivered: res.delivered,
+        suppressed: res.suppressed,
+        failed: res.failed,
+      });
+    } catch (err) {
+      return handleGrpcError(err, reply);
+    }
+  });
+};
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    success: false,
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -41,6 +41,7 @@ import { registerCmsRoutes } from './routes/cms.js';
 import { registerConfigRoutes } from './routes/config.js';
 import { registerDashboardRoutes } from './routes/dashboard.js';
 import { registerDevicesRoutes } from './routes/devices.js';
+import { registerBroadcastRoutes } from './routes/broadcast.js';
 import { registerEmailRoutes } from './routes/email.js';
 import { registerFieldPermissionsRoutes } from './routes/field-permissions.js';
 import { registerLegalRoutes } from './routes/legal.js';
@@ -183,6 +184,10 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     // /api/v1/email/templates/* — admin email-template CRUD. The
     // email_templates table is owned by service.notifications.
     await registerEmailRoutes(server, { client: opts.notificationsClient });
+    // /api/v1/notifications/broadcast — admin fan-out. Sits under the
+    // notifications cutover gate (the upstream call lives in service.
+    // notifications, which in turn calls service.auth for the cohort).
+    await registerBroadcastRoutes(server, { client: opts.notificationsClient });
   }
   // /api/v1/users/* — profile + composed preferences. Requires BOTH
   // auth (profile + privacy prefs) and notifications (in-app channel

--- a/services/notifications/src/config.ts
+++ b/services/notifications/src/config.ts
@@ -17,6 +17,11 @@ export type NotificationsConfig = {
   // Fastify HTTP server; the gateway dials this address when proxying
   // /api/notifications/* to the extracted service (Phase 1.6).
   grpcPort: number;
+  // service.auth gRPC URL — needed by the Broadcast RPC which calls
+  // AuthService.ListUserIdsByCohort to expand the cohort filter into
+  // concrete user_ids. Optional in tests / migrations smokes; Broadcast
+  // returns INTERNAL when unset.
+  authGrpcUrl?: string;
   // Environment label, surfaced in health responses and on log lines.
   environment: string;
   // Postgres connection string. Required for migrations + the runtime
@@ -72,6 +77,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): NotificationsC
   return {
     port,
     grpcPort,
+    authGrpcUrl: env.AUTH_GRPC_URL?.trim() || undefined,
     host: env.NOTIFICATIONS_HOST?.trim() || DEFAULT_HOST,
     environment: env.NODE_ENV?.trim() || 'development',
     databaseUrl,

--- a/services/notifications/src/grpc/auth-client.ts
+++ b/services/notifications/src/grpc/auth-client.ts
@@ -1,0 +1,51 @@
+// Promise-wrapped client for service.auth — just the cohort RPC the
+// broadcast handler needs. Defining it locally (rather than depending on
+// the gateway's full AuthClient interface) keeps the notifications
+// service decoupled from the gateway and means a slimmer dial table.
+
+import { credentials, Metadata } from '@grpc/grpc-js';
+
+import {
+  AuthV1,
+  type ListUserIdsByCohortRequest,
+  type ListUserIdsByCohortResponse,
+} from '@adopt-dont-shop/proto';
+
+import type { AuthCohortClient } from './handlers.js';
+
+export type CreateAuthCohortClientOptions = {
+  address: string;
+  // System principal metadata — needed because ListUserIdsByCohort gates
+  // on admin.users.broadcast. The notifications service runs as
+  // `svc-notifications` with the same permission seeded by the auth
+  // service. Stamping it here means callers (the broadcast handler)
+  // don't need to thread metadata through — they're already gating
+  // on admin.notifications.broadcast against the caller's principal.
+  systemUserId?: string;
+  systemRoles?: string;
+  systemPermissions?: string;
+};
+
+export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): AuthCohortClient & {
+  close(): void;
+} {
+  const stub = new AuthV1.AuthServiceClient(opts.address, credentials.createInsecure());
+  const systemMeta = new Metadata();
+  systemMeta.set('x-user-id', opts.systemUserId ?? 'svc-notifications');
+  systemMeta.set('x-user-roles', opts.systemRoles ?? 'admin');
+  systemMeta.set('x-user-permissions', opts.systemPermissions ?? 'admin.users.broadcast');
+
+  return {
+    listUserIdsByCohort: (req: ListUserIdsByCohortRequest): Promise<ListUserIdsByCohortResponse> =>
+      new Promise((resolve, reject) => {
+        stub.listUserIdsByCohort(req, systemMeta, (err, res) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(res);
+        });
+      }),
+    close: () => stub.close(),
+  };
+}

--- a/services/notifications/src/grpc/broadcast-handlers.test.ts
+++ b/services/notifications/src/grpc/broadcast-handlers.test.ts
@@ -1,0 +1,331 @@
+import type { NatsConnection } from 'nats';
+import type { Pool } from 'pg';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Principal } from '@adopt-dont-shop/authz';
+import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
+import { NotificationsV1 } from '@adopt-dont-shop/proto';
+
+import { broadcast, isInQuietHours } from './broadcast-handlers.js';
+import type { AuthCohortClient, HandlerDeps } from './handlers.js';
+
+const BROADCASTER: Principal = {
+  userId: 'svc-bcast' as UserId,
+  roles: ['admin'],
+  permissions: ['admin.notifications.broadcast' as Permission],
+};
+
+const NO_PERMS: Principal = {
+  userId: 'usr-nobody' as UserId,
+  roles: [],
+  permissions: [],
+};
+
+function makeMocks(authClient?: AuthCohortClient) {
+  const clientScript: Array<{ rows: unknown[] }> = [];
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      const op = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      const next = clientScript.shift();
+      if (!next) {
+        throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);
+      }
+      return next;
+    }),
+    release: vi.fn(),
+  };
+  const pool = {
+    connect: vi.fn().mockResolvedValue(client),
+    query: vi.fn(),
+  };
+  const nats = { publish: vi.fn() };
+  const deps: HandlerDeps = {
+    pool: pool as unknown as Pool,
+    nats: nats as unknown as NatsConnection,
+    authClient,
+  };
+  return { deps, poolMock: pool, clientMock: client, natsMock: nats, clientScript };
+}
+
+const prefsRow = (over: Record<string, unknown> = {}) => ({
+  user_id: 'u-1',
+  quiet_hours_start: null,
+  quiet_hours_end: null,
+  timezone: 'UTC',
+  ...over,
+});
+
+describe('broadcast', () => {
+  it('rejects callers without admin.notifications.broadcast', async () => {
+    const mocks = makeMocks();
+    await expect(
+      broadcast(mocks.deps, NO_PERMS, {
+        cohort: { userTypes: [], statuses: [] },
+        type: 0,
+        title: 't',
+        message: 'm',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects when no auth client is wired', async () => {
+    const mocks = makeMocks(undefined);
+    await expect(
+      broadcast(mocks.deps, BROADCASTER, {
+        cohort: { userTypes: [], statuses: [] },
+        type: 0,
+        title: 't',
+        message: 'm',
+      })
+    ).rejects.toMatchObject({ code: 'INTERNAL' });
+  });
+
+  it('rejects empty title / message with INVALID_ARGUMENT', async () => {
+    const authClient: AuthCohortClient = {
+      listUserIdsByCohort: vi.fn(),
+    };
+    const mocks = makeMocks(authClient);
+    await expect(
+      broadcast(mocks.deps, BROADCASTER, {
+        cohort: { userTypes: [], statuses: [] },
+        type: 0,
+        title: '',
+        message: 'm',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+    await expect(
+      broadcast(mocks.deps, BROADCASTER, {
+        cohort: { userTypes: [], statuses: [] },
+        type: 0,
+        title: 't',
+        message: '   ',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+
+  it('fans out to the cohort and counts delivered / suppressed / failed', async () => {
+    const authClient: AuthCohortClient = {
+      listUserIdsByCohort: vi.fn().mockResolvedValue({
+        userIds: ['u-1', 'u-2', 'u-3'],
+        total: 3,
+        page: 1,
+        totalPages: 1,
+      }),
+    };
+    const mocks = makeMocks(authClient);
+    // u-1: prefs (no DND), insert
+    mocks.clientScript.push({ rows: [prefsRow({ user_id: 'u-1' })] });
+    mocks.clientScript.push({ rows: [] }); // INSERT notification
+    // u-2: prefs with active DND window (always-on)
+    mocks.clientScript.push({
+      rows: [
+        prefsRow({
+          user_id: 'u-2',
+          quiet_hours_start: '00:00',
+          quiet_hours_end: '23:59',
+          timezone: 'UTC',
+        }),
+      ],
+    });
+    // u-3: prefs, insert
+    mocks.clientScript.push({ rows: [prefsRow({ user_id: 'u-3' })] });
+    mocks.clientScript.push({ rows: [] });
+
+    const res = await broadcast(mocks.deps, BROADCASTER, {
+      cohort: { userTypes: ['adopter'], statuses: [], emailVerified: true },
+      type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_SYSTEM_ANNOUNCEMENT,
+      title: 'Maintenance',
+      message: 'Brief downtime tonight',
+    });
+
+    expect(res.targeted).toBe(3);
+    expect(res.delivered).toBe(2);
+    expect(res.suppressed).toBe(1);
+    expect(res.failed).toBe(0);
+
+    // Cohort lookup used the mapped enum values.
+    const cohortReq = (authClient.listUserIdsByCohort as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(cohortReq.userTypes).toEqual([1]); // USER_ROLE_ADOPTER
+    expect(cohortReq.emailVerified).toBe(true);
+  });
+
+  it('counts INSERT failures into failed and continues the loop', async () => {
+    const authClient: AuthCohortClient = {
+      listUserIdsByCohort: vi.fn().mockResolvedValue({
+        userIds: ['u-1', 'u-2'],
+        total: 2,
+        page: 1,
+        totalPages: 1,
+      }),
+    };
+    const mocks = makeMocks(authClient);
+    // Replace the default query stub with one that throws on the FIRST
+    // INSERT INTO notifications.notifications (u-1's). u-2's INSERT
+    // succeeds. BEGIN/COMMIT/ROLLBACK still no-op; SELECT/UPSERT prefs
+    // still drain from clientScript.
+    let insertCount = 0;
+    mocks.clientMock.query = vi.fn(async (sql: string) => {
+      const op = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      if (sql.includes('INSERT INTO notifications.notifications')) {
+        insertCount++;
+        if (insertCount === 1) {
+          throw new Error('boom');
+        }
+        return { rows: [] };
+      }
+      // prefs UPSERT
+      const next = mocks.clientScript.shift();
+      if (!next) {
+        throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);
+      }
+      return next;
+    });
+    mocks.clientScript.push({ rows: [prefsRow({ user_id: 'u-1' })] });
+    mocks.clientScript.push({ rows: [prefsRow({ user_id: 'u-2' })] });
+
+    const res = await broadcast(mocks.deps, BROADCASTER, {
+      cohort: { userTypes: [], statuses: [] },
+      type: 0,
+      title: 't',
+      message: 'm',
+    });
+
+    expect(res.delivered).toBe(1);
+    expect(res.failed).toBe(1);
+  });
+
+  it('defers when scheduledFor is set (passes Date through to INSERT)', async () => {
+    const authClient: AuthCohortClient = {
+      listUserIdsByCohort: vi.fn().mockResolvedValue({
+        userIds: ['u-1'],
+        total: 1,
+        page: 1,
+        totalPages: 1,
+      }),
+    };
+    const mocks = makeMocks(authClient);
+    mocks.clientScript.push({ rows: [prefsRow({ user_id: 'u-1' })] });
+    mocks.clientScript.push({ rows: [] });
+
+    await broadcast(mocks.deps, BROADCASTER, {
+      cohort: { userTypes: [], statuses: [] },
+      type: 0,
+      title: 't',
+      message: 'm',
+      scheduledFor: '2030-01-01T00:00:00Z',
+    });
+
+    const insertCall = mocks.clientMock.query.mock.calls.find(c =>
+      String(c[0]).includes('INSERT INTO notifications.notifications')
+    );
+    const params = insertCall![1] as unknown[];
+    // scheduled_for is the 7th param ($7).
+    expect(params[6]).toBeInstanceOf(Date);
+  });
+
+  it('rejects invalid scheduledFor with INVALID_ARGUMENT', async () => {
+    const authClient: AuthCohortClient = {
+      listUserIdsByCohort: vi.fn(),
+    };
+    const mocks = makeMocks(authClient);
+    await expect(
+      broadcast(mocks.deps, BROADCASTER, {
+        cohort: { userTypes: [], statuses: [] },
+        type: 0,
+        title: 't',
+        message: 'm',
+        scheduledFor: 'not a date',
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
+  });
+});
+
+describe('isInQuietHours', () => {
+  it('returns false when no DND window is set', () => {
+    expect(
+      isInQuietHours({
+        user_id: 'u',
+        quiet_hours_start: null,
+        quiet_hours_end: null,
+        timezone: 'UTC',
+      })
+    ).toBe(false);
+  });
+
+  it('detects in-window for a normal (non-wrapping) range', () => {
+    // 13:30 UTC inside 12:00–14:00.
+    const noon = new Date('2026-06-01T13:30:00Z');
+    expect(
+      isInQuietHours(
+        {
+          user_id: 'u',
+          quiet_hours_start: '12:00',
+          quiet_hours_end: '14:00',
+          timezone: 'UTC',
+        },
+        noon
+      )
+    ).toBe(true);
+  });
+
+  it('detects in-window for a wrap-midnight range (22:00 → 07:00)', () => {
+    const lateNight = new Date('2026-06-01T23:30:00Z');
+    expect(
+      isInQuietHours(
+        {
+          user_id: 'u',
+          quiet_hours_start: '22:00',
+          quiet_hours_end: '07:00',
+          timezone: 'UTC',
+        },
+        lateNight
+      )
+    ).toBe(true);
+
+    const earlyMorning = new Date('2026-06-01T03:00:00Z');
+    expect(
+      isInQuietHours(
+        {
+          user_id: 'u',
+          quiet_hours_start: '22:00',
+          quiet_hours_end: '07:00',
+          timezone: 'UTC',
+        },
+        earlyMorning
+      )
+    ).toBe(true);
+
+    const noonAgain = new Date('2026-06-01T12:00:00Z');
+    expect(
+      isInQuietHours(
+        {
+          user_id: 'u',
+          quiet_hours_start: '22:00',
+          quiet_hours_end: '07:00',
+          timezone: 'UTC',
+        },
+        noonAgain
+      )
+    ).toBe(false);
+  });
+
+  it('falls back to UTC when timezone is unknown', () => {
+    expect(
+      isInQuietHours(
+        {
+          user_id: 'u',
+          quiet_hours_start: '00:00',
+          quiet_hours_end: '23:59',
+          timezone: 'Not/A_Zone',
+        },
+        new Date('2026-06-01T12:00:00Z')
+      )
+    ).toBe(true);
+  });
+});

--- a/services/notifications/src/grpc/broadcast-handlers.ts
+++ b/services/notifications/src/grpc/broadcast-handlers.ts
@@ -1,0 +1,323 @@
+// gRPC handler for NotificationService.Broadcast — fan a single in-app
+// notification across a cohort of users.
+//
+// Flow:
+//   1. Permission gate (admin.notifications.broadcast).
+//   2. Resolve the cohort by calling AuthService.ListUserIdsByCohort
+//      (cross-service gRPC; injected via deps.authClient so unit tests
+//      can mock).
+//   3. For each user_id, INSERT a notification row, honouring the
+//      per-user quiet_hours window (DND skip). Channel toggles do NOT
+//      apply — in-app notifications are always on the in-app channel,
+//      which the prefs row models with no opt-out (only email/push/sms
+//      have toggles).
+//   4. Per-user failures are absorbed so a single bad row doesn't
+//      poison the batch; failed counter increments and the loop moves
+//      on.
+//
+// publish-after-commit: each insert + its `notifications.broadcastSent`
+// event runs inside its own withTransaction. Per-recipient atomicity
+// matters more than batch atomicity here — a partial fan-out is the
+// right behaviour when one recipient's row insert fails.
+
+import { randomUUID } from 'node:crypto';
+
+import { hasPermission, type Principal } from '@adopt-dont-shop/authz';
+import { withTransaction } from '@adopt-dont-shop/events';
+import type { Permission } from '@adopt-dont-shop/lib.types';
+import {
+  AuthV1,
+  NotificationsV1,
+  type BroadcastRequest,
+  type BroadcastResponse,
+} from '@adopt-dont-shop/proto';
+
+import { HandlerError, type HandlerDeps } from './handlers.js';
+
+const NOTIFICATIONS_BROADCAST: Permission = 'admin.notifications.broadcast' as Permission;
+
+// Map cohort filter strings (admin UI sends string forms of UserRole /
+// UserStatus) onto the auth proto enum values. The gRPC ListUserIdsByCohort
+// handler will normalise these back to DB strings.
+const ROLE_FROM_STRING: Record<string, AuthV1.UserRole> = {
+  adopter: AuthV1.UserRole.USER_ROLE_ADOPTER,
+  rescue_staff: AuthV1.UserRole.USER_ROLE_RESCUE_STAFF,
+  admin: AuthV1.UserRole.USER_ROLE_ADMIN,
+  moderator: AuthV1.UserRole.USER_ROLE_MODERATOR,
+  super_admin: AuthV1.UserRole.USER_ROLE_SUPER_ADMIN,
+  support_agent: AuthV1.UserRole.USER_ROLE_SUPPORT_AGENT,
+};
+
+const STATUS_FROM_STRING: Record<string, AuthV1.UserStatus> = {
+  active: AuthV1.UserStatus.USER_STATUS_ACTIVE,
+  inactive: AuthV1.UserStatus.USER_STATUS_INACTIVE,
+  suspended: AuthV1.UserStatus.USER_STATUS_SUSPENDED,
+  pending_verification: AuthV1.UserStatus.USER_STATUS_PENDING_VERIFICATION,
+  deactivated: AuthV1.UserStatus.USER_STATUS_DEACTIVATED,
+};
+
+const COHORT_PAGE_LIMIT = 500;
+
+type PrefsRow = {
+  user_id: string;
+  quiet_hours_start: string | null;
+  quiet_hours_end: string | null;
+  timezone: string;
+};
+
+// Quiet-hours check. quiet_hours_* are stored as HH:MM strings; both
+// must be set to enable the window. The check uses the user's timezone
+// so a US user at 23:30 doesn't get pinged because the broadcast issued
+// in UTC midday.
+//
+// Returns true when the user is currently inside their DND window and
+// the broadcast should be suppressed.
+export function isInQuietHours(prefs: PrefsRow, now: Date = new Date()): boolean {
+  if (!prefs.quiet_hours_start || !prefs.quiet_hours_end) {
+    return false;
+  }
+  // Localise `now` to the user's timezone. Intl.DateTimeFormat gives us
+  // HH:MM in the target zone without pulling in a tz library.
+  let hhmm: string;
+  try {
+    hhmm = new Intl.DateTimeFormat('en-GB', {
+      timeZone: prefs.timezone || 'UTC',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).format(now);
+  } catch {
+    // Unknown timezone — fall back to UTC rather than throwing.
+    hhmm = new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'UTC',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).format(now);
+  }
+  const start = prefs.quiet_hours_start;
+  const end = prefs.quiet_hours_end;
+  // Window may wrap midnight (e.g. 22:00 → 07:00).
+  if (start <= end) {
+    return hhmm >= start && hhmm < end;
+  }
+  return hhmm >= start || hhmm < end;
+}
+
+export async function broadcast(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: BroadcastRequest
+): Promise<BroadcastResponse> {
+  if (!hasPermission(principal, NOTIFICATIONS_BROADCAST)) {
+    throw new HandlerError('PERMISSION_DENIED', `'${NOTIFICATIONS_BROADCAST}' required`);
+  }
+  if (!deps.authClient) {
+    throw new HandlerError(
+      'INTERNAL',
+      'broadcast requires auth client; service.notifications was not wired with one'
+    );
+  }
+  const title = req.title?.trim() ?? '';
+  const message = req.message?.trim() ?? '';
+  if (title === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'title is required');
+  }
+  if (message === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'message is required');
+  }
+
+  // Map the string cohort filters onto the auth proto enums. Unknown
+  // strings drop silently — the auth handler treats missing as "any".
+  const cohort = req.cohort ?? { userTypes: [], statuses: [] };
+  const userTypes = (cohort.userTypes ?? [])
+    .map(s => ROLE_FROM_STRING[s])
+    .filter((v): v is AuthV1.UserRole => v !== undefined);
+  const statuses = (cohort.statuses ?? [])
+    .map(s => STATUS_FROM_STRING[s])
+    .filter((v): v is AuthV1.UserStatus => v !== undefined);
+
+  // Drive the cohort in pages so we don't pull millions of ids into a
+  // single buffer for a very-large announcement.
+  let page = 1;
+  let total = 0;
+  let targeted = 0;
+  let delivered = 0;
+  let suppressed = 0;
+  let failed = 0;
+
+  const type =
+    req.type === undefined ||
+    req.type === NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED
+      ? NotificationsV1.NotificationType.NOTIFICATION_TYPE_SYSTEM_ANNOUNCEMENT
+      : req.type;
+  const scheduledFor =
+    req.scheduledFor && req.scheduledFor !== '' ? new Date(req.scheduledFor) : null;
+  if (scheduledFor !== null && !Number.isFinite(scheduledFor.getTime())) {
+    throw new HandlerError('INVALID_ARGUMENT', 'scheduled_for must be RFC 3339');
+  }
+
+  const now = new Date();
+
+  while (true) {
+    const lookup = await deps.authClient.listUserIdsByCohort({
+      userTypes,
+      statuses,
+      emailVerified: cohort.emailVerified,
+      page,
+      limit: COHORT_PAGE_LIMIT,
+    });
+    if (page === 1) {
+      total = lookup.total;
+    }
+    targeted += lookup.userIds.length;
+    for (const userId of lookup.userIds) {
+      try {
+        const outcome = await sendOne(
+          deps,
+          userId,
+          {
+            type,
+            title,
+            message,
+            actionUrl: req.actionUrl,
+            dataJson: req.dataJson,
+            scheduledFor,
+            actorId: principal.userId,
+          },
+          now
+        );
+        if (outcome === 'delivered') {
+          delivered++;
+        } else if (outcome === 'suppressed') {
+          suppressed++;
+        }
+      } catch {
+        failed++;
+      }
+    }
+    if (lookup.userIds.length < COHORT_PAGE_LIMIT) {
+      break;
+    }
+    page++;
+    // Safety: cap iterations at total/page to avoid an infinite loop if
+    // a buggy auth client never shrinks its result set.
+    if (page > Math.ceil(total / COHORT_PAGE_LIMIT) + 1) {
+      break;
+    }
+  }
+
+  return { targeted, delivered, suppressed, failed };
+}
+
+type SendInput = {
+  type: NotificationsV1.NotificationType;
+  title: string;
+  message: string;
+  actionUrl?: string;
+  dataJson?: string;
+  scheduledFor: Date | null;
+  actorId: string;
+};
+
+// Insert one row + publish the per-recipient event. Returns 'delivered'
+// on success, 'suppressed' when the user's DND window says no.
+async function sendOne(
+  deps: HandlerDeps,
+  userId: string,
+  input: SendInput,
+  now: Date
+): Promise<'delivered' | 'suppressed'> {
+  return withTransaction(deps, async ({ client, publish }) => {
+    // Load prefs (auto-create defaults so the broadcast never errors on
+    // missing-row). The defaults disable DND, so a brand-new user gets
+    // the announcement.
+    const prefsResult = await client.query<PrefsRow>(
+      `INSERT INTO notifications.user_notification_prefs (user_id)
+         VALUES ($1)
+         ON CONFLICT (user_id) DO UPDATE SET user_id = EXCLUDED.user_id
+       RETURNING user_id, quiet_hours_start, quiet_hours_end, timezone`,
+      [userId]
+    );
+    const prefs = prefsResult.rows[0];
+
+    if (prefs && isInQuietHours(prefs, now)) {
+      return 'suppressed';
+    }
+
+    const notificationId = randomUUID();
+    // Merge action_url into the `data` jsonb so it round-trips through the
+    // existing read path (the table has no dedicated column for it).
+    const data = mergeActionUrl(input.dataJson, input.actionUrl);
+
+    await client.query(
+      `INSERT INTO notifications.notifications (
+         notification_id, user_id, type, channel, priority, status,
+         title, message, data, related_entity_type, related_entity_id,
+         scheduled_for, expires_at, retry_count, max_retries, version,
+         created_at, updated_at
+       )
+       VALUES (
+         $1, $2, $3, 'in_app', 'normal', 'pending',
+         $4, $5, $6::jsonb, NULL, NULL,
+         $7, NULL, 0, 3, 0,
+         now(), now()
+       )`,
+      [
+        notificationId,
+        userId,
+        notificationTypeToDb(input.type),
+        input.title,
+        input.message,
+        data,
+        input.scheduledFor,
+      ]
+    );
+
+    publish({
+      id: notificationId,
+      type: 'notifications.broadcastSent',
+      payload: {
+        notificationId,
+        userId,
+        actorId: input.actorId,
+      },
+    });
+    return 'delivered';
+  });
+}
+
+// Minimal proto → DB type mapping. Anything we don't explicitly map
+// falls back to `system_announcement` — broadcasts are admin pushes
+// and that's the schema enum value reserved for them.
+function notificationTypeToDb(t: NotificationsV1.NotificationType): string {
+  switch (t) {
+    case NotificationsV1.NotificationType.NOTIFICATION_TYPE_APPLICATION_STATUS:
+      return 'application_status';
+    case NotificationsV1.NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED:
+      return 'message_received';
+    case NotificationsV1.NotificationType.NOTIFICATION_TYPE_PET_AVAILABLE:
+      return 'pet_available';
+    default:
+      return 'system_announcement';
+  }
+}
+
+function mergeActionUrl(dataJson: string | undefined, actionUrl: string | undefined): string {
+  let data: Record<string, unknown> = {};
+  if (dataJson && dataJson !== '') {
+    try {
+      const parsed = JSON.parse(dataJson) as unknown;
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        data = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Malformed JSON from a caller — start fresh rather than throw,
+      // so the broadcast still goes out for the rest of the cohort.
+    }
+  }
+  if (actionUrl && actionUrl !== '') {
+    data.actionUrl = actionUrl;
+  }
+  return JSON.stringify(data);
+}

--- a/services/notifications/src/grpc/handlers.ts
+++ b/services/notifications/src/grpc/handlers.ts
@@ -52,7 +52,20 @@ import {
   type RelatedEntityTypeDb,
 } from './enum-map.js';
 
-export type HandlerDeps = WithTransactionDeps;
+// AuthCohortClient — the slice of @adopt-dont-shop/proto's AuthServiceClient
+// the broadcast handler needs. Defined inline so handler tests can supply a
+// simple mock object without standing up a real gRPC stub.
+export type AuthCohortClient = {
+  listUserIdsByCohort: (
+    req: import('@adopt-dont-shop/proto').ListUserIdsByCohortRequest
+  ) => Promise<import('@adopt-dont-shop/proto').ListUserIdsByCohortResponse>;
+};
+
+export type HandlerDeps = WithTransactionDeps & {
+  // Optional — only broadcast-handlers reads it. Other handlers (Create,
+  // List, Dismiss, etc.) work fine without a cross-service client wired.
+  authClient?: AuthCohortClient;
+};
 
 export type HandlerErrorCode =
   | 'INVALID_ARGUMENT'

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -19,6 +19,7 @@ import { NotificationsV1 } from '@adopt-dont-shop/proto';
 import type { NotificationsConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
+import { broadcast } from './broadcast-handlers.js';
 import {
   listDeviceTokensHandler,
   registerDeviceTokenHandler,
@@ -50,6 +51,11 @@ export type CreateGrpcServerOptions = {
   pool: Pool;
   nats: NatsConnection;
   logger: Logger;
+  // Optional cross-service client for cohort lookups. Only the Broadcast
+  // RPC reads it; wiring it in production happens from index.ts. Smoke
+  // tests + unit tests can omit it — Broadcast will return INTERNAL when
+  // the wiring is missing, which is the correct signal.
+  authClient?: import('./handlers.js').AuthCohortClient;
 };
 
 export type RunningGrpcServer = {
@@ -63,7 +69,8 @@ export type RunningGrpcServer = {
 };
 
 export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
-  const { config, pool, nats, logger } = opts;
+  const { config, pool, nats, logger, authClient } = opts;
+  const deps = { pool, nats, authClient };
   const server = new Server();
 
   // ts-proto emits `NotificationServiceService` as the Definition
@@ -102,6 +109,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
     updateEmailTemplate: adapt(updateEmailTemplate, { deps: { pool, nats }, logger }),
     deleteEmailTemplate: adapt(deleteEmailTemplate, { deps: { pool, nats }, logger }),
     previewEmailTemplate: adapt(previewEmailTemplate, { deps: { pool, nats }, logger }),
+    broadcast: adapt(broadcast, { deps, logger }),
   });
 
   logger.info('gRPC NotificationService registered', {
@@ -129,6 +137,7 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
       'updateEmailTemplate',
       'deleteEmailTemplate',
       'previewEmailTemplate',
+      'broadcast',
     ],
     grpcPort: config.grpcPort,
   });

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -4,6 +4,7 @@ import { createDbClient } from '@adopt-dont-shop/db';
 import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
+import { createAuthCohortClient } from './grpc/auth-client.js';
 import { createProvider } from './email/providers/factory.js';
 import { startEmailWorker, type RunningEmailWorker } from './email/worker.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
@@ -37,7 +38,13 @@ const main = async (): Promise<void> => {
     });
     nats = await connect({ servers: config.natsUrl });
 
-    grpc = await startGrpcServer({ config, pool, nats, logger });
+    // Auth-cohort client for the Broadcast RPC. Only created when the
+    // AUTH_GRPC_URL env is set; without it, Broadcast returns INTERNAL.
+    const authClient = config.authGrpcUrl
+      ? createAuthCohortClient({ address: config.authGrpcUrl })
+      : undefined;
+
+    grpc = await startGrpcServer({ config, pool, nats, logger, authClient });
     // NATS subscribers register AFTER gRPC so a fast event arriving on
     // applications.submitted before we're ready to handle gRPC calls
     // can't race against partially-constructed deps. Shutdown drains the


### PR DESCRIPTION
## Summary

Adds an admin "send announcement to a cohort" surface that fans a single in-app notification across users matching a role/status filter.

End-to-end shape:
```
POST /api/v1/notifications/broadcast (gateway, REST)
  → NotificationService.Broadcast (service.notifications, gRPC)
    → AuthService.ListUserIdsByCohort (service.auth, gRPC) for the cohort lookup
    → INSERT INTO notifications.notifications per user, honouring each user's
      quiet_hours_* DND window
  → BroadcastResponse { targeted, delivered, suppressed, failed }
```

## service.auth

- New `ListUserIdsByCohort` RPC. `user_types` + `statuses` act as AND-of-IN filters; empty `statuses` defaults to `active`-only (the safe broadcast default)
- `admin.users.broadcast` gates it
- 6 new handler tests covering perm gate, default-status behaviour, type/status/email filters, pagination

## service.notifications

- New `broadcast` handler reads the cohort via an injected `AuthCohortClient` (so unit tests can mock without a gRPC stub)
- **Per-recipient `withTransaction` isolation** — a single bad row doesn't poison the batch; counters increment and the loop continues
- **DND check uses `Intl.DateTimeFormat`** so the user's timezone wins over the broadcast issuer's. Correctly handles wrap-around midnight windows (22:00 → 07:00)
- New `auth-client.ts` wires the cross-service gRPC call with a system principal (`svc-notifications` + `admin.users.broadcast`) so the cohort RPC's perm check passes
- 11 new handler tests (perms, DND, fan-out, scheduled-for, INSERT failure absorption, snake_case body keys, wrap-midnight DND)

## services/gateway

- `POST /api/v1/notifications/broadcast` route. Accepts both camelCase and snake_case body keys; `data` object body is JSON-stringified into `dataJson` for the proto
- `NotificationsClient` interface + stub bindings extended with `broadcast`
- 6 new route tests

## Wiring

Sits under the existing `CUTOVER_NOTIFICATIONS` gate. When NOTIFICATIONS is off the request falls through to the monolith; when on, the route goes to `service.notifications` which needs `AUTH_GRPC_URL` set so it can mint an authenticated cohort client (returns `INTERNAL` when unset, a clear ops signal).

## Test plan

- [x] 6 auth handler tests for `ListUserIdsByCohort`
- [x] 11 notifications broadcast tests (including the wrap-midnight DND case)
- [x] 6 gateway route tests
- [x] All 180 auth + 190 notifications + 439 gateway tests pass

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_