### PR TITLE
feat(events,gateway,services): gdpr erasure saga across all services

### DIFF
--- a/packages/events/src/gdpr-saga.test.ts
+++ b/packages/events/src/gdpr-saga.test.ts
@@ -1,0 +1,146 @@
+import type { NatsConnection, Subscription } from 'nats';
+import type { Pool, PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  GDPR_ERASURE_COMPLETED,
+  GDPR_ERASURE_REQUESTED,
+  registerGdprSubscriber,
+  type GdprErasureCompletedPayload,
+  type GdprErasureRequestedPayload,
+} from './index.js';
+
+function fakeSubscription(messages: Array<Record<string, unknown>>): Subscription {
+  const enc = new TextEncoder();
+  const queue = messages.map(m => ({
+    subject: GDPR_ERASURE_REQUESTED,
+    data: enc.encode(JSON.stringify({ payload: m })),
+  }));
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const m of queue) {
+        yield m;
+      }
+    },
+    drain: vi.fn(),
+    unsubscribe: vi.fn(),
+  } as unknown as Subscription;
+}
+
+function fakeNats(payload: GdprErasureRequestedPayload) {
+  // publish() callers pass either a JSON string (from publishStaged) or a
+  // Uint8Array (from the failure path's raw publish). Store both shapes.
+  const published: Array<{ subject: string; data: string | Uint8Array }> = [];
+  const nc = {
+    subscribe: vi
+      .fn()
+      .mockReturnValue(fakeSubscription([payload as unknown as Record<string, unknown>])),
+    publish: vi.fn((subject: string, data: string | Uint8Array) =>
+      published.push({ subject, data })
+    ),
+  };
+  return { nc: nc as unknown as NatsConnection, published };
+}
+
+function fakePool(client: PoolClient) {
+  return {
+    connect: vi.fn().mockResolvedValue(client),
+  } as unknown as Pool;
+}
+
+const flush = async (): Promise<void> => {
+  // The subscriber drives a `for await` loop, plus withTransaction does its
+  // own BEGIN → callback → COMMIT chain. We need to step over enough
+  // microtasks for all three to settle.
+  for (let i = 0; i < 50; i++) {
+    await new Promise(r => setImmediate(r));
+  }
+};
+
+const PAYLOAD: GdprErasureRequestedPayload = {
+  userId: 'usr-1',
+  correlationId: 'corr-abc',
+  requestedAt: '2026-06-09T12:00:00Z',
+};
+
+function decode(data: string | Uint8Array): Record<string, unknown> {
+  const s = typeof data === 'string' ? data : new TextDecoder().decode(data);
+  return JSON.parse(s) as Record<string, unknown>;
+}
+
+describe('registerGdprSubscriber', () => {
+  it('runs erase inside a transaction and publishes a completion event', async () => {
+    const queries: string[] = [];
+    const client = {
+      query: vi.fn(async (sql: string) => {
+        queries.push(sql);
+        return { rows: [] };
+      }),
+      release: vi.fn(),
+    } as unknown as PoolClient;
+
+    const { nc, published } = fakeNats(PAYLOAD);
+    registerGdprSubscriber({
+      nats: nc,
+      pool: fakePool(client),
+      service: 'auth',
+      erase: async () => 7,
+    });
+    await flush();
+
+    // BEGIN + COMMIT bracket the erase callback.
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries[queries.length - 1]).toBe('COMMIT');
+
+    // Completion event published after commit.
+    expect(published).toHaveLength(1);
+    expect(published[0].subject).toBe(GDPR_ERASURE_COMPLETED);
+    const env = decode(published[0].data) as { payload: GdprErasureCompletedPayload };
+    expect(env.payload).toMatchObject({
+      userId: 'usr-1',
+      correlationId: 'corr-abc',
+      service: 'auth',
+      recordsErased: 7,
+    });
+    expect(env.payload.error).toBeUndefined();
+  });
+
+  it('rolls back and publishes a failure completion when erase throws', async () => {
+    const client = {
+      query: vi.fn(async () => ({ rows: [] })),
+      release: vi.fn(),
+    } as unknown as PoolClient;
+
+    const { nc, published } = fakeNats(PAYLOAD);
+    registerGdprSubscriber({
+      nats: nc,
+      pool: fakePool(client),
+      service: 'notifications',
+      erase: async () => {
+        throw new Error('boom');
+      },
+    });
+    await flush();
+
+    expect(published).toHaveLength(1);
+    const env = decode(published[0].data) as { payload: GdprErasureCompletedPayload };
+    expect(env.payload).toMatchObject({
+      service: 'notifications',
+      recordsErased: 0,
+      error: 'boom',
+    });
+  });
+
+  it('uses gdpr.<service> as the queue group by default', () => {
+    const client = { query: vi.fn(), release: vi.fn() } as unknown as PoolClient;
+    const subscribe = vi.fn().mockReturnValue(fakeSubscription([]));
+    const nc = { subscribe, publish: vi.fn() } as unknown as NatsConnection;
+    registerGdprSubscriber({
+      nats: nc,
+      pool: fakePool(client),
+      service: 'pets',
+      erase: async () => 0,
+    });
+    expect(subscribe.mock.calls[0][1]).toMatchObject({ queue: 'gdpr.pets' });
+  });
+});

--- a/packages/events/src/gdpr-saga.ts
+++ b/packages/events/src/gdpr-saga.ts
@@ -1,0 +1,104 @@
+// Per-service GDPR subscriber helper. Each service uses this to:
+//
+//   * Subscribe to gdpr.erasureRequested
+//   * Run its erasure callback inside a transaction (so the per-row scrub
+//     either fully succeeds or is rolled back)
+//   * Publish gdpr.erasureCompleted with the resulting row count — or
+//     with an error message if the callback threw
+//
+// Keeps each service's gdpr-subscriber.ts file down to a few lines. The
+// callback receives the Pool client inside an open transaction and
+// returns the number of rows it touched. Errors are caught here; the
+// completion event is always published so the audit consumer's saga
+// tracker doesn't stall on a silent service failure.
+
+import type { NatsConnection, Subscription } from 'nats';
+import type { Pool } from 'pg';
+
+import { withTransaction } from './publish.js';
+import { subscribe } from './subscribe.js';
+import {
+  GDPR_ERASURE_COMPLETED,
+  GDPR_ERASURE_REQUESTED,
+  type GdprErasureCompletedPayload,
+  type GdprErasureRequestedPayload,
+} from './gdpr.js';
+
+export type GdprEraseFn = (
+  // PoolClient — typed as `unknown` here so this package doesn't pull in
+  // pg types just to forward them. The per-service callback re-types it.
+  client: import('pg').PoolClient,
+  payload: GdprErasureRequestedPayload
+) => Promise<number>;
+
+export type RegisterGdprSubscriberOptions = {
+  nats: NatsConnection;
+  pool: Pool;
+  service: string;
+  // Optional queue-group name. When set, multiple replicas of the same
+  // service load-share the erasure requests. Defaults to `gdpr.<service>`
+  // which is the right shape for every horizontally-scaled subscriber.
+  queue?: string;
+  erase: GdprEraseFn;
+  onError?: (err: unknown, subject: string) => void;
+};
+
+export function registerGdprSubscriber(opts: RegisterGdprSubscriberOptions): Subscription {
+  const { nats, pool, service, erase } = opts;
+  const queue = opts.queue ?? `gdpr.${service}`;
+
+  return subscribe<GdprErasureRequestedPayload>(
+    nats,
+    {
+      subject: GDPR_ERASURE_REQUESTED,
+      queue,
+      onError: opts.onError ? (err, ctx) => opts.onError?.(err, ctx.subject) : undefined,
+    },
+    async (payload, _meta) => {
+      let recordsErased = 0;
+      let errorMessage: string | undefined;
+      try {
+        await withTransaction({ pool, nats }, async ({ client, publish }) => {
+          recordsErased = await erase(client, payload);
+          const completion: GdprErasureCompletedPayload = {
+            userId: payload.userId,
+            correlationId: payload.correlationId,
+            service,
+            recordsErased,
+            completedAt: new Date().toISOString(),
+          };
+          publish({
+            id: `${payload.correlationId}.${service}`,
+            type: GDPR_ERASURE_COMPLETED,
+            payload: completion,
+          });
+        });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : String(err);
+        // Publish a failure completion OUTSIDE the rolled-back transaction
+        // so the audit tracker doesn't stall waiting on this service.
+        const failure: GdprErasureCompletedPayload = {
+          userId: payload.userId,
+          correlationId: payload.correlationId,
+          service,
+          recordsErased: 0,
+          completedAt: new Date().toISOString(),
+          error: errorMessage,
+        };
+        const envelope = {
+          id: `${payload.correlationId}.${service}`,
+          occurredAt: new Date(),
+          payload: failure,
+        };
+        try {
+          nats.publish(GDPR_ERASURE_COMPLETED, new TextEncoder().encode(JSON.stringify(envelope)));
+        } catch {
+          // If even publishing the failure fails, the audit tracker's
+          // timeout sweep will surface the missing ack — nothing more
+          // useful we can do from inside a poison-pill catch.
+        }
+        opts.onError?.(err, GDPR_ERASURE_REQUESTED);
+      }
+    }
+  );
+}

--- a/packages/events/src/gdpr.ts
+++ b/packages/events/src/gdpr.ts
@@ -1,0 +1,48 @@
+// Shared schemas for the GDPR erasure saga.
+//
+// Flow:
+//   1. Gateway publishes `gdpr.erasureRequested` with { userId, correlationId,
+//      requestedAt }.
+//   2. Every service that owns user-keyed data subscribes and erases its
+//      slice (delete / soft-delete / anonymise — service's choice based
+//      on its retention rules).
+//   3. After erasing, each service publishes `gdpr.erasureCompleted` with
+//      { userId, correlationId, service, recordsErased, completedAt }.
+//   4. service.audit aggregates request + completion rows in
+//      `audit.gdpr_erasure_requests` for the data-controller's records.
+//
+// The two event types are kept together here so every service consumes
+// the same shape — there's exactly one source of truth for the field names.
+
+export const GDPR_ERASURE_REQUESTED = 'gdpr.erasureRequested';
+export const GDPR_ERASURE_COMPLETED = 'gdpr.erasureCompleted';
+
+export type GdprErasureRequestedPayload = {
+  // The user being erased — primary key in auth.users.
+  userId: string;
+  // Saga-wide correlation id. Mint at the gateway; every subscriber
+  // echoes it on its completion event so the audit consumer can join.
+  correlationId: string;
+  // RFC 3339 timestamp the gateway recorded the request at.
+  requestedAt: string;
+  // Optional free-text reason the user supplied (e.g. "moving to a
+  // different country"). Stored verbatim in the audit row.
+  reason?: string;
+};
+
+export type GdprErasureCompletedPayload = {
+  userId: string;
+  correlationId: string;
+  // Short service name. Examples: 'auth', 'notifications', 'pets'.
+  service: string;
+  // How many rows the subscriber touched. Useful in audit for sanity-
+  // checking that all the obvious tables were affected. 0 is fine for
+  // services where the user had no data.
+  recordsErased: number;
+  // RFC 3339 timestamp.
+  completedAt: string;
+  // Optional human-readable error message — set when the subscriber
+  // couldn't complete cleanly (the audit consumer surfaces this so an
+  // operator can intervene). When unset, the completion is a success.
+  error?: string;
+};

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -2,3 +2,11 @@ export { withTransaction } from './publish.js';
 export type { DomainEvent, TransactionalScope, WithTransactionDeps } from './publish.js';
 export { subscribe } from './subscribe.js';
 export type { MessageHandler, SubscribeOptions } from './subscribe.js';
+export {
+  GDPR_ERASURE_REQUESTED,
+  GDPR_ERASURE_COMPLETED,
+  type GdprErasureRequestedPayload,
+  type GdprErasureCompletedPayload,
+} from './gdpr.js';
+export { registerGdprSubscriber } from './gdpr-saga.js';
+export type { GdprEraseFn, RegisterGdprSubscriberOptions } from './gdpr-saga.js';

--- a/packages/proto/proto/adopt_dont_shop/audit/v1/audit.proto
+++ b/packages/proto/proto/adopt_dont_shop/audit/v1/audit.proto
@@ -25,6 +25,34 @@ service AuditQueryService {
   // (e.g. an application aggregate may have applications.*,
   // notifications.*, moderation.* events tied to it).
   rpc GetByTarget(GetByTargetRequest) returns (GetByTargetResponse);
+
+  // GDPR saga status. Returns a single row from
+  // audit.gdpr_erasure_requests keyed on correlation_id. NOT_FOUND when
+  // the saga hasn't been requested. Gated on admin.gdpr.read OR
+  // self-ownership (the requesting user reads their own row).
+  rpc GetGdprErasureRequest(GetGdprErasureRequestRequest)
+      returns (GetGdprErasureRequestResponse);
+}
+
+// --- GDPR saga messages ----------------------------------------------
+
+message GdprErasureRequest {
+  string correlation_id = 1;
+  string user_id = 2;
+  optional string reason = 3;
+  string requested_at = 4;
+  // JSON-encoded { service: { recordsErased, completedAt, error? } } map.
+  string completions_json = 5;
+  optional string completed_at = 6;
+  string created_at = 7;
+  string updated_at = 8;
+}
+
+message GetGdprErasureRequestRequest {
+  string correlation_id = 1;
+}
+message GetGdprErasureRequestResponse {
+  GdprErasureRequest request = 1;
 }
 
 // ===== Enums =========================================================

--- a/packages/proto/src/generated/proto/adopt_dont_shop/audit/v1/audit.ts
+++ b/packages/proto/src/generated/proto/adopt_dont_shop/audit/v1/audit.ts
@@ -77,6 +77,26 @@ export function auditOutcomeToJSON(object: AuditOutcome): string {
   }
 }
 
+export interface GdprErasureRequest {
+  correlationId: string;
+  userId: string;
+  reason?: string | undefined;
+  requestedAt: string;
+  /** JSON-encoded { service: { recordsErased, completedAt, error? } } map. */
+  completionsJson: string;
+  completedAt?: string | undefined;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GetGdprErasureRequestRequest {
+  correlationId: string;
+}
+
+export interface GetGdprErasureRequestResponse {
+  request?: GdprErasureRequest | undefined;
+}
+
 /**
  * AuditEvent mirrors the audit.audit_events row. Schema-less
  * payload_json captures the full event body the producing service
@@ -172,6 +192,356 @@ export interface GetByTargetResponse {
   events: AuditEvent[];
   nextCursor?: string | undefined;
 }
+
+function createBaseGdprErasureRequest(): GdprErasureRequest {
+  return {
+    correlationId: '',
+    userId: '',
+    reason: undefined,
+    requestedAt: '',
+    completionsJson: '',
+    completedAt: undefined,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+export const GdprErasureRequest: MessageFns<GdprErasureRequest> = {
+  encode(message: GdprErasureRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.correlationId !== '') {
+      writer.uint32(10).string(message.correlationId);
+    }
+    if (message.userId !== '') {
+      writer.uint32(18).string(message.userId);
+    }
+    if (message.reason !== undefined) {
+      writer.uint32(26).string(message.reason);
+    }
+    if (message.requestedAt !== '') {
+      writer.uint32(34).string(message.requestedAt);
+    }
+    if (message.completionsJson !== '') {
+      writer.uint32(42).string(message.completionsJson);
+    }
+    if (message.completedAt !== undefined) {
+      writer.uint32(50).string(message.completedAt);
+    }
+    if (message.createdAt !== '') {
+      writer.uint32(58).string(message.createdAt);
+    }
+    if (message.updatedAt !== '') {
+      writer.uint32(66).string(message.updatedAt);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GdprErasureRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGdprErasureRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.correlationId = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.userId = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.reason = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.requestedAt = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.completionsJson = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.completedAt = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.createdAt = reader.string();
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.updatedAt = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GdprErasureRequest {
+    return {
+      correlationId: isSet(object.correlationId)
+        ? globalThis.String(object.correlationId)
+        : isSet(object.correlation_id)
+          ? globalThis.String(object.correlation_id)
+          : '',
+      userId: isSet(object.userId)
+        ? globalThis.String(object.userId)
+        : isSet(object.user_id)
+          ? globalThis.String(object.user_id)
+          : '',
+      reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
+      requestedAt: isSet(object.requestedAt)
+        ? globalThis.String(object.requestedAt)
+        : isSet(object.requested_at)
+          ? globalThis.String(object.requested_at)
+          : '',
+      completionsJson: isSet(object.completionsJson)
+        ? globalThis.String(object.completionsJson)
+        : isSet(object.completions_json)
+          ? globalThis.String(object.completions_json)
+          : '',
+      completedAt: isSet(object.completedAt)
+        ? globalThis.String(object.completedAt)
+        : isSet(object.completed_at)
+          ? globalThis.String(object.completed_at)
+          : undefined,
+      createdAt: isSet(object.createdAt)
+        ? globalThis.String(object.createdAt)
+        : isSet(object.created_at)
+          ? globalThis.String(object.created_at)
+          : '',
+      updatedAt: isSet(object.updatedAt)
+        ? globalThis.String(object.updatedAt)
+        : isSet(object.updated_at)
+          ? globalThis.String(object.updated_at)
+          : '',
+    };
+  },
+
+  toJSON(message: GdprErasureRequest): unknown {
+    const obj: any = {};
+    if (message.correlationId !== '') {
+      obj.correlationId = message.correlationId;
+    }
+    if (message.userId !== '') {
+      obj.userId = message.userId;
+    }
+    if (message.reason !== undefined) {
+      obj.reason = message.reason;
+    }
+    if (message.requestedAt !== '') {
+      obj.requestedAt = message.requestedAt;
+    }
+    if (message.completionsJson !== '') {
+      obj.completionsJson = message.completionsJson;
+    }
+    if (message.completedAt !== undefined) {
+      obj.completedAt = message.completedAt;
+    }
+    if (message.createdAt !== '') {
+      obj.createdAt = message.createdAt;
+    }
+    if (message.updatedAt !== '') {
+      obj.updatedAt = message.updatedAt;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GdprErasureRequest>, I>>(base?: I): GdprErasureRequest {
+    return GdprErasureRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GdprErasureRequest>, I>>(object: I): GdprErasureRequest {
+    const message = createBaseGdprErasureRequest();
+    message.correlationId = object.correlationId ?? '';
+    message.userId = object.userId ?? '';
+    message.reason = object.reason ?? undefined;
+    message.requestedAt = object.requestedAt ?? '';
+    message.completionsJson = object.completionsJson ?? '';
+    message.completedAt = object.completedAt ?? undefined;
+    message.createdAt = object.createdAt ?? '';
+    message.updatedAt = object.updatedAt ?? '';
+    return message;
+  },
+};
+
+function createBaseGetGdprErasureRequestRequest(): GetGdprErasureRequestRequest {
+  return { correlationId: '' };
+}
+
+export const GetGdprErasureRequestRequest: MessageFns<GetGdprErasureRequestRequest> = {
+  encode(
+    message: GetGdprErasureRequestRequest,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.correlationId !== '') {
+      writer.uint32(10).string(message.correlationId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetGdprErasureRequestRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetGdprErasureRequestRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.correlationId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetGdprErasureRequestRequest {
+    return {
+      correlationId: isSet(object.correlationId)
+        ? globalThis.String(object.correlationId)
+        : isSet(object.correlation_id)
+          ? globalThis.String(object.correlation_id)
+          : '',
+    };
+  },
+
+  toJSON(message: GetGdprErasureRequestRequest): unknown {
+    const obj: any = {};
+    if (message.correlationId !== '') {
+      obj.correlationId = message.correlationId;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetGdprErasureRequestRequest>, I>>(
+    base?: I
+  ): GetGdprErasureRequestRequest {
+    return GetGdprErasureRequestRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetGdprErasureRequestRequest>, I>>(
+    object: I
+  ): GetGdprErasureRequestRequest {
+    const message = createBaseGetGdprErasureRequestRequest();
+    message.correlationId = object.correlationId ?? '';
+    return message;
+  },
+};
+
+function createBaseGetGdprErasureRequestResponse(): GetGdprErasureRequestResponse {
+  return { request: undefined };
+}
+
+export const GetGdprErasureRequestResponse: MessageFns<GetGdprErasureRequestResponse> = {
+  encode(
+    message: GetGdprErasureRequestResponse,
+    writer: BinaryWriter = new BinaryWriter()
+  ): BinaryWriter {
+    if (message.request !== undefined) {
+      GdprErasureRequest.encode(message.request, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GetGdprErasureRequestResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetGdprErasureRequestResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.request = GdprErasureRequest.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetGdprErasureRequestResponse {
+    return {
+      request: isSet(object.request) ? GdprErasureRequest.fromJSON(object.request) : undefined,
+    };
+  },
+
+  toJSON(message: GetGdprErasureRequestResponse): unknown {
+    const obj: any = {};
+    if (message.request !== undefined) {
+      obj.request = GdprErasureRequest.toJSON(message.request);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetGdprErasureRequestResponse>, I>>(
+    base?: I
+  ): GetGdprErasureRequestResponse {
+    return GetGdprErasureRequestResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<GetGdprErasureRequestResponse>, I>>(
+    object: I
+  ): GetGdprErasureRequestResponse {
+    const message = createBaseGetGdprErasureRequestResponse();
+    message.request =
+      object.request !== undefined && object.request !== null
+        ? GdprErasureRequest.fromPartial(object.request)
+        : undefined;
+    return message;
+  },
+};
 
 function createBaseAuditEvent(): AuditEvent {
   return {
@@ -1020,6 +1390,25 @@ export const AuditQueryServiceService = {
       Buffer.from(GetByTargetResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer): GetByTargetResponse => GetByTargetResponse.decode(value),
   },
+  /**
+   * GDPR saga status. Returns a single row from
+   * audit.gdpr_erasure_requests keyed on correlation_id. NOT_FOUND when
+   * the saga hasn't been requested. Gated on admin.gdpr.read OR
+   * self-ownership (the requesting user reads their own row).
+   */
+  getGdprErasureRequest: {
+    path: '/adopt_dont_shop.audit.v1.AuditQueryService/GetGdprErasureRequest' as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: GetGdprErasureRequestRequest): Buffer =>
+      Buffer.from(GetGdprErasureRequestRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): GetGdprErasureRequestRequest =>
+      GetGdprErasureRequestRequest.decode(value),
+    responseSerialize: (value: GetGdprErasureRequestResponse): Buffer =>
+      Buffer.from(GetGdprErasureRequestResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): GetGdprErasureRequestResponse =>
+      GetGdprErasureRequestResponse.decode(value),
+  },
 } as const;
 
 export interface AuditQueryServiceServer extends UntypedServiceImplementation {
@@ -1039,6 +1428,16 @@ export interface AuditQueryServiceServer extends UntypedServiceImplementation {
    * notifications.*, moderation.* events tied to it).
    */
   getByTarget: handleUnaryCall<GetByTargetRequest, GetByTargetResponse>;
+  /**
+   * GDPR saga status. Returns a single row from
+   * audit.gdpr_erasure_requests keyed on correlation_id. NOT_FOUND when
+   * the saga hasn't been requested. Gated on admin.gdpr.read OR
+   * self-ownership (the requesting user reads their own row).
+   */
+  getGdprErasureRequest: handleUnaryCall<
+    GetGdprErasureRequestRequest,
+    GetGdprErasureRequestResponse
+  >;
 }
 
 export interface AuditQueryServiceClient extends Client {
@@ -1085,6 +1484,27 @@ export interface AuditQueryServiceClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: GetByTargetResponse) => void
+  ): ClientUnaryCall;
+  /**
+   * GDPR saga status. Returns a single row from
+   * audit.gdpr_erasure_requests keyed on correlation_id. NOT_FOUND when
+   * the saga hasn't been requested. Gated on admin.gdpr.read OR
+   * self-ownership (the requesting user reads their own row).
+   */
+  getGdprErasureRequest(
+    request: GetGdprErasureRequestRequest,
+    callback: (error: ServiceError | null, response: GetGdprErasureRequestResponse) => void
+  ): ClientUnaryCall;
+  getGdprErasureRequest(
+    request: GetGdprErasureRequestRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: GetGdprErasureRequestResponse) => void
+  ): ClientUnaryCall;
+  getGdprErasureRequest(
+    request: GetGdprErasureRequestRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: GetGdprErasureRequestResponse) => void
   ): ClientUnaryCall;
 }
 

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -377,6 +377,9 @@ export type {
   QueryResponse as AuditQueryResponse,
   GetByTargetRequest as AuditGetByTargetRequest,
   GetByTargetResponse as AuditGetByTargetResponse,
+  GdprErasureRequest as AuditGdprErasureRequest,
+  GetGdprErasureRequestRequest as AuditGetGdprErasureRequestRequest,
+  GetGdprErasureRequestResponse as AuditGetGdprErasureRequestResponse,
   AuditQueryServiceServer,
   AuditQueryServiceClient,
 } from './generated/proto/adopt_dont_shop/audit/v1/audit.js';

--- a/services/applications/src/gdpr/erase.ts
+++ b/services/applications/src/gdpr/erase.ts
@@ -1,0 +1,45 @@
+// GDPR erasure for the applications schema. Strategy: anonymise the
+// applicant's identifiable fields on every application they filed, but
+// keep the row so rescue staff retain the operational record of past
+// adoptions (legal retention period for rescue records often exceeds
+// the user's own data-retention preference).
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function eraseApplications(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+
+  // The applications table stores the user's answers + references as
+  // JSONB. Scrub these alongside the personal columns.
+  const appsRes = await client.query(
+    `UPDATE applications.applications
+        SET answers = '{}'::jsonb,
+            "references" = '[]'::jsonb,
+            notes = NULL,
+            interview_notes = NULL,
+            home_visit_notes = NULL,
+            updated_at = now()
+      WHERE user_id = $1`,
+    [payload.userId]
+  );
+  total += appsRes.rowCount ?? 0;
+
+  // Documents the user uploaded: hard-delete the metadata rows (the bytes
+  // sitting in storage are erased by a separate retention sweep — see
+  // gateway uploads route).
+  const docsRes = await client.query(
+    `DELETE FROM applications.documents
+       USING applications.applications a
+       WHERE applications.documents.application_id = a.application_id
+         AND a.user_id = $1`,
+    [payload.userId]
+  );
+  total += docsRes.rowCount ?? 0;
+
+  return total;
+}

--- a/services/applications/src/index.ts
+++ b/services/applications/src/index.ts
@@ -28,6 +28,17 @@ const main = async (): Promise<void> => {
     nats = await connect({ servers: config.natsUrl });
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    // GDPR erasure subscriber — drops the user's data in this schema.
+    // Reports back via gdpr.erasureCompleted with service='applications'.
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { eraseApplications } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'applications',
+      erase: eraseApplications,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
 
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });

--- a/services/audit/src/grpc/handlers.test.ts
+++ b/services/audit/src/grpc/handlers.test.ts
@@ -4,7 +4,7 @@ import { AuditV1, type AuditQueryRequest } from '@adopt-dont-shop/proto';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
 import { encodeCursor } from './cursor.js';
-import { getByTarget, query } from './handlers.js';
+import { getByTarget, getGdprErasureRequest, query } from './handlers.js';
 
 function makePrincipal(overrides: Partial<{ userId: string; permissions: string[] }> = {}) {
   return {
@@ -204,5 +204,87 @@ describe('getByTarget', () => {
     });
     expect(res.events).toHaveLength(10);
     expect(res.nextCursor).toBeDefined();
+  });
+});
+
+// --- getGdprErasureRequest -------------------------------------------
+
+function makeGdprRow(overrides: Record<string, unknown> = {}) {
+  return {
+    correlation_id: 'corr-1',
+    user_id: 'usr-1',
+    reason: 'leaving',
+    requested_at: new Date('2026-06-09T12:00:00Z'),
+    completions: { auth: { recordsErased: 7, completedAt: '2026-06-09T12:01:00Z' } },
+    completed_at: null,
+    created_at: new Date('2026-06-09T12:00:00Z'),
+    updated_at: new Date('2026-06-09T12:01:00Z'),
+    ...overrides,
+  };
+}
+
+describe('getGdprErasureRequest', () => {
+  it('returns NOT_FOUND when the row is missing', async () => {
+    const queryMock = vi.fn(() => Promise.resolve({ rows: [] }));
+    const deps = {
+      pool: { query: queryMock },
+      nats: {},
+    } as unknown as HandlerDeps;
+    await expect(
+      getGdprErasureRequest(deps, makePrincipal(), { correlationId: 'corr-x' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('returns the row to an admin', async () => {
+    const queryMock = vi.fn(() => Promise.resolve({ rows: [makeGdprRow()] }));
+    const deps = {
+      pool: { query: queryMock },
+      nats: {},
+    } as unknown as HandlerDeps;
+    const res = await getGdprErasureRequest(
+      deps,
+      makePrincipal({ permissions: ['admin.gdpr.read'] }),
+      { correlationId: 'corr-1' }
+    );
+    expect(res.request?.correlationId).toBe('corr-1');
+    expect(res.request?.completionsJson).toContain('"auth"');
+  });
+
+  it('returns the row to the requesting user (self-ownership)', async () => {
+    const queryMock = vi.fn(() => Promise.resolve({ rows: [makeGdprRow()] }));
+    const deps = {
+      pool: { query: queryMock },
+      nats: {},
+    } as unknown as HandlerDeps;
+    const res = await getGdprErasureRequest(
+      deps,
+      makePrincipal({ userId: 'usr-1', permissions: [] }),
+      { correlationId: 'corr-1' }
+    );
+    expect(res.request?.userId).toBe('usr-1');
+  });
+
+  it('refuses a different user without admin.gdpr.read', async () => {
+    const queryMock = vi.fn(() => Promise.resolve({ rows: [makeGdprRow()] }));
+    const deps = {
+      pool: { query: queryMock },
+      nats: {},
+    } as unknown as HandlerDeps;
+    await expect(
+      getGdprErasureRequest(deps, makePrincipal({ userId: 'usr-2', permissions: [] }), {
+        correlationId: 'corr-1',
+      })
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+  });
+
+  it('rejects empty correlationId with INVALID_ARGUMENT', async () => {
+    const queryMock = vi.fn();
+    const deps = {
+      pool: { query: queryMock },
+      nats: {},
+    } as unknown as HandlerDeps;
+    await expect(
+      getGdprErasureRequest(deps, makePrincipal(), { correlationId: '   ' })
+    ).rejects.toMatchObject({ code: 'INVALID_ARGUMENT' });
   });
 });

--- a/services/audit/src/grpc/handlers.ts
+++ b/services/audit/src/grpc/handlers.ts
@@ -203,3 +203,61 @@ export async function getByTarget(
 
   return response;
 }
+
+// --- GetGdprErasureRequest -------------------------------------------
+
+type GdprRow = {
+  correlation_id: string;
+  user_id: string;
+  reason: string | null;
+  requested_at: Date;
+  completions: unknown;
+  completed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+const ADMIN_GDPR_READ = 'admin.gdpr.read' as import('@adopt-dont-shop/lib.types').Permission;
+
+export async function getGdprErasureRequest(
+  deps: HandlerDeps,
+  principal: Principal,
+  req: import('@adopt-dont-shop/proto').AuditGetGdprErasureRequestRequest
+): Promise<import('@adopt-dont-shop/proto').AuditGetGdprErasureRequestResponse> {
+  const correlationId = req.correlationId?.trim() ?? '';
+  if (correlationId === '') {
+    throw new HandlerError('INVALID_ARGUMENT', 'correlation_id is required');
+  }
+
+  const result = await deps.pool.query<GdprRow>(
+    `SELECT correlation_id, user_id, reason, requested_at,
+            completions, completed_at, created_at, updated_at
+       FROM gdpr_erasure_requests
+       WHERE correlation_id = $1`,
+    [correlationId]
+  );
+  const row = result.rows[0];
+  if (!row) {
+    throw new HandlerError('NOT_FOUND', `erasure request ${correlationId} not found`);
+  }
+
+  // Admin OR self can read. Anything else is denied.
+  const isOwner = row.user_id === principal.userId;
+  const isAdmin = requirePermission(principal, ADMIN_GDPR_READ);
+  if (!isOwner && !isAdmin) {
+    throw new HandlerError('PERMISSION_DENIED', `'${ADMIN_GDPR_READ}' required`);
+  }
+
+  return {
+    request: {
+      correlationId: row.correlation_id,
+      userId: row.user_id,
+      reason: row.reason ?? undefined,
+      requestedAt: row.requested_at.toISOString(),
+      completionsJson: JSON.stringify(row.completions ?? {}),
+      completedAt: row.completed_at?.toISOString(),
+      createdAt: row.created_at.toISOString(),
+      updatedAt: row.updated_at.toISOString(),
+    },
+  };
+}

--- a/services/audit/src/grpc/server.ts
+++ b/services/audit/src/grpc/server.ts
@@ -19,7 +19,7 @@ import { AuditV1 } from '@adopt-dont-shop/proto';
 import type { AuditConfig } from '../config.js';
 
 import { adapt } from './adapter.js';
-import { getByTarget, query } from './handlers.js';
+import { getByTarget, getGdprErasureRequest, query } from './handlers.js';
 
 export type CreateGrpcServerOptions = {
   config: AuditConfig;
@@ -42,10 +42,11 @@ export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   server.addService(AuditV1.AuditQueryServiceService, {
     query: adapt(query, { deps, logger }),
     getByTarget: adapt(getByTarget, { deps, logger }),
+    getGdprErasureRequest: adapt(getGdprErasureRequest, { deps, logger }),
   });
 
   logger.info('gRPC AuditQueryService registered', {
-    methods: ['query', 'getByTarget'],
+    methods: ['query', 'getByTarget', 'getGdprErasureRequest'],
     grpcPort: config.grpcPort,
   });
 

--- a/services/audit/src/index.ts
+++ b/services/audit/src/index.ts
@@ -5,6 +5,7 @@ import { createLogger } from '@adopt-dont-shop/observability';
 
 import { loadConfig } from './config.js';
 import { startGrpcServer, type RunningGrpcServer } from './grpc/server.js';
+import { registerGdprSubscribers } from './nats/gdpr-subscribers.js';
 import { registerSubscribers } from './nats/subscribers.js';
 import { createServer } from './server.js';
 
@@ -35,7 +36,10 @@ const main = async (): Promise<void> => {
     // service is never in a state where it's accepting NATS messages
     // without being able to serve any query routed through gRPC.
     // Phase 10.4 — subscribes to *.actionTaken; persists every event.
-    subscriptions = registerSubscribers({ nats, pool, logger });
+    subscriptions = [
+      ...registerSubscribers({ nats, pool, logger }),
+      ...registerGdprSubscribers({ nats, pool, logger }),
+    ];
 
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });

--- a/services/audit/src/migrations/002_create_gdpr_erasure_requests.ts
+++ b/services/audit/src/migrations/002_create_gdpr_erasure_requests.ts
@@ -1,0 +1,39 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// audit.gdpr_erasure_requests — saga tracker for the GDPR erasure flow.
+//
+// One row per saga (correlation_id PK). Aggregates the per-service
+// completion acks into a JSONB blob; rather than carry a separate
+// completion table, the audit subscriber re-reads + rewrites this
+// single row each time a `gdpr.erasureCompleted` event lands. That's
+// fine at GDPR throughput (a handful of requests per day) and keeps
+// the status lookup a single SELECT.
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.createTable('gdpr_erasure_requests', {
+    correlation_id: { type: 'uuid', primaryKey: true },
+    user_id: { type: 'uuid', notNull: true },
+    reason: { type: 'text' },
+    requested_at: { type: 'timestamptz', notNull: true },
+    // Map of service-name → { recordsErased, completedAt, error? }. Keeps
+    // the schema cheap to evolve; today's services + a future Phase 12
+    // service just plug into the same blob.
+    completions: { type: 'jsonb', notNull: true, default: pgm.func("'{}'::jsonb") },
+    // Set when every service we expect to ack has acked. Optional so a
+    // stuck saga shows as NULL — the operator runs the timeout sweep.
+    completed_at: { type: 'timestamptz' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+  });
+
+  pgm.createIndex('gdpr_erasure_requests', 'user_id', {
+    name: 'gdpr_erasure_requests_user_id_idx',
+  });
+  pgm.createIndex('gdpr_erasure_requests', 'requested_at', {
+    name: 'gdpr_erasure_requests_requested_at_idx',
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropTable('gdpr_erasure_requests');
+};

--- a/services/audit/src/nats/gdpr-subscribers.test.ts
+++ b/services/audit/src/nats/gdpr-subscribers.test.ts
@@ -1,0 +1,88 @@
+import type { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { recordCompletion, recordRequest, EXPECTED_SERVICES } from './gdpr-subscribers.js';
+
+function makePool() {
+  return {
+    query: vi.fn(async () => ({ rows: [], rowCount: 1 })),
+  } as unknown as Pool;
+}
+
+describe('recordRequest', () => {
+  it('INSERTs with ON CONFLICT DO NOTHING (idempotent on correlation_id)', async () => {
+    const pool = makePool();
+    await recordRequest(pool, {
+      userId: 'usr-1',
+      correlationId: 'corr-1',
+      requestedAt: '2026-06-09T12:00:00Z',
+      reason: 'leaving',
+    });
+    const [sql, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      unknown[],
+    ];
+    expect(sql).toContain('INSERT INTO audit.gdpr_erasure_requests');
+    expect(sql).toContain('ON CONFLICT (correlation_id) DO NOTHING');
+    expect(params).toEqual(['corr-1', 'usr-1', 'leaving', '2026-06-09T12:00:00Z']);
+  });
+});
+
+describe('recordCompletion', () => {
+  it('merges the completion into the JSONB blob and threads EXPECTED_SERVICES into the SQL', async () => {
+    const pool = makePool();
+    await recordCompletion(pool, {
+      userId: 'usr-1',
+      correlationId: 'corr-1',
+      service: 'auth',
+      recordsErased: 7,
+      completedAt: '2026-06-09T12:01:00Z',
+    });
+    const [sql, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      unknown[],
+    ];
+    expect(sql).toContain('ON CONFLICT (correlation_id) DO UPDATE');
+    expect(sql).toContain('jsonb_object_keys');
+    // The threshold for completed_at comes from EXPECTED_SERVICES.length.
+    expect(params[5]).toBe(EXPECTED_SERVICES.length);
+    // The completion entry shape.
+    const entry = JSON.parse(params[4] as string) as Record<string, unknown>;
+    expect(entry).toMatchObject({
+      recordsErased: 7,
+      completedAt: '2026-06-09T12:01:00Z',
+    });
+    expect(entry.error).toBeUndefined();
+  });
+
+  it('records error field when the failure path lands', async () => {
+    const pool = makePool();
+    await recordCompletion(pool, {
+      userId: 'usr-1',
+      correlationId: 'corr-1',
+      service: 'pets',
+      recordsErased: 0,
+      completedAt: '2026-06-09T12:01:00Z',
+      error: 'pool timeout',
+    });
+    const params = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0][1] as unknown[];
+    const entry = JSON.parse(params[4] as string) as Record<string, unknown>;
+    expect(entry.error).toBe('pool timeout');
+  });
+});
+
+describe('EXPECTED_SERVICES', () => {
+  it('lists the 9 services that should ack every erasure', () => {
+    expect(EXPECTED_SERVICES).toEqual([
+      'auth',
+      'notifications',
+      'pets',
+      'chat',
+      'applications',
+      'matching',
+      'moderation',
+      'cms',
+      'rescue',
+    ]);
+  });
+});

--- a/services/audit/src/nats/gdpr-subscribers.ts
+++ b/services/audit/src/nats/gdpr-subscribers.ts
@@ -1,0 +1,138 @@
+// NATS subscribers for the GDPR erasure saga. Two streams:
+//
+//   * `gdpr.erasureRequested` — INSERT a row into
+//     audit.gdpr_erasure_requests. Idempotent via ON CONFLICT (correlation_id).
+//   * `gdpr.erasureCompleted` — merge the per-service completion into the
+//     `completions` JSONB blob. Updates `completed_at` once every service
+//     in the configured EXPECTED_SERVICES set has acked.
+//
+// Both subscribers share the audit-workers queue group so a replicated
+// audit deployment load-balances saga tracking.
+
+import type { NatsConnection, Subscription } from 'nats';
+import type { Pool } from 'pg';
+import type { Logger } from 'winston';
+
+import {
+  GDPR_ERASURE_COMPLETED,
+  GDPR_ERASURE_REQUESTED,
+  subscribe,
+  type GdprErasureCompletedPayload,
+  type GdprErasureRequestedPayload,
+} from '@adopt-dont-shop/events';
+
+// The set of services we expect to ack each request. Once every one of
+// these has a completion entry, the request flips to completed_at = now().
+// Keep this in sync with services/{auth,notifications,pets,chat,
+// applications,matching,moderation,cms,rescue}/src/index.ts subscriber
+// wiring.
+export const EXPECTED_SERVICES = [
+  'auth',
+  'notifications',
+  'pets',
+  'chat',
+  'applications',
+  'matching',
+  'moderation',
+  'cms',
+  'rescue',
+] as const;
+
+const QUEUE_GROUP = 'audit-workers';
+
+export type RegisterGdprSubscribersOptions = {
+  nats: NatsConnection;
+  pool: Pool;
+  logger: Logger;
+};
+
+export const registerGdprSubscribers = (opts: RegisterGdprSubscribersOptions): Subscription[] => {
+  const { nats, pool, logger } = opts;
+
+  const onError = (err: unknown, ctx: { subject: string }): void => {
+    logger.error('audit gdpr subscriber handler failed', {
+      subject: ctx.subject,
+      err: (err as Error)?.message ?? String(err),
+    });
+  };
+
+  return [
+    subscribe<GdprErasureRequestedPayload>(
+      nats,
+      { subject: GDPR_ERASURE_REQUESTED, queue: QUEUE_GROUP, onError },
+      async payload => {
+        await recordRequest(pool, payload);
+      }
+    ),
+    subscribe<GdprErasureCompletedPayload>(
+      nats,
+      { subject: GDPR_ERASURE_COMPLETED, queue: QUEUE_GROUP, onError },
+      async payload => {
+        await recordCompletion(pool, payload);
+      }
+    ),
+  ];
+};
+
+// INSERT the saga row. ON CONFLICT means a replayed event is a no-op,
+// and a completion that arrives BEFORE the request (the bus can reorder
+// across subjects) still gets attached when the request finally lands —
+// the completion handler's UPDATE locks the row and merges into the
+// existing completions blob.
+export async function recordRequest(
+  pool: Pool,
+  payload: GdprErasureRequestedPayload
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO audit.gdpr_erasure_requests
+       (correlation_id, user_id, reason, requested_at)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (correlation_id) DO NOTHING`,
+    [payload.correlationId, payload.userId, payload.reason ?? null, payload.requestedAt]
+  );
+}
+
+// Merge a per-service completion into the row. When every expected
+// service has acked, stamp completed_at. If the row hasn't been recorded
+// yet (out-of-order delivery), INSERT a skeleton with the completion
+// already merged.
+export async function recordCompletion(
+  pool: Pool,
+  payload: GdprErasureCompletedPayload
+): Promise<void> {
+  const entry = {
+    recordsErased: payload.recordsErased,
+    completedAt: payload.completedAt,
+    ...(payload.error ? { error: payload.error } : {}),
+  };
+
+  await pool.query(
+    `INSERT INTO audit.gdpr_erasure_requests
+       (correlation_id, user_id, reason, requested_at, completions)
+     VALUES ($1, $2, NULL, $3, jsonb_build_object($4::text, $5::jsonb))
+     ON CONFLICT (correlation_id) DO UPDATE
+       SET completions = audit.gdpr_erasure_requests.completions
+                       || jsonb_build_object($4::text, $5::jsonb),
+           completed_at = CASE
+             WHEN audit.gdpr_erasure_requests.completed_at IS NOT NULL
+               THEN audit.gdpr_erasure_requests.completed_at
+             WHEN (
+               SELECT count(*) FROM jsonb_object_keys(
+                 audit.gdpr_erasure_requests.completions
+                   || jsonb_build_object($4::text, $5::jsonb)
+               )
+             ) >= $6
+               THEN now()
+             ELSE NULL
+           END,
+           updated_at = now()`,
+    [
+      payload.correlationId,
+      payload.userId,
+      payload.completedAt,
+      payload.service,
+      JSON.stringify(entry),
+      EXPECTED_SERVICES.length,
+    ]
+  );
+}

--- a/services/auth/src/gdpr/erase.test.ts
+++ b/services/auth/src/gdpr/erase.test.ts
@@ -1,0 +1,67 @@
+import type { PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+import { eraseAuth } from './erase.js';
+
+const PAYLOAD: GdprErasureRequestedPayload = {
+  userId: 'usr-1',
+  correlationId: 'corr-abc',
+  requestedAt: '2026-06-09T00:00:00Z',
+};
+
+function fakeClient(rowCounts: number[]): PoolClient {
+  let i = 0;
+  return {
+    query: vi.fn(async () => {
+      const rowCount = rowCounts[i] ?? 0;
+      i++;
+      return { rows: [], rowCount };
+    }),
+    release: vi.fn(),
+  } as unknown as PoolClient;
+}
+
+describe('eraseAuth', () => {
+  it('scrubs the users row + drops sessions / prefs / roles', async () => {
+    const client = fakeClient([1, 3, 1, 2]); // UPDATE users (1), DELETE refresh (3), prefs (1), roles (2)
+    const total = await eraseAuth(client, PAYLOAD);
+    expect(total).toBe(7);
+
+    const calls = (client.query as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(4);
+
+    const usersSql = String(calls[0][0]);
+    expect(usersSql).toContain('UPDATE auth.users');
+    expect(usersSql).toContain("status = 'deactivated'");
+    expect(usersSql).toContain('deleted_at = now()');
+    // PII columns are nulled or replaced.
+    expect(usersSql).toContain('first_name = NULL');
+    expect(usersSql).toContain('phone_number = NULL');
+    expect(usersSql).toContain('email = $2');
+
+    // refresh_tokens / privacy_prefs / user_roles deleted by user_id.
+    expect(String(calls[1][0])).toContain('DELETE FROM auth.refresh_tokens');
+    expect(String(calls[2][0])).toContain('DELETE FROM auth.user_privacy_prefs');
+    expect(String(calls[3][0])).toContain('DELETE FROM auth.user_roles');
+    for (const c of calls) {
+      expect((c[1] as unknown[])[0]).toBe('usr-1');
+    }
+  });
+
+  it('returns 0 when the user did not exist (idempotent re-run)', async () => {
+    const client = fakeClient([0, 0, 0, 0]);
+    const total = await eraseAuth(client, PAYLOAD);
+    expect(total).toBe(0);
+  });
+
+  it('uses a stable scrubbed-email placeholder (no PII leak in the new value)', async () => {
+    const client = fakeClient([1, 0, 0, 0]);
+    await eraseAuth(client, PAYLOAD);
+    const calls = (client.query as ReturnType<typeof vi.fn>).mock.calls;
+    const scrubbedEmail = (calls[0][1] as unknown[])[1] as string;
+    expect(scrubbedEmail).toMatch(/^erased\+/);
+    expect(scrubbedEmail).toContain('@example.invalid');
+  });
+});

--- a/services/auth/src/gdpr/erase.ts
+++ b/services/auth/src/gdpr/erase.ts
@@ -1,0 +1,73 @@
+// GDPR erasure for the auth schema. Strategy: anonymise the users row
+// in place (set deleted_at, scrub PII columns) and hard-delete the
+// session + refresh-token state. We never DELETE the users row itself
+// because foreign keys live in other schemas as opaque user_id strings —
+// rebroadcasting "user gone" lets downstream services clean themselves
+// up via the saga, but the row needs to stay for FK integrity until the
+// retention period passes.
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function eraseAuth(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+
+  // Anonymise the users row. Keeps user_id so cross-schema lookups still
+  // resolve, but strips every column that could identify the person.
+  const userRes = await client.query<{ user_id: string }>(
+    `UPDATE auth.users
+        SET email = $2,
+            password = '__erased__',
+            first_name = NULL,
+            last_name = NULL,
+            phone_number = NULL,
+            date_of_birth = NULL,
+            bio = NULL,
+            profile_image_url = NULL,
+            country = NULL,
+            city = NULL,
+            address_line_1 = NULL,
+            address_line_2 = NULL,
+            postal_code = NULL,
+            two_factor_secret = NULL,
+            backup_codes = NULL,
+            reset_token = NULL,
+            verification_token = NULL,
+            email_verified = false,
+            phone_verified = false,
+            status = 'deactivated',
+            deleted_at = now(),
+            updated_at = now()
+      WHERE user_id = $1
+      RETURNING user_id`,
+    [payload.userId, `erased+${payload.userId}@example.invalid`]
+  );
+  total += userRes.rowCount ?? 0;
+
+  // Hard-delete sessions + refresh tokens so the user can't be impersonated
+  // after the erasure window. Idempotent: a re-run on an already-erased
+  // user is a no-op.
+  const sessRes = await client.query(`DELETE FROM auth.refresh_tokens WHERE user_id = $1`, [
+    payload.userId,
+  ]);
+  total += sessRes.rowCount ?? 0;
+
+  // Privacy prefs no longer apply — drop the row.
+  const prefsRes = await client.query(`DELETE FROM auth.user_privacy_prefs WHERE user_id = $1`, [
+    payload.userId,
+  ]);
+  total += prefsRes.rowCount ?? 0;
+
+  // User-role rows so the principal evaluator can no longer derive
+  // permissions for them.
+  const rolesRes = await client.query(`DELETE FROM auth.user_roles WHERE user_id = $1`, [
+    payload.userId,
+  ]);
+  total += rolesRes.rowCount ?? 0;
+
+  return total;
+}

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -43,6 +43,20 @@ const main = async (): Promise<void> => {
       logger,
     });
 
+    // GDPR erasure subscriber. Listens on `gdpr.erasureRequested`,
+    // scrubs the user's row + drops sessions/prefs/roles, then publishes
+    // `gdpr.erasureCompleted` with service='auth'. The subscriber lives
+    // for the whole process — drained on shutdown via nats.drain().
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { eraseAuth } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'auth',
+      erase: eraseAuth,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
+
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });
 

--- a/services/chat/src/gdpr/erase.ts
+++ b/services/chat/src/gdpr/erase.ts
@@ -1,0 +1,34 @@
+// GDPR erasure for the chat schema. Strategy: anonymise messages
+// (clearing content + sender display) rather than delete, because
+// counterparty users + audit trails of the conversation need to remain
+// intact. Drop reactions / reads / participant rows the erased user
+// owned.
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function eraseChat(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+
+  const msgRes = await client.query(
+    `UPDATE chat.messages
+        SET content = '[erased]', deleted_at = now(), updated_at = now()
+      WHERE sender_id = $1 AND deleted_at IS NULL`,
+    [payload.userId]
+  );
+  total += msgRes.rowCount ?? 0;
+
+  for (const sql of [
+    `DELETE FROM chat.message_reactions WHERE user_id = $1`,
+    `DELETE FROM chat.message_reads WHERE user_id = $1`,
+    `DELETE FROM chat.chat_participants WHERE user_id = $1`,
+  ]) {
+    const res = await client.query(sql, [payload.userId]);
+    total += res.rowCount ?? 0;
+  }
+  return total;
+}

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -25,6 +25,18 @@ const main = async (): Promise<void> => {
     nats = await connect({ servers: config.natsUrl });
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    // GDPR erasure subscriber — drops the user's data in this schema.
+    // Reports back via gdpr.erasureCompleted with service='chat'.
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { eraseChat } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'chat',
+      erase: eraseChat,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
+
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });
 

--- a/services/cms/src/gdpr/erase.ts
+++ b/services/cms/src/gdpr/erase.ts
@@ -1,0 +1,31 @@
+// GDPR erasure for the cms schema. CMS content authored by the user
+// stays (it's published platform content, not user-personal). Just
+// anonymise the author_id + last_modified_by columns so the user can't
+// be re-identified through content authorship.
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function eraseCms(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+
+  const a = await client.query(
+    `UPDATE cms.cms_content SET author_id = NULL, updated_at = now() WHERE author_id = $1`,
+    [payload.userId]
+  );
+  total += a.rowCount ?? 0;
+
+  const b = await client.query(
+    `UPDATE cms.cms_content
+        SET last_modified_by = NULL, updated_at = now()
+      WHERE last_modified_by = $1`,
+    [payload.userId]
+  );
+  total += b.rowCount ?? 0;
+
+  return total;
+}

--- a/services/cms/src/index.ts
+++ b/services/cms/src/index.ts
@@ -20,6 +20,18 @@ const main = async (): Promise<void> => {
     pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });
     nats = await connect({ servers: config.natsUrl });
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    // GDPR erasure subscriber — drops the user's data in this schema.
+    // Reports back via gdpr.erasureCompleted with service='cms'.
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { eraseCms } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'cms',
+      erase: eraseCms,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
+
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });
 

--- a/services/gateway/src/grpc-clients/audit-client.ts
+++ b/services/gateway/src/grpc-clients/audit-client.ts
@@ -14,6 +14,8 @@ import {
   AuditV1,
   type AuditGetByTargetRequest,
   type AuditGetByTargetResponse,
+  type AuditGetGdprErasureRequestRequest,
+  type AuditGetGdprErasureRequestResponse,
   type AuditQueryRequest,
   type AuditQueryResponse,
 } from '@adopt-dont-shop/proto';
@@ -21,6 +23,10 @@ import {
 export type AuditClient = {
   query(req: AuditQueryRequest, metadata: Metadata): Promise<AuditQueryResponse>;
   getByTarget(req: AuditGetByTargetRequest, metadata: Metadata): Promise<AuditGetByTargetResponse>;
+  getGdprErasureRequest(
+    req: AuditGetGdprErasureRequestRequest,
+    metadata: Metadata
+  ): Promise<AuditGetGdprErasureRequestResponse>;
   close(): void;
 };
 
@@ -49,6 +55,7 @@ export const createAuditClient = (opts: CreateAuditClientOptions): AuditClient =
   return {
     query: (req, metadata) => callUnary(stub.query, req, metadata),
     getByTarget: (req, metadata) => callUnary(stub.getByTarget, req, metadata),
+    getGdprErasureRequest: (req, metadata) => callUnary(stub.getGdprErasureRequest, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -52,6 +52,10 @@ const main = async (): Promise<void> => {
     applicationsClient = createApplicationsClient({ address: config.applicationsGrpcUrl });
     chatClient = createChatClient({ address: config.chatGrpcUrl });
 
+    // NATS comes up BEFORE createServer so the GDPR erasure-request route
+    // can publish on it. Socket.IO still attaches after server.listen.
+    nats = await connect({ servers: config.natsUrl });
+
     const server = await createServer({
       config,
       logger,
@@ -64,13 +68,10 @@ const main = async (): Promise<void> => {
       moderationClient,
       applicationsClient,
       chatClient,
+      nats,
     });
 
     await server.listen({ port: config.port, host: config.host });
-
-    // NATS + Socket.IO get wired AFTER the HTTP server binds so the
-    // underlying node http.Server exists for socket.io to attach to.
-    nats = await connect({ servers: config.natsUrl });
     const registry = new SocketRegistry();
     io = attachSocketServer({ httpServer: server.server, registry, logger });
     registerNotificationSubscribers({ nats, registry, logger });

--- a/services/gateway/src/routes/gdpr.test.ts
+++ b/services/gateway/src/routes/gdpr.test.ts
@@ -1,0 +1,152 @@
+import type { NatsConnection } from 'nats';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { status as grpcStatus } from '@grpc/grpc-js';
+
+import { GDPR_ERASURE_REQUESTED } from '@adopt-dont-shop/events';
+
+import type { AuditClient } from '../grpc-clients/audit-client.js';
+
+import { registerGdprRoutes } from './gdpr.js';
+
+function fakeNats() {
+  const published: Array<{ subject: string; data: string }> = [];
+  const nats = {
+    publish: vi.fn((subject: string, data: string) => published.push({ subject, data })),
+  } as unknown as NatsConnection;
+  return { nats, published };
+}
+
+function fakeAuditClient(): { client: AuditClient; getGdpr: ReturnType<typeof vi.fn> } {
+  const getGdpr = vi.fn();
+  const client = { getGdprErasureRequest: getGdpr } as unknown as AuditClient;
+  return { client, getGdpr };
+}
+
+describe('POST /api/v1/users/me/erasure-request', () => {
+  let app: FastifyInstance;
+  let published: Array<{ subject: string; data: string }>;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    const { nats, published: p } = fakeNats();
+    published = p;
+    await registerGdprRoutes(app, { nats });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('publishes gdpr.erasureRequested and returns 202 + correlationId', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/users/me/erasure-request',
+      headers: { 'x-user-id': 'usr-1' },
+      payload: { reason: 'closing account' },
+    });
+    expect(res.statusCode).toBe(202);
+    const body = res.json() as { success: boolean; correlationId: string };
+    expect(body.success).toBe(true);
+    expect(body.correlationId).toMatch(/^[0-9a-f-]{36}$/);
+
+    expect(published).toHaveLength(1);
+    expect(published[0].subject).toBe(GDPR_ERASURE_REQUESTED);
+    const envelope = JSON.parse(published[0].data) as {
+      payload: { userId: string; reason: string; correlationId: string };
+    };
+    expect(envelope.payload.userId).toBe('usr-1');
+    expect(envelope.payload.reason).toBe('closing account');
+    expect(envelope.payload.correlationId).toBe(body.correlationId);
+  });
+
+  it('refuses without an x-user-id header', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/users/me/erasure-request',
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+    expect(published).toHaveLength(0);
+  });
+
+  it('does not require a reason', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/users/me/erasure-request',
+      headers: { 'x-user-id': 'usr-1' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(202);
+    const envelope = JSON.parse(published[0].data) as {
+      payload: { reason?: string };
+    };
+    expect(envelope.payload.reason).toBeUndefined();
+  });
+});
+
+describe('GET /api/v1/users/me/erasure-request/:correlationId', () => {
+  let app: FastifyInstance;
+  let getGdpr: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    const { nats } = fakeNats();
+    const { client, getGdpr: g } = fakeAuditClient();
+    getGdpr = g;
+    await registerGdprRoutes(app, { nats, auditClient: client });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns the saga row + parses completionsJson into a real object', async () => {
+    getGdpr.mockResolvedValue({
+      request: {
+        correlationId: 'corr-1',
+        userId: 'usr-1',
+        reason: 'leaving',
+        requestedAt: '2026-06-09T12:00:00Z',
+        completionsJson: '{"auth":{"recordsErased":7,"completedAt":"2026-06-09T12:01:00Z"}}',
+        completedAt: undefined,
+        createdAt: '2026-06-09T12:00:00Z',
+        updatedAt: '2026-06-09T12:01:00Z',
+      },
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/users/me/erasure-request/corr-1',
+      headers: { 'x-user-id': 'usr-1' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      data: { completions: Record<string, unknown>; correlationId: string };
+    };
+    expect(body.data.correlationId).toBe('corr-1');
+    expect(body.data.completions).toEqual({
+      auth: { recordsErased: 7, completedAt: '2026-06-09T12:01:00Z' },
+    });
+  });
+
+  it('maps gRPC NOT_FOUND → 404', async () => {
+    getGdpr.mockRejectedValue({ code: grpcStatus.NOT_FOUND, details: 'no row' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/users/me/erasure-request/corr-x',
+      headers: { 'x-user-id': 'usr-1' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('maps gRPC PERMISSION_DENIED → 403', async () => {
+    getGdpr.mockRejectedValue({ code: grpcStatus.PERMISSION_DENIED, details: 'no' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/users/me/erasure-request/corr-1',
+      headers: { 'x-user-id': 'usr-2' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/services/gateway/src/routes/gdpr.ts
+++ b/services/gateway/src/routes/gdpr.ts
@@ -1,0 +1,141 @@
+// POST /api/v1/users/me/erasure-request — mint a correlationId and
+// publish gdpr.erasureRequested on NATS. Each service that owns user-
+// keyed data picks it up via @adopt-dont-shop/events.registerGdprSubscriber
+// and acks with gdpr.erasureCompleted.
+//
+// GET /api/v1/users/me/erasure-request/:correlationId — read saga
+// status from service.audit (which aggregates request + completions).
+//
+// The gateway holds no state for the saga.
+
+import { randomUUID } from 'node:crypto';
+
+import { Metadata, status } from '@grpc/grpc-js';
+import { GDPR_ERASURE_REQUESTED, type GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+import type { NatsConnection } from 'nats';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import type { AuditClient } from '../grpc-clients/audit-client.js';
+
+export type GdprRoutesOptions = {
+  nats: NatsConnection;
+  // Optional — when wired, the GET status endpoint is registered.
+  auditClient?: AuditClient;
+};
+
+const GRPC_TO_HTTP: Record<number, number> = {
+  [status.OK]: 200,
+  [status.INVALID_ARGUMENT]: 400,
+  [status.UNAUTHENTICATED]: 401,
+  [status.PERMISSION_DENIED]: 403,
+  [status.NOT_FOUND]: 404,
+  [status.INTERNAL]: 500,
+};
+
+export const registerGdprRoutes = async (
+  app: FastifyInstance,
+  opts: GdprRoutesOptions
+): Promise<void> => {
+  const { nats, auditClient } = opts;
+
+  app.post('/api/v1/users/me/erasure-request', async (req, reply) => {
+    const userId = principalUserId(req);
+    if (!userId) {
+      return reply.code(401).send({ success: false, error: 'unauthenticated' });
+    }
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const reason = typeof body.reason === 'string' ? body.reason : undefined;
+
+    const correlationId = randomUUID();
+    const payload: GdprErasureRequestedPayload = {
+      userId,
+      correlationId,
+      requestedAt: new Date().toISOString(),
+      reason,
+    };
+    const envelope = {
+      id: correlationId,
+      occurredAt: new Date().toISOString(),
+      payload,
+    };
+    nats.publish(GDPR_ERASURE_REQUESTED, JSON.stringify(envelope));
+
+    // 202 — the request is accepted, but actual erasure happens
+    // asynchronously across the services. The client polls the status
+    // endpoint to confirm.
+    return reply.code(202).send({
+      success: true,
+      correlationId,
+      requestedAt: payload.requestedAt,
+    });
+  });
+
+  // GET /api/v1/users/me/erasure-request/:correlationId — read saga
+  // status. The audit handler gates on self-ownership OR admin.gdpr.read,
+  // so this endpoint is safe for both the requesting user and an admin.
+  if (auditClient) {
+    app.get<{ Params: { correlationId: string } }>(
+      '/api/v1/users/me/erasure-request/:correlationId',
+      async (req, reply) => {
+        try {
+          const res = await auditClient.getGdprErasureRequest(
+            { correlationId: req.params.correlationId },
+            buildMetadata(req)
+          );
+          if (!res.request) {
+            return reply.code(404).send({ success: false, error: 'not found' });
+          }
+          let completions: Record<string, unknown> = {};
+          try {
+            completions = JSON.parse(res.request.completionsJson) as Record<string, unknown>;
+          } catch {
+            // Leave as empty object; the SPA can still display the
+            // request state without per-service detail.
+          }
+          return reply.send({
+            success: true,
+            data: {
+              correlationId: res.request.correlationId,
+              userId: res.request.userId,
+              reason: res.request.reason,
+              requestedAt: res.request.requestedAt,
+              completions,
+              completedAt: res.request.completedAt,
+            },
+          });
+        } catch (err) {
+          return handleGrpcError(err, reply);
+        }
+      }
+    );
+  }
+};
+
+function buildMetadata(req: FastifyRequest): Metadata {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+}
+
+type GrpcError = { code?: number; details?: string; message?: string };
+
+function handleGrpcError(err: unknown, reply: FastifyReply): FastifyReply {
+  const grpcErr = err as GrpcError;
+  const httpStatus = (grpcErr?.code !== undefined && GRPC_TO_HTTP[grpcErr.code]) || 500;
+  return reply.code(httpStatus).send({
+    success: false,
+    error: grpcErr?.details ?? grpcErr?.message ?? 'internal_error',
+  });
+}
+
+function principalUserId(req: FastifyRequest): string | null {
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  const raw = headers['x-user-id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -43,6 +43,7 @@ import { registerDashboardRoutes } from './routes/dashboard.js';
 import { registerDevicesRoutes } from './routes/devices.js';
 import { registerEmailRoutes } from './routes/email.js';
 import { registerFieldPermissionsRoutes } from './routes/field-permissions.js';
+import { registerGdprRoutes } from './routes/gdpr.js';
 import { registerLegalRoutes } from './routes/legal.js';
 import { registerMatchingRoutes } from './routes/matching.js';
 import { registerModerationAdminRoutes } from './routes/moderation-admin.js';
@@ -102,6 +103,11 @@ export type CreateServerOptions = {
   // gRPC client to service.cms. Same optional shape — when omitted,
   // /api/v1/cms/* falls through to the catch-all proxy.
   cmsClient?: CmsClient;
+  // NATS connection used by the GDPR erasure-request route to publish
+  // `gdpr.erasureRequested`. Optional in tests; when omitted the route
+  // is skipped (falls through to the catch-all proxy, which means
+  // erasure is monolith-owned).
+  nats?: import('nats').NatsConnection;
 };
 
 export const createServer = async (opts: CreateServerOptions): Promise<FastifyInstance> => {
@@ -294,6 +300,18 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
   // implementation was log-only (winston → Loki, no DB). Folds here so
   // the SPA's analytics flushes don't pay an extra http-proxy hop.
   await registerAnalyticsRoutes(server, { logger });
+
+  // GDPR erasure-request route — only enabled when NATS is wired (real
+  // boot always wires it; smoke tests that mount only /health/simple
+  // skip). When unwired the route doesn't register, which means
+  // /api/v1/users/me/erasure-request falls through to the catch-all
+  // proxy → monolith, preserving today's behaviour.
+  if (opts.nats) {
+    await registerGdprRoutes(server, {
+      nats: opts.nats,
+      auditClient: opts.auditClient,
+    });
+  }
 
   // Catch-all proxy. Phase 0f shipped this; Phase 1.6 leaves it in
   // place for every /api/* path that isn't owned by an extracted

--- a/services/matching/src/gdpr/erase.ts
+++ b/services/matching/src/gdpr/erase.ts
@@ -1,0 +1,27 @@
+// GDPR erasure for the matching schema. Swipe sessions + actions + the
+// adopter's match profile are all pure user-derived data with no shared
+// state — straight hard-delete.
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function eraseMatching(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+  // Order matters: swipe_actions FK swipe_sessions, so drop actions first.
+  for (const sql of [
+    `DELETE FROM matching.swipe_actions
+       USING matching.swipe_sessions s
+       WHERE matching.swipe_actions.session_id = s.session_id
+         AND s.user_id = $1`,
+    `DELETE FROM matching.swipe_sessions WHERE user_id = $1`,
+    `DELETE FROM matching.adopter_match_profiles WHERE user_id = $1`,
+  ]) {
+    const res = await client.query(sql, [payload.userId]);
+    total += res.rowCount ?? 0;
+  }
+  return total;
+}

--- a/services/matching/src/index.ts
+++ b/services/matching/src/index.ts
@@ -28,6 +28,17 @@ const main = async (): Promise<void> => {
     nats = await connect({ servers: config.natsUrl });
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    // GDPR erasure subscriber — drops the user's data in this schema.
+    // Reports back via gdpr.erasureCompleted with service='matching'.
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { eraseMatching } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'matching',
+      erase: eraseMatching,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
 
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });

--- a/services/moderation/src/gdpr/erase.ts
+++ b/services/moderation/src/gdpr/erase.ts
@@ -1,0 +1,36 @@
+// GDPR erasure for the moderation schema. Anonymise reports filed by
+// the user (keep the row so the reported party's moderation history
+// remains intact) and hard-delete the user's support tickets +
+// responses. user_sanctions rows are preserved without modification —
+// they're a record of platform action and survive erasure.
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function eraseModeration(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+
+  // Reports filed BY this user — anonymise reporter_id + description.
+  const rep1 = await client.query(
+    `UPDATE moderation.reports
+        SET reporter_id = NULL,
+            description = '[erased]',
+            updated_at = now()
+      WHERE reporter_id = $1`,
+    [payload.userId]
+  );
+  total += rep1.rowCount ?? 0;
+
+  // Support tickets opened by the user — drop the lot. Ticket
+  // responses cascade via FK ON DELETE CASCADE (set in the migration).
+  const tk = await client.query(`DELETE FROM moderation.support_tickets WHERE user_id = $1`, [
+    payload.userId,
+  ]);
+  total += tk.rowCount ?? 0;
+
+  return total;
+}

--- a/services/moderation/src/index.ts
+++ b/services/moderation/src/index.ts
@@ -29,6 +29,17 @@ const main = async (): Promise<void> => {
     nats = await connect({ servers: config.natsUrl });
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    // GDPR erasure subscriber — drops the user's data in this schema.
+    // Reports back via gdpr.erasureCompleted with service='moderation'.
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { eraseModeration } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'moderation',
+      erase: eraseModeration,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
 
     // Phase 8.4: content-scan + auto-report subscribers on
     // chat.messageCreated, pets.created, applications.submitted. Returned

--- a/services/notifications/src/gdpr/erase.test.ts
+++ b/services/notifications/src/gdpr/erase.test.ts
@@ -1,0 +1,36 @@
+import type { PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+import { eraseNotifications } from './erase.js';
+
+const PAYLOAD = {
+  userId: 'usr-1',
+  correlationId: 'corr',
+  requestedAt: '2026-06-09T00:00:00Z',
+};
+
+function fakeClient(counts: number[]): PoolClient {
+  let i = 0;
+  return {
+    query: vi.fn(async () => {
+      const rowCount = counts[i] ?? 0;
+      i++;
+      return { rows: [], rowCount };
+    }),
+    release: vi.fn(),
+  } as unknown as PoolClient;
+}
+
+describe('eraseNotifications', () => {
+  it('deletes from all four user-keyed tables in the notifications schema', async () => {
+    const client = fakeClient([4, 1, 1, 2]);
+    const total = await eraseNotifications(client, PAYLOAD);
+    expect(total).toBe(8);
+    const calls = (client.query as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(4);
+    expect(String(calls[0][0])).toContain('DELETE FROM notifications.notifications');
+    expect(String(calls[1][0])).toContain('DELETE FROM notifications.user_notification_prefs');
+    expect(String(calls[2][0])).toContain('DELETE FROM notifications.email_preferences');
+    expect(String(calls[3][0])).toContain('DELETE FROM notifications.device_tokens');
+  });
+});

--- a/services/notifications/src/gdpr/erase.ts
+++ b/services/notifications/src/gdpr/erase.ts
@@ -1,0 +1,28 @@
+// GDPR erasure for the notifications schema. Drops notification rows,
+// device tokens, and the per-user prefs entry. No anonymisation
+// strategy here — notifications are intrinsically about the user, so
+// scrubbing PII while leaving the row would still leak (e.g. message
+// body contains the user's name). Hard-delete is the right tool.
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function eraseNotifications(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+
+  const tables = [
+    'notifications.notifications',
+    'notifications.user_notification_prefs',
+    'notifications.email_preferences',
+    'notifications.device_tokens',
+  ];
+  for (const table of tables) {
+    const res = await client.query(`DELETE FROM ${table} WHERE user_id = $1`, [payload.userId]);
+    total += res.rowCount ?? 0;
+  }
+  return total;
+}

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -43,6 +43,18 @@ const main = async (): Promise<void> => {
     // can't race against partially-constructed deps. Shutdown drains the
     // whole NATS connection later, which transparently cancels these.
     registerSubscribers({ nats, deps: { pool, nats }, logger });
+
+    // GDPR erasure subscriber — drops the user's notifications + prefs
+    // + device tokens. Reported back via gdpr.erasureCompleted.
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { eraseNotifications } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'notifications',
+      erase: eraseNotifications,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
     // Email worker drains the email_queue table. Enabled by default;
     // tests + the migrations-only smoke set EMAIL_WORKER_ENABLED=false
     // to keep the loop quiet. Provider factory enforces ADS-549 (no

--- a/services/pets/src/gdpr/erase.ts
+++ b/services/pets/src/gdpr/erase.ts
@@ -1,0 +1,22 @@
+// GDPR erasure for the pets schema. Pet rows are rescue-owned (the
+// rescue lists the pet, not the user); the only user-keyed tables here
+// are favourites and ratings.
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function erasePets(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+  for (const sql of [
+    `DELETE FROM pets.user_favorites WHERE user_id = $1`,
+    `DELETE FROM pets.ratings WHERE user_id = $1`,
+  ]) {
+    const res = await client.query(sql, [payload.userId]);
+    total += res.rowCount ?? 0;
+  }
+  return total;
+}

--- a/services/pets/src/index.ts
+++ b/services/pets/src/index.ts
@@ -27,6 +27,17 @@ const main = async (): Promise<void> => {
     nats = await connect({ servers: config.natsUrl });
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    // GDPR erasure subscriber — drops the user's data in this schema.
+    // Reports back via gdpr.erasureCompleted with service='pets'.
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { erasePets } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'pets',
+      erase: erasePets,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
 
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });

--- a/services/rescue/src/gdpr/erase.ts
+++ b/services/rescue/src/gdpr/erase.ts
@@ -1,0 +1,24 @@
+// GDPR erasure for the rescue schema. Strategy: drop the user's staff
+// memberships (so they no longer have rescue-scoped permissions) and
+// detach them from any foster placements they were running. Rescue
+// rows themselves are organisation records, not user-personal data.
+
+import type { PoolClient } from 'pg';
+
+import type { GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
+
+export async function eraseRescue(
+  client: PoolClient,
+  payload: GdprErasureRequestedPayload
+): Promise<number> {
+  let total = 0;
+  for (const sql of [
+    `DELETE FROM rescue.staff_members WHERE user_id = $1`,
+    `UPDATE rescue.foster_placements SET foster_user_id = NULL, updated_at = now() WHERE foster_user_id = $1`,
+    `DELETE FROM rescue.invitations WHERE invited_user_id = $1`,
+  ]) {
+    const res = await client.query(sql, [payload.userId]);
+    total += res.rowCount ?? 0;
+  }
+  return total;
+}

--- a/services/rescue/src/index.ts
+++ b/services/rescue/src/index.ts
@@ -27,6 +27,17 @@ const main = async (): Promise<void> => {
     nats = await connect({ servers: config.natsUrl });
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    // GDPR erasure subscriber — drops the user's data in this schema.
+    // Reports back via gdpr.erasureCompleted with service='rescue'.
+    const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
+    const { eraseRescue } = await import('./gdpr/erase.js');
+    registerGdprSubscriber({
+      nats,
+      pool,
+      service: 'rescue',
+      erase: eraseRescue,
+      onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
+    });
 
     const httpServer = createServer({ config, logger });
     await httpServer.listen({ port: config.port, host: config.host });


### PR DESCRIPTION
## Summary

Adds end-to-end GDPR right-to-erasure. Flow:

```
POST /api/v1/users/me/erasure-request (gateway, REST)
  → publish gdpr.erasureRequested on NATS
  → 9 services subscribe (one queue-group per service), erase the
    user's slice of their schema inside a transaction, publish
    gdpr.erasureCompleted with { service, recordsErased, completedAt }
  → service.audit aggregates request + completions into
    audit.gdpr_erasure_requests, stamping completed_at once all 9
    services have acked

GET /api/v1/users/me/erasure-request/:correlationId (gateway, REST)
  → AuditQueryService.GetGdprErasureRequest → row with the
    completions blob; gated on self-ownership OR admin.gdpr.read
```

## `@adopt-dont-shop/events`

- `gdpr.ts`: `GDPR_ERASURE_REQUESTED` / `GDPR_ERASURE_COMPLETED` subject constants + request/completion payload types
- `gdpr-saga.ts`: `registerGdprSubscriber()` helper. Wraps each service's `erase` callback in `withTransaction` so the per-row scrub commits atomically, then publishes the completion after commit. **Errors are caught and a failure-completion is published outside the rolled-back transaction** so the audit tracker doesn't stall on a silent failure
- 3 helper tests (happy path, error → failure-completion, default queue-group naming `gdpr.<service>`)

## Per-service erase functions

One file per service, ~20-40 lines each:

| Service | Strategy |
|---|---|
| **auth** | Anonymise users row in place (clear PII columns, deactivate), hard-delete `refresh_tokens` + `user_privacy_prefs` + `user_roles` |
| **notifications** | Hard-delete notifications + prefs + email_preferences + device_tokens |
| **pets** | Drop `user_favorites` + `ratings` |
| **chat** | Anonymise messages by user (keep counterparty context), drop reactions + reads + participants |
| **applications** | Anonymise applicant fields (answers, references, notes, interview_notes, home_visit_notes), drop document metadata rows |
| **matching** | Drop swipe_actions → swipe_sessions → adopter_match_profiles |
| **moderation** | Anonymise reports filed BY user (keep reported party's history), drop support_tickets (cascade to responses); `user_sanctions` preserved |
| **cms** | Anonymise `author_id` + `last_modified_by` (CMS content is platform data) |
| **rescue** | Drop `staff_members`, detach `foster_placements`, drop `invitations` |

## `service.audit`

- New migration `002_create_gdpr_erasure_requests`: `correlation_id` PK, `completions` jsonb, `completed_at` nullable
- `gdpr-subscribers.ts`: two subscribers in the `audit-workers` queue group
  - `recordRequest` INSERTs with `ON CONFLICT DO NOTHING` (idempotent on correlation_id)
  - `recordCompletion` merges into the completions blob and stamps `completed_at` when `jsonb_object_keys` reaches `EXPECTED_SERVICES.length` (currently 9). Out-of-order delivery is handled — the completion handler INSERTs a skeleton row with completions pre-populated if the request hasn't landed yet
- New `GetGdprErasureRequest` RPC on `AuditQueryService`; authz checks self-ownership OR `admin.gdpr.read`
- 4 subscriber tests + 5 handler tests + 1 expected-set pinning test

## `services/gateway`

- New `routes/gdpr.ts`: `POST` publishes the event + returns `202 { correlationId, requestedAt }`; `GET` proxies to audit's `GetGdprErasureRequest`, parsing `completionsJson` back into a real object
- Gateway connects NATS **before** `createServer` so the route can close over it
- `AuditClient` interface + stub binding extended with `getGdprErasureRequest`
- 6 route tests

## Test plan

- [x] 3 saga helper tests
- [x] 3 auth erase tests
- [x] 1 notifications erase test
- [x] 9 audit-side tests
- [x] 6 gateway route tests
- [x] All other service suites continue to pass: events 14, auth 177, notifications 180, pets 94, chat 64, applications 205, matching 122, moderation 272, cms 28, rescue 94, gateway 439, audit 76

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_