### PR TITLE
fix: security and reliability fixes from Linear backlog (ADS-771, ADS-776, ADS-777, ADS-779, ADS-780, ADS-781, ADS-783)

### DIFF
--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -23,6 +23,10 @@ RUN apk update && apk upgrade && apk add --no-cache \
     curl \
     dumb-init \
     && rm -rf /var/cache/apk/*
+# Create non-root user for security [ADS-771]. Build stages stay root (npm
+# install / turbo build); the production stage drops to svcuser below.
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S svcuser -u 1001 -G nodejs
 WORKDIR /app
 # Husky is a dev-only git hook tool; not available (or wanted) in containers.
 ENV HUSKY=0
@@ -79,7 +83,23 @@ CMD ["sh", "-c", "npm run db:migrate --if-present && npm run db:seed --if-presen
 FROM base AS production
 ARG SERVICE_DIR
 ENV NODE_ENV=production
-COPY --from=build /app ./
+COPY --from=build --chown=svcuser:nodejs /app ./
+# Pre-create the uploads mount point owned by svcuser so a *fresh* named
+# volume (uploads:/app/uploads in docker-compose.prod/staging.yml) is
+# initialised writable by the runtime user. [ADS-771]
+RUN mkdir -p /app/uploads && chown svcuser:nodejs /app/uploads
+# Strip setuid/setgid bits from every binary on the image — nothing the
+# Node runtime does legitimately needs a suid/sgid helper, so removing the
+# bits closes off a privilege-escalation path for any RCE. -xdev keeps the
+# find within this layer's filesystem. Mirrors Dockerfile.app.optimized.
+# [ADS-771]
+RUN find / -xdev -perm -4000 -exec chmod -s {} + 2>/dev/null || true && \
+    find / -xdev -perm -2000 -exec chmod -s {} + 2>/dev/null || true
 WORKDIR /app/${SERVICE_DIR}
+# Drop to the unprivileged user for runtime. The CMD only talks to
+# Postgres (db:migrate) and starts node — no root-writable paths needed;
+# the gateway's local upload writes land under /app, owned by svcuser.
+# [ADS-771]
+USER svcuser
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["sh", "-c", "npm run db:migrate --if-present && npm run start"]

--- a/services/audit/src/migrations/004_add_gdpr_failed_at.ts
+++ b/services/audit/src/migrations/004_add_gdpr_failed_at.ts
@@ -1,0 +1,21 @@
+import type { MigrationBuilder } from 'node-pg-migrate';
+
+// ADS-777 — add failed_at to audit.gdpr_erasure_requests.
+//
+// completed_at used to flip as soon as every expected service had a
+// completion entry, even when those entries carried an `error` — so a
+// fully-errored saga looked completed. Now completed_at means "every
+// service acked successfully"; failed_at is stamped the first time any
+// service's ack carries an error and flags the saga for operator
+// attention. NULL in both = saga still in flight (or stuck — the
+// timeout sweep catches those).
+
+export const up = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.addColumn('gdpr_erasure_requests', {
+    failed_at: { type: 'timestamptz' },
+  });
+};
+
+export const down = async (pgm: MigrationBuilder): Promise<void> => {
+  pgm.dropColumn('gdpr_erasure_requests', 'failed_at');
+};

--- a/services/audit/src/migrations/migrations.test.ts
+++ b/services/audit/src/migrations/migrations.test.ts
@@ -38,7 +38,7 @@ describe('audit migrations', () => {
     }
   });
 
-  it.each(['001_create_audit_events.ts'])(
+  it.each(['001_create_audit_events.ts', '004_add_gdpr_failed_at.ts'])(
     '%s exports `up` and `down` functions',
     async filename => {
       const mod = (await import(`./${filename}`)) as {

--- a/services/audit/src/nats/gdpr-subscribers.test.ts
+++ b/services/audit/src/nats/gdpr-subscribers.test.ts
@@ -1,4 +1,5 @@
 import type { Pool } from 'pg';
+import type { Logger } from 'winston';
 import { describe, expect, it, vi } from 'vitest';
 
 import { recordCompletion, recordRequest, EXPECTED_SERVICES } from './gdpr-subscribers.js';
@@ -9,41 +10,113 @@ function makePool() {
   } as unknown as Pool;
 }
 
+function makeLogger() {
+  return {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  } as unknown as Logger;
+}
+
+function capturedCalls(pool: Pool): Array<[string, unknown[]]> {
+  return (pool.query as ReturnType<typeof vi.fn>).mock.calls.map(call => {
+    const [sql, params] = call as [string, unknown[]];
+    return [sql, params];
+  });
+}
+
+const REQUEST_PAYLOAD = {
+  userId: 'usr-1',
+  correlationId: 'corr-1',
+  requestedAt: '2026-06-09T12:00:00Z',
+  reason: 'leaving',
+};
+
+const COMPLETION_PAYLOAD = {
+  userId: 'usr-1',
+  correlationId: 'corr-1',
+  service: 'auth',
+  recordsErased: 7,
+  completedAt: '2026-06-09T12:01:00Z',
+};
+
 describe('recordRequest', () => {
-  it('INSERTs with ON CONFLICT DO NOTHING (idempotent on correlation_id)', async () => {
+  it('INSERTs and back-fills reason/requested_at on conflict (ADS-776)', async () => {
     const pool = makePool();
-    await recordRequest(pool, {
-      userId: 'usr-1',
-      correlationId: 'corr-1',
-      requestedAt: '2026-06-09T12:00:00Z',
-      reason: 'leaving',
-    });
-    const [sql, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0] as [
-      string,
-      unknown[],
-    ];
+    await recordRequest(pool, REQUEST_PAYLOAD);
+    const [[sql, params]] = capturedCalls(pool);
     expect(sql).toContain('INSERT INTO audit.gdpr_erasure_requests');
-    expect(sql).toContain('ON CONFLICT (correlation_id) DO NOTHING');
+    expect(sql).toContain('ON CONFLICT (correlation_id) DO UPDATE');
+    // A completion-first skeleton row has reason = NULL and requested_at =
+    // the completion timestamp; the real request must back-fill both.
+    expect(sql).toMatch(
+      /reason\s*=\s*COALESCE\(audit\.gdpr_erasure_requests\.reason,\s*EXCLUDED\.reason\)/
+    );
+    expect(sql).toMatch(
+      /requested_at\s*=\s*LEAST\(audit\.gdpr_erasure_requests\.requested_at,\s*EXCLUDED\.requested_at\)/
+    );
+    expect(sql).toMatch(
+      /user_id\s*=\s*COALESCE\(audit\.gdpr_erasure_requests\.user_id,\s*EXCLUDED\.user_id\)/
+    );
+    // Must NOT silently drop the replayed values any more.
+    expect(sql).not.toContain('DO NOTHING');
     expect(params).toEqual(['corr-1', 'usr-1', 'leaving', '2026-06-09T12:00:00Z']);
+  });
+
+  it('never touches completions, completed_at, or failed_at (a late request must not clobber saga progress)', async () => {
+    const pool = makePool();
+    await recordRequest(pool, REQUEST_PAYLOAD);
+    const [[sql]] = capturedCalls(pool);
+    expect(sql).not.toContain('completions');
+    expect(sql).not.toContain('completed_at');
+    expect(sql).not.toContain('failed_at');
+  });
+});
+
+describe('out-of-order delivery (ADS-776)', () => {
+  it('completion-first then request issues the same statements as the in-order path, so both orderings converge on the same row', async () => {
+    const logger = makeLogger();
+
+    const inOrderPool = makePool();
+    await recordRequest(inOrderPool, REQUEST_PAYLOAD);
+    await recordCompletion(inOrderPool, COMPLETION_PAYLOAD, logger);
+
+    const outOfOrderPool = makePool();
+    await recordCompletion(outOfOrderPool, COMPLETION_PAYLOAD, logger);
+    await recordRequest(outOfOrderPool, REQUEST_PAYLOAD);
+
+    const inOrder = capturedCalls(inOrderPool);
+    const outOfOrder = capturedCalls(outOfOrderPool);
+
+    // Same two statements, just reordered. Because each statement's
+    // conflict clause only fills gaps (COALESCE/LEAST/||-merge) and never
+    // overwrites the other's columns, statement-set equality means the
+    // final row state is order-independent.
+    expect(outOfOrder).toHaveLength(2);
+    expect(outOfOrder).toEqual(expect.arrayContaining(inOrder));
+    expect(inOrder).toEqual(expect.arrayContaining(outOfOrder));
+
+    // The late-arriving request still carries the real reason and
+    // requested_at — and its COALESCE/LEAST clauses apply them over the
+    // skeleton's NULL reason / completion-timestamp requested_at.
+    const requestCall = outOfOrder.find(([sql]) => !sql.includes('completions'));
+    expect(requestCall).toBeDefined();
+    const [requestSql, requestParams] = requestCall ?? ['', []];
+    expect(requestSql).toContain('COALESCE(audit.gdpr_erasure_requests.reason, EXCLUDED.reason)');
+    expect(requestSql).toContain(
+      'LEAST(audit.gdpr_erasure_requests.requested_at, EXCLUDED.requested_at)'
+    );
+    expect(requestParams[2]).toBe('leaving');
+    expect(requestParams[3]).toBe('2026-06-09T12:00:00Z');
   });
 });
 
 describe('recordCompletion', () => {
   it('merges the completion into the JSONB blob and threads EXPECTED_SERVICES into the SQL', async () => {
     const pool = makePool();
-    await recordCompletion(pool, {
-      userId: 'usr-1',
-      correlationId: 'corr-1',
-      service: 'auth',
-      recordsErased: 7,
-      completedAt: '2026-06-09T12:01:00Z',
-    });
-    const [sql, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0] as [
-      string,
-      unknown[],
-    ];
+    await recordCompletion(pool, COMPLETION_PAYLOAD, makeLogger());
+    const [[sql, params]] = capturedCalls(pool);
     expect(sql).toContain('ON CONFLICT (correlation_id) DO UPDATE');
-    expect(sql).toContain('jsonb_object_keys');
     // The threshold for completed_at comes from EXPECTED_SERVICES.length.
     expect(params[5]).toBe(EXPECTED_SERVICES.length);
     // The completion entry shape.
@@ -57,17 +130,110 @@ describe('recordCompletion', () => {
 
   it('records error field when the failure path lands', async () => {
     const pool = makePool();
-    await recordCompletion(pool, {
-      userId: 'usr-1',
-      correlationId: 'corr-1',
-      service: 'pets',
-      recordsErased: 0,
-      completedAt: '2026-06-09T12:01:00Z',
-      error: 'pool timeout',
-    });
-    const params = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0][1] as unknown[];
+    await recordCompletion(
+      pool,
+      {
+        userId: 'usr-1',
+        correlationId: 'corr-1',
+        service: 'pets',
+        recordsErased: 0,
+        completedAt: '2026-06-09T12:01:00Z',
+        error: 'pool timeout',
+      },
+      makeLogger()
+    );
+    const [[, params]] = capturedCalls(pool);
     const entry = JSON.parse(params[4] as string) as Record<string, unknown>;
     expect(entry.error).toBe('pool timeout');
+  });
+
+  it('only counts error-free acks towards completed_at (ADS-777)', async () => {
+    const pool = makePool();
+    await recordCompletion(pool, COMPLETION_PAYLOAD, makeLogger());
+    const [[sql]] = capturedCalls(pool);
+    // completed_at must be gated on the number of completion entries
+    // WITHOUT an `error` field, not the raw key count.
+    expect(sql).toMatch(/jsonb_each/);
+    expect(sql).toMatch(/NOT\s*\(value \? 'error'\)/);
+    expect(sql).not.toContain('jsonb_object_keys');
+  });
+
+  it('stamps failed_at (once) when a completion carries an error, on both insert and conflict paths', async () => {
+    const pool = makePool();
+    await recordCompletion(pool, COMPLETION_PAYLOAD, makeLogger());
+    const [[sql]] = capturedCalls(pool);
+    expect(sql).toContain('failed_at');
+    // Insert path: skeleton row stamps failed_at if the first ack errored.
+    expect(sql).toMatch(/CASE WHEN \$5::jsonb \? 'error' THEN now\(\)/);
+    // Conflict path: first error wins; later successes never clear it.
+    expect(sql).toMatch(/failed_at\s*=\s*COALESCE\(\s*audit\.gdpr_erasure_requests\.failed_at/);
+  });
+
+  it('warns the operator when a completion arrives with an error, and stays quiet otherwise', async () => {
+    const pool = makePool();
+    const logger = makeLogger();
+
+    await recordCompletion(pool, COMPLETION_PAYLOAD, logger);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    await recordCompletion(
+      pool,
+      { ...COMPLETION_PAYLOAD, service: 'pets', recordsErased: 0, error: 'pool timeout' },
+      logger
+    );
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('gdpr'),
+      expect.objectContaining({
+        correlationId: 'corr-1',
+        service: 'pets',
+        error: 'pool timeout',
+      })
+    );
+  });
+
+  it('a saga where 3 of 9 services ack with errors is flagged failed, not completed (ADS-777)', async () => {
+    const pool = makePool();
+    const logger = makeLogger();
+    const failingServices = new Set(['pets', 'chat', 'cms']);
+
+    for (const service of EXPECTED_SERVICES) {
+      await recordCompletion(
+        pool,
+        {
+          userId: 'usr-1',
+          correlationId: 'corr-1',
+          service,
+          recordsErased: failingServices.has(service) ? 0 : 3,
+          completedAt: '2026-06-09T12:01:00Z',
+          ...(failingServices.has(service) ? { error: 'erase failed' } : {}),
+        },
+        logger
+      );
+    }
+
+    const calls = capturedCalls(pool);
+    expect(calls).toHaveLength(9);
+
+    // Every statement gates completed_at on the count of error-free
+    // entries reaching the full expected-services threshold...
+    for (const [sql, params] of calls) {
+      expect(sql).toMatch(/NOT\s*\(value \? 'error'\)/);
+      expect(params[5]).toBe(EXPECTED_SERVICES.length);
+    }
+
+    // ...and only 6 of the 9 merged entries are error-free, so the
+    // threshold of 9 is never met — completed_at stays NULL.
+    const entries = calls.map(
+      ([, params]) => JSON.parse(params[4] as string) as Record<string, unknown>
+    );
+    const errorFree = entries.filter(entry => entry.error === undefined);
+    expect(errorFree).toHaveLength(EXPECTED_SERVICES.length - failingServices.size);
+    expect(errorFree.length).toBeLessThan(EXPECTED_SERVICES.length);
+
+    // Each errored ack stamps failed_at (COALESCE keeps the first) and
+    // raises a Layer-1 warning for the operator.
+    expect(logger.warn).toHaveBeenCalledTimes(failingServices.size);
   });
 });
 

--- a/services/audit/src/nats/gdpr-subscribers.ts
+++ b/services/audit/src/nats/gdpr-subscribers.ts
@@ -4,7 +4,9 @@
 //     audit.gdpr_erasure_requests. Idempotent via ON CONFLICT (correlation_id).
 //   * `gdpr.erasureCompleted` — merge the per-service completion into the
 //     `completions` JSONB blob. Updates `completed_at` once every service
-//     in the configured EXPECTED_SERVICES set has acked.
+//     in the configured EXPECTED_SERVICES set has acked without an error;
+//     errored acks stamp `failed_at` instead so operators see the saga
+//     needs attention.
 //
 // Both subscribers share the audit-workers queue group so a replicated
 // audit deployment load-balances saga tracking.
@@ -23,7 +25,8 @@ import {
 } from '@adopt-dont-shop/events';
 
 // The set of services we expect to ack each request. Once every one of
-// these has a completion entry, the request flips to completed_at = now().
+// these has an error-free completion entry, the request flips to
+// completed_at = now().
 // Keep this in sync with services/{auth,notifications,pets,chat,
 // applications,matching,moderation,cms,rescue}/src/index.ts subscriber
 // wiring.
@@ -75,17 +78,18 @@ export const registerGdprSubscribers = (
       nats,
       { subject: GDPR_ERASURE_COMPLETED, durable: DURABLE_COMPLETION, onError },
       async payload => {
-        await recordCompletion(pool, payload);
+        await recordCompletion(pool, payload, logger);
       }
     ),
   ];
 };
 
-// INSERT the saga row. ON CONFLICT means a replayed event is a no-op,
-// and a completion that arrives BEFORE the request (the bus can reorder
-// across subjects) still gets attached when the request finally lands —
-// the completion handler's UPDATE locks the row and merges into the
-// existing completions blob.
+// INSERT the saga row. A completion that arrives BEFORE the request (the
+// bus can reorder across subjects) INSERTs a skeleton with reason = NULL
+// and requested_at = the completion timestamp, so the conflict clause
+// back-fills the real values instead of dropping them (ADS-776):
+// COALESCE keeps any already-known reason/user_id (replay safety) and
+// LEAST keeps the earliest requested_at (the true request time).
 export async function recordRequest(
   pool: Pool,
   payload: GdprErasureRequestedPayload
@@ -94,19 +98,35 @@ export async function recordRequest(
     `INSERT INTO audit.gdpr_erasure_requests
        (correlation_id, user_id, reason, requested_at)
      VALUES ($1, $2, $3, $4)
-     ON CONFLICT (correlation_id) DO NOTHING`,
+     ON CONFLICT (correlation_id) DO UPDATE
+       SET reason = COALESCE(audit.gdpr_erasure_requests.reason, EXCLUDED.reason),
+           requested_at = LEAST(audit.gdpr_erasure_requests.requested_at, EXCLUDED.requested_at),
+           user_id = COALESCE(audit.gdpr_erasure_requests.user_id, EXCLUDED.user_id),
+           updated_at = now()`,
     [payload.correlationId, payload.userId, payload.reason ?? null, payload.requestedAt]
   );
 }
 
-// Merge a per-service completion into the row. When every expected
-// service has acked, stamp completed_at. If the row hasn't been recorded
-// yet (out-of-order delivery), INSERT a skeleton with the completion
-// already merged.
+// Merge a per-service completion into the row. completed_at is only
+// stamped once every expected service has acked WITHOUT an error —
+// errored acks still merge into the blob but don't count (ADS-777).
+// The first errored ack stamps failed_at (a later success never clears
+// it; the operator resolves and re-runs the saga) and emits a Layer-1
+// warning. If the row hasn't been recorded yet (out-of-order delivery),
+// INSERT a skeleton with the completion already merged.
 export async function recordCompletion(
   pool: Pool,
-  payload: GdprErasureCompletedPayload
+  payload: GdprErasureCompletedPayload,
+  logger: Logger
 ): Promise<void> {
+  if (payload.error) {
+    logger.warn('gdpr erasure completion reported an error', {
+      correlationId: payload.correlationId,
+      service: payload.service,
+      error: payload.error,
+    });
+  }
+
   const entry = {
     recordsErased: payload.recordsErased,
     completedAt: payload.completedAt,
@@ -115,8 +135,9 @@ export async function recordCompletion(
 
   await pool.query(
     `INSERT INTO audit.gdpr_erasure_requests
-       (correlation_id, user_id, reason, requested_at, completions)
-     VALUES ($1, $2, NULL, $3, jsonb_build_object($4::text, $5::jsonb))
+       (correlation_id, user_id, reason, requested_at, completions, failed_at)
+     VALUES ($1, $2, NULL, $3, jsonb_build_object($4::text, $5::jsonb),
+             CASE WHEN $5::jsonb ? 'error' THEN now() END)
      ON CONFLICT (correlation_id) DO UPDATE
        SET completions = audit.gdpr_erasure_requests.completions
                        || jsonb_build_object($4::text, $5::jsonb),
@@ -124,14 +145,18 @@ export async function recordCompletion(
              WHEN audit.gdpr_erasure_requests.completed_at IS NOT NULL
                THEN audit.gdpr_erasure_requests.completed_at
              WHEN (
-               SELECT count(*) FROM jsonb_object_keys(
+               SELECT count(*) FROM jsonb_each(
                  audit.gdpr_erasure_requests.completions
                    || jsonb_build_object($4::text, $5::jsonb)
-               )
+               ) WHERE NOT (value ? 'error')
              ) >= $6
                THEN now()
              ELSE NULL
            END,
+           failed_at = COALESCE(
+             audit.gdpr_erasure_requests.failed_at,
+             CASE WHEN $5::jsonb ? 'error' THEN now() END
+           ),
            updated_at = now()`,
     [
       payload.correlationId,

--- a/services/cms/src/grpc/handlers.test.ts
+++ b/services/cms/src/grpc/handlers.test.ts
@@ -147,6 +147,22 @@ describe('public reads', () => {
     expect(res.items).toHaveLength(1);
     const [sql1] = mocks.poolMock.query.mock.calls[0] as [string];
     expect(sql1).toContain("status = 'published'");
+    const [sql2, params2] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+    expect(sql2).toContain('LIMIT $1 OFFSET $2');
+    expect(params2).toEqual([10, 0]);
+  });
+
+  it('listPublicContent: parameterises LIMIT/OFFSET after filter params', async () => {
+    mocks.poolScript.push({ rows: [{ count: '0' }] });
+    mocks.poolScript.push({ rows: [] });
+    await listPublicContent(mocks.deps, null, {
+      contentType: CmsV1.ContentType.CONTENT_TYPE_PAGE,
+      page: 3,
+      limit: 10,
+    });
+    const [sql, params] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+    expect(sql).toContain('LIMIT $2 OFFSET $3');
+    expect(params).toEqual(['page', 10, 20]);
   });
 
   it('getPublicContentBySlug: 404 when not found', async () => {
@@ -193,6 +209,9 @@ describe('admin reads', () => {
     });
     const [, params] = mocks.poolMock.query.mock.calls[0] as [string, unknown[]];
     expect(params[0]).toBe('%100\\%%');
+    const [sql2, params2] = mocks.poolMock.query.mock.calls[1] as [string, unknown[]];
+    expect(sql2).toContain('LIMIT $2 OFFSET $3');
+    expect(params2).toEqual(['%100\\%%', 10, 0]);
   });
 
   it('getContent: 404 when missing', async () => {

--- a/services/cms/src/grpc/handlers.ts
+++ b/services/cms/src/grpc/handlers.ts
@@ -289,8 +289,8 @@ export async function listPublicContent(
   const result = await deps.pool.query<ContentRow>(
     `SELECT ${CONTENT_COLUMNS} FROM cms_content ${whereSql}
        ORDER BY published_at DESC NULLS LAST, created_at DESC
-       LIMIT ${limit} OFFSET ${offset}`,
-    params
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+    [...params, limit, offset]
   );
   return {
     items: result.rows.map(rowToContent),
@@ -369,8 +369,8 @@ export async function listContent(
   const result = await deps.pool.query<ContentRow>(
     `SELECT ${CONTENT_COLUMNS} FROM cms_content ${whereSql}
        ORDER BY updated_at DESC
-       LIMIT ${limit} OFFSET ${offset}`,
-    params
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+    [...params, limit, offset]
   );
   return {
     items: result.rows.map(rowToContent),

--- a/services/gateway/src/middleware/pagination.test.ts
+++ b/services/gateway/src/middleware/pagination.test.ts
@@ -1,0 +1,74 @@
+// Behaviour tests for the shared query-string pagination parser
+// (ADS-783). List routes must never forward NaN or an unbounded limit
+// to the gRPC clients.
+
+import { describe, expect, it } from 'vitest';
+
+import { MAX_PAGE_LIMIT, parsePagination } from './pagination.js';
+
+describe('parsePagination', () => {
+  it('returns page 1 / limit 20 when both params are missing', () => {
+    expect(parsePagination({})).toEqual({ ok: true, page: 1, limit: 20 });
+  });
+
+  it('respects per-route defaults when params are missing', () => {
+    expect(parsePagination({}, { limit: 0 })).toEqual({ ok: true, page: 1, limit: 0 });
+    expect(parsePagination({}, { limit: 8 })).toEqual({ ok: true, page: 1, limit: 8 });
+    expect(parsePagination({}, { page: 2, limit: 5 })).toEqual({ ok: true, page: 2, limit: 5 });
+  });
+
+  it('passes valid values through as numbers', () => {
+    expect(parsePagination({ page: '3', limit: '50' })).toEqual({ ok: true, page: 3, limit: 50 });
+  });
+
+  it('accepts limit exactly at the maximum', () => {
+    expect(parsePagination({ limit: String(MAX_PAGE_LIMIT) })).toEqual({
+      ok: true,
+      page: 1,
+      limit: MAX_PAGE_LIMIT,
+    });
+  });
+
+  it('rejects a non-numeric page', () => {
+    const result = parsePagination({ page: 'abc' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('page');
+    }
+  });
+
+  it('rejects a non-numeric limit', () => {
+    const result = parsePagination({ limit: 'abc' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('limit');
+    }
+  });
+
+  it('rejects non-integer values', () => {
+    expect(parsePagination({ limit: '2.5' }).ok).toBe(false);
+    expect(parsePagination({ page: '1e3' }).ok).toBe(false);
+    expect(parsePagination({ limit: '12abc' }).ok).toBe(false);
+  });
+
+  it('rejects limit above the maximum instead of clamping', () => {
+    const result = parsePagination({ limit: '101' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('100');
+    }
+  });
+
+  it('treats zero and negative values as missing (falls back to defaults)', () => {
+    expect(parsePagination({ page: '0', limit: '-5' })).toEqual({ ok: true, page: 1, limit: 20 });
+    expect(parsePagination({ limit: '0' }, { limit: 8 })).toEqual({ ok: true, page: 1, limit: 8 });
+  });
+
+  it('treats empty strings as missing', () => {
+    expect(parsePagination({ page: '', limit: '' }, { limit: 0 })).toEqual({
+      ok: true,
+      page: 1,
+      limit: 0,
+    });
+  });
+});

--- a/services/gateway/src/middleware/pagination.ts
+++ b/services/gateway/src/middleware/pagination.ts
@@ -1,0 +1,57 @@
+// Shared query-string pagination parser (ADS-783). List routes used to
+// inline `Number.parseInt(q.page, 10)` / `Number.parseInt(q.limit, 10)`
+// and forward the raw result — including NaN and unbounded limits — to
+// the gRPC clients. Every list route now goes through parsePagination:
+//
+//   - missing / empty / zero / negative params → the route's defaults
+//     (page 1, limit 20 unless the route overrides them)
+//   - non-integer page/limit (e.g. "abc", "2.5") → { ok: false } and the
+//     route replies 400 in its own error envelope
+//   - limit > MAX_PAGE_LIMIT → { ok: false } (no silent clamp)
+//
+// Returned as a discriminated result rather than a throw so routes stay
+// flat and keep their per-file error envelope ({ error } vs
+// { success: false, error }).
+
+export const MAX_PAGE_LIMIT = 100;
+
+export type PaginationDefaults = {
+  page?: number;
+  limit?: number;
+};
+
+export type PaginationResult =
+  | { ok: true; page: number; limit: number }
+  | { ok: false; error: string };
+
+const INTEGER_PATTERN = /^-?\d+$/;
+
+// undefined → invalid; otherwise the resolved value (defaults applied).
+const parseParam = (raw: string | undefined, fallback: number): number | undefined => {
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+  if (!INTEGER_PATTERN.test(raw.trim())) {
+    return undefined;
+  }
+  const n = Number.parseInt(raw, 10);
+  return n <= 0 ? fallback : n;
+};
+
+export const parsePagination = (
+  query: Record<string, string | undefined>,
+  defaults: PaginationDefaults = {}
+): PaginationResult => {
+  const page = parseParam(query.page, defaults.page ?? 1);
+  if (page === undefined) {
+    return { ok: false, error: 'page must be a positive integer' };
+  }
+  const limit = parseParam(query.limit, defaults.limit ?? 20);
+  if (limit === undefined) {
+    return { ok: false, error: 'limit must be a positive integer' };
+  }
+  if (limit > MAX_PAGE_LIMIT) {
+    return { ok: false, error: `limit must be <= ${MAX_PAGE_LIMIT}` };
+  }
+  return { ok: true, page, limit };
+};

--- a/services/gateway/src/routes/applications.ts
+++ b/services/gateway/src/routes/applications.ts
@@ -49,6 +49,7 @@ import type { ApplicationsClient } from '../grpc-clients/applications-client.js'
 
 import { applicationToView, statsToView, type ApplicationView } from './applications-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type ApplicationsRoutesOptions = {
   client: ApplicationsClient;
@@ -381,9 +382,13 @@ export const registerApplicationsRoutes = async (
 
   app.get('/api/v1/applications', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
     const grpcReq: ListApplicationsRequest = {
       cursor: q.cursor,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      limit: pagination.limit,
       statusFilter: parseStatus(q.status),
       rescueIdFilter: q.rescue,
       adopterIdFilter: q.adopter,

--- a/services/gateway/src/routes/audit.ts
+++ b/services/gateway/src/routes/audit.ts
@@ -29,6 +29,7 @@ import {
 
 import type { AuditClient } from '../grpc-clients/audit-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type AuditRoutesOptions = {
   client: AuditClient;
@@ -64,9 +65,13 @@ export const registerAuditRoutes = async (
     { config: { rateLimit: AUDIT_RATE_LIMITS.query } },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: AuditQueryRequest = {
         cursor: query.cursor,
-        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        limit: pagination.limit,
         service: query.service,
         subject: query.subject,
         actorUserId: query.actor_user_id,
@@ -88,11 +93,15 @@ export const registerAuditRoutes = async (
     { config: { rateLimit: AUDIT_RATE_LIMITS.getByTarget } },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: AuditGetByTargetRequest = {
         aggregateType: req.params.type,
         aggregateId: req.params.id,
         cursor: query.cursor,
-        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        limit: pagination.limit,
       };
       try {
         const res = await client.getByTarget(grpcReq, buildMetadata(req));

--- a/services/gateway/src/routes/broadcast.test.ts
+++ b/services/gateway/src/routes/broadcast.test.ts
@@ -2,6 +2,8 @@ import { status as grpcStatus } from '@grpc/grpc-js';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { NotificationsV1 } from '@adopt-dont-shop/proto';
+
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
 
 import { registerBroadcastRoutes } from './broadcast.js';
@@ -91,6 +93,81 @@ describe('POST /api/v1/notifications/broadcast', () => {
     });
     const [grpcReq] = broadcast.mock.calls[0];
     expect(grpcReq.dataJson).toBe('{"severity":"high"}');
+  });
+
+  it('forwards a string body.type of "pet_available" as the matching enum value', async () => {
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: { cohort: {}, title: 'T', message: 'M', type: 'pet_available' },
+    });
+    const [grpcReq] = broadcast.mock.calls[0];
+    expect(grpcReq.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_PET_AVAILABLE);
+  });
+
+  it('forwards a string body.type of "application_status" as the matching enum value', async () => {
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: { cohort: {}, title: 'T', message: 'M', type: 'application_status' },
+    });
+    const [grpcReq] = broadcast.mock.calls[0];
+    expect(grpcReq.type).toBe(
+      NotificationsV1.NotificationType.NOTIFICATION_TYPE_APPLICATION_STATUS
+    );
+  });
+
+  it('forwards a known numeric body.type unchanged', async () => {
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: {
+        cohort: {},
+        title: 'T',
+        message: 'M',
+        type: NotificationsV1.NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED,
+      },
+    });
+    const [grpcReq] = broadcast.mock.calls[0];
+    expect(grpcReq.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED);
+  });
+
+  it('defaults a missing body.type to UNSPECIFIED', async () => {
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: { cohort: {}, title: 'T', message: 'M' },
+    });
+    const [grpcReq] = broadcast.mock.calls[0];
+    expect(grpcReq.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED);
+  });
+
+  it('defaults an unknown body.type to UNSPECIFIED', async () => {
+    broadcast.mockResolvedValue({ targeted: 0, delivered: 0, suppressed: 0, failed: 0 });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: { cohort: {}, title: 'T', message: 'M', type: 'not_a_real_type' },
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/notifications/broadcast',
+      headers: ADMIN_HEADERS,
+      payload: { cohort: {}, title: 'T', message: 'M', type: 999 },
+    });
+    const [stringReq] = broadcast.mock.calls[0];
+    const [numericReq] = broadcast.mock.calls[1];
+    expect(stringReq.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED);
+    expect(numericReq.type).toBe(NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED);
   });
 
   it('maps gRPC INVALID_ARGUMENT → 400', async () => {

--- a/services/gateway/src/routes/broadcast.ts
+++ b/services/gateway/src/routes/broadcast.ts
@@ -6,10 +6,11 @@
 import { status } from '@grpc/grpc-js';
 import type { FastifyInstance, FastifyReply } from 'fastify';
 
-import type { BroadcastRequest } from '@adopt-dont-shop/proto';
+import { NotificationsV1, type BroadcastRequest } from '@adopt-dont-shop/proto';
 
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parseType } from './notifications.js';
 
 export type BroadcastRoutesOptions = {
   client: NotificationsClient;
@@ -49,7 +50,7 @@ export const registerBroadcastRoutes = async (
               ? cohort.email_verified
               : undefined,
       },
-      type: 0,
+      type: parseBodyType(body.type),
       title: typeof body.title === 'string' ? body.title : '',
       message: typeof body.message === 'string' ? body.message : '',
       actionUrl:
@@ -86,6 +87,22 @@ export const registerBroadcastRoutes = async (
     }
   });
 };
+
+// body.type arrives either as the REST string form ('pet_available') or a
+// numeric proto enum value. Missing / unknown values stay UNSPECIFIED so
+// the downstream handler's default (system_announcement) is unchanged.
+function parseBodyType(raw: unknown): NotificationsV1.NotificationType {
+  if (typeof raw === 'number') {
+    const out = NotificationsV1.notificationTypeFromJSON(raw);
+    return out === NotificationsV1.NotificationType.UNRECOGNIZED
+      ? NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED
+      : out;
+  }
+  if (typeof raw === 'string') {
+    return parseType(raw);
+  }
+  return NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED;
+}
 
 type GrpcError = { code?: number; details?: string; message?: string };
 

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -26,6 +26,7 @@ import {
 
 import type { ChatClient } from '../grpc-clients/chat-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type ChatRoutesOptions = {
   client: ChatClient;
@@ -92,9 +93,13 @@ const registerChatRoutesForPrefix = (
   app.get(prefix, async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(query, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
     const grpcReq: ListChatsRequest = {
       cursor: query.cursor,
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      limit: pagination.limit,
       unreadOnly: query.unreadOnly === 'true' || query.unread_only === 'true',
     };
 
@@ -132,10 +137,14 @@ const registerChatRoutesForPrefix = (
   app.get(`${prefix}/search`, async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(query, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
     const grpcReq: SearchChatsRequest = {
       query: query.query ?? query.q ?? '',
-      page: query.page ? Number.parseInt(query.page, 10) : 1,
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      page: pagination.page,
+      limit: pagination.limit,
       rescueId: query.rescueId ?? query.rescue_id,
     };
 
@@ -232,10 +241,14 @@ const registerChatRoutesForPrefix = (
   app.get<{ Params: { chatId: string } }>(`${prefix}/:chatId/messages`, async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(query, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
     const grpcReq: ListMessagesRequest = {
       chatId: req.params.chatId,
       cursor: query.cursor,
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      limit: pagination.limit,
     };
 
     try {

--- a/services/gateway/src/routes/cms.test.ts
+++ b/services/gateway/src/routes/cms.test.ts
@@ -96,6 +96,20 @@ describe('cms gateway routes', () => {
     expect(json.pagination.total).toBe(1);
   });
 
+  it('GET /public/content rejects a non-numeric page with 400 before calling the service', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/cms/public/content?page=abc' });
+    expect(res.statusCode).toBe(400);
+    const json = res.json() as { success: boolean; error: string };
+    expect(json.success).toBe(false);
+    expect(mocks.listPublicContent).not.toHaveBeenCalled();
+  });
+
+  it('GET /public/content rejects limit > 100 with 400 instead of clamping', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/cms/public/content?limit=101' });
+    expect(res.statusCode).toBe(400);
+    expect(mocks.listPublicContent).not.toHaveBeenCalled();
+  });
+
   it('GET /public/content/:slug returns the content view', async () => {
     mocks.getPublicContentBySlug.mockResolvedValue({ content: CONTENT_FIXTURE });
     const res = await app.inject({ method: 'GET', url: '/api/v1/cms/public/content/hello' });

--- a/services/gateway/src/routes/cms.ts
+++ b/services/gateway/src/routes/cms.ts
@@ -16,6 +16,7 @@ import {
 
 import type { CmsClient } from '../grpc-clients/cms-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type CmsRoutesOptions = {
   client: CmsClient;
@@ -163,10 +164,14 @@ export const registerCmsRoutes = async (
   // --- Public reads (no auth) ----------------------------------------
   app.get('/api/v1/cms/public/content', async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q);
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
     const grpcReq: CmsListPublicContentRequest = {
       contentType: contentTypeFromString(q.type),
-      page: q.page ? Number.parseInt(q.page, 10) : 1,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 20,
+      page: pagination.page,
+      limit: pagination.limit,
     };
     try {
       const res = await client.listPublicContent(grpcReq, buildMetadata(req));
@@ -203,12 +208,16 @@ export const registerCmsRoutes = async (
   // --- Admin content reads ------------------------------------------
   app.get('/api/v1/cms/content', async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q);
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
     const grpcReq: CmsListContentRequest = {
       contentType: contentTypeFromString(q.type),
       status: contentStatusFromString(q.status),
       search: q.search,
-      page: q.page ? Number.parseInt(q.page, 10) : 1,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 20,
+      page: pagination.page,
+      limit: pagination.limit,
     };
     try {
       const res = await client.listContent(grpcReq, buildMetadata(req));

--- a/services/gateway/src/routes/email.ts
+++ b/services/gateway/src/routes/email.ts
@@ -20,6 +20,7 @@ import {
 
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type EmailRoutesOptions = {
   client: NotificationsClient;
@@ -83,13 +84,17 @@ export const registerEmailRoutes = async (
   app.get('/api/v1/email/templates', async (req, reply) => {
     const metadata = buildMetadata(req);
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
     const grpcReq: ListEmailTemplatesRequest = {
       typeFilter: typeFromString(q.type),
       statusFilter: statusFromString(q.status),
       categoryFilter: q.category,
       search: q.search,
-      page: q.page ? Number.parseInt(q.page, 10) : 1,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      page: pagination.page,
+      limit: pagination.limit,
     };
     try {
       const res = await client.listEmailTemplates(grpcReq, metadata);

--- a/services/gateway/src/routes/matching.ts
+++ b/services/gateway/src/routes/matching.ts
@@ -42,6 +42,7 @@ import type { MatchingClient } from '../grpc-clients/matching-client.js';
 
 import { recommendToQueue, searchToView } from './matching-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type MatchingRoutesOptions = {
   client: MatchingClient;
@@ -186,9 +187,13 @@ export const registerMatchingRoutes = async (
     { config: { rateLimit: MATCHING_RATE_LIMITS.listSwipeHistory } },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: ListSwipeHistoryRequest = {
         cursor: query.cursor,
-        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        limit: pagination.limit,
         actionFilter: parseSwipeAction(query.action),
       };
       try {
@@ -255,11 +260,15 @@ export const registerMatchingRoutes = async (
     { config: { rateLimit: MATCHING_RATE_LIMITS.search } },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: SearchPetsRequest = {
         query: query.q ?? query.query,
         filtersJson: query.filters,
         cursor: query.cursor,
-        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        limit: pagination.limit,
       };
       try {
         const res = await client.searchPets(grpcReq, buildMetadata(req));

--- a/services/gateway/src/routes/moderation-admin.ts
+++ b/services/gateway/src/routes/moderation-admin.ts
@@ -37,6 +37,7 @@ import {
   supportTicketToView,
 } from './moderation-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type ModerationAdminRoutesOptions = {
   client: ModerationClient;
@@ -69,9 +70,13 @@ export const registerModerationAdminRoutes = async (
     { config: { rateLimit: RL_READ } },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: ListReportsRequest = {
         cursor: q.cursor,
-        limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+        limit: pagination.limit,
         status: parseEnum(
           ModerationV1.ReportStatus,
           'REPORT_STATUS',
@@ -292,9 +297,13 @@ export const registerModerationAdminRoutes = async (
     { config: { rateLimit: RL_READ } },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: ListModeratorActionsRequest = {
         cursor: q.cursor,
-        limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+        limit: pagination.limit,
         targetUserId: q.user,
         reportId: q.report,
         actionType: parseEnum(
@@ -377,9 +386,13 @@ export const registerModerationAdminRoutes = async (
     { config: { rateLimit: RL_READ } },
     async (req, reply) => {
       const q = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(q, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: ListSupportTicketsRequest = {
         cursor: q.cursor,
-        limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+        limit: pagination.limit,
         status: parseEnum(
           ModerationV1.SupportTicketStatus,
           'SUPPORT_TICKET_STATUS',

--- a/services/gateway/src/routes/moderation.ts
+++ b/services/gateway/src/routes/moderation.ts
@@ -54,6 +54,7 @@ import {
 
 import type { ModerationClient } from '../grpc-clients/moderation-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type ModerationRoutesOptions = {
   client: ModerationClient;
@@ -109,9 +110,13 @@ export const registerModerationRoutes = async (
 
   app.get('/api/v1/moderation/reports', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
     const grpcReq: ListReportsRequest = {
       cursor: q.cursor,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      limit: pagination.limit,
       status: parseReportStatus(q.status),
       severity: parseSeverity(q.severity),
       category: parseCategory(q.category),
@@ -210,9 +215,13 @@ export const registerModerationRoutes = async (
 
   app.get('/api/v1/moderation/actions', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
     const grpcReq: ListModeratorActionsRequest = {
       cursor: q.cursor,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      limit: pagination.limit,
       targetUserId: q.user,
       reportId: q.report,
       actionType: parseActionType(q.action),
@@ -336,9 +345,13 @@ export const registerModerationRoutes = async (
 
   app.get('/api/v1/moderation/tickets', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
     const grpcReq: ListSupportTicketsRequest = {
       cursor: q.cursor,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      limit: pagination.limit,
       status: parseTicketStatus(q.status),
       priority: parseTicketPriority(q.priority),
       category: parseTicketCategory(q.category),

--- a/services/gateway/src/routes/notifications.ts
+++ b/services/gateway/src/routes/notifications.ts
@@ -29,6 +29,7 @@ import {
 
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type NotificationsRoutesOptions = {
   client: NotificationsClient;
@@ -55,12 +56,16 @@ export const registerNotificationsRoutes = async (
   app.get('/api/v1/notifications', async (req, reply) => {
     const metadata = buildMetadata(req);
     const query = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(query, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
 
     const grpcReq: ListNotificationsRequest = {
       cursor: query.cursor,
       // Default 0 → handler clamps to the canonical default. Same shape
       // service.notifications.handlers.listNotifications expects.
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      limit: pagination.limit,
       statusFilter: parseStatus(query.status),
       channelFilter: parseChannel(query.channel),
       typeFilter: parseType(query.type),
@@ -347,7 +352,9 @@ function parseChannel(raw: string | undefined): NotificationsV1.NotificationChan
     : out;
 }
 
-function parseType(raw: string | undefined): NotificationsV1.NotificationType {
+// Exported for reuse by the broadcast route, which accepts the same
+// REST string forms for `type`.
+export function parseType(raw: string | undefined): NotificationsV1.NotificationType {
   if (!raw) {
     return NotificationsV1.NotificationType.NOTIFICATION_TYPE_UNSPECIFIED;
   }

--- a/services/gateway/src/routes/pets.test.ts
+++ b/services/gateway/src/routes/pets.test.ts
@@ -135,13 +135,25 @@ describe('GET /api/v1/pets', () => {
 
   it('maps INVALID_ARGUMENT → 400', async () => {
     listMock.mockRejectedValueOnce(
-      Object.assign(new Error('bad limit'), {
+      Object.assign(new Error('bad filter'), {
         code: grpcStatus.INVALID_ARGUMENT,
-        details: 'bad limit',
+        details: 'bad filter',
       })
     );
+    const res = await app.inject({ method: 'GET', url: '/api/v1/pets?limit=50' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects limit > 100 at the gateway without calling the service', async () => {
     const res = await app.inject({ method: 'GET', url: '/api/v1/pets?limit=200' });
     expect(res.statusCode).toBe(400);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric limit at the gateway', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/pets?limit=abc' });
+    expect(res.statusCode).toBe(400);
+    expect(listMock).not.toHaveBeenCalled();
   });
 });
 

--- a/services/gateway/src/routes/pets.ts
+++ b/services/gateway/src/routes/pets.ts
@@ -34,6 +34,7 @@ import {
   viewToUpdateRequest,
 } from './pets-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type PetsRoutesOptions = {
   client: PetsClient;
@@ -104,9 +105,13 @@ export const registerPetsRoutes = async (
     },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: ListPetsRequest = {
         cursor: query.cursor,
-        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        limit: pagination.limit,
         statusFilter: parseStatus(query.status),
         typeFilter: parseType(query.type),
         sizeFilter: parseSize(query.size),

--- a/services/gateway/src/routes/reports.ts
+++ b/services/gateway/src/routes/reports.ts
@@ -19,6 +19,7 @@ import {
 
 import type { AuditClient } from '../grpc-clients/audit-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type ReportsRoutesOptions = {
   client: AuditClient;
@@ -99,6 +100,10 @@ export const registerReportsRoutes = async (
   // GET /api/v1/reports — paginated list. Self-scoped at the service.
   app.get('/api/v1/reports', async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q);
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
     const grpcReq: AuditListSavedReportsRequest = {
       rescueId: q.rescue_id || q.rescueId,
       isArchived:
@@ -107,8 +112,8 @@ export const registerReportsRoutes = async (
           : q.is_archived === 'false' || q.archived === 'false'
             ? false
             : undefined,
-      page: q.page ? Number.parseInt(q.page, 10) : 1,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 20,
+      page: pagination.page,
+      limit: pagination.limit,
     };
     try {
       const res = await client.listSavedReports(grpcReq, buildMetadata(req));

--- a/services/gateway/src/routes/rescue.test.ts
+++ b/services/gateway/src/routes/rescue.test.ts
@@ -115,13 +115,25 @@ describe('GET /api/v1/rescue', () => {
 
   it('maps INVALID_ARGUMENT → 400', async () => {
     listMock.mockRejectedValueOnce(
-      Object.assign(new Error('limit too big'), {
+      Object.assign(new Error('bad filter'), {
         code: grpcStatus.INVALID_ARGUMENT,
-        details: 'limit must be <= 100',
+        details: 'bad filter',
       })
     );
+    const res = await app.inject({ method: 'GET', url: '/api/v1/rescue?limit=50' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects limit > 100 at the gateway without calling the service', async () => {
     const res = await app.inject({ method: 'GET', url: '/api/v1/rescue?limit=200' });
     expect(res.statusCode).toBe(400);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-numeric limit at the gateway', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/rescue?limit=abc' });
+    expect(res.statusCode).toBe(400);
+    expect(listMock).not.toHaveBeenCalled();
   });
 });
 

--- a/services/gateway/src/routes/rescue.ts
+++ b/services/gateway/src/routes/rescue.ts
@@ -32,6 +32,7 @@ import {
 
 import type { RescueClient } from '../grpc-clients/rescue-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type RescueRoutesOptions = {
   client: RescueClient;
@@ -85,9 +86,13 @@ export const registerRescueRoutes = async (
     { config: { rateLimit: RESCUE_RATE_LIMITS.list } },
     async (req, reply) => {
       const query = req.query as Record<string, string | undefined>;
+      const pagination = parsePagination(query, { limit: 0 });
+      if (!pagination.ok) {
+        return reply.code(400).send({ error: pagination.error });
+      }
       const grpcReq: ListRescuesRequest = {
         cursor: query.cursor,
-        limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+        limit: pagination.limit,
         statusFilter: parseStatus(query.status),
       };
       try {

--- a/services/gateway/src/routes/rescues-public.ts
+++ b/services/gateway/src/routes/rescues-public.ts
@@ -22,6 +22,7 @@ import type { RescueClient } from '../grpc-clients/rescue-client.js';
 
 import { rescueDataEnvelope, rescueListEnvelope } from './rescue-view.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type RescuesPublicRoutesOptions = {
   client: RescueClient;
@@ -52,7 +53,11 @@ export const registerRescuesPublicRoutes = async (
   // hit this with `search=` / cursor params.
   app.get('/api/v1/rescues', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
-    const grpcReq = buildListRequest(q);
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
+    const grpcReq = buildListRequest(q, pagination.limit);
     try {
       const res = await client.list(grpcReq, buildMetadata(req));
       return reply.send(rescueListEnvelope(res));
@@ -65,8 +70,12 @@ export const registerRescuesPublicRoutes = async (
   // defaults to 8 since the SPA renders a small carousel.
   app.get('/api/v1/rescues/featured', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 8 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
     const grpcReq: ListRescuesRequest = {
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 8,
+      limit: pagination.limit,
       statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
       randomize: true,
     };
@@ -82,7 +91,11 @@ export const registerRescuesPublicRoutes = async (
   // name_search wired in.
   app.get('/api/v1/rescues/search', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
-    const grpcReq = buildListRequest({ ...q, search: q.search ?? q.q });
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
+    const grpcReq = buildListRequest({ ...q, search: q.search ?? q.q }, pagination.limit);
     try {
       const res = await client.list(grpcReq, buildMetadata(req));
       return reply.send(rescueListEnvelope(res));
@@ -97,11 +110,15 @@ export const registerRescuesPublicRoutes = async (
   // cleanly when that happens.
   app.get('/api/v1/rescues/nearby', { config: { rateLimit: RL_READ } }, async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 20 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
     const lat = q.lat ? Number.parseFloat(q.lat) : undefined;
     const lng = q.lng ? Number.parseFloat(q.lng) : undefined;
     const radius = q.radiusKm ? Number.parseFloat(q.radiusKm) : undefined;
     const grpcReq: ListRescuesRequest = {
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 20,
+      limit: pagination.limit,
       statusFilter: RescueV1.RescueStatus.RESCUE_STATUS_UNSPECIFIED,
       latitude: lat,
       longitude: lng,
@@ -159,7 +176,10 @@ export const registerRescuesPublicRoutes = async (
 
 // --- Helpers ---------------------------------------------------------
 
-function buildListRequest(q: Record<string, string | undefined>): ListRescuesRequest {
+function buildListRequest(
+  q: Record<string, string | undefined>,
+  limit: number
+): ListRescuesRequest {
   const status = q.status;
   const statusFilter =
     !status || status === ''
@@ -167,7 +187,7 @@ function buildListRequest(q: Record<string, string | undefined>): ListRescuesReq
       : parseStatusFilter(status);
   return {
     cursor: q.cursor,
-    limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+    limit,
     statusFilter,
     nameSearch: q.search,
   };

--- a/services/gateway/src/routes/support.ts
+++ b/services/gateway/src/routes/support.ts
@@ -24,6 +24,7 @@ import {
 
 import type { ModerationClient } from '../grpc-clients/moderation-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type SupportRoutesOptions = {
   client: ModerationClient;
@@ -121,12 +122,16 @@ export const registerSupportRoutes = async (
   // filter needed.
   app.get('/api/v1/support/my-tickets', async (req, reply) => {
     const query = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(query, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ error: pagination.error });
+    }
     const grpcReq: ListSupportTicketsRequest = {
       status: statusFromString(query.status),
       // page/limit — the monolith uses page-based; we forward limit
       // only. Page-based pagination over a keyset cursor RPC is left
       // to the SPA (cursor in/out).
-      limit: query.limit ? Number.parseInt(query.limit, 10) : 0,
+      limit: pagination.limit,
       cursor: query.cursor,
     } as ListSupportTicketsRequest;
     try {

--- a/services/gateway/src/routes/users.ts
+++ b/services/gateway/src/routes/users.ts
@@ -35,6 +35,7 @@ import {
 import type { AuthClient } from '../grpc-clients/auth-client.js';
 import type { NotificationsClient } from '../grpc-clients/notifications-client.js';
 import { buildMetadata } from '../middleware/metadata.js';
+import { parsePagination } from '../middleware/pagination.js';
 
 export type UsersRoutesOptions = {
   authClient: AuthClient;
@@ -246,6 +247,10 @@ export const registerUsersRoutes = async (
   app.get('/api/v1/users/search', async (req, reply) => {
     const metadata = buildMetadata(req);
     const q = req.query as Record<string, string | undefined>;
+    const pagination = parsePagination(q, { limit: 0 });
+    if (!pagination.ok) {
+      return reply.code(400).send({ success: false, error: pagination.error });
+    }
     const grpcReq: SearchUsersRequest = {
       search: q.search,
       statusFilter: statusFilterFromString(q.status),
@@ -253,8 +258,8 @@ export const registerUsersRoutes = async (
       emailVerified: q.emailVerified ? q.emailVerified === 'true' : undefined,
       createdFrom: q.createdFrom ?? q.created_from,
       createdTo: q.createdTo ?? q.created_to,
-      page: q.page ? Number.parseInt(q.page, 10) : 1,
-      limit: q.limit ? Number.parseInt(q.limit, 10) : 0,
+      page: pagination.page,
+      limit: pagination.limit,
       sortBy: q.sortBy ?? q.sort_by,
       sortOrder: q.sortOrder ?? q.sort_order,
     };

--- a/services/notifications/src/grpc/broadcast-handlers.test.ts
+++ b/services/notifications/src/grpc/broadcast-handlers.test.ts
@@ -1,6 +1,7 @@
 import type { NatsConnection } from 'nats';
 import type { Pool } from 'pg';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from 'winston';
 
 import type { Principal } from '@adopt-dont-shop/authz';
 import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
@@ -21,7 +22,7 @@ const NO_PERMS: Principal = {
   permissions: [],
 };
 
-function makeMocks(authClient?: AuthCohortClient) {
+function makeMocks(authClient?: AuthCohortClient, logger?: Logger) {
   const clientScript: Array<{ rows: unknown[] }> = [];
   const client = {
     query: vi.fn(async (sql: string) => {
@@ -49,6 +50,7 @@ function makeMocks(authClient?: AuthCohortClient) {
     pool: pool as unknown as Pool,
     nats: nats as unknown as NatsConnection,
     authClient,
+    logger,
   };
   return { deps, poolMock: pool, clientMock: client, natsMock: nats, clientScript };
 }
@@ -201,6 +203,93 @@ describe('broadcast', () => {
 
     expect(res.delivered).toBe(1);
     expect(res.failed).toBe(1);
+  });
+
+  it('logs a warn with the userId and error message when a recipient write fails', async () => {
+    const authClient: AuthCohortClient = {
+      listUserIdsByCohort: vi.fn().mockResolvedValue({
+        userIds: ['u-1', 'u-2'],
+        total: 2,
+        page: 1,
+        totalPages: 1,
+      }),
+    };
+    const warn = vi.fn();
+    const logger = { warn } as unknown as Logger;
+    const mocks = makeMocks(authClient, logger);
+    // u-1's INSERT throws; u-2's succeeds.
+    let insertCount = 0;
+    mocks.clientMock.query = vi.fn(async (sql: string) => {
+      const op = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      if (sql.includes('INSERT INTO notifications.notifications')) {
+        insertCount++;
+        if (insertCount === 1) {
+          throw new Error('boom');
+        }
+        return { rows: [] };
+      }
+      const next = mocks.clientScript.shift();
+      if (!next) {
+        throw new Error(`client.query unscripted: ${sql.slice(0, 80)}`);
+      }
+      return next;
+    });
+    mocks.clientScript.push({ rows: [prefsRow({ user_id: 'u-1' })] });
+    mocks.clientScript.push({ rows: [prefsRow({ user_id: 'u-2' })] });
+
+    const res = await broadcast(mocks.deps, BROADCASTER, {
+      cohort: { userTypes: [], statuses: [] },
+      type: 0,
+      title: 't',
+      message: 'm',
+    });
+
+    expect(res.delivered).toBe(1);
+    expect(res.failed).toBe(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('broadcast recipient write failed', {
+      userId: 'u-1',
+      error: 'boom',
+    });
+  });
+
+  it('caps failure logging at 50 entries per broadcast', async () => {
+    const userIds = Array.from({ length: 60 }, (_, i) => `u-${i}`);
+    const authClient: AuthCohortClient = {
+      listUserIdsByCohort: vi.fn().mockResolvedValue({
+        userIds,
+        total: userIds.length,
+        page: 1,
+        totalPages: 1,
+      }),
+    };
+    const warn = vi.fn();
+    const logger = { warn } as unknown as Logger;
+    const mocks = makeMocks(authClient, logger);
+    // Every INSERT fails; prefs upserts succeed for everyone.
+    mocks.clientMock.query = vi.fn(async (sql: string) => {
+      const op = sql.trim().split(/\s+/)[0].toUpperCase();
+      if (op === 'BEGIN' || op === 'COMMIT' || op === 'ROLLBACK') {
+        return { rows: [] };
+      }
+      if (sql.includes('INSERT INTO notifications.notifications')) {
+        throw new Error('boom');
+      }
+      return { rows: [prefsRow()] };
+    });
+
+    const res = await broadcast(mocks.deps, BROADCASTER, {
+      cohort: { userTypes: [], statuses: [] },
+      type: 0,
+      title: 't',
+      message: 'm',
+    });
+
+    expect(res.failed).toBe(60);
+    expect(warn).toHaveBeenCalledTimes(50);
   });
 
   it('defers when scheduledFor is set (passes Date through to INSERT)', async () => {

--- a/services/notifications/src/grpc/broadcast-handlers.ts
+++ b/services/notifications/src/grpc/broadcast-handlers.ts
@@ -12,8 +12,9 @@
 //      which the prefs row models with no opt-out (only email/push/sms
 //      have toggles).
 //   4. Per-user failures are absorbed so a single bad row doesn't
-//      poison the batch; failed counter increments and the loop moves
-//      on.
+//      poison the batch; failed counter increments, a warn is logged
+//      (capped at MAX_LOGGED_FAILURES per broadcast), and the loop
+//      moves on.
 //
 // publish-after-commit: each insert + its `notifications.broadcastSent`
 // event runs inside its own withTransaction. Per-recipient atomicity
@@ -57,6 +58,11 @@ const STATUS_FROM_STRING: Record<string, AuthV1.UserStatus> = {
 };
 
 const COHORT_PAGE_LIMIT = 500;
+
+// Per-recipient failures are warned individually so operators can see
+// which users missed a broadcast — but capped so a systemic outage
+// (e.g. DB down mid-fan-out) doesn't flood the logs.
+const MAX_LOGGED_FAILURES = 50;
 
 type PrefsRow = {
   user_id: string;
@@ -145,6 +151,7 @@ export async function broadcast(
   let delivered = 0;
   let suppressed = 0;
   let failed = 0;
+  let loggedFailures = 0;
 
   const type =
     req.type === undefined ||
@@ -192,8 +199,15 @@ export async function broadcast(
         } else if (outcome === 'suppressed') {
           suppressed++;
         }
-      } catch {
+      } catch (err) {
         failed++;
+        if (loggedFailures < MAX_LOGGED_FAILURES) {
+          loggedFailures++;
+          deps.logger?.warn('broadcast recipient write failed', {
+            userId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
     }
     if (lookup.userIds.length < COHORT_PAGE_LIMIT) {

--- a/services/notifications/src/grpc/handlers.ts
+++ b/services/notifications/src/grpc/handlers.ts
@@ -20,6 +20,8 @@
 
 import { randomUUID } from 'node:crypto';
 
+import type { Logger } from 'winston';
+
 import { hasPermission, requirePermission, type Principal } from '@adopt-dont-shop/authz';
 import { withTransaction, type WithTransactionDeps } from '@adopt-dont-shop/events';
 import type { Permission, UserId } from '@adopt-dont-shop/lib.types';
@@ -65,6 +67,9 @@ export type HandlerDeps = WithTransactionDeps & {
   // Optional — only broadcast-handlers reads it. Other handlers (Create,
   // List, Dismiss, etc.) work fine without a cross-service client wired.
   authClient?: AuthCohortClient;
+  // Optional — only broadcast-handlers reads it (per-recipient failure
+  // warns). Other handlers log via the adapt() wrapper's logger.
+  logger?: Logger;
 };
 
 export type HandlerErrorCode =

--- a/services/notifications/src/grpc/server.ts
+++ b/services/notifications/src/grpc/server.ts
@@ -70,7 +70,7 @@ export type RunningGrpcServer = {
 
 export const createGrpcServer = (opts: CreateGrpcServerOptions): Server => {
   const { config, pool, nats, logger, authClient } = opts;
-  const deps = { pool, nats, authClient };
+  const deps = { pool, nats, authClient, logger };
   const server = new Server();
 
   // ts-proto emits `NotificationServiceService` as the Definition


### PR DESCRIPTION
Batch of high-priority backlog fixes, one commit per ticket. Each was developed and verified independently, then the combined tree was re-tested (gateway 483, notifications 195, audit 107, cms 29 tests passing; `tsc --noEmit` clean in all four services).

## Changes

### ADS-779 — CMS SQL parameterisation (High, Security)
`listPublicContent` / `listContent` in `services/cms/src/grpc/handlers.ts` interpolated `LIMIT ${limit} OFFSET ${offset}` into the SQL string. Now passed as `$N` placeholders, matching every other handler. No other interpolation sites remain in `services/cms/`.

### ADS-776 + ADS-777 — GDPR erasure saga record-keeping (High, Bugs)
- **ADS-776:** `recordRequest` used `ON CONFLICT … DO NOTHING`, so when a completion event arrived before its request (NATS doesn't order across subjects), the user-supplied `reason` and true `requested_at` were silently dropped. Now back-fills via `DO UPDATE` with `COALESCE`/`LEAST`, never touching saga progress columns.
- **ADS-777:** `completed_at` fired once 9 completion keys existed — even if every ack carried an `error`. Now only error-free acks count toward completion; a new `failed_at` column (migration `004_add_gdpr_failed_at.ts`) flags sagas needing attention, and each errored completion emits a `logger.warn`.

### ADS-780 + ADS-781 — Notification broadcast (Medium, Bugs)
- **ADS-781:** the gateway broadcast route hard-coded `type: 0` (UNSPECIFIED) and ignored `body.type`, so every broadcast persisted as `system_announcement`. Now parses string or numeric enum values (reusing the existing `parseType` mapping); missing/unknown values still default to UNSPECIFIED.
- **ADS-780:** the per-recipient `catch { failed++; }` swallowed all error detail. Now logs `warn` with `{ userId, error }`, capped at 50 entries per broadcast.

### ADS-783 — Gateway pagination validation (Medium)
New shared `parsePagination` helper (`services/gateway/src/middleware/pagination.ts`) applied across all list routes: non-numeric `page`/`limit` → 400 (previously NaN was forwarded to the proto encoder and silently defaulted), `limit > 100` → 400 (no silent clamp), per-route defaults preserved. Behaviour note: a garbage `page` param on cursor-only routes that previously ignored it now also returns 400.

### ADS-771 — Non-root service containers (High, Security)
`Dockerfile.service` (all 10 microservices + gateway) ran production containers as root. The production stage now copies with `--chown` to `svcuser` (uid 1001), strips setuid/sgid bits (mirroring `Dockerfile.app.optimized`), chowns the `/app/uploads` mount point, and sets `USER svcuser`. Development/build stages stay root (HMR bind mounts, `npm ci`).

**Rollout notes for ADS-771** (ops action likely needed):
- An existing `uploads` volume created under the old root image keeps root-owned dirs — run a one-time `chown -R 1001:1001` on its contents at rollout.
- Bind-mounted file secrets are written `chmod 600` owned by the ssh deploy user; uid 1001 cannot read them unless modes are adjusted (e.g. `chmod 644 secrets/*` with `chmod 700` on the dir). Validate before deploying.
- Docker image build could not be smoke-tested in this sandbox (registry egress blocked); verified by inspection against `Dockerfile.app.optimized`. CI's image build will be the real check.

## Investigated, no change needed

**ADS-770 (Urgent, IDOR on application activity log):** the vulnerable monolith endpoint was deleted in the Phase 11 microservice rewrite. The successor paths both enforce per-resource access: `GetApplication`+timeline checks owner/rescue scope via `requirePermission` (`services/applications/src/grpc/read-handlers.ts`), and the audit-trail route is admin-gated. Existing tests cover cross-rescue and cross-adopter denial. Recommend closing ADS-770 as resolved-by-architecture. Side-finding: `app.admin`'s EntityInspector still calls the dead `/applications/:id/activity` URL (404s) — worth a small follow-up ticket.

https://claude.ai/code/session_01AouCx2c94FmWb2gctSKrfK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AouCx2c94FmWb2gctSKrfK)_