### PR TITLE
feat(observability): /metrics endpoint per service + x-request-id pro…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15508,6 +15508,12 @@
         "node": "*"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -22197,6 +22203,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -24118,6 +24137,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -25984,8 +26012,17 @@
         "@opentelemetry/semantic-conventions": "^1.41.1",
         "@sentry/node": "^10.56.0",
         "@sentry/profiling-node": "^10.56.0",
+        "prom-client": "^15.1.3",
         "winston": "^3.19.0",
         "winston-loki": "^6.1.4"
+      },
+      "peerDependencies": {
+        "fastify": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastify": {
+          "optional": true
+        }
       }
     },
     "packages/proto": {
@@ -26219,6 +26256,9 @@
         "fastify": "^5.8.5",
         "nats": "^2.29.3",
         "socket.io": "^4.8.3"
+      },
+      "devDependencies": {
+        "socket.io-client": "^4.8.3"
       }
     },
     "services/matching": {

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -39,7 +39,16 @@
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@sentry/node": "^10.56.0",
     "@sentry/profiling-node": "^10.56.0",
+    "prom-client": "^15.1.3",
     "winston": "^3.19.0",
     "winston-loki": "^6.1.4"
+  },
+  "peerDependencies": {
+    "fastify": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "fastify": {
+      "optional": true
+    }
   }
 }

--- a/packages/observability/src/grpc-instrumentation.ts
+++ b/packages/observability/src/grpc-instrumentation.ts
@@ -1,0 +1,53 @@
+// Shared instrumentation helpers for the per-service gRPC adapters.
+//
+// Each service ships its own `adapt(handler, ...)` (services/*/src/grpc/
+// adapter.ts) — different HandlerError types make a single shared
+// adapter impractical. But the cross-cutting concerns (read request-id
+// off metadata; record duration + grpc code on completion) are
+// identical. These two tiny helpers let each adapter add observability
+// in three lines.
+
+import { randomUUID } from 'node:crypto';
+
+import type { Metadata } from '@grpc/grpc-js';
+
+import { recordGrpcDuration, type GrpcDirection } from './metrics.js';
+import { REQUEST_ID_HEADER_NAME } from './request-id.js';
+
+// Pull x-request-id off incoming gRPC metadata, fall back to a fresh
+// UUID. Adapter uses this to seed the AsyncLocalStorage context (via
+// runWithRequestId) so log lines + nested outbound calls pick it up.
+export const extractRequestIdFromMetadata = (metadata: Metadata): string => {
+  const raw = metadata.get(REQUEST_ID_HEADER_NAME);
+  for (const v of raw) {
+    if (typeof v === 'string' && v.length > 0) {
+      return v;
+    }
+  }
+  return randomUUID();
+};
+
+// Start a duration measurement for a single gRPC call (handler or
+// outbound client call). Caller invokes `stop(code)` once the call
+// resolves / rejects, passing the final grpc status code (0 on
+// success, the mapped HandlerErrorCode on failure). Direction defaults
+// to 'in' for handler use; the gateway's gRPC clients pass 'out'.
+export type StopFn = (code: number) => void;
+
+export const startGrpcTimer = (
+  service: string,
+  method: string,
+  direction: GrpcDirection = 'in'
+): StopFn => {
+  const start = process.hrtime.bigint();
+  return (code: number) => {
+    const elapsedNs = process.hrtime.bigint() - start;
+    recordGrpcDuration({
+      service,
+      method,
+      code,
+      direction,
+      durationSeconds: Number(elapsedNs) / 1e9,
+    });
+  };
+};

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -6,3 +6,21 @@ export type { SentryOptions } from './sentry.js';
 
 export { createLogger } from './logger.js';
 export type { LoggerOptions } from './logger.js';
+
+export {
+  getMetricsRegistry,
+  recordGrpcDuration,
+  registerMetrics,
+  __resetMetricsForTest,
+} from './metrics.js';
+export type { GrpcDirection, RecordGrpcOptions } from './metrics.js';
+
+export {
+  getRequestId,
+  REQUEST_ID_HEADER_NAME,
+  registerRequestId,
+  runWithRequestId,
+} from './request-id.js';
+
+export { extractRequestIdFromMetadata, startGrpcTimer } from './grpc-instrumentation.js';
+export type { StopFn } from './grpc-instrumentation.js';

--- a/packages/observability/src/metrics.test.ts
+++ b/packages/observability/src/metrics.test.ts
@@ -1,0 +1,97 @@
+import Fastify from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetMetricsForTest,
+  getMetricsRegistry,
+  recordGrpcDuration,
+  registerMetrics,
+} from './metrics.js';
+
+describe('registerMetrics — /metrics endpoint', () => {
+  beforeEach(() => {
+    __resetMetricsForTest();
+  });
+
+  afterEach(() => {
+    __resetMetricsForTest();
+  });
+
+  it('exposes a /metrics endpoint that returns prom text format', async () => {
+    const app = Fastify();
+    registerMetrics(app);
+    try {
+      const res = await app.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toMatch(/text\/plain/);
+      // Must contain the histogram type declaration.
+      expect(res.body).toContain('# TYPE http_request_duration_seconds histogram');
+      expect(res.body).toContain('# TYPE grpc_handler_duration_seconds histogram');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('records http_request_duration_seconds for an inbound request with method, route, status_code labels', async () => {
+    const app = Fastify();
+    registerMetrics(app);
+    app.get('/widgets/:id', async () => ({ ok: true }));
+    try {
+      await app.inject({ method: 'GET', url: '/widgets/abc' });
+      const res = await app.inject({ method: 'GET', url: '/metrics' });
+      const body = res.body;
+      // Templated route — must NOT contain the resolved id.
+      expect(body).toContain('route="/widgets/:id"');
+      expect(body).toContain('method="GET"');
+      expect(body).toContain('status_code="200"');
+      expect(body).not.toContain('route="/widgets/abc"');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('exposes Node default process metrics (process_cpu_user_seconds_total)', async () => {
+    const app = Fastify();
+    registerMetrics(app);
+    try {
+      const res = await app.inject({ method: 'GET', url: '/metrics' });
+      expect(res.body).toContain('process_cpu_user_seconds_total');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('recordGrpcDuration', () => {
+  beforeEach(() => {
+    __resetMetricsForTest();
+  });
+
+  it('records into grpc_handler_duration_seconds with service/method/code/direction labels', async () => {
+    getMetricsRegistry();
+    recordGrpcDuration({
+      service: 'service.auth',
+      method: 'Login',
+      code: 0,
+      direction: 'in',
+      durationSeconds: 0.012,
+    });
+    const text = await getMetricsRegistry().metrics();
+    expect(text).toContain(
+      'grpc_handler_duration_seconds_count{service="service.auth",method="Login",code="0",direction="in"} 1'
+    );
+  });
+
+  it('distinguishes in vs out direction', async () => {
+    getMetricsRegistry();
+    recordGrpcDuration({
+      service: 'service.auth',
+      method: 'ValidateToken',
+      code: 0,
+      direction: 'out',
+      durationSeconds: 0.05,
+    });
+    const text = await getMetricsRegistry().metrics();
+    expect(text).toMatch(/direction="out"/);
+  });
+});

--- a/packages/observability/src/metrics.ts
+++ b/packages/observability/src/metrics.ts
@@ -1,0 +1,133 @@
+// Prometheus metrics — substrate only.
+//
+// Three default instruments shared by every service:
+//   - http_request_duration_seconds{method, route, status_code}
+//     auto-recorded from a Fastify onResponse hook (registerMetrics).
+//   - grpc_handler_duration_seconds{service, method, code, direction}
+//     auto-recorded by the gRPC adapter wrappers in each service +
+//     the gateway's gRPC clients (direction="in" vs "out").
+//   - process metrics via collectDefaultMetrics() — Node memory/GC/CPU.
+//
+// No domain-specific metrics here. Services annotate their own hot
+// paths in a follow-up PR.
+
+import { Counter, Histogram, Registry, collectDefaultMetrics, type LabelValues } from 'prom-client';
+import type { FastifyInstance } from 'fastify';
+
+// Single shared registry — every service mounts this on /metrics. A
+// future multi-collector setup can swap to mergeRegistries() but this
+// works for the one-process-one-service shape we have today.
+let registry: Registry | null = null;
+let httpHistogram: Histogram<string> | null = null;
+let grpcHistogram: Histogram<string> | null = null;
+let defaultsCollected = false;
+
+const HTTP_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+const GRPC_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
+
+export const getMetricsRegistry = (): Registry => {
+  if (registry) {
+    return registry;
+  }
+  registry = new Registry();
+  httpHistogram = new Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP request latency in seconds.',
+    labelNames: ['method', 'route', 'status_code'],
+    buckets: HTTP_BUCKETS,
+    registers: [registry],
+  });
+  grpcHistogram = new Histogram({
+    name: 'grpc_handler_duration_seconds',
+    help: 'gRPC handler latency in seconds.',
+    labelNames: ['service', 'method', 'code', 'direction'],
+    buckets: GRPC_BUCKETS,
+    registers: [registry],
+  });
+  if (!defaultsCollected) {
+    collectDefaultMetrics({ register: registry });
+    defaultsCollected = true;
+  }
+  return registry;
+};
+
+const getHttpHistogram = (): Histogram<string> => {
+  getMetricsRegistry();
+  if (!httpHistogram) {
+    throw new Error('http histogram not initialised');
+  }
+  return httpHistogram;
+};
+
+const getGrpcHistogram = (): Histogram<string> => {
+  getMetricsRegistry();
+  if (!grpcHistogram) {
+    throw new Error('grpc histogram not initialised');
+  }
+  return grpcHistogram;
+};
+
+export type GrpcDirection = 'in' | 'out';
+
+export type RecordGrpcOptions = {
+  service: string;
+  method: string;
+  // grpc-js numeric status code (status.OK = 0, …). Cast to string for
+  // the label so it lands as e.g. `code="0"` in Prometheus.
+  code: number;
+  direction: GrpcDirection;
+  durationSeconds: number;
+};
+
+export const recordGrpcDuration = (opts: RecordGrpcOptions): void => {
+  const labels: LabelValues<string> = {
+    service: opts.service,
+    method: opts.method,
+    code: String(opts.code),
+    direction: opts.direction,
+  };
+  getGrpcHistogram().observe(labels, opts.durationSeconds);
+};
+
+// Fastify plugin — registers the /metrics route + an onResponse hook
+// that records every request into http_request_duration_seconds.
+// Idempotent: callers register once at boot.
+export const registerMetrics = (app: FastifyInstance): void => {
+  const reg = getMetricsRegistry();
+  const histogram = getHttpHistogram();
+
+  app.addHook('onResponse', (req, reply, done) => {
+    // routeOptions.url is the templated path ("/api/v1/users/:userId"),
+    // not the resolved URL — that's the right label for a histogram
+    // because it bounds cardinality. Fall back to req.url for the
+    // handful of edge cases where Fastify can't resolve a route.
+    const route = req.routeOptions?.url ?? req.url;
+    histogram.observe(
+      {
+        method: req.method,
+        route,
+        status_code: String(reply.statusCode),
+      },
+      reply.elapsedTime / 1000
+    );
+    done();
+  });
+
+  app.get('/metrics', async (_req, reply) => {
+    void reply.header('Content-Type', 'text/plain; version=0.0.4');
+    return reg.metrics();
+  });
+};
+
+// --- Test-only helpers ---------------------------------------------
+
+// Vitest needs to reset the registry between suites so cross-test
+// state doesn't leak. Not exported from index.ts — internal contract.
+export const __resetMetricsForTest = (): void => {
+  registry = null;
+  httpHistogram = null;
+  grpcHistogram = null;
+  defaultsCollected = false;
+};
+
+export { Counter, Histogram, Registry };

--- a/packages/observability/src/request-id.test.ts
+++ b/packages/observability/src/request-id.test.ts
@@ -1,0 +1,79 @@
+import Fastify from 'fastify';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getRequestId,
+  REQUEST_ID_HEADER_NAME,
+  registerRequestId,
+  runWithRequestId,
+} from './request-id.js';
+
+describe('registerRequestId — inbound header', () => {
+  it('uses the inbound x-request-id header verbatim and echoes it back', async () => {
+    const app = Fastify();
+    registerRequestId(app);
+    app.get('/x', async req => ({ id: req.requestId }));
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/x',
+        headers: { [REQUEST_ID_HEADER_NAME]: 'caller-supplied-id' },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ id: 'caller-supplied-id' });
+      expect(res.headers[REQUEST_ID_HEADER_NAME]).toBe('caller-supplied-id');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('mints a UUID when the inbound header is absent and echoes it back', async () => {
+    const app = Fastify();
+    registerRequestId(app);
+    app.get('/x', async req => ({ id: req.requestId }));
+    try {
+      const res = await app.inject({ method: 'GET', url: '/x' });
+      expect(res.statusCode).toBe(200);
+      const { id } = res.json() as { id: string };
+      // randomUUID v4 shape.
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      expect(res.headers[REQUEST_ID_HEADER_NAME]).toBe(id);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('AsyncLocalStorage — getRequestId() inside a request', () => {
+  it('returns the active request id from inside an HTTP handler', async () => {
+    const app = Fastify();
+    registerRequestId(app);
+    app.get('/x', async () => ({ id: getRequestId() }));
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/x',
+        headers: { [REQUEST_ID_HEADER_NAME]: 'als-test-id' },
+      });
+      expect(res.json()).toEqual({ id: 'als-test-id' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('returns undefined outside any request context', () => {
+    expect(getRequestId()).toBeUndefined();
+  });
+});
+
+describe('runWithRequestId', () => {
+  it('runs a function inside a synthetic request-id context', async () => {
+    const observed: Array<string | undefined> = [];
+    await runWithRequestId('worker-job-123', async () => {
+      observed.push(getRequestId());
+    });
+    expect(observed).toEqual(['worker-job-123']);
+    // After exiting, the id is gone.
+    expect(getRequestId()).toBeUndefined();
+  });
+});

--- a/packages/observability/src/request-id.ts
+++ b/packages/observability/src/request-id.ts
@@ -1,0 +1,58 @@
+// Request-id middleware + AsyncLocalStorage accessor.
+//
+// One Fastify onRequest hook stamps `req.requestId` and the response
+// `x-request-id` header. Either the inbound `x-request-id` (the gateway
+// usually sets it, downstream services read it off gRPC metadata) or a
+// freshly minted UUID. AsyncLocalStorage lets any code reached during a
+// request — winston meta, downstream gRPC client metadata — fetch the
+// id without threading it through every function signature.
+//
+// Symmetric to the gRPC adapter side: services/*/src/grpc/adapter.ts
+// reads x-request-id off `call.metadata`, runs the handler inside the
+// same ALS context, and getRequestId() returns the id for downstream
+// log lines + any nested outbound calls.
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+
+import type { FastifyInstance } from 'fastify';
+
+const REQUEST_ID_HEADER = 'x-request-id';
+
+type RequestContext = {
+  requestId: string;
+};
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+export const getRequestId = (): string | undefined => storage.getStore()?.requestId;
+
+// Run an async function inside a request-id context. Used by the gRPC
+// adapter on the receiving side and by anything that needs to seed an
+// id manually (background jobs, NATS consumers).
+export const runWithRequestId = <T>(requestId: string, fn: () => Promise<T> | T): Promise<T> | T =>
+  storage.run({ requestId }, fn);
+
+// Fastify decorations augment the request type with `requestId`.
+declare module 'fastify' {
+  interface FastifyRequest {
+    requestId: string;
+  }
+}
+
+export const registerRequestId = (app: FastifyInstance): void => {
+  app.addHook('onRequest', (req, reply, done) => {
+    const inbound = req.headers[REQUEST_ID_HEADER];
+    const fromHeader = typeof inbound === 'string' && inbound.length > 0 ? inbound : undefined;
+    const requestId = fromHeader ?? randomUUID();
+    req.requestId = requestId;
+    void reply.header(REQUEST_ID_HEADER, requestId);
+    storage.run({ requestId }, () => {
+      done();
+    });
+  });
+};
+
+// Exported for tests that need to look up the header name without
+// duplicating the string literal.
+export const REQUEST_ID_HEADER_NAME = REQUEST_ID_HEADER;

--- a/services/applications/src/grpc/adapter.ts
+++ b/services/applications/src/grpc/adapter.ts
@@ -14,7 +14,7 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
@@ -22,6 +22,12 @@ import {
 
 import type { Principal } from '@adopt-dont-shop/authz';
 import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { extractPrincipal, MissingPrincipalError } from './principal.js';
@@ -44,6 +50,8 @@ export class HandlerError extends Error {
     this.name = 'HandlerError';
   }
 }
+
+const SERVICE_NAME = 'service.applications';
 
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
@@ -69,15 +77,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -98,4 +113,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/applications/src/server.test.ts
+++ b/services/applications/src/server.test.ts
@@ -65,3 +65,33 @@ describe('createServer — health endpoint', () => {
     expect(res.json()).toEqual({ error: 'internal_error' });
   });
 });
+
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes the inbound x-request-id header on the response', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-test-id-1234' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-test-id-1234');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/services/applications/src/server.ts
+++ b/services/applications/src/server.ts
@@ -14,7 +14,7 @@
 // (5.4), gateway routing (5.5), and cutover (5.6) arrive in subsequent
 // commits.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { ApplicationsConfig } from './config.js';
@@ -49,6 +49,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck

--- a/services/audit/src/grpc/adapter.ts
+++ b/services/audit/src/grpc/adapter.ts
@@ -13,7 +13,7 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
@@ -21,6 +21,12 @@ import {
 
 import type { Principal } from '@adopt-dont-shop/authz';
 import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { extractPrincipal, MissingPrincipalError } from './principal.js';
@@ -49,6 +55,8 @@ export class HandlerError extends Error {
   }
 }
 
+const SERVICE_NAME = 'service.audit';
+
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
   UNAUTHENTICATED: status.UNAUTHENTICATED,
@@ -73,15 +81,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -102,4 +117,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/audit/src/server.test.ts
+++ b/services/audit/src/server.test.ts
@@ -65,3 +65,33 @@ describe('createServer — health endpoint', () => {
     expect(res.json()).toEqual({ error: 'internal_error' });
   });
 });
+
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes the inbound x-request-id header on the response', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-test-id-1234' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-test-id-1234');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/services/audit/src/server.ts
+++ b/services/audit/src/server.ts
@@ -12,7 +12,7 @@
 // monolith cutover (10.6 — deletes auditLog.service.ts + middleware)
 // arrive in subsequent commits.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { AuditConfig } from './config.js';
@@ -47,6 +47,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck

--- a/services/auth/src/grpc/adapter.test.ts
+++ b/services/auth/src/grpc/adapter.test.ts
@@ -39,8 +39,17 @@ const deps = {
   tokenIssuer: { mint: vi.fn(), verifyAccess: vi.fn(), verifyRefresh: vi.fn() },
 } as unknown as HandlerDeps;
 
-function makeCall<Req>(request: Req, metadata: Metadata): ServerUnaryCall<Req, unknown> {
-  return { request, metadata } as ServerUnaryCall<Req, unknown>;
+function makeCall<Req>(
+  request: Req,
+  metadata: Metadata
+): ServerUnaryCall<Req, unknown> & { sentMetadata: Metadata[] } {
+  const sentMetadata: Metadata[] = [];
+  return {
+    request,
+    metadata,
+    sentMetadata,
+    sendMetadata: (m: Metadata) => sentMetadata.push(m),
+  } as unknown as ServerUnaryCall<Req, unknown> & { sentMetadata: Metadata[] };
 }
 
 describe('adapt (principal-required) — happy path', () => {
@@ -169,5 +178,39 @@ describe('adaptUnauth (principal-optional) — Login/Refresh/Validate', () => {
       code: status.UNAUTHENTICATED,
       details: 'invalid credentials',
     });
+  });
+});
+
+describe('adapt — x-request-id propagation', () => {
+  it('echoes the inbound x-request-id back on the response metadata', async () => {
+    const handler = vi.fn(async (_deps, _principal, _req: unknown) => ({ ok: true }));
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const md = buildMetadata({ ...VALID_PRINCIPAL_HEADERS, 'x-request-id': 'req-abc-123' });
+    const call = makeCall({}, md);
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(call, callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(call.sentMetadata).toHaveLength(1);
+    const sent = call.sentMetadata[0].get('x-request-id');
+    expect(sent).toEqual(['req-abc-123']);
+  });
+
+  it('mints a fresh x-request-id when the inbound metadata has none', async () => {
+    const handler = vi.fn(async (_deps, _principal, _req: unknown) => ({ ok: true }));
+    const { logger } = makeLogger();
+    const wrapped = adapt(handler, { deps, logger });
+
+    const call = makeCall({}, buildMetadata(VALID_PRINCIPAL_HEADERS));
+    const callback = vi.fn() as unknown as sendUnaryData<unknown>;
+    wrapped(call, callback);
+    await new Promise(r => setImmediate(r));
+
+    expect(call.sentMetadata).toHaveLength(1);
+    const sent = call.sentMetadata[0].get('x-request-id');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 });

--- a/services/auth/src/grpc/adapter.ts
+++ b/services/auth/src/grpc/adapter.ts
@@ -17,18 +17,26 @@
 // service.
 
 import {
+  Metadata,
   status,
-  type Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
 } from '@grpc/grpc-js';
 
 import type { Principal } from '@adopt-dont-shop/authz';
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
 import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+const SERVICE_NAME = 'service.auth';
 
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
@@ -61,15 +69,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -80,7 +95,11 @@ export function adaptUnauth<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         // Best-effort principal extraction — pass it through when
         // present (gateway middleware may already have validated a
@@ -93,12 +112,28 @@ export function adaptUnauth<Req, Res>(
           principal = null;
         }
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }
 
 function toServiceError(err: unknown, metadata: Metadata, logger: Logger): ServiceError {

--- a/services/auth/src/server.test.ts
+++ b/services/auth/src/server.test.ts
@@ -59,6 +59,37 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      // Issue a request first so the histogram has at least one sample.
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes inbound x-request-id and stamps it on req.requestId', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-auth-abc' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-auth-abc');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — error handler', () => {
   let server: FastifyInstance;
 

--- a/services/auth/src/server.ts
+++ b/services/auth/src/server.ts
@@ -7,7 +7,7 @@
 // publishers in Phase 2.4, gateway routing in Phase 2.5, cutover in
 // Phase 2.6.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { AuthConfig } from './config.js';
@@ -42,6 +42,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck

--- a/services/chat/src/grpc/adapter.ts
+++ b/services/chat/src/grpc/adapter.ts
@@ -5,16 +5,24 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
 } from '@grpc/grpc-js';
 
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
 import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+const SERVICE_NAME = 'service.chat';
 
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
@@ -42,15 +50,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -71,4 +86,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/chat/src/server.test.ts
+++ b/services/chat/src/server.test.ts
@@ -65,3 +65,33 @@ describe('createServer — health endpoint', () => {
     expect(res.json()).toEqual({ error: 'internal_error' });
   });
 });
+
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes the inbound x-request-id header on the response', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-test-id-1234' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-test-id-1234');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/services/chat/src/server.ts
+++ b/services/chat/src/server.ts
@@ -11,7 +11,7 @@
 // gRPC (6.3), NATS publishers (6.4), gateway routing (6.5), and
 // cutover (6.6) arrive in subsequent commits.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { ChatConfig } from './config.js';
@@ -46,6 +46,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck

--- a/services/cms/src/grpc/adapter.ts
+++ b/services/cms/src/grpc/adapter.ts
@@ -7,17 +7,25 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
 } from '@grpc/grpc-js';
 
 import type { Principal } from '@adopt-dont-shop/authz';
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
 import { extractPrincipal, extractPrincipalOptional, MissingPrincipalError } from './principal.js';
+
+const SERVICE_NAME = 'service.cms';
 
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
@@ -38,15 +46,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -55,15 +70,22 @@ export function adaptUnauth<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipalOptional(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -84,4 +106,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/cms/src/server.ts
+++ b/services/cms/src/server.ts
@@ -1,6 +1,6 @@
 import Fastify, { type FastifyInstance } from 'fastify';
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 
 import type { CmsConfig } from './config.js';
 
@@ -18,6 +18,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     logger.error('request failed', { method: req.method, url: req.url, message: err.message });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — same path the rest of the stack uses.
   server.get('/health/simple', async () => ({

--- a/services/gateway/src/grpc-clients/applications-client.ts
+++ b/services/gateway/src/grpc-clients/applications-client.ts
@@ -45,6 +45,8 @@ import {
   type WithdrawResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type ApplicationsClient = {
   startDraft(req: StartDraftRequest, metadata: Metadata): Promise<StartDraftResponse>;
   saveDraftAnswers(
@@ -105,7 +107,19 @@ export const createApplicationsClient = (
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.applications', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/audit-client.ts
+++ b/services/gateway/src/grpc-clients/audit-client.ts
@@ -32,6 +32,8 @@ import {
   type AuditUpdateSavedReportResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type AuditClient = {
   query(req: AuditQueryRequest, metadata: Metadata): Promise<AuditQueryResponse>;
   getByTarget(req: AuditGetByTargetRequest, metadata: Metadata): Promise<AuditGetByTargetResponse>;
@@ -92,7 +94,19 @@ export const createAuditClient = (opts: CreateAuditClientOptions): AuditClient =
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.audit', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/auth-client.ts
+++ b/services/gateway/src/grpc-clients/auth-client.ts
@@ -81,6 +81,8 @@ import {
   type DeleteFieldPermissionResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type AuthClient = {
   login(req: LoginRequest, metadata: Metadata): Promise<LoginResponse>;
   logout(req: LogoutRequest, metadata: Metadata): Promise<LogoutResponse>;
@@ -189,7 +191,19 @@ export const createAuthClient = (opts: CreateAuthClientOptions): AuthClient => {
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.auth', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/chat-client.ts
+++ b/services/gateway/src/grpc-clients/chat-client.ts
@@ -32,6 +32,8 @@ import {
   type DeleteChatResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type ChatClient = {
   openChat(req: OpenChatRequest, metadata: Metadata): Promise<OpenChatResponse>;
   sendMessage(req: SendMessageRequest, metadata: Metadata): Promise<SendMessageResponse>;
@@ -76,7 +78,19 @@ export const createChatClient = (opts: CreateChatClientOptions): ChatClient => {
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.chat', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/cms-client.ts
+++ b/services/gateway/src/grpc-clients/cms-client.ts
@@ -42,6 +42,8 @@ import {
   type CmsUpdateMenuResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type CmsClient = {
   listPublicContent(
     req: CmsListPublicContentRequest,
@@ -122,7 +124,19 @@ export const createCmsClient = (opts: CreateCmsClientOptions): CmsClient => {
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.cms', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/matching-client.ts
+++ b/services/gateway/src/grpc-clients/matching-client.ts
@@ -37,6 +37,8 @@ import {
   type UpsertMatchProfileResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type MatchingClient = {
   startSession(req: StartSessionRequest, metadata: Metadata): Promise<StartSessionResponse>;
   endSession(req: EndSessionRequest, metadata: Metadata): Promise<EndSessionResponse>;
@@ -92,7 +94,19 @@ export const createMatchingClient = (opts: CreateMatchingClientOptions): Matchin
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.matching', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/moderation-client.ts
+++ b/services/gateway/src/grpc-clients/moderation-client.ts
@@ -43,6 +43,8 @@ import {
   type RespondToTicketResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type ModerationClient = {
   fileReport(req: FileReportRequest, metadata: Metadata): Promise<FileReportResponse>;
   getReport(req: GetReportRequest, metadata: Metadata): Promise<GetReportResponse>;
@@ -109,7 +111,19 @@ export const createModerationClient = (opts: CreateModerationClientOptions): Mod
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.moderation', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/notifications-client.ts
+++ b/services/gateway/src/grpc-clients/notifications-client.ts
@@ -56,6 +56,8 @@ import {
   type PreviewEmailTemplateResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type NotificationsClient = {
   create(req: CreateNotificationRequest, metadata: Metadata): Promise<CreateNotificationResponse>;
   list(req: ListNotificationsRequest, metadata: Metadata): Promise<ListNotificationsResponse>;
@@ -167,7 +169,19 @@ export const createNotificationsClient = (
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.notifications', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/pets-client.ts
+++ b/services/gateway/src/grpc-clients/pets-client.ts
@@ -30,6 +30,8 @@ import {
   type UpdatePetStatusResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type PetsClient = {
   create(req: CreatePetRequest, metadata: Metadata): Promise<CreatePetResponse>;
   get(req: GetPetRequest, metadata: Metadata): Promise<GetPetResponse>;
@@ -67,7 +69,19 @@ export const createPetsClient = (opts: CreatePetsClientOptions): PetsClient => {
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.pets', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/grpc-clients/rescue-client.ts
+++ b/services/gateway/src/grpc-clients/rescue-client.ts
@@ -41,6 +41,8 @@ import {
   type VerifyRescueResponse,
 } from '@adopt-dont-shop/proto';
 
+import { startGrpcTimer } from '@adopt-dont-shop/observability';
+
 export type RescueClient = {
   create(req: CreateRescueRequest, metadata: Metadata): Promise<CreateRescueResponse>;
   get(req: GetRescueRequest, metadata: Metadata): Promise<GetRescueResponse>;
@@ -105,7 +107,19 @@ export const createRescueClient = (opts: CreateRescueClientOptions): RescueClien
       const options: Partial<CallOptions> = {
         deadline: new Date(Date.now() + DEFAULT_DEADLINE_MS),
       };
+      const method = fn.name || 'unknown';
+      const stop = startGrpcTimer('service.rescue', method, 'out');
       fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'number'
+            ? (err as { code: number }).code
+            : err
+              ? 2 // UNKNOWN
+              : 0;
+        stop(code);
         if (err) {
           reject(err);
           return;

--- a/services/gateway/src/middleware/metadata.ts
+++ b/services/gateway/src/middleware/metadata.ts
@@ -1,0 +1,36 @@
+// Shared buildMetadata — lifts the near-identical helper that previously
+// lived in every route file into one place. Every gateway → service gRPC
+// call goes through this so we have exactly one place to add a header.
+//
+// Forwards:
+//   - x-user-id / x-user-roles / x-user-permissions / x-rescue-id
+//     (stamped by the authenticate middleware after ValidateToken)
+//   - x-request-id (stamped by the request-id middleware; either
+//     mirrored from the inbound header or minted as a UUID)
+//
+// Downstream gRPC adapters read x-request-id off `call.metadata` and
+// attach it to their logger context so a single id traces through every
+// hop.
+
+import { Metadata } from '@grpc/grpc-js';
+import type { FastifyRequest } from 'fastify';
+
+const FORWARDED_HEADERS = [
+  'x-user-id',
+  'x-user-roles',
+  'x-user-permissions',
+  'x-rescue-id',
+  'x-request-id',
+] as const;
+
+export const buildMetadata = (req: FastifyRequest): Metadata => {
+  const m = new Metadata();
+  const headers = req.headers as Record<string, string | string[] | undefined>;
+  for (const key of FORWARDED_HEADERS) {
+    const raw = headers[key];
+    if (typeof raw === 'string' && raw.length > 0) {
+      m.set(key, raw);
+    }
+  }
+  return m;
+};

--- a/services/gateway/src/routes/application-documents.ts
+++ b/services/gateway/src/routes/application-documents.ts
@@ -11,14 +11,15 @@
 // storage provider. Wire an AV step in front of `uploadFile` when the
 // scanner is extracted.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import { createStorageProvider, type StorageConfig } from '@adopt-dont-shop/storage';
 
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
 
 import { documentToView } from './applications-view.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type ApplicationDocumentsRoutesOptions = {
   client: ApplicationsClient;
@@ -148,18 +149,6 @@ type MultipartPart = {
   value?: unknown;
   toBuffer: () => Promise<Buffer>;
 };
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -28,7 +28,7 @@
 // to the monolith) — see server.ts.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import {
@@ -48,6 +48,7 @@ import {
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
 
 import { applicationToView, statsToView, type ApplicationView } from './applications-view.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type ApplicationsRoutesOptions = {
   client: ApplicationsClient;
@@ -426,18 +427,6 @@ export const registerApplicationsRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 function headerUserId(req: FastifyRequest): string | undefined {
   const raw = (req.headers as Record<string, string | string[] | undefined>)['x-user-id'];

--- a/services/gateway/src/routes/audit.ts
+++ b/services/gateway/src/routes/audit.ts
@@ -18,8 +18,8 @@
 // middleware already stamps x-user-* metadata.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   AuditV1,
@@ -28,6 +28,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { AuditClient } from '../grpc-clients/audit-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type AuditRoutesOptions = {
   client: AuditClient;
@@ -104,18 +105,6 @@ export const registerAuditRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -21,8 +21,8 @@
 // requests with no Authorization header through to the route.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   AuthV1,
@@ -33,6 +33,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type AuthRoutesOptions = {
   client: AuthClient;
@@ -372,21 +373,6 @@ export const registerAuthRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  // Same set the notifications routes forward — the authenticate
-  // middleware already stripped any spoofs and (when there's a valid
-  // Bearer) stamped the validated principal.
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/broadcast.ts
+++ b/services/gateway/src/routes/broadcast.ts
@@ -3,12 +3,13 @@
 // Thin REST → gRPC translation: parse the JSON body into BroadcastRequest,
 // forward principal metadata, return the aggregate counters.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import type { BroadcastRequest } from '@adopt-dont-shop/proto';
 
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type BroadcastRoutesOptions = {
   client: NotificationsClient;
@@ -85,18 +86,6 @@ export const registerBroadcastRoutes = async (
     }
   });
 };
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -10,8 +10,8 @@
 // `x-user-permissions` / `x-rescue-id` headers from the client become
 // the gRPC metadata the chat handlers' principal extractor reads.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   ChatV1,
@@ -25,6 +25,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { ChatClient } from '../grpc-clients/chat-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type ChatRoutesOptions = {
   client: ChatClient;
@@ -307,18 +308,6 @@ const registerChatRoutesForPrefix = (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/cms.ts
+++ b/services/gateway/src/routes/cms.ts
@@ -3,7 +3,7 @@
 // the existing lib.api CMS client deserialises unchanged.
 
 import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   CmsV1,
@@ -15,6 +15,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { CmsClient } from '../grpc-clients/cms-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type CmsRoutesOptions = {
   client: CmsClient;
@@ -524,18 +525,6 @@ export const registerCmsRoutes = async (
 };
 
 // --- Helpers --------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/dashboard.ts
+++ b/services/gateway/src/routes/dashboard.ts
@@ -17,7 +17,7 @@
 // metadata is set). Admins can pass ?rescueId= explicitly to scope
 // elsewhere. Adopters get 403.
 
-import { Metadata, status } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import {
@@ -33,6 +33,7 @@ import {
 import type { ApplicationsClient } from '../grpc-clients/applications-client.js';
 import type { PetsClient } from '../grpc-clients/pets-client.js';
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type DashboardRoutesOptions = {
   petsClient: PetsClient;
@@ -53,9 +54,13 @@ const DEFAULT_ACTIVITY_LIMIT = 10;
 const MAX_ACTIVITY_LIMIT = 100;
 
 const parseLimit = (raw: string | undefined): number => {
-  if (!raw) return DEFAULT_ACTIVITY_LIMIT;
+  if (!raw) {
+    return DEFAULT_ACTIVITY_LIMIT;
+  }
   const n = Number.parseInt(raw, 10);
-  if (Number.isNaN(n) || n < 1) return DEFAULT_ACTIVITY_LIMIT;
+  if (Number.isNaN(n) || n < 1) {
+    return DEFAULT_ACTIVITY_LIMIT;
+  }
   return Math.min(n, MAX_ACTIVITY_LIMIT);
 };
 
@@ -66,7 +71,9 @@ const parseLimit = (raw: string | undefined): number => {
 // ?rescueId= in the query string.
 const resolveRescueScope = (req: FastifyRequest): string | null => {
   const query = req.query as Record<string, string | undefined>;
-  if (query.rescueId) return query.rescueId;
+  if (query.rescueId) {
+    return query.rescueId;
+  }
   const headers = req.headers as Record<string, string | string[] | undefined>;
   const raw = headers['x-rescue-id'];
   return typeof raw === 'string' && raw.length > 0 ? raw : null;
@@ -241,18 +248,6 @@ export const registerDashboardRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/devices.ts
+++ b/services/gateway/src/routes/devices.ts
@@ -14,8 +14,8 @@
 // (registerDeviceToken / unregisterDeviceToken / listDeviceTokens on
 // NotificationsClient).
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   NotificationsV1,
@@ -25,6 +25,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type DevicesRoutesOptions = {
   client: NotificationsClient;
@@ -132,18 +133,6 @@ export const registerDevicesRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/email.ts
+++ b/services/gateway/src/routes/email.ts
@@ -8,8 +8,8 @@
 // handlers' principal extractor reads, and they gate on
 // email.templates.* permissions.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   NotificationsV1,
@@ -19,6 +19,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type EmailRoutesOptions = {
   client: NotificationsClient;
@@ -34,7 +35,9 @@ const GRPC_TO_HTTP: Record<number, number> = {
 };
 
 const typeFromString = (raw: string | undefined): NotificationsV1.EmailTemplateType => {
-  if (!raw) return NotificationsV1.EmailTemplateType.EMAIL_TEMPLATE_TYPE_UNSPECIFIED;
+  if (!raw) {
+    return NotificationsV1.EmailTemplateType.EMAIL_TEMPLATE_TYPE_UNSPECIFIED;
+  }
   const upper = `EMAIL_TEMPLATE_TYPE_${raw.toUpperCase()}`;
   const parsed = NotificationsV1.emailTemplateTypeFromJSON(
     Object.values(NotificationsV1.EmailTemplateType).includes(upper as never) ? upper : raw
@@ -45,7 +48,9 @@ const typeFromString = (raw: string | undefined): NotificationsV1.EmailTemplateT
 };
 
 const statusFromString = (raw: string | undefined): NotificationsV1.EmailTemplateStatus => {
-  if (!raw) return NotificationsV1.EmailTemplateStatus.EMAIL_TEMPLATE_STATUS_UNSPECIFIED;
+  if (!raw) {
+    return NotificationsV1.EmailTemplateStatus.EMAIL_TEMPLATE_STATUS_UNSPECIFIED;
+  }
   const upper = `EMAIL_TEMPLATE_STATUS_${raw.toUpperCase()}`;
   const parsed = NotificationsV1.emailTemplateStatusFromJSON(
     Object.values(NotificationsV1.EmailTemplateStatus).includes(upper as never) ? upper : raw
@@ -59,8 +64,12 @@ const statusFromString = (raw: string | undefined): NotificationsV1.EmailTemplat
 // send `variables` as an array; we JSON-stringify it for the proto's
 // variables_json field.
 const variablesJson = (v: unknown): string | undefined => {
-  if (v === undefined) return undefined;
-  if (typeof v === 'string') return v;
+  if (v === undefined) {
+    return undefined;
+  }
+  if (typeof v === 'string') {
+    return v;
+  }
   return JSON.stringify(v);
 };
 
@@ -237,18 +246,6 @@ export const registerEmailRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/field-permissions.ts
+++ b/services/gateway/src/routes/field-permissions.ts
@@ -6,8 +6,8 @@
 // existing lib.permissions frontend client (api-service.ts) keeps
 // working unchanged.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   AuthV1,
@@ -16,6 +16,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type FieldPermissionsRoutesOptions = {
   client: AuthClient;
@@ -249,18 +250,6 @@ export const registerFieldPermissionsRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/gdpr.ts
+++ b/services/gateway/src/routes/gdpr.ts
@@ -10,12 +10,13 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { Metadata, status } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
 import { GDPR_ERASURE_REQUESTED, type GdprErasureRequestedPayload } from '@adopt-dont-shop/events';
 import type { NatsConnection } from 'nats';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import type { AuditClient } from '../grpc-clients/audit-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type GdprRoutesOptions = {
   nats: NatsConnection;
@@ -119,18 +120,6 @@ export const registerGdprRoutes = async (
     );
   }
 };
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -25,7 +25,7 @@
 // handlers re-check the permission as defence-in-depth.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import {
@@ -41,6 +41,7 @@ import {
 import type { MatchingClient } from '../grpc-clients/matching-client.js';
 
 import { recommendToQueue, searchToView } from './matching-view.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type MatchingRoutesOptions = {
   client: MatchingClient;
@@ -343,7 +344,9 @@ export const registerMatchingRoutes = async (
 function matchProfileToView(
   profile: MatchingV1.MatchProfile | undefined
 ): Record<string, unknown> | undefined {
-  if (!profile) return undefined;
+  if (!profile) {
+    return undefined;
+  }
   const parseOrNull = (s: string): unknown => (s === '' ? null : safeJson(s));
   return {
     user_id: profile.userId,
@@ -443,18 +446,6 @@ async function openSession(
 }
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/moderation-admin.ts
+++ b/services/gateway/src/routes/moderation-admin.ts
@@ -10,8 +10,8 @@
 // SPA-facing layer.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   ModerationV1,
@@ -36,6 +36,7 @@ import {
   supportTicketResponseToView,
   supportTicketToView,
 } from './moderation-view.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type ModerationAdminRoutesOptions = {
   client: ModerationClient;
@@ -504,18 +505,6 @@ export const registerModerationAdminRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -33,8 +33,8 @@
 // x-user-* metadata via the Phase 2.5 authenticate middleware.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   ModerationV1,
@@ -53,6 +53,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { ModerationClient } from '../grpc-clients/moderation-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type ModerationRoutesOptions = {
   client: ModerationClient;
@@ -390,18 +391,6 @@ export const registerModerationRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -16,8 +16,8 @@
 // REST API the monolith used to serve. Body shape comes from
 // ts-proto's toJSON helper.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   NotificationsV1,
@@ -28,6 +28,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type NotificationsRoutesOptions = {
   client: NotificationsClient;
@@ -306,18 +307,6 @@ function buildPrefsPatch(body: Record<string, unknown>): UpdateNotificationPrefe
 }
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -20,8 +20,8 @@
 // principal so we never pass anonymous traffic through.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import { PetsV1, type ListPetsRequest, type UpdatePetStatusRequest } from '@adopt-dont-shop/proto';
 
@@ -33,6 +33,7 @@ import {
   viewToCreateRequest,
   viewToUpdateRequest,
 } from './pets-view.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type PetsRoutesOptions = {
   client: PetsClient;
@@ -195,18 +196,6 @@ export const registerPetsRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/reports.ts
+++ b/services/gateway/src/routes/reports.ts
@@ -4,8 +4,8 @@
 // the SPA reads the persisted config from here and POSTs to the
 // monolith's /execute when a chart needs to render.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   AuditV1,
@@ -18,6 +18,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { AuditClient } from '../grpc-clients/audit-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type ReportsRoutesOptions = {
   client: AuditClient;
@@ -247,18 +248,6 @@ function encodeConfig(configObj: unknown, configJson: unknown, configSnake: unkn
     return configSnake;
   }
   return '';
-}
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
 }
 
 type GrpcError = { code?: number; details?: string; message?: string };

--- a/services/gateway/src/routes/rescue.ts
+++ b/services/gateway/src/routes/rescue.ts
@@ -18,8 +18,8 @@
 // metadata; every RescueService RPC requires a principal.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   RescueV1,
@@ -31,6 +31,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type RescueRoutesOptions = {
   client: RescueClient;
@@ -201,18 +202,6 @@ export const registerRescueRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -9,7 +9,7 @@
 // on cutover.rescue.
 
 import rateLimit from '@fastify/rate-limit';
-import { Metadata, status } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import {
@@ -21,6 +21,7 @@ import {
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
 
 import { rescueDataEnvelope, rescueListEnvelope } from './rescue-view.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type RescuesPublicRoutesOptions = {
   client: RescueClient;
@@ -230,18 +231,6 @@ async function createRescue(
   } catch (err) {
     return handleGrpcError(err, reply);
   }
-}
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
 }
 
 type GrpcError = { code?: number; details?: string; message?: string };

--- a/services/gateway/src/routes/sessions.ts
+++ b/services/gateway/src/routes/sessions.ts
@@ -11,12 +11,13 @@
 // Mounted under the existing CUTOVER_AUTH flag — sessions are an auth
 // surface, so they cut over together with login/logout/etc.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import { AuthV1, type RevokeSessionRequest } from '@adopt-dont-shop/proto';
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type SessionsRoutesOptions = {
   client: AuthClient;
@@ -77,18 +78,6 @@ export const registerSessionsRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/staff-foster.ts
+++ b/services/gateway/src/routes/staff-foster.ts
@@ -6,8 +6,8 @@
 // `{ success, data }` envelope so the SPA (lib.rescue, staff views)
 // doesn't notice the cutover.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   RescueV1,
@@ -17,6 +17,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type StaffFosterRoutesOptions = {
   client: RescueClient;
@@ -178,18 +179,6 @@ export const registerStaffFosterRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/support.ts
+++ b/services/gateway/src/routes/support.ts
@@ -11,8 +11,8 @@
 //   POST /api/v1/support/tickets/:ticketId/reply          → respondToTicket
 //   GET  /api/v1/support/tickets/:ticketId/messages       → getSupportTicket(includeResponses=true)
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   ModerationV1,
@@ -23,6 +23,7 @@ import {
 } from '@adopt-dont-shop/proto';
 
 import type { ModerationClient } from '../grpc-clients/moderation-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type SupportRoutesOptions = {
   client: ModerationClient;
@@ -38,7 +39,9 @@ const GRPC_TO_HTTP: Record<number, number> = {
 };
 
 const priorityFromString = (raw: string | undefined): ModerationV1.SupportTicketPriority => {
-  if (!raw) return ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_NORMAL;
+  if (!raw) {
+    return ModerationV1.SupportTicketPriority.SUPPORT_TICKET_PRIORITY_NORMAL;
+  }
   const upper = `SUPPORT_TICKET_PRIORITY_${raw.toUpperCase()}`;
   const value = ModerationV1.supportTicketPriorityFromJSON(
     Object.values(ModerationV1.SupportTicketPriority).includes(upper as never) ? upper : raw
@@ -49,7 +52,9 @@ const priorityFromString = (raw: string | undefined): ModerationV1.SupportTicket
 };
 
 const categoryFromString = (raw: string | undefined): ModerationV1.SupportTicketCategory => {
-  if (!raw) return ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_UNSPECIFIED;
+  if (!raw) {
+    return ModerationV1.SupportTicketCategory.SUPPORT_TICKET_CATEGORY_UNSPECIFIED;
+  }
   const upper = `SUPPORT_TICKET_CATEGORY_${raw.toUpperCase()}`;
   const value = ModerationV1.supportTicketCategoryFromJSON(
     Object.values(ModerationV1.SupportTicketCategory).includes(upper as never) ? upper : raw
@@ -60,7 +65,9 @@ const categoryFromString = (raw: string | undefined): ModerationV1.SupportTicket
 };
 
 const statusFromString = (raw: string | undefined): ModerationV1.SupportTicketStatus => {
-  if (!raw) return ModerationV1.SupportTicketStatus.SUPPORT_TICKET_STATUS_UNSPECIFIED;
+  if (!raw) {
+    return ModerationV1.SupportTicketStatus.SUPPORT_TICKET_STATUS_UNSPECIFIED;
+  }
   const upper = `SUPPORT_TICKET_STATUS_${raw.toUpperCase()}`;
   const value = ModerationV1.supportTicketStatusFromJSON(
     Object.values(ModerationV1.SupportTicketStatus).includes(upper as never) ? upper : raw
@@ -199,18 +206,6 @@ export const registerSupportRoutes = async (
 };
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -16,8 +16,8 @@
 // rows. We preserve that contract here so the SPA's lib.api client
 // keeps working without a re-spin.
 
-import { Metadata, status } from '@grpc/grpc-js';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { status } from '@grpc/grpc-js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 
 import {
   AuthV1,
@@ -34,6 +34,7 @@ import {
 
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
+import { buildMetadata } from '../middleware/metadata.js';
 
 export type UsersRoutesOptions = {
   authClient: AuthClient;
@@ -63,7 +64,9 @@ const visibilityProtoToString = (v: AuthV1.ProfileVisibility): string => {
 };
 
 const visibilityStringToProto = (raw: string | undefined): AuthV1.ProfileVisibility => {
-  if (!raw) return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_UNSPECIFIED;
+  if (!raw) {
+    return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_UNSPECIFIED;
+  }
   switch (raw) {
     case 'public':
       return AuthV1.ProfileVisibility.PROFILE_VISIBILITY_PUBLIC;
@@ -459,7 +462,9 @@ export const registerUsersRoutes = async (
 // --- Enum parsing helpers --------------------------------------------
 
 function statusFilterFromString(raw: string | undefined): AuthV1.UserStatus {
-  if (!raw) return AuthV1.UserStatus.USER_STATUS_UNSPECIFIED;
+  if (!raw) {
+    return AuthV1.UserStatus.USER_STATUS_UNSPECIFIED;
+  }
   const upper = `USER_STATUS_${raw.toUpperCase()}`;
   const parsed = AuthV1.userStatusFromJSON(
     Object.values(AuthV1.UserStatus).includes(upper as never) ? upper : raw
@@ -470,7 +475,9 @@ function statusFilterFromString(raw: string | undefined): AuthV1.UserStatus {
 }
 
 function userTypeFilterFromString(raw: string | undefined): AuthV1.UserRole {
-  if (!raw) return AuthV1.UserRole.USER_ROLE_UNSPECIFIED;
+  if (!raw) {
+    return AuthV1.UserRole.USER_ROLE_UNSPECIFIED;
+  }
   const upper = `USER_ROLE_${raw.toUpperCase()}`;
   const parsed = AuthV1.userRoleFromJSON(
     Object.values(AuthV1.UserRole).includes(upper as never) ? upper : raw
@@ -479,18 +486,6 @@ function userTypeFilterFromString(raw: string | undefined): AuthV1.UserRole {
 }
 
 // --- Helpers ---------------------------------------------------------
-
-function buildMetadata(req: FastifyRequest): Metadata {
-  const m = new Metadata();
-  const headers = req.headers as Record<string, string | string[] | undefined>;
-  for (const key of ['x-user-id', 'x-user-roles', 'x-user-permissions', 'x-rescue-id']) {
-    const raw = headers[key];
-    if (typeof raw === 'string' && raw.length > 0) {
-      m.set(key, raw);
-    }
-  }
-  return m;
-}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/server.test.ts
+++ b/services/gateway/src/server.test.ts
@@ -101,6 +101,38 @@ describe('createServer — /api/* fallback', () => {
   });
 });
 
+describe('createServer — /metrics endpoint', () => {
+  let server: FastifyInstance;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    server = await createServer({ config: baseConfig, logger: quietLogger });
+    await server.inject({ method: 'GET', url: '/health/simple' });
+    const res = await server.inject({ method: 'GET', url: '/metrics' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('http_request_duration_seconds');
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  let server: FastifyInstance;
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it('echoes the inbound x-request-id header on the response', async () => {
+    server = await createServer({ config: baseConfig, logger: quietLogger });
+    const res = await server.inject({
+      method: 'GET',
+      url: '/health/simple',
+      headers: { 'x-request-id': 'gw-test-id-1234' },
+    });
+    expect(res.headers['x-request-id']).toBe('gw-test-id-1234');
+  });
+});
+
 // Per-domain cutover gate. With the flag OFF (default) the gateway does
 // NOT register the domain's /api/v1/* routes, so the request 404s.
 // With the flag ON the gateway's route plugin intercepts it.

--- a/services/gateway/src/server.ts
+++ b/services/gateway/src/server.ts
@@ -23,7 +23,7 @@
 //   - /api/v1/uploads/*       (multipart + signed serve)
 // Anything else under /api/* now returns 404 — there's no fallback.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { GatewayConfig } from './config.js';
@@ -147,6 +147,15 @@ export const createServer = async (opts: CreateServerOptions): Promise<FastifyIn
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (including the metrics onResponse hook + the
+  // authenticate hook, which forwards it on downstream gRPC metadata).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — matches service.backend's `/health/simple` path
   // so the Docker compose healthcheck (already wired in the broader

--- a/services/matching/src/grpc/adapter.ts
+++ b/services/matching/src/grpc/adapter.ts
@@ -13,7 +13,7 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
@@ -21,6 +21,12 @@ import {
 
 import type { Principal } from '@adopt-dont-shop/authz';
 import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { extractPrincipal, MissingPrincipalError } from './principal.js';
@@ -43,6 +49,8 @@ export class HandlerError extends Error {
     this.name = 'HandlerError';
   }
 }
+
+const SERVICE_NAME = 'service.matching';
 
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
@@ -68,15 +76,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -97,4 +112,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/matching/src/server.test.ts
+++ b/services/matching/src/server.test.ts
@@ -64,3 +64,33 @@ describe('createServer — health endpoint', () => {
     expect(res.statusCode).toBe(500);
   });
 });
+
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes the inbound x-request-id header on the response', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-test-id-1234' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-test-id-1234');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/services/matching/src/server.ts
+++ b/services/matching/src/server.ts
@@ -2,7 +2,7 @@
 // discovery + search + swipe absorption. Phase 9.1 (this commit) is
 // just the boot skeleton.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { MatchingConfig } from './config.js';
@@ -26,6 +26,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   server.get('/health/simple', async () => ({
     status: 'ok',

--- a/services/moderation/src/grpc/adapter.ts
+++ b/services/moderation/src/grpc/adapter.ts
@@ -12,7 +12,7 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
@@ -20,6 +20,12 @@ import {
 
 import type { Principal } from '@adopt-dont-shop/authz';
 import type { WithTransactionDeps } from '@adopt-dont-shop/events';
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { extractPrincipal, MissingPrincipalError } from './principal.js';
@@ -42,6 +48,8 @@ export class HandlerError extends Error {
     this.name = 'HandlerError';
   }
 }
+
+const SERVICE_NAME = 'service.moderation';
 
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
@@ -67,15 +75,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -96,4 +111,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/moderation/src/server.test.ts
+++ b/services/moderation/src/server.test.ts
@@ -64,3 +64,33 @@ describe('createServer — health endpoint', () => {
     expect(res.statusCode).toBe(500);
   });
 });
+
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes the inbound x-request-id header on the response', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-test-id-1234' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-test-id-1234');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/services/moderation/src/server.ts
+++ b/services/moderation/src/server.ts
@@ -7,7 +7,7 @@
 // gRPC (8.3), NATS subscribers (8.4), gateway routing (8.5), and
 // cutover (8.6) arrive in subsequent commits.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { ModerationConfig } from './config.js';
@@ -31,6 +31,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   server.get('/health/simple', async () => ({
     status: 'ok',

--- a/services/notifications/src/grpc/adapter.ts
+++ b/services/notifications/src/grpc/adapter.ts
@@ -13,12 +13,18 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
 } from '@grpc/grpc-js';
 
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
@@ -26,6 +32,8 @@ import { extractPrincipal, MissingPrincipalError } from './principal.js';
 
 // HandlerErrorCode → grpc.status mapping. Same table the gateway will
 // use when translating gRPC responses to REST status codes in 1.6.
+const SERVICE_NAME = 'service.notifications';
+
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
   UNAUTHENTICATED: status.UNAUTHENTICATED,
@@ -53,15 +61,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -84,4 +99,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/notifications/src/server.test.ts
+++ b/services/notifications/src/server.test.ts
@@ -88,3 +88,33 @@ describe('createServer — error handler', () => {
     expect(res.json()).toEqual({ error: 'internal_error' });
   });
 });
+
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes the inbound x-request-id header on the response', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-test-id-1234' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-test-id-1234');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/services/notifications/src/server.ts
+++ b/services/notifications/src/server.ts
@@ -9,7 +9,7 @@
 // API (1.3), NATS subscriber for fan-out (1.4), and the gateway WS
 // wiring (1.5) build on this foundation.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { NotificationsConfig } from './config.js';
@@ -44,6 +44,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — matches service.backend + service.gateway's
   // `/health/simple` path so the existing Docker compose healthcheck

--- a/services/pets/src/grpc/adapter.ts
+++ b/services/pets/src/grpc/adapter.ts
@@ -9,17 +9,25 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
 } from '@grpc/grpc-js';
 
 import type { Principal } from '@adopt-dont-shop/authz';
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
 import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+const SERVICE_NAME = 'service.pets';
 
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
@@ -45,15 +53,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -74,4 +89,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/pets/src/server.test.ts
+++ b/services/pets/src/server.test.ts
@@ -65,3 +65,33 @@ describe('createServer — health endpoint', () => {
     expect(res.json()).toEqual({ error: 'internal_error' });
   });
 });
+
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes the inbound x-request-id header on the response', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-test-id-1234' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-test-id-1234');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/services/pets/src/server.ts
+++ b/services/pets/src/server.ts
@@ -6,7 +6,7 @@
 // /health/simple, gRPC server attached in Phase 3.3c, NATS publishers
 // in Phase 3.4, gateway routing in Phase 3.5, cutover in Phase 3.6.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { PetsConfig } from './config.js';
@@ -41,6 +41,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck

--- a/services/rescue/src/grpc/adapter.ts
+++ b/services/rescue/src/grpc/adapter.ts
@@ -9,17 +9,25 @@
 
 import {
   status,
-  type Metadata,
+  Metadata,
   type ServerUnaryCall,
   type ServiceError,
   type sendUnaryData,
 } from '@grpc/grpc-js';
 
 import type { Principal } from '@adopt-dont-shop/authz';
+import {
+  extractRequestIdFromMetadata,
+  REQUEST_ID_HEADER_NAME,
+  runWithRequestId,
+  startGrpcTimer,
+} from '@adopt-dont-shop/observability';
 import type { Logger } from 'winston';
 
 import { HandlerError, type HandlerDeps, type HandlerErrorCode } from './handlers.js';
 import { extractPrincipal, MissingPrincipalError } from './principal.js';
+
+const SERVICE_NAME = 'service.rescue';
 
 const CODE_TO_GRPC: Record<HandlerErrorCode, number> = {
   INVALID_ARGUMENT: status.INVALID_ARGUMENT,
@@ -45,15 +53,22 @@ export function adapt<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         const principal = extractPrincipal(call.metadata);
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -72,7 +87,11 @@ export function adaptUnauth<Req, Res>(
   { deps, logger }: AdaptOptions
 ): (call: ServerUnaryCall<Req, Res>, callback: sendUnaryData<Res>) => void {
   return (call, callback) => {
-    void (async () => {
+    const method = handler.name || 'unknown';
+    const stop = startGrpcTimer(SERVICE_NAME, method);
+    const requestId = extractRequestIdFromMetadata(call.metadata);
+    echoRequestId(call, requestId);
+    void runWithRequestId(requestId, async () => {
       try {
         let principal: Principal | null = null;
         try {
@@ -81,11 +100,14 @@ export function adaptUnauth<Req, Res>(
           principal = null;
         }
         const response = await handler(deps, principal, call.request);
+        stop(status.OK);
         callback(null, response);
       } catch (err) {
-        callback(toServiceError(err, call.metadata, logger), null);
+        const svcErr = toServiceError(err, call.metadata, logger);
+        stop(svcErr.code ?? status.INTERNAL);
+        callback(svcErr, null);
       }
-    })();
+    });
   };
 }
 
@@ -106,4 +128,17 @@ function makeServiceError(code: number, message: string, metadata: Metadata): Se
   err.details = message;
   err.metadata = metadata;
   return err;
+}
+
+// Echo x-request-id on the response metadata where the transport
+// supports it. Errors out of sendMetadata (e.g. already sent) are
+// swallowed — observability must never affect the call outcome.
+function echoRequestId<Req, Res>(call: ServerUnaryCall<Req, Res>, requestId: string): void {
+  try {
+    const md = new Metadata();
+    md.set(REQUEST_ID_HEADER_NAME, requestId);
+    call.sendMetadata(md);
+  } catch {
+    // No-op — never let observability break the call.
+  }
 }

--- a/services/rescue/src/server.test.ts
+++ b/services/rescue/src/server.test.ts
@@ -65,3 +65,33 @@ describe('createServer — health endpoint', () => {
     expect(res.json()).toEqual({ error: 'internal_error' });
   });
 });
+
+describe('createServer — /metrics endpoint', () => {
+  it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      await server.inject({ method: 'GET', url: '/health/simple' });
+      const res = await server.inject({ method: 'GET', url: '/metrics' });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain('http_request_duration_seconds');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('createServer — x-request-id', () => {
+  it('echoes the inbound x-request-id header on the response', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/health/simple',
+        headers: { 'x-request-id': 'svc-test-id-1234' },
+      });
+      expect(res.headers['x-request-id']).toBe('svc-test-id-1234');
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/services/rescue/src/server.ts
+++ b/services/rescue/src/server.ts
@@ -6,7 +6,7 @@
 // /health/simple, gRPC server attached in Phase 4.3c, NATS publishers
 // in Phase 4.4, gateway routing in Phase 4.5, cutover in Phase 4.6.
 
-import { createLogger } from '@adopt-dont-shop/observability';
+import { createLogger, registerMetrics, registerRequestId } from '@adopt-dont-shop/observability';
 import Fastify, { type FastifyInstance } from 'fastify';
 
 import type { RescueConfig } from './config.js';
@@ -41,6 +41,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
     });
     void reply.status(err.statusCode ?? 500).send({ error: 'internal_error' });
   });
+
+  // Request-id middleware runs FIRST so the id is on req for every
+  // hook after it (metrics onResponse + any per-route hook).
+  registerRequestId(server);
+
+  // Prometheus /metrics + http_request_duration_seconds onResponse
+  // hook. Substrate only — no domain-specific instruments here.
+  registerMetrics(server);
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck


### PR DESCRIPTION
…pagation

Adds a Prometheus /metrics surface and end-to-end request-id propagation across the gateway and all 10 microservices, so production debugging has something beyond Loki log lines to work with.

What's new in @adopt-dont-shop/observability:
- registerMetrics(server) — mounts /metrics + an onResponse hook that records http_request_duration_seconds{method, route, status_code}.
- registerRequestId(server) — onRequest hook that reads/mints x-request-id, echoes it on the response, and seeds an AsyncLocalStorage context so getRequestId() works anywhere downstream of the hook.
- startGrpcTimer(service, method, direction) — used by gRPC adapters (direction='in') and gateway clients (direction='out') to record grpc_handler_duration_seconds{service, method, code, direction}.
- extractRequestIdFromMetadata + runWithRequestId — gRPC-side seeding.
- collectDefaultMetrics() — Node memory/GC/CPU on the same registry.

Wiring:
- Every services/*/src/server.ts gets a single-line registerMetrics + registerRequestId pair, before the health route.
- Every services/*/src/grpc/adapter.ts (auth, applications, audit, chat, cms, matching, moderation, notifications, pets, rescue) reads x-request-id off call.metadata, runs the handler inside ALS, echoes the id on response metadata via call.sendMetadata, and records the histogram with the final grpc status code.
- Every services/gateway/src/grpc-clients/*-client.ts wraps the unary call to record direction='out' alongside the existing DEFAULT_DEADLINE_MS.

Gateway buildMetadata refactor:
- Lifted the 24 near-identical per-route copies into one shared module at services/gateway/src/middleware/metadata.ts. The shared helper now also forwards x-request-id alongside the existing x-user-* set, so the id threads HTTP → gateway → gRPC out → service gRPC in → logger context with no per-route plumbing.

No domain-specific metrics in this PR — substrate only. Per-service hot paths come in a follow-up.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

<!-- Before opening: make sure you've read [CONTRIBUTING.md](../CONTRIBUTING.md) and that all CI checks pass. -->

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-

## Changes

<!-- List the key files/areas changed. -->

-

## Before requesting review

<!-- Quick PR-readiness signal — see CONTRIBUTING.md for context. -->

- [ ] Ran `npm run ci:local:quick` locally (or installed the pre-push hook — see CONTRIBUTING.md)
- [ ] Tests for new behaviour added (TDD)
- [ ] If touching `.env` requirements, updated `.env.example`'s REQUIRED block
- [ ] If touching a `lib.*`, considered consumer impact across `app.*` and `service.backend`

## Test plan

<!-- How did you verify this works? Check off items as you go. -->

- [ ] Existing tests pass (`npm test`)
- [ ] New behaviour is covered by tests
- [ ] Tested manually (describe how)
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Lint passes (`npm run lint`)

## Screenshots / recordings

<!-- For UI changes, attach a screenshot or recording. Delete if not applicable. -->

## Related

<!-- Link to Linear ticket, related PRs, or issues. -->
