### PR TITLE
feat(auth): lib.auth Bearer-token rework + remove CSRF auto-interceptor

### DIFF
--- a/lib.api/src/__tests__/api-service.test.ts
+++ b/lib.api/src/__tests__/api-service.test.ts
@@ -141,14 +141,6 @@ describe('ApiService', () => {
       const mockResponse = { data: { id: 1, ...requestData } };
       const mockHeaders = new Headers([['content-type', 'application/json']]);
 
-      // Mock CSRF token fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken: 'test-csrf-token' }),
-      } as Response);
-
-      // Mock actual POST request
       mockFetch.mockResolvedValueOnce({
         ok: true,
         headers: mockHeaders,
@@ -163,7 +155,6 @@ describe('ApiService', () => {
           method: 'POST',
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
-            'x-csrf-token': 'test-csrf-token',
           }),
           body: JSON.stringify(requestData),
         })
@@ -176,14 +167,6 @@ describe('ApiService', () => {
       const mockResponse = { data: requestData };
       const mockHeaders = new Headers([['content-type', 'application/json']]);
 
-      // Mock CSRF token fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken: 'test-csrf-token' }),
-      } as Response);
-
-      // Mock actual PUT request
       mockFetch.mockResolvedValueOnce({
         ok: true,
         headers: mockHeaders,
@@ -197,9 +180,6 @@ describe('ApiService', () => {
         expect.objectContaining({
           method: 'PUT',
           body: JSON.stringify(requestData),
-          headers: expect.objectContaining({
-            'x-csrf-token': 'test-csrf-token',
-          }),
         })
       );
       expect(result).toEqual(mockResponse);
@@ -208,14 +188,6 @@ describe('ApiService', () => {
     it('should make DELETE request', async () => {
       const mockHeaders = new Headers([['content-type', 'application/json']]);
 
-      // Mock CSRF token fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken: 'test-csrf-token' }),
-      } as Response);
-
-      // Mock actual DELETE request
       mockFetch.mockResolvedValueOnce({
         ok: true,
         headers: mockHeaders,
@@ -228,9 +200,6 @@ describe('ApiService', () => {
         'https://api.example.com/test/1',
         expect.objectContaining({
           method: 'DELETE',
-          headers: expect.objectContaining({
-            'x-csrf-token': 'test-csrf-token',
-          }),
         })
       );
       expect(result).toEqual({ success: true });
@@ -691,7 +660,7 @@ describe('ApiService', () => {
     });
   });
 
-  describe('CSRF Protection', () => {
+  describe('Request headers', () => {
     beforeEach(() => {
       apiService = new ApiService({
         apiUrl: 'https://api.example.com',
@@ -699,18 +668,9 @@ describe('ApiService', () => {
       });
     });
 
-    it('should fetch CSRF token on first state-changing request', async () => {
-      const csrfToken = 'test-csrf-token-123';
+    it('should not add x-csrf-token to state-changing requests', async () => {
       const mockHeaders = new Headers([['content-type', 'application/json']]);
 
-      // Mock CSRF token endpoint
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken }),
-      } as Response);
-
-      // Mock POST request
       mockFetch.mockResolvedValueOnce({
         ok: true,
         headers: mockHeaders,
@@ -719,154 +679,13 @@ describe('ApiService', () => {
 
       await apiService.post('/test', { data: 'test' });
 
-      // Should fetch CSRF token first
-      expect(mockFetch).toHaveBeenNthCalledWith(
-        1,
-        'https://api.example.com/api/v1/csrf-token',
-        expect.objectContaining({
-          method: 'GET',
-          credentials: 'include',
-        })
-      );
-
-      // Should include CSRF token in POST request
-      expect(mockFetch).toHaveBeenNthCalledWith(
-        2,
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
         'https://api.example.com/test',
         expect.objectContaining({
           method: 'POST',
-          credentials: 'include',
-          headers: expect.objectContaining({
-            'x-csrf-token': csrfToken,
-          }),
+          headers: expect.not.objectContaining({ 'x-csrf-token': expect.any(String) }),
         })
-      );
-    });
-
-    it('should reuse cached CSRF token for subsequent requests', async () => {
-      const csrfToken = 'test-csrf-token-123';
-      const mockHeaders = new Headers([['content-type', 'application/json']]);
-
-      // Mock CSRF token endpoint (should only be called once)
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken }),
-      } as Response);
-
-      // Mock two POST requests
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ success: true }),
-      } as Response);
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ success: true }),
-      } as Response);
-
-      await apiService.post('/test1', { data: 'test1' });
-      await apiService.post('/test2', { data: 'test2' });
-
-      // Should fetch CSRF token only once
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.example.com/api/v1/csrf-token',
-        expect.any(Object)
-      );
-
-      // Both POST requests should include the same CSRF token
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.example.com/test1',
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            'x-csrf-token': csrfToken,
-          }),
-        })
-      );
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.example.com/test2',
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            'x-csrf-token': csrfToken,
-          }),
-        })
-      );
-    });
-
-    it('should not add CSRF token to GET requests', async () => {
-      const mockHeaders = new Headers([['content-type', 'application/json']]);
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ data: 'test' }),
-      } as Response);
-
-      await apiService.get('/test');
-
-      // Should not fetch CSRF token for GET requests
-      expect(mockFetch).not.toHaveBeenCalledWith(
-        expect.stringContaining('/csrf-token'),
-        expect.any(Object)
-      );
-
-      // Should not include x-csrf-token header
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.example.com/test',
-        expect.objectContaining({
-          method: 'GET',
-          headers: expect.not.objectContaining({
-            'x-csrf-token': expect.any(String),
-          }),
-        })
-      );
-    });
-
-    it('should clear CSRF token on 403 CSRF errors', async () => {
-      const csrfToken = 'test-csrf-token-123';
-      const mockHeaders = new Headers([['content-type', 'application/json']]);
-
-      // Mock CSRF token endpoint
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken }),
-      } as Response);
-
-      // Mock POST request with CSRF error
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 403,
-        statusText: 'Forbidden',
-        headers: mockHeaders,
-        json: () => Promise.resolve({ error: 'Invalid CSRF token' }),
-      } as Response);
-
-      await expect(apiService.post('/test', { data: 'test' })).rejects.toThrow();
-
-      // CSRF token should be cleared after 403 error
-      // Verify by checking that a subsequent request fetches a new token
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken: 'new-token' }),
-      } as Response);
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ success: true }),
-      } as Response);
-
-      await apiService.post('/test2', { data: 'test2' });
-
-      // Should have fetched CSRF token again
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.example.com/api/v1/csrf-token',
-        expect.any(Object)
       );
     });
 
@@ -883,52 +702,12 @@ describe('ApiService', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://api.example.com/test',
-        expect.objectContaining({
-          credentials: 'include',
-        })
+        expect.objectContaining({ credentials: 'include' })
       );
     });
 
-    it('should manually clear CSRF token', async () => {
-      const csrfToken = 'test-csrf-token-123';
-      const mockHeaders = new Headers([['content-type', 'application/json']]);
-
-      // Fetch initial CSRF token
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken }),
-      } as Response);
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ success: true }),
-      } as Response);
-
-      await apiService.post('/test1', { data: 'test1' });
-
-      // Clear CSRF token manually
-      apiService.clearCsrfToken();
-
-      // Next request should fetch a new token
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ csrfToken: 'new-token-456' }),
-      } as Response);
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: mockHeaders,
-        json: () => Promise.resolve({ success: true }),
-      } as Response);
-
-      await apiService.post('/test2', { data: 'test2' });
-
-      // Should have fetched CSRF token twice (once for each POST after clear)
-      const csrfTokenCalls = mockFetch.mock.calls.filter((call) => call[0].includes('/csrf-token'));
-      expect(csrfTokenCalls).toHaveLength(2);
+    it('clearCsrfToken is callable without error', () => {
+      expect(() => apiService.clearCsrfToken()).not.toThrow();
     });
   });
 

--- a/lib.api/src/services/api-service.ts
+++ b/lib.api/src/services/api-service.ts
@@ -41,27 +41,6 @@ export class ApiService {
   }
 
   private setupDefaultInterceptors(): void {
-    // Add default request interceptor for CSRF token (must be first)
-    this.interceptors.addRequestInterceptor(async (config) => {
-      // Only add CSRF token for state-changing requests
-      const needsCsrfToken = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(config.method);
-
-      if (needsCsrfToken && !config.headers['x-csrf-token']) {
-        try {
-          const csrfToken = await this.getCsrfToken();
-          if (csrfToken) {
-            config.headers['x-csrf-token'] = csrfToken;
-          }
-        } catch (error) {
-          if (this.config.debug) {
-            console.warn('Failed to get CSRF token:', error);
-          }
-          // Continue without CSRF token - let the server reject if needed
-        }
-      }
-      return config;
-    });
-
     // Add default request interceptor for authentication
     this.interceptors.addRequestInterceptor(async (config) => {
       const token = this.getAuthToken();

--- a/lib.auth/src/__tests__/auth-service.test.ts
+++ b/lib.auth/src/__tests__/auth-service.test.ts
@@ -39,12 +39,12 @@ describe('AuthService', () => {
     updatedAt: '2023-01-01T00:00:00Z',
   };
 
-  // Backend no longer returns refreshToken in body — it's set as httpOnly cookie
   const mockAuthResponse: AuthResponse = {
     user: mockUser,
-    token: 'mock-token',
-    expiresIn: 3600,
-    accessToken: 'mock-token',
+    tokens: {
+      accessToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token',
+    },
   };
 
   beforeEach(() => {
@@ -69,7 +69,7 @@ describe('AuthService', () => {
   });
 
   describe('login', () => {
-    it('should login successfully, store user in localStorage, and not write tokens to JS storage', async () => {
+    it('should login successfully, store user and Bearer token in localStorage', async () => {
       const credentials: LoginRequest = {
         email: 'test@example.com',
         password: 'password123',
@@ -80,21 +80,15 @@ describe('AuthService', () => {
       const result = await authService.login(credentials);
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/login', credentials);
-      // User stored in localStorage (persists across sessions)
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.USER,
         JSON.stringify(mockUser)
       );
-      // Access token NOT stored anywhere JS-accessible — it's an httpOnly cookie
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith(
-        STORAGE_KEYS.AUTH_TOKEN,
-        expect.any(String)
-      );
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith(
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         STORAGE_KEYS.ACCESS_TOKEN,
-        expect.any(String)
+        'mock-access-token'
       );
-      expect(result).toEqual({ ...mockAuthResponse, accessToken: 'mock-token' });
+      expect(result).toEqual(mockAuthResponse);
     });
 
     it('should handle login failure', async () => {
@@ -136,17 +130,14 @@ describe('AuthService', () => {
   });
 
   describe('logout', () => {
-    it('should logout successfully and clear user from localStorage', async () => {
+    it('should logout successfully and clear user and access token from localStorage', async () => {
       (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue({});
 
       await authService.logout();
 
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/logout');
-      // User removed from localStorage
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.USER);
-      // Token cookies are cleared server-side — no JS-side removal needed
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith(STORAGE_KEYS.AUTH_TOKEN);
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
     });
 
     it('should clear storage even if API call fails', async () => {
@@ -230,7 +221,18 @@ describe('AuthService', () => {
   });
 
   describe('getToken', () => {
-    it('should return null — access token lives in httpOnly cookie, not JS storage', () => {
+    it('should return the stored Bearer access token from localStorage', () => {
+      mockLocalStorage.getItem.mockReturnValue('stored-access-token');
+
+      const token = authService.getToken();
+
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
+      expect(token).toBe('stored-access-token');
+    });
+
+    it('should return null when no token is stored', () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
+
       const token = authService.getToken();
 
       expect(token).toBeNull();
@@ -238,37 +240,46 @@ describe('AuthService', () => {
   });
 
   describe('setToken', () => {
-    it('should be a no-op — token is managed as httpOnly cookie by the backend', () => {
-      authService.setToken('some-token');
+    it('should store the Bearer token in localStorage', () => {
+      authService.setToken('new-access-token');
+
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.ACCESS_TOKEN,
+        'new-access-token'
+      );
+    });
+
+    it('should not write to storage when token is null', () => {
+      authService.setToken(null);
 
       expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
   });
 
   describe('clearTokens', () => {
-    it('should be a no-op — token cookies are cleared by the backend logout endpoint', () => {
+    it('should remove the access token from localStorage', () => {
       authService.clearTokens();
 
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEYS.ACCESS_TOKEN);
     });
   });
 
   describe('refreshToken', () => {
-    it('should refresh token via cookie and return the new token value', async () => {
+    it('should refresh the access token, store it, and return the new value', async () => {
       const refreshResponse = {
-        token: 'new-token',
-        // refreshToken not returned — it's set as httpOnly cookie by backend
+        tokens: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' },
       };
 
       (apiService.post as ReturnType<typeof vi.fn>).mockResolvedValue(refreshResponse);
 
       const newToken = await authService.refreshToken();
 
-      // Should NOT send refresh token in body — cookie is auto-sent by browser
       expect(apiService.post).toHaveBeenCalledWith('/api/v1/auth/refresh-token', {});
-      // No token stored in JS-accessible storage
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
-      expect(newToken).toBe('new-token');
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEYS.ACCESS_TOKEN,
+        'new-access-token'
+      );
+      expect(newToken).toBe('new-access-token');
     });
 
     it('should propagate error if refresh API call fails', async () => {

--- a/lib.auth/src/contexts/AuthContext.test.tsx
+++ b/lib.auth/src/contexts/AuthContext.test.tsx
@@ -75,9 +75,7 @@ const devUser: User = {
 
 const buildAuthResponse = (user: User): AuthResponse => ({
   user,
-  token: 'mock-token',
-  expiresIn: 3600,
-  accessToken: 'mock-token',
+  tokens: { accessToken: 'mock-access-token', refreshToken: 'mock-refresh-token' },
 });
 
 // Stable reference so re-renders don't re-trigger the effect that watches it.

--- a/lib.auth/src/services/auth-service.ts
+++ b/lib.auth/src/services/auth-service.ts
@@ -32,17 +32,9 @@ const AUTH_ENDPOINTS = {
   TWO_FACTOR_BACKUP_CODES: '/api/v1/auth/2fa/backup-codes',
 } as const;
 
-/**
- * AuthService - Authentication and user management service
- *
- * Access tokens are stored in httpOnly cookies (managed by the backend,
- * not accessible to JavaScript — XSS-safe). Refresh tokens use a separate
- * httpOnly cookie. All authenticated requests rely on the browser sending
- * these cookies automatically via `credentials: 'include'`.
- */
 export class AuthService {
   constructor() {
-    // Configure the API service to get auth tokens from this service
+    // Wire the API service so Bearer tokens are sent on every authenticated request
     apiService.updateConfig({
       getAuthToken: () => this.getToken(),
     });
@@ -54,13 +46,10 @@ export class AuthService {
   async login(credentials: LoginRequest): Promise<AuthResponse> {
     const response = await apiService.post<AuthResponse>(AUTH_ENDPOINTS.LOGIN, credentials);
 
-    // Access token is set as httpOnly cookie by the backend; refresh token likewise.
+    this.setToken(response.tokens.accessToken);
     this.setUser(response.user);
 
-    return {
-      ...response,
-      accessToken: response.token, // Map backend 'token' to frontend 'accessToken'
-    };
+    return response;
   }
 
   /**
@@ -134,12 +123,12 @@ export class AuthService {
   }
 
   /**
-   * Refresh access token — refresh token and new access token are both set
-   * as httpOnly cookies by the backend; no JS-side storage needed.
+   * Refresh access token — stores the new access token and returns it.
    */
   async refreshToken(): Promise<string> {
     const response = await apiService.post<RefreshTokenResponse>(AUTH_ENDPOINTS.REFRESH, {});
-    return response.token;
+    this.setToken(response.tokens.accessToken);
+    return response.tokens.accessToken;
   }
 
   /**
@@ -273,29 +262,26 @@ export class AuthService {
   }
 
   /**
-   * Returns null — the access token lives in an httpOnly cookie managed by
-   * the backend and is not readable from JavaScript. HTTP requests send it
-   * automatically via `credentials: 'include'`; Socket.IO connections use the
-   * same cookie on the WebSocket upgrade request.
+   * Returns the stored Bearer access token, or null if not authenticated.
    */
-  getToken(): null {
-    return null;
+  getToken(): string | null {
+    return localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
   }
 
   /**
-   * No-op — the access token is set as an httpOnly cookie by the backend
-   * login/refresh response and is never written to JS-accessible storage.
+   * Stores the Bearer access token in localStorage.
    */
-  setToken(_token: string | null | undefined): void {
-    // intentional no-op
+  setToken(token: string | null | undefined): void {
+    if (token) {
+      localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token);
+    }
   }
 
   /**
-   * Clears local user state. The access/refresh token cookies are cleared
-   * by the backend logout endpoint.
+   * Removes the stored access token.
    */
   clearTokens(): void {
-    // Token cookies are cleared server-side on logout; nothing to do here.
+    localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
   }
 
   // Private helper methods

--- a/lib.auth/src/types/auth.ts
+++ b/lib.auth/src/types/auth.ts
@@ -183,14 +183,17 @@ export interface RegisterRequest {
   confirmPassword?: string;
 }
 
-export interface AuthResponse {
+export type TokenPair = {
+  accessToken: string;
+  refreshToken: string;
+  accessExpiresAt?: string;
+  refreshExpiresAt?: string;
+};
+
+export type AuthResponse = {
   user: User;
-  token: string; // Backend returns 'token', not 'accessToken'
-  refreshToken?: string; // No longer returned in body — sent as httpOnly cookie
-  expiresIn: number;
-  // Legacy field for frontend compatibility
-  accessToken?: string;
-}
+  tokens: TokenPair;
+};
 
 export interface ChangePasswordRequest {
   currentPassword: string;
@@ -201,10 +204,9 @@ export interface RefreshTokenRequest {
   refreshToken?: string;
 }
 
-export interface RefreshTokenResponse {
-  token: string;
-  refreshToken?: string; // No longer returned in body — rotated via httpOnly cookie
-}
+export type RefreshTokenResponse = {
+  tokens: TokenPair;
+};
 
 export interface PasswordResetRequest {
   email: string;


### PR DESCRIPTION
## Summary

Closes step 1 of ADS-801 — reworks `lib.auth` and `lib.api` to speak the gateway's Bearer-token contract instead of the deleted monolith's CSRF + httpOnly-cookie model.

- **`lib.auth/src/types/auth.ts`** — adds `TokenPair` type; updates `AuthResponse` and `RefreshTokenResponse` to use `tokens: TokenPair` (drops the old `token: string` / `expiresIn` monolith fields)
- **`lib.auth/src/services/auth-service.ts`** — `login()` reads `tokens.accessToken` and stores it; `getToken()` returns the stored token from `localStorage`; `setToken()` / `clearTokens()` now read/write `STORAGE_KEYS.ACCESS_TOKEN`; `refreshToken()` stores and returns `tokens.accessToken`
- **`lib.api/src/services/api-service.ts`** — removes the CSRF auto-interceptor that fetched `/api/v1/csrf-token` before every state-changing request (the gateway uses Bearer auth, not CSRF+cookies). `getCsrfToken()` / `clearCsrfToken()` are kept as stubs so `AuthContext.tsx` and `lib.chat` callers don't get type errors.
- Test files updated throughout to match new behaviour.

## What's left in ADS-801 (follow-up PRs)

- Verify the three React apps (`app.client`, `app.rescue`, `app.admin`) log in end-to-end against the gateway
- Un-park the three legacy e2e projects in `e2e/playwright.config.ts`
- Delete/rewrite the CSRF spec (`e2e/tests/client/api-csrf-and-cookie-contract.spec.ts`)
- Re-add `test-e2e` to `ci-required.needs` in `ci.yml` once green

## Test plan

- [x] `lib.auth` unit tests: 61 pass (2 pre-existing failures in `LoginForm`/`RegisterForm` due to unbuilt `lib.validation` — unrelated to this change)
- [x] `lib.api` unit tests: 40 pass (0 failures)
- [ ] Full gateway login flow verified with running stack (requires Docker)

https://claude.ai/code/session_01KA2Ebr8aRjNosMQnDbYtyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KA2Ebr8aRjNosMQnDbYtyQ)_