### PR TITLE
feat(dev): seed canonical personas + reference data for the microservice stack

### DIFF
--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -67,9 +67,11 @@ ENV NODE_ENV=development
 WORKDIR /app/${SERVICE_DIR}
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 # Migrate the service's own schema (only services that own a schema define
-# db:migrate — the gateway doesn't, hence --if-present), then start with
-# watch-reload.
-CMD ["sh", "-c", "npm run db:migrate --if-present && npm run dev"]
+# db:migrate — the gateway doesn't, hence --if-present), then seed the
+# canonical dev/e2e fixtures (auth/rescue/pets define db:seed; idempotent
+# ON CONFLICT upserts make re-runs safe), then start with watch-reload.
+# Seeding is dev-only — the production CMD below deliberately omits it.
+CMD ["sh", "-c", "npm run db:migrate --if-present && npm run db:seed --if-present && npm run dev"]
 
 # ---------------------------------------------------------------------------
 # production — compiled dist run with node

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -46,7 +46,7 @@ This keeps tests resilient to markup changes and surfaces accessibility regressi
 - `e2e/.auth/rescue.json` — `rescue.manager@pawsrescue.dev`
 - `e2e/.auth/admin.json` — `superadmin@adoptdontshop.dev`
 
-All seeded users use the password `DevPassword123!` from `service.backend/src/seeders/04-users.ts`.
+All seeded users use the password `DevPassword123!`. The personas are defined in `services/auth/src/db/seed-data.ts` (with matching rescue/pet fixtures in `services/rescue/src/db/seed-data.ts` and `services/pets/src/db/seed-data.ts`) and inserted by the per-service `db:seed` scripts — see [Seeding the stack](#seeding-the-stack) below.
 
 Each project (`client`, `rescue`, `admin`) reuses its role's storageState. Specs that need to test login/registration itself live in the `*-anon` projects with no storageState. Cross-app journeys use the `asRole(...)` fixture to spin up a second authenticated context for a different role.
 
@@ -74,8 +74,12 @@ for url in \
   until curl -fsS --max-time 5 "$url" >/dev/null 2>&1; do sleep 2; done
 done
 
-# 4. Migrate + seed the database
-npm run db:reset
+# 4. Seed the database with the canonical personas + reference data.
+#    Each microservice migrates its own schema on boot; `db:seed` populates
+#    the dev/e2e fixtures (idempotent — safe to re-run). See "Seeding the
+#    stack" below. The dev Docker image also runs this automatically on
+#    container start, so step 4 is only needed if you bypass that.
+npm run db:seed
 
 # 5. Run the suite
 npm run test:e2e                                      # full suite
@@ -90,6 +94,46 @@ E2E_SKIP_HEALTH=1 E2E_SKIP_AUTH=1 npm run test:e2e
 ```
 
 The `test:e2e:single` script forwards all arguments straight through to Playwright in the `e2e` workspace, so any Playwright flag works (`--headed`, `--debug`, `--repeat-each=3`, `--grep "approves"`, etc.).
+
+## Seeding the stack
+
+The microservice stack ships no data on a fresh boot. The dev/e2e seed recreates the canonical personas (so the suite can log in) plus enough reference data to exercise the golden path (browse a pet, view a rescue).
+
+**How it runs:** each schema-owning service exposes a `db:seed` script (`tsx ./src/db/seed.ts`) that inserts directly into its own Postgres schema with idempotent `ON CONFLICT DO UPDATE` upserts. The dev Docker image runs `db:migrate` then `db:seed` on container start, so `npm run docker:dev:detach` already produces a seeded stack. To (re-)seed an already-running stack by hand:
+
+```bash
+npm run db:seed        # root orchestrator: docker compose exec into
+                       # service-auth → service-rescue → service-pets,
+                       # running each service's db:seed in dependency order
+```
+
+`npm run db:seed` is safe to re-run at any time. Per-service overrides are available too (`docker compose exec service-auth npm run db:seed`).
+
+**Seeded personas** (all share the password `DevPassword123!`, override with `SEED_PASSWORD`):
+
+| Email | Role | App |
+| --- | --- | --- |
+| `john.smith@gmail.com` | adopter | app.client |
+| `emily.davis@yahoo.com` | adopter | app.client |
+| `michael.brown@outlook.com` | adopter | app.client |
+| `rescue.manager@pawsrescue.dev` | rescue_staff | app.rescue |
+| `sarah.johnson@pawsrescue.dev` | rescue_staff | app.rescue |
+| `maria@happytailsrescue.dev` | rescue_staff | app.rescue |
+| `superadmin@adoptdontshop.dev` | super_admin | app.admin |
+| `admin@adoptdontshop.dev` | admin | app.admin |
+| `moderator@adoptdontshop.dev` | moderator | app.admin |
+
+**Reference data:** two verified rescues (Paws Rescue, Happy Tails Rescue) with staff links, plus a small pet catalogue (available / pending / adopted / on-hold) attached to those rescues. Pet + adopter ids are pinned to the values `helpers/seeds.ts` expects.
+
+**Verify login** against a running gateway (the gateway is exposed on
+`localhost:4000` in the microservice stack):
+
+```bash
+curl -s -X POST http://localhost:4000/api/v1/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"email":"john.smith@gmail.com","password":"DevPassword123!"}'
+# → 200 with { "user": {...}, "tokens": { "accessToken": "...", ... } }
+```
 
 ## Debugging Failures
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "docker:logs": "docker compose logs -f",
     "docker:ps": "docker compose ps",
     "docker:shell:db": "docker compose exec database psql -U $POSTGRES_USER -d $POSTGRES_DB",
+    "db:seed": "node scripts/seed.mjs",
     "build": "turbo run build",
     "build:libs": "turbo run build --filter='@adopt-dont-shop/lib.*'",
     "build:apps": "turbo run build --filter='@adopt-dont-shop/app.*'",

--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Dev/e2e seed orchestrator.
+ *
+ * Runs each owning service's `db:seed` script in dependency order against
+ * the running docker-compose stack:
+ *
+ *   1. service-auth   — canonical personas (john.smith + admin + rescue staff)
+ *   2. service-rescue — rescue orgs + staff_member links (reference auth ids)
+ *   3. service-pets   — pet catalogue (reference rescue ids)
+ *
+ * This is a HOST-side orchestrator: it must NOT import any
+ * @adopt-dont-shop/* workspace package (CAD lesson — host scripts that pull
+ * in workspace code break when run outside the container's module graph).
+ * It only spawns `docker compose exec`, delegating the actual seeding to the
+ * per-service tsx scripts that run INSIDE each container (where DATABASE_URL
+ * and the workspace are already wired up).
+ *
+ * Idempotent: every per-service seed uses ON CONFLICT DO UPDATE, so this is
+ * safe to re-run. Run it after the stack is up:
+ *
+ *   npm run docker:dev:detach   # or docker:dev in another terminal
+ *   npm run db:seed
+ *
+ * Override the compose service names or the docker binary via env if your
+ * topology differs (SEED_DOCKER, SEED_COMPOSE_FILE).
+ */
+import { spawnSync } from 'node:child_process';
+
+const DOCKER = process.env.SEED_DOCKER ?? 'docker';
+
+// [compose service name, the package the seed lives in] in run order.
+const SEED_TARGETS = [
+  ['service-auth', 'auth users (personas)'],
+  ['service-rescue', 'rescues + staff'],
+  ['service-pets', 'pet catalogue'],
+];
+
+function runSeed(service, label) {
+  process.stdout.write(`\n→ seeding ${label} (${service})...\n`);
+  const result = spawnSync(DOCKER, ['compose', 'exec', '-T', service, 'npm', 'run', 'db:seed'], {
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw new Error(
+      `failed to exec into ${service}: ${result.error.message}. ` +
+        `Is the stack running? Try 'npm run docker:dev:detach' first.`
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(`seed for ${service} exited with code ${result.status}`);
+  }
+}
+
+function main() {
+  for (const [service, label] of SEED_TARGETS) {
+    runSeed(service, label);
+  }
+  process.stdout.write('\n✓ seed complete — login as john.smith@gmail.com / DevPassword123!\n');
+}
+
+main();

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -21,6 +21,7 @@
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
     "db:migrate": "tsx ./src/db/migrate.ts",
+    "db:seed": "tsx ./src/db/seed.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/services/auth/src/db/seed-data.ts
+++ b/services/auth/src/db/seed-data.ts
@@ -1,0 +1,114 @@
+// Canonical dev/e2e personas for the auth.* schema.
+//
+// These rows recreate the accounts the old service.backend seeder used to
+// populate — the same emails/passwords/roles the Playwright e2e suite
+// (e2e/fixtures/roles.ts) and the dev-tools login panel
+// (lib.dev-tools/src/data/seededUsers.ts) expect. Getting these wrong
+// defeats the purpose of the seed, so the values are pinned here and
+// re-asserted by the tests.
+//
+// user_id values are FIXED (deterministic) so cross-service seeds can
+// reference them: rescue.staff_members.user_id and the pets/rescue
+// created_by pointers all join back to these ids application-side.
+// John Smith's id matches e2e/helpers/seeds.ts SEEDED_ADOPTER_USER_ID.
+
+export type UserType =
+  | 'adopter'
+  | 'rescue_staff'
+  | 'admin'
+  | 'moderator'
+  | 'super_admin'
+  | 'support_agent';
+
+export type SeedUser = {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  userType: UserType;
+  phoneNumber?: string;
+};
+
+// Single dev password shared by every seeded persona. Mirrors
+// lib.dev-tools SEEDED_PASSWORD and e2e SEEDED_PASSWORD. Overridable via
+// SEED_PASSWORD for environments that want a different dev secret.
+export const SEED_PASSWORD = process.env.SEED_PASSWORD?.trim() || 'DevPassword123!';
+
+export const SEED_USERS: readonly SeedUser[] = [
+  // --- Admin personas (app.admin) -----------------------------------
+  {
+    userId: 'a0000000-0000-4000-8000-000000000001',
+    firstName: 'Super',
+    lastName: 'Admin',
+    email: 'superadmin@adoptdontshop.dev',
+    userType: 'super_admin',
+    phoneNumber: '+441234567890',
+  },
+  {
+    userId: 'a0000000-0000-4000-8000-000000000002',
+    firstName: 'System',
+    lastName: 'Administrator',
+    email: 'admin@adoptdontshop.dev',
+    userType: 'admin',
+    phoneNumber: '+441234567891',
+  },
+  {
+    userId: 'a0000000-0000-4000-8000-000000000003',
+    firstName: 'Content',
+    lastName: 'Moderator',
+    email: 'moderator@adoptdontshop.dev',
+    userType: 'moderator',
+    phoneNumber: '+441234567892',
+  },
+  // --- Rescue-staff personas (app.rescue) ---------------------------
+  {
+    userId: 'b0000000-0000-4000-8000-000000000001',
+    firstName: 'Rescue',
+    lastName: 'Manager',
+    email: 'rescue.manager@pawsrescue.dev',
+    userType: 'rescue_staff',
+    phoneNumber: '+441234567893',
+  },
+  {
+    userId: 'b0000000-0000-4000-8000-000000000002',
+    firstName: 'Sarah',
+    lastName: 'Johnson',
+    email: 'sarah.johnson@pawsrescue.dev',
+    userType: 'rescue_staff',
+    phoneNumber: '+441234567894',
+  },
+  {
+    userId: 'b0000000-0000-4000-8000-000000000003',
+    firstName: 'Maria',
+    lastName: 'Garcia',
+    email: 'maria@happytailsrescue.dev',
+    userType: 'rescue_staff',
+    phoneNumber: '+441234567895',
+  },
+  // --- Adopter personas (app.client) --------------------------------
+  // John Smith's id is pinned to e2e SEEDED_ADOPTER_USER_ID.
+  {
+    userId: '98915d9e-69ed-46b2-a897-57d8469ff360',
+    firstName: 'John',
+    lastName: 'Smith',
+    email: 'john.smith@gmail.com',
+    userType: 'adopter',
+    phoneNumber: '+441234567896',
+  },
+  {
+    userId: 'c0000000-0000-4000-8000-000000000002',
+    firstName: 'Emily',
+    lastName: 'Davis',
+    email: 'emily.davis@yahoo.com',
+    userType: 'adopter',
+    phoneNumber: '+441234567897',
+  },
+  {
+    userId: 'c0000000-0000-4000-8000-000000000003',
+    firstName: 'Michael',
+    lastName: 'Brown',
+    email: 'michael.brown@outlook.com',
+    userType: 'adopter',
+    phoneNumber: '+441234567898',
+  },
+];

--- a/services/auth/src/db/seed.test.ts
+++ b/services/auth/src/db/seed.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { seedUsers, type QueryFn } from './seed.js';
+import { SEED_PASSWORD, SEED_USERS } from './seed-data.js';
+
+// A recording query stub — the seed is pure aside from the injected
+// query/hash, so we can assert the SQL + params it would run without a
+// live Postgres.
+function recordingQuery(): { query: QueryFn; calls: Array<{ text: string; values: unknown[] }> } {
+  const calls: Array<{ text: string; values: unknown[] }> = [];
+  const query: QueryFn = async (text, values) => {
+    calls.push({ text, values: [...values] });
+    return undefined;
+  };
+  return { query, calls };
+}
+
+const fakeHash = vi.fn(async (password: string) => `hashed:${password}`);
+
+describe('auth seed', () => {
+  it('seeds every canonical persona exactly once', async () => {
+    const { query, calls } = recordingQuery();
+
+    const seeded = await seedUsers({ query, hash: fakeHash });
+
+    expect(calls).toHaveLength(SEED_USERS.length);
+    expect(seeded).toEqual(SEED_USERS.map(u => u.email));
+  });
+
+  it('includes the e2e adopter john.smith with the pinned user id', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedUsers({ query, hash: fakeHash });
+
+    const johnRow = calls.find(c => c.values.includes('john.smith@gmail.com'));
+    expect(johnRow).toBeDefined();
+    // Pinned to e2e/helpers/seeds.ts SEEDED_ADOPTER_USER_ID.
+    expect(johnRow?.values[0]).toBe('98915d9e-69ed-46b2-a897-57d8469ff360');
+    // user_type is the last param.
+    expect(johnRow?.values.at(-1)).toBe('adopter');
+  });
+
+  it('seeds the admin + rescue-staff personas the e2e suite logs in as', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedUsers({ query, hash: fakeHash });
+
+    const emails = calls.flatMap(c => c.values).filter(v => typeof v === 'string');
+    expect(emails).toContain('superadmin@adoptdontshop.dev');
+    expect(emails).toContain('rescue.manager@pawsrescue.dev');
+  });
+
+  it('hashes the shared dev password once and stores the hash, never the plaintext', async () => {
+    const hash = vi.fn(async (password: string) => `hashed:${password}`);
+    const { query, calls } = recordingQuery();
+
+    await seedUsers({ query, hash });
+
+    // One hash call regardless of persona count (all share SEED_PASSWORD).
+    expect(hash).toHaveBeenCalledTimes(1);
+    expect(hash).toHaveBeenCalledWith(SEED_PASSWORD);
+    for (const call of calls) {
+      // password is the 5th param ($5).
+      expect(call.values[4]).toBe(`hashed:${SEED_PASSWORD}`);
+      expect(call.values).not.toContain(SEED_PASSWORD);
+    }
+  });
+
+  it('is idempotent — uses ON CONFLICT DO UPDATE so a re-run does not error', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedUsers({ query, hash: fakeHash });
+
+    for (const call of calls) {
+      expect(call.text).toMatch(/ON CONFLICT \(user_id\) DO UPDATE/);
+    }
+
+    // Re-running produces the same set of statements (no throw, no growth
+    // in distinct targets).
+    const second = recordingQuery();
+    await seedUsers({ query: second.query, hash: fakeHash });
+    expect(second.calls).toHaveLength(calls.length);
+  });
+
+  it('marks every seeded user active + email-verified so login works immediately', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedUsers({ query, hash: fakeHash });
+
+    for (const call of calls) {
+      expect(call.text).toMatch(/email_verified[\s\S]*true/);
+      expect(call.text).toContain("'active'");
+    }
+  });
+});

--- a/services/auth/src/db/seed.ts
+++ b/services/auth/src/db/seed.ts
@@ -1,0 +1,103 @@
+// Seed entry point — populates the auth.* schema with the canonical
+// dev/e2e personas (see seed-data.ts).
+//
+// Mirrors migrate.ts: invoked by `npm run db:seed`, reuses loadConfig()
+// + createDbClient from @adopt-dont-shop/db. Runs AFTER migrations.
+//
+// Idempotent: every INSERT is `ON CONFLICT (user_id) DO UPDATE` so a
+// re-run refreshes the row (e.g. a rotated password) without erroring on
+// the unique email/user_id constraints. Safe to run on every boot.
+
+import bcrypt from 'bcryptjs';
+
+import { createDbClient } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+import { SEED_PASSWORD, SEED_USERS, type SeedUser } from './seed-data.js';
+
+// Matches the runtime hasher (createBcryptPasswordHasher) so a seeded
+// password validates against AuthService.Login without a re-hash.
+const BCRYPT_ROUNDS = 12;
+
+// Minimal shape of the bits of `pg` we use — lets the tests inject a
+// fake without standing up a real Postgres.
+export type QueryFn = (text: string, values: readonly unknown[]) => Promise<unknown>;
+
+const UPSERT_USER = `
+  INSERT INTO auth.users (
+    user_id, first_name, last_name, email, password, phone_number,
+    email_verified, phone_verified, status, user_type,
+    terms_accepted_at, privacy_policy_accepted_at, created_at, updated_at
+  ) VALUES (
+    $1, $2, $3, $4, $5, $6,
+    true, true, 'active', $7,
+    now(), now(), now(), now()
+  )
+  ON CONFLICT (user_id) DO UPDATE SET
+    first_name = EXCLUDED.first_name,
+    last_name = EXCLUDED.last_name,
+    email = EXCLUDED.email,
+    password = EXCLUDED.password,
+    phone_number = EXCLUDED.phone_number,
+    email_verified = true,
+    status = 'active',
+    user_type = EXCLUDED.user_type,
+    updated_at = now()
+`;
+
+export type SeedDeps = {
+  query: QueryFn;
+  hash: (password: string) => Promise<string>;
+};
+
+// Pure-ish core: upserts every persona via the injected query fn. The
+// password is hashed ONCE (all personas share SEED_PASSWORD) to keep the
+// re-run cost low. Returns the emails seeded so callers can log/verify.
+export const seedUsers = async (deps: SeedDeps): Promise<string[]> => {
+  const passwordHash = await deps.hash(SEED_PASSWORD);
+  const seeded: string[] = [];
+  for (const user of SEED_USERS) {
+    await deps.query(UPSERT_USER, paramsFor(user, passwordHash));
+    seeded.push(user.email);
+  }
+  return seeded;
+};
+
+const paramsFor = (user: SeedUser, passwordHash: string): readonly unknown[] => [
+  user.userId,
+  user.firstName,
+  user.lastName,
+  user.email,
+  passwordHash,
+  user.phoneNumber ?? null,
+  user.userType,
+];
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.auth.seed' });
+  const config = loadConfig();
+  const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });
+  try {
+    logger.info('seeding auth personas', { schema: config.schema, count: SEED_USERS.length });
+    const seeded = await seedUsers({
+      query: (text, values) => pool.query(text, values as unknown[]),
+      hash: password => bcrypt.hash(password, BCRYPT_ROUNDS),
+    });
+    logger.info('auth seed complete', { seeded });
+  } catch (err) {
+    logger.error('auth seed failed', {
+      message: (err as Error)?.message,
+      stack: (err as Error)?.stack,
+    });
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+};
+
+// Only run when invoked as a script (not when imported by tests).
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/services/pets/package.json
+++ b/services/pets/package.json
@@ -21,6 +21,7 @@
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
     "db:migrate": "tsx ./src/db/migrate.ts",
+    "db:seed": "tsx ./src/db/seed.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/services/pets/src/db/seed-data.ts
+++ b/services/pets/src/db/seed-data.ts
@@ -1,0 +1,74 @@
+// Canonical dev/e2e fixtures for the pets.* schema.
+//
+// Recreates the headline pet catalogue the old service.backend seeder
+// populated, attached to the seeded rescues. The pet ids are PINNED to
+// the values e2e/helpers/seeds.ts SEEDED_PET_IDS expects so the read-side
+// fixtures resolve. rescue_id / created_by are the FIXED ids from the
+// rescue + auth seeds (application-side link, no cross-schema FK).
+
+export type SeedPet = {
+  petId: string;
+  rescueId: string;
+  name: string;
+  type: 'dog' | 'cat' | 'rabbit' | 'bird' | 'reptile' | 'small_mammal' | 'fish' | 'other';
+  gender: 'male' | 'female' | 'unknown';
+  size: 'extra_small' | 'small' | 'medium' | 'large' | 'extra_large';
+  ageGroup: 'baby' | 'young' | 'adult' | 'senior';
+  status: 'available' | 'pending' | 'adopted' | 'foster' | 'medical_hold' | 'not_available';
+  shortDescription: string;
+};
+
+// Pinned rescue ids (see services/rescue/src/db/seed-data.ts).
+const PAWS_RESCUE_ID = 'd0000000-0000-4000-8000-000000000001';
+const HAPPY_TAILS_RESCUE_ID = 'd0000000-0000-4000-8000-000000000002';
+
+// Pinned rescue-staff user id used as created_by (the Paws manager).
+export const PAWS_MANAGER_ID = 'b0000000-0000-4000-8000-000000000001';
+
+export const SEED_PETS: readonly SeedPet[] = [
+  // Pet ids match e2e/helpers/seeds.ts SEEDED_PET_IDS.
+  {
+    petId: '9ff53898-c5c6-4422-a245-54e52d4c4b78',
+    rescueId: PAWS_RESCUE_ID,
+    name: 'Buddy',
+    type: 'dog',
+    gender: 'male',
+    size: 'large',
+    ageGroup: 'adult',
+    status: 'available',
+    shortDescription: 'A friendly Labrador looking for an active family.',
+  },
+  {
+    petId: 'a1d109eb-e717-44a0-aed7-c7c0af6c152f',
+    rescueId: PAWS_RESCUE_ID,
+    name: 'Luna',
+    type: 'cat',
+    gender: 'female',
+    size: 'small',
+    ageGroup: 'young',
+    status: 'pending',
+    shortDescription: 'A gentle tabby cat, currently under adoption review.',
+  },
+  {
+    petId: 'e2e0a000-0000-4000-8000-000000000001',
+    rescueId: HAPPY_TAILS_RESCUE_ID,
+    name: 'Max',
+    type: 'dog',
+    gender: 'male',
+    size: 'medium',
+    ageGroup: 'senior',
+    status: 'adopted',
+    shortDescription: 'A senior terrier who has found his forever home.',
+  },
+  {
+    petId: 'e2e0a000-0000-4000-8000-000000000002',
+    rescueId: HAPPY_TAILS_RESCUE_ID,
+    name: 'Bella',
+    type: 'dog',
+    gender: 'female',
+    size: 'medium',
+    ageGroup: 'adult',
+    status: 'not_available',
+    shortDescription: 'On hold pending a home check.',
+  },
+];

--- a/services/pets/src/db/seed.test.ts
+++ b/services/pets/src/db/seed.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { seedPets, type QueryFn } from './seed.js';
+import { SEED_PETS } from './seed-data.js';
+
+function recordingQuery(): { query: QueryFn; calls: Array<{ text: string; values: unknown[] }> } {
+  const calls: Array<{ text: string; values: unknown[] }> = [];
+  const query: QueryFn = async (text, values) => {
+    calls.push({ text, values: [...values] });
+    return undefined;
+  };
+  return { query, calls };
+}
+
+describe('pets seed', () => {
+  it('seeds every pet exactly once', async () => {
+    const { query, calls } = recordingQuery();
+
+    const seeded = await seedPets({ query });
+
+    expect(calls).toHaveLength(SEED_PETS.length);
+    expect(seeded).toEqual(SEED_PETS.map(p => p.name));
+  });
+
+  it('seeds the available pet id the e2e suite reads (SEEDED_PET_IDS.available)', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedPets({ query });
+
+    const petIds = calls.map(c => c.values[0]);
+    expect(petIds).toContain('9ff53898-c5c6-4422-a245-54e52d4c4b78');
+  });
+
+  it('attaches pets to a seeded rescue so the golden path resolves an owner', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedPets({ query });
+
+    for (const call of calls) {
+      // rescue_id is the 2nd param ($2) and must be set.
+      expect(call.values[1]).toBeTruthy();
+    }
+  });
+
+  it('is idempotent — every insert uses ON CONFLICT (pet_id) DO UPDATE', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedPets({ query });
+
+    for (const call of calls) {
+      expect(call.text).toMatch(/ON CONFLICT \(pet_id\) DO UPDATE/);
+    }
+
+    const second = recordingQuery();
+    await seedPets({ query: second.query });
+    expect(second.calls).toHaveLength(calls.length);
+  });
+});

--- a/services/pets/src/db/seed.ts
+++ b/services/pets/src/db/seed.ts
@@ -1,0 +1,89 @@
+// Seed entry point — populates the pets.* schema with the canonical
+// dev/e2e pet catalogue (see seed-data.ts).
+//
+// Mirrors migrate.ts: invoked by `npm run db:seed`, reuses loadConfig()
+// + createDbClient. Depends on the rescue seed having run first (pets
+// reference rescue_id), but rows carry no cross-schema FK so the insert
+// succeeds regardless of order — the root orchestrator runs pets last.
+//
+// Idempotent: every INSERT is `ON CONFLICT (pet_id) DO UPDATE`.
+
+import { createDbClient } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+import { PAWS_MANAGER_ID, SEED_PETS, type SeedPet } from './seed-data.js';
+
+export type QueryFn = (text: string, values: readonly unknown[]) => Promise<unknown>;
+
+const UPSERT_PET = `
+  INSERT INTO pets.pets (
+    pet_id, rescue_id, name, type, gender, size, age_group, status,
+    short_description, available_since, created_by, created_at, updated_at
+  ) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8,
+    $9, now(), $10, now(), now()
+  )
+  ON CONFLICT (pet_id) DO UPDATE SET
+    rescue_id = EXCLUDED.rescue_id,
+    name = EXCLUDED.name,
+    type = EXCLUDED.type,
+    gender = EXCLUDED.gender,
+    size = EXCLUDED.size,
+    age_group = EXCLUDED.age_group,
+    status = EXCLUDED.status,
+    short_description = EXCLUDED.short_description,
+    updated_at = now()
+`;
+
+export type SeedDeps = {
+  query: QueryFn;
+};
+
+export const seedPets = async (deps: SeedDeps): Promise<string[]> => {
+  const seeded: string[] = [];
+  for (const pet of SEED_PETS) {
+    await deps.query(UPSERT_PET, petParams(pet));
+    seeded.push(pet.name);
+  }
+  return seeded;
+};
+
+const petParams = (p: SeedPet): readonly unknown[] => [
+  p.petId,
+  p.rescueId,
+  p.name,
+  p.type,
+  p.gender,
+  p.size,
+  p.ageGroup,
+  p.status,
+  p.shortDescription,
+  PAWS_MANAGER_ID,
+];
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.pets.seed' });
+  const config = loadConfig();
+  const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });
+  try {
+    logger.info('seeding pets', { schema: config.schema, count: SEED_PETS.length });
+    const seeded = await seedPets({
+      query: (text, values) => pool.query(text, values as unknown[]),
+    });
+    logger.info('pets seed complete', { seeded });
+  } catch (err) {
+    logger.error('pets seed failed', {
+      message: (err as Error)?.message,
+      stack: (err as Error)?.stack,
+    });
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+};
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/services/rescue/package.json
+++ b/services/rescue/package.json
@@ -21,6 +21,7 @@
     "dev": "tsx watch --import ./src/instrumentation.ts ./src/index.ts",
     "start": "node --import ./dist/instrumentation.js ./dist/index.js",
     "db:migrate": "tsx ./src/db/migrate.ts",
+    "db:seed": "tsx ./src/db/seed.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/services/rescue/src/db/seed-data.ts
+++ b/services/rescue/src/db/seed-data.ts
@@ -1,0 +1,74 @@
+// Canonical dev/e2e fixtures for the rescue.* schema.
+//
+// Recreates the two rescue organisations the old service.backend seeder
+// populated, plus the staff_member rows that link the seeded rescue-staff
+// users (auth.users) to their rescue. user_id / created_by values are the
+// FIXED auth user ids from services/auth/src/db/seed-data.ts — the link is
+// application-side (no cross-schema FK), so the ids must match by hand.
+
+export type SeedRescue = {
+  rescueId: string;
+  name: string;
+  email: string;
+  city: string;
+  zipCode: string;
+  contactPerson: string;
+  description: string;
+};
+
+export type SeedStaff = {
+  staffMemberId: string;
+  rescueId: string;
+  userId: string;
+  title: string;
+};
+
+// Pinned auth user ids (see services/auth/src/db/seed-data.ts).
+const RESCUE_MANAGER_ID = 'b0000000-0000-4000-8000-000000000001';
+const SARAH_JOHNSON_ID = 'b0000000-0000-4000-8000-000000000002';
+const MARIA_GARCIA_ID = 'b0000000-0000-4000-8000-000000000003';
+
+export const PAWS_RESCUE_ID = 'd0000000-0000-4000-8000-000000000001';
+export const HAPPY_TAILS_RESCUE_ID = 'd0000000-0000-4000-8000-000000000002';
+
+export const SEED_RESCUES: readonly SeedRescue[] = [
+  {
+    rescueId: PAWS_RESCUE_ID,
+    name: 'Paws Rescue',
+    email: 'hello@pawsrescue.dev',
+    city: 'Manchester',
+    zipCode: 'M1 1AA',
+    contactPerson: 'Rescue Manager',
+    description: 'A community rescue rehoming dogs and cats across the North West.',
+  },
+  {
+    rescueId: HAPPY_TAILS_RESCUE_ID,
+    name: 'Happy Tails Rescue',
+    email: 'hello@happytailsrescue.dev',
+    city: 'Bristol',
+    zipCode: 'BS1 4DJ',
+    contactPerson: 'Maria Garcia',
+    description: 'Specialists in senior-dog adoption and long-term foster care.',
+  },
+];
+
+export const SEED_STAFF: readonly SeedStaff[] = [
+  {
+    staffMemberId: 'e0000000-0000-4000-8000-000000000001',
+    rescueId: PAWS_RESCUE_ID,
+    userId: RESCUE_MANAGER_ID,
+    title: 'Rescue Manager',
+  },
+  {
+    staffMemberId: 'e0000000-0000-4000-8000-000000000002',
+    rescueId: PAWS_RESCUE_ID,
+    userId: SARAH_JOHNSON_ID,
+    title: 'Veterinary Technician',
+  },
+  {
+    staffMemberId: 'e0000000-0000-4000-8000-000000000003',
+    rescueId: HAPPY_TAILS_RESCUE_ID,
+    userId: MARIA_GARCIA_ID,
+    title: 'Director',
+  },
+];

--- a/services/rescue/src/db/seed.test.ts
+++ b/services/rescue/src/db/seed.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { seedRescues, type QueryFn } from './seed.js';
+import { SEED_RESCUES, SEED_STAFF } from './seed-data.js';
+
+function recordingQuery(): { query: QueryFn; calls: Array<{ text: string; values: unknown[] }> } {
+  const calls: Array<{ text: string; values: unknown[] }> = [];
+  const query: QueryFn = async (text, values) => {
+    calls.push({ text, values: [...values] });
+    return undefined;
+  };
+  return { query, calls };
+}
+
+describe('rescue seed', () => {
+  it('seeds every rescue and staff link', async () => {
+    const { query, calls } = recordingQuery();
+
+    const seeded = await seedRescues({ query });
+
+    expect(calls).toHaveLength(SEED_RESCUES.length + SEED_STAFF.length);
+    expect(seeded).toEqual(SEED_RESCUES.map(r => r.name));
+  });
+
+  it('seeds rescues as verified so the public "view a rescue" path works', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedRescues({ query });
+
+    const rescueCalls = calls.filter(c => c.text.includes('rescue.rescues'));
+    expect(rescueCalls).toHaveLength(SEED_RESCUES.length);
+    for (const call of rescueCalls) {
+      expect(call.text).toContain("'verified'");
+    }
+  });
+
+  it('links staff to their rescue using the pinned auth user ids', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedRescues({ query });
+
+    const staffCalls = calls.filter(c => c.text.includes('rescue.staff_members'));
+    const userIds = staffCalls.map(c => c.values[2]);
+    expect(userIds).toContain('b0000000-0000-4000-8000-000000000001');
+  });
+
+  it('is idempotent — every insert uses ON CONFLICT DO UPDATE', async () => {
+    const { query, calls } = recordingQuery();
+
+    await seedRescues({ query });
+
+    for (const call of calls) {
+      expect(call.text).toMatch(/ON CONFLICT[\s\S]*DO UPDATE/);
+    }
+
+    const second = recordingQuery();
+    await seedRescues({ query: second.query });
+    expect(second.calls).toHaveLength(calls.length);
+  });
+});

--- a/services/rescue/src/db/seed.ts
+++ b/services/rescue/src/db/seed.ts
@@ -1,0 +1,119 @@
+// Seed entry point — populates the rescue.* schema with the canonical
+// dev/e2e rescue organisations + their staff_member links (see
+// seed-data.ts).
+//
+// Mirrors migrate.ts: invoked by `npm run db:seed`, reuses loadConfig()
+// + createDbClient. Depends on the auth seed having run first (the
+// staff_member.user_id pointers reference auth.users), but the rows
+// carry no cross-schema FK so the insert succeeds regardless of order —
+// the root orchestrator (scripts/seed.mjs) still runs auth first.
+//
+// Idempotent: every INSERT is `ON CONFLICT (...) DO UPDATE`. Rescues are
+// inserted as already-verified so the public "view a rescue" path works.
+
+import { createDbClient } from '@adopt-dont-shop/db';
+import { createLogger } from '@adopt-dont-shop/observability';
+
+import { loadConfig } from '../config.js';
+import { SEED_RESCUES, SEED_STAFF, type SeedRescue, type SeedStaff } from './seed-data.js';
+
+export type QueryFn = (text: string, values: readonly unknown[]) => Promise<unknown>;
+
+const UPSERT_RESCUE = `
+  INSERT INTO rescue.rescues (
+    rescue_id, name, email, address, city, zip_code, country,
+    contact_person, description, status, verified_at,
+    created_at, updated_at
+  ) VALUES (
+    $1, $2, $3, $4, $5, $6, 'GB',
+    $7, $8, 'verified', now(),
+    now(), now()
+  )
+  ON CONFLICT (rescue_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    email = EXCLUDED.email,
+    city = EXCLUDED.city,
+    zip_code = EXCLUDED.zip_code,
+    contact_person = EXCLUDED.contact_person,
+    description = EXCLUDED.description,
+    status = 'verified',
+    updated_at = now()
+`;
+
+const UPSERT_STAFF = `
+  INSERT INTO rescue.staff_members (
+    staff_member_id, rescue_id, user_id, title,
+    is_verified, added_by, added_at, created_at, updated_at
+  ) VALUES (
+    $1, $2, $3, $4,
+    true, $3, now(), now(), now()
+  )
+  ON CONFLICT (staff_member_id) DO UPDATE SET
+    rescue_id = EXCLUDED.rescue_id,
+    user_id = EXCLUDED.user_id,
+    title = EXCLUDED.title,
+    is_verified = true,
+    updated_at = now()
+`;
+
+export type SeedDeps = {
+  query: QueryFn;
+};
+
+export const seedRescues = async (deps: SeedDeps): Promise<string[]> => {
+  const seeded: string[] = [];
+  for (const rescue of SEED_RESCUES) {
+    await deps.query(UPSERT_RESCUE, rescueParams(rescue));
+    seeded.push(rescue.name);
+  }
+  for (const staff of SEED_STAFF) {
+    await deps.query(UPSERT_STAFF, staffParams(staff));
+  }
+  return seeded;
+};
+
+const rescueParams = (r: SeedRescue): readonly unknown[] => [
+  r.rescueId,
+  r.name,
+  r.email,
+  // `address` is NOT NULL; the seed data only carries city/zip so we
+  // synthesise a placeholder street line.
+  `${r.city} (dev seed address)`,
+  r.city,
+  r.zipCode,
+  r.contactPerson,
+  r.description,
+];
+
+const staffParams = (s: SeedStaff): readonly unknown[] => [
+  s.staffMemberId,
+  s.rescueId,
+  s.userId,
+  s.title,
+];
+
+const main = async (): Promise<void> => {
+  const logger = createLogger({ serviceName: 'service.rescue.seed' });
+  const config = loadConfig();
+  const pool = createDbClient({ connectionString: config.databaseUrl, schema: config.schema });
+  try {
+    logger.info('seeding rescues', { schema: config.schema, count: SEED_RESCUES.length });
+    const seeded = await seedRescues({
+      query: (text, values) => pool.query(text, values as unknown[]),
+    });
+    logger.info('rescue seed complete', { seeded });
+  } catch (err) {
+    logger.error('rescue seed failed', {
+      message: (err as Error)?.message,
+      stack: (err as Error)?.stack,
+    });
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+};
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}


### PR DESCRIPTION
## What & why

The `service.backend` monolith — and its DB seeder — was deleted, leaving a fresh `docker:dev` stack with **zero data**. The Playwright e2e suite (which logs in as `john.smith@gmail.com / DevPassword123!`) couldn't authenticate, and the golden path (log in → browse a pet → view a rescue) had nothing to render.

This PR adds a seeding mechanism that populates a fresh stack with the canonical dev personas plus enough reference data to exercise the golden path.

## Option chosen: B (per-service direct inserts)

I investigated **Option A** (seed through the gateway's public API) first and ruled it out: `AuthService.Register` always creates `pending_verification` adopters and **ignores `user_type`** (`services/auth/src/grpc/account-handlers.ts` — "adopters self-register; everything else is invitation-based"). The public API therefore cannot express the pre-verified admin / rescue-staff personas, nor assign roles without an already-existing admin. The task anticipated exactly this.

**Option B** mirrors the existing `db:migrate` pattern. Each schema-owning service gets a `db:seed` script (`tsx ./src/db/seed.ts`) that inserts directly into its own Postgres schema, reusing `loadConfig()` + `createDbClient` from `@adopt-dont-shop/db`. All inserts are idempotent (`ON CONFLICT DO UPDATE`) so re-runs are safe.

- `services/auth/src/db/seed.ts` — the personas (active + email-verified, correct `user_type`, bcrypt-hashed `DevPassword123!`).
- `services/rescue/src/db/seed.ts` — two verified rescues + `staff_member` links back to the seeded auth users.
- `services/pets/src/db/seed.ts` — a small pet catalogue attached to the seeded rescues.

A root `scripts/seed.mjs` orchestrator (host-side, **no `@adopt-dont-shop/*` imports** — per the stated hard rule) runs the three in dependency order via `docker compose exec`, wired up as `npm run db:seed`. The dev Docker image (`Dockerfile.service` development target only) also runs `db:seed` after `db:migrate` on container start, so a fresh stack comes up already seeded. Production CMD is untouched.

## Personas seeded (all share `DevPassword123!`, override via `SEED_PASSWORD`)

| Email | user_type | App |
| --- | --- | --- |
| `john.smith@gmail.com` | adopter | app.client |
| `emily.davis@yahoo.com` | adopter | app.client |
| `michael.brown@outlook.com` | adopter | app.client |
| `rescue.manager@pawsrescue.dev` | rescue_staff | app.rescue |
| `sarah.johnson@pawsrescue.dev` | rescue_staff | app.rescue |
| `maria@happytailsrescue.dev` | rescue_staff | app.rescue |
| `superadmin@adoptdontshop.dev` | super_admin | app.admin |
| `admin@adoptdontshop.dev` | admin | app.admin |
| `moderator@adoptdontshop.dev` | moderator | app.admin |

Emails/password match `e2e/fixtures/roles.ts` + `lib.dev-tools/src/data/seededUsers.ts` exactly. `john.smith`'s `user_id` is pinned to e2e `SEEDED_ADOPTER_USER_ID`; pet ids are pinned to e2e `SEEDED_PET_IDS`.

**Reference data:** Paws Rescue + Happy Tails Rescue (both `verified`), with staff links; pets in available / pending / adopted / on-hold states attached to those rescues.

## How to run

```bash
npm run docker:dev:detach   # comes up seeded automatically
# or, to (re-)seed a running stack by hand:
npm run db:seed
```

Documented in `e2e/README.md` ("Seeding the stack"), including the persona table and a `curl` login-verification snippet against the gateway (`localhost:4000`).

## Verification

- **14 new behaviour tests** across the three services (idempotency via `ON CONFLICT DO UPDATE`, pinned ids, single password hash, active + email-verified status, rescues seeded `verified`). All pass.
- Full service suites green: auth 189, rescue 98, pets 98.
- `tsc --noEmit` clean on all three services; eslint + prettier clean on changed files; `node scripts/check-workspace-consistency.mjs` passes.
- **Live login could not be verified** in this environment — Docker is unavailable here, so the stack can't be brought up. The script logic is proven by the unit tests; manual verification steps are documented in `e2e/README.md`.

## Notes / out of scope

- I did **not** attempt to fix the broader Playwright e2e suite (separate follow-up). I did refresh two now-stale references in `e2e/README.md` that pointed at the deleted `service.backend` seeder / the removed root `db:reset` script.
- Pre-existing, unrelated: `e2e` `URLS.api` still defaults to `:5000` (old monolith port) and `nginx/nginx.prod.conf` still routes to `service-backend:5000` — flagged, not touched.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_