### PR TITLE
fix: five high-priority audit fixes — cutover flags, S2S deadlines, report write scoping, pool timeouts, health readiness (ADS-813, ADS-823, ADS-775, ADS-827, ADS-825)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -402,6 +402,21 @@ jobs:
               sleep 2
             done
 
+            # ADS-813: smoke-check that the cutover-gated /api/v1/* routes are
+            # actually registered. /api/v1/auth/login only exists when
+            # CUTOVER_AUTH is on: an empty POST returns 400 when registered,
+            # 404 when the flags never reached the gateway.
+            echo "Smoke-checking POST /api/v1/auth/login (verifies CUTOVER flags are set)..."
+            STATUS=$(docker compose -f $COMPOSE_FILE exec -T service-gateway \
+              curl -o /dev/null -w '%{http_code}' -s -X POST \
+              -H 'content-type: application/json' -d '{}' \
+              http://localhost:4000/api/v1/auth/login 2>/dev/null || echo "000")
+            if [ "$STATUS" = "404" ] || [ "$STATUS" = "000" ]; then
+              echo "ERROR: POST /api/v1/auth/login returned $STATUS — CUTOVER_* flags may be missing or gateway routes not registered."
+              exit 1
+            fi
+            echo "Smoke check passed (HTTP $STATUS)."
+
             # Remove secret files now that containers have started (they hold
             # in-memory copies; the files on disk are no longer needed). [ADS-675]
             if [ "$ENV" = "production" ]; then

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -202,6 +202,20 @@ services:
       # the gateway's own file streaming in production.
       SERVE_LOCAL_UPLOADS: "false"
       UPLOAD_SIGNING_SECRET_FILE: /run/secrets/upload_signing_secret
+      # ADS-813: forward CUTOVER_* flags so the gateway registers /api/v1/*
+      # routes. Without these the gateway boots healthy but 404s every API
+      # route (compose does not pass host env implicitly). Default true — all
+      # domains are extracted in phase 11 and the monolith is gone.
+      CUTOVER_AUTH: '${CUTOVER_AUTH:-true}'
+      CUTOVER_NOTIFICATIONS: '${CUTOVER_NOTIFICATIONS:-true}'
+      CUTOVER_PETS: '${CUTOVER_PETS:-true}'
+      CUTOVER_RESCUE: '${CUTOVER_RESCUE:-true}'
+      CUTOVER_APPLICATIONS: '${CUTOVER_APPLICATIONS:-true}'
+      CUTOVER_MODERATION: '${CUTOVER_MODERATION:-true}'
+      CUTOVER_MATCHING: '${CUTOVER_MATCHING:-true}'
+      CUTOVER_AUDIT: '${CUTOVER_AUDIT:-true}'
+      CUTOVER_CHAT: '${CUTOVER_CHAT:-true}'
+      CUTOVER_CMS: '${CUTOVER_CMS:-true}'
     # Gateway has no DB; it only needs the upload-signing secret.
     secrets:
       - upload_signing_secret

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -181,6 +181,20 @@ services:
       # Staging has no per-stack nginx; the gateway serves /uploads itself.
       SERVE_LOCAL_UPLOADS: "true"
       UPLOAD_SIGNING_SECRET_FILE: /run/secrets/upload_signing_secret
+      # ADS-813: forward CUTOVER_* flags so the gateway registers /api/v1/*
+      # routes. Without these the gateway boots healthy but 404s every API
+      # route (compose does not pass host env implicitly). Default true — all
+      # domains are extracted in phase 11 and the monolith is gone.
+      CUTOVER_AUTH: '${CUTOVER_AUTH:-true}'
+      CUTOVER_NOTIFICATIONS: '${CUTOVER_NOTIFICATIONS:-true}'
+      CUTOVER_PETS: '${CUTOVER_PETS:-true}'
+      CUTOVER_RESCUE: '${CUTOVER_RESCUE:-true}'
+      CUTOVER_APPLICATIONS: '${CUTOVER_APPLICATIONS:-true}'
+      CUTOVER_MODERATION: '${CUTOVER_MODERATION:-true}'
+      CUTOVER_MATCHING: '${CUTOVER_MATCHING:-true}'
+      CUTOVER_AUDIT: '${CUTOVER_AUDIT:-true}'
+      CUTOVER_CHAT: '${CUTOVER_CHAT:-true}'
+      CUTOVER_CMS: '${CUTOVER_CMS:-true}'
     # Gateway has no DB; it only needs the upload-signing secret.
     secrets:
       - upload_signing_secret

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { createDbClient } from './client.js';
+
+describe('createDbClient', () => {
+  describe('timeout defaults', () => {
+    it('applies default timeout values when caller supplies only schema and connectionString', () => {
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+      });
+
+      // Unresponsive Postgres must fail fast — defaults must be present
+      expect(pool.options.connectionTimeoutMillis).toBe(10_000);
+      expect(pool.options.idleTimeoutMillis).toBe(30_000);
+      expect(pool.options.statement_timeout).toBe(30_000);
+      expect(pool.options.query_timeout).toBe(30_000);
+
+      void pool.end();
+    });
+
+    it('allows caller to override connectionTimeoutMillis', () => {
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+        connectionTimeoutMillis: 5_000,
+      });
+
+      expect(pool.options.connectionTimeoutMillis).toBe(5_000);
+
+      void pool.end();
+    });
+
+    it('allows caller to override all timeout defaults', () => {
+      const pool = createDbClient({
+        schema: 'test',
+        connectionString: 'postgres://localhost/test',
+        connectionTimeoutMillis: 1_000,
+        idleTimeoutMillis: 2_000,
+        statement_timeout: 3_000,
+        query_timeout: 4_000,
+      });
+
+      expect(pool.options.connectionTimeoutMillis).toBe(1_000);
+      expect(pool.options.idleTimeoutMillis).toBe(2_000);
+      expect(pool.options.statement_timeout).toBe(3_000);
+      expect(pool.options.query_timeout).toBe(4_000);
+
+      void pool.end();
+    });
+  });
+
+  describe('connection behaviour', () => {
+    it(
+      'rejects within ~connectionTimeoutMillis when connecting to a non-routable address',
+      async () => {
+        const startMs = Date.now();
+        const pool = createDbClient({
+          schema: 'test',
+          // 10.255.255.1 is a non-routable address — TCP SYN will never be answered
+          host: '10.255.255.1',
+          port: 5432,
+          // Small override to keep the test fast and also proves overridability
+          connectionTimeoutMillis: 500,
+        });
+
+        await expect(pool.connect()).rejects.toThrow();
+
+        const elapsedMs = Date.now() - startMs;
+        // Should have rejected within roughly 2× the timeout (generous upper bound)
+        expect(elapsedMs).toBeLessThan(2_000);
+
+        void pool.end();
+      },
+      // Test-level timeout: well above the pool timeout, below the default 5s
+      3_000,
+    );
+  });
+});

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -50,29 +50,24 @@ describe('createDbClient', () => {
   });
 
   describe('connection behaviour', () => {
-    it(
-      'rejects within ~connectionTimeoutMillis when connecting to a non-routable address',
-      async () => {
-        const startMs = Date.now();
-        const pool = createDbClient({
-          schema: 'test',
-          // 10.255.255.1 is a non-routable address — TCP SYN will never be answered
-          host: '10.255.255.1',
-          port: 5432,
-          // Small override to keep the test fast and also proves overridability
-          connectionTimeoutMillis: 500,
-        });
+    it('rejects within ~connectionTimeoutMillis when connecting to a non-routable address', async () => {
+      const startMs = Date.now();
+      const pool = createDbClient({
+        schema: 'test',
+        // 10.255.255.1 is a non-routable address — TCP SYN will never be answered
+        host: '10.255.255.1',
+        port: 5432,
+        // Small override to keep the test fast and also proves overridability
+        connectionTimeoutMillis: 500,
+      });
 
-        await expect(pool.connect()).rejects.toThrow();
+      await expect(pool.connect()).rejects.toThrow();
 
-        const elapsedMs = Date.now() - startMs;
-        // Should have rejected within roughly 2× the timeout (generous upper bound)
-        expect(elapsedMs).toBeLessThan(2_000);
+      const elapsedMs = Date.now() - startMs;
+      // Should have rejected within roughly 2× the timeout (generous upper bound)
+      expect(elapsedMs).toBeLessThan(2_000);
 
-        void pool.end();
-      },
-      // Test-level timeout: well above the pool timeout, below the default 5s
-      3_000,
-    );
+      void pool.end();
+    }, 3_000); // Test-level timeout: well above the pool timeout, below the default 5s
   });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -9,9 +9,18 @@ export type DbClientOptions = PoolConfig & {
   schema: string;
 };
 
+// Unresponsive Postgres must fail fast — these defaults apply unless the
+// caller explicitly overrides them.
+const TIMEOUT_DEFAULTS = {
+  connectionTimeoutMillis: 10_000,
+  idleTimeoutMillis: 30_000,
+  statement_timeout: 30_000,
+  query_timeout: 30_000,
+} satisfies PoolConfig;
+
 export function createDbClient(opts: DbClientOptions): Pool {
   const { schema, ...config } = opts;
-  const pool = new Pool(config);
+  const pool = new Pool({ ...TIMEOUT_DEFAULTS, ...config });
 
   pool.on('connect', client => {
     void client.query(`SET search_path TO "${schema}", public`);

--- a/packages/lib.types/src/types/index.ts
+++ b/packages/lib.types/src/types/index.ts
@@ -108,7 +108,14 @@ export type Permission =
   | 'emails.templates.delete'
   | 'emails.send'
   | 'emails.queue.manage'
-  | 'users.profile.update';
+  | 'users.profile.update'
+  | 'reports.read'
+  | 'reports.read:any'
+  | 'reports.create'
+  | 'reports.update'
+  | 'reports.update:any'
+  | 'reports.delete'
+  | 'reports.delete:any';
 
 /**
  * User with permissions

--- a/services/applications/src/grpc/pets-client.test.ts
+++ b/services/applications/src/grpc/pets-client.test.ts
@@ -1,0 +1,185 @@
+// Behaviour tests for the applications pets-client:
+//   1. A server that never responds → DEADLINE_EXCEEDED within the
+//      configured deadline (bounded by time, not just error code).
+//   2. A server that fails once with UNAVAILABLE then succeeds →
+//      the call resolves and exactly 2 handler invocations occurred.
+//   3. A server that always returns INVALID_ARGUMENT → no retry,
+//      error propagates after exactly 1 attempt.
+//
+// Each test binds a real @grpc/grpc-js Server to 127.0.0.1:0 so there
+// are no port conflicts; the server is torn down in afterEach.
+
+import { promisify } from 'node:util';
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import {
+  PetsV1,
+  type GetPetRequest,
+  type GetPetResponse,
+} from '@adopt-dont-shop/proto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createPetsClient } from './pets-client.js';
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const bindAsync = promisify<string, ServerCredentials, number>(
+  // Bind signature: (address, creds, cb) — promisify wraps that.
+  (addr: string, creds: ServerCredentials, cb: (err: Error | null, port: number) => void) =>
+    new Server().bindAsync(addr, creds, cb)
+);
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+const emptyMetadata = new Metadata();
+const emptyGetRequest: GetPetRequest = { petId: 'test-pet-id' };
+
+// ── test suite ───────────────────────────────────────────────────────
+
+describe('createPetsClient (applications) — deadline + retry behaviour', () => {
+  let server: Server;
+  let port: number;
+
+  beforeEach(async () => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> => {
+    const p = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(boundPort);
+        }
+      });
+    });
+    return p;
+  };
+
+  it('rejects with DEADLINE_EXCEEDED when the server never responds, within the deadline window', async () => {
+    server.addService(PetsV1.PetServiceService, {
+      get: (_call: ServerUnaryCall<GetPetRequest, GetPetResponse>, _cb: sendUnaryData<GetPetResponse>) => {
+        // Intentionally never call _cb — simulates a hung server.
+      },
+      // Stub remaining methods to satisfy the service definition.
+      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      list: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+    });
+
+    port = await startServer();
+    const client = createPetsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 200,
+      maxRetries: 0, // no retries so the test is fast
+    });
+
+    const start = Date.now();
+    try {
+      await client.getPet(emptyGetRequest, emptyMetadata);
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      const elapsed = Date.now() - start;
+      expect((err as { code?: number }).code).toBe(status.DEADLINE_EXCEEDED);
+      // Should finish near the deadline — allow generous upper bound for CI.
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('resolves on the second attempt when the first attempt returns UNAVAILABLE', async () => {
+    let callCount = 0;
+    const successResponse: GetPetResponse = { pet: undefined };
+
+    server.addService(PetsV1.PetServiceService, {
+      get: (_call: ServerUnaryCall<GetPetRequest, GetPetResponse>, cb: sendUnaryData<GetPetResponse>) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, successResponse);
+        }
+      },
+      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      list: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+    });
+
+    port = await startServer();
+    const client = createPetsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      const result = await client.getPet(emptyGetRequest, emptyMetadata);
+      expect(result).toEqual(successResponse);
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('does not retry INVALID_ARGUMENT and propagates the error after exactly 1 attempt', async () => {
+    let callCount = 0;
+
+    server.addService(PetsV1.PetServiceService, {
+      get: (_call: ServerUnaryCall<GetPetRequest, GetPetResponse>, cb: sendUnaryData<GetPetResponse>) => {
+        callCount += 1;
+        cb(makeServiceError(status.INVALID_ARGUMENT, 'bad request'), null);
+      },
+      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      list: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+    });
+
+    port = await startServer();
+    const client = createPetsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      await client.getPet(emptyGetRequest, emptyMetadata);
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      expect((err as { code?: number }).code).toBe(status.INVALID_ARGUMENT);
+      expect(callCount).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/applications/src/grpc/pets-client.test.ts
+++ b/services/applications/src/grpc/pets-client.test.ts
@@ -21,11 +21,7 @@ import {
   status,
 } from '@grpc/grpc-js';
 
-import {
-  PetsV1,
-  type GetPetRequest,
-  type GetPetResponse,
-} from '@adopt-dont-shop/proto';
+import { PetsV1, type GetPetRequest, type GetPetResponse } from '@adopt-dont-shop/proto';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -79,16 +75,25 @@ describe('createPetsClient (applications) — deadline + retry behaviour', () =>
 
   it('rejects with DEADLINE_EXCEEDED when the server never responds, within the deadline window', async () => {
     server.addService(PetsV1.PetServiceService, {
-      get: (_call: ServerUnaryCall<GetPetRequest, GetPetResponse>, _cb: sendUnaryData<GetPetResponse>) => {
+      get: (
+        _call: ServerUnaryCall<GetPetRequest, GetPetResponse>,
+        _cb: sendUnaryData<GetPetResponse>
+      ) => {
         // Intentionally never call _cb — simulates a hung server.
       },
       // Stub remaining methods to satisfy the service definition.
-      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      list: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      create: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      list: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
     });
 
     port = await startServer();
@@ -117,7 +122,10 @@ describe('createPetsClient (applications) — deadline + retry behaviour', () =>
     const successResponse: GetPetResponse = { pet: undefined };
 
     server.addService(PetsV1.PetServiceService, {
-      get: (_call: ServerUnaryCall<GetPetRequest, GetPetResponse>, cb: sendUnaryData<GetPetResponse>) => {
+      get: (
+        _call: ServerUnaryCall<GetPetRequest, GetPetResponse>,
+        cb: sendUnaryData<GetPetResponse>
+      ) => {
         callCount += 1;
         if (callCount === 1) {
           cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
@@ -125,12 +133,18 @@ describe('createPetsClient (applications) — deadline + retry behaviour', () =>
           cb(null, successResponse);
         }
       },
-      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      list: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      create: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      list: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
     });
 
     port = await startServer();
@@ -153,16 +167,25 @@ describe('createPetsClient (applications) — deadline + retry behaviour', () =>
     let callCount = 0;
 
     server.addService(PetsV1.PetServiceService, {
-      get: (_call: ServerUnaryCall<GetPetRequest, GetPetResponse>, cb: sendUnaryData<GetPetResponse>) => {
+      get: (
+        _call: ServerUnaryCall<GetPetRequest, GetPetResponse>,
+        cb: sendUnaryData<GetPetResponse>
+      ) => {
         callCount += 1;
         cb(makeServiceError(status.INVALID_ARGUMENT, 'bad request'), null);
       },
-      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      list: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      create: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      list: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
     });
 
     port = await startServer();

--- a/services/applications/src/grpc/pets-client.ts
+++ b/services/applications/src/grpc/pets-client.ts
@@ -38,7 +38,9 @@ const DEFAULT_MAX_RETRIES = 2;
 const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
 
 const isRetryableError = (err: unknown): boolean => {
-  if (err === null || typeof err !== 'object') return false;
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
   const code = (err as { code?: unknown }).code;
   return typeof code === 'number' && RETRYABLE_CODES.has(code);
 };

--- a/services/applications/src/grpc/pets-client.ts
+++ b/services/applications/src/grpc/pets-client.ts
@@ -11,7 +11,7 @@
 // pets. The interface is exported so the gRPC server boot can inject a
 // real client and tests can substitute a stub.
 
-import { credentials, type Metadata } from '@grpc/grpc-js';
+import { credentials, status, type CallOptions, type Metadata } from '@grpc/grpc-js';
 
 import { PetsV1, type GetPetRequest, type GetPetResponse } from '@adopt-dont-shop/proto';
 
@@ -22,22 +22,76 @@ export type PetsClient = {
 
 export type CreatePetsClientOptions = {
   address: string;
+  // Per-call deadline in milliseconds. Without one, a hung downstream
+  // service would hang this request forever; 5s caps the blast radius
+  // and lets the caller fail fast with DEADLINE_EXCEEDED.
+  deadlineMs?: number;
+  // Maximum additional attempts after the first. Only UNAVAILABLE and
+  // DEADLINE_EXCEEDED trigger a retry (both are safe for idempotent
+  // reads). Defaults to 2 (i.e. up to 3 total attempts).
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+// Retry-eligible status codes for idempotent reads.
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  // Exponential backoff with ±25% jitter: 100ms, 200ms (base defaults).
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
 };
 
 export const createPetsClient = (opts: CreatePetsClientOptions): PetsClient => {
   const stub = new PetsV1.PetServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
 
-  return {
-    getPet: (req, metadata) =>
-      new Promise<GetPetResponse>((resolve, reject) => {
-        stub.get(req, metadata, (err: unknown, res: GetPetResponse) => {
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
           if (err) {
-            reject(err);
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
             return;
           }
           resolve(res);
         });
-      }),
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    getPet: (req, metadata) => callWithRetry(stub.get, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/applications/src/index.ts
+++ b/services/applications/src/index.ts
@@ -14,6 +14,7 @@ const main = async (): Promise<void> => {
   let pool: ReturnType<typeof createDbClient> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -34,6 +35,7 @@ const main = async (): Promise<void> => {
     }
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
     // Reports back via gdpr.erasureCompleted with service='applications'.
     const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
@@ -46,7 +48,7 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.applications running', {

--- a/services/applications/src/server.ts
+++ b/services/applications/src/server.ts
@@ -26,11 +26,16 @@ export type CreateServerOptions = {
   // service emits structured lines through the same pipeline as the
   // rest of the stack.
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.applications' });
+  const isReady = opts.isReady ?? (() => true);
 
   // Disable Fastify's built-in pino — winston handles service-level
   // lines (boot, shutdown, error handler), and OTel's HTTP
@@ -60,12 +65,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck
-  // pattern picks this service up unchanged.
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.applications',
-    environment: config.environment,
-  }));
+  // pattern picks this service up unchanged. Returns 503 until the
+  // gRPC server has bound (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.applications', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/audit/src/grpc/reports-handlers.test.ts
+++ b/services/audit/src/grpc/reports-handlers.test.ts
@@ -209,16 +209,29 @@ describe('updateSavedReport', () => {
     expect(sql).toContain('user_id = $');
   });
 
-  it('admin with :any updates any row', async () => {
+  it('admin with reports.update:any updates any row', async () => {
     queryMock.mockResolvedValue({ rows: [makeRow({ name: 'New' })] });
     const res = await updateSavedReport(
       deps,
-      makePrincipal({ permissions: ['reports.update', 'reports.read:any'] }),
+      makePrincipal({ permissions: ['reports.update', 'reports.update:any'] }),
       { savedReportId: 'rep-1', name: 'New' }
     );
     expect(res.report?.name).toBe('New');
     const sql = queryMock.mock.calls[0][0] as string;
     expect(sql).not.toContain('user_id = $');
+  });
+
+  it('reports.read:any alone does NOT broaden write scoping (regression)', async () => {
+    queryMock.mockResolvedValue({ rows: [], rowCount: 0 });
+    await expect(
+      updateSavedReport(
+        deps,
+        makePrincipal({ permissions: ['reports.update', 'reports.read:any'] }),
+        { savedReportId: 'rep-1', name: 'New' }
+      )
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    const sql = queryMock.mock.calls[0][0] as string;
+    expect(sql).toContain('user_id = $');
   });
 
   it('validates JSON config when configJson is sent', async () => {
@@ -257,6 +270,41 @@ describe('deleteSavedReport', () => {
       savedReportId: 'rep-x',
     });
     expect(res.deleted).toBe(false);
+  });
+
+  it('scopes WHERE to user_id when caller has reports.delete but not reports.delete:any', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    const { deps } = makeDeps(q);
+    await deleteSavedReport(deps, makePrincipal({ permissions: ['reports.delete'] }), {
+      savedReportId: 'rep-1',
+    });
+    const sql = q.mock.calls[0][0] as string;
+    expect(sql).toContain('user_id = $');
+  });
+
+  it('admin with reports.delete:any deletes any row without user_id scope', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [{ saved_report_id: 'rep-1' }], rowCount: 1 });
+    const { deps } = makeDeps(q);
+    const res = await deleteSavedReport(
+      deps,
+      makePrincipal({ permissions: ['reports.delete', 'reports.delete:any'] }),
+      { savedReportId: 'rep-1' }
+    );
+    expect(res.deleted).toBe(true);
+    const sql = q.mock.calls[0][0] as string;
+    expect(sql).not.toContain('user_id = $');
+  });
+
+  it('reports.read:any alone does NOT broaden delete scoping (regression)', async () => {
+    const q = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    const { deps } = makeDeps(q);
+    await deleteSavedReport(
+      deps,
+      makePrincipal({ permissions: ['reports.delete', 'reports.read:any'] }),
+      { savedReportId: 'rep-1' }
+    );
+    const sql = q.mock.calls[0][0] as string;
+    expect(sql).toContain('user_id = $');
   });
 });
 

--- a/services/audit/src/grpc/reports-handlers.ts
+++ b/services/audit/src/grpc/reports-handlers.ts
@@ -10,6 +10,8 @@
 //   reports.read[:any] for reads — without :any, only the principal's
 //     own user_id is returned
 //   reports.create / reports.update / reports.delete for writes
+//   reports.update:any to update any user's saved report (not gated on read:any)
+//   reports.delete:any to delete any user's saved report (not gated on read:any)
 //   reports.read for ListReportTemplates (no separate template perm —
 //     templates aren't sensitive)
 
@@ -35,11 +37,13 @@ import type { Principal } from '@adopt-dont-shop/authz';
 
 import { HandlerError, type HandlerDeps } from './adapter.js';
 
-const REPORTS_READ: Permission = 'reports.read' as Permission;
-const REPORTS_READ_ANY: Permission = 'reports.read:any' as Permission;
-const REPORTS_CREATE: Permission = 'reports.create' as Permission;
-const REPORTS_UPDATE: Permission = 'reports.update' as Permission;
-const REPORTS_DELETE: Permission = 'reports.delete' as Permission;
+const REPORTS_READ: Permission = 'reports.read';
+const REPORTS_READ_ANY: Permission = 'reports.read:any';
+const REPORTS_CREATE: Permission = 'reports.create';
+const REPORTS_UPDATE: Permission = 'reports.update';
+const REPORTS_UPDATE_ANY: Permission = 'reports.update:any';
+const REPORTS_DELETE: Permission = 'reports.delete';
+const REPORTS_DELETE_ANY: Permission = 'reports.delete:any';
 
 const SAVED_REPORT_COLUMNS = `saved_report_id, user_id, rescue_id, template_id, name,
   description, config, is_archived, created_at, updated_at`;
@@ -327,7 +331,7 @@ export async function updateSavedReport(
 
   // Self-ownership filter on the UPDATE for users without :any.
   let whereClause = `saved_report_id = $${params.length} AND deleted_at IS NULL`;
-  if (!hasPerm(principal, REPORTS_READ_ANY)) {
+  if (!hasPerm(principal, REPORTS_UPDATE_ANY)) {
     params.push(principal.userId);
     whereClause += ` AND user_id = $${params.length}`;
   }
@@ -361,7 +365,7 @@ export async function deleteSavedReport(
 
   const params: unknown[] = [id];
   let whereClause = `saved_report_id = $1 AND deleted_at IS NULL`;
-  if (!hasPerm(principal, REPORTS_READ_ANY)) {
+  if (!hasPerm(principal, REPORTS_DELETE_ANY)) {
     params.push(principal.userId);
     whereClause += ` AND user_id = $2`;
   }

--- a/services/audit/src/index.ts
+++ b/services/audit/src/index.ts
@@ -18,6 +18,7 @@ const main = async (): Promise<void> => {
   let grpc: RunningGrpcServer | undefined;
   let subscriptions: SubscriptionHandle[] = [];
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -38,6 +39,7 @@ const main = async (): Promise<void> => {
     }
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    grpcReady = true;
 
     // NATS subscribers register AFTER the gRPC server is up so the
     // service is never in a state where it's accepting NATS messages
@@ -48,7 +50,7 @@ const main = async (): Promise<void> => {
       ...registerGdprSubscribers({ nats, pool, logger }),
     ];
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.audit running', {

--- a/services/audit/src/server.test.ts
+++ b/services/audit/src/server.test.ts
@@ -66,6 +66,54 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — readiness probe', () => {
+  it('returns 503 with status starting when isReady returns false', async () => {
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => false,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ status: 'starting' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 once isReady flips to true', async () => {
+    let ready = false;
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => ready,
+    });
+    try {
+      const notReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(notReady.statusCode).toBe(503);
+
+      ready = true;
+
+      const nowReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(nowReady.statusCode).toBe(200);
+      expect(nowReady.json()).toMatchObject({ status: 'ok' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('defaults to ready (isReady omitted) — existing behaviour unchanged', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
     const server = createServer({ config: baseConfig, logger: quietLogger });

--- a/services/audit/src/server.ts
+++ b/services/audit/src/server.ts
@@ -24,11 +24,16 @@ export type CreateServerOptions = {
   // service emits structured lines through the same pipeline as the
   // rest of the stack.
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.audit' });
+  const isReady = opts.isReady ?? (() => true);
 
   // Disable Fastify's built-in pino — winston handles service-level
   // lines (boot, shutdown, error handler), and OTel's HTTP
@@ -58,12 +63,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck
-  // pattern picks this service up unchanged.
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.audit',
-    environment: config.environment,
-  }));
+  // pattern picks this service up unchanged. Returns 503 until the
+  // gRPC server has bound (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.audit', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -16,6 +16,7 @@ const main = async (): Promise<void> => {
   let pool: ReturnType<typeof createDbClient> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -46,6 +47,7 @@ const main = async (): Promise<void> => {
       tokenIssuer,
       logger,
     });
+    grpcReady = true;
 
     // GDPR erasure subscriber. Listens on `gdpr.erasureRequested`,
     // scrubs the user's row + drops sessions/prefs/roles, then publishes
@@ -61,7 +63,7 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.auth running', {

--- a/services/auth/src/server.test.ts
+++ b/services/auth/src/server.test.ts
@@ -59,6 +59,54 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — readiness probe', () => {
+  it('returns 503 with status starting when isReady returns false', async () => {
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => false,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ status: 'starting' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 once isReady flips to true', async () => {
+    let ready = false;
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => ready,
+    });
+    try {
+      const notReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(notReady.statusCode).toBe(503);
+
+      ready = true;
+
+      const nowReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(nowReady.statusCode).toBe(200);
+      expect(nowReady.json()).toMatchObject({ status: 'ok' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('defaults to ready (isReady omitted) — existing behaviour unchanged', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
     const server = createServer({ config: baseConfig, logger: quietLogger });

--- a/services/auth/src/server.ts
+++ b/services/auth/src/server.ts
@@ -19,11 +19,16 @@ export type CreateServerOptions = {
   // service emits structured lines through the same pipeline as the
   // rest of the stack.
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.auth' });
+  const isReady = opts.isReady ?? (() => true);
 
   // Disable Fastify's built-in pino — winston handles service-level
   // lines (boot, shutdown, error handler), and OTel's HTTP
@@ -53,12 +58,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck
-  // pattern picks this service up unchanged.
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.auth',
-    environment: config.environment,
-  }));
+  // pattern picks this service up unchanged. Returns 503 until the
+  // gRPC server has bound (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.auth', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -14,6 +14,7 @@ const main = async (): Promise<void> => {
   let pool: Awaited<ReturnType<typeof createDbClient>> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -31,6 +32,7 @@ const main = async (): Promise<void> => {
     }
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
     // Reports back via gdpr.erasureCompleted with service='chat'.
     const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
@@ -43,7 +45,7 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.chat running', {

--- a/services/chat/src/server.test.ts
+++ b/services/chat/src/server.test.ts
@@ -66,6 +66,54 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — readiness probe', () => {
+  it('returns 503 with status starting when isReady returns false', async () => {
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => false,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ status: 'starting' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 once isReady flips to true', async () => {
+    let ready = false;
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => ready,
+    });
+    try {
+      const notReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(notReady.statusCode).toBe(503);
+
+      ready = true;
+
+      const nowReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(nowReady.statusCode).toBe(200);
+      expect(nowReady.json()).toMatchObject({ status: 'ok' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('defaults to ready (isReady omitted) — existing behaviour unchanged', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
     const server = createServer({ config: baseConfig, logger: quietLogger });

--- a/services/chat/src/server.ts
+++ b/services/chat/src/server.ts
@@ -23,11 +23,16 @@ export type CreateServerOptions = {
   // service emits structured lines through the same pipeline as the
   // rest of the stack.
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.chat' });
+  const isReady = opts.isReady ?? (() => true);
 
   // Disable Fastify's built-in pino — winston handles service-level
   // lines (boot, shutdown, error handler), and OTel's HTTP
@@ -57,12 +62,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck
-  // pattern picks this service up unchanged.
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.chat',
-    environment: config.environment,
-  }));
+  // pattern picks this service up unchanged. Returns 503 until the
+  // gRPC server has bound (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.chat', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/cms/src/index.ts
+++ b/services/cms/src/index.ts
@@ -14,6 +14,7 @@ const main = async (): Promise<void> => {
   let pool: Awaited<ReturnType<typeof createDbClient>> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -26,6 +27,7 @@ const main = async (): Promise<void> => {
       await ensureStream(nats);
     }
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
     // Reports back via gdpr.erasureCompleted with service='cms'.
     const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
@@ -38,7 +40,7 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.cms running', {

--- a/services/cms/src/server.test.ts
+++ b/services/cms/src/server.test.ts
@@ -1,7 +1,7 @@
 import { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import type { ApplicationsConfig } from './config.js';
+import type { CmsConfig } from './config.js';
 import { createServer } from './server.js';
 
 const quietLogger = {
@@ -12,13 +12,13 @@ const quietLogger = {
   silly: () => undefined,
 } as unknown as ReturnType<typeof import('@adopt-dont-shop/observability').createLogger>;
 
-const baseConfig: ApplicationsConfig = {
+const baseConfig: CmsConfig = {
   port: 0,
   grpcPort: 0,
   host: '127.0.0.1',
   environment: 'test',
   databaseUrl: 'postgres://test',
-  schema: 'applications',
+  schema: 'cms',
   natsUrl: 'nats://localhost:4222',
 };
 
@@ -38,7 +38,7 @@ describe('createServer — health endpoint', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({
       status: 'ok',
-      service: 'service.applications',
+      service: 'service.cms',
       environment: 'test',
     });
   });

--- a/services/cms/src/server.ts
+++ b/services/cms/src/server.ts
@@ -7,11 +7,16 @@ import type { CmsConfig } from './config.js';
 export type CreateServerOptions = {
   config: CmsConfig;
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.cms' });
+  const isReady = opts.isReady ?? (() => true);
   const server = Fastify({ logger: false, trustProxy: true });
 
   server.setErrorHandler((err: Error & { statusCode?: number }, req, reply) => {
@@ -27,12 +32,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   // hook. Substrate only — no domain-specific instruments here.
   registerMetrics(server);
 
-  // Health endpoint — same path the rest of the stack uses.
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.cms',
-    environment: config.environment,
-  }));
+  // Health endpoint — same path the rest of the stack uses. Returns 503
+  // until the gRPC server has bound (isReady probe), then the 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.cms', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/matching/src/grpc/pets-client.test.ts
+++ b/services/matching/src/grpc/pets-client.test.ts
@@ -1,0 +1,182 @@
+// Behaviour tests for the matching pets-client:
+//   1. A server that never responds → DEADLINE_EXCEEDED within the
+//      configured deadline (bounded by time, not just error code).
+//   2. A server that fails once with UNAVAILABLE then succeeds →
+//      the call resolves and exactly 2 handler invocations occurred.
+//   3. A server that always returns INVALID_ARGUMENT → no retry,
+//      error propagates after exactly 1 attempt.
+//
+// Each test binds a real @grpc/grpc-js Server to 127.0.0.1:0 so there
+// are no port conflicts; the server is torn down in afterEach.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import {
+  PetsV1,
+  type ListPetsRequest,
+  type ListPetsResponse,
+} from '@adopt-dont-shop/proto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createPetsClient } from './pets-client.js';
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+const emptyMetadata = new Metadata();
+const emptyListRequest: ListPetsRequest = {
+  limit: 0,
+  statusFilter: 0,
+  typeFilter: 0,
+  sizeFilter: 0,
+};
+
+// ── test suite ───────────────────────────────────────────────────────
+
+describe('createPetsClient (matching) — deadline + retry behaviour', () => {
+  let server: Server;
+  let port: number;
+
+  beforeEach(async () => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> => {
+    const p = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(boundPort);
+        }
+      });
+    });
+    return p;
+  };
+
+  it('rejects with DEADLINE_EXCEEDED when the server never responds, within the deadline window', async () => {
+    server.addService(PetsV1.PetServiceService, {
+      list: (_call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>, _cb: sendUnaryData<ListPetsResponse>) => {
+        // Intentionally never call _cb — simulates a hung server.
+      },
+      // Stub remaining methods to satisfy the service definition.
+      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      get: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+    });
+
+    port = await startServer();
+    const client = createPetsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 200,
+      maxRetries: 0, // no retries so the test is fast
+    });
+
+    const start = Date.now();
+    try {
+      await client.listPets(emptyListRequest, emptyMetadata);
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      const elapsed = Date.now() - start;
+      expect((err as { code?: number }).code).toBe(status.DEADLINE_EXCEEDED);
+      // Should finish near the deadline — allow generous upper bound for CI.
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('resolves on the second attempt when the first attempt returns UNAVAILABLE', async () => {
+    let callCount = 0;
+    const successResponse: ListPetsResponse = { pets: [], nextCursor: undefined };
+
+    server.addService(PetsV1.PetServiceService, {
+      list: (_call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>, cb: sendUnaryData<ListPetsResponse>) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, successResponse);
+        }
+      },
+      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      get: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+    });
+
+    port = await startServer();
+    const client = createPetsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      const result = await client.listPets(emptyListRequest, emptyMetadata);
+      expect(result).toEqual(successResponse);
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('does not retry INVALID_ARGUMENT and propagates the error after exactly 1 attempt', async () => {
+    let callCount = 0;
+
+    server.addService(PetsV1.PetServiceService, {
+      list: (_call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>, cb: sendUnaryData<ListPetsResponse>) => {
+        callCount += 1;
+        cb(makeServiceError(status.INVALID_ARGUMENT, 'bad request'), null);
+      },
+      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      get: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+    });
+
+    port = await startServer();
+    const client = createPetsClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      await client.listPets(emptyListRequest, emptyMetadata);
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      expect((err as { code?: number }).code).toBe(status.INVALID_ARGUMENT);
+      expect(callCount).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/matching/src/grpc/pets-client.test.ts
+++ b/services/matching/src/grpc/pets-client.test.ts
@@ -19,11 +19,7 @@ import {
   status,
 } from '@grpc/grpc-js';
 
-import {
-  PetsV1,
-  type ListPetsRequest,
-  type ListPetsResponse,
-} from '@adopt-dont-shop/proto';
+import { PetsV1, type ListPetsRequest, type ListPetsResponse } from '@adopt-dont-shop/proto';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -76,16 +72,25 @@ describe('createPetsClient (matching) — deadline + retry behaviour', () => {
 
   it('rejects with DEADLINE_EXCEEDED when the server never responds, within the deadline window', async () => {
     server.addService(PetsV1.PetServiceService, {
-      list: (_call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>, _cb: sendUnaryData<ListPetsResponse>) => {
+      list: (
+        _call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>,
+        _cb: sendUnaryData<ListPetsResponse>
+      ) => {
         // Intentionally never call _cb — simulates a hung server.
       },
       // Stub remaining methods to satisfy the service definition.
-      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      get: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      create: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      get: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
     });
 
     port = await startServer();
@@ -114,7 +119,10 @@ describe('createPetsClient (matching) — deadline + retry behaviour', () => {
     const successResponse: ListPetsResponse = { pets: [], nextCursor: undefined };
 
     server.addService(PetsV1.PetServiceService, {
-      list: (_call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>, cb: sendUnaryData<ListPetsResponse>) => {
+      list: (
+        _call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>,
+        cb: sendUnaryData<ListPetsResponse>
+      ) => {
         callCount += 1;
         if (callCount === 1) {
           cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
@@ -122,12 +130,18 @@ describe('createPetsClient (matching) — deadline + retry behaviour', () => {
           cb(null, successResponse);
         }
       },
-      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      get: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      create: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      get: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
     });
 
     port = await startServer();
@@ -150,16 +164,25 @@ describe('createPetsClient (matching) — deadline + retry behaviour', () => {
     let callCount = 0;
 
     server.addService(PetsV1.PetServiceService, {
-      list: (_call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>, cb: sendUnaryData<ListPetsResponse>) => {
+      list: (
+        _call: ServerUnaryCall<ListPetsRequest, ListPetsResponse>,
+        cb: sendUnaryData<ListPetsResponse>
+      ) => {
         callCount += 1;
         cb(makeServiceError(status.INVALID_ARGUMENT, 'bad request'), null);
       },
-      create: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      get: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      update: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      delete: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
-      getStats: (_call: unknown, cb: sendUnaryData<unknown>) => cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      create: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      get: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      update: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      updateStatus: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      delete: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
+      getStats: (_call: unknown, cb: sendUnaryData<unknown>) =>
+        cb(makeServiceError(status.UNIMPLEMENTED, 'not used'), null),
     });
 
     port = await startServer();

--- a/services/matching/src/grpc/pets-client.ts
+++ b/services/matching/src/grpc/pets-client.ts
@@ -36,7 +36,9 @@ const DEFAULT_MAX_RETRIES = 2;
 const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
 
 const isRetryableError = (err: unknown): boolean => {
-  if (err === null || typeof err !== 'object') return false;
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
   const code = (err as { code?: unknown }).code;
   return typeof code === 'number' && RETRYABLE_CODES.has(code);
 };

--- a/services/matching/src/grpc/pets-client.ts
+++ b/services/matching/src/grpc/pets-client.ts
@@ -9,7 +9,7 @@
 // client and tests can substitute a stub. Direct port of
 // services/applications/src/grpc/pets-client.ts.
 
-import { credentials, type Metadata } from '@grpc/grpc-js';
+import { credentials, status, type CallOptions, type Metadata } from '@grpc/grpc-js';
 
 import { PetsV1, type ListPetsRequest, type ListPetsResponse } from '@adopt-dont-shop/proto';
 
@@ -20,22 +20,76 @@ export type PetsClient = {
 
 export type CreatePetsClientOptions = {
   address: string;
+  // Per-call deadline in milliseconds. Without one, a hung downstream
+  // service would hang this request forever; 5s caps the blast radius
+  // and lets the caller fail fast with DEADLINE_EXCEEDED.
+  deadlineMs?: number;
+  // Maximum additional attempts after the first. Only UNAVAILABLE and
+  // DEADLINE_EXCEEDED trigger a retry (both are safe for idempotent
+  // reads). Defaults to 2 (i.e. up to 3 total attempts).
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+// Retry-eligible status codes for idempotent reads.
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  // Exponential backoff with ±25% jitter: 100ms, 200ms (base defaults).
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
 };
 
 export const createPetsClient = (opts: CreatePetsClientOptions): PetsClient => {
   const stub = new PetsV1.PetServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
 
-  return {
-    listPets: (req, metadata) =>
-      new Promise<ListPetsResponse>((resolve, reject) => {
-        stub.list(req, metadata, (err: unknown, res: ListPetsResponse) => {
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req,
+    metadata: Metadata
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, metadata, options, (err: unknown, res: Res) => {
           if (err) {
-            reject(err);
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
             return;
           }
           resolve(res);
         });
-      }),
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    listPets: (req, metadata) => callWithRetry(stub.list, req, metadata),
     close: () => stub.close(),
   };
 };

--- a/services/matching/src/index.ts
+++ b/services/matching/src/index.ts
@@ -14,6 +14,7 @@ const main = async (): Promise<void> => {
   let pool: ReturnType<typeof createDbClient> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -34,6 +35,7 @@ const main = async (): Promise<void> => {
     }
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
     // Reports back via gdpr.erasureCompleted with service='matching'.
     const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
@@ -46,7 +48,7 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.matching running', {

--- a/services/matching/src/server.test.ts
+++ b/services/matching/src/server.test.ts
@@ -65,6 +65,54 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — readiness probe', () => {
+  it('returns 503 with status starting when isReady returns false', async () => {
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => false,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ status: 'starting' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 once isReady flips to true', async () => {
+    let ready = false;
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => ready,
+    });
+    try {
+      const notReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(notReady.statusCode).toBe(503);
+
+      ready = true;
+
+      const nowReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(nowReady.statusCode).toBe(200);
+      expect(nowReady.json()).toMatchObject({ status: 'ok' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('defaults to ready (isReady omitted) — existing behaviour unchanged', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
     const server = createServer({ config: baseConfig, logger: quietLogger });

--- a/services/matching/src/server.ts
+++ b/services/matching/src/server.ts
@@ -10,11 +10,16 @@ import type { MatchingConfig } from './config.js';
 export type CreateServerOptions = {
   config: MatchingConfig;
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.matching' });
+  const isReady = opts.isReady ?? (() => true);
 
   const server = Fastify({ logger: false, trustProxy: true });
 
@@ -35,11 +40,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   // hook. Substrate only — no domain-specific instruments here.
   registerMetrics(server);
 
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.matching',
-    environment: config.environment,
-  }));
+  // Health endpoint — returns 503 until the gRPC server has bound
+  // (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.matching', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/moderation/src/index.ts
+++ b/services/moderation/src/index.ts
@@ -15,6 +15,7 @@ const main = async (): Promise<void> => {
   let pool: ReturnType<typeof createDbClient> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -35,6 +36,7 @@ const main = async (): Promise<void> => {
     }
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
     // Reports back via gdpr.erasureCompleted with service='moderation'.
     const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
@@ -53,7 +55,7 @@ const main = async (): Promise<void> => {
     // connection on shutdown.
     registerSubscribers({ nats, deps: { pool, nats }, logger });
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.moderation running', {

--- a/services/moderation/src/server.test.ts
+++ b/services/moderation/src/server.test.ts
@@ -65,6 +65,54 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — readiness probe', () => {
+  it('returns 503 with status starting when isReady returns false', async () => {
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => false,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ status: 'starting' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 once isReady flips to true', async () => {
+    let ready = false;
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => ready,
+    });
+    try {
+      const notReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(notReady.statusCode).toBe(503);
+
+      ready = true;
+
+      const nowReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(nowReady.statusCode).toBe(200);
+      expect(nowReady.json()).toMatchObject({ status: 'ok' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('defaults to ready (isReady omitted) — existing behaviour unchanged', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
     const server = createServer({ config: baseConfig, logger: quietLogger });

--- a/services/moderation/src/server.ts
+++ b/services/moderation/src/server.ts
@@ -15,11 +15,16 @@ import type { ModerationConfig } from './config.js';
 export type CreateServerOptions = {
   config: ModerationConfig;
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.moderation' });
+  const isReady = opts.isReady ?? (() => true);
 
   const server = Fastify({ logger: false, trustProxy: true });
 
@@ -40,11 +45,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   // hook. Substrate only — no domain-specific instruments here.
   registerMetrics(server);
 
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.moderation',
-    environment: config.environment,
-  }));
+  // Health endpoint — returns 503 until the gRPC server has bound
+  // (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.moderation', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/notifications/src/grpc/auth-client.test.ts
+++ b/services/notifications/src/grpc/auth-client.test.ts
@@ -1,0 +1,180 @@
+// Behaviour tests for the notifications auth-client:
+//   1. A server that never responds → DEADLINE_EXCEEDED within the
+//      configured deadline (bounded by time, not just error code).
+//   2. A server that fails once with UNAVAILABLE then succeeds →
+//      the call resolves and exactly 2 handler invocations occurred.
+//   3. A server that always returns INVALID_ARGUMENT → no retry,
+//      error propagates after exactly 1 attempt.
+//
+// Each test binds a real @grpc/grpc-js Server to 127.0.0.1:0 so there
+// are no port conflicts; the server is torn down in afterEach.
+//
+// Note: the auth-client stamps system metadata internally, so callers
+// don't supply Metadata — this test just verifies that the retry and
+// deadline logic fires correctly.
+
+import {
+  Metadata,
+  Server,
+  ServerCredentials,
+  ServerUnaryCall,
+  sendUnaryData,
+  ServiceError,
+  status,
+} from '@grpc/grpc-js';
+
+import {
+  AuthV1,
+  type ListUserIdsByCohortRequest,
+  type ListUserIdsByCohortResponse,
+} from '@adopt-dont-shop/proto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createAuthCohortClient } from './auth-client.js';
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const makeServiceError = (code: number, details: string): ServiceError => {
+  const err = new Error(details) as ServiceError;
+  err.code = code;
+  err.details = details;
+  err.metadata = new Metadata();
+  return err;
+};
+
+const emptyListRequest: ListUserIdsByCohortRequest = {
+  userTypes: [],
+  statuses: [],
+  page: 1,
+  limit: 10,
+};
+
+// ── test suite ───────────────────────────────────────────────────────
+
+describe('createAuthCohortClient (notifications) — deadline + retry behaviour', () => {
+  let server: Server;
+  let port: number;
+
+  beforeEach(async () => {
+    server = new Server();
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.tryShutdown(() => resolve()));
+  });
+
+  const startServer = async (): Promise<number> => {
+    const p = await new Promise<number>((resolve, reject) => {
+      server.bindAsync('127.0.0.1:0', ServerCredentials.createInsecure(), (err, boundPort) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(boundPort);
+        }
+      });
+    });
+    return p;
+  };
+
+  it('rejects with DEADLINE_EXCEEDED when the server never responds, within the deadline window', async () => {
+    server.addService(AuthV1.AuthServiceService, {
+      listUserIdsByCohort: (
+        _call: ServerUnaryCall<ListUserIdsByCohortRequest, ListUserIdsByCohortResponse>,
+        _cb: sendUnaryData<ListUserIdsByCohortResponse>
+      ) => {
+        // Intentionally never call _cb — simulates a hung server.
+      },
+    });
+
+    port = await startServer();
+    const client = createAuthCohortClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 200,
+      maxRetries: 0, // no retries so the test is fast
+    });
+
+    const start = Date.now();
+    try {
+      await client.listUserIdsByCohort(emptyListRequest);
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      const elapsed = Date.now() - start;
+      expect((err as { code?: number }).code).toBe(status.DEADLINE_EXCEEDED);
+      // Should finish near the deadline — allow generous upper bound for CI.
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('resolves on the second attempt when the first attempt returns UNAVAILABLE', async () => {
+    let callCount = 0;
+    const successResponse: ListUserIdsByCohortResponse = {
+      userIds: ['user-1'],
+      total: 1,
+      page: 1,
+      totalPages: 1,
+    };
+
+    server.addService(AuthV1.AuthServiceService, {
+      listUserIdsByCohort: (
+        _call: ServerUnaryCall<ListUserIdsByCohortRequest, ListUserIdsByCohortResponse>,
+        cb: sendUnaryData<ListUserIdsByCohortResponse>
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          cb(makeServiceError(status.UNAVAILABLE, 'service unavailable'), null);
+        } else {
+          cb(null, successResponse);
+        }
+      },
+    });
+
+    port = await startServer();
+    const client = createAuthCohortClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      const result = await client.listUserIdsByCohort(emptyListRequest);
+      expect(result).toEqual(successResponse);
+      expect(callCount).toBe(2);
+    } finally {
+      client.close();
+    }
+  });
+
+  it('does not retry INVALID_ARGUMENT and propagates the error after exactly 1 attempt', async () => {
+    let callCount = 0;
+
+    server.addService(AuthV1.AuthServiceService, {
+      listUserIdsByCohort: (
+        _call: ServerUnaryCall<ListUserIdsByCohortRequest, ListUserIdsByCohortResponse>,
+        cb: sendUnaryData<ListUserIdsByCohortResponse>
+      ) => {
+        callCount += 1;
+        cb(makeServiceError(status.INVALID_ARGUMENT, 'bad request'), null);
+      },
+    });
+
+    port = await startServer();
+    const client = createAuthCohortClient({
+      address: `127.0.0.1:${port}`,
+      deadlineMs: 2_000,
+      maxRetries: 2,
+    });
+
+    try {
+      await client.listUserIdsByCohort(emptyListRequest);
+      expect.fail('expected rejection');
+    } catch (err: unknown) {
+      expect((err as { code?: number }).code).toBe(status.INVALID_ARGUMENT);
+      expect(callCount).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/services/notifications/src/grpc/auth-client.ts
+++ b/services/notifications/src/grpc/auth-client.ts
@@ -3,7 +3,7 @@
 // the gateway's full AuthClient interface) keeps the notifications
 // service decoupled from the gateway and means a slimmer dial table.
 
-import { credentials, Metadata } from '@grpc/grpc-js';
+import { credentials, status, type CallOptions, Metadata } from '@grpc/grpc-js';
 
 import {
   AuthV1,
@@ -24,28 +24,83 @@ export type CreateAuthCohortClientOptions = {
   systemUserId?: string;
   systemRoles?: string;
   systemPermissions?: string;
+  // Per-call deadline in milliseconds. Without one, a hung downstream
+  // service would hang this request forever; 5s caps the blast radius
+  // and lets the caller fail fast with DEADLINE_EXCEEDED.
+  deadlineMs?: number;
+  // Maximum additional attempts after the first. Only UNAVAILABLE and
+  // DEADLINE_EXCEEDED trigger a retry (both are safe for idempotent
+  // reads). Defaults to 2 (i.e. up to 3 total attempts).
+  maxRetries?: number;
+};
+
+const DEFAULT_DEADLINE_MS = 5_000;
+const DEFAULT_MAX_RETRIES = 2;
+// Retry-eligible status codes for idempotent reads.
+const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
+
+const isRetryableError = (err: unknown): boolean => {
+  if (err === null || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && RETRYABLE_CODES.has(code);
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+const jitteredBackoff = (attempt: number, baseMs: number): number => {
+  // Exponential backoff with ±25% jitter: 100ms, 200ms (base defaults).
+  const base = baseMs * Math.pow(2, attempt - 1);
+  return base * (0.75 + Math.random() * 0.5);
 };
 
 export function createAuthCohortClient(opts: CreateAuthCohortClientOptions): AuthCohortClient & {
   close(): void;
 } {
   const stub = new AuthV1.AuthServiceClient(opts.address, credentials.createInsecure());
+  const deadlineMs = opts.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+
   const systemMeta = new Metadata();
   systemMeta.set('x-user-id', opts.systemUserId ?? 'svc-notifications');
   systemMeta.set('x-user-roles', opts.systemRoles ?? 'admin');
   systemMeta.set('x-user-permissions', opts.systemPermissions ?? 'admin.users.broadcast');
 
-  return {
-    listUserIdsByCohort: (req: ListUserIdsByCohortRequest): Promise<ListUserIdsByCohortResponse> =>
-      new Promise((resolve, reject) => {
-        stub.listUserIdsByCohort(req, systemMeta, (err, res) => {
+  const callWithRetry = <Req, Res>(
+    fn: (
+      req: Req,
+      metadata: Metadata,
+      options: Partial<CallOptions>,
+      cb: (err: unknown, res: Res) => void
+    ) => unknown,
+    req: Req
+  ): Promise<Res> => {
+    const attempt = (remaining: number): Promise<Res> =>
+      new Promise<Res>((resolve, reject) => {
+        const options: Partial<CallOptions> = {
+          deadline: new Date(Date.now() + deadlineMs),
+        };
+        fn.call(stub, req, systemMeta, options, (err: unknown, res: Res) => {
           if (err) {
-            reject(err);
+            if (remaining > 0 && isRetryableError(err)) {
+              const retryIndex = maxRetries - remaining + 1;
+              sleep(jitteredBackoff(retryIndex, 100))
+                .then(() => attempt(remaining - 1))
+                .then(resolve, reject);
+            } else {
+              reject(err);
+            }
             return;
           }
           resolve(res);
         });
-      }),
+      });
+
+    return attempt(maxRetries);
+  };
+
+  return {
+    listUserIdsByCohort: (req: ListUserIdsByCohortRequest): Promise<ListUserIdsByCohortResponse> =>
+      callWithRetry(stub.listUserIdsByCohort, req),
     close: () => stub.close(),
   };
 }

--- a/services/notifications/src/grpc/auth-client.ts
+++ b/services/notifications/src/grpc/auth-client.ts
@@ -40,7 +40,9 @@ const DEFAULT_MAX_RETRIES = 2;
 const RETRYABLE_CODES = new Set([status.UNAVAILABLE, status.DEADLINE_EXCEEDED]);
 
 const isRetryableError = (err: unknown): boolean => {
-  if (err === null || typeof err !== 'object') return false;
+  if (err === null || typeof err !== 'object') {
+    return false;
+  }
   const code = (err as { code?: unknown }).code;
   return typeof code === 'number' && RETRYABLE_CODES.has(code);
 };

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -25,6 +25,7 @@ const main = async (): Promise<void> => {
   let pushWorker: RunningPushWorker | undefined;
   let scheduler: RunningScheduler | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -51,6 +52,7 @@ const main = async (): Promise<void> => {
       : undefined;
 
     grpc = await startGrpcServer({ config, pool, nats, logger, authClient });
+    grpcReady = true;
     // NATS subscribers register AFTER gRPC so a fast event arriving on
     // applications.submitted before we're ready to handle gRPC calls
     // can't race against partially-constructed deps. Shutdown drains the
@@ -127,7 +129,7 @@ const main = async (): Promise<void> => {
         { logger }
       );
     }
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.notifications running', {

--- a/services/notifications/src/server.test.ts
+++ b/services/notifications/src/server.test.ts
@@ -89,6 +89,54 @@ describe('createServer — error handler', () => {
   });
 });
 
+describe('createServer — readiness probe', () => {
+  it('returns 503 with status starting when isReady returns false', async () => {
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => false,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ status: 'starting' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 once isReady flips to true', async () => {
+    let ready = false;
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => ready,
+    });
+    try {
+      const notReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(notReady.statusCode).toBe(503);
+
+      ready = true;
+
+      const nowReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(nowReady.statusCode).toBe(200);
+      expect(nowReady.json()).toMatchObject({ status: 'ok' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('defaults to ready (isReady omitted) — existing behaviour unchanged', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
     const server = createServer({ config: baseConfig, logger: quietLogger });

--- a/services/notifications/src/server.ts
+++ b/services/notifications/src/server.ts
@@ -21,11 +21,16 @@ export type CreateServerOptions = {
   // service emits structured lines through the same pipeline as the
   // rest of the stack.
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.notifications' });
+  const isReady = opts.isReady ?? (() => true);
 
   // Disable Fastify's built-in pino — winston handles service-level
   // lines (boot, shutdown, error handler), and OTel's HTTP
@@ -55,12 +60,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
 
   // Health endpoint — matches service.backend + service.gateway's
   // `/health/simple` path so the existing Docker compose healthcheck
-  // pattern picks this service up without changes.
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.notifications',
-    environment: config.environment,
-  }));
+  // pattern picks this service up without changes. Returns 503 until
+  // the gRPC server has bound (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.notifications', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/pets/src/index.ts
+++ b/services/pets/src/index.ts
@@ -14,6 +14,7 @@ const main = async (): Promise<void> => {
   let pool: ReturnType<typeof createDbClient> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -33,6 +34,7 @@ const main = async (): Promise<void> => {
     }
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
     // Reports back via gdpr.erasureCompleted with service='pets'.
     const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
@@ -45,7 +47,7 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.pets running', {

--- a/services/pets/src/server.test.ts
+++ b/services/pets/src/server.test.ts
@@ -66,6 +66,54 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — readiness probe', () => {
+  it('returns 503 with status starting when isReady returns false', async () => {
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => false,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ status: 'starting' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 once isReady flips to true', async () => {
+    let ready = false;
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => ready,
+    });
+    try {
+      const notReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(notReady.statusCode).toBe(503);
+
+      ready = true;
+
+      const nowReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(nowReady.statusCode).toBe(200);
+      expect(nowReady.json()).toMatchObject({ status: 'ok' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('defaults to ready (isReady omitted) — existing behaviour unchanged', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
     const server = createServer({ config: baseConfig, logger: quietLogger });

--- a/services/pets/src/server.ts
+++ b/services/pets/src/server.ts
@@ -18,11 +18,16 @@ export type CreateServerOptions = {
   // service emits structured lines through the same pipeline as the
   // rest of the stack.
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.pets' });
+  const isReady = opts.isReady ?? (() => true);
 
   // Disable Fastify's built-in pino — winston handles service-level
   // lines (boot, shutdown, error handler), and OTel's HTTP
@@ -52,12 +57,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck
-  // pattern picks this service up unchanged.
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.pets',
-    environment: config.environment,
-  }));
+  // pattern picks this service up unchanged. Returns 503 until the
+  // gRPC server has bound (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.pets', environment: config.environment };
+  });
 
   return server;
 };

--- a/services/rescue/src/index.ts
+++ b/services/rescue/src/index.ts
@@ -14,6 +14,7 @@ const main = async (): Promise<void> => {
   let pool: ReturnType<typeof createDbClient> | undefined;
   let grpc: RunningGrpcServer | undefined;
   let httpClosed = false;
+  let grpcReady = false;
 
   try {
     const config = loadConfig();
@@ -33,6 +34,7 @@ const main = async (): Promise<void> => {
     }
 
     grpc = await startGrpcServer({ config, pool, nats, logger });
+    grpcReady = true;
     // GDPR erasure subscriber — drops the user's data in this schema.
     // Reports back via gdpr.erasureCompleted with service='rescue'.
     const { registerGdprSubscriber } = await import('@adopt-dont-shop/events');
@@ -45,7 +47,7 @@ const main = async (): Promise<void> => {
       onError: (err, subject) => logger.error('gdpr erasure subscriber error', { subject, err }),
     });
 
-    const httpServer = createServer({ config, logger });
+    const httpServer = createServer({ config, logger, isReady: () => grpcReady });
     await httpServer.listen({ port: config.port, host: config.host });
 
     logger.info('service.rescue running', {

--- a/services/rescue/src/server.test.ts
+++ b/services/rescue/src/server.test.ts
@@ -66,6 +66,54 @@ describe('createServer — health endpoint', () => {
   });
 });
 
+describe('createServer — readiness probe', () => {
+  it('returns 503 with status starting when isReady returns false', async () => {
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => false,
+    });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({ status: 'starting' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns 200 once isReady flips to true', async () => {
+    let ready = false;
+    const server = createServer({
+      config: baseConfig,
+      logger: quietLogger,
+      isReady: () => ready,
+    });
+    try {
+      const notReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(notReady.statusCode).toBe(503);
+
+      ready = true;
+
+      const nowReady = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(nowReady.statusCode).toBe(200);
+      expect(nowReady.json()).toMatchObject({ status: 'ok' });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('defaults to ready (isReady omitted) — existing behaviour unchanged', async () => {
+    const server = createServer({ config: baseConfig, logger: quietLogger });
+    try {
+      const res = await server.inject({ method: 'GET', url: '/health/simple' });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
 describe('createServer — /metrics endpoint', () => {
   it('exposes Prometheus metrics with http_request_duration_seconds', async () => {
     const server = createServer({ config: baseConfig, logger: quietLogger });

--- a/services/rescue/src/server.ts
+++ b/services/rescue/src/server.ts
@@ -18,11 +18,16 @@ export type CreateServerOptions = {
   // service emits structured lines through the same pipeline as the
   // rest of the stack.
   logger?: ReturnType<typeof createLogger>;
+  // Readiness probe — /health/simple returns 503 until this returns
+  // true. Defaults to () => true so existing call-sites compile
+  // unchanged. index.ts flips a local boolean after gRPC binds.
+  isReady?: () => boolean;
 };
 
 export const createServer = (opts: CreateServerOptions): FastifyInstance => {
   const { config } = opts;
   const logger = opts.logger ?? createLogger({ serviceName: 'service.rescue' });
+  const isReady = opts.isReady ?? (() => true);
 
   // Disable Fastify's built-in pino — winston handles service-level
   // lines (boot, shutdown, error handler), and OTel's HTTP
@@ -52,12 +57,14 @@ export const createServer = (opts: CreateServerOptions): FastifyInstance => {
 
   // Health endpoint — matches the rest of the stack's
   // `/health/simple` path so the existing Docker compose healthcheck
-  // pattern picks this service up unchanged.
-  server.get('/health/simple', async () => ({
-    status: 'ok',
-    service: 'service.rescue',
-    environment: config.environment,
-  }));
+  // pattern picks this service up unchanged. Returns 503 until the
+  // gRPC server has bound (isReady probe), then the normal 200 payload.
+  server.get('/health/simple', async (_req, reply) => {
+    if (!isReady()) {
+      return reply.status(503).send({ status: 'starting' });
+    }
+    return { status: 'ok', service: 'service.rescue', environment: config.environment };
+  });
 
   return server;
 };


### PR DESCRIPTION
Implements five high-priority Linear tickets from the June 2026 microservices architecture audit. Each ticket is a separate conventional commit; all were developed test-first and verified with full per-package suites plus cross-package lint and type-check.

## ADS-813 (Urgent, Bug) — forward CUTOVER_* flags to gateway in prod/staging compose
Without these the gateway boots healthy but 404s every `/api/v1/*` route (compose doesn't pass host env implicitly; the monolith fall-through was deleted in Phase 11). Mirrors the dev compose fix from #1011 with default `true`, and adds a post-deploy smoke check against a cutover-gated route (`POST /api/v1/auth/login` → 400 when registered, 404 when not).

## ADS-823 (Urgent) — deadlines + bounded retries on internal S2S gRPC clients
applications→pets, matching→pets and notifications→auth previously set no deadline, so a hung downstream held the calling RPC open indefinitely. Every unary call now carries a 5s deadline (gateway's existing pattern) and retries UNAVAILABLE/DEADLINE_EXCEEDED up to 2 more times with jittered backoff (idempotent reads only; other codes propagate). Covered by stub-gRPC-server tests: never-responds → fast DEADLINE_EXCEEDED; fails-once → succeeds on retry; INVALID_ARGUMENT → no retry.

## ADS-775 (High, Security) — report write scoping no longer piggybacks on reports.read:any
`updateSavedReport`/`deleteSavedReport` decided WHERE-clause scoping via `reports.read:any`, so view-all read access + base write permissions silently granted edit-any/delete-any. Write scoping now requires explicit `reports.update:any` / `reports.delete:any`; the `reports.*` permissions are first-class members of the `Permission` union (removing `as` casts). Regression tests assert `reports.read:any` alone no longer broadens writes. Note: permissions are granted at runtime via the admin flow (no static seed exists), so admins needing cross-user write access must be granted the new permissions.

## ADS-827 (High) — default timeouts on the shared pg Pool
`createDbClient` now applies `connectionTimeoutMillis` 10s, `idleTimeoutMillis` 30s, `statement_timeout`/`query_timeout` 30s unless overridden, so an unresponsive Postgres fails fast in all 10 consuming services. Tested including a non-routable-address timeout case.

## ADS-825 (High) — /health/simple gated on gRPC listener readiness
Health previously returned 200 as soon as Fastify listened, before the gRPC port bound — CI documents the resulting ECONNREFUSED race (`ci.yml:478-481`). All 10 gRPC services now return 503 `{status:'starting'}` until a readiness flag flips after `startGrpcServer` resolves. Identical minimal pattern per service; gateway (no gRPC server) unchanged. cms gained its first `server.test.ts`.

## Verification
- Full vitest suites green for all touched packages: applications 213, notifications 201, moderation 277, auth 196, audit 111→114, matching 130, pets 103, rescue 103, chat 69, cms 37, packages/db 9
- `turbo type-check` and `turbo lint` clean across all touched services + packages
- Both prod/staging compose files validate via `docker compose config`

Held back deliberately (need owner decisions / dedicated sessions): ADS-822/792 (CI E2E rework), ADS-824 (per-service image tagging strategy), ADS-800 (mTLS), ADS-826 (GitHub environment approval gating).

https://claude.ai/code/session_01TkXXzRRpj4roTevghDLV6n

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkXXzRRpj4roTevghDLV6n)_