### PR TITLE
feat(config): shared secret-file loader + re-wire staging/prod compose to file secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,11 @@ uploads
 ### Docker ###
 docker-compose.override.yml
 # Materialized Docker secret files (written by deploy workflow, never committed)
-secrets/
-**/secrets/
+# — the README + the directory-local .gitignore are kept so the directory
+# exists in the repo and explains the layout to operators.
+secrets/*
+!secrets/README.md
+!secrets/.gitignore
 
 ### Development ###
 .env.development

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,12 +30,12 @@ x-logging: &default-logging
 # shares one Postgres (schema-per-service) + NATS + Redis and migrates its own
 # schema on start (entrypoint runs `npm run db:migrate --if-present`).
 #
-# TODO (post-monolith hardening): the monolith read JWT / session / CSRF /
-# encryption / upload-signing / db / redis secrets from file-mounted Docker
-# secrets via readSecretOrEnv(). The extracted services don't yet have a
-# secret-file loader, so credentials are passed via env interpolation
-# (POSTGRES_PASSWORD / JWT_SECRET / REDIS_PASSWORD from the host .env). Re-wire
-# onto file-mounted secrets once each service grows that loader.
+# Credentials flow through file-mounted Docker secrets via the shared
+# @adopt-dont-shop/config-secrets loader — each service reads e.g.
+# DATABASE_URL_FILE / JWT_SECRET_FILE rather than the raw env value, keeping
+# secrets out of `docker inspect`. This restores the readSecretOrEnv() shape
+# the deleted monolith used (ADS-675). The loader still honours the plaintext
+# env value when *_FILE is unset, which is what the dev compose relies on.
 # ----------------------------------------------------------------------------
 x-service-common: &service-common
   restart: always
@@ -52,6 +52,12 @@ x-service-common: &service-common
       condition: service_healthy
     nats:
       condition: service_healthy
+  # Default secret mounts for every domain service: DATABASE_URL_FILE +
+  # REDIS_URL_FILE come from these. Services that need additional secrets
+  # (auth → jwt; gateway → upload signing) override this list.
+  secrets:
+    - database_url
+    - redis_url
   deploy:
     resources:
       limits:
@@ -63,9 +69,11 @@ x-service-common: &service-common
 
 x-service-env: &service-env
   NODE_ENV: production
-  DATABASE_URL: "postgresql://${POSTGRES_USER:?Error: POSTGRES_USER required}:${POSTGRES_PASSWORD:?Error: POSTGRES_PASSWORD required}@database:5432/${POSTGRES_DB:?Error: POSTGRES_DB required}"
+  # See the comment block above the anchor — the loader prefers the *_FILE
+  # path and only consults the raw env var as a documented escape hatch.
+  DATABASE_URL_FILE: /run/secrets/database_url
   NATS_URL: "nats://nats:4222"
-  REDIS_URL: "redis://:${REDIS_PASSWORD:?Error: REDIS_PASSWORD required}@redis:6379"
+  REDIS_URL_FILE: /run/secrets/redis_url
 
 services:
   # Database - Production configuration
@@ -193,6 +201,10 @@ services:
       # ADS-422: the per-stack nginx serves /uploads via auth_request; disable
       # the gateway's own file streaming in production.
       SERVE_LOCAL_UPLOADS: "false"
+      UPLOAD_SIGNING_SECRET_FILE: /run/secrets/upload_signing_secret
+    # Gateway has no DB; it only needs the upload-signing secret.
+    secrets:
+      - upload_signing_secret
     volumes:
       - uploads:/app/uploads
     expose:
@@ -214,8 +226,14 @@ services:
     container_name: ads_prod_auth
     environment:
       <<: *service-env
-      JWT_SECRET: "${JWT_SECRET:?Error: JWT_SECRET required}"
-      JWT_REFRESH_SECRET: "${JWT_REFRESH_SECRET:?Error: JWT_REFRESH_SECRET required}"
+      JWT_SECRET_FILE: /run/secrets/jwt_secret
+      JWT_REFRESH_SECRET_FILE: /run/secrets/jwt_refresh_secret
+    # Auth needs the JWT signing secrets on top of the common DB/Redis ones.
+    secrets:
+      - database_url
+      - redis_url
+      - jwt_secret
+      - jwt_refresh_secret
     expose:
       - "5002"
     healthcheck:
@@ -527,17 +545,23 @@ networks:
     external: false
 
 # ============================================================================
-# Docker Secrets — REMOVED in the post-monolith cleanup
+# Docker Secrets
 # ============================================================================
-# The monolith (ADS-675) consumed JWT / session / CSRF / encryption /
-# upload-signing / db / redis secrets as file-mounted Docker secrets via
-# readSecretOrEnv(). The extracted gRPC services don't yet have a secret-file
-# loader, so the stack now passes those credentials via env interpolation
-# (POSTGRES_PASSWORD / JWT_SECRET / REDIS_PASSWORD from the host .env — see the
-# x-service-env anchor at the top of this file). The database container reads
-# POSTGRES_PASSWORD directly.
-#
-# TODO (post-monolith hardening): re-introduce a top-level `secrets:` block and
-# wire each service onto file-mounted secrets once the services grow a
-# secret-file loader, to keep credentials out of `docker inspect`. The deploy
-# workflow's secret-file materialisation hook is preserved for that purpose.
+# Mounted as in-memory tmpfs files at /run/secrets/<name>; never written to
+# disk and invisible to `docker inspect`. Each gRPC service reads credentials
+# through the @adopt-dont-shop/config-secrets loader (NAME_FILE wins over
+# NAME), restoring the file-mounted-secret layout the deleted monolith
+# consumed via readSecretOrEnv(). The deploy workflow
+# (.github/workflows/deploy.yml) materialises ./secrets/<name> on the host
+# before `docker compose up -d`.
+secrets:
+  database_url:
+    file: ./secrets/database_url
+  redis_url:
+    file: ./secrets/redis_url
+  jwt_secret:
+    file: ./secrets/jwt_secret
+  jwt_refresh_secret:
+    file: ./secrets/jwt_refresh_secret
+  upload_signing_secret:
+    file: ./secrets/upload_signing_secret

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -19,11 +19,11 @@ x-logging: &default-logging
 # + Redis and migrates its own schema on start (entrypoint runs
 # `npm run db:migrate --if-present`).
 #
-# NOTE (post-monolith cleanup): the per-service production env contract here is
-# adapted from the dev compose. DATABASE_URL is composed from the db_password
-# Docker secret via shell interpolation at container start; review per-service
-# env (TLS, pool sizes, service-specific secrets) before relying on this for a
-# real deploy.
+# Credentials are sourced from file-mounted Docker secrets via the shared
+# `@adopt-dont-shop/config-secrets` loader (readSecret/requireSecret) — each
+# service reads e.g. DATABASE_URL_FILE / JWT_SECRET_FILE instead of the raw
+# env value. The loader also accepts plaintext env vars (NAME=…) as a
+# documented escape hatch, which is what the dev compose still uses.
 # ----------------------------------------------------------------------------
 x-service-common: &service-common
   restart: always
@@ -37,6 +37,12 @@ x-service-common: &service-common
       condition: service_healthy
     nats:
       condition: service_healthy
+  # Default secret mounts for every domain service: DATABASE_URL_FILE +
+  # REDIS_URL_FILE come from these. Services that need additional secrets
+  # (auth → jwt; gateway → upload signing) override this list.
+  secrets:
+    - database_url
+    - redis_url
   deploy:
     resources:
       limits:
@@ -48,13 +54,13 @@ x-service-common: &service-common
 
 x-service-env: &service-env
   NODE_ENV: production
-  # DATABASE_URL mirrors the dev compose anchor. POSTGRES_PASSWORD must be set
-  # in the staging host .env (alongside the db_password secret file used by the
-  # database container). See the post-monolith cleanup note above — moving the
-  # services onto file-mounted secrets is a follow-up.
-  DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD:?Error: POSTGRES_PASSWORD required for service DATABASE_URL}@database:5432/${POSTGRES_DB}"
+  # The loader (@adopt-dont-shop/config-secrets) reads ${NAME}_FILE when set
+  # and falls back to ${NAME} otherwise. Staging gives every service the file
+  # path; the deploy workflow materialises ./secrets/<name> on the host before
+  # `docker compose up -d`.
+  DATABASE_URL_FILE: /run/secrets/database_url
   NATS_URL: "nats://nats:4222"
-  REDIS_URL: "redis://:${REDIS_PASSWORD}@redis:6379"
+  REDIS_URL_FILE: /run/secrets/redis_url
 
 services:
   database:
@@ -174,6 +180,10 @@ services:
       CORS_ORIGIN: "${CORS_ORIGIN:?Error: CORS_ORIGIN required}"
       # Staging has no per-stack nginx; the gateway serves /uploads itself.
       SERVE_LOCAL_UPLOADS: "true"
+      UPLOAD_SIGNING_SECRET_FILE: /run/secrets/upload_signing_secret
+    # Gateway has no DB; it only needs the upload-signing secret.
+    secrets:
+      - upload_signing_secret
     volumes:
       - uploads:/app/uploads
     expose:
@@ -195,8 +205,14 @@ services:
     container_name: ads_staging_auth
     environment:
       <<: *service-env
-      JWT_SECRET: "${JWT_SECRET:?Error: JWT_SECRET required}"
-      JWT_REFRESH_SECRET: "${JWT_REFRESH_SECRET:?Error: JWT_REFRESH_SECRET required}"
+      JWT_SECRET_FILE: /run/secrets/jwt_secret
+      JWT_REFRESH_SECRET_FILE: /run/secrets/jwt_refresh_secret
+    # Auth needs the JWT signing secrets on top of the common DB/Redis ones.
+    secrets:
+      - database_url
+      - redis_url
+      - jwt_secret
+      - jwt_refresh_secret
     expose:
       - "5002"
     healthcheck:
@@ -439,16 +455,21 @@ networks:
 # Docker Secrets (ADS-752)
 # ============================================================================
 # Mounted as in-memory tmpfs files at /run/secrets/<name>; never written to
-# disk and invisible to `docker inspect`. The database reads db_password via
-# POSTGRES_PASSWORD_FILE. The deploy workflow (.github/workflows/deploy.yml)
-# materialises secrets/db_password on the host before `docker compose up -d`.
-#
-# TODO (post-monolith): the gRPC services currently take JWT/Redis/DB creds via
-# plaintext env interpolation (POSTGRES_PASSWORD / JWT_SECRET / REDIS_PASSWORD
-# in the host .env). Moving them onto file-mounted secrets — as the monolith
-# did via readSecretOrEnv() — is a follow-up once each service grows a
-# secret-file loader. The jwt_secret/session_secret/etc. files the monolith
-# consumed are no longer wired here.
+# disk and invisible to `docker inspect`. The database container reads
+# db_password via POSTGRES_PASSWORD_FILE; the gRPC services read every other
+# credential through the @adopt-dont-shop/config-secrets loader (NAME_FILE wins
+# over NAME). The deploy workflow (.github/workflows/deploy.yml) materialises
+# these files on the host before `docker compose up -d`.
 secrets:
   db_password:
     file: ./secrets/db_password
+  database_url:
+    file: ./secrets/database_url
+  redis_url:
+    file: ./secrets/redis_url
+  jwt_secret:
+    file: ./secrets/jwt_secret
+  jwt_refresh_secret:
+    file: ./secrets/jwt_refresh_secret
+  upload_signing_secret:
+    file: ./secrets/upload_signing_secret

--- a/package-lock.json
+++ b/package-lock.json
@@ -4709,6 +4709,10 @@
       "resolved": "packages/authz",
       "link": true
     },
+    "node_modules/@adopt-dont-shop/config-secrets": {
+      "resolved": "packages/config-secrets",
+      "link": true
+    },
     "node_modules/@adopt-dont-shop/db": {
       "resolved": "packages/db",
       "link": true
@@ -25947,6 +25951,10 @@
         "@adopt-dont-shop/lib.types": "*"
       }
     },
+    "packages/config-secrets": {
+      "name": "@adopt-dont-shop/config-secrets",
+      "version": "0.1.0"
+    },
     "packages/db": {
       "name": "@adopt-dont-shop/db",
       "version": "0.1.0",
@@ -26123,6 +26131,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26139,6 +26148,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26156,6 +26166,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26177,6 +26188,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26193,6 +26205,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26209,6 +26222,7 @@
       "name": "@adopt-dont-shop/service.gateway",
       "version": "0.1.0",
       "dependencies": {
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/observability": "*",
         "@adopt-dont-shop/proto": "*",
@@ -26219,6 +26233,9 @@
         "fastify": "^5.8.5",
         "nats": "^2.29.3",
         "socket.io": "^4.8.3"
+      },
+      "devDependencies": {
+        "socket.io-client": "^4.8.3"
       }
     },
     "services/matching": {
@@ -26226,6 +26243,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26242,6 +26260,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26258,6 +26277,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26279,6 +26299,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",
@@ -26295,6 +26316,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@adopt-dont-shop/authz": "*",
+        "@adopt-dont-shop/config-secrets": "*",
         "@adopt-dont-shop/db": "*",
         "@adopt-dont-shop/events": "*",
         "@adopt-dont-shop/lib.types": "*",

--- a/packages/config-secrets/package.json
+++ b/packages/config-secrets/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@adopt-dont-shop/config-secrets",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared boot-time secret loader for backend microservices. Reads credentials from file-mounted Docker secrets (NAME_FILE) when present, otherwise from plain env vars (NAME). Mirrors the readSecretOrEnv() helper the deleted service.backend monolith used so each extracted service can opt onto file-mounted secrets without changing its config contract.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "type-check": "tsc --noEmit"
+  }
+}

--- a/packages/config-secrets/src/index.test.ts
+++ b/packages/config-secrets/src/index.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readSecret, requireSecret } from './index.js';
+
+describe('readSecret', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'config-secrets-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns the trimmed contents of the file when NAME_FILE is set', () => {
+    const file = join(tmp, 'jwt');
+    writeFileSync(file, '  super-secret-value\n');
+
+    expect(readSecret('JWT_SECRET', { JWT_SECRET_FILE: file })).toBe('super-secret-value');
+  });
+
+  it('returns the env value as-is when NAME is set and NAME_FILE is not', () => {
+    expect(readSecret('JWT_SECRET', { JWT_SECRET: 'plain-env-value' })).toBe('plain-env-value');
+  });
+
+  it('returns undefined when neither NAME nor NAME_FILE is set', () => {
+    expect(readSecret('JWT_SECRET', {})).toBeUndefined();
+  });
+
+  it('refuses to guess when both NAME and NAME_FILE are set', () => {
+    const file = join(tmp, 'jwt');
+    writeFileSync(file, 'file-value');
+
+    expect(() =>
+      readSecret('JWT_SECRET', { JWT_SECRET: 'env-value', JWT_SECRET_FILE: file })
+    ).toThrow(/JWT_SECRET and JWT_SECRET_FILE are both set/);
+  });
+
+  it('propagates fs errors when NAME_FILE points at a missing file', () => {
+    expect(() =>
+      readSecret('JWT_SECRET', { JWT_SECRET_FILE: join(tmp, 'does-not-exist') })
+    ).toThrow();
+  });
+
+  it('preserves an empty-string env value (treats it as set, not absent)', () => {
+    expect(readSecret('JWT_SECRET', { JWT_SECRET: '' })).toBe('');
+  });
+
+  it('returns an empty string when the file is empty / whitespace only', () => {
+    const file = join(tmp, 'jwt');
+    writeFileSync(file, '   \n');
+
+    expect(readSecret('JWT_SECRET', { JWT_SECRET_FILE: file })).toBe('');
+  });
+});
+
+describe('requireSecret', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'config-secrets-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns the value when NAME is set', () => {
+    expect(requireSecret('JWT_SECRET', { JWT_SECRET: 'value' })).toBe('value');
+  });
+
+  it('returns the file contents when NAME_FILE is set', () => {
+    const file = join(tmp, 'jwt');
+    writeFileSync(file, 'file-value');
+
+    expect(requireSecret('JWT_SECRET', { JWT_SECRET_FILE: file })).toBe('file-value');
+  });
+
+  it('throws a descriptive error naming both env shapes when missing', () => {
+    expect(() => requireSecret('JWT_SECRET', {})).toThrow(
+      /JWT_SECRET \(or JWT_SECRET_FILE\) is required/
+    );
+  });
+});

--- a/packages/config-secrets/src/index.ts
+++ b/packages/config-secrets/src/index.ts
@@ -1,0 +1,64 @@
+// Shared boot-time secret loader. Each extracted microservice calls
+// readSecret/requireSecret instead of touching process.env directly for any
+// credential, so an operator can supply the value either as a plaintext env
+// var (NAME=…, dev / escape hatch) or as a file-mounted Docker secret
+// (NAME_FILE=/run/secrets/name). The file path wins when present.
+//
+// This mirrors the readSecretOrEnv() helper the deleted service.backend
+// monolith used so the same secret-file layout (terraform / deploy workflow
+// drops files under /run/secrets/) keeps working post-extraction.
+//
+// Sync on purpose — secrets are read at boot, before the event loop starts
+// doing real work. Failures should crash the process loud and fast.
+
+import { readFileSync } from 'node:fs';
+
+/**
+ * Resolve a secret value from either a file-mounted Docker secret or a
+ * plain env var.
+ *
+ * Precedence:
+ *   1. `${name}_FILE` set     → read that path, return trimmed contents.
+ *   2. `${name}` set          → return the env value as-is.
+ *   3. neither set            → return `undefined`.
+ *
+ * Both set is an error — refusing to guess which one to trust avoids
+ * silently shipping the wrong credential when a deploy is half-migrated.
+ *
+ * Errors reading the file path through.
+ */
+export const readSecret = (
+  name: string,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined => {
+  const filePath = env[`${name}_FILE`];
+  const direct = env[name];
+
+  if (filePath !== undefined && direct !== undefined) {
+    throw new Error(
+      `${name} and ${name}_FILE are both set — refusing to guess which to use. Pick one.`
+    );
+  }
+
+  if (filePath !== undefined) {
+    return readFileSync(filePath, 'utf8').trim();
+  }
+
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  return undefined;
+};
+
+/**
+ * Same as {@link readSecret} but throws if the secret is missing. Use for
+ * credentials whose absence should fail boot immediately.
+ */
+export const requireSecret = (name: string, env: NodeJS.ProcessEnv = process.env): string => {
+  const value = readSecret(name, env);
+  if (value === undefined) {
+    throw new Error(`${name} (or ${name}_FILE) is required`);
+  }
+  return value;
+};

--- a/packages/config-secrets/tsconfig.json
+++ b/packages/config-secrets/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/config-secrets/vitest.config.ts
+++ b/packages/config-secrets/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/secrets/.gitignore
+++ b/secrets/.gitignore
@@ -1,0 +1,7 @@
+# Local-only secret material for docker-compose.{staging,prod}.yml.
+# The compose files mount ./secrets/<name> as Docker secrets; operators
+# populate these files on the host (deploy workflow does this for the
+# CI-driven path). Nothing in here should ever be committed.
+*
+!.gitignore
+!README.md

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,33 @@
+# Docker secret files
+
+This directory holds the file-mounted secrets consumed by
+`docker-compose.staging.yml` and `docker-compose.prod.yml`. Each service reads
+them at boot through the `@adopt-dont-shop/config-secrets` loader
+(`NAME_FILE` wins over `NAME`).
+
+**Nothing in here is committed** — `.gitignore` excludes everything except
+itself and this README. Operators populate these files on the deploy host
+before `docker compose up -d`; the deploy workflow
+(`.github/workflows/deploy.yml`) does it automatically for the CI path.
+
+## Required files
+
+| File                          | Consumed by                     | Contents                                                      |
+| ----------------------------- | ------------------------------- | ------------------------------------------------------------- |
+| `database_url`                | every domain service            | `postgresql://user:pass@database:5432/db`                      |
+| `redis_url`                   | every domain service            | `redis://:pass@redis:6379`                                     |
+| `jwt_secret`                  | `service-auth`                  | access-token signing secret                                    |
+| `jwt_refresh_secret`          | `service-auth`                  | refresh-token signing secret                                   |
+| `upload_signing_secret`       | `service-gateway`               | HMAC secret for `/uploads-signed` URLs                         |
+| `db_password` (staging only)  | `database` container            | Postgres superuser password (read via `POSTGRES_PASSWORD_FILE`) |
+
+Each file must contain only the secret value (trailing whitespace is
+trimmed by the loader). No quoting, no `KEY=value` framing — just the value.
+
+## Dev / escape hatch
+
+The dev compose (`docker-compose.yml`) does **not** use these files; it relies
+on plaintext env interpolation from `.env`. The loader also accepts plaintext
+env vars (`NAME=…`) when the `*_FILE` form is absent, so an operator who
+can't mount files for some reason can still boot the stack by setting the raw
+env vars.

--- a/services/applications/package.json
+++ b/services/applications/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/applications/src/config.ts
+++ b/services/applications/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type ApplicationsConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
   // from service.backend's 5000, service.gateway's 4000,
@@ -48,7 +50,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ApplicationsCo
     'APPLICATIONS_GRPC_PORT'
   );
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/audit/src/config.ts
+++ b/services/audit/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type AuditConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
   // from service.backend's 5000, service.gateway's 4000,
@@ -36,7 +38,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AuditConfig =>
   const port = parsePort(env.AUDIT_PORT, DEFAULT_PORT, 'AUDIT_PORT');
   const grpcPort = parsePort(env.AUDIT_GRPC_PORT, DEFAULT_GRPC_PORT, 'AUDIT_GRPC_PORT');
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/auth/src/config.ts
+++ b/services/auth/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type AuthConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
   // from service.backend's 5000, service.gateway's 4000,
@@ -39,17 +41,17 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AuthConfig => 
   const port = parsePort(env.AUTH_PORT, DEFAULT_PORT, 'AUTH_PORT');
   const grpcPort = parsePort(env.AUTH_GRPC_PORT, DEFAULT_GRPC_PORT, 'AUTH_GRPC_PORT');
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }
 
-  const jwtSecret = env.JWT_SECRET?.trim();
+  const jwtSecret = readSecret('JWT_SECRET', env)?.trim();
   if (!jwtSecret) {
     throw new Error('JWT_SECRET is required (access-token signing secret)');
   }
 
-  const jwtRefreshSecret = env.JWT_REFRESH_SECRET?.trim();
+  const jwtRefreshSecret = readSecret('JWT_REFRESH_SECRET', env)?.trim();
   if (!jwtRefreshSecret) {
     throw new Error('JWT_REFRESH_SECRET is required (refresh-token signing secret)');
   }

--- a/services/chat/package.json
+++ b/services/chat/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/chat/src/config.ts
+++ b/services/chat/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type ChatConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
   // from service.backend's 5000, service.gateway's 4000,
@@ -35,7 +37,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ChatConfig => 
   const port = parsePort(env.CHAT_PORT, DEFAULT_PORT, 'CHAT_PORT');
   const grpcPort = parsePort(env.CHAT_GRPC_PORT, DEFAULT_GRPC_PORT, 'CHAT_GRPC_PORT');
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }

--- a/services/cms/package.json
+++ b/services/cms/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/cms/src/config.ts
+++ b/services/cms/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type CmsConfig = {
   port: number;
   host: string;
@@ -20,7 +22,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): CmsConfig => {
   const port = parsePort(env.CMS_PORT, DEFAULT_PORT, 'CMS_PORT');
   const grpcPort = parsePort(env.CMS_GRPC_PORT, DEFAULT_GRPC_PORT, 'CMS_GRPC_PORT');
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -32,6 +32,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/observability": "*",
     "@adopt-dont-shop/proto": "*",

--- a/services/gateway/src/config.ts
+++ b/services/gateway/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type GatewayConfig = {
   // Port the gateway listens on. Nginx (already in docker-compose)
   // routes the public api.localhost host here.
@@ -188,6 +190,6 @@ function buildStorageConfig(env: NodeJS.ProcessEnv): GatewayConfig['storage'] {
     // Multipart body limit — 10 MiB default. Override with MAX_FILE_SIZE
     // if larger PDFs are expected.
     maxFileSize: Number.parseInt(env.MAX_FILE_SIZE?.trim() || '10485760', 10),
-    signingSecret: env.UPLOAD_SIGNING_SECRET?.trim() || undefined,
+    signingSecret: readSecret('UPLOAD_SIGNING_SECRET', env)?.trim() || undefined,
   };
 }

--- a/services/matching/package.json
+++ b/services/matching/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/matching/src/config.ts
+++ b/services/matching/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type MatchingConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
   // from every other service in the stack (5000 backend, 4000 gateway,
@@ -38,7 +40,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): MatchingConfig
   const port = parsePort(env.MATCHING_PORT, DEFAULT_PORT, 'MATCHING_PORT');
   const grpcPort = parsePort(env.MATCHING_GRPC_PORT, DEFAULT_GRPC_PORT, 'MATCHING_GRPC_PORT');
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }

--- a/services/moderation/package.json
+++ b/services/moderation/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/moderation/src/config.ts
+++ b/services/moderation/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type ModerationConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
   // from every other service in the stack (5000 backend, 4000 gateway,
@@ -34,7 +36,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ModerationConf
   const port = parsePort(env.MODERATION_PORT, DEFAULT_PORT, 'MODERATION_PORT');
   const grpcPort = parsePort(env.MODERATION_GRPC_PORT, DEFAULT_GRPC_PORT, 'MODERATION_GRPC_PORT');
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/notifications/src/config.ts
+++ b/services/notifications/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type EmailProviderConfig =
   | { kind: 'console' }
   | { kind: 'ethereal' }
@@ -69,7 +71,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): NotificationsC
     'NOTIFICATIONS_GRPC_PORT'
   );
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }

--- a/services/pets/package.json
+++ b/services/pets/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/pets/src/config.ts
+++ b/services/pets/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type PetsConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
   // from service.backend's 5000, service.gateway's 4000,
@@ -33,7 +35,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): PetsConfig => 
   const port = parsePort(env.PETS_PORT, DEFAULT_PORT, 'PETS_PORT');
   const grpcPort = parsePort(env.PETS_GRPC_PORT, DEFAULT_GRPC_PORT, 'PETS_GRPC_PORT');
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }

--- a/services/rescue/package.json
+++ b/services/rescue/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@adopt-dont-shop/authz": "*",
+    "@adopt-dont-shop/config-secrets": "*",
     "@adopt-dont-shop/db": "*",
     "@adopt-dont-shop/events": "*",
     "@adopt-dont-shop/lib.types": "*",

--- a/services/rescue/src/config.ts
+++ b/services/rescue/src/config.ts
@@ -1,3 +1,5 @@
+import { readSecret } from '@adopt-dont-shop/config-secrets';
+
 export type RescueConfig = {
   // HTTP port for the boot-readiness surface (/health/simple). Distinct
   // from service.backend's 5000, service.gateway's 4000,
@@ -35,7 +37,7 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): RescueConfig =
   const port = parsePort(env.RESCUE_PORT, DEFAULT_PORT, 'RESCUE_PORT');
   const grpcPort = parsePort(env.RESCUE_GRPC_PORT, DEFAULT_GRPC_PORT, 'RESCUE_GRPC_PORT');
 
-  const databaseUrl = env.DATABASE_URL?.trim();
+  const databaseUrl = readSecret('DATABASE_URL', env)?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required (Postgres connection string)');
   }


### PR DESCRIPTION
## Summary

Closes the TODO PR #1001 left in `docker-compose.staging.yml` / `docker-compose.prod.yml` about moving the extracted services back onto file-mounted Docker secrets (the layout the deleted monolith used via `readSecretOrEnv()`).

Two deliverables:

1. **New shared package `@adopt-dont-shop/config-secrets`** under `packages/config-secrets/`. Single-file, zero-runtime-dep wrapper over `node:fs.readFileSync`:
   - `readSecret(name, env?)` — returns `env[NAME_FILE]` file contents (trimmed) when set, else `env[NAME]`, else `undefined`. Both set is an error — the loader refuses to guess which one to trust.
   - `requireSecret(name, env?)` — same as `readSecret` but throws `"<NAME> (or <NAME>_FILE) is required"` if missing.
   - 10 vitest cases cover file path, env path, undefined, ambiguity error, missing file, empty-string handling.

2. **Each service's `config.ts` now sources credentials through `readSecret`** instead of touching `process.env` directly. The config-shape contract is unchanged — same `Config` types, same error messages on missing values — so existing `loadConfig` tests still pass against plaintext env input. Only the SOURCE changed (env OR file).

3. **`docker-compose.staging.yml` + `docker-compose.prod.yml` re-wired onto file-mounted secrets.** A `secrets:` block declares each file; per-service env vars switch from inline values to `*_FILE` paths under `/run/secrets/`. The TODO comment block PR #1001 left explaining the deferral is removed.

## Secrets now file-mounted

| Secret                  | File                                  | Used by                          |
| ----------------------- | ------------------------------------- | -------------------------------- |
| `database_url`          | `./secrets/database_url`              | every domain service             |
| `redis_url`             | `./secrets/redis_url`                 | every domain service             |
| `jwt_secret`            | `./secrets/jwt_secret`                | `service-auth`                   |
| `jwt_refresh_secret`    | `./secrets/jwt_refresh_secret`        | `service-auth`                   |
| `upload_signing_secret` | `./secrets/upload_signing_secret`     | `service-gateway`                |
| `db_password`           | `./secrets/db_password` *(unchanged)* | `database` container (staging)   |

A `secrets/` directory with `README.md` + `.gitignore` documents the layout; the actual secret bodies stay out of git.

## Dev fallback

The dev `docker-compose.yml` is **untouched** — it still uses plaintext env interpolation. The loader honours that path automatically: when `*_FILE` is unset, it consults the raw env var. That dual-path behaviour is also the documented escape hatch for any operator who can't mount files in staging/prod.

## Test plan

- [x] `npx vitest run` in `packages/config-secrets` — 10/10 pass.
- [x] `npx turbo test --filter='@adopt-dont-shop/service.*'` — all 11 services pass (no `loadConfig` tests broke; the contract stayed identical).
- [x] `npx turbo type-check --filter=@adopt-dont-shop/config-secrets --filter='@adopt-dont-shop/service.*'` clean.
- [x] `npx turbo lint --filter=@adopt-dont-shop/config-secrets --filter='@adopt-dont-shop/service.*'` clean.
- [x] `docker compose -f docker-compose.staging.yml config --quiet` validates.
- [x] `docker compose -f docker-compose.prod.yml config --quiet` validates.

https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqp9Zwo9M3NMRNC7NahosP)_