### PR TITLE
ci: Trivy CVE scans for every microservice image on push-to-main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,3 +104,113 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
 
+  # ============================================================================
+  # BUILD SERVICES — dev image on all triggers, prod image + Trivy scan on push
+  #
+  # Replaces the CVE-scan coverage lost when the service.backend monolith
+  # was deleted in #995 (the old `build-backend` job ran a single Trivy
+  # scan against that one image). Each of the 11 microservice images is
+  # now built from the shared Dockerfile.service and scanned independently
+  # so a CVE in one service surfaces in the Security tab without being
+  # masked by another image's findings (fail-fast: false).
+  # ============================================================================
+  build-services:
+    name: Build ${{ matrix.service }} Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - gateway
+          - auth
+          - notifications
+          - pets
+          - rescue
+          - applications
+          - chat
+          - moderation
+          - matching
+          - audit
+          - cms
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.23.0
+            network=host
+
+      - name: Log in to GHCR (for Trivy DB pulls)
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build development image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile.service
+          target: development
+          build-args: |
+            SERVICE=@adopt-dont-shop/service.${{ matrix.service }}
+            SERVICE_DIR=services/${{ matrix.service }}
+            BUILDKIT_INLINE_CACHE=1
+          push: false
+          tags: paragonjenko/adoptdontshop:service-${{ matrix.service }}-dev-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
+
+      # Push-only: the prod stage re-runs the full multi-stage build,
+      # which is expensive across 11 images. ci.yml + E2E already cover
+      # source-level regressions on PRs; keep prod build + Trivy as a
+      # pre-deploy gate on main pushes.
+      - name: Build production image
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile.service
+          target: production
+          load: true
+          build-args: |
+            SERVICE=@adopt-dont-shop/service.${{ matrix.service }}
+            SERVICE_DIR=services/${{ matrix.service }}
+            BUILDKIT_INLINE_CACHE=1
+          push: false
+          tags: paragonjenko/adoptdontshop:service-${{ matrix.service }}-prod-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
+
+      - name: Run Trivy vulnerability scanner
+        if: github.event_name != 'pull_request'
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$PWD:/workspace" -w /workspace \
+            -e TRIVY_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-db:2 \
+            -e TRIVY_JAVA_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-java-db:1 \
+            aquasec/trivy:0.63.0 image \
+              --format sarif \
+              --output trivy-results-${{ matrix.service }}.sarif \
+              --severity CRITICAL,HIGH \
+              --exit-code 1 \
+              paragonjenko/adoptdontshop:service-${{ matrix.service }}-prod-${{ github.sha }}
+
+      - name: Upload Trivy results to GitHub Security tab
+        if: github.event_name != 'pull_request' && always() && hashFiles(format('trivy-results-{0}.sarif', matrix.service)) != ''
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463  # v4.36.1
+        with:
+          sarif_file: 'trivy-results-${{ matrix.service }}.sarif'
+          category: 'trivy-service-${{ matrix.service }}'
+


### PR DESCRIPTION
## Summary

Restores the container vulnerability scanning that was lost when the `service.backend` monolith — and with it the `build-backend` job in `.github/workflows/docker.yml` — was deleted in #995. That job ran a single Trivy scan against one image; the 11 microservice images built from the shared `Dockerfile.service` were never picked up by a per-service replacement.

This PR adds a `build-services` matrix job to `docker.yml` that mirrors the existing `build-apps` pattern.

### What's scanned

Matrix over all 11 services:

`gateway`, `auth`, `notifications`, `pets`, `rescue`, `applications`, `chat`, `moderation`, `matching`, `audit`, `cms`

Each matrix entry builds the **production** stage of `Dockerfile.service` with `SERVICE=@adopt-dont-shop/service.<name>` and `SERVICE_DIR=services/<name>`, then runs `aquasec/trivy:0.63.0` against the built image — same invocation the deleted `build-backend` job used (`severity: CRITICAL,HIGH`, `exit-code: 1`, SARIF output). The SARIF is uploaded to the GitHub Security tab via `github/codeql-action/upload-sarif` under a per-service `category` (`trivy-service-<name>`) so each service's findings stay separate and don't overwrite each other.

`fail-fast: false` means a CVE in one image surfaces alongside CVEs in the others rather than masking them.

### Triggers

- **Dev-stage build:** every workflow run (push, PR, workflow_dispatch) — cheap, useful as a Dockerfile smoke test.
- **Prod-stage build + Trivy + SARIF upload:** push events only (`if: github.event_name != 'pull_request'`), matching the existing `build-apps` pattern. Trivy across 11 prod images is multi-minute work; the PR loop is already covered by `ci.yml` + the E2E job. `workflow_dispatch` remains for ad-hoc dry-runs.

### What this PR does *not* change

- Does not touch `ci-required.needs` in `ci.yml` — Trivy informs the Security tab and gates the deploy pipeline downstream; it doesn't need to gate every merge to main.
- Does not widen the `pull_request` paths block on `docker.yml`.
- Does not modify `Dockerfile.service`, compose files, services, or anything outside `.github/workflows/docker.yml`.
- Does not touch `.github/workflow-source-paths.yml` — its existing `**/Dockerfile*` glob already covers `Dockerfile.service`, and `node scripts/check-workflow-paths.mjs` still passes.

### Local validation

- `node scripts/check-workflow-paths.mjs` — passes
- `node scripts/check-workspace-consistency.mjs` — passes
- `node -e "require('js-yaml').load(require('fs').readFileSync('.github/workflows/docker.yml','utf8'))"` — parses cleanly

Trivy itself can't be exercised locally without Docker; CI on this PR's first push-to-main run after merge is the real validation. Reviewers who want to dry-run before merge can use the `workflow_dispatch` trigger.

## Test plan

- [ ] CI runs on this PR show the new `build-services` matrix builds the dev image for all 11 services (Trivy step skipped on PR per `if:` guard)
- [ ] After merge, the first push-to-main run of `docker.yml` shows 11 prod builds + 11 Trivy scans
- [ ] GitHub Security tab shows 11 distinct categories (`trivy-service-gateway`, `trivy-service-auth`, …, `trivy-service-cms`) on the next push-to-main run
- [ ] `node scripts/check-workflow-paths.mjs` remains green

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_