### PR TITLE
fix(gateway): authenticate WebSocket handshakes + add gRPC client deadlines

### DIFF
--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -42,5 +42,8 @@
     "fastify": "^5.8.5",
     "nats": "^2.29.3",
     "socket.io": "^4.8.3"
+  },
+  "devDependencies": {
+    "socket.io-client": "^4.8.3"
   }
 }

--- a/services/gateway/src/grpc-clients/applications-client.ts
+++ b/services/gateway/src/grpc-clients/applications-client.ts
@@ -7,7 +7,7 @@
 // The interface is exported so tests can substitute a mock; the routes
 // depend on the shape, not the @grpc/grpc-js client.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   ApplicationsV1,
@@ -78,6 +78,11 @@ export type CreateApplicationsClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createApplicationsClient = (
   opts: CreateApplicationsClientOptions
 ): ApplicationsClient => {
@@ -87,12 +92,20 @@ export const createApplicationsClient = (
   );
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/audit-client.ts
+++ b/services/gateway/src/grpc-clients/audit-client.ts
@@ -8,7 +8,7 @@
 // The interface is exported so tests can substitute a mock; the
 // routes depend on the shape, not the @grpc/grpc-js client.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   AuditV1,
@@ -70,16 +70,29 @@ export type CreateAuditClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createAuditClient = (opts: CreateAuditClientOptions): AuditClient => {
   const stub = new AuditV1.AuditQueryServiceClient(opts.address, credentials.createInsecure());
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/auth-client.ts
+++ b/services/gateway/src/grpc-clients/auth-client.ts
@@ -9,7 +9,7 @@
 // the interface is exported so tests can substitute a mock; the
 // middleware + routes depend on the shape, not the @grpc/grpc-js client.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   AuthV1,
@@ -167,16 +167,29 @@ export type CreateAuthClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createAuthClient = (opts: CreateAuthClientOptions): AuthClient => {
   const stub = new AuthV1.AuthServiceClient(opts.address, credentials.createInsecure());
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/chat-client.ts
+++ b/services/gateway/src/grpc-clients/chat-client.ts
@@ -4,7 +4,7 @@
 // callback-shaped methods get wrapped in Promises, and the interface
 // is exported so route tests can substitute a mock.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   ChatV1,
@@ -54,16 +54,29 @@ export type CreateChatClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createChatClient = (opts: CreateChatClientOptions): ChatClient => {
   const stub = new ChatV1.ChatServiceClient(opts.address, credentials.createInsecure());
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/cms-client.ts
+++ b/services/gateway/src/grpc-clients/cms-client.ts
@@ -1,6 +1,6 @@
 // Promise-wrapped client for service.cms.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   CmsV1,
@@ -101,15 +101,28 @@ export type CreateCmsClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createCmsClient = (opts: CreateCmsClientOptions): CmsClient => {
   const stub = new CmsV1.CmsServiceClient(opts.address, credentials.createInsecure());
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/matching-client.ts
+++ b/services/gateway/src/grpc-clients/matching-client.ts
@@ -11,7 +11,7 @@
 // Same Promise-wrapped shape as other grpc-clients (rescue / pets /
 // auth / notifications / audit).
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   MatchingV1,
@@ -70,16 +70,29 @@ export type CreateMatchingClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createMatchingClient = (opts: CreateMatchingClientOptions): MatchingClient => {
   const stub = new MatchingV1.MatchingServiceClient(opts.address, credentials.createInsecure());
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/moderation-client.ts
+++ b/services/gateway/src/grpc-clients/moderation-client.ts
@@ -7,7 +7,7 @@
 // The interface is exported so tests can substitute a mock; the
 // routes depend on the shape, not the @grpc/grpc-js client.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   ModerationV1,
@@ -87,16 +87,29 @@ export type CreateModerationClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createModerationClient = (opts: CreateModerationClientOptions): ModerationClient => {
   const stub = new ModerationV1.ModerationServiceClient(opts.address, credentials.createInsecure());
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/notifications-client.ts
+++ b/services/gateway/src/grpc-clients/notifications-client.ts
@@ -10,7 +10,7 @@
 // substitute a mock — the route plugin depends on the shape, not the
 // gRPC client directly.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   NotificationsV1,
@@ -140,6 +140,11 @@ export type CreateNotificationsClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createNotificationsClient = (
   opts: CreateNotificationsClientOptions
 ): NotificationsClient => {
@@ -149,12 +154,20 @@ export const createNotificationsClient = (
   );
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/pets-client.ts
+++ b/services/gateway/src/grpc-clients/pets-client.ts
@@ -10,7 +10,7 @@
 // The interface is exported so tests can substitute a mock; the
 // routes depend on the shape, not the @grpc/grpc-js client.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   PetsV1,
@@ -45,16 +45,29 @@ export type CreatePetsClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createPetsClient = (opts: CreatePetsClientOptions): PetsClient => {
   const stub = new PetsV1.PetServiceClient(opts.address, credentials.createInsecure());
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/rescue-client.ts
+++ b/services/gateway/src/grpc-clients/rescue-client.ts
@@ -9,7 +9,7 @@
 // The interface is exported so tests can substitute a mock; the
 // routes depend on the shape, not the @grpc/grpc-js client.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, Metadata, type CallOptions } from '@grpc/grpc-js';
 
 import {
   RescueV1,
@@ -83,16 +83,29 @@ export type CreateRescueClientOptions = {
   address: string;
 };
 
+// Default per-call deadline. Without one, a hung downstream service
+// would hang the gateway request forever; 5s caps the blast radius
+// and lets the caller fail fast with DEADLINE_EXCEEDED.
+const DEFAULT_DEADLINE_MS = 5_000;
+
 export const createRescueClient = (opts: CreateRescueClientOptions): RescueClient => {
   const stub = new RescueV1.RescueServiceClient(opts.address, credentials.createInsecure());
 
   const callUnary = <Req, Res>(
-    fn: (req: Req, metadata: Metadata, cb: (err: unknown, res: Res) => void) => unknown,
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
     req: Req,
     metadata: Metadata
   ): Promise<Res> =>
     new Promise<Res>((resolve, reject) => {
-      fn.call(stub, req, metadata, (err: unknown, res: Res) => {
+      const options: Partial<CallOptions> = {
+        deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
+      };
+      fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -73,7 +73,7 @@ const main = async (): Promise<void> => {
 
     await server.listen({ port: config.port, host: config.host });
     const registry = new SocketRegistry();
-    io = attachSocketServer({ httpServer: server.server, registry, logger });
+    io = attachSocketServer({ httpServer: server.server, registry, logger, authClient });
     registerNotificationSubscribers({ nats, registry, logger });
     registerChatSubscribers({ nats, registry, logger });
 

--- a/services/gateway/src/ws/socket-server.test.ts
+++ b/services/gateway/src/ws/socket-server.test.ts
@@ -1,0 +1,172 @@
+import { createServer, type Server as HttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { io as ioClient, type Socket as ClientSocket } from 'socket.io-client';
+import type { Server as IOServer } from 'socket.io';
+import type { Logger } from 'winston';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ValidateTokenResponse } from '@adopt-dont-shop/proto';
+
+import type { AuthClient } from '../grpc-clients/auth-client.js';
+
+import { SocketRegistry } from './socket-registry.js';
+import { attachSocketServer, type AttachSocketServerOptions } from './socket-server.js';
+
+function quietLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    silly: vi.fn(),
+  } as unknown as Logger;
+}
+
+// One-method auth client stub — mirrors authenticate.test.ts. The full
+// AuthClient shape is huge; the socket server only depends on
+// validateToken, so a narrow stub is the honest dependency.
+function makeAuthClient(validateMock: ReturnType<typeof vi.fn>): AuthClient {
+  return { validateToken: validateMock, close: vi.fn() } as unknown as AuthClient;
+}
+
+type Harness = {
+  httpServer: HttpServer;
+  io: IOServer;
+  registry: SocketRegistry;
+  url: string;
+};
+
+const harnesses: Harness[] = [];
+const clients: ClientSocket[] = [];
+
+async function startServer(
+  opts: Omit<AttachSocketServerOptions, 'httpServer' | 'registry'>
+): Promise<Harness> {
+  const httpServer = createServer();
+  const registry = new SocketRegistry();
+  const io = attachSocketServer({ httpServer, registry, ...opts });
+  await new Promise<void>(resolve => httpServer.listen(0, resolve));
+  const port = (httpServer.address() as AddressInfo).port;
+  const harness: Harness = { httpServer, io, registry, url: `http://127.0.0.1:${port}` };
+  harnesses.push(harness);
+  return harness;
+}
+
+function connectClient(url: string, handshake: { auth?: Record<string, unknown> }): ClientSocket {
+  const client = ioClient(url, {
+    path: '/socket.io',
+    transports: ['websocket'],
+    reconnection: false,
+    ...handshake,
+  });
+  clients.push(client);
+  return client;
+}
+
+// Resolves true if the client connects, false if it's rejected.
+function awaitConnectOutcome(client: ClientSocket): Promise<boolean> {
+  return new Promise<boolean>(resolve => {
+    client.on('connect', () => resolve(true));
+    client.on('connect_error', () => resolve(false));
+  });
+}
+
+const VALID_RES: ValidateTokenResponse = {
+  principal: {
+    userId: 'usr-from-principal',
+    roles: [],
+    permissions: [],
+  },
+  expiresAt: '2026-06-05T18:30:00Z',
+};
+
+beforeEach(() => {
+  harnesses.length = 0;
+  clients.length = 0;
+});
+
+afterEach(async () => {
+  for (const client of clients) {
+    client.disconnect();
+  }
+  for (const h of harnesses) {
+    h.io.close();
+    await new Promise<void>(resolve => h.httpServer.close(() => resolve()));
+  }
+});
+
+describe('attachSocketServer — handshake authentication', () => {
+  it('rejects a handshake with no token', async () => {
+    const validateMock = vi.fn();
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(validateMock),
+    });
+
+    const client = connectClient(url, { auth: {} });
+    const connected = await awaitConnectOutcome(client);
+
+    expect(connected).toBe(false);
+    expect(validateMock).not.toHaveBeenCalled();
+    expect(registry.size()).toBe(0);
+  });
+
+  it('rejects a handshake whose token the auth service rejects', async () => {
+    const validateMock = vi.fn().mockRejectedValue(new Error('invalid token'));
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(validateMock),
+    });
+
+    const client = connectClient(url, { auth: { token: 'bad.jwt' } });
+    const connected = await awaitConnectOutcome(client);
+
+    expect(connected).toBe(false);
+    expect(validateMock).toHaveBeenCalledWith({ accessToken: 'bad.jwt' }, expect.anything());
+    expect(registry.size()).toBe(0);
+  });
+
+  it('registers the socket under the principal userId, ignoring a forged client userId', async () => {
+    const validateMock = vi.fn().mockResolvedValue(VALID_RES);
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      authClient: makeAuthClient(validateMock),
+    });
+
+    // The attacker passes BOTH a valid token AND a forged userId. The
+    // server must register the principal's userId, never the forged one.
+    const client = connectClient(url, {
+      auth: { token: 'good.jwt', userId: 'usr-attacker' },
+    });
+    const connected = await awaitConnectOutcome(client);
+
+    expect(connected).toBe(true);
+    expect(validateMock).toHaveBeenCalledWith({ accessToken: 'good.jwt' }, expect.anything());
+    expect(registry.socketsFor('usr-from-principal')).toHaveLength(1);
+    expect(registry.socketsFor('usr-attacker')).toHaveLength(0);
+  });
+
+  it('rejects every handshake when no auth client is wired (fails closed)', async () => {
+    const { url, registry } = await startServer({ logger: quietLogger() });
+
+    const client = connectClient(url, { auth: { token: 'good.jwt' } });
+    const connected = await awaitConnectOutcome(client);
+
+    expect(connected).toBe(false);
+    expect(registry.size()).toBe(0);
+  });
+
+  it('honours the explicit dev-only client-supplied-userId fallback', async () => {
+    const { url, registry } = await startServer({
+      logger: quietLogger(),
+      allowUnauthenticated: true,
+    });
+
+    const client = connectClient(url, { auth: { userId: 'usr-dev' } });
+    const connected = await awaitConnectOutcome(client);
+
+    expect(connected).toBe(true);
+    expect(registry.socketsFor('usr-dev')).toHaveLength(1);
+  });
+});

--- a/services/gateway/src/ws/socket-server.ts
+++ b/services/gateway/src/ws/socket-server.ts
@@ -1,34 +1,61 @@
 // Socket.IO server attached to the gateway's underlying HTTP server.
 //
-// Auth (Phase 1.5 dev-mode): the client supplies `?userId=<id>` on the
-// handshake query string. No real authentication — the gateway trusts
-// the value. Phase 2 replaces this with token verification via
-// service.auth.ValidateToken, after which the principal carried in
-// gRPC metadata for HTTP requests will also drive socket identity.
+// Auth: the WebSocket handshake is verified the same way the HTTP path
+// is (services/gateway/src/middleware/authenticate.ts). An `io.use(...)`
+// middleware pulls the access token off the handshake, calls
+// `service.auth.ValidateToken`, and derives the socket's userId from the
+// returned principal. The client-supplied userId is NEVER trusted — that
+// was the Phase 1.5 dev mode and it was an IDOR over the whole realtime
+// spine (anyone could connect claiming any userId and receive that
+// user's notifications + chat).
+//
+// Token sources, in priority order:
+//   1. `handshake.auth.token` — the Socket.IO idiomatic spot; the React
+//      clients pass it here via `io(url, { auth: { token } })`.
+//   2. The `accessToken` httpOnly cookie on the upgrade request
+//      (`handshake.headers.cookie`) — what the web frontend relies on,
+//      since the access token is not JS-readable and rides along
+//      automatically on the WebSocket upgrade.
 //
 // Lifecycle:
-//   - On connect: extract userId, register the socket in the per-
-//     replica SocketRegistry.
+//   - On handshake: verify the token, reject with `unauthorized` on a
+//     missing/invalid token, otherwise stash the principal's userId on
+//     `socket.data`.
+//   - On connect: register the socket in the per-replica SocketRegistry.
 //   - On disconnect: unregister.
-//   - On message from client: ignored for now (Phase 1.5 is server-
-//     to-client only). Phase 6 (chat) adds typing indicators, presence,
-//     and outbound messages from the client.
 
 import type { Server as HttpServer } from 'node:http';
 
+import { Metadata } from '@grpc/grpc-js';
 import { Server as IOServer, type Socket } from 'socket.io';
 import type { Logger } from 'winston';
 
+import type { AuthClient } from '../grpc-clients/auth-client.js';
+
 import type { SocketRegistry } from './socket-registry.js';
+
+// Only the validateToken method is needed here — narrow the dependency so
+// tests can supply a one-method stub, mirroring authenticate.ts.
+type SocketAuthClient = Pick<AuthClient, 'validateToken'>;
 
 export type AttachSocketServerOptions = {
   httpServer: HttpServer;
   registry: SocketRegistry;
   logger: Logger;
+  // The auth gRPC client used to verify handshake tokens. Required in
+  // production (wired in index.ts). Optional only so pure unit tests of
+  // the registry/subscriber wiring don't have to stand one up.
+  authClient?: SocketAuthClient;
+  // Explicit, dangerous escape hatch: when no authClient is wired AND
+  // this is true, fall back to trusting the client-supplied userId.
+  // ONLY for local dev / tests — never set in production. When false
+  // (the default) a missing authClient rejects every handshake, so a
+  // misconfigured deploy fails closed instead of trusting clients.
+  allowUnauthenticated?: boolean;
 };
 
 export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer => {
-  const { httpServer, registry, logger } = opts;
+  const { httpServer, registry, logger, authClient, allowUnauthenticated = false } = opts;
 
   const io = new IOServer(httpServer, {
     // Permissive CORS in dev — nginx is the real terminator in prod
@@ -40,10 +67,28 @@ export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer =>
     path: '/socket.io',
   });
 
+  io.use((socket, next) => {
+    void authenticateHandshake(socket, { authClient, allowUnauthenticated, logger })
+      .then(userId => {
+        if (!userId) {
+          next(new Error('unauthorized'));
+          return;
+        }
+        socket.data.userId = userId;
+        next();
+      })
+      .catch(() => {
+        next(new Error('unauthorized'));
+      });
+  });
+
   io.on('connection', (socket: Socket) => {
-    const userId = extractUserId(socket);
-    if (!userId) {
-      logger.warn('socket connection rejected — missing userId', {
+    const userId = socket.data.userId;
+    if (typeof userId !== 'string' || userId.length === 0) {
+      // Should be unreachable — the io.use middleware rejects before
+      // connection without a userId — but guard so a future contract
+      // drift fails closed.
+      logger.warn('socket connection rejected — missing authenticated userId', {
         socketId: socket.id,
       });
       socket.disconnect(true);
@@ -66,11 +111,79 @@ export const attachSocketServer = (opts: AttachSocketServerOptions): IOServer =>
   return io;
 };
 
-// userId can land on either the handshake auth object (Socket.IO v3+
-// preferred — `io({ auth: { userId } })`) or the query string (legacy
-// clients). Accept both during the migration so we don't have to
-// version-gate the connect call across all three React apps.
-function extractUserId(socket: Socket): string | undefined {
+type AuthenticateHandshakeDeps = {
+  authClient?: SocketAuthClient;
+  allowUnauthenticated: boolean;
+  logger: Logger;
+};
+
+// Returns the authenticated userId, or undefined to reject the handshake.
+async function authenticateHandshake(
+  socket: Socket,
+  deps: AuthenticateHandshakeDeps
+): Promise<string | undefined> {
+  const { authClient, allowUnauthenticated, logger } = deps;
+
+  // No auth client wired. In production this never happens (index.ts
+  // always passes one); when it does it's a misconfiguration and we fail
+  // closed UNLESS the explicit dev/test escape hatch is set, in which
+  // case we preserve the old client-supplied-userId behaviour.
+  if (!authClient) {
+    if (allowUnauthenticated) {
+      return extractClientSuppliedUserId(socket);
+    }
+    logger.error('socket handshake rejected — no auth client configured');
+    return undefined;
+  }
+
+  const token = extractToken(socket);
+  if (!token) {
+    return undefined;
+  }
+
+  try {
+    const res = await authClient.validateToken({ accessToken: token }, new Metadata());
+    const userId = res.principal?.userId;
+    return typeof userId === 'string' && userId.length > 0 ? userId : undefined;
+  } catch {
+    // Invalid / expired / revoked token, or the auth service is down.
+    // Either way the handshake is not trusted.
+    return undefined;
+  }
+}
+
+// Access token from the handshake. `auth.token` (Socket.IO idiomatic)
+// takes priority; the `accessToken` httpOnly cookie on the upgrade
+// request is the fallback the web frontend depends on.
+function extractToken(socket: Socket): string | undefined {
+  const fromAuth = socket.handshake.auth?.token;
+  if (typeof fromAuth === 'string' && fromAuth.length > 0) {
+    return fromAuth;
+  }
+  return extractCookieToken(socket.handshake.headers.cookie);
+}
+
+// Parse the `accessToken` value out of a Cookie header. A plain split is
+// O(n) and can't backtrack — same ReDoS-avoidance discipline as the HTTP
+// bearer extractor.
+function extractCookieToken(cookieHeader: string | undefined): string | undefined {
+  if (!cookieHeader) {
+    return undefined;
+  }
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith('accessToken=')) {
+      const value = trimmed.slice('accessToken='.length);
+      return value.length > 0 ? decodeURIComponent(value) : undefined;
+    }
+  }
+  return undefined;
+}
+
+// Dev/test-only fallback: the pre-auth behaviour of trusting a
+// client-supplied userId off the handshake. Reachable ONLY when no auth
+// client is wired and allowUnauthenticated is explicitly true.
+function extractClientSuppliedUserId(socket: Socket): string | undefined {
   const fromAuth = socket.handshake.auth?.userId;
   if (typeof fromAuth === 'string' && fromAuth.length > 0) {
     return fromAuth;


### PR DESCRIPTION
## Summary

Two fixes that secure the realtime spine and harden the gateway's gRPC fan-out.

### Fix 1 (CRITICAL): authenticate the WebSocket handshake — closes an IDOR

`services/gateway/src/ws/socket-server.ts` previously read `userId` straight off the Socket.IO handshake (`handshake.auth.userId` / `handshake.query.userId`) and **trusted it**. Anyone could connect claiming any `userId` and receive that user's notifications + chat messages — an IDOR over the entire realtime spine.

The handshake now runs an `io.use(...)` middleware that:

- Pulls the access token from `handshake.auth.token` (the Socket.IO idiomatic spot the React clients use), falling back to the `accessToken` httpOnly cookie on the upgrade request — which is what the web frontend actually relies on, since the token is not JS-readable and rides along automatically on the WebSocket upgrade.
- Calls `service.auth.ValidateToken` — the **same gRPC path** the HTTP `authenticate.ts` middleware uses — and derives the socket's `userId` from the returned **principal**, never from the client-supplied value.
- Rejects missing/invalid/expired/revoked tokens with `next(new Error('unauthorized'))`.

The auth client stays **injectable** (narrowed to `Pick<AuthClient, 'validateToken'>`). With no client wired the server **fails closed** (rejects every handshake) unless an explicit `allowUnauthenticated` dev/test flag is set, which restores the old client-supplied-userId behaviour for local use only. `index.ts` always wires the real client, so the production path never trusts client identity.

### Fix 2 (HIGH): add default deadlines to every gRPC client

Every gateway gRPC client (`services/gateway/src/grpc-clients/*.ts`) called unary methods with no deadline, so one hung downstream service could hang a gateway request forever. Each client's near-identical `callUnary` helper now threads a default **5s** deadline (a small named `DEFAULT_DEADLINE_MS` constant) through the grpc-js call options, so a hung downstream now fails fast with `DEADLINE_EXCEEDED`. Applied consistently across all 10 clients (auth, applications, audit, chat, cms, matching, moderation, notifications, pets, rescue).

## Test plan

New `services/gateway/src/ws/socket-server.test.ts` drives a real Socket.IO client against a real server and asserts the behaviour as a black box:

- A handshake with **no token** is rejected (and `validateToken` is never called).
- A handshake whose token the **auth service rejects** is refused.
- A **valid token** connects and registers the socket under the **principal's** `userId`, while a **forged client-supplied `userId`** passed alongside is ignored.
- With **no auth client wired** the server fails closed (rejects).
- The explicit `allowUnauthenticated` dev fallback registers the client-supplied userId.

From `services/gateway/`:

- `npx vitest run` — 457 passed (43 files), including the 5 new socket-server tests.
- `npx tsc --noEmit` — clean.
- `npx eslint src` — 0 errors (only pre-existing warnings in unrelated files).
- `npx prettier --check "src/**/*.ts"` — clean.

## Notes / decisions

- **How the frontend opens the socket:** `lib.chat`'s `ChatService.connect()` calls `io(url, { auth: { token } })`, but `ChatProvider` invokes it with **no token** because the access token lives in an httpOnly cookie (`lib.auth` `getToken()` returns `null` by design). The real web client therefore authenticates via the `accessToken` **cookie** on the WS upgrade — so the handshake reader supports both `auth.token` and the cookie. This is the token field settled on.
- A `socket.io-client` devDependency was added to the gateway (already hoisted in the workspace at the same version) so the test can drive a real client.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_